### PR TITLE
[all] add disruption budget for replicated services (min 2)

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -110,3 +110,13 @@ spec:
      resource:
        name: cpu
        targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: auth
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: auth

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -152,7 +152,8 @@ class Job:
             body=kube.client.V1PersistentVolumeClaim(
                 metadata=kube.client.V1ObjectMeta(
                     name=self._pvc_name,
-                    labels={'app': 'batch-job',
+                    labels={'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true',
+                            'app': 'batch-job',
                             'hail.is/batch-instance': INSTANCE_ID,
                             'batch_id': str(self.batch_id),
                             'job_id': str(self.job_id),

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -261,3 +261,13 @@ spec:
      resource:
        name: cpu
        targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: batch2
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: batch2

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -64,3 +64,13 @@ spec:
      resource:
        name: cpu
        targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: gateway

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -56,3 +56,13 @@ spec:
      resource:
        name: cpu
        targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: internal-gateway
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: internal-gateway

--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -536,6 +536,16 @@ spec:
         requests:
           storage: 30Gi
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: es-cluster
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: elasticsearch
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/monitoring/router.yaml
+++ b/monitoring/router.yaml
@@ -38,3 +38,13 @@ spec:
     targetPort: 80
   selector:
     app: router
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: router
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: router

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -115,3 +115,13 @@ spec:
      resource:
        name: cpu
        targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: router-resolver
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: router-resolver

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -243,3 +243,13 @@ spec:
     resource:
       name: cpu
       targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: router
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: router

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -73,3 +73,13 @@ spec:
     resource:
       name: cpu
       targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: site
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: site


### PR DESCRIPTION
Also, make batch pods eviction-safe.

This should allow the cluster autoscaler to scale the cluster down, according to: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
