### PR TITLE
[batch2] secure driver endpoints

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -253,7 +253,7 @@ async def schedule_job(app, record, instance):
     await check_call_procedure(
         db,
         'CALL schedule_job(%s, %s, %s);',
-        (batch_id, job_id, instance.id))
+        (batch_id, job_id, instance.name))
 
     log.info(f'schedule job {id} on {instance}: updated database')
 

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -94,9 +94,9 @@ async def mark_job_complete(app, batch_id, job_id, new_state, status):
 
     log.info(f'job {id} changed state: {rv["old_state"]} => {new_state}')
 
-    instance_id = rv['instance_id']
-    if instance_id is not None:
-        instance = inst_pool.id_instance.get(instance_id)
+    instance_name = rv['instance_name']
+    if instance_name:
+        instance = inst_pool.name_instance.get(instance_name)
         if instance:
             log.info(f'updating {instance}')
 
@@ -155,20 +155,20 @@ async def unschedule_job(app, record):
     job_id = record['job_id']
     id = (batch_id, job_id)
 
-    instance_id = record['instance_id']
-    assert instance_id is not None
+    instance_name = record['instance_name']
+    assert instance_name is not None
 
-    log.info(f'unscheduling job {id} from instance {instance_id}')
+    log.info(f'unscheduling job {id} from instance {instance_name}')
 
-    instance = inst_pool.id_instance.get(instance_id)
+    instance = inst_pool.name_instance.get(instance_name)
     if not instance:
-        log.warning(f'unschedule job {id}: unknown instance {instance_id}')
+        log.warning(f'unschedule job {id}: unknown instance {instance_name}')
         return
 
     await check_call_procedure(
         db,
         'CALL unschedule_job(%s, %s, %s);',
-        (batch_id, job_id, instance_id))
+        (batch_id, job_id, instance_name))
 
     log.info(f'unschedule job {id}: updated database')
 

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -74,7 +74,7 @@ def instances_only(fun):
 
         db = request.app['db']
         record = await db.execute_and_fetchone(
-            'SELECT state FROM intances WHERE id = %s AND token = %s;',
+            'SELECT state FROM instances WHERE id = %s AND token = %s;',
             (instance_name, token))
         if not record:
             raise web.HTTPUnauthorized()

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -74,7 +74,7 @@ def instances_only(fun):
 
         db = request.app['db']
         record = await db.execute_and_fetchone(
-            'SELECT state FROM instances WHERE id = %s AND token = %s;',
+            'SELECT state FROM instances WHERE name = %s AND token = %s;',
             (instance_name, token))
         if not record:
             raise web.HTTPUnauthorized()

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -1,6 +1,8 @@
-import asyncio
-import concurrent
+import secrets
 import logging
+from functools import wraps
+import concurrent
+import asyncio
 from aiohttp import web
 import kubernetes_asyncio as kube
 import google.oauth2.service_account
@@ -31,12 +33,63 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 
+def batch_only(fun):
+    @wraps(fun)
+    async def wrapped(request):
+        auth_header = request.headers.get('Authorization')
+        if not auth_header:
+            raise web.HTTPUnauthorized()
+        if not auth_header.startswith('Bearer '):
+            raise web.HTTPUnauthorized()
+        token = auth_header[7:]
+        if not secrets.compare_digest(token, request.app['internal_token']):
+            raise web.HTTPUnauthorized()
+
+        return await fun(request)
+    return wrapped
+
+
+def instances_only(fun):
+    @wraps(fun)
+    async def wrapped(request):
+        app = request.app
+
+        instance_name = request.headers.get('X-Hail-Instance-Name')
+        if not instance_name:
+            raise web.HTTPUnauthorized()
+
+        instance_pool = app['inst_pool']
+        instance = instance_pool.name_instance.get(instance_name)
+        if not instance:
+            raise web.HTTPUnauthorized()
+        if instance.state not in ('pending', 'active'):
+            raise web.HTTPUnauthorized()
+
+        auth_header = request.headers.get('Authorization')
+        if not auth_header:
+            raise web.HTTPUnauthorized()
+        if not auth_header.startswith('Bearer '):
+            raise web.HTTPUnauthorized()
+        token = auth_header[7:]
+
+        db = request.app['db']
+        record = await db.execute_and_fetchone(
+            'SELECT state FROM intances WHERE id = %s AND token = %s;',
+            (instance_name, token))
+        if not record:
+            raise web.HTTPUnauthorized()
+
+        return await fun(request, instance)
+    return wrapped
+
+
 @routes.get('/healthcheck')
 async def get_healthcheck(request):  # pylint: disable=W0613
     return web.Response()
 
 
 @routes.patch('/api/v1alpha/batches/{user}/{batch_id}/close')
+@batch_only
 async def close_batch(request):
     db = request.app['db']
 
@@ -57,6 +110,7 @@ SELECT state FROM batches WHERE user = %s AND id = %s;
 
 
 @routes.patch('/api/v1alpha/batches/{user}/{batch_id}/cancel')
+@batch_only
 async def cancel_batch(request):
     db = request.app['db']
 
@@ -78,6 +132,7 @@ SELECT state FROM batches WHERE user = %s AND id = %s;
 
 
 @routes.delete('/api/v1alpha/batches/{user}/{batch_id}')
+@batch_only
 async def delete_batch(request):
     db = request.app['db']
 
@@ -114,18 +169,9 @@ WHERE deleted AND (NOT closed OR n_jobs = n_completed);
         await asyncio.sleep(REFRESH_INTERVAL_IN_SECONDS)
 
 
-async def activate_instance_1(request):
-    app = request.app
-    inst_pool = app['inst_pool']
-
+async def activate_instance_1(request, instance):
     body = await request.json()
-    inst_token = body['inst_token']
     ip_address = body['ip_address']
-
-    instance = inst_pool.token_inst.get(inst_token)
-    if not instance:
-        log.warning(f'/activate_worker from unknown instance {inst_token}')
-        raise web.HTTPNotFound()
 
     log.info(f'activating {instance}')
     await instance.activate(ip_address)
@@ -134,21 +180,12 @@ async def activate_instance_1(request):
 
 
 @routes.post('/api/v1alpha/instances/activate')
-async def activate_instance(request):
-    return await asyncio.shield(activate_instance_1(request))
+@instances_only
+async def activate_instance(request, instance):
+    return await asyncio.shield(activate_instance_1(request, instance))
 
 
-async def deactivate_instance_1(request):
-    inst_pool = request.app['inst_pool']
-
-    body = await request.json()
-    inst_token = body['inst_token']
-
-    instance = inst_pool.token_inst.get(inst_token)
-    if not instance:
-        log.warning(f'/deactivate_worker from unknown instance {inst_token}')
-        raise web.HTTPNotFound()
-
+async def deactivate_instance_1(instance):
     log.info(f'deactivating {instance}')
     await instance.deactivate()
     await instance.mark_healthy()
@@ -156,22 +193,14 @@ async def deactivate_instance_1(request):
 
 
 @routes.post('/api/v1alpha/instances/deactivate')
-async def deactivate_instance(request):
-    return await asyncio.shield(deactivate_instance_1(request))
+@instances_only
+async def deactivate_instance(request, instance):  # pylint: disable=unused-argument
+    return await asyncio.shield(deactivate_instance_1(instance))
 
 
-async def job_complete_1(request):
-    app = request.app
-    inst_pool = app['inst_pool']
-
+async def job_complete_1(request, instance):
     body = await request.json()
-    inst_token = body['inst_token']
     status = body['status']
-
-    instance = inst_pool.token_inst.get(inst_token)
-    if not instance:
-        log.warning(f'job_complete from unknown instance {inst_token}')
-        raise web.HTTPNotFound()
 
     batch_id = status['batch_id']
     job_id = status['job_id']
@@ -185,14 +214,17 @@ async def job_complete_1(request):
         assert status_state == 'failed', status_state
         new_state = 'Failed'
 
-    await mark_job_complete(app, batch_id, job_id, new_state, status)
+    await mark_job_complete(request.app, batch_id, job_id, new_state, status)
+
     await instance.mark_healthy()
+
     return web.Response()
 
 
 @routes.post('/api/v1alpha/instances/job_complete')
-async def job_complete(request):
-    return await asyncio.shield(job_complete_1(request))
+@instances_only
+async def job_complete(request, instance):
+    return await asyncio.shield(job_complete_1(request, instance))
 
 
 async def on_startup(app):
@@ -219,6 +251,11 @@ async def on_startup(app):
     instance_id = row['token']
     log.info(f'instance_id {instance_id}')
     app['instance_id'] = instance_id
+
+    row = await db.execute_and_fetchone(
+        'SELECT token FROM tokens WHERE name = %s;',
+        'internal')
+    app['internal_token'] = row['token']
 
     machine_name_prefix = f'batch2-worker-{BATCH_NAMESPACE}-'
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(

--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -41,7 +41,7 @@ class Scheduler:
     async def cancel_1(self):
         records = self.db.execute_and_fetchall(
             '''
-SELECT job_id, batch_id, cores_mcpu, instance_id
+SELECT job_id, batch_id, cores_mcpu, instance_name
 FROM jobs
 INNER JOIN batches ON batches.id = jobs.batch_id
 WHERE jobs.state = 'Running' AND (NOT jobs.always_run) AND batches.closed AND batches.cancelled

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -131,7 +131,7 @@ FROM jobs
 INNER JOIN batches
   ON jobs.batch_id = batches.id
 LEFT JOIN instances
-  ON jobs.instance_id = instances.id
+  ON jobs.instance_name = instances.name
 WHERE user = %s AND batch_id = %s AND NOT deleted AND job_id = %s;
 ''',
                                            (user, batch_id, job_id))
@@ -575,7 +575,7 @@ FROM jobs
 INNER JOIN batches
   ON jobs.batch_id = batches.id
 LEFT JOIN instances
-  ON jobs.instance_id = instances.id
+  ON jobs.instance_name = instances.name
 WHERE user = %s AND batch_id = %s AND NOT deleted AND job_id = %s;
 ''',
                                            (user, batch_id, job_id))

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -397,7 +397,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
-            deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}/cancel'))
+            deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}/cancel'),
+            headers=app['driver_headers'])
 
     return web.Response()
 
@@ -430,7 +431,8 @@ async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
 
-    db = request.app['db']
+    app = request.app
+    db = app['db']
 
     record = await db.execute_and_fetchone(
         '''
@@ -457,7 +459,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
-            deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'))
+            deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
+            headers=app['driver_headers'])
 
     return web.Response()
 
@@ -469,7 +472,8 @@ async def delete_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
 
-    db = request.app['db']
+    app = request.app
+    db = app['db']
 
     record = await db.execute_and_fetchone(
         '''
@@ -489,7 +493,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
             try:
                 await request_retry_transient_errors(
                     session, 'DELETE',
-                    deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}'))
+                    deploy_config.url('batch2-driver', f'/api/v1alpha/batches/{user}/{batch_id}'),
+                    headers=app['driver_headers'])
             except aiohttp.ClientResponseError as e:
                 if e.status == 404:
                     pass
@@ -635,6 +640,13 @@ async def on_startup(app):
     instance_id = row['token']
     log.info(f'instance_id {instance_id}')
     app['instance_id'] = instance_id
+
+    row = await db.execute_and_fetchone(
+        'SELECT token FROM tokens WHERE name = %s;',
+        'internal')
+    app['driver_headers'] = {
+        'Authorization': f'Bearer {row["token"]}'
+    }
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
         '/batch-gsa-key/privateKeyData')

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -1,14 +1,8 @@
 import re
 import time
-import secrets
 import logging
 
 log = logging.getLogger('utils')
-
-
-def new_token(n=5):
-    return ''.join([secrets.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(n)])
-
 
 cpu_regex = re.compile(r"^(\d*\.\d+|\d+)([m]?)$")
 

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -28,19 +28,27 @@ from .log_store import LogStore
 # uvloop.install()
 
 configure_logging()
-log = logging.getLogger('batch2-agent')
-
-docker = aiodocker.Docker()
+log = logging.getLogger('batch2-worker')
 
 MAX_IDLE_TIME_SECS = 60
 
+CORES = int(os.environ['CORES'])
 NAME = os.environ['NAME']
+NAMESPACE = os.environ['NAMESPACE']
 BUCKET_NAME = os.environ['BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
+IP_ADDRESS = os.environ['IP_ADDRESS']
 
+log.info(f'CORES {CORES}')
 log.info(f'NAME {NAME}')
+log.info(f'NAMESPACE {NAMESPACE}')
 log.info(f'BUCKET_NAME {BUCKET_NAME}')
 log.info(f'INSTANCE_ID {INSTANCE_ID}')
+log.info(f'IP_ADDRESS {IP_ADDRESS}')
+
+deploy_config = DeployConfig('gce', NAMESPACE, {})
+
+docker = aiodocker.Docker()
 
 
 async def docker_call_retry(f, *args, **kwargs):
@@ -486,14 +494,15 @@ class Job:
 
 
 class Worker:
-    def __init__(self, cores, deploy_config, token, ip_address):
-        self.cores_mcpu = cores * 1000
-        self.deploy_config = deploy_config
-        self.token = token
+    def __init__(self):
+        self.cores_mcpu = CORES * 1000
         self.free_cores_mcpu = self.cores_mcpu
         self.last_updated = time.time()
         self.cpu_sem = WeightedSemaphore(self.cores_mcpu)
-        self.ip_address = ip_address
+        self._headers = {
+            'X-Hail-Instance-Name': NAME,
+            'Authorization': f'Bearer {os.environ["TOKEN"]}'
+        }
 
         pool = concurrent.futures.ThreadPoolExecutor()
         self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, pool)
@@ -606,7 +615,6 @@ class Worker:
 
             log.info(f'idle {idle_duration} seconds, exiting')
 
-            body = {'inst_token': self.token}
             async with aiohttp.ClientSession(
                     raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                 # Don't retry.  If it doesn't go through, the driver
@@ -615,7 +623,8 @@ class Worker:
                 # infinite loop and the instance won't be deleted.
                 await session.post(
                     self.deploy_config.url('batch2-driver', '/api/v1alpha/instances/deactivate'),
-                    json=body)
+                    json=body,
+                    headers=self._headers)
             log.info('deactivated')
         finally:
             log.info('shutting down')
@@ -628,7 +637,6 @@ class Worker:
 
     async def post_job_complete(self, job_status):
         body = {
-            'inst_token': self.token,
             'status': job_status
         }
 
@@ -638,8 +646,8 @@ class Worker:
                 async with aiohttp.ClientSession(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     await session.post(
-                        self.deploy_config.url('batch2-driver', '/api/v1alpha/instances/job_complete'),
-                        json=body)
+                        deploy_config.url('batch2-driver', '/api/v1alpha/instances/job_complete'),
+                        json=body, headers=self._headers)
                     return
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
@@ -653,25 +661,16 @@ class Worker:
             delay = min(delay * 2, 60.0)
 
     async def activate(self):
-        body = {
-            'inst_token': self.token,
-            'ip_address': self.ip_address
-        }
+        body = {'ip_address': IP_ADDRESS}
         async with aiohttp.ClientSession(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             await request_retry_transient_errors(
                 session, 'POST',
-                self.deploy_config.url('batch2-driver', '/api/v1alpha/instances/activate'),
-                json=body)
+                deploy_config.url('batch2-driver', '/api/v1alpha/instances/activate'),
+                json=body, headers=self._headers)
 
 
-cores = int(os.environ['CORES'])
-namespace = os.environ['NAMESPACE']
-inst_token = os.environ['INST_TOKEN']
-ip_address = os.environ['INTERNAL_IP']
-
-deploy_config = DeployConfig('gce', namespace, {})
-worker = Worker(cores, deploy_config, inst_token, ip_address)
+worker = Worker()
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(worker.run())

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -622,8 +622,7 @@ class Worker:
                 # gone (e.g. testing a PR), this would go into an
                 # infinite loop and the instance won't be deleted.
                 await session.post(
-                    self.deploy_config.url('batch2-driver', '/api/v1alpha/instances/deactivate'),
-                    json=body,
+                    deploy_config.url('batch2-driver', '/api/v1alpha/instances/deactivate'),
                     headers=self._headers)
             log.info('deactivated')
         finally:

--- a/batch2/delete-batch-tables.sql
+++ b/batch2/delete-batch-tables.sql
@@ -1,3 +1,11 @@
+DROP PROCEDURE IF EXISTS activate_instance;
+DROP PROCEDURE IF EXISTS deactivate_instance;
+DROP PROCEDURE IF EXISTS mark_instance_deleted;
+DROP PROCEDURE IF EXISTS close_batch;
+DROP PROCEDURE IF EXISTS schedule_job;
+DROP PROCEDURE IF EXISTS unschedule_job;
+DROP PROCEDURE IF EXISTS mark_job_complete;
+
 DROP TABLE IF EXISTS `batch_attributes`;
 DROP TABLE IF EXISTS `job_attributes`;
 DROP TABLE IF EXISTS `job_parents`;
@@ -6,10 +14,3 @@ DROP TABLE IF EXISTS `jobs`;
 DROP TABLE IF EXISTS `batches`;
 DROP TABLE IF EXISTS `instances`;
 DROP TABLE IF EXISTS `tokens`;
-DROP PROCEDURE IF EXISTS activate_instance;
-DROP PROCEDURE IF EXISTS deactivate_instance;
-DROP PROCEDURE IF EXISTS mark_instance_deleted;
-DROP PROCEDURE IF EXISTS close_batch;
-DROP PROCEDURE IF EXISTS schedule_job;
-DROP PROCEDURE IF EXISTS unschedule_job;
-DROP PROCEDURE IF EXISTS mark_job_complete;


### PR DESCRIPTION
This secures the batch2 driver endpoints.  The driver is called by workers on activate, deactivate and when a job is complete.  It is also called by the front end to notify it when a batch is closed, cancelled or deleted.

Workers have a random token stored in the database that is sent along with requests.  The front end and driver share another random, internal token which is also placed in the authorization header.

The driver has to decorators to protect request handlers: batch_only and instances_only.
