### PR TITLE
[batch2] track instance health

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -2,7 +2,7 @@ import json
 import logging
 import asyncio
 import aiohttp
-from hailtop.utils import sleep_and_back_off, is_transient_error
+from hailtop.utils import sleep_and_backoff, is_transient_error
 
 from .globals import complete_states, tasks
 from .database import check_call_procedure
@@ -201,7 +201,7 @@ async def unschedule_job(app, record):
                     pass
                 else:
                     raise
-        delay = await sleep_and_back_off(delay)
+        delay = await sleep_and_backoff(delay)
 
     log.info(f'unschedule job {id}: called delete job')
 

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -2,7 +2,7 @@ import json
 import logging
 import asyncio
 import aiohttp
-from hailtop.utils import request_retry_transient_errors
+from hailtop.utils import sleep_and_back_off, is_transient_error
 
 from .globals import complete_states, tasks
 from .database import check_call_procedure
@@ -103,8 +103,6 @@ async def mark_job_complete(app, batch_id, job_id, new_state, status):
 
             instance.adjust_free_cores_in_memory(rv['cores_mcpu'])
             scheduler_state_changed.set()
-
-            await instance.update_timestamp()
         else:
             log.warning(f'mark_complete for job {id} from unknown {instance}')
 
@@ -180,18 +178,30 @@ async def unschedule_job(app, record):
 
     log.info(f'unschedule job {id}: updated {instance} free cores')
 
-    async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-        url = (f'http://{instance.ip_address}:5000'
-               f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/delete')
+    url = (f'http://{instance.ip_address}:5000'
+           f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/delete')
+    delay = 0.1
+    while True:
+        if instance.state in ('inactive', 'deleted'):
+            break
         try:
-            await request_retry_transient_errors(session, 'DELETE', url)
-            await instance.update_timestamp()
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                pass
+            async with aiohttp.ClientSession(
+                    raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                await session.delete(url)
+                await instance.mark_healthy()
+                break
+        except Exception as e:
+            if (isinstance(e, aiohttp.ClientResponseError) and
+                    e.status == 404):  # pylint: disable=no-member
+                await instance.mark_healthy()
+                break
             else:
-                raise
+                await instance.incr_failed_request_count()
+                if is_transient_error(e):
+                    pass
+                else:
+                    raise
+        delay = await sleep_and_back_off(delay)
 
     log.info(f'unschedule job {id}: called delete job')
 
@@ -227,14 +237,17 @@ async def schedule_job(app, record, instance):
     job_id = record['job_id']
     id = (batch_id, job_id)
 
-    async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-        url = f'http://{instance.ip_address}:5000/api/v1alpha/batches/jobs/create'
-        body = await job_config(app, record)
-        await request_retry_transient_errors(
-            session, 'POST',
-            url, json=body)
-        await instance.update_timestamp()
+    try:
+        async with aiohttp.ClientSession(
+                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+            url = (f'http://{instance.ip_address}:5000'
+                   f'/api/v1alpha/batches/jobs/create')
+            body = await job_config(app, record)
+            await session.post(url, json=body)
+            await instance.mark_healthy()
+    except Exception:
+        await instance.incr_failed_request_count()
+        raise
 
     log.info(f'schedule job {id} on {instance}: called create job')
 

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -130,7 +130,7 @@ WHERE id = %s;
         now = time.time()
         await self.db.execute_update(
             'UPDATE instances  SET failed_request_count = 0 WHERE id = %s;',
-            (now, self.id))
+            (self.id,))
 
         self.instance_pool.adjust_for_remove_instance(self)
         self._failed_request_count = 0

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -129,13 +129,13 @@ WHERE id = %s;
     async def incr_failed_request_count(self):
         await self.db.execute_update(
             '''
-UPDATE instances 
+UPDATE instances
 SET failed_request_count = failed_request_count + 1 WHERE id = %s;
 ''',
             (self.id,))
 
         self.instance_pool.adjust_for_remove_instance(self)
-        self._failed_request_count = 0
+        self._failed_request_count += 1
         self.instance_pool.adjust_for_add_instance(self)
 
     @property

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -127,7 +127,6 @@ WHERE id = %s;
         self.instance_pool.adjust_for_add_instance(self)
 
     async def incr_failed_request_count(self):
-        now = time.time()
         await self.db.execute_update(
             'UPDATE instances  SET failed_request_count = 0 WHERE id = %s;',
             (self.id,))

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -128,7 +128,10 @@ WHERE id = %s;
 
     async def incr_failed_request_count(self):
         await self.db.execute_update(
-            'UPDATE instances  SET failed_request_count = 0 WHERE id = %s;',
+            '''
+UPDATE instances 
+SET failed_request_count = failed_request_count + 1 WHERE id = %s;
+''',
             (self.id,))
 
         self.instance_pool.adjust_for_remove_instance(self)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -85,7 +85,8 @@ class InstancePool:
         self.instances_by_last_updated.remove(instance)
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu -= instance.free_cores_mcpu
-        self.healthy_instances_by_free_cores.remove(instance)
+        if instance in self.healthy_instances_by_free_cores:
+            self.healthy_instances_by_free_cores.remove(instance)
 
     async def remove_instance(self, instance):
         await self.db.just_execute(

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -366,15 +366,16 @@ gcloud -q compute instances delete $NAME --zone=$ZONE
             await asyncio.sleep(15)
 
     async def check_on_instance(self, instance):
-        try:
-            async with aiohttp.ClientSession(
-                    raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-                await session.get(f'http://{instance.ip_address}:5000/healthcheck')
-                await instance.mark_healthy()
-                return
-        except Exception:
-            log.exception(f'while requesting {instance} /healthcheck')
-            await instance.incr_failed_request_count()
+        if instance.ip_address:
+            try:
+                async with aiohttp.ClientSession(
+                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                    await session.get(f'http://{instance.ip_address}:5000/healthcheck')
+                    await instance.mark_healthy()
+                    return
+            except Exception:
+                log.exception(f'while requesting {instance} /healthcheck')
+                await instance.incr_failed_request_count()
 
         try:
             spec = await self.gservices.get_instance(instance.name)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -46,7 +46,7 @@ class InstancePool:
         self.instances_by_last_updated = sortedcontainers.SortedSet(
             key=lambda instance: instance.last_updated)
 
-        self.active_instances_by_free_cores = sortedcontainers.SortedSet(
+        self.healthy_instances_by_free_cores = sortedcontainers.SortedSet(
             key=lambda instance: instance.free_cores_mcpu)
 
         self.n_instances_by_state = {
@@ -85,7 +85,7 @@ class InstancePool:
         self.instances_by_last_updated.remove(instance)
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu -= instance.free_cores_mcpu
-        self.active_instances_by_free_cores.remove(instance)
+        self.healthy_instances_by_free_cores.remove(instance)
 
     async def remove_instance(self, instance):
         await self.db.just_execute(
@@ -104,7 +104,7 @@ class InstancePool:
             self.live_free_cores_mcpu += instance.free_cores_mcpu
         if (instance.state == 'active' and
                 instance.failed_request_count <= 1):
-            self.active_instances_by_free_cores.add(instance)
+            self.healthy_instances_by_free_cores.add(instance)
 
     def add_instance(self, instance):
         assert instance.token not in self.token_inst

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -369,7 +369,7 @@ gcloud -q compute instances delete $NAME --zone=$ZONE
         try:
             async with aiohttp.ClientSession(
                     raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-                await session.get('http://{instance.ip_address}:5000/healthcheck')
+                await session.get(f'http://{instance.ip_address}:5000/healthcheck')
                 await instance.mark_healthy()
                 return
         except Exception:

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -103,7 +103,7 @@ class InstancePool:
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu += instance.free_cores_mcpu
         if (instance.state == 'active' and
-                instance.failed_request_count <= 3):
+                instance.failed_request_count <= 1):
             self.active_instances_by_free_cores.add(instance)
 
     def add_instance(self, instance):

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -129,7 +129,7 @@ async def activate_instance_1(request):
 
     log.info(f'activating {instance}')
     await instance.activate(ip_address)
-    await instance.update_timestamp()
+    await instance.mark_healthy()
     return web.Response()
 
 
@@ -151,7 +151,7 @@ async def deactivate_instance_1(request):
 
     log.info(f'deactivating {instance}')
     await instance.deactivate()
-    await instance.update_timestamp()
+    await instance.mark_healthy()
     return web.Response()
 
 
@@ -186,7 +186,7 @@ async def job_complete_1(request):
         new_state = 'Failed'
 
     await mark_job_complete(app, batch_id, job_id, new_state, status)
-
+    await instance.mark_healthy()
     return web.Response()
 
 

--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -81,9 +81,9 @@ LIMIT 50;
                 should_wait = False
                 continue
 
-            i = self.inst_pool.active_instances_by_free_cores.bisect_key_left(record['cores_mcpu'])
-            if i < len(self.inst_pool.active_instances_by_free_cores):
-                instance = self.inst_pool.active_instances_by_free_cores[i]
+            i = self.inst_pool.healthy_instances_by_free_cores.bisect_key_left(record['cores_mcpu'])
+            if i < len(self.inst_pool.healthy_instances_by_free_cores):
+                instance = self.inst_pool.healthy_instances_by_free_cores[i]
                 assert record['cores_mcpu'] <= instance.free_cores_mcpu
                 log.info(f'scheduling job {id} on {instance}')
                 try:

--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -86,7 +86,10 @@ LIMIT 50;
                 instance = self.inst_pool.active_instances_by_free_cores[i]
                 assert record['cores_mcpu'] <= instance.free_cores_mcpu
                 log.info(f'scheduling job {id} on {instance}')
-                await schedule_job(self.app, record, instance)
+                try:
+                    await schedule_job(self.app, record, instance)
+                except Exception:
+                    log.exception('while scheduling job {id} on {instance}')
                 should_wait = False
 
         return should_wait

--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `instances` (
   `cores_mcpu` INT NOT NULL,
   `free_cores_mcpu` INT NOT NULL,
   `time_created` DOUBLE NOT NULL,
+  `failed_request_count` INT NOT NULL DEFAULT 0,
   `last_updated` DOUBLE NOT NULL,
   `ip_address` VARCHAR(100),
   PRIMARY KEY (`id`)

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,5 +1,5 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    bounded_gather, grouped, sleep_and_back_off, is_transient_error, \
+    bounded_gather, grouped, sleep_and_backoff, is_transient_error, \
     request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
@@ -14,7 +14,7 @@ __all__ = [
     'bounded_gather',
     'grouped',
     'is_transient_error',
-    'sleep_and_back_off',
+    'sleep_and_backoff',
     'request_retry_transient_errors',
     'request_raise_transient_errors'
 ]

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,5 +1,6 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    bounded_gather, grouped, request_retry_transient_errors, request_raise_transient_errors
+    bounded_gather, grouped, sleep_and_back_off, is_transient_error, \
+    request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
@@ -12,6 +13,8 @@ __all__ = [
     'check_shell_output',
     'bounded_gather',
     'grouped',
+    'is_transient_error',
+    'sleep_and_back_off',
     'request_retry_transient_errors',
     'request_raise_transient_errors'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -158,7 +158,7 @@ def is_transient_error(e):
     return False
 
 
-async def sleep_and_back_off(delay):
+async def sleep_and_backoff(delay):
     # exponentially back off, up to (expected) max of 30s
     t = delay * random.random()
     await asyncio.sleep(t)
@@ -170,18 +170,18 @@ async def request_retry_transient_errors(session, method, url, **kwargs):
     while True:
         try:
             return await session.request(method, url, **kwargs)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             if is_transient_error(e):
                 pass
             else:
                 raise
-        delay = sleep_and_back_off(delay)
+        delay = sleep_and_backoff(delay)
 
 
 async def request_raise_transient_errors(session, method, url, **kwargs):
     try:
         return await session.request(method, url, **kwargs)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         if is_transient_error(e):
             log.exception('request failed with transient exception: {method} {url}')
             raise web.HTTPServiceUnavailable()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -158,6 +158,13 @@ def is_transient_error(e):
     return False
 
 
+async def sleep_and_back_off(delay):
+    # exponentially back off, up to (expected) max of 30s
+    t = delay * random.random()
+    await asyncio.sleep(t)
+    return min(delay * 2, 60.0)
+
+
 async def request_retry_transient_errors(session, method, url, **kwargs):
     delay = 0.1
     while True:
@@ -168,10 +175,7 @@ async def request_retry_transient_errors(session, method, url, **kwargs):
                 pass
             else:
                 raise
-        # exponentially back off, up to (expected) max of 30s
-        t = delay * random.random()
-        await asyncio.sleep(t)
-        delay = min(delay * 2, 60.0)
+        delay = sleep_and_back_off(delay)
 
 
 async def request_raise_transient_errors(session, method, url, **kwargs):


### PR DESCRIPTION
One more if/when you want to take a look.

Changes:
 - Keep track of failed requests to workers, failed_request_count.  Reset on a successful communication in Instance.mark_healthy.
 - Don't retry the /job/create request.  The scheduler loop will just retry.
 - Don't schedule on nodes with failed count > 1.  This basically ignores 1-off hiccups.
 - The /jobs/delete (unscheduled) call is an interested situation.  I decided to retry with back off and stop if the instance gets deactivated.  Retry abstractions seem hard, I'm not quite sure how to share this code with request_retry_transient_error, for example, given different exit conditions.  Sometime to think about as we see more examples.
 - Ignore errors for each schedule attempt, so if there is a failure, count the request as failed and keep scheduling the current block of jobs before getting another block.
 - Don't kill unhealthy instances.  You might object to this, but I'm worried about when a job has been running for 3hrs (or 5 weeks, once we support scheduling on non-premptibles) and we delete an instance after a 5m network disconnect.  I appreciate the need to clean up resources, I have more thoughts about that that I'll write elsewhere.