### PR TITLE
[batch2] fix startup failure

### DIFF
--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -236,8 +236,8 @@ async def on_startup(app):
     app['log_store'] = log_store
 
     inst_pool = InstancePool(app, machine_name_prefix)
-    await inst_pool.async_init()
     app['inst_pool'] = inst_pool
+    await inst_pool.async_init()
 
     scheduler = Scheduler(app)
     await scheduler.async_init()

--- a/batch2/batch/front_end/templates/batches.html
+++ b/batch2/batch/front_end/templates/batches.html
@@ -28,7 +28,7 @@
           {% if not batch['complete'] and batch['state'] != 'Cancelled' %}
             <td>
               <form action="{{ base_path }}/batches/{{ batch['id'] }}/cancel" method="post">
-                <input type="hidden" name="_csrf" value="{{ token }}"/>
+                <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
                 <button>Cancel</button>
               </form>
             </td>

--- a/hail/python/hailtop/pipeline/task.py
+++ b/hail/python/hailtop/pipeline/task.py
@@ -347,7 +347,7 @@ class Task:
         :class:`.Task`
             Same task object with memory requirements set.
         """
-        self._memory = memory
+        self._memory = str(memory)
         return self
 
     def cpu(self, cores):
@@ -373,7 +373,7 @@ class Task:
             Same task object with CPU requirements set.
         """
 
-        self._cpu = cores
+        self._cpu = str(cores)
         return self
 
     def image(self, image):


### PR DESCRIPTION
If there are live instances, batch2 won't startup.  Instances get the instance pool via the app, so it needs to be set before calling InstancePool.async_init.

Also, convert cores and memory to strings in pipeline.  The batch2 API requires a string for cpu.
