### PR TITLE
[batch2] fix instance_id integrity

### DIFF
--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -88,6 +88,8 @@ class InstancePool:
             self.active_instances_by_free_cores.remove(instance)
 
     async def remove_instance(self, instance):
+        await instance.deactivate()
+
         await self.db.just_execute(
             'DELETE FROM instances WHERE id = %s;', (instance.id,))
 

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -5,6 +5,7 @@ import json
 import asyncio
 import aiohttp
 from aiohttp import web
+import aiohttp_session
 import aiohttp_jinja2
 import cerberus
 import prometheus_client as pc
@@ -19,7 +20,8 @@ from hailtop import batch_client
 from gear import Database, setup_aiohttp_session, \
     rest_authenticated_users_only, web_authenticated_users_only, \
     check_csrf_token
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
+from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
+    set_message
 
 # import uvloop
 

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -517,6 +517,8 @@ async def ui_cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
     await _cancel_batch(request.app, batch_id, user)
+    session = await aiohttp_session.get_session(request)
+    set_message(session, 'Batch {batch_id} cancelled.', 'info')
     location = request.app.router['batches'].url_for()
     raise web.HTTPFound(location=location)
 

--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   `cancelled` BOOLEAN NOT NULL DEFAULT FALSE,
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
-  FOREIGN KEY (`instance_id`) REFERENCES instances(id) ON DELETE SET NULL
+  FOREIGN KEY (`instance_id`) REFERENCES instances(id)
 ) ENGINE = InnoDB;
 CREATE INDEX `jobs_state` ON `jobs` (`state`);
 CREATE INDEX `jobs_instance_id` ON `jobs` (`instance_id`);


### PR DESCRIPTION
A little chaos testing revealed a database integrity issue.  If jobs.state = Running, instance_id must be non-null.  I incorrectly had `ON DELETE SET NULL`.  Instead, make sure that the instance has been deactivated (which reschedules all jobs, setting state = Ready) before deleting the instance entry.

Also, feedback on cancellation.
