### PR TITLE
retry in setup/cleanup

### DIFF
--- a/batch2/Makefile
+++ b/batch2/Makefile
@@ -4,6 +4,9 @@ ZONE := us-central1-a
 BATCH2_LATEST = gcr.io/$(PROJECT)/batch2:latest
 BATCH2_IMAGE = gcr.io/$(PROJECT)/batch2:$(shell docker images -q --no-trunc batch2 | sed -e 's,[^:]*:,,')
 
+BATCH2_WORKER_LATEST = gcr.io/$(PROJECT)/batch2-worker:latest
+BATCH2_WORKER_IMAGE = gcr.io/$(PROJECT)/batch2-worker:$(shell docker images -q --no-trunc batch2-worker | sed -e 's,[^:]*:,,')
+
 PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$(PYTHONPATH) python3
 
@@ -16,20 +19,29 @@ build:
 	-docker pull $(BATCH2_LATEST)
 	python3 ../ci/jinja2_render.py '{"service_base_image":{"image":"service-base"}}' Dockerfile Dockerfile.out
 	docker build -t batch2 -f Dockerfile.out --cache-from batch2,$(BATCH2_LATEST),service-base ..
+	-docker pull python:3.6-slim-stretch
+	-docker pull $(BATCH2_WORKER_LATEST)
+	docker build -t batch2-worker -f Dockerfile.worker --cache-from batch2-worker,$(BATCH2_WORKER_LATEST),python:3.6-slim-stretch ..
 
 push: build
 	docker tag batch2 $(BATCH2_LATEST)
 	docker push $(BATCH2_LATEST)
 	docker tag batch2 $(BATCH2_IMAGE)
 	docker push $(BATCH2_IMAGE)
+	docker tag batch2 $(BATCH2_WORKER_LATEST)
+	docker push $(BATCH2_WORKER_LATEST)
+	docker tag batch2 $(BATCH2_WORKER_IMAGE)
+	docker push $(BATCH2_WORKER_IMAGE)
 
 deploy: push
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"batch2_image":{"image":"$(BATCH2_IMAGE)"},"default_ns":{"name":"default"},"batch_pods_ns":{"name":"batch-pods"},"batch2_database":{"user_secret_name":"sql-batch2-batch2-admin-config"},"global":{"domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"batch2_image":{"image":"$(BATCH2_IMAGE)"},"batch2_worker_image":{"image":"$(BATCH2_WORKER_IMAGE)"},"default_ns":{"name":"default"},"batch_pods_ns":{"name":"batch-pods"},"batch2_database":{"user_secret_name":"sql-batch2-batch2-admin-config"},"global":{"domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out
 
-build-worker-image:
+create-build-worker-image-instance:
 	-gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch2-worker-image
-	gcloud -q compute --project $(PROJECT) instances create --zone=$(ZONE) build-batch2-worker-image --machine-type=n1-standard-1 --network=default --network-tier=PREMIUM --metadata-from-file startup-script=build-batch2-worker-image-startup.sh --no-restart-on-failure --maintenance-policy=MIGRATE --scopes=https://www.googleapis.com/auth/cloud-platform --image=ubuntu-minimal-1804-bionic-v20191008 --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-ssd
-	gcloud -q compute --project $(PROJECT) instances stop --zone=$(ZONE) build-batch2-worker-image
-	gcloud -q compute --project $(PROJECT) images create batch2-worker-4 --source-disk=build-batch2-worker-image --source-disk-zone=$(ZONE)
+	gcloud -q compute --project $(PROJECT) instances create --zone=$(ZONE) build-batch2-worker-image --machine-type=n1-standard-1 --network=default --network-tier=PREMIUM --metadata-from-file startup-script=build-batch2-worker-image-startup.sh --no-restart-on-failure --maintenance-policy=MIGRATE --scopes=https://www.googleapis.com/auth/cloud-platform --image=ubuntu-minimal-1804-bionic-v20191024 --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-ssd
+
+create-worker-image:
+	gcloud -q compute --project $(PROJECT) images delete batch2-worker-6
+	gcloud -q compute --project $(PROJECT) images create batch2-worker-6 --source-disk=build-batch2-worker-image --source-disk-zone=$(ZONE)
 	gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch2-worker-image

--- a/batch2/build-batch2-worker-image-startup.sh
+++ b/batch2/build-batch2-worker-image-startup.sh
@@ -31,3 +31,5 @@ docker-credential-gcr configure-docker
 
 docker pull ubuntu:18.04
 docker pull google/cloud-sdk:237.0.0-alpine
+
+shutdown -h now

--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -323,7 +323,8 @@ BEGIN
 	     jobs.job_id = `job_parents`.job_id
 	WHERE jobs.batch_id = in_batch_id AND
 	      `job_parents`.batch_id = in_batch_id AND
-	      `job_parents`.parent_id = in_job_id);
+	      `job_parents`.parent_id = in_job_id AND
+	      jobs.n_pending_parents = 1);
 
     UPDATE jobs
       INNER JOIN `job_parents`

--- a/batch2/delete-batch-tables.sql
+++ b/batch2/delete-batch-tables.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS `job_attributes`;
 DROP TABLE IF EXISTS `job_parents`;
 DROP TABLE IF EXISTS `ready_cores`;
 DROP TABLE IF EXISTS `jobs`;
-DROP TABLE IF EXISTS `batch`;
+DROP TABLE IF EXISTS `batches`;
 DROP TABLE IF EXISTS `instances`;
 DROP TABLE IF EXISTS `tokens`;
 DROP PROCEDURE IF EXISTS activate_instance;


### PR DESCRIPTION
First, I'm seeing transient (but common, maybe 10% of the time?!  Have you seen this before, Jackie?) gsutil errors in the setup/cleanup containers that look like: [Errno 2] No such file or directory.  I ran with -DD, the file is there in gs://, something is going wrong in the container.  It happens with and without -m.

I tried to upgrade google/cloud-sdk, but ran into a problem: after updating the instance base image, the worker container can no longer get credentials from the metadata server and therefore gets permission denied when trying to copy out the logs.  Upon reflection, in our setup, containers being able to access the metadata server seems very insecure!  So we should (1) make sure containers we run can't access the metadata service, (2) run the instance as no service account, or an account with no privileges.  Then we need to figure out how to get the credentials to to the worker to copy out logs.

I also added a retry (3x) to the setup/cleanup scripts.  I think ultimately using the client libraries directly instead of gsutil might ultimately be the way to go (and it makes it easier for us to see what errors we're getting and which we want to retry).

Changes:
 - retry in setup/cleanup
 - fix "make deploy" in batch2 (build worker image)
 - I fixed up the worker Google image builder logic.  There was a race condition with the step command.  I broke it into two manual steps.  The instance steps itself in the first step.  The user should verify the instance is stopped and then run the second step.  This can be automated later.
 - Fixed bug in mark_jobs_complete updating ready_cores.  It counted all children, not just children that are going to transition to ready.
 - fixed bug in delete tables script: batch => batches
