### PR TITLE
[batch2] send batch-gsa-key on activation, upgrade worker image

### DIFF
--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -186,7 +186,7 @@ set -x
 # only allow udp/53 (dns) to metadata server
 # -I inserts at the head of the chain, so the ACCEPT rule runs first
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
-iptables -I FORWARD -i docker0 -d 169.254.169.254 --dport 53 -p udp -j ACCEPT
+iptables -I FORWARD -i docker0 -d 169.254.169.254 -m udp --destination-port 53 -p udp -j ACCEPT
 
 iptables -S
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -183,6 +183,10 @@ nohup /bin/bash run.sh >run.log 2>&1 &
 #!/bin/bash
 set -x
 
+# only allow udp/53 (dns) to metadata server
+iptables -I FORWARD -i docker0 -d 169.254.169.254 --dport 53 -p udp -j ACCEPT
+iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
+
 export HOME=/root
 
 CORES=$(nproc)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -186,7 +186,7 @@ set -x
 # only allow udp/53 (dns) to metadata server
 # -I inserts at the head of the chain, so the ACCEPT rule runs first
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
-iptables -I FORWARD -i docker0 -d 169.254.169.254 -m udp --destination-port 53 -p udp -j ACCEPT
+iptables -I FORWARD -i docker0 -d 169.254.169.254 -p udp -m udp --destination-port 53 -j ACCEPT
 
 iptables -S
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -188,8 +188,6 @@ set -x
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -p udp -m udp --destination-port 53 -j ACCEPT
 
-iptables -S
-
 export HOME=/root
 
 CORES=$(nproc)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -131,7 +131,7 @@ class InstancePool:
             'name': machine_name,
             'machineType': f'projects/{PROJECT}/zones/{ZONE}/machineTypes/n1-{WORKER_TYPE}-{WORKER_CORES}',
             'labels': {
-                'role': 'batch2-worker',
+                'role': 'batch2-agent',
                 'namespace': BATCH_NAMESPACE
             },
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -184,8 +184,9 @@ nohup /bin/bash run.sh >run.log 2>&1 &
 set -x
 
 # only allow udp/53 (dns) to metadata server
-iptables -I FORWARD -i docker0 -d 169.254.169.254 --dport 53 -p udp -j ACCEPT
+# -I inserts at the head of the chain, so the ACCEPT rule runs first
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
+iptables -I FORWARD -i docker0 -d 169.254.169.254 --dport 53 -p udp -j ACCEPT
 
 iptables -S
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -187,6 +187,8 @@ set -x
 iptables -I FORWARD -i docker0 -d 169.254.169.254 --dport 53 -p udp -j ACCEPT
 iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
 
+iptables -S
+
 export HOME=/root
 
 CORES=$(nproc)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -196,6 +196,7 @@ CORES=$(nproc)
 NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")
 ACTIVATION_TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/activation_token")
 IP_ADDRESS=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+PROJECT=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/project/project-id")
 
 BUCKET_NAME=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/bucket_name")
 INSTANCE_ID=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance_id")
@@ -217,6 +218,7 @@ docker run \
     -e IP_ADDRESS=$IP_ADDRESS \
     -e BUCKET_NAME=$BUCKET_NAME \
     -e INSTANCE_ID=$INSTANCE_ID \
+    -e PROJECT=$PROJECT \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/bin/docker:/usr/bin/docker \
     -v /batch:/batch \

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -319,7 +319,7 @@ async def on_startup(app):
     cancel_state_changed = asyncio.Event()
     app['cancel_state_changed'] = cancel_state_changed
 
-    log_store = LogStore(bucket_name, instance_id, pool, credentials)
+    log_store = LogStore(bucket_name, instance_id, pool, credentials=credentials)
     app['log_store'] = log_store
 
     inst_pool = InstancePool(app, machine_name_prefix)

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -1,5 +1,6 @@
 import secrets
 import logging
+import json
 from functools import wraps
 import concurrent
 import asyncio
@@ -33,15 +34,22 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 
+def authorization_token(request):
+    auth_header = request.headers.get('Authorization')
+    if not auth_header:
+        return None
+    if not auth_header.startswith('Bearer '):
+        return None
+    return auth_header[7:]
+
+
 def batch_only(fun):
     @wraps(fun)
     async def wrapped(request):
-        auth_header = request.headers.get('Authorization')
-        if not auth_header:
+        token = authorization_token(request)
+        if not token:
             raise web.HTTPUnauthorized()
-        if not auth_header.startswith('Bearer '):
-            raise web.HTTPUnauthorized()
-        token = auth_header[7:]
+
         if not secrets.compare_digest(token, request.app['internal_token']):
             raise web.HTTPUnauthorized()
 
@@ -49,34 +57,69 @@ def batch_only(fun):
     return wrapped
 
 
-def instances_only(fun):
+def instance_from_request(request):
+    instance_name = request.headers.get('X-Hail-Instance-Name')
+    if not instance_name:
+        return None
+
+    instance_pool = request.app['inst_pool']
+    return instance_pool.name_instance.get(instance_name)
+
+
+def activating_instances_only(fun):
     @wraps(fun)
     async def wrapped(request):
-        app = request.app
-
-        instance_name = request.headers.get('X-Hail-Instance-Name')
-        if not instance_name:
-            raise web.HTTPUnauthorized()
-
-        instance_pool = app['inst_pool']
-        instance = instance_pool.name_instance.get(instance_name)
+        instance = instance_from_request(request)
         if not instance:
-            raise web.HTTPUnauthorized()
-        if instance.state not in ('pending', 'active'):
+            log.info('instance not found')
             raise web.HTTPUnauthorized()
 
-        auth_header = request.headers.get('Authorization')
-        if not auth_header:
+        if instance.state != 'pending':
+            log.info('instance not pending')
             raise web.HTTPUnauthorized()
-        if not auth_header.startswith('Bearer '):
+
+        activation_token = authorization_token(request)
+        if not activation_token:
+            log.info('activation token not found')
             raise web.HTTPUnauthorized()
-        token = auth_header[7:]
+
+        db = request.app['db']
+        record = await db.execute_and_fetchone(
+            'SELECT state FROM instances WHERE name = %s AND activation_token = %s;',
+            (instance.name, activation_token))
+        if not record:
+            log.info('instance, activation token not found in database')
+            raise web.HTTPUnauthorized()
+
+        resp = await fun(request, instance)
+
+        return resp
+    return wrapped
+
+
+def active_instances_only(fun):
+    @wraps(fun)
+    async def wrapped(request):
+        instance = instance_from_request(request)
+        if not instance:
+            log.info('instance not found')
+            raise web.HTTPUnauthorized()
+
+        if instance.state != 'active':
+            log.info('instance not active')
+            raise web.HTTPUnauthorized()
+
+        token = authorization_token(request)
+        if not token:
+            log.info('token not found')
+            raise web.HTTPUnauthorized()
 
         db = request.app['db']
         record = await db.execute_and_fetchone(
             'SELECT state FROM instances WHERE name = %s AND token = %s;',
-            (instance_name, token))
+            (instance.name, token))
         if not record:
+            log.info('instance, token not found in database')
             raise web.HTTPUnauthorized()
 
         return await fun(request, instance)
@@ -174,13 +217,19 @@ async def activate_instance_1(request, instance):
     ip_address = body['ip_address']
 
     log.info(f'activating {instance}')
-    await instance.activate(ip_address)
+    token = await instance.activate(ip_address)
     await instance.mark_healthy()
-    return web.Response()
+
+    with open('/batch-gsa-key/privateKeyData', 'r') as f:
+        key = json.loads(f.read())
+    return web.json_response({
+        'token': token,
+        'key': key
+    })
 
 
 @routes.post('/api/v1alpha/instances/activate')
-@instances_only
+@activating_instances_only
 async def activate_instance(request, instance):
     return await asyncio.shield(activate_instance_1(request, instance))
 
@@ -193,7 +242,7 @@ async def deactivate_instance_1(instance):
 
 
 @routes.post('/api/v1alpha/instances/deactivate')
-@instances_only
+@active_instances_only
 async def deactivate_instance(request, instance):  # pylint: disable=unused-argument
     return await asyncio.shield(deactivate_instance_1(instance))
 
@@ -222,7 +271,7 @@ async def job_complete_1(request, instance):
 
 
 @routes.post('/api/v1alpha/instances/job_complete')
-@instances_only
+@active_instances_only
 async def job_complete(request, instance):
     return await asyncio.shield(job_complete_1(request, instance))
 
@@ -258,6 +307,7 @@ async def on_startup(app):
     app['internal_token'] = row['token']
 
     machine_name_prefix = f'batch2-worker-{BATCH_NAMESPACE}-'
+
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
         '/batch-gsa-key/privateKeyData')
     gservices = GServices(machine_name_prefix, credentials)

--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -89,7 +89,7 @@ LIMIT 50;
                 try:
                     await schedule_job(self.app, record, instance)
                 except Exception:
-                    log.exception('while scheduling job {id} on {instance}')
+                    log.exception(f'while scheduling job {id} on {instance}')
                 should_wait = False
 
         return should_wait

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -650,7 +650,7 @@ async def on_startup(app):
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
         '/batch-gsa-key/privateKeyData')
-    app['log_store'] = LogStore(bucket_name, instance_id, pool, credentials)
+    app['log_store'] = LogStore(bucket_name, instance_id, pool, credentials=credentials)
 
 
 async def on_cleanup(app):

--- a/batch2/batch/google_storage.py
+++ b/batch2/batch/google_storage.py
@@ -13,9 +13,16 @@ class GCS:
         path = '/'.join(uri[1:])
         return bucket, path
 
-    def __init__(self, blocking_pool, credentials=None):
+    def __init__(self, blocking_pool, project=None, credentials=None):
         self.blocking_pool = blocking_pool
-        self.gcs_client = google.cloud.storage.Client(credentials=credentials)
+        # project=None doesn't mean default, it means no project:
+        # https://github.com/googleapis/google-cloud-python/blob/master/storage/google/cloud/storage/client.py#L86
+        if project:
+            self.gcs_client = google.cloud.storage.Client(
+                project=project, credentials=credentials)
+        else:
+            self.gcs_client = google.cloud.storage.Client(
+                credentials=credentials)
         self._wrapped_write_gs_file = self._wrap_network_call(GCS._write_gs_file)
         self._wrapped_read_gs_file = self._wrap_network_call(GCS._read_gs_file)
         self._wrapped_delete_gs_file = self._wrap_network_call(GCS._delete_gs_file)

--- a/batch2/batch/google_storage.py
+++ b/batch2/batch/google_storage.py
@@ -13,7 +13,7 @@ class GCS:
         path = '/'.join(uri[1:])
         return bucket, path
 
-    def __init__(self, blocking_pool, project=None, credentials=None):
+    def __init__(self, blocking_pool, *, project=None, credentials=None):
         self.blocking_pool = blocking_pool
         # project=None doesn't mean default, it means no project:
         # https://github.com/googleapis/google-cloud-python/blob/master/storage/google/cloud/storage/client.py#L86

--- a/batch2/batch/log_store.py
+++ b/batch2/batch/log_store.py
@@ -10,7 +10,7 @@ class LogStore:
         self.bucket_name = bucket_name
         self.instance_id = instance_id
         self.log_root = f'gs://{bucket_name}/batch2/logs/{instance_id}'
-        self.gcs = GCS(blocking_pool, project, credentials)
+        self.gcs = GCS(blocking_pool, project=project, credentials=credentials)
 
     def worker_log_path(self, machine_name, log_file):
         # this has to match worker startup-script

--- a/batch2/batch/log_store.py
+++ b/batch2/batch/log_store.py
@@ -6,7 +6,7 @@ log = logging.getLogger('logstore')
 
 
 class LogStore:
-    def __init__(self, bucket_name, instance_id, blocking_pool, project=None, credentials=None):
+    def __init__(self, bucket_name, instance_id, blocking_pool, *, project=None, credentials=None):
         self.bucket_name = bucket_name
         self.instance_id = instance_id
         self.log_root = f'gs://{bucket_name}/batch2/logs/{instance_id}'

--- a/batch2/batch/log_store.py
+++ b/batch2/batch/log_store.py
@@ -6,11 +6,11 @@ log = logging.getLogger('logstore')
 
 
 class LogStore:
-    def __init__(self, bucket_name, instance_id, blocking_pool, credentials=None):
+    def __init__(self, bucket_name, instance_id, blocking_pool, project=None, credentials=None):
         self.bucket_name = bucket_name
         self.instance_id = instance_id
         self.log_root = f'gs://{bucket_name}/batch2/logs/{instance_id}'
-        self.gcs = GCS(blocking_pool, credentials)
+        self.gcs = GCS(blocking_pool, project, credentials)
 
     def worker_log_path(self, machine_name, log_file):
         # this has to match worker startup-script

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -669,6 +669,7 @@ class Worker:
                     'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
                 })
             resp_json = await resp.json()
+            log.info(f'resp_json {resp_json}')
             self.headers = {
                 'X-Hail-Instance-Name': NAME,
                 'Authorization': f'Bearer {resp_json["token"]}'
@@ -676,6 +677,7 @@ class Worker:
 
             credentials = google.oauth2.service_account.Credentials.from_service_account_info(
                 resp_json['key'])
+            log.info(f'credentials {credentials}')
             self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool, credentials)
 
 

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -685,7 +685,7 @@ class Worker:
             credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 'key.json')
             self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool,
-                                      project=PROJECT, credentials)
+                                      project=PROJECT, credentials=credentials)
 
 
 worker = Worker()

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -669,7 +669,6 @@ class Worker:
                     'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
                 })
             resp_json = await resp.json()
-            log.info(f'resp_json {resp_json}')
             self.headers = {
                 'X-Hail-Instance-Name': NAME,
                 'Authorization': f'Bearer {resp_json["token"]}'
@@ -677,7 +676,6 @@ class Worker:
 
             credentials = google.oauth2.service_account.Credentials.from_service_account_info(
                 resp_json['key'])
-            log.info(f'credentials {credentials}')
             self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool, credentials)
 
 

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -674,8 +674,11 @@ class Worker:
                 'Authorization': f'Bearer {resp_json["token"]}'
             }
 
-            credentials = google.oauth2.service_account.Credentials.from_service_account_info(
-                resp_json['key'])
+            with open('key.json', 'w') as f:
+                f.write(json.dumps(resp_json['key']))
+
+            credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+                'key.json')
             self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool, credentials)
 
 

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -306,7 +306,7 @@ retry gcloud -q auth activate-service-account --key-file=/gsa-key/privateKeyData
 def copy_container(job, name, files, volume_mounts):
     sh_expression = copy(files)
     copy_spec = {
-        'image': 'google/cloud-sdk:237.0.0-alpine',
+        'image': 'google/cloud-sdk:269.0.0-alpine',
         'name': name,
         'command': ['/bin/sh', '-c', sh_expression],
         'cpu': '500m' if files else '100m',

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from shlex import quote as shq
 import time
 import logging

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -37,16 +37,20 @@ MAX_IDLE_TIME_SECS = 5 * 60
 CORES = int(os.environ['CORES'])
 NAME = os.environ['NAME']
 NAMESPACE = os.environ['NAMESPACE']
+# ACTIVATION_TOKEN
+IP_ADDRESS = os.environ['IP_ADDRESS']
 BUCKET_NAME = os.environ['BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
-IP_ADDRESS = os.environ['IP_ADDRESS']
+PROJECT = os.environ['PROJECT']
 
 log.info(f'CORES {CORES}')
 log.info(f'NAME {NAME}')
 log.info(f'NAMESPACE {NAMESPACE}')
+# ACTIVATION_TOKEN
+log.info(f'IP_ADDRESS {IP_ADDRESS}')
 log.info(f'BUCKET_NAME {BUCKET_NAME}')
 log.info(f'INSTANCE_ID {INSTANCE_ID}')
-log.info(f'IP_ADDRESS {IP_ADDRESS}')
+log.info(f'PROJECT {PROJECT}')
 
 deploy_config = DeployConfig('gce', NAMESPACE, {})
 
@@ -680,7 +684,8 @@ class Worker:
 
             credentials = google.oauth2.service_account.Credentials.from_service_account_file(
                 'key.json')
-            self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool, credentials)
+            self.log_store = LogStore(BUCKET_NAME, INSTANCE_ID, self.pool,
+                                      project=PROJECT, credentials)
 
 
 worker = Worker()

--- a/batch2/build-batch2-worker-image-startup.sh
+++ b/batch2/build-batch2-worker-image-startup.sh
@@ -30,6 +30,6 @@ curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/release
 docker-credential-gcr configure-docker
 
 docker pull ubuntu:18.04
-docker pull google/cloud-sdk:237.0.0-alpine
+docker pull google/cloud-sdk:269.0.0-alpine
 
 shutdown -h now


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/7440

Changes:
 - start the instance with a 1-time use activation token in the metadata
 - on activation, clear the activation token, send the worker the normal token and batch-gsa-key
 - upgrade the worker image to -6 which has the latest cloud-sdk (v269)

As far as I can tell, the metadata server is still available from within the worker container after the upgrade, so I'm not 100% sure why this change was necessary.  However, it will make things easier to lock down later.  I think the picture we want is:
 - store the worker and batch logs in different buckets,
  - the worker instance service account only has instance.delete* and object.insert on the worker log bucket,
 - the service account used by the worker only has object.insert on the batch logs bucket,
 - we block access to the metdata srever from within the docker containers.Leaving this for reference:

https://stackoverflow.com/questions/32512597/block-docker-access-to-specific-ip

This isn't 100% trivial because the metadata server is also the DNS server.  We could try blocking everything except udp/53.  I think ideally, we'd put the docker containers on a different network that could only route to the outside and use a public DNS server like 8.8.8.8.

*An instance doesn't need extra permissions to shut itself down, so we could just do `shutdown -h now` on the worker and have the batch driver actually delete the instance.

I think once this goes in we can try scale up tests again.
