### PR TITLE
docs fixes

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1800,7 +1800,7 @@ def qchisqtail(p, df) -> Float64Expression:
     Notes
     -----
     Returns right-quantile `x` for which `p` = Prob(:math:`Z^2` > x) with :math:`Z^2` a chi-squared random
-     variable with degrees of freedom specified by `df`. `p` must satisfy 0 < `p` <= 1.
+    variable with degrees of freedom specified by `df`. `p` must satisfy 0 < `p` <= 1.
 
     Parameters
     ----------

--- a/hail/python/hail/methods/family_methods.py
+++ b/hail/python/hail/methods/family_methods.py
@@ -592,20 +592,20 @@ def de_novo(mt: MatrixTable,
 
     .. math::
 
-        \mathrm{P_{\text{de novo}}} = \frac{\mathrm{P}(d\,|\,x)}{\mathrm{P}(d\,|\,x) + \mathrm{P}(m\,|\,x)}
+        \mathrm{P_{\text{de novo}}} = \frac{\mathrm{P}(d \mid x)}{\mathrm{P}(d \mid x) + \mathrm{P}(m \mid x)}
 
     Applying Bayes rule to the numerator and denominator yields
 
     .. math::
 
-        \frac{\mathrm{P}(x\,|\,d)\,\mathrm{P}(d)}{\mathrm{P}(x\,|\,d)\,\mathrm{P}(d) +
-        \mathrm{P}(x\,|\,m)\,\mathrm{P}(m)}
+        \frac{\mathrm{P}(x \mid d)\,\mathrm{P}(d)}{\mathrm{P}(x \mid d)\,\mathrm{P}(d) +
+        \mathrm{P}(x \mid m)\,\mathrm{P}(m)}
 
     The prior on de novo mutation is estimated from the rate in the literature:
 
     .. math::
 
-        \mathrm{P}(d) = \frac{1 \text{mutation}}{30,000,000\, \text{bases}}
+        \mathrm{P}(d) = \frac{1 \, \text{mutation}}{30{,}000{,}000 \, \text{bases}}
 
     The prior used for at least one alternate allele between the parents
     depends on the alternate allele frequency:
@@ -614,27 +614,31 @@ def de_novo(mt: MatrixTable,
 
         \mathrm{P}(m) = 1 - (1 - AF)^4
 
-    The likelihoods :math:`\mathrm{P}(x\,|\,d)` and :math:`\mathrm{P}(x\,|\,m)`
+    The likelihoods :math:`\mathrm{P}(x \mid d)` and :math:`\mathrm{P}(x \mid m)`
     are computed from the PL (genotype likelihood) fields using these
     factorizations:
 
     .. math::
-
-        \mathrm{P}(x = (AA, AA, AB) \,|\,d) = \Big(
-        &\mathrm{P}(x_{\mathrm{father}} = AA \,|\, \mathrm{father} = AA) \\
-        \cdot &\mathrm{P}(x_{\mathrm{mother}} = AA \,|\, \mathrm{mother} =
-        AA) \\ \cdot &\mathrm{P}(x_{\mathrm{proband}} = AB \,|\,
-        \mathrm{proband} = AB) \Big)
+        \mathrm{P}(x = (AA, AA, AB) \mid d) = \left(
+        \begin{aligned}
+                &\mathrm{P}(x_{\mathrm{father}} = AA \mid \mathrm{father} = AA) \\
+                {} \cdot {} &\mathrm{P}(x_{\mathrm{mother}} = AA \mid \mathrm{mother} = AA) \\
+                {} \cdot {} &\mathrm{P}(x_{\mathrm{proband}} = AB \mid \mathrm{proband} = AB)
+        \end{aligned}
+        \right)
 
     .. math::
-
-        \mathrm{P}(x = (AA, AA, AB) \,|\,m) = \Big( &
-        \mathrm{P}(x_{\mathrm{father}} = AA \,|\, \mathrm{father} = AB)
-        \cdot \mathrm{P}(x_{\mathrm{mother}} = AA \,|\, \mathrm{mother} =
-        AA) \\ + \, &\mathrm{P}(x_{\mathrm{father}} = AA \,|\,
-        \mathrm{father} = AA) \cdot \mathrm{P}(x_{\mathrm{mother}} = AA
-        \,|\, \mathrm{mother} = AB) \Big) \\ \cdot \,
-        &\mathrm{P}(x_{\mathrm{proband}} = AB \,|\, \mathrm{proband} = AB)
+        \begin{aligned}
+        \mathrm{P}(x = (AA, AA, AB) \mid m) = &\left(
+            \begin{aligned}
+                &\mathrm{P}(x_{\mathrm{father}} = AA \mid \mathrm{father} = AB)
+                    \cdot \mathrm{P}(x_{\mathrm{mother}} = AA \mid \mathrm{mother} = AA) \\
+                {} + {} &\mathrm{P}(x_{\mathrm{father}} = AA \mid \mathrm{father} = AA)
+                    \cdot \mathrm{P}(x_{\mathrm{mother}} = AA \mid \mathrm{mother} = AB)
+            \end{aligned}
+        \right) \\
+        &{} \cdot \mathrm{P}(x_{\mathrm{proband}} = AB \mid \mathrm{proband} = AB)
+        \end{aligned}
 
     (Technically, the second factorization assumes there is exactly (rather
     than at least) one alternate allele among the parents, which may be
@@ -657,7 +661,7 @@ def de_novo(mt: MatrixTable,
      - ``AC`` refers to the count of alternate alleles across all individuals
        in the dataset at the site.
      - ``p`` refers to :math:`\mathrm{P_{\text{de novo}}}`.
-     - ``min_p`` refers to the ``min_p`` function parameter.
+     - ``min_p`` refers to the `min_p` function parameter.
 
     HIGH-quality SNV:
 
@@ -702,10 +706,10 @@ def de_novo(mt: MatrixTable,
        (AB > 0.2)
 
     Additionally, de novo candidates are not considered if the proband GQ is
-    smaller than the ``min_gq`` parameter, if the proband allele balance is
-    lower than the ``min_child_ab`` parameter, if the depth ratio between the
-    proband and parents is smaller than the ``min_depth_ratio`` parameter, if
-    the allele balance in a parent is above the ``max_parent_ab`` parameter, or
+    smaller than the `min_gq` parameter, if the proband allele balance is
+    lower than the `min_child_ab` parameter, if the depth ratio between the
+    proband and parents is smaller than the `min_depth_ratio` parameter, if
+    the allele balance in a parent is above the `max_parent_ab` parameter, or
     if the posterior probability `p` is smaller than the `min_p` parameter.
 
     Parameters

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -317,7 +317,7 @@ def filter_intervals(ds, intervals, keep=True) -> Union[Table, MatrixTable]:
 
     Notes
     -----
-    Based on the ``keep`` argument, this method will either restrict to points
+    Based on the `keep` argument, this method will either restrict to points
     in the supplied interval ranges, or remove all rows in those ranges.
 
     When ``keep=True``, partitions that don't overlap any supplied interval

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -54,7 +54,7 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     - `n_hom_ref` (``int64``) -- Number of homozygous reference calls.
     - `n_het` (``int64``) -- Number of heterozygous calls.
     - `n_hom_var` (``int64``) -- Number of homozygous alternate calls.
-    - `n_non_ref` (``int64``) -- Sum of ``n_het`` and ``n_hom_var``.
+    - `n_non_ref` (``int64``) -- Sum of `n_het` and `n_hom_var`.
     - `n_snp` (``int64``) -- Number of SNP alternate alleles.
     - `n_insertion` (``int64``) -- Number of insertion alternate alleles.
     - `n_deletion` (``int64``) -- Number of deletion alternate alleles.

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -1608,11 +1608,11 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     .. math::
 
-      \widehat{\phi_{ij}} :=
+      \widehat{\phi_{ij}} \coloneqq
         \frac{1}{|S_{ij}|}
         \sum_{s \in S_{ij}}
           \frac{(g_{is} - 2 p_s) (g_{js} - 2 p_s)}
-                {4 \sum_{s \in S_{ij} p_s (1 - p_s)}}
+                {4 \sum_{s \in S_{ij}} p_s (1 - p_s)}
 
     This estimator is true under the model that the sharing of common
     (relative to the population) alleles is not very informative to
@@ -2916,10 +2916,10 @@ def filter_alleles(mt: MatrixTable,
        the minimal representation.
      - `old_alleles` (``array<str>``) -- The old alleles, before filtering and
        computing the minimal representation.
-     - old_to_new (``array<int32>``) -- An array that maps old allele index to
+     - `old_to_new` (``array<int32>``) -- An array that maps old allele index to
        new allele index. Its length is the same as `old_alleles`. Alleles that
        are filtered are missing.
-     - new_to_old (``array<int32>``) -- An array that maps new allele index to
+     - `new_to_old` (``array<int32>``) -- An array that maps new allele index to
        the old allele index. Its length is the same as the modified `alleles`
        field.
 
@@ -3044,10 +3044,10 @@ def filter_alleles_hts(mt: MatrixTable,
        the minimal representation.
      - `old_alleles` (``array<str>``) -- The old alleles, before filtering and
        computing the minimal representation.
-     - old_to_new (``array<int32>``) -- An array that maps old allele index to
+     - `old_to_new` (``array<int32>``) -- An array that maps old allele index to
        new allele index. Its length is the same as `old_alleles`. Alleles that
        are filtered are missing.
-     - new_to_old (``array<int32>``) -- An array that maps new allele index to
+     - `new_to_old` (``array<int32>``) -- An array that maps new allele index to
        the old allele index. Its length is the same as the modified `alleles`
        field.
 

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -159,7 +159,7 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
 
     5. For each row and column with a non-missing genotype call, :math:`E`, the
        expected number of homozygotes (from population AAF), is computed as
-       :math:`1.0 - (2.0*maf*(1.0-maf))`.
+       :math:`1.0 - (2.0*\mathrm{maf}*(1.0-\mathrm{maf}))`.
 
     6. For each row and column with a non-missing genotype call, :math:`O`, the
        observed number of homozygotes, is computed interpreting ``0`` as
@@ -859,10 +859,11 @@ def linear_mixed_model(y,
     the number of random effects :math:`m`. At least one dimension must be less
     than or equal to 46300. If `standardize` is true, each random effect is first
     standardized to have mean 0 and variance :math:`\frac{1}{m}`, so that the
-    diagonal values of the kinship matrix `K = ZZ^T` are 1.0 in expectation.
-    This kinship matrix corresponds to the :meth:`realized_relationship_matrix`
-    in genetics. See :meth:`.LinearMixedModel.from_random_effects`
-    and :meth:`.BlockMatrix.svd` for more details.
+    diagonal values of the kinship matrix :math:`K = ZZ^T` are 1.0 in
+    expectation. This kinship matrix corresponds to the
+    :meth:`realized_relationship_matrix` in genetics. See
+    :meth:`.LinearMixedModel.from_random_effects` and :meth:`.BlockMatrix.svd`
+    for more details.
 
     If `k` is set, the model is full-rank. For correct results, the indices of
     `k` **must be aligned** with columns of the source of `y`.
@@ -1636,7 +1637,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
     principal component coordinates. As such, the efficacy of this method
     rests on two assumptions:
 
-     - an individual's first ``k`` principal component coordinates fully
+     - an individual's first `k` principal component coordinates fully
        describe their allele-frequency-relevant ancestry, and
 
      - the relationship between ancestry (as described by principal
@@ -1654,17 +1655,17 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
      - :math:`\widehat{\mu_{is}} \in [0, 1]` be the individual-specific allele
        frequency for individual :math:`i` at genetic locus :math:`s`
 
-     - :math:`{\widehat{\sigma^2_{is}}} := \widehat{\mu_{is}} (1 - \widehat{\mu_{is}})`,
+     - :math:`{\widehat{\sigma^2_{is}}} \coloneqq \widehat{\mu_{is}} (1 - \widehat{\mu_{is}})`,
        the binomial variance of :math:`\widehat{\mu_{is}}`
 
-     - :math:`\widehat{\sigma_{is}} := \sqrt{\widehat{\sigma^2_{is}}}`,
+     - :math:`\widehat{\sigma_{is}} \coloneqq \sqrt{\widehat{\sigma^2_{is}}}`,
        the binomial standard deviation of :math:`\widehat{\mu_{is}}`
 
-     - :math:`\text{IBS}^{(0)}_{ij} := \sum_{s \in S_{ij}} \mathbb{1}_{||g_{is} - g_{js} = 2||}`,
+     - :math:`\text{IBS}^{(0)}_{ij} \coloneqq \sum_{s \in S_{ij}} \mathbb{1}_{||g_{is} - g_{js} = 2||}`,
        the number of genetic loci at which individuals :math:`i` and :math:`j`
        share no alleles
 
-     - :math:`\widehat{f_i} := 2 \widehat{\phi_{ii}} - 1`, the inbreeding
+     - :math:`\widehat{f_i} \coloneqq 2 \widehat{\phi_{ii}} - 1`, the inbreeding
        coefficient for individual :math:`i`
 
      - :math:`g^D_{is}` be a dominance encoding of the genotype matrix, and
@@ -1672,20 +1673,21 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     .. math::
 
-        g^D_{is} :=
+        g^D_{is} \coloneqq
           \begin{cases}
             \widehat{\mu_{is}}     & g_{is} = 0 \\
             0                        & g_{is} = 1 \\
             1 - \widehat{\mu_{is}} & g_{is} = 2
           \end{cases}
 
-        X_{is} := g^D_{is} - \widehat{\sigma^2_{is}} (1 - \widehat{f_i})
+        \qquad
+        X_{is} \coloneqq g^D_{is} - \widehat{\sigma^2_{is}} (1 - \widehat{f_i})
 
     The estimator for kinship is given by:
 
     .. math::
 
-      \widehat{\phi_{ij}} :=
+      \widehat{\phi_{ij}} \coloneqq
         \frac{\sum_{s \in S_{ij}}(g - 2 \mu)_{is} (g - 2 \mu)_{js}}
               {4 * \sum_{s \in S_{ij}}
                             \widehat{\sigma_{is}} \widehat{\sigma_{js}}}
@@ -1694,7 +1696,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     .. math::
 
-      \widehat{k^{(2)}_{ij}} :=
+      \widehat{k^{(2)}_{ij}} \coloneqq
         \frac{\sum_{s \in S_{ij}}X_{is} X_{js}}{\sum_{s \in S_{ij}}
           \widehat{\sigma^2_{is}} \widehat{\sigma^2_{js}}}
 
@@ -1702,7 +1704,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     .. math::
 
-      \widehat{k^{(0)}_{ij}} :=
+      \widehat{k^{(0)}_{ij}} \coloneqq
         \begin{cases}
           \frac{\text{IBS}^{(0)}_{ij}}
                 {\sum_{s \in S_{ij}}
@@ -1717,7 +1719,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     .. math::
 
-      \widehat{k^{(1)}_{ij}} :=
+      \widehat{k^{(1)}_{ij}} \coloneqq
         1 - \widehat{k^{(2)}_{ij}} - \widehat{k^{(0)}_{ij}}
 
     Note that, even if present, phase information is ignored by this method.
@@ -1808,7 +1810,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
         corresponding to the number of principal components, and all scores must
         be non-missing. Exactly one of `k` and `scores_expr` must be specified.
     min_kinship : :obj:`float`, optional
-        If set, pairs of samples with kinship lower than ``min_kinship`` are excluded
+        If set, pairs of samples with kinship lower than `min_kinship` are excluded
         from the results.
     statistics : :obj:`str`
         Set of statistics to compute.
@@ -2306,7 +2308,7 @@ def genetic_relatedness_matrix(call_expr) -> BlockMatrix:
 
         G_{ik} = \frac{1}{m} \sum_{j=1}^m \frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}
 
-    This method drops variants with :math:`p_j = 0` or math:`p_j = 1` before
+    This method drops variants with :math:`p_j = 0` or :math:`p_j = 1` before
     computing kinship.
 
     Parameters
@@ -2590,13 +2592,13 @@ def ld_matrix(entry_expr, locus_expr, radius, coord_expr=None, block_size=None) 
     or genotype dosage. Missing values are mean-imputed within variant.
 
     The method produces a symmetric block-sparse matrix supported in a
-    neighborhood of the diagonal. If variants ``i`` and ``j`` are on the same
-    contig and within `radius` base pairs (inclusive) then the ``(i, j)``
-    element is their
+    neighborhood of the diagonal. If variants :math:`i` and :math:`j` are on the
+    same contig and within `radius` base pairs (inclusive) then the
+    :math:`(i, j)` element is their
     `Pearson correlation coefficient <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`__.
-    Otherwise, the ``(i, j)`` element is ``0.0``.
+    Otherwise, the :math:`(i, j)` element is ``0.0``.
 
-    Rows with a constant value (i.e., zero variance) will result in `nan`
+    Rows with a constant value (i.e., zero variance) will result in ``nan``
     correlation values. To avoid this, first check that all variants vary or
     filter out constant variants (for example, with the help of
     :func:`.aggregators.stats`).
@@ -2692,15 +2694,15 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
     This method simulates a matrix table of variants, samples, and genotypes
     using the Balding-Nichols model, which we now define.
 
-    - :math:`K` populations are labeled by integers 0, 1, ..., K - 1.
-    - :math:`N` samples are labeled by strings 0, 1, ..., N - 1.
+    - :math:`K` populations are labeled by integers :math:`0, 1, \dots, K - 1`.
+    - :math:`N` samples are labeled by strings :math:`0, 1, \dots, N - 1`.
     - :math:`M` variants are defined as ``1:1:A:C``, ``1:2:A:C``, ...,
       ``1:M:A:C``.
     - The default distribution for population assignment :math:`\pi` is uniform.
     - The default ancestral frequency distribution :math:`P_0` is uniform on
-      ``[0.1, 0.9]``.
+      :math:`[0.1, 0.9]`.
       All three classes are located in ``hail.stats``.
-    - The default :math:`F_{ST}` values are all 0.1.
+    - The default :math:`F_{ST}` values are all :math:`0.1`.
 
     The Balding-Nichols model models genotypes of individuals from a structured
     population comprising :math:`K` homogeneous modern populations that have
@@ -2728,13 +2730,12 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
     The generative model is then given by:
 
     .. math::
-        k_n \,&\sim\, \pi
-
-        p_m \,&\sim\, P_0
-
-        p_{k,m} \mid p_m\,&\sim\, \mathrm{Beta}(\mu = p_m,\, \sigma^2 = F_k p_m (1 - p_m))
-
-        g_{n,m} \mid k_n, p_{k, m} \,&\sim\, \mathrm{Binomial}(2, p_{k_n, m})
+        \begin{aligned}
+            k_n \,&\sim\, \pi \\
+            p_m \,&\sim\, P_0 \\
+            p_{k,m} \mid p_m\,&\sim\, \mathrm{Beta}(\mu = p_m,\, \sigma^2 = F_k p_m (1 - p_m)) \\
+            g_{n,m} \mid k_n, p_{k, m} \,&\sim\, \mathrm{Binomial}(2, p_{k_n, m})
+        \end{aligned}
 
     The beta distribution by its mean and variance above; the usual parameters
     are :math:`a = (1 - p) \frac{1 - F}{F}` and :math:`b = p \frac{1 - F}{F}` with
@@ -2791,10 +2792,10 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
         Default is 1 partition per million entries or 8, whichever is larger.
     pop_dist : :obj:`list` of :obj:`float`, optional
         Unnormalized population distribution, a list of length
-        ``n_populations`` with non-negative values.
+        `n_populations` with non-negative values.
         Default is ``[1, ..., 1]``.
     fst : :obj:`list` of :obj:`float`, optional
-        :math:`F_{ST}` values, a list of length ``n_populations`` with values
+        :math:`F_{ST}` values, a list of length `n_populations` with values
         in (0, 1). Default is ``[0.1, ..., 0.1]``.
     af_dist : :class:`.Float64Expression` representing a random function.
         Ancestral allele frequency distribution.
@@ -2925,7 +2926,7 @@ def filter_alleles(mt: MatrixTable,
     If all alternate alleles of a variant are filtered out, the variant itself
     is filtered out.
 
-    **Using _f_**
+    **Using** `f`
 
     The `f` argument is a function or lambda evaluated per alternate allele to
     determine whether that allele is kept. If `f` evaluates to ``True``, the
@@ -3020,7 +3021,7 @@ def filter_alleles_hts(mt: MatrixTable,
 
     Notes
     -----
-    For usage of the _f_ argument, see the :func:`.filter_alleles`
+    For usage of the `f` argument, see the :func:`.filter_alleles`
     documentation.
 
     :func:`.filter_alleles_hts` requires the dataset have the GATK VCF schema,


### PR DESCRIPTION
Assorted fixes to the docs I found while reviewing the math formatting under KaTeX.

Besides a couple actually broken spots, mostly consists of LaTeX tweaks and fixing argument references using \`\`arg\`\` to \`arg\` (which is the style we use in most of the docs).