### PR TITLE
[hail] make float parsing correspond more precisely to python semantics

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1351,6 +1351,19 @@ class Tests(unittest.TestCase):
         self.assertFalse(hl.eval(s_whitespace.startswith('a')))
         self.assertFalse(hl.eval(s_whitespace.endswith('a')))
 
+    def test_str_parsing(self):
+        for x in ('nan', 'Nan', 'naN', 'NaN'):
+            for f in (hl.float, hl.float32, hl.float64):
+                self.assertTrue(hl.eval(hl.is_nan(f(x))))
+                self.assertTrue(hl.eval(hl.is_nan(f('+' + x))))
+                self.assertTrue(hl.eval(hl.is_nan(f('-' + x))))
+        for x in ('inf', 'Inf', 'iNf', 'InF'):
+            for f in (hl.float, hl.float32, hl.float64):
+                self.assertTrue(hl.eval(hl.is_infinite(f(x))))
+                self.assertTrue(hl.eval(hl.is_infinite(f('+' + x))))
+                self.assertTrue(hl.eval(hl.is_infinite(f('-' + x))))
+                self.assertTrue(hl.eval(f('-' + x) < 0.0))
+
     def test_str_missingness(self):
         self.assertEqual(hl.eval(hl.str(1)), '1')
         self.assertEqual(hl.eval(hl.str(hl.null('int32'))), None)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1357,7 +1357,7 @@ class Tests(unittest.TestCase):
                 self.assertTrue(hl.eval(hl.is_nan(f(x))))
                 self.assertTrue(hl.eval(hl.is_nan(f('+' + x))))
                 self.assertTrue(hl.eval(hl.is_nan(f('-' + x))))
-        for x in ('inf', 'Inf', 'iNf', 'InF'):
+        for x in ('inf', 'Inf', 'iNf', 'InF', 'infinity', 'InfiNitY', 'INFINITY'):
             for f in (hl.float, hl.float32, hl.float64):
                 self.assertTrue(hl.eval(hl.is_infinite(f(x))))
                 self.assertTrue(hl.eval(hl.is_infinite(f('+' + x))))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -22,18 +22,15 @@ object UtilFunctions extends RegistryFunctions {
   private val POS_INF = 2
   private val NEG_INF = 3
 
-  def parseSpecialNum(s: String, i: Int, inf: Int): Int =
-    if ((s charAt i).toLower == 'n' && (s charAt i + 1).toLower == 'a' && (s charAt i + 2).toLower == 'n')
-      NAN
-    else if ((s charAt i).toLower == 'i' && (s charAt i + 1).toLower == 'n' && (s charAt i + 2).toLower == 'f')
-      inf
-    else
-      0
-
   def parseSpecialNum(s: String): Int = s.length match {
-    case 3 => parseSpecialNum(s, 0, POS_INF)
-    case 4 if (s(0) == '+') => parseSpecialNum(s, 1, POS_INF)
-    case 4 if (s(0) == '-') => parseSpecialNum(s, 1, NEG_INF)
+    case 3 if s equalsCI "nan" => NAN
+    case 4 if (s equalsCI "+nan") || (s equalsCI "-nan") => NAN
+    case 3 if s equalsCI "inf" => POS_INF
+    case 4 if s equalsCI "+inf" => POS_INF
+    case 4 if s equalsCI "-inf" => NEG_INF
+    case 8 if s equalsCI "infinity" => POS_INF
+    case 9 if s equalsCI "+infinity" => POS_INF
+    case 9 if s equalsCI "-infinity" => NEG_INF
     case _ => 0
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -18,17 +18,36 @@ object UtilFunctions extends RegistryFunctions {
 
   def parseInt64(s: String): Long = s.toLong
 
-  def parseFloat32(s: String): Float = s match {
-    case "nan" => Float.NaN
-    case "inf" => Float.PositiveInfinity
-    case "-inf" => Float.NegativeInfinity
+  private val NAN = 1
+  private val POS_INF = 2
+  private val NEG_INF = 3
+
+  def parseSpecialNum(s: String, i: Int, inf: Int): Int =
+    if ((s charAt i).toLower == 'n' && (s charAt i + 1).toLower == 'a' && (s charAt i + 2).toLower == 'n')
+      NAN
+    else if ((s charAt i).toLower == 'i' && (s charAt i + 1).toLower == 'n' && (s charAt i + 2).toLower == 'f')
+      inf
+    else
+      0
+
+  def parseSpecialNum(s: String): Int = s.length match {
+    case 3 => parseSpecialNum(s, 0, POS_INF)
+    case 4 if (s(0) == '+') => parseSpecialNum(s, 1, POS_INF)
+    case 4 if (s(0) == '-') => parseSpecialNum(s, 1, NEG_INF)
+    case _ => 0
+  }
+
+  def parseFloat32(s: String): Float = parseSpecialNum(s) match {
+    case NAN => Float.NaN
+    case POS_INF => Float.PositiveInfinity
+    case NEG_INF => Float.NegativeInfinity
     case _ => s.toFloat
   }
 
-  def parseFloat64(s: String): Double = s match {
-    case "nan" => Double.NaN
-    case "inf" => Double.PositiveInfinity
-    case "-inf" => Double.NegativeInfinity
+  def parseFloat64(s: String): Double = parseSpecialNum(s) match {
+    case NAN => Double.NaN
+    case POS_INF => Double.PositiveInfinity
+    case NEG_INF => Double.NegativeInfinity
     case _ => s.toDouble
   }
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichString.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichString.scala
@@ -8,4 +8,14 @@ class RichString(val str: String) extends AnyVal {
 
     def strings: (String, String) = (truncate, str)
   }
+
+  def equalsCI(other: String): Boolean =
+    if (str.length == other.length) {
+      for (i <- 0 until str.length)
+        if ((str charAt i).toLower != (other charAt i).toLower)
+          return false
+      true
+    }
+    else
+      false
 }


### PR DESCRIPTION
while i was working on #7408, i realized that our parsing of nan and infinity deviated from python's in a strange way. specifically, it would behave like java's `parseFloat`, handling `[+-]NaN` and `[+-]Infinity` (case sensitive, permitting a sign). it would also accept `nan` and `inf` (like python), but would not support the other variations allowed by python (`[+-]nan`, `[+-]infinity`, and total case insensitivity).

with this change it should behave identically to python's `float(<str>)`, at least wrt. nan and infinity.