### PR TITLE
[batch2] add auth for gcr pull using user gsa-key

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -209,6 +209,7 @@ async def job_config(app, record):
     k8s_client = app['k8s_client']
 
     job_spec = json.loads(record['spec'])
+    userdata = json.loads(record['userdata'])
 
     secrets = job_spec['secrets']
     k8s_secrets = await asyncio.gather(*[
@@ -220,7 +221,7 @@ async def job_config(app, record):
 
     gsa_key = None
     for secret, k8s_secret in zip(secrets, k8s_secrets):
-        if secret['name'] == job_spec['userdata']['gsa_key_secret_name']:
+        if secret['name'] == userdata['gsa_key_secret_name']:
             gsa_key = k8s_secret.data
         secret['data'] = k8s_secret.data
 

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -220,7 +220,7 @@ async def job_config(app, record):
 
     gsa_key = None
     for secret, k8s_secret in zip(secrets, k8s_secrets):
-        if secret['gsa_key_secret_name'] == job_spec['userdata']['gsa_key_secret_name']:
+        if secret['name'] == job_spec['userdata']['gsa_key_secret_name']:
             gsa_key = k8s_secret.data
         secret['data'] = k8s_secret.data
 

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -217,12 +217,19 @@ async def job_config(app, record):
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
         for secret in secrets
     ])
+
+    gsa_key = None
     for secret, k8s_secret in zip(secrets, k8s_secrets):
+        if secret['gsa_key_secret_name'] == job_spec['userdata']['gsa_key_secret_name']:
+            gsa_key = k8s_secret.data
         secret['data'] = k8s_secret.data
+
+    assert gsa_key
 
     return {
         'batch_id': record['batch_id'],
         'user': record['user'],
+        'gsa_key': gsa_key,
         'job_spec': job_spec
     }
 

--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -59,8 +59,8 @@ LIMIT 50;
         records = self.db.execute_and_fetchall(
             '''
 SELECT job_id, batch_id, spec, cores_mcpu,
-  ((jobs.cancelled OR batches.cancelled) AND NOT always_run) as cancel,
-  batches.user
+  ((jobs.cancelled OR batches.cancelled) AND NOT always_run) AS cancel,
+  userdata, user
 FROM jobs
 INNER JOIN batches ON batches.id = jobs.batch_id
 WHERE jobs.state = 'Ready' AND batches.closed

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -181,7 +181,7 @@ class Container:
                 else:
                     # this caches public images
                     try:
-                        docker_call_retry(docker.images.get, self.image)
+                        await docker_call_retry(docker.images.get, self.image)
                     except DockerError as e:
                         if e.status == 404:
                             await docker_call_retry(docker.images.pull, self.image)

--- a/batch2/test-batch-pod.yaml
+++ b/batch2/test-batch-pod.yaml
@@ -13,6 +13,8 @@ spec:
            fieldPath: status.podIP
      - name: HAIL_DEPLOY_CONFIG_FILE
        value: /deploy-config/deploy-config.json
+     - name: HAIL_BASE_IMAGE
+       value: {{ base_image.image }}
     volumeMounts:
       - mountPath: /deploy-config
         readOnly: true

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -337,3 +337,11 @@ class Test(unittest.TestCase):
             assert e.status == 401, e
         finally:
             bc.close()
+
+    def test_gcr_image(self):
+        builder = self.client.create_batch()
+        j = builder.create_job(os.environ['HAIL_BASE_IMAGE'], ['echo', 'test'])
+        b = builder.submit()
+        status = j.wait()
+
+        self.assertEqual(status['state'], 'Success', (status, j.log()))

--- a/build.yaml
+++ b/build.yaml
@@ -791,6 +791,7 @@ steps:
       timeout: 1200
    dependsOn:
     - default_ns
+    - base_image
     - batch_pods_ns
     - deploy_batch2
     - test_batch2_image


### PR DESCRIPTION
Images are stored in a global cache, so we have to be careful that a private image pulled by one user isn't executed by another user.  Therefore, pull each time for private images.  We could speed this up by having a per-user private image cache.
