### PR TITLE
[batch2] driver status page

### DIFF
--- a/batch2/MANIFEST.in
+++ b/batch2/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include batch/front_end/templates *
+recursive-include batch/driver/templates *

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -1,7 +1,14 @@
 import time
+import datetime
 import secrets
+import humanize
 
 from ..database import check_call_procedure
+
+
+def fmt_timestamp(t):
+    return datetime.datetime.utcfromtimestamp(t).strftime(
+        '%Y-%m-%dT%H:%M:%SZ')
 
 
 class Instance:
@@ -152,6 +159,14 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
         self.instance_pool.adjust_for_remove_instance(self)
         self._last_updated = now
         self.instance_pool.adjust_for_add_instance(self)
+
+    def time_created_str(self):
+        return datetime.datetime.utcfromtimestamp(self.time_created).strftime(
+            '%Y-%m-%dT%H:%M:%SZ')
+
+    def last_updated_str(self):
+        return humanize.naturaldelta(
+            datetime.datetime.utcnow() - datetime.datetime.utcfromtimestamp(self.last_updated))
 
     def __str__(self):
         return f'instance {self.name}'

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -292,7 +292,7 @@ async def get_index(request, userdata):
     page_context = {
         'instance_id': app['instance_id'],
         'n_instances_by_state': instance_pool.n_instances_by_state,
-        'instances': instance_pool.name_instances.values(),
+        'instances': instance_pool.name_instance.values(),
         'ready_cores_mcpu': ready_cores_mcpu,
         'live_free_cores_mcpu': instance_pool.live_free_cores_mcpu
     }

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -292,7 +292,7 @@ async def get_index(request, userdata):
     page_context = {
         'instance_id': app['instance_id'],
         'n_instances_by_state': instance_pool.n_instances_by_state,
-        'instances': instance_pool.instances.values(),
+        'instances': instance_pool.name_instances.values(),
         'ready_cores_mcpu': ready_cores_mcpu,
         'live_free_cores_mcpu': instance_pool.live_free_cores_mcpu
     }

--- a/batch2/batch/driver/templates/index.html
+++ b/batch2/batch/driver/templates/index.html
@@ -17,22 +17,22 @@
   <table class="data-table" id="instances">
     <thead>
       <tr>
-        <th>Time Created</th>
         <th>Name</th>
         <th>State</th>
         <th>Free Cores</th>
-	<th>Failed Requests</th>
+        <th>Failed Requests</th>
+        <th>Time Created</th>
         <th>Last Updated</th>
       </tr>
     </thead>
     <tbody>
       {% for instance in instances %}
       <tr>
-        <td>{{ instance.time_created_str() }}</td>
         <td>{{ instance.name }}</td>
         <td>{{ instance.state }}</td>
         <td class="numeric-cell">{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
         <td class="numeric-cell">{{ instance.failed_request_count }}</td>
+        <td>{{ instance.time_created_str() }}</td>
         <td>{{ instance.last_updated_str() }} ago</td>
       </tr>
       {% endfor %}

--- a/batch2/batch/driver/templates/index.html
+++ b/batch2/batch/driver/templates/index.html
@@ -1,0 +1,42 @@
+{% extends "layout.html" %}
+{% block title %}Batch2 Status{% endblock %}
+{% block content %}
+  <h1>Status</h1>
+  <div class="attributes">
+    <div>instance ID: {{ instance_id }}</div>
+    <div>ready cores: {{ ready_cores_mcpu / 1000 }}</div>
+  </div>
+  <h1>Instances</h1>
+  <div class="attributes">
+    <div>pending: {{ n_instances_by_state['pending'] }}</div>
+    <div>active: {{ n_instances_by_state['active'] }}</div>
+    <div>inactive: {{ n_instances_by_state['inactive'] }}</div>
+    <div>deleted: {{ n_instances_by_state['deleted'] }}</div>
+    <div>live free cores: {{ live_free_cores_mcpu / 1000 }}</div>
+  </div>
+  <table class="data-table" id="instances">
+    <thead>
+      <tr>
+        <th>Time Created</th>
+        <th>Name</th>
+        <th>State</th>
+        <th>Free Cores</th>
+	<th>Failed Requests</th>
+        <th>Last Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for instance in instances %}
+      <tr>
+        <td>{{ instance.time_created }}</td>
+        <td>{{ instance.name }}</td>
+        <td>{{ instance.state }}</td>
+        <td>{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
+        <td>{{ instance.failed_request_count }}</td>
+        <td>{{ instance.last_updated }}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/batch2/batch/driver/templates/index.html
+++ b/batch2/batch/driver/templates/index.html
@@ -31,8 +31,8 @@
         <td>{{ instance.time_created_str() }}</td>
         <td>{{ instance.name }}</td>
         <td>{{ instance.state }}</td>
-        <td>{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
-        <td>{{ instance.failed_request_count }}</td>
+        <td class="numeric-cell">{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
+        <td class="numeric-cell">{{ instance.failed_request_count }}</td>
         <td>{{ instance.last_updated_str() }} ago</td>
       </tr>
       {% endfor %}

--- a/batch2/batch/driver/templates/index.html
+++ b/batch2/batch/driver/templates/index.html
@@ -28,12 +28,12 @@
     <tbody>
       {% for instance in instances %}
       <tr>
-        <td>{{ instance.time_created }}</td>
+        <td>{{ instance.time_created_str }}</td>
         <td>{{ instance.name }}</td>
         <td>{{ instance.state }}</td>
         <td>{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
         <td>{{ instance.failed_request_count }}</td>
-        <td>{{ instance.last_updated }}</td>
+        <td>{{ instance.last_updated_str }} ago</td>
       </tr>
       {% endfor %}
       </tbody>

--- a/batch2/batch/driver/templates/index.html
+++ b/batch2/batch/driver/templates/index.html
@@ -28,12 +28,12 @@
     <tbody>
       {% for instance in instances %}
       <tr>
-        <td>{{ instance.time_created_str }}</td>
+        <td>{{ instance.time_created_str() }}</td>
         <td>{{ instance.name }}</td>
         <td>{{ instance.state }}</td>
         <td>{{ instance.free_cores_mcpu / 1000 }} / {{ instance.cores_mcpu / 1000 }}</td>
         <td>{{ instance.failed_request_count }}</td>
-        <td>{{ instance.last_updated_str }} ago</td>
+        <td>{{ instance.last_updated_str() }} ago</td>
       </tr>
       {% endfor %}
       </tbody>

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -152,12 +152,17 @@ a {
 }
 
 .notebook-caret:after {
-    /* 74 (measured) / 2 + 9 - 20 / 2 = 38px */
+    /* 74 (measured width of Notebook) / 2 + 9 - 20 / 2 = 38px */
     left: 36px;
 }
 
+.batch2-caret:after {
+    /* 52 (measured width of Batch2) / 2 + 9 - 20 / 2 = 25px */
+    left: 25px;
+}
+
 .monitoring-caret:after {
-    /* 82 (measured) / 2 + 9 - 20 / 2 = 42px */
+    /* 82 (measured width of Monitoring) / 2 + 9 - 20 / 2 = 42px */
     left: 40px;
 }
 

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -24,9 +24,20 @@
     Batch
   </a>
 
-  <a class="header-link" href="{{ batch2_base_url }}">
-    Batch2
-  </a>
+  
+  {% if userdata['developer'] == 1 %}
+    <div class="header-dropdown">
+      <div class="header-dropdown-item-margin">
+	<a href="{{ batch2_base_url }}" class="header-dropdown-link">Batch2</a>
+	<div class="header-dropdown-menu">
+	  <div class="batch2-caret header-dropdown-menu-caret"></div>
+	  <a class="header-dropdown-menu-link" href="{{ batch2_driver_base_url }}">Driver</a>
+	</div>
+      </div>
+    </div>
+  {% else %}
+    <a class="header-link" href="{{ batch2_base_url }}">Batch2</a>
+  {% endif %}
 
   {% if userdata['developer'] == 1 %}
     <a class="header-link" href="{{ ci_base_url }}">

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -62,6 +62,7 @@ def base_context(session, userdata, service):
         'auth_base_url': deploy_config.external_url('auth', ''),
         'batch_base_url': deploy_config.external_url('batch', ''),
         'batch2_base_url': deploy_config.external_url('batch2', ''),
+        'batch2_driver_base_url': deploy_config.external_url('batch2-driver', ''),
         'ci_base_url': deploy_config.external_url('ci', ''),
         'scorecard_base_url': deploy_config.external_url('scorecard', ''),
         'userdata': userdata


### PR DESCRIPTION
This adds a bare-bones status page for the batch2-driver.  It includes:
 - a Driver dropdown from the Batch2 header item,
 - the instance ID and ready cores,
 - list of instances with their name, state, free cores, created and last updated time.
