### PR TITLE
[batch2] fix instances schema for activation token

### DIFF
--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `tokens` (
 CREATE TABLE IF NOT EXISTS `instances` (
   `name` VARCHAR(100) NOT NULL,
   `state` VARCHAR(40) NOT NULL,
-  `activation_token` VARCHAR(100) NOT NULL,
+  `activation_token` VARCHAR(100),
   `token` VARCHAR(100) NOT NULL,
   `cores_mcpu` INT NOT NULL,
   `free_cores_mcpu` INT NOT NULL,


### PR DESCRIPTION
Fixes this warning message I got when activating the instance:
```
/usr/local/lib/python3.6/dist-packages/aiomysql/cursors.py:192: Warning: Column 'activation_token' cannot be null
  await self._do_get_result()
```