### PR TITLE
[ci, batch2] fix batch2 secrets part 1

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -7,7 +7,7 @@ from hailtop.utils import sleep_and_backoff, is_transient_error
 
 from .globals import complete_states, tasks
 from .database import check_call_procedure
-from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_PODS_NAMESPACE,
+from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_PODS_NAMESPACE, \
     KUBERNETES_SERVER_URL
 
 log = logging.getLogger('batch')

--- a/batch2/batch/batch_configuration.py
+++ b/batch2/batch/batch_configuration.py
@@ -2,7 +2,8 @@ import os
 
 KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
 REFRESH_INTERVAL_IN_SECONDS = int(os.environ.get('REFRESH_INTERVAL_IN_SECONDS', 5 * 60))
-BATCH_NAMESPACE = os.environ.get('BATCH_NAMESPACE', 'default')
+DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
+BATCH_PODS_NAMESPACE = os.environ['HAIL_BATCH_PODS_NAMESPACE']
 BATCH_WORKER_IMAGE = os.environ.get('BATCH_WORKER_IMAGE', 'gcr.io/hail-vdc/batch-worker:latest')
 PROJECT = os.environ.get('PROJECT', 'hail-vdc')
 ZONE = os.environ.get('ZONE', 'us-central1-a')

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -6,7 +6,7 @@ import sortedcontainers
 import aiohttp
 import googleapiclient.errors
 
-from ..batch_configuration import BATCH_NAMESPACE, BATCH_WORKER_IMAGE, \
+from ..batch_configuration import DEFAULT_NAMESPACE, BATCH_WORKER_IMAGE, \
     PROJECT, ZONE, WORKER_TYPE, WORKER_CORES, WORKER_DISK_SIZE_GB, \
     POOL_SIZE, MAX_INSTANCES
 
@@ -132,7 +132,7 @@ class InstancePool:
             'machineType': f'projects/{PROJECT}/zones/{ZONE}/machineTypes/n1-{WORKER_TYPE}-{WORKER_CORES}',
             'labels': {
                 'role': 'batch2-agent',
-                'namespace': BATCH_NAMESPACE
+                'namespace': DEFAULT_NAMESPACE
             },
 
             'disks': [{
@@ -250,7 +250,7 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
                     'value': BATCH_WORKER_IMAGE
                 }, {
                     'key': 'namespace',
-                    'value': BATCH_NAMESPACE
+                    'value': DEFAULT_NAMESPACE
                 }, {
                     'key': 'bucket_name',
                     'value': self.log_store.bucket_name

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -18,7 +18,7 @@ from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_
 from ..batch import mark_job_complete
 from ..log_store import LogStore
 from ..batch_configuration import REFRESH_INTERVAL_IN_SECONDS, \
-    BATCH_NAMESPACE
+    DEFAULT_NAMESPACE
 from ..google_compute import GServices
 
 from .instance_pool import InstancePool
@@ -329,7 +329,7 @@ async def on_startup(app):
         'internal')
     app['internal_token'] = row['token']
 
-    machine_name_prefix = f'batch2-worker-{BATCH_NAMESPACE}-'
+    machine_name_prefix = f'batch2-worker-{DEFAULT_NAMESPACE}-'
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
         '/batch-gsa-key/privateKeyData')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -30,6 +30,7 @@ from ..utils import parse_cpu_in_mcpu, LoggingTimer
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
+from ..batch_configuration import BATCH_PODS_NAMESPACE
 
 from . import schemas
 
@@ -276,7 +277,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     secrets = []
                     spec['secrets'] = secrets
                 secrets.append({
-                    'namespace': 'batch-pods',  # FIXME unused
+                    'namespace': BATCH_PODS_NAMESPACE,
                     'name': userdata['gsa_key_secret_name'],
                     'mount_path': '/gsa-key',
                     'mount_in_copy': True

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -147,6 +147,10 @@ spec:
            value: "{{ global.domain }}"
          - name: HAIL_DEPLOY_CONFIG_FILE
            value: /deploy-config/deploy-config.json
+         - name: HAIL_DEFAULT_NAMESPACE
+           value: "{{ default_ns.name }}"
+         - name: HAIL_BATCH_PODS_NAMESPACE
+           value: "{{ batch_pods_ns.name }}"
          - name: KUBERNETES_SERVER_URL
            value: "{{ global.k8s_server_url }}"	   
 {% if not deploy %}

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -39,8 +39,10 @@ spec:
            value: /deploy-config/deploy-config.json
          - name: BATCH_WORKER_IMAGE
            value: "{{ batch2_worker_image.image }}"
-         - name: BATCH_NAMESPACE
+         - name: HAIL_DEFAULT_NAMESPACE
            value: "{{ default_ns.name }}"
+         - name: HAIL_BATCH_PODS_NAMESPACE
+           value: "{{ batch_pods_ns.name }}"
          - name: KUBERNETES_SERVER_URL
            value: "{{ global.k8s_server_url }}"
 {% if not deploy %}

--- a/batch2/service-account-batch-pods.yaml
+++ b/batch2/service-account-batch-pods.yaml
@@ -1,0 +1,21 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: batch2
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "serviceaccounts"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: batch2
+subjects:
+- kind: ServiceAccount
+  name: batch2
+  namespace: {{ default_ns.name }}
+roleRef:
+  kind: Role
+  name: batch2
+  apiGroup: ""

--- a/build.yaml
+++ b/build.yaml
@@ -67,35 +67,18 @@ steps:
  - kind: deploy
    name: deploy_ci_agent
    namespace:
-     valueFrom: default_ns.name
-   config: ci/service-account.yaml
-   dependsOn:
-    - default_ns
-   scopes:
-    - test
-    - dev
-# deploy_ci_agent_sa and deploy_ci_agent_role are only needed
-# when ci is submitting jobs in batch-pods
- - kind: deploy
-   name: deploy_ci_agent_sa
-   namespace:
      valueFrom: batch_pods_ns.name
-   config: ci/ci-agent-sa.yaml
+   config: ci/ci-agent.yaml
    dependsOn:
-    - batch_pods_ns
-   scopes:
-    - test
+    - default_ns
  - kind: deploy
-   name: deploy_ci_agent_role
+   name: deploy_ci_agent_default
    namespace:
      valueFrom: default_ns.name
-   config: ci/ci-agent-role.yaml
+   config: ci/ci-agent-default.yaml
    dependsOn:
     - default_ns
     - batch_pods_ns
-    - deploy_ci_agent_sa
-   scopes:
-    - test
  - kind: buildImage
    name: base_image
    dockerFile: docker/Dockerfile.base

--- a/build.yaml
+++ b/build.yaml
@@ -938,7 +938,6 @@ steps:
     - default_ns
     - batch_pods_ns
     - deploy_ci
-    - deploy_ci_default
     - test_ci_image
     - create_ci_test_repo
  - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -70,7 +70,7 @@ steps:
      valueFrom: batch_pods_ns.name
    config: ci/ci-agent.yaml
    dependsOn:
-    - default_ns
+    - batch_pods_ns
  - kind: deploy
    name: deploy_ci_agent_default
    namespace:

--- a/build.yaml
+++ b/build.yaml
@@ -23,7 +23,7 @@ steps:
      valueFrom: default_ns.name
    config: batch2/service-account.yaml
    dependsOn:
-    - default_ns    
+    - default_ns
  - kind: createNamespace
    name: batch_pods_ns
    namespaceName: batch-pods
@@ -39,6 +39,15 @@ steps:
     - hail-ci-0-1-service-account-key
    dependsOn:
     - default_ns
+    - deploy_batch2_sa
+ - kind: deploy
+   name: deploy_batch2_sa_batch_pods
+   namespace:
+     valueFrom: batch_pods_ns.name
+   config: batch2/service-account-batch-pods.yaml
+   dependsOn:
+    - default_ns
+    - batch_pods_ns
     - deploy_batch2_sa
  - kind: deploy
    name: deploy_batch_output_sa
@@ -799,6 +808,7 @@ steps:
     - batch_pods_ns
     - deploy_router
     - deploy_batch2_sa
+    - deploy_batch2_sa_batch_pods
     - create_accounts
     - batch2_image
     - batch2_worker_image

--- a/build.yaml
+++ b/build.yaml
@@ -920,6 +920,7 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - batch_pods_ns
     - ci_image
     - ci_utils_image
     - create_accounts

--- a/build.yaml
+++ b/build.yaml
@@ -922,8 +922,8 @@ steps:
     - deploy_auth
     - deploy_batch
     - create_ci_test_repo
-    - deploy_ci_agent_role
     - deploy_ci_agent
+    - deploy_ci_agent_default
  - kind: deploy
    name: test_ci
    namespace:
@@ -938,7 +938,7 @@ steps:
     - default_ns
     - batch_pods_ns
     - deploy_ci
-    - deploy_ci_agent_role
+    - deploy_ci_default
     - test_ci_image
     - create_ci_test_repo
  - kind: runImage

--- a/ci/ci-agent-default.yaml
+++ b/ci/ci-agent-default.yaml
@@ -1,8 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ci-agent-role
-  namespace: {{ default_ns.name }}
+  name: ci-agent
 rules:
 - apiGroups: [""]
   resources: ["services", "pods", "pods/log"]
@@ -14,13 +13,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ci-agent-binding
-  namespace: {{ default_ns.name }}
+  name: ci-agent
 subjects:
 - kind: ServiceAccount
   name: ci-agent
   namespace: {{ batch_pods_ns.name }}
 roleRef:
   kind: Role
-  name: ci-agent-role
+  name: ci-agent
   apiGroup: ""

--- a/ci/ci-agent-sa.yaml
+++ b/ci/ci-agent-sa.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ci-agent
-  namespace: {{ batch_pods_ns.name }}

--- a/ci/ci-agent.yaml
+++ b/ci/ci-agent.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ci-agent
-  namespace: {{ batch_pods_ns.name }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ci/ci-agent.yaml
+++ b/ci/ci-agent.yaml
@@ -2,13 +2,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ci-agent
-  namespace: {{ default_ns.name }}
+  namespace: {{ batch_pods_ns.name }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ci-agent
-  namespace: {{ default_ns.name }}
 rules:
 - apiGroups: [""]
   resources: ["services", "pods", "pods/log"]
@@ -21,11 +20,9 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ci-agent
-  namespace: {{ default_ns.name }}
 subjects:
 - kind: ServiceAccount
   name: ci-agent
-  namespace: {{ default_ns.name }}
 roleRef:
   kind: Role
   name: ci-agent

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -5,5 +5,6 @@ DOMAIN = os.environ['HAIL_DOMAIN']
 IP = os.environ.get('HAIL_IP')
 CI_UTILS_IMAGE = os.environ.get('HAIL_CI_UTILS_IMAGE', 'gcr.io/hail-vdc/ci-utils:latest')
 SELF_HOSTNAME = os.environ.get('HAIL_SELF_HOSTNAME')
-CI_NAMESPACE = os.environ.get('HAIL_CI_NAMESPACE', 'default')
+DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
+BATCH_PODS_NAMESPACE = os.environ['HAIL_BATCH_PODS_NAMESPACE']
 KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -48,8 +48,10 @@ spec:
              value: "{{ global.domain }}"
            - name: HAIL_SELF_HOSTNAME
              value: ci
-           - name: HAIL_CI_NAMESPACE
+           - name: HAIL_DEFAULT_NAMESPACE
              value: "{{ default_ns.name }}"
+           - name: HAIL_BATCH_PODS_NAMESPACE
+             value: "{{ batch_pods_ns.name }}"
            - name: KUBERNETES_SERVER_URL
              value: "{{ global.k8s_server_url }}"
           ports:


### PR DESCRIPTION
First of 3 changes, I think:
 - batch2 secret field now requires namespace and it is used for lookup (it was required before in validation, but ignored)
 - CI now sets namespace consistently.  Since batch1 pods can only mount secrets from batch-pods, it only sets this to batch-pods.  The one exception is when the secretes come from a runImage step.  Then the namespace is taken from the runImage step if it is present, and otherwise defaults to batch-pods.

Two more PRs:
1. Set the namespace in all runImage step secrets
2. Make the namespace required in runImage steps

Then, when we switch CI from batch1 => batch2, we can create runImage steps that use secrets from namespaces other than batch-pods.