### PR TITLE
ndarray arange

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1950,7 +1950,7 @@ def range(start, stop=None, step=1) -> ArrayNumericExpression:
     The range includes `start`, but excludes `stop`.
 
     If provided exactly one argument, the argument is interpreted as `stop` and
-    `start` is set to zero. This matches the behavior Python's ``range``.
+    `start` is set to zero. This matches the behavior of Python's ``range``.
 
     Parameters
     ----------

--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,3 +1,3 @@
-from .nd import array, full, zeros, ones
+from .nd import array, arange, full, zeros, ones
 
-__all__ = ["array", "full", "zeros", "ones"]
+__all__ = ["array", "arange", "full", "zeros", "ones"]

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -57,7 +57,7 @@ def full(shape, value, dtype=None):
         shape_product = shape
     else:
         shape_product = reduce(lambda a, b: a * b, shape)
-    return array(hl.range(hl.int32(shape_product)).map(lambda x: cast_expr(value, dtype))).reshape(shape)
+    return arange(hl.int32(shape_product)).map(lambda x: cast_expr(value, dtype)).reshape(shape)
 
 
 @typecheck(shape=oneof(expr_int64, tupleof(expr_int64), expr_tuple()), dtype=HailType)

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -4,11 +4,51 @@ import hail as hl
 from hail.expr.functions import _ndarray
 from hail.expr.types import HailType
 from hail.typecheck import *
-from hail.expr.expressions import expr_int64, expr_tuple, expr_any, Int64Expression, cast_expr
+from hail.expr.expressions import expr_int32, expr_int64, expr_tuple, expr_any, Int64Expression, cast_expr
+from hail.expr.expressions.typed_expressions import NDArrayNumericExpression
 
 
 def array(input_array):
     return _ndarray(input_array)
+
+
+@typecheck(start=expr_int32, stop=nullable(expr_int32), step=expr_int32)
+def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
+    """Returns a 1-dimensions ndarray of integers from `start` to `stop` by `step`.
+
+    Examples
+    --------
+
+    >>> hl.eval(hl._nd.arange(10))
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    >>> hl.eval(hl._nd.arange(3, 10))
+    [3, 4, 5, 6, 7, 8, 9]
+
+    >>> hl.eval(hl._nd.arange(0, 10, step=3))
+    [0, 3, 6, 9]
+
+    Notes
+    -----
+    The range includes `start`, but excludes `stop`.
+
+    If provided exactly one argument, the argument is interpreted as `stop` and
+    `start` is set to zero. This matches the behavior of Python's ``range``.
+
+    Parameters
+    ----------
+    start : int or :class:`.Expression` of type :py:data:`.tint32`
+        Start of range.
+    stop : int or :class:`.Expression` of type :py:data:`.tint32`
+        End of range.
+    step : int or :class:`.Expression` of type :py:data:`.tint32`
+        Step of range.
+
+    Returns
+    -------
+    :class:`.NDArrayNumericExpression`
+    """
+    return array(hl.range(start, stop, step))
 
 
 @typecheck(shape=oneof(expr_int64, tupleof(expr_int64), expr_tuple()), value=expr_any, dtype=nullable(HailType))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -20,13 +20,13 @@ def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
     --------
 
     >>> hl.eval(hl._nd.arange(10))
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int32)
 
     >>> hl.eval(hl._nd.arange(3, 10))
-    [3, 4, 5, 6, 7, 8, 9]
+    array([3, 4, 5, 6, 7, 8, 9], dtype=int32)
 
     >>> hl.eval(hl._nd.arange(0, 10, step=3))
-    [0, 3, 6, 9]
+    array([0, 3, 6, 9], dtype=int32)
 
     Notes
     -----

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -474,6 +474,18 @@ def test_ndarray_full():
     assert hl.eval(hl._nd.full((5, 6, 7), hl.int32(3), dtype=hl.tfloat64)).dtype, np.float64
 
 @skip_unless_spark_backend()
+def test_ndarray_arange():
+    assert_ndarrays_eq(
+        (hl._nd.arange(40), np.arange(40)),
+        (hl._nd.arange(5, 50), np.arange(5, 50)),
+        (hl._nd.arange(2, 47, 13), np.arange(2, 47, 13))
+    )
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(hl._nd.arange(5, 20, 0))
+    assert "Array range cannot have step size 0" in str(exc)
+
+@skip_unless_spark_backend()
 def test_ndarray_mixed():
     assert hl.eval(hl.null(hl.tndarray(hl.tint64, 2)).map(lambda x: x * x).reshape((4, 5)).T) is None
     assert hl.eval(


### PR DESCRIPTION
Adding the numpy style function `arange` to the `nd` module, as a shortcut for `hl._nd.array(hl.range(start, stop, step))`. I was mostly just tired of typing it, plus numpy consistency seems good. 