### PR TITLE
[hail] Improve execution timer.

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -25,28 +25,31 @@ abstract class Backend {
   def lower(ir: IR, timer: Option[ExecutionTimer], optimize: Boolean = true): IR =
       LowerTableIR(ir, timer, optimize)
 
-  def jvmLowerAndExecute(ir0: IR, optimize: Boolean, print: Option[PrintWriter] = None): (Any, Timings) = {
+  def jvmLowerAndExecute(ir0: IR, optimize: Boolean, print: Option[PrintWriter] = None): (Any, ExecutionTimer) = {
     val timer = new ExecutionTimer()
     val ir = lower(ir0, Some(timer), optimize)
 
     if (!Compilable(ir))
-      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ir)}")
+      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")
 
-    val res = Region.scoped { region =>
-      ir.typ match {
-        case TVoid =>
-          val (_, f) = timer.time(Compile[Unit](ir, print), "JVM compile")
-          timer.time(f(0, region)(region), "Runtime")
-        case _ =>
-          val (pt: PTuple, f) = timer.time(Compile[Long](MakeTuple.ordered(FastSeq(ir)), print), "JVM compile")
-          timer.time(SafeRow(pt, region, f(0, region)(region)).get(0), "Runtime")
+    val res = timer.time("JVMLowerAndExecute") {
+      Region.scoped { region =>
+        ir.typ match {
+          case TVoid =>
+            val (_, f) = timer.time("Compile")(Compile[Unit](ir, print))
+            timer.time("Run")(f(0, region)(region))
+
+          case _ =>
+            val (pt: PTuple, f) = timer.time("Compile")(Compile[Long](MakeTuple.ordered(FastSeq(ir)), print))
+            timer.time("Run")(SafeRow(pt, region, f(0, region)(region)).get(0))
+        }
       }
     }
 
-    (res, timer.timings)
+    (res, timer)
   }
 
-  def execute(ir: IR, optimize: Boolean): (Any, Timings) = {
+  def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) = {
     TypeCheck(ir)
     try {
       if (HailContext.get.flags.get("lower") == null)
@@ -54,7 +57,7 @@ abstract class Backend {
       jvmLowerAndExecute(ir, optimize)
     } catch {
       case _: LowererUnsupportedOperation =>
-        ExecuteContext.scoped(ctx => (CompileAndEvaluate(ctx, ir, optimize = optimize), ctx.timer.timings))
+        ExecuteContext.scoped(ctx => (CompileAndEvaluate(ctx, ir, optimize = optimize), ctx.timer))
     }
   }
 
@@ -62,9 +65,10 @@ abstract class Backend {
     val t = ir.typ
     val (value, timings) = execute(ir, optimize = true)
     val jsonValue = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
+    timings.finish()
     timings.logInfo()
 
-    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.value))(new DefaultFormats {})
+    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
   }
 
   def asSpark(): SparkBackend = fatal("SparkBackend needed for this operation.")

--- a/hail/src/main/scala/is/hail/backend/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/LowerTableIR.scala
@@ -37,11 +37,10 @@ object LowerTableIR {
   def apply(ir0: IR, timer: Option[ExecutionTimer], optimize: Boolean = true): IR = {
 
     def opt(context: String, ir: IR): IR =
-      Optimize(ir, noisy = true,
-        Some(context))
+      Optimize(ir, noisy = true, context)
 
     def time(context: String, ir: (String) => IR): IR =
-      timer.map(t => t.time(ir(context), context))
+      timer.map(t => t.time(context)(ir(context)))
         .getOrElse(ir(context))
 
     var ir = ir0

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -2,7 +2,7 @@ package is.hail.backend.local
 
 import is.hail.backend.{Backend, BroadcastValue}
 import is.hail.expr.ir._
-import is.hail.utils.{ExecutionTimer, Timings}
+import is.hail.utils.ExecutionTimer
 
 import scala.reflect.ClassTag
 

--- a/hail/src/main/scala/is/hail/backend/local/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LowerTableIR.scala
@@ -32,10 +32,10 @@ object LowerTableIR {
   def apply(ir0: IR, timer: Option[ExecutionTimer], optimize: Boolean = true): IR = {
 
     def opt(context: String, ir: IR): IR =
-      Optimize(ir, noisy = true, Some(context))
+      Optimize(ir, noisy = true, context)
 
     def time(context: String, ir: (String) => IR): IR =
-      timer.map(t => t.time(ir(context), context))
+      timer.map(t => t.time(context)(ir(context)))
         .getOrElse(ir(context))
 
     var ir = ir0

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -40,7 +40,7 @@ object Compile {
 
     var ir = body
     if (optimize)
-      ir = Optimize(ir, noisy = true, context = Some("Compile"))
+      ir = Optimize(ir, noisy = true, context = "Compile")
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
 
     val env = args
@@ -225,7 +225,7 @@ object CompileWithAggregators2 {
 
     var ir = body
     if (optimize)
-      ir = Optimize(ir, noisy = true, context = Some("Compile"))
+      ir = Optimize(ir, noisy = true, context = "Compile")
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
 
     val env = args

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -11,21 +11,22 @@ object CompileAndEvaluate {
     ir0: IR,
     optimize: Boolean = true
   ): T = {
+    ctx.timer.time("CompileAndEvaluate") {
+
     val ir = LoweringPipeline.relationalLowerer.apply(ctx, ir0, optimize).asInstanceOf[IR]
 
     if (ir.typ == TVoid)
     // void is not really supported by IR utilities
       return ().asInstanceOf[T]
 
-    val (resultPType, f) = ctx.timer.time(Compile[Long](
-      MakeTuple.ordered(FastSeq(ir)), None, optimize = false),
-      "CompileAndEvaluate.compile")
+    val (resultPType, f) = ctx.timer.time("Compile")(Compile[Long](
+      MakeTuple.ordered(FastSeq(ir)), None, optimize = false))
 
-    val fRunnable = ctx.timer.time(f(0, ctx.r), "create compiled function")
-    val resultAddress = ctx.timer.time(fRunnable(ctx.r), "run compiled function")
+    val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(0, ctx.r))
+    val resultAddress = ctx.timer.time("RunCompiledFunction")(fRunnable(ctx.r))
 
-    ctx.timer.time(
-      SafeRow(resultPType.asInstanceOf[PBaseStruct], ctx.r, resultAddress).getAs[T](0),
-      "convert to safe value")
+    ctx.timer.time("ConvertToSafeValue")(
+      SafeRow(resultPType.asInstanceOf[PBaseStruct], ctx.r, resultAddress).getAs[T](0))
+    }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -876,11 +876,11 @@ private class Emit(
             val (newContainer, aggSetup, aggCleanup) = AggContainer.fromFunctionBuilder(extracted.aggs, mb.fb, "array_agg")
 
             val init = Optimize(extracted.init, noisy = true,
-              context = Some("ArrayAgg/agg.Extract/init"))
+              context = "ArrayAgg/agg.Extract/init")
             val perElt = Optimize(extracted.seqPerElt, noisy = true,
-              context = Some("ArrayAgg/agg.Extract/perElt"))
+              context = "ArrayAgg/agg.Extract/perElt")
             val postAggIR = Optimize(Let(res, extracted.results, extracted.postAggIR), noisy = true,
-              context = Some("ArrayAgg/agg.Extract/postAggIR"))
+              context = "ArrayAgg/agg.Extract/postAggIR")
 
             val codeInit = emit(init, env = env, container = Some(newContainer))
             val codePerElt = emit(perElt, env = perEltEnv, container = Some(newContainer))
@@ -920,11 +920,11 @@ private class Emit(
 
         val StagedExtractedAggregators(postAggIR_, resultType, init_, perElt_, makeRVAggs) = ExtractAggregators.staged(mb.fb, query)
         val postAggIR = Optimize(postAggIR_, noisy = true,
-          context = Some("ArrayAgg/StagedExtractAggregators/postAggIR"))
+          context = "ArrayAgg/StagedExtractAggregators/postAggIR")
         val init = Optimize(init_, noisy = true,
-          context = Some("ArrayAgg/StagedExtractAggregators/init"))
+          context = "ArrayAgg/StagedExtractAggregators/init")
         val perElt = Optimize(perElt_, noisy = true,
-          context = Some("ArrayAgg/StagedExtractAggregators/perElt"))
+          context = "ArrayAgg/StagedExtractAggregators/perElt")
 
         val rvas = mb.newField[Array[RegionValueAggregator]]("rvas")
 
@@ -2133,11 +2133,11 @@ private class Emit(
             val (newContainer, aggSetup, aggCleanup) = AggContainer.fromFunctionBuilder(aggSigs, mb.fb, "array_agg_scan")
 
             val init = Optimize(extracted.init, noisy = true,
-              context = Some("ArrayAggScan/StagedExtractAggregators/postAggIR"))
+              context = "ArrayAggScan/StagedExtractAggregators/postAggIR")
             val perElt = Optimize(extracted.seqPerElt, noisy = true,
-              context = Some("ArrayAggScan/StagedExtractAggregators/init"))
+              context = "ArrayAggScan/StagedExtractAggregators/init")
             val postAgg = Optimize(Let(res, extracted.results, extracted.postAggIR), noisy = true,
-              context = Some("ArrayAggScan/StagedExtractAggregators/perElt"))
+              context = "ArrayAggScan/StagedExtractAggregators/perElt")
 
             val codeInit = this.emit(init, env, None, er, Some(newContainer))
             val codeSeq = this.emit(perElt, bodyEnv, None, er, Some(newContainer))
@@ -2168,11 +2168,11 @@ private class Emit(
           ExtractAggregators.staged(mb.fb, CompileWithAggregators.liftScan(query))
 
         val postAggIR = Optimize(postAggIR_, noisy = true,
-          context = Some("ArrayAggScan/StagedExtractAggregators/postAggIR"))
+          context = "ArrayAggScan/StagedExtractAggregators/postAggIR")
         val init = Optimize(init_, noisy = true,
-          context = Some("ArrayAggScan/StagedExtractAggregators/init"))
+          context = "ArrayAggScan/StagedExtractAggregators/init")
         val perElt = Optimize(perElt_, noisy = true,
-          context = Some("ArrayAggScan/StagedExtractAggregators/perElt"))
+          context = "ArrayAggScan/StagedExtractAggregators/perElt")
 
         val rvas = mb.newField[Array[RegionValueAggregator]]("rvas")
         val aggInit = this.emit(init, env, Some(rvas), er, container)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -46,7 +46,7 @@ object Interpret {
     var ir = ir0.unwrap
 
     def optimizeIR(context: String) {
-      ir = Optimize(ir, noisy = true, context = Some(context))
+      ir = Optimize(ir, noisy = true, context = context)
       TypeCheck(ir, BindingEnv(typeEnv, agg = aggArgs.map { agg =>
         agg._2.fields.foldLeft(Env.empty[Type]) { case (env, f) =>
           env.bind(f.name, f.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -4,49 +4,70 @@ import is.hail.HailContext
 import is.hail.utils._
 
 object Optimize {
-  def optimize(ir0: BaseIR, noisy: Boolean, context: Option[String]): BaseIR = {
-    val contextStr = context.map(s => s" ($s)").getOrElse("")
+  def optimize(ir0: BaseIR, noisy: Boolean, context: String, ctx: Option[ExecuteContext] = None): BaseIR = {
     if (noisy)
-      log.info(s"optimize$contextStr: before: IR size ${ IRSize(ir0) }: \n" + Pretty(ir0, elideLiterals = true))
+      log.info(s"optimize $context: before: IR size ${ IRSize(ir0) }: \n" + Pretty(ir0, elideLiterals = true))
+
+    def maybeTime[T](x: => T): T = {
+      ctx match {
+        case Some(ctx) => ctx.timer.time("Optimize")(x)
+        case None => x
+      }
+    }
 
     var ir = ir0
     var last: BaseIR = null
     var iter = 0
     val maxIter = HailContext.get.optimizerIterations
-    while (iter < maxIter && ir != last) {
-      last = ir
-      ir = FoldConstants(ir)
-      ir = ExtractIntervalFilters(ir)
-      ir = Simplify(ir)
-      ir = ForwardLets(ir)
-      ir = ForwardRelationalLets(ir)
-      ir = PruneDeadFields(ir)
 
-      iter += 1
+    def runOpt(f: BaseIR => BaseIR, iter: Int, optContext: String): Unit = {
+      ctx match {
+        case None =>
+          ir = f(ir)
+        case Some(ctx) =>
+          ir = ctx.timer.time(optContext)(f(ir))
+      }
     }
 
+    maybeTime({
+      while (iter < maxIter && ir != last) {
+        last = ir
+        runOpt(FoldConstants(_), iter, "FoldConstants")
+        runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
+        runOpt(Simplify(_), iter, "Simplify")
+        runOpt(ForwardLets(_), iter, "ForwardLets")
+        runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")
+        runOpt(PruneDeadFields(_), iter, "PruneDeadFields")
+
+        iter += 1
+      }
+    })
+
     if (ir.typ != ir0.typ)
-      throw new RuntimeException(s"optimization changed type!\n  before: ${ ir0.typ.parsableString() }\n  after:  ${ ir.typ.parsableString() }" +
-        s"\n  Before IR:\n  ----------\n${ Pretty(ir0) }\n  After IR:\n  ---------\n${ Pretty(ir) }")
+      throw new RuntimeException(s"optimization changed type!" +
+        s"\n  before: ${ ir0.typ.parsableString() }" +
+        s"\n  after:  ${ ir.typ.parsableString() }" +
+        s"\n  Before IR:\n  ----------\n${ Pretty(ir0) }" +
+        s"\n  After IR:\n  ---------\n${ Pretty(ir) }")
 
     if (noisy)
-      log.info(s"optimize$contextStr: after: IR size ${ IRSize(ir) }:\n" + Pretty(ir, elideLiterals = true))
+      log.info(s"optimize $context: after: IR size ${ IRSize(ir) }:\n" + Pretty(ir, elideLiterals = true))
 
     ir
   }
 
   def apply(ir: TableIR, noisy: Boolean): TableIR =
-    optimize(ir, noisy, None).asInstanceOf[TableIR]
+    optimize(ir, noisy, "").asInstanceOf[TableIR]
 
   def apply(ir: TableIR): TableIR = apply(ir, true)
 
   def apply(ir: MatrixIR, noisy: Boolean): MatrixIR =
-   optimize(ir, noisy, None).asInstanceOf[MatrixIR]
+    optimize(ir, noisy, "").asInstanceOf[MatrixIR]
 
   def apply(ir: MatrixIR): MatrixIR = apply(ir, true)
 
-  def apply(ir: IR, noisy: Boolean, context: Option[String]): IR =
+  def apply(ir: IR, noisy: Boolean, context: String): IR =
     optimize(ir, noisy, context).asInstanceOf[IR]
 
-  def apply(ir: IR): IR = apply(ir, true, None)
+  def apply(ir: IR): IR = apply(ir, true, "")
 }

--- a/hail/src/main/scala/is/hail/utils/ArrayStack.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayStack.scala
@@ -24,6 +24,8 @@ final class ArrayStack[@specialized T](hintSize: Int = 16)(implicit tct: ClassTa
     a(size_ - 1)
   }
 
+  def topOption: Option[T] = if (size_ > 0) Some(top) else None
+
   def push(x: T) {
     if (size_ == a.length) {
       val newA = new Array[T](size_ * 2)
@@ -51,4 +53,6 @@ final class ArrayStack[@specialized T](hintSize: Int = 16)(implicit tct: ClassTa
     assert(i >= 0 && i < size_)
     a(size_ - i - 1)
   }
+
+  def toArray: Array[T] = (0 until size).map(apply).toArray
 }

--- a/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
+++ b/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
@@ -2,31 +2,123 @@ package is.hail.utils
 
 import scala.collection.mutable
 
-class Timings(val value: mutable.Map[String, Long], ord: mutable.ArrayBuffer[String]) {
-  def +=(timing: (String, Long)) {
-    ord += timing._1
-    value += timing
+
+case class TimeBlock(name: String, parent: Option[TimeBlock]) {
+  parent.foreach(_.isLeaf = false)
+  private val start: Long = System.nanoTime()
+  private var end: Long = 0L
+  private var finished: Boolean = false
+  private var isLeaf: Boolean = true
+  private var coveredDuration: Long = 0L
+
+  def isLeafNode: Boolean = isLeaf
+
+  def finish(): Unit = {
+    assert(!finished)
+    end = System.nanoTime()
+    finished = true
+    parent.foreach { p =>
+      assert(!p.isLeaf)
+      p.coveredDuration += getCoveredDuration
+    }
   }
 
-  def logInfo() {
-    ord.foreach { stage =>
-      val timing = value(stage)
-      log.info(s"Time taken for $stage: ${ formatTime(timing) }")
-    }
+  def getCoveredDuration: Long = {
+    assert(finished)
+    if (isLeaf)
+      end - start
+    else
+      coveredDuration
+  }
+
+  private def appendPath(ab: ArrayBuilder[String]): Unit = {
+    parent.foreach(_.appendPath(ab))
+    ab += name
+  }
+
+  def path(): Array[String] = {
+    val ab = new ArrayBuilder[String]
+    appendPath(ab)
+    ab.result()
+  }
+
+  def duration: Long = {
+    assert(finished)
+    end - start
+  }
+
+  def fmtDuration: String = {
+    formatTime(duration)
+  }
+
+  def report(jobStartTime: Long): Unit = {
+    assert(finished)
+    val cov = if (!isLeaf) s", tagged coverage ${ formatDouble(coveredDuration.toDouble / duration * 100, 1) }" else ""
+    log.info(s"Timer: Time taken for ${ path().mkString(" -- ") } : $fmtDuration, total ${ formatTime(end - jobStartTime) }$cov")
   }
 }
 
 class ExecutionTimer {
-  val timings: Timings = new Timings(mutable.Map.empty, mutable.ArrayBuffer.empty)
+  private val stack = new ArrayStack[TimeBlock]()
+  private val measurements: mutable.ArrayBuffer[TimeBlock] = mutable.ArrayBuffer.empty
 
-  def time[T](block: => T, operation: String): T = {
-    val t0 = System.nanoTime()
+  def time[T](tag: String)(block: => T): T = {
+    assert(!finished)
+    val preSize = stack.size
+    stack.push(TimeBlock(tag, stack.topOption))
     val result = block
-    val t1 = System.nanoTime()
-
-    val nanos = t1 - t0
-    timings += s"$operation" -> nanos
-
+    val finishedBlock = stack.pop()
+    finishedBlock.finish()
+    finishedBlock.report(startTime)
+    measurements += finishedBlock
+    assert(stack.size == preSize)
     result
   }
+
+  private val startTime = System.nanoTime()
+
+  private var finished: Boolean = false
+  private var endTime: Long = _
+
+  def register(block: TimeBlock): Unit = {
+    assert(!finished)
+    block.report(startTime)
+    measurements += block
+  }
+
+  def finish(): Unit = {
+    finished = true
+    endTime = System.nanoTime()
+  }
+
+  def logInfo() {
+    assert(finished)
+    log.info("Timer: all timings:")
+    measurements.foreach { t =>
+      t.report(startTime)
+    }
+    log.info("Timer: aggregate:")
+    measurements.filter { t => t.isLeafNode }
+      .groupBy(_.name)
+      .toArray
+      .map { case (tag, ab) => (tag, ab.map(_.duration).sum, ab.size) }
+      .sortBy(_._2)
+      .foreach { case (tag, sum, n) =>
+        log.info(s"Time taken for tag '$tag' ($n): ${ formatTime(sum) }")
+      }
+    val taggedSum = measurements.iterator.filter { t => t.isLeafNode }.map(_.duration).sum
+    val totalTime = endTime - startTime
+    val percentCovered = taggedSum.toDouble / totalTime * 100
+    log.info(s"Timer: Fraction covered by a tagged leaf: ${ formatTime(totalTime - taggedSum) } (${ formatDouble(percentCovered, 1) }%)")
+  }
+
+  def asMap(): mutable.Map[String, Long] = {
+    assert(finished)
+    val m = mutable.Map.empty[String, Long]
+    measurements.foreach { t =>
+      m += ((t.path().mkString(" -- "), t.duration))
+    }
+    m
+  }
+
 }

--- a/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
+++ b/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
@@ -104,7 +104,7 @@ class ExecutionTimer {
       .map { case (tag, ab) => (tag, ab.map(_.duration).sum, ab.size) }
       .sortBy(_._2)
       .foreach { case (tag, sum, n) =>
-        log.info(s"Time taken for tag '$tag' ($n): ${ formatTime(sum) }")
+        log.info(s"Timer: Time taken for tag '$tag' ($n): ${ formatTime(sum) }")
       }
     val taggedSum = measurements.iterator.filter { t => t.isLeafNode }.map(_.duration).sum
     val totalTime = endTime - startTime
@@ -120,5 +120,4 @@ class ExecutionTimer {
     }
     m
   }
-
 }


### PR DESCRIPTION
stacked on #7446

This is the first step toward broad integration of the timer throughout the compiler.

This gives us output like:
```
2019-11-06 18:44:11 root: INFO: Timer: all timings:
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- FoldConstants : 5.811ms, total 29.474ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ExtractIntervalFilters : 21.579ms, total 51.305ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- Simplify : 38.711ms, total 90.246ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardLets : 58.138ms, total 148.873ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardRelationalLets : 4.892ms, total 154.106ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- PruneDeadFields : 70.932ms, total 225.284ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- FoldConstants : 2.673ms, total 228.575ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ExtractIntervalFilters : 6.413ms, total 235.357ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- Simplify : 4.736ms, total 240.359ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardLets : 38.152ms, total 278.793ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardRelationalLets : 3.185ms, total 282.285ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- PruneDeadFields : 25.086ms, total 307.692ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- FoldConstants : 1.938ms, total 310.139ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ExtractIntervalFilters : 13.601ms, total 324.665ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- Simplify : 4.231ms, total 329.178ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardLets : 27.172ms, total 356.625ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- ForwardRelationalLets : 6.605ms, total 363.564ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize -- PruneDeadFields : 29.964ms, total 394.795ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- Optimize : 371.542ms, total 395.164ms()
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- LowerMatrixToTable -- Verify : 3.975ms, total 407.299ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- LowerMatrixToTable -- LoweringTransformation : 77.664ms, total 485.244ms, tagged coverage 0.0
2019-11-06 18:44:11 root: INFO: Time taken for CompileAndEvaluate -- LowerMatrixToTable -- Verify : 1.780ms, total 487.281ms, tagged coverage 0.0
...
...
...
2019-11-06 18:44:11 root: INFO: Timer: aggregate:
2019-11-06 18:44:11 root: INFO: Time taken for tag 'Verify' (8): 8.109ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'ConvertToSafeValue' (2): 12.828ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'InitializeCompiledFunction' (2): 14.536ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'ForwardRelationalLets' (7): 20.388ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'FoldConstants' (7): 21.650ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'RunCompiledFunction' (2): 44.571ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'ExtractIntervalFilters' (7): 70.933ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'LoweringTransformation' (3): 79.703ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'Simplify' (7): 135.960ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'ForwardLets' (7): 200.163ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'Compile' (2): 269.978ms
2019-11-06 18:44:11 root: INFO: Time taken for tag 'PruneDeadFields' (7): 274.850ms
2019-11-06 18:44:11 root: INFO: Fraction covered by a tagged leaf: 13.383s (7.9%)
```