### PR TITLE
[hail] Fix TVariable

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -735,7 +735,7 @@ object Interpret {
           val offset = rvb.end()
 
           val resultOffset = f(region, offset, false)
-          SafeRow(PTuple(ir.implementation.returnType.subst().physicalType), region, resultOffset)
+          SafeRow(PTuple(ir.implementation.returnPType(argTuple.types)), region, resultOffset)
             .get(0)
         }
       case Uniroot(functionid, fn, minIR, maxIR) =>

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -31,17 +31,17 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase, override val re
     sb.append("ndarray<")
     elementType.pyString(sb)
     sb.append(", ")
-    sb.append(nDims)
+    sb.append(nDimsBase)
     sb.append('>')
   }
 
-  def _toPretty = s"NDArray[$elementType,$nDims]"
+  def _toPretty = s"NDArray[$elementType,$nDimsBase]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
     sb.append("NDArray[")
     elementType.pretty(sb, indent, compact)
     sb.append(",")
-    sb.append(nDims)
+    sb.append(nDimsBase)
     sb.append("]")
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
@@ -42,7 +42,7 @@ final case class TVariable(name: String, cond: String = null) extends Type {
 
   def physicalType: PType = ???
 
-  def t: Type = b.get
+  lazy val t: Type = b.get
 
   override val required = true
 
@@ -72,6 +72,8 @@ final case class TVariable(name: String, cond: String = null) extends Type {
 
   override def subst(): Type = {
     assert(b.isDefined)
+    if (!condf(t))
+      throw new RuntimeException(s"TVariable subst error: $this, ${t.parsableString()}")
     t
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/TVariableSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TVariableSuite.scala
@@ -1,0 +1,25 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.virtual.{TInt32, TString, TVariable}
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class TVariableSuite extends TestNGSuite {
+
+  @Test def testMutability(): Unit = {
+    val tv1 = TVariable("T")
+    val tv2 = TVariable("T")
+
+    tv1.unify(TInt32())
+    val t1 = tv1.subst()
+    assert(t1 == TInt32())
+
+    tv2.clear()
+    tv2.unify(TString())
+    val t2 = tv2.subst()
+    assert(t2 == TString())
+
+    assert(t1 == tv1.subst())
+    assert(t2 == tv2.subst())
+  }
+}


### PR DESCRIPTION
I encountered an inscrutable bug revealed by the lowering changes:

```scala
val impl = ir.implementation
println(s"implementation = ${impl}")
println(s"ret typ is ${impl.returnType}")
println(s"ret typ subst is ${impl.returnType.subst()}")
```
```
implementation = Locus(str, int32): ?T:locus
ret typ is ?T:locus
ret typ subst is struct{het_freq_hwe: float64, p_value: float64}
```

The `lazy val` fix resolves this by ensuring that the type is filled in when subst() is called, not later, when there could be anything in the box.

The rest of the changes here are QoL changes made while debugging.