### PR TITLE
[combiner][hail] reorganize/rename functions

### DIFF
--- a/hail/python/cluster-tests/cluster-read-vcfs-check.py
+++ b/hail/python/cluster-tests/cluster-read-vcfs-check.py
@@ -19,5 +19,5 @@ parts_json = [
 ]
 
 parts = hl.tarray(hl.tinterval(hl.tstruct(locus=hl.tlocus('GRCh38'))))._convert_from_json(parts_json)
-for mt in hl.import_vcfs(gvcfs, parts):
+for mt in hl.import_gvcfs(gvcfs, parts):
     mt._force_count_rows()

--- a/hail/python/hail/docs/methods/impex.rst
+++ b/hail/python/hail/docs/methods/impex.rst
@@ -44,7 +44,7 @@ Import data from a non-Hail format into a Hail format.
     import_plink
     import_table
     import_vcf
-    import_vcfs
+    import_gvcfs
 
 .. _methods_impex_read:
 
@@ -74,6 +74,6 @@ Read data from a Hail format.
 .. autofunction:: import_plink
 .. autofunction:: import_table
 .. autofunction:: import_vcf
-.. autofunction:: import_vcfs
+.. autofunction:: import_gvcfs
 .. autofunction:: read_matrix_table
 .. autofunction:: read_table

--- a/hail/python/hail/docs/methods/index.rst
+++ b/hail/python/hail/docs/methods/index.rst
@@ -30,7 +30,7 @@ Methods
     import_plink
     import_table
     import_vcf
-    import_vcfs
+    import_gvcfs
     index_bgen
     read_matrix_table
     read_table

--- a/hail/python/hail/methods/__init__.py
+++ b/hail/python/hail/methods/__init__.py
@@ -1,8 +1,8 @@
 from .family_methods import trio_matrix, mendel_errors, transmission_disequilibrium_test, de_novo
 from .impex import export_elasticsearch, export_gen, export_bgen, export_plink, export_vcf, \
     import_locus_intervals, import_bed, import_fam, grep, import_bgen, import_gen, import_table, \
-    import_plink, read_matrix_table, read_table, get_vcf_metadata, import_vcf, import_vcfs, \
-    index_bgen, import_matrix_table
+    import_plink, read_matrix_table, read_table, get_vcf_metadata, import_vcf, import_gvcfs, \
+    import_vcfs, index_bgen, import_matrix_table
 from .statgen import skat, identity_by_descent, impute_sex, \
     genetic_relatedness_matrix, realized_relationship_matrix, pca, \
     hwe_normalized_pca, pc_relate, split_multi, filter_alleles, filter_alleles_hts, \
@@ -56,8 +56,9 @@ __all__ = ['trio_matrix',
            'read_matrix_table',
            'read_table',
            'get_vcf_metadata',
-           'import_vcfs',
            'import_vcf',
+           'import_vcfs',
+           'import_gvcfs',
            'index_bgen',
            'balding_nichols_model',
            'ld_prune',

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2120,20 +2120,20 @@ def import_vcf(path,
            find_replace=nullable(sized_tupleof(str, str)),
            _external_sample_ids=nullable(sequenceof(sequenceof(str))),
            _external_header=nullable(str))
-def import_vcfs(path,
-                partitions,
-                force=False,
-                force_bgz=False,
-                call_fields=['PGT'],
-                entry_float_type=tfloat64,
-                reference_genome='default',
-                contig_recoding=None,
-                array_elements_required=True,
-                skip_invalid_loci=False,
-                filter=None,
-                find_replace=None,
-                _external_sample_ids=None,
-                _external_header=None) -> List[MatrixTable]:
+def import_gvcfs(path,
+                 partitions,
+                 force=False,
+                 force_bgz=False,
+                 call_fields=['PGT'],
+                 entry_float_type=tfloat64,
+                 reference_genome='default',
+                 contig_recoding=None,
+                 array_elements_required=True,
+                 skip_invalid_loci=False,
+                 filter=None,
+                 find_replace=None,
+                 _external_sample_ids=None,
+                 _external_header=None) -> List[MatrixTable]:
     """(Experimental) Import multiple vcfs as multiple :class:`.MatrixTable`.
 
     .. include:: ../_templates/experimental.rst
@@ -2153,8 +2153,8 @@ def import_vcfs(path,
     The ``includes_start`` and ``includes_end`` keys must be ``True``. The
     ``contig`` fields must be the same.
 
-    One difference between :func:`.import_vcfs` and :func:`.import_vcf` is that
-    :func:`.import_vcfs` only keys the resulting matrix tables by ``locus``
+    One difference between :func:`.import_gvcfs` and :func:`.import_vcf` is that
+    :func:`.import_gvcfs` only keys the resulting matrix tables by ``locus``
     rather than ``locus, alleles``.
     """
 
@@ -2191,6 +2191,37 @@ def import_vcfs(path,
                                   hl.tmatrix._from_json(vector_ref['type']))
 
     return [MatrixTable(JavaMatrixVectorRef(jir_vref, idx)) for idx in range(len(jir_vref))]
+
+
+def import_vcfs(path,
+                partitions,
+                force=False,
+                force_bgz=False,
+                call_fields=['PGT'],
+                entry_float_type=tfloat64,
+                reference_genome='default',
+                contig_recoding=None,
+                array_elements_required=True,
+                skip_invalid_loci=False,
+                filter=None,
+                find_replace=None,
+                _external_sample_ids=None,
+                _external_header=None) -> List[MatrixTable]:
+    """This function is deprecated, use :func:`.import_gvcfs` instead"""
+    return import_gvcfs(path,
+                        partitions,
+                        force,
+                        force_bgz,
+                        call_fields,
+                        entry_float_type,
+                        reference_genome,
+                        contig_recoding,
+                        array_elements_required,
+                        skip_invalid_loci,
+                        filter,
+                        find_replace,
+                        _external_sample_ids,
+                        _external_header)
 
 
 @typecheck(path=oneof(str, sequenceof(str)),

--- a/hail/python/scripts/drive_combiner.py
+++ b/hail/python/scripts/drive_combiner.py
@@ -18,7 +18,7 @@ def chunks(seq, size):
 def h(paths, sample_names, tmp_path, json, header, out_path, i, first):
     """inner part of stage one, including transformation from a gvcf into the combiner's format"""
     vcfs = [comb.transform_one(vcf)
-            for vcf in hl.import_vcfs(paths, json, array_elements_required=False,
+            for vcf in hl.import_gvcfs(paths, json, array_elements_required=False,
                                       _external_header=header,
                                       _external_sample_ids=sample_names)]
     combined = [comb.combine_gvcfs(mts) for mts in chunks(vcfs, MAX_COMBINE_NUMBER)]

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -268,7 +268,7 @@ class VCFTests(unittest.TestCase):
         self.assertTrue(mt._same(mt2))
 
     @skip_unless_spark_backend()
-    def test_import_vcfs(self):
+    def test_import_gvcfs(self):
         path = resource('sample.vcf.bgz')
         parts = [
             hl.Interval(start=hl.Struct(locus=hl.Locus('20', 1)),
@@ -282,7 +282,7 @@ class VCFTests(unittest.TestCase):
                         includes_end=True)
         ]
         vcf1 = hl.import_vcf(path).key_rows_by('locus')
-        vcf2 = hl.import_vcfs([path], parts)[0]
+        vcf2 = hl.import_gvcfs([path], parts)[0]
         self.assertEqual(len(parts), vcf2.n_partitions())
         self.assertTrue(vcf1._same(vcf2))
 
@@ -301,7 +301,7 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(hl.filter_intervals(vcf2, interval_c).n_partitions(), 3)
 
     @skip_unless_spark_backend()
-    def test_import_vcfs_subset(self):
+    def test_import_gvcfs_subset(self):
         path = resource('sample.vcf.bgz')
         parts = [
             hl.Interval(start=hl.Struct(locus=hl.Locus('20', 13509136)),
@@ -309,7 +309,7 @@ class VCFTests(unittest.TestCase):
                         includes_end=True)
         ]
         vcf1 = hl.import_vcf(path).key_rows_by('locus')
-        vcf2 = hl.import_vcfs([path], parts)[0]
+        vcf2 = hl.import_gvcfs([path], parts)[0]
         interval = [hl.parse_locus_interval('[20:13509136-16493533]')]
         filter1 = hl.filter_intervals(vcf1, interval)
         self.assertTrue(vcf2._same(filter1))
@@ -346,7 +346,7 @@ class VCFTests(unittest.TestCase):
         ]
         int0 = hl.parse_locus_interval('[chr20:17821257-18708366]', reference_genome='GRCh38')
         int1 = hl.parse_locus_interval('[chr20:18708367-19776611]', reference_genome='GRCh38')
-        hg00096, hg00268 = hl.import_vcfs(paths, parts, reference_genome='GRCh38')
+        hg00096, hg00268 = hl.import_gvcfs(paths, parts, reference_genome='GRCh38')
         filt096 = hl.filter_intervals(hg00096, [int0])
         filt268 = hl.filter_intervals(hg00268, [int1])
         self.assertEqual(1, filt096.n_partitions())
@@ -375,7 +375,7 @@ class VCFTests(unittest.TestCase):
             MQ_DP=hl.null(hl.tint32),
             VarDP=hl.null(hl.tint32),
             QUALapprox=hl.null(hl.tint32))))
-                for mt in hl.import_vcfs(paths, parts, reference_genome='GRCh38',
+                for mt in hl.import_gvcfs(paths, parts, reference_genome='GRCh38',
                                          array_elements_required=False)]
         comb = combine_gvcfs(vcfs)
         self.assertEqual(len(parts), comb.n_partitions())


### PR DESCRIPTION
* Make old functions the passthroughs, not the newer functions
* Don't `@typecheck` the passthrough functions.