### PR TITLE
[hail][ndarray] Better PNDArray._toPretty

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -15,7 +15,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
 
   def _asIdent: String = s"ndarray_of_${elementType.asIdent}"
 
-  override def _toPretty = throw new NotImplementedError("Only _pretty should be called.")//s"NDArray[${if (elementType.required) "+" else ""}${elementType._toPretty},$nDims]"
+  override def _toPretty = throw new NotImplementedError("Only _pretty should be called.")
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
     sb.append("NDArray[")

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -15,7 +15,13 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
 
   def _asIdent: String = s"ndarray_of_${elementType.asIdent}"
 
-  override def _toPretty = s"NDArray[${if (elementType.required) "+" else ""}${elementType._toPretty},$nDims]"
+  override def _toPretty = throw new NotImplementedError("Only _pretty should be called.")//s"NDArray[${if (elementType.required) "+" else ""}${elementType._toPretty},$nDims]"
+
+  override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb.append("NDArray[")
+    elementType.pretty(sb, indent, compact)
+    sb.append(s",$nDims]")
+  }
 
   override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = throw new UnsupportedOperationException
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -14,7 +14,8 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
   assert(elementType.required, "elementType must be required")
 
   def _asIdent: String = s"ndarray_of_${elementType.asIdent}"
-  override def _toPretty = s"NDArray[$elementType,$nDims]"
+
+  override def _toPretty = s"NDArray[${if (elementType.required) "+" else ""}${elementType._toPretty},$nDims]"
 
   override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = throw new UnsupportedOperationException
 


### PR DESCRIPTION
The previous version was incorrect, could not be parsed by `IRParser.parsePType`, and so prevented me from calling `.show()` on a table containing an NDArray. Now I can call `show`, but the output is terrible, will fix that in a subsequent PR. 

Additionally, I was surprised that the `_toPretty` method on `PInt32` didn't handle the requiredness plus sign on its own, but didn't want to change it in case there was a reason it didn't. 