### PR TITLE
[batch2] remove /batch endpoint include_jobs param

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -14,7 +14,7 @@ from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \
 log = logging.getLogger('batch')
 
 
-async def batch_record_to_dict(record):
+def batch_record_to_dict(record):
     if record['n_failed'] > 0:
         state = 'failure'
     elif record['n_cancelled'] > 0:
@@ -59,7 +59,7 @@ WHERE id = %s AND NOT deleted AND callback IS NOT NULL AND
     try:
         async with aiohttp.ClientSession(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-            await session.post(callback, json=await batch_record_to_dict(record))
+            await session.post(callback, json=batch_record_to_dict(record))
             log.info(f'callback for batch {batch_id} successful')
     except Exception:
         log.exception(f'callback for batch {batch_id} failed, will not retry.')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -74,7 +74,7 @@ async def _get_batch_jobs(app, batch_id, user):
 
     record = await db.execute_and_fetchone(
         '''
-SELECT state FROM batches
+SELECT id FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''', (user, batch_id))
     if not record:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -74,7 +74,7 @@ async def _get_batch_jobs(app, batch_id, user):
 
     record = await db.execute_and_fetchone(
         '''
-SELECT status FROM batches
+SELECT state FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''', (user, batch_id))
     if not record:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -39,6 +39,7 @@ from . import schemas
 log = logging.getLogger('batch.front_end')
 
 REQUEST_TIME = pc.Summary('batch2_request_latency_seconds', 'Batch request latency in seconds', ['endpoint', 'verb'])
+REQUEST_TIME_GET_JOBS = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs', verb="GET")
 REQUEST_TIME_GET_JOB = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id', verb="GET")
 REQUEST_TIME_GET_JOB_STATUS = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id/status', verb="GET")
 REQUEST_TIME_GET_JOB_LOG = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id/log', verb="GET")
@@ -66,6 +67,36 @@ BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.75
 @routes.get('/healthcheck')
 async def get_healthcheck(request):  # pylint: disable=W0613
     return web.Response()
+
+
+async def _get_batch_jobs(app, batch_id, user):
+    db = app['db']
+
+    record = await db.execute_and_fetchone(
+        '''
+SELECT status FROM batches
+WHERE user = %s AND id = %s AND NOT deleted;
+''', (user, batch_id))
+    if not record:
+        raise web.HTTPNotFound()
+
+    jobs = [
+        job_record_to_dict(record)
+        async for record
+        in db.execute_and_fetchall(
+            'SELECT * FROM jobs WHERE batch_id = %s',
+            (batch_id,))
+    ]
+    return sorted(jobs, key=lambda j: j['job_id'])
+
+
+@routes.get('/api/v1alpha/batches/{batch_id}/jobs')
+@prom_async_time(REQUEST_TIME_GET_JOBS)
+@rest_authenticated_users_only
+async def get_jobs(request, userdata):
+    batch_id = int(request.match_info['batch_id'])
+    user = userdata['username']
+    return web.json_response(_get_batch_jobs(request.app, batch_id, user))
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
@@ -196,7 +227,7 @@ SELECT * FROM batches
 WHERE {" AND ".join(where_conditions)};
 '''
 
-    return [await batch_record_to_dict(db, record, include_jobs=False)
+    return [await batch_record_to_dict(record)
             async for record in db.execute_and_fetchall(sql, where_args)]
 
 
@@ -370,7 +401,7 @@ VALUES (%s, %s, %s)
     return web.json_response({'id': id})
 
 
-async def _get_batch(app, batch_id, user, include_jobs):
+async def _get_batch(app, batch_id, user):
     db = app['db']
 
     record = await db.execute_and_fetchone(
@@ -380,7 +411,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
 ''', (user, batch_id))
     if not record:
         raise web.HTTPNotFound()
-    return await batch_record_to_dict(db, record, include_jobs=include_jobs)
+
+    return await batch_record_to_dict(record)
 
 
 async def _cancel_batch(app, batch_id, user):
@@ -416,9 +448,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
-    params = request.query
-    include_jobs = params.get('include_jobs') == '1'
-    return web.json_response(await _get_batch(request.app, batch_id, user, include_jobs))
+    return web.json_response(await _get_batch(request.app, batch_id, user))
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
@@ -515,10 +545,13 @@ WHERE user = %s AND id = %s AND NOT deleted;
 @prom_async_time(REQUEST_TIME_GET_BATCH_UI)
 @web_authenticated_users_only()
 async def ui_batch(request, userdata):
+    app = request.app
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
+    batch = await _get_batch(app, batch_id, user)
+    batch['jobs'] = _get_batch_jobs(app, batch_id, user)
     page_context = {
-        'batch': await _get_batch(request.app, batch_id, user, include_jobs=True)
+        'batch': batch
     }
     return await render_template('batch2', request, userdata, 'batch.html', page_context)
 

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -96,7 +96,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 async def get_jobs(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
-    return web.json_response(_get_batch_jobs(request.app, batch_id, user))
+    return web.json_response(await _get_batch_jobs(request.app, batch_id, user))
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
@@ -549,7 +549,7 @@ async def ui_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
     batch = await _get_batch(app, batch_id, user)
-    batch['jobs'] = _get_batch_jobs(app, batch_id, user)
+    batch['jobs'] = await _get_batch_jobs(app, batch_id, user)
     page_context = {
         'batch': batch
     }

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -227,7 +227,7 @@ SELECT * FROM batches
 WHERE {" AND ".join(where_conditions)};
 '''
 
-    return [await batch_record_to_dict(record)
+    return [batch_record_to_dict(record)
             async for record in db.execute_and_fetchall(sql, where_args)]
 
 
@@ -412,7 +412,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
     if not record:
         raise web.HTTPNotFound()
 
-    return await batch_record_to_dict(record)
+    return batch_record_to_dict(record)
 
 
 async def _cancel_batch(app, batch_id, user):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -123,9 +123,6 @@ class Job:
     async def log(self):
         return await self._job.log()
 
-    async def pod_status(self):
-        return await self._job.pod_status()
-
 
 class UnsubmittedJob:
     def _submit(self, batch):
@@ -172,9 +169,6 @@ class UnsubmittedJob:
 
     async def log(self):
         raise ValueError("cannot get the log of an unsubmitted job")
-
-    async def pod_status(self):
-        raise ValueError("cannot get the pod status of an unsubmitted job")
 
 
 class SubmittedJob:
@@ -225,10 +219,6 @@ class SubmittedJob:
         resp = await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/log')
         return await resp.json()
 
-    async def pod_status(self):
-        resp = await self._batch._client._get(f'/api/v1alpha/batches/{self.batch_id}/jobs/{self.job_id}/pod_status')
-        return await resp.json()
-
 
 class Batch:
     def __init__(self, client, id, attributes):
@@ -240,12 +230,13 @@ class Batch:
         await self._client._patch(f'/api/v1alpha/batches/{self.id}/cancel')
 
     async def status(self, include_jobs=True):
+        resp = await self._client._get(f'/api/v1alpha/batches/{self.id}')
+        batch = await resp.json()
         if include_jobs:
-            params = {'include_jobs': '1'}
-        else:
-            params = None
-        resp = await self._client._get(f'/api/v1alpha/batches/{self.id}', params=params)
-        return await resp.json()
+            resp = await self._client._get(f'/api/v1alpha/batches/{self.id}/jobs')
+            jobs = await resp.json()
+            batch['jobs'] = jobs['jobs']
+        reutrn batch
 
     async def wait(self):
         i = 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -236,7 +236,7 @@ class Batch:
             resp = await self._client._get(f'/api/v1alpha/batches/{self.id}/jobs')
             jobs = await resp.json()
             batch['jobs'] = jobs
-        reutrn batch
+        return batch
 
     async def wait(self):
         i = 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -235,7 +235,7 @@ class Batch:
         if include_jobs:
             resp = await self._client._get(f'/api/v1alpha/batches/{self.id}/jobs')
             jobs = await resp.json()
-            batch['jobs'] = jobs['jobs']
+            batch['jobs'] = jobs
         reutrn batch
 
     async def wait(self):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -65,9 +65,6 @@ class Job:
     def log(self):
         return async_to_blocking(self._async_job.log())
 
-    def pod_status(self):
-        return async_to_blocking(self._async_job.pod_status())
-
 
 class Batch:
     @classmethod


### PR DESCRIPTION
First of a few PRs cleaning up the batch2 API.  Goal is to remove the legacy job spec (now that batch1 is gone) and all endpoints that return multiple items (/batches, /jobs) need to support pagination and search.