### PR TITLE
[hail] Disable currently-invalid simplify rule

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -208,7 +208,7 @@ class SimplifySuite extends HailSuite {
     }
   }
 
-  @Test def testFilterIntervalsKeyByToFilter() {
+  @Test(enabled = false) def testFilterIntervalsKeyByToFilter() {
     var t: TableIR = TableRange(100, 10)
     t = TableMapRows(t, InsertFields(Ref("row", t.typ.rowType), FastSeq(("x", I32(1) - GetField(Ref("row", t.typ.rowType), "idx")))))
     t = TableKeyBy(t, FastIndexedSeq("x"))


### PR DESCRIPTION
This is invalid because our system currently doesn't know how to handle intervals of structs that are shorter than the full type.