### PR TITLE
Showing ndarrays is no longer useless

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -492,3 +492,10 @@ def test_ndarray_mixed():
         (hl._nd.zeros((5, 10)).map(lambda x: x - 2) +
          hl._nd.ones((5, 10)).map(lambda x: x + 5)).reshape(hl.null(hl.ttuple(hl.tint64, hl.tint64))).T.reshape((10, 5))) is None
     assert hl.eval(hl.or_missing(False, hl._ndarray(np.arange(10)).reshape((5,2)).map(lambda x: x * 2)).map(lambda y: y * 2)) is None
+
+@skip_unless_spark_backend()
+def test_ndarray_show():
+    hl._nd.array(3).show()
+    hl._nd.arange(6).show()
+    hl._nd.arange(6).reshape((2, 3)).show()
+    hl._nd.arange(8).reshape((2, 2, 2)).show()

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.types.virtual
 
-import is.hail.annotations.ExtendedOrdering
-import is.hail.expr.{NatBase, Nat}
+import is.hail.annotations.{Annotation, ExtendedOrdering, UnsafeIndexedSeq}
+import is.hail.expr.{Nat, NatBase}
 import is.hail.expr.types.physical.PNDArray
 import org.apache.spark.sql.Row
 
@@ -43,6 +43,38 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase, override val re
     sb.append(",")
     sb.append(nDims)
     sb.append("]")
+  }
+
+  override def str(a: Annotation): String = {
+    if (a == null) "NA" else {
+      val a_row = a.asInstanceOf[Row]
+      val shape = a_row(2).asInstanceOf[Row].toSeq.asInstanceOf[Seq[Long]].map(_.toInt)
+      val data = a_row(4).asInstanceOf[UnsafeIndexedSeq]
+
+      def dataToNestedString(data: Iterator[Annotation], shape: Seq[Int], sb: StringBuilder):Unit  = {
+        if (shape.isEmpty) {
+          sb.append(data.next().toString)
+        }
+        else {
+          sb.append("[")
+          val howMany = shape.head
+          (0 until howMany).foreach{repeat =>
+            dataToNestedString(data, shape.tail, sb)
+            if (repeat != howMany - 1) {
+              sb.append(", ")
+            }
+          }
+          sb.append("]")
+        }
+      }
+
+      val stringBuilder = new StringBuilder("")
+      dataToNestedString(data.iterator, shape, stringBuilder)
+      val prettyData = stringBuilder.result()
+      val prettyShape = "(" + shape.mkString(", ") + ")"
+
+      s"ndarray{shape=${prettyShape}, data=${prettyData}}"
+    }
   }
 
   override def unify(concrete: Type): Boolean = {

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -58,11 +58,13 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase, override val re
         else {
           sb.append("[")
           val howMany = shape.head
-          (0 until howMany).foreach{repeat =>
+          var repeat = 0
+          while (repeat < howMany) {
             dataToNestedString(data, shape.tail, sb)
             if (repeat != howMany - 1) {
               sb.append(", ")
             }
+            repeat += 1
           }
           sb.append("]")
         }


### PR DESCRIPTION
I wasn't sure what this should look like. For now it does this, would be open to suggestions on how it should look. Currently the tests just test that it doesn't crash, if you're good with how this output looks I'll figure out how to test the output.

Some examples:

Boring case with 0 dimensional ndarrays
```
t = hl.utils.range_table(6)
t = t.annotate(a = hl._nd.array(t.idx))
t.show()
+-------+---------------------------+
|   idx | a                         |
+-------+---------------------------+
| int32 | ndarray<int32, 0>         |
+-------+---------------------------+
|     0 | ndarray{shape=(), data=0} |
|     1 | ndarray{shape=(), data=1} |
|     2 | ndarray{shape=(), data=2} |
|     3 | ndarray{shape=(), data=3} |
|     4 | ndarray{shape=(), data=4} |
|     5 | ndarray{shape=(), data=5} |
+-------+---------------------------+
```

Less boring case with 1d ndarrays of length `idx`

```
t = hl.utils.range_table(6)
t = t.annotate(a = hl._nd.arange(t.idx))
t.show()
+-------+------------------------------------------+
|   idx | a                                        |
+-------+------------------------------------------+
| int32 | ndarray<int32, 1>                        |
+-------+------------------------------------------+
|     0 | ndarray{shape=(0), data=[]}              |
|     1 | ndarray{shape=(1), data=[0]}             |
|     2 | ndarray{shape=(2), data=[0, 1]}          |
|     3 | ndarray{shape=(3), data=[0, 1, 2]}       |
|     4 | ndarray{shape=(4), data=[0, 1, 2, 3]}    |
|     5 | ndarray{shape=(5), data=[0, 1, 2, 3, 4]} |
+-------+------------------------------------------+
```

Now, 2 dimensional:

```
t = hl.utils.range_table(6)
t = t.annotate(a = hl._nd.arange(t.idx).reshape((3, 2)))
t.show()
+-------+------------------------------------------------------+
|   idx | a                                                    |
+-------+------------------------------------------------------+
| int32 | ndarray<int32, 2>                                    |
+-------+------------------------------------------------------+
|     0 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
|     1 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
|     2 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
|     3 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
|     4 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
|     5 | ndarray{shape=(3, 2), data=[[0, 1], [2, 3], [4, 5]]} |
+-------+------------------------------------------------------+
```
