### PR TITLE
[batch2] fix delete_instances build step

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1067,7 +1067,7 @@ steps:
      gcloud -q compute instances list \
          --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \
          --format="value(name)" \
-       | xargs -r gcloud -q compute instances delete --zone {{ global.zone }}
+       | xargs -r gcloud -q compute instances delete --zone {{ global.zone }} --project {{ global.project }}
    secrets:
     - name: test-gsa-key
       namespace:


### PR DESCRIPTION
Fixes this problem:

```
+ xargs -r gcloud -q compute instances delete --zone
ERROR: (gcloud.compute.instances.list) The required property [project] is not currently set.
You may set it for your current workspace by running:

  $ gcloud config set project VALUE

or it can be set temporarily by the environment variable [CLOUDSDK_CORE_PROJECT]
```