### PR TITLE
[batch2] fix status if error occurred when getting the job config

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -316,7 +316,7 @@ async def schedule_job(app, record, instance):
             'user': record['user'],
             'state': 'error',
             'error': traceback.format_exc(),
-            'container_statuses': None
+            'container_statuses': {k: {} for k in tasks}
         }
         await mark_job_complete(app, batch_id, job_id, 'Error', status)
         return


### PR DESCRIPTION
The other option to fix this was to make `job_record_to_dict` have an extra layer of getopt everywhere, so I thought this was simpler.