### PR TITLE
[hail][ndarray] Make NDArrays serializable

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1344,3 +1344,11 @@ def test_join_distinct_preserves_count():
     n_defined_2, keys_2 = joined_2.aggregate((hl.agg.count_where(hl.is_defined(joined_2.r)), hl.agg.collect(joined_2.i)))
     assert n_defined_2 == 0
     assert keys_2 == left_pos
+
+def test_write_table_containing_ndarray():
+    t = hl.utils.range_table(5)
+    t = t.annotate(n = hl._nd.arange(t.idx))
+    f = new_temp_file(suffix='ht')
+    t.write(f)
+    t2 = hl.read_table(f)
+    assert t._same(t2)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -25,21 +25,21 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
 
   override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = throw new UnsupportedOperationException
 
-  val flags = new StaticallyKnownField(PInt32Required, (r, off) => Region.loadInt(representation.loadField(r, off, "flags")))
-  val offset = new StaticallyKnownField(
+  @transient lazy val flags = new StaticallyKnownField(PInt32Required, (r, off) => Region.loadInt(representation.loadField(r, off, "flags")))
+  @transient lazy val offset = new StaticallyKnownField(
     PInt32Required,
     (r, off) => Region.loadInt(representation.loadField(r, off, "offset"))
   )
-  val shape = new StaticallyKnownField(
+  @transient lazy val shape = new StaticallyKnownField(
     PTuple(true, Array.tabulate(nDims)(_ => PInt64Required):_*),
     (r, off) => representation.loadField(r, off, "shape")
   )
-  val strides = new StaticallyKnownField(
+  @transient lazy val strides = new StaticallyKnownField(
     PTuple(true, Array.tabulate(nDims)(_ => PInt64Required):_*),
     (r, off) => representation.loadField(r, off, "strides")
   )
 
-  val data = new StaticallyKnownField(
+  @transient lazy val data = new StaticallyKnownField(
     PArray(elementType, required = true),
     (r, off) => representation.loadField(r, off, "data")
   )


### PR DESCRIPTION
Fixes #7532. Previously, could not write a table containing an NDArray because `StaticallyKnownField` is not serializable. There's no reason to serialize that thing though, so I made it transient lazy. 