### PR TITLE
Table show works with no row fields

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1292,6 +1292,8 @@ class Table(ExprContainer):
             column_blocks.append((start, i))
 
             def format_hline(widths):
+                if not widths:
+                    return "++\n"
                 return '+-' + '-+-'.join(['-' * w for w in widths]) + '-+\n'
 
             def pad(v, w, ra):
@@ -1302,6 +1304,8 @@ class Table(ExprContainer):
                     return v + ' ' * e
 
             def format_line(values, widths, right_align):
+                if not values:
+                    return "||\n"
                 values = map(pad, values, widths, right_align)
                 return '| ' + ' | '.join(values) + ' |\n'
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1281,15 +1281,14 @@ class Table(ExprContainer):
             column_blocks = []
             start = 0
             i = 1
-            w = column_width[0] + 4
-            while i < len(fields):
+            w = column_width[0] + 4 if column_width else 0
+            while i < n_fields:
                 w = w + column_width[i] + 3
                 if w > self.width:
                     column_blocks.append((start, i))
                     start = i
                     w = column_width[i] + 4
                 i = i + 1
-            assert i == n_fields
             column_blocks.append((start, i))
 
             def format_hline(widths):

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1088,6 +1088,9 @@ class Tests(unittest.TestCase):
     def test_empty_show(self):
         hl.utils.range_table(1).filter(False).show()
 
+    def test_no_row_fields_show(self):
+        hl.utils.range_table(5).key_by().select().show()
+
     def test_same_equal(self):
         t1 = hl.utils.range_table(1)
         self.assertTrue(t1._same(t1))


### PR DESCRIPTION
Fixes #7545. I opted to just make it print a degenerate table that looks like:

```
++
||
++
||
++
||
||
||
||
||
++
```

Admittedly I just sort of added special cases for empty list where necessary as opposed to trying to reword it to more naturally handle empty lists. 