### PR TITLE
[hail] clean up BlockMatrixMap IRs, delegate optimization of broadcasting for scalars to Simplify pass

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -5,6 +5,7 @@ from hail.ir import BlockMatrixIR, IR
 from hail.ir.blockmatrix_reader import BlockMatrixReader
 from hail.ir import BlockMatrixIR, IR, tarray, Renderer
 from hail.typecheck import typecheck_method, sequenceof, sized_tupleof, oneof
+from hail.utils.misc import escape_id
 
 from typing import List
 
@@ -28,8 +29,9 @@ class BlockMatrixRead(BlockMatrixIR):
 
 
 class BlockMatrixMap(BlockMatrixIR):
-    @typecheck_method(child=BlockMatrixIR, f=IR)
-    def __init__(self, child, f):
+    @typecheck_method(child=BlockMatrixIR, name=str, f=IR)
+    def __init__(self, child, name, f):
+        super().__init__(child, f)
         super().__init__(child, name, f)
         self.child = child
         self.name = name
@@ -53,9 +55,9 @@ class BlockMatrixMap(BlockMatrixIR):
 
 
 class BlockMatrixMap2(BlockMatrixIR):
-    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, f=IR)
-    def __init__(self, left, right, f):
-        super().__init__(left, right, left_name, right_name, f)
+    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, left_name=str, right_name=str, f=IR)
+    def __init__(self, left, right, left_name, right_name, f):
+        super().__init__(left, right, f)
         self.left = left
         self.right = right
         self.left_name = left_name

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -79,12 +79,12 @@ class BlockMatrixMap2(BlockMatrixIR):
                 r_value = self.right.typ.element_type
             else:
                 (l_value, r_value) = (default_value, default_value)
-            return {'l': l_value, 'r': r_value}
+            return {self.left_name: l_value, self.right_name: r_value}
         else:
             return {}
 
     def binds(self, i):
-        return {'l', 'r'} if i == 2 else {}
+        return {self.left_name, self.right_name} if i == 2 else {}
 
 
 class BlockMatrixDot(BlockMatrixIR):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -32,7 +32,6 @@ class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, name=str, f=IR)
     def __init__(self, child, name, f):
         super().__init__(child, f)
-        super().__init__(child, name, f)
         self.child = child
         self.name = name
         self.f = f

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -30,35 +30,45 @@ class BlockMatrixRead(BlockMatrixIR):
 class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, f=IR)
     def __init__(self, child, f):
-        super().__init__(child, f)
+        super().__init__(child, name, f)
         self.child = child
+        self.name = name
         self.f = f
 
     def _compute_type(self):
         self._type = self.child.typ
 
+    def head_str(self):
+        return escape_id(self.name)
+
     def bindings(self, i: int, default_value=None):
         if i == 1:
             value = self.child.typ.element_type if default_value is None else default_value
-            return {'element': value}
+            return {self.name: value}
         else:
             return {}
 
     def binds(self, i):
-        return {'element'} if i == 1 else {}
+        return {self.name} if i == 1 else {}
 
 
 class BlockMatrixMap2(BlockMatrixIR):
     @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, f=IR)
     def __init__(self, left, right, f):
-        super().__init__(left, right, f)
+        super().__init__(left, right, left_name, right_name, f)
         self.left = left
         self.right = right
+        self.left_name = left_name
+        self.right_name = right_name
         self.f = f
 
     def _compute_type(self):
         self.right.typ  # Force
         self._type = self.left.typ
+
+
+    def head_str(self):
+        return escape_id(self.left_name) + " " + escape_id(self.right_name)
 
     def bindings(self, i: int, default_value=None):
         if i == 2:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -7,7 +7,7 @@ import scipy.linalg as spla
 
 import hail as hl
 import hail.expr.aggregators as agg
-from hail.expr import construct_expr
+from hail.expr import construct_expr, construct_variable
 from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
 from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
@@ -1289,12 +1289,12 @@ class BlockMatrix(object):
     def _binary_op(op):
         return lambda l, r: construct_expr(ApplyBinaryPrimOp(op, l._ir, r._ir), hl.tfloat64)
 
-    @typecheck_method(f=func_spec(1, expr_numeric))
+    @typecheck_method(f=func_spec(1, expr_float64))
     def _apply_map(self, f):
         uid = Env.get_uid()
         return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir))
 
-    @typecheck_method(f=func_spec(2, expr_numeric),
+    @typecheck_method(f=func_spec(2, expr_float64),
                       other=oneof(numeric, np.ndarray, block_matrix_type),
                       reverse=bool)
     def _apply_map2(self, f, other, reverse=False):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1422,7 +1422,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(lambda l, r: l ** r, x)
+        return self._apply_map(lambda i: i ** x)
 
     def sqrt(self):
         """Element-wise square root.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1467,7 +1467,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.log)
+        return self._apply_map(lambda x: hl.log(x))
 
     def diagonal(self):
         """Extracts diagonal elements as a row vector.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1283,20 +1283,18 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(ApplyUnaryPrimOp('-', Ref('element')))
-
-    def _unary_func_ir(self, hail_func):
-        return hail_func(construct_expr(Ref('element'), self.element_type))._ir
+        return self._apply_map(lambda x: construct_expr(ApplyUnaryPrimOp('-', x._ir), hl.tfloat64))
 
     @staticmethod
-    def _binary_op_ir(op):
-        return ApplyBinaryPrimOp(op, Ref('l'), Ref('r'))
+    def _binary_op(op):
+        return lambda l, r: construct_expr(ApplyBinaryPrimOp(op, l._ir, r._ir), hl.tfloat64)
 
-    @typecheck_method(f=IR)
+    @typecheck_method(f=func_spec(1, expr_numeric))
     def _apply_map(self, f):
-        return BlockMatrix(BlockMatrixMap(self._bmir, f))
+        uid = Env.get_uid()
+        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir))
 
-    @typecheck_method(f=IR,
+    @typecheck_method(f=func_spec(2, expr_numeric),
                       other=oneof(numeric, np.ndarray, block_matrix_type),
                       reverse=bool)
     def _apply_map2(self, f, other, reverse=False):
@@ -1314,7 +1312,10 @@ class BlockMatrix(object):
         else:
             left, right = self_bmir, other_bmir
 
-        return BlockMatrix(BlockMatrixMap2(left, right, f))
+        lv = Env.get_uid()
+        rv = Env.get_uid()
+        f_ir = f(construct_variable(lv, hl.tfloat64), construct_variable(rv, hl.tfloat64))._ir
+        return BlockMatrix(BlockMatrixMap2(left, right, lv, rv, f_ir))
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __add__(self, b):
@@ -1328,7 +1329,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op_ir('+'), b)
+        return self._apply_map2(BlockMatrix._binary_op('+'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __sub__(self, b):
@@ -1342,7 +1343,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op_ir('-'), b)
+        return self._apply_map2(BlockMatrix._binary_op('-'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __mul__(self, b):
@@ -1356,7 +1357,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op_ir('*'), b)
+        return self._apply_map2(BlockMatrix._binary_op('*'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __truediv__(self, b):
@@ -1370,23 +1371,23 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op_ir('/'), b)
+        return self._apply_map2(BlockMatrix._binary_op('/'), b)
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op_ir('+'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('+'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rsub__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op_ir('-'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('-'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rmul__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op_ir('*'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('*'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rtruediv__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op_ir('/'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('/'), b, reverse=True)
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
     def __matmul__(self, b):
@@ -1421,8 +1422,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        pow_ir = (construct_expr(Ref('l'), self.element_type) ** construct_expr(Ref('r'), hl.tfloat64))._ir
-        return self._apply_map2(pow_ir, x)
+        return self._apply_map2(lambda l, r: l ** r, x)
 
     def sqrt(self):
         """Element-wise square root.
@@ -1431,7 +1431,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(self._unary_func_ir(hl.sqrt))
+        return self._apply_map(hl.sqrt)
 
     def ceil(self):
         """Element-wise ceiling.
@@ -1440,7 +1440,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(self._unary_func_ir(hl.ceil))
+        return self._apply_map(hl.ceil)
 
     def floor(self):
         """Element-wise floor.
@@ -1449,7 +1449,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(self._unary_func_ir(hl.floor))
+        return self._apply_map(hl.floor)
 
     def abs(self):
         """Element-wise absolute value.
@@ -1458,7 +1458,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(self._unary_func_ir(hl.abs))
+        return self._apply_map(hl.abs)
 
     def log(self):
         """Element-wise natural logarithm.
@@ -1467,7 +1467,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(self._unary_func_ir(hl.log))
+        return self._apply_map(hl.log)
 
     def diagonal(self):
         """Extracts diagonal elements as a row vector.

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -289,9 +289,9 @@ class BlockMatrixIRTests(unittest.TestCase):
         vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
-        add_two_bms = ir.BlockMatrixMap2(read, read, ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')))
-        negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryPrimOp('-', ir.Ref('element')))
-        sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
+        add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')))
+        negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')))
+        sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
@@ -303,7 +303,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         matmul = ir.BlockMatrixDot(broadcast_scalar, transpose)
 
         pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir
-        squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, pow_ir)
+        squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, 'l', 'r', pow_ir)
         slice_bm = ir.BlockMatrixSlice(matmul, [slice(0, 2, 1), slice(0, 1, 1)])
 
         return [

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -50,8 +50,8 @@ object Bindings {
     case MatrixMapGlobals(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case MatrixAggregateColsByKey(child, _, _) => if (i == 1) child.typ.rowEnv.m else if (i == 2) child.typ.globalEnv.m else empty
     case MatrixAggregateRowsByKey(child, _, _) => if (i == 1) child.typ.colEnv.m else if (i == 2) child.typ.globalEnv.m else empty
-    case BlockMatrixMap(_, _) => if (i == 1) Array("element" -> TFloat64()) else empty
-    case BlockMatrixMap2(_, _, _) => if (i == 2) Array("l" -> TFloat64(), "r" -> TFloat64()) else empty
+    case BlockMatrixMap(_, eltName, _) => if (i == 1) Array(eltName -> TFloat64()) else empty
+    case BlockMatrixMap2(_, _, lName, rName, _) => if (i == 2) Array(lName -> TFloat64(), rName -> TFloat64()) else empty
     case _ => empty
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -62,8 +62,7 @@ abstract sealed class BlockMatrixIR extends BaseIR {
 
   def pyExecute(): BlockMatrix = {
     ExecuteContext.scoped { ctx =>
-      val opt = Optimize.optimize(this, noisy = true, context = "BlockMatrixIR", ctx = Some(ctx))
-      opt.asInstanceOf[BlockMatrixIR].execute(ctx)
+      Interpret(this, ctx, optimize = true)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -154,11 +154,11 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR) extends 
 
   override lazy val typ: BlockMatrixType = child.typ
 
-  lazy val children: IndexedSeq[BaseIR] = Array(child)
+  lazy val children: IndexedSeq[BaseIR] = Array(child, f)
 
   def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap = {
-    assert(newChildren.length == 1)
-    BlockMatrixMap(newChildren(0).asInstanceOf[BlockMatrixIR], eltName, f)
+    val IndexedSeq(newChild: BlockMatrixIR, newF: IR) = newChildren
+    BlockMatrixMap(newChild, eltName, newF)
   }
 
   val blockCostIsLinear: Boolean = child.blockCostIsLinear
@@ -212,8 +212,8 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR) extends 
 
     if (reqDense)
       prev.densify().blockMap(breezeF, name, reqDense = true)
-
-    prev.blockMap(breezeF, name, reqDense = false)
+    else
+      prev.blockMap(breezeF, name, reqDense = false)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -308,11 +308,6 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
       case ApplyBinaryPrimOp(Multiply(), _, _) => left.mul(right)
       case ApplyBinaryPrimOp(Subtract(), _, _) => left.sub(right)
       case ApplyBinaryPrimOp(FloatingPointDivide(), _, _) => left.div(right)
-      case Apply("**", _, _) =>
-        assert(right.nRows == 1 && right.nCols == 1)
-        // BlockMatrix does not currently support elem-wise pow and this case would
-        // only get hit when left and right are both 1x1
-        left.pow(right.getElement(row = 0, col = 0))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -58,7 +58,12 @@ object BlockMatrixIR {
 abstract sealed class BlockMatrixIR extends BaseIR {
   def typ: BlockMatrixType
 
-  def pyExecute(): BlockMatrix = ExecuteContext.scoped(execute)
+  def pyExecute(): BlockMatrix = {
+    ExecuteContext.scoped { ctx =>
+      val opt = Optimize.optimize(this, noisy = true, context = "Lowerer, initial IR", ctx = Some(ctx))
+      opt.execute(ctx)
+    }
+  }
 
   protected[ir] def execute(ctx: ExecuteContext): BlockMatrix =
     fatal("tried to execute unexecutable IR:\n" + Pretty(this))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -237,11 +237,11 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
 
   override protected[ir] def execute(ctx: ExecuteContext): BlockMatrix = {
     left match {
-      case BlockMatrixBroadcast(vectorIR: BlockMatrixIR,inIndexExpr, _, _) =>
+      case BlockMatrixBroadcast(vectorIR: BlockMatrixIR, IndexedSeq(x), _, _) =>
         val vector = coerceToVector(ctx , vectorIR)
-        inIndexExpr match {
-          case IndexedSeq(1) => rowVectorOnLeft(ctx, vector, right, f)
-          case IndexedSeq(0) => colVectorOnLeft(ctx, vector, right, f)
+        x match {
+          case 1 => rowVectorOnLeft(ctx, vector, right, f)
+          case 0 => colVectorOnLeft(ctx, vector, right, f)
         }
       case _ =>
         matrixOnLeft(ctx, left.execute(ctx), right, f)
@@ -256,12 +256,12 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
 
   private def matrixOnLeft(ctx: ExecuteContext, matrix: BlockMatrix, right: BlockMatrixIR, f: IR): BlockMatrix = {
     right match {
-      case BlockMatrixBroadcast(vectorIR, inIndexExpr, _, _) =>
-        inIndexExpr match {
-          case IndexedSeq(1) =>
+      case BlockMatrixBroadcast(vectorIR, IndexedSeq(x), _, _) =>
+        x match {
+          case 1 =>
             val rightAsRowVec = coerceToVector(ctx, vectorIR)
             opWithRowVector(matrix, rightAsRowVec, f, reverse = false)
-          case IndexedSeq(0) =>
+          case 0 =>
             val rightAsColVec = coerceToVector(ctx, vectorIR)
             opWithColVector(matrix, rightAsColVec, f, reverse = false)
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -8,6 +8,7 @@ import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.types.physical.{PTuple, PType}
 import is.hail.expr.types.virtual._
 import is.hail.io.BufferSpec
+import is.hail.linalg.BlockMatrix
 import is.hail.methods._
 import is.hail.rvd.RVDContext
 import is.hail.utils._
@@ -27,6 +28,11 @@ object Interpret {
 
   def apply(mir: MatrixIR, ctx: ExecuteContext, optimize: Boolean): TableValue = {
     val lowered = LoweringPipeline.legacyRelationalLowerer(ctx, mir, optimize).asInstanceOf[TableIR]
+    lowered.execute(ctx)
+  }
+
+  def apply(bmir: BlockMatrixIR, ctx: ExecuteContext, optimize: Boolean): BlockMatrix = {
+    val lowered = LoweringPipeline.legacyRelationalLowerer(ctx, bmir, optimize).asInstanceOf[BlockMatrixIR]
     lowered.execute(ctx)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -30,6 +30,13 @@ object LowerMatrixIR {
     ab.result().foldRight[TableIR](l1) { case ((ident, value), body) => RelationalLetTable(ident, value, body) }
   }
 
+  def apply(bmir: BlockMatrixIR): BlockMatrixIR = {
+    val ab = new ArrayBuilder[(String, IR)]
+
+    val l1 = lower(bmir, ab)
+    ab.result().foldRight[BlockMatrixIR](l1) { case ((ident, value), body) => RelationalLetBlockMatrix(ident, value, body) }
+  }
+
 
   private[this] def lowerChildren(ir: BaseIR, ab: ArrayBuilder[(String, IR)]): BaseIR = {
     val loweredChildren = ir.children.map {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1389,14 +1389,17 @@ object IRParser {
         val reader = deserialize[BlockMatrixReader](readerStr)
         BlockMatrixRead(reader)
       case "BlockMatrixMap" =>
+        val name = identifier(it)
         val child = blockmatrix_ir(env)(it)
-        val f = ir_value_expr(env + ("element" -> child.typ.elementType))(it)
-        BlockMatrixMap(child, f)
+        val f = ir_value_expr(env + (name -> child.typ.elementType))(it)
+        BlockMatrixMap(child, name, f)
       case "BlockMatrixMap2" =>
+        val lName = identifier(it)
+        val rName = identifier(it)
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)
-        val f = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
-        BlockMatrixMap2(left, right, f)
+        val f = ir_value_expr(env.update(Map(lName -> left.typ.elementType, rName -> right.typ.elementType)))(it)
+        BlockMatrixMap2(left, right, lName, rName, f)
       case "BlockMatrixDot" =>
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -308,6 +308,10 @@ object Pretty {
               prettyBooleanLiteral(gaussian) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " "
+            case BlockMatrixMap(_, name, _) =>
+              prettyIdentifier(name)
+            case BlockMatrixMap2(_, _, lName, rName, _) =>
+              prettyIdentifier(lName) + " " + prettyIdentifier(rName)
             case MatrixRowsHead(_, n) => n.toString
             case MatrixColsHead(_, n) => n.toString
             case MatrixRowsTail(_, n) => n.toString

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -513,7 +513,7 @@ object Simplify {
     } => query
 
     case BlockMatrixToValueApply(ValueToBlockMatrix(child, IndexedSeq(nrows, ncols), _), functions.GetElement(Seq(i, j))) =>
-      if (child.typ.isInstanceOf[TArray]) ArrayRef(child, i * ncols + j) else child
+      if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -512,6 +512,8 @@ object Simplify {
       canBeLifted(query)
     } => query
 
+    case BlockMatrixToValueApply(ValueToBlockMatrix(child, IndexedSeq(nrows, ncols), _), functions.GetElement(Seq(i, j))) =>
+      if (child.typ.isInstanceOf[TArray]) ArrayRef(child, i * ncols + j) else child
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {
@@ -882,8 +884,14 @@ object Simplify {
 
   private[this] def blockMatrixRules: PartialFunction[BlockMatrixIR, BlockMatrixIR] = {
     case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _) => child
-    case BlockMatrixSlice(BlockMatrixMap(child, f), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), f)
-    case BlockMatrixSlice(BlockMatrixMap2(l, r, f), slices) =>
-      BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), f)
+    case BlockMatrixSlice(BlockMatrixMap(child, n, f), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), n, f)
+    case BlockMatrixSlice(BlockMatrixMap2(l, r, ln, rn, f), slices) =>
+      BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f)
+    case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f) =>
+      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
+      BlockMatrixMap(right, rightName, Let(leftName, getElement, f))
+    case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f) =>
+      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
+      BlockMatrixMap(left, leftName, Let(rightName, getElement, f))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -889,9 +889,9 @@ object Simplify {
       BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f)
     case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(right, rightName, Let(leftName, getElement, f))
+      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)))
     case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(left, leftName, Let(rightName, getElement, f))
+      BlockMatrixMap(left, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir.{BaseIR, ExecuteContext, IR, InterpretNonCompilable, LowerMatrixIR, MatrixIR, TableIR}
+import is.hail.expr.ir.{BaseIR, BlockMatrixIR, ExecuteContext, IR, InterpretNonCompilable, LowerMatrixIR, MatrixIR, TableIR}
 
 trait LoweringPass {
   val before: IRState
@@ -28,6 +28,7 @@ case object LowerMatrixToTablePass extends LoweringPass {
     case x: IR => LowerMatrixIR(x)
     case x: TableIR => LowerMatrixIR(x)
     case x: MatrixIR => LowerMatrixIR(x)
+    case x: BlockMatrixIR => LowerMatrixIR(x)
   }
 }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -201,6 +201,10 @@ object BlockMatrix {
     }
   }
 
+  def negationOp: BDM[Double] => BDM[Double] = -_
+
+  def reverseScalarDiv(r: BDM[Double], l: Double): BDM[Double] = l /:/ r
+
   object ops {
 
     implicit class Shim(l: M) {

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -72,21 +72,18 @@ class BlockMatrixIRSuite extends HailSuite {
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
-      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 0),
-      FastIndexedSeq(), shape, 0)
+      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 4096),
+      FastIndexedSeq(), shape, 4096)
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
     val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply())
     val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide())
-    val twosPowTwo = BlockMatrixMap2(new BlockMatrixLiteral(twos), broadcastTwo, "l", "r",
-      Apply("**", FastIndexedSeq(Ref("l", TFloat64()), Ref("r", TFloat64())), TFloat64()))
 
     assertBmEq(onesAddTwo.execute(ctx), threes)
     assertBmEq(threesSubTwo.execute(ctx), ones)
     assertBmEq(twosMulTwo.execute(ctx), fours)
     assertBmEq(foursDivTwo.execute(ctx), twos)
-    assertBmEq(twosPowTwo.execute(ctx), fours)
   }
 
   @Test def testBlockMatrixBroadcastValue_Vectors() {

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -40,7 +40,7 @@ class BlockMatrixIRSuite extends HailSuite {
 
   def makeMap2(left: BlockMatrixIR, right: BlockMatrixIR,  op: BinaryOp):
   BlockMatrixMap2 = {
-    BlockMatrixMap2(left, right, ApplyBinaryPrimOp(op, Ref("l", TFloat64()), Ref("l", TFloat64())))
+    BlockMatrixMap2(left, right, "l", "r", ApplyBinaryPrimOp(op, Ref("l", TFloat64()), Ref("r", TFloat64())))
   }
 
   def assertBmEq(actual: BlockMatrix, expected: BlockMatrix) {
@@ -59,10 +59,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
+    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
+    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
+    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
+    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
 
     assertBmEq(sqrtFoursIR.execute(ctx), twos)
     assertBmEq(negFoursIR.execute(ctx), negFours)
@@ -79,7 +79,7 @@ class BlockMatrixIRSuite extends HailSuite {
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
     val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply())
     val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide())
-    val twosPowTwo = BlockMatrixMap2(new BlockMatrixLiteral(twos), broadcastTwo,
+    val twosPowTwo = BlockMatrixMap2(new BlockMatrixLiteral(twos), broadcastTwo, "l", "r",
       Apply("**", FastIndexedSeq(Ref("l", TFloat64()), Ref("r", TFloat64())), TFloat64()))
 
     assertBmEq(onesAddTwo.execute(ctx), threes)


### PR DESCRIPTION
The main goal of this PR was to remove some of the vector/scalar logic from the BlockMatrixMap2 node, and to support the scalar operations on BlockMatrixMap. I basically accomplished this by taking the cases that are matched on in BlockMatrixMap2 and lifting them into the Simplify rules.

The only endpoint that I believe I needed to cover was the BlockMatrix.pyExecute() one; all the others will go through the usual CompileAndEvaluate.

There's another part of the PR that fixes the variable bindings, which are currently hard-coded and unchecked. I needed this to construct the right expressions for the IR expressions, so I changed it to handle variable bindings with the rest of our IR.