### PR TITLE
Cheatsheets page with a link to the download

### DIFF
--- a/hail/python/hail/docs/cheatsheets.rst
+++ b/hail/python/hail/docs/cheatsheets.rst
@@ -1,0 +1,12 @@
+.. _sec-cheatsheets:
+
+=============
+Cheatsheets
+=============
+
+.. note::
+    Hail's cheatsheets are in their early stages. We welcome suggestions
+    for additional cheatsheets, as well as feedback about our documentation. If
+    you'd like to add a cheatsheet to the documentation, make a pull request!
+
+`Hail Tables Cheatsheet <https://github.com/hail-is/hail/raw/master/hail/cheatsheets/hail_tables_cheat_sheet.pdf>`_

--- a/hail/python/hail/docs/index.rst
+++ b/hail/python/hail/docs/index.rst
@@ -24,6 +24,7 @@ Contents
     Datasets <datasets>
     Annotation Database <annotation_database_ui>
     How-To Guides <guides>
+    Cheatsheets <cheatsheets>
     For Software Developers <getting_started_developing>
     Other Resources <other_resources>
     Change Log <change_log>


### PR DESCRIPTION
I added a cheatsheets page to the docs. It has a link to the single current cheat sheet. I just used the fact that it's already on github to create a download link, if that's bad practice I'm happy to do something else. 