### PR TITLE
[hail] introduce keep_sparsity flag for unary operations

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -29,18 +29,19 @@ class BlockMatrixRead(BlockMatrixIR):
 
 
 class BlockMatrixMap(BlockMatrixIR):
-    @typecheck_method(child=BlockMatrixIR, name=str, f=IR)
-    def __init__(self, child, name, f):
+    @typecheck_method(child=BlockMatrixIR, name=str, f=IR, keep_sparsity=bool)
+    def __init__(self, child, name, f, keep_sparsity):
         super().__init__(child, f)
         self.child = child
         self.name = name
         self.f = f
+        self.keep_sparsity = keep_sparsity
 
     def _compute_type(self):
         self._type = self.child.typ
 
     def head_str(self):
-        return escape_id(self.name)
+        return escape_id(self.name) + " " + str(self.keep_sparsity)
 
     def bindings(self, i: int, default_value=None):
         if i == 1:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1289,10 +1289,10 @@ class BlockMatrix(object):
     def _binary_op(op):
         return lambda l, r: construct_expr(ApplyBinaryPrimOp(op, l._ir, r._ir), hl.tfloat64)
 
-    @typecheck_method(f=func_spec(1, expr_float64))
-    def _apply_map(self, f):
+    @typecheck_method(f=func_spec(1, expr_float64), keep_sparsity=bool)
+    def _apply_map(self, f, keep_sparsity = False):
         uid = Env.get_uid()
-        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir))
+        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir, keep_sparsity))
 
     @typecheck_method(f=func_spec(2, expr_float64),
                       other=oneof(numeric, np.ndarray, block_matrix_type),

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -50,7 +50,7 @@ object Bindings {
     case MatrixMapGlobals(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case MatrixAggregateColsByKey(child, _, _) => if (i == 1) child.typ.rowEnv.m else if (i == 2) child.typ.globalEnv.m else empty
     case MatrixAggregateRowsByKey(child, _, _) => if (i == 1) child.typ.colEnv.m else if (i == 2) child.typ.globalEnv.m else empty
-    case BlockMatrixMap(_, eltName, _) => if (i == 1) Array(eltName -> TFloat64()) else empty
+    case BlockMatrixMap(_, eltName, _, _) => if (i == 1) Array(eltName -> TFloat64()) else empty
     case BlockMatrixMap2(_, _, lName, rName, _) => if (i == 2) Array(lName -> TFloat64(), rName -> TFloat64()) else empty
     case _ => empty
   }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -149,7 +149,7 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
   val blockCostIsLinear: Boolean = true // not guaranteed
 }
 
-case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR) extends BlockMatrixIR {
+case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, keepSparsity: Boolean) extends BlockMatrixIR {
   assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply] || f.isInstanceOf[ApplyBinaryPrimOp])
 
   override lazy val typ: BlockMatrixType = child.typ
@@ -158,7 +158,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR) extends 
 
   def copy(newChildren: IndexedSeq[BaseIR]): BlockMatrixMap = {
     val IndexedSeq(newChild: BlockMatrixIR, newF: IR) = newChildren
-    BlockMatrixMap(newChild, eltName, newF)
+    BlockMatrixMap(newChild, eltName, newF, keepSparsity)
   }
 
   val blockCostIsLinear: Boolean = child.blockCostIsLinear
@@ -210,7 +210,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR) extends 
       case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(f)}")
     }
 
-    if (reqDense)
+    if ((!keepSparsity) && reqDense)
       prev.densify().blockMap(breezeF, name, reqDense = true)
     else
       prev.blockMap(breezeF, name, reqDense = false)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1390,9 +1390,10 @@ object IRParser {
         BlockMatrixRead(reader)
       case "BlockMatrixMap" =>
         val name = identifier(it)
+        val keepSparsity = boolean_literal(it)
         val child = blockmatrix_ir(env)(it)
         val f = ir_value_expr(env + (name -> child.typ.elementType))(it)
-        BlockMatrixMap(child, name, f)
+        BlockMatrixMap(child, name, f, keepSparsity)
       case "BlockMatrixMap2" =>
         val lName = identifier(it)
         val rName = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -308,8 +308,8 @@ object Pretty {
               prettyBooleanLiteral(gaussian) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " "
-            case BlockMatrixMap(_, name, _) =>
-              prettyIdentifier(name)
+            case BlockMatrixMap(_, name, _, keepSparsity) =>
+              prettyIdentifier(name) + " " + prettyBooleanLiteral(keepSparsity)
             case BlockMatrixMap2(_, _, lName, rName, _) =>
               prettyIdentifier(lName) + " " + prettyIdentifier(rName)
             case MatrixRowsHead(_, n) => n.toString

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -884,14 +884,14 @@ object Simplify {
 
   private[this] def blockMatrixRules: PartialFunction[BlockMatrixIR, BlockMatrixIR] = {
     case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _) => child
-    case BlockMatrixSlice(BlockMatrixMap(child, n, f), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), n, f)
+    case BlockMatrixSlice(BlockMatrixMap(child, n, f, keepSparsity), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), n, f, keepSparsity)
     case BlockMatrixSlice(BlockMatrixMap2(l, r, ln, rn, f), slices) =>
       BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f)
     case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)))
+      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)), keepSparsity = false)
     case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(left, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)))
+      BlockMatrixMap(left, leftName,  Subst(f, BindingEnv.eval(rightName -> getElement)), keepSparsity = false)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -59,10 +59,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
+    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), false)
+    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())), false)
+    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), false)
+    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), false)
 
     assertBmEq(sqrtFoursIR.execute(ctx), twos)
     assertBmEq(negFoursIR.execute(ctx), negFours)


### PR DESCRIPTION
This allows us to not forcibly densify when doing map operations that would otherwise densify, e.g. bm + 1. 

This behavior isn't exposed and I don't believe we want to expose it, since preserving the sparsity for functions where f(0) != 0 means we don't uniformly map all the elements of the matrix, but it can be useful in some cases.

One thing to be careful about is that this only preserves sparsity at the block level---if any elements have been zeroed out in blocks during a sparsify operation, those will be mapped as usual. (This is because we don't currently preserve information about which elements have been zeroed out due to a sparsify operation.) As an illustration, we'd see:

```
>>> bm = hl.linalg.BlockMatrix.fill(12, 12, 7, 3)
>>> bm = bm.sparsify_band(-1, 1)
>>> bm.to_numpy()
array([[7., 7., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
       [7., 7., 7., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
       [0., 7., 7., 7., 0., 0., 0., 0., 0., 0., 0., 0.],
       [0., 0., 7., 7., 7., 0., 0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 7., 7., 7., 0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 7., 7., 7., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0., 7., 7., 7., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0., 0., 7., 7., 7., 0., 0., 0.],
       [0., 0., 0., 0., 0., 0., 0., 7., 7., 7., 0., 0.],
       [0., 0., 0., 0., 0., 0., 0., 0., 7., 7., 7., 0.],
       [0., 0., 0., 0., 0., 0., 0., 0., 0., 7., 7., 7.],
       [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 7., 7.]])
>>> bm._apply_map(lambda i: i + 1).to_numpy()
array([[8., 8., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
       [8., 8., 8., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
       [1., 8., 8., 8., 1., 1., 1., 1., 1., 1., 1., 1.],
       [1., 1., 8., 8., 8., 1., 1., 1., 1., 1., 1., 1.],
       [1., 1., 1., 8., 8., 8., 1., 1., 1., 1., 1., 1.],
       [1., 1., 1., 1., 8., 8., 8., 1., 1., 1., 1., 1.],
       [1., 1., 1., 1., 1., 8., 8., 8., 1., 1., 1., 1.],
       [1., 1., 1., 1., 1., 1., 8., 8., 8., 1., 1., 1.],
       [1., 1., 1., 1., 1., 1., 1., 8., 8., 8., 1., 1.],
       [1., 1., 1., 1., 1., 1., 1., 1., 8., 8., 8., 1.],
       [1., 1., 1., 1., 1., 1., 1., 1., 1., 8., 8., 8.],
       [1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 8., 8.]])
>>> bm._apply_map(lambda i: i + 1, keep_sparsity=True).to_numpy()
array([[8., 8., 1., 1., 1., 1., 0., 0., 0., 0., 0., 0.],
       [8., 8., 8., 1., 1., 1., 0., 0., 0., 0., 0., 0.],
       [1., 8., 8., 8., 1., 1., 0., 0., 0., 0., 0., 0.],
       [1., 1., 8., 8., 8., 1., 1., 1., 1., 0., 0., 0.],
       [1., 1., 1., 8., 8., 8., 1., 1., 1., 0., 0., 0.],
       [1., 1., 1., 1., 8., 8., 8., 1., 1., 0., 0., 0.],
       [0., 0., 0., 1., 1., 8., 8., 8., 1., 1., 1., 1.],
       [0., 0., 0., 1., 1., 1., 8., 8., 8., 1., 1., 1.],
       [0., 0., 0., 1., 1., 1., 1., 8., 8., 8., 1., 1.],
       [0., 0., 0., 0., 0., 0., 1., 1., 8., 8., 8., 1.],
       [0., 0., 0., 0., 0., 0., 1., 1., 1., 8., 8., 8.],
       [0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 8., 8.]])
```
cc @konradjk 