### PR TITLE
[hail] Rename `MatrixTable.scala` and move to `is.hail.expr.ir`

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -1,22 +1,14 @@
-package is.hail.variant
+package is.hail.expr.ir
 
+import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.check.Gen
-import is.hail.expr.ir
-import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.expr.types.physical.{PArray, PStruct}
+import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.rvd._
-import is.hail.sparkextras.ContextRDD
-import is.hail.table.{AbstractTableSpec, Table, TableSpec}
+import is.hail.table.{AbstractTableSpec, TableSpec}
 import is.hail.utils._
-import is.hail.{HailContext, utils}
-import is.hail.io.fs.FS
-import org.apache.hadoop
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
+import is.hail.variant.ReferenceGenome
 import org.json4s._
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.Serialization

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -5,7 +5,6 @@ import is.hail.expr.ir.functions.RelationalFunctions
 import is.hail.expr.types.virtual.{TArray, TInterval}
 import is.hail.table.Ascending
 import is.hail.utils._
-import is.hail.variant.RelationalSpec
 import org.json4s.jackson.{JsonMethods, Serialization}
 
 object Pretty {

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -11,7 +11,7 @@ import is.hail.rvd.{AbstractRVDSpec, RVD, RVDContext, RVDType}
 import is.hail.sparkextras.ContextRDD
 import is.hail.table.TableSpec
 import is.hail.utils._
-import is.hail.variant.{FileFormat, PartitionCountsComponentSpec, RVDComponentSpec, ReferenceGenome}
+import is.hail.variant.ReferenceGenome
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -1,12 +1,11 @@
 package is.hail.expr.ir.functions
 
-import is.hail.expr.ir.{ExecuteContext, LowerMatrixIR, MatrixValue, TableValue}
+import is.hail.expr.ir.{ExecuteContext, LowerMatrixIR, MatrixValue, RelationalSpec, TableValue}
 import is.hail.expr.types.virtual.Type
 import is.hail.expr.types.{BlockMatrixType, MatrixType, TableType}
 import is.hail.linalg.BlockMatrix
 import is.hail.methods._
 import is.hail.rvd.RVDType
-import is.hail.variant.RelationalSpec
 import org.json4s.ShortTypeHints
 import org.json4s.jackson.Serialization
 

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.language.implicitConversions
 import is.hail.expr.Parser._
-import is.hail.expr.ir.EmitFunctionBuilder
+import is.hail.expr.ir.{EmitFunctionBuilder, RelationalSpec}
 import is.hail.expr.ir.functions.{IRFunctionRegistry, ReferenceGenomeFunctions}
 import is.hail.expr.types.virtual.{TInt64, TInterval, TLocus, Type}
 import is.hail.io.reference.LiftOver


### PR DESCRIPTION
stacked on #7578