### PR TITLE
[batch2] add memory request to docker container config

### DIFF
--- a/batch2/batch/batch_configuration.py
+++ b/batch2/batch/batch_configuration.py
@@ -13,3 +13,13 @@ WORKER_DISK_SIZE_GB = os.environ.get('WORKER_DISK_SIZE_GB', '100')
 POOL_SIZE = int(os.environ.get('POOL_SIZE', 10))
 MAX_INSTANCES = int(os.environ.get('MAX_INSTANCES', 12))
 KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']
+
+
+if WORKER_TYPE == 'standard':
+    m = 3.75
+elif WORKER_TYPE == 'highmem':
+    m = 6.5
+else:
+    assert WORKER_TYPE == 'highcpu', WORKER_TYPE
+    m = 0.9
+WORKER_MEMORY_PER_CORE_GB = 0.9 * m

--- a/batch2/batch/batch_configuration.py
+++ b/batch2/batch/batch_configuration.py
@@ -13,13 +13,3 @@ WORKER_DISK_SIZE_GB = os.environ.get('WORKER_DISK_SIZE_GB', '100')
 POOL_SIZE = int(os.environ.get('POOL_SIZE', 10))
 MAX_INSTANCES = int(os.environ.get('MAX_INSTANCES', 12))
 KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']
-
-
-if WORKER_TYPE == 'standard':
-    m = 3.75
-elif WORKER_TYPE == 'highmem':
-    m = 6.5
-else:
-    assert WORKER_TYPE == 'highcpu', WORKER_TYPE
-    m = 0.9
-WORKER_MEMORY_PER_CORE_BYTES = int(0.9 * m * 1024**3)

--- a/batch2/batch/batch_configuration.py
+++ b/batch2/batch/batch_configuration.py
@@ -22,4 +22,4 @@ elif WORKER_TYPE == 'highmem':
 else:
     assert WORKER_TYPE == 'highcpu', WORKER_TYPE
     m = 0.9
-WORKER_MEMORY_PER_CORE_GB = 0.9 * m
+WORKER_MEMORY_PER_CORE_BYTES = int(0.9 * m * 1024**3)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -8,7 +8,7 @@ import googleapiclient.errors
 
 from ..batch_configuration import DEFAULT_NAMESPACE, BATCH_WORKER_IMAGE, \
     PROJECT, ZONE, WORKER_TYPE, WORKER_CORES, WORKER_DISK_SIZE_GB, \
-    WORKER_MEMORY_PER_CORE_GB, POOL_SIZE, MAX_INSTANCES
+    POOL_SIZE, MAX_INSTANCES
 
 from .instance import Instance
 
@@ -17,7 +17,6 @@ log = logging.getLogger('instance_pool')
 WORKER_CORES_MCPU = WORKER_CORES * 1000
 
 log.info(f'WORKER_CORES {WORKER_CORES}')
-log.info(f'WORKER_MEMORY_PER_CORE_GB {WORKER_MEMORY_PER_CORE_GB}')
 log.info(f'WORKER_TYPE {WORKER_TYPE}')
 log.info(f'WORKER_DISK_SIZE_GB {WORKER_DISK_SIZE_GB}')
 log.info(f'POOL_SIZE {POOL_SIZE}')
@@ -34,8 +33,6 @@ class InstancePool:
         self.gservices = app['gservices']
         self.k8s = app['k8s_client']
         self.machine_name_prefix = machine_name_prefix
-
-        self.worker_memory = WORKER_MEMORY_PER_CORE_GB
 
         self.instances_by_last_updated = sortedcontainers.SortedSet(
             key=lambda instance: instance.last_updated)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -8,7 +8,7 @@ import googleapiclient.errors
 
 from ..batch_configuration import DEFAULT_NAMESPACE, BATCH_WORKER_IMAGE, \
     PROJECT, ZONE, WORKER_TYPE, WORKER_CORES, WORKER_DISK_SIZE_GB, \
-    POOL_SIZE, MAX_INSTANCES
+    WORKER_MEMORY_PER_CORE_GB, POOL_SIZE, MAX_INSTANCES
 
 from .instance import Instance
 
@@ -17,6 +17,7 @@ log = logging.getLogger('instance_pool')
 WORKER_CORES_MCPU = WORKER_CORES * 1000
 
 log.info(f'WORKER_CORES {WORKER_CORES}')
+log.info(f'WORKER_MEMORY_PER_CORE_GB {WORKER_MEMORY_PER_CORE_GB}')
 log.info(f'WORKER_TYPE {WORKER_TYPE}')
 log.info(f'WORKER_DISK_SIZE_GB {WORKER_DISK_SIZE_GB}')
 log.info(f'POOL_SIZE {POOL_SIZE}')
@@ -34,14 +35,7 @@ class InstancePool:
         self.k8s = app['k8s_client']
         self.machine_name_prefix = machine_name_prefix
 
-        if WORKER_TYPE == 'standard':
-            m = 3.75
-        elif WORKER_TYPE == 'highmem':
-            m = 6.5
-        else:
-            assert WORKER_TYPE == 'highcpu', WORKER_TYPE
-            m = 0.9
-        self.worker_memory = 0.9 * m
+        self.worker_memory = WORKER_MEMORY_PER_CORE_GB
 
         self.instances_by_last_updated = sortedcontainers.SortedSet(
             key=lambda instance: instance.last_updated)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -194,6 +194,7 @@ PROJECT=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/
 
 BUCKET_NAME=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/bucket_name")
 INSTANCE_ID=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance_id")
+WORKER_TYPE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/worker_type")
 NAME=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
 ZONE=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
 
@@ -213,6 +214,7 @@ docker run \
     -e BUCKET_NAME=$BUCKET_NAME \
     -e INSTANCE_ID=$INSTANCE_ID \
     -e PROJECT=$PROJECT \
+    -e WORKER_TYPE=$WORKER_TYPE \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/bin/docker:/usr/bin/docker \
     -v /batch:/batch \
@@ -253,6 +255,9 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
                 }, {
                     'key': 'instance_id',
                     'value': self.log_store.instance_id
+                }, {
+                    'key': 'worker_type',
+                    'value': WORKER_TYPE
                 }]
             },
             'tags': {

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -296,11 +296,11 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 cores_mcpu = adjust_cores_for_memory_request(req_cores_mcpu, req_memory_bytes, WORKER_TYPE)
 
                 if cores_mcpu > WORKER_CORES * 1000:
-                    total_memory_available = round(worker_memory_per_core_gb(WORKER_TYPE) * WORKER_CORES, 2)
+                    total_memory_available = worker_memory_per_core_gb(WORKER_TYPE) * WORKER_CORES
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '
                         f'requested: cpu={resources["cpu"]}, memory={resources["memory"]} '
-                        f'maximum: cpu={WORKER_CORES}, memory={total_memory_available}GB')
+                        f'maximum: cpu={WORKER_CORES}, memory={total_memory_available}G')
 
                 secrets = spec.get('secrets')
                 if not secrets:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -293,6 +293,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes)
                 log.info(f'adjusted cores_mcpu {cores_mcpu}')
 
+                log.info(f'WORKER_CORES = {WORKER_CORES}')
                 if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -293,7 +293,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     f'are unsatisfiable: cpu={resources["cpu"]}, memory={resources["memory"]}')
                 if cores_mcpu == 0:
                     raise web.HTTPBadRequest(reason=f'resource requests for job {id} '
-                                             f'are unsatisfiable: cpu must be greater than 0')
+                    f'are unsatisfiable: cpu must be greater than 0')
 
                 secrets = spec.get('secrets')
                 if not secrets:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -287,8 +287,9 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
                 memory_bytes = parse_memory_in_bytes(resources['memory'])
+                log.info(f'cores_mcpu = {cores_mcpu} memory_bytes = {memory_bytes}')
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes, WORKER_TYPE)
-
+                log.info(f'adjusted_cores_mcpu = {cores_mcpu}')
                 if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -60,7 +60,7 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 BATCH_JOB_DEFAULT_CPU = os.environ.get('HAIL_BATCH_JOB_DEFAULT_CPU', '1')
-BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.75G')
+BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.375G')
 
 
 @routes.get('/healthcheck')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -290,16 +290,17 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 if req_cores_mcpu == 0:
                     raise web.HTTPBadRequest(
-                        reason=f'resource requests for job {id} are not allowed: '
-                        f'cpu must be greater than 0')
+                        reason=f'bad resource request for job {id}: '
+                        f'cpu cannot be 0')
 
                 cores_mcpu = adjust_cores_for_memory_request(req_cores_mcpu, req_memory_bytes, WORKER_TYPE)
 
                 if cores_mcpu > WORKER_CORES * 1000:
+                    total_memory_available = round(worker_memory_per_core_gb(WORKER_TYPE) * WORKER_CORES, 2)
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '
                         f'requested: cpu={resources["cpu"]}, memory={resources["memory"]} '
-                        f'maximum: cpu={WORKER_CORES}, memory={worker_memory_per_core_gb(WORKER_TYPE)}GB')
+                        f'maximum: cpu={WORKER_CORES}, memory={total_memory_available}GB')
 
                 secrets = spec.get('secrets')
                 if not secrets:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -30,7 +30,7 @@ from ..utils import parse_cpu_in_mcpu, parse_memory_in_bytes, adjust_cores_for_m
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
-from ..batch_configuration import BATCH_PODS_NAMESPACE, WORKER_CORES
+from ..batch_configuration import BATCH_PODS_NAMESPACE, WORKER_CORES, WORKER_TYPE
 
 from . import schemas
 
@@ -287,7 +287,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
                 memory_bytes = parse_memory_in_bytes(resources['memory'])
-                cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes)
+                cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes, WORKER_TYPE)
 
                 if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -285,9 +285,14 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if 'memory' not in resources:
                     resources['memory'] = BATCH_JOB_DEFAULT_MEMORY
 
+                log.info(f'raw inputs from user {(resources["cpu"], resources["memory"])}')
                 cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
+                log.info(f'cores_mcpu from user = {cores_mcpu}')
                 memory_bytes = parse_memory_in_bytes(resources['memory'])
+                log.info(f'memory_bytes from user = {memory_bytes}')
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes)
+                log.info(f'adjusted cores_mcpu {cores_mcpu}')
+                log.info(f'WORKER CORES = {WORKER_CORES}')
                 if cores_mcpu > WORKER_CORES:
                     raise web.HTTPBadRequest(reason=f'resource requests for job {id} '
                     f'are unsatisfiable: cpu={resources["cpu"]}, memory={resources["memory"]}')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -285,15 +285,10 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if 'memory' not in resources:
                     resources['memory'] = BATCH_JOB_DEFAULT_MEMORY
 
-                log.info(f'raw inputs from user {(resources["cpu"], resources["memory"])}')
                 cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
-                log.info(f'cores_mcpu from user = {cores_mcpu}')
                 memory_bytes = parse_memory_in_bytes(resources['memory'])
-                log.info(f'memory_bytes from user = {memory_bytes}')
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes)
-                log.info(f'adjusted cores_mcpu {cores_mcpu}')
 
-                log.info(f'WORKER_CORES = {WORKER_CORES}')
                 if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -60,7 +60,7 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 BATCH_JOB_DEFAULT_CPU = os.environ.get('HAIL_BATCH_JOB_DEFAULT_CPU', '1')
-BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.375G')
+BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.75G')
 
 
 @routes.get('/healthcheck')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -294,11 +294,13 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 log.info(f'adjusted cores_mcpu {cores_mcpu}')
                 log.info(f'WORKER CORES = {WORKER_CORES}')
                 if cores_mcpu > WORKER_CORES:
-                    raise web.HTTPBadRequest(reason=f'resource requests for job {id} '
-                    f'are unsatisfiable: cpu={resources["cpu"]}, memory={resources["memory"]}')
+                    raise web.HTTPBadRequest(
+                        reason=f'resource requests for job {id} are unsatisfiable: '
+                        f'cpu={resources["cpu"]}, memory={resources["memory"]}')
                 if cores_mcpu == 0:
-                    raise web.HTTPBadRequest(reason=f'resource requests for job {id} '
-                    f'are unsatisfiable: cpu must be greater than 0')
+                    raise web.HTTPBadRequest(
+                        reason=f'resource requests for job {id} are unsatisfiable: '
+                        f'cpu must be greater than 0')
 
                 secrets = spec.get('secrets')
                 if not secrets:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -287,9 +287,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
                 memory_bytes = parse_memory_in_bytes(resources['memory'])
-                log.info(f'cores_mcpu = {cores_mcpu} memory_bytes = {memory_bytes}')
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes, WORKER_TYPE)
-                log.info(f'adjusted_cores_mcpu = {cores_mcpu}')
+
                 if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -292,8 +292,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 log.info(f'memory_bytes from user = {memory_bytes}')
                 cores_mcpu = adjust_cores_for_memory_request(cores_mcpu, memory_bytes)
                 log.info(f'adjusted cores_mcpu {cores_mcpu}')
-                log.info(f'WORKER CORES = {WORKER_CORES}')
-                if cores_mcpu > WORKER_CORES:
+
+                if cores_mcpu > WORKER_CORES * 1000:
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '
                         f'cpu={resources["cpu"]}, memory={resources["memory"]}')

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -50,7 +50,7 @@ def worker_memory_per_core_gb(worker_type):
 
 def worker_memory_per_core_bytes(worker_type):
     m = worker_memory_per_core_gb(worker_type)
-    return math.ceil(m * 1000**3)  # GCE memory/core are in GB not GiB
+    return int(m * 1000**3)  # GCE memory/core are in GB not GiB
 
 
 def memory_bytes_to_cores_mcpu(memory_in_bytes, worker_type):
@@ -58,7 +58,7 @@ def memory_bytes_to_cores_mcpu(memory_in_bytes, worker_type):
 
 
 def cores_mcpu_to_memory_bytes(cores_in_mcpu, worker_type):
-    return math.ceil((cores_in_mcpu / 1000) * worker_memory_per_core_bytes(worker_type))
+    return int((cores_in_mcpu / 1000) * worker_memory_per_core_bytes(worker_type))
 
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes, worker_type):

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -3,6 +3,7 @@ import time
 import logging
 
 from hailtop.batch_client.validate import CPU_REGEX, MEMORY_REGEX
+from .batch_configuration import WORKER_MEMORY_PER_CORE_GB
 
 
 log = logging.getLogger('utils')
@@ -34,6 +35,19 @@ def parse_memory_in_bytes(memory_string):
         suffix = match.group(2)
         return int(number * conv_factor[suffix])
     return None
+
+
+def memory_bytes_to_cores_mcpu(memory_in_bytes):
+    return int((memory_in_bytes / (WORKER_MEMORY_PER_CORE_GB * 1024 * 1024 * 1024)) * 1000)
+
+
+def cores_mcpu_to_memory_bytes(cores_in_mcpu):
+    return int((cores_in_mcpu / 1000) * WORKER_MEMORY_PER_CORE_GB * 1024 * 1024 * 1024)
+
+
+def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes):
+    min_cores_mcpu = memory_bytes_to_cores_mcpu(memory_in_bytes)
+    return max(cores_in_mcpu, min_cores_mcpu)
 
 
 image_regex = re.compile(r"(?:.+/)?([^:]+)(:(.+))?")

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -44,7 +44,7 @@ def worker_memory_per_core_bytes(worker_type):
     else:
         assert worker_type == 'highcpu', worker_type
         m = 0.9
-    return int(0.9 * m * 1000**3)  # GCE memory/core are in GB not GiB
+    return int(m * 1000**3)  # GCE memory/core are in GB not GiB
 
 
 def memory_bytes_to_cores_mcpu(memory_in_bytes, worker_type):

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -47,7 +47,6 @@ def cores_mcpu_to_memory_bytes(cores_in_mcpu):
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes):
     min_cores_mcpu = memory_bytes_to_cores_mcpu(memory_in_bytes)
-    log.info(f'min_cores_mcpu = {min_cores_mcpu} cores_in_mcpu = {cores_in_mcpu}')
     return max(cores_in_mcpu, min_cores_mcpu)
 
 

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -3,7 +3,7 @@ import time
 import logging
 
 from hailtop.batch_client.validate import CPU_REGEX, MEMORY_REGEX
-from .batch_configuration import WORKER_MEMORY_PER_CORE_GB
+from .batch_configuration import WORKER_MEMORY_PER_CORE_BYTES
 
 
 log = logging.getLogger('utils')
@@ -38,11 +38,11 @@ def parse_memory_in_bytes(memory_string):
 
 
 def memory_bytes_to_cores_mcpu(memory_in_bytes):
-    return int((memory_in_bytes / (WORKER_MEMORY_PER_CORE_GB * 1024 * 1024 * 1024)) * 1000)
+    return int((memory_in_bytes / WORKER_MEMORY_PER_CORE_BYTES) * 1000)
 
 
 def cores_mcpu_to_memory_bytes(cores_in_mcpu):
-    return int((cores_in_mcpu / 1000) * WORKER_MEMORY_PER_CORE_GB * 1024 * 1024 * 1024)
+    return int((cores_in_mcpu / 1000) * WORKER_MEMORY_PER_CORE_BYTES)
 
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes):

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -1,6 +1,7 @@
 import re
 import time
 import logging
+import math
 
 from hailtop.batch_client.validate import CPU_REGEX, MEMORY_REGEX
 
@@ -49,15 +50,15 @@ def worker_memory_per_core_gb(worker_type):
 
 def worker_memory_per_core_bytes(worker_type):
     m = worker_memory_per_core_gb(worker_type)
-    return int(m * 1000**3)  # GCE memory/core are in GB not GiB
+    return math.ceil(m * 1000**3)  # GCE memory/core are in GB not GiB
 
 
 def memory_bytes_to_cores_mcpu(memory_in_bytes, worker_type):
-    return int((memory_in_bytes / worker_memory_per_core_bytes(worker_type)) * 1000)
+    return math.ceil((memory_in_bytes / worker_memory_per_core_bytes(worker_type)) * 1000)
 
 
 def cores_mcpu_to_memory_bytes(cores_in_mcpu, worker_type):
-    return int((cores_in_mcpu / 1000) * worker_memory_per_core_bytes(worker_type))
+    return math.ceil((cores_in_mcpu / 1000) * worker_memory_per_core_bytes(worker_type))
 
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes, worker_type):

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -47,6 +47,7 @@ def cores_mcpu_to_memory_bytes(cores_in_mcpu):
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes):
     min_cores_mcpu = memory_bytes_to_cores_mcpu(memory_in_bytes)
+    log.info(f'min_cores_mcpu = {min_cores_mcpu} cores_in_mcpu = {cores_in_mcpu}')
     return max(cores_in_mcpu, min_cores_mcpu)
 
 

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -2,18 +2,37 @@ import re
 import time
 import logging
 
-log = logging.getLogger('utils')
+from hailtop.batch_client.validate import CPU_REGEX, MEMORY_REGEX
 
-cpu_regex = re.compile(r"^(\d*\.\d+|\d+)([m]?)$")
+
+log = logging.getLogger('utils')
 
 
 def parse_cpu_in_mcpu(cpu_string):
-    match = cpu_regex.fullmatch(cpu_string)
+    match = CPU_REGEX.fullmatch(cpu_string)
     if match:
         number = float(match.group(1))
         if match.group(2) == 'm':
             number /= 1000
         return int(number * 1000)
+    return None
+
+
+conv_factor = {
+    'K': 1000, 'Ki': 1024,
+    'M': 1000**2, 'Mi': 1024**2,
+    'G': 1000**3, 'Gi': 1024**3,
+    'T': 1000**4, 'Ti': 1024**4,
+    'P': 1000**5, 'Pi': 1024**5
+}
+
+
+def parse_memory_in_bytes(memory_string):
+    match = MEMORY_REGEX.fullmatch(memory_string)
+    if match:
+        number = float(match.group(1))
+        suffix = match.group(2)
+        return int(number * conv_factor[suffix])
     return None
 
 

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -36,7 +36,7 @@ def parse_memory_in_bytes(memory_string):
     return None
 
 
-def worker_memory_per_core_bytes(worker_type):
+def worker_memory_per_core_gb(worker_type):
     if worker_type == 'standard':
         m = 3.75
     elif worker_type == 'highmem':
@@ -44,6 +44,11 @@ def worker_memory_per_core_bytes(worker_type):
     else:
         assert worker_type == 'highcpu', worker_type
         m = 0.9
+    return m
+
+
+def worker_memory_per_core_bytes(worker_type):
+    m = worker_memory_per_core_gb(worker_type)
     return int(m * 1000**3)  # GCE memory/core are in GB not GiB
 
 

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -168,7 +168,7 @@ class Container:
         status = {
             'state': cstate['Status'],
             'started_at': cstate['StartedAt'],
-            'finished_at': cstate['FinishedAt'],
+            'finished_at': cstate['FinishedAt']
         }
         cerror = cstate['Error']
         if cerror:
@@ -284,7 +284,7 @@ class Container:
     #     finished_at: str, (date)
     #     out_of_memory: boolean, (optional)
     #     error: str, (one of error, exit_code will be present)
-    #     exit_code: int,
+    #     exit_code: int
     #   }
     # }
     async def status(self, state=None):
@@ -439,7 +439,7 @@ class Job:
 
     @property
     def id(self):
-        return self.batch_id, self.job_id
+        return (self.batch_id, self.job_id)
 
     async def run(self, worker):
         try:

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -166,13 +166,15 @@ class Container:
         status = {
             'state': cstate['Status'],
             'started_at': cstate['StartedAt'],
-            'finished_at': cstate['FinishedAt']
+            'finished_at': cstate['FinishedAt'],
+            'out_of_memory': cstate['OOMKilled']
         }
         cerror = cstate['Error']
         if cerror:
             status['error'] = cerror
         else:
             status['exit_code'] = cstate['ExitCode']
+
         return status
 
     async def run(self, worker):
@@ -276,8 +278,9 @@ class Container:
     #     state: str,
     #     started_at: str, (date)
     #     finished_at: str, (date)
+    #     out_of_memory: boolean
     #     error: str, (one of error, exit_code will be present)
-    #     exit_code: int
+    #     exit_code: int,
     #   }
     # }
     async def status(self, state=None):

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -23,7 +23,7 @@ from hailtop.utils import request_retry_transient_errors
 from hailtop.config import DeployConfig
 from gear import configure_logging
 
-from .utils import parse_cpu_in_mcpu, parse_image_tag
+from .utils import parse_cpu_in_mcpu, parse_image_tag, parse_memory_in_bytes
 from .semaphore import WeightedSemaphore
 from .log_store import LogStore
 
@@ -118,6 +118,7 @@ class Container:
         self.image = image
 
         self.cpu_in_mcpu = parse_cpu_in_mcpu(spec['cpu'])
+        self.memory_in_bytes = parse_memory_in_bytes(spec['memory'])
 
         self.container = None
         self.state = 'pending'
@@ -136,7 +137,8 @@ class Container:
             'Cmd': self.spec['command'],
             'Image': self.image,
             'HostConfig': {'CpuPeriod': 100000,
-                           'CpuQuota': self.cpu_in_mcpu * 100}
+                           'CpuQuota': self.cpu_in_mcpu * 100,
+                           'Memory': self.memory_in_bytes}
         }
 
         env = self.spec.get('env')
@@ -336,6 +338,7 @@ def copy_container(job, name, files, volume_mounts):
         'name': name,
         'command': ['/bin/sh', '-c', sh_expression],
         'cpu': '500m' if files else '100m',
+        'memory': '0.5Gi',
         'volume_mounts': volume_mounts
     }
     return Container(job, name, copy_spec)
@@ -408,6 +411,7 @@ class Job:
             'name': 'main',
             'env': env,
             'cpu': job_spec['resources']['cpu'],
+            'memory': job_spec['resources']['memory'],
             'volume_mounts': main_volume_mounts
         }
         containers['main'] = Container(self, 'main', main_spec)

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -168,16 +168,14 @@ class Container:
         status = {
             'state': cstate['Status'],
             'started_at': cstate['StartedAt'],
-            'finished_at': cstate['FinishedAt']
+            'finished_at': cstate['FinishedAt'],
+            'out_of_memory': cstate['OOMKilled']
         }
         cerror = cstate['Error']
         if cerror:
             status['error'] = cerror
         else:
             status['exit_code'] = cstate['ExitCode']
-
-        if cstate['OOMKilled']:
-            status['out_of_memory'] = True
 
         return status
 
@@ -282,7 +280,7 @@ class Container:
     #     state: str,
     #     started_at: str, (date)
     #     finished_at: str, (date)
-    #     out_of_memory: boolean, (optional)
+    #     out_of_memory: boolean
     #     error: str, (one of error, exit_code will be present)
     #     exit_code: int
     #   }

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -435,7 +435,7 @@ class Job:
 
     @property
     def id(self):
-        return (self.batch_id, self.job_id)
+        return self.batch_id, self.job_id
 
     async def run(self, worker):
         try:

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -169,13 +169,15 @@ class Container:
             'state': cstate['Status'],
             'started_at': cstate['StartedAt'],
             'finished_at': cstate['FinishedAt'],
-            'out_of_memory': cstate['OOMKilled']
         }
         cerror = cstate['Error']
         if cerror:
             status['error'] = cerror
         else:
             status['exit_code'] = cstate['ExitCode']
+
+        if cstate['OOMKilled']:
+            status['out_of_memory'] = True
 
         return status
 
@@ -280,7 +282,7 @@ class Container:
     #     state: str,
     #     started_at: str, (date)
     #     finished_at: str, (date)
-    #     out_of_memory: boolean
+    #     out_of_memory: boolean, (optional)
     #     error: str, (one of error, exit_code will be present)
     #     exit_code: int,
     #   }

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -23,7 +23,6 @@ from hailtop.utils import request_retry_transient_errors
 from hailtop.config import DeployConfig
 from gear import configure_logging
 
-from .batch_configuration import WORKER_MEMORY_PER_CORE_GB
 from .utils import parse_cpu_in_mcpu, parse_image_tag, parse_memory_in_bytes, \
     adjust_cores_for_memory_request, cores_mcpu_to_memory_bytes
 from .semaphore import WeightedSemaphore

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -43,12 +43,14 @@ IP_ADDRESS = os.environ['IP_ADDRESS']
 BUCKET_NAME = os.environ['BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
 PROJECT = os.environ['PROJECT']
+WORKER_TYPE = os.environ['WORKER_TYPE']
 
 log.info(f'CORES {CORES}')
 log.info(f'NAME {NAME}')
 log.info(f'NAMESPACE {NAMESPACE}')
 # ACTIVATION_TOKEN
 log.info(f'IP_ADDRESS {IP_ADDRESS}')
+log.info(f'WORKER_TYPE {WORKER_TYPE}')
 log.info(f'BUCKET_NAME {BUCKET_NAME}')
 log.info(f'INSTANCE_ID {INSTANCE_ID}')
 log.info(f'PROJECT {PROJECT}')
@@ -121,8 +123,8 @@ class Container:
         req_cpu_in_mcpu = parse_cpu_in_mcpu(spec['cpu'])
         req_memory_in_bytes = parse_memory_in_bytes(spec['memory'])
 
-        self.cpu_in_mcpu = adjust_cores_for_memory_request(req_cpu_in_mcpu, req_memory_in_bytes)
-        self.memory_in_bytes = cores_mcpu_to_memory_bytes(self.cpu_in_mcpu)
+        self.cpu_in_mcpu = adjust_cores_for_memory_request(req_cpu_in_mcpu, req_memory_in_bytes, WORKER_TYPE)
+        self.memory_in_bytes = cores_mcpu_to_memory_bytes(self.cpu_in_mcpu, WORKER_TYPE)
 
         self.container = None
         self.state = 'pending'

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -166,7 +166,7 @@ spec:
          - name: HAIL_BATCH_JOB_DEFAULT_CPU
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
-           value: "375Mi"
+           value: "0.3375Gi"
          - name: WORKER_TYPE
            value: "standard"
          - name: WORKER_CORES

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -166,7 +166,7 @@ spec:
          - name: HAIL_BATCH_JOB_DEFAULT_CPU
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
-           value: "0.3375Gi"
+           value: "337.5M"
          - name: WORKER_TYPE
            value: "standard"
          - name: WORKER_CORES

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -166,7 +166,7 @@ spec:
          - name: HAIL_BATCH_JOB_DEFAULT_CPU
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
-           value: "337.5M"
+           value: "375M"
          - name: WORKER_TYPE
            value: "standard"
          - name: WORKER_CORES

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -166,7 +166,17 @@ spec:
          - name: HAIL_BATCH_JOB_DEFAULT_CPU
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
-           value: "375M"
+           value: "375Mi"
+         - name: WORKER_TYPE
+           value: "standard"
+         - name: WORKER_CORES
+           value: "1"
+         - name: WORKER_DISK_SIZE_GB
+           value: "10"
+         - name: POOL_SIZE
+           value: "2"
+         - name: MAX_INSTANCES
+           value: "3"
 {% endif %}
         ports:
          - containerPort: 5000

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0', 'memory': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*unsatisfiable'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*not allowed'):
             builder.submit()
 
     def test_out_of_memory(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -85,20 +85,20 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '1', 'memory': '28Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*unsatisfiable'):
             builder.submit()
 
         builder = self.client.create_batch()
         resources = {'cpu': '0', 'memory': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*unsatisfiable'):
             builder.submit()
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', 'x = "a" * 400 * 1000**2; print(x)'],
+                               ['python', '-c', 'x = "a" * 400 * 1000**2'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -94,6 +94,16 @@ class Test(unittest.TestCase):
         with self.assertRaisesRegex('resource requests'):
             builder.submit()
 
+    def test_out_of_memory(self):
+        builder = self.client.create_batch()
+        resources = {'cpu': '0.1', 'memory': '4Mi'}
+        builder.create_job('python:3.6-slim-stretch',
+                           ['python', '-c', '"x = [i for i in range(100000000)]"'],
+                           resources=resources)
+        builder.submit()
+        status = j.wait()
+        assert status[]
+
     def test_unsubmitted_state(self):
         builder = self.client.create_batch()
         j = builder.create_job('ubuntu:18.04', ['echo', 'test'])

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0', 'memory': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*not allowed'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'bad resource requests.*cpu cannot be 0'):
             builder.submit()
 
     def test_out_of_memory(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = list([i for i in range(100000000000)])"'],
+                               ['python', '-c', '"x = \'a\' * 1000000000000000"'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -81,6 +81,19 @@ class Test(unittest.TestCase):
         assert j._get_error(status, 'main') is not None
         assert status['state'] == 'Error', status
 
+    def test_invalid_resource_requests(self):
+        builder = self.client.create_batch()
+        resources = {'cpu': '1', 'memory': '28Gi'}
+        builder.create_job('ubuntu:18.04', ['true'], resources=resources)
+        with self.assertRaisesRegex('resource requests'):
+            builder.submit()
+
+        builder = self.client.create_batch()
+        resources = {'cpu': '0', 'memory': '1Gi'}
+        builder.create_job('ubuntu:18.04', ['true'], resources=resources)
+        with self.assertRaisesRegex('resource requests'):
+            builder.submit()
+
     def test_unsubmitted_state(self):
         builder = self.client.create_batch()
         j = builder.create_job('ubuntu:18.04', ['echo', 'test'])

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -97,12 +97,12 @@ class Test(unittest.TestCase):
     def test_out_of_memory(self):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '4Mi'}
-        builder.create_job('python:3.6-slim-stretch',
-                           ['python', '-c', '"x = [i for i in range(100000000)]"'],
-                           resources=resources)
+        j = builder.create_job('python:3.6-slim-stretch',
+                               ['python', '-c', '"x = [i for i in range(100000000)]"'],
+                               resources=resources)
         builder.submit()
         status = j.wait()
-        assert status[]
+        assert status['container_statuses']['main']['out_of_memory']
 
     def test_unsubmitted_state(self):
         builder = self.client.create_batch()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -96,9 +96,9 @@ class Test(unittest.TestCase):
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '0.1', 'memory': '4Mi'}
+        resources = {'cpu': '0.1', 'memory': '4M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = [i for i in range(100000000)]"'],
+                               ['python', '-c', '"x = list([i for i in range(100000000)])"'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -102,6 +102,7 @@ class Test(unittest.TestCase):
                                resources=resources)
         builder.submit()
         status = j.wait()
+        print(status)
         assert j._get_out_of_memory(status, 'main')
 
     def test_unsubmitted_state(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -96,7 +96,7 @@ class Test(unittest.TestCase):
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '0.1', 'memory': '4M'}
+        resources = {'cpu': '0.001', 'memory': '4M'}
         j = builder.create_job('python:3.6-slim-stretch',
                                ['python', '-c', '"x = list([i for i in range(100000000)])"'],
                                resources=resources)

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -96,9 +96,9 @@ class Test(unittest.TestCase):
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '0.001', 'memory': '10M'}
+        resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = list([i for i in range(100000000)])"'],
+                               ['python', '-c', '"x = list([i for i in range(100000000000)])"'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -102,7 +102,6 @@ class Test(unittest.TestCase):
                                resources=resources)
         builder.submit()
         status = j.wait()
-        print(status)
         assert j._get_out_of_memory(status, 'main')
 
     def test_unsubmitted_state(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -96,13 +96,12 @@ class Test(unittest.TestCase):
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '0.001', 'memory': '4M'}
+        resources = {'cpu': '0.001', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
                                ['python', '-c', '"x = list([i for i in range(100000000)])"'],
                                resources=resources)
         builder.submit()
         status = j.wait()
-        print(status)
         assert j._get_out_of_memory(status, 'main')
 
     def test_unsubmitted_state(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = \'a\' * 400 * 1000**2; print(x)"'],
+                               ['python', '-c', 'x = "a" * 400 * 1000**2; print(x)'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -85,13 +85,13 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '1', 'memory': '28Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex('resource requests'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests'):
             builder.submit()
 
         builder = self.client.create_batch()
         resources = {'cpu': '0', 'memory': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex('resource requests'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests'):
             builder.submit()
 
     def test_out_of_memory(self):
@@ -102,7 +102,7 @@ class Test(unittest.TestCase):
                                resources=resources)
         builder.submit()
         status = j.wait()
-        assert status['container_statuses']['main']['out_of_memory']
+        assert j._get_out_of_memory(status, 'main')
 
     def test_unsubmitted_state(self):
         builder = self.client.create_batch()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0', 'memory': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
-        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'bad resource requests.*cpu cannot be 0'):
+        with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'bad resource request.*cpu cannot be 0'):
             builder.submit()
 
     def test_out_of_memory(self):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = \'a\' * 1000000000000000"'],
+                               ['python', '-c', '"x = \'a\' * 1000000000000000; print(x)"'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -98,7 +98,7 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {'cpu': '0.1', 'memory': '10M'}
         j = builder.create_job('python:3.6-slim-stretch',
-                               ['python', '-c', '"x = \'a\' * 1000000000000000; print(x)"'],
+                               ['python', '-c', '"x = \'a\' * 400 * 1000**2; print(x)"'],
                                resources=resources)
         builder.submit()
         status = j.wait()

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -64,11 +64,11 @@ class Job:
 
     @staticmethod
     def _get_container_status_exit_code(container_status):
-        dcontainer_status = container_status.get('container_status')
-        if not dcontainer_status:
+        docker_container_status = container_status.get('container_status')
+        if not docker_container_status:
             return None
 
-        return dcontainer_status.get('exit_code')
+        return docker_container_status.get('exit_code')
 
     @staticmethod
     def _get_exit_code(job_status, task):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -80,7 +80,7 @@ class Job:
         if not docker_container_status:
             return None
 
-        return docker_container_status.get('out_of_memory')
+        return docker_container_status['out_of_memory']
 
     @staticmethod
     def _get_container_status_exit_code(container_status):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -76,7 +76,11 @@ class Job:
         if not container_status:
             return None
 
-        return container_status.get('out_of_memory')
+        docker_container_status = container_status.get('container_status')
+        if not docker_container_status:
+            return None
+
+        return docker_container_status.get('out_of_memory')
 
     @staticmethod
     def _get_container_status_exit_code(container_status):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -63,6 +63,22 @@ class Job:
         return docker_container_status.get('error')
 
     @staticmethod
+    def _get_out_of_memory(job_status, task):
+        status = job_status.get('status')
+        if not status:
+            return None
+
+        container_statuses = status.get('container_statuses')
+        if not container_statuses:
+            return None
+
+        container_status = container_statuses.get(task)
+        if not container_status:
+            return None
+
+        return container_status.get('out_of_memory')
+
+    @staticmethod
     def _get_container_status_exit_code(container_status):
         docker_container_status = container_status.get('container_status')
         if not docker_container_status:

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -13,6 +13,10 @@ class Job:
         return aioclient.Job._get_error(job_status, task)
 
     @staticmethod
+    def _get_out_of_memory(job_status, task):
+        return aioclient.Job._get_out_of_memory(job_status, task)
+
+    @staticmethod
     def _get_exit_code(job_status, task):
         return aioclient.Job._get_exit_code(job_status, task)
 

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -47,10 +47,10 @@ FILE_KEYS = {'from', 'to'}
 K8S_NAME_REGEXPAT = r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*'
 K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
 
-MEMORY_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+(?:[KMGTP][i]?)?'
+MEMORY_REGEXPAT = r'[+]?((?:[0-9]*[.])?[0-9]+)([KMGTP][i]?)?'
 MEMORY_REGEX = re.compile(MEMORY_REGEXPAT)
 
-CPU_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[m]?'
+CPU_REGEXPAT = r'[+]?((?:[0-9]*[.])?[0-9]+)([m])?'
 CPU_REGEX = re.compile(CPU_REGEXPAT)
 
 


### PR DESCRIPTION
This is an enhancement of #7498.

We adjust the number of cores in a user's request to make sure they have enough memory based on the memory per core rather than giving them the exact resources they asked for.