### PR TITLE
[hail/region] pretty printer does not need to live on region instance

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValue.scala
@@ -61,7 +61,7 @@ final class RegionValue(
     offset = newOffset
   }
 
-  def pretty(t: PType): String = region.pretty(t, offset)
+  def pretty(t: PType): String = Region.pretty(t, offset)
 
   private def writeObject(s: ObjectOutputStream): Unit = {
     throw new NotImplementedException()

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -132,7 +132,7 @@ class UnsafeRow(var t: PBaseStruct,
 
   def copy(): Row = new UnsafeRow(t, region, offset)
 
-  def pretty(): String = region.pretty(t, offset)
+  def pretty(): String = Region.pretty(t, offset)
 
   override def getInt(i: Int): Int = {
     assertDefined(i)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -238,13 +238,7 @@ abstract class PBaseStruct extends PType {
 
   def loadField(rv: RegionValue, fieldIdx: Int): Long = loadField(rv.region, rv.offset, fieldIdx)
 
-  def loadField(region: Region, offset: Long, fieldIdx: Int): Long = {
-    val off = fieldOffset(offset, fieldIdx)
-    types(fieldIdx).fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(off)
-      case _ => off
-    }
-  }
+  def loadField(region: Region, offset: Long, fieldIdx: Int): Long = loadField(offset, fieldIdx)
 
   def loadField(offset: Long, fieldIdx: Int): Long = {
     val off = fieldOffset(offset, fieldIdx)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -246,6 +246,14 @@ abstract class PBaseStruct extends PType {
     }
   }
 
+  def loadField(offset: Long, fieldIdx: Int): Long = {
+    val off = fieldOffset(offset, fieldIdx)
+    types(fieldIdx).fundamentalType match {
+      case _: PArray | _: PBinary => Region.loadAddress(off)
+      case _ => off
+    }
+  }
+
   def loadField(offset: Code[Long], fieldIdx: Int): Code[Long] =
     loadField(fieldOffset(offset, fieldIdx), types(fieldIdx))
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -90,13 +90,12 @@ abstract class PContainer extends PIterable {
   }
 
   def isElementMissing(region: Region, aoff: Long, i: Int): Boolean =
-    !isElementDefined(region, aoff, i)
-
-  def isElementDefined(region: Region, aoff: Long, i: Int): Boolean =
-    elementType.required || !Region.loadBit(aoff + 4, i)
+    !isElementDefined(aoff, i)
 
   def isElementDefined(aoff: Long, i: Int): Boolean =
     elementType.required || !Region.loadBit(aoff + 4, i)
+
+  def isElementDefined(region: Region, aoff: Long, i: Int): Boolean = isElementDefined(aoff, i)
 
   def isElementMissing(aoff: Code[Long], i: Code[Int]): Code[Boolean] =
     !isElementDefined(aoff, i)
@@ -147,14 +146,6 @@ abstract class PContainer extends PIterable {
   def elementOffsetInRegion(region: Code[Region], aoff: Code[Long], i: Code[Int]): Code[Long] =
     elementOffset(aoff, loadLength(region, aoff), i)
 
-  def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = {
-    val off = elementOffset(aoff, length, i)
-    elementType.fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(off)
-      case _ => off
-    }
-  }
-
   def loadElement(aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
@@ -162,6 +153,8 @@ abstract class PContainer extends PIterable {
       case _ => off
     }
   }
+
+  def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = loadElement(aoff, length, i)
 
   def loadElement(region: Code[Region], aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = {
     val off = elementOffset(aoff, length, i)
@@ -171,8 +164,7 @@ abstract class PContainer extends PIterable {
     }
   }
 
-  def loadElement(region: Region, aoff: Long, i: Int): Long =
-    loadElement(region, aoff, Region.loadInt(aoff), i)
+  def loadElement(region: Region, aoff: Long, i: Int): Long = loadElement(aoff, Region.loadInt(aoff), i)
 
   def loadElement(aoff: Code[Long], i: Code[Int]): Code[Long] = {
     val off = elementOffset(aoff, Region.loadInt(aoff), i)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -32,6 +32,9 @@ abstract class PContainer extends PIterable {
   final def loadLength(region: Region, aoff: Long): Int =
     PContainer.loadLength(aoff)
 
+  final def loadLength(aoff: Long): Int =
+    PContainer.loadLength(aoff)
+
   final def loadLength(aoff: Code[Long]): Code[Int] =
     PContainer.loadLength(aoff)
 
@@ -92,6 +95,9 @@ abstract class PContainer extends PIterable {
   def isElementDefined(region: Region, aoff: Long, i: Int): Boolean =
     elementType.required || !Region.loadBit(aoff + 4, i)
 
+  def isElementDefined(aoff: Long, i: Int): Boolean =
+    elementType.required || !Region.loadBit(aoff + 4, i)
+
   def isElementMissing(aoff: Code[Long], i: Code[Int]): Code[Boolean] =
     !isElementDefined(aoff, i)
 
@@ -142,6 +148,14 @@ abstract class PContainer extends PIterable {
     elementOffset(aoff, loadLength(region, aoff), i)
 
   def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = {
+    val off = elementOffset(aoff, length, i)
+    elementType.fundamentalType match {
+      case _: PArray | _: PBinary => Region.loadAddress(off)
+      case _ => off
+    }
+  }
+
+  def loadElement(aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
       case _: PArray | _: PBinary => Region.loadAddress(off)


### PR DESCRIPTION
(since doesn't use any constructor arguments or other instance state). Should cost a bit less memory per region instance.

Part of upcoming larger refactor that removes region instances where possible
