### PR TITLE
[batch2] submit jobs in groups of at most 1MB

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -24,7 +24,7 @@ server {
 
 server {
     server_name internal.hail.is;
-    client_max_body_size 10000m;
+    client_max_body_size 8m;
 
     location = /auth {
         internal;
@@ -62,7 +62,7 @@ server {
 
 server {
     server_name hail.is;
-    client_max_body_size 8M;
+    client_max_body_size 8m;
 
     location / {
         proxy_pass http://router/;

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -512,10 +512,10 @@ class BatchClient:
             self._session, 'GET',
             self.url + path, params=params, headers=self._headers)
 
-    async def _post(self, path, json=None):
+    async def _post(self, path, data=None, json=None):
         return await request_retry_transient_errors(
             self._session, 'POST',
-            self.url + path, json=json, headers=self._headers)
+            self.url + path, data=data, json=json, headers=self._headers)
 
     async def _patch(self, path):
         return await request_retry_transient_errors(

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -76,6 +76,7 @@ server {
 
 server {
     server_name batch2.*;
+    client_max_body_size 8m;
 
     location / {
         proxy_pass http://batch2/;
@@ -246,6 +247,7 @@ server {
 
 server {
     server_name blog.*;
+    client_max_body_size 8m;
 
     location / {
         proxy_pass http://blog/;
@@ -257,6 +259,5 @@ server {
 
     listen 80;
     listen [::]:80;
-	client_max_body_size 8M;
 }
 


### PR DESCRIPTION
Also, consistently make max client size 8m.

@konradjk this should permanently solve the 413 entity too large issue
