### PR TITLE
[aioclient] limit group to 1000 jobs max

### DIFF
--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -454,7 +454,7 @@ class BatchBuilder:
         group_size = 0
         for spec in byte_job_specs:
             n = len(spec)
-            if group_size + n < 1000000:
+            if group_size + n < 1000000 and len(group) < 1000:
                 group.append(spec)
                 group_size += n
             else:


### PR DESCRIPTION
I think the database insert didn't perform as well with > 1000 jobs per insert in the front_end create_jobs, but I can't figure out where I got that. Feel free to reject this change.