### PR TITLE
[hail][experimental] Pass Custom names to `export_block_matrices`

### DIFF
--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -29,7 +29,7 @@ def block_matrices_tofiles(bms: List[BlockMatrix], prefix: str, overwrite: bool 
            header=nullable(str),
            add_index=bool,
            compression=nullable(enumeration('gz', 'bgz')),
-           custom_file_names = nullable(sequenceof[str]))
+           custom_file_names=nullable(sequenceof[str]))
 def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
                           delimiter: str = '\t', header: Optional[str] = None,  add_index: bool = False,
                           compression: Optional[str] = None, custom_filenames=None):

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -28,9 +28,14 @@ def block_matrices_tofiles(bms: List[BlockMatrix], prefix: str, overwrite: bool 
            delimiter=str,
            header=nullable(str),
            add_index=bool,
-           compression=nullable(enumeration('gz', 'bgz')))
+           compression=nullable(enumeration('gz', 'bgz')),
+           custom_file_names = nullable(sequenceof[str]))
 def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
                           delimiter: str = '\t', header: Optional[str] = None,  add_index: bool = False,
-                          compression: Optional[str] = None):
-    writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression)
+                          compression: Optional[str] = None, custom_filenames=None):
+
+    if custom_filenames:
+        assert len(custom_filenames) == len(bms)
+
+    writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression, custom_filenames)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -35,7 +35,7 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
                           compression: Optional[str] = None, custom_filenames=None):
 
     if custom_filenames:
-        assert len(custom_filenames) == len(bms)
+        assert len(custom_filenames) == len(bms), "Number of block matrices and number of custom filenames must be equal"
 
     writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression, custom_filenames)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -29,7 +29,7 @@ def block_matrices_tofiles(bms: List[BlockMatrix], prefix: str, overwrite: bool 
            header=nullable(str),
            add_index=bool,
            compression=nullable(enumeration('gz', 'bgz')),
-           custom_file_names=nullable(sequenceof[str]))
+           custom_filenames=nullable(sequenceof(str)))
 def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
                           delimiter: str = '\t', header: Optional[str] = None,  add_index: bool = False,
                           compression: Optional[str] = None, custom_filenames=None):

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -111,7 +111,7 @@ class BlockMatrixBinaryMultiWriter(BlockMatrixMultiWriter):
 
 class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
     @typecheck_method(prefix=str, overwrite=bool, delimiter=str, header=nullable(str), add_index=bool,
-                      compression=nullable(enumeration('gz', 'bgz')))
+                      compression=nullable(enumeration('gz', 'bgz')), custom_filenames=nullable(sequenceof(str)))
     def __init__(self, prefix, overwrite, delimiter, header, add_index, compression, custom_filenames):
         self.prefix = prefix
         self.overwrite = overwrite
@@ -119,7 +119,7 @@ class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
         self.header = header
         self.add_index = add_index
         self.compression = compression
-        self.custom_filenames
+        self.custom_filenames = custom_filenames
 
     def render(self):
         writer = {'name': 'BlockMatrixTextMultiWriter',

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -112,13 +112,14 @@ class BlockMatrixBinaryMultiWriter(BlockMatrixMultiWriter):
 class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
     @typecheck_method(prefix=str, overwrite=bool, delimiter=str, header=nullable(str), add_index=bool,
                       compression=nullable(enumeration('gz', 'bgz')))
-    def __init__(self, prefix, overwrite, delimiter, header, add_index, compression):
+    def __init__(self, prefix, overwrite, delimiter, header, add_index, compression, custom_filenames):
         self.prefix = prefix
         self.overwrite = overwrite
         self.delimiter = delimiter
         self.header = header
         self.add_index = add_index
         self.compression = compression
+        self.custom_filenames
 
     def render(self):
         writer = {'name': 'BlockMatrixTextMultiWriter',
@@ -127,7 +128,8 @@ class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
                   'delimiter': self.delimiter,
                   'header': self.header,
                   'addIndex': self.add_index,
-                  'compression': self.compression}
+                  'compression': self.compression,
+                  'custom_filenames': self.custom_filenames}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
@@ -137,4 +139,5 @@ class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
                self.delimiter == other.overwrite and \
                self.header == other.header and \
                self.add_index == other.add_index and \
-               self.compression == other.compression
+               self.compression == other.compression and \
+               self.custom_filenames == other.custom_filenames

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -129,7 +129,7 @@ class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
                   'header': self.header,
                   'addIndex': self.add_index,
                   'compression': self.compression,
-                  'custom_filenames': self.custom_filenames}
+                  'customFilenames': self.custom_filenames}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -332,3 +332,11 @@ class Tests(unittest.TestCase):
             a = arrs[i]
             a2 = np.loadtxt(f'{prefix}/files/{i}.tsv')
             self.assertTrue(np.array_equal(a, a2))
+
+        prefix2 = new_local_temp_dir()
+        custom_names = ["nameA", "inner/nameB"]
+        hl.experimental.export_block_matrices(bms, f'{prefix2}/files', custom_filenames=custom_names)
+        for i in range(len(bms)):
+            a = arrs[i]
+            a2 = np.loadtxt(f'{prefix2}/files/{custom_names[i]}.tsv')
+            self.assertTrue(np.array_equal(a, a2))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -63,8 +63,9 @@ case class BlockMatrixTextMultiWriter(
   delimiter: String,
   header: Option[String],
   addIndex: Boolean,
-  compression: Option[String]) extends BlockMatrixMultiWriter {
+  compression: Option[String],
+  customFilenames: Option[Array[String]]) extends BlockMatrixMultiWriter {
 
   def apply(bms: IndexedSeq[BlockMatrix]): Unit =
-    BlockMatrix.exportBlockMatrices(bms, prefix, overwrite, delimiter, header, addIndex, compression)
+    BlockMatrix.exportBlockMatrices(bms, prefix, overwrite, delimiter, header, addIndex, compression, customFilenames)
 }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -279,6 +279,8 @@ object BlockMatrix {
     val d = digitsNeeded(bms.length)
     val bcFS = HailContext.bcFS
 
+    info(f"customFilenames is None? ${customFilenames.isEmpty}")
+
     val nameFunction = customFilenames match {
       case None => i: Int => StringUtils.leftPad(i.toString, d, '0')
       case Some(filenames) => filenames.apply(_)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -278,9 +278,7 @@ object BlockMatrix {
 
     val d = digitsNeeded(bms.length)
     val bcFS = HailContext.bcFS
-
-    info(f"customFilenames is None? ${customFilenames.isEmpty}")
-
+    
     val nameFunction = customFilenames match {
       case None => i: Int => StringUtils.leftPad(i.toString, d, '0')
       case Some(filenames) => filenames.apply(_)


### PR DESCRIPTION
Just numbering the matrices in order is creating a lot of post processing work for Jacob and Masahiro. This allows users to specify the filenames they want. 