### PR TITLE
Document hail.version

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -280,6 +280,12 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
 
 
 def version():
+    """Get the installed hail version.
+
+    Returns
+    -------
+    str
+    """
     if hail.__version__ is None:
         # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
         hail.__version__ = pkg_resources.resource_string(__name__, 'hail_version').decode().strip()

--- a/hail/python/hail/docs/api.rst
+++ b/hail/python/hail/docs/api.rst
@@ -51,3 +51,4 @@ Top-Level Functions
 .. autofunction:: hail.get_reference
 .. autofunction:: hail.set_global_seed
 .. autofunction:: hail.citation
+.. autofunction:: hail.version


### PR DESCRIPTION
`hl.version` didn't have any generated documentation.