### PR TITLE
Prevent conda from autoinstalling 3.8

### DIFF
--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -55,7 +55,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create -n hail python\>=3.6
+    conda create -n hail python=3.7.4
     conda activate hail
     pip install hail
 


### PR DESCRIPTION
Conda added python 3.8, so our current docs result in someone getting python 3.8 as their hail environment. We are not compatible with python 3.8 because of pyspark problems.