### PR TITLE
[hail] tail-recursive loops

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -19,6 +19,7 @@ from .codec import encode, decode
 from .db import DB
 from .compile import compile_comparison_binary, compiled_compare
 from .vcf_combiner import lgt_to_gt
+from .loop import loop
 
 __all__ = ['ld_score',
            'ld_score_regression',
@@ -51,4 +52,5 @@ __all__ = ['ld_score',
            'decode',
            'compile_comparison_binary',
            'compiled_compare',
-           'lgt_to_gt']
+           'lgt_to_gt',
+           'loop']

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -1,0 +1,83 @@
+import builtins
+from typing import Callable
+
+from hail.expr.expressions import construct_variable, construct_expr, expr_any, to_expr, unify_all
+from hail.expr.types import hail_type
+from hail.ir.ir import Loop, Recur
+from hail.typecheck import anytype, typecheck
+from hail.utils.java import Env
+
+
+# FIXME, infer loop type?
+@typecheck(f=anytype, typ=hail_type, exprs=expr_any)
+def loop(f: Callable, typ, *exprs):
+    """Expression for writing tail recursive expressions.
+    Example
+    -------
+    To find the sum of all the numbers from n=1...10:
+    >>> x = hl.experimental.loop(lambda recur, acc, n: hl.cond(n > 10, acc, recur(acc + n, n + 1)), hl.tint32, 0, 0)
+    >>> hl.eval(x)
+    55
+    Notes
+    -----
+    The first argument to the lambda is a marker for the recursive call.
+    Some infinite loop detection is done, and if an infinite loop is detected, `loop` will not
+    typecheck.
+    Parameters
+    ----------
+    f : function ( (marker, *args) -> :class:`.Expression`
+        Function of one callable marker, denoting where the recursive call (or calls) is located,
+        and many `exprs`, the loop variables.
+    typ : :obj:`str` or :class:`.HailType`
+        Type the loop returns.
+    exprs : variable-length args of :class:`.Expression`
+        Expressions to initialize the loop values.
+    Returns
+    -------
+    :class:`.Expression`
+        Result of the loop with `exprs` as initial loop values.
+    """
+
+    def contains_recursive_call(non_recursive):
+        return len(non_recursive.search(lambda i: isinstance(i, Recur))) == 0
+
+    def check_tail_recursive(loop_ir):
+        if isinstance(loop_ir, ir.If):
+            check_tail_recursive(loop_ir.cnsq)
+            check_tail_recursive(loop_ir.altr)
+        elif isinstance(loop_ir, ir.Let):
+            if contains_recursive_call(loop_ir.value):
+                raise FatalError("bound value used in other expression can't contain recursive call!")
+            check_tail_recursive(loop_ir.body)
+
+    @typecheck(recur_exprs=expr_any)
+    def make_loop(*recur_exprs):
+        if len(recur_exprs) != len(exprs):
+            raise TypeError('Recursive call in loop has wrong number of arguments')
+        err = None
+        for i, (rexpr, expr) in enumerate(zip(recur_exprs, exprs)):
+            if rexpr.dtype != expr.dtype:
+                if err is None:
+                    err = 'Type error in recursive call,'
+                err += f'\n  at argument index {i}, loop arg type: {expr.dtype}, '
+                err += f'recur arg type: {rexpr.dtype}'
+        if err is not None:
+            raise TypeError(err)
+        irs = [expr._ir for expr in recur_exprs]
+        indices, aggregations = unify_all(*recur_exprs)
+        return construct_expr(Recur(irs, typ), typ, indices, aggregations)
+
+    uid_irs = []
+    loop_vars = []
+
+    for expr in exprs:
+        uid = Env.get_uid()
+        loop_vars.append(construct_variable(uid, expr._type, expr._indices, expr._aggregations))
+        uid_irs.append((uid, expr._ir))
+
+    lambda_res = to_expr(f(make_loop, *loop_vars))
+    indices, aggregations = unify_all(*exprs, lambda_res)
+    ir = Loop(uid_irs, lambda_res._ir)
+    if ir.typ != typ:
+        raise TypeError(f"requested type {typ} does not match inferred type {ir.typ}")
+    return construct_expr(ir, lambda_res.dtype, indices, aggregations)

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -54,7 +54,7 @@ def loop(f: Callable, typ, *args):
     Example
     -------
     To find the sum of all the numbers from n=1...10:
-    >>> triangle_f = lambda f, x, total: hl.cond(n == 0, total, f(x - 1, total + x))
+    >>> triangle_f = lambda f, x, total: hl.cond(x == 0, total, f(x - 1, total + x))
     >>> x = hl.experimental.loop(triangle_f, hl.tint32, 0, 10)
     >>> hl.eval(x)
     55

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -55,7 +55,7 @@ def loop(f: Callable, typ, *args):
     -------
     To find the sum of all the numbers from n=1...10:
     >>> triangle_f = lambda f, x, total: hl.cond(x == 0, total, f(x - 1, total + x))
-    >>> x = hl.experimental.loop(triangle_f, hl.tint32, 0, 10)
+    >>> x = hl.experimental.loop(triangle_f, hl.tint32, 10, 0)
     >>> hl.eval(x)
     55
 

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -42,11 +42,10 @@ def loop(f: Callable, typ, *exprs):
             return True
         if isinstance(non_recursive, ir.TailLoop):
             return False
-        if len(non_recursive.children) == 0:
-            return False
-        return all([contains_recursive_call(c) for c in non_recursive.children])
+        return any([contains_recursive_call(c) for c in non_recursive.children])
 
     def check_tail_recursive(loop_ir):
+        print(str(loop_ir))
         if isinstance(loop_ir, ir.If):
             if contains_recursive_call(loop_ir.cond):
                 raise TypeError("branch condition can't contain recursive call!")

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -37,11 +37,11 @@ def loop(f: Callable, typ, *exprs):
         Result of the loop with `exprs` as initial loop values.
     """
 
+    loop_name = Env.get_uid()
+
     def contains_recursive_call(non_recursive):
-        if isinstance(non_recursive, ir.Recur):
+        if isinstance(non_recursive, ir.Recur) and non_recursive.name == loop_name:
             return True
-        if isinstance(non_recursive, ir.TailLoop):
-            return False
         return any([contains_recursive_call(c) for c in non_recursive.children])
 
     def check_tail_recursive(loop_ir):
@@ -57,8 +57,6 @@ def loop(f: Callable, typ, *exprs):
             check_tail_recursive(loop_ir.body)
         elif not isinstance(loop_ir, ir.Recur) and contains_recursive_call(loop_ir):
             raise TypeError("found recursive expression outside of tail position!")
-
-    loop_name = Env.get_uid()
 
     @typecheck(recur_exprs=expr_any)
     def make_loop(*recur_exprs):

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -89,4 +89,4 @@ def loop(f: Callable, typ, *exprs):
     indices, aggregations = unify_all(*exprs, loop_f)
     if loop_f.dtype != typ:
         raise TypeError(f"requested type {typ} does not match inferred type {loop_f.typ}")
-    return construct_expr(ir.Loop(uid_irs, loop_f._ir), loop_f.dtype, indices, aggregations)
+    return construct_expr(ir.TailLoop(uid_irs, loop_f._ir), loop_f.dtype, indices, aggregations)

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -3,7 +3,6 @@ from typing import Callable
 
 import hail as hl
 import hail.ir as ir
-from hail.table import ExprContainer
 from hail.expr.expressions import construct_variable, construct_expr, expr_any, to_expr, unify_all, expr_bool
 from hail.expr.types import hail_type
 from hail.typecheck import anytype, typecheck
@@ -19,9 +18,11 @@ def loop(f: Callable, typ, *exprs):
     >>> x = hl.experimental.loop(lambda recur, acc, n: hl.cond(n > 10, acc, recur(acc + n, n + 1)), hl.tint32, 0, 0)
     >>> hl.eval(x)
     55
+
     Notes
     -----
     The first argument to the lambda is a marker for the recursive call.
+
     Parameters
     ----------
     f : function ( (marker, *args) -> :class:`.Expression`

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -388,6 +388,72 @@ class TopLevelReference(Ref):
         self._type = env[self.name]
 
 
+class TailLoop(IR):
+
+    @typecheck_method(name=str, body=IR, params=sequenceof(sized_tupleof(str, IR)))
+    def __init__(self, name, body, params):
+        super().__init__(*([v for n, v in params] + [body]))
+        self.name = name
+        self.params = params
+        self.body = body
+
+    def copy(self, *children):
+        params = children[:-1]
+        body = children[-1]
+        assert len(params) == len(self.params)
+        return TailLoop(self.name, [(n, v) for (n, _), v in zip(self.params, params)], body)
+
+    def head_str(self):
+        return f'{escape_id(self.name)} ({" ".join([escape_id(n) for n, _ in self.params])})'
+
+    def _eq(self, other):
+        return self.name == other.name
+
+    def _compute_type(self, env, agg_env):
+        self._type = self.body._compute_type(env, agg_env)
+
+    @property
+    def bound_variables(self):
+        return {n for n, _ in self.params} | {self.name} | super().bound_variables
+
+    def _compute_type(self, env, agg_env):
+        self.body._compute_type(_env_bind(env, self.bindings(len(self.params))), agg_env)
+        self._type = self.body.typ
+
+    def renderable_bindings(self, i, default_value=None):
+        if i == len(self.params):
+            if default_value is None:
+                return {self.name: None, **{n: v.typ for n, v in self.params}}
+            else:
+                value = default_value
+                return {self.name: value, **{n: value for n, _ in self.params}}
+        else:
+            return {}
+
+
+class Recur(IR):
+    @typecheck_method(name=str, args=sequenceof(IR), return_type=hail_type)
+    def __init__(self, name, args, return_type):
+        super().__init__(*args)
+        self.name = name
+        self.args = args
+        self.return_type = return_type
+        self._free_vars = {name}
+
+    def copy(self, args):
+        return Recur(self.name, args, self.return_type)
+
+    def head_str(self):
+        return f'{escape_id(self.name)} {self.return_type._parsable_string()}'
+
+    def _eq(self, other):
+        return other.name == self.name
+
+    def _compute_type(self, env, agg_env):
+        assert self.name in env
+        self._type = self.return_type
+
+
 class ApplyBinaryPrimOp(IR):
     @typecheck_method(op=str, l=IR, r=IR)
     def __init__(self, op, l, r):

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -347,3 +347,17 @@ class Tests(unittest.TestCase):
             a = arrs[i]
             a2 = np.loadtxt(f'{prefix2}/files/{custom_names[i]}')
             self.assertTrue(np.array_equal(a, a2))
+
+    def test_loop(self):
+        print("foo")
+        from math import factorial
+
+        def fact(f, x, accum):
+            return hl.cond(x > 0,
+                           f(x - 1, accum * x),
+                           accum)
+
+        def hail_factorial(n):
+            return hl.experimental.loop(fact, n, 1)
+
+        self.assertEquals(hl.eval(hail_factorial(20)), factorial(20))

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -130,7 +130,9 @@ def run_with_cxx_compile():
 
 
 def assert_evals_to(e, v):
-    assert hl.eval(e) == v
+    res = hl.eval(e)
+    if res != v:
+        raise ValueError(f'  actual: {res}\n  expected: {v}')
 
 
 def assert_all_eval_to(*expr_and_expected):

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -719,6 +719,19 @@ class CodeArray[T](val lhs: Code[Array[T]])(implicit tti: TypeInfo[T]) {
     Code(lhs, new InsnNode(ARRAYLENGTH))
 }
 
+class CodeLabel() extends Code[Unit] {
+  val n = new LabelNode
+  def emit(il: Growable[AbstractInsnNode]): Unit = {
+    il += n
+  }
+
+  def goto: Code[Unit] = new Code[Unit] {
+    def emit(il: Growable[AbstractInsnNode]): Unit = {
+      il += new JumpInsnNode(GOTO, n)
+    }
+  }
+}
+
 object Invokeable {
   def apply[T](cls: Class[T], c: Constructor[_]): Invokeable[T, Unit] = new Invokeable[T, Unit](
     cls,

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -13,6 +13,9 @@ object Bindings {
 
   def apply(x: BaseIR, i: Int): Iterable[(String, Type)] = x match {
     case Let(name, value, _) => if (i == 1) Array(name -> value.typ) else empty
+    case TailLoop(args, body) => if (i == args.length)
+      args.map { case (name, ir) => name -> ir.typ } :+
+        TailLoop.bindingSym -> TTuple(TTuple(args.map(_._2.typ): _*), body.typ) else empty
     case ArrayMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFor(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFlatMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -13,9 +13,9 @@ object Bindings {
 
   def apply(x: BaseIR, i: Int): Iterable[(String, Type)] = x match {
     case Let(name, value, _) => if (i == 1) Array(name -> value.typ) else empty
-    case TailLoop(args, body) => if (i == args.length)
+    case TailLoop(name, args, body) => if (i == args.length)
       args.map { case (name, ir) => name -> ir.typ } :+
-        TailLoop.bindingSym -> TTuple(TTuple(args.map(_._2.typ): _*), body.typ) else empty
+        name -> TTuple(TTuple(args.map(_._2.typ): _*), body.typ) else empty
     case ArrayMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFor(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFlatMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -31,6 +31,10 @@ object Children {
       Array(value, body)
     case AggLet(name, value, body, _) =>
       Array(value, body)
+    case TailLoop(args, body) =>
+      args.map(_._2).toFastIndexedSeq :+ body
+    case Recur(args, _) =>
+      args.toFastIndexedSeq
     case Ref(name, typ) =>
       none
     case RelationalRef(_, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -31,9 +31,9 @@ object Children {
       Array(value, body)
     case AggLet(name, value, body, _) =>
       Array(value, body)
-    case TailLoop(args, body) =>
+    case TailLoop(_, args, body) =>
       args.map(_._2).toFastIndexedSeq :+ body
-    case Recur(args, _) =>
+    case Recur(_, args, _) =>
       args.toFastIndexedSeq
     case Ref(name, typ) =>
       none

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -33,6 +33,12 @@ object Copy {
       case AggLet(name, _, _, isScan) =>
         assert(newChildren.length == 2)
         AggLet(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
+      case TailLoop(params, body) =>
+        assert(newChildren.length == params.length + 1)
+        TailLoop(params.map(_._1).zip(newChildren.init.map(_.asInstanceOf[IR])), newChildren.last.asInstanceOf[IR])
+      case Recur(args, t) =>
+        assert(newChildren.length == args.length)
+        Recur(newChildren.map(_.asInstanceOf[IR]), t)
       case Ref(name, t) => Ref(name, t)
       case RelationalRef(name, t) => RelationalRef(name, t)
       case RelationalLet(name, _, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -33,12 +33,12 @@ object Copy {
       case AggLet(name, _, _, isScan) =>
         assert(newChildren.length == 2)
         AggLet(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
-      case TailLoop(params, body) =>
+      case TailLoop(name, params, _) =>
         assert(newChildren.length == params.length + 1)
-        TailLoop(params.map(_._1).zip(newChildren.init.map(_.asInstanceOf[IR])), newChildren.last.asInstanceOf[IR])
-      case Recur(args, t) =>
+        TailLoop(name, params.map(_._1).zip(newChildren.init.map(_.asInstanceOf[IR])), newChildren.last.asInstanceOf[IR])
+      case Recur(name, args, t) =>
         assert(newChildren.length == args.length)
-        Recur(newChildren.map(_.asInstanceOf[IR]), t)
+        Recur(name, newChildren.map(_.asInstanceOf[IR]), t)
       case Ref(name, t) => Ref(name, t)
       case RelationalRef(name, t) => RelationalRef(name, t)
       case RelationalLet(name, _, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1576,6 +1576,11 @@ private class Emit(
               ctxab.invoke[Array[Array[Byte]]]("result"),
               baos.invoke[Array[Byte]]("toByteArray")),
             decodeResult))
+      case x@Loop(args, body, rt) =>
+        val (argRefs, argIRs) = args.unzip
+        val refs = args.map { case (name, ir) => Ref(name, ir.typ) }
+        val args.map()
+
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -314,7 +314,10 @@ private class Emit(
     * {@code tAggIn.elementType}.  {@code tAggIn.symTab} is not used by Emit.
     *
     **/
-  private[ir] def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer], loopEnv: Option[Env[Array[LoopRef]]]): EmitTriplet = {
+  private[ir] def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer]): EmitTriplet =
+    emit(ir, env, er, container)
+
+  private def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer], loopEnv: Option[Env[Array[LoopRef]]]): EmitTriplet = {
 
     def emit(ir: IR, env: E = env, er: EmitRegion = er, container: Option[AggContainer] = container, loopEnv: Option[Env[Array[LoopRef]]] = loopEnv): EmitTriplet =
       this.emit(ir, env, er, container, loopEnv)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1599,7 +1599,7 @@ private class Emit(
           .bind(name, (typeToTypeInfo(x.typ), const(false), label.goto))
 
         val newLoopEnv = loopEnv.getOrElse(Env.empty)
-        val bodyT = emit(body, argEnv, loopEnv = newLoopEnv.bind(name, loopRefs.map(_._2).toArray))
+        val bodyT = emit(body, argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRefs.map(_._2).toArray)))
         val bodyF = Code(
           bodyT.setup,
           m := bodyT.m,

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -315,7 +315,7 @@ private class Emit(
     *
     **/
   private[ir] def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer]): EmitTriplet =
-    emit(ir, env, er, container)
+    emit(ir, env, er, container, None)
 
   private def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer], loopEnv: Option[Env[Array[LoopRef]]]): EmitTriplet = {
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1580,27 +1580,25 @@ private class Emit(
               baos.invoke[Array[Byte]]("toByteArray")),
             decodeResult))
       case x@TailLoop(args, body) =>
-        val (storeInitArgs, refs) = args.map { case (name, ir) =>
-          val t = emit(ir)
+        val loopRefs = args.map { case (name, ir) =>
           val ti = typeToTypeInfo(ir.typ)
-          val m = mb.newField[Boolean]
-          val v: ClassFieldRef[_] = mb.newField()(ti)
-          (Code(t.setup, m := t.m, (!m).orEmpty(v := t.value)), (name, ti, m, v))
-        }.unzip
+          ti -> LoopRef(mb.newField[Boolean], mb.newField()(ti), mb.newLocal[Boolean], mb.newLocal()(ti))
+        }
+
+        val storeInitArgs = args.zip(loopRefs).map { case ((_, ir), (_, loopref)) =>
+          val t = emit(ir)
+          Code(t.setup, loopref.m := t.m, (!loopref.m).orEmpty(loopref.v := t.value))
+        }
 
         val label = new CodeLabel
         val m = mb.newField[Boolean]
         val v = mb.newField()(typeToTypeInfo(x.typ))
 
         val argEnv = env
-          .bind(refs.map { case (name, ti, m, v) => name -> (ti, m.load(), v.load()) } : _*)
+          .bind(args.zip(loopRefs).map { case ((name, _), (ti, ref)) => (name, (ti, ref.m.load(), ref.v.load())) } : _*)
           .bind(TailLoop.bindingSym, (typeToTypeInfo(x.typ), const(false), label.goto))
 
-        val newLoopRefs = refs.map { case (name, ti, m, v) =>
-            LoopRef(m, v, mb.newLocal[Boolean], mb.newLocal()(ti))
-        }
-
-        val bodyT = emit(body, argEnv, Some(newLoopRefs))
+        val bodyT = emit(body, argEnv, loopRefs = Some(loopRefs.map(_._2).toArray))
         val bodyF = Code(
           bodyT.setup,
           m := bodyT.m,
@@ -1612,11 +1610,11 @@ private class Emit(
         val (_, _, jump) = env.lookup(TailLoop.bindingSym)
         val refs = loopRefs.get
         val storeTempArgs = Array.tabulate(refs.length) { i =>
-          emit(args(i), env.delete())
-
-
+          val t = emit(args(i), env.delete(TailLoop.bindingSym), loopRefs = None)
+          Code(t.setup, refs(i).tempM := t.m, refs(i).tempV.storeAny(refs(i).tempM.mux(defaultValue(args(i).typ), t.v)))
         }
-        EmitTriplet(Code(Code(storeArgs: _*), jump), const(false), Code._empty)
+        val moveArgs = refs.map( ref =>  Code(ref.m := ref.tempM, ref.v.storeAny(ref.tempV)) )
+        EmitTriplet(Code(Code(storeTempArgs ++ moveArgs: _*), coerce[Unit](jump)), const(false), Code._empty)
     }
   }
 
@@ -1682,7 +1680,7 @@ private class Emit(
     }
 
   private def emitOldArrayIterator(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer]): ArrayIteratorTriplet = {
-    def emit(ir: IR, env: E = env) = this.emit(ir, env, er, container)
+    def emit(ir: IR, env: E = env) = this.emit(ir, env, er, container, None)
 
     def emitArrayIterator(ir: IR, env: E = env) =
       this.emitOldArrayIterator(ir, env, er, container)
@@ -1940,9 +1938,9 @@ private class Emit(
         val postAgg = Optimize[IR](Let(res, extracted.results, extracted.postAggIR), noisy = true,
           context = "ArrayAggScan/StagedExtractAggregators/perElt", ctx)
 
-        val codeInit = this.emit(init, env, er, Some(newContainer))
-        val codeSeq = this.emit(perElt, bodyEnv, er, Some(newContainer))
-        val newElt = this.emit(postAgg, bodyEnv, er, Some(newContainer))
+        val codeInit = this.emit(init, env, er, Some(newContainer), None)
+        val codeSeq = this.emit(perElt, bodyEnv, er, Some(newContainer), None)
+        val newElt = this.emit(postAgg, bodyEnv, er, Some(newContainer), None)
 
         val it = emitArrayIterator(a)
         val ae = { cont: Emit.F =>

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -155,6 +155,12 @@ final case class AggLet(name: String, value: IR, body: IR, isScan: Boolean) exte
 final case class Let(name: String, value: IR, body: IR) extends IR
 final case class Ref(name: String, var _typ: Type) extends IR
 
+
+// Recur can't exist outside of loop
+// Loops can be nested, but we can't call outer loops in terms of inner loops
+final case class Loop(params: Seq[(String, IR)], body: IR, _typ: Type) extends IR
+final case class Recur(args: Seq[IR], _typ: Type) extends IR
+
 final case class RelationalLet(name: String, value: IR, body: IR) extends IR
 final case class RelationalRef(name: String, _typ: Type) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -157,8 +157,11 @@ final case class Ref(name: String, var _typ: Type) extends IR
 
 
 // Recur can't exist outside of loop
-// Loops can be nested, but we can't call outer loops in terms of inner loops
-final case class Loop(params: Seq[(String, IR)], body: IR, _typ: Type) extends IR
+// Loops can be nested, but we can't call outer loops in terms of inner loops so there can only be one loop "active" in a given context
+object TailLoop {
+  val bindingSym: String = "__TAIL_LOOP"
+}
+final case class TailLoop(params: Seq[(String, IR)], body: IR) extends IR
 final case class Recur(args: Seq[IR], _typ: Type) extends IR
 
 final case class RelationalLet(name: String, value: IR, body: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -158,11 +158,8 @@ final case class Ref(name: String, var _typ: Type) extends IR
 
 // Recur can't exist outside of loop
 // Loops can be nested, but we can't call outer loops in terms of inner loops so there can only be one loop "active" in a given context
-object TailLoop {
-  val bindingSym: String = "__TAIL_LOOP"
-}
-final case class TailLoop(params: Seq[(String, IR)], body: IR) extends IR
-final case class Recur(args: Seq[IR], _typ: Type) extends IR
+final case class TailLoop(name: String, params: Seq[(String, IR)], body: IR) extends IR
+final case class Recur(name: String, args: Seq[IR], _typ: Type) extends IR
 
 final case class RelationalLet(name: String, value: IR, body: IR) extends IR
 final case class RelationalRef(name: String, _typ: Type) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InTailPosition.scala
@@ -1,0 +1,9 @@
+package is.hail.expr.ir
+
+object InTailPosition {
+  def apply(x: IR, i: Int): Boolean = x match {
+    case Let(_, _, _) => i == 1
+    case If(_, _, _) => i != 0
+    case _ => false
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -119,6 +119,15 @@ object InferPType {
 
         body.pType2
       }
+      case TailLoop(args, body) =>
+        args.foreach { case (_, ir) => InferPType(ir, env) }
+        InferPType(body, env.bind(args.map { case (n, ir) => n -> ir.pType2 }: _*))
+        body.pType2
+      case Recur(args, typ) =>
+        // FIXME: This may be difficult to infer properly from a bottom-up pass.
+        args.foreach { a => InferPType(a, env) }
+        PType.canonical(typ)
+
       case ApplyBinaryPrimOp(op, l, r) => {
           InferPType(l, env)
           InferPType(r, env)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -119,11 +119,11 @@ object InferPType {
 
         body.pType2
       }
-      case TailLoop(args, body) =>
+      case TailLoop(_, args, body) =>
         args.foreach { case (_, ir) => InferPType(ir, env) }
         InferPType(body, env.bind(args.map { case (n, ir) => n -> ir.pType2 }: _*))
         body.pType2
-      case Recur(args, typ) =>
+      case Recur(_, args, typ) =>
         // FIXME: This may be difficult to infer properly from a bottom-up pass.
         args.foreach { a => InferPType(a, env) }
         PType.canonical(typ)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -54,6 +54,10 @@ object InferType {
         body.typ
       case AggLet(name, value, body, _) =>
         body.typ
+      case TailLoop(_, body) =>
+        body.typ
+      case Recur(_, typ) =>
+        typ
       case ApplyBinaryPrimOp(op, l, r) =>
         BinaryOp.getReturnType(op, l.typ, r.typ).setRequired(l.typ.required && r.typ.required)
       case ApplyUnaryPrimOp(op, v) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -54,9 +54,9 @@ object InferType {
         body.typ
       case AggLet(name, value, body, _) =>
         body.typ
-      case TailLoop(_, body) =>
+      case TailLoop(_, _, body) =>
         body.typ
-      case Recur(_, typ) =>
+      case Recur(_, _, typ) =>
         typ
       case ApplyBinaryPrimOp(op, l, r) =>
         BinaryOp.getReturnType(op, l.typ, r.typ).setRequired(l.typ.required && r.typ.required)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -655,19 +655,19 @@ object Interpret {
         wrapped.get(0)
       case x: ReadPartition =>
         fatal(s"cannot interpret ${ Pretty(x) }")
-      case TailLoop(args, body) =>
+      case TailLoop(name, args, body) =>
         val inits = args.map { case (name, arg) => name -> interpret(arg) }
         val argEnv = env.bind(inits: _*)
         val names = args.map(_._1)
         val types = args.map(_._2.typ)
         val f: Seq[IR] => Any = { newArgs: Seq[Any] =>
           val lits = newArgs.zip(types).map { case (a, t) => Literal.coerce(t, a) }
-          interpret(TailLoop(names.zip(lits), body), env)
+          interpret(TailLoop(name, names.zip(lits), body), env)
         }
-        interpret(body, argEnv.bind(TailLoop.bindingSym, f))
+        interpret(body, argEnv.bind(name, f))
 
-      case Recur(args, _) =>
-        val f = env.lookup(TailLoop.bindingSym).asInstanceOf[Seq[Any] => Any]
+      case Recur(name, args, _) =>
+        val f = env.lookup(name).asInstanceOf[Seq[Any] => Any]
         val argValues = args.map(interpret(_))
         f(argValues)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -655,6 +655,21 @@ object Interpret {
         wrapped.get(0)
       case x: ReadPartition =>
         fatal(s"cannot interpret ${ Pretty(x) }")
+      case TailLoop(args, body) =>
+        val inits = args.map { case (name, arg) => name -> interpret(arg) }
+        val argEnv = env.bind(inits: _*)
+        val names = args.map(_._1)
+        val types = args.map(_._2.typ)
+        val f: Seq[IR] => Any = { newArgs: Seq[Any] =>
+          val lits = newArgs.zip(types).map { case (a, t) => Literal.coerce(t, a) }
+          interpret(TailLoop(names.zip(lits), body), env)
+        }
+        interpret(body, argEnv.bind(TailLoop.bindingSym, f))
+
+      case Recur(args, _) =>
+        val f = env.lookup(TailLoop.bindingSym).asInstanceOf[Seq[Any] => Any]
+        val argValues = args.map(interpret(_))
+        f(argValues)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -87,6 +87,10 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         else
           env.promoteAgg -> env.bindAgg(name, newName)
         AggLet(newName, normalize(value, valueEnv), normalize(body, bodyEnv), isScan)
+      case TailLoop(args, body) =>
+        val newNames = Array.tabulate(args.length)(i => gen())
+        val (names, values) = args.unzip
+        TailLoop(newNames.zip(values.map(v => normalize(v))), normalize(body, env.copy(eval = env.eval.bind(names.zip(newNames): _*))))
       case ArraySort(a, left, right, compare) =>
         val newLeft = gen()
         val newRight = gen()

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -85,7 +85,7 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           case Some(n) => n
           case None =>
             if (!allowFreeVariables)
-              throw new RuntimeException(s"found free variable in normalize: $name")
+              throw new RuntimeException(s"found free loop variable in normalize: $name")
             else
               name
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -624,6 +624,14 @@ object IRParser {
         val value = ir_value_expr(env)(it)
         val body = ir_value_expr(env + (name -> value.typ))(it)
         AggLet(name, value, body, isScan)
+      case "TailLoop" =>
+        val args = named_value_irs(env)(it)
+        val body = ir_value_expr(env)(it)
+        TailLoop(args, body)
+      case "Recur" =>
+        val typ = type_expr(env.typEnv)(it)
+        val args = ir_value_children(env)(it)
+        Recur(args, typ)
       case "Ref" =>
         val id = identifier(it)
         Ref(id, env.refMap(id))

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -625,13 +625,15 @@ object IRParser {
         val body = ir_value_expr(env + (name -> value.typ))(it)
         AggLet(name, value, body, isScan)
       case "TailLoop" =>
-        val args = named_value_irs(env)(it)
+        val name = identifier(it)
         val body = ir_value_expr(env)(it)
-        TailLoop(args, body)
+        val args = named_value_irs(env)(it)
+        TailLoop(name, args, body)
       case "Recur" =>
+        val name = identifier(it)
         val typ = type_expr(env.typEnv)(it)
         val args = ir_value_children(env)(it)
-        Recur(args, typ)
+        Recur(name, args, typ)
       case "Ref" =>
         val id = identifier(it)
         Ref(id, env.refMap(id))

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -626,9 +626,11 @@ object IRParser {
         AggLet(name, value, body, isScan)
       case "TailLoop" =>
         val name = identifier(it)
-        val body = ir_value_expr(env)(it)
-        val args = named_value_irs(env)(it)
-        TailLoop(name, args, body)
+        val paramNames = identifiers(it)
+        val params = paramNames.map { n => n -> ir_value_expr(env)(it) }
+        val bodyEnv = env.update(params.map { case (n, v) => n -> v.typ}.toMap)
+        val body = ir_value_expr(bodyEnv)(it)
+        TailLoop(name, params, body)
       case "Recur" =>
         val name = identifier(it)
         val typ = type_expr(env.typEnv)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -200,6 +200,21 @@ object Pretty {
               sb += ')'
             }(sb += '\n')
           }
+        case TailLoop(args, body) =>
+          sb += '\n'
+          if (args.nonEmpty) {
+            sb += '\n'
+            args.foreachBetween { case (n, a) =>
+              sb.append(" " * (depth + 2))
+              sb += '('
+              sb.append(prettyIdentifier(n))
+              sb += '\n'
+              pretty(a, depth + 4)
+              sb += ')'
+            }(sb += '\n')
+            sb += '\n'
+            pretty(body, depth + 2)
+          }
         case _ =>
           val header = ir match {
             case I32(x) => x.toString
@@ -219,6 +234,7 @@ object Pretty {
                 )
             case Let(name, _, _) => prettyIdentifier(name)
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
+            case Recur(_, t) => t.parsableString()
             case Ref(name, _) => prettyIdentifier(name)
             case RelationalRef(name, t) => prettyIdentifier(name) + " " + t.parsableString()
             case RelationalLet(name, _, _) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -200,7 +200,11 @@ object Pretty {
               sb += ')'
             }(sb += '\n')
           }
-        case TailLoop(args, body) =>
+        case TailLoop(name, args, body) =>
+          sb += '\n'
+          prettyIdentifier(name)
+          sb += '\n'
+          pretty(body, depth + 2)
           sb += '\n'
           if (args.nonEmpty) {
             sb += '\n'
@@ -212,8 +216,6 @@ object Pretty {
               pretty(a, depth + 4)
               sb += ')'
             }(sb += '\n')
-            sb += '\n'
-            pretty(body, depth + 2)
           }
         case _ =>
           val header = ir match {
@@ -234,7 +236,7 @@ object Pretty {
                 )
             case Let(name, _, _) => prettyIdentifier(name)
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
-            case Recur(_, t) => t.parsableString()
+            case Recur(name, _, t) => prettyIdentifier(name) + " " + t.parsableString()
             case Ref(name, _) => prettyIdentifier(name)
             case RelationalRef(name, t) => prettyIdentifier(name) + " " + t.parsableString()
             case RelationalLet(name, _, _) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -200,23 +200,6 @@ object Pretty {
               sb += ')'
             }(sb += '\n')
           }
-        case TailLoop(name, args, body) =>
-          sb += '\n'
-          prettyIdentifier(name)
-          sb += '\n'
-          pretty(body, depth + 2)
-          sb += '\n'
-          if (args.nonEmpty) {
-            sb += '\n'
-            args.foreachBetween { case (n, a) =>
-              sb.append(" " * (depth + 2))
-              sb += '('
-              sb.append(prettyIdentifier(n))
-              sb += '\n'
-              pretty(a, depth + 4)
-              sb += ')'
-            }(sb += '\n')
-          }
         case _ =>
           val header = ir match {
             case I32(x) => x.toString
@@ -236,6 +219,7 @@ object Pretty {
                 )
             case Let(name, _, _) => prettyIdentifier(name)
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
+            case TailLoop(name, args, _) => prettyIdentifier(name) + " " + prettyIdentifiers(args.map(_._1).toFastIndexedSeq)
             case Recur(name, _, t) => prettyIdentifier(name) + " " + t.parsableString()
             case Ref(name, _) => prettyIdentifier(name)
             case RelationalRef(name, t) => prettyIdentifier(name) + " " + t.parsableString()

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -117,7 +117,7 @@ object TypeCheck {
         val expected = env.eval.lookup(name)
         assert(x.typ == expected, s"type mismatch:\n  name: $name\n  actual: ${ x.typ.parsableString() }\n  expect: ${ expected.parsableString() }")
       case RelationalRef(_, _) =>
-      case x@TailLoop(_, body) =>
+      case x@TailLoop(_, _, body) =>
         assert(x.typ == body.typ)
         def checkRecurOnlyInTail(node: IR, tailPosition: Boolean): Boolean = {
           if (node.isInstanceOf[Recur] && !tailPosition)
@@ -130,8 +130,8 @@ object TypeCheck {
               }
           }
         assert(checkRecurOnlyInTail(body, true))
-      case x@Recur(args, typ) =>
-        val TTuple(IndexedSeq(TupleField(_, argTypes), TupleField(_, rt)), _) = env.eval.lookup(TailLoop.bindingSym)
+      case x@Recur(name, args, typ) =>
+        val TTuple(IndexedSeq(TupleField(_, argTypes), TupleField(_, rt)), _) = env.eval.lookup(name)
         assert(argTypes.asInstanceOf[TTuple].types.zip(args).forall { case (t, ir) => t == ir.typ } )
         assert(typ == rt)
       case x@ApplyBinaryPrimOp(op, l, r) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -117,6 +117,23 @@ object TypeCheck {
         val expected = env.eval.lookup(name)
         assert(x.typ == expected, s"type mismatch:\n  name: $name\n  actual: ${ x.typ.parsableString() }\n  expect: ${ expected.parsableString() }")
       case RelationalRef(_, _) =>
+      case x@TailLoop(_, body) =>
+        assert(x.typ == body.typ)
+        def checkRecurOnlyInTail(node: IR, tailPosition: Boolean): Boolean = {
+          if (node.isInstanceOf[Recur] && !tailPosition)
+            false
+          else
+            node.children.zipWithIndex
+              .filterNot { case (c, _) => c.isInstanceOf[TailLoop] | !c.isInstanceOf[IR] }
+              .forall { case (c, i) =>
+                checkRecurOnlyInTail(c.asInstanceOf[IR], tailPosition && InTailPosition(x, i))
+              }
+          }
+        assert(checkRecurOnlyInTail(body, true))
+      case x@Recur(args, typ) =>
+        val TTuple(IndexedSeq(TupleField(_, argTypes), TupleField(_, rt)), _) = env.eval.lookup(TailLoop.bindingSym)
+        assert(argTypes.asInstanceOf[TTuple].types.zip(args).forall { case (t, ir) => t == ir.typ } )
+        assert(typ == rt)
       case x@ApplyBinaryPrimOp(op, l, r) =>
         assert(x.typ == BinaryOp.getReturnType(op, l.typ, r.typ))
       case x@ApplyUnaryPrimOp(op, v) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -124,9 +124,9 @@ object TypeCheck {
             false
           else
             node.children.zipWithIndex
-              .filterNot { case (c, _) => c.isInstanceOf[TailLoop] | !c.isInstanceOf[IR] }
+              .filterNot { case (c, _) => c.isInstanceOf[TailLoop] || !c.isInstanceOf[IR] }
               .forall { case (c, i) =>
-                checkRecurOnlyInTail(c.asInstanceOf[IR], tailPosition && InTailPosition(x, i))
+                checkRecurOnlyInTail(c.asInstanceOf[IR], tailPosition && InTailPosition(node, i))
               }
           }
         assert(checkRecurOnlyInTail(body, true))

--- a/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
+++ b/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
@@ -37,7 +37,7 @@ This is the list of things you need to do to add a new IR node.
 
  - Implement it in Emit (the compiler) or add it to Compilable as false
 
- - If it binds a variable, add support to Binds and Subst
+ - If it binds a variable, add support to Bindings
 
 * MatrixIR
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2427,7 +2427,8 @@ class IRSuite extends HailSuite {
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
-      RelationalLet("x", I32(0), I32(0))
+      RelationalLet("x", I32(0), I32(0)),
+      TailLoop(IndexedSeq("x" -> I32(0)), Recur(FastSeq(I32(4)), TInt32()))
     )
     irs.map(x => Array(x))
   }
@@ -2995,5 +2996,38 @@ class IRSuite extends HailSuite {
           Interval(
             Row(Locus("20", 10277621)), Row(Locus("20", 11898992)), includesStart = true, includesEnd = false)),
         v))
+  }
+
+  @Test def testSimpleTailLoop(): Unit = {
+    val triangleSum: IR = TailLoop(
+      FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> I32(0)),
+      If(Ref("x", TInt32()) <= I32(0),
+        Ref("accum", TInt32()),
+        Recur(FastIndexedSeq(
+          Ref("x", TInt32()) - I32(1),
+          Ref("accum", TInt32()) + Ref("x", TInt32())),
+          TInt32())))
+
+    assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32()), 15)
+  }
+
+  @Test def testNestedTailLoop(): Unit = {
+    val triangleSum: IR = TailLoop(
+      FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> I32(0)),
+      If(Ref("x", TInt32()) <= I32(0),
+        TailLoop(
+          FastIndexedSeq("x2" -> Ref("accum", TInt32()), "accum2" -> I32(0)),
+          If(Ref("x2", TInt32()) <= I32(0),
+            Ref("accum2", TInt32()),
+            Recur(FastIndexedSeq(
+              Ref("x2", TInt32()) - I32(5),
+              Ref("accum2", TInt32()) + Ref("x2", TInt32())),
+              TInt32()))),
+        Recur(FastIndexedSeq(
+          Ref("x", TInt32()) - I32(1),
+          Ref("accum", TInt32()) + Ref("x", TInt32())),
+          TInt32())))
+
+    assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32()), 15 + 10 + 5)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3000,7 +3000,7 @@ class IRSuite extends HailSuite {
 
   @Test def testSimpleTailLoop(): Unit = {
     val triangleSum: IR = TailLoop("f",
-      FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> I32(0)),
+      FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> In(1, TInt32())),
       If(Ref("x", TInt32()) <= I32(0),
         Ref("accum", TInt32()),
         Recur("f",
@@ -3009,7 +3009,9 @@ class IRSuite extends HailSuite {
             Ref("accum", TInt32()) + Ref("x", TInt32())),
           TInt32())))
 
-    assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32()), 15)
+    assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32(), 0 -> TInt32()), 15)
+    assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32(), (null, TInt32())), null)
+    assertEvalsTo(triangleSum, FastIndexedSeq((null, TInt32()),  0 -> TInt32()), null)
   }
 
   @Test def testNestedTailLoop(): Unit = {


### PR DESCRIPTION
I don't think I'm quite satisfied with this implementation, although I think that it will do the things we need it to do, for the most part. It mostly adheres to the structure that @chrisvittal was implementing in #5228, although I had some questions/notes about implementation/interface and would love some input:

* I'd like to implement (in python) some sort of while loop construct, but I'm not sure what it looks like. I think I'd like to think of that as our primary loop construct since the general recursive loop function can be confusing to start with in terms of what's allowed (what is tail-recursive? what is non-tail-recursive?) if you're just trying to implement some convergence criteria. Some initial thoughts on interface:
```
1:
loop = hl.WhileBuilder(i=0, x=0)
loop.cond(loop.i < 10)
    .update(x = loop.x + i, 
            i = loop.i + 1)
    .result(loop.x)

2: 
loop = hl.while_loop(
    lambda i, x: i < 10, 
    lambda i, x: (x + i, i + 1), 
    lambda i, x: x, 
    0, 0)

3:
loop = hl.while_loop(
    lambda i, x: 
    hl.loop.cond(i < 10)
           .update(i + 1, x + i)
           .result(x).
    0, 0)
```
but I'm not sure I really like any of them.
* the scoping for `Recur` is difficult to check and enforce.
  * It's difficult to check if a TailLoop is invalidly attempting to recur a function from a different loop (in a nested environment), except by the type signature. I think I could give each loop a name so that `Recur` unambiguously refers to a loop defined in the surrounding scope, mostly treating `Recur` as something of a function reference.
* The code generation is rather inconsistent, since the `Recur` node technically has the same type as the return type of the function, but the code generated needs to be a jump node with no actual value (which makes the generated EmitTriplet look a lot like it has type TVoid!)
  * @patrick-schultz proposed a similar design, but with two additional types to make the difference between the type of the `Recur` concept and the actual return type more explicit. I have not yet implemented it because I think it might make this python interface more difficult to support, and I rather like its simplicity.
* @patrick-schultz and I were talking about rewriting loops in the stream interface.
  * We can only emit calls to recur in the same method that the original loop is defined in, because we are using jumps to implement them. This means we need to know that we are not going to wrap any calls that contain `Recur` in a method. I don't believe there are any cases where we wrap `If` conditions or `Let` bodies in methods, so this is fine for now, but we're not enforcing it in any way. I believe that the iteration for the stream codegen stuff will always be in the same method, so we wouldn't have to deal with this specially there.
  * I've implemented a pretty simple version of here, as part of the `Streamify` pass. I believe it should handle all the valid tail-recursive cases, but I don't think we want to use it right now since it'll always allocate (as opposed to not allocating if all state is primitive). We could potentially revisit this once we can allow stream elements like this to basically store their elements in primitive fields, if that prevents allocation. You can take a look here: https://github.com/catoverdrive/hail/compare/loops...catoverdrive:loops-as-stream?expand=1

cc @cseed @patrick-schultz @chrisvittal 