### PR TITLE
[hail] 3.6 or 3.7

### DIFF
--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -55,7 +55,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create -n hail python=3.7.4
+    conda create -n hail python'>=3.6,<3.8'
     conda activate hail
     pip install hail
 


### PR DESCRIPTION
It seems not right to pin to a specific patch version of python 3.7. This is unnecessarily more generous, but seems fine.