### PR TITLE
[ci] extract files from archives in buildImage

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -450,7 +450,7 @@ class RunImageStep(Step):
                 if i.get('directory') != 'archive':
                     batch_copy_destination = i["to"]
                 else:
-                    batch_copy_destination = f'/io/{self.token}/i["from"]'
+                    batch_copy_destination = f'/io/{self.token}/{i["from"]}'
                     actual_destination = shq(f'{i["to"]}')
                     if 'extract' not in i:
                         copy_inputs.append(f'tar -xzf {batch_copy_destination} -C {actual_destination}')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -465,7 +465,7 @@ class RunImageStep(Step):
         if self.outputs:
             output_files = []
             for o in self.outputs:
-                if i.get('directory') != 'archive':
+                if o.get('directory') != 'archive':
                     batch_copy_source = o["from"]
                 else:
                     batch_copy_source = f'/io/{self.token}/o["to"]'

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -485,7 +485,7 @@ class RunImageStep(Step):
                     'mount_path': mount_path
                 })
 
-        final_script = ';\n'.join([f'mkdir -p /io/{self.token}', *copy_inputs, rendered_script, *copy_outputs])
+        final_script = '\n\n'.join([f'mkdir -p /io/{self.token}', *copy_inputs, rendered_script, *copy_outputs])
 
         self.job = batch.create_job(
             self.image,

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -469,7 +469,7 @@ class RunImageStep(Step):
                     batch_copy_source = o["from"]
                 else:
                     batch_copy_source = f'/io/{self.token}/{o["to"]}'
-                    copy_outputs.append(f'tar -czf {batch_copy_source} -C {os.path.dirname(o["from"])} {o["from"]}')
+                    copy_outputs.append(f'tar -czf {batch_copy_source} -C {os.path.dirname(o["from"])} {os.path.basename(o["from"])}')
                 output_files.append((batch_copy_source,
                                      f'{BUCKET}/build/{batch.attributes["token"]}{o["to"]}'))
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -485,7 +485,7 @@ class RunImageStep(Step):
                     'mount_path': mount_path
                 })
 
-        final_script = ';\n'.join([*copy_inputs, rendered_script, *copy_outputs])
+        final_script = ';\n'.join([f'mkdir -p /io/{self.token}', *copy_inputs, rendered_script, *copy_outputs])
 
         self.job = batch.create_job(
             self.image,

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -468,7 +468,7 @@ class RunImageStep(Step):
                 if o.get('directory') != 'archive':
                     batch_copy_source = o["from"]
                 else:
-                    batch_copy_source = f'/io/{self.token}/o["to"]'
+                    batch_copy_source = f'/io/{self.token}/{o["to"]}'
                     copy_outputs += f'tar -czf {batch_copy_source} {o["from"]}'
                 output_files.append((batch_copy_source,
                                      f'{BUCKET}/build/{batch.attributes["token"]}{o["to"]}'))

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -31,11 +31,11 @@ steps:
      COPY archived-foo/foo/data data1
      COPY recursive-foo/foo/data data2
      RUN diff data1 data2
-EOF
+     EOF
 
      cat >data <<EOF
      some data
-EOF
+     EOF
 
      git add Dockerfile
      git commit -m "first commit"
@@ -44,7 +44,7 @@ EOF
 
      cat >uncompressed-file <<EOF
      this is an uncompressed file
-EOF
+     EOF
    outputs:
      - from: /io/foo
        to: /foo.tgz

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -130,6 +130,22 @@ steps:
      valueFrom: default_ns.name
    dependsOn:
     - default_ns
+ - kind: runImage
+   name: checkout_this_repo
+   image:
+     valueFrom: git_image.image
+   script: |
+     set -ex
+     cd /io
+     mkdir repo
+     cd repo
+     {{ code.checkout_script }}
+   outputs:
+    - from: /io/repo
+      to: /repo
+      directory: archive
+   dependsOn:
+     - git_image
  - kind: createDatabase2
    name: hello2_database
    databaseName: hello2
@@ -139,13 +155,16 @@ steps:
     - name: insert
       script: /io/sql/insert.py
    inputs:
-    - from: /repo/ci/test/resources/sql
+    - from: /repo
       to: /io/
+      directory: archive
+      extract:
+        - ci/test/resources/sql
    namespace:
      valueFrom: default_ns.name
    dependsOn:
     - default_ns
-    - copy_files
+    - checkout_this_repo
  - kind: runImage
    name: test_hello2_database
    image:

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -96,6 +96,8 @@ steps:
        directory: recursive
      - from: /uncompressed-file
        to: /io/uncompressed-file
+   dependsOn:
+     - git_image
  - kind: buildImage
    name: base_image
    dockerFile: docker/Dockerfile.base

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -29,7 +29,7 @@ steps:
      FROM ubuntu:18.04
      COPY uncompressed-file .
      COPY archived-foo/foo/data data1
-     COPY recursive-foo/foo/data data2
+     COPY foo/data data2
      RUN diff data1 data2
      EOF
 
@@ -59,7 +59,7 @@ steps:
      - git_image
  - kind: buildImage
    name: verify_copy_inputs_for_build_image_works
-   dockerFile: /recursive-foo/Dockerfile
+   dockerFile: /Dockerfile
    contextPath: .
    inputs:
      - from: /foo.tgz
@@ -68,7 +68,7 @@ steps:
        extract:
          - foo/data
      - from: /foo
-       to: /recursive-foo
+       to: /
        directory: recursive
      - from: /uncompressed-file
        to: /uncompressed-file

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -45,6 +45,7 @@ steps:
      cat >uncompressed-file <<EOF
      this is an uncompressed file
      EOF
+     # without a newline after EOF bash things the heredoc is unterminated
    outputs:
      - from: /io/foo
        to: /foo.tgz

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -4,34 +4,60 @@ steps:
    namespaceName: default
    public: true
  - kind: buildImage
-   name: inline_image
+   name: git_image
    dockerFile:
      inline: |
        FROM ubuntu:18.04
        RUN apt-get update && apt-get install -y git
    contextPath: .
  - kind: runImage
-   name: run_inline_image
+   name: create_git_repo
    image:
-     valueFrom: inline_image.image
-   script: |
-     git init
-   dependsOn:
-     - inline_image
- - kind: runImage
-   name: copy_files
-   image:
-     valueFrom: inline_image.image
+     valueFrom:
+       git_image.image
    script: |
      cd /io
-     mkdir repo
-     cd repo
-     {{ code.checkout_script }}
+     mkdir foo
+     cd foo
+     git init
+
+     cat >Dockerfile <<EOF
+     FROM ubuntu:18.04
+     COPY uncompressed-file .
+     EOF
+
+     git add Dockerfile
+     git commit -m "first commit"
+
+     cd ..
+     tar -xczf foo.tgz foo
+
+     cat >uncompressed-file <<EOF
+     this is an uncompressed file
+     EOF
    outputs:
-    - from: /io/repo
-      to: /
+     - from: /io/foo.tgz
+       to: /foo.tgz
+     - from: /io/uncompressed-file
+       to: /uncompressed-file
    dependsOn:
-    - inline_image
+     - git_image
+ - kind: buildImage
+   name: verify_decompress_works
+   dockerFile: /foo/Dockerfile
+   contextPath: /
+   inputs:
+     - from: /foo.tgz
+       to: /foo.tgz
+       decompress: True
+     - from: /uncompressed-file
+       to: /uncompressed-file
+   image:
+     valueFrom:
+       git_image.image
+   dependsOn:
+     - git_image
+     - create_git_repo
  - kind: buildImage
    name: base_image
    dockerFile: docker/Dockerfile.base

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -31,11 +31,11 @@ steps:
      COPY archived-foo/foo/data data1
      COPY recursive-foo/foo/data data2
      RUN diff data1 data2
-     EOF
+EOF
 
      cat >data <<EOF
      some data
-     EOF
+EOF
 
      git add Dockerfile
      git commit -m "first commit"
@@ -44,7 +44,7 @@ steps:
 
      cat >uncompressed-file <<EOF
      this is an uncompressed file
-     EOF
+EOF
    outputs:
      - from: /io/foo
        to: /foo.tgz

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -16,40 +16,59 @@ steps:
      valueFrom:
        git_image.image
    script: |
+     set -ex
+
      cd /io
      mkdir foo
      cd foo
+     git config --global user.email "you@example.com"
+     git config --global user.name "Your Name"
      git init
 
      cat >Dockerfile <<EOF
      FROM ubuntu:18.04
      COPY uncompressed-file .
+     COPY archived-foo/foo/data data1
+     COPY recursive-foo/foo/data data2
+     RUN diff data1 data2
+     EOF
+
+     cat >data <<EOF
+     some data
      EOF
 
      git add Dockerfile
      git commit -m "first commit"
 
      cd ..
-     tar -xczf foo.tgz foo
 
      cat >uncompressed-file <<EOF
      this is an uncompressed file
      EOF
    outputs:
-     - from: /io/foo.tgz
+     - from: /io/foo
        to: /foo.tgz
+       directory: archive
+     - from: /io/foo
+       to: /foo
+       directory: recursive
      - from: /io/uncompressed-file
        to: /uncompressed-file
    dependsOn:
      - git_image
  - kind: buildImage
-   name: verify_decompress_works
-   dockerFile: /foo/Dockerfile
-   contextPath: /
+   name: verify_copy_inputs_for_build_image_works
+   dockerFile: /recursive-foo/Dockerfile
+   contextPath: .
    inputs:
      - from: /foo.tgz
-       to: /foo.tgz
-       decompress: True
+       to: /archived-foo
+       directory: archive
+       extract:
+         - foo/data
+     - from: /foo
+       to: /recursive-foo
+       directory: recursive
      - from: /uncompressed-file
        to: /uncompressed-file
    image:
@@ -58,6 +77,24 @@ steps:
    dependsOn:
      - git_image
      - create_git_repo
+ - kind: runImage
+   name: verify_copy_inputs_for_run_image_works
+   image: ubuntu:18.04
+   script: |
+     cd io
+     diff archived-foo/data recursive-foo/data
+     cat uncompressed-file
+   inputs:
+     - from: /foo.tgz
+       to: /io/archived-foo
+       directory: archive
+       extract:
+         - foo/data
+     - from: /foo
+       to: /io/recursive-foo
+       directory: recursive
+     - from: /uncompressed-file
+       to: /io/uncompressed-file
  - kind: buildImage
    name: base_image
    dockerFile: docker/Dockerfile.base

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -83,7 +83,7 @@ steps:
    image: ubuntu:18.04
    script: |
      cd io
-     diff archived-foo/data recursive-foo/data
+     diff archived-foo/data data
      cat uncompressed-file
    inputs:
      - from: /foo.tgz
@@ -92,7 +92,7 @@ steps:
        extract:
          - foo/data
      - from: /foo
-       to: /io/recursive-foo
+       to: /io/
        directory: recursive
      - from: /uncompressed-file
        to: /io/uncompressed-file


### PR DESCRIPTION
I want to use this in the PR that uses one git repo checkout step for the whole build. There I'll have one step to clone the repo:
```
 - kind: runImage
   name: clone
   image:
     valueFrom: git_bash_image.image
   script: |
     mkdir /io/repo
     cd /io/repo
     {{ code.checkout_script }}
     cd ..
     tar -cvzf repo.tgz repo
   outputs:
    - from: /io/repo.tgz
      to: /repo.tgz
   dependsOn:
     - git_bash_image
```
and every buildImage step will be able to extract only the relevant files from that large tar archive:
```
 - kind: buildImage
   name: base_image
   dockerFile: docker/Dockerfile.base
   contextPath: /
   publishAs: base
   inputs:
    - from: /repo.tgz
      to: /
      extract:
        - docker
        - pylintrc
   dependsOn:
     - clone
```