### PR TITLE
[ci] remove irrelevant wait parameters

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1173,9 +1173,6 @@ steps:
       name: blog
       for: alive
       resource_type: statefulset
-      endpoint: /
-      headers:
-        X-Forwarded-Proto: https
    dependsOn:
     - default_ns
     - deploy_router


### PR DESCRIPTION
This is covered by readiness probes, which blog already has. Moreover, these parameters are unused due to PR #7564 "wait for stateful set" which fixes waiting on StatefulSets to work with headless ones.