### PR TITLE
[batch2] fix costs

### DIFF
--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -40,7 +40,10 @@ def batch_record_to_dict(record):
     if attributes:
         d['attributes'] = attributes
 
-    cost = cost_from_msec_mcpu(record['msec_mcpu'])
+    msec_mcpu = record['msec_mcpu']
+    d['msec_mcpu'] = msec_mcpu
+
+    cost = cost_from_msec_mcpu(msec_mcpu)
     d['cost'] = f'${cost:.4f}'
 
     return d
@@ -152,7 +155,10 @@ def job_record_to_dict(record, running_status=None):
     if status:
         result['status'] = status
 
-    cost = cost_from_msec_mcpu(record['msec_mcpu'])
+    msec_mcpu = record['msec_mcpu']
+    result['msec_mcpu'] = msec_mcpu
+
+    cost = cost_from_msec_mcpu(msec_mcpu)
     result['cost'] = f'${cost:.4f}'
 
     return result

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -1,12 +1,11 @@
 import json
-import time
 import logging
 import asyncio
 import aiohttp
 import secrets
 import base64
 import traceback
-from hailtop.utils import sleep_and_backoff, is_transient_error
+from hailtop.utils import time_msecs, sleep_and_backoff, is_transient_error
 
 from .globals import complete_states, tasks
 from .database import check_call_procedure
@@ -84,7 +83,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, new_state, status
 
     log.info(f'marking job {id} complete new_state {new_state}')
 
-    now = time.time()
+    now = time_msecs()
 
     rv = await check_call_procedure(
         db,
@@ -183,7 +182,7 @@ async def unschedule_job(app, record):
         log.warning(f'unschedule job {id}: unknown instance {instance_name}')
         return
 
-    end_time = time.time()
+    end_time = time_msecs()
     await check_call_procedure(
         db,
         'CALL unschedule_job(%s, %s, %s, %s, %s);',

--- a/batch2/batch/driver/instance.py
+++ b/batch2/batch/driver/instance.py
@@ -1,14 +1,9 @@
-import time
 import datetime
 import secrets
 import humanize
+from hailtop.utils import time_msecs, time_msecs_str
 
 from ..database import check_call_procedure
-
-
-def fmt_timestamp(t):
-    return datetime.datetime.utcfromtimestamp(t).strftime(
-        '%Y-%m-%dT%H:%M:%SZ')
 
 
 class Instance:
@@ -25,7 +20,7 @@ class Instance:
         db = app['db']
 
         state = 'pending'
-        now = time.time()
+        now = time_msecs()
         token = secrets.token_urlsafe(32)
         await db.just_execute(
             '''
@@ -78,7 +73,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
             return
 
         if not timestamp:
-            timestamp = time.time()
+            timestamp = time_msecs()
 
         await check_call_procedure(
             self.db,
@@ -122,7 +117,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
         return self._failed_request_count
 
     async def mark_healthy(self):
-        now = time.time()
+        now = time_msecs()
         await self.db.execute_update(
             '''
 UPDATE instances
@@ -154,7 +149,7 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
         return self._last_updated
 
     async def update_timestamp(self):
-        now = time.time()
+        now = time_msecs()
         await self.db.execute_update(
             'UPDATE instances SET last_updated = %s WHERE name = %s;',
             (now, self.name))
@@ -164,12 +159,11 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
         self.instance_pool.adjust_for_add_instance(self)
 
     def time_created_str(self):
-        return datetime.datetime.utcfromtimestamp(self.time_created).strftime(
-            '%Y-%m-%dT%H:%M:%SZ')
+        return time_msecs_str(self.time_created)
 
     def last_updated_str(self):
         return humanize.naturaldelta(
-            datetime.datetime.utcnow() - datetime.datetime.utcfromtimestamp(self.last_updated))
+            datetime.timedelta(milliseconds=(time_msecs() - self.last_updated)))
 
     def __str__(self):
         return f'instance {self.name}'

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -1,10 +1,10 @@
-import time
 import secrets
 import asyncio
 import logging
 import sortedcontainers
 import aiohttp
 import googleapiclient.errors
+from hailtop.utils import time_msecs
 
 from ..batch_configuration import DEFAULT_NAMESPACE, BATCH_WORKER_IMAGE, \
     PROJECT, ZONE

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -456,7 +456,7 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
 
         if (gce_state in ('STAGING', 'RUNNING') and
                 instance.state == 'pending' and
-                time.time() - instance.time_created > 5 * 60):
+                time_msecs() - instance.time_created > 5 * 60):
             # FIXME shouldn't count time in PROVISIONING
             log.info(f'{instance} did not activate within 5m, deleting')
             await self.call_delete_instance(instance, 'activation_timeout')
@@ -475,7 +475,7 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
                 if self.instances_by_last_updated:
                     # 0 is the smallest (oldest)
                     instance = self.instances_by_last_updated[0]
-                    since_last_updated = time.time() - instance.last_updated
+                    since_last_updated = time_msecs() - instance.last_updated
                     if since_last_updated > 60:
                         log.info(f'checking on {instance}, last updated {since_last_updated}s ago')
                         await self.check_on_instance(instance)

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -456,7 +456,7 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
 
         if (gce_state in ('STAGING', 'RUNNING') and
                 instance.state == 'pending' and
-                time_msecs() - instance.time_created > 5 * 60):
+                time_msecs() - instance.time_created > 5 * 60 * 1000):
             # FIXME shouldn't count time in PROVISIONING
             log.info(f'{instance} did not activate within 5m, deleting')
             await self.call_delete_instance(instance, 'activation_timeout')
@@ -476,8 +476,8 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch2/logs/$I
                     # 0 is the smallest (oldest)
                     instance = self.instances_by_last_updated[0]
                     since_last_updated = time_msecs() - instance.last_updated
-                    if since_last_updated > 60:
-                        log.info(f'checking on {instance}, last updated {since_last_updated}s ago')
+                    if since_last_updated > 60 * 1000:
+                        log.info(f'checking on {instance}, last updated {since_last_updated / 1000}s ago')
                         await self.check_on_instance(instance)
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -1,10 +1,10 @@
 import os
+import datetime
 import concurrent
 import logging
 import json
 import asyncio
 import aiohttp
-import time
 from aiohttp import web
 import aiohttp_session
 import humanize
@@ -149,7 +149,7 @@ FROM jobs
 INNER JOIN batches
   ON jobs.batch_id = batches.id
 LEFT JOIN attempts
-  ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id AND jobs.attempt_id = attempts.attempt_id  
+  ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id AND jobs.attempt_id = attempts.attempt_id
 LEFT JOIN instances
   ON attempts.instance_name = instances.name
 WHERE user = %s AND jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 import concurrent
 import logging
 import json
@@ -7,14 +6,13 @@ import asyncio
 import aiohttp
 from aiohttp import web
 import aiohttp_session
-import humanize
 import cerberus
 import prometheus_client as pc
 from prometheus_async.aio import time as prom_async_time
 from prometheus_async.aio.web import server_stats
 import google.oauth2.service_account
 import google.api_core.exceptions
-from hailtop.utils import time_msecs, request_retry_transient_errors
+from hailtop.utils import time_msecs, humanize_timedelta_msecs, request_retry_transient_errors
 from hailtop.auth import async_get_userinfo
 from hailtop.config import get_deploy_config
 from hailtop import batch_client
@@ -560,7 +558,7 @@ async def ui_batch(request, userdata):
     jobs = await _get_batch_jobs(app, batch_id, user)
     for job in jobs:
         job['exit_code'] = Job.exit_code(job)
-        job['duration'] = humanize.naturaldelta(datetime.timedelta(milliseconds=Job.total_duration_msecs(job)))
+        job['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(job))
     batch['jobs'] = jobs
     page_context = {
         'batch': batch

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -1,8 +1,8 @@
 import re
-import time
 import logging
 import math
 
+from hailtop.utils import time_msecs
 from hailtop.batch_client.validate import CPU_REGEX, MEMORY_REGEX
 
 

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -88,10 +88,10 @@ class LoggingTimerStep:
         self.start_time = None
 
     async def __aenter__(self):
-        self.start_time = time.time()
+        self.start_time = time_msecs()
 
     async def __aexit__(self, exc_type, exc, tb):
-        finish_time = time.time()
+        finish_time = time_msecs()
         self.timer.timing[self.name] = finish_time - self.start_time
 
 
@@ -105,11 +105,11 @@ class LoggingTimer:
         return LoggingTimerStep(self, name)
 
     async def __aenter__(self):
-        self.start_time = time.time()
+        self.start_time = time_msecs()
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        finish_time = time.time()
+        finish_time = time_msecs()
         self.timing['total'] = finish_time - self.start_time
 
         log.info(f'{self.description} timing {self.timing}')

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -704,7 +704,7 @@ class Worker:
         }
 
         start_time = time_msecs()
-        delay = 0.1
+        delay_secs = 0.1
         while True:
             try:
                 async with aiohttp.ClientSession(
@@ -724,15 +724,15 @@ class Worker:
             now = time_msecs()
             elapsed = now - start_time
             if (job.id in self.jobs and
-                    elapsed > 180.0 and
+                    elapsed > 180 * 1000 and
                     elapsed > run_duration / 2):
                 log.info(f'too much time elapsed marking {job} complete, removing from jobs, will keep retrying')
                 del self.jobs[job.id]
                 self.last_updated = time_msecs()
 
             # exponentially back off, up to (expected) max of 30s
-            t = delay * random.uniform(0.7, 1.3)
-            await asyncio.sleep(t)
+            await asyncio.sleep(
+                delay_secs * random.uniform(0.7, 1.3))
             delay = min(delay * 2, 30.0)
 
     async def post_job_complete(self, job, run_duration):

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -733,7 +733,7 @@ class Worker:
             # exponentially back off, up to (expected) max of 30s
             await asyncio.sleep(
                 delay_secs * random.uniform(0.7, 1.3))
-            delay = min(delay * 2, 30.0)
+            delay_secs = min(delay_secs * 2, 30.0)
 
     async def post_job_complete(self, job, run_duration):
         try:

--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -137,7 +137,7 @@ CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
 FOR EACH ROW
 BEGIN
   DECLARE job_cores_mcpu INT;
-  DECLARE time_diff BIGINT;
+  DECLARE msec_diff BIGINT;
   DECLARE msec_mcpu_diff BIGINT;
 
   SELECT cores_mcpu INTO job_cores_mcpu FROM jobs

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -65,7 +65,7 @@ class Test(unittest.TestCase):
             job_status = job['status']
 
             # tests run at 0.1cpu
-            job_msec_mcpu2 = int(0.1 * 1000 * 1000 * (job_status['end_time'] - job_status['start_time']))
+            job_msec_mcpu2 = int(0.1 * 1000 * 1000 * (job_status['end_time'] - job_status['start_time'] + 0.5))
             assert job['msec_mcpu'] == job_msec_mcpu2, batch
 
             batch_msec_mcpu2 += job_msec_mcpu2

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -65,7 +65,7 @@ class Test(unittest.TestCase):
             job_status = job['status']
 
             # tests run at 0.1cpu
-            job_msec_mcpu2 = int(0.1 * 1000 * 1000 * (job_status['end_time'] - job_status['start_time'] + 0.5))
+            job_msec_mcpu2 = int(0.1 * 1000 * 1000 * (job_status['end_time'] - job_status['start_time']) + 0.5)
             assert job['msec_mcpu'] == job_msec_mcpu2, batch
 
             batch_msec_mcpu2 += job_msec_mcpu2

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -64,9 +64,10 @@ class Test(unittest.TestCase):
         for job in batch['jobs']:
             job_status = job['status']
 
-            # tests run at 0.1cpu
-            job_msec_mcpu2 = int(0.1 * 1000 * 1000 * (job_status['end_time'] - job_status['start_time']) + 0.5)
-            assert job['msec_mcpu'] == job_msec_mcpu2, batch
+            # tests run at 100mcpu
+            job_msec_mcpu2 = 100 * max(job_status['end_time'] - job_status['start_time'], 0)
+            # greater than in case there are multiple attempts
+            assert job['msec_mcpu'] >= job_msec_mcpu2, batch
 
             batch_msec_mcpu2 += job_msec_mcpu2
 

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -50,6 +50,14 @@ class Test(unittest.TestCase):
 
         self.assertEqual(j.log()['main'], 'test\n', status)
 
+        # tests run at 0.1cpu
+        msec_mcpu2 = int(0.1 * 1000 * 1000 * (status['end_time'] - status['start_time']))
+        assert status['msec_mcpu'] == msec_mcpu2
+
+        # 1 job, so batch and job resource usage should agree
+        bstatus = b.status()
+        assert bstatus['msec_mcpu'] == msec_mcpu2
+
         self.assertTrue(j.is_complete())
 
     def test_attributes(self):

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -140,13 +140,15 @@ def test_callback(client):
                 break
         callback_body = callback_body[0]
 
+        # verify msec_mcpu, cost present
+        callback_body.pop('cost')
+        callback_body.pop('msec_mcpu')
         assert (callback_body == {
             'id': b.id,
             'state': 'success',
             'complete': True,
             'closed': True,
-            'attributes': {'foo': 'bar'},
-            'cost': '$0.0000'
+            'attributes': {'foo': 'bar'}
         }), callback_body
     finally:
         if server:

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -113,7 +113,7 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
         if hasattr(pr.batch, 'id'):
             status = await pr.batch.status()
             for j in status['jobs']:
-                j['duration'] = humanize.naturaldelta(Job.total_duration(j))
+                j['duration'] = humanize.naturaldelta(datetime.timedelta(milliseconds=Job.total_duration_mscs(j)))
                 j['exit_code'] = Job.exit_code(j)
                 attrs = j['attributes']
                 if 'link' in attrs:
@@ -157,7 +157,7 @@ async def get_batch(request, userdata):
     b = await batch_client.get_batch(batch_id)
     status = await b.status()
     for j in status['jobs']:
-        j['duration'] = humanize.naturaldelta(Job.total_duration(j))
+        j['duration'] = humanize.naturaldelta(datetime.timedelta(milliseconds=Job.total_duration_msecs(j)))
         j['exit_code'] = Job.exit_code(j)
     page_context = {
         'batch': status

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -4,14 +4,13 @@ import os
 import logging
 import asyncio
 import concurrent.futures
-import datetime
 import aiohttp
 from aiohttp import web
 import aiohttp_session
 import aiomysql
 import uvloop
-import humanize
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
+from hailtop.utils import humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient, Job
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, \
@@ -38,8 +37,6 @@ watched_branches = [
 ]
 
 routes = web.RouteTableDef()
-
-start_time = datetime.datetime.now()
 
 
 @routes.get('')
@@ -85,8 +82,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
         wb_configs.append(wb_config)
 
     page_context = {
-        'watched_branches': wb_configs,
-        'age': humanize.naturaldelta(datetime.datetime.now() - start_time)
+        'watched_branches': wb_configs
     }
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
@@ -113,7 +109,7 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
         if hasattr(pr.batch, 'id'):
             status = await pr.batch.status()
             for j in status['jobs']:
-                j['duration'] = humanize.naturaldelta(datetime.timedelta(milliseconds=Job.total_duration_mscs(j)))
+                j['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(j))
                 j['exit_code'] = Job.exit_code(j)
                 attrs = j['attributes']
                 if 'link' in attrs:
@@ -157,7 +153,7 @@ async def get_batch(request, userdata):
     b = await batch_client.get_batch(batch_id)
     status = await b.status()
     for j in status['jobs']:
-        j['duration'] = humanize.naturaldelta(datetime.timedelta(milliseconds=Job.total_duration_msecs(j)))
+        j['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(j))
         j['exit_code'] = Job.exit_code(j)
     page_context = {
         'batch': status

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -18,6 +18,7 @@ log = logging.getLogger('ci')
 
 CALLBACK_URL = get_deploy_config().url('ci', '/api/v1alpha/batch_callback')
 
+
 class Repo:
     def __init__(self, owner, name):
         assert isinstance(owner, str)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -143,7 +143,7 @@ class Job:
         return 0
 
     @staticmethod
-    def total_duration(job_status):
+    def total_duration_msecs(job_status):
         status = job_status.get('status')
         if not status:
             return None

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -29,8 +29,8 @@ class Job:
         return aioclient.Job.exit_code(job_status)
 
     @staticmethod
-    def total_duration(job_status):
-        return aioclient.Job.total_duration(job_status)
+    def total_duration_msecs(job_status):
+        return aioclient.Job.total_duration_msecs(job_status)
 
     @classmethod
     def from_async_job(cls, job):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,9 +1,11 @@
+from .time import time_msecs
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
     bounded_gather, grouped, sleep_and_backoff, is_transient_error, \
     request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
+    'time_msecs',
     'unzip',
     'async_to_blocking',
     'blocking_to_async',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,4 +1,4 @@
-from .time import time_msecs, time_msecs_str
+from .time import time_msecs, time_msecs_str, humanize_timedelta_msecs
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
     bounded_gather, grouped, sleep_and_backoff, is_transient_error, \
     request_retry_transient_errors, request_raise_transient_errors
@@ -7,6 +7,7 @@ from .process import CalledProcessError, check_shell, check_shell_output
 __all__ = [
     'time_msecs',
     'time_msecs_str',
+    'humanize_timedelta_msecs',
     'unzip',
     'async_to_blocking',
     'blocking_to_async',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,4 +1,4 @@
-from .time import time_msecs
+from .time import time_msecs, time_msecs_str
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
     bounded_gather, grouped, sleep_and_backoff, is_transient_error, \
     request_retry_transient_errors, request_raise_transient_errors
@@ -6,6 +6,7 @@ from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
     'time_msecs',
+    'time_msecs_str',
     'unzip',
     'async_to_blocking',
     'blocking_to_async',

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -1,0 +1,8 @@
+import time
+
+def time_msecs():
+    return int(time.time() * 1000 + 0.5)
+
+def time_msecs_str(t):
+    return datetime.datetime.utcfromtimestamp(t / 1000).strftime(
+        '%Y-%m-%dT%H:%M:%SZ')

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -1,4 +1,5 @@
 import time
+import datetime
 import humanize
 
 

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -6,12 +6,14 @@ import humanize
 def time_msecs():
     return int(time.time() * 1000 + 0.5)
 
+
 def time_msecs_str(t):
     return datetime.datetime.utcfromtimestamp(t / 1000).strftime(
         '%Y-%m-%dT%H:%M:%SZ')
 
+
 def humanize_timedelta_msecs(delta_msecs):
     if delta_msecs is None:
         return None
-    
+
     return humanize.naturaldelta(datetime.timedelta(milliseconds=delta_msecs))

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -1,4 +1,6 @@
 import time
+import humanize
+
 
 def time_msecs():
     return int(time.time() * 1000 + 0.5)
@@ -6,3 +8,9 @@ def time_msecs():
 def time_msecs_str(t):
     return datetime.datetime.utcfromtimestamp(t / 1000).strftime(
         '%Y-%m-%dT%H:%M:%SZ')
+
+def humanize_timedelta_msecs(delta_msecs):
+    if delta_msecs is None:
+        return None
+    
+    return humanize.naturaldelta(datetime.timedelta(milliseconds=delta_msecs))


### PR DESCRIPTION
Three changes:

1. I noticed the costs were all 0.  I think this is due to `cores_mcpu INTO cores_mcpu` scoping issues in the attempt triggers, where the local variable was always zero.  At least changing the local variable name immediately fixed the problem.

2. I wrote a test to verify the costs were non-zero and consistent with the reported timing for the succeeding job.  It is hard to do on the cost string, so I included msec_mcpu in the batch/job status response to verify it.  In trying to verify it, I noticed that timestamps in the attempts table were slightly truncated compared to start/end times in the status (JSON).  This lead to rounding errors and slight disagreement.

3. Rather descend into the floating point rabbit hole of madness, I changed times everywhere to be stored as integers in milliseconds (like unix time, since the epoch).  In the database, they are not BIGINT.  Millisecond resolution seems fine for everything we're building.

4. (Bonus change!) Don't let timing for jobs be negative.

This will require another reset.