### PR TITLE
[hail/ptypes] vectorized checkedConvert, clarified offset use

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1484,7 +1484,7 @@ private class Emit(
         val shapet = emit(shapeIR)
         val rowMajort = emit(rowMajorIR)
 
-        val requiredData = dataPType.checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")
+        val requiredData = dataPType.checkedConvertFrom(mb, region, datat.value[Long], dataContainer.asInstanceOf[PArray], "NDArray cannot have missing data")
         val shapeAddress = mb.newField[Long]
 
         val shapeTuple = new CodePTuple(shapePType, region, shapeAddress)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -260,6 +260,36 @@ abstract class PContainer extends PIterable {
     }
   }
 
+  def ensureNoMissingValues(mb: EmitMethodBuilder, sourceOffset: Code[Long], sourceType: PContainer, onFail: Code[_]): Code[Unit] = {
+    if(sourceType.elementType.required) {
+      return Code._empty
+    }
+
+    //  convert from non-required to required
+    val i = mb.newLocal[Long]
+    Code(
+      i := PContainer.nMissingBytes(sourceType.loadLength(sourceOffset)),
+      Code.whileLoop(i > 0L,
+        (i >= 8L).mux(
+          Code(
+            i := i - 8L,
+            Region
+              .loadLong(sourceOffset + sourceType.lengthHeaderBytes + i)
+              .cne(const(0.toByte))
+              .orEmpty(onFail)
+          ),
+          Code(
+            i := i - 1L,
+            Region
+              .loadByte(sourceOffset + sourceType.lengthHeaderBytes + i)
+              .cne(const(0.toByte))
+              .orEmpty(onFail)
+          )
+        )
+      )
+    )
+  }
+
   def checkedConvertFrom(mb: EmitMethodBuilder, r: Code[Region], sourceOffset: Code[Long], sourceType: PContainer, msg: String): Code[Long] = {
     assert(sourceType.elementType.isPrimitive)
 
@@ -270,40 +300,11 @@ abstract class PContainer extends PIterable {
     val newOffset = mb.newField[Long]
     val len = sourceType.loadLength(sourceOffset)
     Code(
-      if (sourceType.elementType.required) {
-        // convert from required to non-required
-        Code._empty
-      } else {
-        //  convert from non-required to required
-        val i = mb.newLocal[Long]
-        Code(
-          i := PContainer.nMissingBytes(len),
-          Code.whileLoop(i > 0L,
-            (i >= 8L).mux(
-              Code(
-                i := i - 8L,
-                Region
-                .loadLong(sourceOffset + sourceType.lengthHeaderBytes + i)
-                .cne(const(0.toByte))
-                .orEmpty(Code._fatal(msg))
-              ),
-              Code(
-                i := i - 1L,
-                Region
-                  .loadByte(sourceOffset + sourceType.lengthHeaderBytes + i)
-                  .cne(const(0.toByte))
-                  .orEmpty(Code._fatal(msg))
-              )
-            )
-          )
-        )
-      },
-      Code(
-        newOffset := allocate(r, len),
-        stagedInitialize(newOffset, len),
-        Region.copyFrom(sourceType.firstElementOffset(sourceOffset, len), firstElementOffset(newOffset, len), len.toL * elementByteSize),
-        newOffset
-      )
+      ensureNoMissingValues(mb, sourceOffset, sourceType, Code._fatal(msg)),
+      newOffset := allocate(r, len),
+      stagedInitialize(newOffset, len),
+      Region.copyFrom(sourceType.firstElementOffset(sourceOffset, len), firstElementOffset(newOffset, len), len.toL * elementByteSize),
+      newOffset
     )
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -265,7 +265,6 @@ abstract class PContainer extends PIterable {
       return Code._empty
     }
 
-    //  convert from non-required to required
     val i = mb.newLocal[Long]
     Code(
       i := PContainer.nMissingBytes(sourceType.loadLength(sourceOffset)),
@@ -291,9 +290,9 @@ abstract class PContainer extends PIterable {
   }
 
   def checkedConvertFrom(mb: EmitMethodBuilder, r: Code[Region], sourceOffset: Code[Long], sourceType: PContainer, msg: String): Code[Long] = {
-    assert(sourceType.elementType.isPrimitive)
+    assert(sourceType.elementType.isPrimitive && this.isOfType(sourceType))
 
-    if (sourceType.elementType == this.elementType) {
+    if (sourceType.elementType.required == this.elementType.required) {
       return sourceOffset
     }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -280,7 +280,10 @@ abstract class PContainer extends PIterable {
         Code(
           i := 0L,
           Code.whileLoop(i < PContainer.nMissingBytes(len),
-            Region.loadByte(oldOffset + i).cne(const(0)).orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing.")),
+            Region
+              .loadByte(oldOffset + lengthHeaderBytes + i)
+              .cne(const(0))
+              .orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing.")),
             i := i + 1L
           )
         )

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -279,13 +279,26 @@ abstract class PContainer extends PIterable {
         val i = mb.newField[Long]
 
         Code(
-          i := 0L,
-          Code.whileLoop(i < PContainer.nMissingBytes(len),
-            Region
-              .loadByte(oldOffset + lengthHeaderBytes + i)
-              .cne(const(0.toByte))
-              .orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing.")),
-            i := i + 1L
+          i := PContainer.nMissingBytes(len) - 1L,
+          Code.whileLoop(i > 0L,
+            (i >= 8L).mux(
+              Code(
+                Code._println(s"i >= 8L: ${i}"),
+                i := i - 8L,
+                Region
+                .loadLong(oldOffset + lengthHeaderBytes + i)
+                .cne(const(0.toByte))
+                .orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing."))
+              ),
+              Code(x 
+                Code._println(s"i < 8L: ${i}"),
+                i := i - 1L,
+                Region
+                  .loadByte(oldOffset + lengthHeaderBytes + i)
+                  .cne(const(0.toByte))
+                  .orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing."))
+              )
+            )
           )
         )
       },

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -277,12 +277,13 @@ abstract class PContainer extends PIterable {
       } else {
         //  convert from non-required to required
         val i = mb.newField[Long]
+
         Code(
           i := 0L,
           Code.whileLoop(i < PContainer.nMissingBytes(len),
             Region
               .loadByte(oldOffset + lengthHeaderBytes + i)
-              .cne(const(0))
+              .cne(const(0.toByte))
               .orEmpty(Code._fatal(s"${msg}: convertFrom $otherPT failed: element missing.")),
             i := i + 1L
           )

--- a/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
@@ -1,61 +1,65 @@
 package is.hail.expr.types.physical
 
 import is.hail.HailSuite
-import is.hail.HailSuite
+import is.hail.annotations.{Region, SafeIndexedSeq, ScalaToRegionValue}
 import is.hail.asm4s._
-import is.hail.check.{Gen, Prop}
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion}
-import is.hail.expr.types._
-import is.hail.expr.types.physical._
-import is.hail.expr.types.virtual._
+import is.hail.expr.ir.EmitFunctionBuilder
 import is.hail.utils._
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class PContainerTest extends HailSuite {
-
-
-    val showRVInfo = true
-
-    @Test
-    def testString() {
-      val rt = PString()
-      val input = "hello"
-      val fb = FunctionBuilder.functionBuilder[Region, String, Long]
-      val srvb = new StagedRegionValueBuilder(fb, rt)
-
-      fb.emit(
-        Code(
-          srvb.start(),
-          srvb.addString(fb.getArg[String](2)),
-          srvb.end()
-        )
-      )
-
-      val region = Region()
-      val rv = RegionValue(region)
-      rv.setOffset(fb.result()()(region, input))
-
-      if (showRVInfo) {
-        printRegion(region, "string")
-        println(rv.pretty(rt))
-      }
-
-      val region2 = Region()
-      val rv2 = RegionValue(region2)
-      val bytes = input.getBytes()
-      val boff = PBinary.allocate(region2, bytes.length)
-      Region.storeInt(boff, bytes.length)
-      Region.storeBytes(PBinary.bytesOffset(boff), bytes)
-      rv2.setOffset(boff)
-
-      if (showRVInfo) {
-        printRegion(region2, "string")
-        println(rv2.pretty(rt))
-      }
-
-      assert(rv.pretty(rt) == rv2.pretty(rt))
-      assert(PString.loadString(rv.region, rv.offset) ==
-        PString.loadString(rv2.region, rv2.offset))
+  @Test def checkedConvertFromTest() {
+    def nullInByte(nBytes: Int,  nByteWhereNull: Long, indexInByte: Long) = {
+      IndexedSeq.tabulate(nBytes*8)(i => {
+        if(nByteWhereNull > 0 && i == (nByteWhereNull * 8 - 8 + indexInByte) ) {
+          null
+        } else {
+          i + 1L
+        }
+      })
     }
+
+    def testIt(sourceType: PArray, destType: PArray, data: IndexedSeq[Any], expectFalse: Boolean) {
+      val srcRegion = Region()
+      val src = ScalaToRegionValue(srcRegion, sourceType, data)
+
+      log.debug(s"Testing $data")
+      log.debug(s"PContainer.nMissingBytes(len) == ${PContainer.nMissingBytes(sourceType.loadLength(src))}")
+
+      val fb = EmitFunctionBuilder[Region, Long, Long]("not_empty")
+      val codeRegion = fb.getArg[Region](1).load()
+      val value = fb.getArg[Long](2)
+
+      // checkedConvertFrom(mb: EmitMethodBuilder, r: Code[Region], oldOffset: Code[Long], otherPT: PContainer, msg: String)
+      fb.emit(destType.checkedConvertFrom(fb.apply_method, codeRegion, value, sourceType, "ShouldHaveNoNull"))
+
+      val f = fb.result()()
+      val destRegion = Region()
+      if(expectFalse) {
+        val thrown = intercept[Exception](f(destRegion,src))
+        assert(thrown.getMessage == "ShouldHaveNoNull")
+      } else {
+        f(destRegion,src)
+      }
+    }
+
+    val sourceType = PArray(PInt64(false))
+    val destType = PArray(PInt64(true))
+
+    testIt(sourceType, destType, nullInByte(1, 0, 0), false)
+    testIt(sourceType, destType, nullInByte(1, 1, 0), true)
+    testIt(sourceType, destType, nullInByte(7, 0, 0), false)
+    testIt(sourceType, destType, nullInByte(7, 1, 0), true)
+    testIt(sourceType, destType, nullInByte(7, 7, 7), true)
+    testIt(sourceType, destType, nullInByte(8, 0, 0), false)
+    testIt(sourceType, destType, nullInByte(8, 1, 0), true)
+    testIt(sourceType, destType, nullInByte(8, 5, 0), true)
+    testIt(sourceType, destType, nullInByte(8, 5, 7), true)
+    testIt(sourceType, destType, nullInByte(8, 8, 1), true)
+    testIt(sourceType, destType, nullInByte(8, 8, 7), true)
+    testIt(sourceType, destType, nullInByte(9, 0, 0), false)
+    testIt(sourceType, destType, nullInByte(9, 1, 0), true)
+    testIt(sourceType, destType, nullInByte(9, 1, 7), true)
+    testIt(sourceType, destType, nullInByte(9, 9, 7), true)
+  }
 }

--- a/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
@@ -1,0 +1,61 @@
+package is.hail.expr.types.physical
+
+import is.hail.HailSuite
+import is.hail.HailSuite
+import is.hail.asm4s._
+import is.hail.check.{Gen, Prop}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion}
+import is.hail.expr.types._
+import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual._
+import is.hail.utils._
+import org.apache.spark.sql.Row
+import org.testng.annotations.Test
+
+class PContainerTest extends HailSuite {
+
+
+    val showRVInfo = true
+
+    @Test
+    def testString() {
+      val rt = PString()
+      val input = "hello"
+      val fb = FunctionBuilder.functionBuilder[Region, String, Long]
+      val srvb = new StagedRegionValueBuilder(fb, rt)
+
+      fb.emit(
+        Code(
+          srvb.start(),
+          srvb.addString(fb.getArg[String](2)),
+          srvb.end()
+        )
+      )
+
+      val region = Region()
+      val rv = RegionValue(region)
+      rv.setOffset(fb.result()()(region, input))
+
+      if (showRVInfo) {
+        printRegion(region, "string")
+        println(rv.pretty(rt))
+      }
+
+      val region2 = Region()
+      val rv2 = RegionValue(region2)
+      val bytes = input.getBytes()
+      val boff = PBinary.allocate(region2, bytes.length)
+      Region.storeInt(boff, bytes.length)
+      Region.storeBytes(PBinary.bytesOffset(boff), bytes)
+      rv2.setOffset(boff)
+
+      if (showRVInfo) {
+        printRegion(region2, "string")
+        println(rv2.pretty(rt))
+      }
+
+      assert(rv.pretty(rt) == rv2.pretty(rt))
+      assert(PString.loadString(rv.region, rv.offset) ==
+        PString.loadString(rv2.region, rv2.offset))
+    }
+}


### PR DESCRIPTION
Ready to look at. Assigning John because this code was related to NDArray.

Purpose of this was to clean up the function a bit (some unnecessary assignments, code clarity), reduce the number of loops needed to detect a missing value. We don't need to check every bit O(N) to determine whether a value is missing. Instead, it is sufficient to check groups of at least 1 byte, and in the case that there are more than 64 values, groups of 8 bytes, or 1 byte. We could further improve this by removing the condition in the loop in favor of 2 loops (one over floor(nMissingBytes / 8), one over the remainder), but I think this gets us most of the benefit. We could also check for groups of 4 bytes (int) when groups of 8 bytes (long) are exhausted, but that doesn't really bring us much, since the major benefit comes from the largest batch group.

I also factored out the checking function, because I will use this in upcasting.