### PR TITLE
[batch2] optimize scheduler query

### DIFF
--- a/batch2/batch/driver/scheduler.py
+++ b/batch2/batch/driver/scheduler.py
@@ -43,8 +43,8 @@ class Scheduler:
             '''
 SELECT jobs.job_id, jobs.batch_id, cores_mcpu, instance_name
 FROM jobs
-INNER JOIN batches ON batches.id = jobs.batch_id
-INNER JOIN attempts ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id AND jobs.attempt_id = attempts.attempt_id
+STRAIGHT_JOIN batches ON batches.id = jobs.batch_id
+STRAIGHT_JOIN attempts ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id AND jobs.attempt_id = attempts.attempt_id
 WHERE jobs.state = 'Running' AND (NOT jobs.always_run) AND batches.closed AND batches.cancelled
 LIMIT 50;
 ''')
@@ -63,7 +63,7 @@ SELECT job_id, batch_id, spec, cores_mcpu,
   ((jobs.cancelled OR batches.cancelled) AND NOT always_run) AS cancel,
   userdata, user
 FROM jobs
-INNER JOIN batches ON batches.id = jobs.batch_id
+STRAIGHT_JOIN batches ON batches.id = jobs.batch_id
 WHERE jobs.state = 'Ready' AND batches.closed
 LIMIT 50;
 ''')


### PR DESCRIPTION
The query in the scheduler was running incredibly slowly.  So slowly, I didn't have the patience to let it finish.  

```
mysql> EXPLAIN
    -> SELECT job_id, batch_id, spec, cores_mcpu,
    ->   ((jobs.cancelled OR batches.cancelled) AND NOT always_run) AS cancel,
    ->   userdata, user
    -> FROM jobs
    -> INNER JOIN batches ON batches.id = jobs.batch_id
    -> WHERE jobs.state = 'Ready' AND batches.closed
    -> LIMIT 50;
+----+-------------+---------+------+--------------------+---------+---------+-------------------+------+-------------+
| id | select_type | table   | type | possible_keys      | key     | key_len | ref               | rows | Extra       |
+----+-------------+---------+------+--------------------+---------+---------+-------------------+------+-------------+
|  1 | SIMPLE      | batches | ALL  | PRIMARY            | NULL    | NULL    | NULL              |   31 | Using where |
|  1 | SIMPLE      | jobs    | ref  | PRIMARY,jobs_state | PRIMARY | 8       | batch2.batches.id |   84 | Using where |
+----+-------------+---------+------+--------------------+---------+---------+-------------------+------+-------------+
2 rows in set (0.01 sec)
```

This is because the query was querying closed batches, and then joining against jobs and using a where condition to find ready jobs.  This is an insane execution plan and I still can't believe MySQL is choosing it by default.

To fix this, I changed the inner join to a straight join: https://dev.mysql.com/doc/refman/5.6/en/join.html.  Straight join is a MySQL extension that always scans the left table first.  This leads to the correct execution plan which runs instantly:

```
mysql> EXPLAIN
    -> SELECT job_id, batch_id, spec, cores_mcpu,
    ->   ((jobs.cancelled OR batches.cancelled) AND NOT always_run) AS cancel,
    ->   userdata, user
    -> FROM jobs
    -> STRAIGHT_JOIN batches ON batches.id = jobs.batch_id
    -> WHERE jobs.state = 'Ready' AND batches.closed
    -> LIMIT 50;
+----+-------------+---------+--------+--------------------+------------+---------+----------------------+-------+-----------------------+
| id | select_type | table   | type   | possible_keys      | key        | key_len | ref                  | rows  | Extra                 |
+----+-------------+---------+--------+--------------------+------------+---------+----------------------+-------+-----------------------+
|  1 | SIMPLE      | jobs    | ref    | PRIMARY,jobs_state | jobs_state | 122     | const                | 14264 | Using index condition |
|  1 | SIMPLE      | batches | eq_ref | PRIMARY            | PRIMARY    | 8       | batch2.jobs.batch_id |     1 | Using where           |
+----+-------------+---------+--------+--------------------+------------+---------+----------------------+-------+-----------------------+
2 rows in set (0.00 sec)
```

Now it scans the jobs table first using the job_state index as desired.

Once this goes in I'll turn up the instance pool size again.