### PR TITLE
[batch2] scalable job search/batch page

### DIFF
--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -611,7 +611,7 @@ async def _query_batch_jobs(app, batch_id, user, q):
         where_conditions.append(condition)
         where_args.extend(*args)
 
-    sql = '''
+    sql = f'''
 SELECT * FROM jobs
 WHERE {' AND '.join(where_conditions)}
 LIMIT 50;

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -583,8 +583,8 @@ async def _query_batch_jobs(request, batch_id, q):
             k, v = t.split('=', 1)
             condition = '''
 (EXISTS (SELECT * FROM `job_attributes`
-         WHERE `job_attributes`.batch_id = job.batch_id AND
-           `job_attributes`.job_id = job.job_id AND
+         WHERE `job_attributes`.batch_id = jobs.batch_id AND
+           `job_attributes`.job_id = jobs.job_id AND
            `batch_attributes`.`key` = %s AND
            `batch_attributes`.`value` = %s))
 '''
@@ -593,8 +593,8 @@ async def _query_batch_jobs(request, batch_id, q):
             k = t[4:]
             condition = '''
 (EXISTS (SELECT * FROM `job_attributes`
-         WHERE `job_attributes`.batch_id = job.batch_id AND
-           `job_attributes`.job_id = job.job_id AND
+         WHERE `job_attributes`.batch_id = jobs.batch_id AND
+           `job_attributes`.job_id = jobs.job_id AND
            `batch_attributes`.`key` = %s))
 '''
             args = [k]
@@ -606,7 +606,7 @@ async def _query_batch_jobs(request, batch_id, q):
             args = values
         else:
             session = await aiohttp_session.get_session(request)
-            set_message(session, 'Invalid search term: {t}.', 'error')
+            set_message(session, f'Invalid search term: {t}.', 'error')
             raise web.HTTPFound(deploy_config.external_url('batch2', f'/batches/{batch_id}'))
 
         if negate:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -613,7 +613,7 @@ async def _query_batch_jobs(request, batch_id, q):
             condition = f'(NOT {condition})'
 
         where_conditions.append(condition)
-        where_args.extend(*args)
+        where_args.extend(args)
 
     sql = f'''
 SELECT * FROM jobs
@@ -622,9 +622,11 @@ LIMIT 50;
 '''
     sql_args = where_args
 
-    log.info(f'sql {sql}')
+    log.info(f'sql {sql} args {sql_args}')
 
-    return [job async for job in db.execute_and_fetchall(sql, sql_args)]
+    return [job_record_to_dict(job)
+            async for job
+            in db.execute_and_fetchall(sql, sql_args)]
 
 
 @routes.get('/batches/{batch_id}')

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -556,7 +556,7 @@ async def _query_batch_jobs(request, batch_id):
         'error': ['Error'],
         'failed': ['Failed'],
         'bad': ['Error', 'Failed'],
-        'success': ['success'],
+        'success': ['Success'],
         'done': ['Cancelled', 'Error', 'Failed', 'Success']
     }
 
@@ -577,9 +577,6 @@ async def _query_batch_jobs(request, batch_id):
     q = request.query.get('q', '')
     terms = q.split()
     for t in terms:
-        if not t:
-            continue
-
         if t[0] == '!':
             negate = True
             t = t[1:]
@@ -628,8 +625,6 @@ WHERE {' AND '.join(where_conditions)}
 LIMIT 50;
 '''
     sql_args = where_args
-
-    log.info(f'sql {sql} args {sql_args}')
 
     jobs = [job_record_to_dict(job)
             async for job

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -585,8 +585,8 @@ async def _query_batch_jobs(request, batch_id, q):
 (EXISTS (SELECT * FROM `job_attributes`
          WHERE `job_attributes`.batch_id = jobs.batch_id AND
            `job_attributes`.job_id = jobs.job_id AND
-           `batch_attributes`.`key` = %s AND
-           `batch_attributes`.`value` = %s))
+           `job_attributes`.`key` = %s AND
+           `job_attributes`.`value` = %s))
 '''
             args = [k, v]
         elif t.startswith('has:'):
@@ -595,7 +595,7 @@ async def _query_batch_jobs(request, batch_id, q):
 (EXISTS (SELECT * FROM `job_attributes`
          WHERE `job_attributes`.batch_id = jobs.batch_id AND
            `job_attributes`.job_id = jobs.job_id AND
-           `batch_attributes`.`key` = %s))
+           `job_attributes`.`key` = %s))
 '''
             args = [k]
         elif t in state_query_values:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -546,7 +546,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
     return web.Response()
 
 
-async def _query_batch_jobs(request, batch_id, user, q):
+async def _query_batch_jobs(request, batch_id, q):
     state_query_values = {
         'pending': ['Pending'],
         'ready': ['Ready'],
@@ -562,10 +562,11 @@ async def _query_batch_jobs(request, batch_id, user, q):
 
     db = request.app['db']
 
+    # batch has already been validated
     where_conditions = [
-        '(user = %s)', '(id = %s)', '(NOT deleted)'
+        '(batch_id = %s)'
     ]
-    where_args = [user, batch_id]
+    where_args = [batch_id]
 
     terms = q.split()
     for t in terms:
@@ -637,7 +638,7 @@ async def ui_batch(request, userdata):
     batch = await _get_batch(app, batch_id, user)
 
     q = request.query.get('q', '')
-    jobs = await _query_batch_jobs(request, batch_id, user, q)
+    jobs = await _query_batch_jobs(request, batch_id, q)
 
     for job in jobs:
         job['exit_code'] = Job.exit_code(job)

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -10,7 +10,13 @@
   <h2>Jobs</h2>
     <div class="searchbar-table">
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-	<input style="vertical-align: text-bottom;" name="q" size=30 type="text" value="{{ q }}">
+	<input style="vertical-align:text-bottom;" name="q" size=30 type="text"
+	       {% if q %}
+	         value="{{ q }}"
+	       {% else %}
+	         placeholder="Search terms..."
+	       {% endif %}
+	       >
 	<button type="submit">Search</button>
       </form>
       <table class="data-table" id="batch">
@@ -55,6 +61,15 @@
 	  {% endfor %}
 	</tbody>
       </table>
+      {% if last_job_id is not none %}
+      <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
+	<input type="hidden" name="q" value="{{ q }}" />
+	<input tpye="hidden" name="last_job_id" value="{{ last_job_id }}" />
+	<button>
+	  Next page
+	</button>
+      </form>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -63,7 +63,9 @@
       </table>
       {% if last_job_id is not none %}
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-	<input type="hidden" name="q" value="{{ q }}" />
+	{% if q is not none %}
+	  <input type="hidden" name="q" value="{{ q }}" />
+	{% endif %}
 	<input type="hidden" name="last_job_id" value="{{ last_job_id }}" />
 	<button>
 	  Next page

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -9,7 +9,7 @@
   {% endif %}
   <h2>Jobs</h2>
     <div class="searchbar-table">
-      <form method="GET" action="{{ base_path }}/batches/{{ job['batch_id'] }}">
+      <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	<input name="q" size=30 type="text" value="{{ q }}">
 	<button type="submit">Search</button>
       </form>

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -10,7 +10,7 @@
   <h2>Jobs</h2>
     <div class="searchbar-table">
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-	<input name="q" size=30 type="text" value="{{ q }}">
+	<input style="vertical-align: text-bottom;" name="q" size=30 type="text" value="{{ q }}">
 	<button type="submit">Search</button>
       </form>
       <table class="data-table" id="batch">

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -1,8 +1,5 @@
 {% extends "layout.html" %}
 {% block title %}Batch {{ batch['id'] }}{% endblock %}
-{% block head %}
-    <script src="{{ base_path }}/common_static/search_bar.js"></script>
-{% endblock %}
 {% block content %}
   <h1>Batch {{ batch['id'] }}</h1>
   {% if 'attributes' in batch %}
@@ -11,52 +8,53 @@
   {% endfor %}
   {% endif %}
   <h2>Jobs</h2>
-  <div class="searchbar-table">
-    <input size=30 type="text" id="searchBar" onkeyup="searchTable('batch', 'searchBar')" placeholder="Search terms...">
-    <table class="data-table" id="batch">
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>Name</th>
-          <th>State</th>
-          <th>Exit Code</th>
-          <th>Duration</th>
-          <th>Cost</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for job in batch['jobs'] %}
-        <tr>
-          <td class="numeric-cell">
-	    <a href="{{ base_path }}/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}">{{ job['job_id'] }}</a>
-	  </td>
-          <td>
-            {% if 'attributes' in job and 'name' in job['attributes'] and job['attributes']['name'] is not none %}
-            {{ job['attributes']['name'] }}
-            {% endif %}
-          </td>
-          <td>{{ job['state'] }}</td>
-          <td>
-	    {% if 'exit_code' in job and job['exit_code'] is not none %}
-	      {{ job['exit_code'] }}
-	    {% endif %}
-	  </td>
-          <td>
-	    {% if 'duration' in job and job['duration'] is not none %}
-	      {{ job['duration'] }}
-	    {% endif %}
-	  </td>
-          <td>
-            {% if 'cost' in job and job['cost'] is not none %}
-              {{ job['cost'] }}
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="searchbar-table">
+      <form method="GET" action="{{ base_path }}/batches/{{ job['batch_id'] }}">
+	<input name="q" size=30 type="text" value="{{ q }}">
+	<button type="submit">Search</button>
+      </form>
+      <table class="data-table" id="batch">
+	<thead>
+	  <tr>
+	    <th>ID</th>
+	    <th>Name</th>
+	    <th>State</th>
+	    <th>Exit Code</th>
+	    <th>Duration</th>
+	    <th>Cost</th>
+	  </tr>
+	</thead>
+	<tbody>
+	  {% for job in batch['jobs'] %}
+	  <tr>
+	    <td class="numeric-cell">
+	      <a href="{{ base_path }}/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}">{{ job['job_id'] }}</a>
+	    </td>
+	    <td>
+	      {% if 'attributes' in job and 'name' in job['attributes'] and job['attributes']['name'] is not none %}
+	      {{ job['attributes']['name'] }}
+	      {% endif %}
+	    </td>
+	    <td>{{ job['state'] }}</td>
+	    <td>
+	      {% if 'exit_code' in job and job['exit_code'] is not none %}
+		{{ job['exit_code'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'duration' in job and job['duration'] is not none %}
+		{{ job['duration'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'cost' in job and job['cost'] is not none %}
+		{{ job['cost'] }}
+	      {% endif %}
+	    </td>
+	  </tr>
+	  {% endfor %}
+	</tbody>
+      </table>
+    </div>
   </div>
-  <script type="text/javascript">
-    document.getElementById("searchBar").focus();
-  </script>
 {% endblock %}

--- a/batch2/batch/front_end/templates/batch.html
+++ b/batch2/batch/front_end/templates/batch.html
@@ -64,7 +64,7 @@
       {% if last_job_id is not none %}
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	<input type="hidden" name="q" value="{{ q }}" />
-	<input tpye="hidden" name="last_job_id" value="{{ last_job_id }}" />
+	<input type="hidden" name="last_job_id" value="{{ last_job_id }}" />
 	<button>
 	  Next page
 	</button>


### PR DESCRIPTION
Batch page shows max 50 jobs paginated, with next page button.

Search box supports search with a simple language of terms:
 - k=v - match jobs with attribute key k and value v
 - has:k - match jobs with attribute k, any value
 - state - match jobs with the corresponding states.  Search state terms are lower case (unlike actual job states, which I plan to change) and the recognized state terms are:

   ```
    state_query_values = {
        'pending': ['Pending'],
        'ready': ['Ready'],
        'running': ['Running'],
        'live': ['Ready', 'Running'],
        'cancelled': ['Cancelled'],
        'error': ['Error'],
        'failed': ['Failed'],
        'bad': ['Error', 'Failed'],
        'success': ['success'],
        'done': ['Cancelled', 'Error', 'Failed', 'Success']
    }
   ```
   as you can see, some state search terms, like done, match multiple job states. 
 - !term - match jobs that don't match term

To select specific names, you can do `name=foo`.

Next steps:
 - Make the corresponding changes to the API so you can iterate paginated through all jobs in a batch.
 - Make batches page paginated, too.
 - Help information about the search syntax.
 - We'll probably want to order by fields other than just id.