### PR TITLE
use node selector instead of tolerations/node affinity

### DIFF
--- a/apiserver/test-apiserver-pod.yaml
+++ b/apiserver/test-apiserver-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: test-apiserver
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: test-apiserver
     image: "{{ test_apiserver_image.image }}"

--- a/apiserver/test-apiserver-pod.yaml
+++ b/apiserver/test-apiserver-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: test-apiserver
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/apiserver/test-apiserver-pod.yaml
+++ b/apiserver/test-apiserver-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-apiserver
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: test-apiserver
     image: "{{ test_apiserver_image.image }}"

--- a/apiserver/test-apiserver-pod.yaml
+++ b/apiserver/test-apiserver-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: test-apiserver
     image: "{{ test_apiserver_image.image }}"

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-auth-tables
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: create-auth-tables
     image: "{{ create_auth_tables_image.image }}"

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: create-auth-tables
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: create-auth-tables
     image: "{{ create_auth_tables_image.image }}"

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-auth-tables
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: create-auth-tables
     image: "{{ create_auth_tables_image.image }}"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -128,6 +128,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -138,18 +140,6 @@ spec:
                     values:
                     - auth
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: auth
          image: "{{ auth_image.image }}"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -130,6 +130,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -129,7 +129,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -128,8 +128,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/batch/create-batch-tables-pod.yaml
+++ b/batch/create-batch-tables-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: create-batch-tables
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/batch/create-batch-tables-pod.yaml
+++ b/batch/create-batch-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-batch-tables
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: create-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/create-batch-tables-pod.yaml
+++ b/batch/create-batch-tables-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-batch-tables
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: create-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/create-batch-tables-pod.yaml
+++ b/batch/create-batch-tables-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: create-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/delete-batch-tables-pod.yaml
+++ b/batch/delete-batch-tables-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: delete-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/delete-batch-tables-pod.yaml
+++ b/batch/delete-batch-tables-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: delete-batch-tables
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/batch/delete-batch-tables-pod.yaml
+++ b/batch/delete-batch-tables-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: delete-batch-tables
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: delete-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/delete-batch-tables-pod.yaml
+++ b/batch/delete-batch-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: delete-batch-tables
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: delete-batch-tables
     image: "{{ batch_tables_image.image }}"

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       containers:
       - name: batch-driver
         image: {{ batch_image.image }}
@@ -117,7 +117,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -23,8 +23,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"
@@ -119,8 +117,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -25,6 +25,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       containers:
       - name: batch-driver
         image: {{ batch_image.image }}
@@ -118,6 +121,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -23,6 +23,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       containers:
       - name: batch-driver
         image: {{ batch_image.image }}
@@ -114,6 +116,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -124,15 +128,6 @@ spec:
                     values:
                     - auth
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
       containers:
       - name: batch
         image: {{ batch_image.image }}
@@ -208,9 +203,6 @@ spec:
        - name: gsa-key
          secret:
            secretName: batch-gsa-key
-      tolerations:
-       - key: preemptible
-         value: "true"
 ---
 apiVersion: v1
 kind: Service

--- a/batch/test-batch-pod.yaml
+++ b/batch/test-batch-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: test-batch
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: test-batch
     image: "{{ test_batch_image.image }}"

--- a/batch/test-batch-pod.yaml
+++ b/batch/test-batch-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: test-batch
     image: "{{ test_batch_image.image }}"

--- a/batch/test-batch-pod.yaml
+++ b/batch/test-batch-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: test-batch
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/batch/test-batch-pod.yaml
+++ b/batch/test-batch-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-batch
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: test-batch
     image: "{{ test_batch_image.image }}"

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: false
+        preemptible: "false"
       containers:
       - name: blog
         image: ghost:3.0-alpine

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -18,8 +18,9 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "false"
+      tolerations:
+       - key: preemptible
+         value: "false"
       containers:
       - name: blog
         image: ghost:3.0-alpine

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -18,6 +18,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: false
       containers:
       - name: blog
         image: ghost:3.0-alpine

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: create-ci-tables
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-ci-tables
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: create-ci-tables
     image: "{{ base_image.image }}"

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-ci-tables
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: create-ci-tables
     image: "{{ base_image.image }}"

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: create-ci-tables
     image: "{{ base_image.image }}"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: false
+        preemptible: "false"
       containers:
         - name: ci
           image: "{{ ci_image.image }}"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -19,8 +19,9 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "false"
+      tolerations:
+       - key: preemptible
+         value: "false"
       containers:
         - name: ci
           image: "{{ ci_image.image }}"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -19,6 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: false
       containers:
         - name: ci
           image: "{{ ci_image.image }}"

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,18 +29,6 @@ spec:
                     values:
                     - gateway
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: gateway
          image: "{{ gateway_image.image }}"

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       priorityClassName: infrastructure
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       priorityClassName: infrastructure
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -17,8 +17,6 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/internal-gateway/.gitignore
+++ b/internal-gateway/.gitignore
@@ -1,0 +1,2 @@
+/deployment.yaml.out
+/service.yaml.out

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,18 +29,6 @@ spec:
                     values:
                     - internal-gateway
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: internal-gateway
          image: "{{ internal_gateway_image.image }}"

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       priorityClassName: infrastructure
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       priorityClassName: infrastructure
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -17,8 +17,6 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/letsencrypt/letsencrypt-pod.yaml.in
+++ b/letsencrypt/letsencrypt-pod.yaml.in
@@ -6,8 +6,9 @@ metadata:
     app: letsencrypt
 spec:
   serviceAccountName: letsencrypt
-  nodeSelector:
-    preemptible: false
+  tolerations:
+   - key: preemptible
+     value: "false"
   containers:
   - name: letsencrypt
     image: gcr.io/@project@/letsencrypt

--- a/letsencrypt/letsencrypt-pod.yaml.in
+++ b/letsencrypt/letsencrypt-pod.yaml.in
@@ -6,6 +6,8 @@ metadata:
     app: letsencrypt
 spec:
   serviceAccountName: letsencrypt
+  nodeSelector:
+    preemptible: false
   containers:
   - name: letsencrypt
     image: gcr.io/@project@/letsencrypt

--- a/monitoring/.gitignore
+++ b/monitoring/.gitignore
@@ -1,1 +1,2 @@
+/monitoring.yaml.out
 /router.yaml.out

--- a/monitoring/router.yaml
+++ b/monitoring/router.yaml
@@ -18,8 +18,6 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/monitoring/router.yaml
+++ b/monitoring/router.yaml
@@ -20,6 +20,9 @@ spec:
       priorityClassName: infrastructure
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/monitoring/router.yaml
+++ b/monitoring/router.yaml
@@ -18,6 +18,8 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -28,9 +30,6 @@ spec:
                     values:
                     - router
               topologyKey: "kubernetes.io/hostname"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: router
          image: "{{ monitoring_router_image.image }}"

--- a/notebook/create-notebook-tables-pod.yaml
+++ b/notebook/create-notebook-tables-pod.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   nodeSelector:
     preemptible: "true"
+  tolerations:
+   - key: preemptible
+     value: "true"
   containers:
   - name: create-notebook-tables
     image: "{{ create_notebook_tables_image.image }}"

--- a/notebook/create-notebook-tables-pod.yaml
+++ b/notebook/create-notebook-tables-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-notebook-tables
 spec:
   nodeSelector:
-    preemptible: true
+    preemptible: "true"
   containers:
   - name: create-notebook-tables
     image: "{{ create_notebook_tables_image.image }}"

--- a/notebook/create-notebook-tables-pod.yaml
+++ b/notebook/create-notebook-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-notebook-tables
 spec:
+  nodeSelector:
+    preemptible: true
   containers:
   - name: create-notebook-tables
     image: "{{ create_notebook_tables_image.image }}"

--- a/notebook/create-notebook-tables-pod.yaml
+++ b/notebook/create-notebook-tables-pod.yaml
@@ -3,8 +3,6 @@ kind: Pod
 metadata:
   name: create-notebook-tables
 spec:
-  nodeSelector:
-    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -48,6 +48,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -46,8 +46,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -46,6 +46,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -56,18 +58,6 @@ spec:
                     values:
                     - notebook
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: notebook
          image: "{{ notebook_image.image }}"

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -157,6 +157,9 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
             limits={'cpu': cpu, 'memory': memory})
 
     pod_spec = kube.client.V1PodSpec(
+        node_selector={
+            'preemptible': 'false'
+        },
         service_account_name=service_account_name,
         containers=[
             kube.client.V1Container(

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -157,9 +157,11 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
             limits={'cpu': cpu, 'memory': memory})
 
     pod_spec = kube.client.V1PodSpec(
-        node_selector={
-            'preemptible': 'false'
-        },
+        tolerations=[
+            kube.client.V1Toleration(
+                key='preemptible',
+                value='true')
+        ],
         service_account_name=service_account_name,
         containers=[
             kube.client.V1Container(

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -47,6 +47,9 @@ spec:
       priorityClassName: infrastructure
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: router-resolver
       priorityClassName: infrastructure
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -45,8 +45,6 @@ spec:
     spec:
       serviceAccountName: router-resolver
       priorityClassName: infrastructure
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -45,6 +45,8 @@ spec:
     spec:
       serviceAccountName: router-resolver
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -55,18 +57,6 @@ spec:
                     values:
                     - router-resolver
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: router-resolver
          image: "{{ router_resolver_image.image }}"

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -217,6 +217,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -227,18 +229,6 @@ spec:
                     values:
                     - router
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: router
          image: {{ router_image.image }}

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -217,8 +217,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -219,6 +219,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -218,7 +218,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/scorecard/deployment.yaml
+++ b/scorecard/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: false
+        preemptible: "false"
       containers:
       - name: scorecard
         image: "{{ scorecard_image.image }}"

--- a/scorecard/deployment.yaml
+++ b/scorecard/deployment.yaml
@@ -19,8 +19,9 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "false"
+      tolerations:
+       - key: preemptible
+         value: "false"
       containers:
       - name: scorecard
         image: "{{ scorecard_image.image }}"

--- a/scorecard/deployment.yaml
+++ b/scorecard/deployment.yaml
@@ -19,6 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: false
       containers:
       - name: scorecard
         image: "{{ scorecard_image.image }}"

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -19,6 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,18 +31,6 @@ spec:
                     values:
                     - site
               topologyKey: "kubernetes.io/hostname"
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: preemptible
-                operator: In
-                values:
-                - "true"
-      tolerations:
-       - key: preemptible
-         value: "true"
       containers:
        - name: site
          image: "{{ site_image.image }}"

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -21,6 +21,9 @@ spec:
 {% endif %}
       nodeSelector:
         preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -19,8 +19,6 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      nodeSelector:
-        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       priorityClassName: production
 {% endif %}
       nodeSelector:
-        preemptible: true
+        preemptible: "true"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         app: ukbb-rg-static
     spec:
       nodeSelector:
-        preemptible: false
+        preemptible: "false"
       containers:
        - name: ukbb-rg-static
          image: gcr.io/hail-vdc/ukbb-rg-static
@@ -76,7 +76,7 @@ spec:
         app: ukbb-rg-browser
     spec:
       nodeSelector:
-        preemptible: false
+        preemptible: "false"
       containers:
        - name: ukbb-rg-browser
          image: gcr.io/hail-vdc/ukbb-rg-browser

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       labels:
         app: ukbb-rg-static
     spec:
+      nodeSelector:
+        preemptible: false
       containers:
        - name: ukbb-rg-static
          image: gcr.io/hail-vdc/ukbb-rg-static
@@ -73,6 +75,8 @@ spec:
       labels:
         app: ukbb-rg-browser
     spec:
+      nodeSelector:
+        preemptible: false
       containers:
        - name: ukbb-rg-browser
          image: gcr.io/hail-vdc/ukbb-rg-browser

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -29,8 +29,9 @@ spec:
       labels:
         app: ukbb-rg-static
     spec:
-      nodeSelector:
-        preemptible: "false"
+      tolerations:
+       - key: preemptible
+         value: "false"
       containers:
        - name: ukbb-rg-static
          image: gcr.io/hail-vdc/ukbb-rg-static
@@ -75,8 +76,9 @@ spec:
       labels:
         app: ukbb-rg-browser
     spec:
-      nodeSelector:
-        preemptible: "false"
+      tolerations:
+       - key: preemptible
+         value: "false"
       containers:
        - name: ukbb-rg-browser
          image: gcr.io/hail-vdc/ukbb-rg-browser


### PR DESCRIPTION
And separate preemptible and non-preemptible workloads to run in their own pools.  This should fix the problem where the non-preemptible pool fills up with preemptible things but k8s can't evict.

When this is ready to go in, I will remove the preemptible pool toleration and redeploy the infrastructure components by hand.
