### PR TITLE
[gear] add transactions to database interface

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -57,7 +57,7 @@ def batch_record_to_dict(record):
 
 
 async def notify_batch_job_complete(db, batch_id):
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT *
 FROM batches

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -53,7 +53,7 @@ class InstancePool:
     async def async_init(self):
         log.info('initializing instance pool')
 
-        row = await self.db.execute_and_fetchone(
+        row = await self.db.select_and_fetchone(
             'SELECT worker_type, worker_cores, worker_disk_size_gb, max_instances, pool_size FROM globals;')
 
         self.worker_type = row['worker_type']
@@ -62,7 +62,7 @@ class InstancePool:
         self.max_instances = row['max_instances']
         self.pool_size = row['pool_size']
 
-        async for record in self.db.execute_and_fetchall(
+        async for record in self.db.select_and_fetchall(
                 'SELECT * FROM instances;'):
             instance = Instance.from_record(self.app, record)
             self.add_instance(instance)
@@ -399,7 +399,7 @@ gsutil -m cp run.log worker.log /var/log/syslog gs://$BUCKET_NAME/batch/logs/$IN
         log.info(f'starting control loop')
         while True:
             try:
-                ready_cores = await self.db.execute_and_fetchone(
+                ready_cores = await self.db.select_and_fetchone(
                     'SELECT * FROM ready_cores;')
                 ready_cores_mcpu = ready_cores['ready_cores_mcpu']
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -88,7 +88,7 @@ def activating_instances_only(fun):
             raise web.HTTPUnauthorized()
 
         db = request.app['db']
-        record = await db.execute_and_fetchone(
+        record = await db.select_and_fetchone(
             'SELECT state FROM instances WHERE name = %s AND activation_token = %s;',
             (instance.name, activation_token))
         if not record:
@@ -119,7 +119,7 @@ def active_instances_only(fun):
             raise web.HTTPUnauthorized()
 
         db = request.app['db']
-        record = await db.execute_and_fetchone(
+        record = await db.select_and_fetchone(
             'SELECT state FROM instances WHERE name = %s AND token = %s;',
             (instance.name, token))
         if not record:
@@ -143,7 +143,7 @@ async def close_batch(request):
     user = request.match_info['user']
     batch_id = int(request.match_info['batch_id'])
 
-    record = db.execute_and_fetchone(
+    record = db.select_and_fetchone(
         '''
 SELECT state FROM batches WHERE user = %s AND id = %s;
 ''',
@@ -164,7 +164,7 @@ async def cancel_batch(request):
     user = request.match_info['user']
     batch_id = int(request.match_info['batch_id'])
 
-    record = db.execute_and_fetchone(
+    record = db.select_and_fetchone(
         '''
 SELECT state FROM batches WHERE user = %s AND id = %s;
 ''',
@@ -186,7 +186,7 @@ async def delete_batch(request):
     user = request.match_info['user']
     batch_id = int(request.match_info['batch_id'])
 
-    record = db.execute_and_fetchone(
+    record = db.select_and_fetchone(
         '''
 SELECT state FROM batches WHERE user = %s AND id = %s;
 ''',
@@ -299,7 +299,7 @@ async def get_index(request, userdata):
     db = app['db']
     instance_pool = app['inst_pool']
 
-    ready_cores = await db.execute_and_fetchone(
+    ready_cores = await db.select_and_fetchone(
         'SELECT * FROM ready_cores;')
     ready_cores_mcpu = ready_cores['ready_cores_mcpu']
 
@@ -408,7 +408,7 @@ async def on_startup(app):
     await db.async_init()
     app['db'] = db
 
-    row = await db.execute_and_fetchone(
+    row = await db.select_and_fetchone(
         'SELECT instance_id, internal_token FROM globals;')
     instance_id = row['instance_id']
     log.info(f'instance_id {instance_id}')

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -121,7 +121,7 @@ WHERE ready_cores_mcpu > 0;
                 changed.clear()
 
     async def cancel_1(self):
-        user_records = self.db.execute_and_fetchall(
+        user_records = self.db.select_and_fetchall(
             '''
 SELECT user
 FROM user_resources
@@ -154,7 +154,7 @@ LIMIT 50;
         for user, allocated_cores_mcpu in fair_share.items():
             scheduled_cores_mcpu = 0
 
-            records = self.db.execute_and_fetchall(
+            records = self.db.select_and_fetchall(
                 '''
 SELECT job_id, batch_id, spec, cores_mcpu,
   ((jobs.cancelled OR batches.cancelled) AND NOT always_run) AS cancel,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -150,7 +150,7 @@ LIMIT 50;
 
     jobs = [job_record_to_dict(job)
             async for job
-            in db.execute_and_fetchall(sql, sql_args)]
+            in db.select_and_fetchall(sql, sql_args)]
 
     if len(jobs) == 50:
         last_job_id = jobs[-1]['job_id']
@@ -168,7 +168,7 @@ async def get_jobs(request, userdata):
     user = userdata['username']
 
     db = request.app['db']
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT * FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -229,7 +229,7 @@ async def _get_job_log_from_record(app, batch_id, job_id, record):
 async def _get_job_log(app, batch_id, job_id, user):
     db = app['db']
 
-    record = await db.execute_and_fetchone('''
+    record = await db.select_and_fetchone('''
 SELECT jobs.state, jobs.spec, ip_address
 FROM jobs
 INNER JOIN batches
@@ -240,7 +240,7 @@ LEFT JOIN instances
   ON attempts.instance_name = instances.name
 WHERE user = %s AND jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 ''',
-                                           (user, batch_id, job_id))
+                                          (user, batch_id, job_id))
     if not record:
         raise web.HTTPNotFound()
     return await _get_job_log_from_record(app, batch_id, job_id, record)
@@ -333,7 +333,7 @@ LIMIT 50;
 
     batches = [batch_record_to_dict(batch)
                async for batch
-               in db.execute_and_fetchall(sql, sql_args)]
+               in db.select_and_fetchall(sql, sql_args)]
 
     if len(batches) == 50:
         last_batch_id = batches[-1]['id']
@@ -381,7 +381,7 @@ async def create_jobs(request, userdata):
 
     async with LoggingTimer(f'batch {batch_id} create jobs') as timer:
         async with timer.step('fetch batch'):
-            record = await db.execute_and_fetchone(
+            record = await db.select_and_fetchone(
                 '''
 SELECT closed FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -473,27 +473,22 @@ WHERE user = %s AND id = %s AND NOT deleted;
                             (batch_id, job_id, k, v))
 
         async with timer.step('insert jobs'):
-            async with db.pool.acquire() as conn:
-                await conn.begin()
-                async with conn.cursor() as cursor:
-                    await cursor.executemany('''
+            async with db.start() as tx:
+                await tx.execute_many('''
 INSERT INTO jobs (batch_id, job_id, state, spec, always_run, cores_mcpu, n_pending_parents)
 VALUES (%s, %s, %s, %s, %s, %s, %s);
 ''',
-                                             jobs_args)
-                async with conn.cursor() as cursor:
-                    await cursor.executemany('''
+                                      jobs_args)
+                await tx.execute_many('''
 INSERT INTO `job_parents` (batch_id, job_id, parent_id)
 VALUES (%s, %s, %s);
 ''',
-                                             job_parents_args)
-                async with conn.cursor() as cursor:
-                    await cursor.executemany('''
+                                      job_parents_args)
+                await tx.execute_many('''
 INSERT INTO `job_attributes` (batch_id, job_id, `key`, `value`)
 VALUES (%s, %s, %s, %s);
 ''',
-                                             job_attributes_args)
-                await conn.commit()
+                                      job_attributes_args)
 
         return web.Response()
 
@@ -515,48 +510,41 @@ async def create_batch(request, userdata):
     billing_project = batch_spec['billing_project']
 
     attributes = batch_spec.get('attributes')
-    async with db.pool.acquire() as conn:
-        await conn.begin()
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                '''
-INSERT IGNORE INTO user_resources (user) VALUES (%s);
-''',
-                (user,))
-
-        async with conn.cursor() as cursor:
-            now = time_msecs()
-            await cursor.execute(
-                '''
+    async with db.start() as tx:
+        rows = tx.execute_and_fetchall(
+            '''
 SELECT * FROM billing_project_users
 WHERE billing_project = %s AND user = %s
 ''',
-                (billing_project, user))
-            rows = await cursor.fetchall()
-            if len(rows) != 1:
-                assert len(rows) == 0
-                raise web.HTTPForbidden(reason=f'unknown billing project {billing_project}')
+            (billing_project, user))
+        rows = [row async for row in rows]
+        if len(rows) != 1:
+            assert len(rows) == 0
+            raise web.HTTPForbidden(reason=f'unknown billing project {billing_project}')
 
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                '''
-INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created)
-VALUES (%s, %s, %s, %s, %s, %s, %s);
+        await tx.just_execute(
+            '''
+INSERT IGNORE INTO user_resources (user) VALUES (%s);
 ''',
-                (json.dumps(userdata), user, billing_project, json.dumps(attributes),
-                 batch_spec.get('callback'), batch_spec['n_jobs'],
-                 now))
-            id = cursor.lastrowid
+            (user,))
+
+        now = time_msecs()
+        id = await tx.execute_insertone(
+            '''
+INSERT INTO batches (userdata, user, attributes, callback, n_jobs, time_created)
+VALUES (%s, %s, %s, %s, %s, %s);
+''',
+            (json.dumps(userdata), user, json.dumps(attributes),
+             batch_spec.get('callback'), batch_spec['n_jobs'],
+             now))
 
         if attributes:
-            async with conn.cursor() as cursor:
-                await cursor.executemany(
-                    '''
+            await tx.execute_many(
+                '''
 INSERT INTO `batch_attributes` (batch_id, `key`, `value`)
 VALUES (%s, %s, %s)
 ''',
-                    [(id, k, v) for k, v in attributes.items()])
-        await conn.commit()
+                [(id, k, v) for k, v in attributes.items()])
 
     return web.json_response({'id': id})
 
@@ -564,7 +552,7 @@ VALUES (%s, %s, %s)
 async def _get_batch(app, batch_id, user):
     db = app['db']
 
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT * FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -578,7 +566,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 async def _cancel_batch(app, batch_id, user):
     db = app['db']
 
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT closed FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -631,7 +619,7 @@ async def close_batch(request, userdata):
     app = request.app
     db = app['db']
 
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT closed FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -673,7 +661,7 @@ async def delete_batch(request, userdata):
     app = request.app
     db = app['db']
 
-    record = await db.execute_and_fetchone(
+    record = await db.select_and_fetchone(
         '''
 SELECT closed FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
@@ -780,7 +768,7 @@ async def _get_job_running_status(record):
 async def _get_job(app, batch_id, job_id, user):
     db = app['db']
 
-    record = await db.execute_and_fetchone('''
+    record = await db.select_and_fetchone('''
 SELECT jobs.*, ip_address
 FROM jobs
 INNER JOIN batches
@@ -791,7 +779,7 @@ LEFT JOIN instances
   ON attempts.instance_name = instances.name
 WHERE user = %s AND jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 ''',
-                                           (user, batch_id, job_id))
+                                          (user, batch_id, job_id))
     if not record:
         raise web.HTTPNotFound()
 
@@ -851,7 +839,7 @@ async def on_startup(app):
     await db.async_init()
     app['db'] = db
 
-    row = await db.execute_and_fetchone(
+    row = await db.select_and_fetchone(
         'SELECT worker_type, worker_cores, instance_id, internal_token FROM globals;')
 
     app['worker_type'] = row['worker_type']

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -531,10 +531,10 @@ INSERT IGNORE INTO user_resources (user) VALUES (%s);
         now = time_msecs()
         id = await tx.execute_insertone(
             '''
-INSERT INTO batches (userdata, user, attributes, callback, n_jobs, time_created)
-VALUES (%s, %s, %s, %s, %s, %s);
+INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created)
+VALUES (%s, %s, %s, %s, %s, %s, %s);
 ''',
-            (json.dumps(userdata), user, json.dumps(attributes),
+            (json.dumps(userdata), user, billing_project, json.dumps(attributes),
              batch_spec.get('callback'), batch_spec['n_jobs'],
              now))
 

--- a/batch/batch/google_compute.py
+++ b/batch/batch/google_compute.py
@@ -24,7 +24,7 @@ class EntryIterator:
         self.entries = None
 
     async def async_init(self):
-        row = await self.db.execute_and_fetchone('SELECT * FROM `gevents_mark`;')
+        row = await self.db.select_and_fetchone('SELECT * FROM `gevents_mark`;')
         if row['mark']:
             self.mark = row['mark']
         else:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -5,6 +5,14 @@ import logging
 log = logging.getLogger('gear.database')
 
 
+async def aenter(acontext_manager):
+    return await acontext_manager.__aenter__()
+
+
+async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
+    return await acontext_manager.__aexit__(exc_type, exc_val, exc_tb)
+
+
 async def create_database_pool(autocommit=True, maxsize=10):
     with open('/sql-config/sql-config.json', 'r') as f:
         sql_config = json.loads(f.read())
@@ -16,45 +24,148 @@ async def create_database_pool(autocommit=True, maxsize=10):
         cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
 
 
+class TransactionAsyncContextManager:
+    def __init__(self, db_pool, read_only):
+        self.db_pool = db_pool
+        self.read_only = read_only
+        self.tx = None
+
+    async def __aenter__(self):
+        tx = Transaction()
+        await tx.async_init(self.db_pool, self.read_only)
+        self.tx = tx
+        return tx
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.tx._aexit(exc_type, exc_val, exc_tb)
+        self.tx = None
+
+
+class Transaction:
+    def __init__(self):
+        self.conn_context_manager = None
+        self.conn = None
+
+    async def async_init(self, db_pool, read_only):
+        self.conn_context_manager = db_pool.acquire()
+        self.conn = await aenter(self.conn_context_manager)
+        async with self.conn.cursor() as cursor:
+            if read_only:
+                await cursor.execute('START TRANSACTION READ ONLY;')
+            else:
+                await cursor.execute('START TRANSACTION;')
+
+    async def _aexit(self, exc_type, exc_val, exc_tb):
+        if not self.conn:
+            return
+
+        if exc_type:
+            await self.conn.rollback()
+        else:
+            await self.conn.commit()
+        self.conn = None
+
+        await aexit(self.conn_context_manager, exc_type, exc_val, exc_tb)
+        self.conn_context_manager = None
+
+    async def commit(self):
+        assert self.conn
+        self.conn.commit()
+        self.conn = None
+
+        await aexit(self.conn_context_manager)
+        self.conn_context_manager = None
+
+    async def rollback(self):
+        assert self.conn
+        self.conn.rollback()
+        self.conn = None
+
+        await aexit(self.conn_context_manager)
+        self.conn_context_manager = None
+
+    async def just_execute(self, sql, args=None):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(sql, args)
+
+    async def execute_and_fetchone(self, sql, args=None):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(sql, args)
+            return await cursor.fetchone()
+
+    async def execute_and_fetchall(self, sql, args=None):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(sql, args)
+            while True:
+                rows = await cursor.fetchmany(100)
+                if not rows:
+                    break
+                for row in rows:
+                    yield row
+
+    async def execute_insertone(self, sql, args=None):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(sql, args)
+            return cursor.lastrowid
+
+    async def execute_update(self, sql, args=None):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            return await cursor.execute(sql, args)
+
+    async def execute_many(self, sql, args_array):
+        assert self.conn
+        async with self.conn.cursor() as cursor:
+            return await cursor.executemany(sql, args_array)
+
+
 class Database:
     def __init__(self):
         self.pool = None
 
-    async def async_init(self, autocommit=True, maxsize=10):
-        self.pool = await create_database_pool(autocommit, maxsize)
+    async def async_init(self, maxsize=10):
+        self.pool = await create_database_pool(autocommit=False, maxsize=maxsize)
+
+    def start(self, read_only=False):
+        return TransactionAsyncContextManager(self.pool, read_only)
 
     async def just_execute(self, sql, args=None):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute(sql, args)
+        async with self.start() as tx:
+            await tx.just_execute(sql, args)
 
     async def execute_and_fetchone(self, sql, args=None):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute(sql, args)
-                return await cursor.fetchone()
+        async with self.start() as tx:
+            return await tx.execute_and_fetchone(sql, args)
+
+    async def select_and_fetchone(self, sql, args=None):
+        async with self.start(read_only=True) as tx:
+            return await tx.execute_and_fetchone(sql, args)
 
     async def execute_and_fetchall(self, sql, args=None):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute(sql, args)
-                while True:
-                    rows = await cursor.fetchmany(100)
-                    if not rows:
-                        break
-                    for row in rows:
-                        yield row
+        async with self.start() as tx:
+            async for row in tx.execute_and_fetchall(sql, args):
+                yield row
+
+    async def select_and_fetchall(self, sql, args=None):
+        async with self.start(read_only=True) as tx:
+            async for row in tx.execute_and_fetchall(sql, args):
+                yield row
 
     async def execute_insertone(self, sql, args=None):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute(sql, args)
-                return cursor.lastrowid
+        async with self.start() as tx:
+            return await tx.execute_insertone(sql, args)
 
     async def execute_update(self, sql, args=None):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                return await cursor.execute(sql, args)
+        async with self.start() as tx:
+            return await tx.execute_update(sql, args)
+
+    async def execute_many(self, sql, args_array):
+        async with self.start() as tx:
+            return await tx.execute_many(sql, args_array)
 
     async def async_close(self):
         self.pool.close()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -157,7 +157,8 @@ def is_transient_error(e):
     elif isinstance(e, aiohttp.ClientOSError):
         if (e.errno == errno.ETIMEDOUT or
                 e.errno == errno.ECONNREFUSED or
-                e.errno == errno.EHOSTUNREACH):
+                e.errno == errno.EHOSTUNREACH or
+                e.errno == errno.ECONNRESET):
             return True
     elif isinstance(e, aiohttp.ServerTimeoutError):
         return True


### PR DESCRIPTION
You can now say:

```
  async with db.start() as tx:
    await tx.just_execute(sql)
    row = await tx.execute_fetchone(sql, args)
    ...
```

Transactions support all the database utility functions.  If the transaction context manager exists with an exception, the transaction is rolled back, otherwise it is committed.  You also can explicitly rollback or commit the transaction, although it can't be used again after that.  I also added an execute_many function.

I use this in the front end instead of dropping down to aiomysql to create explicit transactions.

Note on internal changes: I no longer use autocommit now that transaction boundaries are explicit.  You can start a read only transaction, and I do that by default for execute_and_fetch{one, all}, although maybe those should be renamed select_and_fetch{one, all} to make their read-only nature apparent (MySQL throws an error if you try to modify something in a read-only transaction).  This follows mysql best transaction performance recommendations as described here: https://dev.mysql.com/doc/refman/5.6/en/optimizing-innodb-transaction-management.html and https://dev.mysql.com/doc/refman/5.6/en/innodb-performance-ro-txn.html.

FYI @jigold 
