### PR TITLE
[hail] fix read after file close

### DIFF
--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -44,7 +44,7 @@ object TextMatrixReader {
     hasHeader: Boolean
   ): HeaderInfo = {
     val maybeFirstTwoLines = fs.readFile(file) { s =>
-      Source.fromInputStream(s).getLines().take(2).toSeq }
+      Source.fromInputStream(s).getLines().take(2).toArray.toSeq }
 
     (hasHeader, maybeFirstTwoLines) match {
       case (true, Seq()) =>


### PR DESCRIPTION
`.toSeq` is insufficient because a lazy stream is a `Seq`. `.toArray` forces the data to be realized in memory before the file is closed. We convert back to Seq for nice matching syntax. Dunno why the tests didn't catch this, I guess somehow the stream is valid long enough after the file being closed to work for the tests.