### PR TITLE
[tests] Remove parens from test so it isn't always true

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -366,8 +366,8 @@ def test_ndarray_save():
             hl._nd.array(expected).save(f.name)
             actual = np.load(f.name)
 
-            assert(expected.dtype == actual.dtype, f'expected: {expected.dtype}, actual: {actual.dtype}')
-            assert(np.array_equal(expected, actual))
+            assert expected.dtype == actual.dtype, f'expected: {expected.dtype}, actual: {actual.dtype}'
+            assert np.array_equal(expected, actual)
 
 @skip_unless_spark_backend()
 @run_with_cxx_compile()


### PR DESCRIPTION
We don't even run this test currently, but we were generating a warning everytime we ran pytest about the fact that it would always be true if we did run it.