### PR TITLE
Require column key is a string to export vcfs

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -489,6 +489,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
         dictionary should be structured.
 
     """
+    require_col_key_str(dataset, 'export_vcf')
     require_row_key_variant(dataset, 'export_vcf')
     row_fields_used = {'rsid', 'info', 'filters', 'qual'}
 


### PR DESCRIPTION
Fixes #7584. We already require this in Scala, but since we don't require it in python the error message is bad. 