### PR TITLE
[build.yaml] fix delete batch2 instances

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1187,6 +1187,7 @@ steps:
      gcloud -q compute instances list \
          --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \
          --format="value(name)" \
+         --project {{ global.project }} \
        | xargs -r gcloud -q compute instances delete --zone {{ global.zone }} --project {{ global.project }}
    secrets:
     - name: test-gsa-key


### PR DESCRIPTION
Fixes this error:

```
+ gcloud -q compute instances list --filter 'tags.items=batch2-agent AND labels.namespace=pr-7660-default-ne0pow1za1v4' '--format=value(name)'
+ xargs -r gcloud -q compute instances delete --zone us-central1-a --project hail-vdc
ERROR: (gcloud.compute.instances.list) The required property [project] is not currently set.
```