### PR TITLE
[build.yaml] fix delete batch2 instances

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1184,6 +1184,7 @@ steps:
    script: |
      set -ex
      gcloud -q auth activate-service-account --key-file=/test-gsa-key/privateKeyData
+     set +e
      gcloud -q compute instances list \
          --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \
          --format="value(name)" \


### PR DESCRIPTION
Fixes this error:

```
+ gcloud -q compute instances list --filter 'tags.items=batch2-agent AND labels.namespace=pr-7663-default-ccnvti4s750b' '--format=value(name)' --project hail-vdc
+ xargs -r gcloud -q compute instances delete --zone us-central1-a --project hail-vdc
Deleted [https://www.googleapis.com/compute/v1/projects/hail-vdc/zones/us-central1-a/instances/batch2-worker-pr-7663-default-ccnvti4s750b-o2tmf].
ERROR: (gcloud.compute.instances.delete) Could not fetch resource:
 - The resource 'projects/hail-vdc/zones/us-central1-a/instances/batch2-worker-pr-7663-default-ccnvti4s750b-8z4dd' was not found
```