### PR TITLE
[hail] clean up generated IR for struct.select() with only named fields

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1623,6 +1623,9 @@ class StructExpression(Mapping[str, Expression], Expression):
             Struct containing specified existing fields and computed fields.
         """
 
+        if len(fields) == 0:
+            return hl.struct(**named_exprs)
+
         name_set = set()
         for a in fields:
             if not a in self._fields:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1624,7 +1624,7 @@ class StructExpression(Mapping[str, Expression], Expression):
         """
 
         if len(fields) == 0:
-            return hl.struct(**named_exprs)
+            return hl.or_missing(hl.is_defined(self), hl.struct(**named_exprs))
 
         name_set = set()
         for a in fields:


### PR DESCRIPTION
We're currently generating IR that looks like:
```
(InsertFields
  (SelectFields row ())
  (f1 …)
  …
)
```
for something like row.select(**new_field_exprs).

I did this in the process of debugging #7638, but it doesn't actually fix the issue completely; I'm getting past the stack overflow issue on a table with 2000 fields, but then running into a class size issue when trying to generate the code.