### PR TITLE
[pipeline] wait, open options

### DIFF
--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -194,7 +194,7 @@ class BatchBackend(Backend):
     def close(self):
         self._batch_client.close()
 
-    def _run(self, pipeline, dry_run, verbose, delete_scratch_on_exit, wait=False, open=False):  # pylint: disable-msg=R0915
+    def _run(self, pipeline, dry_run, verbose, delete_scratch_on_exit, wait=True, open=False):  # pylint: disable-msg=R0915
         build_dag_start = time.time()
 
         bucket = self._batch_client.bucket
@@ -335,7 +335,7 @@ class BatchBackend(Backend):
             for jid, cmd in jobs_to_command.items():
                 print(f'{jid}: {cmd}')
 
-        print('')
+            print('')
 
         deploy_config = get_deploy_config()
         url = deploy_config.url('batch2', f'/batches/{batch.id}')
@@ -344,6 +344,6 @@ class BatchBackend(Backend):
         if open:
             webbrowser.open(url)
         if wait:
-            print('Waiting for batch {batch.id}...')
+            print(f'Waiting for batch {batch.id}...')
             status = batch.wait()
             print(f'Batch {batch.id} complete: {status["state"]}')

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -6,7 +6,7 @@ import time
 from shlex import quote as shq
 import webbrowser
 from hailtop.config import get_deploy_config
-from hailtop.batch_client.client import BatchClient, Job
+from hailtop.batch_client.client import BatchClient
 
 from .resource import InputResourceFile, TaskResourceFile
 

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -4,10 +4,11 @@ import subprocess as sp
 import uuid
 import time
 from shlex import quote as shq
+import webbrowser
+from hailtop.config import get_deploy_config
 from hailtop.batch_client.client import BatchClient, Job
 
 from .resource import InputResourceFile, TaskResourceFile
-from .utils import PipelineException
 
 
 class Backend:
@@ -193,7 +194,7 @@ class BatchBackend(Backend):
     def close(self):
         self._batch_client.close()
 
-    def _run(self, pipeline, dry_run, verbose, delete_scratch_on_exit):  # pylint: disable-msg=R0915
+    def _run(self, pipeline, dry_run, verbose, delete_scratch_on_exit, wait=False, open=False):  # pylint: disable-msg=R0915
         build_dag_start = time.time()
 
         bucket = self._batch_client.bucket
@@ -334,25 +335,15 @@ class BatchBackend(Backend):
             for jid, cmd in jobs_to_command.items():
                 print(f'{jid}: {cmd}')
 
-        status = batch.wait()
+        print('')
 
-        if status['state'] == 'success':
-            print('Pipeline completed successfully!')
-            return
+        deploy_config = get_deploy_config()
+        url = deploy_config.url('batch2', f'/batches/{batch.id}')
+        print(f'Submitted batch {batch.id}, see {url}')
 
-        failed_jobs = [(j, Job.exit_code(j)) for j in status['jobs']]
-        failed_jobs = [((j['batch_id'], j['job_id']), Job._get_exit_codes(j)) for j, ec in failed_jobs if ec != 0]
-
-        fail_msg = ''
-        for jid, ec in failed_jobs:
-            ec = Job.exit_code(ec)
-            job = self._batch_client.get_job(*jid)
-            log = job.log()
-            name = job.status()['attributes'].get('name', None)
-            fail_msg += (
-                f"Job {jid} failed with exit code {ec}:\n"
-                f"  Task name:\t{name}\n"
-                f"  Command:\t{jobs_to_command[jid]}\n"
-                f"  Log:\t{log}\n")
-
-        raise PipelineException(fail_msg)
+        if open:
+            webbrowser.open(url)
+        if wait:
+            print('Waiting for batch {batch.id}...')
+            status = batch.wait()
+            print(f'Batch {batch.id} complete: {status["state"]}')

--- a/hail/python/hailtop/pipeline/pipeline.py
+++ b/hail/python/hailtop/pipeline/pipeline.py
@@ -342,7 +342,7 @@ class Pipeline:
 
         return [task for task in self._tasks if task.name is not None and re.match(pattern, task.name) is not None]
 
-    def run(self, dry_run=False, verbose=False, delete_scratch_on_exit=True):
+    def run(self, dry_run=False, verbose=False, delete_scratch_on_exit=True, **backend_kwargs):
         """
         Execute a pipeline.
 
@@ -391,7 +391,7 @@ class Pipeline:
                     raise PipelineException("cycle detected in dependency graph")
 
         self._tasks = ordered_tasks
-        self._backend._run(self, dry_run, verbose, delete_scratch_on_exit)
+        self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)
 
     def __str__(self):
         return self._uid

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -3,7 +3,7 @@ import os
 import subprocess as sp
 import tempfile
 
-from hailtop.pipeline import Pipeline, BatchBackend, LocalBackend, PipelineException
+from hailtop.pipeline import Pipeline, BatchBackend, LocalBackend
 
 gcs_input_dir = os.environ.get('SCRATCH') + '/input'
 gcs_output_dir = os.environ.get('SCRATCH') + '/output'
@@ -417,10 +417,3 @@ class BatchTests(unittest.TestCase):
         t.command(f'cat {input}')
         p.write_output(input, f'{gcs_output_dir}/hello.txt')
         p.run(verbose=True)
-
-    def test_failed_job_error_msg(self):
-        with self.assertRaises(PipelineException):
-            p = self.pipeline()
-            t = p.new_task()
-            t.command('false')
-            p.run()


### PR DESCRIPTION
Submitting a pipeline now looks like:

```
$ hail pipeline.py
Submitted batch 120, see https://batch2.hail.is/batches/120
Waiting for batch 120...
Batch 120 complete: failure
```

FYI @konradjk Pipeline.run now passes through kwargs to the backend.  BatchBackend supports two new args: wait (default True) to wait for the pipeline to finish, and open (default False) to open the batch URL in the browser.

It no longer attempts to print the failed jobs.