### PR TITLE
[ptype/pcontainer] remove dependence on contentsByteSize

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -319,7 +319,7 @@ class RegionValueBuilder(var region: Region) {
 
   def fixupArray(t: PArray, fromRegion: Region, fromAOff: Long): Long = {
     val length = t.loadLength(fromRegion, fromAOff)
-    val toAOff = t.copyFrom(fromRegion, fromAOff)
+    val toAOff = t.copyFrom(region, fromAOff)
 
     if (region.ne(fromRegion) && requiresFixup(t.elementType)) {
       var i = 0

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -157,7 +157,7 @@ class RegionValueBuilder(var region: Region) {
 
   private def startArrayInternal(length: Int, init: Boolean, setMissing: Boolean) {
     val t = currentType().asInstanceOf[PArray]
-    val aoff = region.allocate(t.contentsAlignment, t.contentsByteSize(length))
+    val aoff = t.allocate(region, length)
 
     if (typestk.nonEmpty) {
       val off = currentOffset()
@@ -319,9 +319,7 @@ class RegionValueBuilder(var region: Region) {
 
   def fixupArray(t: PArray, fromRegion: Region, fromAOff: Long): Long = {
     val length = t.loadLength(fromRegion, fromAOff)
-    val toAOff = t.allocate(region, length)
-
-    Region.copyFrom(fromAOff, toAOff, t.contentsByteSize(length))
+    val toAOff = t.copyFrom(fromRegion, fromAOff)
 
     if (region.ne(fromRegion) && requiresFixup(t.elementType)) {
       var i = 0

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -319,7 +319,7 @@ class RegionValueBuilder(var region: Region) {
 
   def fixupArray(t: PArray, fromRegion: Region, fromAOff: Long): Long = {
     val length = t.loadLength(fromRegion, fromAOff)
-    val toAOff = t.copyFrom(region, fromAOff)
+    val toAOff = t.copyFrom(fromRegion, fromAOff)
 
     if (region.ne(fromRegion) && requiresFixup(t.elementType)) {
       var i = 0

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -79,13 +79,14 @@ object StagedRegionValueBuilder {
           Region.copyFrom(value, offset, PBinary.contentByteSize(PBinary.loadLength(region, value))))
       case t: PArray =>
         Code(
-          offset := t.copyFrom(region, value),
+          offset := t.copyFrom(fb, region, value),
           fixupArray(fb, region, t, offset))
       case t =>
         Code(
           offset := region.allocate(t.alignment, t.byteSize),
           deepCopy(fb, region, t, Region.getIRIntermediate(t)(value), offset))
     }
+
     Code(copy, offset)
   }
 

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -79,8 +79,7 @@ object StagedRegionValueBuilder {
           Region.copyFrom(value, offset, PBinary.contentByteSize(PBinary.loadLength(region, value))))
       case t: PArray =>
         Code(
-          offset := region.allocate(t.contentsAlignment, t.contentsByteSize(t.loadLength(region, value))),
-          Region.copyFrom(value, offset, t.contentsByteSize(t.loadLength(region, value))),
+          offset := t.copyFrom(region, value),
           fixupArray(fb, region, t, offset))
       case t =>
         Code(
@@ -169,7 +168,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
 
   def start(length: Code[Int], init: Boolean = true): Code[Unit] = {
     val t = ftype.asInstanceOf[PArray]
-    var c = startOffset.store(region.allocate(t.contentsAlignment, t.contentsByteSize(length)))
+    var c = startOffset.store(t.allocate(region, length))
     if (pOffset != null) {
       c = Code(c, Region.storeAddress(pOffset, startOffset))
     }

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -79,7 +79,7 @@ object StagedRegionValueBuilder {
           Region.copyFrom(value, offset, PBinary.contentByteSize(PBinary.loadLength(region, value))))
       case t: PArray =>
         Code(
-          offset := t.copyFrom(fb, region, value),
+          offset := t.copyFrom(fb.apply_method, region, value),
           fixupArray(fb, region, t, offset))
       case t =>
         Code(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -41,7 +41,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
   private val initArray: Code[Unit] =
     Code(
       region.setNumParents((lenRef + 1) * nStates),
-      aoff := region.allocate(arrayType.contentsAlignment, arrayType.contentsByteSize(lenRef)),
+      aoff := arrayType.allocate(region, lenRef),
       Region.storeAddress(typ.fieldOffset(off, 1), aoff),
       arrayType.stagedInitialize(aoff, lenRef),
       typ.setFieldPresent(region, off, 1))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -88,7 +88,7 @@ class StagedBlockLinkedList(val elemType: PType, val fb: EmitFunctionBuilder[_])
     Code(
       dstNode := r.allocate(nodeType.alignment, nodeType.byteSize),
       initNode(dstNode,
-        buf = r.allocate(bufferType.contentsAlignment, bufferType.contentsByteSize(cap)),
+        buf = bufferType.allocate(r, cap),
         count = 0),
       bufferType.stagedInitialize(buffer(dstNode), cap))
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -170,10 +170,13 @@ abstract class PContainer extends PIterable {
     destOff
   }
 
-  def copyFrom(region: Code[Region], srcOff: Code[Long]): Code[Long] = {
-    val destOff = allocate(region, loadLength(srcOff))
-    Region.copyFrom(srcOff,  destOff, contentsByteSize(loadLength(srcOff)))
-    destOff
+  def copyFrom(fb: FunctionBuilder[_], region: Code[Region], srcOff: Code[Long]): Code[Long] = {
+    val destOff = fb.newField[Long]
+    Code(
+      destOff := allocate(region, loadLength(srcOff)),
+      Region.copyFrom(srcOff, destOff, contentsByteSize(loadLength(srcOff))),
+      destOff
+    )
   }
 
   def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = loadElement(aoff, length, i)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -170,8 +170,8 @@ abstract class PContainer extends PIterable {
     destOff
   }
 
-  def copyFrom(fb: FunctionBuilder[_], region: Code[Region], srcOff: Code[Long]): Code[Long] = {
-    val destOff = fb.newField[Long]
+  def copyFrom(mb: MethodBuilder, region: Code[Region], srcOff: Code[Long]): Code[Long] = {
+    val destOff = mb.newField[Long]
     Code(
       destOff := allocate(region, loadLength(srcOff)),
       Region.copyFrom(srcOff, destOff, contentsByteSize(loadLength(srcOff))),

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -83,10 +83,10 @@ abstract class PContainer extends PIterable {
     _elementsOffset(length)
   }
 
-  def contentsByteSize(length: Int): Long =
+  private def contentsByteSize(length: Int): Long =
     elementsOffset(length) + length * elementByteSize
 
-  def contentsByteSize(length: Code[Int]): Code[Long] = {
+  private def contentsByteSize(length: Code[Int]): Code[Long] = {
     elementsOffset(length) + length.toL * elementByteSize
   }
 
@@ -162,6 +162,18 @@ abstract class PContainer extends PIterable {
       case _: PArray | _: PBinary => Region.loadAddress(off)
       case _ => off
     }
+  }
+
+  def copyFrom(region: Region, srcOff: Long): Long = {
+    val destOff = allocate(region, loadLength(srcOff))
+    Region.copyFrom(srcOff,  destOff, contentsByteSize(loadLength(srcOff)))
+    destOff
+  }
+
+  def copyFrom(region: Code[Region], srcOff: Code[Long]): Code[Long] = {
+    val destOff = allocate(region, loadLength(srcOff))
+    Region.copyFrom(srcOff,  destOff, contentsByteSize(loadLength(srcOff)))
+    destOff
   }
 
   def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = loadElement(aoff, length, i)


### PR DESCRIPTION
1) Removes region.allocate called on PContainer instances, in favor of Container's allocate instance method.
2) Introduces a copyeFrom

Goal was to remove contentsByteSize, because as used represents an allocation/copy implementation detail that does not need to live on a public interface.

Part of upcoming introduction of PContainer trait and complimentary PCanonicalArray.