### PR TITLE
[hail] [streams] IR to use region value iterator as stream

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValue.scala
@@ -48,6 +48,8 @@ final class RegionValue(
   var region: Region,
   var offset: Long
 ) extends UnKryoSerializable {
+  def getOffset: Long = offset
+
   def set(newRegion: Region, newOffset: Long) {
     region = newRegion
     offset = newOffset

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1130,9 +1130,7 @@ private class Emit(
           Region.loadIRIntermediate(t.types(idx))(t.fieldOffset(xo, idx)))
 
       case In(i, typ) =>
-        EmitTriplet(Code._empty,
-          mb.getArg[Boolean](normalArgumentPosition(i) + 1),
-          mb.getArg(normalArgumentPosition(i))(typeToTypeInfo(typ)))
+        normalArgument(i, typ)
       case Die(m, typ) =>
         val cm = emit(m)
         EmitTriplet(
@@ -1965,8 +1963,11 @@ private class Emit(
       value)
   }
 
-  private def normalArgumentPosition(idx: Int): Int = {
-    1 + nSpecialArguments + idx * 2
+  private[ir] def normalArgument(idx: Int, pType: PType): EmitTriplet = {
+    val i = 1 + nSpecialArguments + idx * 2
+    EmitTriplet(Code._empty,
+      mb.getArg[Boolean](i + 1),
+      mb.getArg(i)(typeToTypeInfo(pType)))
   }
 
   def deforestNDArray(er: EmitRegion, x: IR, env: Emit.E): NDArrayEmitter = {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -4,9 +4,11 @@ import is.hail.utils._
 import is.hail.asm4s._
 import is.hail.asm4s.joinpoint._
 import is.hail.expr.types.physical._
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.expr.types.virtual.TStream
+import is.hail.annotations.{Region, RegionValue, StagedRegionValueBuilder}
 
 import scala.language.existentials
+import scala.reflect.ClassTag
 
 object EmitStream {
   sealed trait Init[+S]
@@ -294,6 +296,26 @@ object EmitStream {
     }
   }
 
+  def fromIterator[A <: AnyRef : ClassTag]: Parameterized[Code[Iterator[A]], Code[A]] =
+    new Parameterized[Code[Iterator[A]], Code[A]] {
+      type S = Code[Iterator[A]]
+      val stateP: ParameterPack[S] = implicitly
+      def emptyState: S = Code.invokeScalaObject[Iterator[Nothing]](Iterator.getClass, "empty")
+      def length(s0: S): Option[Code[Int]] = None
+
+      def init(mb: MethodBuilder, jb: JoinPointBuilder, iter: S)(
+        k: Init[S] => Code[Ctrl]
+      ): Code[Ctrl] =
+        k(Start(iter))
+
+      def step(mb: MethodBuilder, jb: JoinPointBuilder, iter: S)(
+        k: Step[Code[A], S] => Code[Ctrl]
+      ): Code[Ctrl] =
+        iter.hasNext.mux(
+          ParameterPack.let(mb, iter.next()) { elt => k(Yield(elt, iter)) },
+          k(EOS))
+    }
+
   private[ir] def apply(
     emitter: Emit,
     streamIR0: IR,
@@ -312,6 +334,23 @@ object EmitStream {
       streamIR match {
         case NA(_) =>
           missing
+
+        case (_: Ref | _: In) =>
+          val (m, v, eltType) = streamIR match {
+            case In(i, t@PStream(e, _)) =>
+              val EmitTriplet(_, m, v) = emitter.normalArgument(i, t)
+              (m, v, e)
+            case Ref(x, TStream(e, _)) =>
+              val (_, m, v) = env.lookup(x)
+              (m, v, e.physicalType)
+          }
+          fromIterator[RegionValue]
+            .map { (rv: Code[RegionValue]) =>
+              present(Region.loadIRIntermediate(eltType)(rv.invoke[Long]("getOffset")))
+            }
+            .guardParam { (_, k) =>
+              m.mux(k(None), k(Some(coerce[Iterator[RegionValue]](v))))
+            }
 
         case MakeStream(elements, t) =>
           val e = t.elementType.physicalType

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -335,18 +335,11 @@ object EmitStream {
         case NA(_) =>
           missing
 
-        case (_: Ref | _: In) =>
-          val (m, v, eltType) = streamIR match {
-            case In(i, t@PStream(e, _)) =>
-              val EmitTriplet(_, m, v) = emitter.normalArgument(i, t)
-              (m, v, e)
-            case Ref(x, TStream(e, _)) =>
-              val (_, m, v) = env.lookup(x)
-              (m, v, e.physicalType)
-          }
+        case In(i, t@PStream(eltPType, _)) =>
+          val EmitTriplet(_, m, v) = emitter.normalArgument(i, t)
           fromIterator[RegionValue]
             .map { (rv: Code[RegionValue]) =>
-              present(Region.loadIRIntermediate(eltType)(rv.invoke[Long]("getOffset")))
+              present(Region.loadIRIntermediate(eltPType)(rv.invoke[Long]("getOffset")))
             }
             .guardParam { (_, k) =>
               m.mux(k(None), k(Some(coerce[Iterator[RegionValue]](v))))

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -2,6 +2,7 @@ package is.hail.expr
 
 import is.hail.asm4s
 import is.hail.asm4s._
+import is.hail.annotations.RegionValue
 import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PType
@@ -34,6 +35,7 @@ package object ir {
     case _: TBinary => typeInfo[Long]
     case _: TArray => typeInfo[Long]
     case _: TBaseStruct => typeInfo[Long]
+    case _: TStream => classInfo[Iterator[RegionValue]]
     case TVoid => typeInfo[Unit]
     case _ => throw new RuntimeException(s"unsupported type found, $t")
   }
@@ -47,6 +49,7 @@ package object ir {
     case LongInfo => 0L
     case FloatInfo => 0.0f
     case DoubleInfo => 0.0
+    case _: ClassInfo[_] => Code._null
     case ti => throw new RuntimeException(s"unsupported type found: $t whose type info is $ti")
   }
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -119,4 +119,6 @@ trait Implicits {
   implicit def toRichCodeOutputBuffer(out: Code[OutputBuffer]): RichCodeOutputBuffer = new RichCodeOutputBuffer(out)
 
   implicit def toRichCodeArray[T](arr: Array[Code[T]]): RichCodeArray[T] = new RichCodeArray[T](arr)
+
+  implicit def toRichCodeIterator[T](it: Code[Iterator[T]]): RichCodeIterator[T] = new RichCodeIterator[T](it)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeIterator.scala
@@ -1,0 +1,10 @@
+package is.hail.utils.richUtils
+
+import is.hail.asm4s.Code
+import scala.reflect.ClassTag
+
+class RichCodeIterator[T](it: Code[Iterator[T]]) {
+  def hasNext: Code[Boolean] = it.invoke[Boolean]("hasNext")
+  def next()(implicit ct: ClassTag[T]): Code[T] =
+    Code.checkcast[T](it.invoke[java.lang.Object]("next"))
+}


### PR DESCRIPTION
part of the work for getting TableMapPartitions working

you can use `Ref` or `In` nodes that have type `TStream` as emittable streams. the variable/argument must be bound to a `Iterator[RegionValue]`, which will be iterated over and emitted as part of the stream. this stream can then be composed like other streams.

there's no fancy region management going on in this PR since i'm going to handle that by deep copying in TableMapPartitions