### PR TITLE
[hail] [streams] TableMapPartitions

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -41,6 +41,7 @@ object Bindings {
     case TableMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case TableAggregateByKey(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case TableKeyByAndAggregate(child, _, _, _, _) => if (i == 1) child.typ.globalEnv.m else if (i == 2) child.typ.rowEnv.m else empty
+    case TableMapPartitions(child, n, _) => if (i == 1) Array(n -> TStream(child.typ.rowType)) else empty
     case MatrixMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixFilterRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixMapCols(child, _, _) => if (i == 1) child.typ.colEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -41,7 +41,7 @@ object Bindings {
     case TableMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case TableAggregateByKey(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case TableKeyByAndAggregate(child, _, _, _, _) => if (i == 1) child.typ.globalEnv.m else if (i == 2) child.typ.rowEnv.m else empty
-    case TableMapPartitions(child, n, _) => if (i == 1) Array(n -> TStream(child.typ.rowType)) else empty
+    case TableMapPartitions(child, g, p, _) => if (i == 1) Array(g -> child.typ.globalType, p -> TStream(child.typ.rowType)) else empty
     case MatrixMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixFilterRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixMapCols(child, _, _) => if (i == 1) child.typ.colEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -400,10 +400,30 @@ object CompileIterator {
         GenericTypeInfo[Region], GenericTypeInfo[RegionValue],
         GenericTypeInfo[T0], GenericTypeInfo[Boolean]),
       None)
-    (idx, r, v1, m1) => {
+    (idx, r, v0, m0) => {
       val stepper = makeStepper(idx, r)
       new RegionValueIteratorWrapper {
-        def step(rv: RegionValue): Boolean = stepper(r, rv, v1, m1)
+        def step(rv: RegionValue): Boolean = stepper(r, rv, v0, m0)
+      }
+    }
+  }
+
+  def apply[T0: TypeInfo, T1: TypeInfo](
+    ctx: ExecuteContext,
+    typ0: PType, typ1: PType,
+    ir: IR
+  ): (Int, Region, T0, Boolean, T1, Boolean) => Iterator[RegionValue] = {
+    val makeStepper = compileStepper[AsmFunction6[Region, RegionValue, T0, Boolean, T1, Boolean, Boolean]](
+      ctx, ir,
+      Array[MaybeGenericTypeInfo[_]](
+        GenericTypeInfo[Region], GenericTypeInfo[RegionValue],
+        GenericTypeInfo[T0], GenericTypeInfo[Boolean],
+        GenericTypeInfo[T1], GenericTypeInfo[Boolean]),
+      None)
+    (idx, r, v0, m0, v1, m1) => {
+      val stepper = makeStepper(idx, r)
+      new RegionValueIteratorWrapper {
+        def step(rv: RegionValue): Boolean = stepper(r, rv, v0, m0, v1, m1)
       }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -5,7 +5,7 @@ import java.io.PrintWriter
 import is.hail.annotations._
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.asm4s._
-import is.hail.expr.types.physical.PType
+import is.hail.expr.types.physical.{PType, PBaseStruct}
 import is.hail.expr.types.virtual.Type
 import is.hail.utils._
 
@@ -306,3 +306,105 @@ object CompileWithAggregators2 {
   }
 }
 
+object CompileIterator {
+  import is.hail.asm4s.joinpoint._
+
+  private abstract class RegionValueIteratorWrapper extends Iterator[RegionValue] {
+    def step(rv: RegionValue): Boolean
+
+    private val rv = RegionValue()
+    private var _stepped = false
+    private var _hasNext = false
+    def hasNext: Boolean = {
+      if (!_stepped)
+        _hasNext = step(rv)
+      _stepped = true
+      _hasNext
+    }
+    def next(): RegionValue = {
+      if (!hasNext)
+        return Iterator.empty.next()
+      _stepped = false
+      rv
+    }
+  }
+
+  private def compileStepper[F >: Null: TypeInfo](
+    ctx: ExecuteContext,
+    ir: IR,
+    argTypeInfo: Array[MaybeGenericTypeInfo[_]],
+    printWriter: Option[PrintWriter]
+  ): (Int, Region) => F = {
+
+    val fb = new EmitFunctionBuilder[F](argTypeInfo, GenericTypeInfo[Boolean], namePrefix = "stream")
+    val stepF = fb.apply_method
+    val rv = stepF.getArg[RegionValue](2).load
+    val er = EmitRegion.default(stepF)
+    val emitter = new Emit(ctx, stepF, nSpecialArguments = 2)
+
+    val EmitStream(stream, eltPType) = EmitStream(emitter, ir, Env.empty, er, None)
+    val (setState, state) = stream.stateP.newFields(fb, "state")
+    assert(eltPType.isInstanceOf[PBaseStruct])
+
+    val didInit = fb.newField[Boolean]("did_init")
+    fb.addInitInstructions(didInit := false)
+
+    stepF.emit(JoinPoint.CallCC[Code[Boolean]] { (jb, ret) =>
+      val step = jb.joinPoint()
+      step.define(_ => stream.step(stepF, jb, state) {
+        case EmitStream.EOS => ret(false)
+        case EmitStream.Yield(elt, s1) =>
+          Code(
+            elt.setup,
+            elt.m.mux(Code._fatal("empty row!"),
+              Code(
+                rv.invoke[Region, Unit]("setRegion", er.region),
+                rv.invoke[Long, Unit]("setOffset", elt.value))),
+            setState(s1),
+            ret(true))
+      })
+      didInit.mux(step(()), stream.init(stepF, jb, ()) {
+        case EmitStream.Missing => Code._fatal("missing stream!")
+        case EmitStream.Start(s0) => Code(didInit := true, setState(s0), step(()))
+      })
+    })
+
+    fb.resultWithIndex(printWriter)
+  }
+
+  def apply(
+    ctx: ExecuteContext,
+    ir: IR
+  ): (Int, Region) => Iterator[RegionValue] = {
+    val makeStepper = compileStepper[AsmFunction2[Region, RegionValue, Boolean]](
+      ctx, ir,
+      Array[MaybeGenericTypeInfo[_]](
+        GenericTypeInfo[Region], GenericTypeInfo[RegionValue]),
+      None)
+    (idx, r) => {
+      val stepper = makeStepper(idx, r)
+      new RegionValueIteratorWrapper {
+        def step(rv: RegionValue): Boolean = stepper(r, rv)
+      }
+    }
+  }
+
+  def apply[T0: TypeInfo](
+    ctx: ExecuteContext,
+    typ0: PType,
+    ir: IR
+  ): (Int, Region, T0, Boolean) => Iterator[RegionValue] = {
+    val makeStepper = compileStepper[AsmFunction4[Region, RegionValue, T0, Boolean, Boolean]](
+      ctx, ir,
+      Array[MaybeGenericTypeInfo[_]](
+        GenericTypeInfo[Region], GenericTypeInfo[RegionValue],
+        GenericTypeInfo[T0], GenericTypeInfo[Boolean]),
+      None)
+    (idx, r, v1, m1) => {
+      val stepper = makeStepper(idx, r)
+      new RegionValueIteratorWrapper {
+        def step(rv: RegionValue): Boolean = stepper(r, rv, v1, m1)
+      }
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -339,7 +339,11 @@ object EmitStream {
           val EmitTriplet(_, m, v) = emitter.normalArgument(i, t)
           fromIterator[RegionValue]
             .map { (rv: Code[RegionValue]) =>
-              present(Region.loadIRIntermediate(eltPType)(rv.invoke[Long]("getOffset")))
+              val off = fb.newField[Long]("it_off")
+              present(Code(
+                off := rv.invoke[Long]("getOffset"),
+                off := StagedRegionValueBuilder.deepCopyFromOffset(er, eltPType, off),
+                Region.getIRIntermediate(eltPType)(off)))
             }
             .guardParam { (_, k) =>
               m.mux(k(None), k(Some(coerce[Iterator[RegionValue]](v))))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -1,10 +1,11 @@
 package is.hail.expr.ir
 
-import is.hail.expr.types.virtual.TNDArray
+import is.hail.expr.types.virtual._
 
 object Interpretable {
   def apply(ir: IR): Boolean = {
     !ir.typ.isInstanceOf[TNDArray] &&
+    !ir.typ.isInstanceOf[TStream] &&
       (ir match {
       case
         _: InitOp2 |

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -422,19 +422,19 @@ object PruneDeadFields {
           rowType = unify(child.typ.rowType, requestedType.rowType, selectKey(child.typ.rowType, child.typ.key)),
           globalType = requestedType.globalType)
         memoizeTableIR(child, dep, memo)
-      case TableMapPartitions(child, name, body) =>
+      case TableMapPartitions(child, gName, pName, body) =>
         val reqRowsType = TStream(requestedType.rowType)
         val bodyDep = memoizeValueIR(body, reqRowsType, memo)
-        val depRowType = bodyDep.eval.lookupOption(name) match {
-          case Some(ab) =>
-            unifySeq(child.typ.rowType, ab.result().map(_.asInstanceOf[TStreamable].elementType))
-          case None =>
-            minimal(child.typ.rowType)
-        }
+        val depGlobalType = unifySeq(child.typ.globalType,
+          bodyDep.eval.lookupOption(gName).map(_.result()).getOrElse(Array()))
+        val depRowType = unifySeq(child.typ.rowType,
+          bodyDep.eval.lookupOption(pName)
+            .map(_.result().map(_.asInstanceOf[TStreamable].elementType))
+            .getOrElse(Array()))
         val dep = TableType(
           key = requestedType.key,
           rowType = depRowType.asInstanceOf[TStruct],
-          globalType = requestedType.globalType)
+          globalType = depGlobalType.asInstanceOf[TStruct])
         memoizeTableIR(child, dep, memo)
       case TableMapRows(child, newRow) =>
         val rowDep = memoizeAndGetDep(newRow, requestedType.rowType, child.typ, memo)
@@ -1290,10 +1290,12 @@ object PruneDeadFields {
         val child2 = rebuild(child, memo)
         val pred2 = rebuildIR(pred, BindingEnv(child2.typ.rowEnv), memo)
         TableFilter(child2, pred2)
-      case TableMapPartitions(child, name, body) =>
+      case TableMapPartitions(child, gName, pName, body) =>
         val child2 = rebuild(child, memo)
-        val body2 = rebuildIR(body, BindingEnv(Env(name -> TStream(child2.typ.rowType))), memo)
-        TableMapPartitions(child2, name, body2)
+        val body2 = rebuildIR(body, BindingEnv(Env(
+          gName -> child2.typ.globalType,
+          pName -> TStream(child2.typ.rowType))), memo)
+        TableMapPartitions(child2, gName, pName, body2)
       case TableMapRows(child, newRow) =>
         val child2 = rebuild(child, memo)
         val newRow2 = rebuildIR(newRow, BindingEnv(child2.typ.rowEnv, scan = Some(child2.typ.rowEnv)), memo)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -979,6 +979,7 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
 
 case class TableMapPartitions(child: TableIR, name: String, body: IR) extends TableIR {
   assert(body.typ.isInstanceOf[TStream], s"${body.typ}")
+  assert(EmitStream.isIterationLinear(body, name), "must iterate over the partition exactly once")
   val bodyType = body.typ.asInstanceOf[TStream]
   val newRowType = bodyType.elementType.asInstanceOf[TStruct]
   lazy val typ = child.typ.copy(rowType = newRowType)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -235,7 +235,7 @@ object TypeCheck {
         assert(cond.typ.isOfType(TBoolean()))
       case x@ArrayFlatMap(a, name, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
-        assert(body.typ.isInstanceOf[TArray])
+        assert(body.typ.isInstanceOf[TStreamable])
       case x@ArrayFold(a, zero, accumName, valueName, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -476,5 +476,9 @@ class TableIRSuite extends HailSuite {
         // 0,0,0,0,0,5,5,5,5,5,...
         Row((i / 5) * 5)
       }, Row()))
+
+    interceptAssertion("must iterate over the partition exactly once") {
+      collect(TableMapPartitions(table, "part", ArrayFlatMap(part, "_", part)))
+    }
   }
 }


### PR DESCRIPTION
creates TableMapPartitions IR node such that, for instance:
```scala
TableMapRows(t, newRow)
```
is basically equivalent to
```scala
TableMapPartitions(t, "global", "partition",
  ArrayMap(Ref("partition", TStream(t.typ.rowType)),
    "row", newRow))
```
(similarly for `ArrayFilter` and other nodes)

- added `TableMapPartitions` TableIR
- added `ParameterPack.newFields` to make it easy to store the state of a stream as a set of class fields
- added `CompileIterator` function to produce a `Iterator[RegionValue]` from a stream IR (analogous to `Compile`, which produces a single row value from an IR)
- added `multiplicity` check to make sure that the iterator consumed by a `TableMapPartitions` is only consumed once. trying to consume it more than once is always a bug