### PR TITLE
[ci] use dev database server config in dev deploy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -95,6 +95,8 @@ steps:
     - default_ns
  - kind: runImage
    name: create_database_server_config
+   image:
+     valueFrom: base_image.image
    script: |
      kubectl -n {{ default_ns.name }} get -o json --export secret {{ test_database_instance.admin_secret_name }} | jq '.metadata.name = "database-server-config"' | kubectl -n {{ default_ns.name }} apply -f -
    serviceAccount:

--- a/build.yaml
+++ b/build.yaml
@@ -86,7 +86,7 @@ steps:
      - service_base_image
  - kind: createDatabase
    name: test_database_instance
-   databaseName: test_instance
+   databaseName: test-instance
    namespace:
      valueFrom: default_ns.name
    scopes:

--- a/build.yaml
+++ b/build.yaml
@@ -106,6 +106,7 @@ steps:
    scopes:
     - test
    dependsOn:
+    - base_image
     - test_database_instance
  - kind: createDatabase
    name: users_database

--- a/build.yaml
+++ b/build.yaml
@@ -22,7 +22,6 @@ steps:
    namespaceName: batch-pods
    public: false
    secrets:
-    - database-server-config
     - gcr-push-service-account-key
     - test-gsa-key
     - hail-ci-0-1-service-account-key

--- a/build.yaml
+++ b/build.yaml
@@ -102,7 +102,7 @@ steps:
      namespace:
        valueFrom: default_ns.name
    scopes:
-    - test_instance
+    - test
    dependsOn:
     - test_database_instance
  - kind: createDatabase

--- a/build.yaml
+++ b/build.yaml
@@ -106,6 +106,7 @@ steps:
    scopes:
     - test
    dependsOn:
+    - default_ns
     - base_image
     - test_database_instance
  - kind: createDatabase

--- a/build.yaml
+++ b/build.yaml
@@ -85,6 +85,27 @@ steps:
    dependsOn:
      - service_base_image
  - kind: createDatabase
+   name: test_database_instance
+   databaseName: test_instance
+   namespace:
+     valueFrom: default_ns.name
+   scopes:
+    - test
+   dependsOn:
+    - default_ns
+ - kind: runImage
+   name: create_database_server_config
+   script: |
+     kubectl -n {{ default_ns.name }} get -o json --export secret {{ test_database_instance.admin_secret_name }} | jq '.metadata.name = "database-server-config"' | kubectl -n {{ default_ns.name }} apply -f -
+   serviceAccount:
+     name: admin
+     namespace:
+       valueFrom: default_ns.name
+   scopes:
+    - test_instance
+   dependsOn:
+    - test_database_instance
+ - kind: createDatabase
    name: users_database
    databaseName: users
    namespace:
@@ -863,6 +884,7 @@ steps:
    dependsOn:
     - default_ns
     - batch_pods_ns
+    - create_database_server_config
     - ci_image
     - ci_utils_image
     - create_accounts

--- a/ci/ci-agent-default.yaml
+++ b/ci/ci-agent-default.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ci-agent
 rules:
 - apiGroups: [""]
-  resources: ["services", "pods", "pods/log"]
+  resources: ["services", "pods", "pods/log", "secrets"]
   verbs: ["*"]
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]

--- a/ci/ci-agent.yaml
+++ b/ci/ci-agent.yaml
@@ -9,7 +9,7 @@ metadata:
   name: ci-agent
 rules:
 - apiGroups: [""]
-  resources: ["services", "pods", "pods/log"]
+  resources: ["services", "pods", "pods/log", "secrets"]
   verbs: ["*"]
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -820,8 +820,13 @@ class CreateDatabaseStep(Step):
         self.admin_secret_name = f'sql-{self._name}-{self.admin_username}-config'
         self.user_secret_name = f'sql-{self._name}-{self.user_username}-config'
 
+        if params.scope == 'dev':
+            database_server_config_namespace = params.code.namespace
+        else:
+            database_server_config_namespace = DEFAULT_NAMESPACE
+
         self.secrets = [{
-            'namespace': BATCH_PODS_NAMESPACE,
+            'namespace': database_server_config_namespace,
             'name': 'database-server-config',
             'mount_path': '/secrets/db-config'
         }]

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -829,7 +829,7 @@ class CreateDatabaseStep(Step):
         self.secrets = [{
             'namespace': database_server_config_namespace,
             'name': 'database-server-config',
-            'mount_path': '/secrets/db-config'
+            'mount_path': '/sql-config'
         }]
 
     def wrapped_job(self):
@@ -879,11 +879,11 @@ set -e
 echo date
 date
 
-HOST=$(cat /secrets/db-config/sql-config.json | jq -r '.host')
-INSTANCE=$(cat /secrets/db-config/sql-config.json | jq -r '.instance')
-PORT=$(cat /secrets/db-config/sql-config.json | jq -r '.port')
+HOST=$(cat /sql-config/sql-config.json | jq -r '.host')
+INSTANCE=$(cat /sql-config/sql-config.json | jq -r '.instance')
+PORT=$(cat /sql-config/sql-config.json | jq -r '.port')
 
-DBS=$(echo "SHOW DATABASES LIKE '{self._name}'" | mysql --defaults-extra-file=/secrets/db-config/sql-config.cnf -s)
+DBS=$(echo "SHOW DATABASES LIKE '{self._name}'" | mysql --defaults-extra-file=/sql-config/sql-config.cnf -s)
 if [ "$DBS" == "{self._name}" ]; then
     exit 0
 fi
@@ -891,7 +891,7 @@ fi
 ADMIN_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')
 USER_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')
 
-cat | mysql --defaults-extra-file=/secrets/db-config/sql-config.cnf <<EOF
+cat | mysql --defaults-extra-file=/sql-config/sql-config.cnf <<EOF
 CREATE DATABASE \\`{self._name}\\`;
 
 CREATE USER '{self.admin_username}'@'%' IDENTIFIED BY '$ADMIN_PASSWORD';
@@ -902,7 +902,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON \\`{self._name}\\`.* TO '{self.
 EOF
 
 echo create database, admin and user...
-echo "$SQL_SCRIPT" | mysql --defaults-extra-file=/secrets/db-config/sql-config.cnf
+echo "$SQL_SCRIPT" | mysql --defaults-extra-file=/sql-config/sql-config.cnf
 
 echo create admin secret...
 cat > sql-config.json <<EOF
@@ -975,7 +975,7 @@ echo done.
 set -x
 date
 
-cat | mysql --defaults-extra-file=/secrets/db-config/sql-config.cnf <<EOF
+cat | mysql --defaults-extra-file=/sql-config/sql-config.cnf <<EOF
 DROP DATABASE \\`{self._name}\\`;
 DROP USER '{self.admin_username}';
 DROP USER '{self.user_username}';

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -847,7 +847,7 @@ class CreateDatabaseStep(Step):
         }
 
     def build_cant_create_database(self, batch, code, scope):  # pylint: disable=unused-argument
-        script = '''
+        script = f'''
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.admin_secret_name)} --from-file=/sql-config/sql-config.json --from-file=/sql-config/sql-config.cnf
 
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.user_secret_name)} --from-file=/sql-config/sql-config.json --from-file=/sql-config/sql-config.cnf

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -805,12 +805,18 @@ class CreateDatabaseStep(Step):
         # MySQL user name can be up to 16 characters long before MySQL 5.7.8 (32 after)
         if self.cant_create_database:
             self._name = None
+            self.admin_username = None
+            self.user_username = None
         else:
             if params.scope == 'deploy':
                 self._name = database_name
+                self.admin_username = f'{self._name}-admin'
+                self.user_username = f'{self._name}-user'
             else:
                 assert params.scope == 'test'
                 self._name = f'{params.code.short_str()}-{database_name}-{self.token}'
+                self.admin_username = generate_token()
+                self.user_username = generate_token()
 
         self.admin_secret_name = f'sql-{database_name}-{database_name}-admin-config'
         self.user_secret_name = f'sql-{database_name}-{database_name}-user-config'

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -854,8 +854,10 @@ class CreateDatabaseStep(Step):
 
     def build_cant_create_database(self, batch, code, scope):  # pylint: disable=unused-argument
         script = f'''
+kubectl -n {shq(self.namespace)} delete secret --ignore-not-found {shq(self.admin_secret_name)}
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.admin_secret_name)} --from-file=/sql-config/sql-config.json --from-file=/sql-config/sql-config.cnf
 
+kubectl -n {shq(self.namespace)} delete secret --ignore-not-found {shq(self.user_secret_name)}
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.user_secret_name)} --from-file=/sql-config/sql-config.json --from-file=/sql-config/sql-config.cnf
 '''
 
@@ -923,6 +925,7 @@ user={self.admin_username}
 password="$ADMIN_PASSWORD"
 database={self._name}
 EOF
+kubectl -n {shq(self.namespace)} delete secret --ignore-not-found {shq(self.admin_secret_name)}
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.admin_secret_name)} --from-file=sql-config.json --from-file=sql-config.cnf
 
 echo create user secret...
@@ -944,6 +947,7 @@ user={self.user_username}
 password="$USER_PASSWORD"
 database={self._name}
 EOF
+kubectl -n {shq(self.namespace)} delete secret --ignore-not-found {shq(self.user_secret_name)}
 kubectl -n {shq(self.namespace)} create secret generic {shq(self.user_secret_name)} --from-file=sql-config.json --from-file=sql-config.cnf
 
 echo database = {shq(self._name)}


### PR DESCRIPTION
The assumption is that the default_ns namespace has a database-server-config that has credentials for the database instance which can be used to create various databases.

This is present in default.  We will require this is also present for dev namespaces, database-server-config will be the user's private database.  devs shouldn't have access to the root database credentials.

When we create a test default_ns when running the tests, we also create a "test_instance" database that will be used as the database instance inside the tests.  database-server-config is only used by CI.

Also, there's no reason to use the credentials from batch-pods anymore, so I use the one from default.

This will need to go in before I can finish https://github.com/hail-is/hail/pull/7674