### PR TITLE
[auth] user admin page with automated create, delete

### DIFF
--- a/apiserver/jupyter_notebook_config.py.in
+++ b/apiserver/jupyter_notebook_config.py.in
@@ -1,3 +1,3 @@
 c.NotebookApp.contents_manager_class = 'jgscm.GoogleStorageContentManager'
 c.GoogleStorageContentManager.project = '@project@'
-c.GoogleStorageContentManager.keyfile = '/gsa-key/privateKeyData'
+c.GoogleStorageContentManager.keyfile = '/gsa-key/key.json'

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -5,11 +5,9 @@ FROM {{ service_base_image.image }}
 # https://stackoverflow.com/questions/56555687/oauth-throws-missing-code-validator-in-google-oauth2
 RUN pip3 install --upgrade google-auth-oauthlib==0.3.0
 
-COPY auth/setup.py /auth/
+COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/
 RUN pip3 install --no-cache-dir /auth && \
   rm -rf /auth
 
 EXPOSE 5000
-
-CMD ["python3", "-m", "auth"]

--- a/auth/MANIFEST.in
+++ b/auth/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include auth/templates *

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -5,7 +5,7 @@ AUTH_LATEST = gcr.io/$(PROJECT)/auth:latest
 AUTH_IMAGE = gcr.io/$(PROJECT)/auth:$(shell docker images -q --no-trunc auth:latest | sed -e 's,[^:]*:,,')
 
 PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}
-PYTHON := PYTHONPATH=$(PYTHONPATH)../hail/python:../gear python3
+PYTHON := PYTHONPATH=$(PYTHONPATH)../hail/python:../gear:../web_common python3
 
 .PHONY: check
 check:
@@ -28,7 +28,7 @@ push: build
 
 .PHONY: deploy
 deploy: push
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"auth_image":{"image":"$(AUTH_IMAGE)"},"users_database":{"user_secret_name":"sql-users-users-user-config"},"global":{"domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"auth_image":{"image":"$(AUTH_IMAGE)"},"auth_database":{"user_secret_name":"sql-auth-auth-user-config"},"global":{"domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out
 
 .PHONY:

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -3,15 +3,16 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 import uvloop
-
 import google.auth.transport.requests
 import google.oauth2.id_token
+import google.cloud.storage
 import google_auth_oauthlib.flow
-
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, create_database_pool, \
-    rest_authenticated_users_only, \
+    rest_authenticated_users_only, web_authenticated_developers_only, \
     web_maybe_authenticated_user, create_session, check_csrf_token
+from web_common import setup_aiohttp_jinja2, setup_common_static_routes, \
+    set_message, render_template
 
 log = logging.getLogger('auth')
 
@@ -78,7 +79,7 @@ async def callback(request):
         flow.fetch_token(code=request.query['code'])
         token = google.oauth2.id_token.verify_oauth2_token(
             flow.credentials.id_token, google.auth.transport.requests.Request())
-        id = token['sub']
+        email = token['email']
     except Exception:
         log.exception('oauth2 callback: could not fetch and verify token')
         raise web.HTTPUnauthorized()
@@ -86,7 +87,7 @@ async def callback(request):
     dbpool = request.app['dbpool']
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
-            await cursor.execute('SELECT * from user_data where user_id = %s;', f'google-oauth2|{id}')
+            await cursor.execute("SELECT * FROM users WHERE email = %s AND state = 'active';", email)
             users = await cursor.fetchall()
 
     if len(users) != 1:
@@ -136,6 +137,74 @@ async def rest_login(request):
     })
 
 
+@routes.get('/users')
+@web_authenticated_developers_only()
+async def get_users(request, userdata):
+    dbpool = request.app['dbpool']
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute('SELECT * FROM users;')
+            users = await cursor.fetchall()
+    page_context = {
+        'users': users
+    }
+    return await render_template('auth', request, userdata, 'users.html', page_context)
+
+
+@routes.post('/users')
+@check_csrf_token
+@web_authenticated_developers_only()
+async def post_create_user(request, userdata):  # pylint: disable=unused-argument
+    session = await aiohttp_session.get_session(request)
+    dbpool = request.app['dbpool']
+    post = await request.post()
+    username = post['username']
+    email = post['email']
+    is_developer = post.get('is_developer') == '1'
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                '''
+INSERT INTO users (state, username, email, is_developer)
+VALUES (%s, %s, %s, %s);
+''',
+                ('creating', username, email, is_developer))
+            user_id = cursor.lastrowid
+
+    set_message(session, f'Created user {user_id} {username}.', 'info')
+
+    return web.HTTPFound(deploy_config.external_url('auth', '/users'))
+
+
+@routes.post('/users/delete')
+@check_csrf_token
+@web_authenticated_developers_only()
+async def delete_user(request, userdata):  # pylint: disable=unused-argument
+    session = await aiohttp_session.get_session(request)
+    dbpool = request.app['dbpool']
+    post = await request.post()
+    id = post['id']
+    username = post['username']
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            n_rows = await cursor.execute(
+                '''
+UPDATE users
+SET state = 'deleting'
+WHERE id = %s AND username = %s;
+''',
+                (id, username))
+            if n_rows != 1:
+                assert n_rows == 0
+                set_message(session, f'Delete failed, no such user {id} {username}.', 'error')
+
+    set_message(session, f'Deleted user {id} {username}.', 'info')
+
+    return web.HTTPFound(deploy_config.external_url('auth', '/users'))
+
+
 @routes.get('/api/v1alpha/oauth2callback')
 async def rest_callback(request):
     state = request.query['state']
@@ -147,7 +216,7 @@ async def rest_callback(request):
         flow.fetch_token(code=code)
         token = google.oauth2.id_token.verify_oauth2_token(
             flow.credentials.id_token, google.auth.transport.requests.Request())
-        id = token['sub']
+        email = token['email']
     except Exception:
         log.exception('fetching and decoding token')
         raise web.HTTPUnauthorized()
@@ -155,7 +224,7 @@ async def rest_callback(request):
     dbpool = request.app['dbpool']
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
-            await cursor.execute('SELECT * from user_data where user_id = %s;', f'google-oauth2|{id}')
+            await cursor.execute("SELECT * FROM users WHERE email = %s; AND state = 'active'", email)
             users = await cursor.fetchall()
 
     if len(users) != 1:
@@ -203,9 +272,9 @@ async def userinfo(request):
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
             await cursor.execute('''
-SELECT user_data.*, sessions.session_id FROM user_data
-INNER JOIN sessions ON user_data.id = sessions.user_id
-WHERE (sessions.session_id = %s) AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
+SELECT users.*, sessions.session_id FROM users
+INNER JOIN sessions ON users.id = sessions.user_id
+WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
 ''', session_id)
             users = await cursor.fetchall()
 
@@ -230,8 +299,10 @@ async def on_cleanup(app):
 def run():
     app = web.Application()
 
+    setup_aiohttp_jinja2(app, 'auth')
     setup_aiohttp_session(app)
 
+    setup_common_static_routes(routes)
     app.add_routes(routes)
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)

--- a/auth/auth/driver/__main__.py
+++ b/auth/auth/driver/__main__.py
@@ -1,0 +1,14 @@
+from gear import configure_logging
+# configure logging before importing anything else
+configure_logging()
+
+
+def main():
+    import asyncio
+    from .driver import async_main
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(async_main())
+
+
+main()

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -1,0 +1,627 @@
+import os
+import random
+import json
+import base64
+import logging
+import secrets
+import string
+import concurrent
+import asyncio
+import kubernetes_asyncio as kube
+import google.auth.transport.requests
+import google.oauth2.id_token
+import google.cloud.storage
+import googleapiclient.http
+import googleapiclient.discovery
+from hailtop.utils import blocking_to_async, time_msecs
+from gear import create_database_pool, create_session
+
+log = logging.getLogger('auth.driver')
+
+PROJECT = os.environ['PROJECT']
+ZONE = os.environ['ZONE']
+DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
+BATCH_PODS_NAMESPACE = os.environ['HAIL_BATCH_PODS_NAMESPACE']
+
+is_test_deployment = DEFAULT_NAMESPACE != 'default'
+
+
+class DatabaseConflictError(Exception):
+    pass
+
+
+class GoogleClient:
+    def __init__(self, credentials):
+        # Google API Python clients are not thread safe, create Http object per request
+        # https://github.com/googleapis/google-api-python-client/blob/master/docs/thread_safety.md
+        def build_request(http, *args, **kwargs):  # pylint: disable=unused-argument
+            import google_auth_httplib2
+            new_http = google_auth_httplib2.AuthorizedHttp(credentials=credentials)
+            return googleapiclient.http.HttpRequest(new_http, *args, **kwargs)
+
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=40)
+
+        # https://googleapis.dev/python/storage/latest/index.html
+        self.storage_client = google.cloud.storage.Client(credentials=credentials)
+
+        self.iam_client = googleapiclient.discovery.build('iam', 'v1', cache_discovery=False, credentials=credentials, requestBuilder=build_request)
+
+    def _create_service_account(self, name, body):
+        return self.iam_client.projects().serviceAccounts().create(  # pylint: disable=no-member
+            name=name, body=body).execute()
+
+    async def create_service_account(self, name, body):
+        return await blocking_to_async(self.thread_pool, self._create_service_account, name, body)
+
+    def _delete_service_account(self, gsa_email):
+        self.iam_client.projects().serviceAccounts().delete(  # pylint: disable=no-member
+            name=f'projects/{PROJECT}/serviceAccounts/{gsa_email}'
+        ).execute()
+
+    async def delete_service_account(self, gsa_email):
+        return await blocking_to_async(self.thread_pool, self._delete_service_account, gsa_email)
+
+    def _create_service_account_key(self, gsa_email):
+        return self.iam_client.projects().serviceAccounts().keys().create(  # pylint: disable=no-member
+            name=f'projects/{PROJECT}/serviceAccounts/{gsa_email}',
+            body={}
+        ).execute()
+
+    async def create_service_account_key(self, gsa_email):
+        return await blocking_to_async(self.thread_pool, self._create_service_account_key, gsa_email)
+
+    def _create_bucket(self, name):
+        bucket = self.storage_client.bucket(name)
+        bucket.create()
+        return bucket
+
+    async def create_bucket(self, name):
+        return await blocking_to_async(self.thread_pool, self._create_bucket, name)
+
+    def _delete_bucket(self, name):
+        bucket = self.storage_client.bucket(name)
+        bucket.delete()
+
+    async def delete_bucket(self, name):
+        return await blocking_to_async(self.thread_pool, self._delete_bucket, name)
+
+    @staticmethod
+    def _save_acl(acl):
+        acl.save()
+
+    async def save_acl(self, acl):
+        return await blocking_to_async(self.thread_pool, self._save_acl, acl)
+
+
+class EventHandler:
+    def __init__(self, handler, event=None, bump_secs=60.0, min_delay_secs=0.1):
+        self.handler = handler
+        if event is None:
+            event = asyncio.Event()
+        self.event = event
+        self.bump_secs = bump_secs
+        self.min_delay_secs = min_delay_secs
+
+    async def main_loop(self):
+        delay_secs = self.min_delay_secs
+        while True:
+            try:
+                start_time = time_msecs()
+                while True:
+                    self.event.clear()
+                    should_wait = await self.handler()
+                    if should_wait:
+                        await self.event.wait()
+            except Exception:
+                end_time = time_msecs()
+
+                log.exception(f'caught exception in event handler loop')
+
+                t = delay_secs * random.uniform(0.7, 1.3)
+                await asyncio.sleep(t)
+
+                ran_for_secs = (end_time - start_time) * 1000
+                delay_secs = min(
+                    max(self.min_delay_secs, 2 * delay_secs - min(0, (ran_for_secs - t) / 2)),
+                    30.0)
+
+    async def bump_loop(self):
+        while True:
+            try:
+                self.event.set()
+            except Exception:
+                log.exception('caught exception')
+            await asyncio.sleep(self.bump_secs)
+
+    async def start(self):
+        asyncio.ensure_future(self.main_loop())
+        if self.bump_secs is not None:
+            asyncio.ensure_future(self.bump_loop())
+
+
+class SessionResource:
+    def __init__(self, dbpool, session_id=None):
+        self.dbpool = dbpool
+        self.session_id = session_id
+
+    async def create(self, user_id, *args, **kwargs):
+        self.session_id = await create_session(self.dbpool, user_id, *args, **kwargs)
+
+    async def delete(self):
+        if self.session_id is None:
+            return
+
+        async with self.dbpool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    f'''
+DELETE FROM sessions
+WHERE session_id = %s;
+''',
+                    (self.session_id,))
+        self.session_id = None
+
+
+class K8sSecretResource:
+    def __init__(self, k8s_client, name=None, namespace=None):
+        self.k8s_client = k8s_client
+        self.name = name
+        self.namespace = namespace
+
+    async def create(self, name, namespace, data):
+        assert self.name is None and self.namespace is None
+
+        await self._delete(name, namespace)
+
+        await self.k8s_client.create_namespaced_secret(
+            namespace,
+            kube.client.V1Secret(
+                metadata=kube.client.V1ObjectMeta(
+                    name=name),
+                data={
+                    k: base64.b64encode(v.encode('utf-8')).decode('utf-8')
+                    for k, v in data.items()
+                }))
+        self.name = name
+
+    async def _delete(self, name, namespace):
+        try:
+            await self.k8s_client.delete_namespaced_secret(
+                name, namespace)
+        except kube.client.rest.ApiException as e:
+            if e.status == 404:
+                pass
+            else:
+                raise
+
+    async def delete(self):
+        if self.name is None:
+            return
+        await self._delete(self.name, self.namespace)
+        self.name = None
+        self.namespace = None
+
+
+class GSAResource:
+    def __init__(self, google_client, gsa_email=None):
+        self.google_client = google_client
+        self.gsa_email = gsa_email
+
+    async def create(self, username):
+        assert self.gsa_email is None
+
+        gsa_email = f'{username}@{PROJECT}.iam.gserviceaccount.com'
+
+        await self._delete(gsa_email)
+
+        service_account = await self.google_client.create_service_account(
+            name=f'projects/{PROJECT}',
+            body={
+                "accountId": username,
+                "serviceAccount": {
+                    "displayName": username
+                }
+            })
+        assert service_account['email'] == gsa_email
+        self.gsa_email = gsa_email
+
+        key = await self.google_client.create_service_account_key(self.gsa_email)
+
+        return (self.gsa_email, key)
+
+    async def _delete(self, gsa_email):
+        try:
+            await self.google_client.delete_service_account(gsa_email)
+        except googleapiclient.errors.HttpError as e:
+            if e.resp.status == 404:
+                pass
+            else:
+                raise
+
+    async def delete(self):
+        if self.gsa_email is None:
+            return
+        await self._delete(self.gsa_email)
+        self.gsa_email = None
+
+
+class BucketResource:
+    def __init__(self, google_client, name=None):
+        self.google_client = google_client
+        self.name = name
+
+    async def create(self, name, gsa_email):
+        assert self.name is None
+
+        await self._delete(name)
+
+        bucket = await self.google_client.create_bucket(name)
+        self.name = name
+
+        acl = bucket.acl
+        acl.user(gsa_email).grant_write()
+        acl.user(gsa_email).grant_read()
+        await self.google_client.save_acl(acl)
+
+        default_object_acl = bucket.default_object_acl
+        default_object_acl.user(gsa_email).grant_read()
+        await self.google_client.save_acl(default_object_acl)
+
+    async def _delete(self, name):
+        try:
+            await self.google_client.delete_bucket(name)
+        except google.cloud.exceptions.NotFound:
+            pass
+
+    async def delete(self):
+        if self.name is None:
+            return
+        await self._delete(self.name)
+        self.name = None
+
+
+class DatabaseResource:
+    def __init__(self, db_instance_pool, name=None):
+        self.db_instance_pool = db_instance_pool
+        self.name = name
+        self.password = None
+
+    async def create(self, name):
+        assert self.name is None
+
+        if is_test_deployment:
+            return
+
+        await self._delete(name)
+
+        self.password = secrets.token_urlsafe(16)
+        async with self.db_instance_pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    f'''
+CREATE DATABASE `{name}`;
+
+CREATE USER '{name}'@'%' IDENTIFIED BY '{self.password}';
+GRANT ALL ON `{name}`.* TO '{name}'@'%';
+''')
+        self.name = name
+
+    @staticmethod
+    def secret_data_from_config(config):
+        assert config.get('db') is not None
+        return {
+            'sql-config.json': json.dumps(config),
+            'sql-config.cnf': f'''
+[client]
+host={config['host']}
+user={config['user']}
+password="{config['password']}"
+database={config['db']}
+'''
+        }
+
+    def secret_data(self):
+        with open('/database-server-config/sql-config.json', 'r') as f:
+            server_config = json.loads(f.read())
+
+        if is_test_deployment:
+            return self.secret_data_from_config(server_config)
+
+        assert self.name is not None
+        assert self.password is not None
+
+        config = {
+            'host': server_config['host'],
+            'port': server_config['port'],
+            'user': self.name,
+            'password': self.password,
+            'instance': server_config['instance'],
+            'connection_name': server_config['connection_name'],
+            'db': self.name
+        }
+        return self.secret_data_from_config(config)
+
+    async def _delete(self, name):
+        if is_test_deployment:
+            return
+
+        # no DROP USER IF EXISTS in current db version
+        async with self.db_instance_pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    f'SELECT 1 FROM mysql.user WHERE User = %s;', (name,))
+                row = cursor.fetchone()
+        if row is not None:
+            async with self.db_instance_pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        f"DROP USER '{name}';")
+
+        async with self.db_instance_pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    f'DROP DATABASE IF EXISTS `{name}`;')
+
+    async def delete(self):
+        if self.name is None:
+            return
+        await self._delete(self.name)
+        self.name = None
+
+
+class K8sNamespaceResource:
+    def __init__(self, k8s_client, name=None):
+        self.k8s_client = k8s_client
+        self.name = name
+
+    async def create(self, name):
+        assert self.name is None
+
+        await self._delete(name)
+
+        await self.k8s_client.create_namespace(
+            kube.client.V1Namespace(
+                metadata=kube.client.V1ObjectMeta(
+                    name=name)))
+        self.name = name
+
+    async def _delete(self, name):
+        try:
+            await self.k8s_client.delete_namespace(name)
+        except kube.client.rest.ApiException as e:
+            if e.status == 404:
+                pass
+            else:
+                raise
+
+    async def delete(self):
+        if self.name is None:
+            return
+        await self._delete(self.name)
+        self.name = None
+
+
+async def _create_user(app, user, cleanup):
+    db_instance_pool = app['db_instance_pool']
+    dbpool = app['dbpool']
+    k8s_client = app['k8s_client']
+    google_client = app['google_client']
+
+    if user['is_developer'] == 1:
+        ident = user['username']
+    else:
+        alnum = string.ascii_lowercase + string.digits
+        token = ''.join([secrets.choice(alnum) for _ in range(5)])
+        ident = f'{user["username"]}-{token}'
+
+    updates = {
+        'state': 'active'
+    }
+
+    tokens_secret_name = user['tokens_secret_name']
+    if tokens_secret_name is None:
+        tokens_session = SessionResource(dbpool)
+        cleanup.append(tokens_session.delete)
+        await tokens_session.create(user['id'], max_age_secs=None)
+
+        tokens_secret_name = f'{ident}-tokens'
+        tokens_secret = K8sSecretResource(k8s_client)
+        cleanup.append(tokens_secret.delete)
+        await tokens_secret.create(tokens_secret_name, BATCH_PODS_NAMESPACE, {
+            'tokens.json': json.dumps({
+                DEFAULT_NAMESPACE: tokens_session.session_id
+            })
+        })
+        updates['tokens_secret_name'] = tokens_secret_name
+
+    gsa_email = user['gsa_email']
+    if gsa_email is None:
+        gsa = GSAResource(google_client)
+        cleanup.append(gsa.delete)
+
+        # length of gsa account_id must be >= 6
+        if len(ident) >= 6:
+            gsa_username = ident
+        else:
+            assert user['is_developer'] == 1
+
+            alnum = string.ascii_lowercase + string.digits
+            # if we're going to go to the trouble, at least 3
+            # minus one for the dash
+            n_extra_chars = max(3, 6 - len(ident) - 1)
+            token = ''.join([secrets.choice(alnum) for _ in range(n_extra_chars)])
+            gsa_username = f'{ident}-{token}'
+
+        gsa_email, key = await gsa.create(gsa_username)
+        updates['gsa_email'] = gsa_email
+
+        gsa_key_secret_name = f'{ident}-gsa-key'
+        gsa_key_secret = K8sSecretResource(k8s_client)
+        cleanup.append(gsa_key_secret.delete)
+        await gsa_key_secret.create(gsa_key_secret_name, BATCH_PODS_NAMESPACE, {
+            'key.json': base64.b64decode(key['privateKeyData']).decode('utf-8')
+        })
+        updates['gsa_key_secret_name'] = gsa_key_secret_name
+
+    bucket_name = user['bucket_name']
+    if bucket_name is None:
+        bucket_name = f'hail-{ident}'
+        bucket = BucketResource(google_client)
+        cleanup.append(bucket.delete)
+        await bucket.create(bucket_name, gsa_email)
+        updates['bucket_name'] = bucket_name
+
+    namespace_name = user['namespace_name']
+    if namespace_name is None and user['is_developer'] == 1:
+        namespace_name = ident
+        namespace = K8sNamespaceResource(k8s_client)
+        cleanup.append(namespace.delete)
+        await namespace.create(namespace_name)
+        updates['namespace_name'] = namespace_name
+
+        db = DatabaseResource(db_instance_pool)
+        cleanup.append(db.delete)
+        await db.create(ident)
+
+        db_secret = K8sSecretResource(k8s_client)
+        cleanup.append(db_secret.delete)
+        await db_secret.create(
+            'database-server-config', namespace_name, db.secret_data())
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            n_rows = await cursor.execute(
+                f'''
+UPDATE users
+SET {', '.join([f'{k} = %({k})s' for k in updates])}
+WHERE id = %(id)s AND state = 'creating';
+''',
+                {'id': user['id'], **updates})
+            if n_rows != 1:
+                assert n_rows == 0
+                raise DatabaseConflictError
+
+
+async def create_user(app, user):
+    cleanup = []
+    try:
+        await _create_user(app, user, cleanup)
+    except Exception:
+        log.exception(f'create user {user} failed, will retry')
+
+        for f in cleanup:
+            try:
+                await f()
+            except Exception:
+                log.exception('caught exception while cleaning up user resource, ignoring')
+
+        raise
+
+
+async def delete_user(app, user):
+    db_instance_pool = app['db_instance_pool']
+    dbpool = app['dbpool']
+    k8s_client = app['k8s_client']
+    google_client = app['google_client']
+
+    tokens_secret_name = user['tokens_secret_name']
+    if tokens_secret_name is not None:
+        # don't bother deleting the session since all sessions are
+        # deleted below
+        tokens_secret = K8sSecretResource(k8s_client, tokens_secret_name, BATCH_PODS_NAMESPACE)
+        await tokens_secret.delete()
+
+    gsa_email = user['gsa_email']
+    if gsa_email is not None:
+        gsa = GSAResource(google_client, gsa_email)
+        await gsa.delete()
+
+    gsa_key_secret_name = user['gsa_key_secret_name']
+    if gsa_key_secret_name is not None:
+        gsa_key_secret = K8sSecretResource(k8s_client, gsa_key_secret_name, BATCH_PODS_NAMESPACE)
+        await gsa_key_secret.delete()
+
+    bucket_name = user['bucket_name']
+    if bucket_name is not None:
+        bucket = BucketResource(google_client, bucket_name)
+        await bucket.delete()
+
+    namespace_name = user['namespace_name']
+    if namespace_name is not None:
+        assert user['is_developer'] == 1
+
+        # don't bother deleting database-server-config since we're
+        # deleting the namespace
+        namespace = K8sNamespaceResource(k8s_client, namespace_name)
+        await namespace.delete()
+
+        db = DatabaseResource(db_instance_pool, user['username'])
+        await db.delete()
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                '''
+DELETE FROM sessions WHERE user_id = %s;
+UPDATE users SET state = 'deleted' WHERE id = %s;
+''',
+                (user['id'], user['id']))
+
+
+async def update_users(app):
+    log.info('in update_users')
+
+    dbpool = app['dbpool']
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute('SELECT * FROM users WHERE state = %s;', 'creating')
+            creating_users = await cursor.fetchall()
+
+    for user in creating_users:
+        await create_user(app, user)
+
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute('SELECT * FROM users WHERE state = %s;', 'deleting')
+            deleting_users = await cursor.fetchall()
+
+    for user in deleting_users:
+        await delete_user(app, user)
+
+    return True
+
+
+async def async_main():
+    app = {}
+
+    app['db_instance_pool'] = await create_database_pool(config_file='/database-server-config/sql-config.json')
+
+    app['dbpool'] = await create_database_pool()
+
+    kube.config.load_incluster_config()
+    k8s_client = kube.client.CoreV1Api()
+    app['k8s_client'] = k8s_client
+
+    credentials = google.oauth2.service_account.Credentials.from_service_account_file(
+        '/gsa-key/key.json',
+        scopes=[
+            'https://www.googleapis.com/auth/cloud-platform',
+            'https://www.googleapis.com/auth/devstorage.full_control'
+        ])
+    app['google_client'] = GoogleClient(credentials)
+
+    users_changed_event = asyncio.Event()
+    app['users_changed_event'] = users_changed_event
+
+    async def users_changed_handler():
+        return await update_users(app)
+
+    user_creation_loop = EventHandler(
+        users_changed_handler,
+        event=users_changed_event,
+        min_delay_secs=1.0)
+    await user_creation_loop.start()
+
+    while True:
+        await asyncio.sleep(10000)

--- a/auth/auth/templates/users.html
+++ b/auth/auth/templates/users.html
@@ -1,0 +1,56 @@
+{% extends "layout.html" %}
+{% block title %}Users{% endblock %}
+{% block content %}
+  <h1>Create User</h1>
+  <form action="{{ base_path }}/users" method="POST">
+    <div>Username: <input name="username" /></div>
+    <div>Email: <input name="email" /></div>
+    <div><input type="checkbox" name="is_developer" value="1" /> Developer</div>
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>  
+    <button>
+      Create
+    </button>
+  </form>
+
+  <h1>Delete User</h1>
+  <form action="{{ base_path }}/users/delete" method="POST">
+    <div>User ID: <input name="id" /></div>
+    <div>Username: <input name="username" /></div>
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>  
+    <button  class="dangerous">
+      Delete
+    </button>
+  </form>
+
+  <h1>Users</h1>
+  <table class="data-table">
+    <thead>
+      <tr>
+	<th>ID</th>
+	<th>Username</th>
+	<th>State</th>
+	<th>Developer</th>
+	<th>Robot</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in users %}
+      <tr>
+	<td class="numeric-cell">{{ user['id'] }}</td>
+	<td>{{ user['username'] }}</td>
+	<td>{{ user['state'] }}</td>
+	<td class="numeric-cell">
+	  {% if user['is_developer'] is not none %}
+	  {{ user['is_developer'] }}
+	  {% endif %}
+	</td>
+	<td class="numeric-cell">
+	  {% if user['is_service_account'] is not none %}
+	  {{ user['is_service_account'] }}
+	  {% endif %}
+	</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/auth/auth/templates/users.html
+++ b/auth/auth/templates/users.html
@@ -39,16 +39,8 @@
 	<td class="numeric-cell">{{ user['id'] }}</td>
 	<td>{{ user['username'] }}</td>
 	<td>{{ user['state'] }}</td>
-	<td class="numeric-cell">
-	  {% if user['is_developer'] is not none %}
-	  {{ user['is_developer'] }}
-	  {% endif %}
-	</td>
-	<td class="numeric-cell">
-	  {% if user['is_service_account'] is not none %}
-	  {{ user['is_service_account'] }}
-	  {% endif %}
-	</td>
+	<td class="numeric-cell">{{ user['is_developer'] }}</td>
+	<td class="numeric-cell">{{ user['is_service_account'] }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/auth/cluster-role.yaml
+++ b/auth/cluster-role.yaml
@@ -1,0 +1,21 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auth-driver
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "secrets"]
+  verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auth-driver
+subjects:
+- kind: ServiceAccount
+  name: auth-driver
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: auth-driver
+  apiGroup: rbac.authorization.k8s.io

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -12,8 +12,8 @@ spec:
      - |
        set -ex
        # index creation isn't idempotent, don't create if a table exists
-       USER_DATA=$(echo "SHOW TABLES LIKE 'user_data';" | mysql --defaults-extra-file=/auth-admin-secret/sql-config.cnf -s)
-       if [ "$USER_DATA" != "user_data" ]; then
+       USER_DATA=$(echo "SHOW TABLES LIKE 'users';" | mysql --defaults-extra-file=/auth-admin-secret/sql-config.cnf -s)
+       if [ "$USER_DATA" != "users" ]; then
          mysql --defaults-extra-file=/auth-admin-secret/sql-config.cnf < ./create-auth-tables.sql
        fi
        echo 'show tables;' | mysql --defaults-extra-file=/auth-admin-secret/sql-config.cnf
@@ -25,5 +25,5 @@ spec:
   volumes:
     - name: auth-admin-secret
       secret:
-        secretName: "{{ users_database.admin_secret_name }}"
+        secretName: "{{ auth_database.admin_secret_name }}"
   restartPolicy: Never

--- a/auth/create-auth-tables.sql
+++ b/auth/create-auth-tables.sql
@@ -4,8 +4,8 @@ CREATE TABLE `users` (
   -- creating, active, deleting, deleted
   `username` varchar(255) NOT NULL,
   `email` varchar(255) DEFAULT NULL,
-  `is_developer` tinyint(1) DEFAULT NULL,
-  `is_service_account` tinyint(1) DEFAULT NULL,
+  `is_developer` tinyint(1) NOT NULL DEFAULT 0,
+  `is_service_account` tinyint(1) NOT NULL DEFAULT 0,
   -- session
   `tokens_secret_name` varchar(255) DEFAULT NULL,
   -- gsa

--- a/auth/create-auth-tables.sql
+++ b/auth/create-auth-tables.sql
@@ -1,22 +1,23 @@
-CREATE TABLE `user_data` (
+CREATE TABLE `users` (
   `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `state` VARCHAR(100) NOT NULL,
+  -- creating, active, deleting, deleted
   `username` varchar(255) NOT NULL,
-  `user_id` varchar(255) NOT NULL,
   `email` varchar(255) DEFAULT NULL,
-  `developer` tinyint(1) DEFAULT NULL,
-  `service_account` tinyint(1) DEFAULT NULL,
+  `is_developer` tinyint(1) DEFAULT NULL,
+  `is_service_account` tinyint(1) DEFAULT NULL,
+  -- session
+  `tokens_secret_name` varchar(255) DEFAULT NULL,
+  -- gsa
+  `gsa_email` varchar(255) DEFAULT NULL,
+  `gsa_key_secret_name` varchar(255) DEFAULT NULL,
+  -- bucket
+  `bucket_name` varchar(255) DEFAULT NULL,
+  -- namespace, for developers
   `namespace_name` varchar(255) DEFAULT NULL,
-  `gsa_email` varchar(255) NOT NULL,
-  `ksa_name` varchar(255) DEFAULT NULL,
-  `bucket_name` varchar(255) NOT NULL,
-  `gsa_key_secret_name` varchar(255) NOT NULL,
-  `jwt_secret_name` varchar(255) NOT NULL,
-  `sql_user_secret` varchar(255) DEFAULT NULL,
-  `sql_admin_secret` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `user_id` (`user_id`),
-  KEY `email` (`email`),
-  KEY `username` (`username`)
+  UNIQUE KEY `email` (`email`),
+  UNIQUE KEY `username` (`username`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `sessions` (
@@ -25,7 +26,7 @@ CREATE TABLE `sessions` (
   `max_age_secs` INT(11) UNSIGNED DEFAULT NULL,
   `created` TIMESTAMP DEFAULT NOW(),
   PRIMARY KEY (`session_id`),
-  FOREIGN KEY (`user_id`) REFERENCES user_data(id) ON DELETE CASCADE
+  FOREIGN KEY (`user_id`) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 CREATE EVENT `purge_sessions`

--- a/auth/delete-auth-tables.sql
+++ b/auth/delete-auth-tables.sql
@@ -1,0 +1,4 @@
+DROP EVENT IF EXISTS `purge_sessions`;
+
+DROP TABLE IF EXISTS `sessions`;
+DROP TABLE IF EXISTS `users`;

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -1,3 +1,112 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: auth-driver
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auth-driver
+rules:
+ - apiGroups: [""]
+   resources: ["secrets"]
+   verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: auth-driver
+subjects:
+ - kind: ServiceAccount
+   name: auth-driver
+roleRef:
+  kind: Role
+  name: auth-driver
+  apiGroup: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-driver
+  labels:
+    app: auth-driver
+    hail.is/sha: "{{ code.sha }}"
+spec:
+  selector:
+    matchLabels:
+      app: auth-driver
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: auth-driver
+        hail.is/sha: "{{ code.sha }}"
+    spec:
+      serviceAccountName: auth-driver
+{% if deploy %}
+      priorityClassName: production
+{% endif %}
+      tolerations:
+       - key: preemptible
+         value: "true"
+      containers:
+       - name: auth-driver
+         image: "{{ auth_image.image }}"
+         command:
+          - "python3"
+          - -m
+          - auth.driver
+         env:
+          - name: HAIL_DEPLOY_CONFIG_FILE
+            value: /deploy-config/deploy-config.json
+          - name: HAIL_DOMAIN
+            value: "{{ global.domain }}"
+          - name: PROJECT
+            value: "{{ global.project }}"
+          - name: ZONE
+            value: "{{ global.zone }}"
+          - name: HAIL_DEFAULT_NAMESPACE
+            value: "{{ default_ns.name }}"
+          - name: HAIL_BATCH_PODS_NAMESPACE
+            value: "{{ batch_pods_ns.name }}"
+         resources:
+           requests:
+             memory: "250M"
+             cpu: "100m"
+           limits:
+             memory: "1G"
+             cpu: "1"
+         volumeMounts:
+          - name: deploy-config
+            mountPath: /deploy-config
+            readOnly: true
+          - name: database-server-config
+            mountPath: /database-server-config
+            readOnly: true
+          - name: sql-config
+            mountPath: /sql-config
+            readOnly: true
+          - name: gsa-key
+            mountPath: /gsa-key
+            readOnly: true
+         ports:
+          - containerPort: 5000
+      volumes:
+       - name: deploy-config
+         secret:
+           secretName: deploy-config
+       - name: database-server-config
+         secret:
+           secretName: database-server-config
+       - name: sql-config
+         secret:
+           secretName: "{{ auth_database.user_secret_name }}"
+       - name: gsa-key
+         secret:
+           secretName: auth-gsa-key
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,11 +153,23 @@ spec:
       containers:
        - name: auth
          image: "{{ auth_image.image }}"
+         command:
+          - "python3"
+          - -m
+          - auth
          env:
           - name: HAIL_DEPLOY_CONFIG_FILE
             value: /deploy-config/deploy-config.json
           - name: HAIL_DOMAIN
             value: "{{ global.domain }}"
+          - name: PROJECT
+            value: "{{ global.project }}"
+          - name: ZONE
+            value: "{{ global.zone }}"
+          - name: HAIL_DEFAULT_NAMESPACE
+            value: "{{ default_ns.name }}"
+          - name: HAIL_BATCH_PODS_NAMESPACE
+            value: "{{ batch_pods_ns.name }}"
          resources:
            requests:
              memory: "250M"
@@ -69,6 +190,9 @@ spec:
           - name: sql-config
             mountPath: /sql-config
             readOnly: true
+          - name: gsa-key
+            mountPath: /gsa-key
+            readOnly: true
          ports:
           - containerPort: 5000
          readinessProbe:
@@ -80,20 +204,19 @@ spec:
       volumes:
        - name: deploy-config
          secret:
-           optional: false
            secretName: deploy-config
        - name: auth-oauth2-client-secret
          secret:
-           optional: false
            secretName: auth-oauth2-client-secret
        - name: session-secret-key
          secret:
-           optional: false
            secretName: session-secret-key
        - name: sql-config
          secret:
-           optional: false
-           secretName: "{{ users_database.user_secret_name }}"
+           secretName: "{{ auth_database.user_secret_name }}"
+       - name: gsa-key
+         secret:
+           secretName: auth-gsa-key
 ---
 apiVersion: v1
 kind: Service

--- a/batch/batch/batch_configuration.py
+++ b/batch/batch/batch_configuration.py
@@ -10,3 +10,4 @@ assert PROJECT != ''
 ZONE = os.environ['ZONE']
 assert ZONE != ''
 KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']
+BATCH_BUCKET_NAME = os.environ['HAIL_BATCH_BUCKET_NAME']

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -208,7 +208,7 @@ async def activate_instance_1(request, instance):
     token = await instance.activate(ip_address)
     await instance.mark_healthy()
 
-    with open('/batch-gsa-key/privateKeyData', 'r') as f:
+    with open('/batch-gsa-key/key.json', 'r') as f:
         key = json.loads(f.read())
     return web.json_response({
         'token': token,
@@ -434,7 +434,7 @@ async def on_startup(app):
     machine_name_prefix = f'batch-worker-{DEFAULT_NAMESPACE}-'
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-        '/batch-gsa-key/privateKeyData')
+        '/gsa-key/key.json')
     gservices = GServices(machine_name_prefix, credentials)
     app['gservices'] = gservices
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -11,7 +11,6 @@ import google.oauth2.service_account
 from prometheus_async.aio.web import server_stats
 from gear import Database, setup_aiohttp_session, web_authenticated_developers_only, \
     check_csrf_token
-from hailtop.auth import async_get_userinfo
 from hailtop.config import get_deploy_config
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
@@ -21,7 +20,7 @@ from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_
 from ..batch import mark_job_complete, mark_job_started
 from ..log_store import LogStore
 from ..batch_configuration import REFRESH_INTERVAL_IN_SECONDS, \
-    DEFAULT_NAMESPACE
+    DEFAULT_NAMESPACE, BATCH_BUCKET_NAME
 from ..google_compute import GServices
 
 from .instance_pool import InstancePool
@@ -406,12 +405,6 @@ async def get_user_resources(request, userdata):
 
 
 async def on_startup(app):
-    userinfo = await async_get_userinfo()
-    log.info(f'running as {userinfo["username"]}')
-
-    bucket_name = userinfo['bucket_name']
-    log.info(f'bucket_name {bucket_name}')
-
     pool = concurrent.futures.ThreadPoolExecutor()
     app['blocking_pool'] = pool
 
@@ -444,7 +437,7 @@ async def on_startup(app):
     cancel_state_changed = asyncio.Event()
     app['cancel_state_changed'] = cancel_state_changed
 
-    log_store = LogStore(bucket_name, instance_id, pool, credentials=credentials)
+    log_store = LogStore(BATCH_BUCKET_NAME, instance_id, pool, credentials=credentials)
     app['log_store'] = log_store
 
     inst_pool = InstancePool(app, machine_name_prefix)

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -207,7 +207,7 @@ async def activate_instance_1(request, instance):
     token = await instance.activate(ip_address)
     await instance.mark_healthy()
 
-    with open('/batch-gsa-key/key.json', 'r') as f:
+    with open('/gsa-key/key.json', 'r') as f:
         key = json.loads(f.read())
     return web.json_response({
         'token': token,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -854,7 +854,7 @@ async def on_startup(app):
     }
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-        '/batch-gsa-key/privateKeyData')
+        '/gsa-key/key.json')
     app['log_store'] = LogStore(bucket_name, instance_id, pool, credentials=credentials)
 
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -375,7 +375,7 @@ async def create_jobs(request, userdata):
         'username': user,
         'bucket_name': userdata['bucket_name'],
         'gsa_key_secret_name': userdata['gsa_key_secret_name'],
-        'jwt_secret_name': userdata['jwt_secret_name']
+        'tokens_secret_name': userdata['tokens_secret_name']
     }
 
     async with LoggingTimer(f'batch {batch_id} create jobs') as timer:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -13,7 +13,6 @@ from prometheus_async.aio.web import server_stats
 import google.oauth2.service_account
 import google.api_core.exceptions
 from hailtop.utils import time_msecs, humanize_timedelta_msecs, request_retry_transient_errors
-from hailtop.auth import async_get_userinfo
 from hailtop.config import get_deploy_config
 from hailtop import batch_client
 from hailtop.batch_client.aioclient import Job
@@ -30,7 +29,7 @@ from ..utils import parse_cpu_in_mcpu, parse_memory_in_bytes, adjust_cores_for_m
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
-from ..batch_configuration import BATCH_PODS_NAMESPACE
+from ..batch_configuration import BATCH_PODS_NAMESPACE, BATCH_BUCKET_NAME
 
 from . import schemas
 
@@ -826,12 +825,6 @@ async def index(request, userdata):
 
 
 async def on_startup(app):
-    userinfo = await async_get_userinfo()
-    log.info(f'running as {userinfo["username"]}')
-
-    bucket_name = userinfo['bucket_name']
-    log.info(f'bucket_name {bucket_name}')
-
     pool = concurrent.futures.ThreadPoolExecutor()
     app['blocking_pool'] = pool
 
@@ -855,7 +848,7 @@ async def on_startup(app):
 
     credentials = google.oauth2.service_account.Credentials.from_service_account_file(
         '/gsa-key/key.json')
-    app['log_store'] = LogStore(bucket_name, instance_id, pool, credentials=credentials)
+    app['log_store'] = LogStore(BATCH_BUCKET_NAME, instance_id, pool, credentials=credentials)
 
 
 async def on_cleanup(app):

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -192,7 +192,7 @@ class Container:
             async with self.step('pulling'):
                 if self.image.startswith('gcr.io/'):
                     key = base64.b64decode(
-                        self.job.gsa_key['privateKeyData']).decode()
+                        self.job.gsa_key['key.json']).decode()
                     auth = {
                         'username': '_json_key',
                         'password': key
@@ -345,7 +345,7 @@ function retry() {{
         (sleep 5 && "$@")
 }}
 
-retry gcloud -q auth activate-service-account --key-file=/gsa-key/privateKeyData
+retry gcloud -q auth activate-service-account --key-file=/gsa-key/key.json
 
 {copies}
 '''

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -66,9 +66,6 @@ spec:
          - name: gsa-key
            mountPath: /gsa-key
            readOnly: true
-         - name: batch-tokens
-           mountPath: /user-tokens
-           readOnly: true
         readinessProbe:
           httpGet:
             path: /healthcheck
@@ -88,9 +85,6 @@ spec:
        - name: gsa-key
          secret:
            secretName: batch-gsa-key
-       - name: batch-tokens
-         secret:
-           secretName: batch-tokens
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -64,7 +64,7 @@ spec:
            mountPath: /sql-config
            readOnly: true
          - name: gsa-key
-           mountPath: /batch-gsa-key
+           mountPath: /gsa-key
            readOnly: true
          - name: batch-tokens
            mountPath: /user-tokens
@@ -78,23 +78,18 @@ spec:
       volumes:
        - name: deploy-config
          secret:
-           optional: false
            secretName: deploy-config
        - name: session-secret-key
          secret:
-           optional: false
            secretName: session-secret-key
        - name: sql-config
          secret:
-           optional: false
            secretName: "{{ batch_database.user_secret_name }}"
        - name: gsa-key
          secret:
-           optional: false
            secretName: batch-gsa-key
        - name: batch-tokens
          secret:
-           optional: false
            secretName: batch-tokens
 ---
 apiVersion: apps/v1
@@ -186,10 +181,7 @@ spec:
            mountPath: /sql-config
            readOnly: true
          - name: gsa-key
-           mountPath: /batch-gsa-key
-           readOnly: true
-         - name: batch-tokens
-           mountPath: /user-tokens
+           mountPath: /gsa-key
            readOnly: true
         readinessProbe:
           httpGet:
@@ -200,24 +192,16 @@ spec:
       volumes:
        - name: deploy-config
          secret:
-           optional: false
            secretName: deploy-config
        - name: session-secret-key
          secret:
-           optional: false
            secretName: session-secret-key
        - name: sql-config
          secret:
-           optional: false
            secretName: "{{ batch_database.user_secret_name }}"
        - name: gsa-key
          secret:
-           optional: false
            secretName: batch-gsa-key
-       - name: batch-tokens
-         secret:
-           optional: false
-           secretName: batch-tokens
       tolerations:
        - key: preemptible
          value: "true"

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -51,6 +51,12 @@ spec:
            value: "{{ global.zone }}"
          - name: KUBERNETES_SERVER_URL
            value: "{{ global.k8s_server_url }}"
+         - name: HAIL_BATCH_BUCKET_NAME
+{% if deploy %}
+           value: hail-test-1c9nm
+{% else %}
+           value: hail-batch-3jmp5
+{% endif %}
         ports:
          - containerPort: 5000
         volumeMounts:
@@ -154,6 +160,12 @@ spec:
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
            value: "375M"
+{% endif %}
+         - name: HAIL_BATCH_BUCKET_NAME
+{% if deploy %}
+           value: hail-test-1c9nm
+{% else %}
+           value: hail-batch-3jmp5
 {% endif %}
         ports:
          - containerPort: 5000

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -53,9 +53,9 @@ spec:
            value: "{{ global.k8s_server_url }}"
          - name: HAIL_BATCH_BUCKET_NAME
 {% if deploy %}
-           value: hail-test-1c9nm
-{% else %}
            value: hail-batch-3jmp5
+{% else %}
+           value: hail-test-1c9nm
 {% endif %}
         ports:
          - containerPort: 5000
@@ -163,9 +163,9 @@ spec:
 {% endif %}
          - name: HAIL_BATCH_BUCKET_NAME
 {% if deploy %}
-           value: hail-test-1c9nm
-{% else %}
            value: hail-batch-3jmp5
+{% else %}
+           value: hail-test-1c9nm
 {% endif %}
         ports:
          - containerPort: 5000

--- a/build.yaml
+++ b/build.yaml
@@ -84,6 +84,21 @@ steps:
      python3 -m pylint --rcfile pylintrc web_common
    dependsOn:
      - service_base_image
+ - kind: runImage
+   name: copy_files
+   image:
+     valueFrom: base_image.image
+   script: |
+     set -ex
+     cd /io
+     mkdir repo
+     cd repo
+     {{ code.checkout_script }}
+   outputs:
+     - from: /io/repo/auth/delete-auth-tables.sql
+       to: /auth/
+   dependsOn:
+     - base_image
  - kind: createDatabase
    name: test_database_instance
    databaseName: test-instance
@@ -110,8 +125,8 @@ steps:
     - base_image
     - test_database_instance
  - kind: createDatabase
-   name: users_database
-   databaseName: users
+   name: auth_database
+   databaseName: auth
    namespace:
      valueFrom: default_ns.name
    dependsOn:
@@ -122,6 +137,26 @@ steps:
    contextPath: auth
    dependsOn:
     - base_image
+ - kind: runImage
+   name: cleanup_auth_tables
+   image:
+     valueFrom: base_image.image
+   script: |
+     mysql --defaults-extra-file=/sql-config/sql-config.cnf < /io/delete-auth-tables.sql
+   scopes:
+     - dev
+   inputs:
+    - from: /auth/delete-auth-tables.sql
+      to: /io/
+   secrets:
+    - name: database-server-config
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /sql-config
+   dependsOn:
+     - default_ns
+     - base_image
+     - copy_files
  - kind: deploy
    name: create_auth_tables
    namespace:
@@ -135,7 +170,7 @@ steps:
    dependsOn:
      - default_ns
      - create_auth_tables_image
-     - users_database
+     - auth_database
  - kind: runImage
    name: create_deploy_config
    image:
@@ -215,29 +250,23 @@ steps:
          dbpool = await create_database_pool()
          tokens = get_tokens()
          user_spec = json.loads(sys.argv[1])
-         userdata = await insert_user(dbpool, user_spec)
+         user_id = await insert_user(dbpool, user_spec)
          deploy_config = get_deploy_config()
          auth_ns = deploy_config.service_ns('auth')
-         tokens[auth_ns] = await create_session(dbpool, userdata['id'])
+         tokens[auth_ns] = await create_session(dbpool, user_id)
          tokens.write()
      async_to_blocking(main())
      EOF
-     # create batch
-     N=$(kubectl -n {{ default_ns.name }} get secret --ignore-not-found=true --no-headers batch-tokens | wc -l | tr -d '[:space:]')
-     if [[ $N = 0 ]]; then
-         rm -f /user-tokens/tokens.json
-         kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "batch-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
-         python3 create-session.py '{"username":"batch","user_id":"hail|batch","service_account":1,"gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"batch-gsa-key","jwt_secret_name":"batch-tokens"}'
-         kubectl -n {{ default_ns.name }} create secret generic batch-tokens --from-file=/user-tokens/tokens.json
-     fi
-     # created batch
+     # batch, auth gsa keys
+     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "auth-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
+     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "batch-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
      # create ci
      N=$(kubectl -n {{ default_ns.name }} get secret --ignore-not-found=true --no-headers ci-tokens | wc -l | tr -d '[:space:]')
      if [[ $N = 0 ]]; then
          rm -f /user-tokens/tokens.json
          kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "ci-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
          kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "ci-gsa-key"' | kubectl -n {{ batch_pods_ns.name }} apply -f -
-         python3 create-session.py '{"username":"ci","user_id":"hail|ci","service_account":1,"gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"ci-gsa-key","jwt_secret_name":"ci-tokens"}'
+         python3 create-session.py '{"state":"active","username":"ci","is_service_account":1,"gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"ci-gsa-key","tokens_secret_name":"ci-tokens"}'
          kubectl -n {{ default_ns.name }} create secret generic ci-tokens --from-file=/user-tokens/tokens.json
      fi
      # created ci
@@ -246,19 +275,19 @@ steps:
      if [[ $N = 0 ]]; then
          # if test-tokens does not exist
          rm -f /user-tokens/tokens.json
-         python3 create-session.py '{"username":"test","user_id":"hail|test","gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"test-gsa-key","jwt_secret_name":"test-tokens"}'
+         python3 create-session.py '{"state":"active","username":"test","gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"test-gsa-key","tokens_secret_name":"test-tokens"}'
          kubectl -n {{ batch_pods_ns.name }} create secret generic test-tokens --from-file=/user-tokens/tokens.json
      fi
-     # created test-tokens
-     # create test-dev-tokens
+     # created test
+     # create test-dev
      N=$(kubectl -n {{ default_ns.name }} get secret --ignore-not-found=true --no-headers test-dev-tokens | wc -l | tr -d '[:space:]')
      if [[ $N = 0 ]]; then
          # if test-dev-tokens does not exist
          rm -f /user-tokens/tokens.json
-         python3 create-session.py '{"username":"testdev","user_id":"hail|testdev","gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"test-gsa-key","jwt_secret_name":"test-dev-tokens","developer":1}'
+         python3 create-session.py '{"state":"active","username":"testdev","gsa_email":"hail-test@hail-vdc.iam.gserviceaccount.com","bucket_name":"hail-test-1c9nm","gsa_key_secret_name":"test-gsa-key","tokens_secret_name":"test-dev-tokens","is_developer":1}'
          kubectl -n {{ batch_pods_ns.name }} create secret generic test-dev-tokens --from-file=/user-tokens/tokens.json
      fi
-     # created test-dev-tokens
+     # created test-dev
    scopes:
     - test
     - dev
@@ -268,7 +297,7 @@ steps:
        valueFrom: default_ns.name
    secrets:
     - name:
-        valueFrom: users_database.user_secret_name
+        valueFrom: auth_database.user_secret_name
       namespace:
         valueFrom: default_ns.name
       mountPath: /sql-config
@@ -280,7 +309,7 @@ steps:
     - default_ns
     - batch_pods_ns
     - deploy_default_admin_admin
-    - users_database
+    - auth_database
     - service_base_image
     - create_auth_tables
     - create_deploy_config
@@ -696,10 +725,11 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - batch_pods_ns
     - create_deploy_config
     - create_session_key
     - deploy_router
-    - users_database
+    - auth_database
     - create_auth_tables
     - auth_image
     - create_dummy_oauth2_client_secret
@@ -935,7 +965,7 @@ steps:
      valueFrom: base_image.image
    script: |
      set -e
-     gcloud -q auth activate-service-account --key-file=/test-gsa-key/privateKeyData
+     gcloud -q auth activate-service-account --key-file=/test-gsa-key/key.json
      gsutil -m cp -r /io/test/resources/*  gs://hail-test-1c9nm/{{ token }}/pipeline/input/
    inputs:
     - from: /pipeline/test
@@ -983,7 +1013,7 @@ steps:
    alwaysRun: true
    script: |
      set -e
-     gcloud -q auth activate-service-account --key-file=/test-gsa-key/privateKeyData
+     gcloud -q auth activate-service-account --key-file=/test-gsa-key/key.json
      gsutil -m rm -r gs://hail-test-1c9nm/{{ setup_pipeline.token }}/pipeline
    secrets:
     # hail|test-batch
@@ -1198,7 +1228,7 @@ steps:
    alwaysRun: true     
    script: |
      set -ex
-     gcloud -q auth activate-service-account --key-file=/test-gsa-key/privateKeyData
+     gcloud -q auth activate-service-account --key-file=/test-gsa-key/key.json
      set +e
      gcloud -q compute instances list \
          --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -100,7 +100,7 @@ def web_authenticated_developers_only(redirect=True):
         @web_authenticated_users_only(redirect)
         @wraps(fun)
         async def wrapped(request, userdata, *args, **kwargs):
-            if ('is_developer' in userdata) and userdata['is_developer'] == 1:
+            if userdata['is_developer'] == 1:
                 return await fun(request, userdata, *args, **kwargs)
             raise _web_unauthorized(request, redirect)
         return wrapped
@@ -111,7 +111,7 @@ def rest_authenticated_developers_only(fun):
     @rest_authenticated_users_only
     @wraps(fun)
     async def wrapped(request, userdata, *args, **kwargs):
-        if ('is_developer' in userdata) and userdata['is_developer'] == 1:
+        if userdata['is_developer'] == 1:
             return await fun(request, userdata, *args, **kwargs)
         raise web.HTTPUnauthorized()
     return wrapped

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -100,7 +100,7 @@ def web_authenticated_developers_only(redirect=True):
         @web_authenticated_users_only(redirect)
         @wraps(fun)
         async def wrapped(request, userdata, *args, **kwargs):
-            if ('developer' in userdata) and userdata['developer'] == 1:
+            if ('is_developer' in userdata) and userdata['is_developer'] == 1:
                 return await fun(request, userdata, *args, **kwargs)
             raise _web_unauthorized(request, redirect)
         return wrapped
@@ -111,7 +111,7 @@ def rest_authenticated_developers_only(fun):
     @rest_authenticated_users_only
     @wraps(fun)
     async def wrapped(request, userdata, *args, **kwargs):
-        if ('developer' in userdata) and userdata['developer'] == 1:
+        if ('is_developer' in userdata) and userdata['is_developer'] == 1:
             return await fun(request, userdata, *args, **kwargs)
         raise web.HTTPUnauthorized()
     return wrapped

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -14,8 +14,9 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
     return await acontext_manager.__aexit__(exc_type, exc_val, exc_tb)
 
 
-async def create_database_pool(autocommit=True, maxsize=10):
-    config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
+async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
+    if config_file is None:
+        config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
     with open(config_file, 'r') as f:
         sql_config = json.loads(f.read())
     return await aiomysql.create_pool(
@@ -129,8 +130,8 @@ class Database:
     def __init__(self):
         self.pool = None
 
-    async def async_init(self, maxsize=10):
-        self.pool = await create_database_pool(autocommit=False, maxsize=maxsize)
+    async def async_init(self, config_file=None, maxsize=10):
+        self.pool = await create_database_pool(config_File=config_file, autocommit=False, maxsize=maxsize)
 
     def start(self, read_only=False):
         return TransactionAsyncContextManager(self.pool, read_only)

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -131,7 +131,7 @@ class Database:
         self.pool = None
 
     async def async_init(self, config_file=None, maxsize=10):
-        self.pool = await create_database_pool(config_File=config_file, autocommit=False, maxsize=maxsize)
+        self.pool = await create_database_pool(config_file=config_file, autocommit=False, maxsize=maxsize)
 
     def start(self, read_only=False):
         return TransactionAsyncContextManager(self.pool, read_only)

--- a/hail/python/hail/fs/google_fs.py
+++ b/hail/python/hail/fs/google_fs.py
@@ -11,7 +11,7 @@ from .fs import FS
 class GoogleCloudStorageFS(FS):
     def __init__(self):
         if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
-            os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '/gsa-key/privateKeyData'
+            os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '/gsa-key/key.json'
 
         self.client = gcsfs.core.GCSFileSystem(secure_serialize=True)
 

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -32,7 +32,7 @@ class LocalBackend(Backend):
     tmp_dir: :obj:`str`, optional
         Temporary directory to use.
     gsa_key_file :obj:`str`, optional
-        Mount a file with a gsa key to `/gsa-key/privateKeyData`. Only used if a
+        Mount a file with a gsa key to `/gsa-key/key.json`. Only used if a
         task specifies a docker image. This option will override the value set by
         the environment variable `HAIL_PIPELINE_GSA_KEY_FILE`.
     extra_docker_run_flags :obj:`str`, optional
@@ -54,7 +54,7 @@ class LocalBackend(Backend):
         if gsa_key_file is None:
             gsa_key_file = os.environ.get('HAIL_PIPELINE_GSA_KEY_FILE')
         if gsa_key_file is not None:
-            flags += f' -v {gsa_key_file}:/gsa-key/privateKeyData'
+            flags += f' -v {gsa_key_file}:/gsa-key/key.json'
 
         self._extra_docker_run_flags = flags
 
@@ -221,7 +221,7 @@ class BatchBackend(Backend):
         bash_flags = 'set -e' + ('x' if verbose else '') + '; '
 
         activate_service_account = 'gcloud -q auth activate-service-account ' \
-                                   '--key-file=/gsa-key/privateKeyData'
+                                   '--key-file=/gsa-key/key.json'
 
         def copy_input(r):
             if isinstance(r, InputResourceFile):

--- a/notebook/MANIFEST.in
+++ b/notebook/MANIFEST.in
@@ -1,3 +1,2 @@
 recursive-include notebook/templates *
-recursive-include notebook/static *
 recursive-include notebook/styles *

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -109,7 +109,7 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
         env = [kube.client.V1EnvVar(name='HAIL_DEPLOY_CONFIG_FILE',
                                     value='/deploy-config/deploy-config.json')]
 
-        jwt_secret_name = userdata['jwt_secret_name']
+        tokens_secret_name = userdata['tokens_secret_name']
         gsa_key_secret_name = userdata['gsa_key_secret_name']
         volumes = [
             kube.client.V1Volume(
@@ -123,7 +123,7 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
             kube.client.V1Volume(
                 name='user-tokens',
                 secret=kube.client.V1SecretVolumeSource(
-                    secret_name=jwt_secret_name))
+                    secret_name=tokens_secret_name))
         ]
         volume_mounts = [
             kube.client.V1VolumeMount(

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -45,7 +45,7 @@ async def auth(request):
             async with session.get(deploy_config.url('auth', '/api/v1alpha/userinfo'),
                                    headers=headers) as resp:
                 userdata = await resp.json()
-                if userdata['developer'] != 1:
+                if userdata['is_developer'] != 1:
                     raise web.HTTPUnauthorized()
     except Exception:
         log.exception('getting userinfo')

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -151,9 +151,9 @@ a {
     border: 1px solid black;
 }
 
-.notebook-caret:after {
-    /* 74 (measured width of Notebook) / 2 + 9 - 20 / 2 = 38px */
-    left: 36px;
+.auth-caret:after {
+    /* 35 (measured width of Auth) / 2 + 9 - 20 / 2 = 17px */
+    left: 17px;
 }
 
 .batch-caret:after {
@@ -164,6 +164,11 @@ a {
 .monitoring-caret:after {
     /* 82 (measured width of Monitoring) / 2 + 9 - 20 / 2 = 42px */
     left: 40px;
+}
+
+.notebook-caret:after {
+    /* 74 (measured width of Notebook) / 2 + 9 - 20 / 2 = 38px */
+    left: 36px;
 }
 
 .header-dropdown-menu {

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -3,7 +3,40 @@
     <b>/</b>
   </a>
 
-  {% if userdata['developer'] == 1 %}
+  {% if userdata['is_developer'] == 1 %}
+    <div class="header-dropdown">
+      <div class="header-dropdown-item-margin">
+	<span class="disabled-header-dropdown-item">Auth</span>
+	<div class="header-dropdown-menu">
+	  <div class="auth-caret header-dropdown-menu-caret"></div>
+	  <a class="header-dropdown-menu-link" href="{{ auth_base_url }}/users">Users</a>
+	</div>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if userdata['is_developer'] == 1 %}
+    <div class="header-dropdown">
+      <div class="header-dropdown-item-margin">
+	<a href="{{ batch_base_url }}" class="header-dropdown-link">Batch</a>
+	<div class="header-dropdown-menu">
+	  <div class="batch-caret header-dropdown-menu-caret"></div>
+	  <a class="header-dropdown-menu-link" href="{{ batch_driver_base_url }}">Driver</a>
+	  <a class="header-dropdown-menu-link" href="{{ batch_driver_base_url }}/user_resources">User Resources</a>
+	</div>
+      </div>
+    </div>
+  {% else %}
+    <a class="header-link" href="{{ batch_base_url }}">Batch</a>
+  {% endif %}
+
+  {% if userdata['is_developer'] == 1 %}
+    <a class="header-link" href="{{ ci_base_url }}">
+      CI
+    </a>
+  {% endif %}
+
+  {% if userdata['is_developer'] == 1 %}
     <div class="header-dropdown">
       <div class="header-dropdown-item-margin">
 	<a href="{{ notebook_base_url }}/notebook" class="header-dropdown-link">Notebook</a>
@@ -20,30 +53,7 @@
     </a>
   {% endif %}
 
-  {% if userdata['developer'] == 1 %}
-    <div class="header-dropdown">
-      <div class="header-dropdown-item-margin">
-	<a href="{{ batch_base_url }}" class="header-dropdown-link">Batch</a>
-	<div class="header-dropdown-menu">
-	  <div class="batch-caret header-dropdown-menu-caret"></div>
-	  <a class="header-dropdown-menu-link" href="{{ batch_driver_base_url }}">Driver</a>
-	  <a class="header-dropdown-menu-link" href="{{ batch_driver_base_url }}/user_resources">User Resources</a>
-	</div>
-      </div>
-    </div>
-  {% else %}
-    <a class="header-link" href="{{ batch_base_url }}">Batch</a>
-  {% endif %}
-
-  {% if userdata['developer'] == 1 %}
-    <a class="header-link" href="{{ ci_base_url }}">
-      CI
-    </a>
-
-    <a class="header-link" href="{{ scorecard_base_url }}">
-      Scorecard
-    </a>
-
+  {% if userdata['is_developer'] == 1 %}
     <div class="header-dropdown">
       <div class="header-dropdown-item-margin">
 	<span class="disabled-header-dropdown-item">Monitoring</span>
@@ -61,6 +71,12 @@
 	</div>
       </div>
     </div>
+  {% endif %}
+
+  {% if userdata['is_developer'] == 1 %}
+    <a class="header-link" href="{{ scorecard_base_url }}">
+      Scorecard
+    </a>
   {% endif %}
 
   <div id="header-flex"></div>


### PR DESCRIPTION
Building off your previous user creation logic PR.  Summary of changes:
 - Add auth/users admin page with list of users and automated add, delete user.
 - Bit of database reorg, user_id is gone, users table is now auth.users.
 - Added state to users table, `active` for active users.  Adding (deleting) users just sets state to `adding` (`deleting`)
 - Added a new service (doesn't serve requests) auth-driver that watches the database and processes adding, deleting users.  Only one replica, runs every ~60s
 - Don't actually delete users, just mark them deleted.  This is so we don't lose billing information for users we're deleting.  This will need more thought once we understand what the financial record keeping constraints are.  Maybe we purge users after 90 days?  Maybe keep them forever?
 - Added Auth > Users header link
 - gsa-key now has a single file, `key.json` instead of `privateKeyData`.
 - Added cleanup_auth_tables dev-only build step
 - batch account not actually needed, removed (but we keep around batch-gsa-key)

I have two more code sharing PRs after this goes in:
 - Move GoogleClient to gear and unify with the existing logic in batch (which is a bit disorganized)
 - EventHandler is basically the same logic in the batch scheduler.  Again, move to gear and use there.

One last change that might be nice but I didn't bother with: auth could send auth-driver a notification when the database changes so it can process requests immediately.  (We do this in batch, for example.)  Maybe we if we expect to be adding more users.

Obviously, we'll have to purge the old user resources and re-add the users once this goes in.

A note on testing: I'm reluctant to give tests the privileges necessary to test this (basically full access to the google project and the cluster).  I think I'm inclined to chalk this up a "infrastructure" and plan to test it on a separate staging k8s cluster for infrastructure changes.  For now, I tested almost all the logic with a slightly tweaked version to get around the permissions issues with dev deploy and it looks good.  The only thing I couldn't test was the database creation logic since that's virtualized inside a single database in dev namespaces.