### PR TITLE
[ci] fix database cleanup

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1026,6 +1026,8 @@ class CreateDatabase2Step(Step):
         # MySQL user name can be up to 16 characters long before MySQL 5.7.8 (32 after)
         if self.cant_create_database:
             self._name = None
+            self.admin_username = None
+            self.user_username = None
         elif params.scope == 'deploy':
             self._name = database_name
             self.admin_username = f'{database_name}-admin'

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1028,9 +1028,13 @@ class CreateDatabase2Step(Step):
             self._name = None
         elif params.scope == 'deploy':
             self._name = database_name
+            self.admin_username = f'{database_name}-admin'
+            self.user_username = f'{database_name}-user'
         else:
             assert params.scope == 'test'
             self._name = f'{params.code.short_str()}-{database_name}-{self.token}'
+            self.admin_username = generate_token()
+            self.user_username = generate_token()
 
         self.admin_secret_name = f'sql-{self.database_name}-admin-config'
         self.user_secret_name = f'sql-{self.database_name}-user-config'
@@ -1060,8 +1064,10 @@ class CreateDatabase2Step(Step):
         create_database_config = {
             'namespace': self.namespace,
             'scope': scope,
-            'code_short_str': code.short_str(),
             'database_name': self.database_name,
+            '_name': self._name,
+            'admin_username': self.admin_username,
+            'user_username': self.user_username,
             'cant_create_database': self.cant_create_database,
             'migrations': self.migrations
         }
@@ -1103,8 +1109,8 @@ set -ex
 
 cat | mysql --defaults-extra-file=/sql-config/sql-config.cnf <<EOF
 DROP DATABASE \\`{self._name}\\`;
-DROP USER '{self.database_name}-admin';
-DROP USER '{self.database_name}-user';
+DROP USER '{self.admin_username}';
+DROP USER '{self.user_username}';
 EOF
 '''
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -44,8 +44,6 @@ async def create_database(create_database_config):
         sql_config = json.loads(f.read())
 
     namespace = create_database_config['namespace']
-    scope = create_database_config['scope']
-    code_short_str = create_database_config['code_short_str']
     database_name = create_database_config['database_name']
     cant_create_database = create_database_config['cant_create_database']
 
@@ -56,10 +54,17 @@ async def create_database(create_database_config):
         await write_user_config(namespace, database_name, 'user', sql_config)
         return
 
+    scope = create_database_config['scope']
+    _name = create_database_config['database_name']
+    admin_username = create_database_config['admin_username']
+    user_username = create_database_config['user_username']
+
     db = Database()
     await db.async_init()
 
     if scope == 'deploy':
+        assert _name == database_name
+
         # create if not exists
         rows = db.execute_and_fetchall(
             "SHOW DATABASES LIKE '{database_name}';")
@@ -67,14 +72,6 @@ async def create_database(create_database_config):
         if len(rows) > 0:
             assert len(rows) == 1
             return
-
-        _name = database_name
-        admin_username = f'{database_name}-admin'
-        user_username = f'{database_name}-user'
-    else:
-        _name = f'{code_short_str}-{database_name}-{generate_token()}'
-        admin_username = generate_token()
-        user_username = generate_token()
 
     admin_password = secrets.token_urlsafe(16)
     user_password = secrets.token_urlsafe(16)


### PR DESCRIPTION
Create step needs to generate names that are needed in both the create and cleanup steps (database name, user and admin usernames).