### PR TITLE
[hail] Support Numpy Scalar Types

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -181,6 +181,8 @@ def impute_type(x):
             raise ExpressionException("Hail does not support heterogeneous dicts: "
                                       "found dict with values of types {} ".format(list(vts)))
         return tdict(unified_key_type, unified_value_type)
+    elif isinstance(x, np.generic):
+        return from_numpy(x.dtype)
     elif isinstance(x, np.ndarray):
         element_type = from_numpy(x.dtype)
         return tndarray(element_type, x.ndim)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -185,6 +185,9 @@ def literal(x: Any, dtype: Optional[Union[HailType, str]] = None):
     if dtype is None:
         dtype = impute_type(x)
 
+    if isinstance(x, np.generic):
+        x = x.item()
+
     try:
         dtype._traverse(x, typecheck_expr)
     except TypeError as e:

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3252,3 +3252,12 @@ class Tests(unittest.TestCase):
         assert hl.eval(hl.tuple((3, 4, 5, 10))[1:]) == (4, 5, 10)
         assert hl.eval(hl.tuple((3, 4, 5, 10))[0:4:2]) == (3, 5)
         assert hl.eval(hl.tuple((3, 4, 5, 10))[-2:]) == (5, 10)
+
+    def test_numpy_conversions(self):
+        assert hl.eval(np.int32(3)) == 3
+        assert hl.eval(np.int64(1234)) == 1234
+        assert hl.eval(np.bool(True))
+        assert not hl.eval(np.bool(False))
+        assert np.allclose(hl.eval(np.float32(3.4)), 3.4)
+        assert np.allclose(hl.eval(np.float64(8.89)), 8.89)
+        assert hl.eval(np.str("cat")) == "cat"


### PR DESCRIPTION
Fixes #3699. Makes it so Hail can take in a numpy type anywhere it can take a python number or expression. 