### PR TITLE
[hail] optimize flatten

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -22,6 +22,7 @@ object Optimize {
         last = ir
         runOpt(FoldConstants(_), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
+        runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(Simplify(_), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -22,7 +22,6 @@ object Optimize {
         last = ir
         runOpt(FoldConstants(_), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
-        runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(Simplify(_), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")


### PR DESCRIPTION
Looking at the IR generated by table.flatten, this snippet:
```
>>> import hail as hl
>>> t = hl.utils.range_table(10)
>>> t2 = t.annotate(**{f'f{i}': i for i in range(5)})
>>> t2.flatten().collect()
```
generates the following IR:
```
(GetField rows
  (TableCollect
    (TableMapRows
      (TableOrderBy (Aidx)
        (TableMapRows
          (TableRange 10 8)
          (InsertFields
            (SelectFields (idx)
              (Ref row))
            None
            (f0
              (I32 0))
            (f1
              (I32 1))
            (f2
              (I32 2))
            (f3
              (I32 3))
            (f4
              (I32 4)))))
      (Let __uid_3
        (Ref row)
        (InsertFields
          (SelectFields ()
            (SelectFields (idx f0 f1 f2 f3 f4)
              (Ref row)))
          None
          (idx
            (GetField idx
              (Ref __uid_3)))
          (f0
            (GetField f0
              (Ref __uid_3)))
          (f1
            (GetField f1
              (Ref __uid_3)))
          (f2
            (GetField f2
              (Ref __uid_3)))
          (f3
            (GetField f3
              (Ref __uid_3)))
          (f4
            (GetField f4
              (Ref __uid_3))))))))
```
If we look at the last `TableMapRows` IR, the entire thing `(Let __uid_3 …)` is entirely a no-op, but we're still compiling and generating code for the (post-optimization) IR:
```
(InsertFields
  (SelectFields ()
    (Ref row))
  None
  (idx
    (GetField idx
      (Ref row)))
  (f0
    (GetField f0
      (Ref row)))
  (f1
    (GetField f1
      (Ref row)))
  (f2
    (GetField f2
      (Ref row)))
  (f3
    (GetField f3
      (Ref row)))
  (f4
    (GetField f4
      (Ref row))))
```

(cc @tpoterba I added a second `ForwardLets` in `Optimize` before the `Simplify`, although I'm not sure that's actually the correct place to put it; in this case, I think it may eventually come out in the wash given how many passes we make through any given pipeline, but I've noticed that currently our python tends to generate IR of the form:
```
(TableMapRows
  (Let __uid_n
    (Ref row)
    <mapped value, sometimes using (Ref __uid_n) and sometimes (Ref row)>
```
and that redundant binding at the top level means that the first Simplify pass misses quite a few optimizations! I'm not super attached to leaving it there, but I do think we might want to consider forwarding Lets on any IRs from python before optimization.)