### PR TITLE
[hail] don't bind Refs when deduplicating in InsertFields

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1564,7 +1564,7 @@ class InsertFields(IR):
     def construct_with_deduplication(old, fields, field_order):
         dd = defaultdict(int)
         for k, v in fields:
-            if isinstance(v, GetField):
+            if isinstance(v, GetField) and not isinstance(v.o, Ref):
                 dd[v.o] += 1
 
         replacements = {}

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -22,6 +22,7 @@ object Optimize {
         last = ir
         runOpt(FoldConstants(_), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
+        runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(Simplify(_), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -22,7 +22,6 @@ object Optimize {
         last = ir
         runOpt(FoldConstants(_), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
-        runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(Simplify(_), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")
         runOpt(ForwardRelationalLets(_), iter, "ForwardRelationalLets")


### PR DESCRIPTION
This creates redundant bindings that interfere with our ability to apply certain simplification rules.