### PR TITLE
Benchmark NDArray Addition and Multiplication

### DIFF
--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -17,6 +17,16 @@ def make_ndarray_bench():
     ht._force_count()
 
 @benchmark()
-def ndarray_matmul_benchmark():
-    arr = hl._nd.arange(4096 * 4096).reshape((4096, 4096))
+def ndarray_addition_benchmark():
+    arr = hl._nd.ones((1024, 1024))
+    hl.eval(arr + arr)
+
+@benchmark()
+def ndarray_matmul_int64_benchmark():
+    arr = hl._nd.arange(1024 * 1024).map(hl.int64).reshape((1024, 1024))
+    hl.eval(arr @ arr)
+
+@benchmark()
+def ndarray_matmul_float64_benchmark():
+    arr = hl._nd.arange(1024 * 1024).map(hl.float64).reshape((1024, 1024))
     hl.eval(arr @ arr)

--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -15,3 +15,8 @@ def make_ndarray_bench():
     ht = hl.utils.range_table(200_000)
     ht = ht.annotate(x=hl._nd.array(hl.range(200_000)))
     ht._force_count()
+
+@benchmark()
+def ndarray_matmul_benchmark():
+    arr = hl._nd.arange(4096 * 4096).reshape((4096, 4096))
+    hl.eval(arr @ arr)


### PR DESCRIPTION
Added benchmarks for NDArray addition and multiplication. There are 2 for multiplication because when I add something to use BLAS instead of just naive multiply it will improve the one that is using float64s. 