### PR TITLE
[hail] cap size of struct for passing refs through InsertFields

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -261,7 +261,7 @@ object Simplify {
 
     case top@Let(x, Let(y, yVal, yBody), xBody) if (x != y) => Let(y, yVal, Let(x, yBody, xBody))
 
-    case Let(name, x@InsertFields(old, newFields, fieldOrder), body) if {
+    case Let(name, x@InsertFields(old, newFields, fieldOrder), body) if x.typ.size < 500  && {
       val r = Ref(name, x.typ)
       val nfSet = newFields.map(_._1).toSet
 


### PR DESCRIPTION
When the number of fields in `x` is really huge, this optimization creates huge chains of `Let` bindings which cause stack size issues in downstream IR analysis passes.

(we can remove this cap once our passes will no longer run into stack size issues on very deep IRs.)