### PR TITLE
[hail] fix maximal_independent_set

### DIFF
--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -137,7 +137,7 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None, keyed=True) -> Ta
         wrapped_node_t = ttuple(node_t)
         l = construct_variable('l', wrapped_node_t)
         r = construct_variable('r', wrapped_node_t)
-        tie_breaker_expr = hl.int64(tie_breaker(l[0], r[0]))
+        tie_breaker_expr = hl.float64(tie_breaker(l[0], r[0]))
         t, _ = source._process_joins(i, j, tie_breaker_expr)
         tie_breaker_str = str(tie_breaker_expr._ir)
     else:

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -124,6 +124,13 @@ class Tests(unittest.TestCase):
                          jj=hl.struct(id=ht.j, rank=hl.rand_norm(0, 1)))
         hl.maximal_independent_set(ht.ii, ht.jj).count()
 
+    @skip_unless_spark_backend()
+    def test_maximal_independent_set_on_floats(self):
+        t = hl.utils.range_table(1).annotate(l = hl.struct(s="a", x=3.0), r = hl.struct(s="b", x=2.82))
+        expected = [hl.Struct(node=hl.Struct(s="a", x=3.0))]
+        actual = hl.maximal_independent_set(t.l, t.r, keep=False, tie_breaker=lambda l,r: l.x - r.x).collect()
+        assert actual == expected
+
     def test_matrix_filter_intervals(self):
         ds = hl.import_vcf(resource('sample.vcf'), min_partitions=20)
 

--- a/hail/src/main/scala/is/hail/utils/BinaryHeap.scala
+++ b/hail/src/main/scala/is/hail/utils/BinaryHeap.scala
@@ -1,9 +1,10 @@
 package is.hail.utils
 
+import Math.signum
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Long = null) {
+class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Double = null) {
   private var ts: Array[T] = new Array[T](minimumCapacity)
   private var ranks: Array[Long] = new Array[Long](minimumCapacity)
   private val m: mutable.Map[T, Int] = new mutable.HashMap()
@@ -16,10 +17,11 @@ class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBr
       val tb1 = maybeTieBreaker(a, b)
       val tb2 = maybeTieBreaker(b, a)
 
-      if (tb1 != -tb2)
-        fatal(s"'maximal_independent_set' requires 'tie_breaker(l, r)' equals '-1 * tie_breaker(r, l)'. Found ($tb1, $tb2).")
+      if (signum(tb1) != -signum(tb2))
+        fatal(s"'maximal_independent_set' requires 'tie_breaker(l, r)' to have " +
+          s"the opposite sign of 'tie_breaker(r, l)' (or both to be zero). Found ($tb1, $tb2).")
 
-      tb1 > 0
+      tb1 > 0.0
     }
   }
 

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -58,14 +58,16 @@ object Graph {
     val wrappedNodeType = PTuple(PType.canonical(nodeType))
     val refMap = Map("l" -> wrappedNodeType.virtualType, "r" -> wrappedNodeType.virtualType)
 
-    val tieBreakerF = tieBreaker.map { e =>
-      val ir = IRParser.parse_value_ir(e, IRParserEnvironment(refMap))
-      val (t, f) = Compile[Long, Long, Long](ctx, "l", wrappedNodeType, "r", wrappedNodeType, MakeTuple.ordered(FastSeq(ir)))
-      assert(t.virtualType.isOfType(TTuple(TInt64())))
+    Region.scoped { region =>
+      val tieBreakerF = tieBreaker.map { e =>
+        val ir = IRParser.parse_value_ir(e, IRParserEnvironment(refMap))
+        val (t, f) = Compile[Long, Long, Long](ctx, "l", wrappedNodeType, "r", wrappedNodeType, MakeTuple.ordered(FastSeq(ir)))
+        assert(t.virtualType.isOfType(TTuple(TFloat64())))
+        val resultType = t.asInstanceOf[PTuple]
 
-      (l: Any, r: Any) => {
-        Region.scoped { region =>
-          val rvb = new RegionValueBuilder()
+        val rvb = new RegionValueBuilder()
+          (l: Any, r: Any) => {
+          region.clear()
           rvb.set(region)
 
           rvb.start(wrappedNodeType)
@@ -81,23 +83,29 @@ object Graph {
           val rOffset = rvb.end()
 
           val resultOffset = f(0, region)(region, lOffset, false, rOffset, false)
-          SafeRow(t.asInstanceOf[PBaseStruct], region, resultOffset).get(0).asInstanceOf[Long]
+          if (resultType.isFieldMissing(resultOffset, 0)) {
+            throw new RuntimeException(
+              s"a comparison returned a missing value when " +
+                s"l=${Region.pretty(wrappedNodeType, lOffset)} and r=${Region.pretty(wrappedNodeType, rOffset)}")
+          } else {
+            Region.loadDouble(resultType.loadField(resultOffset, 0))
+          }
         }
       }
-    }
 
-    maximalIndependentSet(mkGraph(edges2), tieBreakerF).toSet
+      maximalIndependentSet(mkGraph(edges2), tieBreakerF).toSet
+    }
   }
 
   def maximalIndependentSet[T: ClassTag](edges: Array[(T, T)]): Array[T] = {
     maximalIndependentSet(mkGraph(edges))
   }
 
-  def maximalIndependentSet[T: ClassTag](edges: Array[(T, T)], tieBreaker: (T, T) => Long): Array[T] = {
+  def maximalIndependentSet[T: ClassTag](edges: Array[(T, T)], tieBreaker: (T, T) => Double): Array[T] = {
     maximalIndependentSet(mkGraph(edges), Some(tieBreaker))
   }
 
-  def maximalIndependentSet[T: ClassTag](g: mutable.MultiMap[T, T], maybeTieBreaker: Option[(T, T) => Long] = None): Array[T] = {
+  def maximalIndependentSet[T: ClassTag](g: mutable.MultiMap[T, T], maybeTieBreaker: Option[(T, T) => Double] = None): Array[T] = {
     val verticesByDegree = new BinaryHeap[T](maybeTieBreaker = maybeTieBreaker.orNull)
 
     g.foreach { case (v, neighbors) =>

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -66,7 +66,8 @@ object Graph {
         val resultType = t.asInstanceOf[PTuple]
 
         val rvb = new RegionValueBuilder()
-          (l: Any, r: Any) => {
+
+        (l: Any, r: Any) => {
           region.clear()
           rvb.set(region)
 

--- a/hail/src/test/scala/is/hail/utils/GraphSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/GraphSuite.scala
@@ -97,7 +97,7 @@ class GraphSuite {
   @Test def tieBreakingOfBipartiteGraphWorks() {
     val g = mkGraph(for (i <- 0 until 10) yield (i, i + 10))
     // prefer to remove big numbers
-    val actual = maximalIndependentSet(g, Some((l: Int, r: Int) => (l - r).toLong))
+    val actual = maximalIndependentSet(g, Some((l: Int, r: Int) => (l - r).toDouble))
 
     assert(isIndependentSet(actual, g))
     assert(actual.length == 10)
@@ -108,7 +108,7 @@ class GraphSuite {
   @Test def tieBreakingInLongCycleWorks() {
     val g = mkGraph(0 -> 1, 1 -> 2, 2 -> 3, 3 -> 4, 4 -> 5, 5 -> 6, 6 -> 0)
     // prefers to remove small numbers
-    val actual = maximalIndependentSet(g, Some((l: Int, r: Int) => (r - l).toLong))
+    val actual = maximalIndependentSet(g, Some((l: Int, r: Int) => (r - l).toDouble))
 
     assert(isIndependentSet(actual, g))
     assert(actual.length == 3)


### PR DESCRIPTION
Maximal independent set has had a bug/misfeature since https://github.com/hail-is/hail/pull/2975. That PR added an `hl.int64(...)` coercion around the tie_breaker function. This allowed users to pass tie_breakers that returned floating point numbers, but it *changed the meaning*. The sign of values with magnitude greater than or equal to one was preserved. All values in (-1, 1) were converted to 0, thus treating them as indistinguishable for the purposes of the MIS.

This PR fixes this long standing bug and adds a simple test for that case. Supporting arbitrary numeric types is actually quite simple! The conversion from any Hail numeric type to float64 is sign-preserving (AFAIK), which is the only property we need to preserve the user's intended ordering.

This change also introduces two mild, obvious performance improvements:
- Use one region for the entire MIS calculation, clearing for each invocation of tie_breaker (MIS is single-threaded)
- Read the tie_breaker value using simple Region and type methods rather than allocating a new SafeRow each time the tie_breaker is invoked.
