### PR TITLE
[hail] Move kryo and result size capacity increases to HailContext

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -8,9 +8,7 @@ import yaml
 from .cluster_config import ClusterConfig
 
 DEFAULT_PROPERTIES = {
-    "spark:spark.driver.maxResultSize": "0",
     "spark:spark.task.maxFailures": "20",
-    "spark:spark.kryoserializer.buffer.max": "1g",
     "spark:spark.driver.extraJavaOptions": "-Xss4M",
     "spark:spark.executor.extraJavaOptions": "-Xss4M",
     "hdfs:dfs.replication": "1",

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -96,6 +96,9 @@ object HailContext {
     conf.set("spark.logConf", "true")
     conf.set("spark.ui.showConsoleProgress", "false")
 
+    conf.set("spark.kryoserializer.buffer.max", "1g")
+    conf.set("spark.driver.maxResultSize", "0")
+
     conf.set(
       "spark.hadoop.io.compression.codecs",
       "org.apache.hadoop.io.compress.DefaultCodec," +


### PR DESCRIPTION
This means people who don't use hailctl get these configurations.