### PR TITLE
[hail] Export VCF floats using %g formatter

### DIFF
--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -36,13 +36,13 @@ object ExportVCF {
         if (x.isNaN)
           sb += '.'
         else
-          sb.append(x.formatted("%.5e"))
+          sb.append(x.formatted("%.6g"))
       case PFloat64(_) =>
         val x = Region.loadDouble(offset)
         if (x.isNaN)
           sb += '.'
         else
-          sb.append(x.formatted("%.5e"))
+          sb.append(x.formatted("%.6g"))
       case PString(_) =>
         sb.append(PString.loadString(m, offset))
       case PCall(_) =>


### PR DESCRIPTION
Fixes #6963.

%e vs %g:

```scala
scala> val big = 12345678910112d
big: Double = 1.2345678910112E13

scala> val small = 0.0000000000123123
small: Double = 1.23123E-11

scala> val medium = 1.12345
medium: Double = 1.12345

scala> Array(big, small, medium).foreach { x => println(x.formatted("%.5e")) }
1.23457e+13
1.23123e-11
1.12345e+00

scala> Array(big, small, medium).foreach { x => println(x.formatted("%.6g")) }
1.23457e+13
1.23123e-11
1.12345
```