### PR TITLE
[hail] rewrite uniroot in python

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5108,8 +5108,8 @@ def liftover(x, dest_reference_genome, min_match=0.95, include_strand=False):
            max=expr_float64,
            max_iter=builtins.int,
            epsilon=builtins.float,
-           base_tolerance=builtins.float)
-def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e-16, base_tolerance=1.220703e-4):
+           tolerance=builtins.float)
+def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e-16, tolerance=1.220703e-4):
     """Finds a root of the function `f` within the interval `[min, max]`.
 
     Examples
@@ -5137,6 +5137,9 @@ def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e
         The root of the function `f`.
     """
 
+    # Based on:
+    # https://github.com/wch/r-source/blob/e5b21d0397c607883ff25cca379687b86933d730/src/library/stats/src/zeroin.c
+
     def error_if_missing(x):
         res = f(x)
         return (case()
@@ -5145,7 +5148,7 @@ def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e
     wrapped_f = hl.experimental.define_function(error_if_missing, 'float')
 
     def uniroot(recur, a, b, c, fa, fb, fc, prev, iterations_remaining):
-        tol = 2 * epsilon * abs(b) + base_tolerance / 2
+        tol = 2 * epsilon * abs(b) + tolerance / 2
         cb = c - b
         t1 = fb / fc
         t2 = fb / fa
@@ -5175,8 +5178,8 @@ def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e
                  recur(b, c, b, fb, fc, fb, prev, iterations_remaining),
                  cond((abs(cb / 2) <= tol) | (fb == 0),
                       b,  # acceptable approximation found
-                      cond(sign(new_fb) == sign(fc),  # use c = a for next iteration if signs match
-                           recur(b, new_b, a, fb, new_fb, fa, new_step, iterations_remaining - 1),
+                      cond(sign(new_fb) == sign(fc),  # use c = b for next iteration if signs match
+                           recur(b, new_b, b, fb, new_fb, fb, new_step, iterations_remaining - 1),
                            recur(b, new_b, c, fb, new_fb, fc, new_step, iterations_remaining - 1)
                            ))))
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5124,12 +5124,24 @@ def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e
 
     If no root can be found, the result of this call will be `NA` (missing).
 
+    :func:`.uniroot` returns an estimate for a root with accuracy
+    `4 * epsilon * abs(x) + tolerance`.
+
+    4*EPSILON*abs(x) + tol
+
     Parameters
     ----------
     f : function ( (arg) -> :class:`.Float64Expression`)
         Must return a :class:`.Float64Expression`.
     min : :class:`.Float64Expression`
     max : :class:`.Float64Expression`
+    max_iter : `int`
+        The maximum number of iterations before giving up.
+    epsilon : `float`
+        The scaling factor in the accuracy of the root found.
+    tolerance : `float`
+        The constant factor in approximate accuracy of the root found.
+
 
     Returns
     -------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5194,8 +5194,8 @@ def uniroot(f: Callable, min, max, *, max_iter=1000, epsilon=2.2204460492503131e
     return (case()
             .when(min < max, case()
                   .when(fmin * fmax <= 0, run_loop(min, max, fmin, fmax))
-                  .or_error(format("sign of endpoints must have opposite signs, got: f(min) = %.1e, f(max) = %.1e", fmin, fmax)))
-            .or_error(format("min must be less than max in call to uniroot, got: min %.1e, max %.1e", min, max)))
+                  .or_error(format("'uniroot': sign of endpoints must have opposite signs, got: f(min) = %.1e, f(max) = %.1e", fmin, fmax)))
+            .or_error(format("'uniroot': min must be less than max in call to uniroot, got: min %.1e, max %.1e", min, max)))
 
 
 @typecheck(f=expr_str, args=expr_any)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2858,6 +2858,7 @@ class Tests(unittest.TestCase):
 
     def test_uniroot(self):
         self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: x - 1, 0, 3)), 1)
+        self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: hl.log(x) - 1, 0, 3)), 2.718281828459045, delta=1.220703e-4)
 
     def test_pT(self):
         self.assert_evals_to(hl.pT(0, 10), 0.5)

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -19,7 +19,6 @@ object FoldConstants {
              _: NDArrayShape |
              _: NDArrayReshape |
              _: NDArraySlice |
-             _: NDArraySlice |
              _: NDArrayMap |
              _: NDArrayMap2 |
              _: NDArrayReindex |

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -653,21 +653,6 @@ object Interpret {
         wrapped.get(0)
       case x: ReadPartition =>
         fatal(s"cannot interpret ${ Pretty(x) }")
-      case TailLoop(name, args, body) =>
-        val inits = args.map { case (name, arg) => name -> interpret(arg) }
-        val argEnv = env.bind(inits: _*)
-        val names = args.map(_._1)
-        val types = args.map(_._2.typ)
-        val f: Seq[IR] => Any = { newArgs: Seq[Any] =>
-          val lits = newArgs.zip(types).map { case (a, t) => Literal.coerce(t, a) }
-          interpret(TailLoop(name, names.zip(lits), body), env)
-        }
-        interpret(body, argEnv.bind(name, f))
-
-      case Recur(name, args, _) =>
-        val f = env.lookup(name).asInstanceOf[Seq[Any] => Any]
-        val argValues = args.map(interpret(_))
-        f(argValues)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -23,7 +23,14 @@ object Interpretable {
         _: NDArrayReindex |
         _: NDArrayAgg |
         _: NDArrayMatMul |
+        _: TailLoop |
+        _: Recur |
         _: NDArrayWrite => false
+      case x: ApplyIR =>
+        !Exists(x.body, {
+          case n: IR => !Interpretable(n)
+          case _ => false
+        })
       case _ => true
     })
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2998,6 +2998,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testSimpleTailLoop(): Unit = {
+    implicit val execStrats = ExecStrategy.compileOnly
     val triangleSum: IR = TailLoop("f",
       FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> In(1, TInt32())),
       If(Ref("x", TInt32()) <= I32(0),
@@ -3014,6 +3015,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testNestedTailLoop(): Unit = {
+    implicit val execStrats = ExecStrategy.compileOnly
     val triangleSum: IR = TailLoop("f1",
       FastIndexedSeq("x" -> In(0, TInt32()), "accum" -> I32(0)),
       If(Ref("x", TInt32()) <= I32(0),

--- a/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -38,6 +38,15 @@ class MathFunctionsSuite extends HailSuite {
     assertEvalsTo(ir, -3.0)
   }
 
+  @Test def pyUniroot() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
+    val fn = ApplyBinaryPrimOp(Subtract(), invoke("**", TFloat64(), Ref("x", TFloat64()), F64(2)), F64(3))
+    val ir = Uniroot("x", fn, F64(0), F64(10))
+
+    println(eval(ir))
+  }
+
   @Test def unirootWithRegionManipulation() {
     implicit val execStrats = ExecStrategy.javaOnly
 

--- a/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -38,15 +38,6 @@ class MathFunctionsSuite extends HailSuite {
     assertEvalsTo(ir, -3.0)
   }
 
-  @Test def pyUniroot() {
-    implicit val execStrats = ExecStrategy.javaOnly
-
-    val fn = ApplyBinaryPrimOp(Subtract(), invoke("**", TFloat64(), Ref("x", TFloat64()), F64(2)), F64(3))
-    val ir = Uniroot("x", fn, F64(0), F64(10))
-
-    println(eval(ir))
-  }
-
   @Test def unirootWithRegionManipulation() {
     implicit val execStrats = ExecStrategy.javaOnly
 


### PR DESCRIPTION
I haven't ripped out the Scala uniroot stuff in this PR; I'll do that if/when this goes in.

It's based on the same thing that the Scala version is, here:
https://github.com/wch/r-source/blob/e5b21d0397c607883ff25cca379687b86933d730/src/library/stats/src/zeroin.c