### PR TITLE
[hail/ptypes] PSet, PDict: better unsafeOrdering

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
@@ -164,7 +164,5 @@ trait PArrayBackedContainer extends PContainer {
   def copyFrom(mb: MethodBuilder, region: Code[Region], srcOff: Code[Long]): Code[Long] =
     arrayRep.copyFrom(mb, region, srcOff)
 
-  override def unsafeOrdering: UnsafeOrdering = unsafeOrdering(this)
-
   override def unsafeOrdering(rightType: PType): UnsafeOrdering = arrayRep.unsafeOrdering(rightType)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PDict.scala
@@ -24,6 +24,8 @@ abstract class PDict extends PContainer {
     CodeOrdering.mapOrdering(this, other.asInstanceOf[PDict], mb)
   }
 
+  override def unsafeOrdering: UnsafeOrdering = unsafeOrdering(this)
+
   override def pyString(sb: StringBuilder): Unit = {
     sb.append("dict<")
     keyType.pyString(sb)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.types.physical
 
-import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.annotations.{CodeOrdering, Region, UnsafeOrdering}
 import is.hail.asm4s.Code
 import is.hail.expr.ir.{EmitMethodBuilder, SortOrder}
 import is.hail.expr.types.BaseStruct
@@ -33,6 +33,8 @@ final case class PTuple(_types: IndexedSeq[PTupleField], override val required: 
     assert(so == null || so.size == types.size)
     CodeOrdering.rowOrdering(this, other.asInstanceOf[PTuple], mb, so)
   }
+
+  override def unsafeOrdering: UnsafeOrdering = unsafeOrdering(this)
 
   override def truncate(newSize: Int): PTuple =
     PTuple(_types.take(newSize), required)


### PR DESCRIPTION
@tpoterba in line with your recommendation (https://github.com/hail-is/hail/pull/7712#discussion_r358433830 I put unsafeOrdering) I put unsafeOrdering on PSet, PDict.

However I couldn't move the other constructor, because that depends on arrayRep. I can move this constructor from PArrayBackedContainer to PCanonicalSet and PCanonicalDict, or make a protected arrayRep on PSet, PDict and move the constructor there (which I don't think we want, since that implies that all implementations will have an array representation, which I don't think we know).
  * That being said, I don't like having 2 constructors for the same method in 2 different places, makes it much harder to understand, to me. I think I would prefer putting unsafeOrdering both on the canonical implementation, or leave them on PArrayBackedContainer (since that is the canonical implementation for the subset of functions implemented there)