### PR TITLE
[hail/ptypes] PBinary restructure

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -11,9 +11,6 @@ import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
 
-case object PBinaryOptional extends PCanonicalBinary(false)
-case object PBinaryRequired extends PCanonicalBinary(true)
-
 abstract class PBinary extends PType {
   lazy val virtualType: TBinary = TBinary(required)
 
@@ -70,7 +67,7 @@ abstract class PBinary extends PType {
 }
 
 object PBinary {
-  def apply(required: Boolean = false): PBinary = if(required) PBinaryRequired else PBinaryOptional
+  def apply(required: Boolean = false): PBinary = PCanonicalBinary(required)
 
   def unapply(t: PBinary): Option[Boolean] = PCanonicalBinary.unapply(t)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -70,7 +70,7 @@ abstract class PBinary extends PType {
 }
 
 object PBinary {
-  def apply(required: Boolean = false): PBinary = PCanonicalBinary.apply(required)
+  def apply(required: Boolean = false): PBinary = if(required) PBinaryRequired else PBinaryOptional
 
   def unapply(t: PBinary): Option[Boolean] = PCanonicalBinary.unapply(t)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -11,15 +11,11 @@ import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
 
-case object PBinaryOptional extends PBinary(false)
+case object PBinaryOptional extends PCanonicalBinary(false)
+case object PBinaryRequired extends PCanonicalBinary(true)
 
-case object PBinaryRequired extends PBinary(true)
-
-class PBinary(override val required: Boolean) extends PType {
+abstract class PBinary extends PType {
   lazy val virtualType: TBinary = TBinary(required)
-
-  def _asIdent = "binary"
-  def _toPretty = "Binary"
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
@@ -71,56 +67,42 @@ class PBinary(override val required: Boolean) extends PType {
       }
     }
   }
-
-  override def byteSize: Long = 8
-
-  override def containsPointers: Boolean = true
 }
 
 object PBinary {
-  def apply(required: Boolean = false): PBinary = if (required) PBinaryRequired else PBinaryOptional
+  def apply(required: Boolean = false): PBinary = PCanonicalBinary.apply(required)
 
-  def unapply(t: PBinary): Option[Boolean] = Option(t.required)
+  def unapply(t: PBinary): Option[Boolean] = PCanonicalBinary.unapply(t)
 
-  def contentAlignment: Long = 4
+  def contentAlignment: Long = PCanonicalBinary.contentAlignment
 
-  def lengthHeaderBytes: Long = 4
+  def lengthHeaderBytes: Long = PCanonicalBinary.lengthHeaderBytes
 
-  def contentByteSize(length: Int): Long = 4 + length
+  def contentByteSize(length: Int): Long = PCanonicalBinary.contentByteSize(length)
 
-  def contentByteSize(length: Code[Int]): Code[Long] = (const(4) + length).toL
+  def contentByteSize(length: Code[Int]): Code[Long] = PCanonicalBinary.contentByteSize(length)
 
-  def loadLength(boff: Long): Int = Region.loadInt(boff)
+  def loadLength(boff: Long): Int = PCanonicalBinary.loadLength(boff)
 
-  def loadLength(region: Region, boff: Long): Int =
-    Region.loadInt(boff)
+  def loadLength(region: Region, boff: Long): Int = PCanonicalBinary.loadLength(boff)
 
-  def loadLength(boff: Code[Long]): Code[Int] =
-    Region.loadInt(boff)
+  def loadLength(boff: Code[Long]): Code[Int] = PCanonicalBinary.loadLength(boff)
 
-  def loadLength(region: Code[Region], boff: Code[Long]): Code[Int] = loadLength(boff)
+  def loadLength(region: Code[Region], boff: Code[Long]): Code[Int] = PCanonicalBinary.loadLength(boff)
 
-  def storeLength(boff: Long, len: Int): Unit = Region.storeInt(boff, len)
+  def storeLength(boff: Long, len: Int): Unit = PCanonicalBinary.storeLength(boff, len)
 
-  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit] = Region.storeInt(boff, len)
+  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit] = PCanonicalBinary.storeLength(boff, len)
 
-  def bytesOffset(boff: Long): Long = boff + lengthHeaderBytes
+  def bytesOffset(boff: Long): Long = PCanonicalBinary.bytesOffset(boff)
 
-  def bytesOffset(boff: Code[Long]): Code[Long] = boff + lengthHeaderBytes
+  def bytesOffset(boff: Code[Long]): Code[Long] = PCanonicalBinary.bytesOffset(boff)
 
-  def allocate(region: Region, length: Int): Long = {
-    region.allocate(contentAlignment, contentByteSize(length))
-  }
+  def allocate(region: Region, length: Int): Long = PCanonicalBinary.allocate(region, length)
 
-  def allocate(region: Code[Region], length: Code[Int]): Code[Long] = {
-    region.allocate(const(contentAlignment), contentByteSize(length))
-  }
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long] = PCanonicalBinary.allocate(region, length)
 
-  def store(addr: Long, bytes: Array[Byte]): Unit = {
-    Region.storeInt(addr, bytes.length)
-    Region.storeBytes(bytesOffset(addr), bytes)
-  }
+  def store(addr: Long, bytes: Array[Byte]): Unit = PCanonicalBinary.store(addr, bytes)
 
-  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] =
-    Code.invokeScalaObject[Long, Array[Byte], Unit](PBinary.getClass, "store", addr, bytes)
+  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] = PCanonicalBinary.store(addr, bytes)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
@@ -1,0 +1,72 @@
+package is.hail.expr.types.physical
+
+import is.hail.annotations.CodeOrdering
+import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.asm4s._
+import is.hail.check.Arbitrary._
+import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.types.virtual.TBinary
+import is.hail.utils._
+
+import scala.reflect.{ClassTag, _}
+
+case object PCanonicalBinaryOptional extends PCanonicalBinary(false)
+case object PCanonicalBinaryRequired extends PCanonicalBinary(true)
+
+class PCanonicalBinary(val required: Boolean) extends PBinary {
+  def _asIdent = "binary"
+  def _toPretty = "Binary"
+
+  override def byteSize: Long = 8
+
+  override def containsPointers: Boolean = true
+}
+
+object PCanonicalBinary {
+  def apply(required: Boolean = false): PBinary = if (required) PCanonicalBinaryRequired else PCanonicalBinaryOptional
+
+  def unapply(t: PBinary): Option[Boolean] = Option(t.required)
+
+  def contentAlignment: Long = 4
+
+  def lengthHeaderBytes: Long = 4
+
+  def contentByteSize(length: Int): Long = 4 + length
+
+  def contentByteSize(length: Code[Int]): Code[Long] = (const(4) + length).toL
+
+  def loadLength(boff: Long): Int = Region.loadInt(boff)
+
+  def loadLength(region: Region, boff: Long): Int =
+    Region.loadInt(boff)
+
+  def loadLength(boff: Code[Long]): Code[Int] =
+    Region.loadInt(boff)
+
+  def loadLength(region: Code[Region], boff: Code[Long]): Code[Int] = loadLength(boff)
+
+  def storeLength(boff: Long, len: Int): Unit = Region.storeInt(boff, len)
+
+  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit] = Region.storeInt(boff, len)
+
+  def bytesOffset(boff: Long): Long = boff + lengthHeaderBytes
+
+  def bytesOffset(boff: Code[Long]): Code[Long] = boff + lengthHeaderBytes
+
+  def allocate(region: Region, length: Int): Long = {
+    region.allocate(contentAlignment, contentByteSize(length))
+  }
+
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long] = {
+    region.allocate(const(contentAlignment), contentByteSize(length))
+  }
+
+  def store(addr: Long, bytes: Array[Byte]): Unit = {
+    Region.storeInt(addr, bytes.length)
+    Region.storeBytes(bytesOffset(addr), bytes)
+  }
+
+  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] =
+    Code.invokeScalaObject[Long, Array[Byte], Unit](PBinary.getClass, "store", addr, bytes)
+}

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
@@ -24,7 +24,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 }
 
 object PCanonicalBinary {
-  def apply(required: Boolean = false): PBinary = if (required) PCanonicalBinaryRequired else PCanonicalBinaryOptional
+  def apply(required: Boolean = false): PBinary = new PCanonicalBinary(required)
 
   def unapply(t: PBinary): Option[Boolean] = Option(t.required)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
@@ -1,15 +1,8 @@
 package is.hail.expr.types.physical
 
-import is.hail.annotations.CodeOrdering
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.check.Arbitrary._
-import is.hail.check.Gen
-import is.hail.expr.ir.EmitMethodBuilder
-import is.hail.expr.types.virtual.TBinary
 import is.hail.utils._
-
-import scala.reflect.{ClassTag, _}
 
 case object PCanonicalBinaryOptional extends PCanonicalBinary(false)
 case object PCanonicalBinaryRequired extends PCanonicalBinary(true)
@@ -24,7 +17,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 }
 
 object PCanonicalBinary {
-  def apply(required: Boolean = false): PBinary = new PCanonicalBinary(required)
+  def apply(required: Boolean = false): PBinary = if (required) PCanonicalBinaryRequired else PCanonicalBinaryOptional
 
   def unapply(t: PBinary): Option[Boolean] = Option(t.required)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -246,7 +246,7 @@ abstract class PType extends BaseType with Serializable with Requiredness {
 
   final def isOfType(t: PType): Boolean = {
     this match {
-      case PBinary(_) => t == PBinaryOptional || t == PBinaryRequired
+      case PBinary(_) => t == PCanonicalBinaryOptional || t == PCanonicalBinaryRequired
       case PBoolean(_) => t == PBooleanOptional || t == PBooleanRequired
       case PInt32(_) => t == PInt32Optional || t == PInt32Required
       case PInt64(_) => t == PInt64Optional || t == PInt64Required


### PR DESCRIPTION
Closes out the first reorg work.

There are a bunch of utility methods on PBinary, but these are non-trivial to remove. There are places where it isn't clear to me that we have a PBinary instance for instance.

For example,

```scala
srvb.addString("hello"),
```

Would need a PString (and the fundamentalType of that)