### PR TITLE
[hailtop] log every tenth error message

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -191,7 +191,7 @@ async def request_retry_transient_errors(session, method, url, **kwargs):
         except Exception as e:
             errors += 1
             if errors % 10 == 0:
-                log.warning(f'encountered 10 errors, most recent one was {e}', exc_info=True)
+                log.warning(f'encountered {errors} errors, most recent one was {e}', exc_info=True)
             if is_transient_error(e):
                 pass
             else:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -184,10 +184,14 @@ async def sleep_and_backoff(delay):
 
 async def request_retry_transient_errors(session, method, url, **kwargs):
     delay = 0.1
+    errors = 0
     while True:
         try:
             return await session.request(method, url, **kwargs)
         except Exception as e:
+            errors += 1
+            if errors % 10 == 0:
+                log.warning(f'encountered 10 errors, most recent one was {e}', exc_info=True)
             if is_transient_error(e):
                 pass
             else:


### PR DESCRIPTION
For some reason, all output was suppressed so I wasn't even seeing my debugging output. 502 is labelled "transient" but it's not always. I still don't know what's wrong, but something like this would have prevented me from running in circles trying to figure out what the hell changed (this works in a PR, it's only broken in dev deploy, don't know why yet).