### PR TITLE
[hail] Fix `mt.entry.take` performance regression

### DIFF
--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -388,7 +388,7 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
       case None =>
         val PCSubsetOffset(idx, nTake, _) =
           incrementalPCSubsetOffset(n, 0 until getNumPartitions)(
-            runJob(getIteratorSize, _)
+            runJob(getIteratorSizeWithMaxN(n), _)
           )
         idx -> nTake
     }


### PR DESCRIPTION
before:
```
2019-12-19 13:46:39,469: INFO: [1/1] Running matrix_table_take_entry...
2019-12-19 13:46:48,414: INFO: burn in: 8.94s
2019-12-19 13:46:51,170: INFO: run 1: 2.75s
2019-12-19 13:46:53,789: INFO: run 2: 2.62s
2019-12-19 13:46:56,590: INFO: run 3: 2.80s
```

after:
```
2019-12-19 13:51:38,688: INFO: [1/1] Running matrix_table_take_entry...
2019-12-19 13:51:43,457: INFO: burn in: 4.77s
2019-12-19 13:51:43,871: INFO: run 1: 0.41s
2019-12-19 13:51:44,295: INFO: run 2: 0.42s
2019-12-19 13:51:44,742: INFO: run 3: 0.44s
```