### PR TITLE
[hail] increment nesting depth for body of loop to prevent let forwarding into loop

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
@@ -72,6 +72,9 @@ object NestingDepth {
           computeIR(right, depth)
           computeIR(keyF, depth.incrementEval)
           computeIR(joinF, depth.incrementEval)
+        case TailLoop(_, params, body) =>
+          params.foreach { case (_, p) => computeIR(p, depth) }
+          computeIR(body, depth.incrementEval)
         case NDArrayMap(nd, _, body) =>
           computeIR(nd, depth)
           computeIR(body, depth.incrementEval)

--- a/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -33,7 +33,8 @@ class ForwardLetsSuite extends HailSuite {
     val y = Ref("y", TInt32())
     Array(
       NDArrayMap(In(1, TNDArray(TInt32(), Nat(1))), "y", x + y),
-      NDArrayMap2(In(1, TNDArray(TInt32(), Nat(1))), In(2, TNDArray(TInt32(), Nat(1))), "y", "z", x + y + Ref("z", TInt32()))
+      NDArrayMap2(In(1, TNDArray(TInt32(), Nat(1))), In(2, TNDArray(TInt32(), Nat(1))), "y", "z", x + y + Ref("z", TInt32())),
+      TailLoop("f", FastIndexedSeq("y" -> I32(0)), If(y < x, Recur("f", FastIndexedSeq[IR](y - I32(1)), TInt32()), x))
     ).map(ir => Array[IR](Let("x", In(0, TInt32()) + In(0, TInt32()), ir)))
   }
 


### PR DESCRIPTION
Otherwise we would be calculating the (unchanged) value of the binding for each iteration through the loop.