### PR TITLE
[batch] search help for batches, batch jobs

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -22,7 +22,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="min-width:75%;">
+	<div class="expand-content" style="max-width:75%;">
 	  <p>Search jobs with the given search terms.  Return jobs
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -22,7 +22,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="max-width:75%;">
+	<div class="expand-content" style="max-width:450px;">
 	  <p>Search jobs with the given search terms.  Return jobs
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -8,8 +8,8 @@
   {% endfor %}
   {% endif %}
   <h2>Jobs</h2>
-    <div class="searchbar-table">
-      <div>
+    <div class="flex-col-align-right">
+      <div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
 		 {% if q %}
@@ -21,8 +21,8 @@
 	  <button type="submit">Search</button>
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
-	<label for="expand-search-syntax-checkbox" class="expand-label">Search Synax</label>
-	<div class="expand-content">
+	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
+	<div class="expand-content" style="min-width:75%;">
 	  <p>Search jobs with the given search terms.  Return jobs
 	    that match all terms.</p>
 	  <ul>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -9,16 +9,42 @@
   {% endif %}
   <h2>Jobs</h2>
     <div class="searchbar-table">
-      <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-	<input style="vertical-align:text-bottom;" name="q" size=30 type="text"
-	       {% if q %}
+      <div>
+	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
+	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
+		 {% if q %}
 	         value="{{ q }}"
-	       {% else %}
+		 {% else %}
 	         placeholder="Search terms..."
-	       {% endif %}
-	       >
-	<button type="submit">Search</button>
-      </form>
+		 {% endif %}
+		 >
+	  <button type="submit">Search</button>
+	</form>
+	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
+	<label for="expand-search-syntax-checkbox" class="expand-label">Search Synax</label>
+	<div class="expand-content">
+	  <p>Search jobs with the given search terms.  Return jobs
+	    that match all terms.</p>
+	  <ul>
+	    <li>k=v - jobs with an attribute with key k and value v</li>
+	    <li>has:k - jobs that have an attribute with key k</li>
+	    <li>state - jobs in the given state, one of:
+	      <ul>
+		<li>ready</li>
+		<li>running</li>
+		<li>live (ready or running)</li>
+		<li>cancelled</li>
+		<li>error</li>
+		<li>failed</li>
+		<li>bad (error or failed)</li>
+		<li>success</li>
+		<li>done (cancelled, error, failed or success)</li>
+	      </ul>
+	    </li>
+	    <li>!term - jobs not matched by term</li>
+	  </ul>
+	</div>
+      </div>
       <table class="data-table" id="batch">
 	<thead>
 	  <tr>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -24,7 +24,7 @@
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
 	<div class="expand-content" style="min-width:75%;">
 	  <p>Search jobs with the given search terms.  Return jobs
-	    that match all terms.</p>
+	    that match all terms.  Terms:</p>
 	  <ul>
 	    <li>k=v - jobs with an attribute with key k and value v</li>
 	    <li>has:k - jobs that have an attribute with key k</li>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -16,7 +16,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="min-width:75%;">
+	<div class="expand-content" style="max-width:75%;">
 	  <p>Search batches with the given search terms.  Return batches
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -2,17 +2,45 @@
 {% block title %}Batches{% endblock %}
 {% block content %}
   <h1>Batches</h1>
-    <div class="searchbar-table">
-      <form method="GET" action="{{ base_path }}/batches">
-	<input style="vertical-align:text-bottom;" name="q" size=30 type="text"
-	       {% if q %}
+    <div class="flex-col-align-right">
+      <div class="flex-col-align-right">
+	<form method="GET" action="{{ base_path }}/batches">
+	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
+		 {% if q %}
 	         value="{{ q }}"
-	       {% else %}
+		 {% else %}
 	         placeholder="Search terms..."
-	       {% endif %}
-	       >
-	<button type="submit">Search</button>
-      </form>
+		 {% endif %}
+		 >
+	  <button type="submit">Search</button>
+	</form>
+	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
+	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
+	<div class="expand-content" style="min-width:75%;">
+	  <p>Search batches with the given search terms.  Return batches
+	    that match all terms.  Terms:</p>
+	  <ul>
+	    <li>k=v - batches with an attribute with key k and value v</li>
+	    <li>has:k - batches that have an attribute with key k</li>
+	    <li>state - batches in the given state, one of:
+	      <ul>
+		<li>open</li>
+		<li>closed (not open)</li>
+		<li>running</li>
+		<li>cancelled</li>
+		<li>failure</li>
+		<li>success</li>
+		<li>complete</li>
+	      </ul>
+	      <p>Note: cancelled and failure do not imply complete.
+		cancelled means cancel has been called.  failure means
+		one (or more) jobs have failed.  In either case, the
+		batch may still be running.</p>
+	    </li>
+	    <li>!term - batches not matched by term</li>
+	  </ul>
+	</div>
+      </div>
       <table class="data-table" id="batches">
 	<thead>
 	  <tr>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -16,7 +16,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="max-width:75%;">
+	<div class="expand-content" style="max-width:450px;">
 	  <p>Search batches with the given search terms.  Return batches
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -223,7 +223,7 @@ a {
 }
 
 .data-table {
-    min-width: 480px;
+    min-width: 600px;
     border-spacing: 2px;
     thead {
 	color: $white;
@@ -252,6 +252,12 @@ a {
 }
 
 .searchbar-table {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.flex-col-align-right {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -319,6 +325,15 @@ a {
 
   vertical-align: baseline;
 }
+
+.expand-label:hover::after {
+  border-right-color: $devil-gray;
+}
+
+.expand-label:hover {
+    color: $devil-gray;
+}
+
 .expand-checkbox:checked + .expand-label::after {
   transform: rotate(-90deg);
 }

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -302,3 +302,30 @@ a {
     left: 50vw;
     transform: translate(-50%, -50%);
 }
+
+.expand-checkbox {
+  display: none;
+}
+
+.expand-label::after {
+  content: ' ';
+  display: inline-block;
+
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-right: 5px solid black;
+
+  margin-left: 5px;
+
+  vertical-align: baseline;
+}
+.expand-checkbox:checked + .expand-label::after {
+  transform: rotate(-90deg);
+}
+
+.expand-content {
+    display: none;
+}
+.expand-checkbox:checked + .expand-label + .expand-content {
+    display: block;
+}


### PR DESCRIPTION
Add an expandable element just below the search box.

Screen shots, unexpanded:

<img width="761" alt="Screen Shot 2019-12-23 at 4 24 18 PM" src="https://user-images.githubusercontent.com/1244990/71369283-29891200-25a2-11ea-9ecb-1ed3ebac5eaf.png">

And expanded:

<img width="750" alt="Screen Shot 2019-12-23 at 4 24 41 PM" src="https://user-images.githubusercontent.com/1244990/71369286-2d1c9900-25a2-11ea-9678-937d08101c85.png">

@akotlar A CSS thing I couldn't figure out, if you have any ideas: I wanted the width of the expanded help to be 75% the width of the table below it, but `max-width: 75%` doesn't work.  For now, I just set the max-width: 450px, which is 75% of the min-width of the table (now 600px).