### PR TITLE
use nodeSelector, tolerate preemptibles

### DIFF
--- a/apiserver/test-apiserver-pod.yaml
+++ b/apiserver/test-apiserver-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: test-apiserver
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/auth/create-auth-tables-pod.yaml
+++ b/auth/create-auth-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-auth-tables
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -48,6 +48,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"
@@ -128,6 +130,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/batch/create-batch-tables-pod.yaml
+++ b/batch/create-batch-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-batch-tables
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/batch/delete-batch-tables-pod.yaml
+++ b/batch/delete-batch-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: delete-batch-tables
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -23,6 +23,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"
@@ -117,6 +119,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/batch/test-batch-pod.yaml
+++ b/batch/test-batch-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: test-batch
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -18,9 +18,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      tolerations:
-       - key: preemptible
-         value: "false"
+      nodeSelector:
+        preemptible: "false"
       containers:
       - name: blog
         image: ghost:3.0-alpine

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-ci-tables
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -19,9 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      tolerations:
-       - key: preemptible
-         value: "false"
+      nodeSelector:
+        preemptible: "false"
       containers:
         - name: ci
           image: "{{ ci_image.image }}"

--- a/dbuf/deployment.yaml
+++ b/dbuf/deployment.yaml
@@ -29,6 +29,8 @@ spec:
          secret:
            optional: false
            secretName: deploy-config
+      nodeSelector:
+        preemptible: "false"
       containers:
         - name: dbuf
           image: {{ dbuf_image.image }}

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         hail.is/sha: "{{ code.sha }}"
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -28,6 +28,8 @@ spec:
        - name: sys
          hostPath:
            path: /sys
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"
@@ -499,6 +501,8 @@ spec:
         app: elasticsearch
     spec:
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"
@@ -700,6 +704,8 @@ spec:
       priorityClassName: infrastructure
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30
+      nodeSelector:
+        preemptible: "true"
       tolerations:
         - key: "preemptible"
           value: "true"

--- a/notebook/create-notebook-tables-pod.yaml
+++ b/notebook/create-notebook-tables-pod.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: create-notebook-tables
 spec:
+  nodeSelector:
+    preemptible: "true"
   tolerations:
    - key: preemptible
      value: "true"

--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -46,6 +46,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -45,6 +45,8 @@ spec:
     spec:
       serviceAccountName: router-resolver
       priorityClassName: infrastructure
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -217,6 +217,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/scheduler/deployment.yaml
+++ b/scheduler/deployment.yaml
@@ -19,6 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "false"
       containers:
        - name: scheduler
          image: "{{ scheduler_image.image }}"

--- a/scorecard/deployment.yaml
+++ b/scorecard/deployment.yaml
@@ -19,9 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
-      tolerations:
-       - key: preemptible
-         value: "false"
+      nodeSelector:
+        preemptible: "false"
       containers:
       - name: scorecard
         image: "{{ scorecard_image.image }}"

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -19,6 +19,8 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      nodeSelector:
+        preemptible: "true"
       tolerations:
        - key: preemptible
          value: "true"

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -29,9 +29,8 @@ spec:
       labels:
         app: ukbb-rg-static
     spec:
-      tolerations:
-       - key: preemptible
-         value: "false"
+      nodeSelector:
+        preemptible: "false"
       containers:
        - name: ukbb-rg-static
          image: gcr.io/hail-vdc/ukbb-rg-static
@@ -76,9 +75,8 @@ spec:
       labels:
         app: ukbb-rg-browser
     spec:
-      tolerations:
-       - key: preemptible
-         value: "false"
+      nodeSelector:
+        preemptible: "false"
       containers:
        - name: ukbb-rg-browser
          image: gcr.io/hail-vdc/ukbb-rg-browser


### PR DESCRIPTION
We need at least one pool without taints to schedule the kube-system services (e.g. dns).  Therefore, I propose:
 - make the non-preemptible pool untainted,
 - keep taint on preemptibles so kube-system pods are not scheduled there,
 - and keep tolerations for preemptible pods,
 - use nodeSelector to force preemptible pods to be scheduled on the preemptible pool.  In fact, I put nodeSelectos on all pods, although it isn't strictly necessary for non-preemptible pods.

Sound good?