### PR TITLE
[batch] improve alignment

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -44,7 +44,7 @@
 	    <li>!term - jobs not matched by term</li>
 	  </ul>
 	</div>
-	  </div>
+	</div>
 	<div class='flex-col' style="overflow: scroll;">
     <table class="data-table" id="batch">
 	<thead>

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -46,7 +46,7 @@
 	</div>
 	  </div>
 	<div class='flex-col' style="overflow: scroll;">
-      <table class="data-table" id="batch">
+    <table class="data-table" id="batch">
 	<thead>
 	  <tr>
 	    <th>ID</th>
@@ -87,7 +87,7 @@
 	  </tr>
 	  {% endfor %}
 	</tbody>
-	  </table>
+	</table>
 	</div>
       {% if last_job_id is not none %}
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -8,7 +8,7 @@
   {% endfor %}
   {% endif %}
   <h2>Jobs</h2>
-  <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
+  <div class="flex-col" style="width: 66%; min-width: 653px; max-width: 1024px;">
 	<div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -8,7 +8,7 @@
   {% endfor %}
   {% endif %}
   <h2>Jobs</h2>
-    <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
+  <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
 	<div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
@@ -44,7 +44,8 @@
 	    <li>!term - jobs not matched by term</li>
 	  </ul>
 	</div>
-      </div>
+	  </div>
+	<div class='flex-col' style="overflow: scroll;">
       <table class="data-table" id="batch">
 	<thead>
 	  <tr>
@@ -86,7 +87,8 @@
 	  </tr>
 	  {% endfor %}
 	</tbody>
-      </table>
+	  </table>
+	</div>
       {% if last_job_id is not none %}
       <form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	{% if q is not none %}

--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -8,8 +8,8 @@
   {% endfor %}
   {% endif %}
   <h2>Jobs</h2>
-    <div class="flex-col-align-right">
-      <div class="flex-col-align-right">
+    <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
+	<div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
 		 {% if q %}
@@ -22,7 +22,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="max-width:450px;">
+	<div class="expand-content" style="max-width:75%;">
 	  <p>Search jobs with the given search terms.  Return jobs
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -42,7 +42,7 @@
 	</div>
       </div>
 	<div class='flex-col' style="overflow: scroll;">
-	  <table class="data-table" id="batches">
+	<table class="data-table" id="batches">
 	<thead>
 	  <tr>
 	    <th>ID</th>

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -2,7 +2,7 @@
 {% block title %}Batches{% endblock %}
 {% block content %}
   <h1>Batches</h1>
-    <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
+  <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
     <div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
@@ -41,7 +41,8 @@
 	  </ul>
 	</div>
       </div>
-      <table class="data-table" id="batches">
+	<div class='flex-col' style="overflow: scroll;">
+	  <table class="data-table" id="batches">
 	<thead>
 	  <tr>
 	    <th>ID</th>
@@ -86,7 +87,8 @@
 	  </tr>
 	  {% endfor %}
 	</tbody>
-      </table>
+	</table>
+	</div>
       {% if last_batch_id is not none %}
       <form method="GET" action="{{ base_path }}/batches">
 	{% if q is not none %}

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -2,7 +2,7 @@
 {% block title %}Batches{% endblock %}
 {% block content %}
   <h1>Batches</h1>
-  <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
+  <div class="flex-col" style="width: 66%; min-width: 653px; max-width: 1024px;">
     <div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -2,8 +2,8 @@
 {% block title %}Batches{% endblock %}
 {% block content %}
   <h1>Batches</h1>
+    <div class="flex-col" style="width: 66vw; min-width: 653px; max-width: 1024px;">
     <div class="flex-col-align-right">
-      <div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches">
 	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
 		 {% if q %}
@@ -16,7 +16,7 @@
 	</form>
 	<input id="expand-search-syntax-checkbox" class="expand-checkbox" type="checkbox">
 	<label for="expand-search-syntax-checkbox" class="expand-label">Search Help</label>
-	<div class="expand-content" style="max-width:450px;">
+	<div class="expand-content" style="max-width:75%;">
 	  <p>Search batches with the given search terms.  Return batches
 	    that match all terms.  Terms:</p>
 	  <ul>

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -224,14 +224,14 @@ a {
 
 .data-table {
     min-width: 600px;
-    border-spacing: 2px;
+
     thead {
-	color: $white;
-	background-color: #888;
+        color: $white;
+        background-color: #888;
     }
     th {
         white-space: nowrap;
-	padding: 3px 10px;
+	    padding: 3px 10px;
     }
     tr {
         &:nth-child(even) {
@@ -257,10 +257,16 @@ a {
     align-items: flex-end;
 }
 
+.flex-col {
+    display: flex;
+    flex-direction: column;
+}
+
 .flex-col-align-right {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    align-self: flex-end;
 }
 
 .gh-number {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -225,14 +225,13 @@ a {
 .data-table {
     min-width: 600px;
 
-    thead {
+    th {
+        white-space: nowrap;
+        padding: 3px 10px;
         color: $white;
         background-color: #888;
     }
-    th {
-        white-space: nowrap;
-	    padding: 3px 10px;
-    }
+
     tr {
         &:nth-child(even) {
             background-color: #f2f2f2;


### PR DESCRIPTION
Creates a responsive table whose dimensions are defined on the parent (allowing child elements to be set as a percentage of that table), by setting width of the parent based on viewport. If the table exceeds that width, it will scroll, such that the elements above the table are still fixed to the flex-end position. See https://github.com/hail-is/hail/pull/7777


Narrow view (very slightly wider, because 75% of 653 is > 75% of 600, and table is in fact 653px at minimum, even when you set 600px min width):
<img width="774" alt="Screenshot 2019-12-27 15 38 52" src="https://user-images.githubusercontent.com/5543229/71533028-73d10280-28c4-11ea-99be-bea06bc67a10.png">

Wide view:
<img width="1920" alt="Screenshot 2019-12-27 15 38 58" src="https://user-images.githubusercontent.com/5543229/71533029-73d10280-28c4-11ea-98ef-7b8e3afe3ca3.png">



Table that is too wide is scrollable (wider than 1024px):
<img width="804" alt="Screenshot 2019-12-27 16 09 18" src="https://user-images.githubusercontent.com/5543229/71532988-4be19f00-28c4-11ea-915a-1e038f179d1f.png">
after scrolling right:
<img width="1453" alt="Screenshot 2019-12-27 16 09 12" src="https://user-images.githubusercontent.com/5543229/71532989-4be19f00-28c4-11ea-9fbd-0270c881d085.png">


Tested manually in browser in Firefox and Chrome.