### PR TITLE
[hail] Remove dead code in ArrayExpression.__getitem__

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -442,8 +442,6 @@ class ArrayExpression(CollectionExpression):
         """
         if isinstance(item, slice):
             return self._slice(self.dtype, item.start, item.stop, item.step)
-        elif isinstance(item, str):
-            return CollectionExpression.__getitem__(self, item)
         item = to_expr(item)
         if not item.dtype == tint32:
             raise TypeError("array expects key to be type 'slice' or expression of type 'int32', "

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3232,10 +3232,6 @@ class Tests(unittest.TestCase):
         assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
         assert hl.eval(a.b["inner"]) == [[1, 2], [3]]
 
-        self.assertRaises(AttributeError, lambda: hl.array([1,2,3]).a)
-        self.assertRaises(AttributeError, lambda: hl.array([1,2,3])["a"])
-        self.assertRaises(AttributeError, lambda: hl.array([[1],[2],[3]])["a"])
-        self.assertRaises(AttributeError, lambda: hl.array([{1},{2},{3}])["a"])
 
     def test_binary_search(self):
         a = hl.array([0, 2, 4, 8])


### PR DESCRIPTION
Shouldn't lint anyhow -- CollectionExpression does not define __getitem__