### PR TITLE
[hail] include Python stack trace in ArrayRef out-of-bounds error

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -554,7 +554,7 @@ class MakeArray(IR):
 
 
 class ArrayRef(IR):
-    @typecheck_method(a=IR, i=IR)
+    @typecheck_method(a=IR, i=IR, s=IR)
     def __init__(self, a, i, s):
         super().__init__(a, i, s)
         self.a = a

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -555,18 +555,20 @@ class MakeArray(IR):
 
 class ArrayRef(IR):
     @typecheck_method(a=IR, i=IR)
-    def __init__(self, a, i):
-        super().__init__(a, i)
+    def __init__(self, a, i, s):
+        super().__init__(a, i, s)
         self.a = a
         self.i = i
+        self.s = s
 
-    @typecheck_method(a=IR, i=IR)
-    def copy(self, a, i):
-        return ArrayRef(a, i)
+    @typecheck_method(a=IR, i=IR, s=IR)
+    def copy(self, a, i, s):
+        return ArrayRef(a, i, s)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self.i._compute_type(env, agg_env)
+        self.s._compute_type(env, agg_env)
         self._type = self.a.typ.element_type
 
 

--- a/hail/python/hail/ir/register_functions.py
+++ b/hail/python/hail/ir/register_functions.py
@@ -85,7 +85,7 @@ def register_functions():
     register_function("[:*]", (dtype("array<?T>"),dtype("int32"),), dtype("array<?T>"))
     register_function("remove", (dtype("set<?T>"),dtype("?T"),), dtype("set<?T>"))
     register_function("[]", (dtype("str"),dtype("int32"),), dtype("str"))
-    register_function("indexArray", (dtype("array<?T>"),dtype("int32"),), dtype("?T"))
+    register_function("indexArray", (dtype("array<?T>"), dtype("int32"), dtype("str")), dtype("?T"))
     register_function("[]", (dtype("dict<?key, ?value>"),dtype("?key"),), dtype("?value"))
     register_function("dictToArray", (dtype("dict<?key, ?value>"),), dtype("array<tuple(?key, ?value)>"))
     register_function("%", (dtype("array<?T:numeric>"),dtype("array<?T>"),), dtype("array<?T>"))

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -49,7 +49,7 @@ class ValueIRTests(unittest.TestCase):
             ir.ApplyUnaryPrimOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
             ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tarray(hl.tint32)),
-            ir.ArrayRef(a, i),
+            ir.ArrayRef(a, i, ir.Str('foo')),
             ir.ArrayLen(a),
             ir.ArrayRange(ir.I32(0), ir.I32(5), ir.I32(1)),
             ir.ArraySort(a, 'l', 'r', ir.ApplyComparisonOp("LT", ir.Ref('l'), ir.Ref('r'))),

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -49,8 +49,8 @@ object Children {
       args.toFastIndexedSeq
     case MakeStream(args, typ) =>
       args.toFastIndexedSeq
-    case ArrayRef(a, i) =>
-      Array(a, i)
+    case ArrayRef(a, i, s) =>
+      Array(a, i, s)
     case ArrayLen(a) =>
       Array(a)
     case ArrayRange(start, stop, step) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -59,9 +59,9 @@ object Copy {
       case MakeStream(args, typ) =>
         assert(args.length == newChildren.length)
         MakeStream(newChildren.map(_.asInstanceOf[IR]), typ)
-      case ArrayRef(_, _) =>
-        assert(newChildren.length == 2)
-        ArrayRef(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
+      case ArrayRef(_, _, _) =>
+        assert(newChildren.length == 3)
+        ArrayRef(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case ArrayLen(_) =>
         assert(newChildren.length == 1)
         ArrayLen(newChildren(0).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -195,7 +195,12 @@ object MakeArray {
 
 final case class MakeArray(args: Seq[IR], _typ: TArray) extends IR
 final case class MakeStream(args: Seq[IR], _typ: TStream) extends IR
-final case class ArrayRef(a: IR, i: IR) extends IR
+
+object ArrayRef {
+  def apply(a: IR, i: IR): ArrayRef = ArrayRef(a, i, Str(""))
+}
+
+final case class ArrayRef(a: IR, i: IR, msg: IR) extends IR
 final case class ArrayLen(a: IR) extends IR
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR
 final case class StreamRange(start: IR, stop: IR, step: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -169,9 +169,10 @@ object InferPType {
         })
         a.implementation.returnPType(pTypes, a.returnType)
       }
-      case ArrayRef(a, i) => {
+      case ArrayRef(a, i, s) => {
         InferPType(a, env)
         InferPType(i, env)
+        InferPType(s, env)
         assert(i.pType2 isOfType PInt32() )
 
         coerce[PStreamable](a.pType2).elementType.setRequired(a.pType2.required && i.pType2.required)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -73,7 +73,7 @@ object InferType {
         val argTypes = a.args.map(_.typ)
         a.implementation.unify(argTypes :+ a.returnType)
         a.returnType
-      case ArrayRef(a, i) =>
+      case ArrayRef(a, i, s) =>
         assert(i.typ.isOfType(TInt32()))
         coerce[TStreamable](a.typ).elementType.setRequired(a.typ.required && i.typ.required)
       case ArraySort(a, _, _, compare) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -224,7 +224,7 @@ object Interpret {
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
-      case ArrayRef(a, i) =>
+      case x@ArrayRef(a, i, s) =>
         val aValue = interpret(a, env, args)
         val iValue = interpret(i, env, args)
         if (aValue == null || iValue == null)
@@ -232,9 +232,17 @@ object Interpret {
         else {
           val a = aValue.asInstanceOf[IndexedSeq[Any]]
           val i = iValue.asInstanceOf[Int]
-          if (i < 0 || i >= a.length)
-            fatal(s"array index out of bounds: $i / ${ a.length }")
-          else
+
+          if (i < 0 || i >= a.length) {
+            val msg = interpret(s, env, args)
+            val prettied = Pretty(x)
+            val irString =
+              if (prettied.size > 100) prettied.take(100) + " ..."
+              else prettied
+            val toAdd = if (msg == "") "" else s"\n----------\nPython traceback:\n${ msg }"
+            fatal(s"array index out of bounds: index=$i, length=${ a.length }" +
+              s"\n----------\nIR:\n${ irString }$s" + toAdd)
+          } else
             a.apply(i)
         }
       case ArrayLen(a) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -664,7 +664,8 @@ object IRParser {
       case "ArrayRef" =>
         val a = ir_value_expr(env)(it)
         val i = ir_value_expr(env)(it)
-        ArrayRef(a, i)
+        val s = ir_value_expr(env)(it)
+        ArrayRef(a, i, s)
       case "ArrayLen" => ArrayLen(ir_value_expr(env)(it))
       case "ArrayRange" =>
         val start = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -9,8 +9,8 @@ import org.json4s.jackson.{JsonMethods, Serialization}
 object Pretty {
 
   def short(ir: BaseIR, elideLiterals: Boolean = false, maxLen: Int = 100): String = {
-    val s = Pretty(ir)
-    if (s.length < maxLen) s else s.substring(0, maxLen)
+    val s = Pretty(ir, elideLiterals = elideLiterals, maxLen = maxLen)
+    if (s.length < maxLen) s else s.substring(0, maxLen) + "..."
   }
 
   def prettyStringLiteral(s: String): String =
@@ -28,7 +28,7 @@ object Pretty {
 
   val MAX_VALUES_TO_LOG: Int = 25
 
-  def apply(ir: BaseIR, elideLiterals: Boolean = false): String = {
+  def apply(ir: BaseIR, elideLiterals: Boolean = false, maxLen: Int = -1): String = {
     val sb = new StringBuilder
 
     def prettyIntOpt(x: Option[Int]): String = x.map(_.toString).getOrElse("None")
@@ -81,6 +81,9 @@ object Pretty {
     }
 
     def pretty(ir: BaseIR, depth: Int) {
+      if (maxLen > 0 && sb.size > maxLen)
+        return
+
       sb.append(" " * depth)
       sb += '('
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -922,10 +922,12 @@ object PruneDeadFields {
       case MakeArray(args, _) =>
         val eltType = requestedType.asInstanceOf[TStreamable].elementType
         unifyEnvsSeq(args.map(a => memoizeValueIR(a, eltType, memo)))
-      case ArrayRef(a, i) =>
+      case ArrayRef(a, i, s) =>
         unifyEnvs(
           memoizeValueIR(a, a.typ.asInstanceOf[TStreamable].copyStreamable(requestedType), memo),
-          memoizeValueIR(i, i.typ, memo))
+          memoizeValueIR(i, i.typ, memo),
+          memoizeValueIR(s, s.typ, memo)
+        )
       case ArrayLen(a) =>
         memoizeValueIR(a, minimal(a.typ), memo)
       case ArrayMap(a, name, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -200,7 +200,7 @@ object Simplify {
 
     case ArrayLen(ArraySort(a, _, _, _)) => ArrayLen(a)
 
-    case ArrayRef(MakeArray(args, _), I32(i)) if i >= 0 && i < args.length => args(i)
+    case ArrayRef(MakeArray(args, _), I32(i), _) if i >= 0 && i < args.length => args(i)
 
     case ArrayFilter(a, _, True()) => a
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -155,8 +155,9 @@ object TypeCheck {
         args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x == typ.elementType,
           s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
-      case x@ArrayRef(a, i) =>
+      case x@ArrayRef(a, i, s) =>
         assert(i.typ.isOfType(TInt32()))
+        assert(s.typ.isOfType(TString()))
         assert(x.typ == -coerce[TStreamable](a.typ).elementType)
       case ArrayLen(a) =>
         assert(a.typ.isInstanceOf[TStreamable])

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -250,12 +250,12 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerIR("uniqueMaxIndex", TArray(tv("T")), TInt32())(uniqueIndex(_, GT(_)))
 
-    registerIR("indexArray", TArray(tv("T")), TInt32(), tv("T")) { (a, i) =>
+    registerIR("indexArray", TArray(tv("T")), TInt32(), TString(), tv("T")) { (a, i, s) =>
       ArrayRef(
         a,
         If(ApplyComparisonOp(LT(TInt32()), i, I32(0)),
           ApplyBinaryPrimOp(Add(), ArrayLen(a), i),
-          i))
+          i), s)
     }
 
     registerIR("[:]", TArray(tv("T")), TArray(tv("T"))) { (a) => a }

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -208,15 +208,15 @@ class ArrayFunctionsSuite extends HailSuite {
 
   @Test def indexing() {
     val a = IRArray(0, null, 2)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(0)), 0)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(1)), null)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(2)), 2)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(-1)), 2)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(-3)), 0)
-    assertFatal(invoke("indexArray", TInt32(), a, I32(3)), "array index out of bounds")
-    assertFatal(invoke("indexArray", TInt32(), a, I32(-4)), "array index out of bounds")
-    assertEvalsTo(invoke("indexArray", TInt32(), naa, I32(2)), null)
-    assertEvalsTo(invoke("indexArray", TInt32(), a, NA(TInt32())), null)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(0), Str("")), 0)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(1), Str("")), null)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(2), Str("")), 2)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(-1), Str("")), 2)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, I32(-3), Str("")), 0)
+    assertFatal(invoke("indexArray", TInt32(), a, I32(3), Str("")), "array index out of bounds")
+    assertFatal(invoke("indexArray", TInt32(), a, I32(-4), Str("")), "array index out of bounds")
+    assertEvalsTo(invoke("indexArray", TInt32(), naa, I32(2), Str("")), null)
+    assertEvalsTo(invoke("indexArray", TInt32(), a, NA(TInt32()), Str("")), null)
   }
 
   @Test def slicing() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2784,68 +2784,6 @@ class IRSuite extends HailSuite {
     assertEvalsTo(ir, FastIndexedSeq(true -> TBoolean(), FastIndexedSeq(0) -> TArray(TInt32())), FastIndexedSeq(0L))
   }
 
-  @Test def setContainsSegfault(): Unit = {
-    hc // assert initialized
-    val irStr =
-      """
-        |(TableFilter
-        |  (TableMapRows
-        |    (TableKeyBy () False
-        |      (TableMapRows
-        |        (TableKeyBy () False
-        |          (TableMapRows
-        |            (TableRange 1 12)
-        |            (InsertFields
-        |              (Ref row)
-        |              None
-        |              (s
-        |                (Literal Set[String] "[\"foo\"]"))
-        |              (nested
-        |                (NA Struct{elt:String})))))
-        |        (InsertFields
-        |          (Ref row) None)))
-        |    (SelectFields (s nested)
-        |      (Ref row)))
-        |  (Let __uid_1
-        |    (If
-        |      (IsNA
-        |        (GetField s
-        |          (Ref row)))
-        |      (NA Boolean)
-        |      (Let __iruid_1
-        |        (LowerBoundOnOrderedCollection False
-        |          (GetField s
-        |            (Ref row))
-        |          (GetField elt
-        |            (GetField nested
-        |              (Ref row))))
-        |        (If
-        |          (ApplyComparisonOp EQ
-        |            (Ref __iruid_1)
-        |            (ArrayLen
-        |              (ToArray
-        |                (GetField s
-        |                  (Ref row)))))
-        |          (False)
-        |          (ApplyComparisonOp EQ
-        |            (ArrayRef
-        |              (ToArray
-        |                (GetField s
-        |                  (Ref row)))
-        |              (Ref __iruid_1))
-        |            (GetField elt
-        |              (GetField nested
-        |                (Ref row)))))))
-        |    (If
-        |      (IsNA
-        |        (Ref __uid_1))
-        |      (False)
-        |      (Ref __uid_1))))
-      """.stripMargin
-
-    Interpret(ir.IRParser.parse_table_ir(irStr), ctx, optimize = false).rvd.count()
-  }
-
   @Test def testTableGetGlobalsSimplifyRules() {
     implicit val execStrats = ExecStrategy.interpretOnly
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -553,7 +553,7 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testArrayRefMemo() {
-    checkMemo(ArrayRef(arr, I32(0)), justB, Array(TArray(justB), null))
+    checkMemo(ArrayRef(arr, I32(0)), justB, Array(TArray(justB), null, null))
   }
 
   @Test def testArrayLenMemo() {


### PR DESCRIPTION
Fixes #2921

Example:

```
In [3]: mt = mt.annotate_entries(PL=[0])

In [4]: hl.split_multi_hts(mt)._force_count_rows()

... hundreds of lines of java trace ...

Hail version: 0.2.30-bae67f384161
Error summary: HailException: array index out of bounds: index=1, length=1
----------
Python traceback:
  File "<ipython-input-4-ba11ec1cd68e>", line 1, in <module>
    hl.split_multi_hts(mt)._force_count_rows()

  File "/Users/tpoterba/hail/hail/python/hail/methods/statgen.py", line 2246, in split_multi_hts
    (hl.range(0, 3).map(lambda i:

  File "/Users/tpoterba/hail/hail/python/hail/methods/statgen.py", line 2250, in <lambda>
    ).map(lambda j: split.PL[j]))))))

  File "/Users/tpoterba/hail/hail/python/hail/methods/statgen.py", line 2250, in <lambda>
    ).map(lambda j: split.PL[j]))))))
```