### PR TITLE
[ci] Need to use empty list for requested step names

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -83,6 +83,9 @@ class BuildConfiguration:
         name_step = {}
         self.steps = []
 
+        if requested_step_names is None:
+            requested_step_names = []
+
         if requested_step_names:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -83,7 +83,6 @@ class BuildConfiguration:
         name_step = {}
         self.steps = []
 
-
         if requested_step_names:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -78,13 +78,11 @@ class StepParameters:
 
 
 class BuildConfiguration:
-    def __init__(self, code, config_str, scope, requested_step_names=None):
+    def __init__(self, code, config_str, scope, requested_step_names=()):
         config = yaml.safe_load(config_str)
         name_step = {}
         self.steps = []
 
-        if requested_step_names is None:
-            requested_step_names = []
 
         if requested_step_names:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")


### PR DESCRIPTION
The error this fixes is in the line: 
`if not step.run_if_requested or step.name in requested_step_names`

when `requested_step_names is None`, you cannot check if a value is `in` it. I chose not to make the default value of `requested_step_names = []`, since it's dangerous to do that in python (that single mutable list will be shared across invocations of the constructor)