### PR TITLE
[hail] NDArrayMatMul Requiredness Fix

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -423,6 +423,8 @@ def test_ndarray_matmul():
     np_broadcasted_mat = np.arange(4).reshape((1, 2, 2))
     np_six_dim_tensor = np.arange(3 * 7 * 1 * 9 * 4 * 5).reshape((3, 7, 1, 9, 4, 5))
     np_five_dim_tensor = np.arange(7 * 5 * 1 * 5 * 3).reshape((7, 5, 1, 5, 3))
+    np_ones_int32 = np.ones((4, 4), dtype=np.int32)
+    np_ones_float64 = np.ones((4, 4), dtype=np.float64)
 
     v = hl.nd.array(np_v)
     m = hl.nd.array(np_m)
@@ -432,6 +434,9 @@ def test_ndarray_matmul():
     broadcasted_mat = hl.nd.array(np_broadcasted_mat)
     six_dim_tensor = hl.nd.array(np_six_dim_tensor)
     five_dim_tensor = hl.nd.array(np_five_dim_tensor)
+    ones_int32 = hl.nd.array(np_ones_int32)
+    ones_float64 = hl.nd.array(np_ones_float64)
+
 
     assert_ndarrays_eq(
         (v @ v, np_v @ np_v),
@@ -455,6 +460,8 @@ def test_ndarray_matmul():
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat64, 2)) @ hl.null(hl.tndarray(hl.tfloat64, 2))) is None
     assert hl.eval(hl.null(hl.tndarray(hl.tint64, 2)) @ hl.nd.array(np.arange(10).reshape(5, 2))) is None
     assert hl.eval(hl.nd.array(np.arange(10).reshape(5, 2)) @ hl.null(hl.tndarray(hl.tint64, 2))) is None
+
+    assert np.array_equal(hl.eval(ones_int32 @ ones_float64), np_ones_int32 @ np_ones_float64)
 
     with pytest.raises(ValueError):
         m @ 5

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -437,7 +437,6 @@ def test_ndarray_matmul():
     ones_int32 = hl.nd.array(np_ones_int32)
     ones_float64 = hl.nd.array(np_ones_float64)
 
-
     assert_ndarrays_eq(
         (v @ v, np_v @ np_v),
         (m @ m, np_m @ np_m),

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -217,7 +217,7 @@ object TypeCheck {
         assert(r.typ.isInstanceOf[TNDArray])
         val lType = l.typ.asInstanceOf[TNDArray]
         val rType = r.typ.asInstanceOf[TNDArray]
-        assert(lType.elementType == rType.elementType, "element type did not match")
+        assert(lType.elementType isOfType rType.elementType, "element type did not match")
         assert(lType.nDims > 0)
         assert(rType.nDims > 0)
         assert(lType.nDims == 1 || rType.nDims == 1 || lType.nDims == rType.nDims)


### PR DESCRIPTION
Added a new test to make sure type promotion worked correctly (multiplying int matrix by float matrix), found a requiredness issue instead. 