### PR TITLE
Fix strides from numpy

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -653,9 +653,16 @@ class tndarray(HailType):
 
     def _convert_to_json(self, x):
         data = x.reshape(x.size).tolist()
+
+        strides = []
+        running_shape_product = x.itemsize
+        for shape_element in reversed(x.shape):
+            strides.insert(0, running_shape_product)
+            running_shape_product = running_shape_product * (shape_element if shape_element > 0 else 1)
+
         json_dict = {
             "shape": x.shape,
-            "strides": x.strides,
+            "strides": strides,
             "flags": 0,
             "data": data,
             "offset": 0

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -655,10 +655,10 @@ class tndarray(HailType):
         data = x.reshape(x.size).tolist()
 
         strides = []
-        running_shape_product = x.itemsize
-        for shape_element in reversed(x.shape):
-            strides.insert(0, running_shape_product)
-            running_shape_product = running_shape_product * (shape_element if shape_element > 0 else 1)
+        axis_one_step_byte_size = x.itemsize
+        for dimension_size in reversed(x.shape):
+            strides.insert(0, axis_one_step_byte_size)
+            axis_one_step_byte_size *= (dimension_size if dimension_size > 0 else 1)
 
         json_dict = {
             "shape": x.shape,

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -109,6 +109,7 @@ def test_ndarray_eval():
     nd_expr = hl.nd.array(data_list)
     evaled = hl.eval(nd_expr)
     np_equiv = np.array(data_list, dtype=np.int32)
+    np_equiv_fortran_style = np.asfortranarray(np_equiv)
     assert(np.array_equal(evaled, np_equiv))
     assert(evaled.strides == np_equiv.strides)
 
@@ -120,6 +121,9 @@ def test_ndarray_eval():
 
     assert np.array_equal(evaled_zero_array, zero_array)
     assert zero_array.dtype == evaled_zero_array.dtype
+
+    # Testing correct interpretation of numpy strides
+    assert np.array_equal(hl.eval(hl.literal(np_equiv_fortran_style)), np_equiv_fortran_style)
 
     # Testing from hail arrays
     assert np.array_equal(hl.eval(hl.nd.array(hl.range(6))), np.arange(6))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -110,6 +110,7 @@ def test_ndarray_eval():
     evaled = hl.eval(nd_expr)
     np_equiv = np.array(data_list, dtype=np.int32)
     np_equiv_fortran_style = np.asfortranarray(np_equiv)
+    np_equiv_extra_dimension = np_equiv.reshape((3, 1, 3))
     assert(np.array_equal(evaled, np_equiv))
     assert(evaled.strides == np_equiv.strides)
 
@@ -124,6 +125,7 @@ def test_ndarray_eval():
 
     # Testing correct interpretation of numpy strides
     assert np.array_equal(hl.eval(hl.literal(np_equiv_fortran_style)), np_equiv_fortran_style)
+    assert np.array_equal(hl.eval(hl.literal(np_equiv_extra_dimension)), np_equiv_extra_dimension)
 
     # Testing from hail arrays
     assert np.array_equal(hl.eval(hl.nd.array(hl.range(6))), np.arange(6))


### PR DESCRIPTION
It's wrong to use the strides as given from numpy in the current implementation. When we do `x.reshape(x.size).tolist()`, we are flattening the ndarray into a single contiguous list that can be thought of as being stored in row major. So I always want to generate the strides that the row major version of the numpy array would have had. The `if shape_element > 0` bit is because if you have an empty numpy array of a certain type, you still don't want it to have 0 stride.