### PR TITLE
[internal-gateway] increase client max body size to 50m

### DIFF
--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -10,6 +10,7 @@ map $http_x_forwarded_proto $updated_scheme {
 
 server {
     server_name internal.hail;
+    client_max_body_size 50m;
     listen 80;
     listen [::]:80;
 
@@ -34,6 +35,7 @@ server {
 
 server {
     server_name hail;
+    client_max_body_size 50m;
     listen 80 default_server;
     listen [::]:80 default_server;
 


### PR DESCRIPTION
This is sufficiently large to permit the transmission of the Hail JAR
which is about 38 MB. I will use this to test and eventually normally
use the Gradle build cache server.