### PR TITLE
[query] Encoder for encoding arrays of structs as 'structs of arrays'

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -829,7 +829,8 @@ class HailFeatureFlags {
       "lower_bm" -> sys.env.getOrElse("HAIL_DEV_LOWER_BM", null),
       "max_leader_scans" -> sys.env.getOrElse("HAIL_DEV_MAX_LEADER_SCANS", "1000"),
       "jvm_bytecode_dump" -> sys.env.getOrElse("HAIL_DEV_JVM_BYTECODE_DUMP", null),
-      "use_packed_int_encoding" -> sys.env.getOrElse("HAIL_DEV_USE_PACKED_INT_ENCODING", null)
+      "use_packed_int_encoding" -> sys.env.getOrElse("HAIL_DEV_USE_PACKED_INT_ENCODING", null),
+      "use_column_encoding" -> sys.env.getOrElse("HAIL_DEV_USE_COLUMN_ENCODING", null)
     )
 
   val available: java.util.ArrayList[String] =

--- a/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
@@ -254,13 +254,9 @@ final case class ETransposedArrayOfStructs(
                 Code(
                   b := b | (elementPStruct.isFieldMissing(elem(), fidx).toI << (presentIdx & 7)),
                   presentIdx := presentIdx + const(1),
-                  (presentIdx & 7).ceq(0).mux(
-                    Code(out2.writeByte(b.toB), b := 0),
-                    Code._empty))),
+                  (presentIdx & 7).ceq(0).orEmpty(Code(out2.writeByte(b.toB), b := 0)))),
               j := j + const(1))),
-          (presentIdx & 7).cne(0).mux(
-              out2.writeByte(b.toB),
-              Code._empty))
+          (presentIdx & 7).cne(0).orEmpty(out2.writeByte(b.toB)))
         }
 
         Code(
@@ -269,9 +265,8 @@ final case class ETransposedArrayOfStructs(
           Code.whileLoop(j < len,
             Code(
             arrayPType.isElementDefined(addr, j).orEmpty(
-              elementPStruct.isFieldDefined(elem(), fidx).mux(
-                encodeField(Region.loadIRIntermediate(pf.typ)(elementPStruct.fieldOffset(elem(), fidx)), out2),
-                Code._empty)),
+              elementPStruct.isFieldDefined(elem(), fidx).orEmpty(
+                encodeField(Region.loadIRIntermediate(pf.typ)(elementPStruct.fieldOffset(elem(), fidx)), out2))),
               j := j + 1)))
       }.toArray
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
@@ -25,7 +25,7 @@ final case class ETransposedArrayOfStructs(
         false
       else {
         val ps = t.elementType.asInstanceOf[PBaseStruct]
-        ps.required == required &&
+        ps.required == structRequired &&
           size <= ps.size &&
           fields.forall { f =>
             ps.hasField(f.name) && f.typ.encodeCompatible(ps.fieldType(f.name))
@@ -40,7 +40,7 @@ final case class ETransposedArrayOfStructs(
         false
       else {
         val ps = t.elementType.asInstanceOf[PBaseStruct]
-        ps.required == required &&
+        ps.required == structRequired &&
         size <= ps.size &&
         fields.forall { f =>
           ps.hasField(f.name) && f.typ.encodeCompatible(ps.fieldType(f.name))
@@ -208,7 +208,7 @@ final case class ETransposedArrayOfStructs(
     val ps = pa.elementType.asInstanceOf[PBaseStruct]
 
     val array = coerce[Long](v)
-    val len = mb.newLocal[Int]("len")
+    val len = mb.newField[Int]("arrayLength")
     val i = mb.newLocal[Int]("i")
     val nPresent = mb.newLocal[Int]("nPresent")
     val writeLen = out.writeInt(len)

--- a/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
@@ -195,7 +195,7 @@ final case class ETransposedArrayOfStructs(
         alen := 0,
         Code.whileLoop(i < len,
           Code(
-            alen := alen + Region.loadBit(mbytes, i.toL).toI,
+            alen := alen + (!Region.loadBit(mbytes, i.toL)).toI,
             i := i + const(1))),
         anMissing := UnsafeUtils.packBitsToBytes(alen),
         fmbytes := r.allocate(const(1), nMissing.toL),
@@ -296,7 +296,11 @@ final case class ETransposedArrayOfStructs(
   }
 
   def _decodedPType(requestedType: Type): PType = requestedType match {
-    case t: TArray =>
+    case t: TDict =>
+      val keyType = fieldType("key")
+      val valueType = fieldType("value")
+      PDict(keyType.decodedPType(t.keyType), valueType.decodedPType(t.valueType), required)
+    case t: TIterable =>
       val pElementType = t.elementType match {
         case elem: TStruct => PStruct(elem.fields.map { case Field(name, typ, idx) =>
           PField(name, fieldType(name).decodedPType(typ), idx)
@@ -304,8 +308,19 @@ final case class ETransposedArrayOfStructs(
         case elem: TTuple => PTuple(elem.fields.map { case Field(name, typ, idx) =>
           PTupleField(idx, fieldType(name).decodedPType(typ))
         }, structRequired)
+        case elem: TLocus => PLocus(elem.rgBc, structRequired)
+        case elem: TInterval =>
+          val pointType = fieldType("start")
+          require(pointType == fieldType("end"))
+          PInterval(pointType.decodedPType(elem.pointType), structRequired)
+        case elem: TNDArray =>
+          val elementType = fieldType("data").asInstanceOf[EContainer].elementType
+          PNDArray(elementType.decodedPType(elem.elementType), elem.nDims, structRequired)
       }
-      PArray(pElementType, required)
+      t match {
+        case _: TSet => PSet(pElementType, required)
+        case _: TArray => PArray(pElementType, required)
+      }
   }
 
   def _asIdent: String = {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
@@ -1,0 +1,346 @@
+package is.hail.expr.types.encoded
+
+import is.hail.annotations.{Region, UnsafeUtils}
+import is.hail.asm4s._
+import is.hail.expr.types.{BaseStruct, BaseType}
+import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual._
+import is.hail.io.{InputBuffer, OutputBuffer}
+import is.hail.utils._
+
+final case class ETransposedArrayOfStructs(
+  fields: IndexedSeq[EField],
+  override val required: Boolean = false, // is the array required
+  structRequired: Boolean = false // are the structs required
+) extends EType {
+
+  def size: Int = fields.length
+  val fieldIdx: Map[String, Int] = fields.map(f => (f.name, f.index)).toMap
+  def field(name: String): EField = fields(fieldIdx(name))
+  def fieldType(name: String): EType = field(name).typ
+
+  override def _decodeCompatible(pt: PType): Boolean = pt match {
+    case t: PArray =>
+      if (!t.elementType.isInstanceOf[PBaseStruct])
+        false
+      else {
+        val ps = t.elementType.asInstanceOf[PBaseStruct]
+        ps.required == required &&
+          size <= ps.size &&
+          fields.forall { f =>
+            ps.hasField(f.name) && f.typ.encodeCompatible(ps.fieldType(f.name))
+          }
+      }
+    case _ => false
+  }
+
+  override def _encodeCompatible(pt: PType): Boolean = pt match {
+    case t: PArray =>
+      if (!t.elementType.isInstanceOf[PBaseStruct])
+        false
+      else {
+        val ps = t.elementType.asInstanceOf[PBaseStruct]
+        ps.required == required &&
+        size <= ps.size &&
+        fields.forall { f =>
+          ps.hasField(f.name) && f.typ.encodeCompatible(ps.fieldType(f.name))
+        }
+      }
+    case _ => false
+  }
+
+  def _buildDecoder(pt: PType, mb: MethodBuilder, region: Value[Region], in: Value[InputBuffer]): Code[_] = {
+    val pa = pt.asInstanceOf[PArray]
+    val ps = pa.elementType.asInstanceOf[PBaseStruct]
+
+    val len = mb.newLocal[Int]("len")
+    val alen = mb.newLocal[Int]("alen")
+    val i = mb.newLocal[Int]("i")
+    val j = mb.newLocal[Int]("j")
+    val nMissing = mb.newLocal[Int]("nMissing")
+    val anMissing = mb.newLocal[Int]("anMissing")
+    val fmbytes = mb.newLocal[Long]("fmbytes")
+    val array = mb.newLocal[Long]("array")
+
+    val prefix = Code(
+      len := in.readInt(),
+      nMissing := pa.nMissingBytes(len),
+      array := pa.allocate(region, len),
+      pa.storeLength(array, len),
+      if (structRequired)
+        Code(
+          alen := len,
+          anMissing := nMissing
+        )
+      else
+        Code(
+          in.readBytes(region, array + const(pa.lengthHeaderBytes), nMissing),
+          i := 0,
+          alen := 0,
+          Code.whileLoop(i < len,
+            Code(
+              alen := alen + pa.isElementMissing(array, i).toI,
+              i := i + const(1))),
+          anMissing := UnsafeUtils.packBitsToBytes(alen)),
+      if (fields.forall(_.typ.required)) {
+        fmbytes := 0
+      } else {
+        fmbytes := region.allocate(const(1), anMissing.toL)
+      }
+    )
+
+    val decodeFields = Code.concat(fields.map { ef =>
+      ps.selfField(ef.name) match {
+        case Some(pf) =>
+          val inplaceDecode = ef.typ.buildInplaceDecoder(pf.typ, mb)
+          val elem = pa.elementOffset(array, len, i)
+          val fld = ps.fieldOffset(elem, pf.index)
+          if (ef.typ.required) {
+            Code(
+              i := 0,
+              Code.whileLoop(i < len,
+                Code(
+                  pa.isElementDefined(array, i).mux(
+                    inplaceDecode(region, fld, in),
+                    Code._empty),
+                  i := i + const(1))))
+          } else {
+            Code(
+              in.readBytes(region, fmbytes, anMissing),
+              i := 0,
+              j := 0,
+              Code.whileLoop(i < len,
+                  Code.concat(
+                    pa.isElementDefined(array, i).mux(
+                    Code(
+                      Region.loadBit(fmbytes, j.toL).mux(
+                        ps.setFieldMissing(elem, pf.index),
+                        Code(
+                          ps.setFieldPresent(elem, pf.index),
+                          inplaceDecode(region, fld, in))),
+                      j := j + const(1)),
+                    Code._empty))))
+          }
+        case None =>
+          val skip = ef.typ.buildSkip(mb)
+          if (ef.typ.required) {
+            Code(
+              i := 0,
+              Code.whileLoop(i < alen, Code(skip(region, in), i := i + const(1)))
+            )
+          } else {
+            Code(
+              in.readBytes(region, fmbytes, anMissing),
+              i := 0,
+              Code.whileLoop(i < alen,
+                Code(
+                  Region.loadBit(fmbytes, i.toL).mux(
+                    Code._empty,
+                    skip(region, in)),
+                  i := i + 1)))
+          }
+      }
+    }: _*)
+
+    Code(
+      prefix,
+      decodeFields,
+      array
+    )
+  }
+
+  def _buildSkip(mb: MethodBuilder, r: Value[Region], in: Value[InputBuffer]): Code[Unit] = {
+    val len = mb.newLocal[Int]("len")
+    val i = mb.newLocal[Int]("i")
+    val nMissing = mb.newLocal[Int]("nMissing")
+    val alen = mb.newLocal[Int]("alen")
+    val anMissing = mb.newLocal[Int]("anMissing")
+    val fmbytes = mb.newLocal[Long]("fmbytes")
+    val skipFields = Code.concat(fields.map { f =>
+      val skip = f.typ.buildSkip(mb)
+      if (f.typ.required) {
+        Code(
+          i := 0,
+          Code.whileLoop(i < alen, Code(skip(r, in), i := i + 1)))
+      } else {
+        Code(
+          in.readBytes(r, fmbytes, anMissing),
+          i := 0,
+          Code.whileLoop(i < alen,
+            Code(
+              Region.loadBit(fmbytes, i.toL).mux(
+                Code._empty,
+                skip(r, in)),
+              i := i + 1)))
+      }
+    }: _*)
+
+    val prefix = Code(len := in.readInt(), nMissing := UnsafeUtils.packBitsToBytes(len))
+    if (structRequired) {
+      Code(
+        prefix,
+        alen := len,
+        anMissing := UnsafeUtils.packBitsToBytes(alen),
+        fmbytes := r.allocate(const(1), nMissing.toL),
+        skipFields
+      )
+    } else {
+      val mbytes = mb.newLocal[Long]("mbytes")
+      Code(
+        prefix,
+        mbytes := r.allocate(const(1), nMissing.toL),
+        in.readBytes(r, mbytes, nMissing),
+        i := 0,
+        alen := 0,
+        Code.whileLoop(i < len,
+          Code(
+            alen := alen + Region.loadBit(mbytes, i.toL).toI,
+            i := i + const(1))),
+        anMissing := UnsafeUtils.packBitsToBytes(alen),
+        fmbytes := r.allocate(const(1), nMissing.toL),
+        skipFields
+      )
+    }
+  }
+
+  def _buildEncoder(pt: PType, mb: MethodBuilder, v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
+    val pa = pt.asInstanceOf[PArray]
+    val ps = pa.elementType.asInstanceOf[PBaseStruct]
+
+    val array = coerce[Long](v)
+    val len = mb.newLocal[Int]("len")
+    val i = mb.newLocal[Int]("i")
+    val nPresent = mb.newLocal[Int]("nPresent")
+    val writeLen = out.writeInt(len)
+
+    val writeMissingBytes =
+      if (!structRequired) {
+        out.writeBytes(array + const(pa.lengthHeaderBytes), pa.nMissingBytes(len))
+      } else
+        Code._empty
+
+    val countPresent = Code.whileLoop(
+      i < len,
+      Code(
+        pa.isElementDefined(array, i).mux(
+          nPresent := nPresent + const(1),
+          Code._empty),
+        i := i + const(1)))
+
+    val writeFields = Code.concat(fields.grouped(64).zipWithIndex.map { case (fieldGroup, groupIdx) =>
+      val groupMB = mb.fb.newMethod(s"write_fields_group_$groupIdx", Array[TypeInfo[_]](LongInfo, classInfo[OutputBuffer]), UnitInfo)
+      val addr = groupMB.getArg[Long](1)
+      val out2 = groupMB.getArg[OutputBuffer](2)
+
+      val b = groupMB.newLocal[Int]("b")
+      val j = groupMB.newLocal[Int]("j")
+      val presentIdx = groupMB.newLocal[Int]("presentIdx")
+
+      val encoders = fieldGroup.map { ef =>
+        val fidx = ps.fieldIdx(ef.name)
+        val pf = ps.fields(fidx)
+        val encodeField = ef.typ.buildEncoder(pf.typ, groupMB)
+        val elem = pa.elementOffset(addr, len, j)
+        val f = ps.fieldOffset(elem, fidx)
+
+        val writeMissingBytes = if (ef.typ.required)
+          Code._empty
+        else {
+          Code(
+          b := 0,
+          j := 0,
+          presentIdx := 0,
+          Code.whileLoop(j < len,
+            Code(
+              pa.isElementDefined(addr, j).mux(
+                Code(
+                  b := b | (ps.isFieldMissing(elem, fidx).toI << (presentIdx & 7)),
+                  presentIdx := presentIdx + const(1),
+                  (presentIdx & 7).ceq(0).mux(
+                    Code(out2.load().writeByte(b.toB), b := 0),
+                    Code._empty)),
+                Code._empty),
+              j := j + const(1))),
+          (presentIdx & 7).cne(0).mux(
+              out2.load().writeByte(b.toB),
+              Code._empty))
+        }
+
+        Code(
+          writeMissingBytes,
+          j := 0,
+          Code.whileLoop(j < len,
+            Code(
+            pa.isElementDefined(addr, j).mux(
+              ps.isFieldDefined(elem, fidx).mux(
+                encodeField(Region.loadIRIntermediate(pf.typ)(f), out2),
+                Code._empty),
+              Code._empty),
+              j := j + 1)))
+      }
+
+      groupMB.emit(Code.concat(encoders: _*))
+      groupMB.invoke(addr, out)
+    }.toArray: _*)
+
+    Code(
+      i := 0,
+      nPresent := 0,
+      len := pa.loadLength(array),
+      countPresent,
+
+      writeLen,
+      writeMissingBytes,
+      writeFields)
+  }
+
+  def _decodedPType(requestedType: Type): PType = requestedType match {
+    case t: TArray =>
+      val pElementType = t.elementType match {
+        case elem: TStruct => PStruct(elem.fields.map { case Field(name, typ, idx) =>
+          PField(name, fieldType(name).decodedPType(typ), idx)
+        }, structRequired)
+        case elem: TTuple => PTuple(elem.fields.map { case Field(name, typ, idx) =>
+          PTupleField(idx, fieldType(name).decodedPType(typ))
+        }, structRequired)
+      }
+      PArray(pElementType, required)
+  }
+
+  def _asIdent: String = {
+    val sb = new StringBuilder
+    sb.append(s"transposed_array_of_${if (structRequired) "r" else "o"}_struct_of_")
+    fields.foreachBetween { f =>
+      sb.append(f.typ.asIdent)
+    } {
+      sb.append("AND")
+    }
+    sb.append("END")
+    sb.result()
+  }
+
+  def _toPretty: String = {
+    val sb = new StringBuilder
+    _pretty(sb, 0, compact = true)
+    sb.result()
+  }
+
+  override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
+    if (compact) {
+      sb.append(s"ETransposedArrayOfStructs[${if (structRequired) "True" else "False"}]{")
+      fields.foreachBetween(_.pretty(sb, indent, compact))(sb += ',')
+      sb += '}'
+    } else {
+      if (fields.length == 0)
+        sb.append("ETransposedArrayOfStructs { }")
+      else {
+        sb.append("ETransposedArrayOfStructs {")
+        sb += '\n'
+        fields.foreachBetween(_.pretty(sb, indent + 4, compact))(sb.append(",\n"))
+        sb += '\n'
+        sb.append(" " * indent)
+        sb += '}'
+      }
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/ETransposedArrayOfStructs.scala
@@ -18,6 +18,7 @@ final case class ETransposedArrayOfStructs(
   val fieldIdx: Map[String, Int] = fields.map(f => (f.name, f.index)).toMap
   def field(name: String): EField = fields(fieldIdx(name))
   def fieldType(name: String): EType = field(name).typ
+  def hasField(name: String): Boolean = fieldIdx.contains(name)
 
   override def _decodeCompatible(pt: PType): Boolean = pt match {
     case t: PArray =>
@@ -26,9 +27,9 @@ final case class ETransposedArrayOfStructs(
       else {
         val ps = t.elementType.asInstanceOf[PBaseStruct]
         ps.required == structRequired &&
-          size <= ps.size &&
-          fields.forall { f =>
-            ps.hasField(f.name) && f.typ.encodeCompatible(ps.fieldType(f.name))
+          size >= ps.size &&
+          ps.fields.forall { f =>
+            hasField(f.name) && fieldType(f.name).decodeCompatible(f.typ)
           }
       }
     case _ => false

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -257,6 +257,14 @@ object EType {
       case t: PArray if t.elementType.fundamentalType.isOfType(PInt32(t.elementType.required)) &&
           HailContext.get.flags.get("use_packed_int_encoding") != null =>
          EPackedIntArray(required, t.elementType.required)
+      // FIXME(chrisvittal): Turn this on when it works
+      // case t: PArray if t.elementType.isInstanceOf[PBaseStruct] =>
+      //   val et = t.elementType.asInstanceOf[PBaseStruct]
+      //   ETransposedArrayOfStructs(
+      //     et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
+      //     t.required,
+      //     et.required
+      //   )
       case t: PArray => EArray(defaultFromPType(t.elementType), t.required)
       case t: PBaseStruct => EBaseStruct(t.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)), t.required)
     }
@@ -292,6 +300,14 @@ object EType {
         val args = IRParser.repsepUntil(it, IRParser.struct_field(eTypeParser), PunctuationToken(","), PunctuationToken("}"))
         IRParser.punctuation(it, "}")
         EBaseStruct(args.zipWithIndex.map { case ((name, t), i) => EField(name, t, i) }, req)
+      case "ETransposedArrayOfStructs" =>
+        IRParser.punctuation(it, "[")
+        val structRequired = IRParser.boolean_literal(it)
+        IRParser.punctuation(it, "]")
+        IRParser.punctuation(it, "{")
+        val args = IRParser.repsepUntil(it, IRParser.struct_field(eTypeParser), PunctuationToken(","), PunctuationToken("}"))
+        IRParser.punctuation(it, "}")
+        ETransposedArrayOfStructs(args.zipWithIndex.map { case ((name, t), i) => EField(name, t, i) }, req, structRequired)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -244,9 +244,7 @@ object EType {
     }
   }
 
-  def defaultFromPType(pt: PType): EType = defaultFromPType(pt, pt.required)
-
-  def defaultFromPType(pt: PType, required: Boolean): EType = {
+  def defaultFromPType(pt: PType): EType = {
     pt.fundamentalType match {
       case t: PInt32 => EInt32(t.required)
       case t: PInt64 => EInt64(t.required)
@@ -257,7 +255,7 @@ object EType {
       // FIXME(chrisvittal): turn this on when performance is adequate
       case t: PArray if t.elementType.fundamentalType.isOfType(PInt32(t.elementType.required)) &&
           HailContext.get.flags.get("use_packed_int_encoding") != null =>
-         EPackedIntArray(required, t.elementType.required)
+         EPackedIntArray(t.required, t.elementType.required)
       // FIXME(chrisvittal): Turn this on when it works
       case t: PArray if t.elementType.isInstanceOf[PBaseStruct] &&
           HailContext.get.flags.get("use_column_encoding") != null =>

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -244,7 +244,9 @@ object EType {
     }
   }
 
-  def defaultFromPType(pt: PType): EType = {
+  def defaultFromPType(pt: PType,
+    useTransposedArrayOfStructs: Boolean = true
+  ): EType = {
     pt.fundamentalType match {
       case t: PInt32 => EInt32(t.required)
       case t: PInt64 => EInt64(t.required)
@@ -257,16 +259,17 @@ object EType {
           HailContext.get.flags.get("use_packed_int_encoding") != null =>
          EPackedIntArray(t.required, t.elementType.required)
       // FIXME(chrisvittal): Turn this on when it works
-      case t: PArray if t.elementType.isInstanceOf[PBaseStruct] &&
+      case t: PArray if t.elementType.isInstanceOf[PBaseStruct] && useTransposedArrayOfStructs &&
           HailContext.get.flags.get("use_column_encoding") != null =>
         val et = t.elementType.asInstanceOf[PBaseStruct]
         ETransposedArrayOfStructs(
-          et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
+          et.fields.map(f => EField(f.name, defaultFromPType(f.typ, useTransposedArrayOfStructs), f.index)),
           required = t.required,
           structRequired = et.required
         )
-      case t: PArray => EArray(defaultFromPType(t.elementType), t.required)
-      case t: PBaseStruct => EBaseStruct(t.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)), t.required)
+      case t: PArray => EArray(defaultFromPType(t.elementType, useTransposedArrayOfStructs), t.required)
+      case t: PBaseStruct => EBaseStruct(t.fields.map(f =>
+          EField(f.name, defaultFromPType(f.typ, useTransposedArrayOfStructs), f.index)), t.required)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -150,7 +150,8 @@ abstract class EType extends BaseType with Serializable with Requiredness {
     assert(decodeCompatible(ret),
       s"""Invalid requested type, cannot decode
          |encoded type  : ${ this }
-         |requested type: $requestedType""".stripMargin)
+         |requested type: $requestedType
+         |chosen ptype  : $ret""".stripMargin)
     ret
   }
 
@@ -263,8 +264,8 @@ object EType {
         val et = t.elementType.asInstanceOf[PBaseStruct]
         ETransposedArrayOfStructs(
           et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
-          t.required,
-          et.required
+          required = t.required,
+          structRequired = et.required
         )
       case t: PArray => EArray(defaultFromPType(t.elementType), t.required)
       case t: PBaseStruct => EBaseStruct(t.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)), t.required)

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -244,9 +244,7 @@ object EType {
     }
   }
 
-  def defaultFromPType(pt: PType,
-    useTransposedArrayOfStructs: Boolean = true
-  ): EType = {
+  def defaultFromPType(pt: PType): EType = {
     pt.fundamentalType match {
       case t: PInt32 => EInt32(t.required)
       case t: PInt64 => EInt64(t.required)
@@ -259,17 +257,17 @@ object EType {
           HailContext.get.flags.get("use_packed_int_encoding") != null =>
          EPackedIntArray(t.required, t.elementType.required)
       // FIXME(chrisvittal): Turn this on when it works
-      case t: PArray if t.elementType.isInstanceOf[PBaseStruct] && useTransposedArrayOfStructs &&
+      case t: PArray if t.elementType.isInstanceOf[PBaseStruct] &&
           HailContext.get.flags.get("use_column_encoding") != null =>
         val et = t.elementType.asInstanceOf[PBaseStruct]
         ETransposedArrayOfStructs(
-          et.fields.map(f => EField(f.name, defaultFromPType(f.typ, useTransposedArrayOfStructs), f.index)),
+          et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
           required = t.required,
           structRequired = et.required
         )
-      case t: PArray => EArray(defaultFromPType(t.elementType, useTransposedArrayOfStructs), t.required)
+      case t: PArray => EArray(defaultFromPType(t.elementType), t.required)
       case t: PBaseStruct => EBaseStruct(t.fields.map(f =>
-          EField(f.name, defaultFromPType(f.typ, useTransposedArrayOfStructs), f.index)), t.required)
+          EField(f.name, defaultFromPType(f.typ), f.index)), t.required)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -258,13 +258,14 @@ object EType {
           HailContext.get.flags.get("use_packed_int_encoding") != null =>
          EPackedIntArray(required, t.elementType.required)
       // FIXME(chrisvittal): Turn this on when it works
-      // case t: PArray if t.elementType.isInstanceOf[PBaseStruct] =>
-      //   val et = t.elementType.asInstanceOf[PBaseStruct]
-      //   ETransposedArrayOfStructs(
-      //     et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
-      //     t.required,
-      //     et.required
-      //   )
+      case t: PArray if t.elementType.isInstanceOf[PBaseStruct] &&
+          HailContext.get.flags.get("use_column_encoding") != null =>
+        val et = t.elementType.asInstanceOf[PBaseStruct]
+        ETransposedArrayOfStructs(
+          et.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)),
+          t.required,
+          et.required
+        )
       case t: PArray => EArray(defaultFromPType(t.elementType), t.required)
       case t: PBaseStruct => EBaseStruct(t.fields.map(f => EField(f.name, defaultFromPType(f.typ), f.index)), t.required)
     }

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -6,7 +6,7 @@ import is.hail.annotations._
 import is.hail.expr.types.physical._
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexWriter
-import is.hail.rvd.{IndexSpec, MakeRVDSpec, RVDContext, RVDPartitioner, RVDType}
+import is.hail.rvd.{AbstractIndexSpec, IndexSpec, MakeRVDSpec, RVDContext, RVDPartitioner, RVDType}
 import is.hail.sparkextras._
 import is.hail.utils._
 import is.hail.utils.richUtils.ByteTrackingOutputStream
@@ -152,19 +152,20 @@ object RichContextRDDRegionValue {
     path: String,
     rowsCodecSpec: AbstractTypedCodecSpec,
     entriesCodecSpec: AbstractTypedCodecSpec,
+    rowsIndexSpec: AbstractIndexSpec,
+    entriesIndexSpec: AbstractIndexSpec,
     t: RVDType,
     rowsRVType: PStruct,
     entriesRVType: PStruct,
     partFiles: Array[String],
     partitioner: RVDPartitioner
   ) {
-    val rowsSpec = MakeRVDSpec(
-      t.key, rowsCodecSpec, partFiles, partitioner, IndexSpec.defaultAnnotation("../../index", t.kType))
+    val rowsSpec = MakeRVDSpec(t.key, rowsCodecSpec, partFiles, partitioner, rowsIndexSpec)
     rowsSpec.write(fs, path + "/rows/rows")
 
     val entriesSpec = MakeRVDSpec(
       FastIndexedSeq(), entriesCodecSpec, partFiles, RVDPartitioner.unkeyed(partitioner.numPartitions),
-      IndexSpec.defaultAnnotation("../../index", t.kType, withOffsetField = true))
+      entriesIndexSpec)
     entriesSpec.write(fs, path + "/entries/rows")
   }
 }

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -3,6 +3,7 @@ package is.hail.io.index
 import java.io.OutputStream
 
 import is.hail.annotations.{Annotation, Region, RegionValueBuilder}
+import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual.Type
 import is.hail.io.fs.FS
@@ -78,10 +79,14 @@ object IndexWriter {
     attributes: Map[String, Any] = Map.empty[String, Any]
   ): (FS, String) => IndexWriter = {
     val leafPType = LeafNodeBuilder.typ(keyType, annotationType)
-    val makeLeafEnc = TypedCodecSpec(leafPType, BufferSpec.default).buildEncoder(leafPType)
+    val makeLeafEnc = TypedCodecSpec(EType.defaultFromPType(leafPType, useTransposedArrayOfStructs = false),
+      leafPType.virtualType,
+      BufferSpec.default).buildEncoder(leafPType)
 
     val intPType = InternalNodeBuilder.typ(keyType, annotationType)
-    val makeIntEnc = TypedCodecSpec(intPType, BufferSpec.default).buildEncoder(intPType)
+    val makeIntEnc = TypedCodecSpec(EType.defaultFromPType(intPType, useTransposedArrayOfStructs = false),
+      intPType.virtualType,
+      BufferSpec.default).buildEncoder(intPType)
 
 
     { (fs: FS, path: String) =>

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -79,12 +79,12 @@ object IndexWriter {
     attributes: Map[String, Any] = Map.empty[String, Any]
   ): (FS, String) => IndexWriter = {
     val leafPType = LeafNodeBuilder.typ(keyType, annotationType)
-    val makeLeafEnc = TypedCodecSpec(EType.defaultFromPType(leafPType, useTransposedArrayOfStructs = false),
+    val makeLeafEnc = TypedCodecSpec(EType.defaultFromPType(leafPType),
       leafPType.virtualType,
       BufferSpec.default).buildEncoder(leafPType)
 
     val intPType = InternalNodeBuilder.typ(keyType, annotationType)
-    val makeIntEnc = TypedCodecSpec(EType.defaultFromPType(intPType, useTransposedArrayOfStructs = false),
+    val makeIntEnc = TypedCodecSpec(EType.defaultFromPType(intPType),
       intPType.virtualType,
       BufferSpec.default).buildEncoder(intPType)
 

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -79,15 +79,10 @@ object IndexWriter {
     attributes: Map[String, Any] = Map.empty[String, Any]
   ): (FS, String) => IndexWriter = {
     val leafPType = LeafNodeBuilder.typ(keyType, annotationType)
-    val makeLeafEnc = TypedCodecSpec(EType.defaultFromPType(leafPType),
-      leafPType.virtualType,
-      BufferSpec.default).buildEncoder(leafPType)
+    val makeLeafEnc = TypedCodecSpec(leafPType, BufferSpec.default).buildEncoder(leafPType)
 
     val intPType = InternalNodeBuilder.typ(keyType, annotationType)
-    val makeIntEnc = TypedCodecSpec(EType.defaultFromPType(intPType),
-      intPType.virtualType,
-      BufferSpec.default).buildEncoder(intPType)
-
+    val makeIntEnc = TypedCodecSpec(intPType, BufferSpec.default).buildEncoder(intPType)
 
     { (fs: FS, path: String) =>
       new IndexWriter(

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -3,7 +3,7 @@ package is.hail.rvd
 import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.ExecuteContext
-import is.hail.expr.types.encoded.ETypeSerializer
+import is.hail.expr.types.encoded.{ETypeSerializer, EType}
 import is.hail.expr.types.physical.{PInt64Optional, PInt64Required, PStruct, PType, PTypeSerializer}
 import is.hail.expr.types.virtual.{TStructSerializer, _}
 import is.hail.io._
@@ -233,8 +233,16 @@ case class IndexSpec2(_relPath: String,
 
 object IndexSpec {
   def fromKeyAndValuePTypes(relPath: String, keyPType: PType, annotationPType: PType, offsetFieldName: Option[String]): AbstractIndexSpec = {
-    val leafNodeSpec = TypedCodecSpec(LeafNodeBuilder.typ(keyPType, annotationPType), BufferSpec.default)
-    val internalNodeSpec = TypedCodecSpec(InternalNodeBuilder.typ(keyPType, annotationPType), BufferSpec.default)
+    val leafType = LeafNodeBuilder.typ(keyPType, annotationPType)
+    val leafNodeSpec = TypedCodecSpec(
+      EType.defaultFromPType(leafType, useTransposedArrayOfStructs = false),
+      leafType.virtualType,
+      BufferSpec.default)
+    val internalType = InternalNodeBuilder.typ(keyPType, annotationPType)
+    val internalNodeSpec = TypedCodecSpec(
+      EType.defaultFromPType(internalType, useTransposedArrayOfStructs = false),
+      internalType.virtualType,
+      BufferSpec.default)
     IndexSpec2(relPath, leafNodeSpec, internalNodeSpec, keyPType.virtualType, annotationPType.virtualType, offsetFieldName)
   }
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -235,12 +235,12 @@ object IndexSpec {
   def fromKeyAndValuePTypes(relPath: String, keyPType: PType, annotationPType: PType, offsetFieldName: Option[String]): AbstractIndexSpec = {
     val leafType = LeafNodeBuilder.typ(keyPType, annotationPType)
     val leafNodeSpec = TypedCodecSpec(
-      EType.defaultFromPType(leafType, useTransposedArrayOfStructs = false),
+      EType.defaultFromPType(leafType),
       leafType.virtualType,
       BufferSpec.default)
     val internalType = InternalNodeBuilder.typ(keyPType, annotationPType)
     val internalNodeSpec = TypedCodecSpec(
-      EType.defaultFromPType(internalType, useTransposedArrayOfStructs = false),
+      EType.defaultFromPType(internalType),
       internalType.virtualType,
       BufferSpec.default)
     IndexSpec2(relPath, leafNodeSpec, internalNodeSpec, keyPType.virtualType, annotationPType.virtualType, offsetFieldName)

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -234,15 +234,9 @@ case class IndexSpec2(_relPath: String,
 object IndexSpec {
   def fromKeyAndValuePTypes(relPath: String, keyPType: PType, annotationPType: PType, offsetFieldName: Option[String]): AbstractIndexSpec = {
     val leafType = LeafNodeBuilder.typ(keyPType, annotationPType)
-    val leafNodeSpec = TypedCodecSpec(
-      EType.defaultFromPType(leafType),
-      leafType.virtualType,
-      BufferSpec.default)
+    val leafNodeSpec = TypedCodecSpec(leafType, BufferSpec.default)
     val internalType = InternalNodeBuilder.typ(keyPType, annotationPType)
-    val internalNodeSpec = TypedCodecSpec(
-      EType.defaultFromPType(internalType),
-      internalType.virtualType,
-      BufferSpec.default)
+    val internalNodeSpec = TypedCodecSpec(internalType, BufferSpec.default)
     IndexSpec2(relPath, leafNodeSpec, internalNodeSpec, keyPType.virtualType, annotationPType.virtualType, offsetFieldName)
   }
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -814,6 +814,8 @@ class RVD(
 
     val rowsCodecSpec = TypedCodecSpec(rowsRVType, bufferSpec)
     val entriesCodecSpec = TypedCodecSpec(entriesRVType, bufferSpec)
+    val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", typ.kType)
+    val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", typ.kType, withOffsetField = true)
     val makeRowsEnc = rowsCodecSpec.buildEncoder(fullRowType)
     val makeEntriesEnc = entriesCodecSpec.buildEncoder(fullRowType)
     val makeIndexWriter = IndexWriter.builder(typ.kType, +PStruct("entries_offset" -> PInt64()))
@@ -938,7 +940,9 @@ class RVD(
 
     val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
 
-    RichContextRDDRegionValue.writeSplitSpecs(fs, path, rowsCodecSpec, entriesCodecSpec, typ, rowsRVType, entriesRVType, partFiles,
+    RichContextRDDRegionValue.writeSplitSpecs(fs, path,
+      rowsCodecSpec, entriesCodecSpec, rowsIndexSpec, entriesIndexSpec,
+      typ, rowsRVType, entriesRVType, partFiles,
       if (targetPartitioner != null) targetPartitioner else partitioner)
 
     partitionCounts
@@ -1497,6 +1501,8 @@ object RVD {
 
     val rowsCodecSpec = TypedCodecSpec(rowsRVType, bufferSpec)
     val entriesCodecSpec = TypedCodecSpec(entriesRVType, bufferSpec)
+    val rowsIndexSpec = IndexSpec.defaultAnnotation("../../index", localTyp.kType)
+    val entriesIndexSpec = IndexSpec.defaultAnnotation("../../index", localTyp.kType, withOffsetField = true)
     val makeRowsEnc = rowsCodecSpec.buildEncoder(fullRowType)
     val makeEntriesEnc = entriesCodecSpec.buildEncoder(fullRowType)
     val makeIndexWriter = IndexWriter.builder(localTyp.kType, +PStruct("entries_offset" -> PInt64()))
@@ -1551,7 +1557,9 @@ object RVD {
         val fs = bcFS.value
         val s = StringUtils.leftPad(i.toString, fileDigits, '0')
         val basePath = path + s + ".mt"
-        RichContextRDDRegionValue.writeSplitSpecs(fs, basePath, rowsCodecSpec, entriesCodecSpec, localTyp, rowsRVType, entriesRVType, partFiles, partitionerBc.value)
+        RichContextRDDRegionValue.writeSplitSpecs(fs, basePath,
+          rowsCodecSpec, entriesCodecSpec, rowsIndexSpec, entriesIndexSpec,
+          localTyp, rowsRVType, entriesRVType, partFiles, partitionerBc.value)
       }
 
     partCounts

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -267,7 +267,7 @@ class IndexSuite extends HailSuite {
         stringsWithDups.zipWithIndex.map { case (s, i) => Row(s, i) },
         stringsWithDups.indices.map(i => Row()).toArray,
         keyType,
-        +PStruct(),
+        PStruct(),
         branchingFactor,
         Map.empty)
 

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -56,8 +56,8 @@ class IndexSuite extends HailSuite {
   def indexReader(fs: FS, file: String, annotationPType: PType, keyPType: PType): IndexReader = {
     val leafPType = LeafNodeBuilder.typ(keyPType, annotationPType)
     val intPType = InternalNodeBuilder.typ(keyPType, annotationPType)
-    val leafSpec = TypedCodecSpec(EType.defaultFromPType(leafPType), leafPType.virtualType, BufferSpec.default)
-    val intSpec = TypedCodecSpec(EType.defaultFromPType(intPType), intPType.virtualType, BufferSpec.default)
+    val leafSpec = TypedCodecSpec(leafPType, BufferSpec.default)
+    val intSpec = TypedCodecSpec(intPType, BufferSpec.default)
 
     val (lrt, leafDec) = leafSpec.buildDecoder(leafPType.virtualType)
     assert(lrt == leafPType)

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -267,7 +267,7 @@ class IndexSuite extends HailSuite {
         stringsWithDups.zipWithIndex.map { case (s, i) => Row(s, i) },
         stringsWithDups.indices.map(i => Row()).toArray,
         keyType,
-        PStruct(),
+        +PStruct(),
         branchingFactor,
         Map.empty)
 


### PR DESCRIPTION
High level changes are as follows:
+ Add one new EType, ETransposedArrayOfStructs.

The layout of ETransposedArrayOfStructs is as follows:
```
START:
    encoded length (int)
    array's missing bits (sequenceof byte) [if struct not required]
    FOREACH field in struct:
        field's missing bits (sequenceof byte, length is NOTE) [if field not required]
        field elements (sequence of encoded field)

NOTE:
    The length of a field's missing bits is equal to the number of present array elements.
    If the array is of length 100, but only has 10 present elements, then each field's
    missing bits will have 10 bits (2 bytes).
```