### PR TITLE
[batch] fix batch tests in deployment

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -53,7 +53,10 @@ class Test(unittest.TestCase):
 
     def test_msec_mcpu(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '100m'}
+        resources = {
+            'cpu': '100m',
+            'memory': '375M'
+        }
         # two jobs so the batch msec_mcpu computation is non-trivial
         builder.create_job('ubuntu:18.04', ['echo', 'foo'], resources=resources)
         builder.create_job('ubuntu:18.04', ['echo', 'bar'], resources=resources)


### PR DESCRIPTION
Sorry, attempt #2.  Batch currently keeps the cpu/memory ratio constant, and the default memory is 3.75G (= 1 core), so in spite of setting the cpu=100m, it was still getting 1 core.