### PR TITLE
[admin-pod] add admin pod

### DIFF
--- a/admin-pod/.gitignore
+++ b/admin-pod/.gitignore
@@ -1,0 +1,1 @@
+/admin-pod.yaml.out

--- a/admin-pod/Makefile
+++ b/admin-pod/Makefile
@@ -1,0 +1,9 @@
+PROJECT := $(shell gcloud config get-value project)
+
+SERVICE_BASE_IMAGE = gcr.io/$(PROJECT)/service-base:$(shell docker images -q --no-trunc service-base:latest | sed -e 's,[^:]*:,,')
+
+.PHONY: deploy
+deploy:
+	make -C ../docker push
+	python3 ../ci/jinja2_render.py '{"service_base_image":{"image":"$(SERVICE_BASE_IMAGE)"}}' admin-pod.yaml admin-pod.yaml.out
+	kubectl -n default apply -f admin-pod.yaml.out

--- a/admin-pod/admin-pod.yaml
+++ b/admin-pod/admin-pod.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin-pod
+  template:
+    metadata:
+      labels:
+        app: admin-pod
+    spec:
+      containers:
+       - name: admin-pod
+         command:
+          - bash
+          - -c
+          - |
+              ln -s /sql-config/sql-config.cnf $HOME/.my.cnf
+              while true; do sleep 1000; done
+         image: {{ service_base_image.image }}
+         imagePullPolicy: Always
+         volumeMounts:
+          - name: deploy-config
+            mountPath: /deploy-config
+            readOnly: true
+          - name: sql-config
+            mountPath: /sql-config
+            readOnly: true
+      volumes:
+       - name: deploy-config
+         secret:
+           secretName: deploy-config
+       - name: sql-config
+         secret:
+           secretName: database-server-config

--- a/admin-pod/admin-pod.yaml
+++ b/admin-pod/admin-pod.yaml
@@ -21,7 +21,6 @@ spec:
               ln -s /sql-config/sql-config.cnf $HOME/.my.cnf
               while true; do sleep 1000; done
          image: {{ service_base_image.image }}
-         imagePullPolicy: Always
          volumeMounts:
           - name: deploy-config
             mountPath: /deploy-config

--- a/build.yaml
+++ b/build.yaml
@@ -198,6 +198,17 @@ steps:
     - batch_pods_ns
     - base_image
     - deploy_default_admin_admin
+ - kind: deploy
+   name: deploy_admin_pod
+   namespace:
+     valueFrom: default_ns.name
+   config: admin-pod/admin-pod.yaml
+   scope:
+    - deploy
+    - dev
+   dependsOn:
+    - default_ns
+    - create_deploy_config
  - kind: runImage
    name: create_session_key
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -208,6 +208,7 @@ steps:
     - dev
    dependsOn:
     - default_ns
+    - service_base_image
     - create_deploy_config
  - kind: runImage
    name: create_session_key


### PR DESCRIPTION
This is a pod running in default that mounts deploy-config and database-server-config.  `mysql` will connect to the database as root.  Useful for troubleshooting.  I often have it running, but figure it should be official.

Doesn't run in test since it doesn't have a database-server-config.