### PR TITLE
[hail] Add packed integer EType

### DIFF
--- a/hail/src/main/java/is/hail/utils/IntPacker.java
+++ b/hail/src/main/java/is/hail/utils/IntPacker.java
@@ -1,0 +1,108 @@
+package is.hail.utils;
+
+import is.hail.annotations.Region;
+
+public class IntPacker {
+    public int shift = 0;
+    public int key = 0;
+    public int ki = 0;
+    public int di = 0;
+    public byte[] keys = null;
+    public byte[] data = null;
+
+    public void ensureSpace(int keyLen, int dataLen) {
+        if (keys == null || keyLen > keys.length) {
+            keys = new byte[keyLen];
+        }
+
+        if (data == null || dataLen > data.length) {
+            data = new byte[dataLen];
+        }
+    }
+
+    public void resetPack() {
+        shift = 0;
+        key = 0;
+        ki = 0;
+        di = 0;
+    }
+
+    // assumes that keys and data are properly initialized
+    public void resetUnpack() {
+        shift = 0;
+        ki = 1;
+        di = 0;
+        if (keys.length > 0) {
+            key = (int)keys[0] & 0xFF;
+        } else {
+            key = 0;
+        }
+    }
+
+    public void pack(long addr) {
+        if (shift == 8) {
+            shift = 0;
+            keys[ki] = (byte)key;
+            ki += 1;
+            key = 0;
+        }
+
+        int code;
+        int v = Region.loadInt(addr);
+        if (v > 0 && v < (1 << 8)) {
+            code = 0;
+        } else if (v > 0 && v < (1 << 16)) {
+            code = 1;
+        } else if (v > 0 && v < (1 << 24)) {
+            code = 2;
+        } else {
+            code = 3;
+        }
+
+        Region.loadBytes(addr, data, di, code + 1);
+        key |= code << shift;
+        di += code + 1;
+        shift += 2;
+    }
+
+    public void finish() {
+        if (keys.length == 0)
+            return;
+
+        keys[ki] = (byte)key;
+        ki += 1;
+    }
+
+    public void unpack(long addr) {
+        if (shift == 8) {
+            shift = 0;
+            key = ((int)keys[ki]) & 0xFF;
+            ki += 1;
+        }
+
+        switch ((key >> shift) & 0x3) {
+            case 0:
+                Region.storeByte(addr, data[di]);
+                Region.setMemory(addr + 1, 3L, (byte)0);
+                di += 1;
+                break;
+            case 1:
+                Region.storeBytes(addr, data, di, 2);
+                Region.setMemory(addr + 2, 2L, (byte)0);
+                di += 2;
+                break;
+            case 2:
+                Region.storeBytes(addr, data, di, 3);
+                Region.storeByte(addr + 3, (byte)0);
+                di += 3;
+                break;
+            case 3:
+                Region.storeBytes(addr, data, di, 4);
+                di += 4;
+                break;
+            default:
+                throw new HailException("unreachable code reached, this is a bug");
+        }
+        shift += 2;
+    }
+}

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -827,7 +827,8 @@ class HailFeatureFlags {
     mutable.Map[String, String](
       "lower" -> sys.env.getOrElse("HAIL_DEV_LOWER", null),
       "max_leader_scans" -> sys.env.getOrElse("HAIL_DEV_MAX_LEADER_SCANS", "1000"),
-      "jvm_bytecode_dump" -> sys.env.getOrElse("HAIL_DEV_JVM_BYTECODE_DUMP", null)
+      "jvm_bytecode_dump" -> sys.env.getOrElse("HAIL_DEV_JVM_BYTECODE_DUMP", null),
+      "use_packed_int_encoding" -> sys.env.getOrElse("HAIL_DEV_USE_PACKED_INT_ENCODING", null)
     )
 
   val available: java.util.ArrayList[String] =

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -157,5 +157,5 @@ case class MatrixTableSpec(
 }
 
 object FileFormat {
-  val version: SemanticVersion = SemanticVersion(1, 3, 0)
+  val version: SemanticVersion = SemanticVersion(1, 4, 0)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -39,7 +39,7 @@ class StagedBlockLinkedList(val elemType: PType, val fb: EmitFunctionBuilder[_])
   type Node = Code[Long]
 
   val bufferType = PArray(elemType, required = true)
-  val bufferEType = EType.defaultFromPType(bufferType).asInstanceOf[EArray]
+  val bufferEType = EArray(EType.defaultFromPType(elemType), required = true)
 
   val nodeType = PStruct(
     "buf" -> bufferType,

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EPackedIntArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EPackedIntArray.scala
@@ -1,0 +1,128 @@
+package is.hail.expr.types.encoded
+
+import is.hail.annotations.{Region, UnsafeUtils}
+import is.hail.asm4s._
+import is.hail.expr.types.BaseType
+import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual._
+import is.hail.io.{InputBuffer, OutputBuffer}
+import is.hail.utils._
+
+final case class EPackedIntArray(
+  override val required: Boolean = false,
+  val elementsRequired: Boolean
+) extends EType {
+  override def _compatible(pt: PType): Boolean = {
+    pt.required == required &&
+      pt.isInstanceOf[PArray] &&
+      EInt32(elementsRequired).decodeCompatible(pt.asInstanceOf[PArray].elementType)
+  }
+
+  def _decodedPType(requestedType: Type): PType = EArray(EInt32(elementsRequired), required)._decodedPType(requestedType)
+
+  def _buildDecoder(pt: PType, mb: MethodBuilder, region: Code[Region], in: Code[InputBuffer]): Code[_] = {
+    val pa = pt.asInstanceOf[PArray]
+
+    val i = mb.newLocal[Int]("i")
+    val len = mb.newLocal[Int]("len")
+    val n = mb.newLocal[Int]("n")
+    val dlen = mb.newLocal[Int]("dlen")
+    val klen = mb.newLocal[Int]("klen")
+    val array = mb.newLocal[Long]("array")
+    val keys = mb.newLocal[Array[Byte]]("keys")
+    val data = mb.newLocal[Array[Byte]]("data")
+    val unpacker = mb.newLocal[IntPacker]("unpacker")
+
+    Code.concat[Long](
+      unpacker := getPacker(mb).load(),
+      len := in.readInt(),
+      array := pa.allocate(region, len),
+      pa.storeLength(array, len),
+      if (elementsRequired)
+        Code._empty
+      else
+        in.readBytes(region, array + const(pa.lengthHeaderBytes), pa.nMissingBytes(len)),
+      dlen := in.readInt(),
+      if (elementsRequired)
+        n := len
+      else
+        Code(
+          i := 0,
+          n := 0,
+          Code.whileLoop(i < len,
+            Code(
+              n := n + pa.isElementDefined(array, i).toI,
+              i := i + 1))),
+      klen := (n + const(3)) / const(4),
+      dlen := dlen - klen,
+      unpacker.load().ensureSpace(klen, dlen),
+      in.read(unpacker.load().keys, 0, klen),
+      in.read(unpacker.load().data, 0, dlen),
+      unpacker.load().resetUnpack(),
+      i := 0,
+      Code.whileLoop(i < len,
+        Code(
+          pa.isElementDefined(array, i).mux(
+            unpacker.invoke[Long, Unit]("unpack", pa.elementOffset(array, len, i)),
+            Code._empty),
+          i := i + 1
+        )),
+      array)
+  }
+
+  def _buildSkip(mb: MethodBuilder, r: Code[Region], in: Code[InputBuffer]): Code[Unit] = {
+    val len = mb.newLocal[Int]("len")
+
+    Code(
+      len := in.readInt(),
+      if (elementsRequired)
+        Code._empty
+      else
+        in.skipBytes(UnsafeUtils.packBitsToBytes(len)),
+      len := in.readInt(),
+      in.skipBytes(len)
+    )
+  }
+
+  def _buildEncoder(pt: PType, mb: MethodBuilder, v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
+    val pa = pt.asInstanceOf[PArray]
+
+    val packer = mb.newLocal[IntPacker]("packer")
+    val len = mb.newLocal[Int]("len")
+    val i = mb.newLocal[Int]("i")
+    val array = coerce[Long](v)
+    val keysLen = mb.newLocal[Int]("keysLen")
+    val dataLen = mb.newLocal[Int]("dataLen")
+
+    Code.concat[Unit](
+      packer := getPacker(mb).load(),
+      len := pa.loadLength(array),
+      out.writeInt(len),
+      if (elementsRequired)
+        Code._empty
+      else
+        out.writeBytes(array + const(pa.lengthHeaderBytes), pa.nMissingBytes(len)),
+      keysLen := (len + const(3)) / const(4),
+      dataLen := len * const(4),
+      packer.load().ensureSpace(keysLen, dataLen),
+      packer.load().resetPack(),
+      i := 0,
+      Code.whileLoop(i < len,
+          Code(
+            pa.isElementDefined(array, i).mux(
+              packer.invoke[Long, Unit]("pack", pa.elementOffset(array, len, i)),
+              Code._empty),
+            i := i + const(1))),
+      packer.load().finish(),
+      out.writeInt(packer.load().ki + packer.load().di),
+      out.write(packer.load().keys, const(0), packer.load().ki),
+      out.write(packer.load().data, const(0), packer.load().di))
+  }
+
+  def _asIdent: String = s"packedintarray_w_${if (elementsRequired) "required" else "optional"}_elements"
+  def _toPretty: String = s"EPackedIntArray[${if (elementsRequired) "True" else "False"}]"
+
+  private def getPacker(mb: MethodBuilder): LazyFieldRef[IntPacker] = {
+    mb.fb.getOrDefineLazyField[IntPacker](Code.newInstance[IntPacker], "thePacker")
+  }
+}

--- a/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
+++ b/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
@@ -113,6 +113,12 @@ final class MemoryBuffer extends Serializable {
     pos += n
   }
 
+  def readBytesArray(dst: Array[Byte], n: Int) {
+    assert(pos + n <= end)
+    System.arraycopy(mem, pos, dst, 0, n);
+    pos += n
+  }
+
   def skipByte() {
     assert(pos + 1 <= end)
     pos += 1

--- a/hail/src/main/scala/is/hail/io/OutputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/OutputBuffers.scala
@@ -17,6 +17,16 @@ trait OutputBuffer extends Closeable {
 
   def writeByte(b: Byte): Unit
 
+  def write(buf: Array[Byte]): Unit = write(buf, 0, buf.length)
+
+  def write(buf: Array[Byte], startPos: Int, endPos: Int): Unit = {
+    var i = startPos
+    while (i < endPos) {
+      writeByte(buf(i))
+      i += 1
+    }
+  }
+
   def writeInt(i: Int): Unit
 
   def writeLong(l: Long): Unit

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -8,7 +8,7 @@ import is.hail.asm4s.{Code, Value}
 import is.hail.io.{InputBuffer, OutputBuffer, RichContextRDDRegionValue}
 import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
-import is.hail.utils.{HailIterator, MultiArray2, Truncatable, WithContext}
+import is.hail.utils.{IntPacker, HailIterator, MultiArray2, Truncatable, WithContext}
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix
 import org.apache.spark.rdd.RDD
@@ -125,4 +125,6 @@ trait Implicits {
   implicit def toRichCodeIterator[T](it: Code[Iterator[T]]): RichCodeIterator[T] = new RichCodeIterator[T](it)
 
   implicit def valueToRichCodeIterator[T](it: Value[Iterator[T]]): RichCodeIterator[T] = new RichCodeIterator[T](it)
+
+  implicit def toRichCodeIntPacker(p: Code[IntPacker]): RichCodeIntPacker = new RichCodeIntPacker(p)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -12,6 +12,10 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
     in.invoke[Byte]("readByte")
   }
 
+  def read(buf: Code[Array[Byte]], toOff: Code[Int], n: Code[Int]): Code[Unit] = {
+    in.invoke[Array[Byte], Int, Int, Unit]("read", buf, toOff, n)
+  }
+
   def readBoolean(): Code[Boolean] = {
     in.invoke[Boolean]("readBoolean")
   }
@@ -45,6 +49,8 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
     else
     in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
   }
+
+  def readBytesArray(n: Code[Int]): Code[Array[Byte]] = in.invoke[Int, Array[Byte]]("readBytesArray", n)
 
   def skipBoolean(): Code[Unit] = in.invoke[Unit]("skipBoolean")
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeIntPacker.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeIntPacker.scala
@@ -1,0 +1,20 @@
+package is.hail.utils.richUtils
+
+import is.hail.annotations.Region
+import is.hail.asm4s.Code
+import is.hail.utils.IntPacker
+
+class RichCodeIntPacker(val p: Code[IntPacker]) extends AnyVal {
+  def ki: Code[Int] = p.getField[Int]("ki")
+  def di: Code[Int] = p.getField[Int]("di")
+  def keys: Code[Array[Byte]] = p.getField[Array[Byte]]("keys")
+  def data: Code[Array[Byte]] = p.getField[Array[Byte]]("data")
+
+  def ensureSpace(keyLen: Code[Int], dataLen: Code[Int]): Code[Unit] = p.invoke[Int, Int, Unit]("ensureSpace", keyLen, dataLen)
+  def resetPack(): Code[Unit] = p.invoke[Unit]("resetPack")
+  def resetUnpack(): Code[Unit] = p.invoke[Unit]("resetUnpack")
+
+  def pack(addr: Code[Long]): Code[Unit] = p.invoke[Long, Unit]("pack", addr)
+  def finish(): Code[Unit] = p.invoke[Unit]("finish")
+  def unpack(addr: Code[Long]): Code[Unit] = p.invoke[Long, Unit]("unpack", addr)
+}

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -14,6 +14,14 @@ class RichCodeOutputBuffer(out: Code[OutputBuffer]) {
     out.invoke[Byte, Unit]("writeByte", b)
   }
 
+  def write(buf: Code[Array[Byte]]): Code[Unit] = {
+    out.invoke[Array[Byte], Unit]("write", buf)
+  }
+
+  def write(buf: Code[Array[Byte]], startPos: Code[Int], endPos: Code[Int]): Code[Unit] = {
+    out.invoke[Array[Byte], Int, Int, Unit]("write", buf, startPos, endPos)
+  }
+
   def writeInt(i: Code[Int]): Code[Unit] = {
     out.invoke[Int, Unit]("writeInt", i)
   }


### PR DESCRIPTION
We use Lemire et al.'s Stream VByte algorithm, as described in 
https://arxiv.org/abs/1709.08990

```
Encoded Format:
  int (length)
  missing bits (if necessary)
  int (length of control bytes)
  int (length of data bytes)
  control bytes
  data bytes
```

This was split off from continuted development on top of #7803, ideally they should be merged together.