### PR TITLE
[hail/ptypes] add initialize and stagedInitialize methods to PBaseStruct

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -109,7 +109,7 @@ class RegionValueBuilder(var region: Region) {
     indexstk.push(0)
 
     if (init)
-      t.clearMissingBits(region, off)
+      t.initialize(off)
   }
 
   def endBaseStruct() {

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -189,7 +189,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
     if (t.size > 0)
       c = Code(c, elementsOffset := startOffset + t.byteOffsets(0))
     if (init)
-      c = Code(c, t.clearMissingBits(region, startOffset))
+      c = Code(c, t.stagedInitialize(startOffset))
     c
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -37,8 +37,8 @@ class AppendOnlyBTree(fb: EmitFunctionBuilder[_], key: BTreeKey, region: Code[Re
 
   private def createNode(nodeBucket: Settable[Long]): Code[Unit] = Code(
     nodeBucket := region.allocate(storageType.alignment, storageType.byteSize),
-    storageType.setAllMissing(nodeBucket),
-    elementsType.setAllMissing(elements(nodeBucket)))
+    storageType.stagedInitialize(nodeBucket, true),
+    elementsType.stagedInitialize(elements(nodeBucket), true))
 
   private def isRoot(node: Code[Long]): Code[Boolean] = storageType.isFieldMissing(node, 0)
   private def isLeaf(node: Code[Long]): Code[Boolean] = storageType.isFieldMissing(node, 1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -31,7 +31,7 @@ class TypedKey(typ: PType, fb: EmitFunctionBuilder[_], region: Code[Region]) ext
     if (!typ.required)
       m.mux(
         Code(storageType.setFieldPresent(dest, 1), storageType.setFieldMissing(dest, 0)),
-        Code(storageType.clearMissingBits(dest), c))
+        Code(storageType.stagedInitialize(dest), c))
     else
       Code(storageType.setFieldPresent(dest, 1), c)
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -165,25 +165,6 @@ abstract class PBaseStruct extends PType {
     Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if (setMissing) 0xFF.toByte else 0.toByte))
   }
 
-  def clearMissingBits(region: Region, off: Long) {
-    if (allFieldsRequired) {
-      return
-    }
-
-    Region.setMemory(off, nMissingBytes.toLong, 0.toByte)
-  }
-
-  def clearMissingBits(off: Code[Long]): Code[Unit] = {
-    if (allFieldsRequired) {
-      return Code._empty
-    }
-
-    Region.setMemory(off, const(nMissingBytes.toLong), const(0.toByte))
-  }
-
-  def clearMissingBits(region: Code[Region], off: Code[Long]): Code[Unit] =
-    clearMissingBits(off)
-
   def isFieldDefined(rv: RegionValue, fieldIdx: Int): Boolean =
     isFieldDefined(rv.region, rv.offset, fieldIdx)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -150,23 +150,23 @@ abstract class PBaseStruct extends PType {
   def allocate(region: Code[Region]): Code[Long] = region.allocate(alignment, byteSize)
 
   def initialize(structAddress: Long, setMissing: Boolean = false): Unit = {
-    if(allFieldsRequired) {
+    if (allFieldsRequired) {
       return
     }
 
-    Region.setMemory(structAddress, nMissingBytes.toLong, if(setMissing) 0xFF.toByte else 0.toByte)
+    Region.setMemory(structAddress, nMissingBytes.toLong, if (setMissing) 0xFF.toByte else 0.toByte)
   }
 
   def stagedInitialize(structAddress: Code[Long], setMissing: Boolean = false): Code[Unit] = {
-    if(allFieldsRequired) {
+    if (allFieldsRequired) {
       return Code._empty
     }
 
-    Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if(setMissing) 0xFF.toByte else 0.toByte))
+    Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if (setMissing) 0xFF.toByte else 0.toByte))
   }
 
   def clearMissingBits(region: Region, off: Long) {
-    if(allFieldsRequired) {
+    if (allFieldsRequired) {
       return
     }
 
@@ -174,7 +174,7 @@ abstract class PBaseStruct extends PType {
   }
 
   def clearMissingBits(off: Code[Long]): Code[Unit] = {
-    if(allFieldsRequired) {
+    if (allFieldsRequired) {
       return Code._empty
     }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -149,12 +149,20 @@ abstract class PBaseStruct extends PType {
 
   def allocate(region: Code[Region]): Code[Long] = region.allocate(alignment, byteSize)
 
-  def stagedInitialize(structAddress: Code[Long], allMissing: Boolean = false): Code[Unit] = {
+  def initialize(structAddress: Long, setMissing: Boolean = false): Unit = {
+    if(allFieldsRequired) {
+      return
+    }
+
+    Region.setMemory(structAddress, nMissingBytes.toLong, if(setMissing) 0xFF.toByte else 0.toByte)
+  }
+
+  def stagedInitialize(structAddress: Code[Long], setMissing: Boolean = false): Code[Unit] = {
     if(allFieldsRequired) {
       return Code._empty
     }
 
-    Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if(allMissing) 0xFF.toByte else 0.toByte))
+    Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if(setMissing) 0xFF.toByte else 0.toByte))
   }
 
   def clearMissingBits(region: Region, off: Long) {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -149,12 +149,12 @@ abstract class PBaseStruct extends PType {
 
   def allocate(region: Code[Region]): Code[Long] = region.allocate(alignment, byteSize)
 
-  def setAllMissing(off: Code[Long]): Code[Unit] = {
+  def stagedInitialize(structAddress: Code[Long], allMissing: Boolean = false): Code[Unit] = {
     if(allFieldsRequired) {
       return Code._empty
     }
 
-    Region.setMemory(off, const(nMissingBytes.toLong), const(0xFF.toByte))
+    Region.setMemory(structAddress, const(nMissingBytes.toLong), const(if(allMissing) 0xFF.toByte else 0.toByte))
   }
 
   def clearMissingBits(region: Region, off: Long) {

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -24,7 +24,7 @@ class TestBTreeKey(mb: EmitMethodBuilder) extends BTreeKey {
 
   def storeKey(off: Code[Long], m: Code[Boolean], v: Code[Long]): Code[Unit] =
     Code(
-      storageType.clearMissingBits(off),
+      storageType.stagedInitialize(off),
       m.mux(
         storageType.setFieldMissing(off, 0),
         Region.storeLong(storageType.fieldOffset(off, 0), v)))


### PR DESCRIPTION
Replaces setAllMissing (1, staged-only function), clearMissingBits (3 functions with both staged and unstated implementations) with staged/non-staged initialization functions, mirroring the PContainer API.

Semantically this is more correct (for instance clearMissingBits was used mostly behind the condition like `if (init)`), and represents 2 fewer functions to maintain (3 if you count that we may have eventually wanted a setAllMissing in the non-staged world)