### PR TITLE
[batch] overschedule batch workers 2 cores

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -97,7 +97,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
             (batch_id, job_id, attempt_id, instance_name, new_state,
              json.dumps(status) if status is not None else None,
              start_time, end_time, reason, now))
-    except:
+    except Exception:
         log.exception(f'error while marking job {id} complete on instance {instance_name}')
         raise
 
@@ -138,7 +138,7 @@ async def mark_job_started(app, batch_id, job_id, attempt_id, instance, start_ti
     CALL mark_job_started(%s, %s, %s, %s, %s);
     ''',
             (batch_id, job_id, attempt_id, instance.name, start_time))
-    except:
+    except Exception:
         log.exception(f'error while marking job {id} started on {instance}')
         raise
 
@@ -198,7 +198,7 @@ async def unschedule_job(app, record):
         rv = await db.execute_and_fetchone(
             'CALL unschedule_job(%s, %s, %s, %s, %s, %s);',
             (batch_id, job_id, attempt_id, instance_name, end_time, 'cancelled'))
-    except:
+    except Exception:
         log.exception(f'error while unscheduling job {id} on instance {instance_name}')
         raise
 
@@ -383,7 +383,7 @@ async def schedule_job(app, record, instance):
 CALL schedule_job(%s, %s, %s, %s);
 ''',
             (batch_id, job_id, attempt_id, instance.name))
-    except:  # pylint: disable=bare-except
+    except Exception:
         log.exception(f'error while scheduling job {id} on {instance}')
         if instance.state == 'active':
             instance.adjust_free_cores_in_memory(record['cores_mcpu'])


### PR DESCRIPTION
Overschedule batch workers by 2 cores.  Changes:
 - `free_cores_mcpu` in `compute_fair_share` includes the overschedule cores, which will get allocated to users, and
 - when scheduling, schedule if the job fits on the node with the overschedule cores, or the node is not yet overscheduled.  This allows us to overschedule jobs that need >2 cores.

This shouldn't go in until after @jigold's parallel scheduler PR.

FYI @danking 
