### PR TITLE
[batch] satisfy as many items as possible in fifo sem

### DIFF
--- a/batch/batch/semaphore.py
+++ b/batch/batch/semaphore.py
@@ -45,12 +45,14 @@ class FIFOWeightedSemaphore:
     def release(self, weight):
         self.value += weight
 
-        if self.queue:
+        while self.queue:
             head_event, head_weight = self.queue[0]
             if self.value >= head_weight:
                 head_event.set()
                 self.queue.popleft()
                 self.value -= head_weight
+            else:
+                break
 
     def __call__(self, weight):
         return FIFOWeightedSemaphoreContextManager(self, weight)


### PR DESCRIPTION
This fixes a bug in the fifo sem.  If we release a large job, we would only start at most 1, not as many as we could.  This could actually lead to worker deadlock.
