### PR TITLE
[hail] Don't let TableOrderBy blow away already-sorted TableKeyBy nodes

### DIFF
--- a/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
@@ -67,6 +67,11 @@ def matrix_table_take_entry(mt_path):
     mt = hl.read_matrix_table(mt_path)
     mt.GT.take(100)
 
+@benchmark(args=profile_25.handle('mt'))
+def matrix_table_entries_show(mt_path):
+    mt = hl.read_matrix_table(mt_path)
+    mt.entries().show()
+
 
 @benchmark(args=profile_25.handle('mt'))
 def matrix_table_take_row(mt_path):

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -543,7 +543,7 @@ object Simplify {
     case TableFilter(TableKeyBy(child, key, isSorted), p) if canRepartition => TableKeyBy(TableFilter(child, p), key, isSorted)
     case TableFilter(TableRepartition(child, n, strategy), p) => TableRepartition(TableFilter(child, p), n, strategy)
 
-    case TableOrderBy(TableKeyBy(child, _, _), sortFields) => TableOrderBy(child, sortFields)
+    case TableOrderBy(TableKeyBy(child, _, false), sortFields) => TableOrderBy(child, sortFields)
 
     case TableFilter(TableOrderBy(child, sortFields), pred) if canRepartition =>
       TableOrderBy(TableFilter(child, pred), sortFields)


### PR DESCRIPTION
Fixes O(N) performance of mt.entries().show()