### PR TITLE
[hail] Rewrite PType.subsetTo to avoid using `canonical`, which is wrong

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -33,13 +33,6 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
   val kRowOrd: UnsafeOrdering =
     RVDType.selectUnsafeOrdering(kType, Array.range(0, kType.size), rowType, kFieldIdx)
 
-  def subsetTo(requestedType: TStruct): RVDType = {
-    RVDType(
-      rowType.subsetTo(requestedType).asInstanceOf[PStruct],
-      key.takeWhile(requestedType.hasField)
-    )
-  }
-
   def kComp(other: RVDType): UnsafeOrdering =
     RVDType.selectUnsafeOrdering(
       this.rowType,


### PR DESCRIPTION
Stacked on #7869