### PR TITLE
[batch] insertion progress bars

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -35,6 +35,7 @@ python-json-logger==0.1.11
 requests==2.22.0
 sortedcontainers==2.1.0
 tabulate==0.8.3
+tqdm==4.41.1
 urllib3==1.24.3
 uvloop==0.12.2
 Werkzeug==0.15.4

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -16,8 +16,6 @@ from .globals import tasks, complete_states
 
 log = logging.getLogger('batch_client.aioclient')
 log.setLevel('WARNING')
-# To tqdm_notebook, None means do not display. To standard tqdm, None means
-# display only when connected to a TTY.
 
 
 class Job:
@@ -506,7 +504,6 @@ class BatchBuilder:
                 bunch_n_jobs = 1
         if bunch:
             byte_job_specs_bunches.append(bunch)
-
             bunch_sizes.append(bunch_n_jobs)
 
         with tqdm(total=len(self._job_specs),

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -10,12 +10,14 @@ from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import async_get_userinfo, service_auth_headers
-from hailtop.utils import bounded_gather, request_retry_transient_errors
+from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
 
 from .globals import tasks, complete_states
 
 log = logging.getLogger('batch_client.aioclient')
 log.setLevel('WARNING')
+# To tqdm_notebook, None means do not display. To standard tqdm, None means
+# display only when connected to a TTY.
 
 
 class Job:
@@ -301,10 +303,11 @@ class SubmittedJob:
 
 
 class Batch:
-    def __init__(self, client, id, attributes):
+    def __init__(self, client, id, attributes, n_jobs):
         self._client = client
         self.id = id
         self.attributes = attributes
+        self.n_jobs = n_jobs
 
     async def cancel(self):
         await self._client._patch(f'/api/v1alpha/batches/{self.id}/cancel')
@@ -327,17 +330,21 @@ class Batch:
         resp = await self._client._get(f'/api/v1alpha/batches/{self.id}')
         return await resp.json()
 
-    async def wait(self):
+    async def wait(self, *, disable_progress_bar=TQDM_DEFAULT_DISABLE):
         i = 0
-        while True:
-            status = await self.status()
-            if status['complete']:
-                return status
-            j = random.randrange(math.floor(1.1 ** i))
-            await asyncio.sleep(0.100 * j)
-            # max 44.5s
-            if i < 64:
-                i = i + 1
+        with tqdm(total=self.n_jobs,
+                  disable=disable_progress_bar,
+                  desc='completed jobs') as pbar:
+            while True:
+                status = await self.status()
+                pbar.update(status['n_completed'] - pbar.n)
+                if status['complete']:
+                    return status
+                j = random.randrange(math.floor(1.1 ** i))
+                await asyncio.sleep(0.100 * j)
+                # max 44.5s
+                if i < 64:
+                    i = i + 1
 
     async def delete(self):
         await self._client._delete(f'/api/v1alpha/batches/{self.id}')
@@ -425,7 +432,7 @@ class BatchBuilder:
         self._jobs.append(j)
         return j
 
-    async def _submit_jobs(self, batch_id, byte_job_specs):
+    async def _submit_jobs(self, batch_id, byte_job_specs, n_jobs, pbar):
         assert len(byte_job_specs) > 0, byte_job_specs
 
         b = bytearray()
@@ -445,27 +452,29 @@ class BatchBuilder:
             f'/api/v1alpha/batches/{batch_id}/jobs/create',
             data=aiohttp.BytesPayload(
                 b, content_type='application/json', encoding='utf-8'))
+        pbar.update(n_jobs)
 
     async def _create(self, batch_token=None):
         batch_token = batch_token or secrets.token_urlsafe(32)
+        n_jobs = len(self._job_specs)
         batch_spec = {'billing_project': self._client.billing_project,
-                      'n_jobs': len(self._job_specs),
+                      'n_jobs': n_jobs,
                       'token': batch_token}
         if self.attributes:
             batch_spec['attributes'] = self.attributes
         if self.callback:
             batch_spec['callback'] = self.callback
-
         batch_json = await (await self._client._post('/api/v1alpha/batches/create',
                                                      json=batch_spec)).json()
-        return Batch(self._client, batch_json['id'], self.attributes)
+        return Batch(self._client, batch_json['id'], self.attributes, n_jobs)
 
     MAX_BUNCH_BYTESIZE = 8 * 1024 * 1024 - 512 * 1024  # max request size minus room for headers etc
     MAX_BUNCH_SIZE = 8 * 1024  # ???
 
     async def submit(self,
                      max_bunch_bytesize=MAX_BUNCH_BYTESIZE,
-                     max_bunch_size=MAX_BUNCH_SIZE):
+                     max_bunch_size=MAX_BUNCH_SIZE,
+                     disable_progress_bar=TQDM_DEFAULT_DISABLE):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0
         if self._submitted:
@@ -477,10 +486,12 @@ class BatchBuilder:
         id = batch.id
 
         byte_job_specs_bunches = []
+        bunch_sizes = []
         byte_job_specs = [json.dumps(job_spec).encode('utf-8')
                           for job_spec in self._job_specs]
         bunch = []
         bunch_n_bytes = 0
+        bunch_n_jobs = 0
         for spec in byte_job_specs:
             n_bytes = len(spec)
             assert n_bytes < max_bunch_bytesize, (
@@ -489,16 +500,21 @@ class BatchBuilder:
             if bunch_n_bytes + n_bytes < max_bunch_bytesize and len(bunch) < max_bunch_size:
                 bunch.append(spec)
                 bunch_n_bytes += n_bytes
+                bunch_n_jobs += 1
             else:
                 byte_job_specs_bunches.append(bunch)
+                bunch_sizes.append(bunch_n_jobs)
                 bunch = [spec]
                 bunch_n_bytes = n_bytes
+                bunch_n_jobs = 1
         if bunch:
             byte_job_specs_bunches.append(bunch)
 
+            bunch_sizes.append(bunch_n_jobs)
+
         await bounded_gather(
-            *[functools.partial(self._submit_jobs, id, bunch)
-              for bunch in byte_job_specs_bunches],
+            *[functools.partial(self._submit_jobs, id, bunch, size)
+              for bunch, size in zip(byte_job_specs_bunches, bunch_sizes)],
             parallelism=50)
 
         await self._client._patch(f'/api/v1alpha/batches/{id}/close')
@@ -576,7 +592,7 @@ class BatchClient:
             body = await resp.json()
 
             for batch in body['batches']:
-                yield Batch(self, batch['id'], attributes=batch.get('attributes'))
+                yield Batch(self, batch['id'], attributes=batch.get('attributes'), n_jobs=int(batch['n_jobs']))
             last_batch_id = body.get('last_batch_id')
             if last_batch_id is None:
                 break
@@ -597,7 +613,8 @@ class BatchClient:
         b = await b_resp.json()
         return Batch(self,
                      b['id'],
-                     attributes=b.get('attributes'))
+                     attributes=b.get('attributes'),
+                     n_jobs=int(b['n_jobs']))
 
     def create_batch(self, attributes=None, callback=None):
         return BatchBuilder(self, attributes, callback)

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -98,8 +98,8 @@ class Batch:
         b._async_batch = batch
         return b
 
-    def __init__(self, client, id, attributes):
-        self._async_batch = aioclient.Batch(client, id, attributes)
+    def __init__(self, client, id, attributes, n_jobs):
+        self._async_batch = aioclient.Batch(client, id, attributes, n_jobs)
 
     @property
     def id(self):

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -353,3 +353,4 @@ class BatchBackend(Backend):
             print(f'Waiting for batch {batch.id}...')
             status = batch.wait()
             print(f'Batch {batch.id} complete: {status["state"]}')
+        return batch

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -313,7 +313,7 @@ class BatchBackend(Backend):
 
         if dry_run:
             print("\n\n".join(commands))
-            return
+            return None
 
         if delete_scratch_on_exit and used_remote_tmpdir:
             parents = list(jobs_to_command.keys())

--- a/hail/python/hailtop/pipeline/pipeline.py
+++ b/hail/python/hailtop/pipeline/pipeline.py
@@ -391,7 +391,7 @@ class Pipeline:
                     raise PipelineException("cycle detected in dependency graph")
 
         self._tasks = ordered_tasks
-        self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)
+        return self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)
 
     def __str__(self):
         return self._uid

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -4,6 +4,7 @@ from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     request_retry_transient_errors, request_raise_transient_errors, \
     collect_agen, retry_forever, retry_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
+from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 
 __all__ = [
     'time_msecs',
@@ -24,5 +25,7 @@ __all__ = [
     'request_retry_transient_errors',
     'request_raise_transient_errors',
     'collect_agen',
-    'retry_forever'
+    'retry_forever',
+    'tqdm',
+    'TQDM_DEFAULT_DISABLE'
 ]

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,6 +1,8 @@
 from tqdm.notebook import tqdm as tqdm_notebook
 from tqdm.auto import tqdm as tqdm_auto
 
+# To tqdm_notebook, None means do not display. To standard tqdm, None means
+# display only when connected to a TTY.
 TQDM_DEFAULT_DISABLE = False if tqdm_auto == tqdm_notebook else None
 
 

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,0 +1,8 @@
+from tqdm.notebook import tqdm as tqdm_notebook
+from tqdm.auto import tqdm as tqdm_auto
+
+TQDM_DEFAULT_DISABLE = False if tqdm_auto == tqdm_notebook else None
+
+
+def tqdm(*args, disable=TQDM_DEFAULT_DISABLE, **kwargs):
+    return tqdm_auto(*args, disable=disable, **kwargs)


### PR DESCRIPTION
Progress bars for batch submit (which work even if individual bunches fail).

Stacked on #7875

<img width="885" alt="Screen Shot 2020-01-14 at 3 53 40 PM" src="https://user-images.githubusercontent.com/106194/72382076-829e1e80-36e6-11ea-9626-1e67e5aa54ce.png">

Now also works in Jupyter Notebook (you get a GUI bar).

I added `hailtop.utils.tqdm` and `hailtop.utils.TQDM_DEFAULT_DISABLE` because the "correct" default argument for disable is different between Jupyter Notebook and the console tqdm. In particular, console tqdm treats `None` as "if I'm connected to a TTY, display, otherwise hide". Jupyter tqdm treats `None` as "do not display" (which is clearly the wrong default, but 🤷‍♀ ).