### PR TITLE
[ci] rename createDatabase2 #1

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -193,7 +193,7 @@ class Step(abc.ABC):
             return CreateNamespaceStep.from_json(params)
         if kind == 'deploy':
             return DeployStep.from_json(params)
-        if kind == 'createDatabase2' or kind == 'createDatabase':
+        if kind in ('createDatabase2', 'createDatabase2'):
             return CreateDatabaseStep.from_json(params)
         raise ValueError(f'unknown build step kind: {kind}')
 
@@ -851,11 +851,11 @@ class CreateDatabaseStep(Step):
     def from_json(params):
         json = params.json
         return CreateDatabaseStep(params,
-                                   json['databaseName'],
-                                   json['namespace'],
-                                   json['migrations'],
-                                   json.get('shutdowns', []),
-                                   json.get('inputs'))
+                                  json['databaseName'],
+                                  json['namespace'],
+                                  json['migrations'],
+                                  json.get('shutdowns', []),
+                                  json.get('inputs'))
 
     def config(self, scope):  # pylint: disable=unused-argument
         return {

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -193,8 +193,8 @@ class Step(abc.ABC):
             return CreateNamespaceStep.from_json(params)
         if kind == 'deploy':
             return DeployStep.from_json(params)
-        if kind == 'createDatabase2':
-            return CreateDatabase2Step.from_json(params)
+        if kind == 'createDatabase2' or kind == 'createDatabase':
+            return CreateDatabaseStep.from_json(params)
         raise ValueError(f'unknown build step kind: {kind}')
 
     def __eq__(self, other):
@@ -799,7 +799,7 @@ date
                                         always_run=True)
 
 
-class CreateDatabase2Step(Step):
+class CreateDatabaseStep(Step):
     def __init__(self, params, database_name, namespace, migrations, shutdowns, inputs):
         super().__init__(params)
 
@@ -850,7 +850,7 @@ class CreateDatabase2Step(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return CreateDatabase2Step(params,
+        return CreateDatabaseStep(params,
                                    json['databaseName'],
                                    json['namespace'],
                                    json['migrations'],


### PR DESCRIPTION
Now that createDatabase is gone, rename createDatabase2Step => createDatabase2, and accept createDatabase in build.yaml for creating database.  In follow up PRs, I will:
 - rename createDatabase2 => createDatabase in build.yaml,
 - don't support createDatabase2, completing the change.

I can't do this in one change because this PR is tested/deployed by the _previous_ CI, not the one in this PR, so it has to be done in stages.  Such is the microservices life. 