### PR TITLE
[hail] Support nested ArrayExpression in arguments to hl.nd.array

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4033,8 +4033,6 @@ def _ndarray(collection, row_major=None):
         else:
             return current_level_correct & (hl.all(lambda inner: check_arrays_uniform(inner, shape_list, ndim - 1), nested_arr))
 
-
-
     if isinstance(collection, Expression):
         if isinstance(collection, ArrayNumericExpression):
             data_expr = collection

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4036,6 +4036,29 @@ def _ndarray(collection, row_major=None):
             data_expr = array([collection])
             shape_expr = hl.tuple([])
             ndim = 0
+        elif isinstance(collection, ArrayExpression):
+            # step 1, determine nesting depth.
+            recursive_type = collection.dtype
+            ndim = 0
+            while isinstance(recursive_type, tarray):
+                recursive_type = recursive_type._element_type
+                ndim += 1
+
+            # step 2, flatten that many times - 1
+            flattened_collection = collection
+            #import pdb; pdb.set_trace()
+            for i in builtins.range(ndim - 1):
+                flattened_collection = hl.flatten(flattened_collection)
+            data_expr = flattened_collection
+
+            # step 3, Shape? Could just keep asking for the shape of the first element.
+            temp = collection
+            shape_list = []
+            for i in builtins.range(ndim - 1):
+                shape_list.append(hl.int64(hl.len(temp)))
+                temp = shape_list[0]
+
+            shape_expr = hl.tuple(shape_list)
         else:
             raise ValueError(f"{collection} cannot be converted into an ndarray")
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4049,10 +4049,9 @@ def _ndarray(collection, row_major=None):
                 recursive_type = recursive_type._element_type
                 ndim += 1
 
-            flattened_collection = collection
+            data_expr = collection
             for i in builtins.range(ndim - 1):
-                flattened_collection = hl.flatten(flattened_collection)
-            data_expr = flattened_collection
+                data_expr = hl.flatten(data_expr)
 
             nested_collection = collection
             shape_list = []

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -103,9 +103,14 @@ def test_ndarray_slice():
         hl.eval(flat[::0])
     assert "Slice step cannot be zero" in str(exc)
 
+
 @skip_unless_spark_backend()
 def test_ndarray_eval():
     data_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    mishapen_data_list1 = [[4], [1, 2, 3]]
+    mishapen_data_list2 = [[[1], [2, 3]]]
+    mishapen_data_list3 = [[4], [1, 2, 3], 5]
+
     nd_expr = hl.nd.array(data_list)
     evaled = hl.eval(nd_expr)
     np_equiv = np.array(data_list, dtype=np.int32)
@@ -138,7 +143,19 @@ def test_ndarray_eval():
     assert hl.eval(hl.nd.array(hl.null(hl.tarray(hl.tint32)))) is None
 
     with pytest.raises(ValueError) as exc:
-        hl.nd.array([[4], [1, 2, 3], 5])
+        hl.nd.array(mishapen_data_list1)
+    assert "inner dimensions do not match" in str(exc.value)
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(hl.nd.array(hl.array(mishapen_data_list1)))
+    assert "inner dimensions do not match" in str(exc.value)
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(hl.nd.array(hl.array(mishapen_data_list2)))
+    assert "inner dimensions do not match" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:
+        hl.nd.array(mishapen_data_list3)
     assert "inner dimensions do not match" in str(exc.value)
 
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -131,6 +131,9 @@ def test_ndarray_eval():
     assert np.array_equal(hl.eval(hl.nd.array(hl.range(6))), np.arange(6))
     assert np.array_equal(hl.eval(hl.nd.array(hl.int64(4))), np.array(4))
 
+    # Testing from nested hail arrays
+    assert np.array_equal(hl.eval(hl.nd.array(hl.array([hl.array(x) for x in data_list]))), np.arange(9).reshape((3, 3)) + 1)
+
     # Testing missing data
     assert hl.eval(hl.nd.array(hl.null(hl.tarray(hl.tint32)))) is None
 


### PR DESCRIPTION
This PR adds support for `hl.nd.array` to take an arbitrarily nested `ArrayExpression` as an argument. 