### PR TITLE
[hail] implement ReadPartitions IR node

### DIFF
--- a/hail/src/main/scala/is/hail/compatibility/LegacyBufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyBufferSpecs.scala
@@ -1,11 +1,13 @@
 package is.hail.compatibility
 
+import is.hail.asm4s.Code
 import is.hail.io.compress.LZ4
 import is.hail.io._
 
 final case class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
   def lz4 = LZ4.hc
+  def stagedlz4: Code[LZ4] = Code.invokeScalaObject[LZ4](LZ4.getClass, "hc")
   def typeName = "LZ4BlockBufferSpec"
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.annotations.Annotation
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.functions._
+import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.io.{AbstractTypedCodecSpec, BufferSpec}
@@ -445,6 +446,7 @@ final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWrite
 final case class BlockMatrixMultiWrite(blockMatrices: IndexedSeq[BlockMatrixIR], writer: BlockMatrixMultiWriter) extends IR
 
 final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
+
 final case class ReadPartition(path: IR, spec: AbstractTypedCodecSpec, rowType: TStruct) extends IR
 
 class PrimitiveIR(val self: IR) extends AnyVal {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -79,11 +79,11 @@ object LowerTableIR {
           val globalsPath = r.spec.globalsComponent.absolutePath(path)
           val globalsSpec = AbstractRVDSpec.read(HailContext.get, globalsPath)
           val gPath = AbstractRVDSpec.partPath(globalsPath, globalsSpec.partFiles.head)
-          val gSpec = globalsSpec.typedCodecSpec
+          val globals = ArrayRef(ToArray(ReadPartition(Str(gPath), globalsSpec.typedCodecSpec, gType)), 0)
 
           if (dropRows) {
             TableStage(
-              MakeStruct(FastIndexedSeq(globalRef -> ArrayRef(ReadPartition(Str(gPath), gSpec, gType), 0))),
+              MakeStruct(FastIndexedSeq(globalRef -> globals)),
               globalRef,
               rvdType,
               RVDPartitioner.empty(rvdType),
@@ -99,7 +99,7 @@ object LowerTableIR {
 
             if (rowsSpec.key startsWith typ.key) {
               TableStage(
-                MakeStruct(FastIndexedSeq(globalRef -> ArrayRef(ToArray(ReadPartition(Str(gPath), gSpec, gType)), 0))),
+                MakeStruct(FastIndexedSeq(globalRef -> globals)),
                 globalRef,
                 rvdType,
                 partitioner,

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -120,6 +120,8 @@ abstract class LZ4BlockBufferSpecCommon extends BlockBufferSpec {
 
   def lz4: LZ4
 
+  def stagedlz4: Code[LZ4]
+
   def blockSize: Int
 
   def child: BlockBufferSpec
@@ -129,21 +131,23 @@ abstract class LZ4BlockBufferSpecCommon extends BlockBufferSpec {
   def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new LZ4OutputBlockBuffer(lz4, blockSize, child.buildOutputBuffer(out))
 
   def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
-    Code.newInstance[LZ4InputBlockBuffer, Int, InputBlockBuffer](blockSize, child.buildCodeInputBuffer(in))
+    Code.newInstance[LZ4InputBlockBuffer, LZ4, Int, InputBlockBuffer](stagedlz4, blockSize, child.buildCodeInputBuffer(in))
 
   def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
-    Code.newInstance[LZ4OutputBlockBuffer, Int, OutputBlockBuffer](blockSize, child.buildCodeOutputBuffer(out))
+    Code.newInstance[LZ4OutputBlockBuffer, LZ4, Int, OutputBlockBuffer](stagedlz4, blockSize, child.buildCodeOutputBuffer(out))
 }
 
 final case class LZ4HCBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
   def lz4 = LZ4.hc
+  def stagedlz4: Code[LZ4] = Code.invokeScalaObject[LZ4](LZ4.getClass, "hc")
   def typeName = "LZ4HCBlockBufferSpec"
 }
 
 final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
     extends LZ4BlockBufferSpecCommon {
   def lz4 = LZ4.fast
+  def stagedlz4: Code[LZ4] = Code.invokeScalaObject[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4FastBlockBufferSpec"
 }
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -158,6 +158,8 @@ abstract class AbstractRVDSpec {
 
   def partFiles: Array[String]
 
+  def absolutePartPaths(path: String): Array[String] = partFiles.map(path + "/parts/" + _)
+
   def typedCodecSpec: AbstractTypedCodecSpec
 
   def indexed: Boolean = false

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -28,7 +28,6 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testRangeRead() {
-//    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
     val original = TableKeyBy(TableMapGlobals(TableRange(10, 3), MakeStruct(FastIndexedSeq("foo" -> I32(57)))), FastIndexedSeq())
 
     val path = tmpDir.createTempFile()
@@ -39,8 +38,6 @@ class TableIRSuite extends HailSuite {
 
     val expectedRows = Array.tabulate(10)(i => Row(i)).toFastIndexedSeq
     val expectedGlobals = Row(57)
-
-//    println(Pretty(collect(read)))
 
     assertEvalsTo(TableCollect(read), Row(expectedRows, expectedGlobals))
     assertEvalsTo(TableCollect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -28,8 +28,8 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testRangeRead() {
-    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
-    val original = TableMapGlobals(TableRange(10, 3), MakeStruct(FastIndexedSeq("foo" -> I32(57))))
+//    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
+    val original = TableKeyBy(TableMapGlobals(TableRange(10, 3), MakeStruct(FastIndexedSeq("foo" -> I32(57)))), FastIndexedSeq())
 
     val path = tmpDir.createTempFile()
     CompileAndEvaluate[Unit](ctx, TableWrite(original, TableNativeWriter(path, overwrite = true)), false)
@@ -40,8 +40,10 @@ class TableIRSuite extends HailSuite {
     val expectedRows = Array.tabulate(10)(i => Row(i)).toFastIndexedSeq
     val expectedGlobals = Row(57)
 
-    assertEvalsTo(collect(read), Row(expectedRows, expectedGlobals))
-    assertEvalsTo(collect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))
+//    println(Pretty(collect(read)))
+
+    assertEvalsTo(TableCollect(read), Row(expectedRows, expectedGlobals))
+    assertEvalsTo(TableCollect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))
   }
 
   @Test def testRangeCollect() {


### PR DESCRIPTION
also used it to read the column values in MatrixNativeReader directly instead of doing a TableCollect on a TableRead.