### PR TITLE
[batch] cancelled batches should have cancelled state

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -19,7 +19,7 @@ def batch_record_to_dict(app, record):
         state = 'open'
     elif record['n_failed'] > 0:
         state = 'failure'
-    elif record['n_cancelled'] > 0:
+    elif record['cancelled']:
         state = 'cancelled'
     elif record['closed'] and record['n_succeeded'] == record['n_jobs']:
         state = 'success'


### PR DESCRIPTION
This is an improvement, but I think we should reconsider the batch state.

Thinking out loud: The batch and CI UIs have slightly different displays.  If you're running, have had a failed job, but also been cancelled, what should your state be?  I think we either need columns in the batch display for open/closed, cancelled, complete and the simple state (open, running, cancelled, failure, success ... where the latter 3 mean complete), or display compound states like "running failure cancelled".
