### PR TITLE
[build] fix delete_batch_instances if instance not found

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1251,7 +1251,7 @@ steps:
          --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \
          --format="value(name)" \
          --project {{ global.project }} \
-       | xargs -r gcloud -q compute instances delete --zone {{ global.zone }} --project {{ global.project }}
+       | xargs -r gcloud -q compute instances delete --zone {{ global.zone }} --project {{ global.project }} || true
    secrets:
     - name: test-gsa-key
       namespace:


### PR DESCRIPTION
fixes

```
+ gcloud -q auth activate-service-account --key-file=/test-gsa-key/key.json
Activated service account credentials for: [test-665@hail-vdc.iam.gserviceaccount.com]
+ set +e
+ gcloud -q compute instances list --filter 'tags.items=batch2-agent AND labels.namespace=pr-7890-default-b9qytu01zuim' '--format=value(name)' --project hail-vdc
+ xargs -r gcloud -q compute instances delete --zone us-central1-a --project hail-vdc
Deleted [https://www.googleapis.com/compute/v1/projects/hail-vdc/zones/us-central1-a/instances/batch-worker-pr-7890-default-b9qytu01zuim-15e3g].
ERROR: (gcloud.compute.instances.delete) Could not fetch resource:
 - The resource 'projects/hail-vdc/zones/us-central1-a/instances/batch-worker-pr-7890-default-b9qytu01zuim-hr6b9' was not found
```