### PR TITLE
[hail/ptypes] refactor getNestedElementPTypes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -514,4 +514,9 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
     dstAddress
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val elementType = this.elementType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PArray].elementType))
+    PCanonicalArray(elementType, ptypes.forall(_.required))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
@@ -20,4 +20,11 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
     valueType.pretty(sb, indent, compact)
     sb.append("]")
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val keyType = this.keyType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PDict].keyType))
+    val valueType = this.valueType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PDict].valueType))
+
+    PCanonicalDict(keyType, valueType, ptypes.forall(_.required))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
@@ -50,4 +50,9 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
     def includeEnd(off: Code[Long]): Code[Boolean] =
       Region.loadBoolean(representation.loadField(off, 3))
+
+    override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+      val unifiedPointType = this.pointType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PInterval].pointType))
+      PCanonicalInterval(unifiedPointType, ptypes.forall(_.required))
+    }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
@@ -97,4 +97,7 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
       }
     }
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType =
+    PCanonicalLocus(rgBc, ptypes.forall(_.required))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
@@ -99,5 +99,5 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
   }
 
   override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType =
-    PCanonicalLocus(rgBc, ptypes.forall(_.required))
+    PCanonicalLocus(this.rgBc, ptypes.forall(_.required))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -231,4 +231,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
     this.representation.copyFromType(region, sourceNDPType.representation, srcAddress, forceDeep)
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val elementType = this.elementType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PCanonicalNDArray].elementType))
+    PCanonicalNDArray(elementType, this.nDims, ptypes.forall(_.required))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
@@ -12,4 +12,9 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
     elementType.pretty(sb, indent, compact)
     sb.append("]")
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val elementType = this.elementType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PSet].elementType))
+    PCanonicalSet(elementType, ptypes.forall(_.required))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalStruct.scala
@@ -261,4 +261,10 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
     }
     PCanonicalStruct(ab.result(), required)
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    PCanonicalStruct(ptypes.forall(_.required), this.fields.map( field =>
+      field.name -> field.typ.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PStruct].field(field.name).typ))
+    ):_*)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalTuple.scala
@@ -40,4 +40,15 @@ final case class PCanonicalTuple(_types: IndexedSeq[PTupleField], override val r
     else
       PCanonicalTuple(fundamentalFieldTypes, required)
   }
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val pTupleFields = this._types.map(pTupleField =>
+      PTupleField(
+        pTupleField.index,
+        pTupleField.typ.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PTuple]._types(pTupleField.index).typ))
+      )
+    )
+
+    PCanonicalTuple(pTupleFields, ptypes.forall(_.required))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
@@ -47,5 +47,10 @@ final case class PStream(elementType: PType, override val required: Boolean = fa
 
   def storeShallowAtOffset(dstAddress: Long, srcAddress: Long) =
     throw new UnsupportedOperationException("Stream storeShallowAtOffset is currently undefined")
+
+  override def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType = {
+    val elementType = this.elementType.deepPTypeUnifyOnSameVirtualTypes(ptypes.map(_.asInstanceOf[PStream].elementType))
+    PStream(elementType, ptypes.forall(_.required))
+  }
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -152,6 +152,11 @@ object PType {
       case PVoid => PVoid
     }
   }
+
+  def deepTypeUnify(ptypes: Seq[PType]): PType = {
+    assert(ptypes.forall(_.virtualType.isOfType(ptypes.head.virtualType)))
+    ptypes.head.deepPTypeUnifyOnSameVirtualTypes(ptypes)
+  }
 }
 
 abstract class PType extends Serializable with Requiredness {
@@ -330,4 +335,7 @@ abstract class PType extends Serializable with Requiredness {
   def storeShallowAtOffset(dstAddress: Code[Long], srcAddress: Code[Long]): Code[Unit]
 
   def storeShallowAtOffset(dstAddress: Long, srcAddress: Long)
+
+  def deepPTypeUnifyOnSameVirtualTypes(ptypes: Seq[PType]): PType =
+    ptypes.head.setRequired(ptypes.forall(_.required))
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -898,6 +898,42 @@ class IRSuite extends HailSuite {
     assert(res == PInt32(true))
   }
 
+  @Test def testGetNestedElementPCall() {
+    var types = Seq(PCanonicalCall(true))
+    var res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalCall(true))
+
+    types = Seq(PCanonicalCall(false))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalCall(false))
+
+    types = Seq(PCanonicalCall(false), PCanonicalCall(true))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalCall(false))
+
+    types = Seq(PCanonicalCall(true), PCanonicalCall(true))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalCall(true))
+  }
+
+  @Test def testGetNestedElementPNDArray() {
+    var types = Seq(PCanonicalNDArray(PInt32(true), 3, true))
+    var res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalNDArray(PInt32(true), 3, true))
+
+    types = Seq(PCanonicalNDArray(PInt32(true), 3, false))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalNDArray(PInt32(true), 3, false))
+
+    types = Seq(PCanonicalNDArray(PInt32(true), 3, true), PCanonicalNDArray(PInt32(true), 3, false))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalNDArray(PInt32(true), 3, false))
+
+    types = Seq(PCanonicalNDArray(PInt32(true), 3, true), PCanonicalNDArray(PInt32(true), 3, true))
+    res  = PType.deepTypeUnify(types)
+    assert(res == PCanonicalNDArray(PInt32(true), 3, true))
+  }
+
   @Test def testGetNestedElementPTypesI64() {
     var types = Seq(PInt64(true))
     var res  = PType.deepTypeUnify(types)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -835,571 +835,571 @@ class IRSuite extends HailSuite {
 
   @Test def testGetNestedElementPTypesI32() {
     var types = Seq(PInt32(true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PInt32(true))
 
     types = Seq(PInt32(false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt32(false))
 
     types = Seq(PInt32(false), PInt32(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt32(false))
 
     types = Seq(PInt32(true), PInt32(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt32(true))
   }
 
   @Test def testGetNestedElementPTypesI64() {
     var types = Seq(PInt64(true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PInt64(true))
 
     types = Seq(PInt64(false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt64(false))
 
     types = Seq(PInt64(false), PInt64(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt64(false))
 
     types = Seq(PInt64(true), PInt64(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PInt64(true))
   }
 
   @Test def testGetNestedElementPFloat32() {
     var types = Seq(PFloat32(true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PFloat32(true))
 
     types = Seq(PFloat32(false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat32(false))
 
     types = Seq(PFloat32(false), PFloat32(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat32(false))
 
     types = Seq(PFloat32(true), PFloat32(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat32(true))
   }
 
   @Test def testGetNestedElementPFloat64() {
     var types = Seq(PFloat64(true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PFloat64(true))
 
     types = Seq(PFloat64(false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat64(false))
 
     types = Seq(PFloat64(false), PFloat64(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat64(false))
 
     types = Seq(PFloat64(true), PFloat64(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PFloat64(true))
   }
 
   @Test def testGetNestedElementPString() {
     var types = Seq(PString(true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PString(true))
 
     types = Seq(PString(false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PString(false))
 
     types = Seq(PString(false), PString(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PString(false))
 
     types = Seq(PString(true), PString(true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PString(true))
   }
 
   @Test def testGetNestedPArray() {
     var types = Seq(PArray(PInt32(true), true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(true), true))
 
     types = Seq(PArray(PInt32(true), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(true), false))
 
     types = Seq(PArray(PInt32(false), true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(false), true))
 
     types = Seq(PArray(PInt32(false), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(false), false))
 
     types = Seq(
       PArray(PInt32(true), true),
       PArray(PInt32(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(true), true))
 
     types = Seq(
       PArray(PInt32(false), true),
       PArray(PInt32(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(false), true))
 
     types = Seq(
       PArray(PInt32(false), true),
       PArray(PInt32(true), false)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PInt32(false), false))
 
     types = Seq(
       PArray(PArray(PInt32(true), true), true),
       PArray(PArray(PInt32(true), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PArray(PInt32(true), true), true))
 
     types = Seq(
       PArray(PArray(PInt32(true), true), true),
       PArray(PArray(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PArray(PInt32(false), true), true))
 
     types = Seq(
       PArray(PArray(PInt32(true), false), true),
       PArray(PArray(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PArray(PInt32(false), false), true))
 
     types = Seq(
       PArray(PArray(PInt32(true), false), false),
       PArray(PArray(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PArray(PArray(PInt32(false), false), false))
   }
 
   @Test def testGetNestedPStream() {
     var types = Seq(PStream(PInt32(true), true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(true), true))
 
     types = Seq(PStream(PInt32(true), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(true), false))
 
     types = Seq(PStream(PInt32(false), true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(false), true))
 
     types = Seq(PStream(PInt32(false), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(false), false))
 
     types = Seq(
       PStream(PInt32(true), true),
       PStream(PInt32(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(true), true))
 
     types = Seq(
       PStream(PInt32(false), true),
       PStream(PInt32(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(false), true))
 
     types = Seq(
       PStream(PInt32(false), true),
       PStream(PInt32(true), false)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PInt32(false), false))
 
     types = Seq(
       PStream(PStream(PInt32(true), true), true),
       PStream(PStream(PInt32(true), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PStream(PInt32(true), true), true))
 
     types = Seq(
       PStream(PStream(PInt32(true), true), true),
       PStream(PStream(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PStream(PInt32(false), true), true))
 
     types = Seq(
       PStream(PStream(PInt32(true), false), true),
       PStream(PStream(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PStream(PInt32(false), false), true))
 
     types = Seq(
       PStream(PStream(PInt32(true), false), false),
       PStream(PStream(PInt32(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PStream(PStream(PInt32(false), false), false))
   }
 
   @Test def testGetNestedElementPDict() {
     var types = Seq(PDict(PInt32(true), PString(true), true))
-    var res  = InferPType.getNestedElementPTypes(types)
+    var res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PString(true), true))
 
     types = Seq(PDict(PInt32(false), PString(true), true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(false), PString(true), true))
 
     types = Seq(PDict(PInt32(true), PString(false), true))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PString(false), true))
 
     types = Seq(PDict(PInt32(true), PString(true), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PString(true), false))
 
     types = Seq(PDict(PInt32(false), PString(false), false))
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(false), PString(false), false))
 
     types = Seq(
       PDict(PInt32(true), PString(true), true),
       PDict(PInt32(true), PString(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PString(true), true))
 
     types = Seq(
       PDict(PInt32(true), PString(true), false),
       PDict(PInt32(true), PString(true), false)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PString(true), false))
 
     types = Seq(
       PDict(PInt32(false), PString(true), true),
       PDict(PInt32(true), PString(true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(false), PString(true), true))
 
     types = Seq(
       PDict(PInt32(false), PString(true), true),
       PDict(PInt32(true), PString(false), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(false), PString(false), true))
 
     types = Seq(
       PDict(PInt32(false), PString(true), false),
       PDict(PInt32(true), PString(false), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(false), PString(false), false))
 
     types = Seq(
       PDict(PInt32(true), PDict(PInt32(true), PString(true), true), true),
       PDict(PInt32(true), PDict(PInt32(true), PString(true), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PDict(PInt32(true), PString(true), true), true))
 
     types = Seq(
       PDict(PInt32(true), PDict(PInt32(false), PString(true), true), true),
       PDict(PInt32(true), PDict(PInt32(true), PString(true), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PDict(PInt32(false), PString(true), true), true))
 
     types = Seq(
       PDict(PInt32(true), PDict(PInt32(false), PString(true), true), true),
       PDict(PInt32(true), PDict(PInt32(true), PString(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PDict(PInt32(false), PString(false), true), true))
 
     types = Seq(
       PDict(PInt32(true), PDict(PInt32(false), PString(true), true), true),
       PDict(PInt32(true), PDict(PInt32(true), PString(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PDict(PInt32(false), PString(false), true), true))
 
     types = Seq(
       PDict(PInt32(true), PDict(PInt32(false), PString(true), false), true),
       PDict(PInt32(true), PDict(PInt32(true), PString(false), true), true)
     )
-    res  = InferPType.getNestedElementPTypes(types)
+    res  = PType.deepTypeUnify(types)
     assert(res == PDict(PInt32(true), PDict(PInt32(false), PString(false), false), true))
   }
 
   @Test def testGetNestedElementPStruct() {
     var types = Seq(PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
-    var res = InferPType.getNestedElementPTypes(types)
+    var res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(PStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(PStruct(true, "a" -> PInt32(false), "b" -> PInt32(true)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PInt32(false), "b" -> PInt32(true)))
 
     types = Seq(PStruct(true, "a" -> PInt32(true), "b" -> PInt32(false)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PInt32(true), "b" -> PInt32(false)))
 
     types = Seq(PStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)),
       PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(
       PStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)),
       PStruct(true, "a" -> PInt32(false), "b" -> PInt32(false))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)),
       PStruct(true, "a" -> PInt32(false), "b" -> PInt32(false))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PStruct(true, "a" -> PStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)),"b" -> PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
 
     types = Seq(
       PStruct(true, "a" -> PStruct(true, "c" -> PInt32(false), "d" -> PInt32(true)),"b" -> PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PStruct(true, "c" -> PInt32(false), "d" -> PInt32(true)), "b" -> PInt32(true)))
 
     types = Seq(
       PStruct(true, "a" -> PStruct(true, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)),
       PStruct(true, "a" -> PStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PStruct(true, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)))
 
     types = Seq(
       PStruct(true, "a" -> PStruct(false, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)),
       PStruct(true, "a" -> PStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PStruct(true, "a" -> PStruct(false, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)))
   }
 
   @Test def testGetNestedElementPTuple() {
     var types = Seq(PTuple(true, PInt32(true)))
-    var res = InferPType.getNestedElementPTypes(types)
+    var res = PType.deepTypeUnify(types)
     assert(res == PTuple(true, PInt32(true)))
 
     types = Seq(PTuple(false, PInt32(true)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(false, PInt32(true)))
 
     types = Seq(PTuple(true, PInt32(false)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(true, PInt32(false)))
 
     types = Seq(PTuple(false, PInt32(false)))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(false, PInt32(false)))
 
     types = Seq(
       PTuple(true, PInt32(true)),
       PTuple(true, PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(true, PInt32(true)))
 
     types = Seq(
       PTuple(true, PInt32(true)),
       PTuple(false, PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(false, PInt32(true)))
 
     types = Seq(
       PTuple(true, PInt32(false)),
       PTuple(false, PInt32(true))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(false, PInt32(false)))
 
     types = Seq(
       PTuple(true, PTuple(true, PInt32(true))),
       PTuple(true, PTuple(true, PInt32(false)))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(true, PTuple(true, PInt32(false))))
 
     types = Seq(
       PTuple(true, PTuple(false, PInt32(true))),
       PTuple(true, PTuple(true, PInt32(false)))
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PTuple(true, PTuple(false, PInt32(false))))
   }
 
   @Test def testGetNestedElementPSet() {
     var types = Seq(PSet(PInt32(true), true))
-    var res = InferPType.getNestedElementPTypes(types)
+    var res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(true), true))
 
     types = Seq(PSet(PInt32(true), false))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(true), false))
 
     types = Seq(PSet(PInt32(false), true))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(false), true))
 
     types = Seq(PSet(PInt32(false), false))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(false), false))
 
     types = Seq(
       PSet(PInt32(true), true),
       PSet(PInt32(true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(true), true))
 
     types = Seq(
       PSet(PInt32(false), true),
       PSet(PInt32(true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(false), true))
 
     types = Seq(
       PSet(PInt32(false), true),
       PSet(PInt32(true), false)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PInt32(false), false))
 
     types = Seq(
       PSet(PSet(PInt32(true), true), true),
       PSet(PSet(PInt32(true), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PSet(PInt32(true), true), true))
 
     types = Seq(
       PSet(PSet(PInt32(true), true), true),
       PSet(PSet(PInt32(false), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PSet(PInt32(false), true), true))
 
     types = Seq(
       PSet(PSet(PInt32(true), false), true),
       PSet(PSet(PInt32(false), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PSet(PSet(PInt32(false), false), true))
   }
 
   @Test def testGetNestedElementPInterval() {
     var types = Seq(PInterval(PInt32(true), true))
-    var res = InferPType.getNestedElementPTypes(types)
+    var res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(true), true))
 
     types = Seq(PInterval(PInt32(true), false))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(true), false))
 
     types = Seq(PInterval(PInt32(false), true))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(false), true))
 
     types = Seq(PInterval(PInt32(false), false))
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(false), false))
 
     types = Seq(
       PInterval(PInt32(true), true),
       PInterval(PInt32(true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(true), true))
 
     types = Seq(
       PInterval(PInt32(false), true),
       PInterval(PInt32(true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(false), true))
 
     types = Seq(
       PInterval(PInt32(true), true),
       PInterval(PInt32(true), false)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(true), false))
 
     types = Seq(
       PInterval(PInt32(false), true),
       PInterval(PInt32(true), false)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInt32(false), false))
 
     types = Seq(
       PInterval(PInterval(PInt32(true), true), true),
       PInterval(PInterval(PInt32(true), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInterval(PInt32(true), true), true))
 
     types = Seq(
       PInterval(PInterval(PInt32(true), false), true),
       PInterval(PInterval(PInt32(true), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInterval(PInt32(true), false), true))
 
     types = Seq(
       PInterval(PInterval(PInt32(false), true), true),
       PInterval(PInterval(PInt32(true), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInterval(PInt32(false), true), true))
 
     types = Seq(
       PInterval(PInterval(PInt32(true), false), true),
       PInterval(PInterval(PInt32(false), true), true)
     )
-    res = InferPType.getNestedElementPTypes(types)
+    res = PType.deepTypeUnify(types)
     assert(res == PInterval(PInterval(PInt32(false), false), true))
   }
 


### PR DESCRIPTION
Makes the unification functionality work for non-canonical ptypes.