### PR TITLE
[hail] assert non-empty stream in InputBuffers.scala

### DIFF
--- a/hail/src/main/scala/is/hail/io/InputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/InputBuffers.scala
@@ -61,27 +61,27 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   def seek(offset: Long) = in.asInstanceOf[ByteTrackingInputStream].seek(offset)
 
   def readByte(): Byte = {
-    in.read(buff, 0, 1)
+    assert(in.read(buff, 0, 1) == 1)
     Memory.loadByte(buff, 0)
   }
 
   def readInt(): Int = {
-    in.read(buff, 0, 4)
+    assert(in.read(buff, 0, 4) == 4)
     Memory.loadInt(buff, 0)
   }
 
   def readLong(): Long = {
-    in.read(buff)
+    assert(in.read(buff) == 8)
     Memory.loadLong(buff, 0)
   }
 
   def readFloat(): Float = {
-    in.read(buff, 0, 4)
+    assert(in.read(buff, 0, 4) == 4)
     Memory.loadFloat(buff, 0)
   }
 
   def readDouble(): Double = {
-    in.read(buff)
+    assert(in.read(buff) == 8)
     Memory.loadDouble(buff, 0)
   }
 
@@ -89,17 +89,17 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
     Region.storeBytes(toOff, Array.tabulate(n)(_ => readByte()))
   }
 
-  def skipByte(): Unit = in.skip(1)
+  def skipByte(): Unit = assert(in.skip(1) == 1L)
 
-  def skipInt(): Unit = in.skip(4)
+  def skipInt(): Unit = assert(in.skip(4) == 4L)
 
-  def skipLong(): Unit = in.skip(8)
+  def skipLong(): Unit = assert(in.skip(8) == 8L)
 
-  def skipFloat(): Unit = in.skip(4)
+  def skipFloat(): Unit = assert(in.skip(4) == 4L)
 
-  def skipDouble(): Unit = in.skip(8)
+  def skipDouble(): Unit = assert(in.skip(8) == 8L)
 
-  def skipBytes(n: Int): Unit = in.skip(n)
+  def skipBytes(n: Int): Unit = assert(in.skip(n) == n)
 
   def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
     var i = 0

--- a/hail/src/main/scala/is/hail/io/InputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/InputBuffers.scala
@@ -61,27 +61,32 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   def seek(offset: Long) = in.asInstanceOf[ByteTrackingInputStream].seek(offset)
 
   def readByte(): Byte = {
-    assert(in.read(buff, 0, 1) == 1)
+    val bytesRead = in.read(buff, 0, 1)
+    assert(bytesRead == 1)
     Memory.loadByte(buff, 0)
   }
 
   def readInt(): Int = {
-    assert(in.read(buff, 0, 4) == 4)
+    val bytesRead = in.read(buff, 0, 4)
+    assert(bytesRead == 4)
     Memory.loadInt(buff, 0)
   }
 
   def readLong(): Long = {
-    assert(in.read(buff) == 8)
+    val bytesRead = in.read(buff)
+    assert(bytesRead == 8)
     Memory.loadLong(buff, 0)
   }
 
   def readFloat(): Float = {
-    assert(in.read(buff, 0, 4) == 4)
+    val bytesRead = in.read(buff, 0, 4)
+    assert(bytesRead == 4)
     Memory.loadFloat(buff, 0)
   }
 
   def readDouble(): Double = {
-    assert(in.read(buff) == 8)
+    val bytesRead = in.read(buff)
+    assert(bytesRead == 8)
     Memory.loadDouble(buff, 0)
   }
 
@@ -89,17 +94,35 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
     Region.storeBytes(toOff, Array.tabulate(n)(_ => readByte()))
   }
 
-  def skipByte(): Unit = assert(in.skip(1) == 1L)
+  def skipByte(): Unit = {
+    val bytesRead = in.skip(1)
+    assert(bytesRead == 1L)
+  }
 
-  def skipInt(): Unit = assert(in.skip(4) == 4L)
+  def skipInt(): Unit = {
+    val bytesRead = in.skip(4)
+    assert(bytesRead == 4L)
+  }
 
-  def skipLong(): Unit = assert(in.skip(8) == 8L)
+  def skipLong(): Unit = {
+    val bytesRead = in.skip(8)
+    assert(bytesRead == 8L)
+  }
 
-  def skipFloat(): Unit = assert(in.skip(4) == 4L)
+  def skipFloat(): Unit = {
+    val bytesRead = in.skip(4)
+    assert(bytesRead == 4L)
+  }
 
-  def skipDouble(): Unit = assert(in.skip(8) == 8L)
+  def skipDouble(): Unit = {
+    val bytesRead = in.skip(8)
+    assert(bytesRead == 8L)
+  }
 
-  def skipBytes(n: Int): Unit = assert(in.skip(n) == n)
+  def skipBytes(n: Int): Unit = {
+    val bytesRead = in.skip(n)
+    assert(bytesRead == n)
+  }
 
   def readDoubles(to: Array[Double], off: Int, n: Int): Unit = {
     var i = 0


### PR DESCRIPTION
I followed the rabbit hole form https://github.com/hail-is/hail/pull/7922 and was a bit concerned that we weren't verifying the stream met our expectations. I don't think we need to handle errors more gracefully (these assertions should only fail on malformed files).