### PR TITLE
[batch] improve cancel

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -82,6 +82,7 @@ WHERE id = %s AND NOT deleted AND callback IS NOT NULL AND
 async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, new_state,
                             status, start_time, end_time, reason):
     scheduler_state_changed = app['scheduler_state_changed']
+    cancel_ready_changed = app['cancel_ready_changed']
     db = app['db']
     inst_pool = app['inst_pool']
 
@@ -107,6 +108,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
             if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
                 instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
                 scheduler_state_changed.set()
+                cancel_ready_changed.set()
         else:
             log.warning(f'mark_complete for job {id} from unknown {instance}')
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -30,7 +30,6 @@ def batch_record_to_dict(app, record):
     d = {
         'id': record['id'],
         'billing_project': record['billing_project'],
-        # FIXME switching to record['state']
         'state': state,
         'complete': record['state'] == 'complete',
         'closed': record['state'] != 'open',

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -82,7 +82,7 @@ WHERE id = %s AND NOT deleted AND callback IS NOT NULL AND
 async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, new_state,
                             status, start_time, end_time, reason):
     scheduler_state_changed = app['scheduler_state_changed']
-    cancel_ready_changed = app['cancel_ready_changed']
+    cancel_ready_state_changed = app['cancel_ready_state_changed']
     db = app['db']
     inst_pool = app['inst_pool']
 
@@ -108,7 +108,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
             if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
                 instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
                 scheduler_state_changed.set()
-                cancel_ready_changed.set()
+                cancel_ready_state_changed.set()
         else:
             log.warning(f'mark_complete for job {id} from unknown {instance}')
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -27,8 +27,6 @@ def batch_record_to_dict(app, record):
     else:
         state = 'running'
 
-    complete = record['state'] == 'complete'
-
     d = {
         'id': record['id'],
         'billing_project': record['billing_project'],
@@ -62,7 +60,7 @@ async def notify_batch_job_complete(app, db, batch_id):
 SELECT *
 FROM batches
 WHERE id = %s AND NOT deleted AND callback IS NOT NULL AND
-   `state` = 'complete'
+   batches.`state` = 'complete'
 ''',
         (batch_id,))
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -386,6 +386,8 @@ async def get_user_resources(request, userdata):
 
 
 async def check_incremental_loop(db):
+    clean = True
+
     @transaction(db, read_only=True)
     async def check(tx):
         ready_cores = await tx.execute_and_fetchone('''
@@ -408,6 +410,7 @@ LOCK IN SHARE MODE;
         computed_ready_cores_mcpu = computed_ready_cores['ready_cores_mcpu']
 
         if ready_cores_mcpu != computed_ready_cores_mcpu:
+            clean = False
             log.error(f'ready_cores corrupt: ready_cores_mcpu {ready_cores_mcpu} != computed_ready_cores_mcpu {computed_ready_cores_mcpu}')
 
         user_resources = tx.execute_and_fetchall('''
@@ -461,12 +464,13 @@ GROUP BY user;
                 computed_v = user_get(user_resources, u, f)
 
                 if v != computed_v:
+                    clean = False
                     log.error(f'user_resources corrupt: user_resources[{u}][{f}] {v} != computed_user_resources[{u}][{f}] {computed_v}')
 
-    while True:
+    while clean:
         try:
             # 10/s
-            asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)
             await check()  # pylint: disable=no-value-for-parameter
         except Exception:
             log.exception('while checking incremental')

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -525,7 +525,7 @@ async def on_startup(app):
     await scheduler.async_init()
     app['scheduler'] = scheduler
 
-    asyncio.ensure_future(check_incremental_loop(db))
+    # asyncio.ensure_future(check_incremental_loop(db))
 
 
 async def on_cleanup(app):

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -386,7 +386,7 @@ async def get_user_resources(request, userdata):
 
 
 async def check_incremental_loop(db):
-    @transaction(db, ready_only=True)
+    @transaction(db, read_only=True)
     async def check(tx):
         ready_cores = await tx.execute_and_fetchone('''
 SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -147,7 +147,7 @@ async def close_batch(request):
     user = request.match_info['user']
     batch_id = int(request.match_info['batch_id'])
 
-    record = db.select_and_fetchone (
+    record = db.select_and_fetchone(
         '''
 SELECT state FROM batches WHERE user = %s AND id = %s;
 ''',

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -407,7 +407,8 @@ LOCK IN SHARE MODE;
 ''')
         computed_ready_cores_mcpu = computed_ready_cores['ready_cores_mcpu']
 
-        log.error(f'ready_cores corrupt: ready_cores_mcpu {ready_cores_mcpu} != computed_ready_cores_mcpu {computed_ready_cores_mcpu}')
+        if ready_cores_mcpu != computed_ready_cores_mcpu:
+            log.error(f'ready_cores corrupt: ready_cores_mcpu {ready_cores_mcpu} != computed_ready_cores_mcpu {computed_ready_cores_mcpu}')
 
         user_resources = tx.execute_and_fetchall('''
 SELECT user,
@@ -420,7 +421,7 @@ FROM user_resources
 GROUP BY user
 LOCK IN SHARE MODE;
 ''')
-        user_resources = [record async for record in user_resources]
+        user_resources = {record['user']: record async for record in user_resources}
 
         computed_user_resources = tx.execute_and_fetchall('''
 SELECT user,
@@ -442,7 +443,7 @@ FROM (SELECT
   LOCK IN SHARE MODE) AS s
 GROUP BY user;
 ''')
-        computed_user_resources = [record async for record in computed_user_resources]
+        computed_user_resources = {record['user']: record async for record in computed_user_resources}
 
         def user_get(d, u, f):
             if u not in d:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -415,6 +415,7 @@ SELECT user,
   CAST(COALESCE(SUM(n_ready_jobs), 0) AS SIGNED) AS n_ready_jobs,
   CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu,
   CAST(COALESCE(SUM(n_running_jobs), 0) AS SIGNED) AS n_running_jobs,
+  CAST(COALESCE(SUM(running_cores_mcpu), 0) AS SIGNED) AS running_cores_mcpu,
   CAST(COALESCE(SUM(n_cancelled_ready_jobs), 0) AS SIGNED) AS n_cancelled_ready_jobs,
   CAST(COALESCE(SUM(n_cancelled_running_jobs), 0) AS SIGNED) AS n_cancelled_running_jobs
 FROM user_resources
@@ -425,10 +426,10 @@ LOCK IN SHARE MODE;
 
         computed_user_resources = tx.execute_and_fetchall('''
 SELECT user,
-    COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
-    COALESCE(SUM(IF(state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
     COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_ready_jobs,
     COALESCE(SUM(IF(state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
+    COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+    COALESCE(SUM(IF(state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
     COALESCE(SUM(state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
     COALESCE(SUM(state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs
 FROM (SELECT

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -163,16 +163,16 @@ SELECT state FROM batches WHERE user = %s AND id = %s;
 @routes.post('/api/v1alpha/batches/cancel')
 @batch_only
 async def cancel_batch(request):
-    request.app['cancel_state_changed'].set()
-    request.app['scheduler_state_changed'].set()
+    request.app['cancel_running_state_changed'].set()
+    request.app['cancel_ready_state_changed'].set()
     return web.Response()
 
 
 @routes.post('/api/v1alpha/batches/delete')
 @batch_only
 async def delete_batch(request):
-    request.app['cancel_state_changed'].set()
-    request.app['scheduler_state_changed'].set()
+    request.app['cancel_running_state_changed'].set()
+    request.app['cancel_ready_state_changed'].set()
     return web.Response()
 
 
@@ -421,8 +421,11 @@ async def on_startup(app):
     scheduler_state_changed = asyncio.Event()
     app['scheduler_state_changed'] = scheduler_state_changed
 
-    cancel_state_changed = asyncio.Event()
-    app['cancel_state_changed'] = cancel_state_changed
+    cancel_ready_state_changed = asyncio.Event()
+    app['cancel_ready_state_changed'] = cancel_ready_state_changed
+
+    cancel_running_state_changed = asyncio.Event()
+    app['cancel_running_state_changed'] = cancel_running_state_changed
 
     log_store = LogStore(BATCH_BUCKET_NAME, instance_id, pool, credentials=credentials)
     app['log_store'] = log_store

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -140,7 +140,7 @@ WHERE n_cancelled_ready_jobs > 0;
 
         total = sum(user_n_cancelled_ready_jobs.values())
         user_share = {
-            user: max(int(1000 * user_n_jobs / total), 20)
+            user: max(int(1000 * user_n_jobs / total + 0.5), 20)
             for user, user_n_jobs in user_n_cancelled_ready_jobs.items()
         }
 
@@ -222,7 +222,7 @@ WHERE n_cancelled_running_jobs > 0;
 
         total = sum(user_n_cancelled_running_jobs.values())
         user_share = {
-            user: max(int(1000 * user_n_jobs / total), 20)
+            user: max(int(1000 * user_n_jobs / total + 0.5), 20)
             for user, user_n_jobs in user_n_cancelled_running_jobs.items()
         }
 
@@ -287,7 +287,7 @@ LIMIT %s;
         if not total:
             return
         user_share = {
-            user: max(1000 * resources['allocated_cores_mcpu'] / total, 20)
+            user: max(int(1000 * resources['allocated_cores_mcpu'] / total + 0.5), 20)
             for user, resources in user_resources.items()
         }
 

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -244,7 +244,7 @@ SELECT jobs.job_id, attempts.attempt_id, attempts.instance_name
 FROM jobs
 STRAIGHT_JOIN attempts
   ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
-WHERE jobs.batch_id = %s AND state = 'Running' always_run = 0 AND AND cancelled = 0
+WHERE jobs.batch_id = %s AND state = 'Running' AND always_run = 0 AND cancelled = 0
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value)):

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -159,7 +159,7 @@ WHERE user = %s AND `state` = 'running';
                             '''
 SELECT jobs.job_id
 FROM jobs
-WHERE batch_id = %s AND always_run = 0 AND state = 'Ready'
+WHERE batch_id = %s AND state = 'Ready' AND always_run = 0
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value)):
@@ -170,7 +170,7 @@ LIMIT %s;
                             '''
 SELECT jobs.job_id
 FROM jobs
-WHERE batch_id = %s AND always_run = 0 AND state = 'Ready' AND cancelled = 1
+WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND cancelled = 1
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value)):
@@ -244,7 +244,7 @@ SELECT jobs.job_id, attempts.attempt_id, attempts.instance_name
 FROM jobs
 STRAIGHT_JOIN attempts
   ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
-WHERE jobs.batch_id = %s AND always_run = 0 AND state = 'Running' AND cancelled = 0
+WHERE jobs.batch_id = %s AND state = 'Running' always_run = 0 AND AND cancelled = 0
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value)):
@@ -305,7 +305,7 @@ WHERE user = %s AND `state` = 'running';
                         '''
 SELECT job_id, spec, cores_mcpu
 FROM jobs
-WHERE batch_id = %s AND always_run = 1 AND state = 'Ready'
+WHERE batch_id = %s AND state = 'Ready' AND always_run = 1
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value)):
@@ -318,7 +318,7 @@ LIMIT %s;
                             '''
 SELECT job_id, spec, cores_mcpu
 FROM jobs
-WHERE batch_id = %s AND always_run = 0 AND state = 'Ready' AND cancelled = 0
+WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND cancelled = 0
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value)):

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -132,7 +132,7 @@ SELECT attempts.job_id, attempts.batch_id, attempts.attempt_id, instance_name
 FROM attempts
 STRAIGHT_JOIN batches ON batches.id = attempts.batch_id
 STRAIGHT_JOIN jobs ON jobs.batch_id = attempts.batch_id AND jobs.job_id = attempts.job_id
-WHERE jobs.state = 'Running' AND (NOT jobs.always_run) AND batches.closed AND batches.cancelled AND batches.user = %s
+WHERE jobs.state = 'Running' AND (NOT jobs.always_run) AND batches.`state` = 'running' AND batches.cancelled AND batches.user = %s
 LIMIT 50;
 ''',
                 (user_record['user'],))
@@ -175,7 +175,7 @@ SELECT job_id, batch_id, spec, cores_mcpu,
   userdata, user
 FROM jobs
 STRAIGHT_JOIN batches ON batches.id = jobs.batch_id
-WHERE jobs.state = 'Ready' AND batches.closed AND batches.user = %s
+WHERE jobs.state = 'Ready' AND batches.`state` = 'running' AND batches.user = %s
 LIMIT 50;
 ''',
                 (user, ))

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -236,13 +236,13 @@ WHERE user = %s AND `state` = 'running' AND cancelled = 1;
                     (user,)):
                 async for record in self.db.select_and_fetchall(
                         '''
-SELECT jobs.job_id, jobs.attempt_id, attempts.instance_name,
+SELECT jobs.job_id, jobs.attempt_id, attempts.instance_name
 FROM jobs
 STRAIGHT_JOIN attempts
-ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
-AND attempts.attempt_id = jobs.attempt_id
+  ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
+    AND attempts.attempt_id = jobs.attempt_id
 WHERE batch_id = %s AND always_run = 0 AND state = 'Running' AND cancelled = 0
-AND jobs.attempt_id IS NOT NULL
+  AND jobs.attempt_id IS NOT NULL
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value)):

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -241,7 +241,7 @@ FROM jobs
 STRAIGHT_JOIN attempts
   ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
     AND attempts.attempt_id = jobs.attempt_id
-WHERE batch_id = %s AND always_run = 0 AND state = 'Running' AND cancelled = 0
+WHERE jobs.batch_id = %s AND always_run = 0 AND state = 'Running' AND cancelled = 0
   AND jobs.attempt_id IS NOT NULL
 LIMIT %s;
 ''',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -623,8 +623,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
     if not record['closed']:
         raise web.HTTPBadRequest(reason=f'cannot cancel open batch {batch_id}')
 
-    await db.execute_update(
-        'UPDATE batches SET cancelled = closed WHERE id = %s;', (batch_id,))
+    await db.just_execute(
+        'CALL cancel_batch(%s);', (batch_id,))
 
     app['cancel_batch_state_changed'].set()
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -322,7 +322,7 @@ async def _query_batches(request, user):
         elif t == 'success':
             # need complete because there might be no jobs
             condition = "(`state` = 'complete' AND n_succeeded = n_jobs)"
-            args = [t]
+            args = []
         else:
             session = await aiohttp_session.get_session(request)
             set_message(session, f'Invalid search term: {t}.', 'error')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -536,7 +536,7 @@ ON DUPLICATE KEY UPDATE
                                          n_jobs, n_ready_jobs, ready_cores_mcpu,
                                          n_jobs, n_ready_jobs, ready_cores_mcpu))
                 await tx.execute_update('''
-INSERT INTO batch_ready_cancellable (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
 VALUES (%s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
   n_ready_cancellable_jobs = n_ready_cancellable_jobs + %s,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -583,7 +583,7 @@ WHERE token = %s AND user = %s FOR UPDATE;
         id = await tx.execute_insertone(
             '''
 INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created, token, state)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
             (json.dumps(userdata), user, billing_project, json.dumps(attributes),
              batch_spec.get('callback'), batch_spec['n_jobs'],

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -582,12 +582,12 @@ WHERE token = %s AND user = %s FOR UPDATE;
         now = time_msecs()
         id = await tx.execute_insertone(
             '''
-INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created, token)
+INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created, token, state)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
 ''',
             (json.dumps(userdata), user, billing_project, json.dumps(attributes),
              batch_spec.get('callback'), batch_spec['n_jobs'],
-             now, token))
+             now, token, 'open'))
 
         if attributes:
             await tx.execute_many(

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -301,14 +301,27 @@ async def _query_batches(request, user):
            `batch_attributes`.`key` = %s))
 '''
             args = [k]
-        elif t == 'complete':
-            condition = '(closed AND n_jobs = n_completed)'
+        elif t == 'open':
+            condition = "(`state` = 'open')"
             args = []
         elif t == 'closed':
-            condition = '(closed)'
+            condition = "(`state` != 'open')"
             args = []
-        elif t in ('open', 'running', 'success', 'cancelled', 'failure'):
-            condition = '(state = %s)'
+        elif t == 'complete':
+            condition = "(`state` = 'complete')"
+            args = []
+        elif t == 'running':
+            condition = "(`state` = 'running')"
+            args = []
+        elif t == 'cancelled':
+            condition = '(cancelled)'
+            args = []
+        elif t == 'failure':
+            condition = '(n_failed > 0)'
+            args = []
+        elif t == 'success':
+            # need complete because there might be no jobs
+            condition = "(`state` = 'complete' AND n_succeeded = n_jobs)"
             args = [t]
         else:
             session = await aiohttp_session.get_session(request)
@@ -323,14 +336,7 @@ async def _query_batches(request, user):
 
     sql = f'''
 SELECT *
-FROM (SELECT *, CASE
-    WHEN NOT closed THEN 'open'
-    WHEN n_failed > 0 THEN 'failure'
-    WHEN n_cancelled > 0 THEN 'cancelled'
-    WHEN n_succeeded = n_jobs THEN 'success'
-    ELSE 'running'
-  END AS state
-FROM batches) as t
+FROM batches
 WHERE {' AND '.join(where_conditions)}
 ORDER BY id DESC
 LIMIT 50;
@@ -389,15 +395,15 @@ async def create_jobs(request, userdata):
         async with timer.step('fetch batch'):
             record = await db.select_and_fetchone(
                 '''
-SELECT closed FROM batches
+SELECT `state` FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
                 (user, batch_id))
 
         if not record:
             raise web.HTTPNotFound()
-        if record['closed']:
-            raise web.HTTPBadRequest(reason=f'batch {batch_id} is already closed')
+        if record['state'] != 'open':
+            raise web.HTTPBadRequest(reason=f'batch {batch_id} is not open')
 
         async with timer.step('get request json'):
             job_specs = await request.json()
@@ -614,13 +620,13 @@ async def _cancel_batch(app, batch_id, user):
 
     record = await db.select_and_fetchone(
         '''
-SELECT closed FROM batches
+SELECT `state` FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
         (user, batch_id))
     if not record:
         raise web.HTTPNotFound()
-    if not record['closed']:
+    if record['state'] == 'open':
         raise web.HTTPBadRequest(reason=f'cannot cancel open batch {batch_id}')
 
     await db.just_execute(
@@ -636,17 +642,19 @@ async def _delete_batch(app, batch_id, user):
 
     record = await db.select_and_fetchone(
         '''
-SELECT closed FROM batches
+SELECT `state` FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
         (user, batch_id))
     if not record:
         raise web.HTTPNotFound()
 
+    await db.just_execute(
+        'CALL cancel_batch(%s);', (batch_id,))
     await db.execute_update(
-        'UPDATE batches SET cancelled = closed, deleted = 1 WHERE id = %s;', (batch_id,))
+        'UPDATE batches SET deleted = 1 WHERE id = %s;', (batch_id,))
 
-    if record['closed']:
+    if record['state'] == 'running':
         app['delete_batch_state_changed'].set()
 
 
@@ -681,7 +689,7 @@ async def close_batch(request, userdata):
 
     record = await db.select_and_fetchone(
         '''
-SELECT closed FROM batches
+SELECT 1 FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
         (user, batch_id))

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -1,3 +1,5 @@
+DROP PROCEDURE IF EXISTS recompute_incremental;
+DROP PROCEDURE IF EXISTS cancel_batch;
 DROP PROCEDURE IF EXISTS activate_instance;
 DROP PROCEDURE IF EXISTS deactivate_instance;
 DROP PROCEDURE IF EXISTS mark_instance_deleted;
@@ -13,6 +15,7 @@ DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 
+DROP TABLE IF EXISTS `batch_ready_cancellable`;
 DROP TABLE IF EXISTS `globals`;
 DROP TABLE IF EXISTS `attempts`;
 DROP TABLE IF EXISTS `batch_attributes`;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -15,7 +15,7 @@ DROP TRIGGER IF EXISTS attempts_before_update;
 DROP TRIGGER IF EXISTS attempts_after_update;
 DROP TRIGGER IF EXISTS jobs_after_update;
 
-DROP TABLE IF EXISTS `batch_ready_cancellable`;
+DROP TABLE IF EXISTS `batch_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;
 DROP TABLE IF EXISTS `attempts`;
 DROP TABLE IF EXISTS `batch_attributes`;

--- a/batch/sql/estimated-current.txt
+++ b/batch/sql/estimated-current.txt
@@ -41,11 +41,13 @@ CREATE INDEX `instances_removed` ON `instances` (`removed`);
 
 CREATE TABLE IF NOT EXISTS `user_resources` (
   `user` VARCHAR(100) NOT NULL,
+  `token` INT NOT NULL,
   `n_ready_jobs` INT NOT NULL DEFAULT 0,
   `n_running_jobs` INT NOT NULL DEFAULT 0,
   `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
   `running_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
-  `token` INT NOT NULL
+  `n_cancelled_ready_jobs` INT NOT NULL DEFAULT 0,
+  `n_cancelled_running_jobs` INT NOT NULL DEFAULT 0,
   PRIMARY KEY (`user`, `token`)
 ) ENGINE = InnoDB;
 
@@ -56,9 +58,9 @@ CREATE TABLE IF NOT EXISTS `batches` (
   `billing_project` VARCHAR(100) NOT NULL,
   `attributes` TEXT,
   `callback` TEXT,
+  `state` VARCHAR(40) NOT NULL,
   `deleted` BOOLEAN NOT NULL DEFAULT FALSE,
   `cancelled` BOOLEAN NOT NULL DEFAULT FALSE,
-  `closed` BOOLEAN NOT NULL DEFAULT FALSE,
   `n_jobs` INT NOT NULL,
   `n_completed` INT NOT NULL DEFAULT 0,
   `n_succeeded` INT NOT NULL DEFAULT 0,
@@ -71,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `batches` (
   PRIMARY KEY (`id`),
   FOREIGN KEY (`billing_project`) REFERENCES billing_projects(name)
 ) ENGINE = InnoDB;
-CREATE INDEX `batches_user` ON `batches` (`user`);
+CREATE INDEX `batches_user_state_cancelled` ON `batches` (`user`, `state`, `cancelled`);
 CREATE INDEX `batches_deleted` ON `batches` (`deleted`);
 CREATE INDEX `batches_token` ON `batches` (`token`);
 
@@ -83,6 +85,18 @@ CREATE TABLE IF NOT EXISTS `batches_staging` (
   `ready_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (`batch_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE
+) ENGINE = InnoDB;
+
+CREATE TABLE `batch_cancellable_resources` (
+  `batch_id` BIGINT NOT NULL,
+  `token` INT NOT NULL,
+  # neither run_always nor cancelled
+  `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `running_cancellable_cores_mcpu` INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `jobs` (
@@ -100,7 +114,7 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
-CREATE INDEX `jobs_state` ON `jobs` (`state`);
+CREATE INDEX `jobs_batch_id_always_run_state_cancelled` ON `jobs` (`batch_id`, `always_run`, `state`, `cancelled`);
 
 CREATE TABLE IF NOT EXISTS `attempts` (
   `batch_id` BIGINT NOT NULL,
@@ -212,51 +226,206 @@ END $$
 CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
 FOR EACH ROW
 BEGIN
-  DECLARE in_user VARCHAR(100);
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
   DECLARE cur_n_tokens INT;
   DECLARE rand_token INT;
 
-  SELECT user INTO in_user from batches
+  SELECT user, cancelled INTO cur_user, cur_batch_cancelled FROM batches
   WHERE id = NEW.batch_id;
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   IF OLD.state = 'Ready' THEN
-    INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu) VALUES (in_user, rand_token, -1, -1 * OLD.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      n_ready_jobs = n_ready_jobs - 1,
-      ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
 
-    INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (rand_token, -1 * OLD.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+	n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
+      # runnable
+      INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_jobs = n_ready_jobs - 1,
+	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+
+      INSERT INTO ready_cores (token, ready_cores_mcpu)
+      VALUES (rand_token, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Running' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_cancellable_resources (batch_id, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+	running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_resources (user, token, n_cancelled_running_jobs)
+      VALUES (cur_user, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+	n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+    ELSE
+      # running
+      INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_running_jobs = n_running_jobs - 1,
+	running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+    END IF;
   END IF;
 
   IF NEW.state = 'Ready' THEN
-    INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu) VALUES (in_user, rand_token, 1, NEW.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      n_ready_jobs = n_ready_jobs + 1,
-      ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
 
-    INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (rand_token, NEW.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
-  END IF;
+    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+	n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
+      # runnable
+      INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_jobs = n_ready_jobs + 1,
+	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
 
-  IF OLD.state = 'Running' THEN
-    INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu) VALUES (in_user, rand_token, -1, -1 * OLD.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      n_running_jobs = n_running_jobs - 1,
-      running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
-  END IF;
+      INSERT INTO ready_cores (token, ready_cores_mcpu)
+      VALUES (rand_token, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_cancellable_resources (batch_id, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+	running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
 
-  IF NEW.state = 'Running' THEN
-    INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu) VALUES (in_user, rand_token, 1, NEW.cores_mcpu)
-    ON DUPLICATE KEY UPDATE
-      n_running_jobs = n_running_jobs + 1,
-      running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_resources (user, token, n_cancelled_running_jobs)
+      VALUES (cur_user, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+	n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+    ELSE
+      # running
+      INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_running_jobs = n_running_jobs + 1,
+	running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    END IF;
   END IF;
+END $$
+
+CREATE PROCEDURE recompute_incremental(
+) BEGIN
+
+  START TRANSACTION;
+
+  DELETE FROM batches_staging;
+  DELETE FROM batch_cancellable_resources;
+  DELETE FROM ready_cores;
+  DELETE FROM user_resources;
+
+  INSERT INTO batches_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT t.batch_id, 0, t.n_jobs, t.n_ready_jobs, t.ready_cores_mcpu
+  FROM (SELECT batch_id,
+      COALESCE(SUM(1), 0) as n_jobs,
+      COALESCE(SUM(state = 'Ready'), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(state = 'Ready', cores_mcpu, 0)), 0) as ready_cores_mcpu
+    FROM (SELECT
+        batches.id as batch_id,
+	jobs.state,
+	jobs.cores_mcpu
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE NOT batches.`state` = 'open') AS s
+    GROUP BY batch_id) as t;
+
+  INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+  SELECT t.batch_id, 0, t.n_ready_cancellable_jobs, t.ready_cancellable_cores_mcpu
+  FROM (SELECT batch_id,
+      COALESCE(SUM(cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu
+    FROM (SELECT
+        batches.id as batch_id,
+	jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE batches.`state` = 'running'
+        AND jobs.state = 'Ready') AS s
+    GROUP BY batch_id) as t;
+
+  INSERT INTO ready_cores (token, ready_cores_mcpu)
+  SELECT 0, t.ready_cores_mcpu
+  FROM (SELECT COALESCE(SUM(cores_mcpu), 0) as ready_cores_mcpu
+    FROM jobs
+    INNER JOIN batches ON batches.id = jobs.batch_id
+    WHERE batches.`state` = 'running'
+	    AND jobs.state = 'Ready'
+	    # runnable
+	    AND (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled))) as t;
+
+  INSERT INTO user_resources (token, user, n_ready_jobs, ready_cores_mcpu,
+    n_running_jobs, running_cores_mcpu,
+    n_cancelled_ready_jobs, n_cancelled_running_jobs)
+  SELECT 0, t.user, t.n_ready_jobs, t.ready_cores_mcpu,
+    t.n_running_jobs, t.running_cores_mcpu,
+    t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs
+  FROM (SELECT user,
+      COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+      COALESCE(SUM(IF(state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
+      COALESCE(SUM(state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs
+    FROM (SELECT
+        jobs.state,
+	jobs.cores_mcpu,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+	(NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled,
+        batches.user
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE batches.`state` = 'running') AS s
+    GROUP BY user) as t;
+
+  COMMIT;
+
 END $$
 
 CREATE PROCEDURE activate_instance(
@@ -350,7 +519,7 @@ CREATE PROCEDURE close_batch(
   IN in_timestamp BIGINT
 )
 BEGIN
-  DECLARE cur_batch_closed BOOLEAN;
+  DECLARE cur_batch_state VARCHAR(40);
   DECLARE expected_n_jobs INT;
   DECLARE staging_n_jobs INT;
   DECLARE staging_n_ready_jobs INT;
@@ -359,11 +528,11 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT n_jobs, closed INTO expected_n_jobs, cur_batch_closed FROM batches
+  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
   WHERE id = in_batch_id AND NOT deleted
   FOR UPDATE;
 
-  IF cur_batch_closed THEN
+  IF cur_batch_state != 'open' THEN
     COMMIT;
     SELECT 0 as rc;
   ELSE
@@ -376,12 +545,17 @@ BEGIN
     SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
 
     IF staging_n_jobs = expected_n_jobs THEN
-      UPDATE batches SET closed = 1 WHERE id = in_batch_id;
-      UPDATE batches SET time_completed = in_timestamp
-        WHERE id = in_batch_id AND n_completed = batches.n_jobs;
+      IF expected_n_jobs = 0 THEN
+        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp
+          WHERE id = in_batch_id;
+      ELSE
+        UPDATE batches SET `state` = 'running'
+	  WHERE id = in_batch_id;
+      END IF;
 
-      INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (0, staging_ready_cores_mcpu)
-        ON DUPLICATE KEY UPDATE ready_cores_mcpu = ready_cores_mcpu + staging_ready_cores_mcpu;
+      INSERT INTO ready_cores (token, ready_cores_mcpu)
+      VALUES (0, staging_ready_cores_mcpu)
+      ON DUPLICATE KEY UPDATE ready_cores_mcpu = ready_cores_mcpu + staging_ready_cores_mcpu;
 
       INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
       VALUES (cur_user, 0, staging_n_ready_jobs, staging_ready_cores_mcpu)
@@ -398,6 +572,64 @@ BEGIN
       SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
     END IF;
   END IF;
+END $$
+
+CREATE PROCEDURE cancel_batch(
+  IN in_batch_id VARCHAR(100)
+)
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_state VARCHAR(40);
+  DECLARE cur_cancelled BOOLEAN;
+  DECLARE cur_n_cancelled_ready_jobs INT;
+  DECLARE cur_cancelled_ready_cores_mcpu BIGINT;
+  DECLARE cur_n_cancelled_running_jobs INT;
+  DECLARE cur_cancelled_running_cores_mcpu BIGINT;
+
+  START TRANSACTION;
+
+  SELECT user, `state`, cancelled INTO cur_user, cur_batch_state, cur_cancelled FROM batches
+  WHERE id = in_batch_id
+  FOR UPDATE;
+
+  IF cur_batch_state = 'running' AND NOT cur_cancelled THEN
+    SELECT COALESCE(SUM(n_ready_cancellable_jobs), 0),
+      COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+      COALESCE(SUM(n_running_cancellable_jobs), 0),
+      COALESCE(SUM(running_cancellable_cores_mcpu), 0)
+    INTO cur_n_cancelled_ready_jobs, cur_cancelled_ready_cores_mcpu,
+      cur_n_cancelled_running_jobs, cur_cancelled_running_cores_mcpu
+    FROM batch_cancellable_resources
+    WHERE batch_id = in_batch_id;
+
+    INSERT INTO user_resources (user, token,
+      n_ready_jobs, ready_cores_mcpu,
+      n_running_jobs, running_cores_mcpu,
+      n_cancelled_ready_jobs, n_cancelled_running_jobs)
+    VALUES (cur_user, 0,
+      -cur_n_cancelled_ready_jobs, -cur_cancelled_ready_cores_mcpu,
+      -cur_n_cancelled_running_jobs, cur_cancelled_running_cores_mcpu,
+      cur_n_cancelled_ready_jobs, cur_n_cancelled_running_jobs)
+    ON DUPLICATE KEY UPDATE
+      n_ready_jobs = n_ready_jobs - cur_n_cancelled_ready_jobs,
+      ready_cores_mcpu = ready_cores_mcpu - cur_cancelled_ready_cores_mcpu,
+      n_running_jobs = n_running_jobs - cur_n_cancelled_running_jobs,
+      running_cores_mcpu = running_cores_mcpu - cur_cancelled_running_cores_mcpu,
+      n_cancelled_ready_jobs = n_cancelled_ready_jobs + cur_n_cancelled_ready_jobs,
+      n_cancelled_running_jobs = n_cancelled_running_jobs + cur_n_cancelled_running_jobs;
+
+    INSERT INTO ready_cores (token, ready_cores_mcpu)
+    VALUES (0, -cur_cancelled_ready_cores_mcpu)
+    ON DUPLICATE KEY UPDATE
+      ready_cores_mcpu = ready_cores_mcpu - cur_cancelled_ready_cores_mcpu;
+
+    # there are no cancellable jobs left, they have been cancelled
+    DELETE FROM batch_cancellable_resources WHERE batch_id = in_batch_id;
+
+    UPDATE batches SET cancelled = 1 WHERE id = in_batch_id;
+  END IF;
+
+  COMMIT;
 END $$
 
 CREATE PROCEDURE add_attempt(
@@ -444,12 +676,12 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT state, cores_mcpu, attempt_id,
+  SELECT jobs.state, cores_mcpu, attempt_id,
     (jobs.cancelled OR batches.cancelled) AND NOT always_run
   INTO cur_job_state, cur_cores_mcpu, cur_attempt_id, cur_job_cancel
   FROM jobs
   INNER JOIN batches ON batches.id = jobs.batch_id
-  WHERE batch_id = in_batch_id AND batches.closed
+  WHERE batch_id = in_batch_id AND batches.`state` = 'running'
     AND job_id = in_job_id
   FOR UPDATE;
 
@@ -548,12 +780,12 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT state, cores_mcpu,
+  SELECT jobs.state, cores_mcpu,
     (jobs.cancelled OR batches.cancelled) AND NOT always_run
   INTO cur_job_state, cur_cores_mcpu, cur_job_cancel
   FROM jobs
   INNER JOIN batches ON batches.id = jobs.batch_id
-  WHERE batch_id = in_batch_id AND batches.closed
+  WHERE batch_id = in_batch_id AND batches.`state` = 'running'
     AND job_id = in_job_id
   FOR UPDATE;
 
@@ -635,7 +867,9 @@ BEGIN
     WHERE batch_id = in_batch_id AND job_id = in_job_id;
 
     UPDATE batches SET n_completed = n_completed + 1 WHERE id = in_batch_id;
-    UPDATE batches SET time_completed = new_timestamp
+    UPDATE batches
+      SET time_completed = new_timestamp,
+          `state` = 'complete'
       WHERE id = in_batch_id AND n_completed = batches.n_jobs;
 
     IF new_state = 'Cancelled' THEN

--- a/batch/sql/estimated-current.txt
+++ b/batch/sql/estimated-current.txt
@@ -94,7 +94,7 @@ CREATE TABLE `batch_cancellable_resources` (
   `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
   `n_running_cancellable_jobs` INT NOT NULL DEFAULT 0,
-  `running_cancellable_cores_mcpu` INT NOT NULL DEFAULT 0,
+  `running_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (`batch_id`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -114,7 +114,7 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
-CREATE INDEX `jobs_batch_id_always_run_state_cancelled` ON `jobs` (`batch_id`, `always_run`, `state`, `cancelled`);
+CREATE INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `cancelled`);
 
 CREATE TABLE IF NOT EXISTS `attempts` (
   `batch_id` BIGINT NOT NULL,
@@ -232,7 +232,8 @@ BEGIN
   DECLARE rand_token INT;
 
   SELECT user, cancelled INTO cur_user, cur_batch_cancelled FROM batches
-  WHERE id = NEW.batch_id;
+  WHERE id = NEW.batch_id
+  LOCK IN SHARE MODE;
 
   SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
   SET rand_token = FLOOR(RAND() * cur_n_tokens);
@@ -243,8 +244,8 @@ BEGIN
       INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
       VALUES (OLD.batch_id, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
-	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
     END IF;
 
     IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
@@ -252,19 +253,19 @@ BEGIN
       INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
       VALUES (cur_user, rand_token, -1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
     ELSE
       # runnable
       INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
       VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_ready_jobs = n_ready_jobs - 1,
-	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+        n_ready_jobs = n_ready_jobs - 1,
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
 
       INSERT INTO ready_cores (token, ready_cores_mcpu)
       VALUES (rand_token, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
     END IF;
   ELSEIF OLD.state = 'Running' THEN
     IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
@@ -272,8 +273,8 @@ BEGIN
       INSERT INTO batch_cancellable_resources (batch_id, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
       VALUES (OLD.batch_id, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
-	running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
     END IF;
 
     # state = 'Running' jobs cannot be cancelled at the job level
@@ -282,14 +283,14 @@ BEGIN
       INSERT INTO user_resources (user, token, n_cancelled_running_jobs)
       VALUES (cur_user, rand_token, -1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
     ELSE
       # running
       INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu)
       VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_running_jobs = n_running_jobs - 1,
-	running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+        n_running_jobs = n_running_jobs - 1,
+        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
     END IF;
   END IF;
 
@@ -299,8 +300,8 @@ BEGIN
       INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
       VALUES (NEW.batch_id, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
-	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
     END IF;
 
     IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
@@ -308,19 +309,19 @@ BEGIN
       INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
       VALUES (cur_user, rand_token, 1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
     ELSE
       # runnable
       INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
       VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_ready_jobs = n_ready_jobs + 1,
-	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+        n_ready_jobs = n_ready_jobs + 1,
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
 
       INSERT INTO ready_cores (token, ready_cores_mcpu)
       VALUES (rand_token, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
     END IF;
   ELSEIF NEW.state = 'Running' THEN
     IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
@@ -328,8 +329,8 @@ BEGIN
       INSERT INTO batch_cancellable_resources (batch_id, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
       VALUES (NEW.batch_id, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
-	running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
     END IF;
 
     # state = 'Running' jobs cannot be cancelled at the job level
@@ -338,14 +339,14 @@ BEGIN
       INSERT INTO user_resources (user, token, n_cancelled_running_jobs)
       VALUES (cur_user, rand_token, 1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
     ELSE
       # running
       INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu)
       VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
       ON DUPLICATE KEY UPDATE
-	n_running_jobs = n_running_jobs + 1,
-	running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+        n_running_jobs = n_running_jobs + 1,
+        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
     END IF;
   END IF;
 END $$
@@ -353,78 +354,75 @@ END $$
 CREATE PROCEDURE recompute_incremental(
 ) BEGIN
 
-  START TRANSACTION;
-
   DELETE FROM batches_staging;
   DELETE FROM batch_cancellable_resources;
   DELETE FROM ready_cores;
   DELETE FROM user_resources;
 
-  INSERT INTO batches_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
-  SELECT t.batch_id, 0, t.n_jobs, t.n_ready_jobs, t.ready_cores_mcpu
-  FROM (SELECT batch_id,
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_resources`;
+
+  CREATE TEMPORARY TABLE `tmp_batch_resources` AS (
+    SELECT batch_id, batch_state, batch_cancelled, user,
       COALESCE(SUM(1), 0) as n_jobs,
-      COALESCE(SUM(state = 'Ready'), 0) as n_ready_jobs,
-      COALESCE(SUM(IF(state = 'Ready', cores_mcpu, 0)), 0) as ready_cores_mcpu
-    FROM (SELECT
+      COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND runnable), 0) as n_runnable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as runnable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(job_state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs
+    FROM (
+      SELECT batches.user,
         batches.id as batch_id,
-	jobs.state,
-	jobs.cores_mcpu
+        batches.state as batch_state,
+        batches.cancelled as batch_cancelled,
+        jobs.state as job_state,
+        jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+        (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
       FROM jobs
-      INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE NOT batches.`state` = 'open') AS s
-    GROUP BY batch_id) as t;
+      INNER JOIN batches
+        ON batches.id = jobs.batch_id
+      LOCK IN SHARE MODE) as t
+    GROUP BY batch_id, batch_state, batch_cancelled, user
+  );
+
+  INSERT INTO batches_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, 0, n_jobs, n_runnable_jobs, runnable_cores_mcpu
+  FROM tmp_batch_resources
+  WHERE batch_state = 'open';
 
   INSERT INTO batch_cancellable_resources (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
-  SELECT t.batch_id, 0, t.n_ready_cancellable_jobs, t.ready_cancellable_cores_mcpu
-  FROM (SELECT batch_id,
-      COALESCE(SUM(cancellable), 0) as n_ready_cancellable_jobs,
-      COALESCE(SUM(IF(cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu
-    FROM (SELECT
-        batches.id as batch_id,
-	jobs.cores_mcpu,
-        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable
-      FROM jobs
-      INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE batches.`state` = 'running'
-        AND jobs.state = 'Ready') AS s
-    GROUP BY batch_id) as t;
+  SELECT batch_id, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu
+  FROM tmp_batch_resources
+  WHERE NOT batch_cancelled;
 
   INSERT INTO ready_cores (token, ready_cores_mcpu)
-  SELECT 0, t.ready_cores_mcpu
-  FROM (SELECT COALESCE(SUM(cores_mcpu), 0) as ready_cores_mcpu
-    FROM jobs
-    INNER JOIN batches ON batches.id = jobs.batch_id
-    WHERE batches.`state` = 'running'
-	    AND jobs.state = 'Ready'
-	    # runnable
-	    AND (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled))) as t;
+  SELECT 0, t.runnable_cores_mcpu
+  FROM (SELECT COALESCE(SUM(runnable_cores_mcpu), 0) as runnable_cores_mcpu
+    FROM tmp_batch_resources
+    WHERE batch_state != 'open') as t;
 
   INSERT INTO user_resources (token, user, n_ready_jobs, ready_cores_mcpu,
     n_running_jobs, running_cores_mcpu,
     n_cancelled_ready_jobs, n_cancelled_running_jobs)
-  SELECT 0, t.user, t.n_ready_jobs, t.ready_cores_mcpu,
+  SELECT 0, t.user, t.n_runnable_jobs, t.runnable_cores_mcpu,
     t.n_running_jobs, t.running_cores_mcpu,
     t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs
   FROM (SELECT user,
-      COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
-      COALESCE(SUM(IF(state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
-      COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_ready_jobs,
-      COALESCE(SUM(IF(state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
-      COALESCE(SUM(state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
-      COALESCE(SUM(state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs
-    FROM (SELECT
-        jobs.state,
-	jobs.cores_mcpu,
-        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
-	(NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled,
-        batches.user
-      FROM jobs
-      INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE batches.`state` = 'running') AS s
-    GROUP BY user) as t;
+      COALESCE(SUM(n_running_jobs), 0) as n_running_jobs,
+      COALESCE(SUM(running_cores_mcpu), 0) as running_cores_mcpu,
+      COALESCE(SUM(n_runnable_jobs), 0) as n_runnable_jobs,
+      COALESCE(SUM(runnable_cores_mcpu), 0) as runnable_cores_mcpu,
+      COALESCE(SUM(n_cancelled_ready_jobs), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs
+    FROM tmp_batch_resources
+    WHERE batch_state != 'open'
+    GROUP by user) as t;
 
-  COMMIT;
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_resources`;
 
 END $$
 
@@ -550,7 +548,7 @@ BEGIN
           WHERE id = in_batch_id;
       ELSE
         UPDATE batches SET `state` = 'running'
-	  WHERE id = in_batch_id;
+          WHERE id = in_batch_id;
       END IF;
 
       INSERT INTO ready_cores (token, ready_cores_mcpu)
@@ -600,7 +598,8 @@ BEGIN
     INTO cur_n_cancelled_ready_jobs, cur_cancelled_ready_cores_mcpu,
       cur_n_cancelled_running_jobs, cur_cancelled_running_cores_mcpu
     FROM batch_cancellable_resources
-    WHERE batch_id = in_batch_id;
+    WHERE batch_id = in_batch_id
+    LOCK IN SHARE MODE;
 
     INSERT INTO user_resources (user, token,
       n_ready_jobs, ready_cores_mcpu,
@@ -608,7 +607,7 @@ BEGIN
       n_cancelled_ready_jobs, n_cancelled_running_jobs)
     VALUES (cur_user, 0,
       -cur_n_cancelled_ready_jobs, -cur_cancelled_ready_cores_mcpu,
-      -cur_n_cancelled_running_jobs, cur_cancelled_running_cores_mcpu,
+      -cur_n_cancelled_running_jobs, -cur_cancelled_running_cores_mcpu,
       cur_n_cancelled_ready_jobs, cur_n_cancelled_running_jobs)
     ON DUPLICATE KEY UPDATE
       n_ready_jobs = n_ready_jobs - cur_n_cancelled_ready_jobs,

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -60,7 +60,7 @@ CREATE PROCEDURE recompute_incremental(
     FROM (
       SELECT jobs.batch_id,
         jobs.state,
-        jobs.cores_mcpu
+        jobs.cores_mcpu,
         NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
         (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
         (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -1,4 +1,19 @@
 
+ALTER TABLE `batches` ADD COLUMN `state` VARCHAR(40);
+
+UPDATE `batches`
+SET `state` = CASE
+  WHEN NOT closed THEN 'open'
+  WHEN n_completed = n_jobs THEN 'complete'
+  ELSE 'running'
+  END;
+
+ALTER TABLE `batches`
+  MODIFY COLUMN `state` VARCHAR(40) NOT NULL,
+  DROP COLUMN closed;
+
+CREATE INDEX `batches_state_cancelled` ON `batches` (`state`, `cancelled`);
+
 CREATE TABLE `batch_ready_cancellable` (
   `batch_id` BIGINT NOT NULL,
   `token` INT NOT NULL,
@@ -33,7 +48,7 @@ CREATE PROCEDURE recompute_incremental(
 	jobs.cores_mcpu
       FROM jobs
       INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE NOT batches.closed) AS s
+      WHERE NOT batches.`state` = 'open') AS s
     GROUP BY batch_id) as t;
 
   INSERT INTO batch_ready_cancellable (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
@@ -47,7 +62,7 @@ CREATE PROCEDURE recompute_incremental(
         NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable
       FROM jobs
       INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE batches.closed
+      WHERE batches.`state` = 'running'
         AND jobs.state = 'Ready') AS s
     GROUP BY batch_id) as t;
 
@@ -56,7 +71,7 @@ CREATE PROCEDURE recompute_incremental(
   FROM (SELECT COALESCE(SUM(cores_mcpu), 0) as ready_cores_mcpu
     FROM jobs
     INNER JOIN batches ON batches.id = jobs.batch_id
-    WHERE batches.closed
+    WHERE batches.`state` = 'running'
 	    AND jobs.state = 'Ready'
 	    # runnable
 	    AND (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled))) as t;
@@ -75,7 +90,7 @@ CREATE PROCEDURE recompute_incremental(
         batches.user
       FROM jobs
       INNER JOIN batches ON batches.id = jobs.batch_id
-      WHERE batches.closed) AS s
+      WHERE batches.`state` = 'running') AS s
     GROUP BY user) as t;
 
   COMMIT;
@@ -87,18 +102,18 @@ CREATE PROCEDURE cancel_batch(
 )
 BEGIN
   DECLARE cur_user VARCHAR(100);
-  DECLARE cur_closed BOOLEAN;
+  DECLARE cur_batch_state BOOLEAN;
   DECLARE cur_cancelled BOOLEAN;
   DECLARE cur_n_ready_cancelled_jobs INT;
   DECLARE cur_ready_cancelled_cores_mcpu BIGINT;
 
   START TRANSACTION;
 
-  SELECT user, closed, cancelled INTO cur_user, cur_closed, cur_cancelled FROM batches
+  SELECT user, `state`, cancelled INTO cur_user, cur_batch_state, cur_cancelled FROM batches
   WHERE id = in_batch_id
   FOR UPDATE;
 
-  IF cur_closed AND NOT cur_cancelled THEN
+  IF cur_batch_state = 'running' AND NOT cur_cancelled THEN
     SELECT COALESCE(SUM(n_ready_cancellable_jobs), 0), COALESCE(SUM(ready_cancellable_cores_mcpu), 0)
     INTO cur_n_ready_cancelled_jobs, cur_ready_cancelled_cores_mcpu
     FROM batch_ready_cancellable
@@ -122,6 +137,271 @@ BEGIN
   END IF;
 
   COMMIT;
+END $$
+
+DROP PROCEDURE IF EXISTS close_batch;
+CREATE PROCEDURE close_batch(
+  IN in_batch_id BIGINT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_batch_state BOOLEAN;
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+
+  START TRANSACTION;
+
+  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
+  WHERE id = in_batch_id AND NOT deleted
+  FOR UPDATE;
+
+  IF cur_batch_state != 'open' THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batches_staging
+    WHERE batch_id = in_batch_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      IF expected_n_jobs = 0 THEN
+        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp
+          WHERE id = in_batch_id;
+      ELSE
+        UPDATE batches SET `state` = 'running'
+	  WHERE id = in_batch_id;
+      ENDIF;
+
+      INSERT INTO ready_cores (token, ready_cores_mcpu)
+      VALUES (0, staging_ready_cores_mcpu)
+      ON DUPLICATE KEY UPDATE ready_cores_mcpu = ready_cores_mcpu + staging_ready_cores_mcpu;
+
+      INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, 0, staging_n_ready_jobs, staging_ready_cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + staging_n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + staging_ready_cores_mcpu;
+
+      DELETE FROM batches_staging WHERE batch_id = in_batch_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS schedule_job;
+CREATE PROCEDURE schedule_job(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100)
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_job_cancel BOOLEAN;
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_attempt_id VARCHAR(40);
+  DECLARE delta_cores_mcpu INT;
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu, attempt_id,
+    (jobs.cancelled OR batches.cancelled) AND NOT always_run
+  INTO cur_job_state, cur_cores_mcpu, cur_attempt_id, cur_job_cancel
+  FROM jobs
+  INNER JOIN batches ON batches.id = jobs.batch_id
+  WHERE batch_id = in_batch_id AND batches.`state` = 'running'
+    AND job_id = in_job_id
+  FOR UPDATE;
+
+  # FIXME if state is complete this will have the wrong cores_mcpu
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  IF delta_cores_mcpu = 0 THEN
+    SET delta_cores_mcpu = cur_cores_mcpu;
+  ELSE
+    SET delta_cores_mcpu = 0;
+  END IF;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  # FIXME when making attempt for inactive instance, attempt endtime should match instance?
+  IF cur_job_state = 'Ready' AND NOT cur_job_cancel AND cur_instance_state = 'active' THEN
+    UPDATE jobs SET state = 'Running', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
+    COMMIT;
+    SELECT 0 as rc, in_instance_name, delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      cur_job_cancel,
+      cur_instance_state,
+      in_instance_name,
+      cur_attempt_id,
+      delta_cores_mcpu,
+      'job not Ready or cancelled or instance not active, but attempt already exists' as message;
+  END IF;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_started;
+CREATE PROCEDURE mark_job_started(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_start_time BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_job_cancel BOOLEAN;
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE delta_cores_mcpu INT;
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu,
+    (jobs.cancelled OR batches.cancelled) AND NOT always_run
+  INTO cur_job_state, cur_cores_mcpu, cur_job_cancel
+  FROM jobs
+  INNER JOIN batches ON batches.id = jobs.batch_id
+  WHERE batch_id = in_batch_id AND batches.`state` = 'running'
+    AND job_id = in_job_id
+  FOR UPDATE;
+
+  # FIXME if state is complete this will have the wrong cores_mcpu
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  UPDATE attempts SET start_time = new_start_time
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  IF cur_job_state = 'Ready' AND NOT cur_job_cancel AND cur_instance_state = 'active' THEN
+    UPDATE jobs SET state = 'Running', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
+  END IF;
+
+  COMMIT;
+  SELECT 0 as rc, delta_cores_mcpu;
+END $$
+
+DROP PROCEDURE IF EXISTS mark_job_complete;
+CREATE PROCEDURE mark_job_complete(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100),
+  IN new_state VARCHAR(40),
+  IN new_status TEXT,
+  IN new_start_time BIGINT,
+  IN new_end_time BIGINT,
+  IN new_reason VARCHAR(40),
+  IN new_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE delta_cores_mcpu INT DEFAULT 0;
+  DECLARE expected_attempt_id VARCHAR(40);
+
+  START TRANSACTION;
+
+  SELECT state, cores_mcpu
+  INTO cur_job_state, cur_cores_mcpu
+  FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  SELECT end_time INTO cur_end_time FROM attempts
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id
+  FOR UPDATE;
+
+  UPDATE attempts
+  SET start_time = new_start_time, end_time = new_end_time, reason = new_reason
+  WHERE batch_id = in_batch_id AND job_id = in_job_id AND attempt_id = in_attempt_id;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name FOR UPDATE;
+  IF cur_instance_state = 'active' AND cur_end_time IS NULL THEN
+    UPDATE instances
+    SET free_cores_mcpu = free_cores_mcpu + cur_cores_mcpu
+    WHERE name = in_instance_name;
+
+    SET delta_cores_mcpu = delta_cores_mcpu + cur_cores_mcpu;
+  END IF;
+
+  SELECT attempt_id INTO expected_attempt_id FROM jobs
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  IF expected_attempt_id != in_attempt_id THEN
+    COMMIT;
+    SELECT 2 as rc,
+      expected_attempt_id,
+      delta_cores_mcpu,
+      'input attempt id does not match expected attempt id' as message;
+  ELSEIF cur_job_state = 'Ready' OR cur_job_state = 'Running' THEN
+    UPDATE jobs
+    SET state = new_state, status = new_status, attempt_id = NULL
+    WHERE batch_id = in_batch_id AND job_id = in_job_id;
+
+    UPDATE batches SET n_completed = n_completed + 1 WHERE id = in_batch_id;
+    UPDATE batches
+      SET time_completed = new_timestamp,
+          `state` = 'complete'
+      WHERE id = in_batch_id AND n_completed = batches.n_jobs;
+
+    IF new_state = 'Cancelled' THEN
+      UPDATE batches SET n_cancelled = n_cancelled + 1 WHERE id = in_batch_id;
+    ELSEIF new_state = 'Error' OR new_state = 'Failed' THEN
+      UPDATE batches SET n_failed = n_failed + 1 WHERE id = in_batch_id;
+    ELSE
+      UPDATE batches SET n_succeeded = n_succeeded + 1 WHERE id = in_batch_id;
+    END IF;
+
+    UPDATE jobs
+      INNER JOIN `job_parents`
+        ON jobs.batch_id = `job_parents`.batch_id AND
+           jobs.job_id = `job_parents`.job_id
+      SET jobs.state = IF(jobs.n_pending_parents = 1, 'Ready', 'Pending'),
+          jobs.n_pending_parents = jobs.n_pending_parents - 1,
+          jobs.cancelled = IF(new_state = 'Success', jobs.cancelled, 1)
+      WHERE jobs.batch_id = in_batch_id AND
+            `job_parents`.batch_id = in_batch_id AND
+            `job_parents`.parent_id = in_job_id;
+
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSEIF cur_job_state = 'Cancelled' OR cur_job_state = 'Error' OR
+         cur_job_state = 'Failed' OR cur_job_state = 'Success' THEN
+    COMMIT;
+    SELECT 0 as rc,
+      cur_job_state as old_state,
+      delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      delta_cores_mcpu,
+      'job state not Ready, Running or complete' as message;
+  END IF;
 END $$
 
 DROP TRIGGER IF EXISTS jobs_after_update;

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -217,7 +217,7 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT state, cores_mcpu, attempt_id,
+  SELECT jobs.state, cores_mcpu, attempt_id,
     (jobs.cancelled OR batches.cancelled) AND NOT always_run
   INTO cur_job_state, cur_cores_mcpu, cur_attempt_id, cur_job_cancel
   FROM jobs
@@ -272,7 +272,7 @@ BEGIN
 
   START TRANSACTION;
 
-  SELECT state, cores_mcpu,
+  SELECT jobs.state, cores_mcpu,
     (jobs.cancelled OR batches.cancelled) AND NOT always_run
   INTO cur_job_state, cur_cores_mcpu, cur_job_cancel
   FROM jobs

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -159,7 +159,7 @@ BEGIN
       INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (rand_token, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
 	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
-    ENDIF;
+    END IF;
   ELSEIF OLD.state = 'Running' THEN
     INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu) VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
     ON DUPLICATE KEY UPDATE

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -68,7 +68,8 @@ CREATE PROCEDURE recompute_incremental(
         (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
       FROM jobs
       INNER JOIN batches
-        ON batches.id = jobs.batch_id) as t
+        ON batches.id = jobs.batch_id
+      LOCK IN SHARE MODE) as t
     GROUP BY batch_id, batch_state, user
   );
 

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -464,12 +464,11 @@ BEGIN
 
     IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
       # cancelled
-      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs, cancelled_ready_cores_mcpu)
-      VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
+      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, rand_token, -1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1,
-	cancelled_ready_cores_mcpu = cancelled_ready_cores_mcpu - OLD.cores_mcpu;
-    ELSE    
+	n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
       # runnable
       INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
       VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
@@ -521,12 +520,11 @@ BEGIN
 
     IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
       # cancelled
-      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs, cancelled_ready_cores_mcpu)
-      VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
+      INSERT INTO user_resources (user, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, rand_token, 1)
       ON DUPLICATE KEY UPDATE
-	n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1,
-	cancelled_ready_cores_mcpu = cancelled_ready_cores_mcpu + NEW.cores_mcpu;
-    ELSE    
+	n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
       # runnable
       INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
       VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -50,7 +50,7 @@ CREATE PROCEDURE recompute_incremental(
     SELECT batch_id, state, user,
       COALESCE(SUM(1), 0) as n_jobs,
       COALESCE(SUM(state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
-      COALESCE(SUM(IF(state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu
+      COALESCE(SUM(IF(state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
       COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
       COALESCE(SUM(IF(state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
       COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_runnable_jobs,

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -12,14 +12,11 @@ ALTER TABLE `batches`
   MODIFY COLUMN `state` VARCHAR(40) NOT NULL,
   DROP COLUMN closed;
 
-
 DROP INDEX `batches_user` ON `batches`;
 CREATE INDEX `batches_user_state_cancelled` ON `batches` (`user`, `state`, `cancelled`);
 
 DROP INDEX `jobs_state` ON `jobs`;
 CREATE INDEX `jobs_batch_id_always_run_state_cancelled` ON `jobs` (`batch_id`, `always_run`, `state`, `cancelled`);
-
-CREATE INDEX `batches_state_cancelled` ON `batches` (`state`, `cancelled`);
 
 ALTER TABLE `user_resources`
   ADD COLUMN `n_cancelled_ready_jobs` INT NOT NULL DEFAULT 0,

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -259,7 +259,6 @@ BEGIN
     AND job_id = in_job_id
   FOR UPDATE;
 
-  # FIXME if state is complete this will have the wrong cores_mcpu
   CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
 
   IF delta_cores_mcpu = 0 THEN
@@ -270,7 +269,6 @@ BEGIN
 
   SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
 
-  # FIXME when making attempt for inactive instance, attempt endtime should match instance?
   IF cur_job_state = 'Ready' AND NOT cur_job_cancel AND cur_instance_state = 'active' THEN
     UPDATE jobs SET state = 'Running', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
     COMMIT;
@@ -314,7 +312,6 @@ BEGIN
     AND job_id = in_job_id
   FOR UPDATE;
 
-  # FIXME if state is complete this will have the wrong cores_mcpu
   CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
 
   UPDATE attempts SET start_time = new_start_time

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -6,7 +6,7 @@ CREATE TABLE `batch_ready_cancellable` (
   `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
   `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (`batch_id`, `token`),
-  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
 
 DELIMITER $$

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -16,7 +16,7 @@ DROP INDEX `batches_user` ON `batches`;
 CREATE INDEX `batches_user_state_cancelled` ON `batches` (`user`, `state`, `cancelled`);
 
 DROP INDEX `jobs_state` ON `jobs`;
-CREATE INDEX `jobs_batch_id_always_run_state_cancelled` ON `jobs` (`batch_id`, `always_run`, `state`, `cancelled`);
+CREATE INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `cancelled`);
 
 ALTER TABLE `user_resources`
   ADD COLUMN `n_cancelled_ready_jobs` INT NOT NULL DEFAULT 0,

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -60,8 +60,8 @@ CREATE PROCEDURE recompute_incremental(
     FROM (
       SELECT batches.user,
         batches.id as batch_id,
-	batches.state as batch_state,
-	batches.cancelled as batch_cancelled,
+        batches.state as batch_state,
+        batches.cancelled as batch_cancelled,
         jobs.state as job_state,
         jobs.cores_mcpu,
         NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -177,7 +177,7 @@ BEGIN
       ELSE
         UPDATE batches SET `state` = 'running'
 	  WHERE id = in_batch_id;
-      ENDIF;
+      END IF;
 
       INSERT INTO ready_cores (token, ready_cores_mcpu)
       VALUES (0, staging_ready_cores_mcpu)

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -1,0 +1,201 @@
+
+CREATE TABLE `batch_ready_cancellable` (
+  `batch_id` BIGINT NOT NULL,
+  `token` INT NOT NULL,
+  # neither run_always nor cancelled
+  `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,
+  `ready_cancellable_cores_mcpu` BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (`batch_id`, `token`),
+  FOREIGN KEY (`batch_id`) REFERENCES batches(id) ON DELETE CASCADE,
+) ENGINE = InnoDB;
+
+DELIMITER $$
+
+CREATE PROCEDURE recompute_incremental(
+) BEGIN
+
+  START TRANSACTION;
+
+  DELETE FROM batch_staging;
+  DELETE FROM batch_ready_cancellable;
+  DELETE FROM ready_cores;
+  DELETE FROM user_resources;
+
+  INSERT INTO batch_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT t.batch_id, 0, t.n_jobs, t.n_ready_jobs, t.ready_cores_mcpu
+  FROM (SELECT batch_id,
+      COALESCE(SUM(1), 0) as n_jobs,
+      COALESCE(SUM(state = 'Ready'), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(state = 'Ready', cores_mcpu, 0)), 0) as ready_cores_mcpu
+    FROM (SELECT
+        batches.id as batch_id,
+	jobs.state,
+	jobs.cores_mcpu
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE NOT batches.closed) AS s
+    GROUP BY batch_id) as t;
+
+  INSERT INTO batch_ready_cancellable (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+  SELECT t.batch_id, 0, t.n_ready_cancellable_jobs, t.ready_cancellable_cores_mcpu
+  FROM (SELECT batch_id,
+      COALESCE(SUM(cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu
+    FROM (SELECT
+        batches.id as batch_id,
+	jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE batches.closed
+        AND jobs.state = 'Ready') AS s
+    GROUP BY batch_id) as t;
+
+  INSERT INTO ready_cores (token, ready_cores_mcpu)
+  SELECT 0, t.ready_cores_mcpu
+  FROM (SELECT COALESCE(SUM(cores_mcpu), 0) as ready_cores_mcpu
+    FROM jobs
+    INNER JOIN batches ON batches.id = jobs.batch_id
+    WHERE batches.closed
+	    AND jobs.state = 'Ready'
+	    # runnable
+	    AND (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled))) as t;
+
+  INSERT INTO user_resources (token, user, n_ready_jobs, ready_cores_mcpu, n_running_jobs, running_cores_mcpu)
+  SELECT 0, t.user, t.n_ready_jobs, t.ready_cores_mcpu,t.n_running_jobs, t.running_cores_mcpu
+  FROM (SELECT user,
+      COALESCE(SUM(state = 'Running'), 0) as n_running_jobs,
+      COALESCE(SUM(IF(state = 'Running', cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_ready_jobs,
+      COALESCE(SUM(IF(state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu
+    FROM (SELECT
+        jobs.state,
+	jobs.cores_mcpu,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+        batches.user
+      FROM jobs
+      INNER JOIN batches ON batches.id = jobs.batch_id
+      WHERE batches.closed) AS s
+    GROUP BY user) as t;
+
+  COMMIT;
+
+END $$
+
+CREATE PROCEDURE cancel_batch(
+  IN in_batch_id VARCHAR(100)
+)
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_closed BOOLEAN;
+  DECLARE cur_cancelled BOOLEAN;
+  DECLARE cur_n_ready_cancelled_jobs INT;
+  DECLARE cur_ready_cancelled_cores_mcpu BIGINT;
+
+  START TRANSACTION;
+
+  SELECT user, closed, cancelled INTO cur_user, cur_closed, cur_cancelled FROM batches
+  WHERE id = in_batch_id
+  FOR UPDATE;
+
+  IF cur_closed AND NOT cur_cancelled THEN
+    SELECT COALESCE(SUM(n_ready_cancellable_jobs), 0), COALESCE(SUM(ready_cancellable_cores_mcpu), 0)
+    INTO cur_n_ready_cancelled_jobs, cur_ready_cancelled_cores_mcpu
+    FROM batch_ready_cancellable
+    WHERE batch_id = in_batch_id;
+
+    INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu)
+    VALUES (cur_user, 0, -cur_n_ready_cancelled_jobs, -cur_ready_cancelled_cores_mcpu)
+    ON DUPLICATE KEY UPDATE
+      n_ready_jobs = n_ready_jobs - cur_n_ready_cancelled_jobs,
+      ready_cores_mcpu = ready_cores_mcpu - cur_ready_cancelled_cores_mcpu;
+
+    INSERT INTO ready_cores (token, ready_cores_mcpu)
+    VALUES (0, -cur_ready_cancelled_cores_mcpu)
+    ON DUPLICATE KEY UPDATE
+      ready_cores_mcpu = ready_cores_mcpu - cur_ready_cancelled_cores_mcpu;
+
+    # there are no cancellable left, they have been cancelled
+    DELETE FROM batch_ready_cancellable WHERE batch_id = in_batch_id;
+
+    UPDATE batches SET cancelled = 1 WHERE id = in_batch_id;
+  END IF;
+
+  COMMIT;
+END $$
+
+DROP TRIGGER IF EXISTS jobs_after_update;
+CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT user, cancelled INTO cur_user, cur_batch_cancelled FROM batches
+  WHERE id = NEW.batch_id;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  IF OLD.state = 'Ready' THEN
+    # cancellable (and not cancelled)
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      INSERT INTO batch_ready_cancellable (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # runnable
+    IF OLD.always_run OR NOT (OLD.cancelled OR cur_batch_cancelled) THEN
+      INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu) VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_jobs = n_ready_jobs - 1,
+	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+
+      INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (rand_token, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    ENDIF;
+  ELSEIF OLD.state = 'Running' THEN
+    INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu) VALUES (cur_user, rand_token, -1, -OLD.cores_mcpu)
+    ON DUPLICATE KEY UPDATE
+      n_running_jobs = n_running_jobs - 1,
+      running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+  END IF;
+
+  IF NEW.state = 'Ready' THEN
+    # cancellable (and not cancelled)
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      INSERT INTO batch_ready_cancellable (batch_id, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+	ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    # runnable
+    IF NEW.always_run OR NOT (NEW.cancelled OR cur_batch_cancelled) THEN
+      INSERT INTO user_resources (user, token, n_ready_jobs, ready_cores_mcpu) VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	n_ready_jobs = n_ready_jobs + 1,
+	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+
+      INSERT INTO ready_cores (token, ready_cores_mcpu) VALUES (rand_token, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+	ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    INSERT INTO user_resources (user, token, n_running_jobs, running_cores_mcpu) VALUES (cur_user, rand_token, 1, NEW.cores_mcpu)
+    ON DUPLICATE KEY UPDATE
+      n_running_jobs = n_running_jobs + 1,
+      running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+  END IF;
+END $$
+
+DELIMITER ;
+
+CALL recompute_incremental();

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -102,7 +102,7 @@ CREATE PROCEDURE cancel_batch(
 )
 BEGIN
   DECLARE cur_user VARCHAR(100);
-  DECLARE cur_batch_state BOOLEAN;
+  DECLARE cur_batch_state VARCHAR(40);
   DECLARE cur_cancelled BOOLEAN;
   DECLARE cur_n_ready_cancelled_jobs INT;
   DECLARE cur_ready_cancelled_cores_mcpu BIGINT;
@@ -145,7 +145,7 @@ CREATE PROCEDURE close_batch(
   IN in_timestamp BIGINT
 )
 BEGIN
-  DECLARE cur_batch_state BOOLEAN;
+  DECLARE cur_batch_state VARCHAR(40);
   DECLARE expected_n_jobs INT;
   DECLARE staging_n_jobs INT;
   DECLARE staging_n_ready_jobs INT;

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -159,9 +159,9 @@ BEGIN
       n_cancelled_running_jobs = n_cancelled_running_jobs + cur_n_cancelled_running_jobs;
 
     INSERT INTO ready_cores (token, ready_cores_mcpu)
-    VALUES (0, -cur_ready_cancelled_cores_mcpu)
+    VALUES (0, -cur_cancelled_ready_cores_mcpu)
     ON DUPLICATE KEY UPDATE
-      ready_cores_mcpu = ready_cores_mcpu - cur_ready_cancelled_cores_mcpu;
+      ready_cores_mcpu = ready_cores_mcpu - cur_cancelled_ready_cores_mcpu;
 
     # there are no cancellable jobs left, they have been cancelled
     DELETE FROM batch_cancellable_resources WHERE batch_id = in_batch_id;

--- a/batch/sql/improve-cancel.sql
+++ b/batch/sql/improve-cancel.sql
@@ -16,12 +16,12 @@ CREATE PROCEDURE recompute_incremental(
 
   START TRANSACTION;
 
-  DELETE FROM batch_staging;
+  DELETE FROM batches_staging;
   DELETE FROM batch_ready_cancellable;
   DELETE FROM ready_cores;
   DELETE FROM user_resources;
 
-  INSERT INTO batch_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  INSERT INTO batches_staging (batch_id, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
   SELECT t.batch_id, 0, t.n_jobs, t.n_ready_jobs, t.ready_cores_mcpu
   FROM (SELECT batch_id,
       COALESCE(SUM(1), 0) as n_jobs,

--- a/batch/utils/stress.py
+++ b/batch/utils/stress.py
@@ -27,7 +27,7 @@ def stress():
             if flip(0.2):
                 c._always_run = True
 
-    p.run(open=True)
+    p.run(open=True, wait=False)
 
 if __name__ == "__main__":
     stress()

--- a/batch/utils/stress.py
+++ b/batch/utils/stress.py
@@ -27,7 +27,7 @@ def stress():
             if flip(0.2):
                 c._always_run = True
 
-    p.run(open=True, wait=False)
+    p.run(open=False, wait=False)
 
 if __name__ == "__main__":
     stress()

--- a/batch/utils/stress.py
+++ b/batch/utils/stress.py
@@ -1,0 +1,33 @@
+from hailtop import pipeline
+import random
+
+def flip(p):
+    return random.random() <= p
+
+def stress():
+    p = pipeline.Pipeline(
+        name='stress',
+        backend=pipeline.BatchBackend(billing_project='hail'),
+        default_image='ubuntu:18.04')
+
+    for i in range(100):
+        t = (p
+             .new_task(name=f'parent_{i}'))
+        d = random.choice(range(4))
+        if flip(0.2):
+            t.command(f'sleep {d}; exit 1')
+        else:
+            t.command(f'sleep {d}; echo parent {i}')
+        for j in range(10):
+            d = random.choice(range(4))
+            c = (p
+                 .new_task(name=f'child_{i}_{j}')
+                 .command(f'sleep {d}; echo child {i} {j}'))
+            c.depends_on(t)
+            if flip(0.2):
+                c._always_run = True
+
+    p.run(open=True)
+
+if __name__ == "__main__":
+    stress()

--- a/build.yaml
+++ b/build.yaml
@@ -830,6 +830,8 @@ steps:
       script: /io/sql/add-lock-in-share-mode.sql
     - name: add-batch-create-token
       script: /io/sql/add-batch-create-token.sql
+    - name: improve-cancel
+      script: /io/sql/improve-cancel.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -305,7 +305,8 @@ class BatchBackend(Backend):
                                  resources=resources,
                                  input_files=inputs if len(inputs) > 0 else None,
                                  output_files=outputs if len(outputs) > 0 else None,
-                                 pvc_size=task._storage)
+                                 pvc_size=task._storage,
+                                 always_run=task._always_run)
             n_jobs_submitted += 1
 
             task_to_job_mapping[task] = j

--- a/hail/python/hailtop/pipeline/task.py
+++ b/hail/python/hailtop/pipeline/task.py
@@ -80,6 +80,7 @@ class Task:
         self._mentioned = set()  # resources used in the command
         self._valid = set()  # resources declared in the appropriate place
         self._dependencies = set()
+        self._always_run = False
 
     def _get_resource(self, item):
         if item not in self._resources:


### PR DESCRIPTION
I finally figured out the "right" way to do cancellation.

I introduce the following notions:
 - a job is cancellable if it is ready or running, it hasn't been cancelled, but if the batch is cancelled, it will be cancelled (not always_run),
 - a job is runnable if it is ready but has not been cancelled.

Now we aim to incremental maintain the following information:

Globally:
 - runnable jobs and cores

Per user:
 - runnable and running jobs and cores,
 - running cancelled jobs, and
 - ready cancelled jobs.

The global runnable cores are needed by the instance pool controller.

The per-user stats are needed by the three threads of the scheduler:
 - for the fair share allocator and the scheduler,
 - to cancel running jobs on workers that have been cancelled (because the batch was cancelled),
 - to cancel ready jobs that have been cancelled (either because the batch was cancelled or a parent failed).

In order to update these values efficiently when a batch is cancelled, we also track in `batch_cancellable_resources` table, per batch:
 - cancellable ready jobs and cores,
 - cancellable running jobs and cores.
I added a `cancel_batch` procedure that uses these values to update ready_cores and user_resources when a batch is cancelled.

I also reorganized the threads of the scheduler.  Each one uses the above structures to compute a fair share for each user of work to do in a give iteration (dividing up 1000 tasks, with a per-user min of 20).  Those tasks are then executed with 100-way parallelism.

Other changes:
 - I added a recompute_incremental procedure for recomputing all the incremental structures,
 - I added a batches.state field (open, running or complete) and removed the closed column,
 - I updated the batch and jobs indexes to make sure all scheduler queries are probably indexed.  This isn't the case right now and we're seeing a lot of load on the database because of it.

I'm going to do some more testing and possibly rename some stuff, but it is passing and the incremental structures all line up at the end of the tests.

The only issue I see is I loop through all running batches for a user in the scheduler.  If a user submits many many small batches, this could be an issue.  I plan to address this in a later PR.

FYI @danking 