### PR TITLE
[hail] Clear trailing missing bits on encoded arrays as well

### DIFF
--- a/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
@@ -94,6 +94,12 @@ def write_range_matrix_table_p100():
 
 
 @benchmark(args=profile_25.handle('mt'))
+def write_profile_mt(mt_path):
+    with TemporaryDirectory() as tmpdir:
+        hl.read_matrix_table(mt_path).write(path.join(tmpdir, 'tmp.mt'))
+
+
+@benchmark(args=profile_25.handle('mt'))
 def matrix_table_rows_is_transition(mt_path):
     ht = hl.read_matrix_table(mt_path).rows().key_by()
     ht.select(is_snp=hl.is_snp(ht.alleles[0], ht.alleles[1]))._force_count()

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -52,7 +52,7 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
               out.writeBytes(array + const(pt.lengthHeaderBytes), nMissingLocal - 1),
               out.writeByte((Region.loadByte(array + const(pt.lengthHeaderBytes) +
                 (nMissingLocal - 1).toL) & Code.invokeScalaObject[Array[Byte]](EType.getClass, "lowBitMask")
-                .apply(nMissingLocal & 0x7)).toB)
+                .apply(prefixLen & 0x7)).toB)
             )
           )
         )

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -51,8 +51,7 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
             Code(
               out.writeBytes(array + const(pt.lengthHeaderBytes), nMissingLocal - 1),
               out.writeByte((Region.loadByte(array + const(pt.lengthHeaderBytes) +
-                (nMissingLocal - 1).toL) & Code.invokeScalaObject[Array[Byte]](EType.getClass, "lowBitMask")
-                .apply(prefixLen & 0x7)).toB)
+                (nMissingLocal - 1).toL) & EType.lowBitMask(prefixLen)).toB)
             )
           )
         )

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -44,7 +44,18 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
     val writeLen = out.writeInt(prefixLen)
     val writeMissingBytes =
       if (!pt.elementType.required) {
-        out.writeBytes(array + const(pt.lengthHeaderBytes), pt.nMissingBytes(prefixLen))
+        val nMissingLocal = mb.newLocal[Int]("nMissingBytes")
+        Code(
+          nMissingLocal := pt.nMissingBytes(prefixLen),
+          (nMissingLocal > 0).orEmpty(
+            Code(
+              out.writeBytes(array + const(pt.lengthHeaderBytes), nMissingLocal - 1),
+              out.writeByte((Region.loadByte(array + const(pt.lengthHeaderBytes) +
+                (nMissingLocal - 1).toL) & Code.invokeScalaObject[Array[Byte]](EType.getClass, "lowBitMask")
+                .apply(nMissingLocal & 0x7)).toB)
+            )
+          )
+        )
       } else
         Code._empty[Unit]
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
@@ -90,15 +90,6 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       PNDArray(elementType, t.nDims, required)
   }
 
-  val lowBitMask: Array[Byte] = {
-    val a = new Array[Byte](8)
-    a(0) = (-1).toByte
-    (1 until 8).foreach { i =>
-      a(i) = ((1 << i) - 1).toByte
-    }
-    a
-  }
-
   def _buildEncoder(pt: PType, mb: EmitMethodBuilder, v: Code[_], out: Code[OutputBuffer]): Code[Unit] = {
     val ft = pt.asInstanceOf[PBaseStruct]
     val writeMissingBytes = if (ft.size == size) {
@@ -107,7 +98,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       if (nMissingBytes > 1)
         c = Code(c, out.writeBytes(coerce[Long](v), missingBytes - 1))
       if (nMissingBytes > 0)
-        c = Code(c, out.writeByte((Region.loadByte(coerce[Long](v) + (missingBytes.toLong - 1)).toI & const(lowBitMask(ft.nMissing & 0x7))).toB))
+        c = Code(c, out.writeByte((Region.loadByte(coerce[Long](v) + (missingBytes.toLong - 1)).toI & const(EType.lowBitMask(ft.nMissing & 0x7))).toB))
       c
     } else {
       val groupSize = 64

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -162,15 +162,8 @@ trait EncoderAsmFunction { def apply(off: Long, out: OutputBuffer): Unit }
 
 object EType {
 
-  protected[encoded] val lowBitMask: Array[Byte] = {
-    val a = new Array[Byte](8)
-    a(0) = (-1).toByte
-    (1 until 8).foreach { i =>
-      a(i) = ((1 << i) - 1).toByte
-    }
-    a
-  }
-
+  protected[encoded] def lowBitMask(n: Int): Byte = (0xFF >>> ((-n) & 0x7)).toByte
+  protected[encoded] def lowBitMask(n: Code[Int]): Code[Byte] = (const(0xFF) >>> ((-n) & 0x7)).toB
 
   val cacheCapacity = 256
   protected val encoderCache = new util.LinkedHashMap[(EType, PType), () => EncoderAsmFunction](cacheCapacity, 0.75f, true) {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -162,6 +162,16 @@ trait EncoderAsmFunction { def apply(off: Long, out: OutputBuffer): Unit }
 
 object EType {
 
+  protected[encoded] val lowBitMask: Array[Byte] = {
+    val a = new Array[Byte](8)
+    a(0) = (-1).toByte
+    (1 until 8).foreach { i =>
+      a(i) = ((1 << i) - 1).toByte
+    }
+    a
+  }
+
+
   val cacheCapacity = 256
   protected val encoderCache = new util.LinkedHashMap[(EType, PType), () => EncoderAsmFunction](cacheCapacity, 0.75f, true) {
     override def removeEldestEntry(eldest: Entry[(EType, PType), () => EncoderAsmFunction]): Boolean = size() > cacheCapacity


### PR DESCRIPTION
Benchmark:
```
$ hail-bench compare /tmp/before.json /tmp/after.json
            Name      Ratio    Time 1    Time 2
            ----      -----    ------    ------
write_profile_mt     100.4%    31.130    31.249
----------------------
Geometric mean: 100.4%
Simple mean: 100.4%
Median:  100.4%
```