### PR TITLE
[tests] rename test that has "fail" in its name

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -263,7 +263,7 @@ class MatrixIRSuite extends HailSuite {
     }
   }
 
-  @Test def testMatrixMultiWriteDifferentTypesFails() {
+  @Test def testMatrixMultiWriteDifferentTypesRaisesError() {
     val vcf = is.hail.TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
     val range = rangeMatrix(10, 2, None)
     val path = tmpDir.createLocalTempFile()


### PR DESCRIPTION
I use text search for "fail" in the CI logs, and this always pops up.