### PR TITLE
Document installing dependencies for pytest

### DIFF
--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -53,6 +53,10 @@ Serve the built website on http://localhost:8000/ ::
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
+Install development dependencies::
+
+    make install-dev-deps
+
 A couple Hail tests compare to PLINK 1.9 (not PLINK 2.0 [ignore the confusing
 URL]):
 


### PR DESCRIPTION
In a new environment,
```
cd hail
make install
make pytest
```
fails with
```
...
ERROR: usage: setup.py [options] [file_or_dir] [file_or_dir] [...]
setup.py: error: unrecognized arguments: --instafail --self-contained-html --html=../build/reports/pytest.html
  inifile: None
  rootdir: /path/to/hail/hail/python
```

because the pytest plugins in hail/python/dev-requirements.txt are not installed.

This documents the need to install them before running tests.