### PR TITLE
Change exception type for __getattr__ on struct collection expressions

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -691,7 +691,10 @@ class ArrayStructExpression(ArrayExpression):
     """
 
     def __getattr__(self, item):
-        return ArrayStructExpression.__getitem__(self, item)
+        try:
+            return ArrayStructExpression.__getitem__(self, item)
+        except KeyError as e:
+            raise AttributeError(str(e)) from e
 
     def __getitem__(self, item):
         """If a string, get a field from each struct in this array. If an integer, get
@@ -1176,7 +1179,10 @@ class SetStructExpression(SetExpression):
     """
 
     def __getattr__(self, item):
-        return SetStructExpression.__getitem__(self, item)
+        try:
+            return SetStructExpression.__getitem__(self, item)
+        except KeyError as e:
+            raise AttributeError(str(e)) from e
 
     @typecheck_method(item=oneof(str))
     def __getitem__(self, item):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3231,6 +3231,16 @@ class Tests(unittest.TestCase):
         assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
         assert hl.eval(a.b["inner"]) == [[1, 2], [3]]
 
+    def test_struct_collection_getattr(self):
+        collection_types = [hl.array, hl.set]
+        for htyp in collection_types:
+            a = htyp([hl.struct(x='foo'), hl.struct(x='bar')])
+
+            assert hasattr(a, 'x') == True
+            assert hasattr(a, 'y') == False
+
+            with pytest.raises(AttributeError, match="has no field"):
+                getattr(a, 'y')
 
     def test_binary_search(self):
         a = hl.array([0, 2, 4, 8])


### PR DESCRIPTION
Since #5913, `__getattr__` for ArrayStructExpressions and SetStructExpressions calls `__getitem__` so that collection expressions behave more like tables. However, this means that when the requested attribute is not a field of the collection's elements, `__getattr__` throws a KeyError when it [should throw an AttributeError](https://docs.python.org/3/reference/datamodel.html#object.__getattr__).

This breaks `hasattr`, since it [checks whether `getattr` raises an AttributeError](https://docs.python.org/3/library/functions.html#hasattr). 
```python
hasattr(hl.struct(foo="bar"), "someattribute")
# False

hasattr(hl.literal([hl.struct(foo="bar")]), "someattribute")
# KeyError: StructExpression instance has no field 'someattribute'
#     Hint: use 'describe()' to show the names of all data fields.
```

This changes `__getattr__` to catch the KeyError thrown by `__getitem__` and throw an AttributeError instead.

---

I found this because the broken `hasattr` prevents Array/SetStructExpressions from being used in pytest parametrized test cases (parametrize calls `hasattr(val, "__name__")`).
```python
@pytest.mark.parametrize(
    "i,o", [
        (hl.literal([hl.utils.Struct(foo=1)]),
        [hl.utils.Struct(foo=1)]),
    ],
)
def test_parametrize(i, o):
    assert hl.eval(i) == o

# KeyError: StructExpression instance has no field '__name__'
#    Hint: use 'describe()' to show the names of all data fields.
```