### PR TITLE
Fix group within partitions region management and serialization

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1391,3 +1391,8 @@ def test_group_within_partitions():
                                   hl.Struct(idx=3, grouped_fields=[hl.Struct(idx=3, sq=9.0), hl.Struct(idx=4, sq=16.0)]),
                                   hl.Struct(idx=5, grouped_fields=[hl.Struct(idx=5, sq=25.0), hl.Struct(idx=6, sq=36.0), hl.Struct(idx=7, sq=49.0)]),
                                   hl.Struct(idx=8, grouped_fields=[hl.Struct(idx=8, sq=64.0), hl.Struct(idx=9, sq=81.0)])]
+
+    # Testing after a filter
+    ht = hl.utils.range_table(100).naive_coalesce(10)
+    filter_then_group = ht.filter(ht.idx % 2 == 0)._group_within_partitions(5).collect()
+    assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1769,6 +1769,7 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
     val newRVDType = prevRVD.typ.copy(rowType = rowType)
     val keyIndices = child.typ.keyFieldIdx
 
+    val blockSize = n
     val newRVD = prevRVD.mapPartitionsWithIndex(newRVDType, { (int, ctx, it) =>
       val targetRegion = ctx.region
 
@@ -1781,9 +1782,9 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
           if (!hasNext)
             throw new java.util.NoSuchElementException()
 
-          val offsetArray = new Array[Long](n) // May be longer than the amount of data
+          val offsetArray = new Array[Long](blockSize) // May be longer than the amount of data
           var childIterationCount = 0
-          while (it.hasNext && childIterationCount != n) {
+          while (it.hasNext && childIterationCount != blockSize) {
             val nextRV = it.next()
             offsetArray(childIterationCount) = nextRV.offset
             childIterationCount += 1

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1772,8 +1772,6 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
     val blockSize = n
     val newRVD = prevRVD.mapPartitionsWithIndex(newRVDType, { (int, ctx, it) =>
       val targetRegion = ctx.region
-      val myRegion = Region(100)
-      myRegion.addReferenceTo(targetRegion)
 
       new Iterator[RegionValue] {
         override def hasNext: Boolean = {
@@ -1788,6 +1786,7 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
           var childIterationCount = 0
           while (it.hasNext && childIterationCount != blockSize) {
             val nextRV = it.next()
+            targetRegion.addReferenceTo(nextRV.region)
             offsetArray(childIterationCount) = nextRV.offset
             childIterationCount += 1
           }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1772,6 +1772,8 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
     val blockSize = n
     val newRVD = prevRVD.mapPartitionsWithIndex(newRVDType, { (int, ctx, it) =>
       val targetRegion = ctx.region
+      val myRegion = Region(100)
+      myRegion.addReferenceTo(targetRegion)
 
       new Iterator[RegionValue] {
         override def hasNext: Boolean = {


### PR DESCRIPTION
This PR introduces a new test case that was failing. It fixes two problems:

1. needed to bind `n` to `blockSize` so that it didn't serialize the whole IR. 
2. needed to add references to the regions from producer to `targetRegion` to ensure that the filter test passes. 

Question: Does this keep too much garbage in memory? Ideally, I'd release the references to the regions of my producer once I finished constructing the new `RegionValue`. 