### PR TITLE
[batch] log scheduler queries timing

### DIFF
--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -166,7 +166,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 0
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value),
-                            timer_description=f'in cancel_cancelled_ready_jobs: get {user} {batch["id"]} ready cancelled jobs (1)'):
+                            timer_description=f'in cancel_cancelled_ready_jobs: get {user} batch {batch["id"]} ready cancelled jobs (1)'):
                         record['batch_id'] = batch['id']
                         yield record
                 else:
@@ -178,7 +178,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND cancelled = 1
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value),
-                            timer_description=f'in cancel_cancelled_ready_jobs: get {user} {batch["id"]} ready cancelled jobs (2)'):
+                            timer_description=f'in cancel_cancelled_ready_jobs: get {user} batch {batch["id"]} ready cancelled jobs (2)'):
                         record['batch_id'] = batch['id']
                         yield record
 
@@ -255,7 +255,7 @@ WHERE jobs.batch_id = %s AND state = 'Running' AND always_run = 0 AND cancelled 
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value),
-                        timer_description=f'in cancel_cancelled_running_jobs: get {user} {batch["id"]} running cancelled jobs'):
+                        timer_description=f'in cancel_cancelled_running_jobs: get {user} batch {batch["id"]} running cancelled jobs'):
                     record['batch_id'] = batch['id']
                     yield record
 
@@ -318,7 +318,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 1
 LIMIT %s;
 ''',
                         (batch['id'], remaining.value),
-                        timer_description=f'in schedule: get {user} {batch["id"]} runnable jobs (1)'):
+                        timer_description=f'in schedule: get {user} batch {batch["id"]} runnable jobs (1)'):
                     record['batch_id'] = batch['id']
                     record['userdata'] = batch['userdata']
                     record['user'] = batch['user']
@@ -332,7 +332,7 @@ WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND cancelled = 0
 LIMIT %s;
 ''',
                             (batch['id'], remaining.value),
-                            timer_description=f'in schedule: get {user} {batch["id"]} runnable jobs (2)'):
+                            timer_description=f'in schedule: get {user} batch {batch["id"]} runnable jobs (2)'):
                         record['batch_id'] = batch['id']
                         record['userdata'] = batch['userdata']
                         record['user'] = batch['user']

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -14,7 +14,8 @@ from prometheus_async.aio.web import server_stats
 import google.oauth2.service_account
 import google.api_core.exceptions
 from hailtop.utils import time_msecs, time_msecs_str, humanize_timedelta_msecs, \
-    request_retry_transient_errors, run_if_changed, retry_long_running
+    request_retry_transient_errors, run_if_changed, retry_long_running, \
+    LoggingTimer
 from hailtop.config import get_deploy_config
 from hailtop.batch_client.aioclient import Job
 from gear import Database, setup_aiohttp_session, \
@@ -26,7 +27,7 @@ from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_
 # import uvloop
 
 from ..utils import parse_cpu_in_mcpu, parse_memory_in_bytes, adjust_cores_for_memory_request, \
-    worker_memory_per_core_gb, LoggingTimer
+    worker_memory_per_core_gb
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -2,8 +2,6 @@ import re
 import logging
 import math
 
-from hailtop.utils import time_msecs
-
 from .front_end.validate import CPU_REGEX, MEMORY_REGEX
 
 log = logging.getLogger('utils')
@@ -95,37 +93,3 @@ def parse_image_tag(image_string):
     if match:
         return match.group(3)
     return None
-
-
-class LoggingTimerStep:
-    def __init__(self, timer, name):
-        self.timer = timer
-        self.name = name
-        self.start_time = None
-
-    async def __aenter__(self):
-        self.start_time = time_msecs()
-
-    async def __aexit__(self, exc_type, exc, tb):
-        finish_time = time_msecs()
-        self.timer.timing[self.name] = finish_time - self.start_time
-
-
-class LoggingTimer:
-    def __init__(self, description):
-        self.description = description
-        self.timing = {}
-        self.start_time = None
-
-    def step(self, name):
-        return LoggingTimerStep(self, name)
-
-    async def __aenter__(self):
-        self.start_time = time_msecs()
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        finish_time = time_msecs()
-        self.timing['total'] = finish_time - self.start_time
-
-        log.info(f'{self.description} timing {self.timing}')

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -3,7 +3,7 @@ from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     bounded_gather, grouped, sleep_and_backoff, is_transient_error, \
     request_retry_transient_errors, request_raise_transient_errors, \
     collect_agen, retry_forever, retry_transient_errors, \
-    retry_long_running, run_if_changed
+    retry_long_running, run_if_changed, LoggingTimer
 from .process import CalledProcessError, check_shell, check_shell_output
 from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 
@@ -25,6 +25,7 @@ __all__ = [
     'retry_transient_errors',
     'retry_long_running',
     'run_if_changed',
+    'LoggingTimer',
     'request_retry_transient_errors',
     'request_raise_transient_errors',
     'collect_agen',


### PR DESCRIPTION
Changes:
 - move LoggingTimer to hailtop.utils
 - add timer_description option to fetchall functions in gear.database
 - add descriptions for all scheduler queries

We have to call the timer inside fetchall because it is an async generator.  The other database functions can be timed by the client code with LoggingTimer directly.
