### PR TITLE
[hail] PC Relate improvements

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2435,7 +2435,7 @@ class MatrixTable(ExprContainer):
                       _read_if_exists=bool)
     def checkpoint(self, output: str, overwrite: bool = False, stage_locally: bool = False,
               _codec_spec: Optional[str] = None, _read_if_exists: bool = False) -> 'MatrixTable':
-        """Checkpoint the matrix table to disk by writing and reading.
+        """Checkpoint the matrix table to disk by writing and reading using a fast, but less space-efficient codec.
 
         Parameters
         ----------
@@ -2457,14 +2457,15 @@ class MatrixTable(ExprContainer):
 
         Notes
         -----
-        An alias for :meth:`write` followed by :func:`.read_matrix_table`. It
-        is possible to read the file at this path later with
-        :func:`.read_matrix_table`.
+        An alias for :meth:`write` followed by :func:`.read_matrix_table`. It is
+        possible to read the file at this path later with
+        :func:`.read_matrix_table`. A faster, but less efficient, codec is used
+        or writing the data so the file will be larger than if one used
+        :meth:`write`.
 
         Examples
         --------
         >>> dataset = dataset.checkpoint('output/dataset_checkpoint.mt')
-
         """
         if _codec_spec is None:
             _codec_spec = """{

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2466,6 +2466,21 @@ class MatrixTable(ExprContainer):
         >>> dataset = dataset.checkpoint('output/dataset_checkpoint.mt')
 
         """
+        if _codec_spec is None:
+            _codec_spec = """{
+  "name": "LEB128BufferSpec",
+  "child": {
+    "name": "BlockingBufferSpec",
+    "blockSize": 32768,
+    "child": {
+      "name": "LZ4FastBlockBufferSpec",
+      "blockSize": 32768,
+      "child": {
+        "name": "StreamBlockBufferSpec"
+      }
+    }
+  }
+}"""
         if not _read_if_exists or not hl.hadoop_exists(f'{output}/_SUCCESS'):
             self.write(output=output, overwrite=overwrite, stage_locally=stage_locally, _codec_spec=_codec_spec)
         return hl.read_matrix_table(output)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -49,7 +49,7 @@ def identity_by_descent(dataset, maf=None, bounded=True, min=None, max=None) -> 
 
     Notes
     -----
-
+    
     The dataset must have a column field named `s` which is a :class:`.StringExpression`
     and which uniquely identifies a column.
 
@@ -786,7 +786,7 @@ def poisson_regression_rows(test, y, x, covariates, pass_through=()) -> Table:
         'covFields': cov_field_names,
         'passThrough': [x for x in row_fields if x not in mt.row_key]
     }
-
+    
     return Table(MatrixToTableApply(mt._mir, config)).persist()
 
 

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -49,7 +49,7 @@ def identity_by_descent(dataset, maf=None, bounded=True, min=None, max=None) -> 
 
     Notes
     -----
-    
+
     The dataset must have a column field named `s` which is a :class:`.StringExpression`
     and which uniquely identifies a column.
 
@@ -786,7 +786,7 @@ def poisson_regression_rows(test, y, x, covariates, pass_through=()) -> Table:
         'covFields': cov_field_names,
         'passThrough': [x for x in row_fields if x not in mt.row_key]
     }
-    
+
     return Table(MatrixToTableApply(mt._mir, config)).persist()
 
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
@@ -7,6 +7,13 @@ object PArray {
   def apply(elementType: PType, required: Boolean = false) = new PCanonicalArray(elementType, required)
 }
 
+trait PArrayIterator {
+  def hasNext: Boolean
+  def isDefined: Boolean
+  def value: Long
+  def iterate(): Unit
+}
+
 abstract class PArray extends PContainer with PStreamable {
   lazy val virtualType: TArray = TArray(elementType.virtualType, required)
 
@@ -16,4 +23,6 @@ abstract class PArray extends PContainer with PStreamable {
     assert(this isOfType other)
     CodeOrdering.iterableOrdering(this, other.asInstanceOf[PArray], mb)
   }
+
+  def elementIterator(aoff: Long, length: Int): PArrayIterator
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -163,6 +163,22 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def loadElement(aoff: Code[Long], i: Code[Int]): Code[Long] = loadElement(aoff, loadLength(aoff), i)
 
+  class Iterator (
+    private[this] val aoff: Long,
+    private[this] val length: Int,
+    private[this] var i: Int = 0
+  ) extends PArrayIterator {
+    private[this] val firstElementOffset = PCanonicalArray.this.firstElementOffset(
+      aoff, length)
+    def hasNext: Boolean = i != length
+    def isDefined: Boolean = isElementDefined(aoff, i)
+    def value: Long =
+      firstElementOffset + i * elementByteSize
+    def iterate: Unit = i += 1
+  }
+
+  def elementIterator(aoff: Long, length: Int): Iterator = new Iterator(aoff, length)
+
   def allocate(region: Region, length: Int): Long = {
     region.allocate(contentsAlignment, contentsByteSize(length))
   }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1089,30 +1089,17 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       val iOffset = i.toLong * blockSize
       val jOffset = j.toLong * blockSize
       val size = lm.cols * lm.rows
-      if (lm.isCompact && !lm.isTranspose) {
-        var jj = 0
-        while (jj < lm.cols) {
-          var ii = 0
-          while (ii < lm.rows) {
-            lm.data(ii + jj * lm.rows) = op(iOffset + ii, jOffset + jj, lm(ii, jj))
-            ii += 1
-          }
-          jj += 1
+      val result = new Array[Double](size)
+      var jj = 0
+      while (jj < lm.cols) {
+        var ii = 0
+        while (ii < lm.rows) {
+          result(ii + jj * lm.rows) = op(iOffset + ii, jOffset + jj, lm(ii, jj))
+          ii += 1
         }
-        lm
-      } else {
-        val result = new Array[Double](size)
-        var jj = 0
-        while (jj < lm.cols) {
-          var ii = 0
-          while (ii < lm.rows) {
-            result(ii + jj * lm.rows) = op(iOffset + ii, jOffset + jj, lm(ii, jj))
-            ii += 1
-          }
-          jj += 1
-        }
-        new BDM(lm.rows, lm.cols, result)
+        jj += 1
       }
+      new BDM(lm.rows, lm.cols, result)
     }
     new BlockMatrix(newBlocks, blockSize, nRows, nCols)
   }
@@ -1141,30 +1128,17 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
           val iOffset = i1.toLong * blockSize
           val jOffset = j1.toLong * blockSize
           val size = lm1.cols * lm1.rows
-          if (lm1.isCompact && !lm1.isTranspose) {
-            var jj = 0
-            while (jj < lm1.cols) {
-              var ii = 0
-              while (ii < lm1.rows) {
-                lm1.data(ii + jj * lm1.rows) = op(iOffset + ii, jOffset + jj, lm1(ii, jj), lm2(ii, jj))
-                ii += 1
-              }
-              jj += 1
+          val result = new Array[Double](size)
+          var jj = 0
+          while (jj < lm1.cols) {
+            var ii = 0
+            while (ii < lm1.rows) {
+              result(ii + jj * lm1.rows) = op(iOffset + ii, jOffset + jj, lm1(ii, jj), lm2(ii, jj))
+              ii += 1
             }
-            ((i1, j1), lm1)
-          } else {
-            val result = new Array[Double](size)
-            var jj = 0
-            while (jj < lm1.cols) {
-              var ii = 0
-              while (ii < lm1.rows) {
-                result(ii + jj * lm1.rows) = op(iOffset + ii, jOffset + jj, lm1(ii, jj), lm2(ii, jj))
-                ii += 1
-              }
-              jj += 1
-            }
-            ((i1, j1), new BDM(lm1.rows, lm1.cols, result))
+            jj += 1
           }
+          ((i1, j1), new BDM(lm1.rows, lm1.cols, result))
         }
       }
     }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1888,7 +1888,7 @@ class WriteBlocksRDD(path: String,
             while (j < n) {
               assert(colIt.hasNext)
               if (colIt.isDefined) {
-                val entryOffset = colIt.value // entryArrayType.loadElement(entryArrayOffset, colIdx)
+                val entryOffset = colIt.value
                 if (entryType.isFieldDefined(entryOffset, fieldIdx)) {
                   val fieldOffset = entryType.loadField(entryOffset, fieldIdx)
                   data(j) = Region.loadDouble(fieldOffset)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -30,22 +30,6 @@ import org.json4s._
 
 import scala.collection.immutable.NumericRange
 
-trait DtoD extends Serializable {
-  def apply (x: Double): Double
-}
-trait DDtoD extends Serializable {
-  def apply (x: Double, y: Double): Double
-}
-trait DDDDtoD extends Serializable {
-  def apply (x: Double, y: Double, z: Double, a: Double): Double
-}
-trait LLDtoD extends Serializable {
-  def apply (x: Long, y: Long, z: Double): Double
-}
-trait LLDDtoD extends Serializable {
-  def apply (x: Long, y: Long, z: Double, a: Double): Double
-}
-
 case class CollectMatricesRDDPartition(index: Int, firstPartition: Int, blockPartitions: Array[Partition], blockSize: Int, nRows: Int, nCols: Int) extends Partition {
   def nBlocks: Int = blockPartitions.length
 }
@@ -160,10 +144,10 @@ object BlockMatrix {
       ((i, j), BDM.rand[Double](gp.blockRowNRows(i), gp.blockColNCols(j), rand))
     } )
 
-  def map2(f: DDtoD)(l: M, r: M): M =
+  def map2(f: (Double, Double) => Double)(l: M, r: M): M =
     l.map2(r, f)
 
-  def map4(f: DDDDtoD)(a: M, b: M, c: M, d: M): M =
+  def map4(f: (Double, Double, Double, Double) => Double)(a: M, b: M, c: M, d: M): M =
     a.map4(b, c, d, f)
 
   val metadataRelativePath = "/metadata.json"
@@ -949,7 +933,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     new BlockMatrix(newBlocks, blockSize, nRows, nCols)
   }
 
-  def map(op: DtoD,
+  def map(op: Double => Double,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense)
@@ -968,7 +952,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   def map2(that: M,
-    op: DDtoD,
+    op: (Double, Double) => Double,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense) {
@@ -1020,9 +1004,8 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     new BlockMatrix(newBlocks, blockSize, nRows, nCols)
   }
 
-
   def map4(bm2: M, bm3: M, bm4: M,
-    op: DDDDtoD,
+    op: (Double, Double, Double, Double) => Double,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense) {

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1657,7 +1657,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
         }
       })
 
-  def dgemm(c: BDM[Double], _a: BDM[Double], _b: BDM[Double]) {
+  def fma(c: BDM[Double], _a: BDM[Double], _b: BDM[Double]) {
     assert(_a.cols == _b.rows)
 
     val a = if (_a.majorStride < math.max(if (_a.isTranspose) _a.cols else _a.rows, 1)) _a.copy else _a
@@ -1682,7 +1682,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
       val left = block(l, lParts, lGP, context, i, k)
       val right = block(r, rParts, rGP, context, k, j)
       if (left.isDefined && right.isDefined) {
-        dgemm(product, left.get, right.get)
+        fma(product, left.get, right.get)
       }
       k += 1
     }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -30,6 +30,22 @@ import org.json4s._
 
 import scala.collection.immutable.NumericRange
 
+trait DtoD {
+  def apply (x: Double): Double
+}
+trait DDtoD {
+  def apply (x: Double, y: Double): Double
+}
+trait DDDDtoD {
+  def apply (x: Double, y: Double, z: Double, a: Double): Double
+}
+trait LLDtoD {
+  def apply (x: Long, y: Long, z: Double): Double
+}
+trait LLDDtoD {
+  def apply (x: Long, y: Long, z: Double, a: Double): Double
+}
+
 case class CollectMatricesRDDPartition(index: Int, firstPartition: Int, blockPartitions: Array[Partition], blockSize: Int, nRows: Int, nCols: Int) extends Partition {
   def nBlocks: Int = blockPartitions.length
 }
@@ -144,10 +160,10 @@ object BlockMatrix {
       ((i, j), BDM.rand[Double](gp.blockRowNRows(i), gp.blockColNCols(j), rand))
     } )
 
-  def map2(f: (Double, Double) => Double)(l: M, r: M): M =
+  def map2(f: DDtoD)(l: M, r: M): M =
     l.map2(r, f)
 
-  def map4(f: (Double, Double, Double, Double) => Double)(a: M, b: M, c: M, d: M): M =
+  def map4(f: DDDDtoD)(a: M, b: M, c: M, d: M): M =
     a.map4(b, c, d, f)
 
   val metadataRelativePath = "/metadata.json"
@@ -933,7 +949,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     new BlockMatrix(newBlocks, blockSize, nRows, nCols)
   }
 
-  def map(op: Double => Double,
+  def map(op: DtoD,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense)
@@ -953,7 +969,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   def map2(that: M,
-    op: (Double, Double) => Double,
+    op: DDtoD,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense) {
@@ -1006,8 +1022,9 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     new BlockMatrix(newBlocks, blockSize, nRows, nCols)
   }
 
+
   def map4(bm2: M, bm3: M, bm4: M,
-    op: (Double, Double, Double, Double) => Double,
+    op: DDDDtoD,
     name: String = "operation",
     reqDense: Boolean = true): M = {
     if (reqDense) {

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -88,25 +88,25 @@ object BlockMatrix {
     new BlockingBufferSpec(32 * 1024,
       new LZ4FastBlockBufferSpec(32 * 1024,
         new StreamBlockBufferSpec))
-  
+
   def apply(sc: SparkContext, gp: GridPartitioner, piBlock: (GridPartitioner, Int) => ((Int, Int), BDM[Double])): BlockMatrix =
     new BlockMatrix(
       new RDD[((Int, Int), BDM[Double])](sc, Nil) {
         override val partitioner = Some(gp)
-  
+
         protected def getPartitions: Array[Partition] = Array.tabulate(gp.numPartitions)(pi =>
           new Partition { def index: Int = pi } )
-  
+
         def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] =
           Iterator.single(piBlock(gp, split.index))
       }, gp.blockSize, gp.nRows, gp.nCols)
-  
+
   def fromBreezeMatrix(sc: SparkContext, lm: BDM[Double]): M =
     fromBreezeMatrix(sc, lm, defaultBlockSize)
 
   def fromBreezeMatrix(sc: SparkContext, lm: BDM[Double], blockSize: Int): M = {
     val gp = GridPartitioner(blockSize, lm.rows, lm.cols)
-    
+
     val localBlocksBc = Array.tabulate(gp.numPartitions) { pi =>
       val (i, j) = gp.blockCoordinates(pi)
       val (blockNRows, blockNCols) = gp.blockDims(pi)
@@ -115,7 +115,7 @@ object BlockMatrix {
 
       HailContext.backend.broadcast(lm(iOffset until iOffset + blockNRows, jOffset until jOffset + blockNCols).copy)
     }
-    
+
     BlockMatrix(sc, gp, (gp, pi) => (gp.blockCoordinates(pi), localBlocksBc(pi).value))
   }
 
@@ -130,7 +130,7 @@ object BlockMatrix {
       val (i, j) = gp.blockCoordinates(pi)
       ((i, j), BDM.fill[Double](gp.blockRowNRows(i), gp.blockColNCols(j))(value))
     })
-  
+
   // uniform or Gaussian
   def random(hc: HailContext, nRows: Long, nCols: Long, blockSize: Int = defaultBlockSize,
     seed: Long = 0, gaussian: Boolean): M =
@@ -140,7 +140,7 @@ object BlockMatrix {
 
       val randBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(blockSeed)))
       val rand = if (gaussian) randBasis.gaussian else randBasis.uniform
-      
+
       ((i, j), BDM.rand[Double](gp.blockRowNRows(i), gp.blockColNCols(j), rand))
     } )
 
@@ -154,9 +154,9 @@ object BlockMatrix {
 
   def checkWriteSuccess(hc: HailContext, uri: String) {
     if (!hc.sFS.exists(uri + "/_SUCCESS"))
-      fatal(s"Error reading block matrix. Earlier write failed: no success indicator found at uri $uri")    
+      fatal(s"Error reading block matrix. Earlier write failed: no success indicator found at uri $uri")
   }
-  
+
   def readMetadata(hc: HailContext, uri: String): BlockMatrixMetadata = {
     hc.sFS.readTextFile(uri + metadataRelativePath) { isr =>
       implicit val formats = defaultJSONFormats
@@ -278,7 +278,7 @@ object BlockMatrix {
 
     val d = digitsNeeded(bms.length)
     val bcFS = HailContext.bcFS
-    
+
     val nameFunction = customFilenames match {
       case None => i: Int => StringUtils.leftPad(i.toString, d, '0') + ".tsv"
       case Some(filenames) => filenames.apply(_)
@@ -344,11 +344,11 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   require(blocks.partitioner.get.isInstanceOf[GridPartitioner])
 
   val gp: GridPartitioner = blocks.partitioner.get.asInstanceOf[GridPartitioner]
-  
+
   require(gp.blockSize == blockSize && gp.nRows == nRows && gp.nCols == nCols)
-  
+
   val isSparse: Boolean = gp.maybeBlocks.isDefined
-  
+
   def requireDense(name: String): Unit =
     if (isSparse)
       fatal(s"$name is not supported for block-sparse matrices.")
@@ -359,15 +359,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       realizeBlocks(None)
     } else
       this
-  
+
   // if Some(bis), unrealized blocks in bis are replaced with zero blocks
   // if None, all unrealized blocks are replaced with zero blocks
-  def realizeBlocks(maybeBlocksToRealize: Option[Array[Int]]): BlockMatrix = {    
+  def realizeBlocks(maybeBlocksToRealize: Option[Array[Int]]): BlockMatrix = {
     val realizeGP = gp.copy(maybeBlocks =
       if (maybeBlocksToRealize.exists(_.length == gp.maxNBlocks)) None else maybeBlocksToRealize)
 
     val newGP = gp.union(realizeGP)
-    
+
     if (newGP.numPartitions == gp.numPartitions)
       this
     else {
@@ -388,7 +388,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       this
     else
       subsetBlocks(gp.intersect(gp.copy(maybeBlocks = Some(blocksToKeep))))
-    
+
   // assumes subsetGP blocks are subset of gp blocks, as with subsetGP = gp.intersect(gp2)
   def subsetBlocks(subsetGP: GridPartitioner): BlockMatrix = {
     if (subsetGP.numPartitions == gp.numPartitions)
@@ -399,7 +399,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         blockSize, nRows, nCols)
     }
   }
-  
+
   // filter to blocks overlapping diagonal band of all elements with lower <= jj - ii <= upper
   // if not blocksOnly, also zero out all remaining elements outside band
   def filterBand(lower: Long, upper: Long, blocksOnly: Boolean): BlockMatrix = {
@@ -412,25 +412,25 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     else
       filteredBM.zeroBand(lower, upper)
   }
-  
-  def zeroBand(lower: Long, upper: Long): BlockMatrix = {    
+
+  def zeroBand(lower: Long, upper: Long): BlockMatrix = {
     val zeroedBlocks = blocks.mapPartitions( { it =>
       assert(it.hasNext)
       val ((i, j), lm0) = it.next()
       assert(!it.hasNext)
-      
+
       val nRowsInBlock = lm0.rows
       val nColsInBlock = lm0.cols
 
       val diagIndex = (j - i).toLong * blockSize
       val lowestDiagIndex = diagIndex - (nRowsInBlock - 1)
       val highestDiagIndex = diagIndex + (nColsInBlock - 1)
-      
+
       if (lowestDiagIndex >= lower && highestDiagIndex <= upper)
         Iterator.single(((i, j), lm0))
       else {
         val lm = lm0.copy // avoidable?
-        
+
         if (lower > lowestDiagIndex) {
           val iiLeft = math.max(diagIndex - lower, 0).toInt
           val iiRight = math.min(diagIndex - lower + nColsInBlock, nRowsInBlock).toInt
@@ -442,16 +442,16 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
             ii += 1
             jj += 1
           }
-          
+
           lm(iiRight until nRowsInBlock, ::) := 0.0
         }
-        
+
         if (upper < highestDiagIndex) {
           val iiLeft = math.max(diagIndex - upper, 0).toInt
           val iiRight = math.min(diagIndex - upper + nColsInBlock, nRowsInBlock).toInt
 
           lm(0 until iiLeft, ::) := 0.0
-          
+
           var ii = iiLeft
           var jj = math.max(upper - diagIndex, 0).toInt + 1
           while (ii < iiRight) {
@@ -463,10 +463,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         Iterator.single(((i, j), lm))
       }
     }, preservesPartitioning = true)
-    
+
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-  
+
   // for row i, filter to indices [starts[i], stops[i]) by dropping non-overlapping blocks
   // if not blocksOnly, also zero out elements outside ranges in overlapping blocks
   // checked in Python: start >= 0 && start <= stop && stop <= nCols
@@ -492,7 +492,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       blocksOnly)
   }
 
-  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {    
+  def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {
     val backend = HailContext.backend
     val startBlockIndexBc = backend.broadcast(starts.map(gp.indexBlockIndex))
     val stopBlockIndexBc = backend.broadcast(stops.map(stop => (stop / blockSize).toInt))
@@ -530,17 +530,17 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         row += 1
         ii += 1
       }
-      
+
       Iterator.single(((i, j), lm))
     }, preservesPartitioning = true)
-    
+
     new BlockMatrix(zeroedBlocks, blockSize, nRows, nCols)
   }
-  
+
   def filterRectangles(flattenedRectangles: Array[Long]): BlockMatrix = {
     require(flattenedRectangles.length % 4 == 0)
     val rectangles = flattenedRectangles.grouped(4).toArray
-    
+
     filterBlocks(gp.rectanglesBlocks(rectangles))
   }
 
@@ -596,7 +596,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   // element-wise ops
   def unary_+(): M = this
-  
+
   def unary_-(): M = blockMap(-_,
     "negation",
     reqDense = false)
@@ -617,7 +617,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(addBlocks, blockSize, nRows, nCols)
     }
-  
+
   def sub(that: M): M =
     if (sameBlocks(that)) {
       blockMap2(that, _ - _,
@@ -634,7 +634,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       )
       new BlockMatrix(subBlocks, blockSize, nRows, nCols)
     }
-  
+
   def mul(that: M): M = {
     val newGP = gp.intersect(that.gp)
     subsetBlocks(newGP).blockMap2(
@@ -642,42 +642,42 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       "element-wise multiplication",
       reqDense = false)
   }
-  
+
   def div(that: M): M = blockMap2(that, _ /:/ _,
     "element-wise division")
-  
+
   // row broadcast
   def rowVectorAdd(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) + lv,
     "broadcasted addition of row-vector")(a)
-  
+
   def rowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::) - lv,
     "broadcasted subtraction of row-vector")(a)
-  
+
   def rowVectorMul(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) *:* lv,
     "broadcasted multiplication by row-vector containing nan, or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-  
-  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv, 
+
+  def rowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::) /:/ lv,
     "broadcasted division by row-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
 
   def reverseRowVectorSub(a: Array[Double]): M = densify().rowVectorOp((lm, lv) => lm(*, ::).map(lv - _),
     "broadcasted row-vector minus block matrix")(a)
- 
+
   def reverseRowVectorDiv(a: Array[Double]): M = rowVectorOp((lm, lv) => lm(*, ::).map(lv /:/ _),
     "broadcasted row-vector divided by block matrix")(a)
-  
+
   // column broadcast
   def colVectorAdd(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) + lv,
     "broadcasted addition of column-vector")(a)
-  
+
   def colVectorSub(a: Array[Double]): M = densify().colVectorOp((lm, lv) => lm(::, *) - lv,
     "broadcasted subtraction of column-vector")(a)
-  
+
   def colVectorMul(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) *:* lv,
     "broadcasted multiplication column-vector containing nan or infinity",
     reqDense = a.exists(i => i.isNaN | i.isInfinity))(a)
-  
+
   def colVectorDiv(a: Array[Double]): M = colVectorOp((lm, lv) => lm(::, *) /:/ lv,
     "broadcasted division by column-vector containing zero, nan, or infinity",
     reqDense = a.exists(i => i == 0.0 | i.isNaN | i.isInfinity))(a)
@@ -691,21 +691,21 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   // scalar
   def scalarAdd(i: Double): M = densify().blockMap(_ + i,
     "scalar addition")
-  
+
   def scalarSub(i: Double): M = densify().blockMap(_ - i,
     "scalar subtraction")
-  
+
   def scalarMul(i: Double): M = blockMap(_ *:* i,
       s"multiplication by scalar $i",
       reqDense = i.isNaN | i.isInfinity)
-  
+
   def scalarDiv(i: Double): M = blockMap(_ /:/ i,
       s"division by scalar $i",
       reqDense = i == 0.0 | i.isNaN | i.isInfinity)
-  
+
   def reverseScalarSub(i: Double): M = densify().blockMap(i - _,
     s"scalar minus block matrix")
-  
+
   def reverseScalarDiv(i: Double): M = blockMap(i /:/ _,
     s"scalar divided by block matrix")
 
@@ -725,14 +725,14 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   def pow(exponent: Double): M = blockMap(breezePow(_, exponent),
     s"exponentiation by negative power $exponent",
     reqDense = exponent < 0)
-  
+
   def log(): M = blockMap(breezeLog(_),
     "natural logarithm")
 
   def abs(): M = blockMap(breezeAbs(_),
     "absolute value",
     reqDense = false)
-  
+
   // matrix ops
   def dot(that: M): M = new BlockMatrix(new BlockMatrixMultiplyRDD(this, that), blockSize, nRows, that.nCols)
 
@@ -759,10 +759,10 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     }
 
     val result = new Array[Double](nDiagElements)
-    
+
     val nDiagBlocks = math.min(gp.nBlockRows, gp.nBlockCols)
     val diagBlocks = Array.tabulate(nDiagBlocks)(i => gp.coordinatesBlock(i, i))
-    
+
     filterBlocks(diagBlocks).blocks
       .map { case ((i, j), lm) =>
         assert(i == j)
@@ -770,7 +770,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       }
       .collect()
       .foreach { case (i, a) => System.arraycopy(a, 0, result, i * blockSize, a.length) }
-    
+
     result
   }
 
@@ -875,7 +875,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     if (!sameBlocks(that))
       fatal(s"$name requires block matrices to have the same set of blocks present")
   }
-  
+
   private def sameBlocks(that: M): Boolean = {
     (gp.maybeBlocks, that.gp.maybeBlocks) match {
       case (Some(bis), Some(bis2)) => bis sameElements bis2
@@ -883,7 +883,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       case _ => false
     }
   }
-  
+
   def blockMap(op: BDM[Double] => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -891,7 +891,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       requireDense(name)
     new BlockMatrix(blocks.mapValues(op), blockSize, nRows, nCols)
   }
-  
+
   def blockMapWithIndex(op: ((Int, Int), BDM[Double]) => BDM[Double],
     name: String = "operation",
     reqDense: Boolean = true): M = {
@@ -1184,15 +1184,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         .reduceByKey(GridPartitioner(blockSize, 1, nCols, gp.maybeBlockCols()), vectorOp)
         .mapValues(v => new BDM[Double](1, v.length, v.data)),
       blockSize, 1, nCols)
-  
-  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =    
+
+  def colReduce(blockOp: BDM[Double] => BDV[Double], vectorOp: (BDV[Double], BDV[Double]) => BDV[Double]): BlockMatrix =
     new BlockMatrix(
       blocks
         .map { case ((i, j), lm) => ((i, 0), blockOp(lm)) }
         .reduceByKey(GridPartitioner(blockSize, nRows, 1, gp.maybeBlockRows()), vectorOp)
         .mapValues(v => new BDM[Double](v.length, 1, v.data)),
       blockSize, nRows, 1)
-  
+
   def toIndexedRowMatrix(): IndexedRowMatrix = {
     require(nCols <= Integer.MAX_VALUE)
     val nColsInt = nCols.toInt
@@ -1240,7 +1240,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     } else
       0.0
   }
-  
+
   def filterRows(keep: Array[Long]): BlockMatrix = {
     transpose().filterCols(keep).transpose()
   }
@@ -1256,7 +1256,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
   def entriesTable(ctx: ExecuteContext): TableValue = {
     val rowType = PStruct("i" -> PInt64Optional, "j" -> PInt64Optional, "entry" -> PFloat64Optional)
-    
+
     val entriesRDD = ContextRDD.weaken[RVDContext](blocks).cflatMap { case (ctx, ((blockRow, blockCol), block)) =>
       val rowOffset = blockRow * blockSize.toLong
       val colOffset = blockCol * blockSize.toLong
@@ -1349,7 +1349,7 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
   log.info("Constructing BlockMatrixFilterRDD")
 
   val t0 = System.nanoTime()
-  
+
   private val originalGP = bm.gp
 
   if (bm.isSparse) {
@@ -1604,7 +1604,7 @@ private class BlockMatrixUnionOpRDD(
 
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
-  
+
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](
       new NarrowDependency(l.blocks) {
@@ -1617,7 +1617,7 @@ private class BlockMatrixUnionOpRDD(
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
     val (i, j) = gp.partCoordinates(split.index)
     val lm = op(block(l, lParts, lGP, context, i, j) -> block(r, rParts, rGP, context, i, j))
-    
+
     Iterator.single(((i, j), lm))
   }
 
@@ -1640,7 +1640,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
   private val lGP = l.gp
   private val rGP = r.gp
   private val gp = GridPartitioner(l.blockSize, l.nRows, r.nCols)
-  
+
   private val lParts = l.blocks.partitions
   private val rParts = r.blocks.partitions
   private val nProducts = lGP.nBlockCols

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -211,9 +211,9 @@ case class PCRelate(
 
     val qr.QR(q, r) = qr.reduced(pcsWithIntercept)
 
-    val halfBeta = (inv(2.0 * r) * q.t).matrixMultiply(blockedG.T)
+    val halfBeta = writeRead((inv(2.0 * r) * q.t).matrixMultiply(blockedG.T))
 
-    pcsWithIntercept.matrixMultiply(halfBeta).T
+    writeRead(pcsWithIntercept.matrixMultiply(halfBeta).T)
   }
 
   private[methods] def phi(mu: M, variance: M, g: M): M = {

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -162,8 +162,7 @@ case class PCRelate(
   }
 
   private def gram(m: M): M = {
-    val mc = writeRead(m)
-    mc.T.dot(mc)
+    writeRead(m.T.dot(m))
   }
 
   private[this] def cacheWhen(statisticsLevel: StatisticSubset)(m: M): M =
@@ -267,7 +266,7 @@ case class PCRelate(
     val oneMinusMu2 =
       mu.map(mu => if (mu.isNaN) 0.0 else (1.0 - mu) * (1.0 - mu))
 
-    val temp = mu2.T.dot(oneMinusMu2)
+    val temp = writeRead(mu2.T.dot(oneMinusMu2))
     val denom = temp + temp.T
 
     BlockMatrix.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -162,13 +162,15 @@ case class PCRelate(
   }
 
   private def gram(m: M): M = {
-    writeRead(m.T.dot(m))
+    val pm = m.cache()
+    writeRead(pm.T.dot(pm))
   }
 
   private[this] def cacheWhen(statisticsLevel: StatisticSubset)(m: M): M =
     if (statistics >= statisticsLevel) writeRead(m) else m
 
-  def computeResult(blockedG: M, pcs: BDM[Double]): Result[M] = {
+  def computeResult(_blockedG: M, pcs: BDM[Double]): Result[M] = {
+    val blockedG = _blockedG.cache()
     val preMu = this.mu(blockedG, pcs)
     val mu = BlockMatrix.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -1,7 +1,7 @@
 package is.hail.methods
 
 import breeze.linalg.{DenseMatrix => BDM}
-import is.hail.linalg.BlockMatrix
+import is.hail.linalg._
 import is.hail.linalg.BlockMatrix.ops._
 import is.hail.utils._
 import is.hail.HailContext
@@ -170,14 +170,15 @@ case class PCRelate(
 
   def computeResult(blockedG: M, pcs: BDM[Double]): Result[M] = {
     val preMu = this.mu(blockedG, pcs)
-    val mu = writeRead(BlockMatrix.map2 { (g, mu) =>
+    val mu = writeRead(BlockMatrix.map2(new DDtoD() { def apply(g: Double, mu: Double): Double = {
       if (badgt(g) || badmu(mu))
         Double.NaN
       else
         mu
-    } (blockedG, preMu))
+    }}) (blockedG, preMu))
     val variance = cacheWhen(PhiK2)(
-      mu.map(mu => if (mu.isNaN) 0.0 else mu * (1.0 - mu)))
+      mu.map(new DtoD() { def apply(mu: Double): Double =
+        if (mu.isNaN) 0.0 else mu * (1.0 - mu)}))
 
     // write phi to cache and increase parallelism of multiplies before phi.diagonal()
     val phi = writeRead(this.phi(mu, variance, blockedG))
@@ -217,9 +218,9 @@ case class PCRelate(
   }
 
   private[methods] def phi(mu: M, variance: M, g: M): M = {
-    val centeredAF = BlockMatrix.map2 { (g, mu) =>
+    val centeredAF = BlockMatrix.map2(new DDtoD() { def apply(g: Double, mu: Double): Double = {
       if (mu.isNaN) 0.0 else g / 2 - mu
-    } (g, mu)
+    }}) (g, mu)
 
     val stddev = variance.sqrt()
 
@@ -228,14 +229,14 @@ case class PCRelate(
 
   private[methods] def ibs0(g: M, mu: M): M = {
     val homalt =
-      BlockMatrix.map2 { (g, mu) =>
+      BlockMatrix.map2(new DDtoD() { def apply(g: Double, mu: Double): Double = {
         if (mu.isNaN || g != 2.0) 0.0 else 1.0
-      } (g, mu)
+      }}) (g, mu)
 
     val homref =
-      BlockMatrix.map2 { (g, mu) =>
+      BlockMatrix.map2(new DDtoD() { def apply(g: Double, mu: Double): Double = {
         if (mu.isNaN || g != 0.0) 0.0 else 1.0
-      } (g, mu)
+      }}) (g, mu)
 
     val temp = writeRead(homalt.T.dot(homref))
 
@@ -261,19 +262,21 @@ case class PCRelate(
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {
     val mu2 =
-      mu.map(mu => if (mu.isNaN) 0.0 else mu * mu)
+      mu.map(new DtoD() { def apply(mu: Double): Double =
+        if (mu.isNaN) 0.0 else mu * mu})
 
     val oneMinusMu2 =
-      mu.map(mu => if (mu.isNaN) 0.0 else (1.0 - mu) * (1.0 - mu))
+      mu.map(new DtoD() { def apply(mu: Double): Double =
+        if (mu.isNaN) 0.0 else (1.0 - mu) * (1.0 - mu)})
 
     val temp = writeRead(mu2.T.dot(oneMinusMu2))
     val denom = temp + temp.T
 
-    BlockMatrix.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>
+    BlockMatrix.map4(new DDDDtoD() { def apply(phi: Double, denom: Double, k2: Double, ibs0: Double): Double = {
       if (phi <= k0cutoff)
         1.0 - 4.0 * phi + k2
       else
         ibs0 / denom
-    } (phi, denom, k2, ibs0)
+    }}) (phi, denom, k2, ibs0)
   }
 }


### PR DESCRIPTION
I changed the Spark `persist`s to `writeRead` which writes and then reads. I tried to maintain this invariant: a block matrix partition always reads a linear number of partitions in the number of referenced block matrices. In particular, the result of *any* matmul must `writeRead`.

I removed the boxing of Doubles to check for NaN.

I avoided a bunch of allocation when performing matmul by using a fused multiply and add operation (`dgemm`).

I sped up conversation to BlockMatrix somewhat by introducing an iterator that caches the firstelementoffset.

I substantially improved `BlockMatrix.checkpoint` by using the fast lz4 codec.

*new*: I also added some tasteful cache'ing to PCRelate which substantially reduced the time spent reading data from disk.

cc: @johnc1231 @konradjk 