### PR TITLE
[batch] adjust client parameters

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -427,7 +427,7 @@ echo $HAIL_BATCH_WORKER_IP
         builder = self.client.create_batch()
         for i in range(4):
             builder.create_job('ubuntu:18.04',
-                               ['echo', 'a' * (3 * 1024 * 1024)])
+                               ['echo', 'a' * (900 * 1024)])
         builder.submit()
 
     def test_restartable_insert(self):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -466,8 +466,8 @@ class BatchBuilder:
                                                      json=batch_spec)).json()
         return Batch(self._client, batch_json['id'], self.attributes, n_jobs)
 
-    MAX_BUNCH_BYTESIZE = 8 * 1024 * 1024 - 512 * 1024  # max request size minus room for headers etc
-    MAX_BUNCH_SIZE = 8 * 1024  # ???
+    MAX_BUNCH_BYTESIZE = 1024 * 1024
+    MAX_BUNCH_SIZE = 1024
 
     async def submit(self,
                      max_bunch_bytesize=MAX_BUNCH_BYTESIZE,
@@ -512,7 +512,7 @@ class BatchBuilder:
             await bounded_gather(
                 *[functools.partial(self._submit_jobs, id, bunch, size, pbar)
                   for bunch, size in zip(byte_job_specs_bunches, bunch_sizes)],
-                parallelism=50)
+                parallelism=6)
 
         await self._client._patch(f'/api/v1alpha/batches/{id}/close')
         log.info(f'closed batch {id}')


### PR DESCRIPTION
It is impossible to submit large batches without this.  What happens?  The timeout per request is 60s.  We have 50 x 8MB = 400MB worth of requests in flight.  That means the client needs a reliable sustained MINIMUM bandwidth of ~7MB/s to not time out.  This doesn't seem reasonable.

Without this change, Konrad wasn't able to submit a large batch (although it probably would have gone through eventually with enough retry/backoff).  With this, 136K jobs took 2-3m to submit.

FYI @konradjk 