### PR TITLE
[hail] add pc_relate_big benchmark

### DIFF
--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -101,7 +101,7 @@ def pc_relate(mt_path):
 
 @benchmark()
 def pc_relate_big():
-    mt = hl.balding_nichols_model(3, 2 * 4096, 2 * 4096)
+    mt = hl.balding_nichols_model(3, 2 * 4096, 2 * 4096).checkpoint(hl.utils.new_temp_file(suffix='mt'))
     mt = mt.annotate_cols(scores = hl.range(2).map(lambda x: hl.rand_unif(0, 1)))
     rel = hl.pc_relate(mt.GT,
                        0.05,

--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -97,3 +97,15 @@ def pc_relate(mt_path):
                        statistics='kin',
                        min_kinship=0.05)
     rel._force_count()
+
+
+@benchmark(args=profile_25.handle('mt'))
+def pc_relate_big(mt_path):
+    mt = hl.balding_nichols_model(3, 2 * 4096, 2 * 4096).checkpoint('/tmp/foo.mt', overwrite=True)
+    mt = mt.annotate_cols(scores = hl.range(2).map(lambda x: hl.rand_unif(0, 1)))
+    rel = hl.pc_relate(mt.GT,
+                       0.05,
+                       scores_expr=mt.scores,
+                       statistics='kin',
+                       min_kinship=0.05)
+    rel._force_count()

--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -99,9 +99,9 @@ def pc_relate(mt_path):
     rel._force_count()
 
 
-@benchmark(args=profile_25.handle('mt'))
-def pc_relate_big(mt_path):
-    mt = hl.balding_nichols_model(3, 2 * 4096, 2 * 4096).checkpoint('/tmp/foo.mt', overwrite=True)
+@benchmark()
+def pc_relate_big():
+    mt = hl.balding_nichols_model(3, 2 * 4096, 2 * 4096)
     mt = mt.annotate_cols(scores = hl.range(2).map(lambda x: hl.rand_unif(0, 1)))
     rel = hl.pc_relate(mt.GT,
                        0.05,


### PR DESCRIPTION
This larger benchmark shows clearer separation between the old pc-relate approach and the current one.

this branch (which include's master's improvements)
```
2020-01-27 13:16:20,975: INFO: [1/1] Running pc_relate_big...
2020-01-27 13:18:12,886: INFO: burn in: 111.90s
2020-01-27 13:19:56,255: INFO: run 1: 103.35s
2020-01-27 13:21:46,801: INFO: run 2: 110.54s
2020-01-27 13:23:39,147: INFO: run 3: 112.37s
{"config": {"cores": 1, "version": "0.2.31-68d448411ab5", "timestamp": "2020-01-27 13:23:39.157122", "system": "darwin"}, "benchmarks": [{"name": "pc_relate_big", "failed": false, "timed_out": false, "times": [103.35172498200001, 110.53654034999997, 112.369625832]}]}
```
before improvements `becbbc6d2` (run against this branch's new benchmark)
```
2020-01-27 13:25:15,789: INFO: [1/1] Running pc_relate_big...
2020-01-27 13:27:25,725: INFO: burn in: 129.92s
2020-01-27 13:29:44,260: INFO: run 1: 138.48s
2020-01-27 13:31:49,675: INFO: run 2: 125.40s
2020-01-27 13:33:59,580: INFO: run 3: 129.86s
```

cc: @tpoterba 