### PR TITLE
[hailctl/dataproc] Support Broad's GCP Security Best Practices Document

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -201,7 +201,7 @@ def main(args, pass_through_args):
         print("Starting cluster '{}'...".format(args.name))
         sp.check_call(cmd)
 
-    if args.master_tags:
-        sp.check_call([
-            'gcloud', 'compute', 'instances', 'add-tags', args.name + '-m', '--tags',
-            args.master_tags])
+        if args.master_tags:
+            sp.check_call([
+                'gcloud', 'compute', 'instances', 'add-tags', args.name + '-m', '--tags',
+                args.master_tags])

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -166,7 +166,8 @@ def main(args, pass_through_args):
     conf.flags['worker-machine-type'] = args.worker_machine_type
     conf.flags['zone'] = args.zone
     conf.flags['initialization-action-timeout'] = args.init_timeout
-    conf.flags['network'] = args.network
+    if args.network:
+        conf.flags['network'] = args.network
     if args.configuration:
         conf.flags['configuration'] = args.configuration
     if args.project:

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -84,6 +84,7 @@ def init_parser(parser):
     parser.add_argument('--max-age', type=str, help='If specified, maximum age before shutdown (e.g. 60m).')
     parser.add_argument('--bucket', type=str,
                         help='The Google Cloud Storage bucket to use for cluster staging (just the bucket name, no gs:// prefix).')
+    parser.add_argument('--network', type=str, help='the network for all nodes in this cluster')
     parser.add_argument('--master-tags', type=str, help='comma-separated list of instance tags to apply to the mastern node')
 
     parser.add_argument('--wheel', help='Non-default Hail installation. Warning: experimental.')
@@ -165,6 +166,7 @@ def main(args, pass_through_args):
     conf.flags['worker-machine-type'] = args.worker_machine_type
     conf.flags['zone'] = args.zone
     conf.flags['initialization-action-timeout'] = args.init_timeout
+    conf.flags['network'] = args.network
     if args.configuration:
         conf.flags['configuration'] = args.configuration
     if args.project:

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -84,6 +84,7 @@ def init_parser(parser):
     parser.add_argument('--max-age', type=str, help='If specified, maximum age before shutdown (e.g. 60m).')
     parser.add_argument('--bucket', type=str,
                         help='The Google Cloud Storage bucket to use for cluster staging (just the bucket name, no gs:// prefix).')
+    parser.add_argument('--master-tags', type=str, help='comma-separated list of instance tags to apply to the mastern node')
 
     parser.add_argument('--wheel', help='Non-default Hail installation. Warning: experimental.')
 
@@ -196,3 +197,8 @@ def main(args, pass_through_args):
     if not args.dry_run:
         print("Starting cluster '{}'...".format(args.name))
         sp.check_call(cmd)
+
+    if args.master_tags:
+        sp.check_call([
+            'gcloud', 'compute', 'instances', 'add-tags', args.name + '-m', '--tags',
+            args.master_tags])


### PR DESCRIPTION
These changes enable hailctl clusters to work correctly in an Broad GCP Security Best Practices configured project, with minor hail-specific set-up. See further details in team chat.