### PR TITLE
2d by 1d matmul fix

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -442,6 +442,7 @@ def test_ndarray_transpose():
 @skip_unless_spark_backend()
 def test_ndarray_matmul():
     np_v = np.array([1, 2])
+    np_y = np.array([1, 1, 1])
     np_m = np.array([[1, 2], [3, 4]])
     np_m_f32 = np_m.astype(np.float32)
     np_m_f64 = np_m.astype(np.float64)
@@ -457,6 +458,7 @@ def test_ndarray_matmul():
     np_ones_float64 = np.ones((4, 4), dtype=np.float64)
 
     v = hl.nd.array(np_v)
+    y = hl.nd.array(np_y)
     m = hl.nd.array(np_m)
     m_f32 = hl.nd.array(np_m_f32)
     m_f64 = hl.nd.array(np_m_f64)
@@ -483,6 +485,7 @@ def test_ndarray_matmul():
         (r_f64 @ r_f64.T, np_r_f64 @ np_r_f64.T),
         (v @ m, np_v @ np_m),
         (m @ v, np_m @ np_v),
+        (r @ y, np_r @ np_y),
         (cube @ cube, np_cube @ np_cube),
         (cube @ v, np_cube @ np_v),
         (v @ cube, np_v @ np_cube),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -485,6 +485,7 @@ def test_ndarray_matmul():
         (r_f64 @ r_f64.T, np_r_f64 @ np_r_f64.T),
         (v @ m, np_v @ np_m),
         (m @ v, np_m @ np_v),
+        (v @ r, np_v @ np_r),
         (r @ y, np_r @ np_y),
         (cube @ cube, np_cube @ np_cube),
         (cube @ v, np_cube @ np_v),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2289,7 +2289,7 @@ object NDArrayEmitter {
       case (Seq(l), rs :+ r2 :+ r1) =>
         ((l, r2), (rs :+ r1).toArray)
       case (ls :+ l2 :+ l1, Seq(r)) =>
-        ((l1, r), (ls :+ l1).toArray)
+        ((l1, r), (ls :+ l2).toArray)
       case (
         ls :+ l2 :+ l1,
         rs :+ r2 :+ r1


### PR DESCRIPTION
I accidentally got the dimensions wrong in one of the `matmulShape` cases, causing this issue: #7982. This didn't come out in testing because in my 2 dimensional by 1 dimensional ndarray test, I used a square 2 dimensional array, so the shape was the same on either side. This PR adds another test and makes the fix. 