### PR TITLE
[hail][bugfix] Resolve performance bug in variant_qc

### DIFF
--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -41,6 +41,42 @@ def variant_and_sample_qc(mt_path):
 
 
 @benchmark(args=profile_25.handle('mt'))
+def variant_and_sample_qc_nested_with_filters_2(mt_path):
+    mt = hl.read_matrix_table(mt_path)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .8)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .8)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .98)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .98)
+    mt.count()
+
+
+@benchmark(args=profile_25.handle('mt'))
+def variant_and_sample_qc_nested_with_filters_4(mt_path):
+    mt = hl.read_matrix_table(mt_path)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .8)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .8)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .98)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .98)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .99)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .99)
+    mt = hl.variant_qc(mt)
+    mt = mt.filter_rows(mt.variant_qc.call_rate >= .999)
+    mt = hl.sample_qc(mt)
+    mt = mt.filter_cols(mt.sample_qc.call_rate >= .999)
+    mt.count()
+
+
+@benchmark(args=profile_25.handle('mt'))
 def hwe_normalized_pca(mt_path):
     mt = hl.read_matrix_table(mt_path)
     mt = mt.filter_rows(mt.info.AF[0] > 0.01)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2269,6 +2269,20 @@ class Literal(IR):
         self._type = self._typ
 
 
+class LiftMeOut(IR):
+    @typecheck_method(child=IR)
+    def __init__(self, child):
+        super().__init__(child)
+        self.child = child
+
+    def copy(self, child):
+        return LiftMeOut(child)
+
+    def _compute_type(self, env, agg_env):
+        self.child._compute_type(env, agg_env)
+        self._type = self.child.typ
+
+
 class Join(IR):
     _idx = 0
 

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1988,7 +1988,7 @@ class MatrixTable(ExprContainer):
         if _localize:
             return Env.backend().execute(agg_ir)
         else:
-            return construct_expr(agg_ir, expr.dtype)
+            return construct_expr(LiftMeOut(agg_ir), expr.dtype)
 
     @typecheck_method(expr=expr_any, _localize=bool)
     def aggregate_cols(self, expr, _localize=True) -> Any:
@@ -2038,7 +2038,7 @@ class MatrixTable(ExprContainer):
         if _localize:
             return Env.backend().execute(agg_ir)
         else:
-            return construct_expr(agg_ir, expr.dtype)
+            return construct_expr(LiftMeOut(agg_ir), expr.dtype)
 
     @typecheck_method(expr=expr_any, _localize=bool)
     def aggregate_entries(self, expr, _localize=True):
@@ -2082,9 +2082,7 @@ class MatrixTable(ExprContainer):
         if _localize:
             return Env.backend().execute(agg_ir)
         else:
-            return construct_expr(agg_ir, expr.dtype)
-
-        return Env.backend().execute(MatrixAggregate(base._mir, expr._ir))
+            return construct_expr(LiftMeOut(agg_ir), expr.dtype)
 
     @typecheck_method(field_expr=oneof(str, Expression))
     def explode_rows(self, field_expr) -> 'MatrixTable':
@@ -2383,7 +2381,7 @@ class MatrixTable(ExprContainer):
         if _localize:
             return Env.backend().execute(ir)
         else:
-            return construct_expr(ir, hl.tint64)
+            return construct_expr(LiftMeOut(ir), hl.tint64)
 
     def _force_count_rows(self):
         return Env.backend().execute(MatrixToValueApply(self._mir, {'name': 'ForceCountMatrixTable'}))
@@ -2411,7 +2409,7 @@ class MatrixTable(ExprContainer):
         if _localize:
             return Env.backend().execute(ir)
         else:
-            return construct_expr(ir, hl.tint64)
+            return construct_expr(LiftMeOut(ir), hl.tint64)
 
     def count(self) -> Tuple[int, int]:
         """Count the number of rows and columns in the matrix.

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1144,7 +1144,7 @@ class Table(ExprContainer):
         if _localize:
             return Env.backend().execute(agg_ir)
         else:
-            return construct_expr(agg_ir, expr.dtype)
+            return construct_expr(LiftMeOut(agg_ir), expr.dtype)
 
     @typecheck_method(output=str,
                       overwrite=bool,

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -110,7 +110,8 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),
-            ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake_file_path', False, False, False))
+            ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake_file_path', False, False, False)),
+            ir.LiftMeOut(ir.I32(1))
         ]
 
         return value_irs

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -176,6 +176,7 @@ object ChildEnvWithoutBindings {
       case MatrixAggregate(_, _) => BindingEnv(Env.empty, agg = Some(Env.empty))
       case TableAggregate(_, _) => BindingEnv(Env.empty, agg = Some(Env.empty))
       case RelationalLet(_, _, _) => if (i == 0) BindingEnv.empty else env
+      case LiftMeOut(_) => BindingEnv.empty
       case _ => if (UsesAggEnv(ir, i)) env.promoteAgg else if (UsesScanEnv(ir, i)) env.promoteScan else env
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -185,5 +185,6 @@ object Children {
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
     case ReadPartition(path, _, _) => Array(path)
+    case LiftMeOut(child) => Array(child)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 object InterpretableButNotCompilable {
   def apply(x: IR): Boolean = x match {
+    case _: LiftMeOut => true
     case _: TableCount => true
     case _: TableGetGlobals => true
     case _: TableCollect => true
@@ -24,6 +25,7 @@ object InterpretableButNotCompilable {
 object Compilable {
   def apply(ir: IR): Boolean = {
     ir match {
+      case _: LiftMeOut => false
       case _: TableCount => false
       case _: TableGetGlobals => false
       case _: TableCollect => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -294,6 +294,8 @@ object Copy {
       case ReadPartition(path, spec, rowType) =>
         assert(newChildren.length == 1)
         ReadPartition(newChildren(0).asInstanceOf[IR], spec, rowType)
+      case LiftMeOut(_) =>
+        LiftMeOut(newChildren(0).asInstanceOf[IR])
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -383,6 +383,7 @@ final case class ApplySeeded(function: String, args: Seq[IR], seed: Long, return
 
 final case class ApplySpecial(function: String, args: Seq[IR], returnType: Type) extends AbstractApplyNode[IRFunctionWithMissingness]
 
+final case class LiftMeOut(child: IR) extends IR
 final case class TableCount(child: TableIR) extends IR
 final case class TableAggregate(child: TableIR, query: IR) extends IR
 final case class MatrixAggregate(child: MatrixIR, query: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -215,6 +215,7 @@ object InferType {
       case BlockMatrixToValueApply(child, function) => function.typ(child.typ)
       case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
       case ReadPartition(_, _, rowType) => TStream(rowType)
+      case LiftMeOut(child) => child.typ
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -674,6 +674,12 @@ object Interpret {
         wrapped.get(0)
       case x: ReadPartition =>
         fatal(s"cannot interpret ${ Pretty(x) }")
+      case LiftMeOut(child) =>
+        val (rt, makeFunction) = Compile[Long](ctx, MakeTuple.ordered(FastSeq(child)), None, false)
+        Region.scoped { r =>
+          SafeRow.read(rt, r, makeFunction(0, r)(r)).asInstanceOf[Row](0)
+        }
+
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -769,16 +769,12 @@ object LowerMatrixIR {
           val sortedCols = if (colKey.isEmpty)
             '__cols_and_globals (colsField)
           else
-            irRange(0, irArrayLen('__cols_and_globals (colsField)), 1)
-              .map {
-                'i ~> let(__cols_element = '__cols_and_globals (colsField)('i)) {
-                  makeStruct(
-                    // key struct
-                    '_1 -> '__cols_element.selectFields(colKey: _*),
-                    '_2 -> '__cols_element)
-                }
-              }
-              .sort(true, onKey = true)
+            '__cols_and_globals (colsField).map { '__cols_element ~>
+              makeStruct(
+                // key struct
+                '_1 -> '__cols_element.selectFields(colKey: _*),
+                '_2 -> '__cols_element)
+            }.sort(true, onKey = true)
               .map {
                 'elt ~> 'elt ('_2)
               }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1156,6 +1156,8 @@ object IRParser {
         val rowType = coerce[TStruct](type_expr(env.typEnv)(it))
         val path = ir_value_expr(env)(it)
         ReadPartition(path, spec, rowType)
+      case "LiftMeOut" =>
+        LiftMeOut(ir_value_expr(env)(it))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1402,7 +1402,7 @@ object PruneDeadFields {
         // FIXME: remove this when all readers know how to read without keys
         val requestedTypeWithKeys = MatrixType(
           rowKey = typ.rowKey,
-          colKey = typ.colKey,
+          colKey = requestedType.colKey,
           rowType = unify(typ.rowType, selectKey(typ.rowType, typ.rowKey), requestedType.rowType),
           entryType = requestedType.entryType,
           colType = unify(typ.colType, selectKey(typ.colType, typ.colKey), requestedType.colType),

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1402,7 +1402,7 @@ object PruneDeadFields {
         // FIXME: remove this when all readers know how to read without keys
         val requestedTypeWithKeys = MatrixType(
           rowKey = typ.rowKey,
-          colKey = requestedType.colKey,
+          colKey = typ.colKey,
           rowType = unify(typ.rowType, selectKey(typ.rowType, typ.rowKey), requestedType.rowType),
           entryType = requestedType.entryType,
           colType = unify(typ.colType, selectKey(typ.colType, typ.colKey), requestedType.colType),

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -524,6 +524,8 @@ object Simplify {
 
     case BlockMatrixToValueApply(ValueToBlockMatrix(child, IndexedSeq(nrows, ncols), _), functions.GetElement(Seq(i, j))) =>
       if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
+
+    case LiftMeOut(child) if IsConstant(child) => child
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -384,6 +384,7 @@ object TypeCheck {
       case x@ReadPartition(path, _, rowType) =>
         assert(path.typ == TString())
         assert(x.typ == TStream(rowType))
+      case LiftMeOut(_) =>
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2565,6 +2565,7 @@ class IRSuite extends HailSuite {
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
+      LiftMeOut(I32(1)),
       RelationalLet("x", I32(0), I32(0)),
       TailLoop("y", IndexedSeq("x" -> I32(0)), Recur("y", FastSeq(I32(4)), TInt32()))
     )


### PR DESCRIPTION
We were reading the column values per row. This was bad.

Introduce the LiftMeOut node that is evaluated in the
`InterpretNonCompilable` lowering pass.

The benchmarked pipelines are still exponential in the number of
iterations of QC, which I will fix in a forthcoming PR.

Before:

```
2020-01-29 12:36:38,135: INFO: [1/1] Running variant_and_sample_qc_nested_with_filters...
2020-01-29 12:38:31,070: INFO: burn in: 112.93s
2020-01-29 12:40:17,863: INFO: run 1: 106.79s
2020-01-29 12:42:01,471: INFO: run 2: 103.61s
2020-01-29 12:43:47,330: INFO: run 3: 105.86s
```

After:
```
2020-01-29 12:30:18,619: INFO: [1/1] Running variant_and_sample_qc_nested_with_filters...
2020-01-29 12:31:24,969: INFO: burn in: 66.34s
2020-01-29 12:32:24,797: INFO: run 1: 59.82s
2020-01-29 12:33:22,849: INFO: run 2: 58.05s
2020-01-29 12:34:20,667: INFO: run 3: 57.81s
```

SSDs are fast.