### PR TITLE
[ci] fix ui in batch page -- attributes interface change

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -152,6 +152,7 @@ async def get_batch(request, userdata):
     for j in jobs:
         j['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(j))
         j['exit_code'] = Job.exit_code(j)
+        j['attributes'] = await j.attributes()
     page_context = {
         'batch': status,
         'jobs': jobs


### PR DESCRIPTION
I think this is right. I think `j` is an async Job rather than a sync one even though we collect_agen.