### PR TITLE
[batch] fix issues with exit code, duration

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -4,8 +4,7 @@ import asyncio
 import aiohttp
 import base64
 import traceback
-from hailtop.utils import time_msecs, sleep_and_backoff, is_transient_error, \
-    humanize_timedelta_msecs
+from hailtop.utils import time_msecs, sleep_and_backoff, is_transient_error
 
 from .globals import complete_states, tasks
 from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -157,7 +157,6 @@ def job_record_to_dict(app, record):
     if db_status:
         db_status = json.loads(db_status)
         exit_code, duration = format_version.get_status_exit_code_duration(db_status)
-        duration = humanize_timedelta_msecs(duration)
     else:
         exit_code = None
         duration = None

--- a/batch/batch/batch_format_version.py
+++ b/batch/batch/batch_format_version.py
@@ -78,6 +78,7 @@ class BatchFormatVersion:
 
     def get_status_exit_code_duration(self, status):
         if self.format_version == 1:
-            return (Job.exit_code(status), Job.total_duration_msecs(status))
+            job_status = {'status': status}
+            return (Job.exit_code(job_status), Job.total_duration_msecs(job_status))
         assert len(status) == 2
         return status

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -882,6 +882,8 @@ async def ui_batch(request, userdata):
     batch = await _get_batch(app, batch_id, user)
 
     jobs, last_job_id = await _query_batch_jobs(request, batch_id)
+    for j in jobs:
+        j['duration'] = humanize_timedelta_msecs(j['duration'])
     batch['jobs'] = jobs
 
     page_context = {

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -49,9 +49,18 @@ class Test(unittest.TestCase):
         status = j.wait()
         self.assertTrue('attributes' not in status, (status, j.log()))
         self.assertEqual(status['state'], 'Success', (status, j.log()))
+        self.assertEqual(status['exit_code'], 0, status)
         self.assertEqual(j._get_exit_code(status, 'main'), 0, (status, j.log()))
 
         self.assertEqual(j.log()['main'], 'test\n', status)
+
+    def test_exit_code(self):
+        builder = self.client.create_batch()
+        j = builder.create_job('ubuntu:18.04', ['exit', '7'])
+        b = builder.submit()
+        status = j.wait()
+        self.assertEqual(status['exit_code'], 7, status)
+        self.assertEqual(j._get_exit_code(status, 'main'), 8, status)
 
     def test_msec_mcpu(self):
         builder = self.client.create_batch()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -80,7 +80,7 @@ class Test(unittest.TestCase):
         batch_msec_mcpu2 = 0
         for job in b.jobs():
             # I'm dying
-            job = self.client.get_job(job['job_id'])
+            job = self.client.get_job(job['batch_id'], job['job_id'])
             job = job.status()
 
             # runs at 100mcpu

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -56,7 +56,7 @@ class Test(unittest.TestCase):
 
     def test_exit_code_duration(self):
         builder = self.client.create_batch()
-        j = builder.create_job('ubuntu:18.04', ['exit', '7'])
+        j = builder.create_job('ubuntu:18.04', ['bash', '-c', 'exit 7'])
         b = builder.submit()
         status = j.wait()
         self.assertEqual(status['exit_code'], 7, status)
@@ -79,8 +79,12 @@ class Test(unittest.TestCase):
 
         batch_msec_mcpu2 = 0
         for job in b.jobs():
+            # I'm dying
+            job = self.client.get_job(job['job_id'])
+            job = job.status()
+
             # runs at 100mcpu
-            job_msec_mcpu2 = 100 * max(job['end_time'] - job['start_time'], 0)
+            job_msec_mcpu2 = 100 * max(job['status']['end_time'] - job['status']['start_time'], 0)
             # greater than in case there are multiple attempts
             assert job['msec_mcpu'] >= job_msec_mcpu2, batch
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -54,12 +54,13 @@ class Test(unittest.TestCase):
 
         self.assertEqual(j.log()['main'], 'test\n', status)
 
-    def test_exit_code(self):
+    def test_exit_code_duration(self):
         builder = self.client.create_batch()
         j = builder.create_job('ubuntu:18.04', ['exit', '7'])
         b = builder.submit()
         status = j.wait()
         self.assertEqual(status['exit_code'], 7, status)
+        assert isinstance(status['duration'], int)
         self.assertEqual(j._get_exit_code(status, 'main'), 7, status)
 
     def test_msec_mcpu(self):
@@ -78,12 +79,10 @@ class Test(unittest.TestCase):
 
         batch_msec_mcpu2 = 0
         for job in b.jobs():
-            job_status = job.status()
-
             # runs at 100mcpu
-            job_msec_mcpu2 = 100 * max(job_status['status']['end_time'] - job_status['status']['start_time'], 0)
+            job_msec_mcpu2 = 100 * max(job['status']['end_time'] - job['status']['start_time'], 0)
             # greater than in case there are multiple attempts
-            assert job_status['msec_mcpu'] >= job_msec_mcpu2, batch
+            assert job['msec_mcpu'] >= job_msec_mcpu2, batch
 
             batch_msec_mcpu2 += job_msec_mcpu2
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -80,7 +80,7 @@ class Test(unittest.TestCase):
         batch_msec_mcpu2 = 0
         for job in b.jobs():
             # runs at 100mcpu
-            job_msec_mcpu2 = 100 * max(job['status']['end_time'] - job['status']['start_time'], 0)
+            job_msec_mcpu2 = 100 * max(job['end_time'] - job['start_time'], 0)
             # greater than in case there are multiple attempts
             assert job['msec_mcpu'] >= job_msec_mcpu2, batch
 
@@ -318,7 +318,7 @@ class Test(unittest.TestCase):
         assert n_cancelled <= 1, bstatus
         assert n_cancelled + n_complete == 3, bstatus
 
-        n_failed = sum([Job._get_exit_code(j, 'main') > 0 for j in bstatus['jobs'] if j['state'] in ('Failed', 'Error')])
+        n_failed = sum([j['exit_code'] > 0 for j in bstatus['jobs'] if j['state'] in ('Failed', 'Error')])
         assert n_failed == 1, bstatus
 
     def test_batch_status(self):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -60,7 +60,7 @@ class Test(unittest.TestCase):
         b = builder.submit()
         status = j.wait()
         self.assertEqual(status['exit_code'], 7, status)
-        self.assertEqual(j._get_exit_code(status, 'main'), 8, status)
+        self.assertEqual(j._get_exit_code(status, 'main'), 7, status)
 
     def test_msec_mcpu(self):
         builder = self.client.create_batch()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -8,7 +8,7 @@ from hailtop.batch_client.client import BatchClient, Job
 import hailtop.batch_client.aioclient as aioclient
 from hailtop.auth import get_userinfo
 
-from .utils import batch_status_job_counter, batch_status_exit_codes, \
+from .utils import batch_status_job_counter, \
     legacy_batch_status
 from .serverthread import ServerThread
 
@@ -28,8 +28,7 @@ def test_simple(client):
     batch.wait()
     status = legacy_batch_status(batch)
     assert batch_status_job_counter(status, 'Success') == 2, status
-    assert batch_status_exit_codes(status) == [
-        {'main': 0}, {'main': 0}], status
+    assert all([j['exit_code'] == 0 for j in status['jobs']])
 
 
 def test_missing_parent_is_400(client):

--- a/batch/test/test_scale.py
+++ b/batch/test/test_scale.py
@@ -2,7 +2,7 @@ import random
 import pytest
 from hailtop.batch_client.client import BatchClient
 
-from .utils import batch_status_job_counter, batch_status_exit_codes, \
+from .utils import batch_status_job_counter, \
     legacy_batch_status
 
 @pytest.fixture
@@ -26,4 +26,4 @@ def test_scale(client):
     assert batch_status_job_counter(status, 'Success') == n_jobs, status
 
     exit_codes = [{'input': 0, 'main': 0, 'output': 0} for _ in range(n_jobs)]
-    assert batch_status_exit_codes(status) == exit_codes, status
+    assert all([j['exit_code'] == 0 for j in status['jobs']])

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -5,10 +5,6 @@ def batch_status_job_counter(batch_status, job_state):
     return len([j for j in batch_status['jobs'] if j['state'] == job_state])
 
 
-def batch_status_exit_codes(batch_status):
-    return [Job._get_exit_codes(j) for j in batch_status['jobs']]
-
-
 def legacy_batch_status(batch):
     status = batch.status()
     status['jobs'] = list(batch.jobs())

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -11,5 +11,5 @@ def batch_status_exit_codes(batch_status):
 
 def legacy_batch_status(batch):
     status = batch.status()
-    status['jobs'] = [j.status() for j in batch.jobs()]
+    status['jobs'] = list(batch.jobs())
     return status

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -108,10 +108,9 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
     if pr.batch:
         if hasattr(pr.batch, 'id'):
             status = await pr.batch.status()
-            jobs = [await j.status() for j in await collect_agen(pr.batch.jobs())]
+            jobs = await collect_agen(pr.batch.jobs())
             for j in jobs:
-                j['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(j))
-                j['exit_code'] = Job.exit_code(j)
+                j['duration'] = humanize_timedelta_msecs(j['duration'])
             page_context['batch'] = status
             page_context['jobs'] = jobs
             # [4:] strips off gs:/
@@ -148,10 +147,9 @@ async def get_batch(request, userdata):
     batch_client = request.app['batch_client']
     b = await batch_client.get_batch(batch_id)
     status = await b.status()
-    jobs = [await j.status() for j in await collect_agen(b.jobs())]
+    jobs = await collect_agen(b.jobs())
     for j in jobs:
-        j['duration'] = humanize_timedelta_msecs(Job.total_duration_msecs(j))
-        j['exit_code'] = Job.exit_code(j)
+        j['duration'] = humanize_timedelta_msecs(j['duration'])
     page_context = {
         'batch': status,
         'jobs': jobs

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -11,7 +11,7 @@ import aiomysql
 import uvloop
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
-from hailtop.batch_client.aioclient import BatchClient, Job
+from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, \
     rest_authenticated_developers_only, web_authenticated_developers_only, \

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -307,7 +307,7 @@ class Batch:
             resp = await self._client._get(f'/api/v1alpha/batches/{self.id}/jobs', params=params)
             body = await resp.json()
             for job in body['jobs']:
-                yield Job.submitted_job(self, job['job_id'])
+                yield job
             last_job_id = body.get('last_job_id')
             if last_job_id is None:
                 break

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -111,7 +111,7 @@ class Batch:
         return async_to_blocking(self._async_batch.status())
 
     def jobs(self):
-        return [Job.from_async_job(job) for job in agen_to_blocking(self._async_batch.jobs())]
+        return agen_to_blocking(self._async_batch.jobs())
 
     def wait(self):
         return async_to_blocking(self._async_batch.wait())


### PR DESCRIPTION
This fixes a few of problems:
 - Batch.jobs() was discarding the job json objects and returning an Job objects.  This is not OK because we need the metadata from the json objects for efficiency (e.g. in CI PR/batch pages).
 - We confused Job.status(), which is the job json object, with the status field of that object.  In particular, we got that wrong in BatchFormatVersion.get_status_exit_code_duration in the call to Job.{exit_code, total_duration_msecs}.  Add a test to check we got this right.
 - Return the duration in msecs, not a string, because as an API, the string is useless.  humanize it before sending it to the API.

I think the batch client is (1) has a lot of legacy baggage that can be cleaned up, and (2) is massive overkill and can probably be cleaned up.  It should probably have no objects, pass around job_id ints or (batch_id, job_id) tuples, and be a thin wrapper around request calls.  Pipeline should be the high level API.

Finally, I think we need a little document (just a comment) about the format of GET /batches/batch_id and GET /jobs/job_id.  It's changed enough that it is getting a little hard to follow.

I'm going to dev deploy to test the UI.  Don't approve until it checks out, please.

FYI @jigold 