### PR TITLE
[batch] kick scheduler after job completes

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -104,13 +104,15 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
         log.exception(f'error while marking job {id} complete on instance {instance_name}')
         raise
 
+    scheduler_state_changed.set()
+    cancel_ready_state_changed.set()
+
     if instance_name:
         instance = inst_pool.name_instance.get(instance_name)
         if instance:
             if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
+                # may also create scheduling opportunities, set above
                 instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])
-                scheduler_state_changed.set()
-                cancel_ready_state_changed.set()
         else:
             log.warning(f'mark_complete for job {id} from unknown {instance}')
 


### PR DESCRIPTION
Scenario: we mark a ready job cancelled, and it doesn't change the free core counts.  It may cause another job to cancellable or runnable (if it was always_run).

This is another timing issue that was causing the batch tests to take longer than necessary.