### PR TITLE
Diagonal function for 2d ndarrays

### DIFF
--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,1 +1,1 @@
-from .nd import array, arange, full, zeros, ones, qr
+from .nd import array, arange, full, zeros, ones, qr, diagonal

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -189,6 +189,24 @@ def ones(shape, dtype=hl.tfloat64):
     return full(shape, 1, dtype)
 
 
+@typecheck(nd=expr_ndarray())
+def diagonal(nd):
+    """Gets the diagonal of a 2 dimensional NDArray.
+
+    Examples
+    --------
+
+    >>> hl.eval(hl.nd.diagonal(hl.nd.array([[1, 2], [3, 4]])))
+    array([1, 4], dtype=int32)
+
+    :param nd: A 2 dimensional NDArray, shape(M, N).
+    :return: A 1 dimension NDArray of length min (M, N), containing the diagonal of `nd`.
+    """
+    assert nd.ndim == 2, "diagonal requires 2 dimensional ndarray"
+    shape_min = hl.min(nd.shape[0], nd.shape[1])
+    return hl.nd.array(hl.range(hl.int32(shape_min)).map(lambda i: nd[i, i]))
+
+
 @typecheck(nd=expr_ndarray(), mode=str)
 def qr(nd, mode="reduced"):
     """Performs a QR decomposition.

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -568,6 +568,18 @@ def test_ndarray_show():
     hl.nd.arange(6).reshape((2, 3)).show()
     hl.nd.arange(8).reshape((2, 2, 2)).show()
 
+
+@skip_unless_spark_backend()
+def test_ndarray_diagonal():
+    assert np.array_equal(hl.eval(hl.nd.diagonal(hl.nd.array([[1, 2], [3, 4]]))), np.array([1, 4]))
+    assert np.array_equal(hl.eval(hl.nd.diagonal(hl.nd.array([[1, 2, 3], [4, 5, 6]]))), np.array([1, 5]))
+    assert np.array_equal(hl.eval(hl.nd.diagonal(hl.nd.array([[1, 2], [3, 4], [5, 6]]))), np.array([1, 4]))
+
+    with pytest.raises(AssertionError) as exc:
+        hl.nd.diagonal(hl.nd.array([1, 2]))
+    assert "2 dimensional" in str(exc)
+
+
 @skip_unless_spark_backend()
 def test_ndarray_qr():
     def assert_raw_equivalence(hl_ndarray, np_ndarray):


### PR DESCRIPTION
This just adds a convenience function to get the diagonal of a 2d ndarray. The numpy version offers more functionality when you have something greater than 2 dimensions, but I haven't needed that yet so starting with this. It won't be a breaking interface change to add more arguments to this function to support what numpy does. 