### PR TITLE
[batch] Fix catch duplicate key

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -635,7 +635,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s);
                                           jobs_args)
                 except pymysql.err.IntegrityError as err:
                     # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
-                    if err.args[1] == 1062:
+                    if err.args[0] == 1062:
                         log.info(f'bunch containing job {(batch_id, jobs_args[0][1])} already inserted ({err})')
                         raise web.Response()
                     raise


### PR DESCRIPTION
We saw this error in production:
```
pymysql.err.IntegrityError: (1062, "Duplicate entry '7433-432443' for key 'PRIMARY'")
```
hand deploy in progress already.