### PR TITLE
Block Matrix Shape Bug

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -175,10 +175,21 @@ class BlockMatrixFilter(BlockMatrixIR):
 
     def _compute_type(self):
         assert len(self.indices_to_keep) == 2
-        shape = [len(idxs) if len(idxs) != 0 else self.child.typ.shape[i] for i, idxs in
+
+        child_tensor_shape = self.child.typ.shape
+        child_ndim = len(child_tensor_shape)
+        if child_ndim == 1:
+            if self.child.typ.is_row_vector:
+                child_matrix_shape = [1, child_tensor_shape[0]]
+            else:
+                child_matrix_shape = [child_tensor_shape[0], 1]
+        else:
+            child_matrix_shape = child_tensor_shape
+
+        matrix_shape = [len(idxs) if len(idxs) != 0 else child_matrix_shape[i] for i, idxs in
                  enumerate(self.indices_to_keep)]
 
-        tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(shape[0], shape[1])
+        tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(matrix_shape[0], matrix_shape[1])
         self._type = tblockmatrix(self.child.typ.element_type,
                                   tensor_shape,
                                   is_row_vector,

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -972,3 +972,11 @@ class Tests(unittest.TestCase):
 
         s = x.svd(compute_uv=False, complexity_bound=0)
         assert np.all(s >= 0)
+
+
+    @skip_unless_spark_backend()
+    def test_filtering(self):
+        np_square = np.arange(16).reshape((4, 4))
+        bm = BlockMatrix.from_numpy(np_square)
+        assert np.array_equal(bm.filter([3], [3]).to_numpy(), np.array([[15]]))
+        assert np.array_equal(bm.filter_rows([3]).filter_cols([3]).to_numpy(), np.array([[15]]))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from hail.linalg import BlockMatrix
 from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalError
@@ -976,7 +976,18 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_filtering(self):
-        np_square = np.arange(16).reshape((4, 4))
+        np_square = np.arange(16, dtype=np.float64).reshape((4, 4))
         bm = BlockMatrix.from_numpy(np_square)
         assert np.array_equal(bm.filter([3], [3]).to_numpy(), np.array([[15]]))
         assert np.array_equal(bm.filter_rows([3]).filter_cols([3]).to_numpy(), np.array([[15]]))
+        assert np.array_equal(bm.filter_cols([3]).filter_rows([3]).to_numpy(), np.array([[15]]))
+        assert np.array_equal(bm.filter_rows([2]).filter_rows([0]).to_numpy(), np_square[2:3, :])
+        assert np.array_equal(bm.filter_cols([2]).filter_cols([0]).to_numpy(), np_square[:, 2:3])
+
+        with pytest.raises(ValueError) as exc:
+            bm.filter_cols([0]).filter_cols([3]).to_numpy()
+        assert "index" in str(exc)
+
+        with pytest.raises(ValueError) as exc:
+            bm.filter_rows([0]).filter_rows([3]).to_numpy()
+        assert "index" in str(exc)


### PR DESCRIPTION
For block matrices, we apparently have a notion of "tensor shape" vs "matrix shape". I am so far not a huge fan of this, as I don't think `BlockMatrix` was really designed to be anything other than a matrix. Anyway, the bug here is that the types contain the "tensor shape", and the block matrix filtering code was acting under the assumption that the types contained the "matrix shape". I've tried to be explicit when naming them below. 

I also added some python tests to catch this. We have Scala filtering tests as well, so just added enough python tests to convince myself this bug was fixed. 