### PR TITLE
[batch] fix up instance polling

### DIFF
--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -130,7 +130,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
         if self._state == 'active' and self.ip_address:
             try:
                 async with aiohttp.ClientSession(
-                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     await session.get(f'http://{self.ip_address}:5000/healthcheck')
                     await self.mark_healthy()
                     return True

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -458,6 +458,7 @@ FROM ready_cores;
             if e.resp['status'] == '404':
                 await self.remove_instance(instance, 'does_not_exist')
                 return
+            raise
 
         # PROVISIONING, STAGING, RUNNING, STOPPING, TERMINATED
         gce_state = spec['status']


### PR DESCRIPTION
1. If we receive an error other than 404 from Google when asking about an instance, we should raise. This is unexpected. (The later lines will fail anyway because spec is `None`)
2. (the main issue) if the instance is not active, do not bother contacting it and, crucially, continue `check_on_instance` eventually learning the instance does not exist.
3. Drop timeout to 5s to talk to a batch agent

Fixes the zombie instance issue.