### PR TITLE
[hail/ptypes] Copy IRs before inferring

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -42,7 +42,7 @@ object Compile {
     if (optimize)
       ir = Optimize(ir, noisy = true, context = "Compile", ctx)
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
-    InferPType(ir.deepCopy(), Env(args.map { case (n, pt, _) => n -> pt}: _*))
+    InferPType(if (HasIRSharing(ir)) ir.deepCopy() else ir, Env(args.map { case (n, pt, _) => n -> pt}: _*))
 
     val env = args
       .zipWithIndex

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -42,7 +42,7 @@ object Compile {
     if (optimize)
       ir = Optimize(ir, noisy = true, context = "Compile", ctx)
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
-    InferPType(ir, Env(args.map { case (n, pt, _) => n -> pt}: _*))
+    InferPType(ir.deepCopy(), Env(args.map { case (n, pt, _) => n -> pt}: _*))
 
     val env = args
       .zipWithIndex

--- a/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
@@ -59,7 +59,16 @@ object HasIRSharing {
   def apply(ir: BaseIR): Boolean = {
     val m = mutable.HashSet.empty[RefEquality[BaseIR]]
 
-    def recur(x: BaseIR): Boolean = m.contains(RefEquality(x)) || x.children.exists(recur)
+    def recur(x: BaseIR): Boolean = {
+      println(s"$x: $m")
+      val re = RefEquality(x)
+      if (m.contains(re))
+        true
+      else {
+        m.add(RefEquality(x))
+        x.children.exists(recur)
+      }
+    }
 
     recur(ir)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
@@ -54,3 +54,13 @@ class Memo[T] private(val m: mutable.HashMap[RefEquality[BaseIR], T]) {
   def delete(ir: RefEquality[BaseIR]): Unit = m -= ir
 }
 
+
+object HasIRSharing {
+  def apply(ir: BaseIR): Boolean = {
+    val m = mutable.HashSet.empty[RefEquality[BaseIR]]
+
+    def recur(x: BaseIR): Boolean = m.contains(RefEquality(x)) || x.children.exists(recur)
+
+    recur(ir)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
@@ -60,12 +60,11 @@ object HasIRSharing {
     val m = mutable.HashSet.empty[RefEquality[BaseIR]]
 
     def recur(x: BaseIR): Boolean = {
-      println(s"$x: $m")
       val re = RefEquality(x)
       if (m.contains(re))
         true
       else {
-        m.add(RefEquality(x))
+        m.add(re)
         x.children.exists(recur)
       }
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3114,4 +3114,11 @@ class IRSuite extends HailSuite {
 
     assertEvalsTo(triangleSum, FastIndexedSeq(5 -> TInt32()), 15 + 10 + 5)
   }
+
+  @Test def testHasIRSharing(): Unit = {
+    val r = Ref("x", TInt32())
+    val ir1 = MakeTuple.ordered(FastSeq(I64(1), r, r, I32(1)))
+    assert(HasIRSharing(ir1))
+    assert(!HasIRSharing(ir1.deepCopy()))
+  }
 }


### PR DESCRIPTION
The `assert(_ptype2 == null)` check in InferPType is breaking here on
certain complex pipelines in a way I don't want to debug.

There's no IR sharing within the IR (see utility I added), but there
must be subtrees that are inferred multiple times in different Compile
calls.

This is a safe stop-gap.