### PR TITLE
[hail] Improve IR generated by VQC/SQC to avoid exponential blowup

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -105,7 +105,7 @@ class MatrixMapCols(MatrixIR):
 
     def _compute_type(self):
         child_typ = self.child.typ
-        self.new_col._compute_type(child_typ.col_env(), child_typ.entry_env())
+        self.new_col._compute_type({**child_typ.col_env(), 'n_rows': hl.tint64}, child_typ.entry_env())
         self._type = hl.tmatrix(
             child_typ.global_type,
             self.new_col.typ,
@@ -118,6 +118,7 @@ class MatrixMapCols(MatrixIR):
         if i == 1:
             env = self.child.typ.col_env(default_value)
             env[BaseIR.agg_capability] = default_value
+            env['n_rows'] = default_value
             return env
         else:
             return {}
@@ -216,7 +217,7 @@ class MatrixMapRows(MatrixIR):
 
     def _compute_type(self):
         child_typ = self.child.typ
-        self.new_row._compute_type(child_typ.row_env(), child_typ.entry_env())
+        self.new_row._compute_type({**child_typ.row_env(), 'n_cols': hl.tint32}, child_typ.entry_env())
         self._type = hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
@@ -229,6 +230,7 @@ class MatrixMapRows(MatrixIR):
         if i == 1:
             env = self.child.typ.row_env(default_value)
             env[BaseIR.agg_capability] = default_value
+            env['n_cols'] = default_value
             return env
         else:
             return {}

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -45,9 +45,9 @@ object Bindings {
     case TableMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case TableAggregateByKey(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case TableKeyByAndAggregate(child, _, _, _, _) => if (i == 1) child.typ.globalEnv.m else if (i == 2) child.typ.rowEnv.m else empty
-    case MatrixMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
+    case MatrixMapRows(child, _) => if (i == 1) child.typ.rowEnv.bind("n_cols", TInt32()).m else empty
     case MatrixFilterRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
-    case MatrixMapCols(child, _, _) => if (i == 1) child.typ.colEnv.m else empty
+    case MatrixMapCols(child, _, _) => if (i == 1) child.typ.colEnv.bind("n_rows", TInt64()).m else empty
     case MatrixFilterCols(child, _) => if (i == 1) child.typ.colEnv.m else empty
     case MatrixMapEntries(child, _) => if (i == 1) child.typ.entryEnv.m else empty
     case MatrixFilterEntries(child, _) => if (i == 1) child.typ.entryEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1370,7 +1370,7 @@ object IRParser {
       case "MatrixMapCols" =>
         val newKey = opt(it, string_literals)
         val child = matrix_ir(env)(it)
-        val newCol = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        val newCol = ir_value_expr(env.withRefMap(child.typ.refMap) + ("n_rows" -> TInt64()))(it)
         MatrixMapCols(child, newCol, newKey.map(_.toFastIndexedSeq))
       case "MatrixKeyRowsBy" =>
         val key = identifiers(it)
@@ -1379,7 +1379,7 @@ object IRParser {
         MatrixKeyRowsBy(child, key, isSorted)
       case "MatrixMapRows" =>
         val child = matrix_ir(env)(it)
-        val newRow = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        val newRow = ir_value_expr(env.withRefMap(child.typ.refMap) + ("n_cols" -> TInt32()))(it)
         MatrixMapRows(child, newRow)
       case "MatrixMapEntries" =>
         val child = matrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -796,7 +796,7 @@ object PruneDeadFields {
     val depEnv = memoizeValueIR(ir, requestedType, memo)
     val depEnvUnified = concatEnvs(FastIndexedSeq(depEnv.eval) ++ FastIndexedSeq(depEnv.agg, depEnv.scan).flatten)
 
-    val expectedBindingSet = Set("va", "sa", "g", "global")
+    val expectedBindingSet = Set("va", "sa", "g", "global", "n_rows", "n_cols")
     depEnvUnified.m.keys.foreach { k =>
       if (!expectedBindingSet.contains(k))
         throw new RuntimeException(s"found unexpected free variable in pruning: $k\n  ${ Pretty(ir) }")


### PR DESCRIPTION
This change lets the call_rate calculation in variant_qc and sample_qc use the same IR without forking (which led to an exponential duplication of the IR, when these appeared iteratively).

We do this by introducing a new binding in MatrixMapCols and MatrixMapRows which refers to the row/col count. These metrics can be computed at essentially no marginal cost.

```
$ hail-bench compare ~/misc/debug/qc_before.json ~/misc/debug/qc_after.json
                                       Name      Ratio    Time 1    Time 2
                                       ----      -----    ------    ------
                                  sample_qc     102.3%    13.173    13.470
                                 variant_qc      91.4%     5.259     4.809
variant_and_sample_qc_nested_with_filters_2      29.9%    55.963    16.749
variant_and_sample_qc_nested_with_filters_4       3.2%   1183.905    38.048
```