### PR TITLE
[hail] Add MatrixCount IR node

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2011,6 +2011,20 @@ class TableAggregate(IR):
     def renderable_agg_bindings(self, i, default_value=None):
         return self.child.typ.row_env(default_value) if i == 1 else {}
 
+class MatrixCount(IR):
+    @typecheck_method(child=MatrixIR)
+    def __init__(self, child):
+        super().__init__(child)
+        self.child = child
+
+    @typecheck_method(child=MatrixIR)
+    def copy(self, child):
+        return TableCount(child)
+
+    def _compute_type(self, env, agg_env):
+        self.child._compute_type()
+        self._type = ttuple(tint64, tint32)
+
 
 class MatrixAggregate(IR):
     @typecheck_method(child=MatrixIR, query=IR)

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2424,7 +2424,8 @@ class MatrixTable(ExprContainer):
         :obj:`int`, :obj:`int`
             Number of rows, number of cols.
         """
-        return (self.count_rows(), self.count_cols())
+        ir = MatrixCount(self._mir)
+        return Env.backend().execute(ir)
 
     @typecheck_method(output=str,
                       overwrite=bool,

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -171,6 +171,7 @@ object Children {
     case MatrixMultiWrite(children, _) => children
     // from TableIR
     case TableCount(child) => Array(child)
+    case MatrixCount(child) => Array(child)
     case TableGetGlobals(child) => Array(child)
     case TableCollect(child) => Array(child)
     case TableAggregate(child, query) => Array(child, query)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -253,6 +253,9 @@ object Copy {
         MatrixWrite(newChildren(0).asInstanceOf[MatrixIR], writer)
       case MatrixMultiWrite(_, writer) =>
         MatrixMultiWrite(newChildren.map(_.asInstanceOf[MatrixIR]), writer)
+      case MatrixCount(_) =>
+        assert(newChildren.length == 1)
+        MatrixCount(newChildren(0).asInstanceOf[MatrixIR])
       // from TableIR
       case TableCount(_) =>
         assert(newChildren.length == 1)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -394,6 +394,7 @@ final case class ApplySpecial(function: String, args: Seq[IR], returnType: Type)
 
 final case class LiftMeOut(child: IR) extends IR
 final case class TableCount(child: TableIR) extends IR
+final case class MatrixCount(child: MatrixIR) extends IR
 final case class TableAggregate(child: TableIR, query: IR) extends IR
 final case class MatrixAggregate(child: MatrixIR, query: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -198,6 +198,7 @@ object InferType {
         val fd = t.fields(t.fieldIndex(idx)).typ
         fd.setRequired(t.required && fd.required)
       case TableCount(_) => TInt64()
+      case MatrixCount(_) => TTuple(TInt64(), TInt32())
       case TableAggregate(child, query) =>
         query.typ
       case MatrixAggregate(child, query) =>

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -810,6 +810,9 @@ object LowerMatrixIR {
         TableWrite(lower(child, ab), WrappedMatrixWriter(writer, colsFieldName, entriesFieldName, child.typ.colKey))
       case MatrixMultiWrite(children, writer) =>
         TableMultiWrite(children.map(lower(_, ab)), WrappedMatrixNativeMultiWriter(writer, children.head.typ.colKey))
+      case MatrixCount(child) =>
+        lower(child, ab)
+          .aggregate(makeTuple(applyAggOp(Count(), FastIndexedSeq(), FastIndexedSeq()), 'global(colsField).len))
       case MatrixAggregate(child, query) =>
         val lc = lower(child, ab)
         val idx = Symbol(genUID())

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -720,7 +720,7 @@ case class MatrixRowsHead(child: MatrixIR, n: Long) extends MatrixIR {
   override lazy val partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts.map { pc =>
     val prefixSums = pc.iterator.scanLeft(0L)(_ + _).drop(1)
     pc.iterator.zip(prefixSums)
-      .takeWhile { case (prefixSum, value) => prefixSum + value <= n }
+      .takeWhile { case (prefixSum, _) => prefixSum < n }
       .map { case (prefixSum, value) => if (prefixSum + value > n) value - prefixSum else value }
       .toArray
   }
@@ -767,7 +767,7 @@ case class MatrixRowsTail(child: MatrixIR, n: Long) extends MatrixIR {
   override lazy val partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts.map { pc =>
     val prefixSums = pc.reverseIterator.scanLeft(0L)(_ + _).drop(1)
     pc.reverseIterator.zip(prefixSums)
-      .takeWhile { case (prefixSum, value) => prefixSum + value <= n }
+      .takeWhile { case (prefixSum, _) => prefixSum <= n }
       .map { case (prefixSum, value) => if (prefixSum + value > n) value - prefixSum else value }
       .toArray
       .reverse

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1081,6 +1081,9 @@ object IRParser {
         val rt = type_expr(env.typEnv)(it)
         val args = ir_value_children(env)(it)
         invoke(function, rt, args: _*)
+      case "MatrixCount" =>
+        val child = matrix_ir(env.withRefMap(Map.empty))(it)
+        MatrixCount(child)
       case "TableCount" =>
         val child = table_ir(env.withRefMap(Map.empty))(it)
         TableCount(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -37,7 +37,7 @@ object Pretty {
 
   val MAX_VALUES_TO_LOG: Int = 25
 
-  def apply(ir: BaseIR, elideLiterals: Boolean = false, maxLen: Int = -1): String = {
+  def apply(ir: BaseIR, elideLiterals: Boolean = true, maxLen: Int = -1): String = {
     val sb = new StringBuilder
 
     def prettyIntOpt(x: Option[Int]): String = x.map(_.toString).getOrElse("None")
@@ -244,7 +244,7 @@ object Pretty {
             case I64(x) => x.toString
             case F32(x) => x.toString
             case F64(x) => x.toString
-            case Str(x) => prettyStringLiteral(x)
+            case Str(x) => prettyStringLiteral(if (elideLiterals && x.length > 13) x.take(10) + "..." else x)
             case Cast(_, typ) => typ.parsableString()
             case CastRename(_, typ) => typ.parsableString()
             case NA(typ) => typ.parsableString()

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1235,6 +1235,9 @@ object PruneDeadFields {
         val childTupleType = o.typ.asInstanceOf[TTuple]
         val tupleDep = TTuple(FastIndexedSeq(TupleField(idx, requestedType)), childTupleType.required)
         memoizeValueIR(o, tupleDep, memo)
+      case MatrixCount(child) =>
+        memoizeMatrixIR(child, minimal(child.typ), memo)
+        BindingEnv.empty
       case TableCount(child) =>
         memoizeTableIR(child, minimal(child.typ), memo)
         BindingEnv.empty

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -372,6 +372,7 @@ object TypeCheck {
       case TableWrite(_, _) =>
       case TableMultiWrite(_, _) =>
       case TableCount(_) =>
+      case MatrixCount(_) =>
       case TableGetGlobals(_) =>
       case TableCollect(child) =>
         assert(child.typ.key.isEmpty)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2787,7 +2787,7 @@ class IRSuite extends HailSuite {
       "x" -> TInt32()
     ))
 
-    val s = Pretty(x)
+    val s = Pretty(x, elideLiterals = false)
     val x2 = IRParser.parse_value_ir(s, env)
 
     assert(x2 == x)
@@ -2795,21 +2795,21 @@ class IRSuite extends HailSuite {
 
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
-    val s = Pretty(x)
+    val s = Pretty(x, elideLiterals = false)
     val x2 = IRParser.parse_table_ir(s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
-    val s = Pretty(x)
+    val s = Pretty(x, elideLiterals = false)
     val x2 = IRParser.parse_matrix_ir(s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "blockMatrixIRs")
   def testBlockMatrixIRParser(x: BlockMatrixIR) {
-    val s = Pretty(x)
+    val s = Pretty(x, elideLiterals = false)
     val x2 = IRParser.parse_blockmatrix_ir(s)
     assert(x2 == x)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2561,6 +2561,7 @@ class IRSuite extends HailSuite {
       invoke("toFloat64", TFloat64(), i), // Apply
       Literal(TStruct("x" -> TInt32()), Row(1)),
       TableCount(table),
+      MatrixCount(mt),
       TableGetGlobals(table),
       TableCollect(table),
       TableAggregate(table, MakeStruct(Seq("foo" -> count))),
@@ -3079,7 +3080,7 @@ class IRSuite extends HailSuite {
     val lit = Literal(t, Row(1L))
 
     assert(IRParser.parseType(t.parsableString()) == t)
-    assert(IRParser.parse_value_ir(Pretty(lit)) == lit)
+    assert(IRParser.parse_value_ir(Pretty(lit, elideLiterals = false)) == lit)
   }
 
   @Test def regressionTestUnifyBug(): Unit = {


### PR DESCRIPTION
Stacked on #8032

Compared to parent:
```
$ hail-bench compare ~/misc/debug/qc_after.json ~/misc/debug/qc_after_2.json
                                       Name      Ratio    Time 1    Time 2
                                       ----      -----    ------    ------
                                 variant_qc      95.0%     4.809     4.568
                                  sample_qc      94.1%    13.470    12.671
variant_and_sample_qc_nested_with_filters_2      79.1%    16.749    13.246
variant_and_sample_qc_nested_with_filters_4      65.2%    38.048    24.797
```