### PR TITLE
Fix warning when running combiner script

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -18,7 +18,7 @@ from .tidyr import gather, separate, spread
 from .codec import encode, decode
 from .db import DB
 from .compile import compile_comparison_binary, compiled_compare
-from .vcf_combiner import lgt_to_gt
+from .sparse_mt_utils import lgt_to_gt
 from .loop import loop
 from .time import strftime, strptime
 

--- a/hail/python/hail/experimental/sparse_mt_utils.py
+++ b/hail/python/hail/experimental/sparse_mt_utils.py
@@ -1,0 +1,25 @@
+from hail import call
+from hail.expr.expressions import expr_array, expr_call, expr_int32
+from hail.typecheck import typecheck
+
+
+@typecheck(lgt=expr_call, la=expr_array(expr_int32))
+def lgt_to_gt(lgt, la):
+    """Transforming Local GT and Local Alleles into the true GT
+
+    Parameters
+    ----------
+    lgt : :class:`.CallExpression`
+        The LGT value
+    la : :class:`.ArrayExpression`
+        The Local Alleles array
+
+    Returns
+    -------
+    :class:`.CallExpression`
+
+    Notes
+    -----
+    This function assumes diploid genotypes.
+    """
+    return call(la[lgt[0]], la[lgt[1]])

--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -7,7 +7,7 @@ import uuid
 import hail as hl
 from hail import MatrixTable, Table
 from hail.expr import StructExpression
-from hail.expr.expressions import expr_bool, expr_call, expr_array, expr_int32, expr_str
+from hail.expr.expressions import expr_bool, expr_str
 from hail.genetics.reference_genome import reference_genome_type
 from hail.ir import Apply, TableMapRows, TopLevelReference
 from hail.typecheck import oneof, sequenceof, typecheck
@@ -249,27 +249,6 @@ def combine_gvcfs(mts):
     ts = hl.Table.multi_way_zip_join([localize(mt) for mt in mts], 'data', 'g')
     combined = combine(ts)
     return unlocalize(combined)
-
-@typecheck(lgt=expr_call, la=expr_array(expr_int32))
-def lgt_to_gt(lgt, la):
-    """Transforming Local GT and Local Alleles into the true GT
-
-    Parameters
-    ----------
-    lgt : :class:`.CallExpression`
-        The LGT value
-    la : :class:`.ArrayExpression`
-        The Local Alleles array
-
-    Returns
-    -------
-    :class:`.CallExpression`
-
-    Notes
-    -----
-    This function assumes diploid genotypes.
-    """
-    return hl.call(la[lgt[0]], la[lgt[1]])
 
 @typecheck(ht=hl.Table, n=int, reference_genome=reference_genome_type)
 def calculate_new_intervals(ht, n, reference_genome='default'):


### PR DESCRIPTION
Saw this warning: /usr/lib/python3.7/runpy.py:125: RuntimeWarning: 'hail.experimental.vcf_combiner' found in sys.modules after import of package 'hail.experimental', but prior to execution of 'hail.experimental.vcf_combiner'; this may result in unpredictable behaviour

when running:

    python -m hail.experimental.vcf_combiner -h

This restructure fixes it while not changing the export point of
`lgt_to_gt`.