### PR TITLE
[hail] remove nSpecialArgs argument to Emit

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -10,7 +10,7 @@ import is.hail.utils._
 
 import scala.reflect.{ClassTag, classTag}
 
-case class CodeCacheKey(aggSigs: IndexedSeq[PhysicalAggSignature], args: Seq[(String, PType)], nSpecialArgs: Int, body: IR)
+case class CodeCacheKey(aggSigs: IndexedSeq[PhysicalAggSignature], args: Seq[(String, PType)], body: IR)
 
 case class CodeCacheValue(typ: PType, f: (Int, Region) => Any)
 
@@ -23,13 +23,12 @@ object Compile {
     args: Seq[(String, PType, ClassTag[_])],
     argTypeInfo: Array[MaybeGenericTypeInfo[_]],
     body: IR,
-    nSpecialArgs: Int,
     optimize: Boolean
   ): (PType, (Int, Region) => F) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
       Env(args.map { case (n, _, _) => n -> n }: _*))
-    val k = CodeCacheKey(FastIndexedSeq[PhysicalAggSignature](), args.map { case (n, pt, _) => (n, pt) }, nSpecialArgs, normalizedBody)
+    val k = CodeCacheKey(FastIndexedSeq[PhysicalAggSignature](), args.map { case (n, pt, _) => (n, pt) }, normalizedBody)
     codeCache.get(k) match {
       case Some(v) =>
         return (v.typ, v.f.asInstanceOf[(Int, Region) => F])
@@ -51,7 +50,7 @@ object Compile {
     ir = Subst(ir, BindingEnv(env))
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
 
-    Emit(ctx, ir, fb, nSpecialArgs)
+    Emit(ctx, ir, fb)
 
     val f = fb.resultWithIndex(print)
     codeCache += k -> CodeCacheValue(ir.pType, f)
@@ -63,7 +62,6 @@ object Compile {
     print: Option[PrintWriter],
     args: Seq[(String, PType, ClassTag[_])],
     body: IR,
-    nSpecialArgs: Int,
     optimize: Boolean
   ): (PType, (Int, Region) => F) = {
     assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
@@ -77,7 +75,7 @@ object Compile {
 
     val argTypeInfo: Array[MaybeGenericTypeInfo[_]] = ab.result()
 
-    Compile[F, R](ctx, print, args, argTypeInfo, body, nSpecialArgs, optimize)
+    Compile[F, R](ctx, print, args, argTypeInfo, body, optimize)
   }
 
   def apply[R: TypeInfo : ClassTag](
@@ -86,7 +84,7 @@ object Compile {
     print: Option[PrintWriter],
     optimize: Boolean = true
   ): (PType, (Int, Region) => AsmFunction1[Region, R]) = {
-    apply[AsmFunction1[Region, R], R](ctx, print, FastSeq[(String, PType, ClassTag[_])](), body, 1, optimize)
+    apply[AsmFunction1[Region, R], R](ctx, print, FastSeq[(String, PType, ClassTag[_])](), body, optimize)
   }
 
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
@@ -97,7 +95,7 @@ object Compile {
     optimize: Boolean,
     print: Option[PrintWriter]
   ): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
-    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize)
+    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0])), body, optimize)
   }
 
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
@@ -123,7 +121,7 @@ object Compile {
     typ1: PType,
     body: IR,
     print: Option[PrintWriter]): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
+    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, optimize = true)
   }
 
   def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
@@ -153,7 +151,7 @@ object Compile {
       (name0, typ0, classTag[T0]),
       (name1, typ1, classTag[T1]),
       (name2, typ2, classTag[T2])
-    ), body, 1,
+    ), body,
       optimize = true)
   }
 
@@ -175,7 +173,7 @@ object Compile {
       (name1, typ1, classTag[T1]),
       (name2, typ2, classTag[T2]),
       (name3, typ3, classTag[T3])
-    ), body, 1,
+    ), body,
       optimize = true)
   }
 
@@ -204,7 +202,7 @@ object Compile {
       (name3, typ3, classTag[T3]),
       (name4, typ4, classTag[T4]),
       (name5, typ5, classTag[T5])
-    ), body, 1,
+    ), body,
       optimize = true)
   }
 }
@@ -218,13 +216,12 @@ object CompileWithAggregators2 {
     args: Seq[(String, PType, ClassTag[_])],
     argTypeInfo: Array[MaybeGenericTypeInfo[_]],
     body: IR,
-    nSpecialArgs: Int,
     optimize: Boolean
   ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
       Env(args.map { case (n, _, _) => n -> n }: _*))
-    val k = CodeCacheKey(aggSigs.toFastIndexedSeq, args.map { case (n, pt, _) => (n, pt) }, nSpecialArgs, normalizedBody)
+    val k = CodeCacheKey(aggSigs.toFastIndexedSeq, args.map { case (n, pt, _) => (n, pt) }, normalizedBody)
     codeCache.get(k) match {
       case Some(v) =>
         return (v.typ, v.f.asInstanceOf[(Int, Region) => (F with FunctionWithAggRegion)])
@@ -245,7 +242,7 @@ object CompileWithAggregators2 {
     ir = Subst(ir, BindingEnv(env))
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
 
-    Emit(ctx, ir, fb, nSpecialArgs, Some(aggSigs))
+    Emit(ctx, ir, fb, Some(aggSigs))
 
     val f = fb.resultWithIndex()
     codeCache += k -> CodeCacheValue(ir.pType, f)
@@ -257,7 +254,6 @@ object CompileWithAggregators2 {
     aggSigs: Array[PhysicalAggSignature],
     args: Seq[(String, PType, ClassTag[_])],
     body: IR,
-    nSpecialArgs: Int,
     optimize: Boolean
   ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
     assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
@@ -271,7 +267,7 @@ object CompileWithAggregators2 {
 
     val argTypeInfo: Array[MaybeGenericTypeInfo[_]] = ab.result()
 
-    CompileWithAggregators2[F, R](ctx, aggSigs, args, argTypeInfo, body, nSpecialArgs, optimize)
+    CompileWithAggregators2[F, R](ctx, aggSigs, args, argTypeInfo, body, optimize)
   }
 
   def apply[R: TypeInfo : ClassTag](
@@ -279,7 +275,7 @@ object CompileWithAggregators2 {
     aggSigs: Array[PhysicalAggSignature],
     body: IR): (PType, (Int, Region) => AsmFunction1[Region, R] with FunctionWithAggRegion) = {
 
-    apply[AsmFunction1[Region, R], R](ctx, aggSigs, FastSeq[(String, PType, ClassTag[_])](), body, 1, optimize = true)
+    apply[AsmFunction1[Region, R], R](ctx, aggSigs, FastSeq[(String, PType, ClassTag[_])](), body, optimize = true)
   }
 
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
@@ -288,7 +284,7 @@ object CompileWithAggregators2 {
     name0: String, typ0: PType,
     body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R] with FunctionWithAggRegion) = {
 
-    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize = true)
+    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0])), body, optimize = true)
   }
 
   def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
@@ -298,7 +294,7 @@ object CompileWithAggregators2 {
     name1: String, typ1: PType,
     body: IR): (PType, (Int, Region) => (AsmFunction5[Region, T0, Boolean, T1, Boolean, R] with FunctionWithAggRegion)) = {
 
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
+    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, optimize = true)
   }
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -25,7 +25,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = new EmitFunctionBuilder[F](argTypeInfos.result(), GenericTypeInfo[Long])
     val mb = fb.apply_method
     val stream = ExecuteContext.scoped { ctx =>
-      EmitStream(new Emit(ctx, mb, 1), streamIR, Env.empty, EmitRegion.default(mb), None)
+      EmitStream(new Emit(ctx, mb), streamIR, Env.empty, EmitRegion.default(mb), None)
     }
     mb.emit {
       val arrayt = stream
@@ -76,7 +76,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[Region, Int]("eval_stream_len")
     val mb = fb.apply_method
     val stream = ExecuteContext.scoped { ctx =>
-      EmitStream(new Emit(ctx, mb, 1), streamIR, Env.empty, EmitRegion.default(mb), None)
+      EmitStream(new Emit(ctx, mb), streamIR, Env.empty, EmitRegion.default(mb), None)
     }
     fb.emit {
       JoinPoint.CallCC[Code[Int]] { (jb, ret) =>


### PR DESCRIPTION
Mostly a dead code thing at this point; there's nothing that uses nSpecialArgs != 1 and we've moved away from using that as a way of tracking objects.