### PR TITLE
[hail] broadcast globals separately for CollectDistributedArray

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -3,7 +3,7 @@ package is.hail.backend
 import java.io.PrintWriter
 
 import is.hail.HailContext
-import is.hail.annotations.{Region, SafeRow}
+import is.hail.annotations.SafeRow
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, LoweringPipeline}

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -1,30 +1,55 @@
 package is.hail.backend
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
+
 import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.io.{Decoder, DecoderBuilder}
 
-class BackendUtils(mods: Array[(String, (Int, Region) => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
+import scala.collection.mutable
 
-  type F = AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]
+class BroadcastHailValue(val bc: BroadcastValue[(InputStream => Decoder, Array[Byte])]) extends AnyVal {
+  def toRegion(r: Region): Long = {
+    val (makeDec, value) = bc.value
+    makeDec(new ByteArrayInputStream(value)).readRegionValue(r)
+  }
+}
+
+class BackendUtils(mods: Array[(String, (Int, Region) => AsmFunction4[Region, Long, InputStream, OutputStream, Unit])]) {
+  type F = AsmFunction4[Region, Long, InputStream, OutputStream, Unit]
 
   private[this] val loadedModules: Map[String, (Int, Region) => F] = mods.toMap
+  private[this] val broadcastValues: mutable.Map[String, BroadcastHailValue] = new mutable.HashMap()
 
   def getModule(id: String): (Int, Region) => F = loadedModules(id)
 
-  def collectDArray(modID: String, contexts: Array[Array[Byte]], globals: Array[Byte]): Array[Array[Byte]] = {
+  def addBroadcast(id: String, makeDec: DecoderBuilder, encoded: Array[Byte]): Unit =
+    broadcastValues += id -> new BroadcastHailValue(HailContext.backend.broadcast(makeDec.v -> encoded))
+
+  def getBroadcast(id: String): Region => Long = {
+    val bc = broadcastValues(id)
+    bc.toRegion
+  }
+
+  def removeBroadcast(id: String): Unit =
+    broadcastValues.remove(id)
+
+  def collectDArray(modID: String, contexts: Array[Array[Byte]], globals: String): Array[Array[Byte]] = {
     if (contexts.isEmpty)
       return Array()
     val backend = HailContext.backend
-    val globalsBC = backend.broadcast(globals)
     val f = getModule(modID)
+    val gsBC = getBroadcast(globals)
 
     if (contexts.isEmpty) { return Array() }
     backend.parallelizeAndComputeWithIndex(contexts) { (ctx, i) =>
-      val gs = globalsBC.value
       Region.scoped { region =>
-        val res = f(i, region)(region, ctx, gs)
-        res
+        val gs = gsBC(region)
+        val ctxIS = new ByteArrayInputStream(ctx)
+        val os = new ByteArrayOutputStream()
+        f(i, region)(region, gs, ctxIS, os)
+        os.toByteArray
       }
     }
   }

--- a/hail/src/main/scala/is/hail/io/Decoder.scala
+++ b/hail/src/main/scala/is/hail/io/Decoder.scala
@@ -9,6 +9,8 @@ import is.hail.expr.types.encoded.DecoderAsmFunction
 
 class DecoderBuilder(val v: InputStream => Decoder) extends Serializable {
   def apply(is: InputStream): Decoder = v(is)
+  def readRegionValue(is: InputStream, region: Region): Long =
+    v(is).readRegionValue(region)
 }
 
 trait Decoder extends Closeable {

--- a/hail/src/main/scala/is/hail/io/Decoder.scala
+++ b/hail/src/main/scala/is/hail/io/Decoder.scala
@@ -7,6 +7,10 @@ import is.hail.asm4s._
 import is.hail.utils.RestartableByteArrayInputStream
 import is.hail.expr.types.encoded.DecoderAsmFunction
 
+class DecoderBuilder(val v: InputStream => Decoder) extends Serializable {
+  def apply(is: InputStream): Decoder = v(is)
+}
+
 trait Decoder extends Closeable {
   def close()
 

--- a/hail/src/main/scala/is/hail/io/Encoder.scala
+++ b/hail/src/main/scala/is/hail/io/Encoder.scala
@@ -8,6 +8,12 @@ import is.hail.expr.types.encoded.EncoderAsmFunction
 
 class EncoderBuilder(val v: OutputStream => Encoder) extends Serializable {
   def apply(os: OutputStream): Encoder = v(os)
+  def writeRegionValue(os: OutputStream, region: Region, offset: Long): Unit = {
+    val enc = v(os)
+    enc.writeRegionValue(region, offset)
+    enc.flush()
+    enc.close()
+  }
 }
 
 trait Encoder extends Closeable {

--- a/hail/src/main/scala/is/hail/io/Encoder.scala
+++ b/hail/src/main/scala/is/hail/io/Encoder.scala
@@ -6,6 +6,10 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.types.encoded.EncoderAsmFunction
 
+class EncoderBuilder(val v: OutputStream => Encoder) extends Serializable {
+  def apply(os: OutputStream): Encoder = v(os)
+}
+
 trait Encoder extends Closeable {
   def flush(): Unit
 


### PR DESCRIPTION
This PR separates the ability to broadcast values in generated code on the backend from the collectDArray function. In order to support this, I did three things:

- allowed the function builder to build and store Encoder/Decoder objects, which wasn't strictly necessary but makes generating encoders/decoders for staged code much easier (I'll probably run some performance comparisons on this, shortly, but hopefully this doesn't introduce unacceptable amounts of overhead.)
- added broadcast support on BackendUtils to be able to broadcast serialized Hail values with a given decoder
- rewrote the CollectDistributedArray codegen to exercise the broadcasting on BackendUtils instead of manually serializing/broadcasting/deserializing the globals in generated code