### PR TITLE
[hail/ptypes] unsafeOrdering: require equality of ptypes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -108,7 +108,7 @@ abstract class PBaseStruct extends PType {
     unsafeOrdering(this)
 
   override def unsafeOrdering(rightType: PType): UnsafeOrdering = {
-    require(this.isOfType(rightType))
+    require(this == rightType)
 
     val right = rightType.asInstanceOf[PBaseStruct]
     val fieldOrderings: Array[UnsafeOrdering] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -170,7 +170,7 @@ abstract class PType extends Serializable with Requiredness {
   def isCanonical: Boolean = PType.canonical(this) == this // will recons, may need to rewrite this method
 
   def unsafeOrdering(rightType: PType): UnsafeOrdering = {
-    require(this.isOfType(rightType))
+    require(this == rightType)
     unsafeOrdering()
   }
 


### PR DESCRIPTION
pytest and jvm-test pass, so it seems the looser assertion can be tightened to make this safer.