### PR TITLE
[hail] nominally move sparsify operations to IR

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -196,6 +196,84 @@ class BlockMatrixFilter(BlockMatrixIR):
                                   self.child.typ.block_size)
 
 
+class BlockMatrixDensify(BlockMatrixIR):
+    @typecheck_method(child=BlockMatrixIR)
+    def __init__(self, child):
+        super().__init__(child)
+        self.child = child
+        self.indices_to_keep = indices_to_keep
+
+    def _compute_type(self):
+        self._type = self.child.typ
+
+
+class BlockMatrixSparsifer(object):
+    def head_str(self):
+        return ''
+
+    def __repr__(self):
+        head_str = self.head_str()
+        if head_str != '':
+            head_str = f' {head_str}'
+        return f'({self.__class__.__name__}{head_str})'
+
+    def _eq(self, other):
+        return True
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and and self._eq(other)
+
+
+class BandSparsifier(BlockMatrixSparsifer):
+    @typecheck_method(blocks_only=bool)
+    def __init__(self, blocks_only):
+        self.blocks_only = blocks_only
+
+    def head_str(self):
+        return str(self.blocks_only)
+
+    def _eq(self, other):
+        return self.blocks_only == other.blocks_only
+
+
+class RowIntervalSparsifier(BlockMatrixSparsifer):
+    @typecheck_method(blocks_only=bool)
+    def __init__(self, blocks_only):
+        self.blocks_only = blocks_only
+
+    def head_str(self):
+        return str(self.blocks_only)
+
+    def _eq(self, other):
+        return self.blocks_only == other.blocks_only
+
+
+class _RectangleSparsifier(BlockMatrixSparsifer):
+    def __init__(self):
+        pass
+
+
+RectangleSparsifier = _RectangleSparsifier()
+
+
+class BlockMatrixSparsify(BlockMatrixIR):
+    @typecheck_method(child=BlockMatrixIR, value=IR, sparsifier=BlockMatrixSparsifier)
+    def __init__(self, child, value, sparsifier):
+        super().__init__(child, value)
+        self.child = child
+        self.value = value
+        self.sparsifier = sparsifier
+
+    def head_str(self):
+        return str(self.sparsifier)
+
+    def _eq(self, other):
+        return self.sparsifier == other.sparsifier
+
+    def _compute_type(self):
+        self._type = self.child.typ
+
+
 class BlockMatrixSlice(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, slices=sequenceof(slice))
     def __init__(self, child, slices):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -207,7 +207,7 @@ class BlockMatrixDensify(BlockMatrixIR):
         self._type = self.child.typ
 
 
-class BlockMatrixSparsifer(object):
+class BlockMatrixSparsifier(object):
     def head_str(self):
         return ''
 
@@ -224,7 +224,7 @@ class BlockMatrixSparsifer(object):
         return isinstance(other, self.__class__) and self._eq(other)
 
 
-class BandSparsifier(BlockMatrixSparsifer):
+class BandSparsifier(BlockMatrixSparsifier):
     @typecheck_method(blocks_only=bool)
     def __init__(self, blocks_only):
         self.blocks_only = blocks_only
@@ -236,7 +236,7 @@ class BandSparsifier(BlockMatrixSparsifer):
         return self.blocks_only == other.blocks_only
 
 
-class RowIntervalSparsifier(BlockMatrixSparsifer):
+class RowIntervalSparsifier(BlockMatrixSparsifier):
     @typecheck_method(blocks_only=bool)
     def __init__(self, blocks_only):
         self.blocks_only = blocks_only
@@ -248,7 +248,7 @@ class RowIntervalSparsifier(BlockMatrixSparsifer):
         return self.blocks_only == other.blocks_only
 
 
-class _RectangleSparsifier(BlockMatrixSparsifer):
+class _RectangleSparsifier(BlockMatrixSparsifier):
     def __init__(self):
         pass
 

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -252,6 +252,9 @@ class _RectangleSparsifier(BlockMatrixSparsifier):
     def __init__(self):
         pass
 
+    def __repr__(self):
+        return f'(RectangleSparsifier)'
+
 
 RectangleSparsifier = _RectangleSparsifier()
 

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -221,7 +221,7 @@ class BlockMatrixSparsifer(object):
         return True
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and and self._eq(other)
+        return isinstance(other, self.__class__) and self._eq(other)
 
 
 class BandSparsifier(BlockMatrixSparsifer):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -201,7 +201,6 @@ class BlockMatrixDensify(BlockMatrixIR):
     def __init__(self, child):
         super().__init__(child)
         self.child = child
-        self.indices_to_keep = indices_to_keep
 
     def _compute_type(self):
         self._type = self.child.typ

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -13,7 +13,8 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F
     BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryPrimOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter, TableFromBlockMatrixNativeReader, TableRead, \
-    BlockMatrixSlice
+    BlockMatrixSlice, BlockMatrixSparsify, BlockMatrixDensify, RectangleSparsifier, \
+    RowIntervalSparsifier, BandSparsifier
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter
 from hail.table import Table

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -932,7 +932,8 @@ class BlockMatrix(object):
         if lower > upper:
             raise ValueError(f'sparsify_band: lower={lower} is greater than upper={upper}')
 
-        return BlockMatrix._from_java(self._jbm.filterBand(lower, upper, blocks_only))
+        bounds = hl.literal((lower, upper), hl.ttuple(hl.tint64, hl.tint64))
+        return BlockMatrix(BlockMatrixSparsify(self._bmir, bounds._ir, BandSparsifier(blocks_only)))
 
     @typecheck_method(lower=bool, blocks_only=bool)
     def sparsify_triangle(self, lower=False, blocks_only=False):
@@ -1088,10 +1089,13 @@ class BlockMatrix(object):
         if any([starts[i] > stops[i] for i in range(0, n_rows)]):
             raise ValueError('every start value must be less than or equal to the corresponding stop value')
 
-        return BlockMatrix._from_java(self._jbm.filterRowIntervals(
-            jarray(Env.jvm().long, starts),
-            jarray(Env.jvm().long, stops),
-            blocks_only))
+        starts_and_stops = hl.literal(
+            (starts, stops),
+            hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))
+        return BlockMatrix(
+            BlockMatrixSparsify(self._bmir,
+                                starts_and_stops._ir,
+                                RowIntervalSparsifier(blocks_only)))
 
     @typecheck_method(uri=str)
     def tofile(self, uri):
@@ -1210,7 +1214,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return BlockMatrix._from_java(self._jbm.densify())
+        return BlockMatrix(BlockMatrixDensify(self._bmir))
 
     def cache(self):
         """Persist this block matrix in memory.
@@ -1880,7 +1884,9 @@ class BlockMatrix(object):
                                  f'0 <= r[0] <= r[1] <= n_rows and 0 <= r[2] <= r[3] <= n_cols')
 
         flattened_rectangles = jarray(Env.jvm().long, list(itertools.chain(*rectangles)))
-        return BlockMatrix._from_java(self._jbm.filterRectangles(flattened_rectangles))
+        rectangles = hl.literal(flattened_rectangles, hl.tarray(hl.tint64))
+        return BlockMatrix(
+            BlockMatrixSparsify(self._bmir, rectangles._ir, RectangleSparsifier))
 
     @typecheck_method(path_out=str,
                       rectangles=sequenceof(sequenceof(int)),

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2646,9 +2646,10 @@ def ld_matrix(entry_expr, locus_expr, radius, coord_expr=None, block_size=None) 
     """
     starts_and_stops = hl.linalg.utils.locus_windows(locus_expr, radius, coord_expr, _localize=False)
     ld = hl.row_correlation(entry_expr, block_size)
-    return BlockMatrix._from_java(ld._jbm.filterRowIntervalsIR(
-        Env.backend()._to_java_ir(starts_and_stops._ir),
-        False))
+    return BlockMatrix(
+        BlockMatrixSparsify(ld._bmir,
+                            starts_and_stops._ir,
+                            RowIntervalSparsifier(blocks_only=False)))
 
 
 @typecheck(n_populations=int,

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2645,10 +2645,11 @@ def ld_matrix(entry_expr, locus_expr, radius, coord_expr=None, block_size=None) 
         Row and column indices correspond to matrix table variant index.
     """
     starts_and_stops = hl.linalg.utils.locus_windows(locus_expr, radius, coord_expr, _localize=False)
+    starts_and_stops = hl.tuple([starts_and_stops[0].map(lambda i: hl.int64(i)), starts_and_stops[1].map(lambda i: hl.int64(i))])
     ld = hl.row_correlation(entry_expr, block_size)
     return BlockMatrix(
         BlockMatrixSparsify(ld._bmir,
-                            hl.cast_expr(starts_and_stops, hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))._ir,
+                            starts_and_stops._ir,
                             RowIntervalSparsifier(blocks_only=False)))
 
 

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2648,7 +2648,7 @@ def ld_matrix(entry_expr, locus_expr, radius, coord_expr=None, block_size=None) 
     ld = hl.row_correlation(entry_expr, block_size)
     return BlockMatrix(
         BlockMatrixSparsify(ld._bmir,
-                            starts_and_stops._ir,
+                            hl.cast_expr(starts_and_stops, hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))._ir,
                             RowIntervalSparsifier(blocks_only=False)))
 
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -302,6 +302,16 @@ class BlockMatrixIRTests(unittest.TestCase):
         transpose = ir.BlockMatrixBroadcast(broadcast_scalar, [1, 0], [2, 2], 256)
         matmul = ir.BlockMatrixDot(broadcast_scalar, transpose)
 
+        rectangle = ir.Literal([0, 1, 5, 6], hl.tarray(hl.tint64))
+        band = ir.Literal((-1, 1), hl.ttuple(hl.tint64, hl.tint64))
+        intervals = ir.Literal(([0, 1, 5, 6], [5, 6, 8, 9]), hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))
+
+        sparsify1 = ir.BlockMatrixSparsify(read, rectangle, ir.RectangleSparsifier)
+        sparsify2 = ir.BlockMatrixSparsify(read, band, ir.BandSparsifier(True))
+        sparsify3 = ir.BlockMatrixSparsify(read, intervals, ir.RowIntervalSparsifier(True))
+
+        densify = ir.BlockMatrixDensify(read)
+
         pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir
         squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, 'l', 'r', pow_ir)
         slice_bm = ir.BlockMatrixSlice(matmul, [slice(0, 2, 1), slice(0, 1, 1)])
@@ -319,6 +329,10 @@ class BlockMatrixIRTests(unittest.TestCase):
             broadcast_row,
             squared_bm,
             transpose,
+            sparsify1,
+            sparsify2,
+            sparsify3,
+            densify,
             matmul,
             slice_bm
         ]

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -302,9 +302,9 @@ class BlockMatrixIRTests(unittest.TestCase):
         transpose = ir.BlockMatrixBroadcast(broadcast_scalar, [1, 0], [2, 2], 256)
         matmul = ir.BlockMatrixDot(broadcast_scalar, transpose)
 
-        rectangle = ir.Literal([0, 1, 5, 6], hl.tarray(hl.tint64))
-        band = ir.Literal((-1, 1), hl.ttuple(hl.tint64, hl.tint64))
-        intervals = ir.Literal(([0, 1, 5, 6], [5, 6, 8, 9]), hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))
+        rectangle = ir.Literal(hl.tarray(hl.tint64), [0, 1, 5, 6])
+        band = ir.Literal(hl.ttuple(hl.tint64, hl.tint64), (-1, 1))
+        intervals = ir.Literal(hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)), ([0, 1, 5, 6], [5, 6, 8, 9]))
 
         sparsify1 = ir.BlockMatrixSparsify(read, rectangle, ir.RectangleSparsifier)
         sparsify2 = ir.BlockMatrixSparsify(read, band, ir.BandSparsifier(True))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -530,7 +530,7 @@ case class BandSparsifier(blocksOnly: Boolean) extends BlockMatrixSparsifier {
 
 case class RowIntervalSparsifier(blocksOnly: Boolean) extends BlockMatrixSparsifier {
   def sparsify(ctx: ExecuteContext, bm: BlockMatrix, value: IR): BlockMatrix = {
-    val Row(starts: IndexedSeq[Int], stops: IndexedSeq[Int]) = CompileAndEvaluate[Row](ctx, value, optimize = true)
+    val Row(starts: IndexedSeq[Int @unchecked], stops: IndexedSeq[Int @unchecked]) = CompileAndEvaluate[Row](ctx, value, optimize = true)
     bm.filterRowIntervals(starts.map(_.toLong).toArray, stops.map(_.toLong).toArray, blocksOnly)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1576,9 +1576,9 @@ object IRParser {
         val child = blockmatrix_ir(env)(it)
         BlockMatrixDensify(child)
       case "BlockMatrixSparsify" =>
+        val sparsifier = blockmatrix_sparsifier(it)
         val child = blockmatrix_ir(env)(it)
         val value = ir_value_expr(env)(it)
-        val sparsifier = blockmatrix_sparsifier(it)
         BlockMatrixSparsify(child, value, sparsifier)
       case "BlockMatrixSlice" =>
         val slices = literals(literals(int64_literal))(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1512,6 +1512,22 @@ object IRParser {
     }
   }
 
+  def blockmatrix_sparsifier(it: TokenIterator): BlockMatrixSparsifier = {
+    punctuation(it, "(")
+    val s = identifier(it) match {
+      case "RowIntervalSparsifier" =>
+        val blocksOnly = boolean_literal(it)
+        RowIntervalSparsifier(blocksOnly)
+      case "BandSparsifier" =>
+        val blocksOnly = boolean_literal(it)
+        BandSparsifier(blocksOnly)
+      case "RectangleSparsifier" =>
+        RectangleSparsifier
+    }
+    punctuation(it, ")")
+    s
+  }
+
   def blockmatrix_ir(env: IRParserEnvironment)(it: TokenIterator): BlockMatrixIR = {
     punctuation(it, "(")
     val ir = blockmatrix_ir1(env)(it)
@@ -1556,6 +1572,14 @@ object IRParser {
         val indices = literals(literals(int64_literal))(it)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixFilter(child, indices)
+      case "BlockMatrixDensify" =>
+        val child = blockmatrix_ir(env)(it)
+        BlockMatrixDensify(child)
+      case "BlockMatrixSparsify" =>
+        val child = blockmatrix_ir(env)(it)
+        val value = ir_value_expr(env)(it)
+        val sparsifier = blockmatrix_sparsifier(it)
+        BlockMatrixSparsify(child, value, sparsifier)
       case "BlockMatrixSlice" =>
         val slices = literals(literals(int64_literal))(it)
         val child = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -26,6 +26,15 @@ object Pretty {
   def prettyClass(x: AnyRef): String =
     x.getClass.getName.split("\\.").last
 
+  def prettyBlockMatrixSparsifier(sparsifier: BlockMatrixSparsifier): String = sparsifier match {
+    case BandSparsifier(blocksOnly) =>
+      s"(BandSparsifier ${ prettyBooleanLiteral(blocksOnly) })"
+    case RowIntervalSparsifier(blocksOnly) =>
+      s"(RowIntervalSparsifier ${ prettyBooleanLiteral(blocksOnly) })"
+    case RectangleSparsifier =>
+      s"(RectangleSparsifier)"
+  }
+
   val MAX_VALUES_TO_LOG: Int = 25
 
   def apply(ir: BaseIR, elideLiterals: Boolean = false, maxLen: Int = -1): String = {
@@ -312,6 +321,8 @@ object Pretty {
               blockSize.toString + " "
             case BlockMatrixFilter(_, indicesToKeepPerDim) =>
               indicesToKeepPerDim.map(indices => prettyLongs(indices)).mkString("(", " ", ")")
+            case BlockMatrixSparsify(_, _, sparsifier) =>
+              prettyBlockMatrixSparsifier(sparsifier)
             case BlockMatrixRandom(seed, gaussian, shape, blockSize) =>
               seed.toString + " " +
               prettyBooleanLiteral(gaussian) + " " +

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2725,9 +2725,23 @@ class IRSuite extends HailSuite {
     val dot = BlockMatrixDot(read, transpose)
     val slice = BlockMatrixSlice(read, FastIndexedSeq(FastIndexedSeq(0, 2, 1), FastIndexedSeq(0, 1, 1)))
 
+    val rectangle = Literal(TArray(TInt64()), FastIndexedSeq(0L, 1L, 5L, 6L))
+    val band = Literal(TTuple(TInt64(), TInt64()), Row(-1, 1))
+    val intervals = Literal(TTuple(TArray(TInt64()), TArray(TInt64())),
+      Row(FastIndexedSeq(0L, 1L, 5L, 6L), FastIndexedSeq(5L, 6L, 8L, 9L)))
+
+    val sparsify1 = BlockMatrixSparsify(read, rectangle, RectangleSparsifier)
+    val sparsify2 = BlockMatrixSparsify(read, band, BandSparsifier(true))
+    val sparsify3 = BlockMatrixSparsify(read, intervals, RowIntervalSparsifier(true))
+    val densify = BlockMatrixDensify(read)
+
     val blockMatrixIRs = Array[BlockMatrixIR](read,
       transpose,
       dot,
+      sparsify1,
+      sparsify2,
+      sparsify3,
+      densify,
       RelationalLetBlockMatrix("x", I32(0), read),
       slice)
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2726,7 +2726,7 @@ class IRSuite extends HailSuite {
     val slice = BlockMatrixSlice(read, FastIndexedSeq(FastIndexedSeq(0, 2, 1), FastIndexedSeq(0, 1, 1)))
 
     val rectangle = Literal(TArray(TInt64()), FastIndexedSeq(0L, 1L, 5L, 6L))
-    val band = Literal(TTuple(TInt64(), TInt64()), Row(-1, 1))
+    val band = Literal(TTuple(TInt64(), TInt64()), Row(-1L, 1L))
     val intervals = Literal(TTuple(TArray(TInt64()), TArray(TInt64())),
       Row(FastIndexedSeq(0L, 1L, 5L, 6L), FastIndexedSeq(5L, 6L, 8L, 9L)))
 


### PR DESCRIPTION
Defines two new BlockMatrixIR nodes, BlockMatrixSparsify and BlockMatrixDensify, to represent the corresponding operations in BlockMatrix. Execution is unchanged.