### PR TITLE
[gateway] log external user's IP in gateway

### DIFF
--- a/gateway/service.yaml
+++ b/gateway/service.yaml
@@ -17,4 +17,6 @@ spec:
   selector:
     app: gateway
   loadBalancerIP: "{{ global.ip }}"
+  # https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer
+  externalTrafficPolicy: Local
   type: LoadBalancer


### PR DESCRIPTION
cc: the "services team" @cseed, @johnc1231

This fixes gateway to log the user's IP. Forthcoming PRs will fix all downstream
services.

---

There are two important pieces of which to be aware:

- The gateway pod are exposed via the gateway Service, which is the only
  object modified in this PR.
- K8s fulfills our request for the gateway Service by creating a [Google TCP
  LoadBalancer](https://console.cloud.google.com/net-services/loadbalancing/loadBalancers/list). Moreover,
  we specify `loadBalancerIP` which is a manually (outside of k8s) allocated IP
  which we expose on the public internet.

When you `curl https://hail.is` this is what happens:

- Your packet travels across the internet until it reaches the Google TCP
  LoadBalancer
- The Google TCP LoadBalancer selects one of the kubernetes nodes to send the
  packet to (in principle, it could send the packet to *any* node, even nodes
  that do not have a gateway pod).
- Some part of k8s receives the packet and discovers the nodes that host a
  gateway pod.
- It selects a gateway pod and forwards the packet to the node (possibly itself)
  hosting that gateway pod. In doing so, *it must replace the source IP of the
  packet with its own, internal, IP*.

Note that this is happening at the TCP layer, so no HTTP headers are set. When
the gateway `nginx` receives the packet, there is no trace of the source
IP. Kubernetes has a feature called `externalTrafficPolicy` which is available
in GCP and Azure and preserves the source IP. Kubernetes achieves this by
failing the TCP LoadBalancer healthchecks on nodes without matching pods (in our
case, gateway). The k8s docs on [Source IPs](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer) further explain this strategy. Here's what the healthchecks look like for two
nodes, one hosting a gateway pod and one not hosting a gateway pod (note the
HTTP status code):

```
dking@gke-vdc-preemptible-pool-2-9aa4dbeb-wvxk ~ $ curl -v localhost:32029
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 32029 (#0)
> GET / HTTP/1.1
> Host: localhost:32029
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 05 Feb 2020 20:59:27 GMT
< Content-Length: 88
<
{
	"service": {
		"namespace": "default",
		"name": "gateway"
	},
	"localEndpoints": 1
}
```
```
}dking@gke-vdc-non-preemptible-pool-5-80798769-kp8n ~ $ curl -v localhost:32029
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 32029 (#0)
> GET / HTTP/1.1
> Host: localhost:32029
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 503 Service Unavailable
< Content-Type: application/json
< Date: Wed, 05 Feb 2020 20:59:19 GMT
< Content-Length: 88
<
{
	"service": {
		"namespace": "default",
		"name": "gateway"
	},
	"localEndpoints": 0
}
```