### PR TITLE
[batch] make docker calls idempotent with a timeout

### DIFF
--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -105,10 +105,8 @@ def docker_call_retry(timeout, name):
                     raise
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
-            except aiohttp.client_exceptions.ServerDisconnectedError:
+            except (aiohttp.client_exceptions.ServerDisconnectedError, asyncio.TimeoutError):
                 log.exception(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True)
-            except asyncio.TimeoutError:
-                log.exception(f'timeout in docker call to {f.__name__} for {name}, retrying', stack_info=True)
             delay = await sleep_and_backoff(delay)
     return wrapper
 

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -19,8 +19,7 @@ import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
 from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT, \
-    retry_all_errors
-
+    sleep_and_backoff, retry_all_errors
 
 # import uvloop
 
@@ -42,7 +41,7 @@ log = logging.getLogger('batch-worker')
 MAX_IDLE_TIME_MSECS = 30 * 1000
 MAX_DOCKER_IMAGE_PULL_SECS = 20 * 60
 MAX_DOCKER_WAIT_SECS = 5 * 60
-MAX_DOCKER_TIMEOUT_SECS = 1 * 60
+MAX_DOCKER_OTHER_OPERATION_SECS = 1 * 60
 
 CORES = int(os.environ['CORES'])
 NAME = os.environ['NAME']
@@ -87,49 +86,41 @@ class PortAllocator:
         self.ports.put_nowait(port)
 
 
-def docker_call_retry(timeout, name):
-    async def _wrapper(f, *args, **kwargs):
-        delay = 0.1
-        local_timeout = timeout
-        while True:
-            try:
-                return await asyncio.wait_for(f(*args, **kwargs), local_timeout)
-            except DockerError as e:
-                # 408 request timeout, 503 service unavailable
-                if e.status == 408 or e.status == 503:
-                    log.exception(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True)
-                # DockerError(500, 'Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-                # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
-                elif e.status == 500 and ("request canceled while waiting for connection" in e.message or
-                                          re.match("error creating overlay mount.*device or resource busy", e.message)):
-                    log.exception(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True)
-                else:
-                    raise
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+async def docker_call_retry(timeout, name, f, *args, **kwargs):
+    delay = 0.1
+    local_timeout = timeout
+    while True:
+        try:
+            return await asyncio.wait_for(f(*args, **kwargs), local_timeout)
+        except DockerError as e:
+            # 408 request timeout, 503 service unavailable
+            if e.status == 408 or e.status == 503:
+                log.exception(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True)
+            # DockerError(500, 'Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
+            # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
+            elif e.status == 500 and ("request canceled while waiting for connection" in e.message or
+                                      re.match("error creating overlay mount.*device or resource busy", e.message)):
+                log.exception(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True)
+            else:
                 raise
-            except aiohttp.client_exceptions.ServerDisconnectedError:
-                log.exception(f'in docker call to {f.__name__}, retrying', stack_info=True)
-            except asyncio.TimeoutError:
-                local_timeout *= 2
-                log.exception(f'in docker call to {f.__name__} for {name}, retrying with timeout {local_timeout} seconds', stack_info=True)
-            # exponentially back off, up to (expected) max of 30s
-            t = delay * random.random()
-            await asyncio.sleep(t)
-            delay = min(delay * 2, 60.0)
-    return _wrapper
+        except asyncio.CancelledError:  # pylint: disable=try-except-raise
+            raise
+        except aiohttp.client_exceptions.ServerDisconnectedError:
+            log.exception(f'in docker call to {f.__name__}, retrying', stack_info=True)
+        except asyncio.TimeoutError:
+            local_timeout *= 2
+            log.exception(f'in docker call to {f.__name__} for {name}, retrying with timeout {local_timeout} seconds', stack_info=True)
+        delay = await sleep_and_backoff(delay)
 
 
 async def create_container(config, name):
+    delay = 0.1
     error = 0
-    delay = 1
     while True:
         try:
             return await docker.containers.create(config, name=name)
         except DockerError as e:
-            # exponentially back off, up to (expected) max of 30s
-            t = delay * random.random()
-            await asyncio.sleep(t)
-            delay = min(delay * 2, 60.0)
+            delay = await sleep_and_backoff(delay)
 
             error += 1
             if error == 5:
@@ -144,7 +135,6 @@ async def create_container(config, name):
                     # 404 No such container
                     if eget.status == 404:
                         continue
-                    raise
             raise
 
 
@@ -295,7 +285,8 @@ class Container:
             return None
 
         try:
-            c = await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+            c = await docker_call_retry(
+                MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
                 self.container.show)
         except DockerError as e:
             if e.status == 404:
@@ -332,16 +323,19 @@ class Container:
                     # image.
                     # FIXME improve the performance of this with a
                     # per-user image cache.
-                    await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
+                    await docker_call_retry(
+                        MAX_DOCKER_IMAGE_PULL_SECS, f'{self}',
                         docker.images.pull, self.image, auth=auth)
                 else:
                     # this caches public images
                     try:
-                        await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+                        await docker_call_retry(
+                            MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
                             docker.images.get, self.image)
                     except DockerError as e:
                         if e.status == 404:
-                            await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
+                            await docker_call_retry(
+                                MAX_DOCKER_IMAGE_PULL_SECS, f'{self}',
                                 docker.images.pull, self.image)
 
             if self.port is not None:
@@ -351,7 +345,8 @@ class Container:
             async with self.step('creating'):
                 config = self.container_config()
                 log.info(f'starting {self} config {config}')
-                self.container = await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+                self.container = await docker_call_retry(
+                    MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
                     create_container,
                     config, name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}')
 
@@ -361,13 +356,14 @@ class Container:
                         asyncio.ensure_future(worker.post_job_started(self.job))
 
                     async with self.step('starting'):
-                        await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
-                            start_container,
-                            self.container)
+                        await docker_call_retry(
+                            MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
+                            start_container, self.container)
 
                     async with self.step('running'):
                         async with async_timeout.timeout(self.timeout) as tm:
-                            await docker_call_retry(MAX_DOCKER_WAIT_SECS, f'{self}')(
+                            await docker_call_retry(
+                                MAX_DOCKER_WAIT_SECS, f'{self}',
                                 self.container.wait)
                         if tm.expired:
                             raise JobTimeoutError(f'timed out after {self.timeout}s')
@@ -399,7 +395,8 @@ class Container:
             await self.delete_container()
 
     async def get_container_log(self):
-        logs = await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+        logs = await docker_call_retry(
+            MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
             self.container.log, stderr=True, stdout=True)
         self.log = "".join(logs)
         return self.log
@@ -417,10 +414,12 @@ class Container:
         if self.container:
             try:
                 log.info(f'{self}: deleting container')
-                await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+                await docker_call_retry(
+                    MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
                     stop_container, self.container)
                 # v=True deletes anonymous volumes created by the container
-                await docker_call_retry(MAX_DOCKER_TIMEOUT_SECS, f'{self}')(
+                await docker_call_retry(
+                    MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}',
                     delete_container, self.container, v=True)
                 self.container = None
             except Exception:

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -127,10 +127,10 @@ async def create_container(config, name):
                     # 404 No such container
                     if eget.status == 404:
                         error += 1
-                        if error < 5:
+                        if error < 10:
                             delay = await sleep_and_backoff(delay)
                             continue
-                        log.exception(f'encountered 5 errors while creating container {name}, aborting', stack_info=True)
+                        log.exception(f'encountered 10 errors while creating container {name}, aborting', stack_info=True)
                         raise
             raise
 


### PR DESCRIPTION
This PR makes docker calls idempotent and adds a timeout for docker calls in the retry function.

I got the error codes to ignore from the older docker documentation at the bottom of each API call: https://docs.docker.com/engine/api/v1.30/#operation/ContainerDelete

FYI: @cseed since you had opinions on the timeout times