### PR TITLE
[hail] outline of BlockMatrix lowering

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -1,0 +1,117 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.expr.ir._
+import is.hail.expr.types.BlockMatrixType
+import is.hail.expr.types.virtual._
+import is.hail.utils.{FastIndexedSeq, FastSeq}
+
+case class BlockMatrixStage(
+  ctxName: String,
+  ctxType: Type,
+  blockContexts: Array[Array[Option[IR]]],
+  broadcastVals: Map[String, IR], //optional, for a very specific type of broadcast.
+  body: IR) {
+
+  private lazy val ctxID: String = genUID()
+  private lazy val broadcastID: String = genUID()
+
+  private lazy val bcs = MakeStruct(broadcastVals.toIndexedSeq)
+
+  def toIR(bodyTransform: IR => IR, ordering: Option[Array[(Int, Int)]]): IR = {
+    val ctxs = ordering.map { idxs =>
+      idxs.map { case (i, j) => blockContexts(i)(j).get }
+    }.getOrElse {
+      blockContexts.flatMap(rows => rows.flatten)
+    }
+    val wrappedBody = bcs.fields.foldLeft(bodyTransform(body)) { case (accum, (name, _)) =>
+        Let(name, GetField(Ref(broadcastID, bcs.typ), name), accum)
+    }
+    CollectDistributedArray(MakeArray(ctxs, TArray(ctxType)), bcs, ctxID, broadcastID, wrappedBody)
+  }
+}
+
+
+object LowerBlockMatrixIR {
+
+  def lower(node: IR): IR = node match {
+//    case BlockMatrixCollect(child: BlockMatrixIR) =>
+//      val bm = lower(child)
+//      val lowered = bm.toIR(nd => nd, Some(child.typ.presentBlocks))
+//      if (child.typ.isSparse) {
+//        // insert dense blocks
+//        throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+//      } else {
+//        throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+//      }
+
+    case BlockMatrixMultiWrite(blockMatrices, writer) =>
+      throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+    case BlockMatrixToValueApply(child, function) =>
+      throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+    case BlockMatrixWrite(child, writer) =>
+      throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+
+    case node if node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
+      throw new LowererUnsupportedOperation(s"IR nodes with BlockMatrixIR children must be defined explicitly: \n${ Pretty(node) }")
+
+    case node =>
+      throw new LowererUnsupportedOperation(s"Value IRs with no BlockMatrixIR children must be lowered through LowerIR: \n${ Pretty(node) }")
+  }
+
+  def lower(bmir: BlockMatrixIR): BlockMatrixStage = bmir match {
+    case BlockMatrixRead(reader) =>
+      throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(bmir) }")
+    case BlockMatrixMap(child, eltName, f) =>
+      throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(bmir) }")
+    case x@BlockMatrixDot(leftIR, rightIR) =>
+      val left = lower(leftIR)
+      val right = lower(rightIR)
+      val (_, n) = leftIR.typ.defaultBlockShape
+
+      val newCtxType = TArray(TStruct(
+        left.ctxName -> TArray(left.ctxType),
+        right.ctxName -> TArray(right.ctxType)))
+      val newCtx = Ref(genUID(), newCtxType)
+
+      // group blocks for multiply
+      // the contexts that we're parallelizing, *in general*, are going to involve little-to-no computation so duplicating across nodes seems fine for now.
+      val newContexts = Array.tabulate(x.typ.nRowBlocks) { i =>
+        Array.tabulate[Option[IR]](x.typ.nColBlocks) { j =>
+          if (!x.typ.definedBlocks(i)(j)) None else {
+            Some(MakeArray(Array.tabulate[Option[IR]](n) { k =>
+              left.blockContexts(i)(k).flatMap { leftCtx =>
+                right.blockContexts(k)(j).map { rightCtx =>
+                  MakeStruct(FastIndexedSeq(
+                    left.ctxName -> leftCtx,
+                    right.ctxName -> rightCtx))
+                }
+              }
+            }.flatten, newCtxType))
+          }
+        }
+      }
+
+      val wrapMultiply = { ctxElt: IR =>
+        Let(left.ctxName, GetField(ctxElt, left.ctxName),
+          Let(right.ctxName, GetField(ctxElt, right.ctxName),
+            NDArrayMatMul(left.body, right.body)))
+      }
+
+      // computation for multiply
+      val zero = wrapMultiply(ArrayRef(newCtx, 0))
+      val tail = invoke("[*:]", newCtxType, newCtx, 1)
+      val elt = Ref(genUID(), newCtxType.elementType)
+      val accum = Ref(genUID(), zero.typ)
+      val l = Ref(genUID(), TFloat64())
+      val r = Ref(genUID(), TFloat64())
+      val newBody = ArrayFold(tail, zero, accum.name, elt.name,
+        NDArrayMap2(accum, wrapMultiply(elt), l.name, r.name, ApplyBinaryPrimOp(Add(), l, r)))
+
+      BlockMatrixStage(
+        newCtx.name, newCtx.typ,
+        newContexts,
+        left.broadcastVals ++ right.broadcastVals,
+        newBody)
+  }
+
+}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
@@ -1,0 +1,25 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.expr.ir.lowering.LowerTableIR.lower
+import is.hail.expr.ir.{ArrayFlatMap, ArrayLen, BlockMatrixIR, Cast, Copy, GetField, IR, MakeStruct, MatrixIR, Pretty, Ref, TableCollect, TableCount, TableGetGlobals, TableIR, genUID, invoke}
+import is.hail.expr.types.virtual.{TContainer, TInt64}
+import is.hail.utils.FastIndexedSeq
+
+object LowerIR {
+  def lower(ir: IR, lowerTable: Boolean, lowerBM: Boolean): IR = ir match {
+    case node if lowerTable && node.children.exists( _.isInstanceOf[TableIR] ) =>
+      LowerTableIR.lower(ir)
+
+    case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
+      throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
+
+    case node if lowerBM && node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
+      LowerBlockMatrixIR.lower(ir)
+
+    case node if node.children.forall(_.isInstanceOf[IR]) =>
+      Copy(node, ir.children.map { case c: IR => lower(c, lowerTable, lowerBM) })
+
+    case node =>
+      throw new LowererUnsupportedOperation(s"Cannot lower: \n${ Pretty(node) }")
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -34,7 +34,6 @@ case class TableStage(
 
 object LowerTableIR {
   def lower(ir: IR): IR = ir match {
-
     case TableCount(tableIR) =>
       val stage = lower(tableIR)
       invoke("sum", TInt64(), stage.toIR(node => Cast(ArrayLen(node), TInt64())))
@@ -54,14 +53,8 @@ object LowerTableIR {
     case node if node.children.exists( _.isInstanceOf[TableIR] ) =>
       throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")
 
-    case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
-      throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
-
-    case node if node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
-      throw new LowererUnsupportedOperation(s"BlockMatrixIR nodes are not supported: \n${ Pretty(node) }")
-
     case node =>
-      Copy(node, ir.children.map { case c: IR => lower(c) })
+      throw new LowererUnsupportedOperation(s"Value IRs with no TableIR children must be lowered through LowerIR: \n${ Pretty(node) }")
   }
 
   // table globals should be stored in the first element of `globals` in TableStage;

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -53,5 +53,5 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   val after: IRState = CompilableIR
   val context: String = "LowerTableToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerTableIR.lower(ir.asInstanceOf[IR])
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = false)
 }

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -3,11 +3,66 @@ package is.hail.expr.types
 import is.hail.utils._
 import is.hail.expr.types.virtual.Type
 
+object BlockMatrixType {
+  def tensorToMatrixShape(shape: IndexedSeq[Long], isRowVector: Boolean): (Long, Long) = {
+    shape match {
+      case IndexedSeq() => (1, 1)
+      case IndexedSeq(vectorLength) => if (isRowVector) (1, vectorLength) else (vectorLength, 1)
+      case IndexedSeq(numRows, numCols) => (numRows, numCols)
+    }
+  }
+
+  def matrixToTensorShape(nRows: Long,  nCols: Long): (IndexedSeq[Long], Boolean) = {
+    (nRows, nCols) match {
+      case (1, 1) => (FastIndexedSeq(), false)
+      case (_, 1) => (FastIndexedSeq(nRows), false)
+      case (1, _) => (FastIndexedSeq(nCols), true)
+      case _ => (FastIndexedSeq(nRows, nCols), false)
+    }
+  }
+
+  def numBlocks(n: Long, blockSize: Int): Int =
+    java.lang.Math.floorDiv(n - 1, blockSize).toInt + 1
+
+  def blockIdxFromLinear(nColBlocks: Int, linearIdx: Int): (Int, Int) =
+    java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks
+
+  // this is a shim method for the lowering.
+  def apply(elementType: Type, shape: IndexedSeq[Long], isRowVector: Boolean, blockSize: Int): BlockMatrixType =
+    BlockMatrixType(elementType, shape, isRowVector, blockSize, null)
+
+  def dense(elementType: Type, nRows: Long, nCols: Long, blockSize: Int): BlockMatrixType = {
+    val (shape, isRowVector) = matrixToTensorShape(nRows, nCols)
+    val nRowBlocks = numBlocks(nRows, blockSize)
+    val nColBlocks = numBlocks(nCols, blockSize)
+    BlockMatrixType(elementType, shape, isRowVector, blockSize, Array.fill(nRowBlocks)(Array.fill(nColBlocks)(true)))
+  }
+}
+
 case class BlockMatrixType(
   elementType: Type,
   shape: IndexedSeq[Long],
   isRowVector: Boolean,
-  blockSize: Int) extends BaseType {
+  blockSize: Int,
+  _definedBlocks: Array[Array[Boolean]]
+) extends BaseType {
+
+  lazy val (nRows: Long, nCols: Long) = BlockMatrixType.tensorToMatrixShape(shape, isRowVector)
+
+  def matrixShape: (Long, Long) = nRows -> nCols
+
+  lazy val nRowBlocks: Int = BlockMatrixType.numBlocks(nRows, blockSize)
+  lazy val nColBlocks: Int = BlockMatrixType.numBlocks(nCols, blockSize)
+  lazy val defaultBlockShape: (Int, Int) = (nRowBlocks, nColBlocks)
+
+  lazy val definedBlocks: Array[Array[Boolean]] = {
+    if (_definedBlocks == null)
+      throw new UnsupportedOperationException("sparsity is not defined.")
+    _definedBlocks
+  }
+
+  val hasSparsity: Boolean = _definedBlocks != null
+  lazy val isSparse: Boolean = _definedBlocks != null && definedBlocks.forall(rows => rows.forall(i => i))
 
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0
@@ -43,6 +98,15 @@ case class BlockMatrixType(
 
     sb.append(s"blockSize:$space")
     sb.append(blockSize)
+    sb += ','
+    newline()
+
+    sb.append(s"definedBlocks:$space")
+    if (hasSparsity && isSparse) {
+      sb.append(definedBlocks.map(row => row.mkString("[", ",", "]")).mkString("[", ",", "]"))
+    } else {
+      sb.append("None")
+    }
     sb += ','
     newline()
 


### PR DESCRIPTION
Here's a sketch of what I think the lowering pipeline for BlockMatrix would look like. The relevant bits:

- BlockMatrixType gets an additional `definedBlocks` field to track sparseness.
- LowerBlockMatrixIR.lower on BlockMatrixIRs defines the transformations from BlockMatrixIRs to BlockMatrixStage, and LowerBlockMatrixIR.lower on value IRs with BlockMatrixIR children define rules for transforming the lowered BlockMatrixStage children into IRs, similarly to lowering in TableIRs.
- BlockMatrixStage consists of basically 3 things:
  - blockContext: a matrix of contexts necessary for each partition computation (e.g. filenames of blocks that each partition needs to read, literal NDArray values, etc.)
  - body: the transformation of blockContext that represents the actual NDArray in each partition of the BlockMatrix.
  - broadcastVals (currently unused, perhaps unnecessary): values that we'd potentially want to broadcast to all nodes to use in computation. I could see this being useful in specific broadcast operations, but I'd also be happy to take it out until we have a use case.
  - ctxName and ctxType are used to reference the block context within the body of computation.

Lowering each node would consist of two parts:
- Defining the transformation in LowerBlockMatrixIR
- Propagating the sparsity transformation correctly through each BlockMatrixIR node, so that lowering functions can use it. This looks pretty different, depending on the node being lowered; Filter, for example, will need to lift the sparsity propagation logic from the FilterRDD where it's currently defined, while for BlockMatrixMap it's mostly a matter of making explicit the implicit densification that (sometimes) happens within the node, and then propagating sparsity accordingly.

I've lifted the matrix multiply as an illustration of how this would work, although we can't test it until we have at least one entrypoint and one exit; if this looks reasonable I can clean it up and PR it when I get back on Monday.

Notes on testing:
I'm envisioning that this would be tested really similarly to how we currently test Table lowering; for now, adding an execution strategy in the Scala test framework and using it on specific BlockMatrix pipelines that we expect to be fully lowerable. Once we have a specific/non-trivial pipeline that is fully lowerable, we can add a feature flag that controls whether or not we attempt to lower the execution, and start benchmarking on the python end. I think the second threshold is probably most quickly achieved by lowering the BlockMatrixFromValue node (or BlockMatrixRead, for larger multiplies) and implementing/lowering a NDArrayFromBlockMatrix node.