### PR TITLE
[auth] maybe fix auth flow & close security hole

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -59,7 +59,7 @@ async def login(request, userdata):
         access_type='offline',
         include_granted_scopes='true')
 
-    session = await aiohttp_session.get_session(request)
+    session = await aiohttp_session.new_session(request)
     session['state'] = state
     session['next'] = next
 


### PR DESCRIPTION
It seems that sessions sometimes become inaccessible to auth. Using some
logging, I realized that `/login` will set some session parameters that do not
reappear in `/oauth2callback`. While trying to debug this, I deleted my cookie
and everything started working again. Luckily, my phone was still borked. The
fix is to use `new_session` which I discovered with a big red warning in
aiohttp-session's docs: [Always use new_session() instead of get_session() in
your login views to guard against Session Fixation
attacks!](https://aiohttp-session.readthedocs.io/en/stable/reference.html#aiohttp_session.new_session).

If nothing else, we are now safe from session fixation attacks. I do not
understand why this is necessary for correctness.