### PR TITLE
[batch] fix bugs in worker

### DIFF
--- a/batch/batch/google_storage.py
+++ b/batch/batch/google_storage.py
@@ -2,7 +2,6 @@ import logging
 import google.api_core.exceptions
 import google.oauth2.service_account
 import google.cloud.storage
-import google.api_core.exceptions
 from hailtop.utils import blocking_to_async, retry_transient_errors
 
 

--- a/batch/batch/google_storage.py
+++ b/batch/batch/google_storage.py
@@ -2,6 +2,7 @@ import logging
 import google.api_core.exceptions
 import google.oauth2.service_account
 import google.cloud.storage
+import google.api_core.exceptions
 from hailtop.utils import blocking_to_async, retry_transient_errors
 
 
@@ -89,10 +90,16 @@ class GCS:
         bucket, prefix = GCS._parse_uri(uri_prefix)
         bucket = self.gcs_client.bucket(bucket)
         for blob in bucket.list_blobs(prefix=prefix):
-            blob.delete()
+            try:
+                blob.delete()
+            except google.api_core.exceptions.NotFound:
+                continue
 
     def _delete_gs_file(self, uri):
         bucket, path = GCS._parse_uri(uri)
         bucket = self.gcs_client.bucket(bucket)
         f = bucket.blob(path)
-        f.delete()
+        try:
+            f.delete()
+        except google.api_core.exceptions.NotFound:
+            return

--- a/batch/batch/google_storage.py
+++ b/batch/batch/google_storage.py
@@ -2,7 +2,7 @@ import logging
 import google.api_core.exceptions
 import google.oauth2.service_account
 import google.cloud.storage
-from hailtop.utils import blocking_to_async
+from hailtop.utils import blocking_to_async, retry_transient_errors
 
 
 logging.getLogger("google").setLevel(logging.WARNING)
@@ -34,19 +34,24 @@ class GCS:
         self._wrapped_delete_gs_files = self._wrap_network_call(GCS._delete_gs_files)
 
     async def write_gs_file(self, uri, string, *args, **kwargs):
-        return await self._wrapped_write_gs_file(self, uri, string, *args, **kwargs)
+        return await retry_transient_errors(self._wrapped_write_gs_file,
+                                            self, uri, string, *args, **kwargs)
 
     async def read_gs_file(self, uri, *args, **kwargs):
-        return await self._wrapped_read_gs_file(self, uri, *args, **kwargs)
+        return await retry_transient_errors(self._wrapped_read_gs_file,
+                                            self, uri, *args, **kwargs)
 
     async def read_binary_gs_file(self, uri, *args, **kwargs):
-        return await self._wrapped_read_binary_gs_file(self, uri, *args, **kwargs)
+        return await retry_transient_errors(self._wrapped_read_binary_gs_file,
+                                            self, uri, *args, **kwargs)
 
     async def delete_gs_file(self, uri):
-        return await self._wrapped_delete_gs_file(self, uri)
+        return await retry_transient_errors(self._wrapped_delete_gs_file,
+                                            self, uri)
 
     async def delete_gs_files(self, uri_prefix):
-        return await self._wrapped_delete_gs_files(self, uri_prefix)
+        return await retry_transient_errors(self._wrapped_delete_gs_files,
+                                            self, uri_prefix)
 
     def _wrap_network_call(self, fun):
         async def wrapped(*args, **kwargs):

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -16,8 +16,7 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import time_msecs, request_retry_transient_errors, \
-    retry_transient_errors
+from hailtop.utils import time_msecs, request_retry_transient_errors
 
 # import uvloop
 
@@ -290,13 +289,9 @@ class Container:
             async with self.step('uploading_log'):
                 container_log = await self.get_container_log()
                 self.log = container_log
-                await retry_transient_errors(
-                    worker.log_store.write_log_file,
-                    self.job.format_version,
-                    self.job.batch_id,
-                    self.job.job_id,
-                    self.job.attempt_id,
-                    self.name,
+                await worker.log_store.write_log_file(
+                    self.job.format_version, self.job.batch_id,
+                    self.job.job_id, self.job.attempt_id, self.name,
                     container_log)
 
             async with self.step('deleting'):
@@ -797,8 +792,7 @@ class Worker:
         full_status = await job.status()
 
         if job.format_version.has_full_status_in_gcs():
-            await retry_transient_errors(
-                self.log_store.write_status_file,
+            await self.log_store.write_status_file(
                 job.batch_id,
                 job.job_id,
                 job.attempt_id,

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -16,7 +16,8 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import time_msecs, request_retry_transient_errors
+from hailtop.utils import time_msecs, request_retry_transient_errors, \
+    retry_transient_errors
 
 # import uvloop
 
@@ -287,10 +288,16 @@ class Container:
             log.info(f'{self}: container status {self.container_status}')
 
             async with self.step('uploading_log'):
-                await worker.log_store.write_log_file(
-                    self.job.format_version, self.job.batch_id,
-                    self.job.job_id, self.job.attempt_id, self.name,
-                    await self.get_container_log())
+                container_log = await self.get_container_log()
+                self.log = container_log
+                await retry_transient_errors(
+                    worker.log_store.write_log_file,
+                    self.job.format_version,
+                    self.job.batch_id,
+                    self.job.job_id,
+                    self.job.attempt_id,
+                    self.name,
+                    container_log)
 
             async with self.step('deleting'):
                 await self.delete_container()
@@ -790,10 +797,12 @@ class Worker:
         full_status = await job.status()
 
         if job.format_version.has_full_status_in_gcs():
-            await self.log_store.write_status_file(job.batch_id,
-                                                   job.job_id,
-                                                   job.attempt_id,
-                                                   json.dumps(full_status))
+            await retry_transient_errors(
+                self.log_store.write_status_file,
+                job.batch_id,
+                job.job_id,
+                job.attempt_id,
+                json.dumps(full_status))
 
         db_status = job.format_version.db_status(full_status)
 
@@ -846,6 +855,8 @@ class Worker:
     async def post_job_complete(self, job, run_duration):
         try:
             await self.post_job_complete_1(job, run_duration)
+        except Exception:
+            log.exception(f'error while marking {job} complete')
         finally:
             log.info(f'{job} marked complete, removing from jobs')
             if job.id in self.jobs:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -4,6 +4,8 @@ import logging
 import asyncio
 import aiohttp
 from aiohttp import web
+import urllib3
+import socket
 
 from .time import time_msecs
 
@@ -181,6 +183,10 @@ def is_transient_error(e):
     #
     # during aiohttp request
     # aiohttp.client_exceptions.ClientOSError: [Errno 104] Connection reset by peer
+    #
+    # urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='www.googleapis.com', port=443): Read timed out. (read timeout=60)
+    #
+    # socket.timeout: The read operation timed out
     if isinstance(e, aiohttp.ClientResponseError):
         # nginx returns 502 if it cannot connect to the upstream server
         # 408 request timeout, 500 internal server error, 502 bad gateway
@@ -205,6 +211,10 @@ def is_transient_error(e):
                 e.errno == errno.EHOSTUNREACH or
                 e.errno == errno.ECONNRESET):
             return True
+    elif isinstance(e, urllib3.exceptions.ReadTimeoutError):
+        return True
+    elif isinstance(e, socket.timeout):
+        return True
     return False
 
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -188,6 +188,8 @@ def is_transient_error(e):
     # urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='www.googleapis.com', port=443): Read timed out. (read timeout=60)
     #
     # socket.timeout: The read operation timed out
+    #
+    # ConnectionResetError: [Errno 104] Connection reset by peer
     if isinstance(e, aiohttp.ClientResponseError):
         # nginx returns 502 if it cannot connect to the upstream server
         # 408 request timeout, 500 internal server error, 502 bad gateway
@@ -217,6 +219,8 @@ def is_transient_error(e):
     elif isinstance(e, requests.exceptions.ReadTimeout):
         return True
     elif isinstance(e, socket.timeout):
+        return True
+    elif isinstance(e, ConnectionResetError):
         return True
     return False
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -6,6 +6,7 @@ import aiohttp
 from aiohttp import web
 import urllib3
 import socket
+import requests
 
 from .time import time_msecs
 
@@ -212,6 +213,8 @@ def is_transient_error(e):
                 e.errno == errno.ECONNRESET):
             return True
     elif isinstance(e, urllib3.exceptions.ReadTimeoutError):
+        return True
+    elif isinstance(e, requests.exceptions.ReadTimeout):
         return True
     elif isinstance(e, socket.timeout):
         return True


### PR DESCRIPTION
This fixes two bugs:
1. The container logs weren't being cached. This made the logs "disappear" for previous tasks while the job was still running. FYI @konradjk 

2. My job got stuck in "running" even though the job was deleted from the worker because writing the status to GCS timed out and we didn't actually mark the job complete. I'm not sure if we should always try to retry writing the status rather than failing on non-transient errors.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 384, in _make_request
    six.raise_from(e, None)
  File "<string>", line 2, in raise_from
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 380, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/local/lib/python3.6/http/client.py", line 1354, in getresponse
    response.begin()
  File "/usr/local/lib/python3.6/http/client.py", line 307, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.6/http/client.py", line 268, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.6/socket.py", line 586, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.6/ssl.py", line 1012, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.6/ssl.py", line 874, in read
    return self._sslobj.read(len, buffer)
  File "/usr/local/lib/python3.6/ssl.py", line 631, in read
    v = self._sslobj.read(len, buffer)
socket.timeout: The read operation timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 638, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/retry.py", line 368, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/usr/local/lib/python3.6/site-packages/urllib3/packages/six.py", line 686, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 386, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 306, in _raise_timeout
    raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='www.googleapis.com', port=443): Read timed out. (read timeout=60)

During handling of the above exception, another exception occurred
result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/site-packages/hailtop/utils/utils.py", line 35, in <lambda>
    thread_pool, lambda: fun(*args, **kwargs))
  File "/usr/local/lib/python3.6/site-packages/batch/google_storage.py", line 65, in _write_gs_file
    f.upload_from_string(string, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/google/cloud/storage/blob.py", line 1257, in upload_from_string
    predefined_acl=predefined_acl,
  File "/usr/local/lib/python3.6/site-packages/google/cloud/storage/blob.py", line 1157, in upload_from_file
    client, file_obj, content_type, size, num_retries, predefined_acl
  File "/usr/local/lib/python3.6/site-packages/google/cloud/storage/blob.py", line 1063, in _do_upload
    client, stream, content_type, size, num_retries, predefined_acl
  File "/usr/local/lib/python3.6/site-packages/google/cloud/storage/blob.py", line 857, in _do_multipart_upload
    response = upload.transmit(transport, data, object_metadata, content_type)
  File "/usr/local/lib/python3.6/site-packages/google/resumable_media/requests/upload.py", line 106, in transmit
    retry_strategy=self._retry_strategy,
  File "/usr/local/lib/python3.6/site-packages/google/resumable_media/requests/_helpers.py", line 136, in http_request
    return _helpers.wait_and_retry(func, RequestsMixin._get_status_code, retry_strategy)
  File "/usr/local/lib/python3.6/site-packages/google/resumable_media/_helpers.py", line 150, in wait_and_retry
    response = func()
  File "/usr/local/lib/python3.6/site-packages/google/auth/transport/requests.py", line 317, in request
    **kwargs
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='www.googleapis.com', port=443): Read timed out. (read timeout=60)
```