### PR TITLE
Remove search link from docs home page

### DIFF
--- a/hail/python/hail/docs/index.rst
+++ b/hail/python/hail/docs/index.rst
@@ -34,7 +34,6 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`search`
 
 
 


### PR DESCRIPTION
In the Sphinx theme which the Hail docs use, the search page does not show anything unless a query has been provided and a search performed.

https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/search.html

Thus, the Search link on the [home page of the Hail 0.2 docs](https://hail.is/docs/0.2/index.html) leads to a [blank page](https://hail.is/docs/0.2/search.html).

![image](https://user-images.githubusercontent.com/1156625/74118640-44333c80-4b8a-11ea-9147-7a0d188d44a0.png)

To avoid confusion, this change removes the link to the search page from the home page.