### PR TITLE
[hail] Inline ApplyIR in compile lowering pass.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -61,5 +61,9 @@ object Emittable {
     case _: AggExplode => true
     case _ => false
   }
-  def apply(ir: IR): Boolean = Compilable(ir) && !isNonEmittableAgg(ir)
+  def apply(ir: IR): Boolean = ir match {
+    case x if isNonEmittableAgg(x) => false
+    case _: ApplyIR => false
+    case x => Compilable(x)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1137,23 +1137,6 @@ private class Emit(
                 coerce[String](StringFunctions.wrapArg(er, m.pType)(cm.v)))))),
           false,
           defaultValue(typ))
-      case ir@ApplyIR(fn, args) =>
-        assert(!ir.inline)
-        val mfield = mb.newField[Boolean]
-        val vfield = mb.newField()(typeToTypeInfo(ir.typ))
-
-        val addFields = { (newMB: EmitMethodBuilder, t: PType, v: EmitTriplet) =>
-          Code(
-            v.setup,
-            mfield := v.m,
-            mfield.mux(
-              vfield.storeAny(defaultValue(t)),
-              vfield.storeAny(v.v)))
-        }
-
-        EmitTriplet(
-          wrapToMethod(FastSeq(ir.explicitNode))(addFields),
-          mfield, vfield)
 
       case ir@Apply(fn, args, rt) =>
         val impl = ir.implementation

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
@@ -33,6 +33,10 @@ case object CompilableIR extends IRState {
   val rules: Array[Rule] = Array(ValueIROnly, CompilableValueIRs)
 }
 
+case object CompilableIRNoApply extends IRState {
+  val rules: Array[Rule] = Array(ValueIROnly, CompilableValueIRs, NoApplyIR)
+}
+
 case object EmittableIR extends IRState {
   val rules: Array[Rule] = Array(ValueIROnly, EmittableValueIRs)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.expr.ir.agg.Extract
-import is.hail.expr.ir.{ArrayAgg, ArrayAggScan, ArrayFor, BaseIR, Begin, BlockMatrixIR, ExecuteContext, IR, InterpretNonCompilable, Let, LowerMatrixIR, MatrixIR, Pretty, ResultOp, RewriteBottomUp, RunAgg, RunAggScan, TableIR, genUID}
+import is.hail.expr.ir.{ApplyIR, ArrayAgg, ArrayAggScan, ArrayFor, BaseIR, Begin, BlockMatrixIR, ExecuteContext, IR, InterpretNonCompilable, Let, LowerMatrixIR, MatrixIR, Pretty, ResultOp, RewriteBottomUp, RewriteTopDown, RunAgg, RunAggScan, TableIR, genUID}
 import is.hail.utils.FastSeq
 
 trait LoweringPass {
@@ -58,8 +58,19 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerTableIR.lower(ir.asInstanceOf[IR])
 }
 
-case object LowerArrayAggsToRunAggs extends LoweringPass {
+case object InlineApplyIR extends LoweringPass {
   val before: IRState = CompilableIR
+  val after: IRState = CompilableIRNoApply
+  val context: String = "InlineApplyIR"
+
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = RewriteBottomUp(ir, {
+    case x: ApplyIR => Some(x.explicitNode)
+    case _ => None
+  })
+}
+
+case object LowerArrayAggsToRunAggs extends LoweringPass {
+  val before: IRState = CompilableIRNoApply
   val after: IRState = EmittableIR
   val context: String = "LowerArrayAggsToRunAggs"
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -36,5 +36,5 @@ object LoweringPipeline {
   val legacyRelationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LegacyInterpretNonCompilablePass))
   val tableLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerTableToDistributedArrayPass))
 
-  val compileLowerer: LoweringPipeline = LoweringPipeline(Array(LowerArrayAggsToRunAggs))
+  val compileLowerer: LoweringPipeline = LoweringPipeline(Array(InlineApplyIR, LowerArrayAggsToRunAggs))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir._
+import is.hail.expr.ir.{ApplyIR, BaseIR, Compilable, Emittable, IR, MatrixIR, RelationalLet, RelationalLetBlockMatrix, RelationalLetMatrixTable, RelationalLetTable, RelationalRef}
 
 trait Rule {
   def allows(ir: BaseIR): Boolean
@@ -24,6 +24,13 @@ case object NoRelationalLets extends Rule {
 case object CompilableValueIRs extends Rule {
   def allows(ir: BaseIR): Boolean = ir match {
     case x: IR => Compilable(x)
+    case _ => true
+  }
+}
+
+case object NoApplyIR extends Rule {
+  override def allows(ir: BaseIR): Boolean = ir match {
+    case x: ApplyIR => false
     case _ => true
   }
 }


### PR DESCRIPTION
We're currently emitting the explicit node (without optimization!).
This design is incrementally better, and lets us do ptyping more easily.

The right solution is to do generate a method as the node suggests, but
there are some issues to sort out here, like how to return a missing
value. We may need to return a (possibly null) pointer to an allocated
value, which could be inefficient. Pushing ptypes/requiredness fully
through the system would let us avoid this in many cases.

cc @catoverdrive