### PR TITLE
[hail] add sparsity to BlockMatrixType

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -216,7 +216,7 @@ class BlockMatrixSparsifier(object):
         head_str = self.head_str()
         if head_str != '':
             head_str = f' {head_str}'
-        return f'({self.__class__.__name__}{head_str})'
+        return f'(Py{self.__class__.__name__}{head_str})'
 
     def _eq(self, other):
         return True
@@ -254,7 +254,7 @@ class _RectangleSparsifier(BlockMatrixSparsifier):
         pass
 
     def __repr__(self):
-        return f'(RectangleSparsifier)'
+        return f'(PyRectangleSparsifier)'
 
 
 RectangleSparsifier = _RectangleSparsifier()
@@ -263,7 +263,7 @@ RectangleSparsifier = _RectangleSparsifier()
 class BlockMatrixSparsify(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, value=IR, sparsifier=BlockMatrixSparsifier)
     def __init__(self, child, value, sparsifier):
-        super().__init__(child, value)
+        super().__init__(value, child)
         self.child = child
         self.value = value
         self.sparsifier = sparsifier

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -411,12 +411,12 @@ case class BlockMatrixBroadcast(
         inIndexExpr match {
           case IndexedSeq() => BlockMatrixSparsity.dense
           case IndexedSeq(0) => // broadcast col vector
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(0, j))
+            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(0 -> j))
           case IndexedSeq(1) => // broadcast row vector
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(i, 0))
+            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(i -> 0))
           case IndexedSeq(1, 0) => // transpose
             assert(child.typ.blockSize == blockSize)
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(j, i))
+            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(j -> i))
           case IndexedSeq(0, 1) =>
             assert(child.typ.blockSize == blockSize)
             child.typ.sparsity

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -335,12 +335,24 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
 case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends BlockMatrixIR {
 
   override def typ: BlockMatrixType = {
+    val blockSize = left.typ.blockSize
     val (lRows, lCols) = BlockMatrixIR.tensorShapeToMatrixShape(left)
     val (rRows, rCols) = BlockMatrixIR.tensorShapeToMatrixShape(right)
     assert(lCols == rRows)
 
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(lRows, rCols)
-    BlockMatrixType(left.typ.elementType, tensorShape, isRowVector, left.typ.blockSize)
+    if (left.typ.hasSparsity && right.typ.hasSparsity) {
+      val sparsity = Array.tabulate(BlockMatrixType.numBlocks(lRows, blockSize)) { i =>
+        Array.tabulate(BlockMatrixType.numBlocks(rCols, blockSize)) { j =>
+          Array.tabulate(BlockMatrixType.numBlocks(rCols, blockSize)) { k =>
+            left.typ.definedBlocks(i)(k) && right.typ.definedBlocks(k)(j)
+          }.reduce(_ || _)
+        }
+      }
+      BlockMatrixType(left.typ.elementType, tensorShape, isRowVector, blockSize, sparsity)
+    } else {
+      BlockMatrixType(left.typ.elementType, tensorShape, isRowVector, blockSize)
+    }
   }
 
   lazy val children: IndexedSeq[BaseIR] = Array(left, right)
@@ -654,8 +666,7 @@ case class ValueToBlockMatrix(
   val blockCostIsLinear: Boolean = true
 
   override def typ: BlockMatrixType = {
-    val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
-    BlockMatrixType(elementType(child.typ), tensorShape, isRowVector, blockSize)
+    BlockMatrixType.dense(elementType(child.typ), shape(0), shape(1), blockSize)
   }
 
   private def elementType(childType: Type): Type = {
@@ -696,10 +707,8 @@ case class BlockMatrixRandom(
 
   val blockCostIsLinear: Boolean = true
 
-  override def typ: BlockMatrixType = {
-    val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
-    BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize)
-  }
+  override def typ: BlockMatrixType =
+    BlockMatrixType.dense(TFloat64(), shape(0), shape(1), blockSize)
 
   lazy val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1530,7 +1530,7 @@ object IRParser {
       case "PyRowIntervalSparsifier" =>
         val blocksOnly = boolean_literal(it)
         punctuation(it, ")")
-        val Row(starts: IndexedSeq[Long], stops: IndexedSeq[Long]) =
+        val Row(starts: IndexedSeq[Long @unchecked], stops: IndexedSeq[Long @unchecked]) =
           ExecuteContext.scoped { ctx => CompileAndEvaluate(ctx, ir_value_expr(env)(it)) }
         RowIntervalSparsifier(blocksOnly, starts, stops)
       case "PyBandSparsifier" =>
@@ -1557,7 +1557,7 @@ object IRParser {
         punctuation(it, ")")
         BandSparsifier(blocksOnly, l, u)
       case "RectangleSparsifier" =>
-        val rectangles = int64_literals(it)
+        val rectangles = int64_literals(it).toFastIndexedSeq
         punctuation(it, ")")
         RectangleSparsifier(rectangles.grouped(4).toIndexedSeq)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1531,18 +1531,18 @@ object IRParser {
         val blocksOnly = boolean_literal(it)
         punctuation(it, ")")
         val Row(starts: IndexedSeq[Long @unchecked], stops: IndexedSeq[Long @unchecked]) =
-          ExecuteContext.scoped { ctx => CompileAndEvaluate(ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped[Row] { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
         RowIntervalSparsifier(blocksOnly, starts, stops)
       case "PyBandSparsifier" =>
         val blocksOnly = boolean_literal(it)
         punctuation(it, ")")
         val Row(l: Long, u: Long) =
-          ExecuteContext.scoped { ctx => CompileAndEvaluate(ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped[Row] { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
         BandSparsifier(blocksOnly, l, u)
       case "PyRectangleSparsifier" =>
         punctuation(it, ")")
         val rectangles: IndexedSeq[Long] =
-          ExecuteContext.scoped { ctx => CompileAndEvaluate(ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped { ctx => CompileAndEvaluate[IndexedSeq[Long]](ctx, ir_value_expr(env)(it)) }
         RectangleSparsifier(rectangles.grouped(4).toIndexedSeq)
       case "RowIntervalSparsifier" =>
         val blocksOnly = boolean_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -27,15 +27,6 @@ object Pretty {
   def prettyClass(x: AnyRef): String =
     x.getClass.getName.split("\\.").last
 
-  def prettyBlockMatrixSparsifier(sparsifier: BlockMatrixSparsifier): (String, IR) = sparsifier match {
-    case x@BandSparsifier(blocksOnly, l, r) =>
-      s"(BandSparsifier ${ prettyBooleanLiteral(blocksOnly) })" -> Literal(x.typ, Row(l, r))
-    case x@RowIntervalSparsifier(blocksOnly, starts, stops) =>
-      s"(RowIntervalSparsifier ${ prettyBooleanLiteral(blocksOnly) })" -> Literal(x.typ, Row(starts, stops))
-    case x@RectangleSparsifier(rectangles) =>
-      s"(RectangleSparsifier)" -> Literal(x.typ, rectangles.flatten)
-  }
-
   val MAX_VALUES_TO_LOG: Int = 25
 
   def apply(ir: BaseIR, elideLiterals: Boolean = false, maxLen: Int = -1): String = {
@@ -335,7 +326,7 @@ object Pretty {
             case BlockMatrixFilter(_, indicesToKeepPerDim) =>
               indicesToKeepPerDim.map(indices => prettyLongs(indices)).mkString("(", " ", ")")
             case BlockMatrixSparsify(_, sparsifier) =>
-              prettyBlockMatrixSparsifier(sparsifier)
+              sparsifier.pretty()
             case BlockMatrixRandom(seed, gaussian, shape, blockSize) =>
               seed.toString + " " +
               prettyBooleanLiteral(gaussian) + " " +

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -63,6 +63,24 @@ case class BlockMatrixType(
     if (isSparse) blockSet.contains(idx) else true
   }
 
+  def condenseDefinedBlocks(blockOverlaps: => (Array[Array[Int]], Array[Array[Int]])): Option[IndexedSeq[(Int, Int)]] = {
+    definedBlocks.map { _ =>
+      val defined = new ArrayBuilder[(Int, Int)]()
+      val (ro, co) = blockOverlaps
+      var i = 0
+      var j = 0
+      while (i < ro.length) {
+        while (j < co.length) {
+          if (ro(i).exists { ii => co(j).exists { jj => exists(ii -> jj) } })
+            defined += i -> j
+          j += 1
+        }
+        i += 1
+      }
+      defined.result().toFastIndexedSeq
+    }
+  }
+
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0
 

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -61,6 +61,8 @@ case class BlockMatrixType(
     _definedBlocks
   }
 
+  def getBlockIdx(i: Long): Int = java.lang.Math.floorDiv(i, blockSize).toInt
+
   val hasSparsity: Boolean = _definedBlocks != null
   lazy val isSparse: Boolean = _definedBlocks != null && definedBlocks.forall(rows => rows.forall(i => i))
 

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -8,7 +8,7 @@ object BlockMatrixSparsity {
 
   val dense: BlockMatrixSparsity = BlockMatrixSparsity(None)
 
-  def apply(definedBlocks: IndexedSeq[(Int, Int)]): BlockMatrixSparsity = BlockMatrixSparsity(definedBlocks)
+  def apply(definedBlocks: IndexedSeq[(Int, Int)]): BlockMatrixSparsity = BlockMatrixSparsity(Some(definedBlocks))
 
   def apply(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean): BlockMatrixSparsity = {
     var i = 0

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -26,7 +26,7 @@ object BlockMatrixType {
 
   def sparsityFromLinearBlocks(nCols: Long, nRows: Long, blockSize: Int, definedBlocks: Option[Array[Int]]): Array[Array[Boolean]] = {
     val nColBlocks = numBlocks(nCols, blockSize)
-    val nRowBlocks = numBlocks(nRowBlocks, blockSize)
+    val nRowBlocks = numBlocks(nRows, blockSize)
 
     definedBlocks.map { blocks =>
       val idxs = blocks.map { linearIdx => java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks }.toSet

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -24,8 +24,15 @@ object BlockMatrixType {
   def numBlocks(n: Long, blockSize: Int): Int =
     java.lang.Math.floorDiv(n - 1, blockSize).toInt + 1
 
-  def blockIdxFromLinear(nColBlocks: Int, linearIdx: Int): (Int, Int) =
-    java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks
+  def sparsityFromLinearBlocks(nCols: Long, nRows: Long, blockSize: Int, definedBlocks: Option[Array[Int]]): Array[Array[Boolean]] = {
+    val nColBlocks = numBlocks(nCols, blockSize)
+    val nRowBlocks = numBlocks(nRowBlocks, blockSize)
+
+    definedBlocks.map { blocks =>
+      val idxs = blocks.map { linearIdx => java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks }.toSet
+      Array.tabulate(nRowBlocks)(i => Array.tabulate(nColBlocks)(j => idxs.contains(i -> j)))
+    }.getOrElse(Array.fill(nRowBlocks)(Array.fill(nColBlocks)(true)))
+  }
 
   // this is a shim method for the lowering.
   def apply(elementType: Type, shape: IndexedSeq[Long], isRowVector: Boolean, blockSize: Int): BlockMatrixType =

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -3,11 +3,66 @@ package is.hail.expr.types
 import is.hail.utils._
 import is.hail.expr.types.virtual.Type
 
+object BlockMatrixType {
+  def tensorToMatrixShape(shape: IndexedSeq[Long], isRowVector: Boolean): (Long, Long) = {
+    shape match {
+      case IndexedSeq() => (1, 1)
+      case IndexedSeq(vectorLength) => if (isRowVector) (1, vectorLength) else (vectorLength, 1)
+      case IndexedSeq(numRows, numCols) => (numRows, numCols)
+    }
+  }
+
+  def matrixToTensorShape(nRows: Long,  nCols: Long): (IndexedSeq[Long], Boolean) = {
+    (nRows, nCols) match {
+      case (1, 1) => (FastIndexedSeq(), false)
+      case (_, 1) => (FastIndexedSeq(nRows), false)
+      case (1, _) => (FastIndexedSeq(nCols), true)
+      case _ => (FastIndexedSeq(nRows, nCols), false)
+    }
+  }
+
+  def numBlocks(n: Long, blockSize: Int): Int =
+    java.lang.Math.floorDiv(n - 1, blockSize).toInt + 1
+
+  def blockIdxFromLinear(nColBlocks: Int, linearIdx: Int): (Int, Int) =
+    java.lang.Math.floorDiv(linearIdx, nColBlocks) -> linearIdx % nColBlocks
+
+  // this is a shim method for the lowering.
+  def apply(elementType: Type, shape: IndexedSeq[Long], isRowVector: Boolean, blockSize: Int): BlockMatrixType =
+    BlockMatrixType(elementType, shape, isRowVector, blockSize, null)
+
+  def dense(elementType: Type, nRows: Long, nCols: Long, blockSize: Int): BlockMatrixType = {
+    val (shape, isRowVector) = matrixToTensorShape(nRows, nCols)
+    val nRowBlocks = numBlocks(nRows, blockSize)
+    val nColBlocks = numBlocks(nCols, blockSize)
+    BlockMatrixType(elementType, shape, isRowVector, blockSize, Array.fill(nRowBlocks)(Array.fill(nColBlocks)(true)))
+  }
+}
+
 case class BlockMatrixType(
   elementType: Type,
   shape: IndexedSeq[Long],
   isRowVector: Boolean,
-  blockSize: Int) extends BaseType {
+  blockSize: Int,
+  _definedBlocks: Array[Array[Boolean]]
+) extends BaseType {
+
+  lazy val (nRows: Long, nCols: Long) = BlockMatrixType.tensorToMatrixShape(shape, isRowVector)
+
+  def matrixShape: (Long, Long) = nRows -> nCols
+
+  lazy val nRowBlocks: Int = BlockMatrixType.numBlocks(nRows, blockSize)
+  lazy val nColBlocks: Int = BlockMatrixType.numBlocks(nCols, blockSize)
+  lazy val defaultBlockShape: (Int, Int) = (nRowBlocks, nColBlocks)
+
+  lazy val definedBlocks: Array[Array[Boolean]] = {
+    if (_definedBlocks == null)
+      throw new UnsupportedOperationException("sparsity is not defined.")
+    _definedBlocks
+  }
+
+  val hasSparsity: Boolean = _definedBlocks != null
+  lazy val isSparse: Boolean = _definedBlocks != null && definedBlocks.forall(rows => rows.forall(i => i))
 
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0
@@ -43,6 +98,15 @@ case class BlockMatrixType(
 
     sb.append(s"blockSize:$space")
     sb.append(blockSize)
+    sb += ','
+    newline()
+
+    sb.append(s"definedBlocks:$space")
+    if (hasSparsity && isSparse) {
+      sb.append(definedBlocks.map(row => row.mkString("[", ",", "]")).mkString("[", ",", "]"))
+    } else {
+      sb.append("None")
+    }
     sb += ','
     newline()
 

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -90,9 +90,9 @@ class BlockMatrixIRSuite extends HailSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](1, 3),
-      0), FastIndexedSeq(1), shape, 0)
+      0), FastIndexedSeq(1), shape, ones.blockSize)
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3, 1),
-      0), FastIndexedSeq(0), shape, 0)
+      0), FastIndexedSeq(0), shape, ones.blockSize)
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add(), UnionBlocks)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2806,14 +2806,9 @@ class IRSuite extends HailSuite {
     val dot = BlockMatrixDot(read, transpose)
     val slice = BlockMatrixSlice(read, FastIndexedSeq(FastIndexedSeq(0, 2, 1), FastIndexedSeq(0, 1, 1)))
 
-    val rectangle = Literal(TArray(TInt64()), FastIndexedSeq(0L, 1L, 5L, 6L))
-    val band = Literal(TTuple(TInt64(), TInt64()), Row(-1L, 1L))
-    val intervals = Literal(TTuple(TArray(TInt64()), TArray(TInt64())),
-      Row(FastIndexedSeq(0L, 1L, 5L, 6L), FastIndexedSeq(5L, 6L, 8L, 9L)))
-
-    val sparsify1 = BlockMatrixSparsify(read, rectangle, RectangleSparsifier)
-    val sparsify2 = BlockMatrixSparsify(read, band, BandSparsifier(true))
-    val sparsify3 = BlockMatrixSparsify(read, intervals, RowIntervalSparsifier(true))
+    val sparsify1 = BlockMatrixSparsify(read, RectangleSparsifier(FastIndexedSeq(0L, 1L, 5L, 6L).grouped(4)))
+    val sparsify2 = BlockMatrixSparsify(read, BandSparsifier(true, -1L, 1L))
+    val sparsify3 = BlockMatrixSparsify(read, RowIntervalSparsifier(true, FastIndexedSeq(0L, 1L, 5L, 6L), FastIndexedSeq(5L, 6L, 8L, 9L)))
     val densify = BlockMatrixDensify(read)
 
     val blockMatrixIRs = Array[BlockMatrixIR](read,

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2806,7 +2806,7 @@ class IRSuite extends HailSuite {
     val dot = BlockMatrixDot(read, transpose)
     val slice = BlockMatrixSlice(read, FastIndexedSeq(FastIndexedSeq(0, 2, 1), FastIndexedSeq(0, 1, 1)))
 
-    val sparsify1 = BlockMatrixSparsify(read, RectangleSparsifier(FastIndexedSeq(0L, 1L, 5L, 6L).grouped(4)))
+    val sparsify1 = BlockMatrixSparsify(read, RectangleSparsifier(FastIndexedSeq(FastIndexedSeq(0L, 1L, 5L, 6L))))
     val sparsify2 = BlockMatrixSparsify(read, BandSparsifier(true, -1L, 1L))
     val sparsify3 = BlockMatrixSparsify(read, RowIntervalSparsifier(true, FastIndexedSeq(0L, 1L, 5L, 6L), FastIndexedSeq(5L, 6L, 8L, 9L)))
     val densify = BlockMatrixDensify(read)


### PR DESCRIPTION
adds a notion of sparsity to BlockMatrixType; I've lifted all of the necessary logic except for Map/Map2, which needs #8072 to implement in a sensical way.

I had originally implemented this as a dense boolean matrix, which makes a lot of transformations simpler, but for really large (and very sparse) block matrices, you end up needing ~GB of space just to store the sparsity matrix, which is pretty untenable. This version basically preserves the structure of the version on GridPartitioner, except that we're storing the unlinearized form of the block index.