### PR TITLE
[hail] add sparsity tracking flags to BlockMatrixMap and Map2

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -29,18 +29,19 @@ class BlockMatrixRead(BlockMatrixIR):
 
 
 class BlockMatrixMap(BlockMatrixIR):
-    @typecheck_method(child=BlockMatrixIR, name=str, f=IR)
-    def __init__(self, child, name, f):
+    @typecheck_method(child=BlockMatrixIR, name=str, f=IR, needs_dense=bool)
+    def __init__(self, child, name, f, needs_dense):
         super().__init__(child, f)
         self.child = child
         self.name = name
         self.f = f
+        self.needs_dense = needs_dense
 
     def _compute_type(self):
         self._type = self.child.typ
 
     def head_str(self):
-        return escape_id(self.name)
+        return escape_id(self.name) + " " + str(self.needs_dense)
 
     def bindings(self, i: int, default_value=None):
         if i == 1:
@@ -54,14 +55,15 @@ class BlockMatrixMap(BlockMatrixIR):
 
 
 class BlockMatrixMap2(BlockMatrixIR):
-    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, left_name=str, right_name=str, f=IR)
-    def __init__(self, left, right, left_name, right_name, f):
+    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, left_name=str, right_name=str, f=IR, sparsity_strategy=str)
+    def __init__(self, left, right, left_name, right_name, f, sparsity_strategy):
         super().__init__(left, right, f)
         self.left = left
         self.right = right
         self.left_name = left_name
         self.right_name = right_name
         self.f = f
+        self.sparsity_strategy = sparsity_strategy
 
     def _compute_type(self):
         self.right.typ  # Force
@@ -69,7 +71,7 @@ class BlockMatrixMap2(BlockMatrixIR):
 
 
     def head_str(self):
-        return escape_id(self.left_name) + " " + escape_id(self.right_name)
+        return escape_id(self.left_name) + " " + escape_id(self.right_name) + " " + self.sparsity_strategy
 
     def bindings(self, i: int, default_value=None):
         if i == 2:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1304,9 +1304,9 @@ class BlockMatrix(object):
 
     @typecheck_method(f=func_spec(2, expr_float64),
                       other=oneof(numeric, np.ndarray, block_matrix_type),
-                      reverse=bool,
-                      sparsity_strategy=str)
-    def _apply_map2(self, f, other, reverse=False, sparsity_strategy):
+                      sparsity_strategy=str,
+                      reverse=bool)
+    def _apply_map2(self, f, other, sparsity_strategy, reverse=False):
         if not isinstance(other, BlockMatrix):
             other = BlockMatrix(_to_bmir(other, self.block_size))
 
@@ -1384,19 +1384,19 @@ class BlockMatrix(object):
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('+'), b, reverse=True, sparsity_strategy="Union")
+        return self._apply_map2(BlockMatrix._binary_op('+'), b, sparsity_strategy="Union", reverse=True)
 
     @typecheck_method(b=numeric)
     def __rsub__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('-'), b, reverse=True, sparsity_strategy="Union")
+        return self._apply_map2(BlockMatrix._binary_op('-'), b, sparsity_strategy="Union", reverse=True)
 
     @typecheck_method(b=numeric)
     def __rmul__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('*'), b, reverse=True, sparsity_strategy="Intersection")
+        return self._apply_map2(BlockMatrix._binary_op('*'), b, sparsity_strategy="Intersection", reverse=True)
 
     @typecheck_method(b=numeric)
     def __rtruediv__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('/'), b, reverse=True, sparsity_strategy="NeedsDense")
+        return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense", reverse=True)
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
     def __matmul__(self, b):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1324,7 +1324,7 @@ class BlockMatrix(object):
         lv = Env.get_uid()
         rv = Env.get_uid()
         f_ir = f(construct_variable(lv, hl.tfloat64), construct_variable(rv, hl.tfloat64))._ir
-        return BlockMatrix(BlockMatrixMap2(left, right, lv, rv, f_ir), sparsity_strategy)
+        return BlockMatrix(BlockMatrixMap2(left, right, lv, rv, f_ir, sparsity_strategy))
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __add__(self, b):
@@ -1380,7 +1380,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('/'), sparsity_strategy="NeedsDense")
+        return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense")
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1288,7 +1288,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(lambda x: construct_expr(ApplyUnaryPrimOp('-', x._ir), hl.tfloat64), , needs_dense=False)
+        return self._apply_map(lambda x: construct_expr(ApplyUnaryPrimOp('-', x._ir), hl.tfloat64), needs_dense=False)
 
     @staticmethod
     def _binary_op(op):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1366,7 +1366,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('*'), sparsity_strategy="Intersection")
+        return self._apply_map2(BlockMatrix._binary_op('*'), b, sparsity_strategy="Intersection")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __truediv__(self, b):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1288,21 +1288,22 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(lambda x: construct_expr(ApplyUnaryPrimOp('-', x._ir), hl.tfloat64))
+        return self._apply_map(lambda x: construct_expr(ApplyUnaryPrimOp('-', x._ir), hl.tfloat64), , needs_dense=False)
 
     @staticmethod
     def _binary_op(op):
         return lambda l, r: construct_expr(ApplyBinaryPrimOp(op, l._ir, r._ir), hl.tfloat64)
 
-    @typecheck_method(f=func_spec(1, expr_float64))
-    def _apply_map(self, f):
+    @typecheck_method(f=func_spec(1, expr_float64), needs_dense=bool)
+    def _apply_map(self, f, needs_dense):
         uid = Env.get_uid()
-        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir))
+        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir, needs_dense))
 
     @typecheck_method(f=func_spec(2, expr_float64),
                       other=oneof(numeric, np.ndarray, block_matrix_type),
-                      reverse=bool)
-    def _apply_map2(self, f, other, reverse=False):
+                      reverse=bool,
+                      sparsity_strategy=str)
+    def _apply_map2(self, f, other, reverse=False, sparsity_strategy):
         if not isinstance(other, BlockMatrix):
             other = BlockMatrix(_to_bmir(other, self.block_size))
 
@@ -1320,7 +1321,7 @@ class BlockMatrix(object):
         lv = Env.get_uid()
         rv = Env.get_uid()
         f_ir = f(construct_variable(lv, hl.tfloat64), construct_variable(rv, hl.tfloat64))._ir
-        return BlockMatrix(BlockMatrixMap2(left, right, lv, rv, f_ir))
+        return BlockMatrix(BlockMatrixMap2(left, right, lv, rv, f_ir), sparsity_strategy)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __add__(self, b):
@@ -1334,7 +1335,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('+'), b)
+        return self._apply_map2(BlockMatrix._binary_op('+'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __sub__(self, b):
@@ -1348,7 +1349,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('-'), b)
+        return self._apply_map2(BlockMatrix._binary_op('-'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __mul__(self, b):
@@ -1362,7 +1363,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('*'), b)
+        return self._apply_map2(BlockMatrix._binary_op('*'), sparsity_strategy="Intersection")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __truediv__(self, b):
@@ -1376,23 +1377,23 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2(BlockMatrix._binary_op('/'), b)
+        return self._apply_map2(BlockMatrix._binary_op('/'), sparsity_strategy="NeedsDense")
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('+'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('+'), b, reverse=True, sparsity_strategy="Union")
 
     @typecheck_method(b=numeric)
     def __rsub__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('-'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('-'), b, reverse=True, sparsity_strategy="Union")
 
     @typecheck_method(b=numeric)
     def __rmul__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('*'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('*'), b, reverse=True, sparsity_strategy="Intersection")
 
     @typecheck_method(b=numeric)
     def __rtruediv__(self, b):
-        return self._apply_map2(BlockMatrix._binary_op('/'), b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op('/'), b, reverse=True, sparsity_strategy="NeedsDense")
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
     def __matmul__(self, b):
@@ -1427,7 +1428,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(lambda i: i ** x)
+        return self._apply_map(lambda i: i ** x, needs_dense=False)
 
     def sqrt(self):
         """Element-wise square root.
@@ -1436,7 +1437,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.sqrt)
+        return self._apply_map(hl.sqrt, needs_dense=False)
 
     def ceil(self):
         """Element-wise ceiling.
@@ -1445,7 +1446,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.ceil)
+        return self._apply_map(hl.ceil, needs_dense=False)
 
     def floor(self):
         """Element-wise floor.
@@ -1454,7 +1455,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.floor)
+        return self._apply_map(hl.floor, needs_dense=False)
 
     def abs(self):
         """Element-wise absolute value.
@@ -1463,7 +1464,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.abs)
+        return self._apply_map(hl.abs, needs_dense=False)
 
     def log(self):
         """Element-wise natural logarithm.
@@ -1472,7 +1473,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(lambda x: hl.log(x))
+        return self._apply_map(lambda x: hl.log(x), needs_dense=True)
 
     def diagonal(self):
         """Extracts diagonal elements as a row vector.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1297,7 +1297,10 @@ class BlockMatrix(object):
     @typecheck_method(f=func_spec(1, expr_float64), needs_dense=bool)
     def _apply_map(self, f, needs_dense):
         uid = Env.get_uid()
-        return BlockMatrix(BlockMatrixMap(self._bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir, needs_dense))
+        bmir = self._bmir
+        if needs_dense:
+            bmir = BlockMatrixDensify(bmir)
+        return BlockMatrix(BlockMatrixMap(bmir, uid, f(construct_variable(uid, hl.tfloat64))._ir, needs_dense))
 
     @typecheck_method(f=func_spec(2, expr_float64),
                       other=oneof(numeric, np.ndarray, block_matrix_type),

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -289,9 +289,9 @@ class BlockMatrixIRTests(unittest.TestCase):
         vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
-        add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')))
-        negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')))
-        sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
+        add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')), "Union")
+        negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')), False)
+        sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir, False)
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
@@ -313,7 +313,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         densify = ir.BlockMatrixDensify(read)
 
         pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir
-        squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, 'l', 'r', pow_ir)
+        squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, 'l', 'r', pow_ir, "NeedsDense")
         slice_bm = ir.BlockMatrixSlice(matmul, [slice(0, 2, 1), slice(0, 1, 1)])
 
         return [

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -54,8 +54,8 @@ object Bindings {
     case MatrixMapGlobals(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case MatrixAggregateColsByKey(child, _, _) => if (i == 1) child.typ.rowEnv.m else if (i == 2) child.typ.globalEnv.m else empty
     case MatrixAggregateRowsByKey(child, _, _) => if (i == 1) child.typ.colEnv.m else if (i == 2) child.typ.globalEnv.m else empty
-    case BlockMatrixMap(_, eltName, _) => if (i == 1) Array(eltName -> TFloat64()) else empty
-    case BlockMatrixMap2(_, _, lName, rName, _) => if (i == 2) Array(lName -> TFloat64(), rName -> TFloat64()) else empty
+    case BlockMatrixMap(_, eltName, _, _) => if (i == 1) Array(eltName -> TFloat64()) else empty
+    case BlockMatrixMap2(_, _, lName, rName, _, _) => if (i == 2) Array(lName -> TFloat64(), rName -> TFloat64()) else empty
     case _ => empty
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -176,30 +176,30 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDen
   override protected[ir] def execute(ctx: ExecuteContext): BlockMatrix = {
     val prev = child.execute(ctx)
 
-    val (name, breezeF, reqDense): (String, DenseMatrix[Double] => DenseMatrix[Double], Boolean) = f match {
-      case ApplyUnaryPrimOp(Negate(), _) => ("negate", BlockMatrix.negationOp, false)
-      case Apply("abs", _, _) => ("abs", numerics.abs(_), false)
-      case Apply("log", _, _) => ("log", numerics.log(_), true)
-      case Apply("sqrt", _, _) => ("sqrt", numerics.sqrt(_), false)
-      case Apply("ceil", _, _) => ("ceil", numerics.ceil(_), false)
-      case Apply("floor", _, _) => ("floor", numerics.floor(_), false)
+    val (name, breezeF): (String, DenseMatrix[Double] => DenseMatrix[Double]) = f match {
+      case ApplyUnaryPrimOp(Negate(), _) => ("negate", BlockMatrix.negationOp)
+      case Apply("abs", _, _) => ("abs", numerics.abs(_))
+      case Apply("log", _, _) => ("log", numerics.log(_))
+      case Apply("sqrt", _, _) => ("sqrt", numerics.sqrt(_))
+      case Apply("ceil", _, _) => ("ceil", numerics.ceil(_))
+      case Apply("floor", _, _) => ("floor", numerics.floor(_))
 
       case Apply("**", Seq(Ref(`eltName`, _), r), _) if !Mentions(r, eltName) =>
-        ("**", binaryOp(evalIR(ctx, r), numerics.pow(_, _)), false)
+        ("**", binaryOp(evalIR(ctx, r), numerics.pow(_, _)))
       case ApplyBinaryPrimOp(Add(), Ref(`eltName`, _), r) if !Mentions(r, eltName) =>
-        ("+", binaryOp(evalIR(ctx, r), _ + _), true)
+        ("+", binaryOp(evalIR(ctx, r), _ + _))
       case ApplyBinaryPrimOp(Add(), l, Ref(`eltName`, _)) if !Mentions(l, eltName) =>
-        ("+", binaryOp(evalIR(ctx, l), _ + _), true)
+        ("+", binaryOp(evalIR(ctx, l), _ + _))
       case ApplyBinaryPrimOp(Multiply(), Ref(`eltName`, _), r) if !Mentions(r, eltName) =>
         val i = evalIR(ctx, r)
-        ("*", binaryOp(i, _ *:* _), i.isNaN | i.isInfinity)
+        ("*", binaryOp(i, _ *:* _))
       case ApplyBinaryPrimOp(Multiply(), l, Ref(`eltName`, _)) if !Mentions(l, eltName) =>
         val i = evalIR(ctx, l)
-        ("*", binaryOp(i, _ *:* _), i.isNaN | i.isInfinity)
+        ("*", binaryOp(i, _ *:* _))
       case ApplyBinaryPrimOp(Subtract(), Ref(`eltName`, _), r) if !Mentions(r, eltName) =>
-        ("-", binaryOp(evalIR(ctx, r), (m, s) => m - s), true)
+        ("-", binaryOp(evalIR(ctx, r), (m, s) => m - s))
       case ApplyBinaryPrimOp(Subtract(), l, Ref(`eltName`, _)) if !Mentions(l, eltName) =>
-        ("-", binaryOp(evalIR(ctx, l), (m, s) => s - m), true)
+        ("-", binaryOp(evalIR(ctx, l), (m, s) => s - m))
       case ApplyBinaryPrimOp(FloatingPointDivide(), Ref(`eltName`, _), r) if !Mentions(r, eltName) =>
         val i = evalIR(ctx, r)
         ("/", binaryOp(evalIR(ctx, r), (m, s) => m /:/ s), i == 0.0 | i.isNaN | i.isInfinity)
@@ -210,10 +210,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDen
       case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(f)}")
     }
 
-    if (reqDense)
-      prev.densify().blockMap(breezeF, name, reqDense = true)
-    else
-      prev.blockMap(breezeF, name, reqDense = false)
+    prev.blockMap(breezeF, name, reqDense = needsDense)
   }
 }
 
@@ -221,7 +218,7 @@ object SparsityStrategy {
   def fromString(s: String): SparsityStrategy = s match {
     case "union" | "Union" | "UnionBlocks" => Union
     case "intersection" | "Intersection" | "IntersectionBlocks" => Intersection
-    case "needs_dense", "NeedsDense" => NeedsDense
+    case "needs_dense" | "NeedsDense" => NeedsDense
   }
 
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -202,10 +202,10 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDen
         ("-", binaryOp(evalIR(ctx, l), (m, s) => s - m))
       case ApplyBinaryPrimOp(FloatingPointDivide(), Ref(`eltName`, _), r) if !Mentions(r, eltName) =>
         val i = evalIR(ctx, r)
-        ("/", binaryOp(evalIR(ctx, r), (m, s) => m /:/ s), i == 0.0 | i.isNaN | i.isInfinity)
+        ("/", binaryOp(evalIR(ctx, r), (m, s) => m /:/ s))
       case ApplyBinaryPrimOp(FloatingPointDivide(), l, Ref(`eltName`, _)) if !Mentions(l, eltName) =>
         val i = evalIR(ctx, l)
-        ("/", binaryOp(evalIR(ctx, l), BlockMatrix.reverseScalarDiv), i == 0.0 | i.isNaN | i.isInfinity)
+        ("/", binaryOp(evalIR(ctx, l), BlockMatrix.reverseScalarDiv))
 
       case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(f)}")
     }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -216,8 +216,8 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDen
 
 object SparsityStrategy {
   def fromString(s: String): SparsityStrategy = s match {
-    case "union" | "Union" | "UnionBlocks" => Union
-    case "intersection" | "Intersection" | "IntersectionBlocks" => Intersection
+    case "union" | "Union" | "UnionBlocks" => UnionBlocks
+    case "intersection" | "Intersection" | "IntersectionBlocks" => IntersectionBlocks
     case "needs_dense" | "NeedsDense" => NeedsDense
   }
 
@@ -226,10 +226,10 @@ object SparsityStrategy {
 abstract class SparsityStrategy {
   def exists(leftBlock: Boolean, rightBlock: Boolean): Boolean
 }
-case object Union extends SparsityStrategy {
+case object UnionBlocks extends SparsityStrategy {
   def exists(leftBlock: Boolean, rightBlock: Boolean): Boolean = leftBlock || rightBlock
 }
-case object Intersection extends SparsityStrategy {
+case object IntersectionBlocks extends SparsityStrategy {
   def exists(leftBlock: Boolean, rightBlock: Boolean): Boolean = leftBlock && rightBlock
 }
 case object NeedsDense extends SparsityStrategy {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1548,16 +1548,18 @@ object IRParser {
         BlockMatrixRead(reader)
       case "BlockMatrixMap" =>
         val name = identifier(it)
+        val needs_dense = boolean_literal(it)
         val child = blockmatrix_ir(env)(it)
         val f = ir_value_expr(env + (name -> child.typ.elementType))(it)
-        BlockMatrixMap(child, name, f)
+        BlockMatrixMap(child, name, f, needs_dense)
       case "BlockMatrixMap2" =>
         val lName = identifier(it)
         val rName = identifier(it)
+        val sparsityStrategy = SparsityStrategy.fromString(identifier(it))
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)
         val f = ir_value_expr(env.update(Map(lName -> left.typ.elementType, rName -> right.typ.elementType)))(it)
-        BlockMatrixMap2(left, right, lName, rName, f)
+        BlockMatrixMap2(left, right, lName, rName, f, sparsityStrategy)
       case "BlockMatrixDot" =>
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -339,10 +339,10 @@ object Pretty {
               prettyBooleanLiteral(gaussian) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " "
-            case BlockMatrixMap(_, name, _) =>
-              prettyIdentifier(name)
-            case BlockMatrixMap2(_, _, lName, rName, _) =>
-              prettyIdentifier(lName) + " " + prettyIdentifier(rName)
+            case BlockMatrixMap(_, name, _, needsDense) =>
+              prettyIdentifier(name) + " " + prettyBooleanLiteral(needsDense)
+            case BlockMatrixMap2(_, _, lName, rName, _, sparsityStrategy) =>
+              prettyIdentifier(lName) + " " + prettyIdentifier(rName) + prettyClass(sparsityStrategy)
             case MatrixRowsHead(_, n) => n.toString
             case MatrixColsHead(_, n) => n.toString
             case MatrixRowsTail(_, n) => n.toString

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -905,10 +905,12 @@ object Simplify {
     case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f, sparsityStrategy) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
       val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = true, rightBlock = false)
-      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)), needsDense)
+      val maybeDense = if (needsDense) BlockMatrixDensify(right) else right
+      BlockMatrixMap(maybeDense, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)), needsDense)
     case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f, sparsityStrategy) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
       val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = false, rightBlock = true)
-      BlockMatrixMap(left, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)), needsDense)
+      val maybeDense = if (needsDense) BlockMatrixDensify(left) else left
+      BlockMatrixMap(maybeDense, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)), needsDense)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -899,14 +899,16 @@ object Simplify {
 
   private[this] def blockMatrixRules: PartialFunction[BlockMatrixIR, BlockMatrixIR] = {
     case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _) => child
-    case BlockMatrixSlice(BlockMatrixMap(child, n, f), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), n, f)
-    case BlockMatrixSlice(BlockMatrixMap2(l, r, ln, rn, f), slices) =>
-      BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f)
-    case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f) =>
+    case BlockMatrixSlice(BlockMatrixMap(child, n, f, reqDense), slices) => BlockMatrixMap(BlockMatrixSlice(child, slices), n, f, reqDense)
+    case BlockMatrixSlice(BlockMatrixMap2(l, r, ln, rn, f, sparsityStrategy), slices) =>
+      BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f, sparsityStrategy)
+    case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f, sparsityStrategy) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)))
-    case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f) =>
+      val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = true, rightBlock = false)
+      BlockMatrixMap(right, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)), needsDense)
+    case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f, sparsityStrategy) =>
       val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
-      BlockMatrixMap(left, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)))
+      val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = false, rightBlock = true)
+      BlockMatrixMap(left, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)), needsDense)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -38,9 +38,9 @@ class BlockMatrixIRSuite extends HailSuite {
     toBM(Seq(vec.toArray, vec.toArray, vec.toArray))
   }
 
-  def makeMap2(left: BlockMatrixIR, right: BlockMatrixIR,  op: BinaryOp):
+  def makeMap2(left: BlockMatrixIR, right: BlockMatrixIR,  op: BinaryOp, strategy: SparsityStrategy):
   BlockMatrixMap2 = {
-    BlockMatrixMap2(left, right, "l", "r", ApplyBinaryPrimOp(op, Ref("l", TFloat64()), Ref("r", TFloat64())))
+    BlockMatrixMap2(left, right, "l", "r", ApplyBinaryPrimOp(op, Ref("l", TFloat64()), Ref("r", TFloat64())), strategy)
   }
 
   def assertBmEq(actual: BlockMatrix, expected: BlockMatrix) {
@@ -95,10 +95,10 @@ class BlockMatrixIRSuite extends HailSuite {
       0), FastIndexedSeq(0), shape, 0)
 
     // Addition
-    val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())
-    val actualOnesAddColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Add())
-    val actualOnesAddRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Add())
-    val actualOnesAddColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Add())
+    val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add(), Union)
+    val actualOnesAddColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Add(), Union)
+    val actualOnesAddRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Add(), Union)
+    val actualOnesAddColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Add(), Union)
 
     val expectedOnesAddRow = makeMatFromRow(Seq(2, 3, 4))
     val expectedOnesAddCol = makeMatFromCol(Seq(2, 3, 4))
@@ -110,10 +110,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
     // Multiplication
-    val actualOnesMulRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Multiply())
-    val actualOnesMulColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Multiply())
-    val actualOnesMulRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Multiply())
-    val actualOnesMulColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Multiply())
+    val actualOnesMulRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Multiply(), Intersection)
+    val actualOnesMulColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Multiply(), Intersection)
+    val actualOnesMulRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Multiply(), Intersection)
+    val actualOnesMulColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Multiply(), Intersection)
 
     val expectedOnesMulRow = makeMatFromRow(Seq(1, 2, 3))
     val expectedOnesMulCol = makeMatFromCol(Seq(1, 2, 3))
@@ -125,10 +125,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
     // Subtraction
-    val actualOnesSubRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Subtract())
-    val actualOnesSubColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Subtract())
-    val actualOnesSubRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Subtract())
-    val actualOnesSubColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Subtract())
+    val actualOnesSubRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Subtract(), Union)
+    val actualOnesSubColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Subtract(), Union)
+    val actualOnesSubRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Subtract(), Union)
+    val actualOnesSubColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Subtract(), Union)
 
     val expectedOnesSubRowRight = makeMatFromRow(Seq(0, -1, -2))
     val expectedOnesSubColRight = makeMatFromCol(Seq(0, -1, -2))
@@ -142,10 +142,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
     // Division
-    val actualOnesDivRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, FloatingPointDivide())
-    val actualOnesDivColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, FloatingPointDivide())
-    val actualOnesDivRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), FloatingPointDivide())
-    val actualOnesDivColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), FloatingPointDivide())
+    val actualOnesDivRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, FloatingPointDivide(), NeedsDense)
+    val actualOnesDivColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, FloatingPointDivide(), NeedsDense)
+    val actualOnesDivRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), FloatingPointDivide(), NeedsDense)
+    val actualOnesDivColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), FloatingPointDivide(), NeedsDense)
 
     val expectedOnesDivRowRight = makeMatFromRow(Seq(1, 1.0 / 2.0, 1.0 / 3.0))
     val expectedOnesDivColRight = makeMatFromCol(Seq(1, 1.0 / 2.0, 1.0 / 3.0))

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -59,10 +59,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()))
+    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), false)
+    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())), false)
+    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), true)
+    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64())), TFloat64()), false)
 
     assertBmEq(sqrtFoursIR.execute(ctx), twos)
     assertBmEq(negFoursIR.execute(ctx), negFours)
@@ -75,10 +75,10 @@ class BlockMatrixIRSuite extends HailSuite {
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 4096),
       FastIndexedSeq(), shape, 4096)
 
-    val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
-    val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
-    val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply())
-    val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide())
+    val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add(), UnionBlocks)
+    val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract(), UnionBlocks)
+    val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply(), IntersectionBlocks)
+    val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide(), NeedsDense)
 
     assertBmEq(onesAddTwo.execute(ctx), threes)
     assertBmEq(threesSubTwo.execute(ctx), ones)
@@ -95,10 +95,10 @@ class BlockMatrixIRSuite extends HailSuite {
       0), FastIndexedSeq(0), shape, 0)
 
     // Addition
-    val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add(), Union)
-    val actualOnesAddColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Add(), Union)
-    val actualOnesAddRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Add(), Union)
-    val actualOnesAddColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Add(), Union)
+    val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add(), UnionBlocks)
+    val actualOnesAddColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Add(), UnionBlocks)
+    val actualOnesAddRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Add(), UnionBlocks)
+    val actualOnesAddColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Add(), UnionBlocks)
 
     val expectedOnesAddRow = makeMatFromRow(Seq(2, 3, 4))
     val expectedOnesAddCol = makeMatFromCol(Seq(2, 3, 4))
@@ -110,10 +110,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
     // Multiplication
-    val actualOnesMulRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Multiply(), Intersection)
-    val actualOnesMulColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Multiply(), Intersection)
-    val actualOnesMulRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Multiply(), Intersection)
-    val actualOnesMulColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Multiply(), Intersection)
+    val actualOnesMulRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Multiply(), IntersectionBlocks)
+    val actualOnesMulColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Multiply(), IntersectionBlocks)
+    val actualOnesMulRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Multiply(), IntersectionBlocks)
+    val actualOnesMulColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Multiply(), IntersectionBlocks)
 
     val expectedOnesMulRow = makeMatFromRow(Seq(1, 2, 3))
     val expectedOnesMulCol = makeMatFromCol(Seq(1, 2, 3))
@@ -125,10 +125,10 @@ class BlockMatrixIRSuite extends HailSuite {
 
 
     // Subtraction
-    val actualOnesSubRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Subtract(), Union)
-    val actualOnesSubColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Subtract(), Union)
-    val actualOnesSubRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Subtract(), Union)
-    val actualOnesSubColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Subtract(), Union)
+    val actualOnesSubRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Subtract(), UnionBlocks)
+    val actualOnesSubColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Subtract(), UnionBlocks)
+    val actualOnesSubRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Subtract(), UnionBlocks)
+    val actualOnesSubColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Subtract(), UnionBlocks)
 
     val expectedOnesSubRowRight = makeMatFromRow(Seq(0, -1, -2))
     val expectedOnesSubColRight = makeMatFromCol(Seq(0, -1, -2))


### PR DESCRIPTION
this will let us lift the implicit densification that happens in operations like BlockMatrixMap's sum, etc. into an explicit BlockMatrixDensify node on the python side.

necessary for moving sparsity into BlockMatrixType.