### PR TITLE
[hail] implement (Scala) NDArrayConcat

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -63,6 +63,8 @@ object Children {
       Array(nd)
     case NDArrayReshape(nd, shape) =>
       Array(nd, shape)
+    case NDArrayConcat(nds, _) =>
+      Array(nds)
     case ArraySort(a, _, _, compare) =>
       Array(a, compare)
     case ToSet(a) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -80,6 +80,9 @@ object Copy {
       case NDArrayReshape(_, _) =>
         assert(newChildren.length ==  2)
         NDArrayReshape(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
+      case NDArrayConcat(_, axis) =>
+        assert(newChildren.length ==  1)
+        NDArrayConcat(newChildren(0).asInstanceOf[IR], axis)
       case NDArrayRef(_, _) =>
         NDArrayRef(newChildren(0).asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]))
       case NDArraySlice(_, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -18,6 +18,7 @@ object FoldConstants {
              _: MakeNDArray |
              _: NDArrayShape |
              _: NDArrayReshape |
+             _: NDArrayConcat |
              _: NDArraySlice |
              _: NDArrayMap |
              _: NDArrayMap2 |

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -261,6 +261,8 @@ final case class NDArrayShape(nd: IR) extends IR
 
 final case class NDArrayReshape(nd: IR, shape: IR) extends NDArrayIR
 
+final case class NDArrayConcat(nds: IR, axis: Int) extends NDArrayIR
+
 final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 final case class NDArraySlice(nd: IR, slices: IR) extends NDArrayIR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -248,6 +248,10 @@ object InferPType {
         infer(shape)
 
         PNDArray(coerce[PNDArray](nd.pType2).elementType, shape.pType2.asInstanceOf[PTuple].size, nd.pType2.required)
+      case NDArrayConcat(nds, _) =>
+        infer(nds)
+        val ndtyp = coerce[PNDArray](coerce[PStreamable](nds.pType2).elementType)
+        ndtyp
       case NDArrayMap(nd, name, body) =>
         infer(nd)
         val ndPType = nd.pType2.asInstanceOf[PNDArray]

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -127,6 +127,8 @@ object InferType {
         ndType.representation.fieldType("shape").asInstanceOf[TTuple].setRequired(ndType.required)
       case NDArrayReshape(nd, shape) =>
         TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size), nd.typ.required)
+      case NDArrayConcat(nds, _) =>
+        coerce[TStreamable](nds.typ).elementType
       case NDArrayMap(nd, _, body) =>
         TNDArray(body.typ.setRequired(true), coerce[TNDArray](nd.typ).nDimsBase, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -21,6 +21,7 @@ object Interpretable {
         _: MakeNDArray |
         _: NDArrayShape |
         _: NDArrayReshape |
+        _: NDArrayConcat |
         _: NDArrayRef |
         _: NDArraySlice |
         _: NDArrayMap |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -808,6 +808,10 @@ object IRParser {
         val nd = ir_value_expr(env)(it)
         val shape = ir_value_expr(env)(it)
         NDArrayReshape(nd, shape)
+      case "NDArrayConcat" =>
+        val axis = int32_literal(it)
+        val nds = ir_value_expr(env)(it)
+        NDArrayConcat(nds, axis)
       case "NDArrayMap" =>
         val name = identifier(it)
         val nd = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -294,6 +294,7 @@ object Pretty {
             case NDArrayMap(_, name, _) => prettyIdentifier(name)
             case NDArrayMap2(_, _, lName, rName, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
             case NDArrayReindex(_, indexExpr) => prettyInts(indexExpr)
+            case NDArrayConcat(_, axis) => axis.toString
             case NDArrayAgg(_, axes) => prettyInts(axes)
             case ArraySort(_, l, r, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
             case ApplyIR(function, _) => prettyIdentifier(function) + " " + ir.typ.parsableString()

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -173,6 +173,9 @@ object TypeCheck {
       case x@NDArrayReshape(nd, shape) =>
         assert(nd.typ.isInstanceOf[TNDArray])
         assert(shape.typ.asInstanceOf[TTuple].types.forall(t => t.isInstanceOf[TInt64]))
+      case x@NDArrayConcat(nds, axis) =>
+        assert(coerce[TStreamable](nds.typ).elementType.isInstanceOf[TNDArray])
+        assert(axis < x.typ.nDims)
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
         assert(nd.typ.asInstanceOf[TNDArray].nDims == idxs.length)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -238,4 +238,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   private def deepRenameNDArray(t: TNDArray) =
     PCanonicalNDArray(this.elementType.deepRename(t.elementType), this.nDims, this.required)
+
+  def copy(elementType: PType = this.elementType, nDims: Int = this.nDims, required: Boolean = this.required): PCanonicalNDArray =
+    PCanonicalNDArray(elementType, nDims, required)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -32,6 +32,8 @@ abstract class PNDArray extends PType {
 
   val representation: PStruct
 
+  def copy(elementType: PType = this.elementType, nDims: Int = this.nDims, required: Boolean = this.required): PNDArray
+
   def dimensionLength(off: Code[Long], idx: Int): Code[Long] = {
     Region.loadLong(shape.pType.fieldOffset(shape.load(off), idx))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -1,9 +1,9 @@
 package is.hail.expr.types.physical
 
-import is.hail.annotations.{CodeOrdering, StagedRegionValueBuilder}
+import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, MethodBuilder, _}
 import is.hail.expr.Nat
-import is.hail.expr.ir.{EmitMethodBuilder}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types.virtual.TNDArray
 
 final class StaticallyKnownField[T, U](
@@ -31,6 +31,10 @@ abstract class PNDArray extends PType {
   val data: StaticallyKnownField[PArray, Long]
 
   val representation: PStruct
+
+  def dimensionLength(off: Code[Long], idx: Int): Code[Long] = {
+    Region.loadLong(shape.pType.fieldOffset(shape.load(off), idx))
+  }
 
   def numElements(shape: Array[Code[Long]], mb: MethodBuilder): Code[Long]
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -235,6 +235,7 @@ abstract class PType extends Serializable with Requiredness {
         case t: PInterval => t.copy(required = required)
         case t: PStruct => t.copy(required = required)
         case t: PTuple => t.copy(required = required)
+        case t: PNDArray => t.copy(required = required)
       }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1978,10 +1978,10 @@ class IRSuite extends HailSuite {
     assertNDEvals(NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
 
-    // FIXME: These are changing type during PruneDeadFields for some reason...
+    // FIXME: This is changing type during PruneDeadFields for some reason...
 //    assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
-//    assertNDEvals(NDArrayConcat(nds(na, na), 1), null)
-//    assertNDEvals(NDArrayConcat(NA(TArray(TNDArray(TInt32(), Nat(2)))), 1), null)
+    assertNDEvals(NDArrayConcat(nds(na, na), 1), null)
+    assertNDEvals(NDArrayConcat(NA(TArray(TNDArray(TInt32(), Nat(2)))), 1), null)
   }
 
   @Test def testNDArrayMap() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1918,6 +1918,72 @@ class IRSuite extends HailSuite {
     assertEvalsTo(makeNDArrayRef(mat2, FastIndexedSeq(0, 0)), 1.0)
   }
 
+  @Test def testNDArrayConcat() {
+    implicit val execStrats = ExecStrategy.compileOnly
+    def nds(ndData: (IndexedSeq[Int], Long, Long)*): IR = {
+      MakeArray(ndData.map { case (values, nRows, nCols) =>
+        if (values == null) NA(TNDArray(TInt32(), Nat(2))) else
+          MakeNDArray(Literal(TArray(TInt32()), values),
+            Literal(TTuple(TInt64(), TInt64()), Row(nRows, nCols)), True())
+      }, TArray(TNDArray(TInt32(), Nat(2))))
+    }
+
+    def assertNDEvals(nd: IR, expected: Array[Array[Int]]): Unit = {
+      val arrayIR = if (expected == null) nd else {
+        val nRows = expected.length
+        val nCols = if (nRows == 0) 0 else expected.head.length
+        Let("nd", nd,
+          MakeArray(
+            Array.tabulate(nRows) { i =>
+              MakeArray(Array.tabulate(nCols) { j =>
+                makeNDArrayRef(Ref("nd", nd.typ), FastIndexedSeq(i, j))
+              }, TArray(TInt32()))
+            }, TArray(TArray(TInt32()))))
+      }
+      assertEvalsTo(arrayIR, if (expected == null) null else expected.map(_.toFastIndexedSeq).toFastIndexedSeq)
+    }
+
+    val nd1 = (FastIndexedSeq(
+      0, 1, 2,
+      3, 4, 5), 2L, 3L)
+
+    val rowwise = (FastIndexedSeq(
+      6, 7, 8,
+      9, 10, 11,
+      12, 13, 14), 3L, 3L)
+
+    val colwise = (FastIndexedSeq(
+      15, 16,
+      17, 18), 2L, 2L)
+
+    val emptyRowwise = (FastIndexedSeq(), 0L, 3L)
+    val emptyColwise = (FastIndexedSeq(), 2L, 0L)
+    val na = (null, 0L, 0L)
+
+    val rowwiseExpected = Array(
+      Array(0, 1, 2),
+      Array(3, 4, 5),
+      Array(6, 7, 8),
+      Array(9, 10, 11),
+      Array(12, 13, 14))
+    val colwiseExpected = Array(
+      Array(0, 1, 2, 15, 16),
+      Array(3, 4, 5, 17, 18))
+
+    assertNDEvals(NDArrayConcat(nds(nd1, rowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, rowwise, emptyRowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, emptyRowwise, rowwise), 0), rowwiseExpected)
+
+    assertNDEvals(NDArrayConcat(nds(nd1, colwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
+
+    // FIXME: These are changing type during PruneDeadFields for some reason...
+//    assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
+//    assertNDEvals(NDArrayConcat(nds(na, na), 1), null)
+//    assertNDEvals(NDArrayConcat(NA(TArray(TNDArray(TInt32(), Nat(2)))), 1), null)
+  }
+
   @Test def testNDArrayMap() {
     implicit val execStrats: Set[ExecStrategy] = Set()
 
@@ -2493,6 +2559,7 @@ class IRSuite extends HailSuite {
       MakeStream(FastSeq(i, NA(TInt32()), I32(-3)), TStream(TInt32())),
       nd,
       NDArrayReshape(nd, MakeTuple.ordered(Seq(I64(4)))),
+      NDArrayConcat(MakeArray(FastSeq(nd, nd), TArray(nd.typ)), 0),
       NDArrayRef(nd, FastSeq(I64(1), I64(2))),
       NDArrayMap(nd, "v", ApplyUnaryPrimOp(Negate(), v)),
       NDArrayMap2(nd, nd, "l", "r", ApplyBinaryPrimOp(Add(), l, r)),


### PR DESCRIPTION
The primary use case I have in mind for this right now is to lower a BlockMatrixCollect node; I don't *think* this can be easily implemented in terms of other nodes.

Currently I've only implemented this in Scala but I can expose it in python if necessary.