### PR TITLE
Use Hail version of jgscm

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -41,7 +41,7 @@ if role == 'Master':
         'mkl<2020',
         'lxml<5',
         'google-cloud==0.32.*',
-        'jgscm<0.2',
+        'https://github.com/hail-is/jgscm/archive/v0.1.10-hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',
         'jupyter-console==6.0.*',

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -40,7 +40,7 @@ if role == 'Master':
         'setuptools',
         'mkl<2020',
         'lxml<5',
-        'google-cloud-storage==1.25.*'
+        'google-cloud-storage==1.25.*',
         'https://github.com/hail-is/jgscm/archive/v0.1.10-hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -40,7 +40,6 @@ if role == 'Master':
         'setuptools',
         'mkl<2020',
         'lxml<5',
-        'google-cloud==0.32.*',
         'https://github.com/hail-is/jgscm/archive/v0.1.10-hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -41,7 +41,7 @@ if role == 'Master':
         'mkl<2020',
         'lxml<5',
         'google-cloud-storage==1.25.*',
-        'https://github.com/hail-is/jgscm/archive/v0.1.10-hail.zip',
+        'https://github.com/hail-is/jgscm/archive/v0.1.11-hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',
         'jupyter-console==6.0.*',

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -40,6 +40,7 @@ if role == 'Master':
         'setuptools',
         'mkl<2020',
         'lxml<5',
+        'google-cloud-storage==1.25.*'
         'https://github.com/hail-is/jgscm/archive/v0.1.10-hail.zip',
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',


### PR DESCRIPTION
jgscm doesn't seem to be maintained, relies on super old google libraries. Let's use our hail fork of jgscm instead, as that fork has been modified both to use the new google libraries and to not crash in the presence of requester pays buckets. We may consider just publishing something called `hail-jgscm` to pypi instead of this weird github based method. 