### PR TITLE
[benchmarks] Additional multi-write / combiner benchmarks

### DIFF
--- a/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
@@ -15,12 +15,30 @@ def chunks(seq, size):
     return (seq[pos:pos + size] for pos in range(0, len(seq), size))
 
 
+def setup(path):
+    interval = [hl.eval(hl.parse_locus_interval('chr1:START-END', reference_genome='GRCh38'))]
+    return hl.import_vcfs([path], interval, reference_genome='GRCh38')[0]
+
+
 @benchmark(args=empty_gvcf.handle())
 def compile_10k_merge(path):
-    interval = [hl.eval(hl.parse_locus_interval('chr1:START-END', reference_genome='GRCh38'))]
-    vcfs = hl.import_vcfs([path], interval, reference_genome='GRCh38')
-    vcfs = vcfs * MAX_TO_COMBINE
+    vcf = setup(path)
+    vcfs = [vcf] * MAX_TO_COMBINE
     mts = [comb.transform_gvcf(vcf) for vcf in vcfs]
     combined = [comb.combine_gvcfs(mts) for mts in chunks(mts, COMBINE_GVCF_MAX)]
     with TemporaryDirectory() as tmpdir:
         hl.experimental.write_matrix_tables(combined, os.path.join(tmpdir, 'combiner-multi-write'), overwrite=True)
+
+
+@benchmark(args=empty_gvcf.handle())
+def python_only_10k_transform(path):
+    vcf = setup(path)
+    vcfs = [vcf] * 10_000
+    _ = [comb.transform_gvcf(vcf) for vcf in vcfs]
+
+@benchmark(args=empty_gvcf.handle())
+def python_only_10k_combine(path):
+    vcf = setup(path)
+    mt = comb.transform_gvcf(vcf)
+    mts = [mt] * 10_000
+    _ = [comb.combine_gvcfs(mts) for mts in chunks(mts, COMBINE_GVCF_MAX)]

--- a/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
@@ -21,11 +21,10 @@ def setup(path):
 
 
 @benchmark(args=empty_gvcf.handle())
-def compile_10k_merge(path):
+def compile_2k_merge(path):
     vcf = setup(path)
-    vcfs = [vcf] * MAX_TO_COMBINE
-    mts = [comb.transform_gvcf(vcf) for vcf in vcfs]
-    combined = [comb.combine_gvcfs(mts) for mts in chunks(mts, COMBINE_GVCF_MAX)]
+    vcfs = [comb.transform_gvcf(vcf)] * COMBINE_GVCF_MAX
+    combined = [comb.combine_gvcfs(vcfs)] * 20
     with TemporaryDirectory() as tmpdir:
         hl.experimental.write_matrix_tables(combined, os.path.join(tmpdir, 'combiner-multi-write'), overwrite=True)
 

--- a/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/combiner_benchmarks.py
@@ -1,4 +1,5 @@
-import logging
+import os.path
+from tempfile import TemporaryDirectory
 
 import hail as hl
 import hail.experimental.vcf_combiner as comb
@@ -7,7 +8,7 @@ from .resources import empty_gvcf
 from .utils import benchmark
 
 COMBINE_GVCF_MAX = 100
-MAX_TO_COMBINE = 100 * COMBINE_GVCF_MAX
+MAX_TO_COMBINE = 20 * COMBINE_GVCF_MAX
 
 
 def chunks(seq, size):
@@ -21,4 +22,5 @@ def compile_10k_merge(path):
     vcfs = vcfs * MAX_TO_COMBINE
     mts = [comb.transform_gvcf(vcf) for vcf in vcfs]
     combined = [comb.combine_gvcfs(mts) for mts in chunks(mts, COMBINE_GVCF_MAX)]
-    hl.experimental.write_matrix_tables(combined, '/tmp/combiner-temporary/', overwrite=True)
+    with TemporaryDirectory() as tmpdir:
+        hl.experimental.write_matrix_tables(combined, os.path.join(tmpdir, 'combiner-multi-write'), overwrite=True)

--- a/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/matrix_table_benchmarks.py
@@ -363,3 +363,11 @@ def matrix_table_scan_count_cols():
     mt = hl.utils.range_matrix_table(n_cols=10_000_000, n_rows=10)
     mt.annotate_cols(x=hl.scan.count())
     mt._force_count_rows()
+
+
+@benchmark()
+def matrix_multi_write_nothing():
+    with TemporaryDirectory() as tmpdir:
+        mt = hl.utils.range_matrix_table(1, 1, n_partitions=1)
+        mts = [mt] * 1000
+        hl.experimental.write_matrix_tables(mts, path.join(tmpdir, 'multi-write'), overwrite=True)


### PR DESCRIPTION
* Add an empty multi write benchmark
* Add python only combiner benchmarks (4ms / iteration of `transform_gvcf`!)
* Make the merge and write nothing benchmark actually finish on a laptop and reduce the time it spends in python.