### PR TITLE
[hail] Begin making MatrixValue.finalizeWrite parallelizable 

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -76,7 +76,9 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
 
     val globalsPath = path + "/globals"
     fs.mkDir(globalsPath)
-    AbstractRVDSpec.writeSingle(fs, globalsPath, globals.t, bufferSpec, Array(globals.javaValue))
+    val gblCodecSpec = TypedCodecSpec(globals.t, bufferSpec)
+    val encGlobals = gblCodecSpec.buildEncoder(globals.t)
+    AbstractRVDSpec.writeSingle(encGlobals)(fs, globalsPath, globals.t, gblCodecSpec, Array(globals.javaValue))
 
     val codecSpec = TypedCodecSpec(rvd.rowPType, bufferSpec)
     val partitionCounts = rvd.write(path + "/rows", "../index", stageLocally, codecSpec)


### PR DESCRIPTION
* Require AbstractRVDSpec to take a makeEncoder.
* Add a struct to hold all the encoders needed to write matrix columns and globals.
* Make MatrixValue.{writeGlobals,writeCols} methods take encoders and AbstractTypedCodecSpecs

Basically, where possible try to separate 'compile something' from 'use that compiled code'.

Finalize write is currently not parallelize-able. This is a problem for
`write_matrix_tables` as it creates a large portion of work that is
single threaded. The reason for this is twofold. First, finalizeWrite
compiles encoders for columns, globals, and the globals' globals.
Second, MatrixValue is not serializable, and I don't think it can be.
This is a little trickier as it will require the exploding/broadcasting
of the globals/columns. This refactoring removes compiling encoders from
this logic. 