### PR TITLE
[hail] Inline ApplyIR in compile lowering pass.

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -328,7 +328,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
       cn.accept(cw)
       bytes = cw.toByteArray
 //       This next line should always be commented out!
-//      CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
+      CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
     } catch {
       case e: Exception =>
         // if we fail with frames, try without frames for better error message

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -166,5 +166,5 @@ class JoinPointBuilder private[joinpoint](
     joinPoint(p.newLocals(mb))
 
   def joinPoint(): DefinableJoinPoint[Unit] =
-    joinPoint(ParameterStore.unit)
+    joinPoint(ParameterStoreUnit)
 }

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -4,95 +4,131 @@ import is.hail.asm4s._
 import is.hail.expr.ir
 import is.hail.expr.ir.EmitTriplet
 import is.hail.expr.types.physical.PType
-import org.objectweb.asm.tree.InsnNode
-import org.objectweb.asm.Opcodes
 
-object ParameterPack {
-  implicit val unit: ParameterPack[Unit] = new ParameterPack[Unit] {
-    def push(u: Unit): Code[Unit] = Code._empty
-    def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[Unit] = ParameterStore.unit
-    def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[Unit] = ParameterStore.unit
+trait ParameterPack[A] {
+  def push(a: A): Code[Unit]
+
+  def pushAny(a: Any): Code[Unit] = push(a.asInstanceOf[A])
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[A]
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[A]
+}
+
+case object ParameterPackUnit extends ParameterPack[Unit] {
+  def push(u: Unit): Code[Unit] = Code._empty
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[Unit] = ParameterStoreUnit
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[Unit] = ParameterStoreUnit
+}
+
+case class ParameterPackCode[T](tti: TypeInfo[T]) extends ParameterPack[Code[T]] {
+  def push(v: Code[T]): Code[Unit] = coerce[Unit](v)
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[Code[T]] = {
+    val x = mb.newLocal(name)(tti)
+    new ParameterStore[Code[T]] {
+      def storeInsn: Code[Unit] = x.storeInsn
+
+      def store(a: Code[T]): Code[Unit] = x.store(a)
+
+      def load: Code[T] = x.load()
+
+      def init: Code[Unit] = x.storeAny(ir.defaultValue(tti))
+    }
   }
 
-  implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] =
-    new ParameterPack[Code[T]] {
-      def push(v: Code[T]): Code[Unit] = coerce[Unit](v)
-      def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[Code[T]] = {
-        val x = mb.newLocal(name)(tti)
-        new ParameterStore[Code[T]] {
-          def storeInsn: Code[Unit] = x.storeInsn
-          def store(a: Code[T]): Code[Unit] = x.store(a)
-          def load: Code[T] = x.load()
-        }
-      }
-      def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[Code[T]] = {
-        val x = fb.newField(name)(tti)
-        new ParameterStore[Code[T]] {
-          def storeInsn: Code[Unit] = throw new UnsupportedOperationException("storeInsn not supported for fields")
-          def store(a: Code[T]): Code[Unit] = x.store(a)
-          def load: Code[T] = x.load()
-        }
-      }
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[Code[T]] = {
+    val x = fb.newField(name)(tti)
+    new ParameterStore[Code[T]] {
+      def storeInsn: Code[Unit] = throw new UnsupportedOperationException("storeInsn not supported for fields")
+
+      def store(a: Code[T]): Code[Unit] = x.store(a)
+
+      def load: Code[T] = x.load()
+
+      def init: Code[Unit] = x.storeAny(ir.defaultValue(tti))
     }
+  }
+}
+
+case class ParamPackTuple2[A, B](ap: ParameterPack[A], bp: ParameterPack[B]) extends ParameterPack[(A, B)] {
+  def push(v: (A, B)): Code[Unit] = Code(ap.push(v._1), bp.push(v._2))
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[(A, B)] =
+    if (name == null)
+      ParameterStoreTuple2(ap.newLocals(mb), bp.newLocals(mb))
+    else
+      ParameterStoreTuple2(ap.newLocals(mb, name + "_1"),
+        bp.newLocals(mb, name + "_2"))
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[(A, B)] =
+    ParameterStoreTuple2(ap.newFields(fb, name + "_1"),
+      bp.newFields(fb, name + "_2"))
+}
+
+case class ParamPackTuple3[A, B, C](ap: ParameterPack[A], bp: ParameterPack[B], cp: ParameterPack[C]) extends ParameterPack[(A, B, C)] {
+  def push(v: (A, B, C)): Code[Unit] =
+    Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[(A, B, C)] =
+    if (name == null)
+      ParameterStoreTuple3(ap.newLocals(mb), bp.newLocals(mb), cp.newLocals(mb))
+    else
+      ParameterStoreTuple3(ap.newLocals(mb, name + "_1"),
+        bp.newLocals(mb, name + "_2"),
+        cp.newLocals(mb, name + "_3"))
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[(A, B, C)] =
+    ParameterStoreTuple3(ap.newFields(fb, name + "_1"),
+      bp.newFields(fb, name + "_2"),
+      cp.newFields(fb, name + "_3"))
+}
+
+case class ParamPackArray(pps: IndexedSeq[ParameterPack[_]]) extends ParameterPack[IndexedSeq[_]] {
+  override def push(a: IndexedSeq[_]): Code[Unit] =
+    pps.zip(a).foldLeft(Code._empty[Unit]) { case (acc, (pp, v)) =>
+      Code(acc, pp.pushAny(v))
+    }
+
+  override def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[IndexedSeq[_]] =
+    if (name == null) {
+      ParameterStoreArray(pps.map(_.newLocals(mb)))
+    } else {
+
+      val locals = pps.zipWithIndex.map { case (pp, i) =>
+        pp.newLocals(mb, name + s"_$i")
+      }
+      ParameterStoreArray(locals)
+    }
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[IndexedSeq[_]] = {
+    val fields = pps.zipWithIndex.map { case (pp, i) =>
+      pp.newFields(fb, name + s"_$i")
+    }
+    ParameterStoreArray(fields)
+  }
+}
+
+object ParameterPack {
+  implicit val unit: ParameterPack[Unit] = ParameterPackUnit
+
+  implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] = ParameterPackCode(tti)
 
   implicit def tuple2[A, B](
     implicit ap: ParameterPack[A],
     bp: ParameterPack[B]
-  ): ParameterPack[(A, B)] = new ParameterPack[(A, B)] {
-    def push(v: (A, B)): Code[Unit] = Code(ap.push(v._1), bp.push(v._2))
-    def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[(A, B)] =
-      if (name == null)
-        ParameterStore.tuple(ap.newLocals(mb), bp.newLocals(mb))
-      else
-        ParameterStore.tuple(ap.newLocals(mb, name + "_1"),
-                             bp.newLocals(mb, name + "_2"))
-    def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[(A, B)] =
-      ParameterStore.tuple(ap.newFields(fb, name + "_1"),
-                           bp.newFields(fb, name + "_2"))
-  }
+  ): ParameterPack[(A, B)] = ParamPackTuple2(ap, bp)
 
   implicit def tuple3[A, B, C](
     implicit ap: ParameterPack[A],
     bp: ParameterPack[B],
     cp: ParameterPack[C]
-  ): ParameterPack[(A, B, C)] = new ParameterPack[(A, B, C)] {
-    def push(v: (A, B, C)): Code[Unit] =
-      Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
-    def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[(A, B, C)] =
-      if (name == null)
-        ParameterStore.tuple(ap.newLocals(mb), bp.newLocals(mb), cp.newLocals(mb))
-      else
-        ParameterStore.tuple(ap.newLocals(mb, name + "_1"),
-                             bp.newLocals(mb, name + "_2"),
-                             cp.newLocals(mb, name + "_3"))
-    def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[(A, B, C)] =
-      ParameterStore.tuple(ap.newFields(fb, name + "_1"),
-                           bp.newFields(fb, name + "_2"),
-                           cp.newFields(fb, name + "_3"))
-  }
+  ): ParameterPack[(A, B, C)] = ParamPackTuple3(ap, bp, cp)
 
-  def array(pps: IndexedSeq[ParameterPack[_]]): ParameterPack[IndexedSeq[_]] = new ParameterPack[IndexedSeq[_]] {
-    override def push(a: IndexedSeq[_]): Code[Unit] =
-      pps.zip(a).foldLeft(Code._empty[Unit]) { case (acc, (pp, v)) =>
-        Code(acc, pp.pushAny(v)) }
 
-    override def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[IndexedSeq[_]] =
-      if (name == null)
-        ParameterStore.array(pps.map(_.newLocals(mb)))
-      else {
-        val locals = pps.zipWithIndex.map { case (pp, i) =>
-          pp.newLocals(mb, name + s"_$i")
-        }
-        ParameterStore.array(locals)
-      }
-
-    def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[IndexedSeq[_]] = {
-      val fields = pps.zipWithIndex.map { case (pp, i) =>
-        pp.newFields(fb, name + s"_$i")
-      }
-      ParameterStore.array(fields)
-    }
-  }
+  def array(pps: IndexedSeq[ParameterPack[_]]): ParameterPack[IndexedSeq[_]] = ParamPackArray(pps)
 
   def let[A: ParameterPack, X](mb: MethodBuilder, a0: A)(k: A => Code[X]): Code[X] = {
     val ap = implicitly[ParameterPack[A]]
@@ -101,60 +137,78 @@ object ParameterPack {
   }
 }
 
-trait ParameterPack[A] {
-  def push(a: A): Code[Unit]
-  def pushAny(a: Any): Code[Unit] = push(a.asInstanceOf[A])
-  def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[A]
-  def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[A]
-}
-
-object ParameterStore {
-  def unit: ParameterStore[Unit] = new ParameterStore[Unit] {
-    def storeInsn: Code[Unit] = Code._empty
-    def store(v: Unit): Code[Unit] = Code._empty
-    def load: Unit = ()
-  }
-
-  def tuple[A, B](
-    pa: ParameterStore[A],
-    pb: ParameterStore[B]
-  ): ParameterStore[(A, B)] = new ParameterStore[(A, B)] {
-    def load: (A, B) = (pa.load, pb.load)
-    def store(v: (A, B)): Code[Unit] = v match {
-      case (a, b) => Code(pa.store(a), pb.store(b))
-    }
-    def storeInsn: Code[Unit] = Code(pb.storeInsn, pa.storeInsn)
-  }
-
-  def tuple[A, B, C](
-    pa: ParameterStore[A],
-    pb: ParameterStore[B],
-    pc: ParameterStore[C]
-  ): ParameterStore[(A, B, C)] = new ParameterStore[(A, B, C)] {
-    def load: (A, B, C) = (pa.load, pb.load, pc.load)
-    def store(v: (A, B, C)): Code[Unit] = v match {
-      case (a, b, c) => Code(pa.store(a), pb.store(b), pc.store(c))
-    }
-    def storeInsn: Code[Unit] = Code(pc.storeInsn, pb.storeInsn, pa.storeInsn)
-  }
-
-  def array(pss: IndexedSeq[ParameterStore[_]]): ParameterStore[IndexedSeq[_]] = new ParameterStore[IndexedSeq[_]] {
-    def load: IndexedSeq[_] = pss.map(_.load)
-    def store(vs: IndexedSeq[_]): Code[Unit] =
-      pss.zip(vs).foldLeft(Code._empty[Unit]) { case (acc, (ps, v)) => Code(acc, ps.storeAny(v)) }
-    def storeInsn: Code[Unit] = pss.map(_.storeInsn).fold(Code._empty[Unit]) { case (acc, c) => Code(c, acc) } // order of c and acc is important
-  }
-}
 
 abstract class ParameterStore[A] {
   private[joinpoint] def storeInsn: Code[Unit]
+
   def load: A
+
   def store(v: A): Code[Unit]
 
-  def :=(v: A): Code[Unit] = store(v)
+  def :=(v: A): Code[Unit] = {
+    store(v)
+  }
+
   def :=(cc: JoinPoint.CallCC[A]): Code[Unit] = Code(cc.code, storeInsn)
+
   def storeAny(v: Any): Code[Unit] = store(v.asInstanceOf[A])
+
+  def init: Code[Unit]
 }
+
+case object ParameterStoreUnit extends ParameterStore[Unit] {
+  def storeInsn: Code[Unit] = Code._empty
+
+  def store(v: Unit): Code[Unit] = Code._empty
+
+  def load: Unit = ()
+
+  def init: Code[Unit] = Code._empty[Unit]
+}
+
+case class ParameterStoreTuple2[A, B](pa: ParameterStore[A], pb: ParameterStore[B]) extends ParameterStore[(A, B)] {
+  def load: (A, B) = (pa.load, pb.load)
+
+  def store(v: (A, B)): Code[Unit] = v match {
+    case (a, b) => Code(pa.store(a), pb.store(b))
+  }
+
+  def storeInsn: Code[Unit] = Code(pb.storeInsn, pa.storeInsn)
+
+  def init: Code[Unit] = Code(pa.init, pb.init)
+}
+
+case class ParameterStoreTuple3[A, B, C](
+  pa: ParameterStore[A],
+  pb: ParameterStore[B],
+  pc: ParameterStore[C]
+) extends ParameterStore[(A, B, C)] {
+  def load: (A, B, C) = (pa.load, pb.load, pc.load)
+
+  def store(v: (A, B, C)): Code[Unit] = v match {
+    case (a, b, c) => Code(pa.store(a), pb.store(b), pc.store(c))
+  }
+
+  def storeInsn: Code[Unit] = Code(pc.storeInsn, pb.storeInsn, pa.storeInsn)
+
+  def init: Code[Unit] = Code(pa.init, pb.init, pc.init)
+
+}
+
+case class ParameterStoreArray(pss: IndexedSeq[ParameterStore[_]]) extends ParameterStore[IndexedSeq[_]] {
+  def load: IndexedSeq[_] = pss.map(_.load)
+
+  def store(vs: IndexedSeq[_]): Code[Unit] = {
+    assert(pss.length == vs.length)
+    pss.zip(vs).foldLeft(Code._empty[Unit]) { case (acc, (ps, v)) => Code(acc, ps.storeAny(v)) }
+  }
+
+  def storeInsn: Code[Unit] = pss.map(_.storeInsn).fold(Code._empty[Unit]) { case (acc, c) => Code(c, acc) } // order of c and acc is important
+
+  def init: Code[Unit] = pss.foldLeft[Code[Unit]](Code._empty) { case (acc, ps) => Code(acc, ps.init) }
+
+}
+
 
 object TypedTriplet {
   def apply(t: PType, et: EmitTriplet): TypedTriplet[t.type] =
@@ -165,17 +219,22 @@ object TypedTriplet {
 
   def parameterStore[A](psm: ParameterStore[Code[Boolean]], psv: ParameterStore[Code[A]], defaultValue: Code[A]): ParameterStore[TypedTriplet[A]] = new ParameterStore[TypedTriplet[A]] {
     def load: TypedTriplet[A] = TypedTriplet(Code._empty, psm.load, psv.load)
+
     def store(trip: TypedTriplet[A]): Code[Unit] = Code(
       trip.setup,
       trip.m.mux(
         Code(psm.store(true), psv.store(defaultValue)),
         Code(psm.store(false), psv.storeAny(trip.v))))
-    def storeInsn: Code[Unit] = ParameterStore.tuple(psv, psm).storeInsn
+
+    def storeInsn: Code[Unit] = ParameterStoreTuple2(psv, psm).storeInsn
+
+    def init: Code[Unit] = Code(psm.init, psv.init)
   }
 
   class Pack[P] private[joinpoint](t: PType) extends ParameterPack[TypedTriplet[P]] {
     val ppm = implicitly[ParameterPack[Code[Boolean]]]
     val ppv = ParameterPack.code(ir.typeToTypeInfo(t)).asInstanceOf[ParameterPack[Code[P]]]
+
     def push(trip: TypedTriplet[P]): Code[Unit] = Code(
       trip.setup,
       trip.m.mux(
@@ -183,13 +242,13 @@ object TypedTriplet {
         Code(coerce[Unit](trip.v), coerce[Unit](const(false)))))
 
     def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[TypedTriplet[P]] = {
-      val psm = ppm.newLocals(mb, if (name == null) "m" else s"${name}_missing")
+      val psm = ppm.newLocals(mb, if (name == null) "m" else s"${ name }_missing")
       val psv = ppv.newLocals(mb, if (name == null) "v" else name)
       parameterStore[P](psm, psv, coerce[P](ir.defaultValue(t)))
     }
 
     def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[TypedTriplet[P]] = {
-      val psm = ppm.newFields(fb, if (name == null) "m" else s"${name}_missing")
+      val psm = ppm.newFields(fb, if (name == null) "m" else s"${ name }_missing")
       val psv = ppv.newFields(fb, if (name == null) "v" else name)
       parameterStore[P](psm, psv, coerce[P](ir.defaultValue(t)))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -60,5 +60,9 @@ object Emittable {
     case _: AggExplode => true
     case _ => false
   }
-  def apply(ir: IR): Boolean = Compilable(ir) && !isNonEmittableAgg(ir)
+  def apply(ir: IR): Boolean = ir match {
+    case x if isNonEmittableAgg(x) => false
+    case _: ApplyIR => false
+    case x => Compilable(x)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1137,23 +1137,6 @@ private class Emit(
                 coerce[String](StringFunctions.wrapArg(er, m.pType)(cm.v)))))),
           false,
           defaultValue(typ))
-      case ir@ApplyIR(fn, args) =>
-        assert(!ir.inline)
-        val mfield = mb.newField[Boolean]
-        val vfield = mb.newField()(typeToTypeInfo(ir.typ))
-
-        val addFields = { (newMB: EmitMethodBuilder, t: PType, v: EmitTriplet) =>
-          Code(
-            v.setup,
-            mfield := v.m,
-            mfield.mux(
-              vfield.storeAny(defaultValue(t)),
-              vfield.storeAny(v.v)))
-        }
-
-        EmitTriplet(
-          wrapToMethod(FastSeq(ir.explicitNode))(addFields),
-          mfield, vfield)
 
       case ir@Apply(fn, args, rt) =>
         val impl = ir.implementation

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -4,7 +4,9 @@ import is.hail.expr.types.virtual._
 
 object Streamify {
   def apply(ir: IR): IR = ir match {
-    case NA(t: TStreamable) => NA(TStream(t.elementType, t.required))
+    // If and NA are currently broken
+    // case NA(t: TStreamable) => NA(TStream(t.elementType, t.required))
+    // case If(c, t, e) => If(c, apply(t), apply(e))
     case MakeArray(xs, t) => MakeStream(xs, TStream(t.elementType, t.required))
     case ArrayRange(x, y, z) => StreamRange(x, y, z)
     case ArrayMap(a, n, b) => ArrayMap(apply(a), n, b)
@@ -16,7 +18,6 @@ object Streamify {
     case ArrayAggScan(a, n, q) => ArrayAggScan(apply(a), n, q)
     case RunAggScan(a, name, init, seq, res, sig) => RunAggScan(apply(a), name, init, seq, res, sig)
     case Let(n, v, b) => Let(n, v, apply(b))
-    case If(c, t, e) => If(c, apply(t), apply(e))
     case x: ReadPartition => x
     case ir => ToStream(ir)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
@@ -33,6 +33,10 @@ case object CompilableIR extends IRState {
   val rules: Array[Rule] = Array(ValueIROnly, CompilableValueIRs)
 }
 
+case object CompilableIRNoApply extends IRState {
+  val rules: Array[Rule] = Array(ValueIROnly, CompilableValueIRs, NoApplyIR)
+}
+
 case object EmittableIR extends IRState {
   val rules: Array[Rule] = Array(ValueIROnly, EmittableValueIRs)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.expr.ir.agg.Extract
-import is.hail.expr.ir.{ArrayAgg, ArrayAggScan, ArrayFor, BaseIR, Begin, BlockMatrixIR, ExecuteContext, IR, InterpretNonCompilable, Let, LowerMatrixIR, MatrixIR, Pretty, ResultOp, RewriteBottomUp, RunAgg, RunAggScan, TableIR, genUID}
+import is.hail.expr.ir.{ApplyIR, ArrayAgg, ArrayAggScan, ArrayFor, BaseIR, Begin, BlockMatrixIR, ExecuteContext, IR, InterpretNonCompilable, Let, LowerMatrixIR, MatrixIR, Pretty, ResultOp, RewriteBottomUp, RewriteTopDown, RunAgg, RunAggScan, TableIR, genUID}
 import is.hail.utils.FastSeq
 
 trait LoweringPass {
@@ -58,8 +58,19 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerTableIR.lower(ir.asInstanceOf[IR])
 }
 
-case object LowerArrayAggsToRunAggs extends LoweringPass {
+case object InlineApplyIR extends LoweringPass {
   val before: IRState = CompilableIR
+  val after: IRState = CompilableIRNoApply
+  val context: String = "InlineApplyIR"
+
+  override def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = RewriteBottomUp(ir, {
+    case x: ApplyIR => Some(x.explicitNode)
+    case _ => None
+  })
+}
+
+case object LowerArrayAggsToRunAggs extends LoweringPass {
+  val before: IRState = CompilableIRNoApply
   val after: IRState = EmittableIR
   val context: String = "LowerArrayAggsToRunAggs"
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -36,5 +36,5 @@ object LoweringPipeline {
   val legacyRelationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LegacyInterpretNonCompilablePass))
   val tableLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerTableToDistributedArrayPass))
 
-  val compileLowerer: LoweringPipeline = LoweringPipeline(Array(LowerArrayAggsToRunAggs))
+  val compileLowerer: LoweringPipeline = LoweringPipeline(Array(InlineApplyIR, LowerArrayAggsToRunAggs))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir.{BaseIR, BlockMatrixMultiWrite, BlockMatrixToTableApply, BlockMatrixToValueApply, BlockMatrixWrite, Compilable, Emittable, IR, InterpretableButNotCompilable, MatrixAggregate, MatrixIR, MatrixToValueApply, MatrixWrite, RelationalLet, RelationalLetBlockMatrix, RelationalLetMatrixTable, RelationalLetTable, RelationalRef, TableAggregate, TableCollect, TableCount, TableGetGlobals, TableToValueApply, TableWrite}
+import is.hail.expr.ir.{ApplyIR, BaseIR, BlockMatrixMultiWrite, BlockMatrixToTableApply, BlockMatrixToValueApply, BlockMatrixWrite, Compilable, Emittable, IR, InterpretableButNotCompilable, MatrixAggregate, MatrixIR, MatrixToValueApply, MatrixWrite, RelationalLet, RelationalLetBlockMatrix, RelationalLetMatrixTable, RelationalLetTable, RelationalRef, TableAggregate, TableCollect, TableCount, TableGetGlobals, TableToValueApply, TableWrite}
 
 trait Rule {
   def allows(ir: BaseIR): Boolean
@@ -24,6 +24,13 @@ case object NoRelationalLets extends Rule {
 case object CompilableValueIRs extends Rule {
   def allows(ir: BaseIR): Boolean = ir match {
     case x: IR => Compilable(x)
+    case _ => true
+  }
+}
+
+case object NoApplyIR extends Rule {
+  override def allows(ir: BaseIR): Boolean = ir match {
+    case x: ApplyIR => false
     case _ => true
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -42,7 +42,9 @@ package object ir {
 
   def defaultValue(t: PType): Code[_] = defaultValue(t.virtualType)
 
-  def defaultValue(t: Type): Code[_] = typeToTypeInfo(t) match {
+  def defaultValue(t: Type): Code[_] = defaultValue(typeToTypeInfo(t))
+
+  def defaultValue(ti: TypeInfo[_]): Code[_] = ti match {
     case UnitInfo => Code._empty[Unit]
     case BooleanInfo => false
     case IntInfo => 0
@@ -50,7 +52,7 @@ package object ir {
     case FloatInfo => 0.0f
     case DoubleInfo => 0.0
     case _: ClassInfo[_] => Code._null
-    case ti => throw new RuntimeException(s"unsupported type found: $t whose type info is $ti")
+    case ti => throw new RuntimeException(s"unsupported type found: $ti")
   }
 
   // Build consistent expression for a filter-condition with keep polarity,


### PR DESCRIPTION
We're currently emitting the explicit node (without optimization!).
This design is incrementally better, and lets us do ptyping more easily.

The right solution is to do generate a method as the node suggests, but
there are some issues to sort out here, like how to return a missing
value. We may need to return a (possibly null) pointer to an allocated
value, which could be inefficient. Pushing ptypes/requiredness fully
through the system would let us avoid this in many cases.

Stacked on #8084, don't review until that goes in.