### PR TITLE
[hail] LowerBlockMatrixIR skeleton

### DIFF
--- a/dev-docs/hail-query/linalg/block-matrix-lowering.md
+++ b/dev-docs/hail-query/linalg/block-matrix-lowering.md
@@ -11,9 +11,6 @@ necessary for the block-level computation.
 
 To construct a BlockMatrixStage, we must define the following values and 
 functions:
-
-- nRowBlocks and nColBlocks: the shape of the blocks in the BlockMatrix
-- sparsity: which blocks are defined
 - globalVals: sequence of (named) values that are shared across each context
 - ctxType: the type of the per-block context
 - blockContext(idx): a function taking the block index and returning the context IR for that block
@@ -72,3 +69,7 @@ The function returns an array of results for each block.
 The (optional) block ordering allows the result array to be computed in a 
 specific order; the function otherwise makes no guarantee about the order
 in which blocks will appear in the result array.
+
+The BlockMatrixStage doesn't store any information about the dimensions of the 
+BlockMatrix or which blocks are defined; at any point where the BlockMatrixStage 
+exists, this can be retrieved from the corresponding BlockMatrixIR.

--- a/dev-docs/hail-query/linalg/block-matrix-lowering.md
+++ b/dev-docs/hail-query/linalg/block-matrix-lowering.md
@@ -11,27 +11,26 @@ necessary for the block-level computation.
 
 - ctxRef: a handle for referring to the context
 - blockContexts: sparse map of contexts for each block
-- broadcastVals: map of (named) values that are shared across each context
+- globalVals: sequence of (named) values that are shared across each context
 - body: IR: tranformation of the block context that yields the matrix value of each block
 
-## Broadcast values
+## Global values
 
 If a value is needed in the body of the computation, such as with a relational 
-Let, it should generally be included as a broadcast value.
+Let, it should generally be included as a global value.
 
-Broadcast values are named for ease of reference; all names should be unique.
+Global values are named for ease of reference; all names should be unique.
 
-Since the broadcast values are stored as an unordered map, there is no way to 
-reference other previously defined broadcast values in a new broadcast 
-definition. The current structure of the BlockMatrixIR means that it is 
-unlikely to be necessary.
+Since global values are stored as an ordered array, previously-defined global 
+values can be referenced in the definition of new global values. The current 
+structure of the BlockMatrixIR means that it is unlikely to be necessary, though.
 
 When creating a BlockMatrixStage from other BlockMatrixStages, broadcast values
 should be preserved from all child BlockMatrixStages.
 
-### Referencing broadcast values from contexts and body
+### Referencing global values from contexts and body
 
-Broadcast values can be referenced from both block contexts and the body of the 
+Global values can be referenced from both block contexts and the body of the 
 computation using `Ref(name, value.typ)`.
 
 ## Contexts
@@ -45,7 +44,8 @@ should be minimal.
 
 If a context requires non-trivial computation, such as in `ValueToBlockMatrix`
 which creates an arbitrary NDArray, the computation itself should be stored as 
-a broadcast value and a reference to that value used in the context IR itself.
+a global value and a reference to that value used in the context IR itself. (It 
+will not be broadcast unless needed in distributed computation.)
 
 # lowering value IRs with BlockMatrixStages
 

--- a/dev-docs/hail-query/linalg/block-matrix-lowering.md
+++ b/dev-docs/hail-query/linalg/block-matrix-lowering.md
@@ -1,0 +1,69 @@
+# Overview
+
+This document describes the process for computations represented by BlockMatrixIR 
+nodes into computations represented by value IR nodes using CollectDistributedArray.
+
+# BlockMatrixStage
+
+BlockMatrixStage is the intermediate representation for a lowered BlockMatrix. It 
+represents the block structure of a BlockMatrixIR node as well as all information 
+necessary for the block-level computation.
+
+- ctxRef: a handle for referring to the context
+- blockContexts: sparse map of contexts for each block
+- broadcastVals: map of (named) values that are shared across each context
+- body: IR: tranformation of the block context that yields the matrix value of each block
+
+## Broadcast values
+
+If a value is needed in the body of the computation, such as with a relational 
+Let, it should generally be included as a broadcast value.
+
+Broadcast values are named for ease of reference; all names should be unique.
+
+Since the broadcast values are stored as an unordered map, there is no way to 
+reference other previously defined broadcast values in a new broadcast 
+definition. The current structure of the BlockMatrixIR means that it is 
+unlikely to be necessary.
+
+When creating a BlockMatrixStage from other BlockMatrixStages, broadcast values
+should be preserved from all child BlockMatrixStages.
+
+### Referencing broadcast values from contexts and body
+
+Broadcast values can be referenced from both block contexts and the body of the 
+computation using `Ref(name, value.typ)`.
+
+## Contexts
+
+Each block in a BlockMatrixIR node will need to define its own context as 
+a value IR node.
+
+Since any given block context could be used multiple times in downstream lowering 
+transformations (e.g. multiply), the actual IR constructed for any given context
+should be minimal.
+
+If a context requires non-trivial computation, such as in `ValueToBlockMatrix`
+which creates an arbitrary NDArray, the computation itself should be stored as 
+a broadcast value and a reference to that value used in the context IR itself.
+
+# lowering value IRs with BlockMatrixStages
+
+BlockMatrixStage generates a value IR node which executes all block computations and
+returns the results as a (sparse) array. The primary way for doing this is with the
+function:
+
+```
+toIR(bodyTranform: IR => IR, ordering: Option[Array[(Int, Int)]]): IR
+```
+
+The bodyTransform function should return the (minimal) value from each block 
+necessary to evaluate that node; a `BlockMatrixCollect`, for example, will need 
+the entire NDArray, but a `BlockMatrixWrite` operation might only need to know 
+the filename where the data got written, and perhaps the block indices.
+
+The function returns an array of results for each block.
+
+The (optional) block ordering allows the result array to be computed in a 
+specific order; the function otherwise makes no guarantee about the order
+in which blocks will appear in the result array.

--- a/dev-docs/hail-query/linalg/block-matrix-lowering.md
+++ b/dev-docs/hail-query/linalg/block-matrix-lowering.md
@@ -9,10 +9,15 @@ BlockMatrixStage is the intermediate representation for a lowered BlockMatrix. I
 represents the block structure of a BlockMatrixIR node as well as all information 
 necessary for the block-level computation.
 
-- ctxRef: a handle for referring to the context
-- blockContexts: sparse map of contexts for each block
+To construct a BlockMatrixStage, we must define the following values and 
+functions:
+
+- nRowBlocks and nColBlocks: the shape of the blocks in the BlockMatrix
+- sparsity: which blocks are defined
 - globalVals: sequence of (named) values that are shared across each context
-- body: IR: tranformation of the block context that yields the matrix value of each block
+- ctxType: the type of the per-block context
+- blockContext(idx): a function taking the block index and returning the context IR for that block
+- blockBody(ctxRef): a function tranforming the block context into the matrix value of each block
 
 ## Global values
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -826,6 +826,7 @@ class HailFeatureFlags {
   private[this] val flags: mutable.Map[String, String] =
     mutable.Map[String, String](
       "lower" -> sys.env.getOrElse("HAIL_DEV_LOWER", null),
+      "lower_bm" -> sys.env.getOrElse("HAIL_DEV_LOWER_BM", null),
       "max_leader_scans" -> sys.env.getOrElse("HAIL_DEV_MAX_LEADER_SCANS", "1000"),
       "jvm_bytecode_dump" -> sys.env.getOrElse("HAIL_DEV_JVM_BYTECODE_DUMP", null)
     )

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -263,7 +263,7 @@ sealed trait NDArrayIR extends TypedIR[TNDArray, PNDArray] {
 object MakeNDArray {
   def fill(elt: IR, shape: IndexedSeq[Long], rowMajor: IR): MakeNDArray =
     MakeNDArray(
-      ArrayMap(StreamRange(0, shape.product, 1), genUID(), elt),
+      ToArray(StreamMap(StreamRange(0, shape.product, 1), genUID(), elt)),
       MakeTuple.ordered(shape.map(I64)), rowMajor)
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -263,7 +263,7 @@ sealed trait NDArrayIR extends TypedIR[TNDArray, PNDArray] {
 object MakeNDArray {
   def fill(elt: IR, shape: IndexedSeq[Long], rowMajor: IR): MakeNDArray =
     MakeNDArray(
-      ArrayMap(ArrayRange(0, shape.product, 1), genUID(), elt),
+      ArrayMap(StreamRange(0, shape.product, 1), genUID(), elt),
       MakeTuple.ordered(shape.map(I64)), rowMajor)
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -260,6 +260,13 @@ sealed trait NDArrayIR extends TypedIR[TNDArray, PNDArray] {
   def elementTyp: Type = typ.elementType
 }
 
+object MakeNDArray {
+  def fill(elt: IR, shape: IndexedSeq[Long], rowMajor: IR): MakeNDArray =
+    MakeNDArray(
+      ArrayMap(ArrayRange(0, shape.product, 1), genUID(), elt),
+      MakeTuple.ordered(shape.map(I64)), rowMajor)
+}
+
 final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends NDArrayIR
 
 final case class NDArrayShape(nd: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
@@ -25,8 +25,13 @@ case object MatrixLoweredToTable extends IRState {
   val rules: Array[Rule] = Array(NoMatrixIR)
 }
 
-case object BlockMatrixOnly extends IRState {
-  val rules: Array[Rule] = Array(NoMatrixIR, NoTableIR)
+
+case class LowerableToDArray(t: DArrayLowering.Type) extends IRState {
+  val rules: Array[Rule] = t match {
+    case DArrayLowering.All => Array(NoMatrixIR)
+    case DArrayLowering.TableOnly => Array(NoMatrixIR, NoBlockMatrixIR)
+    case DArrayLowering.BMOnly => Array(NoMatrixIR, NoTableIR)
+  }
 }
 
 case object ExecutableTableIR extends IRState {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
@@ -25,6 +25,10 @@ case object MatrixLoweredToTable extends IRState {
   val rules: Array[Rule] = Array(NoMatrixIR)
 }
 
+case object BlockMatrixOnly extends IRState {
+  val rules: Array[Rule] = Array(NoMatrixIR, NoTableIR)
+}
+
 case object ExecutableTableIR extends IRState {
   val rules: Array[Rule] = Array(NoMatrixIR, NoRelationalLets, CompilableValueIRs)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/IRState.scala
@@ -25,15 +25,6 @@ case object MatrixLoweredToTable extends IRState {
   val rules: Array[Rule] = Array(NoMatrixIR)
 }
 
-
-case class LowerableToDArray(t: DArrayLowering.Type) extends IRState {
-  val rules: Array[Rule] = t match {
-    case DArrayLowering.All => Array(NoMatrixIR)
-    case DArrayLowering.TableOnly => Array(NoMatrixIR, NoBlockMatrixIR)
-    case DArrayLowering.BMOnly => Array(NoMatrixIR, NoTableIR)
-  }
-}
-
 case object ExecutableTableIR extends IRState {
   val rules: Array[Rule] = Array(NoMatrixIR, NoRelationalLets, CompilableValueIRs)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -71,8 +71,8 @@ object LowerBlockMatrixIR {
       } else {
         val i = Ref(genUID(), TInt32())
         val j = Ref(genUID(), TInt32())
-        val cols = ArrayMap(ArrayRange(0, child.typ.nColBlocks, 1), j.name, ArrayRef(blockResults, i * child.typ.nColBlocks + j))
-        ArrayMap(ArrayRange(0, child.typ.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1))
+        val cols = ArrayMap(StreamRange(0, child.typ.nColBlocks, 1), j.name, ArrayRef(blockResults, i * child.typ.nColBlocks + j))
+        ArrayMap(StreamRange(0, child.typ.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1))
       }
       Let(blockResults.name, cda, NDArrayConcat(rows, 0))
     case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -1,0 +1,105 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.expr.ir._
+import is.hail.expr.ir.functions.GetElement
+import is.hail.expr.types.virtual._
+import is.hail.utils.FastIndexedSeq
+
+case class BlockMatrixStage(
+  ctxRef: Ref,
+  blockContexts: Map[(Int, Int), IR],
+  broadcastVals: Map[String, IR], //needed for relational lets
+  body: IR) {
+  def ctxName: String = ctxRef.name
+  def ctxType: Type = ctxRef.typ
+  def toIR(bodyTransform: IR => IR, ordering: Option[Array[(Int, Int)]]): IR = {
+    val bc = MakeStruct(broadcastVals.toArray)
+    val bcRef = Ref(genUID(), bc.typ)
+    val ctxs = ordering.map { idxs =>
+      idxs.map { case (i, j) => blockContexts(i -> j) }
+    }.getOrElse { blockContexts.values.toArray }
+    val bcFields = coerce[TStruct](bc.typ).fieldNames
+    val wrappedBody = bcFields.foldLeft(bodyTransform(body)) { (accum, f) =>
+      Let(f, GetField(bcRef, f), accum)
+    }
+    CollectDistributedArray(MakeArray(ctxs, TArray(ctxRef.typ)), bc, ctxRef.name, bcRef.name, wrappedBody)
+  }
+}
+
+object LowerBlockMatrixIR {
+
+  def unimplemented[T](node: BaseIR): T =
+    throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
+
+  def lower(node: IR): IR = node match {
+//    case BlockMatrixCollect(child: BlockMatrixIR) =>
+    case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)
+    case BlockMatrixWrite(child, writer) => unimplemented(node)
+    case BlockMatrixMultiWrite(blockMatrices, writer) => unimplemented(node)
+    case node if node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
+      throw new LowererUnsupportedOperation(s"IR nodes with BlockMatrixIR children need explicit rules: \n${ Pretty(node) }")
+
+    case node =>
+      throw new LowererUnsupportedOperation(s"Value IRs with no BlockMatrixIR children must be lowered through LowerIR: \n${ Pretty(node) }")
+  }
+
+  def lower(bmir: BlockMatrixIR): BlockMatrixStage = bmir match {
+    case BlockMatrixRead(reader) => unimplemented(bmir)
+    case ValueToBlockMatrix(child, shape, blockSize) => unimplemented(bmir)
+    case x: BlockMatrixLiteral => unimplemented(bmir)
+    case BlockMatrixMap(child, eltName, f) => unimplemented(bmir)
+    case BlockMatrixMap2(left, right, lname, rname, f) => unimplemented(bmir)
+    case BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize) => unimplemented(bmir)
+    case BlockMatrixAgg(child, outIndexExpr) => unimplemented(bmir)
+    case BlockMatrixFilter(child, keep) => unimplemented(bmir)
+    case BlockMatrixSlice(child, slices) => unimplemented(bmir)
+    case BlockMatrixDensify(child) => unimplemented(bmir)
+    case BlockMatrixSparsify(child, value, sparsifier) => unimplemented(bmir)
+    case RelationalLetBlockMatrix(name, value, body) => unimplemented(bmir)
+    case x@BlockMatrixDot(leftIR, rightIR) =>
+      val left = lower(leftIR)
+      val right = lower(rightIR)
+      val (_, n) = leftIR.typ.defaultBlockShape
+
+      val newCtxType = TArray(TStruct(
+        left.ctxName -> TArray(left.ctxType),
+        right.ctxName -> TArray(right.ctxType)))
+
+      // group blocks for multiply
+      // the contexts that we're parallelizing, *in general*, are going to involve little-to-no computation so duplicating across nodes seems fine for now.
+      val newContexts = x.typ.allBlocks.map { case (i, j) =>
+        (i -> j, MakeArray(Array.tabulate[Option[IR]](n) { k =>
+          left.blockContexts.get(i -> k).flatMap { leftCtx =>
+            right.blockContexts.get(k -> j).map { rightCtx =>
+              MakeStruct(FastIndexedSeq(
+                left.ctxName -> leftCtx,
+                right.ctxName -> rightCtx))
+            }
+          }
+        }.flatten, newCtxType))
+      }.toMap
+
+      val wrapMultiply = { ctxElt: IR =>
+        Let(left.ctxName, GetField(ctxElt, left.ctxName),
+          Let(right.ctxName, GetField(ctxElt, right.ctxName),
+            NDArrayMatMul(left.body, right.body)))
+      }
+
+      // computation for multiply
+      val ctxRef = Ref(genUID(), newCtxType)
+      val zero = wrapMultiply(ArrayRef(ctxRef, 0))
+      val tail = invoke("[*:]", newCtxType, ctxRef, 1)
+      val elt = Ref(genUID(), newCtxType.elementType)
+      val accum = Ref(genUID(), zero.typ)
+      val l = Ref(genUID(), TFloat64())
+      val r = Ref(genUID(), TFloat64())
+      val newBody = ArrayFold(tail, zero, accum.name, elt.name,
+        NDArrayMap2(accum, wrapMultiply(elt), l.name, r.name, ApplyBinaryPrimOp(Add(), l, r)))
+
+      BlockMatrixStage(
+        ctxRef,
+        newContexts,
+        left.broadcastVals ++ right.broadcastVals,
+        newBody)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -1,9 +1,28 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.expr.Nat
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.GetElement
 import is.hail.expr.types.virtual._
-import is.hail.utils.FastIndexedSeq
+import is.hail.utils.{FastIndexedSeq, FastSeq}
+
+object BlockMatrixStage {
+  def apply(blockContexts: Map[(Int, Int), IR], globalVals: Array[(String, IR)])(body: Ref => IR): BlockMatrixStage = {
+    assert(blockContexts.nonEmpty)
+    assert(blockContexts.values.reduce((c1, c2) => c1.typ.isOfType(c2.typ)))
+    val ctxRef = Ref(genUID(), blockContexts.values.head.typ)
+    BlockMatrixStage(ctxRef, blockContexts, globalVals, body(ctxRef))
+  }
+
+  def empty(eltType: Type): BlockMatrixStage = {
+    BlockMatrixStage(
+      Ref(genUID(), TInt32()),
+      Map.empty,
+      Array.empty,
+      NA(TNDArray(eltType, Nat(2))))
+  }
+
+}
 
 case class BlockMatrixStage(
   ctxRef: Ref,
@@ -13,11 +32,12 @@ case class BlockMatrixStage(
   def ctxName: String = ctxRef.name
   def ctxType: Type = ctxRef.typ
   def toIR(bodyTransform: IR => IR, ordering: Option[Array[(Int, Int)]]): IR = {
+    if (blockContexts.isEmpty)
+      MakeArray(FastSeq(), TArray(bodyTransform(body).typ))
     val ctxs = MakeArray(
       ordering.map[Array[IR]](idxs => idxs.map(blockContexts(_)))
         .getOrElse[Array[IR]](blockContexts.values.toArray),
       TArray(ctxRef.typ))
-
     val blockResult = bodyTransform(body)
     val bcFields = globalVals.filter { case (f, _) => Mentions(blockResult, f) }
     val bcVals = MakeStruct(bcFields.map { case (f, v) => f -> Ref(f, v.typ) })
@@ -36,7 +56,47 @@ object LowerBlockMatrixIR {
     throw new LowererUnsupportedOperation(s"unimplemented: \n${ Pretty(node) }")
 
   def lower(node: IR): IR = node match {
-//    case BlockMatrixCollect(child: BlockMatrixIR) =>
+    case BlockMatrixCollect(child) =>
+      val bm = lower(child)
+      val nRowBlocks = child.typ.nRowBlocks
+      val nColBlocks = child.typ.nColBlocks
+      val r = Ref(genUID(), bm.body.typ)
+      val c = Ref(genUID(), bm.body.typ)
+      val blocks = Ref(genUID(), TArray(bm.body.typ))
+      if (child.typ.isSparse) {
+        val zeros = MakeNDArray(
+          ArrayMap(ArrayRange(0, child.typ.blockSize ^ 2, 1), genUID(), F64(0.0)),
+          MakeTuple.ordered(FastSeq(I64(child.typ.blockSize), I64(child.typ.blockSize))),
+          True())
+        val order = bm.blockContexts.keys.toArray
+        val map = order.zipWithIndex.toMap
+        val cda = bm.toIR(b => b, Some(order))
+        Let(blocks.name, cda,
+          NDArrayConcat(
+            MakeArray(Array.tabulate(nRowBlocks) { i =>
+              NDArrayConcat(
+                MakeArray(Array.tabulate(nColBlocks) { j =>
+                  map.get(i -> j)
+                    .map[IR](idx => ArrayRef(blocks, idx))
+                    .getOrElse(zeros)
+                }, cda.typ), 1)
+            }, cda.typ), 0))
+
+      } else {
+        val rowMajor = Array.range(0, nRowBlocks)
+          .flatMap(i => Array.tabulate(nColBlocks)(j => i -> j))
+        val cda = bm.toIR(b => b, Some(rowMajor))
+        Let(blocks.name, cda,
+          NDArrayConcat(
+            ArrayMap(
+              ArrayRange(0, nRowBlocks, 1),
+              r.name,
+              NDArrayConcat(
+                ArrayMap(ArrayRange(0, nColBlocks, 1), c.name,
+                  ArrayRef(blocks, (r * nColBlocks) + c)
+                ), 1)), 0))
+      }
+
     case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)
     case BlockMatrixWrite(child, writer) => unimplemented(node)
     case BlockMatrixMultiWrite(blockMatrices, writer) => unimplemented(node)
@@ -47,12 +107,17 @@ object LowerBlockMatrixIR {
       throw new LowererUnsupportedOperation(s"Value IRs with no BlockMatrixIR children must be lowered through LowerIR: \n${ Pretty(node) }")
   }
 
-  def lower(bmir: BlockMatrixIR): BlockMatrixStage = bmir match {
+  def lower(bmir: BlockMatrixIR): BlockMatrixStage = {
+    if (bmir.typ.nDefinedBlocks == 0)
+      BlockMatrixStage.empty(bmir.typ.elementType)
+    else lowerNonEmpty(bmir)
+  }
+
+  def lowerNonEmpty(bmir: BlockMatrixIR): BlockMatrixStage = bmir match {
     case BlockMatrixRead(reader) => unimplemented(bmir)
-    case ValueToBlockMatrix(child, shape, blockSize) => unimplemented(bmir)
     case x: BlockMatrixLiteral => unimplemented(bmir)
-    case BlockMatrixMap(child, eltName, f) => unimplemented(bmir)
-    case BlockMatrixMap2(left, right, lname, rname, f) => unimplemented(bmir)
+    case BlockMatrixMap(child, eltName, f, needsDense) => unimplemented(bmir)
+    case BlockMatrixMap2(left, right, lname, rname, f, sparsityStrategy) => unimplemented(bmir)
     case BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize) => unimplemented(bmir)
     case BlockMatrixAgg(child, outIndexExpr) => unimplemented(bmir)
     case BlockMatrixFilter(child, keep) => unimplemented(bmir)
@@ -60,6 +125,18 @@ object LowerBlockMatrixIR {
     case BlockMatrixDensify(child) => unimplemented(bmir)
     case BlockMatrixSparsify(child, sparsifier) => unimplemented(bmir)
     case RelationalLetBlockMatrix(name, value, body) => unimplemented(bmir)
+    case ValueToBlockMatrix(child, shape, blockSize) if !child.typ.isInstanceOf[TArray] =>
+      throw new LowererUnsupportedOperation("use explicit broadcast for scalars!")
+    case x@ValueToBlockMatrix(child, _, blockSize) => // row major or scalar
+      val v = Ref(genUID(), child.typ)
+      val ctxs = x.typ.allBlocks.map { case (i, j) =>
+        val slice = NDArraySlice(v,
+          MakeTuple.ordered(FastSeq(
+            MakeTuple.ordered(FastSeq[IR](i.toLong * blockSize, (i.toLong + 1) * blockSize, 1L)),
+            MakeTuple.ordered(FastSeq[IR](j.toLong * blockSize, (j.toLong + 1) * blockSize, 1L)))))
+        (i -> j, slice)
+      }.toMap
+      BlockMatrixStage(ctxs, Array(v.name -> child)) { ref: Ref => ref }
     case x@BlockMatrixDot(leftIR, rightIR) =>
       val left = lower(leftIR)
       val right = lower(rightIR)
@@ -94,10 +171,10 @@ object LowerBlockMatrixIR {
       val tail = invoke("[*:]", newCtxType, ctxRef, 1)
       val elt = Ref(genUID(), newCtxType.elementType)
       val accum = Ref(genUID(), zero.typ)
-      val l = Ref(genUID(), TFloat64())
-      val r = Ref(genUID(), TFloat64())
+      val l = Ref(genUID(), leftIR.typ.elementType)
+      val r = Ref(genUID(), rightIR.typ.elementType)
       val newBody = ArrayFold(tail, zero, accum.name, elt.name,
-        NDArrayMap2(accum, wrapMultiply(elt), l.name, r.name, ApplyBinaryPrimOp(Add(), l, r)))
+        NDArrayMap2(accum, wrapMultiply(elt), l.name, r.name, l + r))
 
       BlockMatrixStage(
         ctxRef,

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -3,46 +3,48 @@ package is.hail.expr.ir.lowering
 import is.hail.expr.Nat
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.GetElement
+import is.hail.expr.types.BlockMatrixSparsity
 import is.hail.expr.types.virtual._
 import is.hail.utils.{FastIndexedSeq, FastSeq}
 
 object BlockMatrixStage {
-  def apply(blockContexts: Map[(Int, Int), IR], globalVals: Array[(String, IR)])(body: Ref => IR): BlockMatrixStage = {
-    assert(blockContexts.nonEmpty)
-    assert(blockContexts.values.reduce((c1, c2) => c1.typ.isOfType(c2.typ)))
-    val ctxRef = Ref(genUID(), blockContexts.values.head.typ)
-    BlockMatrixStage(ctxRef, blockContexts, globalVals, body(ctxRef))
-  }
-
-  def empty(eltType: Type): BlockMatrixStage = {
-    BlockMatrixStage(
-      Ref(genUID(), TInt32()),
-      Map.empty,
-      Array.empty,
-      NA(TNDArray(eltType, Nat(2))))
-  }
-
+  def empty(eltType: Type, nr: Int, nc: Int): BlockMatrixStage =
+    EmptyBlockMatrixStage(nr, nc, eltType)
 }
 
-case class BlockMatrixStage(
-  ctxRef: Ref,
-  blockContexts: Map[(Int, Int), IR],
-  globalVals: Array[(String, IR)], //needed for relational lets
-  body: IR) {
-  def ctxName: String = ctxRef.name
-  def ctxType: Type = ctxRef.typ
-  def toIR(bodyTransform: IR => IR, ordering: Option[Array[(Int, Int)]]): IR = {
-    if (blockContexts.isEmpty)
-      MakeArray(FastSeq(), TArray(bodyTransform(body).typ))
-    val ctxs = MakeArray(
-      ordering.map[Array[IR]](idxs => idxs.map(blockContexts(_)))
-        .getOrElse[Array[IR]](blockContexts.values.toArray),
-      TArray(ctxRef.typ))
-    val blockResult = bodyTransform(body)
-    val bcFields = globalVals.filter { case (f, _) => Mentions(blockResult, f) }
+case class EmptyBlockMatrixStage(override val nRowBlocks: Int, override val nColBlocks: Int, eltType: Type) extends BlockMatrixStage(
+  nRowBlocks, nColBlocks,
+  BlockMatrixSparsity(Some(FastIndexedSeq())),
+  Array(), TInt32()) {
+  def blockContext(idx: (Int, Int)): IR =
+    throw new LowererUnsupportedOperation("empty stage has no block contexts!")
+  def blockBody(ctxRef: Ref): IR = NA(TNDArray(eltType, Nat(2)))
+  override def collectBlocks(f: IR => IR, blocksToCollect: Array[(Int, Int)]): IR = {
+    assert(blocksToCollect.isEmpty)
+    MakeArray(FastSeq(), TArray(f(blockBody(Ref("x", ctxType))).typ))
+  }
+}
+
+abstract class BlockMatrixStage(
+  val nRowBlocks: Int, val nColBlocks: Int,
+  val sparsity: BlockMatrixSparsity,
+  val globalVals: Array[(String, IR)],
+  val ctxType: Type
+) {
+  def blockContext(idx: (Int, Int)): IR
+  def blockBody(ctxRef: Ref): IR
+  lazy val blocks: IndexedSeq[(Int, Int)] = sparsity.allBlocks(nRowBlocks, nColBlocks)
+
+  def defines(idx: (Int, Int)): Boolean = sparsity.hasBlock(idx)
+  def collectBlocks(f: IR => IR, blocksToCollect: Array[(Int, Int)]): IR = {
+    assert(blocksToCollect.forall(b => defines(b)))
+    val ctxRef = Ref(genUID(), ctxType)
+    val body = f(blockBody(ctxRef))
+    val ctxs = MakeArray(blocksToCollect.map(idx => blockContext(idx)), TArray(ctxRef.typ))
+    val bcFields = globalVals.filter { case (f, _) => Mentions(body, f) }
     val bcVals = MakeStruct(bcFields.map { case (f, v) => f -> Ref(f, v.typ) })
     val bcRef = Ref(genUID(), bcVals.typ)
-    val wrappedBody = bcFields.foldLeft(blockResult) { case (accum, (f, _)) =>
+    val wrappedBody = bcFields.foldLeft(body) { case (accum, (f, _)) =>
       Let(f, GetField(bcRef, f), accum)
     }
     val collect = CollectDistributedArray(ctxs, bcVals, ctxRef.name, bcRef.name, wrappedBody)
@@ -58,45 +60,31 @@ object LowerBlockMatrixIR {
   def lower(node: IR): IR = node match {
     case BlockMatrixCollect(child) =>
       val bm = lower(child)
-      val nRowBlocks = child.typ.nRowBlocks
-      val nColBlocks = child.typ.nColBlocks
-      val r = Ref(genUID(), bm.body.typ)
-      val c = Ref(genUID(), bm.body.typ)
-      val blocks = Ref(genUID(), TArray(bm.body.typ))
-      if (child.typ.isSparse) {
-        val zeros = MakeNDArray(
-          ArrayMap(ArrayRange(0, child.typ.blockSize ^ 2, 1), genUID(), F64(0.0)),
-          MakeTuple.ordered(FastSeq(I64(child.typ.blockSize), I64(child.typ.blockSize))),
-          True())
-        val order = bm.blockContexts.keys.toArray
-        val map = order.zipWithIndex.toMap
-        val cda = bm.toIR(b => b, Some(order))
-        Let(blocks.name, cda,
-          NDArrayConcat(
-            MakeArray(Array.tabulate(nRowBlocks) { i =>
-              NDArrayConcat(
-                MakeArray(Array.tabulate(nColBlocks) { j =>
-                  map.get(i -> j)
-                    .map[IR](idx => ArrayRef(blocks, idx))
-                    .getOrElse(zeros)
-                }, cda.typ), 1)
-            }, cda.typ), 0))
-
-      } else {
-        val rowMajor = Array.range(0, nRowBlocks)
-          .flatMap(i => Array.tabulate(nColBlocks)(j => i -> j))
-        val cda = bm.toIR(b => b, Some(rowMajor))
-        Let(blocks.name, cda,
-          NDArrayConcat(
-            ArrayMap(
-              ArrayRange(0, nRowBlocks, 1),
-              r.name,
-              NDArrayConcat(
-                ArrayMap(ArrayRange(0, nColBlocks, 1), c.name,
-                  ArrayRef(blocks, (r * nColBlocks) + c)
-                ), 1)), 0))
+      val blocksRowMajor = Array.range(0, bm.nRowBlocks).flatMap { i =>
+        Array.range(0, bm.nColBlocks).flatMap { j => Some(i -> j).filter(bm.defines) }
       }
+      val cda = bm.collectBlocks(b => b, blocksRowMajor)
+      val blockResults = Ref(genUID(), cda.typ)
 
+      val rows = if (bm.sparsity.isSparse) {
+        val blockMap = blocksRowMajor.zipWithIndex.toMap
+        MakeArray(Array.tabulate[IR](bm.nRowBlocks) { i =>
+          NDArrayConcat(MakeArray(Array.tabulate[IR](bm.nColBlocks) { j =>
+            if (blockMap.contains(i -> j))
+              ArrayRef(blockResults, i * bm.nColBlocks + j)
+            else {
+              val (nRows, nCols) = child.typ.blockShape(i, j)
+              MakeNDArray.fill(zero(child.typ.elementType), FastIndexedSeq(nRows, nCols), True())
+            }
+          }, coerce[TArray](cda.typ)), 1)
+        }, coerce[TArray](cda.typ))
+      } else {
+        val i = Ref(genUID(), TInt32())
+        val j = Ref(genUID(), TInt32())
+        val cols = ArrayMap(ArrayRange(0, bm.nColBlocks, 1), j.name, ArrayRef(blockResults, i * bm.nColBlocks + j))
+        ArrayMap(ArrayRange(0, bm.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1))
+      }
+      Let(blockResults.name, cda, NDArrayConcat(rows, 0))
     case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)
     case BlockMatrixWrite(child, writer) => unimplemented(node)
     case BlockMatrixMultiWrite(blockMatrices, writer) => unimplemented(node)
@@ -109,7 +97,7 @@ object LowerBlockMatrixIR {
 
   def lower(bmir: BlockMatrixIR): BlockMatrixStage = {
     if (bmir.typ.nDefinedBlocks == 0)
-      BlockMatrixStage.empty(bmir.typ.elementType)
+      BlockMatrixStage.empty(bmir.typ.elementType, bmir.typ.nRowBlocks, bmir.typ.nColBlocks)
     else lowerNonEmpty(bmir)
   }
 
@@ -128,58 +116,57 @@ object LowerBlockMatrixIR {
     case ValueToBlockMatrix(child, shape, blockSize) if !child.typ.isInstanceOf[TArray] =>
       throw new LowererUnsupportedOperation("use explicit broadcast for scalars!")
     case x@ValueToBlockMatrix(child, _, blockSize) => // row major or scalar
-      val v = Ref(genUID(), child.typ)
-      val ctxs = x.typ.allBlocks.map { case (i, j) =>
-        val slice = NDArraySlice(v,
-          MakeTuple.ordered(FastSeq(
-            MakeTuple.ordered(FastSeq[IR](i.toLong * blockSize, (i.toLong + 1) * blockSize, 1L)),
-            MakeTuple.ordered(FastSeq[IR](j.toLong * blockSize, (j.toLong + 1) * blockSize, 1L)))))
-        (i -> j, slice)
-      }.toMap
-      BlockMatrixStage(ctxs, Array(v.name -> child)) { ref: Ref => ref }
+      val nd = MakeNDArray(child, MakeTuple.ordered(FastSeq(I64(x.typ.nRows), I64(x.typ.nCols))), True())
+      val v = Ref(genUID(), nd.typ)
+      new BlockMatrixStage(
+        x.typ.nRowBlocks, x.typ.nColBlocks,
+        x.typ.sparsity,
+        Array(v.name -> nd),
+        nd.typ) {
+        def blockContext(idx: (Int, Int)): IR = {
+          val (r, c) = idx
+          NDArraySlice(v, MakeTuple.ordered(FastSeq(
+            MakeTuple.ordered(FastSeq(I64(r.toLong * blockSize), I64(java.lang.Math.min((r.toLong + 1) * blockSize, x.typ.nRows)), I64(1))),
+            MakeTuple.ordered(FastSeq(I64(c.toLong * blockSize), I64(java.lang.Math.min((c.toLong + 1) * blockSize, x.typ.nCols)), I64(1))))))
+        }
+        def blockBody(ctxRef: Ref): IR = ctxRef
+      }
     case x@BlockMatrixDot(leftIR, rightIR) =>
       val left = lower(leftIR)
       val right = lower(rightIR)
-      val (_, n) = leftIR.typ.defaultBlockShape
-
-      val newCtxType = TArray(TStruct(
-        left.ctxName -> TArray(left.ctxType),
-        right.ctxName -> TArray(right.ctxType)))
-
-      // group blocks for multiply
-      val newContexts = x.typ.allBlocks.map { case (i, j) =>
-        (i -> j, MakeArray(Array.tabulate[Option[IR]](n) { k =>
-          left.blockContexts.get(i -> k).flatMap { leftCtx =>
-            right.blockContexts.get(k -> j).map { rightCtx =>
-              MakeStruct(FastIndexedSeq(
-                left.ctxName -> leftCtx,
-                right.ctxName -> rightCtx))
-            }
-          }
-        }.flatten[IR], newCtxType))
-      }.toMap
-
-      val wrapMultiply = { ctxElt: IR =>
-        Let(left.ctxName, GetField(ctxElt, left.ctxName),
-          Let(right.ctxName, GetField(ctxElt, right.ctxName),
-            NDArrayMatMul(left.body, right.body)))
-      }
-
-      // computation for multiply
-      val ctxRef = Ref(genUID(), newCtxType)
-      val zero = wrapMultiply(ArrayRef(ctxRef, 0))
-      val tail = invoke("[*:]", newCtxType, ctxRef, 1)
-      val elt = Ref(genUID(), newCtxType.elementType)
-      val accum = Ref(genUID(), zero.typ)
-      val l = Ref(genUID(), leftIR.typ.elementType)
-      val r = Ref(genUID(), rightIR.typ.elementType)
-      val newBody = ArrayFold(tail, zero, accum.name, elt.name,
-        NDArrayMap2(accum, wrapMultiply(elt), l.name, r.name, l + r))
-
-      BlockMatrixStage(
-        ctxRef,
-        newContexts,
+      val newCtxType = TArray(TTuple(left.ctxType, right.ctxType))
+      new BlockMatrixStage(
+        x.typ.nRowBlocks, x.typ.nColBlocks,
+        x.typ.sparsity,
         left.globalVals ++ right.globalVals,
-        newBody)
+        newCtxType) {
+        def blockContext(idx: (Int, Int)): IR = {
+          val (i, j) = idx
+          MakeArray(Array.tabulate[Option[IR]](left.nColBlocks) { k =>
+            if (left.defines(i -> k) && right.defines(k -> j))
+              Some(MakeTuple.ordered(FastSeq(
+                left.blockContext(i -> k), right.blockContext(k -> j))))
+            else None
+          }.flatten[IR], newCtxType)
+        }
+
+        def blockBody(ctxRef: Ref): IR = {
+          val ctxEltRef = Ref(genUID(), newCtxType.elementType)
+          val leftRef = Ref(genUID(), left.ctxType)
+          val rightRef = Ref(genUID(), right.ctxType)
+
+          val blockMultiply = Let(leftRef.name, GetTupleElement(ctxEltRef, 0),
+            Let(rightRef.name, GetTupleElement(ctxEltRef, 1),
+              NDArrayMatMul(left.blockBody(leftRef), right.blockBody(rightRef))))
+
+          val sumRef = Ref(genUID(), blockMultiply.typ)
+          ArrayFold(invoke("[*:]", ctxType, ctxRef, I32(1)),
+            Let(ctxEltRef.name, ArrayRef(ctxRef, 0), blockMultiply),
+            sumRef.name,
+            ctxEltRef.name,
+            NDArrayMap2(sumRef, blockMultiply, "l", "r",
+              Ref("l", x.typ.elementType) + Ref("r", x.typ.elementType)))
+        }
+      }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -32,7 +32,7 @@ abstract class BlockMatrixStage(val globalVals: Array[(String, IR)], val ctxType
   def collectBlocks(f: IR => IR, blocksToCollect: Array[(Int, Int)]): IR = {
     val ctxRef = Ref(genUID(), ctxType)
     val body = f(blockBody(ctxRef))
-    val ctxs = MakeArray(blocksToCollect.map(idx => blockContext(idx)), TArray(ctxRef.typ))
+    val ctxs = MakeStream(blocksToCollect.map(idx => blockContext(idx)), TStream(ctxRef.typ))
     val bodyFreeVars = FreeVariables(body, supportsAgg = false, supportsScan = false)
     val bcFields = globalVals.filter { case (f, _) => bodyFreeVars.eval.lookupOption(f).isDefined }
     val bcVals = MakeStruct(bcFields.map { case (f, v) => f -> Ref(f, v.typ) })

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -71,8 +71,8 @@ object LowerBlockMatrixIR {
       } else {
         val i = Ref(genUID(), TInt32())
         val j = Ref(genUID(), TInt32())
-        val cols = ArrayMap(StreamRange(0, child.typ.nColBlocks, 1), j.name, ArrayRef(blockResults, i * child.typ.nColBlocks + j))
-        ArrayMap(StreamRange(0, child.typ.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1))
+        val cols = ToArray(StreamMap(StreamRange(0, child.typ.nColBlocks, 1), j.name, ArrayRef(blockResults, i * child.typ.nColBlocks + j)))
+        ToArray(StreamMap(StreamRange(0, child.typ.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1)))
       }
       Let(blockResults.name, cda, NDArrayConcat(rows, 0))
     case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)
@@ -144,7 +144,7 @@ object LowerBlockMatrixIR {
               NDArrayMatMul(left.blockBody(leftRef), right.blockBody(rightRef))))
 
           val sumRef = Ref(genUID(), blockMultiply.typ)
-          ArrayFold(invoke("[*:]", ctxType, ctxRef, I32(1)),
+          StreamFold(ToStream(invoke("[*:]", ctxType, ctxRef, I32(1))),
             Let(ctxEltRef.name, ArrayRef(ctxRef, 0), blockMultiply),
             sumRef.name,
             ctxEltRef.name,

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -12,7 +12,7 @@ object BlockMatrixStage {
     EmptyBlockMatrixStage(eltType)
 }
 
-case class EmptyBlockMatrixStage(eltType: Type) extends BlockMatrixStage(Array(), TInt32()) {
+case class EmptyBlockMatrixStage(eltType: Type) extends BlockMatrixStage(Array(), TInt32) {
   def blockContext(idx: (Int, Int)): IR =
     throw new LowererUnsupportedOperation("empty stage has no block contexts!")
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
@@ -1,0 +1,25 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.expr.ir.lowering.LowerTableIR.lower
+import is.hail.expr.ir.{ArrayFlatMap, ArrayLen, BlockMatrixIR, Cast, Copy, GetField, IR, MakeStruct, MatrixIR, Pretty, Ref, TableCollect, TableCount, TableGetGlobals, TableIR, genUID, invoke}
+import is.hail.expr.types.virtual.{TContainer, TInt64}
+import is.hail.utils.FastIndexedSeq
+
+object LowerIR {
+  def lower(ir: IR, lowerTable: Boolean, lowerBM: Boolean): IR = ir match {
+    case node if lowerTable && node.children.exists( _.isInstanceOf[TableIR] ) =>
+      LowerTableIR.lower(ir)
+
+    case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
+      throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
+
+    case node if lowerBM && node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
+      LowerBlockMatrixIR.lower(ir)
+
+    case node if node.children.forall(_.isInstanceOf[IR]) =>
+      Copy(node, ir.children.map { case c: IR => lower(c, lowerTable, lowerBM) })
+
+    case node =>
+      throw new LowererUnsupportedOperation(s"Cannot lower: \n${ Pretty(node) }")
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
@@ -1,25 +1,32 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.expr.ir.lowering.LowerTableIR.lower
-import is.hail.expr.ir.{ArrayFlatMap, ArrayLen, BlockMatrixIR, Cast, Copy, GetField, IR, MakeStruct, MatrixIR, Pretty, Ref, TableCollect, TableCount, TableGetGlobals, TableIR, genUID, invoke}
+import is.hail.expr.ir.{BlockMatrixIR, Copy, IR, MatrixIR, Pretty, TableIR}
 import is.hail.expr.types.virtual.{TContainer, TInt64}
 import is.hail.utils.FastIndexedSeq
 
 object LowerIR {
-  def lower(ir: IR, lowerTable: Boolean, lowerBM: Boolean): IR = ir match {
-    case node if lowerTable && node.children.exists( _.isInstanceOf[TableIR] ) =>
+  def lower(ir: IR, typesToLower: DArrayLowering.Type): IR = ir match {
+    case node if DArrayLowering.lowerTable(typesToLower) && node.children.exists( _.isInstanceOf[TableIR] ) =>
       LowerTableIR.lower(ir)
 
     case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
       throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
 
-    case node if lowerBM && node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
+    case node if DArrayLowering.lowerBM(typesToLower) && node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
       LowerBlockMatrixIR.lower(ir)
 
     case node if node.children.forall(_.isInstanceOf[IR]) =>
-      Copy(node, ir.children.map { case c: IR => lower(c, lowerTable, lowerBM) })
+      Copy(node, ir.children.map { case c: IR => lower(c, typesToLower) })
 
     case node =>
       throw new LowererUnsupportedOperation(s"Cannot lower: \n${ Pretty(node) }")
   }
+}
+
+object DArrayLowering extends Enumeration {
+  type Type = Value
+  val All, TableOnly, BMOnly = Value
+  def lowerTable(t: Type): Boolean = t == All || t == TableOnly
+  def lowerBM(t: Type): Boolean = t == All || t == BMOnly
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerIR.scala
@@ -4,17 +4,17 @@ import is.hail.expr.ir.{BlockMatrixIR, Copy, IR, MatrixIR, Pretty, TableIR}
 
 object LowerIR {
   def lower(ir: IR, typesToLower: DArrayLowering.Type): IR = ir match {
-    case node if node.children.forall(n => n.isInstanceOf[TableIR] || n.isInstanceOf[IR] ) =>
+    case node if node.children.forall(_.isInstanceOf[IR]) =>
+      Copy(node, ir.children.map { case c: IR => lower(c, typesToLower) })
+
+    case node if node.children.exists(n => n.isInstanceOf[TableIR]) &&  node.children.forall(n => n.isInstanceOf[TableIR] || n.isInstanceOf[IR] ) =>
       LowerTableIR.lower(ir, typesToLower)
+
+    case node if node.children.exists(n => n.isInstanceOf[BlockMatrixIR]) &&  node.children.forall(n => n.isInstanceOf[BlockMatrixIR] || n.isInstanceOf[IR] ) =>
+      LowerBlockMatrixIR.lower(ir, typesToLower)
 
     case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
       throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
-
-    case node if node.children.forall(n => n.isInstanceOf[IR] || n.isInstanceOf[BlockMatrixIR] ) =>
-      LowerBlockMatrixIR.lower(ir, typesToLower)
-
-    case node if node.children.forall(_.isInstanceOf[IR]) =>
-      Copy(node, ir.children.map { case c: IR => lower(c, typesToLower) })
 
     case node =>
       throw new LowererUnsupportedOperation(s"Cannot lower: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -33,156 +33,167 @@ case class TableStage(
 }
 
 object LowerTableIR {
+  def lower(ir: IR, typesToLower: DArrayLowering.Type): IR =
+    new LowerTableIR(typesToLower).lower(ir)
+}
+
+class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
+  def lowerIR(ir: IR) = LowerIR.lower(ir, typesToLower)
+
   def lower(ir: IR): IR = ir match {
-    case TableCount(tableIR) =>
-      val stage = lower(tableIR)
-      invoke("sum", TInt64, stage.toIR(node => Cast(ArrayLen(ToArray(node)), TInt64)))
+      case TableCount(tableIR) =>
+        val stage = lower(tableIR)
+        invoke("sum", TInt64, stage.toIR(node => Cast(ArrayLen(ToArray(node)), TInt64())))
 
-    case TableGetGlobals(child) =>
-      val stage = lower(child)
-      GetField(stage.broadcastVals, stage.globalsField)
+      case TableGetGlobals(child) =>
+        val stage = lower(child)
+        GetField(stage.broadcastVals, stage.globalsField)
 
-    case TableCollect(child) =>
-      val lowered = lower(child)
-      val elt = genUID()
-      val cda = lowered.toIR(x => ToArray(x))
-      MakeStruct(FastIndexedSeq(
-        "rows" -> ToArray(StreamFlatMap(ToStream(cda), elt, ToStream(Ref(elt, cda.typ.asInstanceOf[TArray].elementType)))),
-        "global" -> GetField(lowered.broadcastVals, lowered.globalsField)))
+      case TableCollect(child) =>
+        val lowered = lower(child)
+        val elt = genUID()
+        val cda = lowered.toIR(x => ToArray(x))
+        MakeStruct(FastIndexedSeq(
+          "rows" -> ToArray(StreamFlatMap(ToStream(cda), elt, ToStream(Ref(elt, cda.typ.asInstanceOf[TArray].elementType)))),
+          "global" -> GetField(lowered.broadcastVals, lowered.globalsField)))
 
-    case node if node.children.exists( _.isInstanceOf[TableIR] ) =>
-      throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")
+      case node if node.children.exists( _.isInstanceOf[TableIR] ) =>
+        throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")
 
-    case node =>
-      throw new LowererUnsupportedOperation(s"Value IRs with no TableIR children must be lowered through LowerIR: \n${ Pretty(node) }")
-  }
+      case node =>
+        throw new LowererUnsupportedOperation(s"Value IRs with no TableIR children must be lowered through LowerIR: \n${ Pretty(node) }")
+    }
 
   // table globals should be stored in the first element of `globals` in TableStage;
   // globals in TableStage should have unique identifiers.
-  def lower(tir: TableIR): TableStage = tir match {
-    case TableRead(typ, dropRows, reader) =>
-      val gType = typ.globalType
-      val rowType = typ.rowType
-      val globalRef = genUID()
+  def lower(tir: TableIR): TableStage = {
+    if (typesToLower == DArrayLowering.BMOnly)
+      throw new LowererUnsupportedOperation("found TableIR in lowering; lowering only BlockMatrixIRs.")
+    tir match {
+      case TableRead(typ, dropRows, reader) =>
+        val gType = typ.globalType
+        val rowType = typ.rowType
+        val globalRef = genUID()
 
-      reader match {
-        case r@TableNativeReader(path, None, _) =>
-          val globalsPath = r.spec.globalsComponent.absolutePath(path)
-          val globalsSpec = AbstractRVDSpec.read(HailContext.get, globalsPath)
-          val gPath = AbstractRVDSpec.partPath(globalsPath, globalsSpec.partFiles.head)
-          val globals = ArrayRef(ToArray(ReadPartition(Str(gPath), globalsSpec.typedCodecSpec, gType)), 0)
+        reader match {
+          case r@TableNativeReader(path, None, _) =>
+            val globalsPath = r.spec.globalsComponent.absolutePath(path)
+            val globalsSpec = AbstractRVDSpec.read(HailContext.get, globalsPath)
+            val gPath = AbstractRVDSpec.partPath(globalsPath, globalsSpec.partFiles.head)
+            val globals = ArrayRef(ToArray(ReadPartition(Str(gPath), globalsSpec.typedCodecSpec, gType)), 0)
 
-          if (dropRows) {
-            TableStage(
-              MakeStruct(FastIndexedSeq(globalRef -> globals)),
-              globalRef,
-              RVDPartitioner.empty(typ.keyType),
-              TStruct.empty,
-              MakeStream(FastIndexedSeq(), TStream(TStruct.empty)),
-              MakeStream(FastIndexedSeq(), TStream(typ.rowType)))
-          } else {
-            val rowsPath = r.spec.rowsComponent.absolutePath(path)
-            val rowsSpec = AbstractRVDSpec.read(HailContext.get, rowsPath)
-            val partitioner = rowsSpec.partitioner
-            val rSpec = rowsSpec.typedCodecSpec
-            val ctxType = TStruct("path" -> TString)
-
-            if (rowsSpec.key startsWith typ.key) {
+            if (dropRows) {
               TableStage(
                 MakeStruct(FastIndexedSeq(globalRef -> globals)),
                 globalRef,
-                partitioner,
-                ctxType,
-                MakeStream(rowsSpec.partFiles.map(f => MakeStruct(FastIndexedSeq("path" -> Str(AbstractRVDSpec.partPath(rowsPath, f))))), TStream(ctxType)),
-                ReadPartition(GetField(Ref("context", ctxType), "path"), rSpec, rowType))
+                RVDPartitioner.empty(typ.keyType),
+                TStruct.empty,
+                MakeStream(FastIndexedSeq(), TStream(TStruct.empty)),
+                MakeStream(FastIndexedSeq(), TStream(typ.rowType)))
             } else {
-              throw new LowererUnsupportedOperation("can't lower a table if sort is needed after read.")
+              val rowsPath = r.spec.rowsComponent.absolutePath(path)
+              val rowsSpec = AbstractRVDSpec.read(HailContext.get, rowsPath)
+              val partitioner = rowsSpec.partitioner
+              val rSpec = rowsSpec.typedCodecSpec
+              val ctxType = TStruct("path" -> TString)
+
+              if (rowsSpec.key startsWith typ.key) {
+                TableStage(
+                  MakeStruct(FastIndexedSeq(globalRef -> globals)),
+                  globalRef,
+                  partitioner,
+                  ctxType,
+                  MakeStream(rowsSpec.partFiles.map(f => MakeStruct(FastIndexedSeq("path" -> Str(AbstractRVDSpec.partPath(rowsPath, f))))), TStream(ctxType)),
+                  ReadPartition(GetField(Ref("context", ctxType), "path"), rSpec, rowType))
+              } else {
+                throw new LowererUnsupportedOperation("can't lower a table if sort is needed after read.")
+              }
             }
-          }
-        case r =>
-          throw new LowererUnsupportedOperation(s"can't lower a TableRead with reader $r.")
-      }
+          case r =>
+            throw new LowererUnsupportedOperation(s"can't lower a TableRead with reader $r.")
+        }
 
-    case TableRange(n, nPartitions) =>
-      val nPartitionsAdj = math.max(math.min(n, nPartitions), 1)
-      val partCounts = partition(n, nPartitionsAdj)
-      val partStarts = partCounts.scanLeft(0)(_ + _)
+      case TableRange(n, nPartitions) =>
+        val nPartitionsAdj = math.max(math.min(n, nPartitions), 1)
+        val partCounts = partition(n, nPartitionsAdj)
+        val partStarts = partCounts.scanLeft(0)(_ + _)
 
-      val rvdType = RVDType(PType.canonical(tir.typ.rowType).asInstanceOf[PStruct], Array("idx"))
+        val rvdType = RVDType(PType.canonical(tir.typ.rowType).asInstanceOf[PStruct], Array("idx"))
 
-      val contextType = TStruct(
-        "start" -> TInt32,
-        "end" -> TInt32)
+        val contextType = TStruct(
+          "start" -> TInt32,
+          "end" -> TInt32)
 
-      val i = Ref(genUID(), TInt32)
-      val ranges = Array.tabulate(nPartitionsAdj) { i => partStarts(i) -> partStarts(i + 1) }
-      val globalRef = genUID()
+        val i = Ref(genUID(), TInt32)
+        val ranges = Array.tabulate(nPartitionsAdj) { i => partStarts(i) -> partStarts(i + 1) }
+        val globalRef = genUID()
 
-      TableStage(
-        MakeStruct(FastIndexedSeq(globalRef -> MakeStruct(Seq()))),
-        globalRef,
-        new RVDPartitioner(Array("idx"), tir.typ.rowType,
-          ranges.map { case (start, end) =>
-            Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
-          }),
-        contextType,
-        MakeStream(ranges.map { case (start, end) =>
-          MakeStruct(FastIndexedSeq("start" -> start, "end" -> end)) },
-          TStream(contextType)),
-        StreamMap(StreamRange(
-          GetField(Ref("context", contextType), "start"),
-          GetField(Ref("context", contextType), "end"),
-          I32(1)), i.name, MakeStruct(FastSeq("idx" -> i))))
+        TableStage(
+          MakeStruct(FastIndexedSeq(globalRef -> MakeStruct(Seq()))),
+          globalRef,
+          new RVDPartitioner(Array("idx"), tir.typ.rowType,
+            ranges.map { case (start, end) =>
+              Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+            }),
+          contextType,
+          MakeStream(ranges.map { case (start, end) =>
+            MakeStruct(FastIndexedSeq("start" -> start, "end" -> end)) },
+            TStream(contextType)),
+          StreamMap(StreamRange(
+            GetField(Ref("context", contextType), "start"),
+            GetField(Ref("context", contextType), "end"),
+            I32(1)), i.name, MakeStruct(FastSeq("idx" -> i))))
 
-    case TableMapGlobals(child, newGlobals) =>
-      val loweredChild = lower(child)
-      val oldbroadcast = Ref(genUID(), loweredChild.broadcastVals.typ)
-      val newGlobRef = genUID()
-      val newBroadvastVals =
-        Let(
-          oldbroadcast.name,
-          loweredChild.broadcastVals,
-          InsertFields(oldbroadcast,
-            FastIndexedSeq(newGlobRef ->
-              Subst(lower(newGlobals),
-                BindingEnv.eval("global" -> GetField(oldbroadcast, loweredChild.globalsField))))))
+      case TableMapGlobals(child, newGlobals) =>
+        val loweredChild = lower(child)
+        val oldbroadcast = Ref(genUID(), loweredChild.broadcastVals.typ)
+        val newGlobRef = genUID()
+        val newBroadvastVals =
+          Let(
+            oldbroadcast.name,
+            loweredChild.broadcastVals,
+            InsertFields(oldbroadcast,
+              FastIndexedSeq(newGlobRef ->
+                Subst(lowerIR(newGlobals),
+                  BindingEnv.eval("global" -> GetField(oldbroadcast, loweredChild.globalsField))))))
 
-      loweredChild.copy(broadcastVals = newBroadvastVals, globalsField = newGlobRef)
+        loweredChild.copy(broadcastVals = newBroadvastVals, globalsField = newGlobRef)
 
-    case TableFilter(child, cond) =>
-      val loweredChild = lower(child)
-      val row = Ref(genUID(), child.typ.rowType)
-      val env: Env[IR] = Env("row" -> row, "global" -> loweredChild.globals)
-      loweredChild.copy(body = StreamFilter(loweredChild.body, row.name, Subst(cond, BindingEnv(env))))
+      case TableFilter(child, cond) =>
+        val loweredChild = lower(child)
+        val row = Ref(genUID(), child.typ.rowType)
+        val env: Env[IR] = Env("row" -> row, "global" -> loweredChild.globals)
+        loweredChild.copy(body = StreamFilter(loweredChild.body, row.name, Subst(cond, BindingEnv(env))))
 
-    case TableMapRows(child, newRow) =>
-      if (ContainsScan(newRow))
-        throw new LowererUnsupportedOperation(s"scans are not supported: \n${ Pretty(newRow) }")
-      val loweredChild = lower(child)
-      val row = Ref(genUID(), child.typ.rowType)
-      val env: Env[IR] = Env("row" -> row, "global" -> loweredChild.globals)
-      loweredChild.copy(body = StreamMap(loweredChild.body, row.name, Subst(newRow, BindingEnv(env, scan = Some(env)))))
+      case TableMapRows(child, newRow) =>
+        if (ContainsScan(newRow))
+          throw new LowererUnsupportedOperation(s"scans are not supported: \n${ Pretty(newRow) }")
+        val loweredChild = lower(child)
+        val row = Ref(genUID(), child.typ.rowType)
+        val env: Env[IR] = Env("row" -> row, "global" -> loweredChild.globals)
+        loweredChild.copy(body = StreamMap(loweredChild.body, row.name, Subst(newRow, BindingEnv(env, scan = Some(env)))))
 
-    case TableExplode(child, path) =>
-      val loweredChild = lower(child)
-      val row = Ref(genUID(), child.typ.rowType)
+      case TableExplode(child, path) =>
+        val loweredChild = lower(child)
+        val row = Ref(genUID(), child.typ.rowType)
 
-      var fieldRef = path.foldLeft[IR](row) { case (expr, field) => GetField(expr, field) }
-      if (!fieldRef.typ.isInstanceOf[TArray])
-        fieldRef = ToArray(fieldRef)
-      val elt = Ref(genUID(), types.coerce[TContainer](fieldRef.typ).elementType)
+        var fieldRef = path.foldLeft[IR](row) { case (expr, field) => GetField(expr, field) }
+        if (!fieldRef.typ.isInstanceOf[TArray])
+          fieldRef = ToArray(fieldRef)
+        val elt = Ref(genUID(), types.coerce[TContainer](fieldRef.typ).elementType)
 
-      val refs = path.scanLeft(row)((struct, name) =>
-        Ref(genUID(), types.coerce[TStruct](struct.typ).field(name).typ))
-      val newRow = path.zip(refs).zipWithIndex.foldRight[IR](elt) {
-        case (((field, ref), i), arg) =>
-          InsertFields(ref, FastIndexedSeq(field ->
+        val refs = path.scanLeft(row)((struct, name) =>
+          Ref(genUID(), types.coerce[TStruct](struct.typ).field(name).typ))
+        val newRow = path.zip(refs).zipWithIndex.foldRight[IR](elt) {
+          case (((field, ref), i), arg) =>
+            InsertFields(ref, FastIndexedSeq(field ->
               Let(refs(i + 1).name, GetField(ref, field), arg)))
-      }.asInstanceOf[InsertFields]
+        }.asInstanceOf[InsertFields]
 
-      loweredChild.copy(body = StreamFlatMap(loweredChild.body, row.name, StreamMap(fieldRef, elt.name, newRow)))
+        loweredChild.copy(body = StreamFlatMap(loweredChild.body, row.name, StreamMap(fieldRef, elt.name, newRow)))
 
-    case node =>
-      throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")
+      case node =>
+        throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")
+    }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -43,7 +43,7 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
   def lower(ir: IR): IR = ir match {
       case TableCount(tableIR) =>
         val stage = lower(tableIR)
-        invoke("sum", TInt64, stage.toIR(node => Cast(ArrayLen(ToArray(node)), TInt64())))
+        invoke("sum", TInt64, stage.toIR(node => Cast(ArrayLen(ToArray(node)), TInt64)))
 
       case TableGetGlobals(child) =>
         val stage = lower(child)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -34,7 +34,6 @@ case class TableStage(
 
 object LowerTableIR {
   def lower(ir: IR): IR = ir match {
-
     case TableCount(tableIR) =>
       val stage = lower(tableIR)
       invoke("sum", TInt64, stage.toIR(node => Cast(ArrayLen(ToArray(node)), TInt64)))
@@ -54,14 +53,8 @@ object LowerTableIR {
     case node if node.children.exists( _.isInstanceOf[TableIR] ) =>
       throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")
 
-    case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
-      throw new LowererUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
-
-    case node if node.children.exists( _.isInstanceOf[BlockMatrixIR] ) =>
-      throw new LowererUnsupportedOperation(s"BlockMatrixIR nodes are not supported: \n${ Pretty(node) }")
-
     case node =>
-      Copy(node, ir.children.map { case c: IR => lower(c) })
+      throw new LowererUnsupportedOperation(s"Value IRs with no TableIR children must be lowered through LowerIR: \n${ Pretty(node) }")
   }
 
   // table globals should be stored in the first element of `globals` in TableStage;

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -50,24 +50,8 @@ case object InterpretNonCompilablePass extends LoweringPass {
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = InterpretNonCompilable(ctx, ir)
 }
 
-case object LowerTableToDistributedArrayPass extends LoweringPass {
-  val before: IRState = MatrixLoweredToTable
-  val after: IRState = CompilableIR
-  val context: String = "LowerTableToDistributedArray"
-
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], DArrayLowering.TableOnly)
-}
-
-case object LowerBlockMatrixToDistributedArrayPass extends LoweringPass {
-  val before: IRState = LowerableToDArray(DArrayLowering.BMOnly)
-  val after: IRState = CompilableIR
-  val context: String = "LowerBlockMatrixToDistributedArray"
-
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], DArrayLowering.BMOnly)
-}
-
 case class LowerToDistributedArrayPass(t: DArrayLowering.Type) extends LoweringPass {
-  val before: IRState = LowerableToDArray(t)
+  val before: IRState = MatrixLoweredToTable
   val after: IRState = CompilableIR
   val context: String = "LowerToDistributedArray"
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -55,23 +55,23 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   val after: IRState = CompilableIR
   val context: String = "LowerTableToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = false)
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], DArrayLowering.TableOnly)
 }
 
 case object LowerBlockMatrixToDistributedArrayPass extends LoweringPass {
-  val before: IRState = BlockMatrixOnly
+  val before: IRState = LowerableToDArray(DArrayLowering.BMOnly)
   val after: IRState = CompilableIR
   val context: String = "LowerBlockMatrixToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = false, lowerBM = true)
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], DArrayLowering.BMOnly)
 }
 
-case object LowerToDistributedArrayPass extends LoweringPass {
-  val before: IRState = MatrixLoweredToTable
+case class LowerToDistributedArrayPass(t: DArrayLowering.Type) extends LoweringPass {
+  val before: IRState = LowerableToDArray(t)
   val after: IRState = CompilableIR
   val context: String = "LowerToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = true)
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], t)
 }
 
 case object InlineApplyIR extends LoweringPass {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -58,6 +58,22 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = false)
 }
 
+case object LowerBlockMatrixToDistributedArrayPass extends LoweringPass {
+  val before: IRState = BlockMatrixOnly
+  val after: IRState = CompilableIR
+  val context: String = "LowerBlockMatrixToDistributedArray"
+
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = false, lowerBM = true)
+}
+
+case object LowerToDistributedArrayPass extends LoweringPass {
+  val before: IRState = MatrixLoweredToTable
+  val after: IRState = CompilableIR
+  val context: String = "LowerToDistributedArray"
+
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = true)
+}
+
 case object InlineApplyIR extends LoweringPass {
   val before: IRState = CompilableIR
   val after: IRState = CompilableIRNoApply

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -55,7 +55,7 @@ case object LowerTableToDistributedArrayPass extends LoweringPass {
   val after: IRState = CompilableIR
   val context: String = "LowerTableToDistributedArray"
 
-  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerTableIR.lower(ir.asInstanceOf[IR])
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = LowerIR.lower(ir.asInstanceOf[IR], lowerTable = true, lowerBM = false)
 }
 
 case object InlineApplyIR extends LoweringPass {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -35,5 +35,7 @@ object LoweringPipeline {
   val relationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, InterpretNonCompilablePass))
   val legacyRelationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LegacyInterpretNonCompilablePass))
   val tableLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerTableToDistributedArrayPass))
+  val bmLowerer: LoweringPipeline = LoweringPipeline(Array(LowerBlockMatrixToDistributedArrayPass))
+  val tableAndBMLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerToDistributedArrayPass))
   val compileLowerer: LoweringPipeline = LoweringPipeline(Array(InlineApplyIR, LowerArrayAggsToRunAggsPass))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -34,8 +34,9 @@ case class LoweringPipeline(lowerings: IndexedSeq[LoweringPass]) {
 object LoweringPipeline {
   val relationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, InterpretNonCompilablePass))
   val legacyRelationalLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LegacyInterpretNonCompilablePass))
-  val tableLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerTableToDistributedArrayPass))
-  val bmLowerer: LoweringPipeline = LoweringPipeline(Array(LowerBlockMatrixToDistributedArrayPass))
-  val tableAndBMLowerer: LoweringPipeline = LoweringPipeline(Array(LowerMatrixToTablePass, LowerToDistributedArrayPass))
   val compileLowerer: LoweringPipeline = LoweringPipeline(Array(InlineApplyIR, LowerArrayAggsToRunAggsPass))
+  val darrayLowerer: Map[DArrayLowering.Type, LoweringPipeline] = Map(
+    DArrayLowering.All -> LoweringPipeline(Array(LowerMatrixToTablePass, LowerToDistributedArrayPass(DArrayLowering.All))),
+    DArrayLowering.TableOnly -> LoweringPipeline(Array(LowerMatrixToTablePass, LowerToDistributedArrayPass(DArrayLowering.TableOnly))),
+    DArrayLowering.BMOnly -> LoweringPipeline(Array(LowerToDistributedArrayPass(DArrayLowering.BMOnly))))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -11,6 +11,10 @@ case object NoMatrixIR extends Rule {
   def allows(ir: BaseIR): Boolean = !ir.isInstanceOf[MatrixIR]
 }
 
+case object NoTableIR extends Rule {
+  def allows(ir: BaseIR): Boolean = !ir.isInstanceOf[TableIR]
+}
+
 case object NoRelationalLets extends Rule {
   def allows(ir: BaseIR): Boolean = ir match {
     case _: RelationalLet => false

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -15,6 +15,10 @@ case object NoTableIR extends Rule {
   def allows(ir: BaseIR): Boolean = !ir.isInstanceOf[TableIR]
 }
 
+case object NoBlockMatrixIR extends Rule {
+  def allows(ir: BaseIR): Boolean = !ir.isInstanceOf[BlockMatrixIR]
+}
+
 case object NoRelationalLets extends Rule {
   def allows(ir: BaseIR): Boolean = ir match {
     case _: RelationalLet => false

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -13,9 +13,9 @@ object BlockMatrixSparsity {
 
   def apply(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean): BlockMatrixSparsity = {
     var i = 0
-    var j = 0
     builder.clear()
     while (i < nRows) {
+      var j = 0
       while (j < nCols) {
         if (exists(i, j))
           builder += i -> j
@@ -40,7 +40,6 @@ case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
   def hasBlock(idx: (Int, Int)): Boolean = definedBlocks.isEmpty || blockSet.contains(idx)
   def condense(blockOverlaps: => (Array[Array[Int]], Array[Array[Int]])): BlockMatrixSparsity = {
     definedBlocks.map { _ =>
-      val defined = new ArrayBuilder[(Int, Int)]()
       val (ro, co) = blockOverlaps
       BlockMatrixSparsity(ro.length, co.length) { (i, j) =>
         ro(i).exists(ii => co(j).exists(jj => hasBlock(ii -> jj)))
@@ -48,17 +47,19 @@ case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
     }.getOrElse(BlockMatrixSparsity.dense)
   }
   def allBlocks(nRowBlocks: Int, nColBlocks: Int): IndexedSeq[(Int, Int)] = {
-    val foo = Array.fill[(Int, Int)](nRowBlocks * nColBlocks)(null)
-    var i = 0
-    var j = 0
-    while (i < nRowBlocks) {
-      while (j < nColBlocks) {
-        foo(i * nColBlocks + j) = i -> j
-        j += 1
+    definedBlocks.getOrElse {
+      val foo = Array.fill[(Int, Int)](nRowBlocks * nColBlocks)(null)
+      var i = 0
+      while (i < nRowBlocks) {
+        var j = 0
+        while (j < nColBlocks) {
+          foo(i * nColBlocks + j) = i -> j
+          j += 1
+        }
+        i += 1
       }
-      i += 1
+      foo
     }
-    foo
   }
   override def toString: String =
     definedBlocks.map { blocks =>
@@ -131,6 +132,12 @@ case class BlockMatrixType(
     if (isSparse) sparsity.hasBlock(idx) else true
   }
   def allBlocks: IndexedSeq[(Int, Int)] = sparsity.allBlocks(nRowBlocks, nColBlocks)
+
+  def blockShape(i: Int, j: Int): (Long, Long) = {
+    val r = if (i == nRowBlocks - 1) nRows - (i * blockSize) else blockSize
+    val c = if (i == nColBlocks - 1) nCols - (i * blockSize) else blockSize
+    r -> c
+  }
 
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -47,6 +47,19 @@ case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
       }
     }.getOrElse(BlockMatrixSparsity.dense)
   }
+  def allBlocks(nRowBlocks: Int, nColBlocks: Int): IndexedSeq[(Int, Int)] = {
+    val foo = Array.fill[(Int, Int)](nRowBlocks * nColBlocks)(null)
+    var i = 0
+    var j = 0
+    while (i < nRowBlocks) {
+      while (j < nColBlocks) {
+        foo(i * nColBlocks + j) = i -> j
+        j += 1
+      }
+      i += 1
+    }
+    foo
+  }
   override def toString: String =
     definedBlocks.map { blocks =>
       blocks.map { case (i, j) => s"($i,$j)" }.mkString("[", ",", "]")
@@ -115,6 +128,7 @@ case class BlockMatrixType(
   def hasBlock(idx: (Int, Int)): Boolean = {
     if (isSparse) sparsity.hasBlock(idx) else true
   }
+  def allBlocks: IndexedSeq[(Int, Int)] = sparsity.allBlocks(nRowBlocks, nColBlocks)
 
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -125,6 +125,8 @@ case class BlockMatrixType(
 
   def getBlockIdx(i: Long): Int = java.lang.Math.floorDiv(i, blockSize).toInt
   def isSparse: Boolean = sparsity.isSparse
+  def nDefinedBlocks: Int =
+    if (isSparse) sparsity.definedBlocks.get.length else nRowBlocks * nColBlocks
   def hasBlock(idx: (Int, Int)): Boolean = {
     if (isSparse) sparsity.hasBlock(idx) else true
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -242,6 +242,7 @@ abstract class PType extends Serializable with Requiredness {
       case t2: PArray => t.isInstanceOf[PArray] && t.asInstanceOf[PArray].elementType.isOfType(t2.elementType)
       case t2: PSet => t.isInstanceOf[PSet] && t.asInstanceOf[PSet].elementType.isOfType(t2.elementType)
       case t2: PDict => t.isInstanceOf[PDict] && t.asInstanceOf[PDict].keyType.isOfType(t2.keyType) && t.asInstanceOf[PDict].valueType.isOfType(t2.valueType)
+      case t2: PNDArray => t.isInstanceOf[PNDArray] && t.asInstanceOf[PNDArray].elementType.isOfType(t2.elementType) && t.asInstanceOf[PNDArray].nDims == t2.nDims
     }
   }
 

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -153,7 +153,7 @@ object TestUtils {
   ): Any = {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
-    HailContext.backend.jvmLowerAndExecute(x, optimize = false, print = bytecodePrinter)._1
+    HailContext.backend.jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter)._1
   }
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -181,7 +181,7 @@ class BlockMatrixIRSuite extends HailSuite {
     val blockSize = 3
 
     def value(nRows: Long, nCols: Long, data: Double*): (BlockMatrixIR, BDM[Double]) = {
-      val ir = ValueToBlockMatrix(Literal(TArray(TFloat64()), data),
+      val ir = ValueToBlockMatrix(Literal(TArray(TFloat64), data),
         FastIndexedSeq(nRows, nCols), blockSize)
       val bdm = new BDM(nCols.toInt, nRows.toInt, data.toArray).t
       ir -> bdm

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -33,10 +33,10 @@ class BlockMatrixStageSuite extends HailSuite {
   }
 
   @Test def testBlockMatrixCollectOrdering(): Unit = {
-    val ctxs = Array.tabulate[((Int, Int), IR)](5) { i => ((i, 6-i), In(0, TInt32()) + I32(i)) }
+    val ctxs = Array.tabulate[((Int, Int), IR)](5) { i => ((i, 6-i), In(0, TInt32) + I32(i)) }
     assertEvalsTo(
       collected(ctxs, Array(), order = Some(Array.tabulate(5)(i => (4-i, i + 2)))),
-      args = IndexedSeq(0 -> TInt32()),
+      args = IndexedSeq(0 -> TInt32),
       expected = IndexedSeq(4, 3, 2, 1, 0))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -52,10 +52,10 @@ class BlockMatrixStageSuite extends HailSuite {
   @Test def testBodyDependsOnGlobalValue(): Unit = {
     val g1 = "x" -> In(0, TInt32)
     assertEvalsTo(
-      ToSet(
+      ToSet(ToStream(
         collected(Array.tabulate(5)(i => (i -> i, I32(i))),
           Array(g1),
-          body=ref => ref + Ref("x", TInt32))),
+          body=ref => ref + Ref("x", TInt32)))),
       args = IndexedSeq(5 -> TInt32),
       expected = Array.tabulate(5)(i => i + 5).toSet)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -1,0 +1,72 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.{ExecStrategy, HailSuite}
+import is.hail.expr.ir._
+import is.hail.expr.types.virtual._
+import is.hail.TestUtils._
+import is.hail.utils._
+import org.testng.annotations.Test
+
+class BlockMatrixStageSuite extends HailSuite {
+
+  private[this] implicit val execStrats: Set[ExecStrategy.ExecStrategy] = ExecStrategy.compileOnly
+
+  def collected(
+    ctxs: Array[((Int, Int), IR)],
+    globalVals: Array[(String, IR)],
+    body: Ref => IR = ref => ref,
+    order: Option[Array[(Int, Int)]] = None
+  ): IR = {
+    val ctxRef = Ref(genUID(), if (ctxs.isEmpty) TInt32() else ctxs.head._2.typ)
+    BlockMatrixStage(ctxRef, ctxs.toMap, globalVals, body(ctxRef))
+      .toIR(b => b, order)
+  }
+
+  @Test def testBlockMatrixCollectOrdering(): Unit = {
+    val ctxs = Array.tabulate[((Int, Int), IR)](5) { i => ((i, 6-i), In(0, TInt32()) + I32(i)) }
+    assertEvalsTo(
+      collected(ctxs, Array(), order = Some(Array.tabulate(5)(i => (4-i, i + 2)))),
+      args = IndexedSeq(0 -> TInt32()),
+      expected = IndexedSeq(4, 3, 2, 1, 0))
+  }
+
+  @Test def testContextDependsOnGlobalValue(): Unit = {
+    val g1 = "x" -> In(0, TString())
+    assertEvalsTo(
+      collected(Array.tabulate(5)(i => (i -> i, Ref("x", TString()))),
+        Array(g1)),
+      args = IndexedSeq("foo" -> TString()),
+      expected = Array.fill(5)("foo").toFastIndexedSeq)
+  }
+
+  @Test def testBodyDependsOnGlobalValue(): Unit = {
+    val g1 = "x" -> In(0, TInt32())
+    assertEvalsTo(
+      ToSet(
+        collected(Array.tabulate(5)(i => (i -> i, I32(i))),
+          Array(g1),
+          body=ref => ref + Ref("x", TInt32()))),
+      args = IndexedSeq(5 -> TInt32()),
+      expected = Array.tabulate(5)(i => i + 5).toSet)
+  }
+
+  @Test def testGlobalValueDependentBinding(): Unit = {
+    val g1 = "x" -> In(0, TString())
+    val g2 = "y" -> MakeArray(FastIndexedSeq(Ref("x", TString())), TArray(TString()))
+
+    assertEvalsTo(
+      collected(Array.tabulate(5)(i => (i -> i, Ref("y", TArray(TString())))),
+        Array(g1, g2)),
+      args = IndexedSeq("foo" -> TString()),
+      expected = Array.fill(5)(IndexedSeq("foo")).toFastIndexedSeq)
+  }
+
+  @Test def testEmptyContexts(): Unit = {
+    assertEvalsTo(
+      collected(Array(),
+        Array(),
+        body = ref => ref + I32(5)),
+      expected = IndexedSeq())
+  }
+
+}

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -19,7 +19,7 @@ class BlockMatrixStageSuite extends HailSuite {
     order: Option[Array[(Int, Int)]] = None
   ): IR = {
     val stage = if (ctxs.isEmpty)
-      BlockMatrixStage.empty(TInt32())
+      BlockMatrixStage.empty(TInt32)
     else {
       new BlockMatrixStage(
         globalVals,
@@ -41,33 +41,33 @@ class BlockMatrixStageSuite extends HailSuite {
   }
 
   @Test def testContextDependsOnGlobalValue(): Unit = {
-    val g1 = "x" -> In(0, TString())
+    val g1 = "x" -> In(0, TString)
     assertEvalsTo(
-      collected(Array.tabulate(5)(i => (i -> i, Ref("x", TString()))),
+      collected(Array.tabulate(5)(i => (i -> i, Ref("x", TString))),
         Array(g1)),
-      args = IndexedSeq("foo" -> TString()),
+      args = IndexedSeq("foo" -> TString),
       expected = Array.fill(5)("foo").toFastIndexedSeq)
   }
 
   @Test def testBodyDependsOnGlobalValue(): Unit = {
-    val g1 = "x" -> In(0, TInt32())
+    val g1 = "x" -> In(0, TInt32)
     assertEvalsTo(
       ToSet(
         collected(Array.tabulate(5)(i => (i -> i, I32(i))),
           Array(g1),
-          body=ref => ref + Ref("x", TInt32()))),
-      args = IndexedSeq(5 -> TInt32()),
+          body=ref => ref + Ref("x", TInt32))),
+      args = IndexedSeq(5 -> TInt32),
       expected = Array.tabulate(5)(i => i + 5).toSet)
   }
 
   @Test def testGlobalValueDependentBinding(): Unit = {
-    val g1 = "x" -> In(0, TString())
-    val g2 = "y" -> MakeArray(FastIndexedSeq(Ref("x", TString())), TArray(TString()))
+    val g1 = "x" -> In(0, TString)
+    val g2 = "y" -> MakeArray(FastIndexedSeq(Ref("x", TString)), TArray(TString))
 
     assertEvalsTo(
-      collected(Array.tabulate(5)(i => (i -> i, Ref("y", TArray(TString())))),
+      collected(Array.tabulate(5)(i => (i -> i, Ref("y", TArray(TString)))),
         Array(g1, g2)),
-      args = IndexedSeq("foo" -> TString()),
+      args = IndexedSeq("foo" -> TString),
       expected = Array.fill(5)(IndexedSeq("foo")).toFastIndexedSeq)
   }
 


### PR DESCRIPTION
This PR describes a lowering framework for BlockMatrixIR -> CollectDistributedArray.

As part of this, I split out a `LowerIR` function from the `LowerTableIR` value rules so that we can apply lowering more modularly, if desired. It delegates to `LowerTableIR` and `LowerBlockMatrixIR` for the relevant nodes but lets us use both the table lowerer and/or the block matrix lowerer together as desired.

(this PR turned into quite a large change, since I ended up implementing enough to start testing the lowering, but I'm happy to break it up, too.)

cc @cseed @tpoterba @danking @patrick-schultz @johnc1231 