### PR TITLE
[batch] fix exit code when error occurred

### DIFF
--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -94,6 +94,10 @@ class Job:
         if not status:
             return None
 
+        error = status.get('error')
+        if error is not None:
+            return None
+
         container_statuses = status.get('container_statuses')
         if not container_statuses:
             return None


### PR DESCRIPTION
Fixes #8083 

The format of the status is 
```
    # {
    #   worker: str,
    #   batch_id: int,
    #   job_id: int,
    #   attempt_id: int,
    #   user: str,
    #   state: str, (pending, initializing, running, succeeded, error, failed)
    #   format_version: int
    #   error: str, (optional)
    #   container_statuses: [Container.status],
    #   start_time: int,
    #   end_time: int
    # }
```