### PR TITLE
[hail] define BlockMatrixCollect node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -181,6 +181,7 @@ object Children {
     case MatrixToValueApply(child, _) => Array(child)
     // from BlockMatrixIR
     case BlockMatrixToValueApply(child, _) => Array(child)
+    case BlockMatrixCollect(child) => Array(child)
     case BlockMatrixWrite(child, _) => Array(child)
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -35,6 +35,7 @@ object Compilable {
       case _: MatrixWrite => false
       case _: MatrixMultiWrite => false
       case _: TableMultiWrite => false
+      case _: BlockMatrixCollect => false
       case _: BlockMatrixWrite => false
       case _: BlockMatrixMultiWrite => false
       case _: TableToValueApply => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -283,6 +283,9 @@ object Copy {
       case BlockMatrixToValueApply(_, function) =>
         assert(newChildren.length == 1)
         BlockMatrixToValueApply(newChildren(0).asInstanceOf[BlockMatrixIR], function)
+      case BlockMatrixCollect(_) =>
+        assert(newChildren.length == 1)
+        BlockMatrixCollect(newChildren(0).asInstanceOf[BlockMatrixIR])
       case BlockMatrixWrite(_, writer) =>
         assert(newChildren.length == 1)
         BlockMatrixWrite(newChildren(0).asInstanceOf[BlockMatrixIR], writer)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -418,6 +418,8 @@ final case class TableToValueApply(child: TableIR, function: TableToValueFunctio
 final case class MatrixToValueApply(child: MatrixIR, function: MatrixToValueFunction) extends IR
 final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMatrixToValueFunction) extends IR
 
+final case class BlockMatrixCollect(child: BlockMatrixIR) extends NDArrayIR
+
 final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWriter) extends IR
 
 final case class BlockMatrixMultiWrite(blockMatrices: IndexedSeq[BlockMatrixIR], writer: BlockMatrixMultiWriter) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -206,6 +206,7 @@ object InferType {
       case _: TableMultiWrite => TVoid
       case _: MatrixWrite => TVoid
       case _: MatrixMultiWrite => TVoid
+      case _: BlockMatrixCollect => TNDArray(TFloat64(), Nat(2))
       case _: BlockMatrixWrite => TVoid
       case _: BlockMatrixMultiWrite => TVoid
       case TableGetGlobals(child) => child.typ.globalType

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1106,6 +1106,9 @@ object IRParser {
         val config = string_literal(it)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixToValueApply(child, RelationalFunctions.lookupBlockMatrixToValue(config))
+      case "BlockMatrixCollect" =>
+        val child = blockmatrix_ir(env)(it)
+        BlockMatrixCollect(child)
       case "TableWrite" =>
         implicit val formats = TableWriter.formats
         val writerStr = string_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -378,6 +378,7 @@ object TypeCheck {
       case TableToValueApply(_, _) =>
       case MatrixToValueApply(_, _) =>
       case BlockMatrixToValueApply(_, _) =>
+      case BlockMatrixCollect(_) =>
       case BlockMatrixWrite(_, _) =>
       case BlockMatrixMultiWrite(_, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir.{BaseIR, BlockMatrixMultiWrite, BlockMatrixToTableApply, BlockMatrixToValueApply, BlockMatrixWrite, Compilable, Emittable, IR, InterpretableButNotCompilable, MatrixAggregate, MatrixIR, MatrixToValueApply, MatrixWrite, RelationalLet, RelationalLetBlockMatrix, RelationalLetMatrixTable, RelationalLetTable, RelationalRef, TableAggregate, TableCollect, TableCount, TableGetGlobals, TableToValueApply, TableWrite}
+import is.hail.expr.ir._
 
 trait Rule {
   def allows(ir: BaseIR): Boolean

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2574,6 +2574,7 @@ class IRSuite extends HailSuite {
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       TableMultiWrite(Array(table, table), WrappedMatrixNativeMultiWriter(MatrixNativeMultiWriter(tmpDir.createLocalTempFile()), FastIndexedSeq("foo"))),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
+      BlockMatrixCollect(blockMatrix),
       BlockMatrixWrite(blockMatrix, blockMatrixWriter),
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),


### PR DESCRIPTION
Defines, but does not implement, a BlockMatrixCollect value IR node.

This is kind of an awkward node currently. We cannot compile nodes with BlockMatrixIRs. We cannot interpret nodes with NDArrayIRs. So we can't compile this or interpret this, unless we define an interpreted version of NDArray (or a compilable version of BlockMatrix).

I think this node might eventually be useful for Hail BlockMatrix -> Hail NDArray -> Python ndarray conversions, but for now the intention is to use this as a quick way to start testing BlockMatrix lowering.