### PR TITLE
[ci] Retry clones and fetches

### DIFF
--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -16,7 +16,7 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import time_msecs, request_retry_transient_errors
+from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT
 
 # import uvloop
 
@@ -398,11 +398,7 @@ def copy(files):
     return f'''
 set -ex
 
-function retry() {{
-    "$@" ||
-        (sleep 2 && "$@") ||
-        (sleep 5 && "$@")
-}}
+{ RETRY_FUNCTION_SCRIPT }
 
 retry gcloud -q auth activate-service-account --key-file=/gsa-key/key.json
 

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -21,3 +21,6 @@ AUTHORIZED_USERS = {
     'gsarma',
     'mkveerapen'
 }
+
+RETRY_FUNCTION_SCRIPT = """
+"""

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -21,6 +21,3 @@ AUTHORIZED_USERS = {
     'gsarma',
     'mkveerapen'
 }
-
-RETRY_FUNCTION_SCRIPT = """
-"""

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -9,7 +9,7 @@ import gidgethub
 import zulip
 
 from hailtop.config import get_deploy_config
-from hailtop.utils import check_shell, check_shell_output
+from hailtop.utils import check_shell, check_shell_output, RETRY_FUNCTION_SCRIPT
 from .constants import GITHUB_CLONE_URL, AUTHORIZED_USERS
 from .build import BuildConfiguration, Code
 from .globals import is_test_deployment
@@ -133,11 +133,8 @@ DO_NOT_MERGE = {STACKED_PR, WIP}
 
 
 def clone_or_fetch_script(repo):
-    return """function retry() {{
-    "$@" ||
-        (sleep 2 && "$@") ||
-        (sleep 5 && "$@")
-}}
+    return """
+{ RETRY_FUNCTION_SCRIPT }
 
 function clone() {{
     dir=$(mktemp -d)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -133,7 +133,7 @@ DO_NOT_MERGE = {STACKED_PR, WIP}
 
 
 def clone_or_fetch_script(repo):
-    return """
+    return f"""
 { RETRY_FUNCTION_SCRIPT }
 
 function clone() {{

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -140,7 +140,7 @@ function clone() {{
     dir=$(mktemp -d)
     git clone {shq(repo)} $dir
     for x in $(ls -A $dir); do
-        if [ -e "$dir/$x" ]; then mv -- "$dir/$x" ./; fi
+        mv -- "$dir/$x" ./
     done
 }}
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -4,7 +4,7 @@ from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     request_retry_transient_errors, request_raise_transient_errors, \
     collect_agen, retry_forever, retry_transient_errors, \
     retry_long_running, run_if_changed, LoggingTimer, \
-    WaitableSharedPool
+    WaitableSharedPool, RETRY_FUNCTION_SCRIPT
 from .process import CalledProcessError, check_shell, check_shell_output
 from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 
@@ -33,5 +33,6 @@ __all__ = [
     'collect_agen',
     'retry_forever',
     'tqdm',
-    'TQDM_DEFAULT_DISABLE'
+    'TQDM_DEFAULT_DISABLE',
+    'RETRY_FUNCTION_SCRIPT'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -10,6 +10,13 @@ from .time import time_msecs
 log = logging.getLogger('hailtop.utils')
 
 
+RETRY_FUNCTION_SCRIPT = """function retry() {
+    "$@" ||
+        (sleep 2 && "$@") ||
+        (sleep 5 && "$@")
+}"""
+
+
 def grouped(n, ls):
     while len(ls) != 0:
         group = ls[:n]


### PR DESCRIPTION
This got a bit complicated to ensure idempotence.

This should make issues related to GitHub hiccups during clones and fetches even
rarer than they are now (retry three times, as we do for uploading).

I added a function called `clone` which:
- creates a temporary,
- clones into the temporary directory, and
- copies every file in the directory (including hidden files) into the current
  directory

I added retries to clones and fetches (which are already idempotent).

I removed duplication of cloning and fetching scripts. I also moved the shell retry function to `hailtop.utils`.