### PR TITLE
[batch] fix deploy

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -58,7 +58,7 @@ spec:
            value: "{{ code.sha }}"
 {% if deploy or scope == "dev" %}
          - name: HAIL_SHOULD_PROFILE
-           value: 1
+           value: "1"
 {% endif %}
          - name: HAIL_BATCH_BUCKET_NAME
 {% if deploy %}


### PR DESCRIPTION
A field value that can be interpreted as a number in YAML is parsed as an int64 and k8s does not approve of this.