### PR TITLE
[hailtop] add humanize to requirements.txt

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -16,3 +16,4 @@ python-json-logger==0.1.11
 requests>=2.21.0,<2.21.1
 scipy>1.2,<1.4
 tabulate==0.8.3
+tqdm==4.42.1

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -4,6 +4,7 @@ asyncinit>=0.2.4,<0.3
 bokeh>1.1,<1.3
 decorator<5
 gcsfs==0.2.1
+humanize==1.0.0
 hurry.filesize==0.9
 nest_asyncio
 numpy<2


### PR DESCRIPTION
Nik ran into humanize not being imported to use Pipeline. I added it to the requirements.txt that I believe is the correct requirements.txt. I think the other ones in the docker folder are just for creating docker images.