### PR TITLE
[auth] resolve auth bug by pinning google-auth version

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -3,7 +3,10 @@ FROM {{ service_base_image.image }}
 # bug in 0.4.0
 # https://github.com/googleapis/google-auth-library-python-oauthlib/issues/46
 # https://stackoverflow.com/questions/56555687/oauth-throws-missing-code-validator-in-google-oauth2
-RUN pip3 install --upgrade google-auth-oauthlib==0.3.0
+RUN pip3 install --upgrade \
+      google-auth-oauthlib==0.3.0 \
+      # https://github.com/googleapis/google-auth-library-python/issues/443
+      google-auth==1.11.0
 
 COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/


### PR DESCRIPTION
Root cause: https://github.com/googleapis/google-auth-library-python/issues/443

`google-auth-oauthlib` does not pin any version of `google-auth` (I [created a PR](https://github.com/googleapis/google-auth-library-python-oauthlib/pull/71) to start pinning major & minor version). However, that wouldn't have saved us, the change (it increasingly appears to have been a bug, not an accidental breaking change) was introduced in the patch version 1.11.1. This pins *us* to 1.11.0. I am subscribed to the bug and will remove the patch-version pin once a fix is released. 