### PR TITLE
[hail] fix sparsity for Map/Map2/Densify nodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -35,7 +35,7 @@ object BlockMatrixSparsity {
 
 case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
   def isSparse: Boolean = definedBlocks.isDefined
-  private[this] lazy val blockSet: Set[(Int, Int)] = definedBlocks.get.toSet
+  lazy val blockSet: Set[(Int, Int)] = definedBlocks.get.toSet
   def hasBlock(idx: (Int, Int)): Boolean = definedBlocks.isEmpty || blockSet.contains(idx)
   def condense(blockOverlaps: => (Array[Array[Int]], Array[Array[Int]])): BlockMatrixSparsity = {
     definedBlocks.map { _ =>


### PR DESCRIPTION
Map2 needs to compute its sparsity based on the provided merge strategy.

Also apparently i forgot to include densify in the other PR, so I'm including it here.