### PR TITLE
[blog][bugfix] revert router headers for blog

### DIFF
--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -244,7 +244,10 @@ server {
 
     location / {
         proxy_pass http://blog/;
-        include /etc/nginx/proxy.conf;
+	proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+	proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
     }
 
     listen 80;


### PR DESCRIPTION
@danking the changes in the router configuration for the blog are causing an infinite redirect loop when you try to go to https://blog.hail.is. I'd like to change them back to how they were before (I added the X-Real-IP line that was not in the original configuration, which I think is the change you were introducing in that PR, although I have no idea how that works.)