### PR TITLE
[hail] introduce caching to BlockMatrixIR

### DIFF
--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -362,6 +362,9 @@ class BlockMatrixIR(BaseIR):
     def parse(self, code, ref_map={}, ir_map={}):
         return Env.hail().expr.ir.IRParser.parse_blockmatrix_ir(code, ref_map, ir_map)
 
+    def unpersisted(self):
+        return self
+
 
 class JIRVectorReference(object):
     def __init__(self, jid, length, item_type):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -27,6 +27,9 @@ class BlockMatrixRead(BlockMatrixIR):
     def _compute_type(self):
         self._type = Env.backend().blockmatrix_type(self)
 
+    def unpersisted(self):
+        return self.reader.unpersisted(self)
+
 
 class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, name=str, f=IR, needs_dense=bool)

--- a/hail/python/hail/ir/blockmatrix_reader.py
+++ b/hail/python/hail/ir/blockmatrix_reader.py
@@ -14,6 +14,9 @@ class BlockMatrixReader(object):
     def __eq__(self, other):
         pass
 
+    def unpersisted(self, ir):
+        return ir
+
 
 class BlockMatrixNativeReader(BlockMatrixReader):
     @typecheck_method(path=str)
@@ -49,3 +52,21 @@ class BlockMatrixBinaryReader(BlockMatrixReader):
                self.path == other.path and \
                self.shape == other.shape and \
                self.block_size == other.block_size
+
+
+class BlockMatrixPersistReader(BlockMatrixReader):
+    def __init__(self, id, original):
+        self.id = id
+        self.original = original
+
+    def render(self):
+        reader = {'name': 'BlockMatrixPersistReader',
+                  'id': self.id}
+        return escape_str(json.dumps(reader))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixPersistReader) and \
+               self.id == other.id
+
+    def unpersisted(self, ir):
+        return self.original

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -150,7 +150,7 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
         self.storage_level = storage_level
 
     def render(self):
-        writer = {'name': 'BlockMatrixBinaryMultiWriter',
+        writer = {'name': 'BlockMatrixPersistWriter',
                   'id': self.id,
                   'storageLevel': self.storage_level}
         return escape_str(json.dumps(writer))

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -141,3 +141,22 @@ class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
                self.add_index == other.add_index and \
                self.compression == other.compression and \
                self.custom_filenames == other.custom_filenames
+
+
+class BlockMatrixPersistWriter(BlockMatrixWriter):
+    @typecheck_method(id=str, storage_level=str)
+    def __init__(self, id, storage_level):
+        self.id = id
+        self.storage_level = storage_level
+
+    def render(self):
+        writer = {'name': 'BlockMatrixBinaryMultiWriter',
+                  'id': self.id,
+                  'storageLevel': self.storage_level}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixPersistWriter) and \
+               self.id == other.id and \
+               self.storage_level == other.storage_level
+

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2183,6 +2183,24 @@ class BlockMatrixMultiWrite(IR):
         return True
 
 
+class UnpersistBlockMatrix(IR):
+    @typecheck_method(child=BlockMatrixIR)
+    def __init__(self, child):
+        super().__init__(child)
+        self.child = child
+
+    def copy(self, child):
+        return UnpersistBlockMatrix(child)
+
+    def _compute_type(self, env, agg_env):
+        self.child._compute_type()
+        self._type = tvoid
+
+    @staticmethod
+    def is_effectful() -> bool:
+        return True
+
+
 class TableToValueApply(IR):
     def __init__(self, child, config):
         super().__init__(child)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1176,7 +1176,7 @@ class BlockMatrix(object):
         -------
         :obj:`bool`
         """
-        return Env.backend()._to_java_ir(t._tir).typ().isSparse()
+        return Env.backend()._to_java_ir(self._bmir).typ().isSparse()
 
     @property
     def T(self):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -15,9 +15,9 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F
     ApplyUnaryPrimOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter, TableFromBlockMatrixNativeReader, TableRead, \
     BlockMatrixSlice, BlockMatrixSparsify, BlockMatrixDensify, RectangleSparsifier, \
-    RowIntervalSparsifier, BandSparsifier
-from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
-from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter
+    RowIntervalSparsifier, BandSparsifier, UnpersistBlockMatrix
+from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader, BlockMatrixPersistReader
+from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter, BlockMatrixPersistWriter
 from hail.table import Table
 from hail.typecheck import *
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
@@ -213,21 +213,9 @@ class BlockMatrix(object):
 
     - Natural logarithm, :meth:`log`.
     """
-    @staticmethod
-    def _from_java(jbm):
-        return BlockMatrix(JavaBlockMatrix(jbm))
 
     def __init__(self, bmir):
         self._bmir = bmir
-        self._cached_jbm = None
-
-    @property
-    def _jbm(self):
-        if self._cached_jbm is not None:
-            return self._cached_jbm
-        else:
-            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).pyExecute()
-            return self._cached_jbm
 
     @classmethod
     @typecheck_method(path=str)
@@ -1188,7 +1176,7 @@ class BlockMatrix(object):
         -------
         :obj:`bool`
         """
-        return self._jbm.gp().maybeBlocks().isDefined()
+        return Env.backend()._to_java_ir(t._tir).typ().isSparse()
 
     @property
     def T(self):
@@ -1263,7 +1251,9 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
             Persisted block matrix.
         """
-        return BlockMatrix._from_java(self._jbm.persist(storage_level))
+        id = Env.get_uid()
+        Env.backend().execute(BlockMatrixWrite(self._bmir, BlockMatrixPersistWriter(id, storage_level)))
+        return BlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, self._bmir)))
 
     def unpersist(self):
         """Unpersists this block matrix from memory/disk.
@@ -1278,7 +1268,8 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
             Unpersisted block matrix.
         """
-        return BlockMatrix._from_java(self._jbm.unpersist())
+        Env.backend().execute(UnpersistBlockMatrix(self._bmir))
+        return BlockMatrix(self._bmir.unpersisted())
 
     def __pos__(self):
         return self

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -214,8 +214,21 @@ class BlockMatrix(object):
     - Natural logarithm, :meth:`log`.
     """
 
+    @staticmethod
+    def _from_java(jbm):
+        return BlockMatrix(JavaBlockMatrix(jbm))
+
     def __init__(self, bmir):
         self._bmir = bmir
+        self._cached_jbm = None
+
+    @property
+    def _jbm(self):
+        if self._cached_jbm is not None:
+            return self._cached_jbm
+        else:
+            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).pyExecute()
+            return self._cached_jbm
 
     @classmethod
     @typecheck_method(path=str)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -111,7 +111,9 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),
             ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake_file_path', False, False, False)),
-            ir.LiftMeOut(ir.I32(1))
+            ir.LiftMeOut(ir.I32(1)),
+            ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')),
+            ir.UnpersistBlockMatrix(block_matrix_read),
         ]
 
         return value_irs
@@ -292,6 +294,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')), "Union")
         negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')), False)
         sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir, False)
+        persisted = ir.BlockMatrixRead(ir.BlockMatrixPersistReader('x', read))
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
@@ -318,6 +321,7 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         return [
             read,
+            persisted,
             add_two_bms,
             negate_bm,
             sqrt_bm,

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -18,6 +18,8 @@ class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Se
 
 case class SparkBackend(sc: SparkContext) extends Backend {
 
+  override val cache: SparkValueCache = SparkValueCache()
+
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new SparkBroadcastValue[T](sc.broadcast(value))
 
   def parallelizeAndComputeWithIndex[T : ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U] = {

--- a/hail/src/main/scala/is/hail/backend/spark/SparkValueCache.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkValueCache.scala
@@ -1,0 +1,18 @@
+package is.hail.backend.spark
+
+import is.hail.backend.ValueCache
+import is.hail.linalg.BlockMatrix
+
+import scala.collection.mutable
+
+case class SparkValueCache() extends ValueCache {
+  private[this] val blockmatrices: mutable.Map[String, BlockMatrix] = new mutable.HashMap()
+
+  def persistBlockMatrix(id: String, value: BlockMatrix, storageLevel: String): Unit =
+    blockmatrices.update(id, value.persist(storageLevel))
+
+  def getPersistedBlockMatrix(id: String): BlockMatrix = blockmatrices(id)
+
+  def unpersistBlockMatrix(id: String): Unit =
+    blockmatrices(id).unpersist()
+}

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -9,7 +9,8 @@ object BlockMatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(
       List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter],
-        classOf[BlockMatrixBinaryMultiWriter], classOf[BlockMatrixTextMultiWriter]))
+        classOf[BlockMatrixBinaryMultiWriter], classOf[BlockMatrixTextMultiWriter],
+        classOf[BlockMatrixPersistWriter]))
     override val typeHintFieldName: String = "name"
   }
 }
@@ -32,6 +33,11 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
   def apply(hc: HailContext, bm: BlockMatrix): Unit = {
     RichDenseMatrixDouble.exportToDoubles(hc.sFS, path, bm.toBreezeMatrix(), forceRowMajor = true)
   }
+}
+
+case class BlockMatrixPersistWriter(id: String, storageLevel: String) extends BlockMatrixWriter {
+  def apply(hc: HailContext, bm: BlockMatrix): Unit =
+    HailContext.backend.cache.persistBlockMatrix(id, bm, storageLevel)
 }
 
 case class BlockMatrixRectanglesWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -186,6 +186,7 @@ object Children {
     case BlockMatrixToValueApply(child, _) => Array(child)
     case BlockMatrixCollect(child) => Array(child)
     case BlockMatrixWrite(child, _) => Array(child)
+    case UnpersistBlockMatrix(child) => Array(child)
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
     case ReadPartition(path, _, _) => Array(path)

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -13,6 +13,7 @@ object InterpretableButNotCompilable {
     case _: MatrixMultiWrite => true
     case _: TableMultiWrite => true
     case _: BlockMatrixWrite => true
+    case _: UnpersistBlockMatrix => true
     case _: BlockMatrixMultiWrite => true
     case _: TableToValueApply => true
     case _: MatrixToValueApply => true
@@ -37,6 +38,7 @@ object Compilable {
       case _: TableMultiWrite => false
       case _: BlockMatrixCollect => false
       case _: BlockMatrixWrite => false
+      case _: UnpersistBlockMatrix => false
       case _: BlockMatrixMultiWrite => false
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -297,6 +297,9 @@ object Copy {
         BlockMatrixWrite(newChildren(0).asInstanceOf[BlockMatrixIR], writer)
       case BlockMatrixMultiWrite(_, writer) =>
         BlockMatrixMultiWrite(newChildren.map(_.asInstanceOf[BlockMatrixIR]), writer)
+      case UnpersistBlockMatrix(child) =>
+        assert(newChildren.length == 1)
+        UnpersistBlockMatrix(newChildren(0).asInstanceOf[BlockMatrixIR])
       case CollectDistributedArray(_, _, cname, gname, _) =>
         assert(newChildren.length == 3)
         CollectDistributedArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], cname, gname, newChildren(2).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -434,6 +434,8 @@ final case class ReadPartition(path: IR, spec: AbstractTypedCodecSpec, rowType: 
 final case class ReadValue(path: IR, spec: AbstractTypedCodecSpec, requestedType: Type) extends IR
 final case class WriteValue(value: IR, pathPrefix: IR, spec: AbstractTypedCodecSpec) extends IR
 
+final case class UnpersistBlockMatrix(child: BlockMatrixIR) extends IR
+
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)
   def -(other: IR): IR = ApplyBinaryPrimOp(Subtract(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -211,6 +211,7 @@ object InferType {
       case _: BlockMatrixCollect => TNDArray(TFloat64(), Nat(2))
       case _: BlockMatrixWrite => TVoid
       case _: BlockMatrixMultiWrite => TVoid
+      case _: UnpersistBlockMatrix => TVoid
       case TableGetGlobals(child) => child.typ.globalType
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
       case TableToValueApply(child, function) => function.typ(child.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -586,6 +586,9 @@ object Interpret {
         writer(hc, child.execute(ctx))
       case BlockMatrixMultiWrite(blockMatrices, writer) =>
         writer(blockMatrices.map(_.execute(ctx)))
+      case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id))) =>
+        HailContext.backend.cache.unpersistBlockMatrix(id)
+      case _: UnpersistBlockMatrix =>
       case TableToValueApply(child, function) =>
         function.execute(ctx, child.execute(ctx))
       case BlockMatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1155,6 +1155,8 @@ object IRParser {
         val writer = deserialize[BlockMatrixMultiWriter](writerStr)
         val blockMatrices = repUntil(it, blockmatrix_ir(env), PunctuationToken(")"))
         BlockMatrixMultiWrite(blockMatrices.toFastIndexedSeq, writer)
+      case "UnpersistBlockMatrix" =>
+        UnpersistBlockMatrix(blockmatrix_ir(env)(it))
       case "CollectDistributedArray" =>
         val cname = identifier(it)
         val gname = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -556,6 +556,8 @@ object Simplify {
       if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
 
     case LiftMeOut(child) if IsConstant(child) => child
+    case x@UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(_))) => x
+    case _: UnpersistBlockMatrix => Begin(FastIndexedSeq())
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -386,6 +386,7 @@ object TypeCheck {
       case BlockMatrixCollect(_) =>
       case BlockMatrixWrite(_, _) =>
       case BlockMatrixMultiWrite(_, _) =>
+      case UnpersistBlockMatrix(_) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         assert(ctxs.typ.isInstanceOf[TStreamable])
       case x@ReadPartition(path, spec, rowType) =>

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -1,7 +1,8 @@
 package is.hail.expr.types
 
 import is.hail.utils._
-import is.hail.expr.types.virtual.Type
+import is.hail.expr.types.virtual.{TFloat64, Type}
+import is.hail.linalg.BlockMatrix
 
 object BlockMatrixSparsity {
   private val builder: ArrayBuilder[(Int, Int)] = new ArrayBuilder[(Int, Int)]
@@ -78,6 +79,12 @@ object BlockMatrixType {
   def dense(elementType: Type, nRows: Long, nCols: Long, blockSize: Int): BlockMatrixType = {
     val (shape, isRowVector) = matrixToTensorShape(nRows, nCols)
     BlockMatrixType(elementType, shape, isRowVector, blockSize, BlockMatrixSparsity.dense)
+  }
+
+  def fromBlockMatrix(value: BlockMatrix): BlockMatrixType = {
+    val sparsity = BlockMatrixSparsity.fromLinearBlocks(value.nRows, value.nCols, value.blockSize, value.gp.maybeBlocks)
+    val (shape, isRowVector) = matrixToTensorShape(value.nRows, value.nCols)
+    BlockMatrixType(TFloat64(), shape, isRowVector, value.blockSize, sparsity)
   }
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2645,6 +2645,8 @@ class IRSuite extends HailSuite {
       BlockMatrixCollect(blockMatrix),
       BlockMatrixWrite(blockMatrix, blockMatrixWriter),
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
+      BlockMatrixWrite(blockMatrix, BlockMatrixPersistWriter("x", "MEMORY_ONLY")),
+      UnpersistBlockMatrix(blockMatrix),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
       ReadValue(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
@@ -2822,7 +2824,9 @@ class IRSuite extends HailSuite {
       sparsify3,
       densify,
       RelationalLetBlockMatrix("x", I32(0), read),
-      slice)
+      slice,
+      BlockMatrixRead(BlockMatrixPersistReader("x"))
+    )
 
     blockMatrixIRs.map(ir => Array(ir))
   }


### PR DESCRIPTION
This lets us get rid of python-side BlockMatrix (_jbm) and BlockMatrixLiteral (JavaBlockMatrix) notions, so that every BlockMatrix manipulation either generates/transforms a (python-level) BlockMatrix IR or executes one.

I don't *super* like that there's an IR node for unpersist, but it did help move things cleanly into the "everything is BlockMatrixIR or .execute()" world.

This should also let us get rid of `BlockMatrixLiteral` (which I'll do in a separate PR) and lifts over the last piece that was constructing a BlockMatrix directly from python without going through BlockMatrixIR.

Eventually, I'd like to move Table/MatrixTable caching over to something like this as well, since I think it's going to be easier to tie in to the lowering.

cc @tpoterba 