### PR TITLE
[router][blog] fix proxy rules

### DIFF
--- a/router/proxy.conf
+++ b/router/proxy.conf
@@ -1,5 +1,5 @@
 proxy_set_header Host              $http_host;
 proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Host  $http_host;
-proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Host  $updated_host;
+proxy_set_header X-Forwarded-Proto $updated_scheme;
 proxy_set_header X-Real-IP         $http_x_real_ip;

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -244,10 +244,7 @@ server {
 
     location / {
         proxy_pass http://blog/;
-	proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host  $updated_host;
-	proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        proxy_set_header X-Real-IP         $http_x_real_ip;
+        include /etc/nginx/proxy.conf;
     }
 
     listen 80;


### PR DESCRIPTION
The proxy should propagate an existing forwarded protocol and
host if either exists. See the definition of `$updated_...` in
`nginx.conf`.

Revert blog to standard proxy rules now that proxy rules are correct.