### PR TITLE
[hail] write undocumented function for passing expr to sparsify_row_intervals

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -223,7 +223,7 @@ class BlockMatrix(object):
 
     @property
     def _jbm(self):
-        if self._cached_jbm is not None:fi
+        if self._cached_jbm is not None:
             return self._cached_jbm
         else:
             self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).pyExecute()

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1007,8 +1007,8 @@ class BlockMatrix(object):
             BlockMatrixSparsify(self._bmir, intervals._ir,
                                 RowIntervalSparsifier(blocks_only)))
 
-    @typecheck_method(starts=oneof(sequenceof(int), np.ndarray, expr_tuple([exor_int64, expr_int64])),
-                      stops=nullable(oneof(sequenceof(int), np.ndarray)),
+    @typecheck_method(starts=oneof(sequenceof(int), np.ndarray),
+                      stops=oneof(sequenceof(int), np.ndarray),
                       blocks_only=bool)
     def sparsify_row_intervals(self, starts, stops, blocks_only=False):
         """Creates a block-sparse matrix by filtering to an interval for each row.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -8,7 +8,8 @@ import scipy.linalg as spla
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr import construct_expr, construct_variable
-from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
+from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed, \
+    expr_tuple, expr_array, expr_int64
 from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryPrimOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
@@ -222,7 +223,7 @@ class BlockMatrix(object):
 
     @property
     def _jbm(self):
-        if self._cached_jbm is not None:
+        if self._cached_jbm is not None:fi
             return self._cached_jbm
         else:
             self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).pyExecute()
@@ -999,8 +1000,15 @@ class BlockMatrix(object):
 
         return self.sparsify_band(lower_band, upper_band, blocks_only)
 
-    @typecheck_method(starts=oneof(sequenceof(int), np.ndarray),
-                      stops=oneof(sequenceof(int), np.ndarray),
+    @typecheck_method(intervals=expr_tuple([expr_array(expr_int64), expr_array(expr_int64)]),
+                      blocks_only=bool)
+    def _sparsify_row_intervals_expr(self, intervals, blocks_only=False):
+        return BlockMatrix(
+            BlockMatrixSparsify(self._bmir, intervals._ir,
+                                RowIntervalSparsifier(blocks_only)))
+
+    @typecheck_method(starts=oneof(sequenceof(int), np.ndarray, expr_tuple([exor_int64, expr_int64])),
+                      stops=nullable(oneof(sequenceof(int), np.ndarray)),
                       blocks_only=bool)
     def sparsify_row_intervals(self, starts, stops, blocks_only=False):
         """Creates a block-sparse matrix by filtering to an interval for each row.
@@ -1090,13 +1098,7 @@ class BlockMatrix(object):
         if any([starts[i] > stops[i] for i in range(0, n_rows)]):
             raise ValueError('every start value must be less than or equal to the corresponding stop value')
 
-        starts_and_stops = hl.literal(
-            (starts, stops),
-            hl.ttuple(hl.tarray(hl.tint64), hl.tarray(hl.tint64)))
-        return BlockMatrix(
-            BlockMatrixSparsify(self._bmir,
-                                starts_and_stops._ir,
-                                RowIntervalSparsifier(blocks_only)))
+        return self._sparsify_row_intervals_expr((starts, stops), blocks_only)
 
     @typecheck_method(uri=str)
     def tofile(self, uri):

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2647,10 +2647,7 @@ def ld_matrix(entry_expr, locus_expr, radius, coord_expr=None, block_size=None) 
     starts_and_stops = hl.linalg.utils.locus_windows(locus_expr, radius, coord_expr, _localize=False)
     starts_and_stops = hl.tuple([starts_and_stops[0].map(lambda i: hl.int64(i)), starts_and_stops[1].map(lambda i: hl.int64(i))])
     ld = hl.row_correlation(entry_expr, block_size)
-    return BlockMatrix(
-        BlockMatrixSparsify(ld._bmir,
-                            starts_and_stops._ir,
-                            RowIntervalSparsifier(blocks_only=False)))
+    return ld._sparsify_row_intervals_expr(starts_and_stops, blocks_only=False)
 
 
 @typecheck(n_populations=int,


### PR DESCRIPTION
Intended as a replacement for

```
bm = BlockMatrix._from_java(bm._jbm.filterRowIntervalsIR(Env.backend()._to_java_ir(starts_and_stops._ir), False))
```

which I hope to remove support for in the near future. The new invocation would be:

```
bm = bm._sparsify_row_intervals_expr(starts_and_stops, blocks_only = False)
```