### PR TITLE
[hail] implement NDArrayFilter node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -109,6 +109,8 @@ object Children {
       nd +: idxs
     case NDArraySlice(nd, slices) =>
       Array(nd, slices)
+    case NDArrayFilter(nd, keep) =>
+      nd +: keep
     case NDArrayMap(nd, _, body) =>
       Array(nd, body)
     case NDArrayMap2(l, r, _, _, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -88,6 +88,8 @@ object Copy {
       case NDArraySlice(_, _) =>
         assert(newChildren.length ==  2)
         NDArraySlice(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
+      case NDArrayFilter(_, _) =>
+        NDArrayFilter(newChildren(0).asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]))
       case NDArrayMap(_, name, _) =>
         assert(newChildren.length ==  2)
         NDArrayMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -21,6 +21,7 @@ object FoldConstants {
              _: NDArrayReshape |
              _: NDArrayConcat |
              _: NDArraySlice |
+             _: NDArrayFilter |
              _: NDArrayMap |
              _: NDArrayMap2 |
              _: NDArrayReindex |

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -265,6 +265,7 @@ final case class NDArrayConcat(nds: IR, axis: Int) extends NDArrayIR
 
 final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 final case class NDArraySlice(nd: IR, slices: IR) extends NDArrayIR
+final case class NDArrayFilter(nd: IR, keep: IndexedSeq[IR]) extends NDArrayIR
 
 final case class NDArrayMap(nd: IR, valueName: String, body: IR) extends NDArrayIR
 final case class NDArrayMap2(l: IR, r: IR, lName: String, rName: String, body: IR) extends NDArrayIR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -294,6 +294,10 @@ object InferPType {
         infer(slices)
         val remainingDims = coerce[PTuple](slices.pType2).types.filter(_.isInstanceOf[PTuple])
         PNDArray(coerce[PNDArray](nd.pType2).elementType, remainingDims.length, remainingDims.forall(_.required))
+      case NDArrayFilter(nd, filters) =>
+        infer(nd)
+        filters.foreach(infer(_))
+        coerce[PNDArray](nd.pType2)
       case NDArrayMatMul(l, r) =>
         infer(l)
         infer(r)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -146,6 +146,8 @@ object InferType {
         val tuplesOnly = slicesTyp.types.collect { case x: TTuple => x}
         val remainingDims = Nat(tuplesOnly.length)
         TNDArray(childTyp.elementType, remainingDims)
+      case NDArrayFilter(nd, _) =>
+        nd.typ
       case NDArrayMatMul(l, r) =>
         val lTyp = coerce[TNDArray](l.typ)
         val rTyp = coerce[TNDArray](r.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -24,6 +24,7 @@ object Interpretable {
         _: NDArrayConcat |
         _: NDArrayRef |
         _: NDArraySlice |
+        _: NDArrayFilter |
         _: NDArrayMap |
         _: NDArrayMap2 |
         _: NDArrayReindex |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -843,6 +843,10 @@ object IRParser {
         val nd = ir_value_expr(env)(it)
         val slices = ir_value_expr(env)(it)
         NDArraySlice(nd, slices)
+      case "NDArrayFilter" =>
+        val nd = ir_value_expr(env)(it)
+        val filters = Array.fill(coerce[TNDArray](nd.typ).nDims)(ir_value_expr(env)(it))
+        NDArrayFilter(nd, filters.toFastIndexedSeq)
       case "NDArrayMatMul" =>
         val l = ir_value_expr(env)(it)
         val r = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -189,6 +189,10 @@ object TypeCheck {
         assert(slicesTuple.types.forall { t =>
           t == TTuple(TInt64(), TInt64(), TInt64()) || t == TInt64()
         })
+      case NDArrayFilter(nd, filters) =>
+        val ndtyp = coerce[TNDArray](nd.typ)
+        assert(ndtyp.nDims == filters.length)
+        assert(filters.forall(f => coerce[TArray](f.typ).elementType.isOfType(TInt64())))
       case x@NDArrayMap(_, _, body) =>
         assert(x.elementTyp isOfType body.typ)
       case x@NDArrayMap2(l, r, _, _, body) =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2175,9 +2175,6 @@ class IRSuite extends HailSuite {
         MakeArray(FastIndexedSeq(I64(1)), TArray(TInt64())),
         MakeArray(FastIndexedSeq(I64(1)), TArray(TInt64())))),
       Array(Array(4.0)))
-
-
-
   }
 
   @Test def testLeftJoinRightDistinct() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1862,7 +1862,7 @@ class IRSuite extends HailSuite {
     MakeNDArray(MakeArray(data.map(F64), TArray(TFloat64())), MakeTuple.ordered(shape.map(I64)), rowMajor)
   }
 
-  def assertNDEvals(eltType: Type, nd: IR, expected: Array[Array[Any]]): Unit = {
+  def assertNDEvals(eltType: Type, nd: IR, expected: Array[Array[Any]])(implicit execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly): Unit = {
     val arrayIR = if (expected == null) nd else {
       val nRows = expected.length
       val nCols = if (nRows == 0) 0 else expected.head.length
@@ -1935,7 +1935,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testNDArrayConcat() {
-    implicit val execStrats = ExecStrategy.compileOnly
+    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
     def nds(ndData: (IndexedSeq[Int], Long, Long)*): IR = {
       MakeArray(ndData.map { case (values, nRows, nCols) =>
         if (values == null) NA(TNDArray(TInt32(), Nat(2))) else
@@ -1961,13 +1961,13 @@ class IRSuite extends HailSuite {
     val emptyColwise = (FastIndexedSeq(), 2L, 0L)
     val na = (null, 0L, 0L)
 
-    val rowwiseExpected = Array(
+    val rowwiseExpected: Array[Array[Any]] = Array(
       Array(0, 1, 2),
       Array(3, 4, 5),
       Array(6, 7, 8),
       Array(9, 10, 11),
       Array(12, 13, 14))
-    val colwiseExpected = Array(
+    val colwiseExpected: Array[Array[Any]] = Array(
       Array(0, 1, 2, 15, 16),
       Array(3, 4, 5, 17, 18))
 


### PR DESCRIPTION
This node filters an NDArray to a smaller NDArray that has only the specified rows/cols/etc. along a specific axis, in the specified order. It will be used for lowering BlockMatrixFilter.

If the array of indices along a given axis is missing, then we preserve the original indexing along that axis. If an element in the array of indices is missing, we throw a runtime error.

The filter/don't filter decision for a given axis could also be lifted to a compile-time decision, rather than a runtime decision (say by having the type of the filter along that axis being `ttuple[]` instead of `tarray<tint64>`).

Unlike NDArraySlice, it does not give the option of reducing the number of dimensions of the NDArray, although I can change that if we have a use for it.