### PR TITLE
Make IR function registration idempotent

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -268,9 +268,13 @@ class Tests(unittest.TestCase):
         assert mt._same(expected_split_mt)
 
     def test_define_function(self):
-        f = hl.experimental.define_function(
+        f1 = hl.experimental.define_function(
             lambda a, b: (a + 7) * b, hl.tint32, hl.tint32)
-        self.assertEqual(hl.eval(f(1, 3)), 24)
+        self.assertEqual(hl.eval(f1(1, 3)), 24)
+        f2 = hl.experimental.define_function(
+            lambda a, b: (a + 7) * b, hl.tint32, hl.tint32)
+        self.assertEqual(hl.eval(f1(1, 3)), 24) # idempotent
+        self.assertEqual(hl.eval(f2(1, 3)), 24) # idempotent
 
     def test_mt_full_outer_join(self):
         mt1 = hl.utils.range_matrix_table(10, 10)


### PR DESCRIPTION
Right now, IR function registration fails in the following case.
- Multiple Python HailContexts are running on the same cluster
- User on HailContext A calls a function (eg. create histogram) that triggers `hl.experimental.define_function`
  * An anonymous function is used to create a new `Set` in `IRFunctionRegistry.irRegistry`
- User on HailContext B calls the same function
  * The anonymous function is added to create a `Set` of size `2` in `IRFunctionRegistry.irRegistry`, as anonymous functions are never considered equivalent
  * This triggers a fatal error `Multiple functions found that satisfy ...`

By changing the definition of `IRFunctionRegistry.irRegistry` from a `MultiMap(functionName -> Set[argumentTypes, returnType, alwaysInline, anonymousFunction])` to a `Map(functionName -> Map((argumentTypes, returnType, alwaysInline) -> anonymousFunction))` , we ensure function registration is idempotent as we do not compare on the `anonymousFunction`.