### PR TITLE
[hail] define (unimplemented) ReadValue and WriteValue IR nodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -189,6 +189,8 @@ object Children {
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
     case ReadPartition(path, _, _) => Array(path)
+    case ReadValue(path, _, _) => Array(path)
+    case WriteValue(value, pathPrefix, spec) => Array(value, pathPrefix)
     case LiftMeOut(child) => Array(child)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -303,6 +303,12 @@ object Copy {
       case ReadPartition(path, spec, rowType) =>
         assert(newChildren.length == 1)
         ReadPartition(newChildren(0).asInstanceOf[IR], spec, rowType)
+      case ReadValue(path, spec, requestedType) =>
+        assert(newChildren.length == 1)
+        ReadValue(newChildren(0).asInstanceOf[IR], spec, requestedType)
+      case WriteValue(value, pathPrefix, spec) =>
+        assert(newChildren.length == 2)
+        WriteValue(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], spec)
       case LiftMeOut(_) =>
         LiftMeOut(newChildren(0).asInstanceOf[IR])
     }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -431,6 +431,9 @@ final case class CollectDistributedArray(contexts: IR, globals: IR, cname: Strin
 
 final case class ReadPartition(path: IR, spec: AbstractTypedCodecSpec, rowType: TStruct) extends IR
 
+final case class ReadValue(path: IR, spec: AbstractTypedCodecSpec, requestedType: Type) extends IR
+final case class WriteValue(value: IR, pathPrefix: IR, spec: AbstractTypedCodecSpec) extends IR
+
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)
   def -(other: IR): IR = ApplyBinaryPrimOp(Subtract(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -387,10 +387,15 @@ object InferPType {
         PCanonicalArray(bodyIR._pType2, contextsIR._pType2.required)
       case ReadPartition(rowIR, codecSpec, rowType) =>
         infer(rowIR)
-
         val child = codecSpec.buildDecoder(rowType)._1
-
         PStream(child, child.required)
+      case ReadValue(path, spec, requestedType) =>
+        infer(path)
+        spec.buildDecoder(requestedType)._1
+      case WriteValue(value, pathPrefix, spec) =>
+        infer(value)
+        infer(pathPrefix)
+        PCanonicalString(pathPrefix.pType2.required)
       case MakeStream(irs, t) =>
         if (irs.isEmpty) {
           PType.canonical(t, true).deepInnerRequired(true)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -218,6 +218,8 @@ object InferType {
       case BlockMatrixToValueApply(child, function) => function.typ(child.typ)
       case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
       case ReadPartition(_, _, rowType) => TStream(rowType)
+      case ReadValue(_, _, typ) => typ
+      case WriteValue(value, pathPrefix, spec) => TString()
       case LiftMeOut(child) => child.typ
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -672,8 +672,6 @@ object Interpret {
           }
         }
         wrapped.get(0)
-      case x: ReadPartition =>
-        fatal(s"cannot interpret ${ Pretty(x) }")
       case LiftMeOut(child) =>
         val (rt, makeFunction) = Compile[Long](ctx, MakeTuple.ordered(FastSeq(child)), None, false)
         Region.scoped { r =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -31,6 +31,9 @@ object Interpretable {
         _: NDArrayMatMul |
         _: TailLoop |
         _: Recur |
+        _: ReadPartition |
+        _: ReadValue |
+        _: WriteValue |
         _: NDArrayWrite => false
       case x: ApplyIR =>
         !Exists(x.body, {

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -228,7 +228,6 @@ case class MatrixNativeReader(
       val cols = if (partFiles.length == 1) {
         ReadPartition(Str(partFiles.head), colsRVDSpec.typedCodecSpec, mr.typ.colType)
       } else {
-        val partitionReads = partFiles.map(f => ToArray(ReadPartition(Str(f), colsRVDSpec.typedCodecSpec, mr.typ.colType)))
         val partNames = MakeArray(partFiles.map(Str), TArray(TString()))
         val elt = Ref(genUID(), TString())
         ArrayFlatMap(

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1171,6 +1171,18 @@ object IRParser {
         val rowType = coerce[TStruct](type_expr(env.typEnv)(it))
         val path = ir_value_expr(env)(it)
         ReadPartition(path, spec, rowType)
+      case "ReadValue" =>
+        import AbstractRVDSpec.formats
+        val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]
+        val typ = type_expr(env.typEnv)(it)
+        val path = ir_value_expr(env)(it)
+        ReadValue(path, spec, typ)
+      case "WriteValue" =>
+        import AbstractRVDSpec.formats
+        val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]
+        val value = ir_value_expr(env)(it)
+        val path = ir_value_expr(env)(it)
+        WriteValue(value, path, spec)
       case "LiftMeOut" =>
         LiftMeOut(ir_value_expr(env)(it))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -416,8 +416,11 @@ object Pretty {
             case RelationalLetTable(name, _, _) => prettyIdentifier(name)
             case RelationalLetMatrixTable(name, _, _) => prettyIdentifier(name)
             case RelationalLetBlockMatrix(name, _, _) => prettyIdentifier(name)
-            case ReadPartition(path, spec, rowType) =>
+            case ReadPartition(_, spec, rowType) =>
               s"${ prettyStringLiteral(spec.toString) } ${ rowType.parsableString() }"
+            case ReadValue(_, spec, reqType) =>
+              s"${ prettyStringLiteral(spec.toString) } ${ reqType.parsableString() }"
+            case WriteValue(_, _, spec) => prettyStringLiteral(spec.toString)
 
             case _ => ""
           }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -388,9 +388,16 @@ object TypeCheck {
       case BlockMatrixMultiWrite(_, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         assert(ctxs.typ.isInstanceOf[TStreamable])
-      case x@ReadPartition(path, _, rowType) =>
+      case x@ReadPartition(path, spec, rowType) =>
         assert(path.typ == TString())
         assert(x.typ == TStream(rowType))
+        assert(spec.encodedType.decodedPType(rowType).virtualType == rowType)
+      case x@ReadValue(path, spec, requestedType) =>
+        assert(path.typ == TString())
+        assert(spec.encodedType.decodedPType(requestedType).virtualType == requestedType)
+      case x@WriteValue(value, pathPrefix, spec) =>
+        assert(pathPrefix.typ == TString())
+        spec.encodedType.encodeCompatible(value.pType2)
       case LiftMeOut(_) =>
     }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2648,6 +2648,8 @@ class IRSuite extends HailSuite {
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
+      ReadValue(Str("foo"), TypedCodecSpec(PStruct("foo" -> PInt32(), "bar" -> PString()), BufferSpec.default), TStruct("foo" -> TInt32())),
+      WriteValue(I32(1), Str("foo"), TypedCodecSpec(PInt32(), BufferSpec.default)),
       LiftMeOut(I32(1)),
       RelationalLet("x", I32(0), I32(0)),
       TailLoop("y", IndexedSeq("x" -> I32(0)), Recur("y", FastSeq(I32(4)), TInt32()))


### PR DESCRIPTION
ReadValue reads a value from a file. It behaves equivalently to ReadPartitions, except that it reads non-stream objects while ReadPartition reads stream objects.

WriteValue writes a value to a file. It takes a filly qualified path prefix and returns the fully qualified file path. (This is so we can eventually implement the thing we do on writes now, where we could potentially try to write a partition multiple times, appending a unique suffix each time, and will only collect the path names of the ones that completed successfully.)

Eventually, we might want to merge ReadValue/ReadPartition and WriteValue/WritePartition, but it might also be nice to know based on the type of node whether it handles a stream.

This just contains all of the definitions associated with the IR node; I'll implement them in a separate PR.