### PR TITLE
[combiner] s/gVCF/GVCF/g

### DIFF
--- a/hail/python/hail/docs/experimental/vcf_combiner.rst
+++ b/hail/python/hail/docs/experimental/vcf_combiner.rst
@@ -1,11 +1,11 @@
 VCF Combiner
 ============
 
-Library functions for combining gVCFS and sparse matrix tables into
+Library functions for combining GVCFS and sparse matrix tables into
 larger sparse matrix tables.
 
 What this module provides:
-    - A Sensible way to transform input gVCFS.
+    - A Sensible way to transform input GVCFS.
     - The combining function.
 
 What this module does not provide:
@@ -27,7 +27,7 @@ Sparse Matrix Tables
 --------------------
 
 Sparse matrix tables are a new method of representing VCF style data in a space efficient way. They
-are produced them using :func:`transform_gvcf` on an imported gVCF, or by using
+are produced them using :func:`transform_gvcf` on an imported GVCF, or by using
 :func:`combine_gvcfs` on smaller sparse matrix tables. They have two components that differentiate
 them from matrix tables produced by importing VCFs.
 
@@ -46,7 +46,7 @@ example: ::
 This record indicates that S01 is homozygous reference until position 15,000 with approximate ``GQ``
 of 40 across the few hundred base pair block.
 
-A sparse matrix table has an entry field ``END`` that corresponds to the gVCF ``INFO`` field,
+A sparse matrix table has an entry field ``END`` that corresponds to the GVCF ``INFO`` field,
 ``END``. It has the same meaning, but only for the single column where the END resides. In a sparse
 matrix table, there should be no present entries for this sample between ``chr1:14524`` and
 ``chr1:15000``, inclusive.
@@ -64,7 +64,7 @@ over 3 terabytes. Even if we only had the minimum required ``PL`` arrays materia
 still be looking at gigabytes for a single row.
 
 A sparse matrix table solves this issue by creating new fields that are 'local'. It only stores
-information that was present in the imported gVCFs. The :func:`transform_gvcf` does this initial
+information that was present in the imported GVCFs. The :func:`transform_gvcf` does this initial
 conversion. The fields ``GT``, ``AD``, ``PGT``, ``PL``, are converted to their local versions,
 ``LGT``, ``LAD``, ``LPGT``, ``LPL``, and a ``LA`` (local alleles) array is added.  The ``LA`` field
 serves as the map between the ``alleles`` field and the local fields. For example (using VCF-like

--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -402,12 +402,12 @@ def drive_combiner(sample_map_path, intervals, out_file, tmp_path, header, overw
     run_combiner(sample_names, sample_paths, intervals, out_file, tmp_path, header, overwrite)
 
 def main():
-    parser = argparse.ArgumentParser(description="Driver for hail's gVCF combiner")
+    parser = argparse.ArgumentParser(description="Driver for hail's GVCF combiner")
     parser.add_argument('sample_map',
                         help='path to the sample map (must be readable by this script). '
                              'The sample map should be tab separated with two columns. '
                              'The first column is the sample ID, and the second column '
-                             'is the gVCF path.')
+                             'is the GVCF path.')
     parser.add_argument('out_file', help='path to final combiner output')
     parser.add_argument('--tmp-path', help='path to folder for intermediate output (can be a cloud bucket)',
                         default='/tmp')

--- a/hail/python/scripts/drive_combiner.py
+++ b/hail/python/scripts/drive_combiner.py
@@ -1,4 +1,4 @@
-"""A high level script for running the hail gVCF combiner/joint caller"""
+"""A high level script for running the hail GVCF combiner/joint caller"""
 import argparse
 import time
 import uuid
@@ -74,18 +74,18 @@ def run_combiner(samples, intervals, out_file, tmp_path, header, overwrite=True)
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Driver for hail's gVCF combiner")
+    parser = argparse.ArgumentParser(description="Driver for hail's GVCF combiner")
     parser.add_argument('--sample-map',
                         help='path to the sample map (must be filesystem local). '
                              'The sample map should be tab separated with two columns. '
                              'The first column is the sample ID, and the second column '
-                             'is the gVCF path.\n'
-                             'WARNING: the sample names in the gVCFs will be overwritten',
+                             'is the GVCF path.\n'
+                             'WARNING: the sample names in the GVCFs will be overwritten',
                         required=True)
     parser.add_argument('--tmp-path', help='path to folder for temp output (can be a cloud bucket)',
                         default='/tmp')
     parser.add_argument('--out-file', '-o', help='path to final combiner output', required=True)
-    parser.add_argument('--json', help='json to use for the import of the gVCFs'
+    parser.add_argument('--json', help='json to use for the import of the GVCFs'
                                        '(must be filesystem local)', required=True)
     parser.add_argument('--header', help='external header, must be cloud based', required=False)
     args = parser.parse_args()


### PR DESCRIPTION
Official [GATK documenation] uses GVCF.

[GATK documenation]: https://gatk.broadinstitute.org/hc/en-us/articles/360035531812-GVCF-Genomic-Variant-Call-Format