### PR TITLE
[Hail/streams] port more stream consumers

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -109,6 +109,13 @@ case class ParamPackArray(pps: IndexedSeq[ParameterPack[_]]) extends ParameterPa
     }
     ParameterStoreArray(fields)
   }
+
+  def newFields(fb: FunctionBuilder[_], names: IndexedSeq[String]): ParameterStoreArray = {
+    val fields = pps.zip(names).map { case (pp, name) =>
+      pp.newFields(fb, name)
+    }
+    ParameterStoreArray(fields)
+  }
 }
 
 object ParameterPack {
@@ -128,7 +135,7 @@ object ParameterPack {
   ): ParameterPack[(A, B, C)] = ParamPackTuple3(ap, bp, cp)
 
 
-  def array(pps: IndexedSeq[ParameterPack[_]]): ParameterPack[IndexedSeq[_]] = ParamPackArray(pps)
+  def array(pps: IndexedSeq[ParameterPack[_]]): ParamPackArray = ParamPackArray(pps)
 
   def let[A: ParameterPack, X](mb: MethodBuilder, a0: A)(k: A => Code[X]): Code[X] = {
     val ap = implicitly[ParameterPack[A]]
@@ -209,6 +216,42 @@ case class ParameterStoreArray(pss: IndexedSeq[ParameterStore[_]]) extends Param
 
 }
 
+case class ParameterPackTriplet[P](ti: TypeInfo[P]) extends ParameterPack[TypedTriplet[P]] {
+  val ppm = implicitly[ParameterPack[Code[Boolean]]]
+  val ppv = ParameterPack.code(ti)
+
+  def push(trip: TypedTriplet[P]): Code[Unit] = Code(
+    trip.setup,
+    trip.m.mux(
+      Code(coerce[Unit](ir.defaultValue(ti)), coerce[Unit](const(true))),
+      Code(coerce[Unit](trip.v), coerce[Unit](const(false)))))
+
+  def newLocals(mb: MethodBuilder, name: String = null): ParameterStoreTriplet[P] = {
+    val psm = ppm.newLocals(mb, if (name == null) "m" else s"${ name }_missing")
+    val psv = ppv.newLocals(mb, if (name == null) "v" else name)
+    ParameterStoreTriplet[P](ti, psm, psv)
+  }
+
+  def newFields(fb: FunctionBuilder[_], name: String): ParameterStoreTriplet[P] = {
+    val psm = ppm.newFields(fb, if (name == null) "m" else s"${ name }_missing")
+    val psv = ppv.newFields(fb, if (name == null) "v" else name)
+    ParameterStoreTriplet[P](ti, psm, psv)
+  }
+}
+
+case class ParameterStoreTriplet[A](ti: TypeInfo[A], psm: ParameterStore[Code[Boolean]], psv: ParameterStore[Code[A]]) extends ParameterStore[TypedTriplet[A]] {
+  def load: TypedTriplet[A] = TypedTriplet(Code._empty, psm.load, psv.load)
+
+  def store(trip: TypedTriplet[A]): Code[Unit] = Code(
+    trip.setup,
+    trip.m.mux(
+    Code(psm.store(true), psv.storeAny(ir.defaultValue(ti))),
+    Code(psm.store(false), psv.storeAny(trip.v))))
+
+  def storeInsn: Code[Unit] = ParameterStoreTuple2(psv, psm).storeInsn
+
+  def init: Code[Unit] = Code(psm.init, psv.init)
+}
 
 object TypedTriplet {
   def apply(t: PType, et: EmitTriplet): TypedTriplet[t.type] =
@@ -217,44 +260,7 @@ object TypedTriplet {
   def missing(t: PType): TypedTriplet[t.type] =
     TypedTriplet(t, EmitTriplet(Code._empty, true, ir.defaultValue(t)))
 
-  def parameterStore[A](psm: ParameterStore[Code[Boolean]], psv: ParameterStore[Code[A]], defaultValue: Code[A]): ParameterStore[TypedTriplet[A]] = new ParameterStore[TypedTriplet[A]] {
-    def load: TypedTriplet[A] = TypedTriplet(Code._empty, psm.load, psv.load)
-
-    def store(trip: TypedTriplet[A]): Code[Unit] = Code(
-      trip.setup,
-      trip.m.mux(
-        Code(psm.store(true), psv.store(defaultValue)),
-        Code(psm.store(false), psv.storeAny(trip.v))))
-
-    def storeInsn: Code[Unit] = ParameterStoreTuple2(psv, psm).storeInsn
-
-    def init: Code[Unit] = Code(psm.init, psv.init)
-  }
-
-  class Pack[P] private[joinpoint](t: PType) extends ParameterPack[TypedTriplet[P]] {
-    val ppm = implicitly[ParameterPack[Code[Boolean]]]
-    val ppv = ParameterPack.code(ir.typeToTypeInfo(t)).asInstanceOf[ParameterPack[Code[P]]]
-
-    def push(trip: TypedTriplet[P]): Code[Unit] = Code(
-      trip.setup,
-      trip.m.mux(
-        Code(coerce[Unit](ir.defaultValue(t)), coerce[Unit](const(true))),
-        Code(coerce[Unit](trip.v), coerce[Unit](const(false)))))
-
-    def newLocals(mb: MethodBuilder, name: String = null): ParameterStore[TypedTriplet[P]] = {
-      val psm = ppm.newLocals(mb, if (name == null) "m" else s"${ name }_missing")
-      val psv = ppv.newLocals(mb, if (name == null) "v" else name)
-      parameterStore[P](psm, psv, coerce[P](ir.defaultValue(t)))
-    }
-
-    def newFields(fb: FunctionBuilder[_], name: String): ParameterStore[TypedTriplet[P]] = {
-      val psm = ppm.newFields(fb, if (name == null) "m" else s"${ name }_missing")
-      val psv = ppv.newFields(fb, if (name == null) "v" else name)
-      parameterStore[P](psm, psv, coerce[P](ir.defaultValue(t)))
-    }
-  }
-
-  def pack(t: PType): Pack[t.type] = new Pack(t)
+  def pack(t: PType): ParameterPackTriplet[t.type] = ParameterPackTriplet(ir.typeToTypeInfo(t).asInstanceOf[TypeInfo[t.type]])
 }
 
 case class TypedTriplet[P] private(setup: Code[Unit], m: Code[Boolean], v: Code[_]) {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -587,10 +587,7 @@ private class Emit(
         val optStream = emitStream2(array)
         val result = optStream.map { stream =>
           Code(
-            vab.clear,
-            stream.forEach(mb) { et =>
-              Code(et.setup, et.m.mux(vab.addMissing(), vab.add(et.v)))
-            },
+            EmitStream2.write(mb, stream, vab),
             sort,
             distinct,
             sorter.toRegion())
@@ -685,10 +682,7 @@ private class Emit(
         val optStream = emitStream2(collection)
         val result = optStream.map { stream =>
           Code(
-            eab.clear,
-            stream.forEach(mb) { et =>
-              Code(et.setup, et.m.mux(eab.addMissing(), eab.add(et.v)))
-            },
+            EmitStream2.write(mb, stream, eab),
             sorter.sort(sortF),
             sorter.pruneMissing,
             eab.size.ceq(0).mux(

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -112,8 +112,8 @@ object InferType {
         coerce[TStreamable](a.typ).copyStreamable(zero.typ)
       case ArrayAgg(_, _, query) =>
         query.typ
-      case ArrayAggScan(_, _, query) =>
-        TArray(query.typ)
+      case ArrayAggScan(a, _, query) =>
+        a.typ.asInstanceOf[TStreamable].copyStreamable(query.typ)
       case RunAgg(body, result, _) =>
         result.typ
       case RunAggScan(a, _, _, _, result, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -116,8 +116,8 @@ object InferType {
         TArray(query.typ)
       case RunAgg(body, result, _) =>
         result.typ
-      case RunAggScan(_, _, _, _, result, _) =>
-        TArray(result.typ)
+      case RunAggScan(a, _, _, _, result, _) =>
+        a.typ.asInstanceOf[TStreamable].copyStreamable(result.typ)
       case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
         coerce[TStreamable](left.typ).copyStreamable(join.typ)
       case NDArrayShape(nd) =>

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -708,13 +708,13 @@ class Aggregators2Suite extends HailSuite {
   @Test def testRunAggScan(): Unit = {
     implicit val execStrats = ExecStrategy.compileOnly
     val sig = AggSignature(Sum(), FastSeq(), FastSeq(TFloat64()))
-    val x = RunAggScan(
+    val x = ToArray(RunAggScan(
       StreamRange(I32(0), I32(5), I32(1)),
       "foo",
       InitOp(0, FastSeq(), sig),
       SeqOp(0, FastIndexedSeq(Ref("foo", TInt32()).toD), sig),
       GetTupleElement(ResultOp(0, Array(sig.singletonContainer)), 0),
-      Array(sig.singletonContainer))
+      Array(sig.singletonContainer)))
     assertEvalsTo(x, FastIndexedSeq(0.0, 0.0, 1.0, 3.0, 6.0))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -272,7 +272,11 @@ class EmitStreamSuite extends HailSuite {
     val fb = new EmitFunctionBuilder[F](argTypeInfos.result(), GenericTypeInfo[Long])
     val mb = fb.apply_method
     val stream = ExecuteContext.scoped { ctx =>
-      EmitStream(new Emit(ctx, mb), streamIR, Env.empty, EmitRegion.default(mb), None)
+      val s = streamIR match {
+        case ToArray(s) => s
+        case s => s
+      }
+      EmitStream(new Emit(ctx, mb), s, Env.empty, EmitRegion.default(mb), None)
     }
     mb.emit {
       val arrayt = stream
@@ -551,7 +555,7 @@ class EmitStreamSuite extends HailSuite {
     val intsType = TArray(TInt32())
 
     assertAggScan(
-      ArrayAggScan(ToStream(In(0, TArray(pairType))),
+      ArrayAggScan(In(0, TArray(pairType)),
         "foo",
         GetField(Ref("foo", pairType), "y") +
           GetField(

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3015,10 +3015,6 @@ class IRSuite extends HailSuite {
         In(1, TArray(TInt32()))),
       "x", Cast(Ref("x", TInt32()), TInt64()))
 
-    val env = Env.empty[(Any, Type)]
-      .bind("flag" -> ((true, TBoolean())))
-      .bind("array" -> ((FastIndexedSeq(0), TArray(TInt32()))))
-
     assertEvalsTo(ir, FastIndexedSeq(true -> TBoolean(), FastIndexedSeq(0) -> TArray(TInt32())), FastIndexedSeq(0L))
   }
 


### PR DESCRIPTION
~~Stacked on #8129~~

This PR adds support for the new streams in the emit code for `ArrayMap`, and for all stream consumers in `Emit` except `CollectDistributedArray` (ArraySort, ToSet, ToDict, ToArray, GroupByKey, and ArrayFold2). Once `CollectDistributedArray` is ported, we can get rid of `EmitArrayTriplet` and `ArrayIteratorTriplet`.

While I was wrangling with `ArrayFold2`, I made some tweaks and additions to the EmitTriplet ParameterPack to help make the emitter code more readable and easier to work on. I think the changes are likely to be in a similar direction as Cotton's PValue proposal, so I don't anticipate this making migration away from ParameterPack any harder (hopefully easier).