### PR TITLE
[query] Remove MakeArray

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -264,7 +264,7 @@ def _to_expr(e, dtype):
                      else hl.literal(element, dtype.element_type)
                      for element in elements]
             indices, aggregations = unify_all(*exprs)
-        ir = MakeArray([e._ir for e in exprs], None)
+        ir = ToArray(MakeStream([e._ir for e in exprs], None))
         return expressions.construct_expr(ir, dtype, indices, aggregations)
     elif isinstance(dtype, tset):
         elements = []
@@ -281,7 +281,7 @@ def _to_expr(e, dtype):
                      else hl.literal(element, dtype.element_type)
                      for element in elements]
             indices, aggregations = unify_all(*exprs)
-            ir = ToSet(MakeArray([e._ir for e in exprs], None))
+            ir = ToSet(MakeStream([e._ir for e in exprs], None))
             return expressions.construct_expr(ir, dtype, indices, aggregations)
     elif isinstance(dtype, ttuple):
         elements = []

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3983,7 +3983,7 @@ def empty_array(t: Union[HailType, str]) -> ArrayExpression:
     :class:`.ArrayExpression`
     """
     array_t = hl.tarray(t)
-    ir = MakeArray([], array_t)
+    ir = ToArray(MakeStream([], array_t))
     return construct_expr(ir, array_t)
 
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -530,7 +530,7 @@ class ApplyComparisonOp(IR):
         self._type = tbool
 
 
-class MakeArray(IR):
+class MakeStream(IR):
     @typecheck_method(args=sequenceof(IR), type=nullable(hail_type))
     def __init__(self, args, type):
         super().__init__(*args)
@@ -538,7 +538,7 @@ class MakeArray(IR):
         self._type = type
 
     def copy(self, *args):
-        return MakeArray(args, self._type)
+        return MakeStream(args, self._type)
 
     def head_str(self):
         return self._type._parsable_string() if self._type is not None else 'None'
@@ -550,7 +550,7 @@ class MakeArray(IR):
         for a in self.args:
             a._compute_type(env, agg_env)
         if self._type is None:
-            self._type = tarray(self.args[0].typ)
+            self._type = tstream(self.args[0].typ)
 
 
 class ArrayRef(IR):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -48,14 +48,13 @@ class ValueIRTests(unittest.TestCase):
             ir.ApplyBinaryPrimOp('+', i, j),
             ir.ApplyUnaryPrimOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
-            ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tarray(hl.tint32)),
             ir.ArrayRef(a, i, ir.Str('foo')),
             ir.ArrayLen(a),
             ir.ArraySort(a, 'l', 'r', ir.ApplyComparisonOp("LT", ir.Ref('l'), ir.Ref('r'))),
             ir.ToSet(a),
             ir.ToDict(da),
             ir.ToArray(a),
-            ir.MakeNDArray(ir.MakeArray([ir.F64(-1.0), ir.F64(1.0)], hl.tarray(hl.tfloat64)),
+            ir.MakeNDArray(ir.ToArray(ir.MakeStream([ir.F64(-1.0), ir.F64(1.0)], hl.tarray(hl.tfloat64))),
                            ir.MakeTuple([ir.I64(1), ir.I64(2)]),
                            ir.TrueIR()),
             ir.NDArrayShape(nd),
@@ -287,7 +286,7 @@ class MatrixIRTests(unittest.TestCase):
 class BlockMatrixIRTests(unittest.TestCase):
     def blockmatrix_irs(self):
         scalar_ir = ir.F64(2)
-        vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
+        vector_ir = ir.ToArray(ir.MakeStream([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64)))
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
         add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')), "Union")

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -135,6 +135,7 @@ class DefinableJoinPoint[A: ParameterPack] private[joinpoint](
   args: ParameterStore[A],
   stackIndicator: Int
 ) extends JoinPoint[A](stackIndicator) {
+  def init: Code[Unit] = args.init
 
   def define(f: A => Code[Ctrl]): Unit =
     body = Some(Code(args.storeInsn, f(args.load)))

--- a/hail/src/main/scala/is/hail/expr/LowerArrayToStream.scala
+++ b/hail/src/main/scala/is/hail/expr/LowerArrayToStream.scala
@@ -32,7 +32,6 @@ object LowerArrayToStream {
         accum.map { case (name, value) => (name, boundary(value)) },
         valueName, seq.map(boundary), boundary(result))
       case RunAggScan(a, name, init, seq, res, sig) => RunAggScan(toStream(a), name, boundary(init), boundary(seq), boundary(res), sig)
-      case MakeArray(args, t) => MakeStream(args.map(boundary), TStream(t.elementType, t.required))
       case ArrayZip(childIRs, names, body, behavior) => ArrayZip(childIRs.map(toStream), names, boundary(body), behavior)
       case ArrayMap(a, n, b) => ArrayMap(toStream(a), n, boundary(b))
       case ArrayFilter(a, n, b) => ArrayFilter(toStream(a), n, boundary(b))

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -45,8 +45,6 @@ object Children {
       Array(x)
     case ApplyComparisonOp(op, l, r) =>
       Array(l, r)
-    case MakeArray(args, typ) =>
-      args.toFastIndexedSeq
     case MakeStream(args, typ) =>
       args.toFastIndexedSeq
     case ArrayRef(a, i, s) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -53,9 +53,6 @@ object Copy {
       case ApplyComparisonOp(op, _, _) =>
         assert(newChildren.length == 2)
         ApplyComparisonOp(op, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
-      case MakeArray(args, typ) =>
-        assert(args.length == newChildren.length)
-        MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
       case MakeStream(args, typ) =>
         assert(args.length == newChildren.length)
         MakeStream(newChildren.map(_.asInstanceOf[IR]), typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -480,18 +480,6 @@ private class Emit(
               (rm, rm.mux(defaultValue(r.typ), codeR.v)))))
         }
 
-      case x@MakeArray(args, _) =>
-        val pType = x.pType.asInstanceOf[PArray]
-        val srvb = new StagedRegionValueBuilder(mb, pType)
-        val addElement = srvb.addIRIntermediate(pType.elementType)
-
-        val addElts = { (newMB: EmitMethodBuilder, pt: PType, v: EmitTriplet) =>
-          Code(
-            v.setup,
-            v.m.mux(srvb.setMissing(), addElement(pType.elementType.copyFromTypeAndStackValue(newMB, er.region, pt, v.v))),
-            srvb.advance())
-        }
-        present(Code(srvb.start(args.size, init = true), wrapToMethod(args)(addElts), srvb.offset))
       case x@ArrayRef(a, i, s) =>
         val typ = x.typ
         val pArray = coerce[PStreamable](a.pType).asPArray

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -475,8 +475,8 @@ object EmitStream {
       eos.define(_ => k(EOS))
       behavior match {
         case ArrayZipBehavior.AssertSameLength =>
-          val anyEOS = ctx.mb.newLocal[Boolean]
-          val allEOS = ctx.mb.newLocal[Boolean]
+          val anyEOS = ctx.mb.newLocal[Boolean]("anyEOS")
+          val allEOS = ctx.mb.newLocal[Boolean]("allEOS")
           val labels = (0 to streams.size).map(_ => ctx.jb.joinPoint())
 
           val ab = new ArrayBuilder[(EmitTriplet, Any)]
@@ -731,7 +731,7 @@ object EmitStream {
     def step(idx: S)(k: Step[A, S] => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = {
       val eos = ctx.jb.joinPoint()
       val yld = ctx.jb.joinPoint[A](ctx.mb)
-      eos.define { _ => k(EOS) }
+      eos.define { _ => Code(yld.init, k(EOS)) }
       yld.define { a => k(Yield(a, idx + 1)) }
       JoinPoint.switch(idx, eos, elements.map { elt =>
         val j = ctx.jb.joinPoint()

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -331,18 +331,6 @@ object InferPType {
           infer(v)
           PTupleField(idx, v.pType2)
         }.toFastIndexedSeq, true)
-      case MakeArray(irs, t) =>
-        if (irs.isEmpty) {
-          PType.canonical(t, true).deepInnerRequired(true)
-        } else {
-          val elementTypes = irs.map { elt =>
-            infer(elt)
-            elt.pType2
-          }
-
-          val inferredElementType = getNestedElementPTypes(elementTypes)
-          PArray(inferredElementType, true)
-        }
       case GetTupleElement(o, idx) =>
         infer(o)
         val t = coerce[PTuple](o.pType2)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -25,7 +25,6 @@ object InferType {
       case RelationalRef(_, t) => t
       case RelationalLet(_, _, body) => body.typ
       case In(_, t) => t.virtualType
-      case MakeArray(_, t) => t
       case MakeStream(_, t) => t
       case MakeNDArray(data, shape, _) =>
         TNDArray(coerce[TArray](data.typ).elementType.setRequired(true), Nat(shape.typ.asInstanceOf[TTuple].size))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -222,8 +222,7 @@ object Interpret {
             case GTEQ(t, _) => t.ordering.gteq(lValue, rValue)
             case Compare(t, _) => t.ordering.compare(lValue, rValue)
           }
-
-      case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
+      case MakeStream(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
       case x@ArrayRef(a, i, s) =>
         val aValue = interpret(a, env, args)
         val iValue = interpret(i, env, args)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -766,14 +766,10 @@ object IRParser {
         val r = ir_value_expr(env)(it)
         val op = ComparisonOp.fromStringAndTypes((opName, l.typ, r.typ))
         ApplyComparisonOp(op, l, r)
-      case "MakeArray" =>
-        val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TArray]).orNull
-        val args = ir_value_children(env)(it)
-        MakeArray.unify(args, typ)
       case "MakeStream" =>
         val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TStream]).orNull
         val args = ir_value_children(env)(it)
-        MakeStream(args, typ)
+        MakeStream.unify(args, typ)
       case "ArrayRef" =>
         val a = ir_value_expr(env)(it)
         val i = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -260,7 +260,6 @@ object Pretty {
             case GetField(_, name) => prettyIdentifier(name)
             case GetTupleElement(_, idx) => idx.toString
             case MakeTuple(fields) => prettyInts(fields.map(_._1).toFastIndexedSeq)
-            case MakeArray(_, typ) => typ.parsableString()
             case MakeStream(_, typ) => typ.parsableString()
             case ArrayMap(_, name, _) => prettyIdentifier(name)
             case ArrayZip(_, names, _, behavior) => prettyIdentifier(behavior match {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -91,7 +91,7 @@ object Simplify {
     */
   private[this] def isDefinitelyDefined(x: IR): Boolean = {
     x match {
-      case _: MakeArray |
+      case _: MakeStream |
            _: MakeStruct |
            _: MakeTuple |
            _: IsNA |
@@ -192,15 +192,15 @@ object Simplify {
 
     case x: ApplyIR if x.inline || x.body.size < 10 => x.explicitNode
 
-    case ArrayLen(MakeArray(args, _)) => I32(args.length)
+    case ArrayLen(MakeStream(args, _)) => I32(args.length)
 
     case ArrayLen(ArrayMap(a, _, _)) => ArrayLen(a)
 
-    case ArrayLen(ArrayFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
+    case ArrayLen(ArrayFlatMap(a, _, MakeStream(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
 
     case ArrayLen(ArraySort(a, _, _, _)) => ArrayLen(a)
 
-    case ArrayRef(MakeArray(args, _), I32(i), _) if i >= 0 && i < args.length => args(i)
+    case ArrayRef(MakeStream(args, _), I32(i), _) if i >= 0 && i < args.length => args(i)
 
     case ArrayFilter(a, _, True()) => a
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -140,14 +140,8 @@ object TypeCheck {
           case _: Compare => assert(x.typ.isInstanceOf[TInt32])
           case _ => assert(x.typ.isInstanceOf[TBoolean])
         }
-      case x@MakeArray(args, typ) =>
-        assert(typ != null)
-        args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x.isOfType(typ.elementType),
-          s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
-        }
       case x@MakeStream(args, typ) =>
         assert(typ != null)
-
         args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x.isOfType(typ.elementType),
           s"at position $i type mismatch: ${ typ.elementType.parsableString() } ${ x.parsableString() }")
         }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/Rule.scala
@@ -67,7 +67,6 @@ case object StreamableIRs extends Rule {
     case ToSet(a) => a.typ.isInstanceOf[TStream]
     case ArraySort(a, _, _, _) => a.typ.isInstanceOf[TStream]
     case GroupByKey(collection) => collection.typ.isInstanceOf[TStream]
-    case _: MakeArray => false
     case _ => true
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -280,6 +280,7 @@ abstract class PType extends Serializable with Requiredness {
   def deepInnerRequired(required: Boolean): PType =
     this match {
       case t: PArray => PArray(t.elementType.deepInnerRequired(true), required)
+      case t: PStream => PStream(t.elementType.deepInnerRequired(true), required)
       case t: PSet => PSet(t.elementType.deepInnerRequired(true), required)
       case t: PDict => PDict(t.keyType.deepInnerRequired(true), t.valueType.deepInnerRequired(true), required)
       case t: PStruct =>

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TIterable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TIterable.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.types.virtual
 
-import is.hail.expr.types.physical.PIterable
 import is.hail.utils.FastSeq
 
 abstract class TIterable extends Type {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -346,6 +346,7 @@ object TestUtils {
               Interpret[Any](ctx, x, env, args, optimize = false)
             case ExecStrategy.JvmCompile =>
               assert(Forall(x, node => node.isInstanceOf[IR] && Compilable(node.asInstanceOf[IR])))
+              println(Pretty(x))
               eval(x, env, args, agg, bytecodePrinter =
                 Option(HailContext.getFlag("jvm_bytecode_dump"))
                   .map { path =>

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -346,7 +346,6 @@ object TestUtils {
               Interpret[Any](ctx, x, env, args, optimize = false)
             case ExecStrategy.JvmCompile =>
               assert(Forall(x, node => node.isInstanceOf[IR] && Compilable(node.asInstanceOf[IR])))
-              println(Pretty(x))
               eval(x, env, args, agg, bytecodePrinter =
                 Option(HailContext.getFlag("jvm_bytecode_dump"))
                   .map { path =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2872,7 +2872,7 @@ class IRSuite extends HailSuite {
     val s = Pretty(x, elideLiterals = false)
     val x2 = IRParser.parse_value_ir(s, env)
 
-     assert(x2 == x)
+    assert(x2 == x)
   }
 
   @Test(dataProvider = "tableIRs")

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -519,7 +519,8 @@ class PruneSuite extends HailSuite {
   }
 
   val ref = Ref("x", TStruct("a" -> TInt32(), "b" -> TInt32(), "c" -> TInt32()))
-  val arr = MakeArray(FastIndexedSeq(ref, ref), TArray(ref.typ))
+  val st = MakeStream(FastIndexedSeq(ref, ref), TStream(ref.typ))
+  val arr = ToArray(st)
   val ndArr = MakeNDArray(arr, MakeTuple(IndexedSeq((0, I64(2l)))), True())
   val empty = TStruct()
   val justA = TStruct("a" -> TInt32())
@@ -553,8 +554,8 @@ class PruneSuite extends HailSuite {
     checkMemo(AggLet("foo", ref, True(), false), TBoolean(), Array(empty, null))
   }
 
-  @Test def testMakeArrayMemo() {
-    checkMemo(arr, TArray(justB), Array(justB, justB))
+  @Test def testMakeStreamMemo() {
+    checkMemo(st, TStream(justB), Array(justB, justB))
   }
 
   @Test def testArrayRefMemo() {
@@ -1044,10 +1045,10 @@ class PruneSuite extends HailSuite {
       })
   }
 
-  @Test def testMakeArrayRebuild() {
-    checkRebuild(MakeArray(Seq(NA(ts)), TArray(ts)), TArray(subsetTS("b")),
+  @Test def testMakeStreamRebuild() {
+    checkRebuild(MakeStream(Seq(NA(ts)), TStream(ts)), TStream(subsetTS("b")),
       (_: BaseIR, r: BaseIR) => {
-        val ir = r.asInstanceOf[MakeArray]
+        val ir = r.asInstanceOf[MakeStream]
         ir.args.head.typ == subsetTS("b")
       })
   }


### PR DESCRIPTION
Replace with ToArray(MakeStream(...))
Keep MakeArray ctor for compatibility
FIXME ToArray memoization rule isn't complete
FIXME? hack to make ArrayZip of MakeStreams work
FIXME MakeStream needs to get wrapped