### PR TITLE
[batch] batch tweaks

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -196,7 +196,7 @@ SET max_instances = %s, pool_size = %s;
             },
 
             'serviceAccounts': [{
-                'email': 'batch2-agent@hail-vdc.iam.gserviceaccount.com',
+                'email': 'batch2-agent@{PROJECT}.iam.gserviceaccount.com',
                 'scopes': [
                     'https://www.googleapis.com/auth/cloud-platform'
                 ]

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -196,7 +196,7 @@ SET max_instances = %s, pool_size = %s;
             },
 
             'serviceAccounts': [{
-                'email': 'batch2-agent@{PROJECT}.iam.gserviceaccount.com',
+                'email': f'batch2-agent@{PROJECT}.iam.gserviceaccount.com',
                 'scopes': [
                     'https://www.googleapis.com/auth/cloud-platform'
                 ]

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -839,10 +839,10 @@ class Worker:
                 del self.jobs[job.id]
                 self.last_updated = time_msecs()
 
-            # exponentially back off, up to (expected) max of 30s
             await asyncio.sleep(
                 delay_secs * random.uniform(0.7, 1.3))
-            delay_secs = min(delay_secs * 2, 30.0)
+            # exponentially back off, up to (expected) max of 2m
+            delay_secs = min(delay_secs * 2, 2 * 60.0)
 
     async def post_job_complete(self, job, run_duration):
         try:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,9 +27,9 @@ push: build
 	docker push $(BASE_LATEST)
 	docker tag base $(BASE_IMAGE)
 	docker push $(BASE_IMAGE)
-	docker tag base $(SERVICE_BASE_LATEST)
+	docker tag service-base $(SERVICE_BASE_LATEST)
 	docker push $(SERVICE_BASE_LATEST)
-	docker tag base $(SERVICE_BASE_IMAGE)
+	docker tag service-base $(SERVICE_BASE_IMAGE)
 	docker push $(SERVICE_BASE_IMAGE)
 
 .PHONY: deploy

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -99,9 +99,9 @@ class Transaction:
             if self.conn is not None:
                 try:
                     if exc_type:
-                        await conn.rollback()
+                        await self.conn.rollback()
                     else:
-                        await conn.commit()
+                        await self.conn.commit()
                 finally:
                     self.conn = None
         finally:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -95,17 +95,19 @@ class Transaction:
                 await cursor.execute('START TRANSACTION;')
 
     async def _aexit(self, exc_type, exc_val, exc_tb):
-        if not self.conn:
-            return
-
-        if exc_type:
-            await self.conn.rollback()
-        else:
-            await self.conn.commit()
-        self.conn = None
-
-        await aexit(self.conn_context_manager, exc_type, exc_val, exc_tb)
-        self.conn_context_manager = None
+        try:
+            if self.conn is not None:
+                conn = self.conn
+                # clear in case of exception
+                self.conn = None
+                if exc_type:
+                    await conn.rollback()
+                else:
+                    await conn.commit()
+        finally:
+            if self.conn_context_manager is not None:
+                await aexit(self.conn_context_manager, exc_type, exc_val, exc_tb)
+                self.conn_context_manager = None
 
     async def commit(self):
         assert self.conn
@@ -140,13 +142,13 @@ class Transaction:
             if timer_description is None:
                 await cursor.execute(sql, args)
             else:
-                async with LoggingTimer(f'{timer_description}: execute_and_fetchall: execute'):
+                async with LoggingTimer(f'{timer_description}: execute_and_fetchall: execute', threshold_ms=20):
                     await cursor.execute(sql, args)
             while True:
                 if timer_description is None:
                     rows = await cursor.fetchmany(100)
                 else:
-                    async with LoggingTimer(f'{timer_description}: execute_and_fetchall: fetchmany'):
+                    async with LoggingTimer(f'{timer_description}: execute_and_fetchall: fetchmany', threshold_ms=20):
                         rows = await cursor.fetchmany(100)
                 if not rows:
                     break

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -338,8 +338,9 @@ class LoggingTimerStep:
 
 
 class LoggingTimer:
-    def __init__(self, description):
+    def __init__(self, description, threshold_ms=None):
         self.description = description
+        self.threshold_ms = threshold_ms
         self.timing = {}
         self.start_time = None
 
@@ -352,6 +353,7 @@ class LoggingTimer:
 
     async def __aexit__(self, exc_type, exc, tb):
         finish_time = time_msecs()
-        self.timing['total'] = finish_time - self.start_time
-
-        log.info(f'{self.description} timing {self.timing}')
+        total = finish_time - self.start_time
+        if self.threshold_ms is None or total > self.threshold_ms:
+            self.timing['total'] = total
+            log.info(f'{self.description} timing {self.timing}')

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -38,26 +38,9 @@ spec:
          resources:
            requests:
              memory: "250M"
-             cpu: "100m"
+             cpu: "200m"
          ports:
           - containerPort: 80
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: internal-gateway
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: internal-gateway
-  minReplicas: 3
-  maxReplicas: 10
-  metrics:
-   - type: Resource
-     resource:
-       name: cpu
-       targetAverageUtilization: 80
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -8,6 +8,8 @@ map $http_x_forwarded_proto $updated_scheme {
      '' $scheme;
 }
 
+limit_req_zone global zone=limit:1m rate=83r/s;
+
 server {
     server_name internal.hail;
     client_max_body_size 50m;
@@ -15,6 +17,8 @@ server {
     listen [::]:80;
 
     location ~ ^/([^/]+)/([^/]+) {
+    	limit_req zone=limit burst=20 nodelay;
+
         set $namespace $1;
         set $service $2;
 
@@ -40,6 +44,8 @@ server {
     listen [::]:80 default_server;
 
     location / {
+    	limit_req zone=limit burst=20 nodelay;
+
         proxy_pass http://router/;
 
         proxy_set_header Host $http_host;

--- a/letsencrypt/letsencrypt-pod.yaml.in
+++ b/letsencrypt/letsencrypt-pod.yaml.in
@@ -14,11 +14,4 @@ spec:
     image: gcr.io/@project@/letsencrypt
     ports:
     - containerPort: 80
-    volumeMounts:
-      - mountPath: /etc/letsencrypt
-        name: letsencrypt-certs
   restartPolicy: Never
-  volumes:
-    - name: letsencrypt-certs
-      persistentVolumeClaim:
-        claimName: letsencrypt-certs

--- a/router/Makefile
+++ b/router/Makefile
@@ -18,7 +18,7 @@ push: build
 
 .PHONY: deploy
 deploy: push
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"router_image":{"image":"$(ROUTER_IMAGE)"},"default_ns":{"name":"default"},"global":{"domain":"hail.is"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"router_image":{"image":"$(ROUTER_IMAGE)"},"default_ns":{"name":"default"},"global":{"domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out
 
 .PHONY: clean


### PR DESCRIPTION
Summary of changes:
 - At the end of schedule, log total time and number of jobs scheduled.
 - Only log database timing if total query took >20ms.
 - Make sure context_manager is cleaned up in gear.Transaction.
 - Limit workers to max 250 requests/s incoming to batch driver.  I used an nginx limit to do this, but it is per pod, so I turned off autoscaling and increased CPU to roughly what I saw when 100K cores was hammering against a dead driver.
 - Increase the worker exponential backoff from 30s to 2m.

The main thing I was trying to address was the driver getting overloaded when trying to restart with a large standing cluster.  It isn't totally clear why the cluster failed in the first place.  I made a few other changes to mitigate the issue before adding the nginx limit, so I'm not 100% sure which combination of changes fixed the problem:

 - I put a 60s timeout on the scheduler loop.  This probably isn't necessary, although the scheduler does get bogged down if many of the instances it tries to schedule on are not responding.

 - I put a 10s timeout on mark_job_complete.

 - I put a maximum of 150 active mark_job_complete requests being processed, and  returned service unavailable when the max was hit.

I don't think this problem is completely solved.  I think we want to keep the driver in the ~80% CPU load regime where everything is being processed quickly.  I think we want to back off workers if, for example, mark_job_complete is taking more than 95%ile in the not overloaded case.  I'm not sure who should do this, although it could be the batch-driver if internal-gateway is doing front-line throttling.  Exiting in the overload case should be very cheap.  We might want to prioritize mark_job_complete over the scheduler in that case, too.

@danking I'd love to get some metrics for the scheduling loop: schedules/s, jobs/s, and time once this goes in.  Should I switch to logging json to make that easier?