### PR TITLE
Fix text matrix reader partition count

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1519,6 +1519,7 @@ class ImportMatrixTableTests(unittest.TestCase):
         t = hl.import_table(file, types=fields, key=['Chromosome', 'Position'])
 
         self.assertEqual(mt.count_cols(), 0)
+        self.assertEqual(mt.count_rows(), 231)
         self.assertTrue(t._same(mt.rows()))
 
     @skip_unless_spark_backend()

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1663,6 +1663,8 @@ class ImportMatrixTableTests(unittest.TestCase):
             31, None, None, 34]
         assert actual == expected
 
+        assert mt.count_rows() == len(mt.rows().collect())
+
         actual = mt.chr.collect()
         assert actual == ['chr1', 'chr1', 'chr1', None]
         actual = mt[''].collect()

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -184,7 +184,7 @@ object TextMatrixReader {
           }
         }
         it
-      }.countPerPartition().scanLeft(0L)(_ + _)
+      }.countPerPartition()
   }
 }
 


### PR DESCRIPTION
As far as I can tell, the scan we were doing here was just incorrect.