### PR TITLE
[query/streams] port more stream nodes

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -247,8 +247,8 @@ case class ParameterStoreTriplet[A](t: PType, psm: ParameterStore[Code[Boolean]]
   def store(trip: TypedTriplet[A]): Code[Unit] = Code(
     trip.setup,
     trip.m.mux(
-    Code(psm.store(true), psv.storeAny(ir.defaultValue(ti))),
-    Code(psm.store(false), psv.storeAny(trip.v))))
+      Code(psm.store(true), psv.storeAny(ir.defaultValue(ti))),
+      Code(psm.store(false), psv.storeAny(trip.v))))
 
   def storeInsn: Code[Unit] = ParameterStoreTuple2(psv, psm).storeInsn
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -460,7 +460,7 @@ private class Emit(
       case Ref(name, _) =>
         val (m, v) = env.lookup(name)
         if (v.pt != pt)
-          throw new RuntimeException(s"PValue type did not match inferred ptype:\n  pv: ${ v.pt }\n  ir: $pt")
+          throw new RuntimeException(s"PValue type did not match inferred ptype:\n name: $name\n  pv: ${ v.pt }\n  ir: $pt")
         EmitTriplet(Code._empty, m, v)
 
       case ApplyBinaryPrimOp(op, l, r) =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -408,7 +408,7 @@ object CodeStream { self =>
       lPullJP.define(_ => l.pull)
       rPullJP.define(_ => r.pull)
       Source[A](
-        setup0 = Code(b := cond, l.setup0, r.setup0),
+        setup0 = Code(b := false, l.setup0, r.setup0),
         close0 = Code(l.close0, r.close0),
         setup = Code(b := cond, b.load.mux(l.setup, r.setup)),
         close = b.load.mux(l.close, r.close),

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -69,7 +69,7 @@ object COption {
     def apply(none: Code[Ctrl], some: A => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = missing.mux(none, some(value))
   }
 
-  // Empty is the only COption allowed to not call `some` at compile time
+  // None is the only COption allowed to not call `some` at compile time
   object None extends COption[Nothing] {
     def apply(none: Code[Ctrl], some: Nothing => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = none
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -89,6 +89,12 @@ object COption {
     }
   }
 
+  // Returns a COption value equivalent to 'left' when 'useLeft' is true,
+  // otherwise returns a value equivalent to 'right'. In the case where neither
+  // 'left' nor 'right' are missing, uses 'fuse' to combine the values.
+  // Presumably 'fuse' dynamically chooses one or the other based on the same
+  // boolean passed in 'useLeft. 'fuse' is needed because we don't require
+  // a ParameterPack[A]
   def choose[A](useLeft: Code[Boolean], left: COption[A], right: COption[A], fuse: (A, A) => A): COption[A] =
     (left, right) match {
       case (COption.None, COption.None) => COption.None

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -273,7 +273,7 @@ class EmitStreamSuite extends HailSuite {
     val mb = fb.apply_method
     val ir = streamIR.deepCopy()
     InferPType(ir, Env.empty)
-    val eltType = streamIR.pType.asInstanceOf[PStream].elementType
+    val eltType = ir.pType.asInstanceOf[PStream].elementType
     val stream = ExecuteContext.scoped { ctx =>
       val s = ir match {
         case ToArray(s) => s


### PR DESCRIPTION
~~Stacked on #8140~~

This PR adds support for the new streams in the emitter for ArrayFilter, ArrayZip, ArrayFlatMap, If, and Let.

It also changes the semantics of `Stream` slightly: Before, a producer had to close itself before calling EOS on its consumer. Now, the consumer is responsible for closing the producer after the producer calls EOS. This makes flatMap slightly more complicated, but it allows a significant simplification to zip.

To implement the different modes of `ArrayZip`, I added `extendNA` and `take`. `extendNA` turns a stream into an infinite stream, where values after the end are missing, to allow the consumer to decide what to do when the stream ends. `take` is then needed to end infinite streams. Both use `COption` to encode whether the child stream has ended / whether to end the child stream. I still intend to convert uses of `COption` to use `CodeConditional` after lowering is unblocked.