### PR TITLE
[hail/ptypes/PNDArray] remove elementAddress

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2259,7 +2259,7 @@ private class Emit(
         new NDArrayEmitter(mb, nDims, shapeArray,
           xP.shape.pType, xP.elementType, setup, ndt.setup, ndt.m) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] =
-            xP.asInstanceOf[PNDArray].loadElementToIRIntermediate(idxVars, ndAddress, mb)
+            xP.loadElementToIRIntermediate(idxVars, ndAddress, mb)
         }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2259,7 +2259,7 @@ private class Emit(
         new NDArrayEmitter(mb, nDims, shapeArray,
           xP.shape.pType, xP.elementType, setup, ndt.setup, ndt.m) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] =
-            outputElementPType.asInstanceOf[PNDArray].loadElementToIRIntermediate(idxVars, ndAddress, mb)
+            xP.asInstanceOf[PNDArray].loadElementToIRIntermediate(idxVars, ndAddress, mb)
         }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1231,8 +1231,6 @@ private class Emit(
         )
         val cachedIdxVals = idxFields.map(_.load()).toArray
 
-        val targetElementPosition = childPType.getElementAddress(cachedIdxVals, ndAddress, mb)
-
         val setup = coerce[Unit](Code(
           ndt.setup,
           overallMissing := ndt.m,
@@ -1246,7 +1244,7 @@ private class Emit(
           ndAddress := ndt.value[Long],
           idxFieldsBinding,
           childPType.outOfBounds(cachedIdxVals, ndAddress, mb).orEmpty(Code._fatal("Index out of bounds")),
-          Region.loadIRIntermediate(childPType.data.pType.elementType)(targetElementPosition)
+          childPType.loadElementToIRIntermediate(cachedIdxVals, ndAddress, mb)
         )
 
         EmitTriplet(setup, overallMissing, value)
@@ -2190,8 +2188,8 @@ private class Emit(
             }
             Code(
               setupTransformedIdx,
-              Region.loadIRIntermediate(ndType.elementType)(
-                inputNDType.getElementAddress(transformedIdxs, inputType.loadElement(inputArray, i), mb)))
+              inputNDType.loadElementToIRIntermediate(transformedIdxs, inputType.loadElement(inputArray, i), mb)
+            )
           }
         }
 
@@ -2260,10 +2258,8 @@ private class Emit(
 
         new NDArrayEmitter(mb, nDims, shapeArray,
           xP.shape.pType, xP.elementType, setup, ndt.setup, ndt.m) {
-          override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
-            val elementLocation = xP.getElementAddress(idxVars, ndAddress, mb)
-            Region.loadIRIntermediate(outputElementPType)(elementLocation)
-          }
+          override def outputElement(idxVars: Array[Code[Long]]): Code[_] =
+            outputElementPType.asInstanceOf[PNDArray].loadElementToIRIntermediate(idxVars, ndAddress, mb)
         }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -88,7 +88,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     )
   }
 
-  def getElementAddress(indices: Array[Code[Long]], nd: Code[Long], mb: MethodBuilder): Code[Long] = {
+  private def getElementAddress(indices: Array[Code[Long]], nd: Code[Long], mb: MethodBuilder): Code[Long] = {
     val stridesTuple  = new CodePTuple(strides.pType, strides.load(nd))
     val bytesAway = mb.newLocal[Long]
     val dataStore = mb.newLocal[Long]
@@ -106,7 +106,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   }
 
   def loadElementToIRIntermediate(indices: Array[Code[Long]], ndAddress: Code[Long], mb: MethodBuilder): Code[_] = {
-    Region.loadIRIntermediate(this.elementType)(this.getElementAddress(indices, ndAddress, mb))
+    Region.loadIRIntermediate(data.pType.elementType)(this.getElementAddress(indices, ndAddress, mb))
   }
 
   def outOfBounds(indices: Array[Code[Long]], nd: Code[Long], mb: MethodBuilder): Code[Boolean] = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -42,8 +42,6 @@ abstract class PNDArray extends PType {
 
   def makeDefaultStridesBuilder(sourceShapeArray: Array[Code[Long]], mb: MethodBuilder): StagedRegionValueBuilder => Code[Unit]
 
-  def getElementAddress(indices: Array[Code[Long]], nd: Code[Long], mb: MethodBuilder): Code[Long]
-
   def loadElementToIRIntermediate(indices: Array[Code[Long]], ndAddress: Code[Long], mb: MethodBuilder): Code[_]
 
   def outOfBounds(indices: Array[Code[Long]], nd: Code[Long], mb: MethodBuilder): Code[Boolean]


### PR DESCRIPTION
John, to gain some familiarity with your codebase, a proposed change. Makes the interface 1 method smaller, and reduces a bit of complexity in element value loading. Also fixes a potential source of errors long term: element loading should depend on the representation (as this controls memory layout), and not the elementType passed to the PNDArray constructor.

This came up as I was writing down the invariants for PNDArray for the PTypes design doc. Feel free to push back on this if you have plans for getElementAddress (although if that's the case we should get rid of loadElementToIRIntermediate)