### PR TITLE
[vdc] update playbook for using deploy account

### DIFF
--- a/vdc/Makefile
+++ b/vdc/Makefile
@@ -20,8 +20,8 @@ activate-deploy:
 	gcloud --project $(PROJECT) iam service-accounts keys create deploy-sa-key.json \
 	  --iam-account deploy@$(PROJECT).iam.gserviceaccount.com
 	gcloud projects add-iam-policy-binding $(PROJECT) \
-    --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
-    --role=roles/owner
+	  --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
+	  --role=roles/owner
 	gcloud auth activate-service-account --key-file=deploy-sa-key.json
 	rm deploy-sa-key.json
 
@@ -29,8 +29,8 @@ destroy-deploy:
 	gcloud auth login
 	yes | gcloud --project $(PROJECT) iam service-accounts delete deploy@$(PROJECT).iam.gserviceaccount.com
 	gcloud projects remove-iam-policy-binding $(PROJECT) \
-    --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
-    --role=roles/owner
+	  --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
+	  --role=roles/owner
 
 gcloud-config:
 	gcloud config set account deploy@$(PROJECT).iam.gserviceaccount.com

--- a/vdc/Makefile
+++ b/vdc/Makefile
@@ -16,10 +16,21 @@ echo-ip:
 	echo IP=$(IP)
 
 activate-deploy:
-	gcloud iam service-accounts keys create deploy-sa-key.json \
+	gcloud --project $(PROJECT) iam service-accounts create deploy
+	gcloud --project $(PROJECT) iam service-accounts keys create deploy-sa-key.json \
 	  --iam-account deploy@$(PROJECT).iam.gserviceaccount.com
+	gcloud projects add-iam-policy-binding $(PROJECT) \
+    --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
+    --role=roles/owner
 	gcloud auth activate-service-account --key-file=deploy-sa-key.json
 	rm deploy-sa-key.json
+
+destroy-deploy:
+	gcloud auth login
+	yes | gcloud --project $(PROJECT) iam service-accounts delete deploy@$(PROJECT).iam.gserviceaccount.com
+	gcloud projects remove-iam-policy-binding $(PROJECT) \
+    --member=serviceAccount:deploy@$(PROJECT).iam.gserviceaccount.com \
+    --role=roles/owner
 
 gcloud-config:
 	gcloud config set account deploy@$(PROJECT).iam.gserviceaccount.com

--- a/vdc/README.md
+++ b/vdc/README.md
@@ -40,6 +40,10 @@ make PROJECT=hail-vdc IP=35.188.91.25 DOMAIN=hail.is build-out
    to broad-ctsa/artifacts.broad-ctsa.appspot.com to Storage Object
    Viewer role.
 
+### Finish
+
+ - destroy the privileged deploy service account with `make destroy-deploy`
+
 ### FIXME
 
  - Doesn't deploy ci, which can't have multiple running instances.


### PR DESCRIPTION
I verified this manually. The deploy account didn't exist when I started this PR, but it still had a role grant in the project's IAM policy. Now the account still does not exist *and* the role grant is gone.

The `login` forces you to switch to your account since we're deleting the service account (as which you're probably authenticated).