### PR TITLE
[query] Add class builder

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1,12 +1,8 @@
 package is.hail.asm4s
 
 import java.io.PrintStream
-import java.lang.reflect.{Constructor, Field, Method, Modifier}
-import java.util
+import java.lang.reflect
 
-import is.hail.annotations.Region
-import is.hail.expr.types.physical.PTuple
-import is.hail.utils._
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree._
@@ -757,7 +753,7 @@ class CodeLabel() extends Code[Unit] {
 }
 
 object Invokeable {
-  def apply[T](cls: Class[T], c: Constructor[_]): Invokeable[T, Unit] = new Invokeable[T, Unit](
+  def apply[T](cls: Class[T], c: reflect.Constructor[_]): Invokeable[T, Unit] = new Invokeable[T, Unit](
     cls,
     "<init>",
     isStatic = false,
@@ -766,9 +762,9 @@ object Invokeable {
     Type.getConstructorDescriptor(c),
     implicitly[ClassTag[Unit]].runtimeClass)
 
-  def apply[T, S](cls: Class[T], m: Method)(implicit sct: ClassTag[S]): Invokeable[T, S] = {
+  def apply[T, S](cls: Class[T], m: reflect.Method)(implicit sct: ClassTag[S]): Invokeable[T, S] = {
     val isInterface = m.getDeclaringClass.isInterface
-    val isStatic = Modifier.isStatic(m.getModifiers)
+    val isStatic = reflect.Modifier.isStatic(m.getModifiers)
     assert(!(isInterface && isStatic))
     new Invokeable[T, S](cls,
       m.getName,
@@ -906,8 +902,8 @@ class LocalRefInt(val v: LocalRef[Int]) extends AnyRef {
   def ++(): Code[Unit] = +=(1)
 }
 
-class FieldRef[T, S](f: Field)(implicit tct: ClassTag[T], sti: TypeInfo[S]) {
-  def isStatic: Boolean = Modifier.isStatic(f.getModifiers)
+class FieldRef[T, S](f: reflect.Field)(implicit tct: ClassTag[T], sti: TypeInfo[S]) {
+  def isStatic: Boolean = reflect.Modifier.isStatic(f.getModifiers)
 
   def getOp = if (isStatic) GETSTATIC else GETFIELD
 

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -865,19 +865,14 @@ class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Cod
     throw new UnsupportedOperationException("cannot store new value into LazyFieldRef!")
 }
 
-class ClassFieldRef[T: TypeInfo](fb: FunctionBuilder[_], val name: String) extends Settable[T] {
-  val desc: String = typeInfo[T].name
-  val node: FieldNode = new FieldNode(ACC_PUBLIC, name, desc, null, null)
-
-  fb.cn.fields.asInstanceOf[util.List[FieldNode]].add(node)
+class ClassFieldRef[T: TypeInfo](fb: FunctionBuilder[_], f: Field[T]) extends Settable[T] {
+  def name: String = f.name
 
   private def _loadClass: Code[java.lang.Object] = fb.getArg[java.lang.Object](0).load()
-  private def _loadInsn: Code[T] = Code(new FieldInsnNode(GETFIELD, fb.name, name, desc))
-  private def _storeInsn: Code[Unit] = Code(new FieldInsnNode(PUTFIELD, fb.name, name, desc))
 
-  def load(): Code[T] = Code(_loadClass, _loadInsn)
+  def load(): Code[T] = f.get(_loadClass)
 
-  def store(rhs: Code[T]): Code[Unit] = Code(_loadClass, rhs, _storeInsn)
+  def store(rhs: Code[T]): Code[Unit] = f.put(_loadClass, rhs)
 }
 
 class LocalRef[T](val i: Int)(implicit tti: TypeInfo[T]) extends Settable[T] {

--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -3,7 +3,6 @@ package is.hail.asm4s
 import java.io._
 import java.util
 
-import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import org.apache.spark.TaskContext
 import org.objectweb.asm.Opcodes._
@@ -15,6 +14,186 @@ import scala.collection.JavaConverters._
 import scala.collection.generic.Growable
 import scala.collection.mutable
 import scala.reflect.ClassTag
+
+class Field[T: TypeInfo](classBuilder: ClassBuilder[_], val name: String) {
+  val desc: String = typeInfo[T].name
+  val node: FieldNode = new FieldNode(ACC_PUBLIC, name, desc, null, null)
+  classBuilder.addField(node)
+
+  def get(obj: Code[_]): Code[T] =
+    Code(obj, Code[T](new FieldInsnNode(GETFIELD, classBuilder.name, name, desc)))
+
+  def put(obj: Code[_], v: Code[T]): Code[Unit] =
+    Code(obj, v, Code(new FieldInsnNode(PUTFIELD, classBuilder.name, name, desc)))
+}
+
+class ClassBuilder[C](val name: String) {
+  var nameCounter: Int = 0
+
+  val cn = new ClassNode()
+
+  val methods: mutable.ArrayBuffer[MethodBuilder] = new mutable.ArrayBuffer[MethodBuilder](16)
+  val fields: mutable.ArrayBuffer[FieldNode] = new mutable.ArrayBuffer[FieldNode](16)
+
+  val init = new MethodNode(ACC_PUBLIC, "<init>", "()V", null, null)
+
+  val lazyFieldMemo: mutable.Map[Any, LazyFieldRef[_]] = mutable.Map.empty
+
+  protected[this] val children: mutable.ArrayBuffer[DependentFunction[_]] = new mutable.ArrayBuffer[DependentFunction[_]](16)
+
+  // init
+  cn.version = V1_8
+  cn.access = ACC_PUBLIC
+
+  cn.name = name
+  cn.superName = "java/lang/Object"
+  cn.interfaces.asInstanceOf[java.util.List[String]].add("java/io/Serializable")
+
+  cn.methods.asInstanceOf[util.List[MethodNode]].add(init)
+
+  init.instructions.add(new IntInsnNode(ALOAD, 0))
+  init.instructions.add(new MethodInsnNode(INVOKESPECIAL, Type.getInternalName(classOf[java.lang.Object]), "<init>", "()V", false))
+
+  // methods
+  def genName(tag: String): String = {
+    nameCounter += 1
+    s"__$tag$nameCounter"
+  }
+
+  def genName(tag: String, suffix: String): String = {
+    if (suffix == null)
+      return genName(tag)
+
+    nameCounter += 1
+    s"__$tag$nameCounter$suffix"
+  }
+
+  def addInitInstructions(c: Code[Unit]): Unit = {
+    val l = new mutable.ArrayBuffer[AbstractInsnNode]()
+    c.emit(l)
+    l.foreach(init.instructions.add _)
+  }
+
+  def addInterface(name: String): Unit = {
+    cn.interfaces.asInstanceOf[java.util.List[String]].add(name)
+  }
+
+  def addMethod(m: MethodBuilder): Unit = {
+    methods.append(m)
+  }
+
+  def addField(node: FieldNode): Unit = {
+    cn.fields.asInstanceOf[util.List[FieldNode]].add(node)
+  }
+
+  def newDependentFunction[A1 : TypeInfo, R : TypeInfo]: DependentFunction[AsmFunction1[A1, R]] = {
+    val df = new DependentFunctionBuilder[AsmFunction1[A1, R]](Array(GenericTypeInfo[A1]), GenericTypeInfo[R])
+    children += df
+    df
+  }
+
+  def genField[T: TypeInfo](name: String): Field[T] = new Field[T](this, name)
+
+  def genField[T: TypeInfo](): Field[T] = new Field[T](this, genName("f"))
+
+  def genField[T: TypeInfo](suffix: String): Field[T] = new Field[T](this, genName("f", suffix))
+
+  def classAsBytes(print: Option[PrintWriter] = None): Array[Byte] = {
+    init.instructions.add(new InsnNode(RETURN))
+    methods.toArray.foreach { m => m.close() }
+
+    val cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES)
+    val sw1 = new StringWriter()
+    var bytes: Array[Byte] = new Array[Byte](0)
+    try {
+      for (method <- cn.methods.asInstanceOf[util.List[MethodNode]].asScala) {
+        val count = method.instructions.size
+        log.info(s"instruction count: $count: ${ cn.name }.${ method.name }")
+        if (count > 8000)
+          log.warn(s"big method: $count: ${ cn.name }.${ method.name }")
+      }
+
+      cn.accept(cw)
+      bytes = cw.toByteArray
+      //       This next line should always be commented out!
+      //      CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
+    } catch {
+      case e: Exception =>
+        // if we fail with frames, try without frames for better error message
+        val cwNoFrames = new ClassWriter(ClassWriter.COMPUTE_MAXS)
+        val sw2 = new StringWriter()
+        cn.accept(cwNoFrames)
+        try {
+          CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
+        } catch {
+          case e: Exception =>
+            log.error("Verify Output 1 for " + name + ":")
+            throw e
+        }
+
+        if (sw2.toString.length() != 0) {
+          System.err.println("Verify Output 2 for " + name + ":")
+          System.err.println(sw2)
+          throw new IllegalStateException("Bytecode failed verification 1", e)
+        } else {
+          if (sw1.toString.length() != 0) {
+            System.err.println("Verify Output 1 for " + name + ":")
+            System.err.println(sw1)
+          }
+          throw e
+        }
+    }
+
+    if (sw1.toString.length != 0) {
+      System.err.println("Verify Output 1 for " + name + ":")
+      System.err.println(sw1)
+      throw new IllegalStateException("Bytecode failed verification 2")
+    }
+
+    print.foreach { pw =>
+      val cr = new ClassReader(bytes)
+      val tcv = new TraceClassVisitor(null, new Textifier, pw)
+      cr.accept(tcv, 0)
+    }
+    bytes
+  }
+
+  def result(print: Option[PrintWriter] = None): () => C = {
+    val childClasses = children.result().map(f => (f.name.replace("/","."), f.classAsBytes(print)))
+
+    val bytes = classAsBytes(print)
+    val n = name.replace("/",".")
+
+    assert(TaskContext.get() == null,
+      "FunctionBuilder emission should happen on master, but happened on worker")
+
+    new (() => C) with java.io.Serializable {
+      @transient
+      @volatile private var theClass: Class[_] = null
+
+      def apply(): C = {
+        try {
+          if (theClass == null) {
+            this.synchronized {
+              if (theClass == null) {
+                childClasses.foreach { case (fn, b) => loadClass(fn, b) }
+                theClass = loadClass(n, bytes)
+              }
+            }
+          }
+
+          theClass.newInstance().asInstanceOf[C]
+        } catch {
+          //  only triggers on classloader
+          case e@(_: Exception | _: LinkageError) => {
+            FunctionBuilder.bytesToBytecodeString(bytes, FunctionBuilder.stderrAndLoggerErrorOS)
+            throw e
+          }
+        }
+      }
+    }
+  }
+}
 
 object FunctionBuilder {
   val stderrAndLoggerErrorOS = getStderrAndLogOutputStream[FunctionBuilder[_]]
@@ -58,7 +237,6 @@ object FunctionBuilder {
 }
 
 class MethodBuilder(val fb: FunctionBuilder[_], _mname: String, val parameterTypeInfo: Array[TypeInfo[_]], val returnTypeInfo: TypeInfo[_]) {
-
   def descriptor: String = s"(${ parameterTypeInfo.map(_.name).mkString })${ returnTypeInfo.name }"
 
   val mname = {
@@ -67,8 +245,9 @@ class MethodBuilder(val fb: FunctionBuilder[_], _mname: String, val parameterTyp
     require(s.forall(java.lang.Character.isJavaIdentifierPart(_)), "invalid java identifer, " + s)
     s
   }
+
   val mn = new MethodNode(ACC_PUBLIC, mname, descriptor, null, null)
-  fb.cn.methods.asInstanceOf[util.List[MethodNode]].add(mn)
+  fb.classBuilder.cn.methods.asInstanceOf[util.List[MethodNode]].add(mn)
 
   val start = new LabelNode
   val end = new LabelNode
@@ -101,9 +280,7 @@ class MethodBuilder(val fb: FunctionBuilder[_], _mname: String, val parameterTyp
 
   def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] = fb.newField[T](name)
 
-  def newLazyField[T: TypeInfo](setup: Code[T]): LazyFieldRef[T] = newLazyField("")(setup)
-
-  def newLazyField[T: TypeInfo](name: String)(setup: Code[T]): LazyFieldRef[T] = fb.newLazyField(name)(setup)
+  def newLazyField[T: TypeInfo](setup: Code[T], name: String = null): LazyFieldRef[T] = fb.newLazyField(setup, name)
 
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)
@@ -192,33 +369,12 @@ class DependentFunctionBuilder[F >: Null <: AnyRef : TypeInfo : ClassTag](
 
 class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeInfo[_]], val returnTypeInfo: MaybeGenericTypeInfo[_],
   val packageName: String = "is/hail/codegen/generated", namePrefix: String = null)(implicit val interfaceTi: TypeInfo[F]) {
-
   import FunctionBuilder._
 
-  val cn = new ClassNode()
-  cn.version = V1_8
-  cn.access = ACC_PUBLIC
+  val classBuilder: ClassBuilder[F] = new ClassBuilder[F](
+    packageName + "/C" + Option(namePrefix).map(n => s"_${n}_").getOrElse("") + newUniqueID())
 
-  val name = packageName + "/C" + Option(namePrefix).map(n => s"_${n}_").getOrElse("") + newUniqueID()
-  cn.name = name
-  cn.superName = "java/lang/Object"
-  cn.interfaces.asInstanceOf[java.util.List[String]].add("java/io/Serializable")
-
-  val methods: mutable.ArrayBuffer[MethodBuilder] = new mutable.ArrayBuffer[MethodBuilder](16)
-  val fields: mutable.ArrayBuffer[FieldNode] = new mutable.ArrayBuffer[FieldNode](16)
-
-  val init = new MethodNode(ACC_PUBLIC, "<init>", "()V", null, null)
-  // FIXME why is cast necessary?
-  cn.methods.asInstanceOf[util.List[MethodNode]].add(init)
-
-  init.instructions.add(new IntInsnNode(ALOAD, 0))
-  init.instructions.add(new MethodInsnNode(INVOKESPECIAL, Type.getInternalName(classOf[java.lang.Object]), "<init>", "()V", false))
-
-  def addInitInstructions(c: Code[Unit]): Unit = {
-    val l = new mutable.ArrayBuffer[AbstractInsnNode]()
-    c.emit(l)
-    l.foreach(init.instructions.add _)
-  }
+  val name: String = classBuilder.name
 
   private[this] val methodMemo: mutable.Map[Any, MethodBuilder] = mutable.HashMap.empty
 
@@ -234,13 +390,11 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
     }
   }
 
-  protected[this] val children: mutable.ArrayBuffer[DependentFunction[_]] = new mutable.ArrayBuffer[DependentFunction[_]](16)
-
   private[this] lazy val _apply_method: MethodBuilder = {
     val m = new MethodBuilder(this, "apply", parameterTypeInfo.map(_.base), returnTypeInfo.base)
     if (parameterTypeInfo.exists(_.isGeneric) || returnTypeInfo.isGeneric) {
       val generic = new MethodBuilder(this, "apply", parameterTypeInfo.map(_.generic), returnTypeInfo.generic)
-      methods.append(generic)
+      classBuilder.addMethod(generic)
       generic.emit(
         new Code[Unit] {
           def emit(il: Growable[AbstractInsnNode]) {
@@ -261,23 +415,15 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
 
   def newLocalBit(): SettableBit = apply_method.newLocalBit()
 
-  def newDependentFunction[A1 : TypeInfo, R : TypeInfo]: DependentFunction[AsmFunction1[A1, R]] = {
-    val df = new DependentFunctionBuilder[AsmFunction1[A1, R]](Array(GenericTypeInfo[A1]), GenericTypeInfo[R])
-    children += df
-    df
-  }
-
   def newClassBit(): SettableBit = classBitSet.newBit(apply_method)
 
   def newField[T: TypeInfo]: ClassFieldRef[T] = newField()
 
   def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] =
-    new ClassFieldRef[T](this, s"field${ cn.fields.size() }${ if (name == null) "" else s"_$name" }")
+    new ClassFieldRef[T](this, classBuilder.genField[T](name))
 
-  def newLazyField[T: TypeInfo](setup: Code[T]): LazyFieldRef[T] = newLazyField("")(setup)
-
-  def newLazyField[T: TypeInfo](name: String)(setup: Code[T]): LazyFieldRef[T] =
-    new LazyFieldRef[T](this, s"field${ cn.fields.size() }_$name", setup)
+  def newLazyField[T: TypeInfo](setup: Code[T], name: String = null): LazyFieldRef[T] =
+    new LazyFieldRef[T](this, classBuilder.genName("f", name), setup)
 
   val lazyFieldMemo: mutable.Map[Any, LazyFieldRef[_]] = mutable.Map.empty
 
@@ -298,8 +444,8 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
   def emit(insn: AbstractInsnNode) = apply_method.emit(insn)
 
   def newMethod(suffix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilder = {
-    val mb = new MethodBuilder(this, s"m${ methods.size }_${ suffix }", argsInfo, returnInfo)
-    methods.append(mb)
+    val mb = new MethodBuilder(this, classBuilder.genName("m", suffix), argsInfo, returnInfo)
+    classBuilder.addMethod(mb)
     mb
   }
 
@@ -324,104 +470,11 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
   def newMethod[A: TypeInfo, B: TypeInfo, C: TypeInfo, D: TypeInfo, E: TypeInfo, R: TypeInfo]: MethodBuilder =
     newMethod(Array[TypeInfo[_]](typeInfo[A], typeInfo[B], typeInfo[C], typeInfo[D], typeInfo[E]), typeInfo[R])
 
-  def classAsBytes(print: Option[PrintWriter] = None): Array[Byte] = {
-    init.instructions.add(new InsnNode(RETURN))
-    apply_method.close()
-    methods.toArray.foreach { m => m.close() }
+  def classAsBytes(print: Option[PrintWriter] = None): Array[Byte] = classBuilder.classAsBytes(print)
 
-    val cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES)
-    val sw1 = new StringWriter()
-    var bytes: Array[Byte] = new Array[Byte](0)
-    try {
-      for (method <- cn.methods.asInstanceOf[util.List[MethodNode]].asScala) {
-        val count = method.instructions.size
-        log.info(s"instruction count: $count: ${ cn.name }.${ method.name }")
-        if (count > 8000)
-          log.warn(s"big method: $count: ${ cn.name }.${ method.name }")
-      }
+  classBuilder.addInterface(interfaceTi.iname)
 
-      cn.accept(cw)
-      bytes = cw.toByteArray
-//       This next line should always be commented out!
-//      CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
-    } catch {
-      case e: Exception =>
-        // if we fail with frames, try without frames for better error message
-        val cwNoFrames = new ClassWriter(ClassWriter.COMPUTE_MAXS)
-        val sw2 = new StringWriter()
-        cn.accept(cwNoFrames)
-        try {
-          CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
-        } catch {
-          case e: Exception =>
-            log.error("Verify Output 1 for " + name + ":")
-            throw e
-        }
-
-        if (sw2.toString().length() != 0) {
-          System.err.println("Verify Output 2 for " + name + ":")
-          System.err.println(sw2)
-          throw new IllegalStateException("Bytecode failed verification 1", e)
-        } else {
-          if (sw1.toString().length() != 0) {
-            System.err.println("Verify Output 1 for " + name + ":")
-            System.err.println(sw1)
-          }
-          throw e
-        }
-    }
-
-    if (sw1.toString.length != 0) {
-      System.err.println("Verify Output 1 for " + name + ":")
-      System.err.println(sw1)
-      throw new IllegalStateException("Bytecode failed verification 2")
-    }
-
-    print.foreach { pw =>
-      val cr = new ClassReader(bytes)
-      val tcv = new TraceClassVisitor(null, new Textifier, pw)
-      cr.accept(tcv, 0)
-    }
-    bytes
-  }
-
-  cn.interfaces.asInstanceOf[java.util.List[String]].add(interfaceTi.iname)
-
-  def result(print: Option[PrintWriter] = None): () => F = {
-    val childClasses = children.result().map(f => (f.name.replace("/","."), f.classAsBytes(print)))
-
-    val bytes = classAsBytes(print)
-    val n = name.replace("/",".")
-
-    assert(TaskContext.get() == null,
-      "FunctionBuilder emission should happen on master, but happened on worker")
-
-    new (() => F) with java.io.Serializable {
-      @transient
-      @volatile private var theClass: Class[_] = null
-
-      def apply(): F = {
-        try {
-          if (theClass == null) {
-            this.synchronized {
-              if (theClass == null) {
-                childClasses.foreach { case (fn, b) => loadClass(fn, b) }
-                theClass = loadClass(n, bytes)
-              }
-            }
-          }
-
-          theClass.newInstance().asInstanceOf[F]
-        } catch {
-          //  only triggers on classloader
-          case e@(_: Exception | _: LinkageError) => {
-            FunctionBuilder.bytesToBytecodeString(bytes, FunctionBuilder.stderrAndLoggerErrorOS)
-            throw e
-          }
-        }
-      }
-    }
-  }
+  def result(print: Option[PrintWriter] = None): () => F = classBuilder.result(print)
 }
 
 class Function2Builder[A1 : TypeInfo, A2 : TypeInfo, R : TypeInfo](name: String)

--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -287,13 +287,21 @@ class MethodBuilder(val fb: FunctionBuilder[_], _mname: String, val parameterTyp
     new LocalRef[T](argIndex(i))
   }
 
-
   private var emitted = false
+
+  private val startup = new mutable.ArrayBuffer[AbstractInsnNode]()
+
+  def emitStartup(c: Code[_]): Unit = {
+    assert(!emitted)
+    c.emit(startup)
+  }
 
   def emit(c: Code[_]) {
     assert(!emitted)
+    emitted = true
 
     val l = new mutable.ArrayBuffer[AbstractInsnNode]()
+    l ++= startup
     c.emit(l)
 
     val s = mutable.Set[AbstractInsnNode]()
@@ -307,8 +315,6 @@ class MethodBuilder(val fb: FunctionBuilder[_], _mname: String, val parameterTyp
     l.foreach(mn.instructions.add _)
     mn.instructions.add(new InsnNode(returnTypeInfo.returnOp))
     mn.instructions.add(end)
-
-    emitted = true
   }
 
   def invoke[T](args: Code[_]*): Code[T] = {

--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -39,7 +39,7 @@ class ClassBuilder[C](val name: String) {
 
   val lazyFieldMemo: mutable.Map[Any, LazyFieldRef[_]] = mutable.Map.empty
 
-  protected[this] val children: mutable.ArrayBuffer[DependentFunction[_]] = new mutable.ArrayBuffer[DependentFunction[_]](16)
+  val children: mutable.ArrayBuffer[DependentFunction[_]] = new mutable.ArrayBuffer[DependentFunction[_]](16)
 
   // init
   cn.version = V1_8
@@ -92,11 +92,11 @@ class ClassBuilder[C](val name: String) {
     df
   }
 
-  def genField[T: TypeInfo](name: String): Field[T] = new Field[T](this, name)
+  def newField[T: TypeInfo](name: String): Field[T] = new Field[T](this, name)
 
-  def genField[T: TypeInfo](): Field[T] = new Field[T](this, genName("f"))
+  def genField[T: TypeInfo](): Field[T] = newField[T](genName("f"))
 
-  def genField[T: TypeInfo](suffix: String): Field[T] = new Field[T](this, genName("f", suffix))
+  def genField[T: TypeInfo](suffix: String): Field[T] = newField(genName("f", suffix))
 
   def classAsBytes(print: Option[PrintWriter] = None): Array[Byte] = {
     init.instructions.add(new InsnNode(RETURN))
@@ -423,7 +423,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
     new ClassFieldRef[T](this, classBuilder.genField[T](name))
 
   def newLazyField[T: TypeInfo](setup: Code[T], name: String = null): LazyFieldRef[T] =
-    new LazyFieldRef[T](this, classBuilder.genName("f", name), setup)
+    new LazyFieldRef[T](this, name, classBuilder.genName("f", name))
 
   val lazyFieldMemo: mutable.Map[Any, LazyFieldRef[_]] = mutable.Map.empty
 

--- a/hail/src/main/scala/is/hail/asm4s/StagedBitSet.scala
+++ b/hail/src/main/scala/is/hail/asm4s/StagedBitSet.scala
@@ -14,7 +14,7 @@ abstract class StagedBitSet {
     if (used >= 64 || bits == null) {
       bits = getNewVar
       count += 1
-      mb.emit(bits.store(0L))
+      mb.emitStartup(bits.store(0L))
       used = 0
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -11,11 +11,11 @@ class StagedArrayBuilder(val elt: PType, mb: MethodBuilder, len: Code[Int]) {
   val ti: TypeInfo[_] = typeToTypeInfo(elt)
 
   val ref: Settable[Any] = coerce[Any](ti match {
-    case BooleanInfo => mb.newLazyField[BooleanArrayBuilder]("zab")(Code.newInstance[BooleanArrayBuilder, Int](len))
-    case IntInfo => mb.newLazyField[IntArrayBuilder]("iab")(Code.newInstance[IntArrayBuilder, Int](len))
-    case LongInfo => mb.newLazyField[LongArrayBuilder]("jab")(Code.newInstance[LongArrayBuilder, Int](len))
-    case FloatInfo => mb.newLazyField[FloatArrayBuilder]("fab")(Code.newInstance[FloatArrayBuilder, Int](len))
-    case DoubleInfo => mb.newLazyField[DoubleArrayBuilder]("dab")(Code.newInstance[DoubleArrayBuilder, Int](len))
+    case BooleanInfo => mb.newLazyField[BooleanArrayBuilder](Code.newInstance[BooleanArrayBuilder, Int](len), "zab")
+    case IntInfo => mb.newLazyField[IntArrayBuilder](Code.newInstance[IntArrayBuilder, Int](len), "iab")
+    case LongInfo => mb.newLazyField[LongArrayBuilder](Code.newInstance[LongArrayBuilder, Int](len), "jab")
+    case FloatInfo => mb.newLazyField[FloatArrayBuilder](Code.newInstance[FloatArrayBuilder, Int](len), "fab")
+    case DoubleInfo => mb.newLazyField[DoubleArrayBuilder](Code.newInstance[DoubleArrayBuilder, Int](len), "dab")
     case ti => throw new RuntimeException(s"unsupported typeinfo found: $ti")
   })
 

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -330,7 +330,7 @@ class CompiledLineParser(
   @transient private[this] val pos = mb.newField[Int]("pos")
   @transient private[this] val srvb = new StagedRegionValueBuilder(mb, requestedRowType)
 
-  fb.addInitInstructions(Code(
+  fb.classBuilder.addInitInstructions(Code(
     pos := 0,
     filename := Code._null,
     lineNumber := 0L,

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -450,7 +450,7 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def fbFunctionsCanBeNested(): Unit = {
     val fb = FunctionBuilder.functionBuilder[Boolean]
-    val fb2 = fb.newDependentFunction[Int, Boolean]
+    val fb2 = fb.classBuilder.newDependentFunction[Int, Boolean]
     val localF = fb.newField[AsmFunction1[Int, Boolean]]
 
     val wrappedInt = Code.invokeStatic[java.lang.Integer, Int, java.lang.Integer]("valueOf", 0)
@@ -468,7 +468,7 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def dependentFunctionsCanUseParentsFields(): Unit = {
     val fb = FunctionBuilder.functionBuilder[Int, Int, Int]
-    val fb2 = fb.newDependentFunction[Int, Int]
+    val fb2 = fb.classBuilder.newDependentFunction[Int, Int]
 
     val localF = fb.newField[AsmFunction1[Int, Int]]
 

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -8,6 +8,7 @@ import is.hail.check.{Gen, Prop}
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
+import scala.collection.mutable
 import scala.language.postfixOps
 
 trait Z2Z { def apply(z:Boolean): Boolean }
@@ -327,15 +328,20 @@ class ASM4SSuite extends TestNGSuite {
     val fb = FunctionBuilder.functionBuilder[Int]
     val methods = Array.tabulate[MethodBuilder](3)(_ => fb.newMethod[Int, Int, Int])
     val locals = Array.tabulate[LocalRef[Int]](9)(i => methods(i / 3).newLocal[Int])
+    val codes = Array.tabulate[mutable.ArrayBuffer[Code[_]]](3)(_ => mutable.ArrayBuffer[Code[_]]())
     var i = 0
     while (i < 3) {
       var j = 0
       while (j < 3) {
-        methods(i).emit(locals(3*i + j) := const(i))
+        codes(i) += (locals(3*i + j) := const(i))
         j += 1
       }
-      methods(i).emit(locals(3*i))
-      methods(i).mn.instructions
+      codes(i) += locals(3*i)
+      i += 1
+    }
+    i = 0
+    while (i < 3) {
+      methods(i).emit(Code(codes(i): _*))
       i += 1
     }
     fb.emit(Code._return[Int](methods(1).invoke(0,0)))
@@ -440,10 +446,11 @@ class ASM4SSuite extends TestNGSuite {
     val v2 = fb.newField[Int]
     val v1 = fb.newLazyField(v2 + 1)
 
-    fb.emit(v2 := 0)
-    fb.emit(v2 := v1)
-    fb.emit(v2 := v1)
-    fb.emit(v1)
+    fb.emit(Code(
+      v2 := 0,
+      v2 := v1,
+      v2 := v1,
+      v1))
 
     assert(fb.result()()() == 1)
   }


### PR DESCRIPTION
This the beginning of some Code infrastructure changes and cleanup.  The plan is to clean up the tangle of builder classes.  I'm still working on the plan for dependent functions, but the skeleton of the rest looks like:

```
class ClassBuilder[C]
  def newMethod(suffix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilder
  def newField[T]: ...
  def result(): () => C

class MethodBuilder:
  def newLocal[T]: LocalRef[T]
  def emit(c: Code): Unit

class FunctionBuilder[C]:
  val classBuilder: ClassBuilder[C]
  def applyMethod: MethodBuilder
  def result(): () => C = classBuilder.result()

class EmitMethodBuilder
  val mb: MethodBuilder // contain don't extend
```
