### PR TITLE
[hail] implement ReadValue/WriteValue in Emit

### DIFF
--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -1,0 +1,22 @@
+package is.hail.backend
+
+object HailTaskContext {
+  def get(): HailTaskContext = taskContext.get
+
+  private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]
+  protected[backend] def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
+  protected[backend] def unset(): Unit = taskContext.remove()
+}
+
+abstract class HailTaskContext {
+  type BackendType
+  def stageId(): Int
+  def partitionId(): Int
+  def attemptNumber(): Int
+
+  def partSuffix(): String = {
+    val rng = new java.security.SecureRandom()
+    val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
+    s"${ stageId() }-${ partitionId() }-${ attemptNumber() }-$fileUUID"
+  }
+}

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -1,9 +1,10 @@
 package is.hail.backend.spark
 
 import is.hail.HailContext
-import is.hail.backend.{Backend, BroadcastValue}
+import is.hail.backend.{Backend, BroadcastValue, HailTaskContext}
 import is.hail.expr.ir._
-import org.apache.spark.SparkContext
+import is.hail.utils._
+import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 
 import scala.reflect.ClassTag
@@ -16,6 +17,13 @@ class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Se
   def value: T = bc.value
 }
 
+class SparkTaskContext(ctx: TaskContext) extends HailTaskContext {
+  type BackendType = SparkBackend
+  override def stageId(): Int = ctx.stageId()
+  override def partitionId(): Int = ctx.partitionId()
+  override def attemptNumber(): Int = ctx.attemptNumber()
+}
+
 case class SparkBackend(sc: SparkContext) extends Backend {
 
   override val cache: SparkValueCache = SparkValueCache()
@@ -25,6 +33,7 @@ case class SparkBackend(sc: SparkContext) extends Backend {
   def parallelizeAndComputeWithIndex[T : ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U] = {
     val rdd = sc.parallelize[T](collection, numSlices = collection.length)
     rdd.mapPartitionsWithIndex { (i, it) =>
+      HailTaskContext.setTaskContext(new SparkTaskContext(TaskContext.get))
       val elt = it.next()
       assert(!it.hasNext)
       Iterator.single(f(elt, i))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -4,7 +4,8 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import is.hail.annotations._
 import is.hail.asm4s.joinpoint.{Ctrl, ParameterPack, ParameterStore, ParameterStoreTriplet, ParameterStoreArray, TypedTriplet}
-import is.hail.asm4s.{Code, _}
+import is.hail.asm4s._
+import is.hail.backend.HailTaskContext
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
@@ -1858,6 +1859,38 @@ private class Emit(
           Code(ref.m := ref.tempM, ref.v := ref.tempV.load())
         }
         EmitTriplet(Code(Code(storeTempArgs ++ moveArgs), jump.tcode[Unit]), const(false), PValue._empty)
+      case x@ReadValue(path, spec, requestedType) =>
+        val p = emit(path, env)
+        val pathString = coerce[PString](path.pType).loadString(p.value[Long])
+        val rowBuf = spec.buildCodeInputBuffer(mb.fb.getUnsafeReader(pathString, true))
+        val (pt, dec) = spec.buildEmitDecoderF(requestedType, mb.fb, typeToTypeInfo(x.pType))
+        EmitTriplet(p.setup, p.m, PValue(pt, dec(er.region, rowBuf)))
+      case x@WriteValue(value, pathPrefix, spec) =>
+        val v = emit(value, env)
+        val p = emit(pathPrefix, env)
+        val m = mb.newLocal[Boolean]
+        val pv = mb.newLocal[String]
+        val rb = mb.newLocal[OutputBuffer]
+
+        val taskCtx = Code.invokeScalaObject[HailTaskContext](HailTaskContext.getClass, "get")
+        val enc = spec.buildEmitEncoderF(value.pType2, mb.fb, typeToTypeInfo(value.pType2))
+
+        EmitTriplet(
+          Code(
+            p.setup, v.setup,
+            m := p.m || v.m,
+            m.mux(
+              Code(pv := Code._null[String], rb := Code._null[OutputBuffer]),
+              Code(
+                pv := coerce[PString](pathPrefix.pType2).loadString(p.value[Long]),
+                (!taskCtx.isNull).orEmpty(
+                  pv := pv.load().concat("-").concat(taskCtx.invoke[String]("partSuffix"))),
+                rb := spec.buildCodeOutputBuffer(mb.fb.getUnsafeWriter(pv.load())),
+                enc(er.region, v.value, rb.load()),
+                rb.invoke[Unit]("close")
+              ))
+          ), m,
+          PValue(x.pType, coerce[PString](x.pType).allocateAndStoreString(mb, er.region, pv.load())))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1873,7 +1873,7 @@ private class Emit(
         val rb = mb.newLocal[OutputBuffer]
 
         val taskCtx = Code.invokeScalaObject[HailTaskContext](HailTaskContext.getClass, "get")
-        val enc = spec.buildEmitEncoderF(value.pType2, mb.fb, typeToTypeInfo(value.pType2))
+        val enc = spec.buildEmitEncoderF(value.pType, mb.fb, typeToTypeInfo(value.pType2))
 
         EmitTriplet(
           Code(
@@ -1882,7 +1882,7 @@ private class Emit(
             m.mux(
               Code(pv := Code._null[String], rb := Code._null[OutputBuffer]),
               Code(
-                pv := coerce[PString](pathPrefix.pType2).loadString(p.value[Long]),
+                pv := coerce[PString](pathPrefix.pType).loadString(p.value[Long]),
                 (!taskCtx.isNull).orEmpty(
                   pv := pv.load().concat("-").concat(taskCtx.invoke[String]("partSuffix"))),
                 rb := spec.buildCodeOutputBuffer(mb.fb.getUnsafeWriter(pv.load())),

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -517,7 +517,7 @@ object InferPType {
       case WriteValue(value, pathPrefix, spec) =>
         infer(value)
         infer(pathPrefix)
-        PCanonicalString(pathPrefix.pType2.required)
+        PCanonicalString(pathPrefix.pType2.required && value.pType2.required)
       case MakeStream(irs, t) =>
         if (irs.isEmpty) {
           PType.canonical(t, true).deepInnerRequired(true)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -405,7 +405,6 @@ object TypeCheck {
         assert(spec.encodedType.decodedPType(requestedType).virtualType isOfType requestedType)
       case x@WriteValue(value, pathPrefix, spec) =>
         assert(pathPrefix.typ isOfType TString())
-        spec.encodedType.encodeCompatible(value.pType2)
       case LiftMeOut(_) =>
     }
   }

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -3,8 +3,8 @@ package is.hail.io
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 
 import is.hail.annotations.{Region, RegionValue}
-import is.hail.asm4s.Code
-import is.hail.expr.ir.EmitFunctionBuilder
+import is.hail.asm4s.{Code, TypeInfo}
+import is.hail.expr.ir.{EmitFunctionBuilder, typeToTypeInfo}
 import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual.Type
@@ -43,6 +43,17 @@ trait AbstractTypedCodecSpec extends Spec {
   def buildEmitDecoderF[T](requestedType: Type, fb: EmitFunctionBuilder[_]): (PType, StagedDecoderF[T])
 
   def buildEmitEncoderF[T](t: PType, fb: EmitFunctionBuilder[_]): StagedEncoderF[T]
+
+  def buildEmitDecoderF[T](requestedType: Type, fb: EmitFunctionBuilder[_], ti: TypeInfo[T]): (PType, StagedDecoderF[T]) = {
+    val (ptype, dec) = buildEmitDecoderF[T](requestedType, fb)
+    assert(ti == typeToTypeInfo(requestedType))
+    ptype -> dec
+  }
+
+  def buildEmitEncoderF[T](t: PType, fb: EmitFunctionBuilder[_], ti: TypeInfo[T]): StagedEncoderF[T] = {
+    assert(ti == typeToTypeInfo(t))
+    buildEmitEncoderF[T](t, fb)
+  }
 
   // FIXME: is there a better place for this to live?
   def decodeRDD(requestedType: Type, bytes: RDD[Array[Byte]]): (PType, ContextRDD[RVDContext, RegionValue]) = {

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -556,10 +556,16 @@ package object utils extends Logging
     "part-" + StringUtils.leftPad(is, d, "0")
   }
 
+  def partSuffix(ctx: TaskContext): String = {
+    val rng = new java.security.SecureRandom()
+    val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
+    s"${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
+  }
+
   def partFile(d: Int, i: Int, ctx: TaskContext): String = {
     val rng = new java.security.SecureRandom()
     val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-    s"${ partFile(d, i) }-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
+    s"${ partFile(d, i) }-${ partSuffix(ctx) }"
   }
 
   def mangle(strs: Array[String], formatter: Int => String = "_%d".format(_)): (Array[String], Array[(String, String)]) = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3268,7 +3268,7 @@ class IRSuite extends HailSuite {
     Array(TString(), EBinary(), "foo"),
     Array(TArray(TInt32()), EArray(EInt32()), FastIndexedSeq(5, 7, null, 3)),
     Array(TTuple(TInt32(), TString(), TStruct()),
-      EBaseStruct(FastIndexedSeq(EField("0", EInt32(), 0), EField("1", EBinary(), 1), EField("1", EBaseStruct(FastIndexedSeq()), 1))),
+      EBaseStruct(FastIndexedSeq(EField("0", EInt32(), 0), EField("1", EBinary(), 1), EField("2", EBaseStruct(FastIndexedSeq()), 2))),
       Row(3, "bar", Row()))
   )
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3274,8 +3274,7 @@ class IRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.compileOnly
     for (v <- Array(value, null)) {
       val node = Literal.coerce(t, v)
-      InferPType(node, Env.empty)
-      val spec = TypedCodecSpec(node.pType2, BufferSpec.defaultUncompressed)
+      val spec = TypedCodecSpec(node.pType, BufferSpec.defaultUncompressed)
       val prefix = tmpDir.createTempFile()
       val filename = WriteValue(node, Str(prefix), spec)
       assertEvalsTo(ReadValue(filename, spec, t), v)
@@ -3287,14 +3286,13 @@ class IRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.compileOnly
     for (v <- Array(value, null)) {
       val node = Literal.coerce(t, v)
-      InferPType(node, Env.empty)
-      val spec = TypedCodecSpec(node.pType2, BufferSpec.defaultUncompressed)
+      val spec = TypedCodecSpec(node.pType, BufferSpec.defaultUncompressed)
       val prefix = tmpDir.createTempFile()
       val readArray = Let("files",
         CollectDistributedArray(StreamRange(0, 10, 1), MakeStruct(FastSeq()),
           "ctx", "globals",
           WriteValue(node, Str(prefix), spec)),
-        ArrayMap(ToStream(Ref("files", TArray(TString()))), "filename",
+        StreamMap(ToStream(Ref("files", TArray(TString()))), "filename",
           ReadValue(Ref("filename", TString()), spec, t)))
       assertEvalsTo(ToArray(readArray), Array.fill(10)(v).toFastIndexedSeq)
     }


### PR DESCRIPTION
I wanted `WriteValue` to be able to essentially generate filenames exactly like we currently do in crdd.writePartitions, so I added a `HailTaskContext` concept to be able to mimic that behavior. It'll currently generate files named `prefix` if run on the master, and files named `prefix-stage-partition-…` if run in a distributed setting.

We may eventually want to parameterize the behavior of `WriteValue` to have it do different things with the filename, but I think this will be enough to start moving over some of the writers.