### PR TITLE
[query] Add module builder

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -416,7 +416,7 @@ class DependentFunctionBuilder[F >: Null <: AnyRef : TypeInfo : ClassTag](
   returnTypeInfo: MaybeGenericTypeInfo[_],
   packageName: String = "is/hail/codegen/generated",
   initModule: ModuleBuilder = null
-) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName) with DependentFunction[F]
+) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName, initModule = initModule) with DependentFunction[F]
 
 class FunctionBuilder[F >: Null](
   val parameterTypeInfo: Array[MaybeGenericTypeInfo[_]],

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -179,9 +179,11 @@ package object asm4s {
     }
   }
 
-  def loadClass(className: String, b: Array[Byte]): Class[_] = {
+  def loadClass(className: String, b: Array[Byte]): Class[_] =
     HailClassLoader.loadOrDefineClass(className, b)
-  }
+
+  def loadClass(className: String): Class[_] =
+    HailClassLoader.loadClass(className)
 
   def ??? = throw new UnsupportedOperationException
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1885,13 +1885,13 @@ private class Emit(
   private def makeDependentSortingFunction[T: TypeInfo](
     ir: IR, env: Emit.E, leftRightComparatorNames: Array[String]): DependentEmitFunction[AsmFunction2[T, T, Boolean]] = {
     val (newIR, getEnv) = capturedReferences(ir)
-    val f = mb.fb.newDependentFunction[T, T, Boolean]
+    val f = mb.fb.newDependentFunction[T, T, Boolean](namePrefix = "sort_compare")
     val fregion = f.addField[Region](region)
     var newEnv = getEnv(env, f)
 
     val sort = f.newMethod[Region, T, Boolean, T, Boolean, Boolean]
 
-    if(leftRightComparatorNames.nonEmpty) {
+    if (leftRightComparatorNames.nonEmpty) {
       assert(leftRightComparatorNames.length == 2)
       newEnv = newEnv.bindIterable(
         IndexedSeq(

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.backend.BroadcastValue
 import java.io._
 
 import is.hail.HailContext
@@ -8,8 +7,8 @@ import is.hail.annotations.{CodeOrdering, Region, RegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.backend.BackendUtils
 import is.hail.expr.ir.functions.IRRandomness
-import is.hail.expr.types.physical.{PCanonicalTuple, PTuple, PType}
-import is.hail.expr.types.virtual.{TTuple, Type}
+import is.hail.expr.types.physical.{PCanonicalTuple, PType}
+import is.hail.expr.types.virtual.Type
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.io.fs.FS
 import is.hail.utils._
@@ -135,8 +134,12 @@ class DependentEmitFunction[F >: Null <: AnyRef : TypeInfo : ClassTag](
   parentfb: EmitFunctionBuilder[_],
   parameterTypeInfo: Array[MaybeGenericTypeInfo[_]],
   returnTypeInfo: MaybeGenericTypeInfo[_],
-  packageName: String = "is/hail/codegen/generated"
-) extends EmitFunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName) with DependentFunction[F] {
+  packageName: String = "is/hail/codegen/generated",
+  namePrefix: String = null,
+  initModule: ModuleBuilder = null
+) extends EmitFunctionBuilder[F](
+  parameterTypeInfo, returnTypeInfo, packageName, namePrefix = namePrefix, initModule = initModule
+) with DependentFunction[F] {
 
   private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
     mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
@@ -176,8 +179,9 @@ class EmitFunctionBuilder[F >: Null](
   parameterTypeInfo: Array[MaybeGenericTypeInfo[_]],
   returnTypeInfo: MaybeGenericTypeInfo[_],
   packageName: String = "is/hail/codegen/generated",
-  namePrefix: String = null
-)(implicit interfaceTi: TypeInfo[F]) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName, namePrefix) {
+  namePrefix: String = null,
+  initModule: ModuleBuilder = null
+)(implicit interfaceTi: TypeInfo[F]) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName, namePrefix, initModule) {
 
   private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
     mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
@@ -555,18 +559,23 @@ class EmitFunctionBuilder[F >: Null](
   override def newMethod[A: TypeInfo, B: TypeInfo, C: TypeInfo, D: TypeInfo, E: TypeInfo, R: TypeInfo]: EmitMethodBuilder =
     newMethod(Array[TypeInfo[_]](typeInfo[A], typeInfo[B], typeInfo[C], typeInfo[D], typeInfo[E]), typeInfo[R])
 
-  def newDependentFunction[A1: TypeInfo, A2: TypeInfo, R: TypeInfo]: DependentEmitFunction[AsmFunction2[A1, A2, R]] = {
-    val df = new DependentEmitFunction[AsmFunction2[A1, A2, R]](
-      this, Array(GenericTypeInfo[A1], GenericTypeInfo[A2]), GenericTypeInfo[R])
-    classBuilder.children += df
-    df
+  def newDependentFunction[A1: TypeInfo, A2: TypeInfo, R: TypeInfo](
+    namePrefix: String = null
+  ): DependentEmitFunction[AsmFunction2[A1, A2, R]] = {
+    new DependentEmitFunction[AsmFunction2[A1, A2, R]](
+      this,
+      Array(GenericTypeInfo[A1], GenericTypeInfo[A2]),
+      GenericTypeInfo[R],
+      namePrefix = namePrefix,
+      initModule = module)
   }
 
   def newDependentFunction[A1: TypeInfo, A2: TypeInfo, A3: TypeInfo, R: TypeInfo]: DependentEmitFunction[AsmFunction3[A1, A2, A3, R]] = {
-    val df = new DependentEmitFunction[AsmFunction3[A1, A2, A3, R]](
-      this, Array(GenericTypeInfo[A1], GenericTypeInfo[A2], GenericTypeInfo[A3]), GenericTypeInfo[R])
-    classBuilder.children += df
-    df
+    new DependentEmitFunction[AsmFunction3[A1, A2, A3, R]](
+      this,
+      Array(GenericTypeInfo[A1], GenericTypeInfo[A2], GenericTypeInfo[A3]),
+      GenericTypeInfo[R],
+      initModule = module)
   }
 
   val rngs: ArrayBuilder[(ClassFieldRef[IRRandomness], Code[IRRandomness])] = new ArrayBuilder()
@@ -610,7 +619,6 @@ class EmitFunctionBuilder[F >: Null](
   def resultWithIndex(print: Option[PrintWriter] = None): (Int, Region) => F = {
     makeRNGs()
     makeAddPartitionRegion()
-    val childClasses = classBuilder.children.result().map(f => (f.name.replace("/","."), f.classAsBytes(print)))
 
     val hasLiterals: Boolean = literalsMap.nonEmpty
 
@@ -621,8 +629,6 @@ class EmitFunctionBuilder[F >: Null](
       null
     }
 
-    val bytes = classAsBytes(print)
-    val n = name.replace("/",".")
     val localFS = _hfs
 
     val nSerializedAggs = _nSerialized
@@ -633,16 +639,18 @@ class EmitFunctionBuilder[F >: Null](
     assert(TaskContext.get() == null,
       "FunctionBuilder emission should happen on master, but happened on worker")
 
+    val n = name.replace("/", ".")
+    val classesBytes = module.classesBytes()
+
     new ((Int, Region) => F) with java.io.Serializable {
       @transient @volatile private var theClass: Class[_] = null
 
       def apply(idx: Int, region: Region): F = {
-        try {
           if (theClass == null) {
             this.synchronized {
               if (theClass == null) {
-                childClasses.foreach { case (fn, b) => loadClass(fn, b) }
-                theClass = loadClass(n, bytes)
+                classesBytes.load()
+                theClass = loadClass(n)
               }
             }
           }
@@ -658,12 +666,6 @@ class EmitFunctionBuilder[F >: Null](
             f.asInstanceOf[FunctionWithAggRegion].setNumSerialized(nSerializedAggs)
           f.asInstanceOf[FunctionWithSeededRandomness].setPartitionIndex(idx)
           f
-        } catch {
-          //  only triggers on classloader
-          case e@(_: Exception | _: LinkageError) =>
-            FunctionBuilder.bytesToBytecodeString(bytes, FunctionBuilder.stderrAndLoggerErrorOS)
-            throw e
-        }
       }
     }
   }


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/8179

This adds ModuleBuilder.  A module is a collection of classes whose bytecode should be loaded together (like a function and some associated dependent functions).  Dependent functions now add themselves to the module.
