### PR TITLE
[batch] fix retry of clone

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -139,13 +139,13 @@ def clone_or_fetch_script(repo):
     return f"""
 { RETRY_FUNCTION_SCRIPT }
 
-function clone() {{
+function clone() {{ ( set -e
     dir=$(mktemp -d)
     git clone {shq(repo)} $dir
     for x in $(ls -A $dir); do
         mv -- "$dir/$x" ./
     done
-}}
+) }}
 
 if [ ! -d .git ]; then
   time retry clone


### PR DESCRIPTION
I want the function to exit in error if any step fails. I achieve this by
starting a sub-shell and setting -e inside that sub shell. That causes the
sub-shell to exit if any individual command fails.

Previously, the `git clone` could fail but `clone` would still return exit code
zero.