### PR TITLE
[hail] improve unsafe row printed form

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5264,7 +5264,7 @@ def format(f, *args):
     'null'
 
     >>> hl.eval(hl.format('%s %s %s', 'hello', hl.tuple([3, hl.locus('1', 2453)]), True))
-    'hello [3,1:2453] true'
+    'hello (3, 1:2453) true'
 
     Notes
     -----

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3035,8 +3035,9 @@ class Tests(unittest.TestCase):
     def test_format(self):
         self.assertEqual(hl.eval(hl.format("%.4f %s %.3e", 0.25, 'hello', 0.114)), '0.2500 hello 1.140e-01')
         self.assertEqual(hl.eval(hl.format("%.4f %d", hl.null(hl.tint32), hl.null(hl.tint32))), 'null null')
-        self.assertEqual(hl.eval(hl.format("%s", hl.struct(foo=5, bar=True, baz=hl.array([4, 5])))), '[5,true,[4,5]]')
-        self.assertEqual(hl.eval(hl.format("%s %s", hl.locus("1", 356), hl.tuple([9, True, hl.null(hl.tstr)]))), '1:356 [9,true,null]')
+        self.assertEqual(hl.eval(hl.format("%s", hl.struct(foo=5, bar=True, baz=hl.array([4, 5])))),
+                         '{foo: 5, bar: true, baz: [4,5]}')
+        self.assertEqual(hl.eval(hl.format("%s %s", hl.locus("1", 356), hl.tuple([9, True, hl.null(hl.tstr)]))), '1:356 (9, true, null)')
         self.assertEqual(hl.eval(hl.format("%b %B %b %b", hl.null(hl.tint), hl.null(hl.tstr), True, "hello")), "false FALSE true true")
 
     def test_dict_and_set_type_promotion(self):

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -101,6 +101,24 @@ object UnsafeRow {
 class UnsafeRow(var t: PBaseStruct,
   var region: Region, var offset: Long) extends Row with UnKryoSerializable {
 
+  override def toString: String = {
+    val sb = new StringBuilder()
+    var i = 0
+    sb += '{'
+    while (i < t.size) {
+      if (i != 0) {
+        sb ++= ", "
+      }
+      sb ++= t.fieldNames(i)
+      sb ++= ": "
+      val x = get(i)
+      sb ++= (if (x == null) "null" else x.toString())
+      i += 1
+    }
+    sb += '}'
+    sb.toString
+  }
+
   def this(t: PBaseStruct, rv: RegionValue) = this(t, rv.region, rv.offset)
 
   def this(t: PBaseStruct) = this(t, null, 0)

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -102,21 +102,39 @@ class UnsafeRow(var t: PBaseStruct,
   var region: Region, var offset: Long) extends Row with UnKryoSerializable {
 
   override def toString: String = {
-    val sb = new StringBuilder()
-    var i = 0
-    sb += '{'
-    while (i < t.size) {
-      if (i != 0) {
-        sb ++= ", "
+    if (t.isInstanceOf[PStruct]) {
+      val sb = new StringBuilder()
+      var i = 0
+      sb += '{'
+      while (i < t.size) {
+        if (i != 0) {
+          sb ++= ", "
+        }
+        sb ++= t.fieldNames(i)
+        sb ++= ": "
+        val x = get(i)
+        sb ++= (if (x == null) "null" else x.toString())
+        i += 1
       }
-      sb ++= t.fieldNames(i)
-      sb ++= ": "
-      val x = get(i)
-      sb ++= (if (x == null) "null" else x.toString())
-      i += 1
+      sb += '}'
+      sb.toString
+    } else if (t.isInstanceOf[PTuple]) {
+      val sb = new StringBuilder()
+      var i = 0
+      sb += '('
+      while (i < t.size) {
+        if (i != 0) {
+          sb ++= ", "
+        }
+        val x = get(i)
+        sb ++= (if (x == null) "null" else x.toString())
+        i += 1
+      }
+      sb += ')'
+      sb.toString
+    } else {
+      super.toString
     }
-    sb += '}'
-    sb.toString
   }
 
   def this(t: PBaseStruct, rv: RegionValue) = this(t, rv.region, rv.offset)


### PR DESCRIPTION
Instead of `hl.struct(x=3, foo="hi")` looking like `[3, hi]` it will look like `{x: 3, foo: hi}` which is a mild improvement.