### PR TITLE
[batch] fix image not exist on create container

### DIFF
--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -132,6 +132,11 @@ async def create_container(config, name):
                             continue
                         log.exception(f'encountered 10 errors while creating container {name}, aborting', stack_info=True)
                         raise
+            # DockerError(404, 'No such image: ...')
+            if e.status == 404 and "No such image" in e.message:
+                # We must have successfully pulled the image before to get to this point
+                delay = await sleep_and_backoff(delay)
+                continue
             raise
 
 


### PR DESCRIPTION
I think this is a race condition with another process trying to pull the same image after the current process has pulled the image. That would mostly be solved by a per user Docker cache, but I think this solution is still needed as you could have a race condition on the cache timeout boundaries.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/batch/worker.py", line 287, in run
    name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}')
  File "/usr/local/lib/python3.6/site-packages/batch/worker.py", line 91, in docker_call_retry
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/aiodocker/containers.py", line 48, in create
    url, method="POST", data=config, params=kwargs
  File "/usr/local/lib/python3.6/site-packages/aiodocker/docker.py", line 223, in _query_json
    path, method, params=params, data=data, headers=headers, timeout=timeout
  File "/usr/local/lib/python3.6/site-packages/aiodocker/docker.py", line 291, in __aenter__
    resp = await self._coro
  File "/usr/local/lib/python3.6/site-packages/aiodocker/docker.py", line 206, in _do_query
    raise DockerError(response.status, json.loads(what.decode("utf8")))
aiodocker.exceptions.DockerError: DockerError(404, 'No such image: gcr.io/hail-vdc/ci-utils:e9pnvtf1078g')
```