### PR TITLE
[hail-repl] add a hail-repl definition

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -528,6 +528,8 @@ steps:
  - kind: deploy
    name: deploy_hail_repl
    runIfRequested: true
+   scopes:
+    - dev
    namespace:
      valueFrom: default_ns.name
    config: hail/hail_repl.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -490,8 +490,6 @@ steps:
    outputs:
      - from: /io/repo/hail/build/libs/hail-all-spark.jar
        to: /hail.jar
-     - from: /io/repo/hail/build/libs/hail.jar
-       to: /hail-no-spark.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
      - from: /io/repo/hail/testng.xml

--- a/build.yaml
+++ b/build.yaml
@@ -529,7 +529,7 @@ steps:
      - base_image
      - build_hail
  - kind: deploy
-   name: hail_repl
+   name: deploy_hail_repl
    runIfRequested: true
    namespace:
      valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -480,7 +480,6 @@ steps:
      {{ code.checkout_script }}
      cd hail
      make jars python-version-info wheel
-     ./gradlew jar
      (cd python && zip -r hail.zip hail hailtop)
      tar czf test.tar.gz -C python test
      tar czf resources.tar.gz -C src/test resources

--- a/build.yaml
+++ b/build.yaml
@@ -536,6 +536,7 @@ steps:
    config: hail/hail_repl.yaml
    dependsOn:
     - default_ns
+    - hail_repl_image
  - kind: runImage
    name: test_hail_java
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -479,16 +479,20 @@ steps:
      cd repo
      {{ code.checkout_script }}
      cd hail
-     make jars python-version-info
+     make jars python-version-info wheel
+     ./gradlew jar
      (cd python && zip -r hail.zip hail hailtop)
      tar czf test.tar.gz -C python test
      tar czf resources.tar.gz -C src/test resources
      tar czf data.tar.gz -C python/hail/docs data
      tar czf www-src.tar.gz www
      tar czf cluster-tests.tar.gz python/cluster-tests
+     (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
    outputs:
      - from: /io/repo/hail/build/libs/hail-all-spark.jar
        to: /hail.jar
+     - from: /io/repo/hail/build/libs/hail.jar
+       to: /hail-no-spark.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
      - from: /io/repo/hail/testng.xml
@@ -499,6 +503,8 @@ steps:
        to: /testng-distributed-backend.xml
      - from: /io/repo/hail/python/hail.zip
        to: /hail.zip
+     - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
+       to: /wheel-container.tar
      - from: /io/repo/hail/test.tar.gz
        to: /test.tar.gz
      - from: /io/repo/hail/resources.tar.gz
@@ -511,6 +517,25 @@ steps:
        to: /cluster-tests.tar.gz
    dependsOn:
     - hail_build_image
+ - kind: buildImage
+   name: hail_repl_image
+   dockerFile: hail/Dockerfile.hail-repl
+   contextPath: hail
+   publishAs: hail-run
+   inputs:
+    - from: /wheel-container.tar
+      to: /wheel-container.tar
+   dependsOn:
+     - base_image
+     - build_hail
+ - kind: deploy
+   name: hail_repl
+   runIfRequested: true
+   namespace:
+     valueFrom: default_ns.name
+   config: hail/hail_repl.yaml
+   dependsOn:
+    - default_ns
  - kind: runImage
    name: test_hail_java
    image:

--- a/hail/Dockerfile.hail-repl
+++ b/hail/Dockerfile.hail-repl
@@ -1,0 +1,9 @@
+FROM {{ base_image.image }}
+ENV PYTHONPATH ""
+RUN apt-get update && \
+  apt-get -y install \
+    liblz4-dev
+COPY wheel-container.tar ./
+RUN tar -xf wheel-container.tar && \
+    pip3 install -U hail-*-py3-none-any.whl && \
+    rm -rf hail-*-py3-none-any.whl

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -377,3 +377,9 @@ clean: clean-env clean-docs native-lib-clean
 	rm -rf python/README.md
 	rm -rf $(SCALA_BUILD_INFO)
 	rm -rf $(PYTHON_VERSION_INFO)
+
+.PHONY: update-hail-repl
+update-hail-repl: NAMESPACE ?= default
+update-hail-repl: wheel
+	kubectl -n $(NAMESPACE) cp $(WHEEL) $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}'):.
+	kubectl -n $(NAMESPACE) exec -it $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}') -- pip3 install -U hail-$(HAIL_PIP_VERSION)-py3-none-any.whl

--- a/hail/hail_repl.yaml
+++ b/hail/hail_repl.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hail-repl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hail-repl
+  template:
+    metadata:
+      labels:
+        app: hail-repl
+    spec:
+      containers:
+       - name: hail-repl
+         command:
+          - bash
+          - -c
+          - while true; do sleep 1000; done
+         image: {{ hail_repl_image.image }}
+         env:
+           - name: HAIL_DEPLOY_CONFIG_FILE
+             value: "/deploy-config/deploy-config.json"
+         volumeMounts:
+          - name: deploy-config
+            mountPath: /deploy-config
+            readOnly: true
+      volumes:
+       - name: deploy-config
+         secret:
+           secretName: deploy-config


### PR DESCRIPTION
This is runIfRequested deployment that simply has hail
and ipython installed. It facilitates developmnent of
services that interact with Hail Query (i.e. the Shuffler).

I do this silly thing with a tar file because:
- I do not know the hail version (which is included in the wheel filename), so
- I am unable to copy it out with a variable name, and
- python refuses to install a wheel that does not have the version in the filename


I added `make update-hail-repl` to `hail/Makefile` which updates the hail wheel on the hail-repo without changing the pod or rebuilding the image. If the pod is restarted you lose your version, but the risk is worth the immense benefit of 5s deploys.