### PR TITLE
[hail] Add upload-docs dependency to Makefile

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -261,7 +261,7 @@ docs_location := gs://hail-common/builds/0.2/docs/hail-0.2-docs-$(REVISION).tar.
 local_sha_location := build/deploy/latest-hash-spark-$(SPARK_VERSION).txt
 cloud_sha_location := gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.4.0.txt
 .PHONY: set-docs-sha
-set-docs-sha: deploy-annotation-db
+set-docs-sha: upload-docs deploy-annotation-db
 	mkdir -p $(dir $(local_sha_location))
 	gsutil ls $(docs_location)  # make sure file exists
 	echo "$(REVISION)" > $(local_sha_location)


### PR DESCRIPTION
It's not clear to me what the change that broke this was. Must have been when we added the pipeline docs, but I don't see what used to be calling `upload-docs`. Anyway, calling it now. 