### PR TITLE
Region Filter Cleanup

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1410,6 +1410,6 @@ def test_group_within_partitions():
 
 
 def test_map__filter_region_memory():
-    high_mem_table = hl.utils.range_table(20).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = hl.utils.range_table(20).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
     high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1409,7 +1409,7 @@ def test_group_within_partitions():
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
 
 
-def test_map__filter_region_memory():
-    high_mem_table = hl.utils.range_table(60).annotate(big_array=hl.zeros(100_000_000))
-    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-    high_mem_table._force_count()
+# def test_map__filter_region_memory():
+#     high_mem_table = hl.utils.range_table(60).annotate(big_array=hl.zeros(100_000_000))
+#     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+#     high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1373,6 +1373,7 @@ def test_join_distinct_preserves_count():
     assert n_defined_2 == 0
     assert keys_2 == left_pos
 
+
 def test_write_table_containing_ndarray():
     t = hl.utils.range_table(5)
     t = t.annotate(n = hl._nd.arange(t.idx))
@@ -1380,6 +1381,7 @@ def test_write_table_containing_ndarray():
     t.write(f)
     t2 = hl.read_table(f)
     assert t._same(t2)
+
 
 def test_group_within_partitions():
     t = hl.utils.range_table(10).naive_coalesce(2)
@@ -1405,3 +1407,9 @@ def test_group_within_partitions():
     ht = hl.utils.range_table(100).naive_coalesce(10)
     filter_then_group = ht.filter(ht.idx % 2 == 0)._group_within_partitions(5).collect()
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
+
+
+def test_map_region_memory():
+    high_mem_table = hl.utils.range_table(30).annotate(big_array=hl.range(100_000_000))
+    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1410,13 +1410,13 @@ def test_group_within_partitions():
 
 
 def test_map_filter_region_memory():
-    high_mem_table = hl.utils.range_table(100).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-    high_mem_table = high_mem_table.head(30)
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
     assert high_mem_table._force_count() == 15
 
 
-# def test_head_and_tail_region_memory():
-#     high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
-#     high_mem_table = high_mem_table.head(30)
+def test_head_and_tail_region_memory():
+    high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.head(30)
+    high_mem_table._force_count()
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1409,7 +1409,7 @@ def test_group_within_partitions():
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
 
 
-def test_map_region_memory():
-    high_mem_table = hl.utils.range_table(30).annotate(big_array=hl.range(100_000_000))
+def test_map__filter_region_memory():
+    high_mem_table = hl.utils.range_table(60).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
     high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1409,7 +1409,7 @@ def test_group_within_partitions():
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
 
 
-# def test_map__filter_region_memory():
-#     high_mem_table = hl.utils.range_table(60).annotate(big_array=hl.zeros(100_000_000))
-#     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-#     high_mem_table._force_count()
+def test_map__filter_region_memory():
+    high_mem_table = hl.utils.range_table(5).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1410,6 +1410,6 @@ def test_group_within_partitions():
 
 
 def test_map__filter_region_memory():
-    high_mem_table = hl.utils.range_table(5).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = hl.utils.range_table(20).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
     high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1409,7 +1409,14 @@ def test_group_within_partitions():
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
 
 
-def test_map__filter_region_memory():
-    high_mem_table = hl.utils.range_table(20).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+def test_map_filter_region_memory():
+    high_mem_table = hl.utils.range_table(100).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.head(30)
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-    high_mem_table._force_count()
+    assert high_mem_table._force_count() == 15
+
+
+# def test_head_and_tail_region_memory():
+#     high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
+#     high_mem_table = high_mem_table.head(30)
+

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -374,6 +374,11 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
     memory.addReferenceTo(r.memory)
   }
 
+  def move(r: Region): Unit = {
+    this.memory.unsafeMoveReferenceTo(r.memory)
+    this.memory = pool.getMemory(blockSize)
+  }
+
   def nReferencedRegions(): Long = memory.nReferencedRegions()
 
   def getNewRegion(blockSize: Region.Size): Unit = {

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -191,6 +191,10 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     r.referenceCount += 1
   }
 
+  def unsafeMoveReferenceTo(r: RegionMemory): Unit = {
+    references += r
+  }
+
   def nReferencedRegions(): Long = references.size
 
   def setNumParents(n: Int): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -34,6 +34,12 @@ object TableIR {
 abstract sealed class TableIR extends BaseIR {
   def typ: TableType
 
+
+  /**
+    *
+    * @return An IndexedSeq whose length corresponds to the number of partitions. The ith element contains count of
+    *         rows in partition i.
+    */
   def partitionCounts: Option[IndexedSeq[Long]] = None
 
   val rowCountUpperBound: Option[Long]

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -432,7 +432,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     val tv = child.execute(ctx)
 
-    if (pred == True())
+    if (pred == True()) // TODO: This will never happen, simplify rule catches it.
       return tv
     else if (pred == False())
       return tv.copy(rvd = RVD.empty(HailContext.get.sc, typ.canonicalRVDType))

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -432,7 +432,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     val tv = child.execute(ctx)
 
-    if (pred == True()) // TODO: This will never happen, simplify rule catches it.
+    if (pred == True())
       return tv
     else if (pred == False())
       return tv.copy(rvd = RVD.empty(HailContext.get.sc, typ.canonicalRVDType))

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -60,10 +60,6 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
       }, { case ((p, glob), rv) => pred(p, rv, glob) }))
   }
 
-  def filter(p: (RegionValue, RegionValue) => Boolean): TableValue = {
-    filterWithPartitionOp((_, _) => ())((_, rv1, rv2) => p(rv1, rv2))
-  }
-
   def write(path: String, overwrite: Boolean, stageLocally: Boolean, codecSpecJSON: String) {
     assert(typ.isCanonical)
     val hc = HailContext.get

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -173,26 +173,28 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
   def boundary: ContextRDD[RVDContext, RegionValue] =
     crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
       val producerCtx = consumerCtx.freshContext
+      consumerCtx.region.addReferenceTo(producerCtx.region)
       val it = part.flatMap(_ (producerCtx))
-      new Iterator[RegionValue]() {
-        private[this] var cleared: Boolean = false
-
-        def hasNext: Boolean = {
-          if (!cleared) {
-            cleared = true
-            producerCtx.region.clear()
-          }
-          it.hasNext
-        }
-
-        def next: RegionValue = {
-          if (!cleared) {
-            producerCtx.region.clear()
-          }
-          cleared = false
-          it.next
-        }
-      }
+//      new Iterator[RegionValue]() {
+//        private[this] var cleared: Boolean = false
+//
+//        def hasNext: Boolean = {
+//          if (!cleared) {
+//            cleared = true
+//            producerCtx.region.clear()
+//          }
+//          it.hasNext
+//        }
+//
+//        def next: RegionValue = {
+//          if (!cleared) {
+//            producerCtx.region.clear()
+//          }
+//          cleared = false
+//          it.next
+//        }
+//      }
+      it
     }
 
   def writeRows(

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -173,29 +173,29 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
   def boundary: ContextRDD[RVDContext, RegionValue] =
     crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
       val producerCtx = consumerCtx.freshContext
-      consumerCtx.region.addReferenceTo(producerCtx.region)
+      //consumerCtx.region.addReferenceTo(producerCtx.region)
       val it = part.flatMap(_ (producerCtx))
-//      new Iterator[RegionValue]() {
-//        private[this] var cleared: Boolean = false
-//
-//        def hasNext: Boolean = {
-//          if (!cleared) {
-//            cleared = true
-//            producerCtx.region.clear()
-//          }
-//          it.hasNext
-//        }
-//
-//        def next: RegionValue = {
-//          if (!cleared) {
-//            producerCtx.region.clear()
-//          }
-//          cleared = false
-//          it.next
-//        }
-//      }
-      it
+      new Iterator[RegionValue]() {
+
+        def hasNext: Boolean = {
+          it.hasNext
+        }
+
+        def next: RegionValue = {
+          val rv = it.next
+          consumerCtx.region.addReferenceTo(rv.region)
+          producerCtx.region.clear()
+          rv
+        }
+      }
     }
+
+  def transfer: RDD[RegionValue] =
+    crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
+      val producerCtx = consumerCtx.freshContext
+      //consumerCtx.region.addReferenceTo(producerCtx.region)
+      part.flatMap(_ (producerCtx))
+    }.rdd.map()
 
   def writeRows(
     path: String,

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -195,19 +195,6 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
       }
     }
 
-
-  def usingFreshContext: ContextRDD[RVDContext, RegionValue] =
-    crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
-      val producerCtx = consumerCtx.freshContext
-      val it = part.flatMap(_ (producerCtx)).map { rv =>
-        rv.region.move(producerCtx.region)
-        rv.region = producerCtx.region
-        rv
-      }
-      it
-    }
-
-
   def writeRows(
     path: String,
     idxRelPath: String,

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -538,31 +538,6 @@ class RVD(
     filterWithContext((_, _) => (), (_: Any, rv) => p(rv))
   }
 
-//  def filterWithContextNoFresh[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
-//
-//    val rdd = this.crdd.rdd.mapPartitionsWithIndex{ (i, it) =>
-//      Iterator.single(
-//        (consumerCtx: RVDContext) => {
-//          val producerCtx = consumerCtx.freshContext
-//          val iteratorToFilter = it.flatMap(_(producerCtx))
-//          val c = makeContext(i, producerCtx)
-//          iteratorToFilter.filter { rv =>
-//            if (f(c, rv)) {
-//              producerCtx.region.move(consumerCtx.region)
-//              true
-//            }
-//            else {
-//              producerCtx.region.clear()
-//              false
-//            }
-//          }
-//        }
-//      )
-//    }
-//    val crdd = ContextRDD(rdd)
-//    RVD(this.typ, this.partitioner, crdd)
-//  }
-
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
 
     val crdd: ContextRDD[RVDContext, RegionValue] = this.crdd.cmapPartitionsWithContextAndIndex{ (i, consumerCtx: RVDContext, iteratorToFilter) =>

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -534,8 +534,11 @@ class RVD(
     RVD(typ, newPartitioner, newRDD)
   }
 
-  def filter(p: (RegionValue) => Boolean): RVD =
-    RVD(typ, partitioner, crddBoundary.filter(p))
+  def filter(p: (RegionValue) => Boolean): RVD = {
+    val newWay = filterWithContext((_, _) => (), (_: Any, rv) => p(rv))
+    //RVD(typ, partitioner, crddBoundary.filter(p))
+    newWay
+  }
 
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
     mapPartitionsWithIndex(typ, { (i, context, it) =>

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -535,24 +535,7 @@ class RVD(
   }
 
   def filter(p: (RegionValue) => Boolean): RVD = {
-    val newWay = filterWithContext((_, _) => (), (_: Any, rv) => p(rv))
-    //RVD(typ, partitioner, crddBoundary.filter(p))
-    newWay
-  }
-
-  def filterWithContextOld[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
-
-    mapPartitionsWithIndex(typ, { (i, rvdContext, it) =>
-      val c = makeContext(i, rvdContext)
-      it.filter { rv =>
-        if (f(c, rv))
-          true
-        else {
-          rvdContext.r.clear()
-          false
-        }
-      }
-    })
+    filterWithContext((_, _) => (), (_: Any, rv) => p(rv))
   }
 
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -538,32 +538,32 @@ class RVD(
     filterWithContext((_, _) => (), (_: Any, rv) => p(rv))
   }
 
+//  def filterWithContextNoFresh[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
+//
+//    val rdd = this.crdd.rdd.mapPartitionsWithIndex{ (i, it) =>
+//      Iterator.single(
+//        (consumerCtx: RVDContext) => {
+//          val producerCtx = consumerCtx.freshContext
+//          val iteratorToFilter = it.flatMap(_(producerCtx))
+//          val c = makeContext(i, producerCtx)
+//          iteratorToFilter.filter { rv =>
+//            if (f(c, rv)) {
+//              producerCtx.region.move(consumerCtx.region)
+//              true
+//            }
+//            else {
+//              producerCtx.region.clear()
+//              false
+//            }
+//          }
+//        }
+//      )
+//    }
+//    val crdd = ContextRDD(rdd)
+//    RVD(this.typ, this.partitioner, crdd)
+//  }
+
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
-
-    val rdd = this.crdd.rdd.mapPartitionsWithIndex{ (i, it) =>
-      Iterator.single(
-        (consumerCtx: RVDContext) => {
-          val producerCtx = consumerCtx.freshContext
-          val iteratorToFilter = it.flatMap(_(producerCtx))
-          val c = makeContext(i, producerCtx)
-          iteratorToFilter.filter { rv =>
-            if (f(c, rv)) {
-              producerCtx.region.move(consumerCtx.region)
-              true
-            }
-            else {
-              producerCtx.region.clear()
-              false
-            }
-          }
-        }
-      )
-    }
-    val crdd = ContextRDD(rdd)
-    RVD(this.typ, this.partitioner, crdd)
-  }
-
-  def filterWithContext3[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
 
     val crdd: ContextRDD[RVDContext, RegionValue] = this.crdd.usingFreshContext.cmapPartitionsWithIndex{ (i, consumerCtx: RVDContext, iteratorToFilter) => {
           val c = makeContext(i, consumerCtx)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -461,10 +461,10 @@ class RVD(
           case None => return this
         }
       case None =>
-        val crddBoundary = crdd.boundary
+        val crddCleanup = crdd.cleanupRegions
         val PCSubsetOffset(idx, nTake, _) =
           incrementalPCSubsetOffset(n, 0 until getNumPartitions)(
-            crddBoundary.runJob(getIteratorSizeWithMaxN(n), _)
+            crddCleanup.runJob(getIteratorSizeWithMaxN(n), _)
           )
         idx -> nTake
     }
@@ -500,10 +500,10 @@ class RVD(
           case None => return this
         }
       case None =>
-        val crddBoundary = crdd.boundary
+        val crddCleanup = crdd.cleanupRegions
         val PCSubsetOffset(idx, _, nDrop) =
           incrementalPCSubsetOffset(n, Range.inclusive(getNumPartitions - 1, 0, -1))(
-            crddBoundary.runJob(getIteratorSize, _)
+            crddCleanup.runJob(getIteratorSize, _)
           )
         idx -> nDrop
     }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -571,10 +571,10 @@ class RVD(
       iteratorToFilter(producerCtx).filter { rv =>
         val b = f(c, rv)
         if (b) {
-          rv.region.move(consumerCtx.region)
+          producerCtx.region.move(consumerCtx.region)
         }
         else {
-          rv.region.clear()
+          producerCtx.region.clear()
         }
         b
       }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -541,6 +541,10 @@ class RVD(
   }
 
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RegionValue) => Boolean): RVD = {
+    // Call idkYet on my contextRDD to get just an RDD[RegionValue]
+    // Go through the RDD of region values and for each partition
+    //    go through the iterator and either add a reference or clear.
+
     mapPartitionsWithIndex(typ, { (i, context, it) =>
       val c = makeContext(i, context)
       it.filter { rv =>

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -265,6 +265,15 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
       preservesPartitioning),
     mkc)
 
+  def mapAwayContext[U: ClassTag](
+    f: (C, Iterator[T]) => Iterator[U],
+    preservesPartitioning: Boolean = false
+   ): RDD[U] = {
+    rdd.mapPartitions(
+      part => ???
+    )
+  }
+
   def cmapPartitionsAndContext[U: ClassTag](
     f: (C, (Iterator[C => Iterator[T]])) => Iterator[U],
     preservesPartitioning: Boolean = false

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -265,6 +265,22 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
       preservesPartitioning),
     mkc)
 
+  def cmapPartitionsWithContext[U: ClassTag](f: (C, (C) => Iterator[T]) => Iterator[U]): ContextRDD[C, U] = {
+    new ContextRDD(rdd.mapPartitions(
+      part => part.flatMap {
+          x =>  inCtx(consumerCtx => f(consumerCtx, x))
+      }),
+      mkc
+  }
+
+  def cmapPartitionsWithContextAndIndex[U: ClassTag](f: (Int, C, (C) => Iterator[T]) => Iterator[U]): ContextRDD[C, U] = {
+    new ContextRDD(rdd.mapPartitionsWithIndex(
+      (i, part) => part.flatMap {
+        x =>  inCtx(consumerCtx => f(i, consumerCtx, x))
+      }),
+      mkc)
+  }
+
   def cmapPartitionsAndContext[U: ClassTag](
     f: (C, (Iterator[C => Iterator[T]])) => Iterator[U],
     preservesPartitioning: Boolean = false

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -265,15 +265,6 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
       preservesPartitioning),
     mkc)
 
-  def mapAwayContext[U: ClassTag](
-    f: (C, Iterator[T]) => Iterator[U],
-    preservesPartitioning: Boolean = false
-   ): RDD[U] = {
-    rdd.mapPartitions(
-      part => ???
-    )
-  }
-
   def cmapPartitionsAndContext[U: ClassTag](
     f: (C, (Iterator[C => Iterator[T]])) => Iterator[U],
     preservesPartitioning: Boolean = false

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -270,7 +270,7 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
       part => part.flatMap {
           x =>  inCtx(consumerCtx => f(consumerCtx, x))
       }),
-      mkc
+      mkc)
   }
 
   def cmapPartitionsWithContextAndIndex[U: ClassTag](f: (Int, C, (C) => Iterator[T]) => Iterator[U]): ContextRDD[C, U] = {


### PR DESCRIPTION
~So this PR is me trying to switch just `TableFilter` over to the correct region memory management model we've decided on.~

~I used this `usingFreshContext` method to pass a new context to the producer that filter is consuming from so that filter can clear unused rows.~

This PR is where I'm cleaning up region management. So far, I've decided the following:

Addressed: 
- `TableFilter`
- `TableHead` (via `rvd.head`)
- `TableTail` (via `rvd.tail`)

No change needed: 
- `TableMapRows`
- `TableMapGlobals`
- `TableRange`
- `TableLiteral`

I also added a test using the new `hl.zeros` that's intended to catch memory leaks in filter by going through lots of large rows. For some reason, this test is failing on CI with OOM despite seeming to use constant memory on my local machine, I am still looking into why this is.

Mostly, I'm wondering if this is consistent with what y'all imagined correct Region management would look like before I go through and do the rest of them. 
@cseed @tpoterba @catoverdrive @patrick-schultz 