### PR TITLE
[query/streams] remaining non-root stream nodes, add back length tracking

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -263,8 +263,6 @@ private class Emit(
     emit(ir, env, er, container, None)
 
   private def emit(ir: IR, env: E, er: EmitRegion, container: Option[AggContainer], loopEnv: Option[Env[Array[LoopRef]]]): EmitTriplet = {
-    import CodeStream.Stream
-
     def emit(ir: IR, env: E = env, er: EmitRegion = er, container: Option[AggContainer] = container, loopEnv: Option[Env[Array[LoopRef]]] = loopEnv): EmitTriplet =
       this.emit(ir, env, er, container, loopEnv)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -61,9 +61,7 @@ object AggContainer {
       region := Region.stagedCreate(Region.REGULAR),
       region.load().setNumParents(aggs.length),
       off := region.load().allocate(aggState.storageType.alignment, aggState.storageType.byteSize),
-      states.createStates(fb)) //,
-      // this should be taken care of by init?
-//      aggState.newState)
+      states.createStates(fb))
 
     val cleanup = Code(
       region.load().invalidate(),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -61,8 +61,9 @@ object AggContainer {
       region := Region.stagedCreate(Region.REGULAR),
       region.load().setNumParents(aggs.length),
       off := region.load().allocate(aggState.storageType.alignment, aggState.storageType.byteSize),
-      states.createStates(fb),
-      aggState.newState)
+      states.createStates(fb)) //,
+      // this should be taken care of by init?
+//      aggState.newState)
 
     val cleanup = Code(
       region.load().invalidate(),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -708,7 +708,7 @@ private class Emit(
           def foldBody(elt: TypedTriplet[eltType.type], acc: TypedTriplet[accType.type]): TypedTriplet[accType.type] = {
             val xElt = eltPack.newFields(mb.fb, valueName)
             val xAcc = accPack.newFields(mb.fb, accumName)
-            val bodyenv = Emit.bindEnv(env, (accumName -> xAcc), (valueName -> xElt))
+            val bodyenv = Emit.bindEnv(env, accumName -> xAcc, valueName -> xElt)
 
             val codeB = emit(body, env = bodyenv)
             TypedTriplet(accType, EmitTriplet(Code(xElt := elt, xAcc := acc, codeB.setup), codeB.m,
@@ -720,7 +720,7 @@ private class Emit(
             ret(COption.fromEmitTriplet(acc.untyped))
 
           stream.map(TypedTriplet(eltType, _))
-                .fold(TypedTriplet(accType, codeZ), foldBody, retTT)
+                .fold(mb)(TypedTriplet(accType, codeZ), foldBody, retTT)
         }
 
         COption.toEmitTriplet(resOpt, accType, mb)
@@ -762,7 +762,7 @@ private class Emit(
             Code(accVars := accs, ret(COption.fromEmitTriplet(codeR)))
 
           stream.map(TypedTriplet(eltType, _))
-            .foldCPS(zero, foldBody, computeRes)
+            .foldCPS(mb)(zero, foldBody, computeRes)
         }
 
         COption.toEmitTriplet(resOpt, res.pType, mb)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -271,7 +271,7 @@ private class Emit(
     def wrapToMethod(irs: Seq[IR], env: E = env, container: Option[AggContainer] = container)(useValues: (EmitMethodBuilder, PType, EmitTriplet) => Code[Unit]): Code[Unit] =
       this.wrapToMethod(irs, env, container)(useValues)
 
-    def emitStream(ir: IR): COption[Stream[EmitTriplet]] =
+    def emitStream(ir: IR): COption[EmitStream2.SizedStream] =
       EmitStream2(this, ir, env, er, container)
 
     def emitDeforestedNDArray(ir: IR) =
@@ -504,7 +504,8 @@ private class Emit(
         val atyp = coerce[PIterable](x.pType)
         val eltType = atyp.elementType
         val eltVType = eltType.virtualType
-        val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
+
+        val vab = new StagedArrayBuilder(atyp.elementType, mb, 0)
         val sorter = new ArraySorter(er, vab)
 
         val (array, compare, distinct, leftRightComparatorNames: Array[String]) = (x: @unchecked) match {
@@ -607,7 +608,7 @@ private class Emit(
           case DoubleInfo => makeDependentSortingFunction[Double](etyp, compare, env, leftRightComparatorNames)
         }
 
-        val nab = new StagedArrayBuilder(PInt32(), mb, 16)
+        val nab = new StagedArrayBuilder(PInt32(), mb, 0)
         val i = mb.newLocal[Int]
 
         def loadKey(n: Code[Int]): Code[_] =
@@ -720,7 +721,7 @@ private class Emit(
           def retTT(acc: TypedTriplet[accType.type]): Code[Ctrl] =
             ret(COption.fromEmitTriplet(acc.untyped))
 
-          stream.map(TypedTriplet(eltType, _))
+          stream.stream.map(TypedTriplet(eltType, _))
                 .fold(mb)(TypedTriplet(accType, codeZ), foldBody, retTT)
         }
 
@@ -762,7 +763,7 @@ private class Emit(
           def computeRes(accs: IndexedSeq[TypedTriplet[_]]): Code[Ctrl] =
             Code(accVars := accs, ret(COption.fromEmitTriplet(codeR)))
 
-          stream.map(TypedTriplet(eltType, _))
+          stream.stream.map(TypedTriplet(eltType, _))
             .foldCPS(mb)(zero, foldBody, computeRes)
         }
 
@@ -787,7 +788,7 @@ private class Emit(
           streamOpt.cases[Unit](mb)(
             Code._empty,
             stream =>
-              stream.map(TypedTriplet(eltType, _)).forEach(mb)(forBody)),
+              stream.stream.map(TypedTriplet(eltType, _)).forEach(mb)(forBody)),
           const(false),
           PValue._empty)
 
@@ -1720,14 +1721,19 @@ private class Emit(
             srvb.offset)
         }
 
-        def addContexts(ctxStream: Stream[EmitTriplet]): Code[Unit] =
-          ctxStream.map(etToTuple(_, ctxType)).forEach(mb) { offset =>
-            Code(
-              baos.invoke[Unit]("reset"),
-              cEnc(region, offset, buf),
-              buf.invoke[Unit]("flush"),
-              ctxab.invoke[Array[Byte], Unit]("add", baos.invoke[Array[Byte]]("toByteArray")))
-          }
+        def addContexts(ctxStream: EmitStream2.SizedStream): Code[Unit] =
+          Code(
+            ctxStream.length match {
+              case None => ctxab.invoke[Int, Unit]("ensureCapacity", 16)
+              case Some((setupLen, len)) => Code(setupLen, ctxab.invoke[Int, Unit]("ensureCapacity", len))
+            },
+            ctxStream.stream.map(etToTuple(_, ctxType)).forEach(mb) { offset =>
+              Code(
+                baos.invoke[Unit]("reset"),
+                cEnc(region, offset, buf),
+                buf.invoke[Unit]("flush"),
+                ctxab.invoke[Array[Byte], Unit]("add", baos.invoke[Array[Byte]]("toByteArray")))
+            })
 
         val addGlobals = Code(
           gEnc(region, etToTuple(globalsT, gType), buf),

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -158,10 +158,8 @@ object CodeStream { self =>
       CodeStream.fold(this, s0, f, ret)
     def foldCPS[S: ParameterPack](s0: S, f: (A, S, S => Code[Ctrl]) => Code[Ctrl], ret: S => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] =
       CodeStream.foldCPS(this, s0, f, ret)
-    def forEach(f: A => Code[Unit], ret: Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] =
-      CodeStream.forEach(this, f, ret)
     def forEach(mb: MethodBuilder)(f: A => Code[Unit]): Code[Unit] =
-      CallCC[Unit]((jb, ret) => CodeStream.forEach(this, f, ret(()))(EmitStreamContext(mb, jb)))
+      CodeStream.forEach(mb, this, f)
     def mapCPS[B](
       f: (EmitStreamContext, A, B => Code[Ctrl]) => Code[Ctrl],
       setup0: Option[Code[Unit]] = None,
@@ -217,30 +215,47 @@ object CodeStream { self =>
                     (xCur.load, (xCur.load + step, xRem.load)))))
       })
 
+  def foldCPS[A, S: ParameterPack](
+    stream: Stream[A],
+    s0: S,
+    f: (A, S, S => Code[Ctrl]) => Code[Ctrl],
+    ret: S => Code[Ctrl]
+  )(implicit ctx: EmitStreamContext): Code[Ctrl] = {
+    val (scan, s) = scanCPS(stream, s0, f)
+    Code(run(ctx.mb, scan.map(_ => ())), ret(s.load))
+  }
+
   def fold[A, S: ParameterPack](stream: Stream[A], s0: S, f: (A, S) => S, ret: S => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] =
     foldCPS[A, S](stream, s0, (a, s, k) => k(f(a, s)), ret)
 
-  def foldCPS[A, S: ParameterPack](stream: Stream[A], s0: S, f: (A, S, S => Code[Ctrl]) => Code[Ctrl], ret: S => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = {
-    val s = newLocal[S]
-    val pullJP = joinPoint()
-    val eosJP = joinPoint()
-    val source = stream(
-      eos = eosJP(()),
-      push = a => f(a, s.load, s1 => Code(s := s1, pullJP(()))))
-    eosJP.define(_ => Code(source.close, source.close0, ret(s.load)))
-    pullJP.define(_ => source.pull)
-    Code(s := s0, source.setup0, source.setup, pullJP(()))
+  def forEachCPS[A](mb: MethodBuilder, stream: Stream[A], f: (A, Code[Ctrl]) => Code[Ctrl]): Code[Unit] =
+    run(mb, stream.mapCPS[Unit]((_, a, k) => f(a, k(()))))
+
+  def forEach[A](mb: MethodBuilder, stream: Stream[A], f: A => Code[Unit]): Code[Unit] =
+    run(mb, stream.mapCPS((_, a, k) => Code(f(a), k(()))))
+
+  def run(mb: MethodBuilder, stream: Stream[Unit]): Code[Unit] = {
+    CallCC[Unit] { (jb, ret) =>
+      implicit val ctx = EmitStreamContext(mb, jb)
+      val pullJP = joinPoint()
+      val source = stream(eos = ret(()), push = _ => pullJP(()))
+      pullJP.define(_ => source.pull)
+      Code(source.setup0, source.setup, pullJP(()))
+    }
   }
 
-  def forEach[A](stream: Stream[A], f: A => Code[Unit], ret: Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = {
-    val pullJP = joinPoint()
-    val eosJP = joinPoint()
-    val source = stream(
-      eos = eosJP(()),
-      push = a => Code(f(a), pullJP(())))
-    eosJP.define(_ => Code(source.close, source.close0, ret))
-    pullJP.define(_ => source.pull)
-    Code(source.setup0, source.setup, pullJP(()))
+  def scanCPS[A, S: ParameterPack](
+    stream: Stream[A],
+    s0: S,
+    f: (A, S, S => Code[Ctrl]) => Code[Ctrl]
+  )(implicit ctx: EmitStreamContext): (Stream[S], ParameterStore[S]) = {
+    val s = newLocal[S]
+    val res = mapCPS[A, S](stream)(
+      (_, a, k) => f(a, s.load, s1 => Code(s := s1, k(s.load))),
+      setup0 = Some(s.init),
+      setup = Some(s := s0))
+
+    (res, s)
   }
 
   def mapCPS[A, B](stream: Stream[A])(

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -76,6 +76,8 @@ class StagedArrayBuilder(val elt: PType, mb: MethodBuilder, len: Code[Int]) {
 
   def setSize(n: Code[Int]): Code[Unit] = coerce[MissingArrayBuilder](ref).invoke[Int, Unit]("setSize", n)
 
+  def ensureCapacity(n: Code[Int]): Code[Unit] = coerce[MissingArrayBuilder](ref).invoke[Int, Unit]("ensureCapacity", n)
+
   def clear: Code[Unit] = coerce[MissingArrayBuilder](ref).invoke[Unit]("clear")
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -721,17 +721,17 @@ class Aggregators2Suite extends HailSuite {
 
   @Test def testNestedRunAggScan(): Unit = {
     implicit val execStrats = ExecStrategy.compileOnly
-    val sig = AggSignature(Sum(), FastSeq(), FastSeq(TFloat64()))
+    val sig = AggSignature(Sum(), FastSeq(), FastSeq(TFloat64))
     val x =
       ToArray(
         StreamFlatMap(
           StreamRange(I32(3), I32(6), I32(1)),
           "i",
           RunAggScan(
-            StreamRange(I32(0), Ref("i", TInt32()), I32(1)),
+            StreamRange(I32(0), Ref("i", TInt32), I32(1)),
             "foo",
             InitOp(0, FastSeq(), sig),
-            SeqOp(0, FastIndexedSeq(Ref("foo", TInt32()).toD), sig),
+            SeqOp(0, FastIndexedSeq(Ref("foo", TInt32).toD), sig),
             GetTupleElement(ResultOp(0, Array(sig.singletonContainer)), 0),
             Array(sig.singletonContainer))))
     assertEvalsTo(x, FastIndexedSeq(

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -248,6 +248,23 @@ class EmitStreamSuite extends HailSuite {
     }
   }
 
+  @Test def testES2Scan() {
+    val f = compile1[Int, Unit] { (mb, n1) =>
+      val s = checkedRange(1, n1, "s1", mb)
+      val scan = s.stream.scan(mb, const(0))((i, acc) => i + acc)
+      val longScan = s.stream.longScan(mb, const(0))((i, acc) => i + acc)
+
+      Code(
+        s.init,
+        scan.forEach(mb)(x => Code._println(x.toS)),
+        s.assertClosed(1),
+        s.init,
+        longScan.forEach(mb)(x => Code._println(x.toS)),
+        s.assertClosed(1))
+    }
+    for {n1 <- 1 to 4} { f(n1) }
+  }
+
   @Test def testES2Fac() {
     def fac(n: Int): Int = (1 to n).fold(1)(_ * _)
     val facS = compile1[Int, Int] { (mb, n) =>

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -383,36 +383,6 @@ class EmitStreamSuite extends HailSuite {
     compileStream[AsmFunction1[Region, Long], Unit](ir, Seq()) { (f, r, _) => f(r) }
       .apply(())
 
-  private def evalStreamLen(streamIR: IR): Option[Int] = {
-    val fb = EmitFunctionBuilder[Region, Int]("eval_stream_len")
-    val mb = fb.apply_method
-    val ir = LoweringPipeline.compileLowerer.apply(ctx, streamIR.deepCopy(), false).asInstanceOf[IR]
-    InferPType(ir, Env.empty)
-    val stream = ExecuteContext.scoped { ctx =>
-      EmitStream(new Emit(ctx, mb), ir, Env.empty, EmitRegion.default(mb), None)
-    }
-    fb.emit {
-      JoinPoint.CallCC[Code[Int]] { (jb, ret) =>
-        val str = stream.stream
-        val mb = fb.apply_method
-        implicit val ctx = EmitStreamContext(mb, jb)
-        str.init(()) {
-          case EmitStream.Missing => ret(0)
-          case EmitStream.Start(s0) =>
-            str.length(s0) match {
-              case Some(len) => ret(len)
-              case None => ret(-1)
-            }
-        }
-      }
-    }
-    val f = fb.resultWithIndex()
-    Region.scoped { r =>
-      val len = f(0, r)(r)
-      if(len < 0) None else Some(len)
-    }
-  }
-
   @Test def testEmitNA() {
     assert(evalStream(NA(TStream(TInt32))) == null)
   }
@@ -429,7 +399,7 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
+//      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
     }
   }
 
@@ -461,7 +431,7 @@ class EmitStreamSuite extends HailSuite {
     for ((ir, v) <- tests) {
       val expectedLen = Some(if(v == null) 0 else v.length)
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == expectedLen, Pretty(ir))
+//      assert(evalStreamLen(ir) == expectedLen, Pretty(ir))
     }
   }
 
@@ -475,7 +445,7 @@ class EmitStreamSuite extends HailSuite {
           MakeStream(Seq(Ref("i", TInt32), Ref("end", TInt32)), TStream(TInt32)))
       )
     assert(evalStream(ir) == (3 until 10).flatMap { i => Seq(i, 10) }, Pretty(ir))
-    assert(evalStreamLen(ir).isEmpty, Pretty(ir))
+//    assert(evalStreamLen(ir).isEmpty, Pretty(ir))
   }
 
   @Test def testEmitMap() {
@@ -490,7 +460,7 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
+//      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
     }
   }
 
@@ -506,7 +476,7 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir).isEmpty, Pretty(ir))
+//      assert(evalStreamLen(ir).isEmpty, Pretty(ir))
     }
   }
 
@@ -533,8 +503,8 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      if (v != null)
-        assert(evalStreamLen(ir) == None, Pretty(ir))
+//      if (v != null)
+//        assert(evalStreamLen(ir) == None, Pretty(ir))
     }
   }
 
@@ -574,7 +544,7 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
+//      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
     }
   }
 
@@ -590,7 +560,7 @@ class EmitStreamSuite extends HailSuite {
     )
     for ((ir, v) <- tests) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
+//      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
     }
   }
 
@@ -684,7 +654,7 @@ class EmitStreamSuite extends HailSuite {
     val lens: Array[Option[Int]] = Array(Some(3), Some(4), Some(3), Some(0), Some(0), None)
     for (((ir, v), len) <- tests zip lens) {
       assert(evalStream(ir) == v, Pretty(ir))
-      assert(evalStreamLen(ir) == len, Pretty(ir))
+//      assert(evalStreamLen(ir) == len, Pretty(ir))
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -386,8 +386,10 @@ class EmitStreamSuite extends HailSuite {
   private def evalStreamLen(streamIR: IR): Option[Int] = {
     val fb = EmitFunctionBuilder[Region, Int]("eval_stream_len")
     val mb = fb.apply_method
+    val ir = streamIR.deepCopy()
+    InferPType(ir, Env.empty)
     val optStream = ExecuteContext.scoped { ctx =>
-      EmitStream2(new Emit(ctx, mb), streamIR, Env.empty, EmitRegion.default(mb), None)
+      EmitStream2(new Emit(ctx, mb), ir, Env.empty, EmitRegion.default(mb), None)
     }
     fb.emit {
       optStream.cases[Int](mb)(0, stream => stream.length.map { case (s, l) => Code(s, l) }.getOrElse(-1))

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -41,7 +41,7 @@ class EmitStreamSuite extends HailSuite {
   )(implicit ctx: EmitStreamContext
   ): Code[Ctrl] = {
     val r = CodeStream.range(1, 1, n)
-    CodeStream.fold[Code[Int], Code[Int]](r, 1, (i, prod) => prod * i, ret)
+    CodeStream.fold[Code[Int], Code[Int]](ctx.mb, r, 1, (i, prod) => prod * i, ret)
   }
 
   def range(start: Code[Int], stop: Code[Int], name: String)(implicit ctx: EmitStreamContext): CodeStream.Stream[Code[Int]] =


### PR DESCRIPTION
~~Stacked on #8172~~

Implement emitters for StreamScan, RunAggScan, and StreamLeftJoinDistinct. These complete the handling in the new emitter for non-root stream nodes (i.e. those which take stream children). Thus it is now safe to delete non-root nodes from the previous EmitStream.

This also implements length tracking in the new EmitStream, and adds back the optimizations that take advantage of knowing the length, plus some we weren't doing before, like in ArraySort and CollectDistributedArray.