### PR TITLE
[shuffler] initial attempt

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -480,6 +480,7 @@ steps:
      {{ code.checkout_script }}
      cd hail
      make jars python-version-info wheel
+     ./gradlew jar
      (cd python && zip -r hail.zip hail hailtop)
      tar czf test.tar.gz -C python test
      tar czf resources.tar.gz -C src/test resources
@@ -490,6 +491,8 @@ steps:
    outputs:
      - from: /io/repo/hail/build/libs/hail-all-spark.jar
        to: /hail.jar
+     - from: /io/repo/hail/build/libs/hail.jar
+       to: /hail-no-spark.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
      - from: /io/repo/hail/testng.xml
@@ -1350,3 +1353,89 @@ steps:
      - default_ns
      - deploy_dbuf
      - test_dbuf_image
+ - kind: buildImage
+   name: shuffler_build_image
+   dockerFile: shuffler/Dockerfile.build
+   contextPath: shuffler
+   publishAs: shuffler
+   dependsOn:
+    - hail_build_image
+ - kind: runImage
+   name: shuffler_build
+   image:
+     valueFrom: shuffler_build_image.image
+   resources:
+     memory: "7.5G"
+     cpu: "2"
+   script: |
+     set -ex
+     cd /io
+     rm -rf repo
+     mkdir repo
+     cd repo
+     {{ code.checkout_script }}
+     mkdir -p hail/build/libs
+     mv /io/hail-no-spark.jar /io/repo/hail/build/libs/hail.jar
+     cd shuffler
+     sbt assembly
+   outputs:
+     - from: /io/repo/shuffler/target/scala-2.11/shuffler-assembly-0.1.jar
+       to: /shuffler-assembly-0.1.jar
+   inputs:
+     - from: /hail-no-spark.jar
+       to: /io/hail-no-spark.jar
+   dependsOn:
+     - shuffler_build_image
+     - build_hail
+ - kind: buildImage
+   name: shuffler_image
+   dockerFile: shuffler/Dockerfile
+   contextPath: shuffler
+   publishAs: shuffler
+   inputs:
+     - from: /shuffler-assembly-0.1.jar
+       to: /shuffler-assembly-0.1.jar
+   dependsOn:
+     - service_base_image
+     - shuffler_build
+ - kind: deploy
+   name: deploy_shuffler
+   namespace:
+     valueFrom: default_ns.name
+   config: shuffler/deployment.yaml
+   wait:
+    - kind: Service
+      name: shuffler
+      for: alive
+      resource_type: statefulset
+   dependsOn:
+    - default_ns
+    - shuffler_image
+ - kind: buildImage
+   name: test_shuffler_image
+   dockerFile: shuffler/test/Dockerfile
+   contextPath: shuffler/test
+   publishAs: test_shuffler
+   inputs:
+     - from: /wheel-container.tar
+       to: /wheel-container.tar
+   dependsOn:
+     - build_hail
+     - hail_run_image
+ - kind: runImage
+   name: test_shuffler
+   image:
+     valueFrom: test_shuffler_image.image
+   resources:
+     cpu: "2"
+   script: |
+     python3 -m pytest --log-cli-level=INFO -s -v --instafail test_shuffler.py
+   secrets:
+    - name: gce-deploy-config
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /home/hail/.hail
+   dependsOn:
+    - default_ns
+    - test_shuffler_image
+    - deploy_shuffler

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -18,6 +18,7 @@ plugins {
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
 
 repositories {
     mavenCentral()
@@ -175,6 +176,11 @@ dependencies {
 
     unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
+
+    bundled "com.typesafe.akka:akka-http_" + scalaMajorVersion + ":10.1.9"
+    bundled "com.typesafe.akka:akka-stream_" + scalaMajorVersion + ":2.5.23"
+    bundled group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.12.1'
+    bundled group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.12.1'
 }
 
 task(checkSettings) doLast {
@@ -253,6 +259,10 @@ shadowJar {
     classifier = 'spark'
     from project.sourceSets.main.output
     configurations = [project.configurations.hailJar]
+    transform(AppendingTransformer) {
+        resource = 'reference.conf'
+    }
+    with jar
 }
 
 task shadowTestJar(type: ShadowJar) {

--- a/hail/src/main/resources/log4j.properties
+++ b/hail/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L %m%n

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -827,7 +827,9 @@ class HailFeatureFlags {
     mutable.Map[String, String](
       "lower" -> null,
       "max_leader_scans" -> "1000",
-      "jvm_bytecode_dump" -> null
+      "jvm_bytecode_dump" -> null,
+      "shuffle_service_url" -> null,
+      "buffer_service_url" -> null
     )
 
   val available: java.util.ArrayList[String] =

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -829,6 +829,7 @@ class HailFeatureFlags {
       "max_leader_scans" -> "1000",
       "jvm_bytecode_dump" -> null,
       "shuffle_service_url" -> null,
+      "shuffle_buffer_spec" -> null,
       "buffer_service_url" -> null
     )
 

--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -13,7 +13,7 @@ object CodeOrdering {
 
   sealed trait Op {
     type ReturnType
-    val rtti: TypeInfo[ReturnType]
+    def rtti: TypeInfo[ReturnType]
   }
   final case object compare extends Op {
     type ReturnType = Int

--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -13,7 +13,7 @@ object CodeOrdering {
 
   sealed trait Op {
     type ReturnType
-    def rtti: TypeInfo[ReturnType]
+    val rtti: TypeInfo[ReturnType]
   }
   final case object compare extends Op {
     type ReturnType = Int

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -25,7 +25,8 @@ object Compile {
     argTypeInfo: Array[MaybeGenericTypeInfo[_]],
     body: IR,
     optimize: Boolean
-  ): (PType, (Int, Region) => F) = apply(ctx, print, args, argTypeInfo, GenericTypeInfo[R](), body, optimize)
+  ): (PType, (Int, Region) => F) = apply[F, R](
+    ctx, print, args, argTypeInfo, GenericTypeInfo[R](), body, optimize)
 
   def apply[F >: Null : TypeInfo, R: ClassTag](
     ctx: ExecuteContext,

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -25,6 +25,16 @@ object Compile {
     argTypeInfo: Array[MaybeGenericTypeInfo[_]],
     body: IR,
     optimize: Boolean
+  ): (PType, (Int, Region) => F) = apply(ctx, print, args, argTypeInfo, GenericTypeInfo[R](), body, optimize)
+
+  def apply[F >: Null : TypeInfo, R: ClassTag](
+    ctx: ExecuteContext,
+    print: Option[PrintWriter],
+    args: Seq[(String, PType, ClassTag[_])],
+    argTypeInfo: Array[MaybeGenericTypeInfo[_]],
+    returnTypeInfo: MaybeGenericTypeInfo[R],
+    body: IR,
+    optimize: Boolean
   ): (PType, (Int, Region) => F) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
@@ -36,7 +46,7 @@ object Compile {
       case None =>
     }
 
-    val fb = new EmitFunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
+    val fb = new EmitFunctionBuilder[F](argTypeInfo, returnTypeInfo)
 
     var ir = body
     ir = Subst(ir, BindingEnv(args

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1,5 +1,7 @@
 package is.hail.rvd
 
+import is.hail.shuffler.ShuffleClient
+import is.hail.expr.ir.Ascending
 import java.util
 
 import is.hail.HailContext
@@ -43,7 +45,8 @@ class RVD(
   self =>
   require(crdd.getNumPartitions == partitioner.numPartitions)
 
-  require(typ.kType.virtualType isIsomorphicTo partitioner.kType)
+  require(typ.kType.virtualType isIsomorphicTo partitioner.kType,
+    s"${typ.kType.virtualType} isIsomorphicTo ${partitioner.kType}")
 
   // Basic accessors
 
@@ -241,7 +244,6 @@ class RVD(
       val kOrdering = newType.kType.virtualType.ordering
 
       val partBc = newPartitioner.broadcast(crdd.sparkContext)
-      val enc = TypedCodecSpec(rowPType, BufferSpec.wireSpec)
 
       val filtered: RVD = if (filter) filterWithContext[(UnsafeRow, KeyedRow)]({ case (_, _) =>
         val ur = new UnsafeRow(localRowPType, null, 0)
@@ -252,14 +254,26 @@ class RVD(
         partBc.value.contains(key)
       }) else this
 
-      val shuffled: RDD[(Any, Array[Byte])] = new ShuffledRDD(
-        filtered.keyedEncodedRDD(enc, newType.key),
-        newPartitioner.sparkPartitioner(crdd.sparkContext)
-      ).setKeyOrdering(kOrdering.toOrdering)
+      val shuffleService = HailContext.get.flags.get("shuffle_service_url")
+      if (shuffleService != null) {
+        ShuffleClient.shuffle(
+          shuffleService,
+          rowPType,
+          newType.kFieldIdx.map(x => (x, Ascending)),
+          this,
+          Right(newPartitioner),
+          executeContext)
+      } else {
+        val bufferSpec = ShuffleClient.activeShuffleBufferSpec
+        val codec = TypedCodecSpec(rowPType, bufferSpec)
+        val shuffled: RDD[(Any, Array[Byte])] = new ShuffledRDD(
+          filtered.keyedEncodedRDD(codec, newType.key),
+          newPartitioner.sparkPartitioner(crdd.sparkContext)
+        ).setKeyOrdering(kOrdering.toOrdering)
 
-      val (rType: PStruct, shuffledCRDD) = enc.decodeRDD(localRowPType.virtualType, shuffled.values)
-
-      RVD(RVDType(rType, newType.key), newPartitioner, shuffledCRDD)
+        val (rType, shuffledCRDD) = codec.decodeRDD(localRowPType.virtualType, shuffled.values)
+        RVD(RVDType(rType.asInstanceOf[PStruct], newType.key), newPartitioner, shuffledCRDD)
+      }
     } else {
       if (newPartitioner != partitioner)
         new RVD(

--- a/hail/src/main/scala/is/hail/shuffler/BufferClient.scala
+++ b/hail/src/main/scala/is/hail/shuffler/BufferClient.scala
@@ -21,10 +21,8 @@ object BufferClient {
     var rootUrl = maybeRootUrl
     if (rootUrl == null) {
       rootUrl = HailContext.get.flags.get("buffer_service_url")
-      if (rootUrl == null) {
-        rootUrl = "http://localhost:5000"
-      }
     }
+    assert(rootUrl != null)
     val client = new BufferClient(
       rootUrl,
       HTTPClient.post(s"${rootUrl}/s",

--- a/hail/src/main/scala/is/hail/shuffler/BufferClient.scala
+++ b/hail/src/main/scala/is/hail/shuffler/BufferClient.scala
@@ -1,0 +1,133 @@
+package is.hail.shuffler
+
+import is.hail.HailContext
+import is.hail.utils._
+import is.hail.expr.ir.ExecuteContext
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, InputStreamReader, OutputStream }
+import scala.reflect.ClassTag
+
+import org.json4s._
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+object BufferClient {
+  type Key = (String, Int, Int, Int)
+
+  private implicit val f = new DefaultFormats() {}
+
+  def create(
+    executeContext: ExecuteContext,
+    maybeRootUrl: String = null
+  ): BufferClient = {
+    var rootUrl = maybeRootUrl
+    if (rootUrl == null) {
+      rootUrl = HailContext.get.flags.get("buffer_service_url")
+      if (rootUrl == null) {
+        rootUrl = "http://localhost:5000"
+      }
+    }
+    val client = new BufferClient(
+      rootUrl,
+      HTTPClient.post(s"${rootUrl}/s",
+        0, out => (), in => Serialization.read[Int](new InputStreamReader(in))))
+    val url = client.sessionUrl
+    Runtime.getRuntime.addShutdownHook(new Thread(new Runnable() {
+      override def run(): Unit = {
+        log.info(s"shutdown hook buffer ${client.id}")
+        HTTPClient.delete(url)
+      }
+    }))
+    executeContext.addOnExit { () =>
+      HTTPClient.delete(url)
+    }
+    client
+  }
+}
+
+class BufferClient (
+  val rootUrl: String,
+  val id: Int
+) extends Serializable {
+  import BufferClient._
+
+  val sessionUrl = s"${rootUrl}/s/${id}"
+
+  private[this] val me = getWorkers()(0)
+
+  def write(
+    writer: OutputStream => Unit
+  ): Key = {
+    HTTPClient.post(sessionUrl, 0, writer, { in =>
+      val baos = new ByteArrayOutputStream()
+      drainInputStreamToOutputStream(in, baos)
+      val bytes = baos.toByteArray()
+      val JArray(List(JString(s), JInt(fileId), JInt(pos), JInt(n))) =
+        JsonMethods.parse(new InputStreamReader(new ByteArrayInputStream(bytes)))
+      val x = (s, fileId.toInt, pos.toInt, n.toInt)
+      log.info(s"wrote ${x}")
+      x
+    })
+  }
+
+  def read[T](
+    key: Key,
+    reader: InputStream => T
+  ): T =
+    HTTPClient.post(s"${rootUrl.replace(me, key._1)}/s/${id}/get", 0, { out =>
+      Serialization.write(Array(key._1, key._2, key._3, key._4), out)
+    }, reader)
+
+  def readMany[T: ClassTag](
+    keys: Array[Key],
+    reader: InputStream => T
+  ): Array[T] = {
+    assert(keys.length > 0)
+    log.info(s"fetching ${keys.length} keys from ${keys(0)._1}: ${keys.mkString(",")}")
+    var i = 0
+    HTTPClient.post(s"${rootUrl.replace(me, keys(0)._1)}/s/${id}/getmany", 0, { out =>
+      Serialization.write(keys.map(key => Array(key._1, key._2, key._3, key._4)), out)
+    }, decode(_, reader))
+  }
+
+  private[this] def decode[T: ClassTag](
+    in: InputStream,
+    reader: InputStream => T
+  ): Array[T] = {
+    def readInt: Int = {
+      var out = 0
+      var i = in.read()
+      if (i == -1)
+        return i
+      out |= (i & 0xff)
+      i = in.read()
+      if (i == -1)
+        return i
+      out |= (i & 0xff) << 8
+      i = in.read()
+      if (i == -1)
+        return i
+      out |= (i & 0xff) << 16
+      i = in.read()
+      if (i == -1)
+        return i
+      out | (i & 0xff) << 24
+    }
+    val slice = new SlicedInputStream(in)
+    val ab = new ArrayBuilder[T]()
+    var n = readInt
+    while (n >= 0) {
+        assert(n >= 0)
+        slice.startSlice(n)
+        ab += reader(slice)
+        n = readInt
+    }
+    ab.result()
+  }
+
+  def delete(): Unit = HTTPClient.delete(sessionUrl)
+
+  def getWorkers(): Seq[String] =
+    HTTPClient.get(s"${rootUrl}/w", { in =>
+      val JArray(l) = JsonMethods.parse(new InputStreamReader(in))
+      l.map { case JString(s) => s }
+    })
+}

--- a/hail/src/main/scala/is/hail/shuffler/Codec.scala
+++ b/hail/src/main/scala/is/hail/shuffler/Codec.scala
@@ -1,0 +1,26 @@
+package is.hail.shuffler
+
+import is.hail.annotations._
+import is.hail.expr.types.physical._
+import is.hail.io._
+import is.hail.utils._
+import java.io.{ ByteArrayOutputStream, ByteArrayInputStream }
+
+final class Codec (
+  spec: TypedCodecSpec
+) {
+  val (memType, buildDecoder) = spec.buildDecoder(spec._vType)
+  val buildEncoder = spec.buildEncoder(memType)
+
+  def encode(region: Region, offset: Long): Array[Byte] = {
+    val baos = new ByteArrayOutputStream()
+    using(buildEncoder(baos))(_.writeRegionValue(region, offset))
+    baos.toByteArray
+  }
+
+  def decode(bytes: Array[Byte], region: Region): Long = {
+    val bais = new ByteArrayInputStream(bytes)
+    buildDecoder(bais).readRegionValue(region)
+  }
+}
+

--- a/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
+++ b/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
@@ -170,7 +170,6 @@ object ShuffleClient {
     }.clearingRun
     sc.runJob(addRdd, (it: Iterator[Unit]) => it.foreach(_ => ()), (_, _: Unit) => ())
     val keyBytes = shuffler.end_input()
-    val readParallelism = hc.flags.get("shuffle_read_parallelism").toInt
     val shuffledCRDD = ContextRDD.weaken[RVDContext](sc.parallelize((0 until parts), parts)).cflatMap { (ctx, _) =>
       val bufferKeys = shuffler.get(TaskContext.get.partitionId).map { bytes =>
         val bais = new ByteArrayInputStream(bytes)

--- a/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
+++ b/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
@@ -196,22 +196,9 @@ object ShuffleClient {
       r.addReferenceTo(ctx.region)
       keyGroups.result().iterator.flatMap { keys =>
         buffer.readMany(keys, { in =>
-            using(new ByteArrayOutputStream()) { baos =>
-              drainInputStreamToOutputStream(in, baos)
-              val ba = baos.toByteArray()
-              val off = vDec(new ByteArrayInputStream(ba)).readRegionValue(r)
-              println(off)
-              println(ba.map("%02X" format _).mkString)
-              println(new UnsafeRow(decodedRowPType.asInstanceOf[PBaseStruct], r, off))
-              off
-            }
+          vDec(in).readRegionValue(r)
         }).iterator.map { (off: Long) =>
           rv.setOffset(off)
-          assert(decodedRowPType.byteSize < (1 << 31) - 1)
-          val ba = Region.loadBytes(off, decodedRowPType.byteSize.asInstanceOf[Int])
-          println(off)
-          println(ba.map("%02X" format _).mkString)
-          println(new UnsafeRow(decodedRowPType.asInstanceOf[PBaseStruct], r, off))
           rv
         }
       }

--- a/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
+++ b/hail/src/main/scala/is/hail/shuffler/ShuffleClient.scala
@@ -1,0 +1,412 @@
+package is.hail.shuffler
+import is.hail.HailContext
+import is.hail.annotations.{ Region, RegionValue, RegionValueBuilder, SafeRow, UnsafeRow }
+import is.hail.cxx
+import is.hail.expr.ir.ExecuteContext
+import is.hail.expr.types.physical._
+import is.hail.io._
+import is.hail.rvd.{ RVD, RVDContext, RVDPartitioner, RVDType }
+import is.hail.sparkextras.ContextRDD
+import is.hail.expr.ir.{ Ascending, SortOrder }
+import is.hail.utils._
+import is.hail.utils.HTTPClient
+import java.io.{ BufferedReader, ByteArrayInputStream, ByteArrayOutputStream, InputStreamReader }
+import java.net.{ URL, HttpURLConnection }
+import java.io.{ InputStream, OutputStream }
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.charset.{ StandardCharsets }
+import java.util.HashMap
+import java.util.concurrent.{ Callable, Executor, Executors, ThreadPoolExecutor, TimeUnit }
+import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.spark.{ Dependency, Partition, TaskContext }
+import org.apache.spark.rdd.RDD
+import org.json4s.jackson.JsonMethods
+import scala.collection.mutable.{ ArrayBuffer }
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+import org.json4s._
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+
+object ShuffleClient {
+  private implicit val f = new DefaultFormats() {}
+
+  private[this] def typeToParsableUTF8Bytes(t: PType): Array[Byte] =
+    ByteUtils.stringToBytes(t.toString())
+
+  private[this] def sortOrdersToParseableBytes(so: Array[SortOrder]): Array[Byte] =
+    so.map(_.serialize)
+
+  def activeShuffleBufferSpec = BufferSpec.parseOrDefault(
+    HailContext.get.flags.get("shuffle_buffer_spec"),
+    BufferSpec.defaultUncompressed)
+
+  def shuffle(
+    serverUrl: String,
+    rowPType: PBaseStruct,
+    sortFieldsAndOrders: Array[(Int, SortOrder)],
+    rvd: RVD,
+    outPartitioning: Either[Int, RVDPartitioner],
+    executeContext: ExecuteContext,
+    bufferSpec: BufferSpec = activeShuffleBufferSpec,
+    bufferByteSize: Int = 1 * 1024 * 1024,
+    httpChunkSize: Int = 64 * 1024
+  ): RVD = {
+    val keyFieldIndices = sortFieldsAndOrders.map(_._1)
+    val newType = rvd.typ.copy(key =
+      keyFieldIndices.map(rvd.typ.rowType.fieldNames))
+    val keyPType = newType.kType.setRequired(true).asInstanceOf[PStruct]
+    val parts = rvd.getNumPartitions
+    val bufferSpec = ShuffleClient.activeShuffleBufferSpec
+    val shuffler = ShuffleClient(
+      serverUrl,
+      rowPType,
+      keyPType,
+      sortFieldsAndOrders,
+      parts,
+      outPartitioning,
+      executeContext,
+      bufferSpec)
+
+    val keyCodec = new Codec(TypedCodecSpec(keyPType, bufferSpec))
+    val kEnc = keyCodec.buildEncoder
+    val kDec = keyCodec.buildDecoder
+    val decodedKeyPType = keyCodec.memType.asInstanceOf[PStruct]
+
+    val valueCodec = new Codec(TypedCodecSpec(rowPType, bufferSpec))
+    val vEnc = valueCodec.buildEncoder
+    val vDec = valueCodec.buildDecoder
+    val decodedRowPType = valueCodec.memType.asInstanceOf[PStruct]
+
+    val hc = HailContext.get
+    val sc = hc.sc
+    val fs = hc.sFS
+
+    val buffer = BufferClient.create(executeContext)
+
+    val bufferId = buffer.id
+    val _bufferWorkers = buffer.getWorkers
+    val leader = _bufferWorkers(0)
+    val bufferWorkers = _bufferWorkers.map(x =>
+      buffer.rootUrl.replace(leader, x)
+    )
+    val BUFSIZE = 10 * 1024 * 1024
+
+    val addRdd = rvd.crdd.cmapPartitions { (ctx, it) =>
+      val context = TaskContext.get
+      val partitionId = context.partitionId()
+      val taskAttemptId = context.taskAttemptId()
+      val rvb = new RegionValueBuilder(ctx.region)
+      val shufflerPartition = shuffler.startPartition(partitionId, taskAttemptId)
+      val kBae = new ByteArrayEncoder(kEnc)
+      val buffer = new BufferClient(
+        bufferWorkers(context.partitionId() % bufferWorkers.length),
+        bufferId)
+
+      val os = new ByteArrayOutputStream(BUFSIZE)
+      val blocks = new ArrayBuilder[(Int, Int)]()
+      val keys = new ArrayBuilder[Array[Byte]]()
+
+      using(vEnc(os)) { enc =>
+        it.foreach { rv =>
+          val pos = os.size()
+          enc.writeRegionValue(rv.region, rv.offset)
+          enc.flush()
+          blocks += ((pos, os.size() - pos))
+          rvb.start(keyPType)
+          rvb.startStruct()
+          rvb.addFields(rowPType, rv.region, rv.offset, keyFieldIndices)
+          rvb.endStruct()
+          val sortKeyOff = rvb.end()
+          keys += kBae.regionValueToBytes(rv.region, sortKeyOff)
+          ctx.region.clear()
+          if (os.size() > BUFSIZE) {
+            assert(os.size() < 50 * 1024 * 1024)
+            val ks = keys.result()
+            val bs = blocks.result()
+            val ba = os.toByteArray()
+            val (s, fileId, pos, n) = buffer.write(httpos => httpos.write(ba))
+            log.info(s"wrote ${ba.length} bytes to buffer (${pos} ${n})")
+            var i = 0
+            while (i < ks.length) {
+              val key = ks(i)
+              val (off, n) = bs(i)
+              val baos = new ByteArrayOutputStream()
+              Serialization.write(Array(s, fileId, pos + off, n), baos)
+              shufflerPartition.add(key, baos.toByteArray())
+              i += 1
+            }
+            blocks.clear()
+            keys.clear()
+            os.reset()
+            log.info(s"wrote ${i} keys")
+          }
+        }
+        if (os.size() > 0) {
+          assert(os.size() < 50 * 1024 * 1024)
+          val ks = keys.result()
+          val bs = blocks.result()
+          val ba = os.toByteArray()
+          val (s, fileId, pos, n) = buffer.write(httpos => httpos.write(ba))
+          log.info(s"wrote ${ba.length} bytes to buffer (${pos} ${n})")
+          var i = 0
+          while (i < ks.length) {
+            val key = ks(i)
+            val (off, n) = bs(i)
+            val baos = new ByteArrayOutputStream()
+            Serialization.write(Array(s, fileId, pos + off, n), baos)
+            shufflerPartition.add(key, baos.toByteArray())
+            i += 1
+            blocks.clear()
+            keys.clear()
+            os.reset()
+          }
+          log.info(s"wrote ${i} keys")
+        }
+      }
+      shufflerPartition.finishPartition()
+      Iterator.empty
+    }.clearingRun
+    sc.runJob(addRdd, (it: Iterator[Unit]) => it.foreach(_ => ()), (_, _: Unit) => ())
+    val keyBytes = shuffler.end_input()
+    val readParallelism = hc.flags.get("shuffle_read_parallelism").toInt
+    val shuffledCRDD = ContextRDD.weaken[RVDContext](sc.parallelize((0 until parts), parts)).cflatMap { (ctx, _) =>
+      val bufferKeys = shuffler.get(TaskContext.get.partitionId).map { bytes =>
+        val bais = new ByteArrayInputStream(bytes)
+        val JArray(List(JString(s), JInt(fileId), JInt(pos), JInt(n))) = JsonMethods.parse(bais)
+        (s, fileId.toInt, pos.toInt, n.toInt)
+      }
+
+      val keyGroups = new ArrayBuilder[Array[BufferClient.Key]]()
+      var i = 0
+      while (i < bufferKeys.length) {
+        var s = 0
+        val group = new ArrayBuilder[BufferClient.Key]()
+        assert(bufferKeys(i)._4 < BUFSIZE)
+        while (i < bufferKeys.length && s < BUFSIZE) {
+          s += bufferKeys(i)._4
+          group += bufferKeys(i)
+          i += 1
+        }
+        keyGroups += group.result()
+      }
+
+      val rv = RegionValue(ctx.region)
+      val r = Region()
+      r.addReferenceTo(ctx.region)
+      keyGroups.result().iterator.flatMap { keys =>
+        buffer.readMany(keys, { in =>
+            using(new ByteArrayOutputStream()) { baos =>
+              drainInputStreamToOutputStream(in, baos)
+              val ba = baos.toByteArray()
+              val off = vDec(new ByteArrayInputStream(ba)).readRegionValue(r)
+              println(off)
+              println(ba.map("%02X" format _).mkString)
+              println(new UnsafeRow(decodedRowPType.asInstanceOf[PBaseStruct], r, off))
+              off
+            }
+        }).iterator.map { (off: Long) =>
+          rv.setOffset(off)
+          assert(decodedRowPType.byteSize < (1 << 31) - 1)
+          val ba = Region.loadBytes(off, decodedRowPType.byteSize.asInstanceOf[Int])
+          println(off)
+          println(ba.map("%02X" format _).mkString)
+          println(new UnsafeRow(decodedRowPType.asInstanceOf[PBaseStruct], r, off))
+          rv
+        }
+      }
+    }
+    val decodedKeys = Region.scoped { r =>
+      RegionValue.pointerFromBytes(kDec, r, keyBytes.iterator)
+        .map(SafeRow.read(decodedKeyPType, r, _))
+        .toArray
+    }
+    val partitionIntervals = new Array[Interval](parts)
+    var i = 0
+    while (i < partitionIntervals.length) {
+      partitionIntervals(i) = Interval(
+        decodedKeys(i),
+        decodedKeys(i + 1),
+        true,
+        i + 1 != partitionIntervals.length)
+      i += 1
+    }
+    RVD(
+      RVDType(decodedRowPType, newType.key),
+      new RVDPartitioner(
+        decodedKeyPType.virtualType,
+        partitionIntervals),
+      shuffledCRDD)
+  }
+
+  def apply(
+    serverUrl: String,
+    rowPType: PBaseStruct,
+    keyPType: PBaseStruct,
+    sortFieldsAndOrders: Array[(Int, SortOrder)],
+    inPartitions: Int,
+    outPartitioning: Either[Int, RVDPartitioner],
+    executeContext: ExecuteContext,
+    bufferSpec: BufferSpec = activeShuffleBufferSpec,
+    bufferByteSize: Int = 1 * 1024 * 1024,
+    httpChunkSize: Int = 64 * 1024
+  ): ShuffleClient = {
+    val apiUrl = serverUrl + "/api/v1alpha"
+    log.info(s"shuffling bufferSpec: ${bufferSpec.toString}")
+
+    val s = bufferSpec.toString
+    val bufferSpecBytes = ByteUtils.stringToBytes(s)
+    val typeBytes = typeToParsableUTF8Bytes(keyPType)
+    val sortOrderBytes = sortOrdersToParseableBytes(sortFieldsAndOrders.map(_._2))
+    val (partitioningDescriminatorByte, partitioningBytes, nOutPartitions) = outPartitioning match {
+      case Left(nOutPartitions) =>
+        val bytes = new Array[Byte](4)
+        ByteUtils.writeInt(bytes, 0, nOutPartitions)
+        (0.toByte, bytes, nOutPartitions)
+      case Right(partitioner) =>
+        assert(keyPType.virtualType == partitioner.kType.setRequired(true))
+        val typ = PArray(PInterval(keyPType, true), true)
+        val codec = new Codec(TypedCodecSpec(typ, bufferSpec))
+        val enc = new ByteArrayEncoder(codec.buildEncoder)
+        Region.scoped { r =>
+          val rvb = new RegionValueBuilder(r)
+          val bounds = partitioner.rangeBounds
+          log.info(s"bounds length: ${bounds.length}")
+          rvb.start(typ)
+          rvb.addAnnotation(typ.virtualType, bounds.toFastIndexedSeq)
+          (1.toByte, enc.regionValueToBytes(r, rvb.end()), bounds.length)
+        }
+    }
+
+    val id = HTTPClient.post(
+      apiUrl,
+      4 + 4 + bufferSpecBytes.length +
+        + 4 + typeBytes.length
+        + sortOrderBytes.length +
+        + 1 + 4 + partitioningBytes.length,
+      { out =>
+        ByteUtils.writeInt(out, inPartitions)
+        ByteUtils.writeByteArray(out, bufferSpecBytes)
+        ByteUtils.writeByteArray(out, typeBytes)
+        out.write(sortOrderBytes)
+        out.write(partitioningDescriminatorByte)
+        ByteUtils.writeByteArray(out, partitioningBytes)
+        out.flush()
+      }, { in =>
+        using(new BufferedReader(new InputStreamReader(in))) { br =>
+          val id = java.lang.Long.parseLong(br.readLine())
+          assert(in.read() == -1)
+          id
+        }
+      })
+    // FIXME: do we need two shuffles? only reason to pass outPartitions through
+    // is so we can get the list of keys from the shuffler after we're done, but
+    // if we tell the shuffler the partitioner, there's no need for it to tell
+    // us the key bounds, we already know.
+    val shuffleSpecificApiUrl = apiUrl + "/" + id
+    val client = new ShuffleClient(shuffleSpecificApiUrl, bufferByteSize, httpChunkSize, nOutPartitions, bufferSpec)
+    Runtime.getRuntime.addShutdownHook(new Thread(new Runnable() {
+      override def run(): Unit = {
+        log.info(s"shutdown hook shuffle $id")
+        HTTPClient.delete(shuffleSpecificApiUrl)
+      }
+    }))
+    executeContext.addOnExit { () =>
+      HTTPClient.delete(shuffleSpecificApiUrl)
+    }
+    client
+  }
+}
+
+class ShuffleClient private (
+  shuffleSpecificApiUrl: String,
+  bufferByteSize: Int,
+  httpChunkSize: Int,
+  private[this] val outPartitions: Int,
+  private[this] val bufferSpec: BufferSpec
+) extends Serializable {
+  import ShuffleClient._
+  def startPartition(
+    partitionId: Int,
+    attemptId: Long
+  ): ShuffleClientPartition = new ShuffleClientPartition(partitionId, attemptId)
+
+  class ShuffleClientPartition(
+    private[this] val partitionId: Int,
+    private[this] val attemptId: Long
+  ) {
+    private[this] var count: Int = 0
+    private[this] var addBuffer: Array[Byte] = new Array[Byte](bufferByteSize)
+    private[this] var bufferIndex: Int = 0
+
+    private[this] def flushBuffer(): Unit = {
+      HTTPClient.post(
+        shuffleSpecificApiUrl,
+        bufferIndex,
+        { out =>
+          ByteUtils.writeInt(out, partitionId)
+          ByteUtils.writeLong(out, attemptId)
+          ByteUtils.writeInt(out, count)
+          out.write(addBuffer, 0, bufferIndex)
+          out.flush()
+        },
+        _ => (),
+        httpChunkSize)
+      bufferIndex = 0
+      count = 0
+    }
+
+    def add(
+      key: Array[Byte],
+      value: Array[Byte]
+    ): Unit = {
+      if (bufferIndex + 4 + key.size + 4 + value.size >= bufferByteSize) {
+        flushBuffer()
+      }
+      bufferIndex = ByteUtils.writeByteArray(addBuffer, bufferIndex, key)
+      bufferIndex = ByteUtils.writeByteArray(addBuffer, bufferIndex, value)
+      count += 1
+    }
+
+    def finishPartition(): Unit = {
+      if (bufferIndex != 0) {
+        flushBuffer()
+      }
+      HTTPClient.post(shuffleSpecificApiUrl + "/finish_partition",
+        4 + 8,
+        { out =>
+          ByteUtils.writeInt(out, partitionId)
+          ByteUtils.writeLong(out, attemptId)
+        })
+    }
+  }
+
+  def end_input(): Array[Array[Byte]] = HTTPClient.post(shuffleSpecificApiUrl + "/close", 0, _ => (), { in =>
+    val keys = new Array[Array[Byte]](outPartitions + 1)
+    var i = 0
+    while (i < keys.length) {
+      keys(i) = ByteUtils.readByteArray(in)
+      i += 1
+    }
+    keys
+  })
+
+  def get(
+    partition: Int
+  ): Array[Array[Byte]] = HTTPClient.get(shuffleSpecificApiUrl + "/" + partition,
+    { in =>
+      val elementsLength = ByteUtils.readInt(in)
+      val values = new Array[Array[Byte]](elementsLength)
+      var elementIndex = 0
+      while (elementIndex < elementsLength) {
+        // FIXME: should I stop sending the key?
+        ByteUtils.skipByteArray(in)
+        values(elementIndex) = ByteUtils.readByteArray(in)
+        elementIndex += 1
+      }
+      log.info(s"got $elementsLength elements")
+      values
+    })
+}
+

--- a/hail/src/main/scala/is/hail/utils/ByteUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/ByteUtils.scala
@@ -1,0 +1,190 @@
+package is.hail.utils
+
+import java.io.{ ByteArrayOutputStream, InputStream, OutputStream }
+import java.nio.ByteBuffer
+import java.nio.charset.{ Charset, StandardCharsets }
+
+object ByteUtils {
+  def writeInt(out: OutputStream, i: Int): Unit = {
+    out.write(i)
+    out.write(i >> 8)
+    out.write(i >> 16)
+    out.write(i >> 24)
+  }
+
+  def writeInt(out: Array[Byte], off: Int, i: Int): Int = {
+    out(off) = (i & 0xff).toByte
+    out(off + 1) = ((i >> 8) & 0xff).toByte
+    out(off + 2) = ((i >> 16) & 0xff).toByte
+    out(off + 3) = ((i >> 24) & 0xff).toByte
+    off + 4
+  }
+
+  def readInt(in: InputStream): Int = {
+    var out = 0
+    var i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff)
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 8
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 16
+    i = in.read()
+    assert(i != -1)
+    out | (i & 0xff) << 24
+  }
+
+  def skipInt(in: ByteBuffer): Unit = {
+    in.get()
+    in.get()
+    in.get()
+    in.get()
+  }
+
+  def readInt(in: ByteBuffer): Int = {
+    var out = 0
+    var i = in.get()
+    out |= (i & 0xff)
+    i = in.get()
+    out |= (i & 0xff) << 8
+    i = in.get()
+    out |= (i & 0xff) << 16
+    i = in.get()
+    out | (i & 0xff) << 24
+  }
+
+  def writeLong(out: OutputStream, l: Long): Unit = {
+    out.write(l.toInt)
+    out.write((l >> 8).toInt)
+    out.write((l >> 16).toInt)
+    out.write((l >> 24).toInt)
+    out.write((l >> 32).toInt)
+    out.write((l >> 40).toInt)
+    out.write((l >> 48).toInt)
+    out.write((l >> 56).toInt)
+  }
+
+  def writeLong(out: Array[Byte], off: Int, l: Long): Int = {
+    out(off) = (l & 0xff).toByte
+    out(off + 1) = ((l >> 8) & 0xff).toByte
+    out(off + 2) = ((l >> 16) & 0xff).toByte
+    out(off + 3) = ((l >> 24) & 0xff).toByte
+    out(off + 4) = ((l >> 32) & 0xff).toByte
+    out(off + 5) = ((l >> 40) & 0xff).toByte
+    out(off + 6) = ((l >> 48) & 0xff).toByte
+    out(off + 7) = ((l >> 56) & 0xff).toByte
+    off + 8
+  }
+
+  def readLong(in: InputStream): Int = {
+    var out = 0
+    var i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff)
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 8
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 16
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 24
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 32
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 40
+    i = in.read()
+    assert(i != -1)
+    out |= (i & 0xff) << 48
+    i = in.read()
+    assert(i != -1)
+    out | (i & 0xff) << 56
+  }
+
+  def readLong(in: ByteBuffer): Int = {
+    var out = 0
+    var i = in.get()
+    out |= (i & 0xff)
+    i = in.get()
+    out |= (i & 0xff) << 8
+    i = in.get()
+    out |= (i & 0xff) << 16
+    i = in.get()
+    out |= (i & 0xff) << 24
+    i = in.get()
+    out |= (i & 0xff) << 32
+    i = in.get()
+    out |= (i & 0xff) << 40
+    i = in.get()
+    out |= (i & 0xff) << 48
+    i = in.get()
+    out | (i & 0xff) << 56
+  }
+
+  def readBytes(in: InputStream, n: Int): Array[Byte] = {
+    val data = new Array[Byte](n)
+    var offset = 0
+    var bytesRead = 0
+    bytesRead = in.read(data, offset, n - offset)
+    while (bytesRead > 0) {
+      offset += bytesRead
+      bytesRead = in.read(data, offset, n - offset)
+    }
+    assert(bytesRead <= 0)
+    data
+  }
+
+  def readBytes(in: ByteBuffer, n: Int): Array[Byte] = {
+    val data = new Array[Byte](n)
+    in.get(data)
+    data
+  }
+
+  def writeByteArray(out: OutputStream, bytes: Array[Byte]): Unit = {
+    writeInt(out, bytes.length)
+    out.write(bytes)
+  }
+
+  def writeByteArray(out: Array[Byte], _off: Int, bytes: Array[Byte]): Int = {
+    var off = _off
+    off = writeInt(out, off, bytes.length)
+    System.arraycopy(bytes, 0, out, off, bytes.length)
+    off + bytes.length
+  }
+
+  def skipByteArray(in: InputStream): Unit = {
+    val len = readInt(in)
+    in.skip(len)
+  }
+
+  def readByteArray(in: InputStream): Array[Byte] = {
+    val len = readInt(in)
+    readBytes(in, len)
+  }
+
+  def readByteArray(in: ByteBuffer): Array[Byte] = {
+    val len = readInt(in)
+    readBytes(in, len)
+  }
+
+  def stringToBytes(s: String, charset: Charset = StandardCharsets.UTF_8): Array[Byte] =
+    s.getBytes(charset)
+
+  def writeString(
+    out: OutputStream,
+    s: String,
+    charset: Charset = StandardCharsets.UTF_8
+  ): Unit =
+    writeByteArray(out, stringToBytes(s))
+
+  def readString(
+    in: ByteBuffer,
+    charset: Charset = StandardCharsets.UTF_8
+  ): String =
+    new String(readByteArray(in), charset)
+}

--- a/hail/src/main/scala/is/hail/utils/ByteUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/ByteUtils.scala
@@ -78,8 +78,8 @@ object ByteUtils {
     off + 8
   }
 
-  def readLong(in: InputStream): Int = {
-    var out = 0
+  def readLong(in: InputStream): Long = {
+    var out = 0L
     var i = in.read()
     assert(i != -1)
     out |= (i & 0xff)
@@ -106,8 +106,8 @@ object ByteUtils {
     out | (i & 0xff) << 56
   }
 
-  def readLong(in: ByteBuffer): Int = {
-    var out = 0
+  def readLong(in: ByteBuffer): Long = {
+    var out = 0L
     var i = in.get()
     out |= (i & 0xff)
     i = in.get()

--- a/hail/src/main/scala/is/hail/utils/SlicedInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/SlicedInputStream.scala
@@ -1,0 +1,23 @@
+package is.hail.utils
+
+import java.io.InputStream
+
+
+class SlicedInputStream (
+  private[this] val in: InputStream,
+  private[this] var n: Long = -1
+) extends InputStream {
+  private[this] var i = 0
+  override def read(): Int =
+    if (n == -1 || i < n) {
+      i += 1
+      in.read()
+    } else {
+      -1
+    }
+  override def close(): Unit = in.close()
+  def startSlice(_n: Long): Unit = {
+    i = 0
+    n = _n
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -9,6 +9,10 @@ import is.hail.io.{InputBuffer, OutputBuffer, RichContextRDDRegionValue}
 import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
 import is.hail.utils.{HailIterator, MultiArray2, Truncatable, WithContext}
+import java.util.Comparator
+import java.util.concurrent.Callable
+import java.util.function.{ BiConsumer, Consumer, Supplier }
+import org.apache.hadoop
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.distributed.IndexedRowMatrix
 import org.apache.spark.rdd.RDD
@@ -115,4 +119,19 @@ trait Implicits {
   implicit def toRichCodeArray[T](arr: Array[Code[T]]): RichCodeArray[T] = new RichCodeArray[T](arr)
 
   implicit def toRichCodeIterator[T](it: Code[Iterator[T]]): RichCodeIterator[T] = new RichCodeIterator[T](it)
+
+  implicit def scalaFunToConsumer[A](f: A => Unit): Consumer[A] =
+    new Consumer[A]() { def accept(a: A): Unit = f(a) }
+
+  implicit def scalaFunToBiConsumer[A, B](f: (A, B) => Unit): BiConsumer[A, B] =
+    new BiConsumer[A, B]() {def accept(a: A, b: B): Unit = f(a, b) }
+
+  implicit def scalaFunToComparator[A](f: (A, A) => Int): Comparator[A] =
+    new Comparator[A]() { override def compare(l: A, r: A): Int = f(l, r) }
+
+  implicit def scalaFunToSupplier[A](f: () => A): Supplier[A] =
+    new Supplier[A]() { def get(): A = f() }
+
+  implicit def scalaFunToCallable[A](f: () => A): Callable[A] =
+    new Callable[A]() { def call(): A = f() }
 }

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -263,3 +263,16 @@ server {
     listen 80;
     listen [::]:80;
 }
+
+server {
+    server_name ~^(?<sub_domain>.*)\.shuffler\..*$;
+
+    location / {
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://$sub_domain.shuffler.@namespace@.svc.cluster.local:$server_port;
+        include /etc/nginx/proxy.conf;
+    }
+
+    listen 80;
+    listen [::]:80;
+}

--- a/shuffler/.gitignore
+++ b/shuffler/.gitignore
@@ -1,0 +1,5 @@
+/project/boot/
+/project/plugins/project
+build
+shuffler/libhail.dylib
+target/

--- a/shuffler/Dockerfile
+++ b/shuffler/Dockerfile
@@ -1,0 +1,10 @@
+FROM {{ service_base_image.image }}
+
+RUN apt-get update && \
+  apt-get -y install \
+    liblz4-dev
+
+COPY shuffler-assembly-0.1.jar /shuffler-assembly-0.1.jar
+
+ENTRYPOINT ["java", "-jar", "shuffler-assembly-0.1.jar"]
+CMD []

--- a/shuffler/Dockerfile.build
+++ b/shuffler/Dockerfile.build
@@ -1,0 +1,8 @@
+FROM {{ hail_build_image.image }}
+
+#https://www.scala-sbt.org/1.x/docs/Installing-sbt-on-Linux.html
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+    apt-get update && \
+    apt-get install -y sbt && \
+    rm -rf /var/lib/apt/lists/*

--- a/shuffler/Makefile
+++ b/shuffler/Makefile
@@ -1,0 +1,41 @@
+PROJECT = $(shell gcloud config get-value project)
+DOMAIN ?= hail.is
+
+SHUFFLER_LATEST = gcr.io/$(PROJECT)/shuffler:latest
+SHUFFLER_IMAGE = gcr.io/$(PROJECT)/shuffler:$(shell docker images -q --no-trunc shuffler:latest | sed -e 's,[^:]*:,,')
+
+SHUFFLER_TEST_IMAGE = gcr.io/$(PROJECT)/shuffler_test:$(shell docker images -q --no-trunc shuffler_test:latest | sed -e 's,[^:]*:,,')
+
+PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}
+PYTHON := PYTHONPATH=$(PYTHONPATH)../hail/python:../gear:../web_common python3
+
+.PHONY: check
+check:
+	$(PYTHON) -m flake8 shuffler
+	$(PYTHON) -m pylint --rcfile ../pylintrc shuffler --score=n
+
+.PHONY: build
+build:
+	make -C ../docker build
+	-docker pull $(SHUFFLER_LATEST)
+	python3 ../ci/jinja2_render.py '{"service_base_image":{"image":"service-base"}}' Dockerfile Dockerfile.out
+	mkdir context
+	cp target/scala-2.11/shuffler-assembly-0.1.jar context
+	docker build -f Dockerfile.out -t shuffler --cache-from shuffler,$(SHUFFLER_LATEST),base context
+	rm -rf context
+
+.PHONY: push
+push: build
+	docker tag shuffler $(SHUFFLER_LATEST)
+	docker push $(SHUFFLER_LATEST)
+	docker tag shuffler $(SHUFFLER_IMAGE)
+	docker push $(SHUFFLER_IMAGE)
+
+.PHONY: deploy
+deploy: push
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"shuffler_image":{"image":"$(SHUFFLER_IMAGE)"},"global":{"project":"$(PROJECT)","zone":"$(ZONE)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	kubectl -n dking apply -f deployment.yaml.out
+
+.PHONY:
+clean:
+	rm -f Dockerfile.out deployment.yaml.out

--- a/shuffler/Makefile
+++ b/shuffler/Makefile
@@ -4,7 +4,7 @@ DOMAIN ?= hail.is
 SHUFFLER_LATEST = gcr.io/$(PROJECT)/shuffler:latest
 SHUFFLER_IMAGE = gcr.io/$(PROJECT)/shuffler:$(shell docker images -q --no-trunc shuffler:latest | sed -e 's,[^:]*:,,')
 
-SHUFFLER_TEST_IMAGE = gcr.io/$(PROJECT)/shuffler_test:$(shell docker images -q --no-trunc shuffler_test:latest | sed -e 's,[^:]*:,,')
+TEST_SHUFFLER_IMAGE = gcr.io/$(PROJECT)/test_shuffler:$(shell docker images -q --no-trunc test_shuffler:latest | sed -e 's,[^:]*:,,')
 
 PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}
 PYTHON := PYTHONPATH=$(PYTHONPATH)../hail/python:../gear:../web_common python3

--- a/shuffler/build.sbt
+++ b/shuffler/build.sbt
@@ -1,0 +1,55 @@
+import java.nio.file.Paths
+import scala.sys.process._
+
+organization  := "is.hail"
+
+version       := "0.1"
+
+scalaVersion  := "2.11.8"
+
+scalacOptions := Seq(
+  "-Xfatal-warnings",
+  "-Xlint:_",
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-Xlint:-infer-any",
+  "-Xlint:-unsound-match",
+  "-encoding",
+  "utf8"
+)
+
+lazy val compileHail = taskKey[Unit]("compile hail")
+compileHail := {
+  if ((Seq("/bin/sh", "-c", "cd ../hail && ./gradlew jar --build-cache") ! streams.value.log) != 0) {
+    throw new sbt.FeedbackProvidedException() {
+      override def toString() = "`cd ../hail && ./gradlew jar` returned non-zero exit-code" }
+  }
+}
+
+(compile in Compile) := ((compile in Compile) dependsOn compileHail).value
+
+resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
+
+libraryDependencies ++= {
+  val sparkVersion = "2.4.2"
+  Seq(
+      "com.typesafe.akka" %% "akka-http"   % "10.1.9"
+    , "com.typesafe.akka" %% "akka-stream" % "2.5.23"
+    , "is.hail" % "Hail" % "0.1" from s"file://${Paths.get("..").toAbsolutePath}/hail/build/libs/hail.jar"
+    , "log4j" % "log4j" % "1.2.17"
+    , "org.scalanlp" %% "breeze" % "0.13.2"
+    , "org.apache.spark" %% "spark-mllib" % sparkVersion
+    , "org.ow2.asm" % "asm" % "5.1"
+    , "org.ow2.asm" % "asm-util" % "5.1"
+    , "org.ow2.asm" % "asm-analysis" % "5.1"
+  )
+}
+
+mainClass in assembly := Some("is.hail.shuffler.WebServer")
+
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF" | "git.properties", xs @ _*) => MergeStrategy.discard
+ case PathList("reference.conf", xs @ _*) => MergeStrategy.concat
+ case x => MergeStrategy.first
+}

--- a/shuffler/build.sbt
+++ b/shuffler/build.sbt
@@ -46,7 +46,7 @@ libraryDependencies ++= {
   )
 }
 
-mainClass in assembly := Some("is.hail.shuffler.WebServer")
+mainClass in assembly := Some("is.hail.shuffler.Main")
 
 assemblyMergeStrategy in assembly := {
  case PathList("META-INF" | "git.properties", xs @ _*) => MergeStrategy.discard

--- a/shuffler/deployment.yaml
+++ b/shuffler/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: shuffler
+spec:
+  serviceName: shuffler
+  selector:
+    matchLabels:
+      app: shuffler
+  replicas: 1
+  volumeClaimTemplates:
+    - metadata:
+        name: shuffler
+      spec:
+        storageClassName: ssd
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi
+  template:
+    metadata:
+      name: shuffler
+      labels:
+        app: shuffler
+    spec:
+      volumes:
+       - name: deploy-config
+         secret:
+           optional: false
+           secretName: deploy-config
+      containers:
+        - name: shuffler
+          image: {{ shuffler_image.image }}
+          resources:
+            requests:
+              memory: "3750Mi"
+              cpu: "1"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: HAIL_DEPLOY_CONFIG_FILE
+              value: /deploy-config/deploy-config.json
+          volumeMounts:
+            - name: shuffler
+              mountPath: "/tmp"
+            - name: deploy-config
+              mountPath: /deploy-config
+              readOnly: true
+          imagePullPolicy: Always
+          ports:
+           - name: port
+             hostPort: 80
+             containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shuffler
+spec:
+  clusterIP: "None"
+  ports:
+   - port: 80
+     targetPort: 80
+  selector:
+    app: shuffler

--- a/shuffler/project/build.properties
+++ b/shuffler/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.4

--- a/shuffler/project/plugins.sbt
+++ b/shuffler/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/shuffler/src/main/resources/log4j.properties
+++ b/shuffler/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L %m%n

--- a/shuffler/src/main/scala/is/hail/shuffler/Main.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Main.scala
@@ -153,17 +153,7 @@ object WebServer {
               shuffle.get(partitionId, out)
               complete(out.toByteArray())
             }
-          }// ,
-           // delete {
-           //   log.info(s"DELETE api/v1alpha/$id/$partitionId")
-           //   shuffleOr404(id) { shuffle =>
-           //     shuffle.deletePartition(partitionId)
-           //     if (shuffle.allPartitionsDeleted()) {
-           //       shuffles.remove(id)
-           //     }
-           //     complete("")
-           //   }
-           // }
+          }
         )
       },
       path("healthcheck") {

--- a/shuffler/src/main/scala/is/hail/shuffler/Main.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Main.scala
@@ -1,0 +1,193 @@
+package is.hail.shuffler
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.ActorMaterializer
+import akka.stream.ActorMaterializerSettings
+import akka.util.ByteString
+import is.hail.HailContext
+import is.hail.annotations._
+import is.hail.expr.ir.{IRParser, SortOrder}
+import is.hail.expr.types.physical._
+import is.hail.io.{ByteArrayDecoder, BufferSpec}
+import is.hail.utils._
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream }
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import org.apache.log4j.LogManager
+import scala.collection.mutable
+import scala.io.StdIn
+import scala.collection.JavaConverters._
+import com.typesafe.config.ConfigFactory
+import sys.process._
+import scala.language.postfixOps
+
+object WebServer {
+  private[this] val log = LogManager.getLogger("Shuffler")
+
+  def main(args: Array[String]) {
+    implicit val system = ActorSystem("shuffler")
+    implicit val materializer = ActorMaterializer()
+    implicit val executionContext = system.dispatcher
+    val shuffles = new ConcurrentHashMap[Long, Shuffle]()
+
+    def shuffleOr404[T](
+      id: Long
+    )(route: Shuffle => Route
+    ): Route = {
+      if (!shuffles.containsKey(id)) {
+        complete(StatusCodes.NotFound -> s"no shuffle $id")
+      } else {
+        route(shuffles.get(id))
+      }
+    }
+
+    var nextId: AtomicLong = new AtomicLong(0L)
+    val route = concat(
+      path("api" / "v1alpha") {
+        concat(
+          post {
+            extractDataBytes { byteSource =>
+              onSuccess(byteSource.runFold(ByteString())(_ ++ _)) { bytes =>
+                val bb = bytes.asByteBuffer
+                val id = nextId.getAndIncrement()
+                val inPartitions = ByteUtils.readInt(bb)
+                val s = ByteUtils.readString(bb)
+                println(s)
+                val bufferSpec = BufferSpec.parse(s)
+                val wireKeyType = IRParser.parsePType(ByteUtils.readString(bb)).asInstanceOf[PBaseStruct]
+                val serializedSortOrder = new Array[Byte](wireKeyType.size)
+                bb.get(serializedSortOrder, 0, serializedSortOrder.size)
+                val sortOrder = serializedSortOrder.map(SortOrder.deserialize)
+                val hasPartitioner = bb.get() == 1.toByte
+                val outPartitioning = if (!hasPartitioner) {
+                  ByteUtils.skipInt(bb)
+                  val nOutPartitions = ByteUtils.readInt(bb)
+                  Left(nOutPartitions)
+                } else {
+                  Right(ByteUtils.readByteArray(bb))
+                }
+                log.info(s"POST api/v1alpha $inPartitions $outPartitioning $sortOrder")
+                shuffles.put(id,
+                  new Shuffle(id,
+                    wireKeyType,
+                    sortOrder,
+                    bufferSpec,
+                    inPartitions,
+                    outPartitioning))
+                complete(id.toString)
+              }
+            }
+          }
+        )
+      },
+      path("api" / "v1alpha" / LongNumber) { id =>
+        concat(
+          post {
+            extractDataBytes { byteSource =>
+              onSuccess(byteSource.runFold(ByteString())(_ ++ _)) { bytes =>
+                shuffleOr404(id) { shuffle =>
+                  val bb = bytes.asByteBuffer
+                  val partitionId = ByteUtils.readInt(bb)
+                  val attemptId = ByteUtils.readLong(bb)
+                  val pairs = ByteUtils.readInt(bb)
+                  log.info(s"POST api/v1alpha/$id $partitionId $attemptId $pairs ...")
+                  shuffle.addMany(partitionId, attemptId, pairs, bb)
+                  complete("")
+                }
+              }
+            }
+          },
+          delete {
+            log.info(s"DELETE api/v1alpha/$id")
+            var shuffle = shuffles.remove(id)
+            if (shuffle != null) {
+              shuffle.close()
+            }
+            shuffle = null
+            System.gc()
+            complete("")
+          })
+      },
+      path("api" / "v1alpha" / LongNumber / "finish_partition") { id =>
+        post {
+          extractDataBytes { byteSource =>
+            onSuccess(byteSource.runFold(ByteString())(_ ++ _)) { bytes =>
+              shuffleOr404(id) { shuffle =>
+                val bb = bytes.asByteBuffer
+                val partitionId = ByteUtils.readInt(bb)
+                val attemptId = ByteUtils.readLong(bb)
+                log.info(s"POST api/v1alpha/$id/finish_partition $partitionId $attemptId")
+                shuffle.finishPartition(partitionId, attemptId)
+                complete("")
+              }
+            }
+          }
+        }
+      },
+      path("api" / "v1alpha" / LongNumber / "close") { id =>
+        post {
+          log.info(s"POST api/v1alpha/$id/close")
+          shuffleOr404(id) { shuffle =>
+            val out = new ByteArrayOutputStream()
+            shuffle.close(out)
+            complete(out.toByteArray())
+          }
+        }
+      },
+      path("api" / "v1alpha" / LongNumber / IntNumber) { (id, partitionId) =>
+        concat(
+          get {
+            log.info(s"GET api/v1alpha/$id/$partitionId")
+            shuffleOr404(id) { shuffle =>
+              if (!shuffle.closed()) {
+                complete(
+                  StatusCodes.BadRequest -> s"shuffle $id is already closed")
+              }
+              val out = new ByteArrayOutputStream()
+              shuffle.get(partitionId, out)
+              complete(out.toByteArray())
+            }
+          }// ,
+           // delete {
+           //   log.info(s"DELETE api/v1alpha/$id/$partitionId")
+           //   shuffleOr404(id) { shuffle =>
+           //     shuffle.deletePartition(partitionId)
+           //     if (shuffle.allPartitionsDeleted()) {
+           //       shuffles.remove(id)
+           //     }
+           //     complete("")
+           //   }
+           // }
+        )
+      },
+      path("healthcheck") {
+        get {
+          complete("")
+        }
+      }
+    )
+
+    val host = "0.0.0.0"
+    val port = 80
+    log.info(s"serving at ${host}:${port}")
+
+    val basePath = (Seq("python3",
+      "-c",
+      "from hailtop.config import get_deploy_config; print(get_deploy_config().base_path('shuffler-0.shuffler'))") !!
+    ).trim
+
+    val namespacedRoute = if (basePath == "") {
+      route
+    } else {
+      log.info(s"basePath $basePath")
+      pathPrefix(separateOnSlashes(basePath.substring(1)))(route)
+    }
+    val bindingFuture = Http().bindAndHandle(namespacedRoute, host, port)
+  }
+}

--- a/shuffler/src/main/scala/is/hail/shuffler/Main.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Main.scala
@@ -27,7 +27,7 @@ import com.typesafe.config.ConfigFactory
 import sys.process._
 import scala.language.postfixOps
 
-object WebServer {
+object Main {
   private[this] val log = LogManager.getLogger("Shuffler")
 
   def main(args: Array[String]) {

--- a/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
@@ -1,0 +1,279 @@
+package is.hail.shuffler
+
+import is.hail.annotations._
+import is.hail.expr.ir._
+import is.hail.expr.types.virtual._
+import is.hail.expr.types.physical._
+import is.hail.rvd.RVDPartitioner
+import is.hail.asm4s._
+import is.hail.io._
+import is.hail.utils._
+import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream }
+import java.nio.ByteBuffer
+import java.util.function.{ BiConsumer, Consumer, Supplier }
+import java.util.{ Arrays, Comparator, SortedMap, TreeMap }
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.mutable
+import scala.reflect.classTag
+
+class LongArrayByte(val _1: Long, val _2: Array[Byte])
+
+trait RegionCompareFunction { def apply(region: Region, l: Long, r: Long): Int }
+
+object Shuffle {
+  private def compileCompare(
+    keyType: PBaseStruct,
+    sortOrders: Array[SortOrder]
+  ): RegionCompareFunction = {
+    require(keyType.required)
+    val fb = new EmitFunctionBuilder[RegionCompareFunction](
+      Array(NotGenericTypeInfo[Region], NotGenericTypeInfo[Long], NotGenericTypeInfo[Long]),
+      NotGenericTypeInfo[Int],
+      namePrefix = "compare")
+    val apply = fb.apply_method
+    val left = apply.getArg[Long](2)
+    val right = apply.getArg[Long](3)
+    val ordering = keyType.codeOrdering(apply, sortOrders)
+    fb.emit(ordering.compareNonnull(
+      coerce[ordering.T](Region.getIRIntermediate(keyType)(left)),
+      coerce[ordering.T](Region.getIRIntermediate(keyType)(right))))
+    fb.result()()
+  }
+}
+
+class Shuffle (
+  private[this] val id: Long,
+  wireKeyType: PBaseStruct,
+  sortOrder: Array[SortOrder],
+  bufferSpec: BufferSpec,
+  private[this] val inPartitions: Int,
+  private[this] val outPartitionsOrBoundsBytes: Either[Int, Array[Byte]]
+) {
+  require(wireKeyType.required)
+  require(wireKeyType.size == sortOrder.size)
+  import Shuffle._
+  // FIXME: do threads see out of date region information? What are the
+  // semantics of one thread writing to off heap memory and another thread
+  // reading from off heap memory?
+  private[this] val regions = new ConcurrentHashMap[Thread, Region]()
+  private[this] val region = ThreadLocal.withInitial { () =>
+    val r = Region()
+    regions.put(Thread.currentThread(), r)
+    r
+  }
+  private[this] val keyCodec = new Codec(TypedCodecSpec(wireKeyType, bufferSpec))
+  private[this] val comparer = compileCompare(wireKeyType, sortOrder)
+  trait IntervalContainsFunction {
+    def apply(r: Region, i: Long, mi: Boolean, k: Long, mk: Boolean): Boolean
+  }
+  private[this] val (nOutPartitions, maybeBounds) = outPartitionsOrBoundsBytes match {
+    case Left(n) => (n, None)
+    case Right(boundsBytes) =>
+      val intervalType = PInterval(wireKeyType, true)
+      val boundsType = PArray(intervalType, true)
+      val codec = new Codec(TypedCodecSpec(boundsType, bufferSpec))
+      val dec = new ByteArrayDecoder(codec.buildDecoder)
+      val r = region.get
+      val off = dec.regionValueFromBytes(r, boundsBytes)
+      val (_, makeIntervalContains) = ExecuteContext.scoped(ctx => Compile[IntervalContainsFunction, Boolean](
+        ctx,
+        None,
+        Seq(("interval", intervalType, classTag[Long]),
+          ("key", wireKeyType, classTag[Long])),
+        Array[MaybeGenericTypeInfo[_]](
+          NotGenericTypeInfo[Region],
+          NotGenericTypeInfo[Long],
+          NotGenericTypeInfo[Boolean],
+          NotGenericTypeInfo[Long],
+          NotGenericTypeInfo[Boolean]),
+        NotGenericTypeInfo[Boolean],
+        ApplySpecial(
+          "contains",
+          Seq(
+            Ref("interval", intervalType.virtualType),
+            Ref("key", wireKeyType.virtualType)),
+          TBoolean(true)),
+        nSpecialArgs = 1,
+        // if optimize = true we need a hail context
+        optimize = false))
+      val intervalContains = makeIntervalContains(0, region.get)
+      val len = boundsType.loadLength(off)
+      val partitionContainsKey = (r: Region, i: Int, kOff: Long) =>
+        intervalContains(r, boundsType.loadElement(off, len, i), false, kOff, false)
+      (len, Some(partitionContainsKey))
+  }
+  private[this] def str(region: Region, offset: Long): String =
+    UnsafeRow.read(keyCodec.memType, region, offset).toString
+  private[this] var finished: Array[(ArrayBuilder[Long], mutable.ArrayBuffer[Array[Byte]])] =
+    new Array(nOutPartitions)
+  // mutable.ArrayBuffer is not thread-safe, but only one partitionId-attemptId
+  // pair is talking to us at a time
+  private[this] val pending
+      : Array[ConcurrentHashMap[Int, (ArrayBuilder[Long], mutable.ArrayBuffer[Array[Byte]])]] =
+    Array.fill(inPartitions)(new ConcurrentHashMap())
+  private[this] var partitionOffsets: Array[Int] = null
+  private[this] var output: Array[LongArrayByte] = null
+  // private[this] var deletedPartitions: java.util.Set[Int] = null
+
+  private[this] val decoder = ThreadLocal.withInitial(
+    () => new ByteArrayDecoder(keyCodec.buildDecoder))
+  private[this] val encoder = ThreadLocal.withInitial(
+    () => new ByteArrayEncoder(keyCodec.buildEncoder))
+  def addMany(partitionId: Int, attemptId: Int, pairs: Int, bb: ByteBuffer): Unit = {
+    val part = pending(partitionId)
+    part.putIfAbsent(attemptId, (new ArrayBuilder[Long](), new mutable.ArrayBuffer()))
+    val (attemptKeys, attemptValues) = part.get(attemptId)
+    val localDecoder = decoder.get
+    val localRegion = region.get
+    var i = 0
+    while (i < pairs) {
+      val key = ByteUtils.readByteArray(bb)
+      val value = ByteUtils.readByteArray(bb)
+      attemptKeys += localDecoder.regionValueFromBytes(localRegion, key)
+      attemptValues.append(value)
+      i += 1
+    }
+  }
+
+  def finishPartition(partitionId: Int, attemptId: Int): Unit = {
+    val part = pending(partitionId)
+    if (part == null) {
+      log.info(s"""received a second finish for a finished partition
+                  |${partitionId} ${attemptId}""".stripMargin)
+    } else {
+      if (!part.containsKey(attemptId)) {
+        throw new RuntimeException(
+          s"""bogus attempt id ${attemptId} for ${partitionId} not in
+           |${part.keySet} in shuffle ${id}""".stripMargin)
+      }
+      pending(partitionId) = null
+      assert(!finished.contains(partitionId))
+      finished(partitionId) = part.get(attemptId)
+    }
+  }
+
+  def closed(): Boolean = partitionOffsets != null
+
+  def close(os: OutputStream): Unit = {
+    require(pending.forall(_ == null))
+    require(finished.size == inPartitions)
+    var nElements = 0
+    var i = 0
+    while (i < finished.length) {
+      nElements += finished(i)._1.length
+      i += 1
+    }
+    output = new Array[LongArrayByte](nElements)
+    val localRegion = region.get
+    i = 0
+    var k = 0
+    while (i < finished.length) {
+      val (keys, values) = finished(i)
+      var j = 0
+      while (j < keys.length) {
+        output(k) = new LongArrayByte(keys(j), values(j))
+        j += 1
+        k += 1
+      }
+      finished(i) = null
+      i += 1
+    }
+    finished = null
+    // Arrays.sort(output, new Comparator[LongArrayByte]() {
+    Arrays.parallelSort(output, new Comparator[LongArrayByte]() {
+      override def compare(l: LongArrayByte, r: LongArrayByte): Int =
+        comparer(localRegion, l._1, r._1) })
+    maybeBounds match {
+      case None =>
+        val n = output.length
+        val x = n / nOutPartitions
+        val partitionSize = Array.fill(nOutPartitions)(x)
+        var i = 0
+        while (i < n - x * nOutPartitions) {
+          partitionSize(i) += 1
+          i += 1
+        }
+        partitionOffsets = partitionSize.scanLeft(0)(_ + _).toArray
+      case Some(partitionContainsKey) =>
+        val ordering = keyCodec.memType.virtualType.ordering
+        partitionOffsets = new Array[Int](nOutPartitions + 1)
+        var i = 0
+        var partitionIndex = 0
+        while (partitionIndex < nOutPartitions) {
+          while (i < output.length &&
+            // FIXME: put intervals into region and compile this
+            !partitionContainsKey(localRegion, partitionIndex, output(i)._1)) {
+            i += 1
+          }
+          partitionOffsets(partitionIndex) = i
+          partitionIndex += 1
+        }
+        if (nOutPartitions > 0) {
+          while (i < output.length &&
+            partitionContainsKey(localRegion, nOutPartitions - 1, output(i)._1)) {
+            i += 1
+          }
+          partitionOffsets(nOutPartitions) = i
+        }
+    }
+    // deletedPartitions = ConcurrentHashMap.newKeySet[Int]()
+    // var i = 0
+    // while (i < nOutPartitions) {
+    //   deletedPartitions.add(i)
+    //   i += 1
+    // }
+    assert(partitionOffsets.length == nOutPartitions + 1)
+    val localEncoder = encoder.get
+    i = 0
+    while (i < nOutPartitions) {
+      writeByteArray(os,
+        localEncoder.regionValueToBytes(localRegion, output(partitionOffsets(i))._1))
+      i += 1
+    }
+    writeByteArray(os,
+      localEncoder.regionValueToBytes(localRegion, output(output.length - 1)._1))
+  }
+
+  private[this] def writeInt(out: OutputStream, i: Int): Unit = {
+    out.write(i)
+    out.write(i >> 8)
+    out.write(i >> 16)
+    out.write(i >> 24)
+  }
+
+  private[this] def writeByteArray(out: OutputStream, bytes: Array[Byte]): Unit = {
+    writeInt(out, bytes.length)
+    out.write(bytes)
+  }
+
+  def get(partitionId: Int, os: OutputStream): Unit = {
+    val localRegion = region.get
+    val localEncoder = encoder.get
+    require(partitionOffsets != null)
+    if (partitionId > nOutPartitions) {
+      throw new RuntimeException(
+        s"no such partition id ${partitionId} in shuffle ${id}")
+    }
+    var start = partitionOffsets(partitionId)
+    val end = partitionOffsets(partitionId + 1)
+    writeInt(os, end - start)
+    while (start < end) {
+      val kv = output(start)
+      writeByteArray(os, localEncoder.regionValueToBytes(localRegion, kv._1))
+      writeByteArray(os, kv._2)
+      start += 1
+    }
+  }
+
+  def close() {
+    regions.values().forEach((x: Region) => x.close())
+  }
+
+  // def deletePartition(partitionId: Int): Unit = {
+  //   require(deletedPartitions != null)
+  //   require(0 <= partitionId && partitionId < outPartitions, partitionId.toString)
+  //   deletedPartitions.remove(partitionId)
+  // }
+
+  // def allPartitionsDeleted(): Boolean = deletedPartitions.isEmpty
+}

--- a/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
@@ -94,7 +94,6 @@ class Shuffle (
             Ref("interval", intervalType.virtualType),
             Ref("key", wireKeyType.virtualType)),
           TBoolean(true)),
-        nSpecialArgs = 1,
         // if optimize = true we need a hail context
         optimize = false))
       val intervalContains = makeIntervalContains(0, region.get)

--- a/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
+++ b/shuffler/src/main/scala/is/hail/shuffler/Shuffle.scala
@@ -109,7 +109,7 @@ class Shuffle (
   // mutable.ArrayBuffer is not thread-safe, but only one partitionId-attemptId
   // pair is talking to us at a time
   private[this] val pending
-      : Array[ConcurrentHashMap[Int, (ArrayBuilder[Long], mutable.ArrayBuffer[Array[Byte]])]] =
+      : Array[ConcurrentHashMap[Long, (ArrayBuilder[Long], mutable.ArrayBuffer[Array[Byte]])]] =
     Array.fill(inPartitions)(new ConcurrentHashMap())
   private[this] var partitionOffsets: Array[Int] = null
   private[this] var output: Array[LongArrayByte] = null
@@ -118,7 +118,7 @@ class Shuffle (
     () => new ByteArrayDecoder(keyCodec.buildDecoder))
   private[this] val encoder = ThreadLocal.withInitial(
     () => new ByteArrayEncoder(keyCodec.buildEncoder))
-  def addMany(partitionId: Int, attemptId: Int, pairs: Int, bb: ByteBuffer): Unit = {
+  def addMany(partitionId: Int, attemptId: Long, pairs: Int, bb: ByteBuffer): Unit = {
     val part = pending(partitionId)
     part.putIfAbsent(attemptId, (new ArrayBuilder[Long](), new mutable.ArrayBuffer()))
     val (attemptKeys, attemptValues) = part.get(attemptId)
@@ -134,7 +134,7 @@ class Shuffle (
     }
   }
 
-  def finishPartition(partitionId: Int, attemptId: Int): Unit = {
+  def finishPartition(partitionId: Int, attemptId: Long): Unit = {
     val part = pending(partitionId)
     if (part == null) {
       log.info(s"""received a second finish for a finished partition

--- a/shuffler/test/Dockerfile
+++ b/shuffler/test/Dockerfile
@@ -1,0 +1,12 @@
+FROM {{ hail_run_image.image }}
+
+RUN useradd -m hail
+USER hail
+WORKDIR /home/hail
+COPY wheel-container.tar .
+RUN tar -xvf wheel-container.tar && \
+    python3 -m pip install -U hail-*-py3-none-any.whl
+
+ENTRYPOINT []
+
+COPY test_shuffler.py .

--- a/shuffler/test/test_shuffler.py
+++ b/shuffler/test/test_shuffler.py
@@ -1,0 +1,124 @@
+import hail as hl
+
+from hailtop.config import get_deploy_config
+
+shuffle_service_url = get_deploy_config().base_url('shuffler-0.shuffler')
+buffer_service_url = get_deploy_config().base_url('dbuf-0.dbuf')
+print(f'using shuffle service url {shuffle_service_url}')
+
+
+def test_reverse_range_table():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(30, n_partitions=8)
+    t = t.order_by(-t.idx)
+
+    expected = [hl.Struct(idx=x) for x in range(30)]
+    expected = sorted(expected, key=lambda x: -x.idx)
+    assert t.collect() == expected
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)
+
+
+def test_range_table_as_strings():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(30, n_partitions=8)
+    t = t.annotate(x=hl.str(t.idx))
+    t = t.order_by(t.x)
+
+    expected = [hl.Struct(idx=x, x=str(x)) for x in range(30)]
+    expected = sorted(expected, key=lambda x: x.x)
+    assert t.collect() == expected
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)
+
+
+def test_range_table_with_garbage():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(30, n_partitions=8)
+    t = t.annotate(
+        x = 'foo' + hl.str(t.idx),
+        y = 3 * t.idx,
+        z = hl.dict({'x': 3.14, 'y': 6.28, 'idx': hl.float(t.idx)})
+    )
+    t = t.order_by(-t.idx)
+
+    expected = [hl.Struct(idx=x,
+                          x=f'foo{x}',
+                          y=3 * x,
+                          z={'x': 3.14, 'y': 6.28, 'idx': float(x)})
+                for x in range(30)]
+    expected = sorted(expected, key=lambda x: -x.idx)
+    assert t.collect() == expected
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)
+
+
+def test_large_table():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(1_000_000, n_partitions=100)
+    t = t.order_by(-t.idx)
+
+    expected = [hl.Struct(idx=x) for x in range(1_000_000)]
+    expected = sorted(expected, key=lambda x: -x.idx)
+    actual = t.collect()
+    assert actual[:5] == expected[:5]
+    assert actual[-5:] == expected[-5:]
+    assert actual == expected
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)
+
+
+def test_large_table_key_by():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(1_000_000, n_partitions=100)
+    t = t.key_by(rev_idx=-t.idx)
+
+    expected = [hl.Struct(idx=x, rev_idx=-x) for x in range(1_000_000)]
+    expected = sorted(expected, key=lambda x: x.rev_idx)
+    actual = t.collect()
+    assert actual[:5] == expected[:5]
+    assert actual[-5:] == expected[-5:]
+    assert actual == expected, [y for y in zip(actual, expected)
+                                if y[0] != y[1]]
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)
+
+
+def test_large_table_key_by_workaround():
+    optimizer_iterations = hl._get_flags('optimizer_iterations')['optimizer_iterations']
+    hl._set_flags(shuffle_service_url=shuffle_service_url,
+                  buffer_service_url=buffer_service_url,
+                  optimizer_iterations="0")
+    t = hl.utils.range_table(1_000_000, n_partitions=100)
+    t = t.key_by(rev_idx=-t.idx)
+
+    expected = [hl.Struct(idx=x, rev_idx=-x) for x in range(1_000_000)]
+    expected = sorted(expected, key=lambda x: x.rev_idx)
+    actual = t.collect()
+    assert actual[:5] == expected[:5]
+    assert actual[-5:] == expected[-5:]
+    assert actual == expected, [y for y in zip(actual, expected)
+                                if y[0] != y[1]]
+    hl._set_flags(shuffle_service_url=None,
+                  buffer_service_url=None,
+                  optimizer_iterations=optimizer_iterations)


### PR DESCRIPTION
OK, so.

This continues to be a mammoth PR despite a day's worth of pruning.

I think it would be good to start getting some eyes on it.

Over all, I feel a bit weird about it. The intention is for this to be a functional but not scalable or reliable shuffler. It will allow Hail Query to exist, albeit in a limited way (keys cannot exceed shuffler memory). However, in parallel to getting this PR merged, I'm designing the real shuffler: a horizontally scalable sorting system. So. We have to live with this code for a few months, so let's make sure we feel good about it, but also know that this is all going away in a few months. 🤷‍♀ 

# High Level Overview
- implement the shuffler as a single machine, multi-threaded service which buffers keys until the write phase of a shuffle is done, then sorts the keys, then serves them to clients.
- implement non-spark shuffling as: write records to `dbuf` and write pairs of (data key, dbuf key) to shuffler, then read back re-partitioned keys and fetch records from dbuf.
- I use SBT because the Akka examples use it, it's not obvious how to do this SBT assembly merging thing in Gradle
- I'm really not using Akka properly. There's all this DataSource stuff that I don't understand. I'll probably have to get this right to get good performance, but it doesn't seem critical now and the Akka docs are incredibly hard to understand.
- I turn the optimizer off in the tests because it often optimizes away shuffles into local sorts.

There are some FIXMEs throughout the code that I would appreciate thoughts on.