### PR TITLE
[query] remove Code._empty type parameter

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -288,7 +288,7 @@ object Code {
 
   // FIXME: code should really carry around the stack so this type can be correct
   // Currently, this is a huge potential place for errors.
-  def _empty[T]: Code[T] = new Code[T] {
+  def _empty: Code[Unit] = new Code[Unit] {
     def emit(il: Growable[AbstractInsnNode]): Unit = {
     }
   }
@@ -841,7 +841,7 @@ class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Cod
   private[this] val present: ClassFieldRef[Boolean] = fb.newField[Boolean](s"${name}_present")
 
   def load(): Code[T] =
-    Code(present.mux(Code._empty[Unit], Code(value := setup, present := true)), value)
+    Code(present.mux(Code._empty, Code(value := setup, present := true)), value)
 
   def store(rhs: Code[T]): Code[Unit] =
     throw new UnsupportedOperationException("cannot store new value into LazyFieldRef!")
@@ -895,7 +895,7 @@ class FieldRef[T, S](f: reflect.Field)(implicit tct: ClassTag[T], sti: TypeInfo[
 
   def putOp = if (isStatic) PUTSTATIC else PUTFIELD
 
-  def get(): Code[S] = get(Code._empty)
+  def get(): Code[S] = get(null)
 
   def get(lhs: Code[T]): Code[S] =
     new Code[S] {

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -88,7 +88,7 @@ case class ParamPackTuple3[A, B, C](ap: ParameterPack[A], bp: ParameterPack[B], 
 
 case class ParamPackArray(pps: IndexedSeq[ParameterPack[_]]) extends ParameterPack[IndexedSeq[_]] {
   override def push(a: IndexedSeq[_]): Code[Unit] =
-    pps.zip(a).foldLeft(Code._empty[Unit]) { case (acc, (pp, v)) =>
+    pps.zip(a).foldLeft(Code._empty) { case (acc, (pp, v)) =>
       Code(acc, pp.pushAny(v))
     }
 
@@ -170,7 +170,7 @@ case object ParameterStoreUnit extends ParameterStore[Unit] {
 
   def load: Unit = ()
 
-  def init: Code[Unit] = Code._empty[Unit]
+  def init: Code[Unit] = Code._empty
 }
 
 case class ParameterStoreTuple2[A, B](pa: ParameterStore[A], pb: ParameterStore[B]) extends ParameterStore[(A, B)] {
@@ -207,10 +207,10 @@ case class ParameterStoreArray(pss: IndexedSeq[ParameterStore[_]]) extends Param
 
   def store(vs: IndexedSeq[_]): Code[Unit] = {
     assert(pss.length == vs.length)
-    pss.zip(vs).foldLeft(Code._empty[Unit]) { case (acc, (ps, v)) => Code(acc, ps.storeAny(v)) }
+    pss.zip(vs).foldLeft(Code._empty) { case (acc, (ps, v)) => Code(acc, ps.storeAny(v)) }
   }
 
-  def storeInsn: Code[Unit] = pss.map(_.storeInsn).fold(Code._empty[Unit]) { case (acc, c) => Code(c, acc) } // order of c and acc is important
+  def storeInsn: Code[Unit] = pss.map(_.storeInsn).fold(Code._empty) { case (acc, c) => Code(c, acc) } // order of c and acc is important
 
   def init: Code[Unit] = pss.foldLeft[Code[Unit]](Code._empty) { case (acc, ps) => Code(acc, ps.init) }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import is.hail.annotations._
-import is.hail.asm4s.joinpoint.{Ctrl, JoinPoint, ParameterPack, ParameterStore, ParameterStoreTriplet, ParameterStoreArray, TypedTriplet}
+import is.hail.asm4s.joinpoint.{Ctrl, ParameterPack, ParameterStore, ParameterStoreTriplet, ParameterStoreArray, TypedTriplet}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.types.physical._
@@ -384,7 +384,7 @@ private class Emit(
           .foldRight(Code(
             mout := va.last.m,
             out := pt.defaultValue,
-            mout.mux(Code._empty[Unit], out := ir.pType.copyFromPValue(mb, er.region, va.last.pv)))) { case (i, comb) =>
+            mout.mux(Code._empty, out := ir.pType.copyFromPValue(mb, er.region, va.last.pv)))) { case (i, comb) =>
             va(i).m.mux[Unit](
               comb,
               Code(
@@ -562,7 +562,7 @@ private class Emit(
         val sorter = new ArraySorter(er, vab)
 
         val (array, compare, distinct, leftRightComparatorNames: Array[String]) = (x: @unchecked) match {
-          case ArraySort(a, l, r, comp) => (a, comp, Code._empty[Unit], Array(l, r))
+          case ArraySort(a, l, r, comp) => (a, comp, Code._empty, Array(l, r))
           case ToSet(a) =>
             val discardNext = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], sorter.ti, typeInfo[Boolean], sorter.ti, typeInfo[Boolean]), typeInfo[Boolean])
             val EmitTriplet(s, m, pv) = new Emit(ctx, discardNext).emit(ApplyComparisonOp(EQWithNA(eltVType), In(0, eltType), In(1, eltType)), Env.empty, er, container)
@@ -2355,7 +2355,7 @@ abstract class NDArrayEmitter(
    val outputShapePType: PTuple,
    val outputElementPType: PType,
    val setupShape: Code[_],
-   val setupMissing: Code[Unit] = Code._empty[Unit],
+   val setupMissing: Code[Unit] = Code._empty,
    val missing: Code[Boolean] = false) {
 
   private val outputShapeVariables = (0 until nDims).map(_ => mb.newField[Long]).toArray

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1114,7 +1114,7 @@ object EmitStream {
             val bodyt = emitIR(body,
               env.bindIterable(names.zip(mv.map { case (_, m, v) => (m.load(), v.load()) })))
             k(EmitTriplet(
-              Code(xs.zip(mv).foldLeft[Code[Unit]](Code._empty[Unit]) { case (acc, (et, (t, m, v))) =>
+              Code(xs.zip(mv).foldLeft[Code[Unit]](Code._empty) { case (acc, (et, (t, m, v))) =>
                 Code(acc,
                   et.setup,
                   m := et.m,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -194,7 +194,7 @@ class AppendOnlyBTree(fb: EmitFunctionBuilder[_], key: BTreeKey, region: Code[Re
     f.emit(Code(
       (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, -1))),
       Array.range(0, maxElements)
-        .foldRight(Code._empty[Unit]) { (i, cont) =>
+        .foldRight(Code._empty) { (i, cont) =>
           hasKey(node, i).orEmpty(
             Code(
               visitor(loadKey(node, i)),
@@ -216,7 +216,7 @@ class AppendOnlyBTree(fb: EmitFunctionBuilder[_], key: BTreeKey, region: Code[Re
       Code(createNode(newNode),
         f.invoke[Unit](newNode, loadChild(srcNode, i)))
 
-    val copyNodes = Array.range(0, maxElements).foldRight(Code._empty[Unit]) { (i, cont) =>
+    val copyNodes = Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
       hasKey(srcNode, i).orEmpty(
         Code(
           key.deepCopy(er, destNode, srcNode),
@@ -243,7 +243,7 @@ class AppendOnlyBTree(fb: EmitFunctionBuilder[_], key: BTreeKey, region: Code[Re
     f.emit(Code(
       ob.writeBoolean(!isLeaf(node)),
       (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, -1), ob)),
-      Array.range(0, maxElements).foldRight(Code._empty[Unit]) { (i, cont) =>
+      Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
         hasKey(node, i).mux(Code(
           ob.writeBoolean(true),
           keyStore(ob, loadKey(node, i)),
@@ -268,7 +268,7 @@ class AppendOnlyBTree(fb: EmitFunctionBuilder[_], key: BTreeKey, region: Code[Re
           setChild(node, -1, newNode),
           f.invoke(newNode, ib)
       )),
-      Array.range(0, maxElements).foldRight(Code._empty[Unit]) { (i, cont) =>
+      Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
         ib.readBoolean().orEmpty(Code(
           setKeyPresent(node, i),
           keyLoad(ib, keyOffset(node, i)),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -341,7 +341,7 @@ class DownsampleState(val fb: EmitFunctionBuilder[_], labelType: PArray, maxBuff
       val x = mb.newLocal[Double]("x")
       val y = mb.newLocal[Double]("y")
       mb.emit(Code(
-        buffer.size.ceq(0).orEmpty(Code._return(Code._empty[Unit])),
+        buffer.size.ceq(0).orEmpty(Code._return(Code._empty)),
         left := min(left, bufferLeft),
         right := max(right, bufferRight),
         bottom := min(bottom, bufferBottom),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -353,7 +353,7 @@ object ArrayFunctions extends RegistryFunctions {
                     xySum := xySum + x * y,
                     n := n + 1
                   ),
-                  Code._empty[Unit]
+                  Code._empty
                 ),
                 i := i + 1
               )

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -38,7 +38,7 @@ object IntervalFunctions extends RegistryFunctions {
               srvb.addBoolean(includeEnd.value[Boolean]),
               srvb.advance(),
               vv := srvb.offset)),
-          Code._empty[Unit])
+          Code._empty)
 
         EmitTriplet(
           Code(start.setup, end.setup, includeStart.setup, includeEnd.setup, ctor),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -230,7 +230,7 @@ object StringFunctions extends RegistryFunctions {
             Region.loadByte(e1T.bytesOffset(v1) + i.toL)
               .cne(Region.loadByte(e2T.bytesOffset(v2) + i.toL)).mux(
               n += 1,
-              Code._empty[Unit]),
+              Code._empty),
             i += 1),
           n)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -256,7 +256,7 @@ object UtilFunctions extends RegistryFunctions {
               rv.mux(
                 const(8),
                 const(0)))),
-            Code._empty[Unit]))
+            Code._empty))
 
         EmitTriplet(setup,
           ((M >> w) & 1).cne(0),
@@ -286,7 +286,7 @@ object UtilFunctions extends RegistryFunctions {
                 rv.mux(
                   const(8),
                   const(0)))),
-            Code._empty[Unit]))
+            Code._empty))
 
         EmitTriplet(setup,
           ((M >> w) & 1).cne(0),

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -45,7 +45,7 @@ package object ir {
   def defaultValue(t: Type): Code[_] = defaultValue(typeToTypeInfo(t))
 
   def defaultValue(ti: TypeInfo[_]): Code[_] = ti match {
-    case UnitInfo => Code._empty[Unit]
+    case UnitInfo => Code._empty
     case BooleanInfo => false
     case IntInfo => 0
     case LongInfo => 0L

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -55,7 +55,7 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
           )
         )
       } else
-        Code._empty[Unit]
+        Code._empty
 
     val i = mb.newLocal[Int]("i")
 
@@ -68,7 +68,7 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
         Code(
           pt.isElementDefined(array, i).mux(
             writeElemF(Region.loadIRIntermediate(pt.elementType)(elem), out), // XXX, get or loadIRIntermediate
-            Code._empty[Unit]),
+            Code._empty),
           i := i + const(1))))
 
     Code(

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
@@ -93,7 +93,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     val ft = pt.asInstanceOf[PBaseStruct]
     val writeMissingBytes = if (ft.size == size) {
       val missingBytes = UnsafeUtils.packBitsToBytes(ft.nMissing)
-      var c = Code._empty[Unit]
+      var c = Code._empty
       if (nMissingBytes > 1)
         c = Code(c, out.writeBytes(coerce[Long](v), missingBytes - 1))
       if (nMissingBytes > 0)
@@ -103,15 +103,15 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       val groupSize = 64
       var methodIdx = 0
       var currentMB = mb.fb.newMethod(s"missingbits_group_$methodIdx", Array[TypeInfo[_]](LongInfo, classInfo[OutputBuffer]), UnitInfo)
-      var wrappedC: Code[Unit] = Code._empty[Unit]
-      var methodC: Code[Unit] = Code._empty[Unit]
+      var wrappedC: Code[Unit] = Code._empty
+      var methodC: Code[Unit] = Code._empty
 
       var j = 0
       var n = 0
       while (j < size) {
         if (n % groupSize == 0) {
           currentMB.emit(methodC)
-          methodC = Code._empty[Unit]
+          methodC = Code._empty
           wrappedC = Code(wrappedC, currentMB.invoke[Unit](v, out))
           methodIdx += 1
           currentMB = mb.fb.newMethod(s"missingbits_group_$methodIdx", Array[TypeInfo[_]](LongInfo, classInfo[OutputBuffer]), UnitInfo)
@@ -152,7 +152,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
           val v = Region.loadIRIntermediate(pf.typ)(ft.fieldOffset(addr, i))
           ft.isFieldDefined(addr, i).mux(
             encodeField(v, out2),
-            Code._empty[Unit]
+            Code._empty
           )
         }: _*
       )))
@@ -160,7 +160,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       groupMB.invoke[Unit](v, out)
     }.toArray: _*))
 
-    Code(writeMissingBytes, writeFields, Code._empty[Unit])
+    Code(writeMissingBytes, writeFields, Code._empty)
   }
 
   def _buildDecoder(
@@ -214,7 +214,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
             skip(regionArg, inArg)
           else
             Region.loadBit(mbytesArg, const(missingIdx(f.index).toLong)).mux(
-              Code._empty[Unit],
+              Code._empty,
               skip(regionArg, inArg))
         }
       }))
@@ -225,7 +225,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       mbytes := region.allocate(const(1), const(nMissingBytes)),
       in.readBytes(region, mbytes, nMissingBytes),
       readFields,
-      Code._empty[Unit])
+      Code._empty)
   }
   def _buildSkip(mb: MethodBuilder, r: Code[Region], in: Code[InputBuffer]): Code[Unit] = {
     val mbytes = mb.newLocal[Long]("mbytes")

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -96,7 +96,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     coerce[Long](Code(
       dataStore := data.load(nd),
       bytesAway := 0L,
-      indices.zipWithIndex.foldLeft(Code._empty[Unit]){case (codeSoFar: Code[_], (requestedIndex: Code[Long], strideIndex: Int)) =>
+      indices.zipWithIndex.foldLeft(Code._empty){case (codeSoFar: Code[_], (requestedIndex: Code[Long], strideIndex: Int)) =>
         Code(
           codeSoFar,
           bytesAway := bytesAway + requestedIndex * stridesTuple(strideIndex))


### PR DESCRIPTION
It must always be Unit.