### PR TITLE
[query] add PIndexableValue

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -167,7 +167,7 @@ case class ArrayIteratorTriplet(calcLength: Code[Unit], length: Option[Code[Int]
   }
 }
 
-case class LoopRef(m: ClassFieldRef[Boolean], v: PSettable, tempM: LocalRef[Boolean], tempV: PSettable)
+case class LoopRef(m: ClassFieldRef[Boolean], v: PSettable[PValue], tempM: LocalRef[Boolean], tempV: PSettable[PValue])
 
 abstract class MethodBuilderLike[M <: MethodBuilderLike[M]] {
   type MB <: MethodBuilder
@@ -375,7 +375,7 @@ private class Emit(
         val va = values.toArray.map(emit(_))
 
         val mout = mb.newLocal[Boolean]()
-        val out = mb.newPLocal(pt)
+        val out = mb.newPLocal[PValue](pt)
 
         val setup = va.indices
           .init
@@ -383,7 +383,7 @@ private class Emit(
             mout := va.last.m,
             out := pt.defaultValue,
             mout.mux(Code._empty, out := ir.pType.copyFromPValue(mb, er.region, va.last.pv)))) { case (i, comb) =>
-            va(i).m.mux[Unit](
+            va(i).m.mux(
               comb,
               Code(
                 mout := false,
@@ -416,7 +416,7 @@ private class Emit(
             PValue._empty)
         } else {
           val codeCond = emit(cond)
-          val out = mb.newPLocal(pt)
+          val out = mb.newPLocal[PValue](pt)
           val mout = mb.newLocal[Boolean]()
           val codeCnsq = emit(cnsq)
           val codeAltr = emit(altr)
@@ -442,7 +442,7 @@ private class Emit(
 
       case Let(name, value, body) =>
         val mx = mb.newField[Boolean]()
-        val x = mb.newPField(name, value.pType)
+        val x = mb.newPField[PValue](name, value.pType)
         val storeV = wrapToMethod(FastIndexedSeq(value)) { (_, _, codeV) =>
           Code(codeV.setup,
             mx := codeV.m,
@@ -520,7 +520,7 @@ private class Emit(
                   .concat(s.pType.asInstanceOf[PString].loadString(coerce[Long](codeS.v)))))
         }
         val xma = mb.newLocal[Boolean]()
-        val xa = mb.newPLocal(pArray)
+        val xa = mb.newPLocal[PIndexableValue](pArray)
         val xi = mb.newLocal[Int]
         val len = mb.newLocal[Int]
         val xmi = mb.newLocal[Boolean]()
@@ -528,7 +528,7 @@ private class Emit(
         val setup = Code(
           codeA.setup,
           xma := codeA.m,
-          xa := pArray.defaultValue,
+          xa.storeAny(pArray.defaultValue),
           codeI.setup,
           xmi := codeI.m,
           xi := coerce[Int](defaultValue(TInt32())),
@@ -536,19 +536,18 @@ private class Emit(
           (xmi || xma).mux(
             xmv := const(true),
             Code(
-              xa := codeA.pv,
+              xa.storeAny(codeA.pv),
               xi := coerce[Int](codeI.v),
-              len := pArray.loadLength(xa.load().tcode[Long]),
+              len := xa.load().loadLength(),
               (xi < len && xi >= 0).mux(
-                xmv := !pArray.isElementDefined(xa.load().tcode[Long], xi),
+                xmv := !xa.load().isElementDefined(xi),
                 Code._fatal(errorTransformer(
                   const("array index out of bounds: index=")
                     .concat(xi.load().toS)
                     .concat(", length=")
                     .concat(len.load().toS)))))))
 
-        EmitTriplet(setup, xmv, PValue(pt,
-          Region.loadIRIntermediate(x.pType)(pArray.elementOffset(xa.load().tcode[Long], len, xi))))
+        EmitTriplet(setup, xmv, xa.load().loadElement(len, xi))
       case ArrayLen(a) =>
         val codeA = emit(a)
         strict(pt, a.pType.asInstanceOf[PArray].loadLength(coerce[Long](codeA.v)), codeA)
@@ -1818,7 +1817,7 @@ private class Emit(
 
       case x@TailLoop(name, args, body) =>
         val loopRefs = args.map { case (name, ir) =>
-          LoopRef(mb.newField[Boolean], mb.newPField(ir.pType), mb.newLocal[Boolean], mb.newPField(ir.pType))
+          LoopRef(mb.newField[Boolean], mb.newPField[PValue](ir.pType), mb.newLocal[Boolean], mb.newPField[PValue](ir.pType))
         }
 
         val storeInitArgs = args.zip(loopRefs).map { case ((_, ir), loopref) =>
@@ -1828,7 +1827,7 @@ private class Emit(
 
         val label = new CodeLabel
         val m = mb.newField[Boolean]
-        val v = mb.newPField(x.pType)
+        val v = mb.newPField[PValue](x.pType)
 
         val argEnv = env
           .bind(args.zip(loopRefs).map { case ((name, _), ref) => (name, (ref.m.load(), ref.v.load())) } : _*)
@@ -1938,8 +1937,8 @@ private class Emit(
     x match {
       case NDArrayMap(child, elemName, body) =>
         val childP = child.pType.asInstanceOf[PNDArray]
-        val elemPType = childP.elementType
-        val elemRef = mb.newPField(elemName, elemPType)
+        val elemPType = -childP.elementType
+        val elemRef = mb.newPField[PValue](elemName, elemPType)
         val bodyEnv = env.bind(elemName, (const(false), elemRef.load()))
         val bodyt = this.emit(body, bodyEnv, er, None)
 
@@ -1961,8 +1960,8 @@ private class Emit(
         val lP = coerce[PNDArray](lChild.pType)
         val rP = coerce[PNDArray](rChild.pType)
 
-        val lElemRef = mb.newPField(lName, lP.elementType)
-        val rElemRef = mb.newPField(rName, rP.elementType)
+        val lElemRef = mb.newPField[PValue](lName, -lP.elementType)
+        val rElemRef = mb.newPField[PValue](rName, -rP.elementType)
 
         val bodyEnv = env.bind(lName, (const(false), lElemRef.load()))
                          .bind(rName, (const(false), rElemRef.load()))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1937,7 +1937,7 @@ private class Emit(
     x match {
       case NDArrayMap(child, elemName, body) =>
         val childP = child.pType.asInstanceOf[PNDArray]
-        val elemPType = -childP.elementType
+        val elemPType = childP.elementType
         val elemRef = mb.newPField[PValue](elemName, elemPType)
         val bodyEnv = env.bind(elemName, (const(false), elemRef.load()))
         val bodyt = this.emit(body, bodyEnv, er, None)
@@ -1960,8 +1960,8 @@ private class Emit(
         val lP = coerce[PNDArray](lChild.pType)
         val rP = coerce[PNDArray](rChild.pType)
 
-        val lElemRef = mb.newPField[PValue](lName, -lP.elementType)
-        val rElemRef = mb.newPField[PValue](rName, -rP.elementType)
+        val lElemRef = mb.newPField[PValue](lName, lP.elementType)
+        val rElemRef = mb.newPField[PValue](rName, rP.elementType)
 
         val bodyEnv = env.bind(lName, (const(false), lElemRef.load()))
                          .bind(rName, (const(false), rElemRef.load()))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -129,28 +129,28 @@ class EmitMethodBuilder(
 
   def newRNG(seed: Long): Code[IRRandomness] = fb.newRNG(seed)
 
-  def newPLocal(pt: PType): PSettable = new PSettable {
+  def newPLocal[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
     private val l = newLocal(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, l.load())
+    def load(): PV = PValue(pt, l.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = l.storeAny(v.code)
+    def store(v: PV): Code[Unit] = l.storeAny(v.code)
   }
 
-  def newPField(pt: PType): PSettable = new PSettable {
+  def newPField[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
     private val f = newField(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, f.load())
+    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = f.storeAny(v.code)
+    def store(v: PV): Code[Unit] = f.storeAny(v.code)
   }
 
-  def newPField(name: String, pt: PType): PSettable = new PSettable {
+  def newPField[PV <: PValue](name: String, pt: PType): PSettable[PV] = new PSettable[PV] {
     private val f = newField(name)(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, f.load())
+    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = f.storeAny(v.code)
+    def store(v: PV): Code[Unit] = f.storeAny(v.code)
   }
 }
 
@@ -694,27 +694,27 @@ class EmitFunctionBuilder[F >: Null](
     }
   }
 
-  def newPLocal(pt: PType): PSettable = new PSettable {
+  def newPLocal[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
     private val l = newLocal(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, l.load())
+    def load(): PV = PValue(pt, l.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = l.storeAny(v.code)
+    def store(v: PV): Code[Unit] = l.storeAny(v.code)
   }
 
-  def newPField(pt: PType): PSettable = new PSettable {
+  def newPField[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
     private val f = newField(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, f.load())
+    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = f.storeAny(v.code)
+    def store(v: PV): Code[Unit] = f.storeAny(v.code)
   }
 
-  def newPField(name: String, pt: PType): PSettable = new PSettable {
+  def newPField[PV <: PValue](name: String, pt: PType): PSettable[PV] = new PSettable[PV] {
     private val f = newField(name)(typeToTypeInfo(pt))
 
-    def load(): PValue = PValue(pt, f.load())
+    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
 
-    def store(v: PValue): Code[Unit] = f.storeAny(v.code)
+    def store(v: PV): Code[Unit] = f.storeAny(v.code)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1072,7 +1072,7 @@ object EmitStream {
         case Let(name, valueIR, childIR) =>
           val valueType = valueIR.pType
           val vm = fb.newField[Boolean](name + "_missing")
-          val vv = fb.newPField(name, valueType)
+          val vv = fb.newPField[PValue](name, valueType)
           val valuet = emitIR(valueIR, env)
           val bodyEnv = env.bind(name -> ((vm, vv.load())))
           emitStream(childIR, bodyEnv)
@@ -1088,7 +1088,7 @@ object EmitStream {
           val childEltType = childIR.pType.asInstanceOf[PStream].elementType
           emitStream(childIR, env).map { eltt =>
             val eltm = fb.newField[Boolean](name + "_missing")
-            val eltv = fb.newPField(name, childEltType)
+            val eltv = fb.newPField[PValue](name, childEltType)
             val bodyt = emitIR(bodyIR, env.bind(name -> ((eltm, eltv.load()))))
             EmitTriplet(
               Code(eltt.setup,
@@ -1111,7 +1111,7 @@ object EmitStream {
           EmitStream.zip[Any](streams, behavior, { (xs, k) =>
             val mv = names.zip(childEltTypes).map { case (name, t) =>
               val eltm = fb.newField[Boolean](name + "_missing")
-              val eltv = fb.newPField(name, t)
+              val eltv = fb.newPField[PValue](name, t)
               (t, eltm, eltv)
             }
             val bodyt = emitIR(body,
@@ -1136,7 +1136,7 @@ object EmitStream {
 
           emitStream(childIR, env).filterMap { (eltt, k) =>
             val eltm = fb.newField[Boolean](name + "_missing")
-            val eltv = fb.newPField(name, childEltType)
+            val eltv = fb.newPField[PValue](name, childEltType)
             val condt = emitIR(condIR, env.bind(name -> ((eltm, eltv.load()))))
             Code(
               eltt.setup,
@@ -1153,7 +1153,7 @@ object EmitStream {
         case StreamFlatMap(outerIR, name, innerIR) =>
           val outerEltType = outerIR.pType.asInstanceOf[PStream].elementType
           val eltm = fb.newField[Boolean](name + "_missing")
-          val eltv = fb.newPField(name, outerEltType)
+          val eltv = fb.newPField[PValue](name, outerEltType)
           val innerEnv = env.bind(name -> ((eltm, eltv.load())))
           val outer = emitStream(outerIR, env)
           val inner = emitStream(innerIR, innerEnv)

--- a/hail/src/main/scala/is/hail/expr/ir/PValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PValue.scala
@@ -1,27 +1,92 @@
 package is.hail.expr.ir
 
-import is.hail.asm4s.{Code, TypeInfo}
-import is.hail.expr.types.physical.{PType, PVoid}
+import is.hail.annotations.{Region, UnsafeUtils}
+import is.hail.asm4s._
+import is.hail.expr.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, PContainer, PType, PVoid}
 
-abstract class PSettable {
-  def load(): PValue
+abstract class PSettable[PV <: PValue] {
+  def load(): PV
 
-  def store(v: PValue): Code[Unit]
+  def store(v: PV): Code[Unit]
 
-  def :=(v: PValue): Code[Unit] = store(v)
+  def :=(v: PV): Code[Unit] = store(v)
+
+  def storeAny(v: PValue): Code[Unit] = store(v.asInstanceOf[PV])
 }
 
 object PValue {
+  def apply(pt: PType, code: Code[_]): PValue = pt match {
+    case pt: PCanonicalArray =>
+      new PCanonicalIndexableValue(pt, coerce[Long](code))
+    case pt: PCanonicalSet =>
+      new PCanonicalIndexableValue(pt, coerce[Long](code))
+    case pt: PCanonicalDict =>
+      new PCanonicalIndexableValue(pt, coerce[Long](code))
+
+    case _ =>
+      new PrimitivePValue(pt, code)
+  }
+
   def _empty: PValue = PValue(PVoid, Code._empty)
 }
 
-case class PValue(
-  pt: PType,
-  code: Code[_]) {
+abstract class PValue {
+  def pt: PType
+
+  def code: Code[_]
+
+  def typeInfo: TypeInfo[_] = typeToTypeInfo(pt)
+
   def tcode[T](implicit ti: TypeInfo[T]): Code[T] = {
     assert(ti == typeInfo)
     code.asInstanceOf[Code[T]]
   }
+}
 
-  def typeInfo: TypeInfo[_] = typeToTypeInfo(pt)
+class PrimitivePValue(val pt: PType, val code: Code[_]) extends PValue
+
+abstract class PIndexableValue extends PValue {
+  def loadLength(): Code[Int]
+
+  def isElementDefined(i: Code[Int]): Code[Boolean]
+
+  def loadElement(length: Code[Int], i: Code[Int]): PValue
+
+  def loadElement(i: Code[Int]): PValue = loadElement(loadLength(), i)
+
+  def isElementMissing(i: Code[Int]): Code[Boolean] = !isElementDefined(i)
+}
+
+class PCanonicalIndexableValue(val pt: PContainer, val a: Code[Long]) extends PIndexableValue {
+  def code: Code[_] = a
+
+  def elementType: PType = pt.elementType
+
+  def arrayElementSize: Long = UnsafeUtils.arrayElementSize(elementType)
+
+  def loadLength(): Code[Int] = Region.loadInt(a)
+
+  def nMissingBytes(len: Code[Int]): Code[Int] = (len + 7) >>> 3
+
+  def isElementDefined(i: Code[Int]): Code[Boolean] =
+    if (pt.elementType.required)
+      const(true)
+    else
+      !Region.loadBit(a + const(4L), i.toL)
+
+  def elementsOffset(length: Code[Int]): Code[Long] =
+    if (elementType.required)
+      UnsafeUtils.roundUpAlignment(4, elementType.alignment)
+    else
+      UnsafeUtils.roundUpAlignment(const(4L) + nMissingBytes(length).toL, elementType.alignment)
+
+  def elementsAddress(length: Code[Int]): Code[Long] = a + elementsOffset(length)
+
+  def elementAddress(length: Code[Int], i: Code[Int]): Code[Long] =
+    elementsAddress(length) + i.toL * arrayElementSize
+
+  def loadElement(length: Code[Int], i: Code[Int]): PValue = {
+    val elemA = elementAddress(length, i)
+    PValue(elementType, Region.loadIRIntermediate(elementType)(elemA))
+  }
 }


### PR DESCRIPTION
 - add PIndexableValue.  This represents canonical array, set and dict values.
 - use in ArrayRef
 - newP{Local, FIeld} now has a `PV <: PValue` type parameter to eliminate some casting

Where I'm going:

There will be a abstract PValue with the interface for each virtual type (container/indexable, base struct, etc.)  Each concrete PType will have a corresponding PValue implementation (in this case, PCanonicalArray is implemented by PCanonicalIndexableValue.)  I think this will allow us to get rid of PArrayBackedContainer.  Only primitive PValues will have a code method (since other types might be compound).

The code generator should then dispatch through downcasts of PValues get access to the relevant methods.