### PR TITLE
[batch] fix instance check when ip address is reused

### DIFF
--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -131,7 +131,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             try:
                 async with aiohttp.ClientSession(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-                    await session.get(f'http://{self.ip_address}:5000/healthcheck')
+                    async with session.get(f'http://{self.ip_address}:5000/healthcheck') as resp:
+                        actual_name = (await resp.json()).get('name')
+                        if actual_name and actual_name != self.name:
+                            return False
                     await self.mark_healthy()
                     return True
             except Exception:

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -133,7 +133,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     async with session.get(f'http://{self.ip_address}:5000/healthcheck') as resp:
                         actual_name = (await resp.json()).get('name')
-                        if actual_name != self.name:
+                        if actual_name and actual_name != self.name:
                             return False
                     await self.mark_healthy()
                     return True

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -133,7 +133,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     async with session.get(f'http://{self.ip_address}:5000/healthcheck') as resp:
                         actual_name = (await resp.json()).get('name')
-                        if actual_name and actual_name != self.name:
+                        if actual_name != self.name:
                             return False
                     await self.mark_healthy()
                     return True

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -816,7 +816,8 @@ class Worker:
         return await asyncio.shield(self.delete_job_1(request))
 
     async def healthcheck(self, request):  # pylint: disable=unused-argument
-        return web.Response()
+        body = {'name': NAME}
+        return web.json_response(body)
 
     async def run(self):
         app_runner = None


### PR DESCRIPTION
We must have had an instance that was still active in batch, but it's IP address had already been assigned to another instance.

I couldn't find anything about get caching responses without using a separate package to do that.