### PR TITLE
Don't make it seem like NDArray elements have to be doubles

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2391,11 +2391,11 @@ abstract class NDArrayEmitter(
   private def emitLoops(srvb: StagedRegionValueBuilder): Code[Unit] = {
     val idxVars = Array.tabulate(nDims) {_ => mb.newField[Long]}
     val loadedIdxVars = idxVars.map(_.load())
-    val storeElement = mb.newLocal(typeToTypeInfo(outputElementPType.virtualType)).asInstanceOf[LocalRef[Double]]
+    val storeElement = mb.newLocal(typeToTypeInfo(outputElementPType.virtualType)).asInstanceOf[LocalRef[Any]]
 
     val body =
       Code(
-        storeElement := outputElement(loadedIdxVars).asInstanceOf[Code[Double]],
+        storeElement := outputElement(loadedIdxVars).asInstanceOf[Code[Any]],
         srvb.addIRIntermediate(outputElementPType)(storeElement),
         srvb.advance()
       )

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2391,11 +2391,11 @@ abstract class NDArrayEmitter(
   private def emitLoops(srvb: StagedRegionValueBuilder): Code[Unit] = {
     val idxVars = Array.tabulate(nDims) {_ => mb.newField[Long]}
     val loadedIdxVars = idxVars.map(_.load())
-    val storeElement = mb.newLocal(typeToTypeInfo(outputElementPType.virtualType)).asInstanceOf[LocalRef[Any]]
+    val storeElement = mb.newLocal(typeToTypeInfo(outputElementPType.virtualType))
 
     val body =
       Code(
-        storeElement := outputElement(loadedIdxVars).asInstanceOf[Code[Any]],
+        storeElement.storeAny(outputElement(loadedIdxVars)),
         srvb.addIRIntermediate(outputElementPType)(storeElement),
         srvb.advance()
       )


### PR DESCRIPTION
I thought just removing the `asInstanceOf`s altogether would be fine, but it seems the explicit casts to `any` are necessary for this to go through.