### PR TITLE
[query] elide more RG serializing

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -347,9 +347,9 @@ private class Emit(
       case F64(x) =>
         present(pt, const(x))
       case s@Str(x) =>
-        present(pt, mb.fb.addLiteral(x, coerce[PString](s.pType), er.baseRegion))
+        present(pt, mb.fb.addLiteral(x, coerce[PString](s.pType)))
       case x@Literal(t, v) =>
-        present(pt, mb.fb.addLiteral(v, x.pType, er.baseRegion))
+        present(pt, mb.fb.addLiteral(v, x.pType))
       case True() =>
         present(pt, const(true))
       case False() =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -191,7 +191,7 @@ class DependentEmitFunction[F >: Null <: AnyRef : TypeInfo : ClassTag](
   override def addLiteral(v: Any, t: PType, region: Code[Region]): Code[_] = {
     assert(v != null)
     literalsMap.getOrElseUpdate(t -> v, {
-      val fromParent = parentfb.addLiteral(v, t, region)
+      val fromParent = parentfb.addLiteral(v, t)
       val ti: TypeInfo[_] = typeToTypeInfo(t)
       val field = addField(fromParent, dummy = true)(ti)
       field.load()
@@ -237,7 +237,7 @@ class EmitFunctionBuilder[F >: Null](
   private[this] lazy val encLitField: ClassFieldRef[Array[Byte]] = newField[Array[Byte]]("encodedLiterals")
   val partitionRegion: ClassFieldRef[Region] = newField[Region]("partitionRegion")
 
-  def addLiteral(v: Any, t: PType, region: Code[Region]): Code[_] = {
+  def addLiteral(v: Any, t: PType): Code[_] = {
     assert(v != null)
     assert(t.isCanonical)
     val f = literalsMap.getOrElseUpdate(t -> v, newField("literal")(typeToTypeInfo(t)))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -188,7 +188,7 @@ class DependentEmitFunction[F >: Null <: AnyRef : TypeInfo : ClassTag](
       field.load()
     })
 
-  override def addLiteral(v: Any, t: PType, region: Code[Region]): Code[_] = {
+  override def addLiteral(v: Any, t: PType): Code[_] = {
     assert(v != null)
     literalsMap.getOrElseUpdate(t -> v, {
       val fromParent = parentfb.addLiteral(v, t)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -52,7 +52,7 @@ object ArrayFunctions extends RegistryFunctions {
           ToStream(Ref(uid, a1.typ))))))
   }
 
-  def contains(a: IR, value: IR): IR = {
+  def exists(a: IR, cond: IR => IR): IR = {
     val t = -coerce[TArray](a.typ).elementType
     StreamFold(
       ToStream(a),
@@ -61,10 +61,14 @@ object ArrayFunctions extends RegistryFunctions {
       "elt",
       invoke("||",TBoolean(),
         Ref("acc", TBoolean()),
-        ApplyComparisonOp(
-          EQWithNA(t, value.typ),
-          Ref("elt", t),
-          value)))
+        cond(Ref("elt", t))))
+  }
+
+  def contains(a: IR, value: IR): IR = {
+    exists(a, elt => ApplyComparisonOp(
+      EQWithNA(elt.typ, value.typ),
+      elt,
+      value))
   }
 
   def sum(a: IR): IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -166,8 +166,8 @@ abstract class RegistryFunctions {
     case _: PFloat32 => coerce[Float]
     case _: PFloat64 => coerce[Double]
     case _: PCall => coerce[Int]
-    case t: PString => c =>
-      t.loadString(coerce[Long](c))
+    case t: PString => c => t.loadString(coerce[Long](c))
+    case t: PLocus => c => LocusFunctions.getLocus(r, coerce[Long](c), t)
     case _ => c =>
       Code.invokeScalaObject[PType, Region, Long, Any](
         UnsafeRow.getClass, "read",
@@ -182,8 +182,8 @@ abstract class RegistryFunctions {
     case _: PFloat32 => c => Code.boxFloat(coerce[Float](c))
     case _: PFloat64 => c => Code.boxDouble(coerce[Double](c))
     case _: PCall => c => Code.boxInt(coerce[Int](c))
-    case t: PString => c =>
-      t.loadString(coerce[Long](c))
+    case t: PString => c => t.loadString(coerce[Long](c))
+    case t: PLocus => c => LocusFunctions.getLocus(r, coerce[Long](c), t)
     case _ => c =>
       Code.invokeScalaObject[PType, Region, Long, AnyRef](
         UnsafeRow.getClass, "readAnyRef",

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -157,7 +157,7 @@ object LocusFunctions extends RegistryFunctions {
 
   def inPar(locus: IR): IR = {
     val t = locus.typ.asInstanceOf[TLocus]
-    val par = Literal(TArray(TInterval(t)), t.rg.par)
+    val par = Literal(TArray(TInterval(t)), t.rg.par.toFastIndexedSeq)
     ArrayFunctions.exists(par, interval => invoke("contains", TBoolean(), interval, locus))
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -155,13 +155,12 @@ object LocusFunctions extends RegistryFunctions {
     invoke("contains", TBoolean(), yContigs, invoke("contig", TString(), locus))
   }
 
-  // def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locusType.ordering, l))
   def inPar(locus: IR): IR = {
     val t = locus.typ.asInstanceOf[TLocus]
     val par = Literal(TArray(TInterval(t)), t.rg.par)
     ArrayFunctions.exists(par, interval => invoke("contains", TBoolean(), interval, locus))
   }
-  // def isMitochondrial(contig: String): Boolean = mtContigs.contains(contig)
+
   def isMitochondrial(locus: IR): IR = {
     val mtContigs = Literal(TSet(TString()), locus.typ.asInstanceOf[TLocus].rg.mtContigs)
     invoke("contains", TBoolean(), mtContigs, invoke("contig", TString(), locus))
@@ -181,10 +180,10 @@ object LocusFunctions extends RegistryFunctions {
       case (r, rt, (locusT: PLocus, locus: Code[Long])) =>
         locusT.position(locus)
     }
-    // isAutosomal(rg) || inXPar(rg) || inYPar(rg)
     registerLocusCode("isAutosomalOrPseudoAutosomal") { locus =>
       isAutosomal(locus) || ((inX(locus) || inY(locus)) && inPar(locus))
     }
+    registerLocusCode("isAutosomal")(isAutosomal)
     registerLocusCode("isMitochondrial")(isMitochondrial)
     registerLocusCode("inXPar") { locus => inX(locus) && inPar(locus) }
     registerLocusCode("inYPar") { locus => inY(locus) && inPar(locus) }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -22,7 +22,13 @@ object LocusFunctions extends RegistryFunctions {
   def tinterval(name: String): TInterval = TInterval(tlocus(name))
 
   def getLocus(r: EmitRegion, locus: Code[Long], locusT: PLocus): Code[Locus] = {
-    Code.checkcast[Locus](wrapArg(r, locusT)(locus).asInstanceOf[Code[AnyRef]])
+    val l = r.mb.newLocal[Long]
+    val lObject = r.mb.newLocal[Locus]
+    Code(
+      l := locus,
+      lObject := Code.invokeStatic[Locus, String, Int, Locus]("apply",
+        locusT.contigType.loadString(locusT.contig(l)),
+        locusT.position(l)), lObject)
   }
 
   def emitLocus(r: EmitRegion, locus: Code[Locus], rt: PLocus): Code[Long] = {
@@ -136,16 +142,31 @@ object LocusFunctions extends RegistryFunctions {
       srvb.offset)
   }
 
-  def registerLocusCode(methodName: String): Unit = {
-    registerCode(methodName, tv("T", "locus"), TBoolean(), null) {
-      case (r: EmitRegion, rt, (locusT: PLocus, locus: Code[Long])) =>
-        val locusObject = getLocus(r, locus, locusT)
-        val rg = locusT.rg
+  def registerLocusCode(methodName: String)(f: IR => IR): Unit =
+    registerIR(methodName, tlocus("T"), TBoolean())(f)
 
-        val codeRG = r.mb.getReferenceGenome(rg)
-        unwrapReturn(r, rt)(locusObject.invoke[ReferenceGenome, Boolean](methodName, codeRG))
-    }
+  def inX(locus: IR): IR = {
+    val xContigs = Literal(TSet(TString()), locus.typ.asInstanceOf[TLocus].rg.xContigs)
+    invoke("contains", TBoolean(), xContigs, invoke("contig", TString(), locus))
   }
+
+  def inY(locus: IR): IR = {
+    val yContigs = Literal(TSet(TString()), locus.typ.asInstanceOf[TLocus].rg.yContigs)
+    invoke("contains", TBoolean(), yContigs, invoke("contig", TString(), locus))
+  }
+
+  // def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locusType.ordering, l))
+  def inPar(locus: IR): IR = {
+    val t = locus.typ.asInstanceOf[TLocus]
+    val par = Literal(TArray(TInterval(t)), t.rg.par)
+    ArrayFunctions.exists(par, interval => invoke("contains", TBoolean(), interval, locus))
+  }
+  // def isMitochondrial(contig: String): Boolean = mtContigs.contains(contig)
+  def isMitochondrial(locus: IR): IR = {
+    val mtContigs = Literal(TSet(TString()), locus.typ.asInstanceOf[TLocus].rg.mtContigs)
+    invoke("contains", TBoolean(), mtContigs, invoke("contig", TString(), locus))
+  }
+  def isAutosomal(locus: IR): IR = !(inX(locus) || inY(locus) || isMitochondrial(locus))
 
   def registerAll() {
     val locusClass = Locus.getClass
@@ -160,14 +181,15 @@ object LocusFunctions extends RegistryFunctions {
       case (r, rt, (locusT: PLocus, locus: Code[Long])) =>
         locusT.position(locus)
     }
-
-    registerLocusCode("isAutosomalOrPseudoAutosomal")
-    registerLocusCode("isAutosomal")
-    registerLocusCode("inYNonPar")
-    registerLocusCode("inXPar")
-    registerLocusCode("isMitochondrial")
-    registerLocusCode("inXNonPar")
-    registerLocusCode("inYPar")
+    // isAutosomal(rg) || inXPar(rg) || inYPar(rg)
+    registerLocusCode("isAutosomalOrPseudoAutosomal") { locus =>
+      isAutosomal(locus) || ((inX(locus) || inY(locus)) && inPar(locus))
+    }
+    registerLocusCode("isMitochondrial")(isMitochondrial)
+    registerLocusCode("inXPar") { locus => inX(locus) && inPar(locus) }
+    registerLocusCode("inYPar") { locus => inY(locus) && inPar(locus) }
+    registerLocusCode("inXNonPar") { locus => inX(locus) && !inPar(locus) }
+    registerLocusCode("inYNonPar") { locus => inY(locus) && !inPar(locus) }
 
     registerCode("min_rep", tlocus("T"), TArray(TString()), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString())), null) {
       case (r, rt: PStruct, (locusT: PLocus, lOff), (allelesT, aOff)) =>


### PR DESCRIPTION
In this PR:
- removed unused region arg for `fb.addLiteral`
- add non-type-serialization path for PLocus in wrapArgs
- port isAutosomal, … to not rely on RG serialization (does the implementation look reasonable?)