### PR TITLE
[batch] fix test unauthorized users to be resilient to transient errors

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -411,8 +411,18 @@ class Test(unittest.TestCase):
             (requests.get, '/batches/0/jobs/0', 302)]
         for f, url, expected in endpoints:
             full_url = deploy_config.url('batch', url)
-            r = f(full_url, allow_redirects=False)
-            assert r.status_code == expected, (full_url, r, expected)
+            delay = 0.1
+            while True:
+                r = f(full_url, allow_redirects=False)
+                if r.status_code in (408, 500, 502, 503, 504):
+                    # nginx returns 502 if it cannot connect to the upstream server
+                    # 408 request timeout, 500 internal server error, 502 bad gateway
+                    # 503 service unavailable, 504 gateway timeout
+                    t = delay * random.random()
+                    time.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                else:
+                    assert r.status_code == expected, (full_url, r, expected)
 
     def test_bad_token(self):
         token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode('ascii')


### PR DESCRIPTION
Fixes this error in a deploy batch:

```
io/test/test_batch.py::Test::test_authorized_users_only 
-------------------------------- live log setup --------------------------------
2020-03-03T21:02:22 INFO test.conftest conftest.py:8:log_before_after starting test
FAILED
_______________________ Test.test_authorized_users_only ________________________

self = <test.test_batch.Test testMethod=test_authorized_users_only>

    def test_authorized_users_only(self):
        endpoints = [
            (requests.get, '/api/v1alpha/batches/0/jobs/0', 401),
            (requests.get, '/api/v1alpha/batches/0/jobs/0/log', 401),
            (requests.get, '/api/v1alpha/batches', 401),
            (requests.post, '/api/v1alpha/batches/create', 401),
            (requests.post, '/api/v1alpha/batches/0/jobs/create', 401),
            (requests.get, '/api/v1alpha/batches/0', 401),
            (requests.delete, '/api/v1alpha/batches/0', 401),
            (requests.patch, '/api/v1alpha/batches/0/close', 401),
            # redirect to auth/login
            (requests.get, '/batches', 302),
            (requests.get, '/batches/0', 302),
            (requests.post, '/batches/0/cancel', 401),
            (requests.get, '/batches/0/jobs/0', 302)]
        for f, url, expected in endpoints:
            full_url = deploy_config.url('batch', url)
            r = f(full_url, allow_redirects=False)
>           assert r.status_code == expected, (full_url, r, expected)
E           AssertionError: ('http://batch.hail/api/v1alpha/batches/0/jobs/0/log', <Response [503]>, 401)
E           assert 503 == 401
E             -503
E             +401

io/test/test_batch.py:415: AssertionError
```