### PR TITLE
Add PValue load/store.

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -33,6 +33,10 @@ object Region {
 
   def loadByte(addr: Long): Byte = Memory.loadByte(addr)
 
+  def loadShort(addr: Long): Short = Memory.loadShort(addr)
+
+  def loadChar(addr: Long): Char = Memory.loadShort(addr).toChar
+
   def storeInt(addr: Long, v: Int): Unit = Memory.storeInt(addr, v)
 
   def storeLong(addr: Long, v: Long): Unit = Memory.storeLong(addr, v)
@@ -44,6 +48,10 @@ object Region {
   def storeAddress(addr: Long, v: Long): Unit = Memory.storeAddress(addr, v)
 
   def storeByte(addr: Long, v: Byte): Unit = Memory.storeByte(addr, v)
+
+  def storeShort(addr: Long, s: Short): Unit = Memory.storeShort(addr, s)
+
+  def storeChar(addr: Long, c: Char): Unit = Memory.storeShort(addr, c.toShort)
 
   def loadBoolean(addr: Long): Boolean = if (Memory.loadByte(addr) == 0) false else true
 
@@ -112,6 +120,10 @@ object Region {
 
   def loadByte(addr: Code[Long]): Code[Byte] = Code.invokeScalaObject[Long, Byte](Region.getClass, "loadByte", addr)
 
+  def loadShort(addr: Code[Long]): Code[Short] = Code.invokeScalaObject[Long, Short](Region.getClass, "loadShort", addr)
+
+  def loadChar(addr: Code[Long]): Code[Char] = Code.invokeScalaObject[Long, Char](Region.getClass, "loadChar", addr)
+
   def storeInt(addr: Code[Long], v: Code[Int]): Code[Unit] = Code.invokeScalaObject[Long, Int, Unit](Region.getClass, "storeInt", addr, v)
 
   def storeLong(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeLong", addr, v)
@@ -120,9 +132,13 @@ object Region {
 
   def storeDouble(addr: Code[Long], v: Code[Double]): Code[Unit] = Code.invokeScalaObject[Long, Double, Unit](Region.getClass, "storeDouble", addr, v)
 
+  def storeChar(addr: Code[Long], v: Code[Char]): Code[Unit] = Code.invokeScalaObject[Long, Char, Unit](Region.getClass, "storeChar", addr, v)
+
   def storeAddress(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeAddress", addr, v)
 
   def storeByte(addr: Code[Long], v: Code[Byte]): Code[Unit] = Code.invokeScalaObject[Long, Byte, Unit](Region.getClass, "storeByte", addr, v)
+
+  def storeShort(addr: Code[Long], v: Code[Short]): Code[Unit] = Code.invokeScalaObject[Long, Short, Unit](Region.getClass, "storeShort", addr, v)
 
   def loadBoolean(addr: Code[Long]): Code[Boolean] = Code.invokeScalaObject[Long, Boolean](Region.getClass, "loadBoolean", addr)
 

--- a/hail/src/main/scala/is/hail/expr/ir/PValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PValue.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
 import is.hail.utils._
-import is.hail.expr.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, PContainer, PType, PVoid}
+import is.hail.expr.types.physical._
 
 abstract class PSettable[PV <: PValue] {
   def load(): PV
@@ -52,25 +52,8 @@ abstract class PValue {
 }
 
 class PPrimitiveValue(val pt: PType, val code: Code[_]) extends PValue {
-  def store(mb: EmitMethodBuilder ,r: Code[Region], a: Code[Long]): Code[Unit] = {
-    val ti: TypeInfo[_] = typeToTypeInfo(pt)
-    if (ti == ByteInfo)
-      Region.storeByte(a, code.asInstanceOf[Code[Byte]])
-    else if (ti == ShortInfo)
-      Region.storeShort(a, code.asInstanceOf[Code[Short]])
-    else if (ti == IntInfo)
-      Region.storeInt(a, code.asInstanceOf[Code[Int]])
-    else if (ti == LongInfo)
-      Region.storeLong(a, code.asInstanceOf[Code[Long]])
-    else if (ti == FloatInfo)
-      Region.storeFloat(a, code.asInstanceOf[Code[Float]])
-    else if (ti == DoubleInfo)
-      Region.storeDouble(a, code.asInstanceOf[Code[Double]])
-    else {
-      assert(ti == CharInfo)
-      Region.storeChar(a, code.asInstanceOf[Code[Char]])
-    }
-  }
+  def store(mb: EmitMethodBuilder, r: Code[Region], a: Code[Long]): Code[Unit] =
+    Region.storeIRIntermediate(pt)(a, code)
 }
 
 abstract class PIndexableValue extends PValue {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s.Code
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.asm4s.joinpoint._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitMethodBuilder, PCanonicalIndexableValue, PValue}
 import is.hail.expr.types.virtual.{TArray, Type}
 import is.hail.utils._
 
@@ -509,4 +509,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   private def deepRenameArray(t: TArray): PArray =
     PCanonicalArray(this.elementType.deepRename(t.elementType), this.required)
+
+  override def load(src: Code[Long]): PValue =
+    new PCanonicalIndexableValue(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
@@ -1,5 +1,8 @@
 package is.hail.expr.types.physical
 
+import is.hail.annotations.Region
+import is.hail.asm4s.Code
+import is.hail.expr.ir.{PCanonicalIndexableValue, PValue}
 import is.hail.expr.types.virtual.{TArray, TDict, Type}
 
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
@@ -26,4 +29,7 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
 
   private def deepRenameDict(t: TDict) =
     PCanonicalDict(this.keyType.deepRename(t.keyType), this.valueType.deepRename(t.valueType), this.required)
+
+  override def load(src: Code[Long]): PValue =
+    new PCanonicalIndexableValue(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
@@ -1,5 +1,8 @@
 package is.hail.expr.types.physical
 
+import is.hail.annotations.Region
+import is.hail.asm4s.Code
+import is.hail.expr.ir.{PCanonicalIndexableValue, PValue}
 import is.hail.expr.types.virtual.{TSet, Type}
 
 final case class PCanonicalSet(elementType: PType,  required: Boolean = false) extends PSet with PArrayBackedContainer {
@@ -19,4 +22,7 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
 
   private def deepRenameSet(t: TSet) =
     PCanonicalSet(this.elementType.deepRename(t.elementType),  this.required)
+
+  override def load(src: Code[Long]): PValue =
+    new PCanonicalIndexableValue(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -4,7 +4,7 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.check.{Arbitrary, Gen}
 import is.hail.expr.ir
-import is.hail.expr.ir.{Ascending, Descending, EmitMethodBuilder, IRParser, PValue, SortOrder}
+import is.hail.expr.ir._
 import is.hail.expr.types.virtual._
 import is.hail.expr.types.{BaseType, Requiredness}
 import is.hail.utils._
@@ -323,4 +323,26 @@ abstract class PType extends Serializable with Requiredness {
   final def typeCheck(a: Any): Boolean = a == null || _typeCheck(a)
 
   def _typeCheck(a: Any): Boolean = virtualType._typeCheck(a)
+
+  def load(src: Code[Long]): PValue = {
+    val ti: TypeInfo[_] = typeToTypeInfo(this)
+    val v = if (ti == ByteInfo)
+      Region.loadByte(src)
+    else if (ti == ShortInfo)
+      Region.loadShort(src)
+    else if (ti == IntInfo)
+      Region.loadInt(src)
+    else if (ti == LongInfo)
+      Region.loadLong(src)
+    else if (ti == FloatInfo)
+      Region.loadFloat(src)
+    else if (ti == DoubleInfo)
+      Region.loadDouble(src)
+    else {
+      assert(ti == CharInfo)
+      Region.loadChar(src)
+    }
+
+    new PPrimitiveValue(this, v)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -324,25 +324,5 @@ abstract class PType extends Serializable with Requiredness {
 
   def _typeCheck(a: Any): Boolean = virtualType._typeCheck(a)
 
-  def load(src: Code[Long]): PValue = {
-    val ti: TypeInfo[_] = typeToTypeInfo(this)
-    val v = if (ti == ByteInfo)
-      Region.loadByte(src)
-    else if (ti == ShortInfo)
-      Region.loadShort(src)
-    else if (ti == IntInfo)
-      Region.loadInt(src)
-    else if (ti == LongInfo)
-      Region.loadLong(src)
-    else if (ti == FloatInfo)
-      Region.loadFloat(src)
-    else if (ti == DoubleInfo)
-      Region.loadDouble(src)
-    else {
-      assert(ti == CharInfo)
-      Region.loadChar(src)
-    }
-
-    new PPrimitiveValue(this, v)
-  }
+  def load(src: Code[Long]): PValue = PValue(this, Region.loadIRIntermediate(this)(src))
 }


### PR DESCRIPTION
OK, this one is slightly subtle.  A physical value at runtime actually has two forms:

1. It is a bunch a bunch of bytes in memory at a particular address (e.g. a struct field, an array element, or a freestanding value in memory).

2. It is a value made up of JVM primitive values (or, more abstractly, Code[T]'s) that can be operated on immediately.

Note, one option for (2) is just the address (1).  This is what we do for structs (but note, not for arrays).

Therefore, one thing we need is an operation that constructs a PValue from a physical type and an address to go from (1) => (2).  I call this `PType.load`.  It will be used in, for example, loadElement or loadField.  See the use in loadElement below in PCanonicalIndexableValue.

We also need something that goes from (2) => (1).  There are two cases, whether the memory has been allocated already, or not, and I call them `PValue.store` and `PValue.allocateAndStore`.

PType.load should be abstract and the implementation should be pushed to the leaves.  I will do that once the full set of PValues are filled in.

load/store will eventually allow us to eliminate all the IRIntermediate business.

There was some complaint about my `PValue.apply` switching on PType.  Some of the calls to it will go away in favor of load.

I think of load as a kind of PValue constructor that takes a single argument pointing to memory.  There will be other constructors depending on the PType.  Those will eliminate the other calls to PValue.apply.  Hopefully this discussion clears things up.

FYI @tpoterba 