### PR TITLE
Support Requester Pays

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -131,10 +131,10 @@ def main(args, pass_through_args):
 
     # requester pays support
     if args.requester_pays_allow_all or args.requester_pays_allow_buckets:
-        requester_pays_mode = None
         if args.requester_pays_allow_all and args.requester_pays_allow_buckets:
             raise RuntimeError("Cannot specify both 'requester_pays_allow_all' and 'requester_pays_allow_buckets")
-        elif args.requester_pays_allow_all:
+
+        if args.requester_pays_allow_all:
             requester_pays_mode = "AUTO"
         else:
             requester_pays_mode = "CUSTOM"

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -101,11 +101,11 @@ def init_parser(parser):
 
     # requester pays
     parser.add_argument('--requester-pays-allow-all',
-                        help="Allow reading from all requester pays buckets.",
+                        help="Allow reading from all requester-pays buckets.",
                         action='store_true',
                         required=False)
     parser.add_argument('--requester-pays-allow-buckets',
-                        help="Allow reading from only the specified requester pays buckets.")
+                        help="Comma-separated list of requester-pays buckets to allow reading from.")
 
 
 def main(args, pass_through_args):

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -141,11 +141,10 @@ def main(args, pass_through_args):
             conf.extend_flag("properties", {"spark:spark.hadoop.fs.gs.requester.pays.buckets": args.requester_pays_allow_buckets})
 
         # Need to pick requester pays project.
-        requester_pays_project = args.project if args.project else sp.check_output(['gcloud', 'config', 'get-value', 'project']).decode().strip() 
+        requester_pays_project = args.project if args.project else sp.check_output(['gcloud', 'config', 'get-value', 'project']).decode().strip()
 
         conf.extend_flag("properties", {"spark:spark.hadoop.fs.gs.requester.pays.mode": requester_pays_mode,
                                         "spark:spark.hadoop.fs.gs.requester.pays.project.id": requester_pays_project})
-
 
     # add VEP init script
     if args.vep:
@@ -174,7 +173,6 @@ def main(args, pass_through_args):
         if args.vep:
             size = max(size, 200)
         return str(size) + 'GB'
-
 
     conf.extend_flag('properties',
                      {"spark:spark.driver.memory": "{driver_memory}g".format(


### PR DESCRIPTION
Adds two new `hailctl dataproc start` flags to allow reading from requester pays buckets.

```
hailctl dataproc start my-cluster --requester-pays-allow-all
```

allows you to read from any requester pays bucket.

```
hailctl dataproc start  my-cluster --requester-pays-allow-buckets bucket1,bucket2
```

allows you to read from `gs://bucket1` and `gs://bucket2`, regardless of whether they're requester pays. 