### PR TITLE
[query] expand value/code/settable picture to physical and emit code

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -2,7 +2,7 @@ package is.hail.asm4s.joinpoint
 
 import is.hail.asm4s._
 import is.hail.expr.ir
-import is.hail.expr.ir.{EmitTriplet, PValue}
+import is.hail.expr.ir.{EmitCode, PCode}
 import is.hail.expr.types.physical.PType
 
 trait ParameterPack[A] {
@@ -256,20 +256,20 @@ case class ParameterStoreTriplet[A](t: PType, psm: ParameterStore[Code[Boolean]]
 }
 
 object TypedTriplet {
-  def apply(t: PType, et: EmitTriplet): TypedTriplet[t.type] =
+  def apply(t: PType, et: EmitCode): TypedTriplet[t.type] =
     TypedTriplet(et.setup, et.m, et.pv)
 
   def apply[A](t: PType, setup: Code[Unit], m: Code[Boolean], v: Code[_]): TypedTriplet[A] =
-    TypedTriplet(setup, m, PValue(t, v))
+    TypedTriplet(setup, m, PCode(t, v))
 
   def missing(t: PType): TypedTriplet[t.type] =
-    TypedTriplet(t, EmitTriplet(Code._empty, true, t.defaultValue))
+    TypedTriplet(t, EmitCode(Code._empty, true, t.defaultValue))
 
   def pack(t: PType): ParameterPackTriplet[t.type] = ParameterPackTriplet(t)
 }
 
-case class TypedTriplet[P] private(setup: Code[Unit], m: Code[Boolean], pv: PValue) {
+case class TypedTriplet[P] private(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
   def v: Code[_] = pv.code
 
-  def untyped: EmitTriplet = EmitTriplet(setup, m, pv)
+  def untyped: EmitCode = EmitCode(setup, m, pv)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -129,28 +129,28 @@ class EmitMethodBuilder(
 
   def newRNG(seed: Long): Code[IRRandomness] = fb.newRNG(seed)
 
-  def newPLocal[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPLocal(pt: PType): PSettable = new PSettable {
     private val l = newLocal(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, l.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, l.load())
 
-    def store(v: PV): Code[Unit] = l.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = l.storeAny(v.code)
   }
 
-  def newPField[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPField(pt: PType): PSettable = new PSettable {
     private val f = newField(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, f.load())
 
-    def store(v: PV): Code[Unit] = f.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = f.storeAny(v.code)
   }
 
-  def newPField[PV <: PValue](name: String, pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPField(name: String, pt: PType): PSettable = new PSettable {
     private val f = newField(name)(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, f.load())
 
-    def store(v: PV): Code[Unit] = f.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = f.storeAny(v.code)
   }
 }
 
@@ -694,27 +694,27 @@ class EmitFunctionBuilder[F >: Null](
     }
   }
 
-  def newPLocal[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPLocal(pt: PType): PSettable = new PSettable {
     private val l = newLocal(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, l.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, l.load())
 
-    def store(v: PV): Code[Unit] = l.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = l.storeAny(v.code)
   }
 
-  def newPField[PV <: PValue](pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPField(pt: PType): PSettable = new PSettable {
     private val f = newField(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, f.load())
 
-    def store(v: PV): Code[Unit] = f.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = f.storeAny(v.code)
   }
 
-  def newPField[PV <: PValue](name: String, pt: PType): PSettable[PV] = new PSettable[PV] {
+  def newPField(name: String, pt: PType): PSettable = new PSettable {
     private val f = newField(name)(typeToTypeInfo(pt))
 
-    def load(): PV = PValue(pt, f.load()).asInstanceOf[PV]
+    def get: PCode = PCode(pt, f.load()).asInstanceOf
 
-    def store(v: PV): Code[Unit] = f.storeAny(v.code)
+    def store(v: PCode): Code[Unit] = f.storeAny(v.code)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -98,9 +98,9 @@ class TypedRegionBackedAggState(val typ: PType, val fb: EmitFunctionBuilder[_]) 
     storageType.setFieldPresent(off, 0),
     StagedRegionValueBuilder.deepCopy(fb, region, typ, v, storageType.fieldOffset(off, 0)))
 
-  def get(): EmitTriplet = EmitTriplet(Code._empty,
+  def get(): EmitCode = EmitCode(Code._empty,
     storageType.isFieldMissing(off, 0),
-    PValue(typ, Region.loadIRIntermediate(typ)(storageType.fieldOffset(off, 0))))
+    PCode(typ, Region.loadIRIntermediate(typ)(storageType.fieldOffset(off, 0))))
 
   def copyFrom(src: Code[Long]): Code[Unit] =
     Code(newState(off), StagedRegionValueBuilder.deepCopy(fb, region, storageType, src, off))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical.{PBooleanRequired, PInt32Required, PStruct, PType}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.utils._
@@ -113,7 +113,7 @@ class ApproxCDFAggregator extends StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State = new ApproxCDFState(fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(k) = init
     Code(
       k.setup,
@@ -123,7 +123,7 @@ class ApproxCDFAggregator extends StagedAggregator {
       ))
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(x) = seq
     Code(
       x.setup,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -149,7 +149,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
   def createState(fb: EmitFunctionBuilder[_]): State = new ArrayElementState(fb, StateTuple(nestedAggs.map(_.createState(fb))))
 
   // inits all things
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     if (knownLength) {
       val Array(len, inits) = init
       Code(state.init(inits.setup, initLen = false), len.setup,
@@ -161,7 +161,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
   }
 
   //does a length check on arrays
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(len) = seq
     var check = state.checkLength(len.value[Int])
     if (!knownLength)
@@ -216,10 +216,10 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
   def createState(fb: EmitFunctionBuilder[_]): State =
     throw new UnsupportedOperationException(s"State must be created by ArrayElementLengthCheckAggregator")
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] =
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] =
     throw new UnsupportedOperationException("State must be initialized by ArrayElementLengthCheckAggregator.")
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(eltIdx, seqOps) = seq
     Code(
       eltIdx.setup,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.stats.CallStats
@@ -101,7 +101,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State = new CallStatsState(fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(nAlleles) = init
     val addr = state.fb.newField[Long]
     val n = state.fb.newField[Int]
@@ -130,7 +130,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
     ))
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(call) = seq
     val hom = state.fb.newField[Boolean]
     val lastAllele = state.fb.newField[Int]

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -56,12 +56,12 @@ class CollectAggregator(val elemType: PType) extends StagedAggregator {
   def createState(fb: EmitFunctionBuilder[_]): State =
     new State(fb)
 
-  def initOp(state: State, args: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, args: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(args.isEmpty)
     state.bll.init(state.region)
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] =
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] =
     state.bll.push(state.region, seq(0))
 
   def combOp(state: State, other: State, dummy: Boolean): Code[Unit] =

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitTriplet, defaultValue, typeToTypeInfo}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitCode, defaultValue, typeToTypeInfo}
 import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical._
 import is.hail.io._
@@ -148,12 +148,12 @@ class CollectAsSetAggregator(t: PType) extends StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State = new AppendOnlySetState(fb, t)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     state.init
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(elt) = seq
     Code(elt.setup, state.insert(elt.m, elt.v))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical._
 
 object CountAggregator extends StagedAggregator {
@@ -12,13 +12,13 @@ object CountAggregator extends StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State = new PrimitiveRVAState(Array(PInt64(true)), fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     val (_, v, _) = state.fields(0)
     v.storeAny(0L)
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(seq.length == 0)
     val (_, v, _) = state.fields(0)
     v.storeAny(coerce[Long](v) + 1L)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitCode}
 import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
@@ -534,7 +534,7 @@ class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State = new DownsampleState(fb, arrayType)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(nDivisions) = init
     Code(
       nDivisions.setup,
@@ -545,7 +545,7 @@ class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(x, y, label) = seq
 
     Code(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{CodeOrdering, Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitMethodBuilder, EmitRegion, EmitTriplet, defaultValue, typeToTypeInfo}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitMethodBuilder, EmitRegion, EmitCode, defaultValue, typeToTypeInfo}
 import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical._
 import is.hail.io._
@@ -225,12 +225,12 @@ class GroupedAggregator(kt: PType, nestedAggs: Array[StagedAggregator]) extends 
 
   def createState(fb: EmitFunctionBuilder[_]): State = new DictState(fb, kt, StateTuple(nestedAggs.map(_.createState(fb))))
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(inits) = init
     state.init(inits.setup)
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(key, seqs) = seq
     Code(key.setup, state.withContainer(key.m, key.v, seqs.setup))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.agg
 import breeze.linalg.{DenseMatrix, DenseVector, diag, inv}
 import is.hail.annotations.{Region, RegionValueBuilder, StagedRegionValueBuilder, UnsafeRow}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical.{PArray, PFloat64, PInt32, PStruct, PTuple}
 import is.hail.utils.FastIndexedSeq
 
@@ -37,7 +37,7 @@ object LinearRegressionAggregator extends StagedAggregator {
       k0)
   )
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val _initOpF = state.fb.newMethod[Int, Int, Unit]("linregInitOp")(initOpF(state))
     val Array(kt, k0t) = init
     (Code(kt.setup, kt.m) || Code(k0t.setup, k0t.m)).mux(
@@ -88,7 +88,7 @@ object LinearRegressionAggregator extends StagedAggregator {
     nrVec.anyMissing(mb, x).mux(Code._empty, body)
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val _seqOpF = state.fb.newMethod[Double, Long, Unit]("linregSeqOp")(seqOpF(state))
     val Array(y, x) = seq
     (Code(y.setup, y.m) || Code(x.setup, x.m)).mux(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -23,7 +23,7 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
   def createState(fb: EmitFunctionBuilder[_]): State =
     new PrimitiveRVAState(Array(typ.setRequired(monoid.neutral.isDefined)), fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     val (mOpt, v, _) = state.fields(0)
     (mOpt, monoid.neutral) match {
@@ -32,7 +32,7 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     }
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     val Array(elt) = seq
     val (mOpt, v, _) = state.fields(0)
     val eltm = state.fb.newField[Boolean]

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet, typeToTypeInfo}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode, typeToTypeInfo}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 
@@ -13,13 +13,13 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
   def createState(fb: EmitFunctionBuilder[_]): State =
     new TypedRegionBackedAggState(typ.setRequired(false), fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     state.storeMissing()
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
-    val Array(elt: EmitTriplet) = seq
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+    val Array(elt: EmitCode) = seq
     val v = state.fb.newField(typeToTypeInfo(typ))
     Code(
       elt.setup,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical.PType
 
 abstract class StagedAggregator {
@@ -12,16 +12,16 @@ abstract class StagedAggregator {
 
   def createState(fb: EmitFunctionBuilder[_]): State
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit]
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit]
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit]
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit]
 
   def combOp(state: State, other: State, dummy: Boolean): Code[Unit]
 
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit]
 
-  def initOp(state: AggregatorState, init: Array[EmitTriplet]): Code[Unit] = initOp(state.asInstanceOf[State], init, dummy = true)
-  def seqOp(state: AggregatorState, seq: Array[EmitTriplet]): Code[Unit] = seqOp(state.asInstanceOf[State], seq, dummy = true)
+  def initOp(state: AggregatorState, init: Array[EmitCode]): Code[Unit] = initOp(state.asInstanceOf[State], init, dummy = true)
+  def seqOp(state: AggregatorState, seq: Array[EmitCode]): Code[Unit] = seqOp(state.asInstanceOf[State], seq, dummy = true)
   def combOp(state: AggregatorState, other: AggregatorState): Code[Unit] = combOp(state.asInstanceOf[State], other.asInstanceOf[State], dummy = true)
   def result(state: AggregatorState, srvb: StagedRegionValueBuilder): Code[Unit] = result(state.asInstanceOf[State], srvb, dummy = true)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -121,7 +121,7 @@ class StagedBlockLinkedList(val elemType: PType, val fb: EmitFunctionBuilder[_])
         tmpNode := next(tmpNode)))
   }
 
-  private def foreach(mb: MethodBuilder)(f: EmitTriplet => Code[Unit]): Code[Unit] = {
+  private def foreach(mb: MethodBuilder)(f: EmitCode => Code[Unit]): Code[Unit] = {
     val n = mb.newLocal[Long]
     foreachNode(mb, n) {
       val i = mb.newLocal[Int]
@@ -130,7 +130,7 @@ class StagedBlockLinkedList(val elemType: PType, val fb: EmitFunctionBuilder[_])
       Code(
         i := 0,
         Code.whileLoop(i < count(n),
-          f(EmitTriplet(Code._empty, bufim, PValue(elemType, bufiv))),
+          f(EmitCode(Code._empty, bufim, PCode(elemType, bufiv))),
           i := i + 1))
     }
   }
@@ -146,7 +146,7 @@ class StagedBlockLinkedList(val elemType: PType, val fb: EmitFunctionBuilder[_])
       totalCount := totalCount + 1)
   }
 
-  def push(region: Code[Region], elt: EmitTriplet): Code[Unit] = {
+  def push(region: Code[Region], elt: EmitCode): Code[Unit] = {
     val eltTI = typeToTypeInfo(elemType)
     val pushF = fb.newMethod("blockLinkedListPush",
       Array[TypeInfo[_]](typeInfo[Region], typeInfo[Boolean], eltTI),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode}
 import is.hail.expr.types.physical._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.utils._
@@ -59,7 +59,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionB
     )
   }
 
-  def seqOp(elt: EmitTriplet): Code[Unit] = {
+  def seqOp(elt: EmitCode): Code[Unit] = {
     Code(
       elt.setup,
       (builder.size < maxSize)
@@ -118,7 +118,7 @@ class TakeAggregator(typ: PType) extends StagedAggregator {
   def createState(fb: EmitFunctionBuilder[_]): State =
     new TakeRVAS(typ, resultType, fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     Code(
@@ -128,8 +128,8 @@ class TakeAggregator(typ: PType) extends StagedAggregator {
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
-    val Array(elt: EmitTriplet) = seq
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+    val Array(elt: EmitCode) = seq
     state.seqOp(elt)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet, defaultValue, typeToTypeInfo}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitCode, defaultValue, typeToTypeInfo}
 import is.hail.expr.types.physical._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.utils._
@@ -579,7 +579,7 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
   def createState(fb: EmitFunctionBuilder[_]): State =
     new TakeByRVAS(valueType, keyType, resultType, fb)
 
-  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     Code(
@@ -589,8 +589,8 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
-    val Array(value: EmitTriplet, key: EmitTriplet) = seq
+  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+    val Array(value: EmitCode, key: EmitCode) = seq
     assert(value.pv.pt == valueType)
     assert(key.pv.pt == keyType)
     Code(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -307,7 +307,7 @@ object ArrayFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("corr", TArray(TFloat64), TArray(TFloat64), TFloat64, null) {
-      case (r, rt, (t1: PArray, EmitTriplet(setup1, m1, v1)), (t2: PArray, EmitTriplet(setup2, m2, v2))) =>
+      case (r, rt, (t1: PArray, EmitCode(setup1, m1, v1)), (t2: PArray, EmitCode(setup2, m2, v2))) =>
         val xSum = r.mb.newLocal[Double]
         val ySum = r.mb.newLocal[Double]
         val xSqSum = r.mb.newLocal[Double]
@@ -323,7 +323,7 @@ object ArrayFunctions extends RegistryFunctions {
         val a1 = v1.tcode[Long]
         val a2 = v2.tcode[Long]
 
-        EmitTriplet(
+        EmitCode(
           Code(
             setup1,
             setup2),
@@ -336,7 +336,7 @@ object ArrayFunctions extends RegistryFunctions {
                 .concat(", ")
                 .concat(l2.toS)),
               l1.ceq(0))),
-          PValue(PFloat64(), Code(
+          PCode(PFloat64(), Code(
             i := 0,
             n := 0,
             xSum := 0d,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -269,7 +269,7 @@ abstract class RegistryFunctions {
   }
 
   def registerCodeWithMissingness(mname: String, aTypes: Array[Type], rType: Type, pt: Seq[PType] => PType)
-    (impl: (EmitRegion, PType, Array[(PType, EmitTriplet)]) => EmitTriplet) {
+    (impl: (EmitRegion, PType, Array[(PType, EmitCode)]) => EmitCode) {
     IRFunctionRegistry.addIRFunction(new IRFunctionWithMissingness {
       override val name: String = mname
 
@@ -279,7 +279,7 @@ abstract class RegistryFunctions {
 
       override def returnPType(argTypes: Seq[PType], returnType: Type): PType = if (pt == null) PType.canonical(returnType) else pt(argTypes)
 
-      override def apply(r: EmitRegion, rpt: PType, args: (PType, EmitTriplet)*): EmitTriplet = {
+      override def apply(r: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode = {
         unify(args.map(_._1.virtualType))
         impl(r, rpt, args.toArray)
       }
@@ -379,23 +379,23 @@ abstract class RegistryFunctions {
       a5: (PType, Code[A5]) @unchecked)) => impl(r, rt, a1, a2, a3, a4, a5)
     }
 
-  def registerCodeWithMissingness(mname: String, rt: Type, pt: PType)(impl: EmitRegion => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, rt: Type, pt: PType)(impl: EmitRegion => EmitCode): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt, (_: Seq[PType]) => pt) { case (r, rt, Array()) => impl(r) }
 
   def registerCodeWithMissingness(mname: String, mt1: Type, rt: Type, pt: PType => PType)
-    (impl: (EmitRegion, PType, (PType, EmitTriplet)) => EmitTriplet): Unit =
+    (impl: (EmitRegion, PType, (PType, EmitCode)) => EmitCode): Unit =
     registerCodeWithMissingness(mname, Array(mt1), rt, unwrappedApply(pt)) { case (r, rt, Array(a1)) => impl(r, rt, a1) }
 
   def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, rt: Type, pt: (PType, PType) => PType)
-    (impl: (EmitRegion, PType, (PType, EmitTriplet), (PType, EmitTriplet)) => EmitTriplet): Unit =
+    (impl: (EmitRegion, PType, (PType, EmitCode), (PType, EmitCode)) => EmitCode): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2), rt, unwrappedApply(pt)) { case (r, rt, Array(a1, a2)) => impl(r, rt, a1, a2) }
 
   def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type, pt: (PType, PType, PType) => PType)
-    (impl: (EmitRegion, PType, (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet)) => EmitTriplet): Unit =
+    (impl: (EmitRegion, PType, (PType, EmitCode), (PType, EmitCode), (PType, EmitCode), (PType, EmitCode)) => EmitCode): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt)) { case (r, rt, Array(a1, a2, a3, a4)) => impl(r, rt, a1, a2, a3, a4) }
 
   def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, mt6: Type, rt: Type, pt: (PType, PType, PType) => PType)
-    (impl: (EmitRegion, PType, (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet), (PType, EmitTriplet)) => EmitTriplet): Unit =
+    (impl: (EmitRegion, PType, (PType, EmitCode), (PType, EmitCode), (PType, EmitCode), (PType, EmitCode), (PType, EmitCode), (PType, EmitCode)) => EmitCode): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2, mt3, mt4, mt5, mt6), rt, unwrappedApply(pt)) { case (r, rt, Array(a1, a2, a3, a4, a5, a6)) => impl(r, rt, a1, a2, a3, a4, a5, a6) }
 
   def registerIR(mname: String, retType: Type)(f: () => IR): Unit =
@@ -431,13 +431,13 @@ abstract class RegistryFunctions {
         impl(r, rpt, seed, args.toArray)
       }
 
-      def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: (PType, EmitTriplet)*): EmitTriplet = {
+      def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode = {
         val setup = args.map(_._2.setup)
         val rpt = returnPType(args.map(_._1), returnType)
         val missing: Code[Boolean] = if (args.isEmpty) false else args.map(_._2.m).reduce(_ || _)
         val value = applySeeded(seed, r, rpt, args.map { case (t, a) => (t, a.v) }: _*)
 
-        EmitTriplet(setup, missing, PValue(rpt, value))
+        EmitCode(setup, missing, PCode(rpt, value))
       }
 
       override val isStrict: Boolean = true
@@ -475,7 +475,7 @@ sealed abstract class IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: EmitRegion, returnType: PType, args: (PType, EmitTriplet)*): EmitTriplet
+  def apply(mb: EmitRegion, returnType: PType, args: (PType, EmitCode)*): EmitCode
 
   def getAsMethod(fb: EmitFunctionBuilder[_], rpt: PType, args: PType*): EmitMethodBuilder = ???
 
@@ -501,12 +501,12 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
 
   def apply(r: EmitRegion, returnPType: PType, args: (PType, Code[_])*): Code[_]
 
-  def apply(r: EmitRegion, returnPType: PType, args: (PType, EmitTriplet)*): EmitTriplet = {
+  def apply(r: EmitRegion, returnPType: PType, args: (PType, EmitCode)*): EmitCode = {
     val setup = args.map(_._2.setup)
     val missing = args.map(_._2.m).reduce(_ || _)
     val value = apply(r, returnPType, args.map { case (t, a) => (t, a.v) }: _*)
 
-    EmitTriplet(setup, missing, PValue(returnPType, value))
+    EmitCode(setup, missing, PCode(returnPType, value))
   }
 
   override def getAsMethod(fb: EmitFunctionBuilder[_], rpt: PType, args: PType*): EmitMethodBuilder = {
@@ -526,7 +526,7 @@ abstract class IRFunctionWithMissingness extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(r: EmitRegion, rpt: PType, args: (PType, EmitTriplet)*): EmitTriplet
+  def apply(r: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode
 
   def returnType: Type
 }
@@ -540,9 +540,9 @@ abstract class SeededIRFunction extends IRFunction {
 
   def setSeed(s: Long): Unit = { seed = s }
 
-  def applySeeded(seed: Long, region: EmitRegion, rpt: PType, args: (PType, EmitTriplet)*): EmitTriplet
+  def applySeeded(seed: Long, region: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode
 
-  def apply(region: EmitRegion, rpt: PType, args: (PType, EmitTriplet)*): EmitTriplet =
+  def apply(region: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode =
     applySeeded(seed, region, rpt, args: _*)
 
   def returnType: Type

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -40,20 +40,20 @@ object IntervalFunctions extends RegistryFunctions {
               vv := srvb.offset))),
           Code._empty)
 
-        EmitTriplet(
+        EmitCode(
           Code(start.setup, end.setup, includeStart.setup, includeEnd.setup, ctor),
           mv,
-          PValue(rt, vv))
+          PCode(rt, vv))
     }
 
     registerCodeWithMissingness("start", TInterval(tv("T")), tv("T"), (x: PType) => x.asInstanceOf[PInterval].pointType) {
       case (r, rt, (intervalT: PInterval, interval)) =>
         val region = r.region
         val iv = r.mb.newLocal[Long]
-        EmitTriplet(
+        EmitCode(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
           interval.m || !Code(iv := interval.value[Long], intervalT.startDefined(iv)),
-          PValue(rt, Region.loadIRIntermediate(intervalT.pointType)(intervalT.startOffset(iv)))
+          PCode(rt, Region.loadIRIntermediate(intervalT.pointType)(intervalT.startOffset(iv)))
         )
     }
 
@@ -61,10 +61,10 @@ object IntervalFunctions extends RegistryFunctions {
       case (r, rt, (intervalT: PInterval, interval)) =>
         val region = r.region
         val iv = r.mb.newLocal[Long]
-        EmitTriplet(
+        EmitCode(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
           interval.m || !Code(iv := interval.value[Long], intervalT.endDefined(iv)),
-          PValue(rt, Region.loadIRIntermediate(intervalT.pointType)(intervalT.endOffset(iv)))
+          PCode(rt, Region.loadIRIntermediate(intervalT.pointType)(intervalT.endOffset(iv)))
         )
     }
 
@@ -96,10 +96,10 @@ object IntervalFunctions extends RegistryFunctions {
             cmp := compare((mPoint, vPoint), interval.end),
             cmp < 0 || (cmp.ceq(0) && interval.includeEnd)))
 
-        EmitTriplet(
+        EmitCode(
           Code(intTriplet.setup, pointTriplet.setup),
           intTriplet.m,
-          PValue(rt, contains))
+          PCode(rt, contains))
     }
 
     registerCode("isEmpty", TInterval(tv("T")), TBoolean, null) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -328,38 +328,38 @@ object LocusFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("LocusInterval", TString, TBoolean, tinterval("T"), null) {
-      case (r: EmitRegion, rt: PInterval, (strT, ioff: EmitTriplet), (missingT, invalidMissing: EmitTriplet)) =>
+      case (r: EmitRegion, rt: PInterval, (strT, ioff: EmitCode), (missingT, invalidMissing: EmitCode)) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
         val sinterval = asm4s.coerce[String](wrapArg(r, strT)(ioff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval](name="intervalObject")
         val interval = Code.invokeScalaObject[String, ReferenceGenome, Boolean, Interval](
           locusClass, "parseInterval", sinterval, rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
 
-        EmitTriplet(
+        EmitCode(
           Code(ioff.setup, invalidMissing.setup),
           ioff.m || invalidMissing.m || Code(intervalLocal := interval, intervalLocal.load().isNull),
-          PValue(rt, emitInterval(r, interval, rt))
+          PCode(rt, emitInterval(r, interval, rt))
         )
     }
 
     registerCodeWithMissingness("LocusInterval", TString, TInt32, TInt32, TBoolean, TBoolean, TBoolean, tinterval("T"), null) {
       case (r: EmitRegion, rt: PInterval,
-      (locoffT, locoff: EmitTriplet),
-      (pos1T, pos1: EmitTriplet),
-      (pos2T, pos2: EmitTriplet),
-      (include1T, include1: EmitTriplet),
-      (include2T, include2: EmitTriplet),
-      (invalidMissingT, invalidMissing: EmitTriplet)) =>
+      (locoffT, locoff: EmitCode),
+      (pos1T, pos1: EmitCode),
+      (pos2T, pos2: EmitCode),
+      (include1T, include1: EmitCode),
+      (include2T, include2: EmitCode),
+      (invalidMissingT, invalidMissing: EmitCode)) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
         val sloc = asm4s.coerce[String](wrapArg(r, locoffT)(locoff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval]("intervalObject")
         val interval = Code.invokeScalaObject[String, Int, Int, Boolean, Boolean, ReferenceGenome, Boolean, Interval](
           locusClass, "makeInterval", sloc, pos1.value[Int], pos2.value[Int], include1.value[Boolean], include2.value[Boolean], rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
 
-        EmitTriplet(
+        EmitCode(
           Code(locoff.setup, pos1.setup, pos2.setup, include1.setup, include2.setup, invalidMissing.setup),
           locoff.m || pos1.m || pos2.m || include1.m || include2.m || invalidMissing.m || Code(intervalLocal := interval, intervalLocal.load().isNull),
-          PValue(rt, emitInterval(r, interval, rt))
+          PCode(rt, emitInterval(r, interval, rt))
         )
     }
 
@@ -383,10 +383,10 @@ object LocusFunctions extends RegistryFunctions {
         val tlocal = r.mb.newLocal[(Locus, Boolean)]
         val lifted = rgCode(r.mb, srcRG).invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus", destRG.name, locus, minMatch.value[Double])
 
-        EmitTriplet(
+        EmitCode(
           Code(loc.setup, minMatch.setup, tlocal := Code._null),
           loc.m || minMatch.m || Code(tlocal := lifted, tlocal.isNull),
-          PValue(rt, emitLiftoverLocus(r, tlocal, rt))
+          PCode(rt, emitLiftoverLocus(r, tlocal, rt))
         )
     }
 
@@ -398,10 +398,10 @@ object LocusFunctions extends RegistryFunctions {
         val tlocal = r.mb.newLocal[(Interval, Boolean)]
         val lifted = rgCode(r.mb, srcRG).invoke[String, Interval, Double, (Interval, Boolean)]("liftoverLocusInterval", destRG.name, interval, minMatch.value[Double])
 
-        EmitTriplet(
+        EmitCode(
           Code(i.setup, minMatch.setup, tlocal := Code._null),
           i.m || minMatch.m || Code(tlocal := lifted, tlocal.isNull),
-          PValue(rt, emitLiftoverLocusInterval(r, tlocal, rt))
+          PCode(rt, emitLiftoverLocusInterval(r, tlocal, rt))
         )
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -142,14 +142,14 @@ object StringFunctions extends RegistryFunctions {
     registerCodeWithMissingness("showStr", tv("T"), TInt32, TString, null) { case (r, rt, (aT, a), (_, trunc)) =>
       val annotation = Code(a.setup, a.m).mux(Code._null, boxArg(r, aT)(a.v))
       val str = r.mb.getType(aT.virtualType).invoke[Any, Int, String]("showStr", annotation, trunc.value[Int])
-      EmitTriplet(trunc.setup, trunc.m, PValue(rt, unwrapReturn(r, rt)(str)))
+      EmitCode(trunc.setup, trunc.m, PCode(rt, unwrapReturn(r, rt)(str)))
     }
 
     registerCodeWithMissingness("json", tv("T"), TString, null) { case (r, rt, (aT, a)) =>
       val annotation = Code(a.setup, a.m).mux(Code._null, boxArg(r, aT)(a.v))
       val json = r.mb.getType(aT.virtualType).invoke[Any, JValue]("toJSON", annotation)
       val str = Code.invokeScalaObject[JValue, String](JsonMethods.getClass, "compact", json)
-      EmitTriplet(Code._empty, false, PValue(rt, unwrapReturn(r, rt)(str)))
+      EmitCode(Code._empty, false, PCode(rt, unwrapReturn(r, rt)(str)))
     }
 
     registerWrappedScalaFunction("reverse", TString, TString, null)(thisClass,"reverse")
@@ -176,7 +176,7 @@ object StringFunctions extends RegistryFunctions {
     registerWrappedScalaFunction("mkString", TArray(TString), TString, TString, null)(thisClass, "arrayMkString")
 
     registerCodeWithMissingness("firstMatchIn", TString, TString, TArray(TString), null) {
-      case (er: EmitRegion, rt: PArray, (sT: PString, s: EmitTriplet), (rT: PString, r: EmitTriplet)) =>
+      case (er: EmitRegion, rt: PArray, (sT: PString, s: EmitCode), (rT: PString, r: EmitCode)) =>
       val out: LocalRef[IndexedSeq[String]] = er.mb.newLocal[IndexedSeq[String]]
       val nout = new CodeNullable[IndexedSeq[String]](out)
 
@@ -206,11 +206,11 @@ object StringFunctions extends RegistryFunctions {
               srvb.advance()),
             srvb.end()))
 
-      EmitTriplet(setup, missing, PValue(rt, value))
+      EmitCode(setup, missing, PCode(rt, value))
     }
 
     registerCodeWithMissingness("hamming", TString, TString, TInt32, null) {
-      case (r: EmitRegion, rt, (e1T: PString, e1: EmitTriplet), (e2T: PString, e2: EmitTriplet)) =>
+      case (r: EmitRegion, rt, (e1T: PString, e1: EmitCode), (e2T: PString, e2: EmitCode)) =>
       val len = r.mb.newLocal[Int]
       val i = r.mb.newLocal[Int]
       val n = r.mb.newLocal[Int]
@@ -234,10 +234,10 @@ object StringFunctions extends RegistryFunctions {
             i += 1),
           n)
 
-        EmitTriplet(
+        EmitCode(
           Code(e1.setup, e2.setup),
           e1.m || e2.m || m,
-          PValue(rt, m.mux(defaultValue(TInt32), v)))
+          PCode(rt, m.mux(defaultValue(TInt32), v)))
     }
 
     registerWrappedScalaFunction("escapeString", TString, TString, null)(thisClass, "escapeString")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -154,13 +154,13 @@ object UtilFunctions extends RegistryFunctions {
           Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)
       }
       registerCodeWithMissingness(s"to${name}OrMissing", TString, t, null) {
-        case (r, rt, (xT: PString, x: EmitTriplet)) =>
+        case (r, rt, (xT: PString, x: EmitCode)) =>
           val s = r.mb.newLocal[String]
           val m = r.mb.newLocal[Boolean]
-          EmitTriplet(
+          EmitCode(
             Code(x.setup, m := x.m, s := m.mux(Code._null[String], asm4s.coerce[String](wrapArg(r, xT)(x.v)))),
             (m || !Code.invokeScalaObject[String, Boolean](thisClass, s"isValid$name", s)),
-            PValue(rt, Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)))
+            PCode(rt, Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)))
       }
     }
 
@@ -194,11 +194,11 @@ object UtilFunctions extends RegistryFunctions {
           Code.invokeScalaObject[Double, Double, Double](thisClass, ignoreNanName, v1, v2)
       }
 
-      def ignoreMissingTriplet[T](rt: PType, v1: EmitTriplet, v2: EmitTriplet, name: String)(implicit ct: ClassTag[T]): EmitTriplet =
-        EmitTriplet(
+      def ignoreMissingTriplet[T](rt: PType, v1: EmitCode, v2: EmitCode, name: String)(implicit ct: ClassTag[T]): EmitCode =
+        EmitCode(
           Code(v1.setup, v2.setup),
           v1.m && v2.m,
-          PValue(rt, Code.invokeScalaObject[T, Boolean, T, Boolean, T](thisClass, name, v1.v.asInstanceOf[Code[T]], v1.m, v2.v.asInstanceOf[Code[T]], v2.m))
+          PCode(rt, Code.invokeScalaObject[T, Boolean, T, Boolean, T](thisClass, name, v1.v.asInstanceOf[Code[T]], v1.m, v2.v.asInstanceOf[Code[T]], v2.m))
         )
 
       registerCodeWithMissingness(ignoreMissingName, TInt32, TInt32, TInt32, null) {
@@ -258,9 +258,9 @@ object UtilFunctions extends RegistryFunctions {
                 const(0)))),
             Code._empty))
 
-        EmitTriplet(setup,
+        EmitCode(setup,
           ((M >> w) & 1).cne(0),
-          PValue(rt, w.ceq(10)))
+          PCode(rt, w.ceq(10)))
     }
 
     registerCodeWithMissingness("||", TBoolean, TBoolean, TBoolean, null) {
@@ -288,9 +288,9 @@ object UtilFunctions extends RegistryFunctions {
                   const(0)))),
             Code._empty))
 
-        EmitTriplet(setup,
+        EmitCode(setup,
           ((M >> w) & 1).cne(0),
-          PValue(rt, w.cne(0)))
+          PCode(rt, w.cne(0)))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s.Code
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.asm4s.joinpoint._
-import is.hail.expr.ir.{EmitMethodBuilder, PCanonicalIndexableValue, PValue}
+import is.hail.expr.ir.{EmitMethodBuilder, PCanonicalIndexableCode, PCode}
 import is.hail.expr.types.virtual.{TArray, Type}
 import is.hail.utils._
 
@@ -510,6 +510,6 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   private def deepRenameArray(t: TArray): PArray =
     PCanonicalArray(this.elementType.deepRename(t.elementType), this.required)
 
-  override def load(src: Code[Long]): PValue =
-    new PCanonicalIndexableValue(this, Region.loadAddress(src))
+  override def load(src: Code[Long]): PCode =
+    new PCanonicalIndexableCode(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
-import is.hail.expr.ir.{PCanonicalBaseStructValue, PValue}
+import is.hail.expr.ir.{PCanonicalBaseStructCode, PCode}
 import is.hail.expr.types.BaseStruct
 import is.hail.utils._
 
@@ -220,6 +220,6 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     }
   }
 
-  override def load(src: Code[Long]): PValue =
-    new PCanonicalBaseStructValue(this, src)
+  override def load(src: Code[Long]): PCode =
+    new PCanonicalBaseStructCode(this, src)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.Region
 import is.hail.asm4s.Code
-import is.hail.expr.ir.{PCanonicalIndexableValue, PValue}
+import is.hail.expr.ir.{PCanonicalIndexableCode, PCode}
 import is.hail.expr.types.virtual.{TArray, TDict, Type}
 
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
@@ -30,6 +30,6 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
   private def deepRenameDict(t: TDict) =
     PCanonicalDict(this.keyType.deepRename(t.keyType), this.valueType.deepRename(t.valueType), this.required)
 
-  override def load(src: Code[Long]): PValue =
-    new PCanonicalIndexableValue(this, Region.loadAddress(src))
+  override def load(src: Code[Long]): PCode =
+    new PCanonicalIndexableCode(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.Region
 import is.hail.asm4s.Code
-import is.hail.expr.ir.{PCanonicalIndexableValue, PValue}
+import is.hail.expr.ir.{PCanonicalIndexableCode, PCode}
 import is.hail.expr.types.virtual.{TSet, Type}
 
 final case class PCanonicalSet(elementType: PType,  required: Boolean = false) extends PSet with PArrayBackedContainer {
@@ -23,6 +23,6 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
   private def deepRenameSet(t: TSet) =
     PCanonicalSet(this.elementType.deepRename(t.elementType),  this.required)
 
-  override def load(src: Code[Long]): PValue =
-    new PCanonicalIndexableValue(this, Region.loadAddress(src))
+  override def load(src: Code[Long]): PCode =
+    new PCanonicalIndexableCode(this, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -291,14 +291,14 @@ abstract class PType extends Serializable with Requiredness {
 
   def deepRename(t: Type) = this
 
-  def defaultValue: PValue = PValue(this, ir.defaultValue(this))
+  def defaultValue: PCode = PCode(this, ir.defaultValue(this))
 
-  def copyFromPValue(mb: MethodBuilder, region: Code[Region], pv: PValue): PValue =
-    PValue(this, copyFromTypeAndStackValue(mb, region, pv.pt, pv.code))
+  def copyFromPValue(mb: MethodBuilder, region: Code[Region], pv: PCode): PCode =
+    PCode(this, copyFromTypeAndStackValue(mb, region, pv.pt, pv.code))
 
   final def typeCheck(a: Any): Boolean = a == null || _typeCheck(a)
 
   def _typeCheck(a: Any): Boolean = virtualType._typeCheck(a)
 
-  def load(src: Code[Long]): PValue = PValue(this, Region.loadIRIntermediate(this)(src))
+  def load(src: Code[Long]): PCode = PCode(this, Region.loadIRIntermediate(this)(src))
 }

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.agg
 import scala.collection.generic.Growable
 import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue, StagedRegionValueBuilder}
 import is.hail.asm4s.Code
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitTriplet, PValue}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitRegion, EmitCode, PCode}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 import org.scalatest.testng.TestNGSuite
@@ -40,9 +40,9 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val eltOff = fb.getArg[Long](3).load
       fb.emit(Code(
         sbll.load(ptr),
-        sbll.push(r, EmitTriplet(Code._empty,
+        sbll.push(r, EmitCode(Code._empty,
           eltOff.ceq(0),
-          PValue(elemPType, Region.getIRIntermediate(elemPType)(eltOff)))),
+          PCode(elemPType, Region.getIRIntermediate(elemPType)(eltOff)))),
         sbll.store(ptr)))
 
       val f = fb.result()()


### PR DESCRIPTION
The picture is from asm4s:
 - Value[T] is convertible to Code[T] and can be used multiple times: it is a primitive value (constant, variable ref, etc.)
 - Code[T] can be used once
 - Settable[T] extends Value[T] and has a store operation.

Changes:
 - rename PValue => PCode
 - add PValue which is multi-use, PSettable extends PValue
 - rename EmitTriplet => EmitCode
 - add EmitValue and EmitSettable
 - Removed type parameter from PValue and introduced downcast operators.  I'm not really happy with either option.  Will revisit this again in the future.

Changes that are coming:
 - add EmitMethodBuilder.newEmit{Local, Field} that return EmitSettables
 - Emit.E will become Env[EmitSettable]

The goal here is to rip out jointpoint and ParameterPack.  EmitSettables will replace the funtionality of ParameterPack for TypedTriplets (which will go away in favor of EmitTriplet/EmitCode).  Removing joinpoint will cause problems when Code[T] are reused, so the Value types must be pushed throughout the codebase.  I will put out what infrastructure I can as separate PRs, but I'm having a hard time finding way to do this incrementally.