### PR TITLE
query] Fix and reenable flaky ordering tests

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -256,14 +256,21 @@ object ExtendedOrdering {
           val l = fieldOrd.length
 
           val c = outer.compare(xpp, ypp)
-          if (c != 0 || xpp == null || ypp == null || (l < xpp.length && l < ypp.length))
+          if (c != 0)
             c
-          else {
-            val cl = xpp.length compare ypp.length
-            if (cl == 0) xs compare ys
-            else if (cl < 0) xs
-            else -ys
-          }
+          else if (xpp != null && ypp != null) {
+            val ll = xpp.length
+            val rr = ypp.length
+            if (l < ll && l < rr)
+              0
+            else {
+              val cl = Integer.compare(xpp.length, ypp.length)
+              if (cl == 0) Integer.compare(xs, ys)
+              else if (cl < 0) xs
+              else -ys
+            }
+          } else
+            Integer.compare(xs, ys)
         }
 
         // Returns true if for any rows r1 and r2 with r1 < x and r2 > y,
@@ -407,7 +414,7 @@ abstract class ExtendedOrdering extends Serializable {
         if (c != 0)
           c
         else
-          xs compare ys
+          Integer.compare(xs, ys)
       }
 
       override def lteqWithOverlap(allowedOverlap: Int)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean = {

--- a/hail/src/main/scala/is/hail/utils/Interval.scala
+++ b/hail/src/main/scala/is/hail/utils/Interval.scala
@@ -52,6 +52,8 @@ case class IntervalEndpoint(point: Any, sign: Int) extends Serializable {
   * 't2' such that 't.isPrefixOf(t2)' without changing the behavior.
   */
 class Interval(val left: IntervalEndpoint, val right: IntervalEndpoint) extends Serializable {
+  require(left != null)
+  require(right != null)
   def start: Any = left.point
 
   def end: Any = right.point
@@ -218,11 +220,11 @@ object Interval {
       val yi = y.asInstanceOf[Interval]
 
       if (startPrimary) {
-        val c = pord.intervalEndpointOrdering.compare(xi.left, yi.left)
-        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.right, yi.right)
+        val c = pord.intervalEndpointOrdering.compareNonnull(xi.left, yi.left)
+        if (c != 0) c else pord.intervalEndpointOrdering.compareNonnull(xi.right, yi.right)
       } else {
-        val c = pord.intervalEndpointOrdering.compare(xi.right, yi.right)
-        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.left, yi.left)
+        val c = pord.intervalEndpointOrdering.compareNonnull(xi.right, yi.right)
+        if (c != 0) c else pord.intervalEndpointOrdering.compareNonnull(xi.left, yi.left)
       }
     }
   }


### PR DESCRIPTION
Interval struct comparisons were inconsistent/wrong.