### PR TITLE
[query] Fix `hl.agg.downsample` inside array_agg or group_by

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1026,6 +1026,19 @@ class Tests(unittest.TestCase):
         r = ht.aggregate(hl.agg.downsample(ht.idx, ht.y, n_divisions=10))
         self.assertTrue(len(r) == 0)
 
+    def test_downsample_in_array_agg(self):
+        mt = hl.utils.range_matrix_table(50, 50)
+        mt = mt.annotate_rows(y = hl.rand_unif(0, 1))
+        mt = mt.annotate_cols(
+            binned=hl.agg.downsample(
+                mt.row_idx,
+                mt.y,
+                label=hl.str(mt.y),
+                n_divisions=4
+            )
+        )
+        mt.cols()._force_count()
+
     def test_aggregator_info_score(self):
         gen_file = resource('infoScoreTest.gen')
         sample_file = resource('infoScoreTest.sample')

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -172,7 +172,7 @@ class DownsampleState(val fb: EmitFunctionBuilder[_], labelType: PArray, maxBuff
       bottom := Region.loadDouble(storageType.loadField(src, "top")),
       top := Region.loadDouble(storageType.loadField(src, "bottom")),
       treeSize := Region.loadInt(storageType.loadField(src, "treeSize")),
-      tree.deepCopy(src),
+      tree.deepCopy(Region.loadAddress(storageType.loadField(src, "tree"))),
       buffer.copyFrom(storageType.loadField(src, "buffer")))))
     mb.invoke(_src)
   }
@@ -509,7 +509,7 @@ class DownsampleState(val fb: EmitFunctionBuilder[_], labelType: PArray, maxBuff
                   srvb.addDouble(Region.loadDouble(pointType.loadField(point, "y"))),
                   srvb.advance(),
                   pointType.isFieldDefined(point, "label").mux(
-                    srvb.addIRIntermediate(labelType)(pointType.loadField(point, "label")),
+                    srvb.addWithDeepCopy(labelType, pointType.loadField(point, "label")),
                     srvb.setMissing()
                   )
                 )


### PR DESCRIPTION
`copyFrom` method was simply wrong. Also needed to fix memory management
in `result` function.

Fixes #8240