### PR TITLE
[query] Fix `hl.export_bgen` memory leak

### DIFF
--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -327,7 +327,7 @@ object ExportBGEN {
 
     val d = digitsNeeded(mv.rvd.getNumPartitions)
 
-    val (files, droppedPerPart) = mv.rvd.crdd.mapPartitionsWithIndex { case (i: Int, it: Iterator[RegionValue]) =>
+    val (files, droppedPerPart) = mv.rvd.crdd.boundary.mapPartitionsWithIndex { case (i: Int, it: Iterator[RegionValue]) =>
       val context = TaskContext.get
       val pf =
         parallelOutputPath + "/" +


### PR DESCRIPTION
`boundary` is safe because after `it.next()` is called, the previous
value is no longer needed.

Fixes #8163