### PR TITLE
[query] Fix `hl.agg.approx_cdf` inside group_cols_by

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -406,6 +406,12 @@ class Tests(unittest.TestCase):
         table.aggregate(_error_from_cdf(hl.agg.approx_cdf(table.i), .001))
         table.aggregate(_error_from_cdf(hl.agg.approx_cdf(table.i), .001, all_quantiles=True))
 
+    def test_approx_cdf_array_agg(self):
+        mt = hl.utils.range_matrix_table(5, 5)
+        mt = mt.annotate_entries(x = mt.col_idx)
+        mt = mt.group_cols_by(mt.col_idx).aggregate(cdf = hl.agg.approx_cdf(mt.x))
+        mt._force_count_rows()
+
     def test_counter_ordering(self):
         ht = hl.utils.range_table(10)
         assert ht.aggregate(hl.agg.counter(10 - ht.idx).get(10, -1)) == 1

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -26,14 +26,11 @@ class ApproxCDFState(val fb: EmitFunctionBuilder[_]) extends AggregatorState {
   private val kOffset: Code[Long] => Code[Long] = storageType.loadField(_, "k")
 
   def init(k: Code[Int]): Code[Unit] = {
-    this.initialized.mux(
-      Code._fatal[Unit]("approx_cdf already initialized"),
-      Code(
-        this.k := k,
-        aggr := Code.newInstance[ApproxCDFStateManager, Int](this.k),
-        id := region.storeJavaObject(aggr),
-        this.initialized := true
-      )
+    Code(
+      this.k := k,
+      aggr := Code.newInstance[ApproxCDFStateManager, Int](this.k),
+      id := region.storeJavaObject(aggr),
+      this.initialized := true
     )
   }
 


### PR DESCRIPTION
Caveat: The ApproxCDFStateManager object is not freed, but is leaked
to the region. This behavior is similar to other aggregators.

Fixes #7824