### PR TITLE
[batch] upload logs after timeout occurs in worker

### DIFF
--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -357,7 +357,7 @@ class Container:
 
                     async with self.step('running'):
                         try:
-                            async with async_timeout.timeout(self.timeout) as tm:
+                            async with async_timeout.timeout(self.timeout):
                                 await docker_call_retry(MAX_DOCKER_WAIT_SECS, f'{self}')(self.container.wait)
                         except asyncio.TimeoutError:
                             timed_out = True

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -310,6 +310,8 @@ class Container:
 
     async def run(self, worker, cpu_sem):
         try:
+            timed_out = False
+
             async with self.step('pulling'):
                 if self.image.startswith('gcr.io/'):
                     key = base64.b64decode(
@@ -354,10 +356,11 @@ class Container:
                             start_container, self.container)
 
                     async with self.step('running'):
-                        async with async_timeout.timeout(self.timeout) as tm:
-                            await docker_call_retry(MAX_DOCKER_WAIT_SECS, f'{self}')(self.container.wait)
-                        if tm.expired:
-                            raise JobTimeoutError(f'timed out after {self.timeout}s')
+                        try:
+                            async with async_timeout.timeout(self.timeout) as tm:
+                                await docker_call_retry(MAX_DOCKER_WAIT_SECS, f'{self}')(self.container.wait)
+                        except asyncio.TimeoutError:
+                            timed_out = True
 
             self.container_status = await self.get_container_status()
             log.info(f'{self}: container status {self.container_status}')
@@ -370,6 +373,9 @@ class Container:
 
             async with self.step('deleting'):
                 await self.delete_container()
+
+            if timed_out:
+                raise JobTimeoutError(f'timed out after {self.timeout}s')
 
             if 'error' in self.container_status:
                 self.state = 'error'
@@ -392,13 +398,9 @@ class Container:
         return self.log
 
     async def get_log(self):
-        if self.log is not None:
-            return self.log
-
         if self.container:
             return await self.get_container_log()
-
-        return None
+        return self.log
 
     async def delete_container(self):
         if self.container:

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -310,8 +310,6 @@ class Container:
 
     async def run(self, worker, cpu_sem):
         try:
-            timed_out = False
-
             async with self.step('pulling'):
                 if self.image.startswith('gcr.io/'):
                     key = base64.b64decode(
@@ -355,6 +353,7 @@ class Container:
                         await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
                             start_container, self.container)
 
+                    timed_out = False
                     async with self.step('running'):
                         try:
                             async with async_timeout.timeout(self.timeout):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -465,6 +465,8 @@ echo $HAIL_BATCH_WORKER_IP
         b = builder.submit()
         status = j.wait()
         self.assertEqual(status['state'], 'Error', (status, j.log()))
+        error_msg = j._get_error(status, 'main')
+        assert error_msg and 'JobTimeoutError' in error_msg
 
     def test_client_max_size(self):
         builder = self.client.create_batch()


### PR DESCRIPTION
Also fixed getting the logs for a job.

- I didn't realize the context manager for asyncio_timeout was throwing an asyncio.TimeoutError. Now, I handle the TimeoutError exception and then throw our own exception after we've uploaded the logs and cleaned up the container. This way it still shows up as an error.

- I noticed the logs were being cached when a user gets the logs while the job is running and we don't update the cache until the job is complete. Therefore, I think from the code, if the user asks for the logs part-way through the job running, they wouldn't see any updates until the job is completed. I'm not sure why no-one has complained about this yet, so might be good to double check that this is indeed a bug.
