### PR TITLE
[query] Use RDD.coalesce and custom coalescer for non-shuffle repartitioning

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1210,6 +1210,12 @@ class Tests(unittest.TestCase):
         hl.import_vcf(resource('sample.vcf')).rows().key_by('locus').write(path)
         hl.read_table(path).select()._force_count()
 
+    def test_repartition_empty_key(self):
+        data = [{'x': i} for i in range(1000)]
+        ht = hl.Table.parallelize(data, hl.tstruct(x=hl.tint32), key=None, n_partitions=11)
+        assert ht.naive_coalesce(4)._same(ht)
+        assert ht.repartition(3, shuffle=False)._same(ht)
+
 def test_large_number_of_fields(tmpdir):
     ht = hl.utils.range_table(100)
     ht = ht.annotate(**{


### PR DESCRIPTION
Both coalesce and naiveCoalese couldn't handle empty keys because the
partition bounds we generate for unkeyed partitions fail isValid with
allowedOverlap of -1. Even if that was ok (make it so that empty keyed
partition bound sets are automatically valid), we end up duplicating all
the data per partion since RepartitionedOrderedRDD2 uses range bound
queries to determine what data goes into each partition. In the empty
case that duplicates the data once for every partition.

The solution here is to take both coalesce and naiveCoalese away from
using repartition in the shuffle=false case and to using RDD.coalesce.
We need to be sure to use a custom PartitionCoalescer in order to create
identical selection to the previous naiveCoalese that is partitioned
with a key.

fixes #8138
