### PR TITLE
[query] Move spark region finalization from ContextRDD to RegionPool

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -78,7 +78,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     r
   }
 
-  private def isFreed: Boolean = blockSize == -1
+  protected[annotations] def isFreed: Boolean = blockSize == -1
 
   private def freeChunks(): Unit = {
     pool.freeChunks(bigChunks, totalChunkMemory)

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -129,6 +129,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
       currentBlock = 0
       totalChunkMemory = 0
       blockSize = -1
+      referenceCount = 0
     }
   }
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -1,10 +1,17 @@
 package is.hail.annotations
 
 import is.hail.utils._
+import org.apache.spark.TaskContext
 
 object RegionPool {
   private lazy val thePool: ThreadLocal[RegionPool] = new ThreadLocal[RegionPool]() {
-    override def initialValue(): RegionPool = RegionPool()
+    override def initialValue(): RegionPool = {
+      val pool = RegionPool()
+      TaskContext.get().addTaskCompletionListener { (_: TaskContext) =>
+        pool.close()
+      }
+      pool
+    }
   }
 
   def get: RegionPool = thePool.get()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -132,8 +132,10 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
     report("CLEAR")
     var i = 0
     while (i < regions.size) {
-      regions(i).freeMemory()
-      reclaim(regions(i))
+      if (!regions(i).isFreed) {
+        regions(i).freeMemory()
+        reclaim(regions(i))
+      }
       i += 1
     }
   }

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -148,17 +148,9 @@ class ContextRDD[T: ClassTag](
 ) extends Serializable {
   type ElementType = ContextRDD.ElementType[T]
 
-  private[this] def sparkManagedContext(): RVDContext = {
-    val c = RVDContext.default
-    TaskContext.get().addTaskCompletionListener { (_: TaskContext) =>
-      c.close()
-    }
-    c
-  }
-
   def run[U >: T : ClassTag]: RDD[U] =
     rdd.mapPartitions { part =>
-      val c = sparkManagedContext()
+      val c = RVDContext.default
       part.flatMap(_(c))
     }
 
@@ -326,7 +318,7 @@ class ContextRDD[T: ClassTag](
     sparkContext.runJob(
       rdd,
       { (it: Iterator[ElementType]) =>
-        val c = sparkManagedContext()
+        val c = RVDContext.default
         f(it.flatMap(_(c)))
       },
       partitions)


### PR DESCRIPTION
ContextRDD registered a TaskCompletionListener with Spark to close its context no matter why the task ends. But if the region in the context points to RegionMemory that is shared (has refcount > 1), this won't actually free the memory. Plus, this doesn't free any regions not created by an RVDContext.

This PR removes the TaskCompletionListener from ContextRDD, and instead adds a single one to each thread-local RegionPool. This clearly ensures all off-heap memory is freed at the end of the task.