### PR TITLE
[query] add partitionRegion to RVDContext

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -658,7 +658,7 @@ object Interpret {
               }
             },
             { (i: Int, ctx: RVDContext, it: Iterator[RegionValue]) =>
-              val partRegion = ctx.freshRegion
+              val partRegion = ctx.partitionRegion
               val globalsOffset = globalsBc.value.readRegionValue(partRegion)
               val init = initOp(i, partRegion)
               val seqOps = partitionOpSeq(i, partRegion)

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -55,7 +55,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     val localGlobals = globals.broadcast
     copy(rvd = rvd.filterWithContext[(P, RegionValue)](
       { (partitionIdx, ctx) =>
-        val globalRegion = ctx.freshRegion
+        val globalRegion = ctx.partitionRegion
         (partitionOp(partitionIdx, globalRegion), RegionValue(globalRegion, localGlobals.value.readRegionValue(globalRegion)))
       }, { case ((p, glob), rv) => pred(p, rv, glob) }))
   }

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -162,17 +162,17 @@ private class BgenRDD(
       split match {
         case p: IndexBgenPartition =>
           assert(keys == null)
-          new IndexBgenRecordIterator(ctx, p, settings, f(p.partitionIndex, ctx.freshRegion)).flatten
+          new IndexBgenRecordIterator(ctx, p, settings, f(p.partitionIndex, ctx.partitionRegion)).flatten
         case p: LoadBgenPartition =>
           val index: IndexReader = indexBuilder(p.bcFS.value, p.indexPath, 8)
           context.addTaskCompletionListener { (context: TaskContext) =>
             index.close()
           }
           if (keys == null)
-            new BgenRecordIteratorWithoutFilter(ctx, p, settings, f(p.partitionIndex, ctx.freshRegion), index).flatten
+            new BgenRecordIteratorWithoutFilter(ctx, p, settings, f(p.partitionIndex, ctx.partitionRegion), index).flatten
           else {
             val keyIterator = keys.iterator(p.filterPartition, context)
-            new BgenRecordIteratorWithFilter(ctx, p, settings, f(p.partitionIndex, ctx.freshRegion), index, keyIterator).flatten
+            new BgenRecordIteratorWithFilter(ctx, p, settings, f(p.partitionIndex, ctx.partitionRegion), index, keyIterator).flatten
           }
       }
     }


### PR DESCRIPTION
~Stacked on #8283~

We were creating fresh regions to pass as the `partitionRegion` to compiled functions deep within `ContextRDD` pipelines. Doing it that way, there's no clear owner responsible for freeing those regions. We're currently relying on Spark to clean them up.

This PR adds a `partitionRegion` field to `RVDContext`. This way, the root consumer is responsible for creating the partition region before running the iterator, and for freeing it after.

This is a step towards clarifying the structure of region ownership.