### PR TITLE
[query] tidy up BlockMatrixIRSuite

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -98,4 +98,12 @@ package object ir {
     case TFloat32 => F32(0f)
     case TFloat64 => F64(0d)
   }
+
+  def mapIR(stream: IR)(f: IR => IR): IR = {
+    val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)
+    StreamMap(stream, ref.name, f(ref))
+  }
+
+  def rangeIR(n: IR): IR = StreamRange(0, n, 1)
+  def rangeIR(start: IR, stop: IR): IR = StreamRange(start, stop, 1)
 }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -27,7 +27,9 @@ object ExecStrategy extends Enumeration {
   val javaOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile)
   val interpretOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized)
   val nonLowering: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile)
+  val lowering: Set[ExecStrategy] = Set(LoweredJVMCompile)
   val backendOnly: Set[ExecStrategy] = Set(LoweredJVMCompile)
+  val allRelational: Set[ExecStrategy] = interpretOnly.union(lowering)
 }
 
 object TestUtils {
@@ -413,6 +415,81 @@ object TestUtils {
     assertCompiledThrows[HailException](x, regex)
   }
 
+  def assertNDEvals(nd: NDArrayIR, expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
+    assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, expected)
+  }
+
+  def assertNDEvals(nd: NDArrayIR, expected: (Any, IndexedSeq[Long]))
+    (implicit execStrats: Set[ExecStrategy]) {
+    assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, expected._2, expected._1)
+  }
+
+  def assertNDEvals(nd: NDArrayIR, args: IndexedSeq[(Any, Type)], expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
+    assertNDEvals(nd, Env.empty, args, None, expected)
+  }
+
+  def assertNDEvals(nd: NDArrayIR, agg: (IndexedSeq[Row], TStruct), expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
+    assertNDEvals(nd, Env.empty, FastIndexedSeq(), Some(agg), expected)
+  }
+
+  def assertNDEvals(nd: NDArrayIR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)],
+    agg: Option[(IndexedSeq[Row], TStruct)], expected: Any)
+    (implicit execStrats: Set[ExecStrategy]): Unit = {
+    var e: IndexedSeq[Any] = expected.asInstanceOf[IndexedSeq[Any]]
+    val dims = Array.fill(nd.typ.nDims) {
+      val n = e.length
+      if (n != 0 && e.head.isInstanceOf[IndexedSeq[_]])
+        e = e.head.asInstanceOf[IndexedSeq[Any]]
+      n.toLong
+    }
+    assertNDEvals(nd, Env.empty, FastIndexedSeq(), agg, dims, expected)
+  }
+
+  def assertNDEvals(nd: NDArrayIR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)],
+    agg: Option[(IndexedSeq[Row], TStruct)], dims: IndexedSeq[Long], expected: Any)
+    (implicit execStrats: Set[ExecStrategy]): Unit = {
+    val arrayIR = if (expected == null) nd else {
+      val refs = Array.fill(nd.typ.nDims) { Ref(genUID(), TInt32) }
+      Let("nd", nd,
+        dims.zip(refs).foldRight[IR](NDArrayRef(Ref("nd", nd.typ), refs.map(Cast(_, TInt64)))) {
+          case ((n, ref), accum) =>
+            ToArray(StreamMap(rangeIR(n.toInt), ref.name, accum))
+        })
+    }
+    assertEvalsTo(arrayIR, env, args, agg, expected)
+  }
+
+  def assertBMEvalsTo(bm: BlockMatrixIR, expected: DenseMatrix[Double])
+    (implicit execStrats: Set[ExecStrategy]): Unit = {
+    ExecuteContext.scoped { ctx =>
+      val filteredExecStrats: Set[ExecStrategy] =
+        if (HailContext.backend.isInstanceOf[SparkBackend]) execStrats
+        else {
+          info("skipping interpret and non-lowering compile steps on non-spark backend")
+          execStrats.intersect(ExecStrategy.backendOnly)
+        }
+      filteredExecStrats.filter(ExecStrategy.interpretOnly).foreach { strat =>
+        try {
+          val res = strat match {
+            case ExecStrategy.Interpret =>
+              Interpret(bm, ctx, optimize = true)
+            case ExecStrategy.InterpretUnoptimized =>
+              Interpret(bm, ctx, optimize = false)
+          }
+          assert(res.toBreezeMatrix() == expected)
+        } catch {
+          case e: Exception =>
+            error(s"error from strategy $strat")
+            if (execStrats.contains(strat)) throw e
+        }
+      }
+      val expectedArray = Array.tabulate(expected.rows)(i => Array.tabulate(expected.cols)(j => expected(i, j)).toFastIndexedSeq).toFastIndexedSeq
+      assertNDEvals(BlockMatrixCollect(bm), expectedArray)(filteredExecStrats.filterNot(ExecStrategy.interpretOnly))
+    }
+  }
 
   def importVCF(hc: HailContext, file: String, force: Boolean = false,
     forceBGZ: Boolean = false,

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -426,7 +426,7 @@ object TestUtils {
       assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, null, null)
     else
       assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, expected._2, expected._1)
-  }l
+  }
 
   def assertNDEvals(nd: NDArrayIR, args: IndexedSeq[(Any, Type)], expected: Any)
     (implicit execStrats: Set[ExecStrategy]) {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -422,8 +422,11 @@ object TestUtils {
 
   def assertNDEvals(nd: NDArrayIR, expected: (Any, IndexedSeq[Long]))
     (implicit execStrats: Set[ExecStrategy]) {
-    assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, expected._2, expected._1)
-  }
+    if (expected == null)
+      assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, null, null)
+    else
+      assertNDEvals(nd, Env.empty, FastIndexedSeq(), None, expected._2, expected._1)
+  }l
 
   def assertNDEvals(nd: NDArrayIR, args: IndexedSeq[(Any, Type)], expected: Any)
     (implicit execStrats: Set[ExecStrategy]) {

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -3,8 +3,7 @@ package is.hail.expr.ir
 import breeze.linalg.{DenseMatrix => BDM}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.{ExecStrategy, HailSuite}
-import is.hail.expr.types.virtual.{TArray, TFloat64, TNDArray}
-import is.hail.linalg.BlockMatrix
+import is.hail.expr.types.virtual.{TArray, TFloat64}
 import is.hail.utils._
 import is.hail.TestUtils._
 import org.testng.annotations.Test
@@ -13,173 +12,99 @@ class BlockMatrixIRSuite extends HailSuite {
 
   val N_ROWS = 3
   val N_COLS = 3
+  val BLOCK_SIZE = 10
   val shape: Array[Long] = Array[Long](N_ROWS, N_COLS)
 
-  val negFours: BlockMatrix = BlockMatrix.fill(hc, N_ROWS, N_COLS,-4)
-  val zeros: BlockMatrix    = BlockMatrix.fill(hc, N_ROWS, N_COLS, 0)
-  val ones: BlockMatrix     = BlockMatrix.fill(hc, N_ROWS, N_COLS, 1)
-  val twos: BlockMatrix     = BlockMatrix.fill(hc, N_ROWS, N_COLS, 2)
-  val threes: BlockMatrix   = BlockMatrix.fill(hc, N_ROWS, N_COLS, 3)
-  val fours: BlockMatrix    = BlockMatrix.fill(hc, N_ROWS, N_COLS, 4)
+  def fill(v: Double, nRows: Int = N_ROWS, nCols: Int = N_COLS, blockSize: Int = BLOCK_SIZE) =
+    ValueToBlockMatrix(MakeArray(Array.fill(nRows * nCols)(F64(v)).toFastIndexedSeq, TArray(TFloat64)),
+      FastIndexedSeq(nRows, nCols), blockSize)
 
-  def toBM(rows: Seq[Array[Double]]): BlockMatrix =
-    toBM(rows, BlockMatrix.defaultBlockSize)
+  val ones: BlockMatrixIR = fill(1)
 
-  def toBM(rows: Seq[Array[Double]], blockSize: Int): BlockMatrix = {
-    val n = rows.length
-    val m = if (n == 0) 0 else rows.head.length
-
-    BlockMatrix.fromBreezeMatrix(sc, new BDM[Double](m, n, rows.flatten.toArray).t, blockSize)
-  }
-
-  def makeMatFromCol(vec: Seq[Double]): BlockMatrix = {
-    toBM(vec.map(entry => Array(entry, entry, entry)))
-  }
-
-  def makeMatFromRow(vec: Seq[Double]): BlockMatrix = {
-    toBM(Seq(vec.toArray, vec.toArray, vec.toArray))
-  }
+  implicit val execStrats: Set[ExecStrategy] = ExecStrategy.interpretOnly
 
   def makeMap2(left: BlockMatrixIR, right: BlockMatrixIR,  op: BinaryOp, strategy: SparsityStrategy):
   BlockMatrixMap2 = {
     BlockMatrixMap2(left, right, "l", "r", ApplyBinaryPrimOp(op, Ref("l", TFloat64), Ref("r", TFloat64)), strategy)
   }
 
-  def assertBmEq(actual: BlockMatrix, expected: BlockMatrix) {
-    assert(actual.toBreezeMatrix() == expected.toBreezeMatrix())
-  }
-
-
   @Test def testBlockMatrixWriteRead() {
     val tempPath = tmpDir.createLocalTempFile()
-    Interpret[Unit](ctx, BlockMatrixWrite(new BlockMatrixLiteral(ones),
+    Interpret[Unit](ctx, BlockMatrixWrite(ones,
       BlockMatrixNativeWriter(tempPath, false, false, false)))
 
-    val actualMatrix = BlockMatrixRead(BlockMatrixNativeReader(tempPath)).execute(ctx)
-    assertBmEq(actualMatrix, ones)
+    assertBMEvalsTo(BlockMatrixRead(BlockMatrixNativeReader(tempPath)), BDM.fill[Double](N_ROWS, N_COLS)(1))
   }
 
-
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), false)
-    val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64)), false)
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), true)
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), false)
+    val sqrtIR = BlockMatrixMap(ones, "element", Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), false)
+    val negIR = BlockMatrixMap(ones, "element", ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64)), false)
+    val logIR = BlockMatrixMap(ones, "element", Apply("log", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), true)
+    val absIR = BlockMatrixMap(ones, "element", Apply("abs", FastIndexedSeq(Ref("element", TFloat64)), TFloat64), false)
 
-    assertBmEq(sqrtFoursIR.execute(ctx), twos)
-    assertBmEq(negFoursIR.execute(ctx), negFours)
-    assertBmEq(logOnesIR.execute(ctx), zeros)
-    assertBmEq(absNegFoursIR.execute(ctx), fours)
+    assertBMEvalsTo(sqrtIR, BDM.fill[Double](3, 3)(1))
+    assertBMEvalsTo(negIR, BDM.fill[Double](3, 3)(-1))
+    assertBMEvalsTo(logIR, BDM.fill[Double](3, 3)(0))
+    assertBMEvalsTo(absIR, BDM.fill[Double](3, 3)(1))
   }
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
-      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64)), Array[Long](1, 1), 4096),
-      FastIndexedSeq(), shape, 4096)
+      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64)), Array[Long](1, 1), ones.typ.blockSize),
+      FastIndexedSeq(), shape, ones.typ.blockSize)
 
-    val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add(), UnionBlocks)
-    val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract(), UnionBlocks)
-    val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply(), IntersectionBlocks)
-    val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide(), NeedsDense)
+    val onesAddTwo = makeMap2(ones, broadcastTwo, Add(), UnionBlocks)
+    val onesSubTwo = makeMap2(ones, broadcastTwo, Subtract(), UnionBlocks)
+    val onesMulTwo = makeMap2(ones, broadcastTwo, Multiply(), IntersectionBlocks)
+    val onesDivTwo = makeMap2(ones, broadcastTwo, FloatingPointDivide(), NeedsDense)
 
-    assertBmEq(onesAddTwo.execute(ctx), threes)
-    assertBmEq(threesSubTwo.execute(ctx), ones)
-    assertBmEq(twosMulTwo.execute(ctx), fours)
-    assertBmEq(foursDivTwo.execute(ctx), twos)
+    assertBMEvalsTo(onesAddTwo, BDM.fill[Double](3, 3)(1.0 + 2.0))
+    assertBMEvalsTo(onesSubTwo, BDM.fill[Double](3, 3)(1.0 - 2.0))
+    assertBMEvalsTo(onesMulTwo, BDM.fill[Double](3, 3)(1.0 * 2.0))
+    assertBMEvalsTo(onesDivTwo, BDM.fill[Double](3, 3)(1.0 / 2.0))
   }
 
   @Test def testBlockMatrixBroadcastValue_Vectors() {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](1, 3),
-      0), FastIndexedSeq(1), shape, ones.blockSize)
+      ones.typ.blockSize), FastIndexedSeq(1), shape, ones.typ.blockSize)
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3, 1),
-      0), FastIndexedSeq(0), shape, ones.blockSize)
+      ones.typ.blockSize), FastIndexedSeq(0), shape, ones.typ.blockSize)
 
-    // Addition
-    val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add(), UnionBlocks)
-    val actualOnesAddColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Add(), UnionBlocks)
-    val actualOnesAddRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Add(), UnionBlocks)
-    val actualOnesAddColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Add(), UnionBlocks)
+    val ops = Array(
+      (Add(), UnionBlocks, (i: Double, j: Double) => i + j),
+      (Subtract(), UnionBlocks, (i: Double, j: Double) => i - j),
+      (Multiply(), IntersectionBlocks, (i: Double, j: Double) => i * j),
+      (FloatingPointDivide(), NeedsDense, (i: Double, j: Double) => i / j))
+    for ((op, merge, f) <- ops) {
+      val rightRowOp = makeMap2(ones, broadcastRowVector, op, merge)
+      val rightColOp = makeMap2(ones, broadcastColVector, op, merge)
+      val leftRowOp = makeMap2(broadcastRowVector, ones, op, merge)
+      val leftColOp = makeMap2(broadcastColVector, ones, op, merge)
 
-    val expectedOnesAddRow = makeMatFromRow(Seq(2, 3, 4))
-    val expectedOnesAddCol = makeMatFromCol(Seq(2, 3, 4))
+      BDM.tabulate(3, 3){ (_, j) => f(1.0, j + 1) }
 
-    assertBmEq(actualOnesAddRowOnRight.execute(ctx), expectedOnesAddRow)
-    assertBmEq(actualOnesAddColOnRight.execute(ctx), expectedOnesAddCol)
-    assertBmEq(actualOnesAddRowOnLeft.execute(ctx),  expectedOnesAddRow)
-    assertBmEq(actualOnesAddColOnLeft.execute(ctx),  expectedOnesAddCol)
+      val expectedRightRowOp = BDM.tabulate(3, 3){ (_, j) => f(1.0, j + 1) }
+      val expectedRightColOp = BDM.tabulate(3, 3){ (i, _) => f(1.0, i + 1) }
+      val expectedLeftRowOp = BDM.tabulate(3, 3){ (_, j) => f(j + 1, 1.0) }
+      val expectedLeftColOp = BDM.tabulate(3, 3){ (i, _) => f(i + 1, 1.0) }
 
-
-    // Multiplication
-    val actualOnesMulRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Multiply(), IntersectionBlocks)
-    val actualOnesMulColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Multiply(), IntersectionBlocks)
-    val actualOnesMulRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Multiply(), IntersectionBlocks)
-    val actualOnesMulColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Multiply(), IntersectionBlocks)
-
-    val expectedOnesMulRow = makeMatFromRow(Seq(1, 2, 3))
-    val expectedOnesMulCol = makeMatFromCol(Seq(1, 2, 3))
-
-    assertBmEq(actualOnesMulRowOnRight.execute(ctx), expectedOnesMulRow)
-    assertBmEq(actualOnesMulColOnRight.execute(ctx), expectedOnesMulCol)
-    assertBmEq(actualOnesMulRowOnLeft.execute(ctx),  expectedOnesMulRow)
-    assertBmEq(actualOnesMulColOnLeft.execute(ctx),  expectedOnesMulCol)
-
-
-    // Subtraction
-    val actualOnesSubRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Subtract(), UnionBlocks)
-    val actualOnesSubColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, Subtract(), UnionBlocks)
-    val actualOnesSubRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), Subtract(), UnionBlocks)
-    val actualOnesSubColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), Subtract(), UnionBlocks)
-
-    val expectedOnesSubRowRight = makeMatFromRow(Seq(0, -1, -2))
-    val expectedOnesSubColRight = makeMatFromCol(Seq(0, -1, -2))
-    val expectedOnesSubRowLeft = makeMatFromRow(Seq(0, 1, 2))
-    val expectedOnesSubColLeft = makeMatFromCol(Seq(0, 1, 2))
-
-    assertBmEq(actualOnesSubRowOnRight.execute(ctx), expectedOnesSubRowRight)
-    assertBmEq(actualOnesSubColOnRight.execute(ctx), expectedOnesSubColRight)
-    assertBmEq(actualOnesSubRowOnLeft.execute(ctx),  expectedOnesSubRowLeft)
-    assertBmEq(actualOnesSubColOnLeft.execute(ctx),  expectedOnesSubColLeft)
-
-
-    // Division
-    val actualOnesDivRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, FloatingPointDivide(), NeedsDense)
-    val actualOnesDivColOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastColVector, FloatingPointDivide(), NeedsDense)
-    val actualOnesDivRowOnLeft  = makeMap2(broadcastRowVector, new BlockMatrixLiteral(ones), FloatingPointDivide(), NeedsDense)
-    val actualOnesDivColOnLeft  = makeMap2(broadcastColVector, new BlockMatrixLiteral(ones), FloatingPointDivide(), NeedsDense)
-
-    val expectedOnesDivRowRight = makeMatFromRow(Seq(1, 1.0 / 2.0, 1.0 / 3.0))
-    val expectedOnesDivColRight = makeMatFromCol(Seq(1, 1.0 / 2.0, 1.0 / 3.0))
-    val expectedOnesDivRowLeft = makeMatFromRow(Seq(1, 2, 3))
-    val expectedOnesDivColLeft = makeMatFromCol(Seq(1, 2, 3))
-
-    assertBmEq(actualOnesDivRowOnRight.execute(ctx), expectedOnesDivRowRight)
-    assertBmEq(actualOnesDivColOnRight.execute(ctx), expectedOnesDivColRight)
-    assertBmEq(actualOnesDivRowOnLeft.execute(ctx),  expectedOnesDivRowLeft)
-    assertBmEq(actualOnesDivColOnLeft.execute(ctx),  expectedOnesDivColLeft)
+      assertBMEvalsTo(rightRowOp, expectedRightRowOp)
+      assertBMEvalsTo(rightColOp, expectedRightColOp)
+      assertBMEvalsTo(leftRowOp, expectedLeftRowOp)
+      assertBMEvalsTo(leftColOp, expectedLeftColOp)
+    }
   }
 
   @Test def testBlockMatrixDot() {
-    val dotTwosAndThrees = BlockMatrixDot(new BlockMatrixLiteral(twos), new BlockMatrixLiteral(threes))
-    assertBmEq(dotTwosAndThrees.execute(ctx), BlockMatrix.fill(hc, 3, 3, 2 * 3 * 3))
-  }
-
-  def arrayFromNDArray(nRows: Int, nCols: Int, nd: IR): IR = {
-    val ref = Ref(genUID(), nd.typ)
-    Let(ref.name, nd,
-      MakeArray(Array.tabulate(nRows) { i =>
-        MakeArray(Array.tabulate(nCols) { j =>
-          NDArrayRef(ref, IndexedSeq(I64(i), I64(j)))
-        }, TArray(coerce[TNDArray](nd.typ).elementType))
-      }, TArray(TArray(coerce[TNDArray](nd.typ).elementType))))
+    assertBMEvalsTo(BlockMatrixDot(fill(2, nRows = N_ROWS, nCols = 5), fill(3, nRows = 5, nCols = N_COLS)),
+      BDM.fill[Double](N_ROWS, N_COLS)(2 * 3 * 5))
   }
 
   @Test def testLower() {
-    implicit val execStrats: Set[ExecStrategy] = Set(ExecStrategy.LoweredJVMCompile)
-
+    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.allRelational
     val blockSize = 3
-
     def value(nRows: Long, nCols: Long, data: Double*): (BlockMatrixIR, BDM[Double]) = {
       val ir = ValueToBlockMatrix(Literal(TArray(TFloat64), data),
         FastIndexedSeq(nRows, nCols), blockSize)
@@ -187,23 +112,8 @@ class BlockMatrixIRSuite extends HailSuite {
       ir -> bdm
     }
 
-    val (m1IR, m1) = value(5, 4,
-      1, 2, 3, 4,
-      9, 10, 11, 12,
-      17, 18, 19, 20,
-      1, 3, 5, 7,
-      2, 4, 6, 1)
-
-    val (m2IR, m2) = value(4, 6,
-      1,2,3,4,5,6,
-      7,8,9,10,11,12,
-      13,14,15,16,17,18,
-      19,20,21,22,23,24)
-
-    val expected = m1 * m2
-
-    assertEvalsTo(
-      arrayFromNDArray(5, 6, BlockMatrixCollect(BlockMatrixDot(m1IR, m2IR))),
-      Array.tabulate(5)(i => Array.tabulate(6)(j => expected(i, j)).toFastIndexedSeq).toFastIndexedSeq)
+    val (m1IR, m1) = value(5, 4, Array.tabulate(20)(i => i + 1.0): _*)
+    val (m2IR, m2) = value(4, 6, Array.tabulate(24)(i => 25.0 - i): _*)
+    assertBMEvalsTo(BlockMatrixDot(m1IR, m2IR), m1 * m2)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1953,8 +1953,7 @@ class IRSuite extends HailSuite {
     assertNDEvals(NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
     assertNDEvals(NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
 
-    // FIXME: This is changing type during PruneDeadFields for some reason...
-//    assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
+    assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
     assertNDEvals(NDArrayConcat(nds(na, na), 1), null)
     assertNDEvals(NDArrayConcat(NA(TArray(TNDArray(TInt32, Nat(2)))), 1), null)
   }
@@ -2141,7 +2140,7 @@ class IRSuite extends HailSuite {
     assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         NA(TArray(TInt64)), MakeArray(FastIndexedSeq(I64(0)), TArray(TInt64)))),
-      FastIndexedSeq(Array(1.0),
+      FastIndexedSeq(FastIndexedSeq(1.0),
         FastIndexedSeq(3.0)))
 
     assertNDEvals(

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1851,21 +1851,6 @@ class IRSuite extends HailSuite {
     MakeNDArray(MakeArray(data.map(F64), TArray(TFloat64)), MakeTuple.ordered(shape.map(I64)), rowMajor)
   }
 
-  def assertNDEvals(eltType: Type, nd: IR, expected: Array[Array[Any]])(implicit execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly): Unit = {
-    val arrayIR = if (expected == null) nd else {
-      val nRows = expected.length
-      val nCols = if (nRows == 0) 0 else expected.head.length
-      Let("nd", nd,
-        MakeArray(
-          Array.tabulate(nRows) { i =>
-            MakeArray(Array.tabulate(nCols) { j =>
-              makeNDArrayRef(Ref("nd", nd.typ), FastIndexedSeq(i, j))
-            }, TArray(eltType))
-          }, TArray(TArray(eltType))))
-    }
-    assertEvalsTo(arrayIR, if (expected == null) null else expected.map(_.toFastIndexedSeq).toFastIndexedSeq)
-  }
-
   def makeNDArrayRef(nd: IR, indxs: IndexedSeq[Long]): NDArrayRef = NDArrayRef(nd, indxs.map(I64))
 
   val scalarRowMajor = makeNDArray(FastSeq(3.0), FastSeq(), True())
@@ -1950,28 +1935,28 @@ class IRSuite extends HailSuite {
     val emptyColwise = (FastIndexedSeq(), 2L, 0L)
     val na = (null, 0L, 0L)
 
-    val rowwiseExpected: Array[Array[Any]] = Array(
-      Array(0, 1, 2),
-      Array(3, 4, 5),
-      Array(6, 7, 8),
-      Array(9, 10, 11),
-      Array(12, 13, 14))
-    val colwiseExpected: Array[Array[Any]] = Array(
-      Array(0, 1, 2, 15, 16),
-      Array(3, 4, 5, 17, 18))
+    val rowwiseExpected = FastIndexedSeq(
+      FastIndexedSeq(0, 1, 2),
+      FastIndexedSeq(3, 4, 5),
+      FastIndexedSeq(6, 7, 8),
+      FastIndexedSeq(9, 10, 11),
+      FastIndexedSeq(12, 13, 14))
+    val colwiseExpected = FastIndexedSeq(
+      FastIndexedSeq(0, 1, 2, 15, 16),
+      FastIndexedSeq(3, 4, 5, 17, 18))
 
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, rowwise), 0), rowwiseExpected)
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, rowwise, emptyRowwise), 0), rowwiseExpected)
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, emptyRowwise, rowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, rowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, rowwise, emptyRowwise), 0), rowwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, emptyRowwise, rowwise), 0), rowwiseExpected)
 
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, colwise), 1), colwiseExpected)
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
-    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, colwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, colwise, emptyColwise), 1), colwiseExpected)
+    assertNDEvals(NDArrayConcat(nds(nd1, emptyColwise, colwise), 1), colwiseExpected)
 
     // FIXME: This is changing type during PruneDeadFields for some reason...
-//    assertNDEvals(TInt32, NDArrayConcat(nds(nd1, na), 1), null)
-    assertNDEvals(TInt32, NDArrayConcat(nds(na, na), 1), null)
-    assertNDEvals(TInt32, NDArrayConcat(NA(TArray(TNDArray(TInt32, Nat(2)))), 1), null)
+//    assertNDEvals(NDArrayConcat(nds(nd1, na), 1), null)
+    assertNDEvals(NDArrayConcat(nds(na, na), 1), null)
+    assertNDEvals(NDArrayConcat(NA(TArray(TNDArray(TInt32, Nat(2)))), 1), null)
   }
 
   @Test def testNDArrayMap() {
@@ -2129,41 +2114,41 @@ class IRSuite extends HailSuite {
   @Test def testNDArrayFilter() {
     implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(NA(TArray(TInt64)), NA(TArray(TInt64)))),
-      Array(Array(1.0, 2.0),
-        Array(3.0, 4.0)))
+      FastIndexedSeq(FastIndexedSeq(1.0, 2.0),
+        FastIndexedSeq(3.0, 4.0)))
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         MakeArray(FastIndexedSeq(I64(0), I64(1)), TArray(TInt64)),
         MakeArray(FastIndexedSeq(I64(0), I64(1)), TArray(TInt64)))),
-      Array(Array(1.0, 2.0),
-        Array(3.0, 4.0)))
+      FastIndexedSeq(FastIndexedSeq(1.0, 2.0),
+        FastIndexedSeq(3.0, 4.0)))
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         MakeArray(FastIndexedSeq(I64(1), I64(0)), TArray(TInt64)),
         MakeArray(FastIndexedSeq(I64(1), I64(0)), TArray(TInt64)))),
-      Array(Array(4.0, 3.0),
-        Array(2.0, 1.0)))
+      FastIndexedSeq(FastIndexedSeq(4.0, 3.0),
+        FastIndexedSeq(2.0, 1.0)))
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         MakeArray(FastIndexedSeq(I64(0)), TArray(TInt64)), NA(TArray(TInt64)))),
-      Array(Array(1.0, 2.0)))
+      FastIndexedSeq(FastIndexedSeq(1.0, 2.0)))
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         NA(TArray(TInt64)), MakeArray(FastIndexedSeq(I64(0)), TArray(TInt64)))),
-      Array(Array(1.0),
-        Array(3.0)))
+      FastIndexedSeq(Array(1.0),
+        FastIndexedSeq(3.0)))
 
-    assertNDEvals(TFloat64,
+    assertNDEvals(
       NDArrayFilter(matrixRowMajor, FastIndexedSeq(
         MakeArray(FastIndexedSeq(I64(1)), TArray(TInt64)),
         MakeArray(FastIndexedSeq(I64(1)), TArray(TInt64)))),
-      Array(Array(4.0)))
+      FastIndexedSeq(FastIndexedSeq(4.0)))
   }
 
   @Test def testLeftJoinRightDistinct() {


### PR DESCRIPTION
The main point here was to implement an `assertBMEvalsTo` function that works a lot like `assertEvalsTo` for IR---currently only testing existing tests through interpret and BlockMatrix, but as we move lowering things over we can also add eval strategies for existing tests to test them through the lowerer as well.

I also removed a lot of the explicit BlockMatrix construction and conversions since we can handle them through the IR.

(also removed the lowering test in favor of adding the lowered execStrategy to the BlockMatrixDot test as it's essentially a duplicate of that)