### PR TITLE
[batch] fix duplicate key insert error

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -666,7 +666,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s);
                     # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
                     if err.args[0] == 1062:
                         log.info(f'bunch containing job {(batch_id, jobs_args[0][1])} already inserted ({err})')
-                        raise web.Response()
+                        return
                     raise
                 await tx.execute_many('''
 INSERT INTO `job_parents` (batch_id, job_id, parent_id)

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -18,7 +18,7 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import time_msecs, request_retry_transient_errors, \
+from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT, \
     sleep_and_backoff, retry_all_errors
 
 # import uvloop

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -18,7 +18,7 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT, \
+from hailtop.utils import time_msecs, request_retry_transient_errors, \
     sleep_and_backoff, retry_all_errors
 
 # import uvloop


### PR DESCRIPTION
@danking I remember you wanted raise web.Response() here for a reason, so I'll let you decide if this is correct or not.

```
{"levelname": "ERROR", "asctime": "2020-03-13 15:53:52,139", "filename": "web_protocol.py", "funcNameAndLine": "log_exception:355", "message": "Error handling request", "exc_info": "Traceback (most recent call last):
  File \"/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py\", line 635, in insert
    jobs_args)
  File \"/usr/local/lib/python3.6/dist-packages/gear/database.py\", line 172, in execute_many
    return await cursor.executemany(sql, args_array)
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/cursors.py\", line 283, in executemany
    self._get_db().encoding))
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/cursors.py\", line 318, in _do_execute_many
    r = await self.execute(sql + postfix)
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/cursors.py\", line 239, in execute
    await self._query(query)
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/cursors.py\", line 457, in _query
    await conn.query(q)
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/connection.py\", line 428, in query
    await self._read_query_result(unbuffered=unbuffered)
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/connection.py\", line 622, in _read_query_result
    await result.read()
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/connection.py\", line 1105, in read
    first_packet = await self.connection._read_packet()
  File \"/usr/local/lib/python3.6/dist-packages/aiomysql/connection.py\", line 593, in _read_packet
    packet.check_error()
  File \"/usr/local/lib/python3.6/dist-packages/pymysql/protocol.py\", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File \"/usr/local/lib/python3.6/dist-packages/pymysql/err.py\", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1062, \"Duplicate entry '27-122310' for key 'PRIMARY'\")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py\", line 418, in start
    resp = await task
  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py\", line 458, in _handle
    resp = await handler(request)
  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py\", line 119, in impl
    return await handler(request)
  File \"/usr/local/lib/python3.6/dist-packages/aiohttp_session/__init__.py\", line 152, in factory
    response = await handler(request)
  File \"/usr/local/lib/python3.6/dist-packages/prometheus_async/aio/_decorators.py\", line 42, in time_decorator
    rv = await wrapped(*args, **kw)
  File \"/usr/local/lib/python3.6/dist-packages/gear/auth.py\", line 57, in wrapped
    return await fun(request, userdata, *args, **kwargs)
  File \"/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py\", line 681, in create_jobs
    await insert()  # pylint: disable=no-value-for-parameter
  File \"/usr/local/lib/python3.6/dist-packages/gear/database.py\", line 24, in wrapper
    return await f(*args, **kwargs)
  File \"/usr/local/lib/python3.6/dist-packages/gear/database.py\", line 40, in wrapper
    return await fun(tx, *args, **kwargs)
  File \"/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py\", line 640, in insert
    raise web.Response()
TypeError: exceptions must derive from BaseException", "hail_log": 1}
```