### PR TITLE
[query] Change PCode to use type interfaces where possible

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PCode.scala
@@ -12,11 +12,11 @@ abstract class PValue {
 object PCode {
   def apply(pt: PType, code: Code[_]): PCode = pt match {
     case pt: PCanonicalArray =>
-      new PCanonicalIndexableCode(pt, coerce[Long](code))
+      new PCanonicalIndexableCode(pt, pt, coerce[Long](code))
     case pt: PCanonicalSet =>
-      new PCanonicalIndexableCode(pt.arrayRep, coerce[Long](code))
+      new PCanonicalIndexableCode(pt, pt.arrayRep, coerce[Long](code))
     case pt: PCanonicalDict =>
-      new PCanonicalIndexableCode(pt.arrayRep, coerce[Long](code))
+      new PCanonicalIndexableCode(pt, pt.arrayRep, coerce[Long](code))
 
     case pt: PCanonicalBaseStruct =>
       new PCanonicalBaseStructCode(pt, coerce[Long](code))
@@ -77,7 +77,7 @@ abstract class PIndexableCode extends PCode {
   def isElementMissing(i: Code[Int]): Code[Boolean] = !isElementDefined(i)
 }
 
-class PCanonicalIndexableCode(val pt: PCanonicalArray, val a: Code[Long]) extends PIndexableCode {
+class PCanonicalIndexableCode(val pt: PContainer, val arrayRep: PCanonicalArray, val a: Code[Long]) extends PIndexableCode {
   def code: Code[_] = a
 
   def elementType: PType = pt.elementType

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalDict.scala
@@ -8,7 +8,7 @@ import is.hail.expr.types.virtual.{TArray, TDict, Type}
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
   val elementType = PStruct(required = true, "key" -> keyType, "value" -> valueType)
 
-  val arrayRep: PArray = PCanonicalArray(elementType, required)
+  val arrayRep: PCanonicalArray = PCanonicalArray(elementType, required)
 
   def setRequired(required: Boolean) = if(required == this.required) this else PCanonicalDict(keyType, valueType, required)
 
@@ -31,5 +31,5 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
     PCanonicalDict(this.keyType.deepRename(t.keyType), this.valueType.deepRename(t.valueType), this.required)
 
   override def load(src: Code[Long]): PCode =
-    new PCanonicalIndexableCode(this, Region.loadAddress(src))
+    new PCanonicalIndexableCode(this.arrayRep, Region.loadAddress(src))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalSet.scala
@@ -24,5 +24,5 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
     PCanonicalSet(this.elementType.deepRename(t.elementType),  this.required)
 
   override def load(src: Code[Long]): PCode =
-    new PCanonicalIndexableCode(this, Region.loadAddress(src))
+    new PCanonicalIndexableCode(this.arrayRep, Region.loadAddress(src))
 }


### PR DESCRIPTION
Happy to move the implementations on PCode, but we should keep one
implementation in the meantime.