### PR TITLE
[query] Use CRDD[Long] instead of CRDD[RegionValue] in most places

### DIFF
--- a/benchmark/python/benchmark_hail/run/table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/table_benchmarks.py
@@ -380,3 +380,33 @@ def table_scan_sum_1k_partitions():
     ht = hl.utils.range_table(1000000, n_partitions=1000)
     ht = ht.annotate(x = hl.scan.sum(ht.idx))
     ht._force_count()
+
+
+@benchmark
+def test_map_filter_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    assert high_mem_table._force_count() == 15
+
+
+@benchmark
+def test_head_and_tail_region_memory():
+    high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.head(30)
+    high_mem_table._force_count()
+
+
+@benchmark
+def test_inner_join_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    joined = high_mem_table.join(high_mem_table2)
+    joined._force_count()
+
+
+@benchmark
+def test_left_join_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    joined = high_mem_table.join(high_mem_table2, how='left')
+    joined._force_count()

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -11,7 +11,7 @@ _initialized = False
 def startTestHailContext():
     global _initialized
     if not _initialized:
-        hl.init(master='local[1]', min_block_size=0, quiet=True)
+        hl.init(master='local[2]', min_block_size=0, quiet=True)
         _initialized = True
 
 

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -11,7 +11,7 @@ _initialized = False
 def startTestHailContext():
     global _initialized
     if not _initialized:
-        hl.init(master='local[2]', min_block_size=0, quiet=True)
+        hl.init(master='local[1]', min_block_size=0, quiet=True)
         _initialized = True
 
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1458,29 +1458,3 @@ def test_group_within_partitions_after_explode():
     t = t.explode(t.arr)
     t = t._group_within_partitions(10)
     assert(t._force_count() == 20)
-
-
-def test_map_filter_region_memory():
-    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-    assert high_mem_table._force_count() == 15
-
-
-def test_head_and_tail_region_memory():
-    high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
-    high_mem_table = high_mem_table.head(30)
-    high_mem_table._force_count()
-
-
-def test_inner_join_region_memory():
-    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
-    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
-    joined = high_mem_table.join(high_mem_table2)
-    joined._force_count()
-
-
-def test_left_join_region_memory():
-    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
-    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
-    joined = high_mem_table.join(high_mem_table2, how='left')
-    joined._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1451,3 +1451,14 @@ def test_range_annotate_range():
     ht1 = hl.utils.range_table(10)
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
+
+def test_map_filter_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    assert high_mem_table._force_count() == 15
+
+
+def test_head_and_tail_region_memory():
+    high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.head(30)
+    high_mem_table._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1452,6 +1452,14 @@ def test_range_annotate_range():
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
+def test_group_within_partitions_after_explode():
+    t = hl.utils.range_table(10).repartition(2)
+    t = t.annotate(arr=hl.range(0, 20))
+    t = t.explode(t.arr)
+    t = t._group_within_partitions(10)
+    assert(t._force_count() == 20)
+
+
 def test_map_filter_region_memory():
     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1422,7 +1422,7 @@ def test_write_table_containing_ndarray():
     assert t._same(t2)
 
 def test_group_within_partitions():
-    t = hl.utils.range_table(10).naive_coalesce(2)
+    t = hl.utils.range_table(10).repartition(2)
     t = t.annotate(sq=t.idx ** 2)
 
     grouped1_collected = t._group_within_partitions(1).collect()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1452,16 +1452,15 @@ def test_range_annotate_range():
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
-# def test_map_filter_region_memory():
-#     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-#     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-#     assert high_mem_table._force_count() == 15
-
-
 def test_map_region_memory():
     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-    #high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
     assert high_mem_table._force_count() == 30
+
+
+def test_map_filter_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    assert high_mem_table._force_count() == 15
 
 
 def test_head_and_tail_region_memory():

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1446,11 +1446,6 @@ def test_group_within_partitions():
     filter_then_group = ht.filter(ht.idx % 2 == 0)._group_within_partitions(5).collect()
     assert filter_then_group[0] == hl.Struct(idx=0, grouped_fields=[hl.Struct(idx=0), hl.Struct(idx=2), hl.Struct(idx=4), hl.Struct(idx=6), hl.Struct(idx=8)])
 
-def test_range_annotate_range():
-    # tests left join right distinct requiredness
-    ht1 = hl.utils.range_table(10)
-    ht2 = hl.utils.range_table(5).annotate(x = 1)
-    ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
 def test_group_within_partitions_after_explode():
     t = hl.utils.range_table(10).repartition(2)
@@ -1458,3 +1453,10 @@ def test_group_within_partitions_after_explode():
     t = t.explode(t.arr)
     t = t._group_within_partitions(10)
     assert(t._force_count() == 20)
+
+
+def test_range_annotate_range():
+    # tests left join right distinct requiredness
+    ht1 = hl.utils.range_table(10)
+    ht2 = hl.utils.range_table(5).annotate(x = 1)
+    ht1.annotate(x = ht2[ht1.idx].x)._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1452,11 +1452,6 @@ def test_range_annotate_range():
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
-def test_map_region_memory():
-    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-    assert high_mem_table._force_count() == 30
-
-
 def test_map_filter_region_memory():
     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
@@ -1467,3 +1462,17 @@ def test_head_and_tail_region_memory():
     high_mem_table = hl.utils.range_table(100).annotate(big_array=hl.zeros(100_000_000))
     high_mem_table = high_mem_table.head(30)
     high_mem_table._force_count()
+
+
+def test_inner_join_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    joined = high_mem_table.join(high_mem_table2)
+    joined._force_count()
+
+
+def test_left_join_region_memory():
+    high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    high_mem_table2 = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(50_000_000))
+    joined = high_mem_table.join(high_mem_table2, how='left')
+    joined._force_count()

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1452,10 +1452,16 @@ def test_range_annotate_range():
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
-def test_map_filter_region_memory():
+# def test_map_filter_region_memory():
+#     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
+#     high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+#     assert high_mem_table._force_count() == 15
+
+
+def test_map_region_memory():
     high_mem_table = hl.utils.range_table(30).naive_coalesce(1).annotate(big_array=hl.zeros(100_000_000))
-    high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
-    assert high_mem_table._force_count() == 15
+    #high_mem_table = high_mem_table.filter(high_mem_table.idx % 2 == 0)
+    assert high_mem_table._force_count() == 30
 
 
 def test_head_and_tail_region_memory():

--- a/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
@@ -50,7 +50,7 @@ trait BroadcastRegionValue {
     val baos = new ByteArrayOutputStream()
 
     val enc = makeEnc(baos)
-    enc.writeRegionValue(value.region, value.offset)
+    enc.writeRegionValue(value.offset)
     enc.flush()
     enc.close()
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -273,7 +273,7 @@ object Region {
       .getRegion(blockSize)
   }
 
-  def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null, creator: String = "default"): Region = {
+  def makeNamed(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null, creator: String = "default"): Region = {
     (if (pool == null) RegionPool.get else pool)
       .getRegion(blockSize, creator=creator)
   }

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -374,6 +374,11 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
     memory.addReferenceTo(r.memory)
   }
 
+  def move(r: Region): Unit = {
+    this.memory.unsafeMoveReferenceTo(r.memory)
+    this.memory = pool.getMemory(blockSize)
+  }
+
   def nReferencedRegions(): Long = memory.nReferencedRegions()
 
   def getNewRegion(blockSize: Region.Size): Unit = {

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -268,6 +268,11 @@ object Region {
   def stagedCreate(blockSize: Size): Code[Region] =
     Code.invokeScalaObject[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), Code._null)
 
+  def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
+    (if (pool == null) RegionPool.get else pool)
+      .getRegion(blockSize)
+  }
+
   def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null, creator: String = "default"): Region = {
     (if (pool == null) RegionPool.get else pool)
       .getRegion(blockSize, creator=creator)

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -349,7 +349,7 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 
   val fullID = s"$creator-$uuid"
 
-  log.info(s"REGION: New region ${fullID} created.")
+  //log.info(s"REGION: New region ${fullID} created.")
 
   def totalMemory: Long  = {
     if (isValid()) {
@@ -363,12 +363,12 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
   def isValid(): Boolean = memory != null
 
   def allocate(n: Long): Long = {
-    log.info(s"REGION: Allocating $n bytes to region ${fullID}")
+    //log.info(s"REGION: Allocating $n bytes to region ${fullID}")
     memory.allocate(n)
   }
 
   def allocate(a: Long, n: Long): Long = {
-    log.info(s"REGION: Allocating $n bytes to region ${fullID}")
+    //log.info(s"REGION: Allocating $n bytes to region ${fullID}")
     memory.allocate(a, n)
   }
 
@@ -381,10 +381,10 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 
   def clear(): Unit = {
     if (memory.getReferenceCount == 1) {
-      log.info(s"REGION: Actually clearing $fullID, ref count was 1. Total memory = ${this.totalMemory}")
+      //log.info(s"REGION: Actually clearing $fullID, ref count was 1. Total memory = ${this.totalMemory}")
       memory.clear()
     } else {
-      log.info(s"REGION: Not actually clearing $fullID, ref count was ${memory.getReferenceCount}. Total memory = ${this.totalMemory}")
+      //log.info(s"REGION: Not actually clearing $fullID, ref count was ${memory.getReferenceCount}. Total memory = ${this.totalMemory}")
       memory.release()
       memory = pool.getMemory(blockSize)
     }
@@ -395,7 +395,7 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
   }
 
   def addReferenceTo(r: Region): Unit = {
-    log.info(s"REGION: Region ${fullID} adds reference to ${r.fullID}")
+    //log.info(s"REGION: Region ${fullID} adds reference to ${r.fullID}")
     memory.addReferenceTo(r.memory)
   }
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -273,9 +273,9 @@ object Region {
       .getRegion(blockSize)
   }
 
-  def makeNamed(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null, creator: String = "default"): Region = {
+  def makeNamed(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
     (if (pool == null) RegionPool.get else pool)
-      .getRegion(blockSize, creator=creator)
+      .getRegion(blockSize)
   }
 
   def pretty(t: PType, off: Long): String = {
@@ -344,10 +344,10 @@ object Region {
   }
 }
 
-final class Region protected[annotations](var blockSize: Region.Size, var pool: RegionPool, var memory: RegionMemory = null, var creator: String = "default") extends AutoCloseable {
-  val uuid = java.util.UUID.randomUUID.toString
+final class Region protected[annotations](var blockSize: Region.Size, var pool: RegionPool, var memory: RegionMemory = null) extends AutoCloseable {
+  //val uuid = java.util.UUID.randomUUID.toString
 
-  val fullID = s"$creator-$uuid"
+  //val fullID = s"$creator-$uuid"
 
   //log.info(s"REGION: New region ${fullID} created.")
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -345,30 +345,14 @@ object Region {
 }
 
 final class Region protected[annotations](var blockSize: Region.Size, var pool: RegionPool, var memory: RegionMemory = null) extends AutoCloseable {
-  //val uuid = java.util.UUID.randomUUID.toString
-
-  //val fullID = s"$creator-$uuid"
-
-  //log.info(s"REGION: New region ${fullID} created.")
-
-  def totalMemory: Long  = {
-    if (isValid()) {
-      this.memory.getTotalChunkMemory()
-    }
-    else {
-      0L
-    }
-  }
 
   def isValid(): Boolean = memory != null
 
   def allocate(n: Long): Long = {
-    //log.info(s"REGION: Allocating $n bytes to region ${fullID}")
     memory.allocate(n)
   }
 
   def allocate(a: Long, n: Long): Long = {
-    //log.info(s"REGION: Allocating $n bytes to region ${fullID}")
     memory.allocate(a, n)
   }
 
@@ -381,10 +365,8 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 
   def clear(): Unit = {
     if (memory.getReferenceCount == 1) {
-      //log.info(s"REGION: Actually clearing $fullID, ref count was 1. Total memory = ${this.totalMemory}")
       memory.clear()
     } else {
-      //log.info(s"REGION: Not actually clearing $fullID, ref count was ${memory.getReferenceCount}. Total memory = ${this.totalMemory}")
       memory.release()
       memory = pool.getMemory(blockSize)
     }
@@ -395,15 +377,12 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
   }
 
   def addReferenceTo(r: Region): Unit = {
-    //log.info(s"REGION: Region ${fullID} adds reference to ${r.fullID}")
     memory.addReferenceTo(r.memory)
   }
 
   def move(r: Region): Unit = {
     r.addReferenceTo(this)
     this.clear()
-//    this.memory.unsafeMoveReferenceTo(r.memory)
-//    this.memory = pool.getMemory(blockSize)
   }
 
   def nReferencedRegions(): Long = memory.nReferencedRegions()

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -193,10 +193,6 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     r.referenceCount += 1
   }
 
-  def unsafeMoveReferenceTo(r: RegionMemory): Unit = {
-    references += r
-  }
-
   def nReferencedRegions(): Long = references.size
 
   def setNumParents(n: Int): Unit = {

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -191,6 +191,10 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     r.referenceCount += 1
   }
 
+  def unsafeMoveReferenceTo(r: RegionMemory): Unit = {
+    references += r
+  }
+
   def nReferencedRegions(): Long = references.size
 
   def setNumParents(n: Int): Unit = {

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -140,6 +140,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
       freeMemory()
       pool.reclaim(this)
     }
+    stackTrace = None
   }
 
   def getReferenceCount: Long = referenceCount

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -108,6 +108,8 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     usedBlocks.clearAndResize()
   }
 
+  def getTotalChunkMemory(): Long = this.totalChunkMemory
+
   protected[annotations] def freeMemory(): Unit = {
     // freeMemory should be idempotent
     if (isFreed) {

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -10,6 +10,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
   private var totalChunkMemory = 0L
   private var currentBlock: Long = 0L
   private var offsetWithinBlock: Long = _
+  var stackTrace: Option[IndexedSeq[StackTraceElement]] = None
 
   // blockThreshold and blockByteSize are mutable because RegionMemory objects are reused with different sizes
   protected[annotations] var blockSize: Region.Size = -1
@@ -167,6 +168,8 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     assert(referenceCount == 0)
     assert(currentBlock == 0)
     assert(totalChunkMemory == 0)
+
+    this.stackTrace = Some(Thread.currentThread().getStackTrace.toIndexedSeq.drop(4))
 
     blockSize = newSize
     blockByteSize = Region.SIZES(blockSize)

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -10,7 +10,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
   private var totalChunkMemory = 0L
   private var currentBlock: Long = 0L
   private var offsetWithinBlock: Long = _
-  var stackTrace: Option[IndexedSeq[StackTraceElement]] = None
+//  var stackTrace: Option[IndexedSeq[StackTraceElement]] = None
 
   // blockThreshold and blockByteSize are mutable because RegionMemory objects are reused with different sizes
   protected[annotations] var blockSize: Region.Size = -1
@@ -140,7 +140,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
       freeMemory()
       pool.reclaim(this)
     }
-    stackTrace = None
+//    stackTrace = None
   }
 
   def getReferenceCount: Long = referenceCount
@@ -170,7 +170,7 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     assert(currentBlock == 0)
     assert(totalChunkMemory == 0)
 
-    this.stackTrace = Some(Thread.currentThread().getStackTrace.toIndexedSeq.drop(4))
+//    this.stackTrace = Some(Thread.currentThread().getStackTrace.toIndexedSeq.drop(4))
 
     blockSize = newSize
     blockByteSize = Region.SIZES(blockSize)

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -78,8 +78,8 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
 
   def getRegion(): Region = getRegion(Region.REGULAR)
 
-  def getRegion(size: Int): Region = {
-    val r = new Region(size, this)
+  def getRegion(size: Int, creator: String = "default"): Region = {
+    val r = new Region(size, this, creator = creator)
     r.memory = getMemory(size)
     r
   }

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -117,7 +117,7 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
     log.info(s"RegionPool: $context: ${readableBytes(totalAllocatedBytes)} allocated (${readableBytes(inBlocks)} blocks / " +
       s"${readableBytes(totalAllocatedBytes - inBlocks)} chunks), regions.size = ${regions.size}, thread $threadID: $threadName")
     log.info("-----------STACK_TRACES---------")
-    val stacks: String = regions.result().toIndexedSeq.flatMap(_.stackTrace).foldLeft("")((a: String, b) => a + "\n" + b.toString())
+    val stacks: String = regions.result().toIndexedSeq.flatMap(r => r.stackTrace.map((r.getTotalChunkMemory(), _))).foldLeft("")((a: String, b) => a + "\n" + b.toString())
     log.info(stacks)
     log.info("---------------END--------------")
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -78,8 +78,8 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
 
   def getRegion(): Region = getRegion(Region.REGULAR)
 
-  def getRegion(size: Int, creator: String = "default"): Region = {
-    val r = new Region(size, this, creator = creator)
+  def getRegion(size: Int): Region = {
+    val r = new Region(size, this)
     r.memory = getMemory(size)
     r
   }

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -115,7 +115,13 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
     }
 
     log.info(s"RegionPool: $context: ${readableBytes(totalAllocatedBytes)} allocated (${readableBytes(inBlocks)} blocks / " +
-      s"${readableBytes(totalAllocatedBytes - inBlocks)} chunks), thread $threadID: $threadName")
+      s"${readableBytes(totalAllocatedBytes - inBlocks)} chunks), regions.size = ${regions.size}, thread $threadID: $threadName")
+    log.info("-----------STACK_TRACES---------")
+    val stacks: String = regions.result().toIndexedSeq.flatMap(_.stackTrace).foldLeft("")((a: String, b) => a + "\n" + b.toString())
+    log.info(stacks)
+    log.info("---------------END--------------")
+
+
   }
 
   override def finalize(): Unit = close()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -116,10 +116,10 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
 
     log.info(s"RegionPool: $context: ${readableBytes(totalAllocatedBytes)} allocated (${readableBytes(inBlocks)} blocks / " +
       s"${readableBytes(totalAllocatedBytes - inBlocks)} chunks), regions.size = ${regions.size}, thread $threadID: $threadName")
-    log.info("-----------STACK_TRACES---------")
-    val stacks: String = regions.result().toIndexedSeq.flatMap(r => r.stackTrace.map((r.getTotalChunkMemory(), _))).foldLeft("")((a: String, b) => a + "\n" + b.toString())
-    log.info(stacks)
-    log.info("---------------END--------------")
+//    log.info("-----------STACK_TRACES---------")
+//    val stacks: String = regions.result().toIndexedSeq.flatMap(r => r.stackTrace.map((r.getTotalChunkMemory(), _))).foldLeft("")((a: String, b) => a + "\n" + b.toString())
+//    log.info(stacks)
+//    log.info("---------------END--------------")
 
 
   }

--- a/hail/src/main/scala/is/hail/annotations/RegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValue.scala
@@ -18,13 +18,9 @@ object RegionValue {
     makeDec: InputStream => Decoder,
     r: Region,
     byteses: Iterator[Array[Byte]]
-  ): Iterator[RegionValue] = {
-    val rv = RegionValue(r)
+  ): Iterator[Long] = {
     val bad = new ByteArrayDecoder(makeDec)
-    byteses.map { bytes =>
-      rv.setOffset(bad.regionValueFromBytes(r, bytes))
-      rv
-    }
+    byteses.map(bad.regionValueFromBytes(r, _))
   }
 
   def pointerFromBytes(
@@ -38,9 +34,9 @@ object RegionValue {
     }
   }
 
-  def toBytes(makeEnc: OutputStream => Encoder, rvs: Iterator[RegionValue]): Iterator[Array[Byte]] = {
+  def toBytes(makeEnc: OutputStream => Encoder, rvs: Iterator[Long]): Iterator[Array[Byte]] = {
     val bae = new ByteArrayEncoder(makeEnc)
-    rvs.map(rv => bae.regionValueToBytes(rv.region, rv.offset))
+    rvs.map(bae.regionValueToBytes)
   }
 }
 

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -503,6 +503,5 @@ class RegionValueBuilder(var region: Region) {
     }
   }
 
-  def resultPtr(): Long = start
   def result(): RegionValue = RegionValue(region, start)
 }

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -495,5 +495,6 @@ class RegionValueBuilder(var region: Region) {
     }
   }
 
+  def resultPtr(): Long = start
   def result(): RegionValue = RegionValue(region, start)
 }

--- a/hail/src/main/scala/is/hail/annotations/WritableRegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/WritableRegionValue.scala
@@ -33,6 +33,10 @@ class WritableRegionValue private (
   def offset: Long = value.offset
 
   def setSelect(fromT: PStruct, fromFieldIdx: Array[Int], fromRV: RegionValue) {
+    setSelect(fromT, fromFieldIdx, fromRV.region, fromRV.offset)
+  }
+
+  def setSelect(fromT: PStruct, fromFieldIdx: Array[Int], fromRegion: Region, fromOffset: Long) {
     (t: @unchecked) match {
       case t: PStruct =>
         region.clear()
@@ -40,7 +44,7 @@ class WritableRegionValue private (
         rvb.startStruct()
         var i = 0
         while (i < t.size) {
-          rvb.addField(fromT, fromRV, fromFieldIdx(i))
+          rvb.addField(fromT, fromRegion, fromOffset, fromFieldIdx(i))
           i += 1
         }
         rvb.endStruct()

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -318,7 +318,7 @@ class SparkBackend(val sc: SparkContext) extends Backend {
           val codec = TypedCodecSpec(
             EType.defaultFromPType(elementType), elementType.virtualType, bs)
           assert(t.isFieldDefined(off, 0))
-          (elementType.toString, codec.encode(elementType, ctx.r, t.loadField(off, 0)))
+          (elementType.toString, codec.encode(elementType, t.loadField(off, 0)))
       }
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -290,7 +290,7 @@ class EmitClassBuilder[C](
       rvb.startTuple()
       literals.foreach { case ((typ, a), _) => rvb.addAnnotation(typ.virtualType, a) }
       rvb.endTuple()
-      enc.writeRegionValue(region, rvb.end())
+      enc.writeRegionValue(rvb.end())
     }
     enc.flush()
     enc.close()

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -664,7 +664,7 @@ object Interpret {
                 write(aggRegion, initF.getAggOffset())
               }
             },
-            { (i: Int, ctx: RVDContext, it: Iterator[RegionValue]) =>
+            { (i: Int, ctx: RVDContext, it: Iterator[Long]) =>
               val partRegion = ctx.partitionRegion
               val globalsOffset = globalsBc.value.readRegionValue(partRegion)
               val init = initOp(i, partRegion)
@@ -674,8 +674,8 @@ object Interpret {
                 init.newAggState(aggRegion)
                 init(partRegion, globalsOffset)
                 seqOps.setAggState(aggRegion, init.getAggOffset())
-                it.foreach { rv =>
-                  seqOps(rv.region, globalsOffset, rv.offset)
+                it.foreach { ptr =>
+                  seqOps(ctx.region, globalsOffset, ptr)
                   ctx.region.clear()
                 }
                 write(aggRegion, seqOps.getAggOffset())

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -230,7 +230,7 @@ case class MatrixValue(
     RVD.coerce(
       typ.colsTableType.canonicalRVDType,
       ContextRDD.parallelize(hc.sc, colValues.safeJavaValue)
-        .cmapPartitions { (ctx, it) => it.toRegionValueIterator(ctx.region, colPType) },
+        .cmapPartitions { (ctx, it) => it.copyToRegion(ctx.region, colPType) },
       ctx
     )
   }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -252,12 +252,11 @@ case class MatrixValue(
     val fieldIdx = entryType.fieldIdx(entryField)
     val numColsLocal = nCols
 
-    val rows = rvd.mapPartitionsWithIndex { (pi, it) =>
+    val rows = rvd.mapPartitionsWithIndex { (pi, _, it) =>
       var i = partStartsBc.value(pi)
-      it.map { rv =>
-        val region = rv.region
+      it.map { ptr =>
         val data = new Array[Double](numColsLocal)
-        val entryArrayOffset = localRvRowPType.loadField(rv.offset, localEntryArrayIdx)
+        val entryArrayOffset = localRvRowPType.loadField(ptr, localEntryArrayIdx)
         var j = 0
         while (j < numColsLocal) {
           if (localEntryArrayPType.isElementDefined(entryArrayOffset, j)) {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -486,7 +486,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
       Coalesce(FastIndexedSeq(pred, False())))
     assert(rTyp.virtualType == TBoolean)
 
-    tv.filterWithPartitionOp(f)((rowF, rv, globalRV) => rowF(rv.region, rv.offset, globalRV.offset))
+    tv.filterWithPartitionOp(f)((rowF, ctx, ptr, globalPtr) => rowF(ctx.region, ptr, globalPtr))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1444,9 +1444,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
     TableValue(typ,
       prev.globals,
       prev.rvd.boundary.mapPartitionsWithIndex(rvdType) { (i, ctx, it) =>
-        val region2 = ctx.region
         val globalRegion = ctx.partitionRegion
-        val rv2 = RegionValue(region2)
         val lenF = l(i, globalRegion)
         val rowF = f(i, globalRegion)
         it.flatMap { ptr =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -358,7 +358,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
           Iterator.range(0, nRowPartition)
             .map { _ =>
               bais.readValue(ctx.region)
-]           }
+           }
         }
       }
     TableValue(typ, globals, RVD.unkeyed(resultRowType, rvd))

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -999,7 +999,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
     val rvd = RVD(
       typ = RVDType(localNewRowType, typ.key),
       partitioner = newPartitioner,
-      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd.toCRDDRegionValue.boundary)) { (ctx, its) =>
+      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd.toCRDDRegionValue)) { (ctx, its) =>
         val orvIters = its.map(it => OrderedRVIterator(localRVDType, it, ctx))
         rvMerger(ctx, OrderedRVIterator.multiZipJoin(orvIters))
       }.toCRDDPtr)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -443,7 +443,6 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
         ContextRDD.parallelize(hc.sc, Range(0, nPartitionsAdj), nPartitionsAdj)
           .cmapPartitionsWithIndex { case (i, ctx, _) =>
             val region = ctx.region
-            val rv = RegionValue(region)
 
             val start = partStarts(i)
             Iterator.range(start, start + localPartCounts(i))
@@ -451,8 +450,7 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
                 val off = localRowType.allocate(region)
                 localRowType.setFieldPresent(off, 0)
                 Region.storeInt(localRowType.fieldOffset(off, 0), j)
-                rv.setOffset(off)
-                rv
+                off
               }
           }))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1443,7 +1443,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
     )
     TableValue(typ,
       prev.globals,
-      prev.rvd.boundary.mapPartitionsWithIndex(rvdType, { (i, ctx, it) =>
+      prev.rvd.boundary.mapPartitionsWithIndex(rvdType) { (i, ctx, it) =>
         val region2 = ctx.region
         val globalRegion = ctx.partitionRegion
         val rv2 = RegionValue(region2)
@@ -1463,7 +1463,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
             }
           }
         }
-      }))
+      })
   }
 }
 
@@ -1777,7 +1777,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
     val newRVD = prevRVD
       .repartition(prevRVD.partitioner.strictify, ctx)
       .boundary
-      .mapPartitionsWithIndex(newRVDType, { (i, ctx, it) =>
+      .mapPartitionsWithIndex(newRVDType) { (i, ctx, it) =>
         val partRegion = ctx.partitionRegion
         val globalsOff = globalsBc.value.readRegionValue(partRegion)
 
@@ -1826,7 +1826,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
             newRowF(consumerRegion, globalsOff, rowKey.offset)
           }
         }
-      })
+      }
 
     prev.copy(rvd = newRVD, typ = typ)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -352,15 +352,13 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
 
     val rvd = ContextRDD.parallelize(hc.sc, encRows, encRows.length)
       .cmapPartitions { (ctx, it) =>
-        val rv = RegionValue(ctx.region)
         it.flatMap { case (nRowPartition, arr) =>
           val bais = new ByteArrayDecoder(makeDec)
           bais.set(arr)
           Iterator.range(0, nRowPartition)
             .map { _ =>
-              rv.setOffset(bais.readValue(ctx.region))
-              rv
-            }
+              bais.readValue(ctx.region)
+]           }
         }
       }
     TableValue(typ, globals, RVD.unkeyed(resultRowType, rvd))
@@ -1001,10 +999,10 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
     val rvd = RVD(
       typ = RVDType(localNewRowType, typ.key),
       partitioner = newPartitioner,
-      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd.boundary)) { (ctx, its) =>
+      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd.toCRDDRegionValue.boundary)) { (ctx, its) =>
         val orvIters = its.map(it => OrderedRVIterator(localRVDType, it, ctx))
         rvMerger(ctx, OrderedRVIterator.multiZipJoin(orvIters))
-      })
+      }.toCRDDPtr)
 
     val newGlobals = BroadcastRow(ctx,
       Row(childValues.map(_.globals.javaValue)),
@@ -1687,7 +1685,6 @@ case class TableKeyByAndAggregate(
         val globals = globalsBc.value.readRegionValue(partRegion)
         val annotate = makeAnnotate(i, partRegion)
 
-        val rv = RegionValue(region)
         it.map { case (key, aggs) =>
           rvb.set(region)
           rvb.start(newRowType)
@@ -1698,12 +1695,11 @@ case class TableKeyByAndAggregate(
             i += 1
           }
 
-          val aggOff = deserialize(rv.region, aggs)
-          annotate.setAggState(rv.region, aggOff)
+          val aggOff = deserialize(region, aggs)
+          annotate.setAggState(region, aggOff)
           rvb.addAllFields(rTyp, region, annotate(region, globals))
           rvb.endStruct()
-          rv.setOffset(rvb.end())
-          rv
+          rvb.end()
         }
       })
 
@@ -1882,7 +1878,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
     val codec = TypedCodecSpec(prev.rvd.rowPType, BufferSpec.wireSpec)
     val rdd = prev.rvd.keyedEncodedRDD(codec, sortFields.map(_.field)).sortBy(_._1)(ord, act)
     val (rowPType: PStruct, orderedCRDD) = codec.decodeRDD(rowType, rdd.map(_._2))
-    TableValue(typ, prev.globals, RVD.unkeyed(rowPType, orderedCRDD.toCRDDRegionValue))
+    TableValue(typ, prev.globals, RVD.unkeyed(rowPType, orderedCRDD))
   }
 }
 
@@ -2014,7 +2010,7 @@ case class TableGroupWithinPartitions(child: TableIR, n: Int) extends TableIR {
           }
           rvb.endArray()
           rvb.endStruct()
-          rvb.resultPtr()
+          rvb.end()
         }
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1463,7 +1463,7 @@ case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableI
             }
           }
         }
-      })
+      }))
   }
 }
 
@@ -1826,7 +1826,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
             newRowF(consumerRegion, globalsOff, rowKey.offset)
           }
         }
-      }
+      })
 
     prev.copy(rvd = newRVD, typ = typ)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1806,7 +1806,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
             if (!hasNext)
               throw new java.util.NoSuchElementException()
 
-            rowKey.setSelect(localChildRowType, keyIndices, ctx.r, current)
+            rowKey.setSelect(localChildRowType, keyIndices, current, true)
 
             aggRegion.clear()
             initialize.newAggState(aggRegion)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -85,7 +85,7 @@ object TableLiteral {
     val enc = TypedCodecSpec(globalPType, BufferSpec.wireSpec) // use wireSpec to save memory
     using(new ByteArrayEncoder(enc.buildEncoder(value.globals.t))) { encoder =>
       TableLiteral(value.typ, value.rvd, enc,
-        encoder.regionValueToBytes(value.globals.value.region, value.globals.value.offset))
+        encoder.regionValueToBytes(value.globals.value.offset))
     }
   }
 }
@@ -1890,7 +1890,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
     val codec = TypedCodecSpec(prev.rvd.rowPType, BufferSpec.wireSpec)
     val rdd = prev.rvd.keyedEncodedRDD(codec, sortFields.map(_.field)).sortBy(_._1)(ord, act)
     val (rowPType: PStruct, orderedCRDD) = codec.decodeRDD(rowType, rdd.map(_._2))
-    TableValue(typ, prev.globals, RVD.unkeyed(rowPType, orderedCRDD))
+    TableValue(typ, prev.globals, RVD.unkeyed(rowPType, orderedCRDD.toCRDDRegionValue))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -128,11 +128,11 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     val localTypes = fields.map(_.typ)
 
     val localDelim = delimiter
-    rvd.mapPartitions { it =>
+    rvd.mapPartitions { (ctx, it) =>
       val sb = new StringBuilder()
 
-      it.map { rv =>
-        val ur = new UnsafeRow(localSignature, rv)
+      it.map { ptr =>
+        val ur = new UnsafeRow(localSignature, ctx.r, ptr)
         sb.clear()
         localTypes.indices.foreachBetween { i =>
           sb.append(TableAnnotationImpex.exportAnnotation(ur.get(i), localTypes(i)))

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -18,7 +18,7 @@ import org.apache.spark.storage.StorageLevel
 import org.json4s.jackson.JsonMethods
 
 object TableValue {
-  def apply(ctx: ExecuteContext, rowType: PStruct, key: IndexedSeq[String], rdd: ContextRDD[RegionValue]): TableValue = {
+  def apply(ctx: ExecuteContext, rowType: PStruct, key: IndexedSeq[String], rdd: ContextRDD[Long]): TableValue = {
     assert(rowType.required)
     val tt = TableType(rowType.virtualType, key, TStruct.empty)
     TableValue(tt,

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -7,7 +7,7 @@ import is.hail.expr.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, P
 import is.hail.expr.types.virtual.{Field, TArray, TStruct}
 import is.hail.expr.types.{MatrixType, TableType}
 import is.hail.io.{BufferSpec, TypedCodecSpec, exportTypes}
-import is.hail.rvd.{AbstractRVDSpec, RVD, RVDType}
+import is.hail.rvd.{AbstractRVDSpec, RVD, RVDType, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -24,9 +24,9 @@ trait AbstractTypedCodecSpec extends Spec {
 
   def buildDecoder(requestedType: Type): (PType, (InputStream) => Decoder)
 
-  def encode(t: PType, region: Region, offset: Long): Array[Byte] = {
+  def encode(t: PType, offset: Long): Array[Byte] = {
     val baos = new ByteArrayOutputStream()
-    using(buildEncoder(t)(baos))(_.writeRegionValue(region, offset))
+    using(buildEncoder(t)(baos))(_.writeRegionValue(offset))
     baos.toByteArray
   }
 
@@ -56,7 +56,7 @@ trait AbstractTypedCodecSpec extends Spec {
   }
 
   // FIXME: is there a better place for this to live?
-  def decodeRDD(requestedType: Type, bytes: RDD[Array[Byte]]): (PType, ContextRDD[RegionValue]) = {
+  def decodeRDD(requestedType: Type, bytes: RDD[Array[Byte]]): (PType, ContextRDD[Long]) = {
     val (pt, dec) = buildDecoder(requestedType)
     (pt, ContextRDD.weaken(bytes).cmapPartitions { (ctx, it) =>
       RegionValue.fromBytes(dec, ctx.region, it)

--- a/hail/src/main/scala/is/hail/io/Encoder.scala
+++ b/hail/src/main/scala/is/hail/io/Encoder.scala
@@ -63,7 +63,7 @@ final class ByteArrayEncoder(
   }
 
   def reset(): Unit = baos.reset()
-  def writeRegionValue(region: Region, offset: Long): Unit = enc.writeRegionValue(region, offset)
+  def writeRegionValue(region: Region, offset: Long): Unit = enc.writeRegionValue(offset)
 
   def result(): Array[Byte] = {
     enc.flush()

--- a/hail/src/main/scala/is/hail/io/Encoder.scala
+++ b/hail/src/main/scala/is/hail/io/Encoder.scala
@@ -11,7 +11,7 @@ trait Encoder extends Closeable {
 
   def close(): Unit
 
-  def writeRegionValue(region: Region, offset: Long): Unit
+  def writeRegionValue(offset: Long): Unit
 
   def writeByte(b: Byte): Unit
 
@@ -28,7 +28,7 @@ final class CompiledEncoder(out: OutputBuffer, f: () => EncoderAsmFunction) exte
   }
 
   private[this] val compiled = f()
-  def writeRegionValue(region: Region, offset: Long) {
+  def writeRegionValue(offset: Long) {
     compiled(offset, out)
   }
 
@@ -56,8 +56,15 @@ final class ByteArrayEncoder(
     result()
   }
 
+  def regionValueToBytes(offset: Long): Array[Byte] = {
+    baos.reset()
+    enc.writeRegionValue(offset)
+    result()
+  }
+
   def reset(): Unit = baos.reset()
   def writeRegionValue(region: Region, offset: Long): Unit = enc.writeRegionValue(region, offset)
+
   def result(): Array[Byte] = {
     enc.flush()
     baos.toByteArray

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -199,7 +199,8 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
   def toCRDDRegionValue: ContextRDD[RegionValue] =
     crdd.cmapPartitionsWithContext { (consumerCtx, part) =>
       val producerCtx = consumerCtx.freshContext
-      part(producerCtx).map(RegionValue(producerCtx.r, _))
+      val rv = RegionValue(producerCtx.r)
+      part(producerCtx).map(ptr => { rv.setOffset(ptr); rv })
     }
 }
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -255,6 +255,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
 
   def toCRDDPtr: ContextRDD[Long] =
     crdd.cmap { (consumerCtx, rv) =>
+      // Need to track regions that are in use, but don't want to create a cycle.
       if (consumerCtx.region != rv.region) {
         consumerCtx.region.addReferenceTo(rv.region)
       }

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -170,6 +170,39 @@ object RichContextRDDRegionValue {
   }
 }
 
+class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
+  def boundary: ContextRDD[Long] =
+    crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
+      val producerCtx = consumerCtx.freshContext
+      val it = part.flatMap(_ (producerCtx))
+      new Iterator[Long]() {
+        private[this] var cleared: Boolean = false
+
+        def hasNext: Boolean = {
+          if (!cleared) {
+            cleared = true
+            producerCtx.region.clear()
+          }
+          it.hasNext
+        }
+
+        def next: Long = {
+          if (!cleared) {
+            producerCtx.region.clear()
+          }
+          cleared = false
+          it.next
+        }
+      }
+    }
+
+  def toCRDDRegionValue: ContextRDD[RegionValue] =
+    crdd.cmapPartitionsWithContext { (consumerCtx, part) =>
+      val producerCtx = consumerCtx.freshContext
+      part(producerCtx).map(RegionValue(producerCtx.r, _))
+    }
+}
+
 class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVal {
   def boundary: ContextRDD[RegionValue] =
     crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
@@ -195,6 +228,37 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
         }
       }
     }
+
+  def toCRDDPtr: ContextRDD[Long] =
+    crdd.cmap { (consumerCtx, rv) =>
+      consumerCtx.region.addReferenceTo(rv.region)
+      rv.offset
+    }
+
+  def cleanupRegions: ContextRDD[RegionValue] = {
+    crdd.cmapPartitionsAndContext { (ctx, part) =>
+      val it = part.flatMap(_ (ctx))
+      new Iterator[RegionValue]() {
+        private[this] var cleared: Boolean = false
+
+        def hasNext: Boolean = {
+          if (!cleared) {
+            cleared = true
+            ctx.region.clear()
+          }
+          it.hasNext
+        }
+
+        def next: RegionValue = {
+          if (!cleared) {
+            ctx.region.clear()
+          }
+          cleared = false
+          it.next
+        }
+      }
+    }
+  }
 
   def writeRows(
     path: String,

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -215,7 +215,7 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
       path,
       idxRelPath,
       stageLocally,
-      IndexWriter.builder(t.kType, +PStruct()),
+      IndexWriter.builder(t.kType, +PCanonicalStruct()),
       RichContextRDDRegionValue.writeRowsPartition(
         encoding.buildEncoder(t.rowType),
         t.kFieldIdx,
@@ -287,23 +287,23 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
     }
   }
 
-  def writeRows(
-    path: String,
-    idxRelPath: String,
-    t: RVDType,
-    stageLocally: Boolean,
-    encoding: AbstractTypedCodecSpec
-  ): (Array[String], Array[Long]) = {
-    crdd.writePartitions(
-      path,
-      idxRelPath,
-      stageLocally,
-      IndexWriter.builder(t.kType, +PCanonicalStruct()),
-      RichContextRDDRegionValue.writeRowsPartition(
-        encoding.buildEncoder(t.rowType),
-        t.kFieldIdx,
-        t.rowType))
-  }
+//  def writeRows(
+//    path: String,
+//    idxRelPath: String,
+//    t: RVDType,
+//    stageLocally: Boolean,
+//    encoding: AbstractTypedCodecSpec
+//  ): (Array[String], Array[Long]) = {
+//    crdd.writePartitions(
+//      path,
+//      idxRelPath,
+//      stageLocally,
+//      IndexWriter.builder(t.kType, +PCanonicalStruct()),
+//      RichContextRDDRegionValue.writeRowsPartition(
+//        encoding.buildEncoder(t.rowType),
+//        t.kFieldIdx,
+//        t.rowType))
+//  }
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.offset))

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -199,11 +199,10 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
     }
 
   def toCRDDRegionValue: ContextRDD[RegionValue] =
-    boundary.cmapPartitionsWithContext { (consumerCtx, part) =>
-      val producerCtx = consumerCtx.freshContext
-      val rv = RegionValue(producerCtx.r)
-      part(producerCtx).map(ptr => { rv.setOffset(ptr); rv })
-    }
+    boundary.cmapPartitionsWithContext((ctx, part) => {
+      val rv = RegionValue(ctx.r)
+      part(ctx).map(ptr => { rv.setOffset(ptr); rv })
+    })
 
   def writeRows(
     path: String,

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -14,6 +14,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.{ExposedMetrics, TaskContext}
 
+import scala.reflect.ClassTag
+
 object RichContextRDDRegionValue {
   def writeRowsPartition(
     makeEnc: (OutputStream) => Encoder,

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -21,7 +21,7 @@ object RichContextRDDRegionValue {
     makeEnc: (OutputStream) => Encoder,
     indexKeyFieldIndices: Array[Int] = null,
     rowType: PStruct = null
-  )(ctx: RVDContext, it: Iterator[RegionValue], os: OutputStream, iw: IndexWriter): Long = {
+  )(ctx: RVDContext, it: Iterator[Long], os: OutputStream, iw: IndexWriter): Long = {
     val context = TaskContext.get
     val outputMetrics =
       if (context != null)
@@ -32,14 +32,14 @@ object RichContextRDDRegionValue {
     val en = makeEnc(trackedOS)
     var rowCount = 0L
 
-    it.foreach { rv =>
+    it.foreach { ptr =>
       if (iw != null) {
         val off = en.indexOffset()
-        val key = SafeRow.selectFields(rowType, rv)(indexKeyFieldIndices)
+        val key = SafeRow.selectFields(rowType, ctx.r, ptr)(indexKeyFieldIndices)
         iw += (key, off, Row())
       }
       en.writeByte(1)
-      en.writeRegionValue(rv.offset)
+      en.writeRegionValue(ptr)
       ctx.region.clear()
       rowCount += 1
 
@@ -63,7 +63,7 @@ object RichContextRDDRegionValue {
     fs: FS,
     path: String,
     t: RVDType,
-    it: Iterator[RegionValue],
+    it: Iterator[Long],
     idx: Int,
     ctx: RVDContext,
     partDigits: Int,
@@ -105,17 +105,17 @@ object RichContextRDDRegionValue {
 
               var rowCount = 0L
 
-              it.foreach { rv =>
+              it.foreach { ptr =>
                 val rows_off = rowsEN.indexOffset()
                 val ents_off = entriesEN.indexOffset()
-                val key = SafeRow.selectFields(fullRowType, rv)(t.kFieldIdx)
+                val key = SafeRow.selectFields(fullRowType, ctx.r, ptr)(t.kFieldIdx)
                 iw += (key, rows_off, Row(ents_off))
 
                 rowsEN.writeByte(1)
-                rowsEN.writeRegionValue(rv.offset)
+                rowsEN.writeRegionValue(ptr)
 
                 entriesEN.writeByte(1)
-                entriesEN.writeRegionValue(rv.offset)
+                entriesEN.writeRegionValue(ptr)
 
                 ctx.region.clear()
 
@@ -204,6 +204,28 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
       val rv = RegionValue(producerCtx.r)
       part(producerCtx).map(ptr => { rv.setOffset(ptr); rv })
     }
+
+  def writeRows(
+    path: String,
+    idxRelPath: String,
+    t: RVDType,
+    stageLocally: Boolean,
+    encoding: AbstractTypedCodecSpec
+  ): (Array[String], Array[Long]) = {
+    crdd.writePartitions(
+      path,
+      idxRelPath,
+      stageLocally,
+      IndexWriter.builder(t.kType, +PStruct()),
+      RichContextRDDRegionValue.writeRowsPartition(
+        encoding.buildEncoder(t.rowType),
+        t.kFieldIdx,
+        t.rowType))
+  }
+
+  def toRows(rowType: PStruct): RDD[Row] = {
+    crdd.cmap((ctx, ptr) => SafeRow(rowType, ptr)).run
+  }
 }
 
 class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVal {
@@ -280,6 +302,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
         t.kFieldIdx,
         t.rowType))
   }
+
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.offset))

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -199,7 +199,7 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
     }
 
   def toCRDDRegionValue: ContextRDD[RegionValue] =
-    crdd.cmapPartitionsWithContext { (consumerCtx, part) =>
+    boundary.cmapPartitionsWithContext { (consumerCtx, part) =>
       val producerCtx = consumerCtx.freshContext
       val rv = RegionValue(producerCtx.r)
       part(producerCtx).map(ptr => { rv.setOffset(ptr); rv })

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -37,7 +37,7 @@ object RichContextRDDRegionValue {
         iw += (key, off, Row())
       }
       en.writeByte(1)
-      en.writeRegionValue(rv.region, rv.offset)
+      en.writeRegionValue(rv.offset)
       ctx.region.clear()
       rowCount += 1
 
@@ -110,10 +110,10 @@ object RichContextRDDRegionValue {
                 iw += (key, rows_off, Row(ents_off))
 
                 rowsEN.writeByte(1)
-                rowsEN.writeRegionValue(rv.region, rv.offset)
+                rowsEN.writeRegionValue(rv.offset)
 
                 entriesEN.writeByte(1)
-                entriesEN.writeRegionValue(rv.region, rv.offset)
+                entriesEN.writeRegionValue(rv.offset)
 
                 ctx.region.clear()
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -198,31 +198,6 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
       }
     }
 
-  def cleanupRegions: ContextRDD[Long] = {
-    crdd.cmapPartitionsAndContext { (ctx, part) =>
-      val it = part.flatMap(_ (ctx))
-      new Iterator[Long]() {
-        private[this] var cleared: Boolean = false
-
-        def hasNext: Boolean = {
-          if (!cleared) {
-            cleared = true
-            ctx.region.clear()
-          }
-          it.hasNext
-        }
-
-        def next: Long = {
-          if (!cleared) {
-            ctx.region.clear()
-          }
-          cleared = false
-          it.next
-        }
-      }
-    }
-  }
-
   def toCRDDRegionValue: ContextRDD[RegionValue] =
     boundary.cmapPartitionsWithContext((ctx, part) => {
       val rv = RegionValue(ctx.r)
@@ -329,7 +304,6 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
         t.kFieldIdx,
         t.rowType))
   }
-
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.offset))

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -255,7 +255,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
 
   def toCRDDPtr: ContextRDD[Long] =
     crdd.cmap { (consumerCtx, rv) =>
-      consumerCtx.region.addReferenceTo(rv.region)
+      //consumerCtx.region.addReferenceTo(rv.region)
       rv.offset
     }
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -255,7 +255,9 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
 
   def toCRDDPtr: ContextRDD[Long] =
     crdd.cmap { (consumerCtx, rv) =>
-      //consumerCtx.region.addReferenceTo(rv.region)
+      if (consumerCtx.region != rv.region) {
+        consumerCtx.region.addReferenceTo(rv.region)
+      }
       rv.offset
     }
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -286,24 +286,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
       }
     }
   }
-
-//  def writeRows(
-//    path: String,
-//    idxRelPath: String,
-//    t: RVDType,
-//    stageLocally: Boolean,
-//    encoding: AbstractTypedCodecSpec
-//  ): (Array[String], Array[Long]) = {
-//    crdd.writePartitions(
-//      path,
-//      idxRelPath,
-//      stageLocally,
-//      IndexWriter.builder(t.kType, +PCanonicalStruct()),
-//      RichContextRDDRegionValue.writeRowsPartition(
-//        encoding.buildEncoder(t.rowType),
-//        t.kFieldIdx,
-//        t.rowType))
-//  }
+  
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.offset))

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -286,7 +286,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RegionValue]) extends AnyVa
       }
     }
   }
-  
+
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.offset))

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -107,7 +107,7 @@ object IndexBgen {
 
     val rangeBounds = bgenFilePaths.zipWithIndex.map { case (_, i) => Interval(Row(i), Row(i), includesStart = true, includesEnd = true) }
     val partitioner = new RVDPartitioner(Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
-    val crvd = BgenRDD(HailContext.sc, partitions, settings, null)
+    val crvd = BgenRDD(HailContext.sc, partitions, settings, null).toCRDDPtr
 
     val (leafCodec, intCodec) = BgenSettings.indexCodecSpecs(referenceGenome)
     val leafPType = LeafNodeBuilder.typ(indexKeyType, annotationType)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -429,7 +429,7 @@ case class MatrixBGENReader(
       new RVD(
         rvdType,
         partitioner,
-        BgenRDD(sc, partitions, settings, variants))
+        BgenRDD(sc, partitions, settings, variants).toCRDDPtr)
 
     val globalValue = makeGlobalValue(ctx, requestedType, sampleIds.map(Row(_)))
 

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -327,7 +327,7 @@ object ExportBGEN {
 
     val d = digitsNeeded(mv.rvd.getNumPartitions)
 
-    val (files, droppedPerPart) = mv.rvd.crdd.boundary.mapPartitionsWithIndex { case (i: Int, it: Iterator[Long]) =>
+    val (files, droppedPerPart) = mv.rvd.crdd.mapPartitionsWithIndex { case (i: Int, it: Iterator[Long]) =>
       val context = TaskContext.get
       val pf =
         parallelOutputPath + "/" +

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -101,9 +101,9 @@ class BgenPartitionWriter(rowPType: PStruct, nSamples: Int) {
   def emitVariant(rv: RegionValue): (Array[Byte], Long) = {
     bb.clear()
 
-    gs.setRegion(rv)
-    v.setRegion(rv)
-    va.setRegion(rv)
+    gs.set(rv.offset)
+    v.set(rv.offset)
+    va.set(rv.offset)
 
     val alleles = v.alleles()
     val nAlleles = alleles.length

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -98,12 +98,12 @@ class BgenPartitionWriter(rowPType: PStruct, nSamples: Int) {
   val v = new RegionValueVariant(rowPType)
   val va = new GenAnnotationView(rowPType)
 
-  def emitVariant(rv: RegionValue): (Array[Byte], Long) = {
+  def emitVariant(rv: Long): (Array[Byte], Long) = {
     bb.clear()
 
-    gs.set(rv.offset)
-    v.set(rv.offset)
-    va.set(rv.offset)
+    gs.set(rv)
+    v.set(rv)
+    va.set(rv)
 
     val alleles = v.alleles()
     val nAlleles = alleles.length
@@ -327,7 +327,7 @@ object ExportBGEN {
 
     val d = digitsNeeded(mv.rvd.getNumPartitions)
 
-    val (files, droppedPerPart) = mv.rvd.crdd.boundary.mapPartitionsWithIndex { case (i: Int, it: Iterator[RegionValue]) =>
+    val (files, droppedPerPart) = mv.rvd.crdd.boundary.mapPartitionsWithIndex { case (i: Int, it: Iterator[Long]) =>
       val context = TaskContext.get
       val pf =
         parallelOutputPath + "/" +
@@ -347,8 +347,8 @@ object ExportBGEN {
             BgenWriter.headerBlock(sampleIds, partitionSizes(i)))
         }
 
-        it.foreach { rv =>
-          val (b, d) = bpw.emitVariant(rv)
+        it.foreach { ptr =>
+          val (b, d) = bpw.emitVariant(ptr)
           out.write(b)
           dropped += d
         }

--- a/hail/src/main/scala/is/hail/io/gen/ExportGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportGen.scala
@@ -37,16 +37,16 @@ object ExportGen {
     val localNSamples = mv.nCols
     val fullRowType = mv.rvRowPType
 
-    mv.rvd.mapPartitions { it =>
+    mv.rvd.mapPartitions { (ctx, it) =>
       val sb = new StringBuilder
       val gpView = new ArrayGenotypeView(fullRowType)
       val v = new RegionValueVariant(fullRowType)
       val va = new GenAnnotationView(fullRowType)
 
-      it.map { rv =>
-        gpView.setRegion(rv)
-        v.setRegion(rv)
-        va.setRegion(rv)
+      it.map { ptr =>
+        gpView.set(ptr)
+        v.set(ptr)
+        va.set(ptr)
 
         val contig = v.contig()
         val alleles = v.alleles()
@@ -116,7 +116,7 @@ class GenAnnotationView(rowType: PStruct) extends View {
   private var cachedVarid: String = _
   private var cachedRsid: String = _
 
-  def setRegion(region: Region, offset: Long) {
+  def set(offset: Long) {
     assert(rowType.isFieldDefined(offset, varidIdx))
     assert(rowType.isFieldDefined(offset, rsidIdx))
     this.rsidOffset = rowType.loadField(offset, rsidIdx)

--- a/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -195,9 +195,7 @@ case class MatrixGENReader(
     val rvd = RVD.coerce(
       localRVDType,
       ContextRDD.weaken(rdd).cmapPartitions { (ctx, it) =>
-        val region = ctx.region
-        val rvb = new RegionValueBuilder(region)
-        val rv = RegionValue(region)
+        val rvb = ctx.rvb
 
         it.map { case (va, gs) =>
 
@@ -223,8 +221,8 @@ case class MatrixGENReader(
             rvb.endArray()
           }
           rvb.endStruct()
-          rv.setOffset(rvb.end())
-          rv
+
+          rvb.end()
         }
       },
       ctx)

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -143,7 +143,7 @@ class IndexWriter(
     internalEncoder.writeByte(1)
 
     val regionOffset = node.write(rvb)
-    internalEncoder.writeRegionValue(region, regionOffset)
+    internalEncoder.writeRegionValue(regionOffset)
     internalEncoder.flush()
 
     region.clear()
@@ -175,7 +175,7 @@ class IndexWriter(
     leafEncoder.writeByte(0)
 
     val regionOffset = leafNodeBuilder.write(rvb)
-    leafEncoder.writeRegionValue(region, regionOffset)
+    leafEncoder.writeRegionValue(regionOffset)
     leafEncoder.flush()
 
     region.clear()

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -91,12 +91,12 @@ object ExportPlink {
           val hcv = HardCallView(fullRowType)
           val bp = new BitPacker(2, bedOS)
 
-          it.foreach { rv =>
-            v.set(rv.offset)
-            a.set(rv.offset)
+          it.foreach { ptr =>
+            v.set(ptr)
+            a.set(ptr)
             ExportPlink.writeBimRow(v, a, bimOS)
 
-            hcv.set(rv.offset)
+            hcv.set(ptr)
             ExportPlink.writeBedRow(hcv, bp, nSamples)
             ctx.region.clear()
             rowCount += 1

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -92,11 +92,11 @@ object ExportPlink {
           val bp = new BitPacker(2, bedOS)
 
           it.foreach { rv =>
-            v.setRegion(rv)
-            a.setRegion(rv)
+            v.set(rv.offset)
+            a.set(rv.offset)
             ExportPlink.writeBimRow(v, a, bimOS)
 
-            hcv.setRegion(rv)
+            hcv.set(rv.offset)
             ExportPlink.writeBedRow(hcv, bp, nSamples)
             ctx.region.clear()
             rowCount += 1
@@ -136,7 +136,7 @@ class BimAnnotationView(rowType: PStruct) extends View {
 
   private var cachedVarid: String = _
 
-  def setRegion(region: Region, offset: Long) {
+  def set(offset: Long) {
     assert(rowType.isFieldDefined(offset, varidIdx))
     assert(rowType.isFieldDefined(offset, cmPosIdx))
 

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -226,9 +226,7 @@ case class MatrixPLINKReader(
       val rgLocal = referenceGenome
 
       val fastKeys = crdd.cmapPartitions { (ctx, it) =>
-        val region = ctx.region
-        val rvb = new RegionValueBuilder(region)
-        val rv = RegionValue(region)
+        val rvb = ctx.rvb
 
         it.flatMap { case (_, record) =>
           val (contig, pos, _, ref, alt, _) = variantsBc.value(record.getKey)
@@ -244,16 +242,13 @@ case class MatrixPLINKReader(
             rvb.endArray()
             rvb.endStruct()
 
-            rv.setOffset(rvb.end())
-            Some(rv)
+            Some(rvb.end())
           }
         }
       }
 
       val rdd2 = crdd.cmapPartitions { (ctx, it) =>
-        val region = ctx.region
-        val rvb = new RegionValueBuilder(region)
-        val rv = RegionValue(region)
+        val rvb = ctx.rvb
 
         it.flatMap { case (_, record) =>
           val (contig, pos, cmPos, ref, alt, rsid) = variantsBc.value(record.getKey)
@@ -276,8 +271,7 @@ case class MatrixPLINKReader(
               record.getValue(rvb, hasGT)
             rvb.endStruct()
 
-            rv.setOffset(rvb.end())
-            Some(rv)
+            Some(rvb.end())
           }
         }
       }

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1252,13 +1252,12 @@ object LoadVCF {
     contigRecoding: Map[String, String],
     arrayElementsRequired: Boolean,
     skipInvalidLoci: Boolean
-  ): ContextRDD[RegionValue] = {
+  ): ContextRDD[Long] = {
     val hasRSID = rowPType.hasField("rsid")
     lines.cmapPartitions { (ctx, it) =>
-      new Iterator[RegionValue] {
-        val region = ctx.region
+      new Iterator[Long] {
         val rvb = ctx.rvb
-        val rv = RegionValue(region)
+        var ptr: Long = 0
 
         val context: C = makeContext()
 
@@ -1277,7 +1276,7 @@ object LoadVCF {
                 f(context, vcfLine, rvb)
 
                 rvb.endStruct()
-                rv.setOffset(rvb.end())
+                ptr = rvb.end()
               } else
                 rvb.clear()
             } catch {
@@ -1304,12 +1303,12 @@ object LoadVCF {
           present
         }
 
-        def next(): RegionValue = {
+        def next(): Long = {
           // call hasNext to advance if necessary
           if (!hasNext)
             throw new java.util.NoSuchElementException()
           present = false
-          rv
+          ptr
         }
       }
     }

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -204,7 +204,7 @@ object IBD {
     min: Option[Double],
     max: Option[Double],
     sampleIds: IndexedSeq[String],
-    bounded: Boolean): ContextRDD[RegionValue] = {
+    bounded: Boolean): ContextRDD[Long] = {
 
     val nSamples = input.nCols
 
@@ -269,9 +269,7 @@ object IBD {
 
     joined
       .cmapPartitions { (ctx, it) =>
-        val region = ctx.region
-        val rv = RegionValue(region)
-        val rvb = new RegionValueBuilder(region)
+        val rvb = new RegionValueBuilder(ctx.region)
         for {
           ((iChunk, jChunk), ibses) <- it
           si <- (0 until chunkSize).iterator
@@ -289,8 +287,7 @@ object IBD {
           rvb.addString(sampleIds(j))
           eibd.toRegionValue(rvb)
           rvb.endStruct()
-          rv.setOffset(rvb.end())
-          rv
+          rvb.end()
         }
       }
   }

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -313,7 +313,7 @@ case class LocalLDPrune(
     val tableType = typ(mv.typ)
 
     val standardizedRDD = mv.rvd
-      .mapPartitions(mv.rvd.typ.copy(rowType = bpvType))({ (ctx, it) =>
+      .mapPartitions(mv.rvd.typ.copy(rowType = bpvType)){ (ctx, it) =>
         val hcView = new HardCallView(fullRowPType, callField)
         val region = Region()
         val rvb = new RegionValueBuilder(region)

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -62,7 +62,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
           .map(allColValuesJSON)
           .toArray)
 
-      val partFolders = mv.rvd.crdd.mapPartitionsWithIndex { (i, it) =>
+      val partFolders = mv.rvd.crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
 
         val partFolder = partFileBase + partFile(d, i, TaskContext.get())
 
@@ -87,11 +87,11 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
           }
         }
 
-        it.foreach { rv =>
+        it.foreach { ptr =>
 
-          val entriesArray = new UnsafeIndexedSeq(entryArrayType, rv.region, rvType.loadField(rv.offset, entriesIdx))
+          val entriesArray = new UnsafeIndexedSeq(entryArrayType, ctx.region, rvType.loadField(ptr, entriesIdx))
 
-          val fullRow = new UnsafeRow(rvType, rv)
+          val fullRow = new UnsafeRow(rvType, ctx.region, ptr)
 
           val rowFieldStrs = (0 until rvType.size)
             .filter(_ != entriesIdx)

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -121,7 +121,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
 
             os.write('\n')
           }
-          rv.region.clear()
+          ctx.region.clear()
         }
 
         fileHandles.foreach(_.close())

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -460,9 +460,7 @@ object Nirvana {
       nirvanaRVDType,
       prev.partitioner,
       ContextRDD.weaken(annotations).cmapPartitions { (ctx, it) =>
-        val region = ctx.region
-        val rvb = new RegionValueBuilder(region)
-        val rv = RegionValue(region)
+        val rvb = new RegionValueBuilder(ctx.region)
 
         it.map { case (v, nirvana) =>
           rvb.start(nirvanaRowType)
@@ -471,9 +469,8 @@ object Nirvana {
           rvb.addAnnotation(nirvanaRowType.types(1).virtualType, v.asInstanceOf[Row].get(1))
           rvb.addAnnotation(nirvanaRowType.types(2).virtualType, nirvana)
           rvb.endStruct()
-          rv.setOffset(rvb.end())
 
-          rv
+          rvb.end()
         }
       }).persist(StorageLevel.MEMORY_AND_DISK)
 

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -412,7 +412,7 @@ object Nirvana {
     val prev = tv.rvd
 
     val annotations = prev
-      .mapPartitions { it =>
+      .mapPartitions { (_, it) =>
         val pb = new ProcessBuilder(cmd.asJava)
         val env = pb.environment()
         if (path.orNull != null)
@@ -422,8 +422,8 @@ object Nirvana {
 
         val rvv = new RegionValueVariant(localRowType)
 
-        it.map { rv =>
-          rvv.setRegion(rv)
+        it.map { ptr =>
+          rvv.set(ptr)
           (rvv.locus(), rvv.alleles())
         }
           .grouped(localBlockSize)

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -345,7 +345,8 @@ case class Skat(
     val n = completeColIdx.length
     val completeColIdxBc = HailContext.backend.broadcast(completeColIdx)
 
-    (mv.rvd.boundary.mapPartitions { (ctx, it) => it.flatMap { ptr =>
+    // I believe no `boundary` is needed here because `mapPartitions` calls `run` which calls `cleanupRegions`.
+    (mv.rvd.mapPartitions { (ctx, it) => it.flatMap { ptr =>
       val keyIsDefined = fullRowType.isFieldDefined(ptr, keyIndex)
       val weightIsDefined = fullRowType.isFieldDefined(ptr, weightIndex)
 

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -135,7 +135,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
     val prev = tv.rvd
     val annotations = prev
-      .mapPartitions { it =>
+      .mapPartitions { (_, it) =>
         val pb = new ProcessBuilder(cmd.toList.asJava)
         val env = pb.environment()
         conf.env.foreach { case (key, value) =>
@@ -146,8 +146,8 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
         val rvv = new RegionValueVariant(localRowType)
         it
-          .map { rv =>
-            rvv.setRegion(rv)
+          .map { ptr =>
+            rvv.set(ptr)
             (rvv.locus(), rvv.alleles(): IndexedSeq[String])
           }
           .grouped(localBlockSize)

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -224,9 +224,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
       vepRVDType,
       prev.partitioner,
       ContextRDD.weaken(annotations).cmapPartitions { (ctx, it) =>
-        val region = ctx.region
         val rvb = ctx.rvb
-        val rv = RegionValue(region)
 
         it.map { case (v, vep) =>
           rvb.start(vepRowType)
@@ -235,8 +233,8 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
           rvb.addAnnotation(vepRowType.types(1).virtualType, v.asInstanceOf[Row].get(1))
           rvb.addAnnotation(vepRowType.types(2).virtualType, vep)
           rvb.endStruct()
-          rv.setOffset(rvb.end())
-          rv
+
+          rvb.end()
         }
       })
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -61,7 +61,7 @@ object AbstractRVDSpec {
     val f = partPath(path, partFiles(0))
     using(fs.open(f)) { in =>
       val Array(rv) = HailContext.readRowsPartition(dec)(r, in).toArray
-      (rType, rv.offset)
+      (rType, rv)
     }
   }
 
@@ -87,12 +87,11 @@ object AbstractRVDSpec {
       using(fs.create(partsPath + "/" + filePath)) { os =>
         using(RVDContext.default) { ctx =>
           val rvb = ctx.rvb
-          val region = ctx.region
           RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(rowType))(ctx,
             rows.iterator.map { a =>
               rvb.start(rowType)
               rvb.addAnnotation(rowType.virtualType, a)
-              RegionValue(region, rvb.end())
+              rvb.end()
             }, os, null)
         }
       }

--- a/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
@@ -164,7 +164,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
 
     val leftType = this.virtType
     val rightType = right.virtType
-    val jcrdd = repartitionedLeft.crdd.toCRDDRegionValue.boundary.czipPartitions(repartitionedRight.crdd.toCRDDRegionValue.boundary)
+    val jcrdd = repartitionedLeft.crdd.toCRDDRegionValue.czipPartitions(repartitionedRight.crdd.toCRDDRegionValue)
       { (ctx, leftIt, rightIt) =>
         OrderedRVIterator(leftType, leftIt, ctx)
           .zipJoin(OrderedRVIterator(rightType, rightIt, ctx))

--- a/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
@@ -5,7 +5,7 @@ import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.TInterval
 import is.hail.sparkextras._
-import is.hail.utils.{Muple, fatal}
+import is.hail.utils._
 
 import scala.collection.generic.Growable
 
@@ -164,7 +164,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
 
     val leftType = this.virtType
     val rightType = right.virtType
-    val jcrdd = repartitionedLeft.crddBoundary.czipPartitions(repartitionedRight.crddBoundary)
+    val jcrdd = repartitionedLeft.crdd.toCRDDRegionValue.boundary.czipPartitions(repartitionedRight.crdd.toCRDDRegionValue.boundary)
       { (ctx, leftIt, rightIt) =>
         OrderedRVIterator(leftType, leftIt, ctx)
           .zipJoin(OrderedRVIterator(rightType, rightIt, ctx))

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -433,6 +433,14 @@ class RVD(
     )
   }
 
+  def mapPartitionsWithContext(newTyp: RVDType)(f: (Int, RVDContext, RVDContext => Iterator[Long]) => Iterator[Long]): RVD = {
+    RVD(
+      newTyp,
+      partitioner.coarsen(newTyp.key.length),
+      crdd.cmapPartitionsWithContextAndIndex(f)
+    )
+  }
+
   def mapPartitionsWithIndex[T: ClassTag](
     f: (Int, RVDContext, Iterator[Long]) => Iterator[T]
   ): RDD[T] = crdd.cmapPartitionsWithIndex(f).run

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -425,6 +425,14 @@ class RVD(
       crdd.cmapPartitions(f))
   }
 
+  def mapPartitionsWithContext(newTyp: RVDType)(f: (RVDContext, RVDContext => Iterator[Long]) => Iterator[Long]): RVD = {
+    RVD(
+      newTyp,
+      partitioner.coarsen(newTyp.key.length),
+      crdd.cmapPartitionsWithContext(f)
+    )
+  }
+
   def mapPartitionsWithIndex[T: ClassTag](
     f: (Int, RVDContext, Iterator[Long]) => Iterator[T]
   ): RDD[T] = crdd.cmapPartitionsWithIndex(f).run

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -466,10 +466,10 @@ class RVD(
           case None => return this
         }
       case None =>
-        val crddBoundary = crdd.boundary
+        val crddCleanup = crdd.cleanupRegions
         val PCSubsetOffset(idx, nTake, _) =
           incrementalPCSubsetOffset(n, 0 until getNumPartitions)(
-            crddBoundary.runJob(getIteratorSizeWithMaxN(n), _)
+            crddCleanup.runJob(getIteratorSizeWithMaxN(n), _)
           )
         idx -> nTake
     }
@@ -505,10 +505,10 @@ class RVD(
           case None => return this
         }
       case None =>
-        val crddBoundary = crdd.boundary
+        val crddCleanup = crdd.cleanupRegions
         val PCSubsetOffset(idx, _, nDrop) =
           incrementalPCSubsetOffset(n, Range.inclusive(getNumPartitions - 1, 0, -1))(
-            crddBoundary.runJob(getIteratorSize, _)
+            crddCleanup.runJob(getIteratorSize, _)
           )
         idx -> nDrop
     }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -81,7 +81,7 @@ class RVD(
 
   def stabilize(enc: AbstractTypedCodecSpec): RDD[Array[Byte]] = {
     val makeEnc = enc.buildEncoder(rowPType)
-    crdd.mapPartitions(RegionValue.toBytes(makeEnc, _)).clearingRun
+    crdd.mapPartitions(RegionValue.toBytes(makeEnc, _)).run
   }
 
   def encodedRDD(enc: AbstractTypedCodecSpec): RDD[Array[Byte]] =
@@ -102,7 +102,7 @@ class RVD(
         val bytes = encoder.regionValueToBytes(ptr)
         (keys, bytes)
       }
-    }.clearingRun
+    }.run
   }
 
   // Return an OrderedRVD whose key equals or at least starts with 'newKey'.
@@ -401,7 +401,7 @@ class RVD(
   // partitioner remains valid.
 
   def map[T](f: (RVDContext, Long) => T)(implicit tct: ClassTag[T]): RDD[T] =
-    crdd.cmap(f).clearingRun
+    crdd.cmap(f).run
 
   def map(newTyp: RVDType)(f: (RVDContext, Long) => Long): RVD = {
     require(newTyp.kType isPrefixOf typ.kType)
@@ -412,7 +412,7 @@ class RVD(
 
   def mapPartitions[T: ClassTag](
     f: (RVDContext, Iterator[Long]) => Iterator[T]
-  ): RDD[T] = crdd.cmapPartitions(f).clearingRun
+  ): RDD[T] = crdd.cmapPartitions(f).run
 
   def mapPartitions(
     newTyp: RVDType
@@ -427,7 +427,7 @@ class RVD(
 
   def mapPartitionsWithIndex[T: ClassTag](
     f: (Int, RVDContext, Iterator[Long]) => Iterator[T]
-  ): RDD[T] = crdd.cmapPartitionsWithIndex(f).clearingRun
+  ): RDD[T] = crdd.cmapPartitionsWithIndex(f).run
 
   def mapPartitionsWithIndex(
     newTyp: RVDType
@@ -1111,7 +1111,7 @@ class RVD(
         } else
           Iterator()
       }
-    }.clearingRun
+    }.run
 
     val nParts = getNumPartitions
     val intervalOrd = rightTyp.kType.types(0).virtualType.ordering.toOrdering.asInstanceOf[Ordering[Interval]]

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1093,7 +1093,7 @@ class RVD(
     val rightTyp = that.typ
     val codecSpec = TypedCodecSpec(that.rowPType, BufferSpec.wireSpec)
     val makeEnc = codecSpec.buildEncoder(that.rowPType)
-    val partitionKeyedIntervals = that.boundary.crdd.cmapPartitions { (ctx, it) =>
+    val partitionKeyedIntervals = that.crdd.cmapPartitions { (ctx, it) =>
       val encoder = new ByteArrayEncoder(makeEnc)
       TaskContext.get.addTaskCompletionListener { _ =>
         encoder.close()

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -81,7 +81,7 @@ class RVD(
 
   def stabilize(enc: AbstractTypedCodecSpec): RDD[Array[Byte]] = {
     val makeEnc = enc.buildEncoder(rowPType)
-    crdd.mapPartitions(RegionValue.toBytes(makeEnc, _)).clearingRun
+    crdd.toCRDDPtr.mapPartitions(RegionValue.toBytes(makeEnc, _)).clearingRun
   }
 
   def encodedRDD(enc: AbstractTypedCodecSpec): RDD[Array[Byte]] =
@@ -92,14 +92,14 @@ class RVD(
     val kFieldIdx = typ.copy(key = key).kFieldIdx
 
     val localRowPType = rowPType
-    crdd.mapPartitions { it =>
+    crdd.toCRDDPtr.cmapPartitions { (ctx, it) =>
       val encoder = new ByteArrayEncoder(makeEnc)
       TaskContext.get.addTaskCompletionListener { _ =>
         encoder.close()
       }
-      it.map { rv =>
-        val keys: Any = SafeRow.selectFields(localRowPType, rv)(kFieldIdx)
-        val bytes = encoder.regionValueToBytes(rv.region, rv.offset)
+      it.map { ptr =>
+        val keys: Any = SafeRow.selectFields(localRowPType, ctx.r, ptr)(kFieldIdx)
+        val bytes = encoder.regionValueToBytes(ptr)
         (keys, bytes)
       }
     }.clearingRun
@@ -260,7 +260,7 @@ class RVD(
 
       val (rType: PStruct, shuffledCRDD) = enc.decodeRDD(localRowPType.virtualType, shuffled.values)
 
-      RVD(RVDType(rType, newType.key), newPartitioner, shuffledCRDD)
+      RVD(RVDType(rType, newType.key), newPartitioner, shuffledCRDD.toCRDDRegionValue)
     } else {
       if (newPartitioner != partitioner)
         new RVD(
@@ -735,8 +735,8 @@ class RVD(
     val (pType: PStruct, dec) = enc.buildDecoder(rowType)
     Region.scoped { region =>
       RegionValue.fromBytes(dec, region, encodedData.iterator)
-        .map { rv =>
-          val row = SafeRow(pType, rv)
+        .map { ptr =>
+          val row = SafeRow(pType, ptr)
           region.clear()
           row
         }.toArray
@@ -1148,7 +1148,7 @@ class RVD(
           val wrappedInterval = interval.copy(
             start = Row(interval.start),
             end = Row(interval.end))
-          val bytes = encoder.regionValueToBytes(rv.region, rv.offset)
+          val bytes = encoder.regionValueToBytes(rv.offset)
           partBc.value.queryInterval(wrappedInterval).map(i => ((i, interval), bytes))
         } else
           Iterator()
@@ -1171,7 +1171,7 @@ class RVD(
     RVD(
       typ = newTyp,
       partitioner = partitioner,
-      crdd = crddBoundary.czipPartitions(rightCRDD.boundary)(f))
+      crdd = crddBoundary.czipPartitions(rightCRDD.toCRDDRegionValue.boundary)(f))
   }
 
   // Private
@@ -1190,7 +1190,7 @@ class RVD(
     val (rowPType: PStruct, dec) = enc.buildDecoder(rowType)
     (rowPType, ContextRDD.weaken(stable).cmapPartitions { (ctx, it) =>
       RegionValue.fromBytes(dec, ctx.region, it)
-    })
+    }.toCRDDRegionValue)
   }
 
   private[rvd] def crddBoundary: ContextRDD[RegionValue] =

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -685,7 +685,6 @@ class RVD(
       var count = 0L
       it.foreach { _ =>
         count += 1
-        ctx.region.clear()
       }
       Iterator.single(count)
     }.collect()

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -546,7 +546,7 @@ class RVD(
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RVDContext, Long) => Boolean): RVD = {
     val crdd: ContextRDD[Long] = this.crdd.cmapPartitionsWithContextAndIndex { (i, consumerCtx, iteratorToFilter) =>
       val c = makeContext(i, consumerCtx)
-      val producerCtx = consumerCtx.freshContext
+      val producerCtx = consumerCtx.freshContextFrom("RVD.filterWithContext")
       iteratorToFilter(producerCtx).filter { ptr =>
         val b = f(c, consumerCtx, ptr)
         if (b) {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -164,7 +164,8 @@ class RVD(
       typ,
       partitioner,
       crdd.cmapPartitionsWithIndex { case (i, ctx, it) =>
-        val prevK = WritableRegionValue(localType.kType, ctx.freshRegion)
+        val regionForWriting = ctx.freshRegion // This one gets cleaned up when context is freed.
+        val prevK = WritableRegionValue(localType.kType, regionForWriting)
         val kUR = new UnsafeRow(localKPType)
 
         new Iterator[Long] {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -539,8 +539,9 @@ class RVD(
     RVD(typ, newPartitioner, newRDD)
   }
 
-  def filter(p: (RVDContext, Long) => Boolean): RVD =
-    RVD(typ, partitioner, crdd.boundary.cfilter(p))
+  def filter(p: (RVDContext, Long) => Boolean): RVD = {
+    filterWithContext((_, _) => (), (_: Any, c, l) => p(c, l))
+  }
 
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RVDContext, Long) => Boolean): RVD = {
     val crdd: ContextRDD[Long] = this.crdd.cmapPartitionsWithContextAndIndex { (i, consumerCtx, iteratorToFilter) =>

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -433,7 +433,7 @@ class RVD(
     )
   }
 
-  def mapPartitionsWithContext(newTyp: RVDType)(f: (Int, RVDContext, RVDContext => Iterator[Long]) => Iterator[Long]): RVD = {
+  def mapPartitionsWithContextAndIndex(newTyp: RVDType)(f: (Int, RVDContext, RVDContext => Iterator[Long]) => Iterator[Long]): RVD = {
     RVD(
       newTyp,
       partitioner.coarsen(newTyp.key.length),

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1029,7 +1029,7 @@ class RVD(
   ): RVD = RVD(
     newTyp,
     partitioner,
-    crdd.toCRDDRegionValue.boundary.czip(that.crdd.toCRDDRegionValue.boundary)(zipper).toCRDDPtr)
+    crdd.toCRDDRegionValue.czip(that.crdd.toCRDDRegionValue)(zipper).toCRDDPtr)
 
   def zipPartitions(
     newTyp: RVDType,
@@ -1038,7 +1038,7 @@ class RVD(
   ): RVD = RVD(
     newTyp,
     partitioner,
-    crdd.toCRDDRegionValue.boundary.czipPartitions(that.crdd.toCRDDRegionValue.boundary)(zipper).toCRDDPtr)
+    crdd.toCRDDRegionValue.czipPartitions(that.crdd.toCRDDRegionValue)(zipper).toCRDDPtr)
 
   def zipPartitionsWithIndex(
     newTyp: RVDType,
@@ -1047,7 +1047,7 @@ class RVD(
   ): RVD = RVD(
     newTyp,
     partitioner,
-    crdd.toCRDDRegionValue.boundary.czipPartitionsWithIndex(that.crdd.toCRDDRegionValue.boundary)(zipper).toCRDDPtr)
+    crdd.toCRDDRegionValue.czipPartitionsWithIndex(that.crdd.toCRDDRegionValue)(zipper).toCRDDPtr)
 
   // New key type must be prefix of left key type. 'joinKey' must be prefix of
   // both left key and right key. 'zipper' must take all output key values from
@@ -1072,8 +1072,8 @@ class RVD(
     RVD(
       typ = newTyp,
       partitioner = left.partitioner,
-      crdd = left.crdd.toCRDDRegionValue.boundary.czipPartitions(
-        RepartitionedOrderedRDD2(that, this.partitioner.coarsenedRangeBounds(joinKey)).toCRDDRegionValue.boundary
+      crdd = left.crdd.toCRDDRegionValue.czipPartitions(
+        RepartitionedOrderedRDD2(that, this.partitioner.coarsenedRangeBounds(joinKey)).toCRDDRegionValue
       )(zipper).toCRDDPtr)
   }
 
@@ -1127,7 +1127,7 @@ class RVD(
     RVD(
       typ = newTyp,
       partitioner = partitioner,
-      crdd = crdd.toCRDDRegionValue.boundary.czipPartitions(rightCRDD.toCRDDRegionValue.boundary)(f).toCRDDPtr)
+      crdd = crdd.toCRDDRegionValue.czipPartitions(rightCRDD.toCRDDRegionValue)(f).toCRDDPtr)
   }
 
   // Private

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1422,7 +1422,7 @@ object RVD {
     rvds.map { rvd =>
       val srcRowPType = rvd.rowPType
       val newRVDType = rvd.typ.copy(rowType = unifiedRowPType)
-      rvd.map(newRVDType)((ctx, ptr) => unifiedRowPType.copyFromType(ctx.r, srcRowPType, ptr, false))
+      rvd.map(newRVDType)((ctx, ptr) => unifiedRowPType.copyFromAddress(ctx.r, srcRowPType, ptr, false))
     }
   }
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -563,7 +563,7 @@ class RVD(
   def filterWithContext[C](makeContext: (Int, RVDContext) => C, f: (C, RVDContext, Long) => Boolean): RVD = {
     val crdd: ContextRDD[Long] = this.crdd.cmapPartitionsWithContextAndIndex { (i, consumerCtx, iteratorToFilter) =>
       val c = makeContext(i, consumerCtx)
-      val producerCtx = consumerCtx.freshContextFrom("RVD.filterWithContext")
+      val producerCtx = consumerCtx.freshContext
       iteratorToFilter(producerCtx).filter { ptr =>
         val b = f(c, consumerCtx, ptr)
         if (b) {

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -23,17 +23,8 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
 
   own(r)
 
-  def freshContextFrom(caller: String): RVDContext = {
-    freshContextHelper(caller)
-  }
-
-  def freshContext: RVDContext = {
-    freshContextHelper("unnamed")
-  }
-
-  def freshContextHelper(name: String): RVDContext = {
-    log.info(s"FRESH CONTEXT CREATED BY: $name")
-    val ctx = new RVDContext(partitionRegion, Region.makeNamed(creator=name))
+  def freshContext(): RVDContext = {
+    val ctx = new RVDContext(partitionRegion, Region())
     own(ctx)
     ctx
   }

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -1,6 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.utils._
 
 import scala.collection.mutable
 
@@ -22,8 +23,17 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
 
   own(r)
 
+  def freshContextFrom(caller: String): RVDContext = {
+    freshContextHelper(caller)
+  }
+
   def freshContext: RVDContext = {
-    val ctx = new RVDContext(partitionRegion, Region())
+    freshContextHelper("unnamed")
+  }
+
+  def freshContextHelper(name: String): RVDContext = {
+    log.info(s"FRESH CONTEXT CREATED BY: $name")
+    val ctx = new RVDContext(partitionRegion, Region(creator=name))
     own(ctx)
     ctx
   }

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -33,7 +33,7 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
 
   def freshContextHelper(name: String): RVDContext = {
     log.info(s"FRESH CONTEXT CREATED BY: $name")
-    val ctx = new RVDContext(partitionRegion, Region(creator=name))
+    val ctx = new RVDContext(partitionRegion, Region.makeNamed(creator=name))
     own(ctx)
     ctx
   }

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -228,7 +228,7 @@ class ContextRDD[T: ClassTag](
     sparkContext.runJob(
       rdd,
       { (taskContext, it: Iterator[RVDContext => Iterator[T]]) =>
-        val c = sparkManagedContext()
+        val c = RVDContext.default
         f(taskContext.partitionId(), c, it.flatMap(_(c)))
       })
 

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -157,13 +157,14 @@ class ContextRDD[T: ClassTag](
   }
 
   def run[U >: T : ClassTag]: RDD[U] =
-    rdd.mapPartitions { part =>
+    this.cleanupRegions.rdd.mapPartitions { part =>
       val c = sparkManagedContext()
       part.flatMap(_(c))
     }
 
-  def collect(): Array[T] =
+  def collect(): Array[T] = {
     run.collect()
+  }
 
   private[this] def inCtx[U: ClassTag](
     f: RVDContext => Iterator[U]

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -207,6 +207,30 @@ class ContextRDD[T: ClassTag](
       part => inCtx(ctx => f(ctx, part.flatMap(_(ctx)))),
       preservesPartitioning))
 
+  def cmapPartitionsWithContext[U: ClassTag](f: (RVDContext, (RVDContext) => Iterator[T]) => Iterator[U]): ContextRDD[U] = {
+    new ContextRDD(rdd.mapPartitions(
+      part => part.flatMap {
+          x => inCtx(consumerCtx => f(consumerCtx, x))
+      }))
+  }
+
+  def cmapPartitionsWithContextAndIndex[U: ClassTag](f: (Int, RVDContext, (RVDContext) => Iterator[T]) => Iterator[U]): ContextRDD[U] = {
+    new ContextRDD(rdd.mapPartitionsWithIndex(
+      (i, part) => part.flatMap {
+        x => inCtx(consumerCtx => f(i, consumerCtx, x))
+      }))
+  }
+
+  // Gives consumer ownership of the context. Consumer is responsible for freeing
+  // resources per element.
+  def crunJobWithIndex[U: ClassTag](f: (Int, RVDContext, Iterator[T]) => U): Array[U] =
+    sparkContext.runJob(
+      rdd,
+      { (taskContext, it: Iterator[RVDContext => Iterator[T]]) =>
+        val c = sparkManagedContext()
+        f(taskContext.partitionId(), c, it.flatMap(_(c)))
+      })
+
   def cmapPartitionsAndContext[U: ClassTag](
     f: (RVDContext, (Iterator[RVDContext => Iterator[T]])) => Iterator[U],
     preservesPartitioning: Boolean = false

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -120,7 +120,7 @@ class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
     val rvd = RVD(
       RVDType(rowType, LinearMixedModel.tableType.key),
       pa_t.partitioner(),
-      ContextRDD.weaken(rdd)).persist(StorageLevel.MEMORY_AND_DISK)
+      ContextRDD.weaken(rdd).toCRDDPtr).persist(StorageLevel.MEMORY_AND_DISK)
 
     LinearMixedModel.toTableIR(rvd)
   }
@@ -186,7 +186,7 @@ class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
     val rvd = RVD(
       RVDType(rowType, LinearMixedModel.tableType.key),
       pa_t.partitioner(),
-      ContextRDD.weaken(rdd)).persist(StorageLevel.MEMORY_AND_DISK)
+      ContextRDD.weaken(rdd).toCRDDPtr).persist(StorageLevel.MEMORY_AND_DISK)
 
     LinearMixedModel.toTableIR(rvd)
   }

--- a/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -13,7 +13,7 @@ object RegressionUtils {
     offset: Int,
     completeColIdx: Array[Int],
     missingCompleteCols: ArrayBuilder[Int],
-    rv: RegionValue,
+    rv: Long,
     rvRowType: PStruct,
     entryArrayType: PArray,
     entryType: PStruct,
@@ -23,8 +23,7 @@ object RegressionUtils {
     missingCompleteCols.clear()
     val n = completeColIdx.length
     var sum = 0.0
-    val region = rv.region
-    val entryArrayOffset = rvRowType.loadField(rv.offset, entryArrayIdx)
+    val entryArrayOffset = rvRowType.loadField(rv, entryArrayIdx)
 
     var j = 0
     while (j < n) {

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -369,7 +369,6 @@ case class TextTableReader(options: TextTableReaderOptions) extends TableReader 
       }.cmapPartitions { (ctx, it) =>
       val region = ctx.region
       val rvb = ctx.rvb
-      val rv = RegionValue(region)
 
       val ab = new ArrayBuilder[String]
       val sb = new StringBuilder
@@ -379,7 +378,6 @@ case class TextTableReader(options: TextTableReaderOptions) extends TableReader 
           if (sp.length != nFieldOrig)
             fatal(s"expected $nFieldOrig fields, but found ${ sp.length } fields")
 
-          rvb.set(region)
           rvb.start(rowPType)
           rvb.startStruct()
 
@@ -402,8 +400,8 @@ case class TextTableReader(options: TextTableReaderOptions) extends TableReader 
           }
 
           rvb.endStruct()
-          rv.setOffset(rvb.end())
-          rv
+
+          rvb.end()
         }.value
       }
     }

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -45,6 +45,8 @@ trait Implicits {
 
   implicit def toRichIterator[T](it: Iterator[T]): RichIterator[T] = new RichIterator[T](it)
 
+  implicit def toRichIteratorLong(it: Iterator[Long]): RichIteratorLong = new RichIteratorLong(it)
+
   implicit def toRichRowIterator(it: Iterator[Row]): RichRowIterator = new RichRowIterator(it)
 
   implicit def toRichMap[K, V](m: Map[K, V]): RichMap[K, V] = new RichMap(m)

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -5,7 +5,7 @@ import java.io.InputStream
 import breeze.linalg.DenseMatrix
 import is.hail.annotations.{JoinedRegionValue, Region, RegionValue, RegionValueBuilder}
 import is.hail.asm4s.{Code, Value}
-import is.hail.io.{InputBuffer, OutputBuffer, RichContextRDDRegionValue}
+import is.hail.io.{InputBuffer, OutputBuffer, RichContextRDDRegionValue, RichContextRDDLong}
 import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
 import is.hail.utils.{IntPacker, HailIterator, MultiArray2, Truncatable, WithContext}
@@ -69,6 +69,8 @@ trait Implicits {
   implicit def toRichRDD[T](r: RDD[T])(implicit tct: ClassTag[T]): RichRDD[T] = new RichRDD(r)
 
   implicit def toRichContextRDDRegionValue(r: ContextRDD[RegionValue]): RichContextRDDRegionValue = new RichContextRDDRegionValue(r)
+
+  implicit def toRichContextRDDLong(r: ContextRDD[Long]): RichContextRDDLong = new RichContextRDDLong(r)
 
   implicit def toRichRegex(r: Regex): RichRegex = new RichRegex(r)
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -15,13 +15,7 @@ import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
 
 class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
-  // Only use on CRDD's whose T is not dependent on the context
-  def clearingRun: RDD[T] =
-    crdd.cmap { (ctx, v) =>
-      ctx.region.clear()
-      v
-    }.run
-
+  
   def cleanupRegions: ContextRDD[T] = {
     crdd.cmapPartitionsAndContext { (ctx, part) =>
       val it = part.flatMap(_ (ctx))

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDDRow.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDDRow.scala
@@ -8,7 +8,7 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 
 class RichContextRDDRow(crdd: ContextRDD[Row]) {
-  def toRegionValues(rowType: PStruct): ContextRDD[RegionValue] = {
-    crdd.cmapPartitions((ctx, it) => it.toRegionValueIterator(ctx.region, rowType))
+  def toRegionValues(rowType: PStruct): ContextRDD[Long] = {
+    crdd.cmapPartitions((ctx, it) => it.copyToRegion(ctx.region, rowType))
   }
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -125,15 +125,4 @@ class RichRowIterator(val it: Iterator[Row]) extends AnyVal {
       rvb.end()
     }
   }
-
-  def toRegionValueIterator(region: Region, rowTyp: PStruct): Iterator[RegionValue] = {
-    val rvb = new RegionValueBuilder(region)
-    val rv = RegionValue(region)
-    it.map { row =>
-      rvb.start(rowTyp)
-      rvb.addAnnotation(rowTyp.virtualType, row)
-      rv.setOffset(rvb.end())
-      rv
-    }
-  }
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -13,6 +13,13 @@ import org.apache.spark.sql.Row
 
 import scala.reflect.ClassTag
 
+class RichIteratorLong(val it: Iterator[Long]) extends AnyVal {
+  def toIteratorRV(region: Region): Iterator[RegionValue] = {
+    val rv = RegionValue(region)
+    it.map(ptr => { rv.setOffset(ptr); rv })
+  }
+}
+
 class RichIterator[T](val it: Iterator[T]) extends AnyVal {
   def toStagingIterator: StagingIterator[T] = {
     val bit = it.buffered

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -109,6 +109,15 @@ class RichIterator[T](val it: Iterator[T]) extends AnyVal {
 }
 
 class RichRowIterator(val it: Iterator[Row]) extends AnyVal {
+  def copyToRegion(region: Region, rowTyp: PStruct): Iterator[Long] = {
+    val rvb = new RegionValueBuilder(region)
+    it.map { row =>
+      rvb.start(rowTyp)
+      rvb.addAnnotation(rowTyp.virtualType, row)
+      rvb.end()
+    }
+  }
+
   def toRegionValueIterator(region: Region, rowTyp: PStruct): Iterator[RegionValue] = {
     val rvb = new RegionValueBuilder(region)
     val rv = RegionValue(region)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -5,6 +5,7 @@ import java.io.PrintWriter
 import is.hail.annotations.{Region, RegionValue, RegionValueBuilder}
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.TStruct
+import is.hail.rvd.RVDContext
 
 import scala.collection.JavaConverters._
 import scala.io.Source

--- a/hail/src/main/scala/is/hail/variant/HardCallView.scala
+++ b/hail/src/main/scala/is/hail/variant/HardCallView.scala
@@ -34,12 +34,10 @@ final class ArrayGenotypeView(rvType: PStruct) {
   private var gOffset: Long = _
   var gIsDefined: Boolean = _
 
-  def setRegion(mb: Region, offset: Long) {
+  def set(offset: Long) {
     gsOffset = rvType.loadField(offset, entriesIndex)
     gsLength = tgs.loadLength(gsOffset)
   }
-
-  def setRegion(rv: RegionValue): Unit = setRegion(rv.region, rv.offset)
 
   def setGenotype(idx: Int) {
     require(idx >= 0 && idx < gsLength)
@@ -101,12 +99,10 @@ final class HardCallView(rvType: PStruct, callField: String) {
   var gsLength: Int = _
   var gIsDefined: Boolean = _
 
-  def setRegion(mb: Region, offset: Long) {
+  def set(offset: Long) {
     gsOffset = rvType.loadField(offset, entriesIndex)
     gsLength = tgs.loadLength(gsOffset)
   }
-
-  def setRegion(rv: RegionValue): Unit = setRegion(rv.region, rv.offset)
 
   def setGenotype(idx: Int) {
     require(idx >= 0 && idx < gsLength)

--- a/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
+++ b/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
@@ -19,7 +19,7 @@ class RegionValueVariant(rowType: PStruct) extends View {
   private var cachedAlleles: Array[String] = null
   private var cachedLocus: Locus = null
 
-  def setRegion(region: Region, address: Long) {
+  def set(address: Long) {
     if (!rowType.isFieldDefined(address, locusIdx))
       fatal(s"The row field 'locus' cannot have missing values.")
     if (!rowType.isFieldDefined(address, allelesIdx))

--- a/hail/src/main/scala/is/hail/variant/View.scala
+++ b/hail/src/main/scala/is/hail/variant/View.scala
@@ -1,11 +1,5 @@
 package is.hail.variant
 
-import is.hail.annotations._
-
 trait View {
-  final def setRegion(rv: RegionValue) {
-    setRegion(rv.region, rv.offset)
-  }
-
-  def setRegion(region: Region, offset: Long)
+  def set(offset: Long)
 }

--- a/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -91,7 +91,7 @@ class UnsafeSuite extends HailSuite {
 
         val aos = new ByteArrayOutputStream()
         val en = codec.buildEncoder(pt)(aos)
-        en.writeRegionValue(region, offset)
+        en.writeRegionValue(offset)
         en.flush()
 
         region2.clear()
@@ -113,7 +113,7 @@ class UnsafeSuite extends HailSuite {
         val codec2 = TypedCodecSpec(PType.canonical(requestedType), bufferSpec)
         val aos2 = new ByteArrayOutputStream()
         val en2 = codec2.buildEncoder(pt)(aos2)
-        en2.writeRegionValue(region, offset)
+        en2.writeRegionValue(offset)
         en2.flush()
 
         region4.clear()
@@ -153,7 +153,7 @@ class UnsafeSuite extends HailSuite {
           val cs2 = TypedCodecSpec(t, spec)
           val baos = new ByteArrayOutputStream()
           val enc = cs2.buildEncoder(t)(baos)
-          enc.writeRegionValue(region, off)
+          enc.writeRegionValue(off)
           enc.flush()
 
           val serialized = baos.toByteArray

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -75,7 +75,7 @@ object LocalLDPruneSuite {
     val bpvv = new BitPackedVectorView(bitPackedVectorViewType)
     toBitPackedVectorRegionValue(gs, nSamples) match {
       case Some(rv) =>
-        bpvv.setRegion(rv)
+        bpvv.set(rv.offset)
         Some(bpvv)
       case None => None
     }
@@ -89,7 +89,7 @@ object LocalLDPruneSuite {
   def toBitPackedVectorRegionValue(rv: RegionValue, nSamples: Int): Option[RegionValue] = {
     val rvb = new RegionValueBuilder(Region())
     val hcView = HardCallView(PType.canonical(rvRowType).asInstanceOf[PStruct])
-    hcView.setRegion(rv)
+    hcView.set(rv.offset)
 
     rvb.start(bitPackedVectorViewType)
     rvb.startStruct()
@@ -303,11 +303,11 @@ class LocalLDPruneSuite extends HailSuite {
         val view = HardCallView(PType.canonical(LocalLDPruneSuite.rvRowType).asInstanceOf[PStruct])
 
         val rv1 = LocalLDPruneSuite.makeRV(v1Ann)
-        view.setRegion(rv1)
+        view.set(rv1.offset)
         val sgs1 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
 
         val rv2 = LocalLDPruneSuite.makeRV(v2Ann)
-        view.setRegion(rv2)
+        view.set(rv2.offset)
         val sgs2 = TestUtils.normalizedHardCalls(view, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
 
         (bv1, bv2, sgs1, sgs2) match {


### PR DESCRIPTION
So this PR is mostly Patrick ripping out `RegionValues` in a lot of places in favor of just using a `Long`. I think this is useful because it simplifies the memory management situation by ensuring that the only regions to worry about at a particular `TableIR.execute` are the one on the `RegionContext` and any regions created in that `execute`. 

One exception to this is that currently we have methods `toCRDDRegionValue` and `toCRDDPtr` to switch back to a `RegionValue` based CRDD for compatibility with all the join stuff (really, anything that uses `OrderedRVIterator`).

In addition, this PR goes through and tries to systematically fix places where we were not manging regions correctly. This makes it somewhat subtle and hard to review. Some things I'd focus on are: 

- Anywhere a boundary was removed.
- `TableKeyByAndAggregate` and `TableAggregateByKey` (noted below. I haven't done anything aggregator related prior to this, don't fully understand them)
- Spot check of any of the places I listed under "Addressed" below.
- The implementations of `toCRDDRegionValue` and `toCRDDPtr`. 

Addressed:

```
- TableFilter
- TableSubset (just the parent of head and tail)
- TableHead (via rvd.head)
- TableTail (via rvd.tail)
- TableExplode
- LinearRegression
```

No change needed:

```
- TableMapGlobals
- TableRange
- TableLiteral
- TableOrderBy
- TableDistinct
- TableKeyBy
- TableRename
- TableUnion
- TableParallelize
- TableRead
```

Didn't / Minimally Changed, but wasn't really sure about:

```
- TableAggregateByKey
- TableKeyByAndAggregate
- TableMapRows (specifically, the bit about computing `scanPartitionAggs)
```

cc @patrick-schultz @cseed 