### PR TITLE
Fix aggregate rows key error

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2498,7 +2498,7 @@ def subst(ir, env, agg_env):
         return AggArrayPerElement(_subst(ir.array, delete(agg_env, ir.element_name)),
                                   ir.element_name,
                                   ir.index_name,
-                                  ir.agg_ir,
+                                  _subst(ir.agg_ir, delete(env, ir.index_name), delete(agg_env, ir.element_name)),
                                   ir.is_scan)
     else:
         assert isinstance(ir, IR)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2494,6 +2494,8 @@ def subst(ir, env, agg_env):
         return ApplyAggOp(ir.agg_op,
                           subst_init_op_args,
                           subst_seq_op_args)
+    elif isinstance(ir, AggArrayPerElement):
+        return AggArrayPerElement(..., ..., ..., ..., ir.is_scan)
     else:
         assert isinstance(ir, IR)
         return ir.map_ir(lambda x: _subst(x))

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2495,7 +2495,11 @@ def subst(ir, env, agg_env):
                           subst_init_op_args,
                           subst_seq_op_args)
     elif isinstance(ir, AggArrayPerElement):
-        return AggArrayPerElement(..., ..., ..., ..., ir.is_scan)
+        return AggArrayPerElement(_subst(ir.array, delete(agg_env, ir.element_name)),
+                                  ir.element_name,
+                                  ir.index_name,
+                                  ir.agg_ir,
+                                  ir.is_scan)
     else:
         assert isinstance(ir, IR)
         return ir.map_ir(lambda x: _subst(x))

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2495,7 +2495,7 @@ def subst(ir, env, agg_env):
                           subst_init_op_args,
                           subst_seq_op_args)
     elif isinstance(ir, AggArrayPerElement):
-        return AggArrayPerElement(_subst(ir.array, delete(agg_env, ir.element_name)),
+        return AggArrayPerElement(_subst(ir.array, agg_env),
                                   ir.element_name,
                                   ir.index_name,
                                   _subst(ir.agg_ir, delete(env, ir.index_name), delete(agg_env, ir.element_name)),

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -189,6 +189,11 @@ class Tests(unittest.TestCase):
         qgs = mt.aggregate_entries(hl.Struct(x=agg.filter(False, agg.collect(mt.y1)),
                                               y=agg.filter(hl.rand_bool(0.1), agg.collect(mt.GT))))
 
+    def test_aggregate_rows_array_agg(self):
+        mt = hl.utils.range_matrix_table(10, 10)
+        mt = mt.annotate_rows(maf_flag = hl.empty_array('bool'))
+        mt.aggregate_rows(hl.agg.array_agg(lambda x: hl.agg.counter(x), mt.maf_flag))
+
     def test_col_agg_no_rows(self):
         mt = hl.utils.range_matrix_table(3, 3).filter_rows(False)
         mt = mt.annotate_cols(x = hl.agg.count())


### PR DESCRIPTION
Fixes #8316 

I honestly don't know really know how this env/agg_env stuff works, I just know that this makes the tests pass. It's possible that this is an improvement but not a fully correct substitution rule, would appreciate if you could check it / tell me how you figured out what it's supposed to be. 