### PR TITLE
[query] split methods

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -108,15 +108,15 @@ object Region {
   }
 
 
-  def loadInt(addr: Code[Long]): Code[Int] = Code.invokeScalaObject[Long, Int](Region.getClass, "loadInt", addr)
+  def loadInt(addr: Code[Long]): Code[Int] = Code.invokeStatic[Memory, Long, Int]("loadInt", addr)
 
-  def loadLong(addr: Code[Long]): Code[Long] = Code.invokeScalaObject[Long, Long](Region.getClass, "loadLong", addr)
+  def loadLong(addr: Code[Long]): Code[Long] = Code.invokeStatic[Memory, Long, Long]("loadLong", addr)
 
-  def loadFloat(addr: Code[Long]): Code[Float] = Code.invokeScalaObject[Long, Float](Region.getClass, "loadFloat", addr)
+  def loadFloat(addr: Code[Long]): Code[Float] = Code.invokeStatic[Memory, Long, Float]("loadFloat", addr)
 
-  def loadDouble(addr: Code[Long]): Code[Double] = Code.invokeScalaObject[Long, Double](Region.getClass, "loadDouble", addr)
+  def loadDouble(addr: Code[Long]): Code[Double] = Code.invokeStatic[Memory, Long, Double]("loadDouble", addr)
 
-  def loadAddress(addr: Code[Long]): Code[Long] = Code.invokeScalaObject[Long, Long](Region.getClass, "loadAddress", addr)
+  def loadAddress(addr: Code[Long]): Code[Long] = Code.invokeStatic[Memory, Long, Long]("loadAddress", addr)
 
   def loadByte(addr: Code[Long]): Code[Byte] = Code.invokeScalaObject[Long, Byte](Region.getClass, "loadByte", addr)
 
@@ -124,17 +124,17 @@ object Region {
 
   def loadChar(addr: Code[Long]): Code[Char] = Code.invokeScalaObject[Long, Char](Region.getClass, "loadChar", addr)
 
-  def storeInt(addr: Code[Long], v: Code[Int]): Code[Unit] = Code.invokeScalaObject[Long, Int, Unit](Region.getClass, "storeInt", addr, v)
+  def storeInt(addr: Code[Long], v: Code[Int]): Code[Unit] = Code.invokeStatic[Memory, Long, Int, Unit]("storeInt", addr, v)
 
-  def storeLong(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeLong", addr, v)
+  def storeLong(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeStatic[Memory, Long, Long, Unit]("storeLong", addr, v)
 
-  def storeFloat(addr: Code[Long], v: Code[Float]): Code[Unit] = Code.invokeScalaObject[Long, Float, Unit](Region.getClass, "storeFloat", addr, v)
+  def storeFloat(addr: Code[Long], v: Code[Float]): Code[Unit] = Code.invokeStatic[Memory, Long, Float, Unit]("storeFloat", addr, v)
 
-  def storeDouble(addr: Code[Long], v: Code[Double]): Code[Unit] = Code.invokeScalaObject[Long, Double, Unit](Region.getClass, "storeDouble", addr, v)
+  def storeDouble(addr: Code[Long], v: Code[Double]): Code[Unit] = Code.invokeStatic[Memory, Long, Double, Unit]("storeDouble", addr, v)
 
   def storeChar(addr: Code[Long], v: Code[Char]): Code[Unit] = Code.invokeScalaObject[Long, Char, Unit](Region.getClass, "storeChar", addr, v)
 
-  def storeAddress(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeAddress", addr, v)
+  def storeAddress(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeStatic[Memory, Long, Long, Unit]("storeAddress", addr, v)
 
   def storeByte(addr: Code[Long], v: Code[Byte]): Code[Unit] = Code.invokeScalaObject[Long, Byte, Unit](Region.getClass, "storeByte", addr, v)
 

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -68,15 +68,15 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   private val ftype = typ.fundamentalType
 
   private var staticIdx: Int = 0
-  private var idx: ClassFieldRef[Int] = _
-  private var elementsOffset: ClassFieldRef[Long] = _
-  private val startOffset: ClassFieldRef[Long] = mb.newField[Long]("srvb_start")
+  private var idx: Settable[Int] = _
+  private var elementsOffset: Settable[Long] = _
+  private val startOffset: Settable[Long] = mb.newLocal[Long]("srvb_start")
 
   ftype match {
-    case t: PBaseStruct => elementsOffset = mb.newField[Long]("srvb_struct_addr")
+    case t: PBaseStruct => elementsOffset = mb.newLocal[Long]("srvb_struct_addr")
     case t: PArray =>
-      elementsOffset = mb.newField[Long]("srvb_array_addr")
-      idx = mb.newField[Int]("srvb_array_idx")
+      elementsOffset = mb.newLocal[Long]("srvb_array_addr")
+      idx = mb.newLocal[Int]("srvb_array_idx")
     case _ =>
   }
 
@@ -185,8 +185,8 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   }
 
   def addBinary(bytes: Code[Array[Byte]]): Code[Unit] = {
-    val b = mb.newField[Array[Byte]]("srvb_add_binary_bytes")
-    val boff = mb.newField[Long]("srvb_add_binary_addr")
+    val b = mb.newLocal[Array[Byte]]("srvb_add_binary_bytes")
+    val boff = mb.newLocal[Long]("srvb_add_binary_addr")
     val pbT = currentPType().asInstanceOf[PBinary]
 
     Code(

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -126,18 +126,23 @@ object Code {
   def foreach[A](it: Seq[A])(f: A => Code[Unit]): Code[Unit] = Code(it.map(f))
 
   def newInstance[T <: AnyRef](parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T]): Code[T] = {
-    val ti = classInfo[T]
+    val tti = classInfo[T]
 
-    val L = new lir.Block()
+    val tcls = tct.runtimeClass
 
-    val linst = new lir.Local(null, "new_inst", ti)
-    L.append(lir.store(linst, lir.newInstance(ti)))
+    val c = tcls.getDeclaredConstructor(parameterTypes: _*)
+    assert(c != null,
+      s"no such method ${ tcls.getName }(${
+        parameterTypes.map(_.getName).mkString(", ")
+      })")
 
-    val inst = new VCode(L, L, lir.load(linst))
-    val ctor = inst.invokeConstructor(parameterTypes, args)
+    val (start, end, argvs) = Code.sequenceValues(args)
+    val linst = new lir.Local(null, "new_inst", tti)
+    end.append(lir.store(linst, lir.newInstance(tti,
+      Type.getInternalName(tcls), "<init>", Type.getConstructorDescriptor(c), tti, argvs)))
 
-    val newC = new VCode(ctor.start, ctor.end, lir.load(linst))
-    ctor.clear()
+    val newC = new VCode(start, end, lir.load(linst))
+    args.foreach(_.clear())
     newC
   }
 
@@ -401,6 +406,8 @@ object Code {
 }
 
 trait Code[+T] {
+  // val stack = Thread.currentThread().getStackTrace
+
   def start: lir.Block
 
   def end: lir.Block
@@ -998,16 +1005,6 @@ object Invokeable {
 
     Invokeable(cls, m)
   }
-
-  def lookupConstructor[T](cls: Class[T], parameterTypes: Array[Class[_]]): Invokeable[T, Unit] = {
-    val c = cls.getDeclaredConstructor(parameterTypes: _*)
-    assert(c != null,
-      s"no such method ${ cls.getName }(${
-        parameterTypes.map(_.getName).mkString(", ")
-      })")
-
-    Invokeable(cls, c)
-  }
 }
 
 class Invokeable[T, S](tcls: Class[T],
@@ -1032,12 +1029,11 @@ class Invokeable[T, S](tcls: Class[T],
       new VCode(start, end, null)
     } else {
       val t = new lir.Local(null, "invoke", sti)
-      end.append(
-        lir.store(t, lir.methodInsn(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs)))
-      var v = lir.load(t)
+      var r = lir.methodInsn(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs)
       if (concreteReturnType != sct.runtimeClass)
-        v = lir.checkcast(Type.getInternalName(sct.runtimeClass), v)
-      new VCode(start, end, v)
+        r = lir.checkcast(Type.getInternalName(sct.runtimeClass), r)
+      end.append(lir.store(t, r))
+      new VCode(start, end, lir.load(t))
     }
   }
 }
@@ -1145,9 +1141,6 @@ class CodeObject[T <: AnyRef : ClassTag](val lhs: Code[T]) {
 
   def put[S](field: String, rhs: Code[S])(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[Unit] =
     FieldRef[T, S](field).put(lhs, rhs)
-
-  def invokeConstructor(parameterTypes: Array[Class[_]], args: Array[Code[_]]): Code[Unit] =
-    Invokeable.lookupConstructor[T](implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], parameterTypes).invoke(lhs, args)
 
   def invoke[S](method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])
     (implicit sct: ClassTag[S]): Code[S] =

--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -326,8 +326,7 @@ trait DependentFunction[F >: Null <: AnyRef] extends FunctionBuilder[F] {
     val L = new lir.Block()
 
     val obj = mb.lmethod.genLocal("new_dep_fun", classBuilder.ti)
-    L.append(lir.store(obj, lir.newInstance(classBuilder.ti)))
-    L.append(lir.methodStmt(INVOKESPECIAL, classBuilder.lInit, Array(lir.load(obj))))
+    L.append(lir.store(obj, lir.newInstance(classBuilder.ti, classBuilder.lInit, FastIndexedSeq.empty[lir.ValueX])))
 
     var end = L
     setFields.foreach { f =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -199,6 +199,9 @@ class EmitMethodBuilder(
   def newPresentEmitLocal(pt: PType): PresentEmitSettable =
     newPresentEmitSettable(pt, newPLocal(pt))
 
+  def newPresentEmitLocal(name: String, pt: PType): PresentEmitSettable =
+    newPresentEmitSettable(pt, newPLocal(name, pt))
+
   def newPresentEmitField(pt: PType): PresentEmitSettable =
     newPresentEmitSettable(pt, newPField(pt))
 
@@ -587,9 +590,6 @@ class EmitFunctionBuilder[F >: Null](
     }
     m
   }
-
-  def wrapVoids(x: Seq[Code[Unit]], prefix: String, size: Int = 32): Code[Unit] =
-    wrapVoidsWithArgs(x.map { c => (s: Seq[Code[_]]) => c }, prefix, FastIndexedSeq(), FastIndexedSeq(), size)
 
   def wrapVoidsWithArgs(x: Seq[Seq[Code[_]] => Code[Unit]],
     suffix: String,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -99,7 +99,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
     { ob: Value[OutputBuffer] =>
       Code(
         loadInit,
-        nested.toCodeWithArgs(fb, "array_nested_serialize_init", Array[TypeInfo[_]](classInfo[OutputBuffer]),
+        nested.toCodeWithArgs(fb,
           FastIndexedSeq(ob),
           { (i, _, args) =>
             Code.memoize(coerce[OutputBuffer](args.head), "aelca_ser_init_ob") { ob => serializers(i)(ob) }
@@ -108,7 +108,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
         idx := 0,
         Code.whileLoop(idx < lenRef,
           load,
-          nested.toCodeWithArgs(fb, "array_nested_serialize", Array[TypeInfo[_]](classInfo[OutputBuffer]),
+          nested.toCodeWithArgs(fb,
             FastIndexedSeq(ob),
             { case (i, _, args) =>
               Code.memoize(coerce[OutputBuffer](args.head), "aelca_ser_ob") { ob => serializers(i)(ob) }
@@ -121,7 +121,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
     val deserializers = nested.states.map(_.deserialize(codec));
     { ib: Value[InputBuffer] =>
       Code(
-        init(nested.toCodeWithArgs(fb, "array_nested_deserialize_init", Array[TypeInfo[_]](classInfo[InputBuffer]),
+        init(nested.toCodeWithArgs(fb,
           FastIndexedSeq(ib),
           { (i, _, args) =>
             Code.memoize(coerce[InputBuffer](args.head), "aelca_deser_init_ib") { ib =>
@@ -132,7 +132,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
         lenRef := ib.readInt(),
         (lenRef < 0).mux(
           typ.setFieldMissing(off, 1),
-          seq(nested.toCodeWithArgs(fb, "array_nested_deserialize", Array[TypeInfo[_]](classInfo[InputBuffer]),
+          seq(nested.toCodeWithArgs(fb,
             FastIndexedSeq(ib),
             { (i, _, args) =>
               Code.memoize(coerce[InputBuffer](args.head), "aelca_deser_ib") { ib =>
@@ -206,7 +206,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
         other.initLength(state.lenRef)),
       check),
       Code(other.idx := state.idx, other.load, state.load),
-      state.nested.toCode(state.fb, "array_nested_comb", (i, s) => nestedAggs(i).combOp(s, other.nested(i))))
+      state.nested.toCode(state.fb, (i, s) => nestedAggs(i).combOp(s, other.nested(i))))
   }
 
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] =
@@ -221,7 +221,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
                 ssb.start(),
                 state.idx := sab.arrayIdx,
                 state.load,
-                state.nested.toCode(state.fb, "array_nested_result", { (i, s) =>
+                state.nested.toCode(state.fb, { (i, s) =>
                   Code(nestedAggs(i).result(s, ssb), ssb.advance())
                 }))
             }),

--- a/hail/src/main/scala/is/hail/lir/InitializeLocals.scala
+++ b/hail/src/main/scala/is/hail/lir/InitializeLocals.scala
@@ -32,16 +32,22 @@ class InitializeLocals(m: Method) {
       def visit(x: X): Unit = {
         x match {
           case x: StoreX =>
-            val l = localIdx(x.l)
-            geni.clear(l)
-            killi.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.clear(l)
+              killi.set(l)
+            }
           case x: LoadX =>
-            val l = localIdx(x.l)
-            geni.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.set(l)
+            }
           case x: IincX =>
-            val l = localIdx(x.l)
-            geni.set(l)
-            killi.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.set(l)
+              killi.set(l)
+            }
           case _ =>
         }
         x.children.foreach(visit)
@@ -108,11 +114,9 @@ class InitializeLocals(m: Method) {
     var i = entryUsedIn.nextSetBit(0)
     while (i >= 0) {
       val l = locals(i)
-      if (!l.isInstanceOf[Parameter]) {
-        // println(s"  init $l ${l.ti}")
-        m.entry.prepend(
-          store(locals(i), defaultValue(l.ti)))
-      }
+      // println(s"  init $l ${l.ti}")
+      m.entry.prepend(
+        store(locals(i), defaultValue(l.ti)))
 
       i = entryUsedIn.nextSetBit(i + 1)
     }

--- a/hail/src/main/scala/is/hail/lir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/lir/Pretty.scala
@@ -122,7 +122,11 @@ object Pretty {
 
   def header(x: X): String = x match {
     case x: IfX => s"${ asm.util.Printer.OPCODES(x.op) } ${ x.Ltrue } ${ x.Lfalse }"
-    case x: GotoX => x.L.toString
+    case x: GotoX =>
+      if (x.L != null)
+        x.L.toString
+      else
+        "null"
     case x: SwitchX => s"${ x.Ldefault } (${ x.Lcases.mkString(" ") })"
     case x: LdcX => x.a.toString
     case x: InsnX => asm.util.Printer.OPCODES(x.op)
@@ -132,7 +136,7 @@ object Pretty {
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.f }"
     case x: GetFieldX =>
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.f }"
-    case x: NewInstanceX => x.ti.iname
+    case x: NewInstanceX => s"${ x.ti.iname } ${ x.ctor }"
     case x: TypeInsnX =>
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.t }"
     case x: NewArrayX => x.eti.desc

--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -1,0 +1,184 @@
+package is.hail.lir
+
+import is.hail.utils.UnionFind
+
+import scala.collection.mutable
+
+object SimplifyControl {
+  def apply(m: Method): Unit = {
+    new SimplifyControl(m).simplify()
+  }
+}
+
+class SimplifyControl(m: Method) {
+  private val uses = mutable.Map[Block, mutable.Set[(ControlX, Int)]]()
+
+  private val q = mutable.Set[Block]()
+
+  def removeUse(M: Block, c: ControlX, i: Int): Unit = {
+    val r = uses(M).remove((c, i))
+    assert(r)
+  }
+
+  def addUse(M: Block, c: ControlX, i: Int): Unit = {
+    val r = uses(M).add((c, i))
+    assert(r)
+  }
+
+  def finalTarget(b0: Block): Block = {
+    var b = b0
+    while (b.first != null &&
+      b.first.isInstanceOf[GotoX])
+      b = b.first.asInstanceOf[GotoX].L
+    b
+  }
+
+  def simplifyBlock(L: Block): Unit = {
+    val last = L.last.asInstanceOf[ControlX]
+
+    if (uses(L).isEmpty && (L ne m.entry)) {
+      var i = 0
+      while (i < last.targetArity()) {
+        val M = last.target(i)
+        removeUse(M, last, i)
+        last.setTarget(i, null)
+
+        q += M
+        if (uses(M).size == 1) {
+          val (u, _) = uses(M).head
+          q += u.parent
+        }
+
+        i += 1
+      }
+
+      // just popped off q
+      uses -= L
+
+      return
+    }
+
+    var i = 0
+    while (i < last.targetArity()) {
+      val M = last.target(i)
+      val newM = finalTarget(M)
+      if (M ne newM) {
+        removeUse(M, last, i)
+        last.setTarget(i, newM)
+        addUse(newM, last, i)
+
+        q += M
+        if (uses(M).size == 1) {
+          val (u, _) = uses(M).head
+          q += u.parent
+        }
+        q += L
+      }
+      i += 1
+    }
+
+    last match {
+      case x: IfX =>
+        val M = x.Ltrue
+        if (M eq x.Lfalse) {
+          x.remove()
+          removeUse(x.Ltrue, x, 0)
+          x.Ltrue = null
+          removeUse(x.Lfalse, x, 1)
+          x.Lfalse = null
+
+          val g = goto(M)
+          addUse(M, g, 0)
+
+          L.append(g)
+
+          // if there is one parent, it is L
+          q += L
+        }
+
+      case x: GotoX =>
+        val M = x.L
+        if ((M ne L) && uses(M).size == 1 && (m.entry ne M)) {
+          x.remove()
+          removeUse(x.L, x, 0)
+          x.L = null
+
+          while (M.first != null) {
+            val z = M.first
+            z.remove()
+            L.append(z)
+          }
+
+          q -= M
+          uses -= M
+
+          q += L
+        }
+
+      case _ =>
+    }
+  }
+
+  def unify(): Unit = {
+    val (blocks, blockIdx) = m.findAndIndexBlocks()
+
+    val u = new UnionFind(blocks.length)
+    blocks.indices.foreach { i =>
+      u.makeSet(i)
+    }
+
+    for (b <- blocks) {
+      if (b.first != null &&
+        b.first.isInstanceOf[GotoX]) {
+        u.sameSet(
+          blockIdx(b),
+          blockIdx(b.first.asInstanceOf[GotoX].L))
+      }
+    }
+
+    val rootFinalTarget = mutable.Map[Int, Block]()
+    blocks.zipWithIndex.foreach { case (b, i) =>
+      val r = u.find(i)
+      val t = finalTarget(blocks(r))
+      rootFinalTarget(r) = t
+    }
+
+    for (b <- blocks) {
+      val last = b.last.asInstanceOf[ControlX]
+      var i = 0
+      while (i < last.targetArity()) {
+        last.setTarget(i,
+          rootFinalTarget(u.find(blockIdx(last.target(i)))))
+        i += 1
+      }
+    }
+  }
+
+  def simplify(): Unit = {
+    unify()
+
+    val blocks = m.findBlocks()
+
+    blocks.foreach { b =>
+      uses(b) = mutable.Set()
+    }
+
+    for (b <- blocks) {
+      q += b
+
+      val last = b.last.asInstanceOf[ControlX]
+      var i = 0
+      while (i < last.targetArity()) {
+        val t = last.target(i)
+        addUse(t, last, i)
+        i += 1
+      }
+    }
+
+    while (q.nonEmpty) {
+      val b = q.head
+      q -= b
+      simplifyBlock(b)
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -1,0 +1,204 @@
+package is.hail.lir
+
+import is.hail.asm4s.{BooleanInfo, IntInfo, TypeInfo, UnitInfo}
+import is.hail.utils.FastIndexedSeq
+import org.objectweb.asm.Opcodes._
+
+object SplitMethod {
+  val TargetMethodSize: Int = 2000
+
+  def apply(c: Classx[_], m: Method): Unit = {
+    new SplitMethod(c, m).split()
+  }
+}
+
+class SplitMethod(c: Classx[_], m: Method) {
+  private var blocks = m.findBlocks()
+
+  private val paramFields = m.parameterTypeInfo.zipWithIndex.map { case (ti, i) =>
+    c.newField(genName(s"arg$i"), ti)
+  }
+
+  def splitLargeStatements(): Unit = {
+    for (b <- blocks) {
+      def splitLargeStatement(c: StmtX): Unit = {
+        def visit(x: ValueX): Int = {
+          // FIXME this doesn't handle many moderate-sized children
+          val size = 1 + x.children.map(visit).sum
+
+          if (size > SplitMethod.TargetMethodSize / 2) {
+            val l = m.newLocal("spill_large_expr", x.ti)
+            x.replace(load(l))
+            c.insertBefore(store(l, x))
+            1
+          } else
+            size
+        }
+
+        c.children.foreach(visit)
+      }
+
+      var x = b.first
+      while (x != null) {
+        splitLargeStatement(x)
+        x = x.next
+      }
+    }
+  }
+
+  def spillLocals(): Unit = {
+    val (locals, localIdx) = m.findAndIndexLocals(blocks)
+
+    val fields = locals.map { l =>
+      if (l.isInstanceOf[Parameter])
+        null
+      else
+        c.newField(genName(l.name), l.ti)
+    }
+
+    def localField(l: Local): Field =
+      l match {
+        case p: Parameter =>
+          if (p.i == 0)
+            null
+          else
+            paramFields(p.i - 1)
+        case _ => fields(localIdx(l))
+      }
+
+    def spill(x: X): Unit = {
+      x.children.foreach(spill)
+      x match {
+        case x: LoadX =>
+          val f = localField(x.l)
+          if (f != null)
+            x.replace(getField(f, load(m.getParam(0))))
+        case x: IincX =>
+          val f = localField(x.l)
+          assert(f != null)
+          x.replace(
+            putField(f, load(m.getParam(0)),
+              insn(IADD,
+                getField(f, load(m.getParam(0))),
+                ldcInsn(x.i))))
+        case x: StoreX =>
+          val f = localField(x.l)
+          assert(f != null)
+          val v = x.children(0)
+          v.remove()
+          x.replace(putField(f, load(m.getParam(0)), v))
+        case _ =>
+      }
+    }
+
+    for (b <- blocks) {
+      var x = b.first
+      while (x != null) {
+        val n = x.next
+        spill(x)
+        x = n
+      }
+    }
+  }
+
+  def splitBlock(b: Block): Unit = {
+    val last = b.last
+
+    val returnTI = last match {
+      case _: GotoX => UnitInfo
+      case _: IfX => BooleanInfo
+      case _: SwitchX => IntInfo
+      case _: ReturnX => m.returnTypeInfo
+      // case _: ThrowX => UnitInfo
+    }
+
+    var L = new Block()
+    var x = b.first
+    var size = 0
+
+    while (x != last) {
+      if (size > SplitMethod.TargetMethodSize) {
+        val newM = c.newMethod(genName("wrapped"), FastIndexedSeq.empty[TypeInfo[_]], UnitInfo)
+        L.method = newM
+        newM.setEntry(L)
+        L.append(returnx())
+
+        x.insertBefore(methodStmt(INVOKEVIRTUAL, newM, Array(load(m.getParam(0)))))
+
+        L = new Block()
+        size = 0
+      }
+
+      size += x.approxByteCodeSize()
+      val n = x.next
+      x.remove()
+      L.append(x)
+      x = n
+    }
+
+    val newM = c.newMethod(genName("wrapped"), FastIndexedSeq.empty[TypeInfo[_]], returnTI)
+    L.method = newM
+    newM.setEntry(L)
+
+    def invokeNewM(): ValueX =
+      methodInsn(INVOKEVIRTUAL, newM, Array(load(m.getParam(0))))
+
+    def invokeNewMStmt(): StmtX =
+      methodStmt(INVOKEVIRTUAL, newM, Array(load(m.getParam(0))))
+
+    last match {
+      case _: GotoX => // _: ThrowX
+        L.append(returnx())
+        last.insertBefore(invokeNewMStmt())
+      case x: IfX =>
+        val Ltrue = x.Ltrue
+        val Lfalse = x.Lfalse
+
+        x.remove()
+        L.append(x)
+
+        val newLtrue = new Block()
+        newLtrue.method = newM
+        newLtrue.append(returnx(ldcInsn(true)))
+        x.Ltrue = newLtrue
+
+        val newLfalse = new Block()
+        newLfalse.method = newM
+        newLfalse.append(returnx(ldcInsn(false)))
+        x.Lfalse = newLfalse
+
+        b.append(
+          ifx(IFNE, invokeNewM(), Ltrue, Lfalse))
+      case x: SwitchX => IntInfo
+        val i = x.children(0)
+        x.setChild(0, invokeNewM())
+        L.append(returnx(i))
+      case _: ReturnX =>
+        if (returnTI eq UnitInfo) {
+          L.append(returnx())
+          last.insertBefore(invokeNewMStmt())
+        } else {
+          val c = x.children(0)
+          x.setChild(0, invokeNewM())
+          L.append(returnx(c))
+        }
+    }
+  }
+
+  def split(): Unit = {
+    splitLargeStatements()
+    spillLocals()
+
+    for (b <- blocks) {
+      splitBlock(b)
+    }
+
+    // this can't get split
+    m.parameterTypeInfo.indices.foreach { i =>
+      m.entry.prepend(putField(
+        paramFields(i),
+        load(m.getParam(0)),
+        load(m.getParam(i + 1))))
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -3,10 +3,8 @@ package is.hail.lir
 import java.io.PrintWriter
 
 import scala.collection.mutable
-
 import is.hail.asm4s._
 import is.hail.utils._
-
 import org.objectweb.asm.Opcodes._
 
 // FIXME move typeinfo stuff lir
@@ -41,8 +39,6 @@ class Classx[C](val name: String, val superName: String) {
   }
 
   def asBytes(print: Option[PrintWriter]): Array[Byte] = {
-    // println(Pretty(this))
-
     for (m <- methods) {
       val blocks = m.findBlocks()
       for (b <- blocks) {
@@ -66,11 +62,9 @@ class Classx[C](val name: String, val superName: String) {
           if (l.method == null)
             l.method = m
           else {
-            /*
             if (l.method ne m) {
               println(s"$l ${l.method} $m")
             }
-             */
             assert(l.method eq m)
           }
         }
@@ -82,20 +76,32 @@ class Classx[C](val name: String, val superName: String) {
     }
 
     for (m <- methods) {
-      m.simplifyBlocks()
+      SimplifyControl(m)
+    }
+
+    for (m <- methods) {
+      if (m.approxByteCodeSize() > SplitMethod.TargetMethodSize)
+      if (m.name != "<init>")
+        SplitMethod(this, m)
     }
 
     for (m <- methods) {
       InitializeLocals(m)
     }
 
-    // println(Pretty(this))
+    /*
+    {
+      println(name)
+      for (m <- methods) {
+        println(s"  ${ m.name } ${ m.approxByteCodeSize() }")
+      }
+    }
+     */
 
     Emit(this,
       print
       // Some(new PrintWriter(System.out))
     )
-
   }
 }
 
@@ -178,24 +184,26 @@ class Method private[lir] (
     while (s.nonEmpty) {
       val L = s.pop()
       if (!visited.contains(L)) {
-        blocks += L
+        if (L != null) {
+          blocks += L
 
-        var x = L.first
-        while (x != null) {
-          x match {
-            case x: IfX =>
-              s.push(x.Ltrue)
-              s.push(x.Lfalse)
-            case x: GotoX =>
-              s.push(x.L)
-            case x: SwitchX =>
-              s.push(x.Ldefault)
-              x.Lcases.foreach(s.push)
-            case _ =>
+          var x = L.first
+          while (x != null) {
+            x match {
+              case x: IfX =>
+                s.push(x.Ltrue)
+                s.push(x.Lfalse)
+              case x: GotoX =>
+                s.push(x.L)
+              case x: SwitchX =>
+                s.push(x.Ldefault)
+                x.Lcases.foreach(s.push)
+              case _ =>
+            }
+            x = x.next
           }
-          x = x.next
+          visited += L
         }
-        visited += L
       }
     }
 
@@ -213,9 +221,11 @@ class Method private[lir] (
     val visited: mutable.Set[Local] = mutable.Set()
 
     def visitLocal(l: Local): Unit = {
-      if (!visited.contains(l)) {
-        locals += l
-        visited += l
+      if (!l.isInstanceOf[Parameter]) {
+        if (!visited.contains(l)) {
+          locals += l
+          visited += l
+        }
       }
     }
 
@@ -260,53 +270,13 @@ class Method private[lir] (
     }
   }
 
-  def simplifyBlocks(): Unit = {
-    @scala.annotation.tailrec
-    def finalTarget(b: Block): Block = {
-      if (b.first != null &&
-        b.first.isInstanceOf[GotoX]) {
-        finalTarget(b.first.asInstanceOf[GotoX].L)
-      } else
-        b
-    }
-
-    @scala.annotation.tailrec
-    def simplifyBlock(L: Block): Unit = {
-      L.last match {
-        case x: IfX =>
-          x.setLtrue(finalTarget(x.Ltrue))
-          x.setLfalse(finalTarget(x.Lfalse))
-
-          val M = x.Ltrue
-          if (x.Lfalse eq M) {
-            x.remove()
-            x.setLtrue(null)
-            x.setLfalse(null)
-            L.append(goto(M))
-          }
-
-        case x: GotoX =>
-          val M = x.L
-          if ((M ne L) && M.uses.size == 1 && (entry ne M)) {
-            x.remove()
-            x.setL(null)
-            while (M.first != null) {
-              val z = M.first
-              z.remove()
-              L.append(z)
-            }
-            simplifyBlock(L)
-          } else
-            x.setL(finalTarget(x.L))
-
-        case _ =>
-      }
-    }
-
+  def approxByteCodeSize(): Int = {
     val blocks = findBlocks()
-
-    for (ell <- blocks)
-      simplifyBlock(ell)
+    var size = 0
+    for (b <- blocks) {
+      size += b.approxByteCodeSize()
+    }
+    size
   }
 }
 
@@ -329,32 +299,8 @@ class Block {
 
   var method: Method = _
 
-  val uses: mutable.Set[ControlX] = mutable.Set()
-
   var first: StmtX = _
   var last: StmtX = _
-
-  def replace(L: Block): Unit = {
-    if (method != null && (method.entry eq this)) {
-      method.setEntry(L)
-    }
-
-    while (uses.nonEmpty) {
-      val x = uses.head
-      x match {
-        case x: GotoX =>
-          assert(x.L eq this)
-          x.setL(L)
-        case x: IfX =>
-          if (x.Ltrue eq this)
-            x.setLtrue(L)
-          if (x.Lfalse eq this)
-            x.setLfalse(L)
-      }
-    }
-
-    assert(uses.isEmpty)
-  }
 
   def prepend(x: StmtX): Unit = {
     assert(x.parent == null)
@@ -400,6 +346,17 @@ class Block {
   }
 
   override def toString: String = f"L${ System.identityHashCode(this) }%08x"
+
+  def approxByteCodeSize(): Int = {
+    var size = 1 // for the block
+    var x = first
+    while (x != null) {
+      size += x.approxByteCodeSize()
+      x = x.next
+    }
+    size
+  }
+
 }
 
 // X stands for eXpression
@@ -439,6 +396,18 @@ abstract class X {
     }
     children(i) = x
   }
+
+  def remove(): Unit
+
+  def approxByteCodeSize(): Int = {
+    var size = 0
+    def visit(x: X): Unit = {
+      size += 1
+      x.children.foreach(visit)
+    }
+    visit(this)
+    size
+  }
 }
 
 abstract class StmtX extends X {
@@ -462,93 +431,135 @@ abstract class StmtX extends X {
     next = null
     prev = null
   }
+
+  def replace(x: StmtX): Unit = {
+    assert(x.parent == null)
+    assert(parent != null)
+
+    x.next = next
+    x.prev = prev
+    x.parent = parent
+
+    if (parent.first == this)
+      parent.first = x
+    if (parent.last == this)
+      parent.last = x
+    if (next != null)
+      next.prev = x
+    if (prev != null)
+      prev.next = x
+
+    next = null
+    prev = null
+    parent = null
+  }
+
+  def insertBefore(x: StmtX): Unit = {
+    assert(parent != null)
+    assert(x.parent == null)
+
+    x.next = this
+    x.parent = parent
+    if (prev != null) {
+      x.prev = prev
+      prev.next = x
+    } else {
+      parent.first = x
+    }
+    prev = x
+  }
 }
 
-abstract class ControlX extends StmtX
+abstract class ControlX extends StmtX {
+  def targetArity(): Int
+
+  def target(i: Int): Block
+
+  def setTarget(i: Int, b: Block): Unit
+}
 
 abstract class ValueX extends X {
   var parent: X = _
 
   def ti: TypeInfo[_]
+
+  def remove(): Unit = {
+    var i = 0
+    while (parent.children(i) ne this)
+      i += 1
+    parent.setChild(i, null)
+    assert(parent == null)
+  }
+
+  def replace(x: ValueX): Unit = {
+    var i = 0
+    while (parent.children(i) ne this)
+      i += 1
+    parent.setChild(i, x)
+    assert(parent == null)
+  }
 }
 
 class GotoX extends ControlX {
-  var _L: Block = _
+  var L: Block = _
 
-  def L: Block = _L
+  def targetArity(): Int = 1
 
-  def setL(newL: Block): Unit = {
-    if (_L != null)
-      _L.uses -= this
-    if (newL != null)
-      newL.uses += this
-    _L = newL
+  def target(i: Int): Block = {
+    assert(i == 0)
+    L
+  }
+
+  def setTarget(i: Int, b: Block): Unit = {
+    assert(i == 0)
+    L = b
   }
 }
 
 class IfX(val op: Int) extends ControlX {
-  var _Ltrue: Block = _
+  var Ltrue: Block = _
+  var Lfalse: Block = _
 
-  def Ltrue: Block = _Ltrue
+  def targetArity(): Int = 2
 
-  def setLtrue(newLtrue: Block): Unit = {
-    removeUses()
-    _Ltrue = newLtrue
-    addUses()
+  def target(i: Int): Block = {
+    if (i == 0)
+      Ltrue
+    else {
+      assert(i == 1)
+      Lfalse
+    }
   }
 
-  var _Lfalse: Block = _
-
-  def Lfalse: Block = _Lfalse
-
-  def setLfalse(newLfalse: Block): Unit = {
-    removeUses()
-    _Lfalse = newLfalse
-    addUses()
-  }
-
-  private def removeUses(): Unit = {
-    if (_Ltrue != null)
-      _Ltrue.uses -= this
-    if (_Lfalse != null)
-      _Lfalse.uses -= this
-  }
-
-  private def addUses(): Unit = {
-    if (_Ltrue != null)
-      _Ltrue.uses += this
-    if (_Lfalse != null)
-      _Lfalse.uses += this
+  def setTarget(i: Int, b: Block): Unit = {
+    if (i == 0)
+      Ltrue = b
+    else {
+      assert(i == 1)
+      Lfalse = b
+    }
   }
 }
 
 class SwitchX() extends ControlX {
-  private[this] var _Ldefault: Block = _
+  var Ldefault: Block = _
 
-  private[this] var _Lcases: IndexedSeq[Block] = FastIndexedSeq()
+  var Lcases: Array[Block] = Array.empty[Block]
 
-  def Ldefault: Block = _Ldefault
+  def targetArity(): Int = 1 + Lcases.length
 
-  def Lcases: IndexedSeq[Block] = _Lcases
-
-  def setDefault(newDefault: Block): Unit = {
-    if (_Ldefault != null)
-      _Ldefault.uses -= this
-    _Ldefault = newDefault
-    if (_Ldefault != null)
-      _Ldefault.uses += this
+  def target(i: Int): Block = {
+    if (i == 0)
+      Ldefault
+    else
+      Lcases(i - 1)
   }
 
-  def setCases(newCases: IndexedSeq[Block]): Unit = {
-    _Lcases.foreach { c =>
-      if (c != null)
-        c.uses -= this
-    }
-    _Lcases = newCases
-    _Lcases.foreach { c =>
-      if (c != null)
-        c.uses += this
-    }
+  def setTarget(i: Int, b: Block): Unit = {
+    if (i == 0)
+      Ldefault = b
+    else
+      Lcases(i - 1) = b
   }
 }
 
@@ -558,7 +569,13 @@ class PutFieldX(val op: Int, val f: FieldRef) extends StmtX
 
 class IincX(val l: Local, val i: Int) extends StmtX
 
-class ReturnX() extends ControlX
+class ReturnX() extends ControlX {
+  def targetArity(): Int = 0
+
+  def target(i: Int): Block = throw new IndexOutOfBoundsException()
+
+  def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
+}
 
 class StmtOpX(val op: Int) extends StmtX
 
@@ -624,6 +641,9 @@ class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
       case I2D => DoubleInfo
       case L2D => DoubleInfo
       case F2D => DoubleInfo
+      // Boolean
+      case I2B => BooleanInfo
+
     }
   }
 }
@@ -640,7 +660,7 @@ class NewArrayX(val eti: TypeInfo[_]) extends ValueX {
   def ti: TypeInfo[_] = arrayInfo(eti)
 }
 
-class NewInstanceX(val ti: TypeInfo[_]) extends ValueX
+class NewInstanceX(val ti: TypeInfo[_], val ctor: MethodRef) extends ValueX
 
 class LdcX(val a: Any) extends ValueX {
   val ti: TypeInfo[_] = a match {

--- a/hail/src/main/scala/is/hail/lir/package.scala
+++ b/hail/src/main/scala/is/hail/lir/package.scala
@@ -41,16 +41,16 @@ package object lir {
   def ifx(op: Int, c: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c)
-    x.setLtrue(Ltrue)
-    x.setLfalse(Lfalse)
+    x.Ltrue = Ltrue
+    x.Lfalse = Lfalse
     x
   }
 
   def ifx(op: Int, c1: ValueX, c2: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c1, c2)
-    x.setLtrue(Ltrue)
-    x.setLfalse(Lfalse)
+    x.Ltrue = Ltrue
+    x.Lfalse = Lfalse
     x
   }
 
@@ -60,8 +60,8 @@ package object lir {
 
     val x = new SwitchX()
     setChildren(x, c)
-    x.setDefault(Ldefault)
-    x.setCases(cases)
+    x.Ldefault = Ldefault
+    x.Lcases = cases.toArray
     x
   }
 
@@ -69,7 +69,7 @@ package object lir {
     assert(L != null)
     val x = new GotoX
     x.setArity(0)
-    x.setL(L)
+    x.L = L
     x
   }
 
@@ -226,8 +226,20 @@ package object lir {
   }
 
   def newInstance(
-    ti: TypeInfo[_]
-  ): ValueX = new NewInstanceX(ti)
+    ti: TypeInfo[_],
+    owner: String, name: String, desc: String, returnTypeInfo: TypeInfo[_],
+    args: IndexedSeq[ValueX]
+  ): ValueX = {
+    val x = new NewInstanceX(ti, new MethodLit(owner, name, desc, isInterface = false, returnTypeInfo))
+    setChildren(x, args)
+    x
+  }
+
+  def newInstance(ti: TypeInfo[_], method: Method, args: IndexedSeq[ValueX]): ValueX = {
+    val x = new NewInstanceX(ti, method)
+    setChildren(x, args)
+    x
+  }
 
   def checkcast(iname: String): (ValueX) => ValueX = (c) => checkcast(iname, c)
 

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -127,7 +127,7 @@ class FunctionSuite extends HailSuite {
       i := i + 6
     )
 
-    fb.emit(Code(i := 0, fb.wrapVoids(codes, "foo", 2), i))
+    fb.emit(Code(i := 0, Code(codes), i))
     Region.smallScoped { r =>
       assert(fb.resultWithIndex().apply(0, r).apply() == 21)
 


### PR DESCRIPTION
Summary of changes:
 - rip out method wrapping from Emit level
 - Emit now uses locals everywhere instead of fields
 - improved SimplifyControl
 - Changed CodeRegion to call Memory directly, instead of calling Region methods.  This saves a bytecode on native memory accesses.
 - add lir.SplitMethod to break up methods.  For large methods, this breaks the body of each basic block into one (or more) external functions and spills locals to fields.  Splitting is controlled by SplitMethod.TargetMethodSize, currently set to 2000.

PR'ing for testing.  I have a few more improvements and then I will performance test.

Here are the method sizes after splitting for the large `MakeStruct` example:

```
is/hail/codegen/generated/C8
  <init> 4
  apply 235
  apply 19
  setPartitionIndex 11
  addPartitionRegion 5
  __wrapped16 30
  __wrapped17 2003
  __wrapped18 2008
  __wrapped19 2006
  __wrapped20 2008
  __wrapped21 2006
  __wrapped22 2008
  __wrapped23 2006
  __wrapped24 2008
  __wrapped25 2006
  ... you get the picture, remaining 100 methods elided ...
```
