### PR TITLE
[batch][ci] better error message when the deploy test fails

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -260,7 +260,7 @@ async def deploy_status(request, userdata):
     del userdata
     batch_client = request.app['batch_client']
 
-    def get_failure_information(batch):
+    async def get_failure_information(batch):
         return [
             {**j,
              'log': await batch_client.get_job_log(j['batch_id'], j['job_id'])}
@@ -271,7 +271,7 @@ async def deploy_status(request, userdata):
         'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and hasattr(wb.deploy_batch, 'id') else None,
         'deploy_state': wb.deploy_state,
         'repo': wb.branch.repo.short_str(),
-        'failure_information': None if wb.deploy_state == 'success' else get_failure_information(wb.deploy_batch)
+        'failure_information': None if wb.deploy_state == 'success' else await get_failure_information(wb.deploy_batch)
     } for wb in watched_branches]
     return web.json_response(wb_configs)
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -257,14 +257,21 @@ async def batch_callback_handler(request):
 @routes.get('/api/v1alpha/deploy_status')
 @rest_authenticated_developers_only
 async def deploy_status(request, userdata):
-    del request
     del userdata
+    batch_client = request.app['batch_client']
+
+    def get_failure_information(batch):
+        return [
+            {**j,
+             'log': await batch_client.get_job_log(j['batch_id'], j['job_id'])}
+            for j in batch.jobs() if j['state'] != 'Success']
     wb_configs = [{
         'branch': wb.branch.short_str(),
         'sha': wb.sha,
         'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and hasattr(wb.deploy_batch, 'id') else None,
         'deploy_state': wb.deploy_state,
-        'repo': wb.branch.repo.short_str()
+        'repo': wb.branch.repo.short_str(),
+        'failure_information': None if wb.deploy_state == 'success' else get_failure_information(wb.deploy_batch)
     } for wb in watched_branches]
     return web.json_response(wb_configs)
 

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -19,6 +19,7 @@ async def test_deploy():
 
         async def wait_forever():
             deploy_state = None
+            failure_information = None
             while deploy_state is None:
                 resp = await utils.request_retry_transient_errors(
                     session, 'GET', f'{ci_deploy_status_url}', headers=headers)
@@ -26,8 +27,9 @@ async def test_deploy():
                 assert len(deploy_statuses) == 1, deploy_statuses
                 deploy_status = deploy_statuses[0]
                 deploy_state = deploy_status['deploy_state']
+                failure_information = deploy_status.get('failure_information')
                 await asyncio.sleep(5)
-            return deploy_state
+            return deploy_state, failure_information
 
-        deploy_state = await asyncio.wait_for(wait_forever(), timeout=20 * 60)
-        assert deploy_state == 'success', deploy_state
+        deploy_state, failure_information = await asyncio.wait_for(wait_forever(), timeout=20 * 60)
+        assert deploy_state == 'success', failure_information

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -600,6 +600,11 @@ class BatchClient:
             j['job_id'],
             _status=j)
 
+    async def get_job_log(self, batch_id, job_id):
+        resp = await self._get(
+            f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
+        return await resp.json()
+
     async def get_batch(self, id):
         b_resp = await self._get(f'/api/v1alpha/batches/{id}')
         b = await b_resp.json()

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -187,6 +187,10 @@ class BatchClient:
         j = async_to_blocking(self._async_client.get_job(batch_id, job_id))
         return Job.from_async_job(j)
 
+    def get_job_log(self, batch_id, job_id):
+        log = async_to_blocking(self._async_client.get_job_log(batch_id, job_id))
+        return log
+
     def get_batch(self, id):
         b = async_to_blocking(self._async_client.get_batch(id))
         return Batch.from_async_batch(b)


### PR DESCRIPTION
CI gets the logs for every failing job in the batch and sends it with the deploy_status response. This performs O(n_jobs) work for a single request, but this API is developers only and used only by the deploy test which has a small batch. We can revisit if this becomes a problem.