### PR TITLE
[hail] fix hadoop connector in hail base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -29,7 +29,8 @@ RUN wget -nv -O spark-2.4.0-bin-hadoop2.7.tgz https://archive.apache.org/dist/sp
   tar xzf spark-2.4.0-bin-hadoop2.7.tgz && \
   rm spark-2.4.0-bin-hadoop2.7.tgz
 
-RUN wget -nv -O /spark-2.4.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-latest.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
+# Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
+RUN wget -nv -O /spark-2.4.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
 COPY docker/core-site.xml /spark-2.4.0-bin-hadoop2.7/conf/core-site.xml
 
 ENV SPARK_HOME /spark-2.4.0-bin-hadoop2.7

--- a/hail/install-gcs-connector.sh
+++ b/hail/install-gcs-connector.sh
@@ -42,7 +42,7 @@ echo "${SVC_ACCT_ENABLE} true" >> ${CONF_FILE}
 echo "${SVC_ACCT_KEY_FILE} ${KEY_FILE}" >> ${CONF_FILE}
 
 curl -v \
-     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar \
-     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-latest.jar
+     https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+     > ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar
 
 echo "success"


### PR DESCRIPTION
Fixes #8343. The Google Storage Hadoop connector introduced
a backwards incompatible change in 2.1.0 which relies on
a new method in Hadoop 2.8.3 that is not present in Hadoop
2.7.3. There are no Spark releases that include Hadoop 2.8.3
yet, so we choose to downgrade to the last compatible
connector library version.

Randomly picked a hail query person.