### PR TITLE
[query] Fix bugs related to Duncan's permutation pipeline

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -724,7 +724,7 @@ class Expression(object):
             raise NotImplementedError('cannot convert aggregated expression to table')
 
         if source is None:
-            return fallback_name, Env.dummy_table().select(**{fallback_name: self})
+            return fallback_name, hl.Table.parallelize([self], n_partitions=1)
 
         name = source._fields_inverse.get(self)
         top_level = name is not None
@@ -733,7 +733,7 @@ class Expression(object):
         named_self = {name: self}
         if len(axes) == 0:
             x = source.select_globals(**named_self)
-            ds = Env.dummy_table().select(**{name: x.index_globals()[name]})
+            ds = hl.Table.parallelize([x.index_globals()], n_partitions=1)
         elif isinstance(source, hail.Table):
             if top_level and name in source.key:
                 named_self = {}

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -724,7 +724,7 @@ class Expression(object):
             raise NotImplementedError('cannot convert aggregated expression to table')
 
         if source is None:
-            return fallback_name, hl.Table.parallelize([self], n_partitions=1)
+            return fallback_name, hl.Table.parallelize([hl.struct(**{fallback_name: self})], n_partitions=1)
 
         name = source._fields_inverse.get(self)
         top_level = name is not None

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1531,3 +1531,10 @@ class Tests(unittest.TestCase):
         hl.experimental.write_matrix_tables(mts, f)
         assert hl.read_matrix_table(f + '0.mt')._same(mts[0])
         assert hl.read_matrix_table(f + '1.mt')._same(mts[1])
+
+    def test_key_cols_by_extract_issue(self):
+        mt = hl.utils.range_matrix_table(1000, 100)
+        mt = mt.key_cols_by(col_id = hl.str(mt.col_idx))
+        mt = mt.add_col_index()
+        mt.show()
+

--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -24,11 +24,11 @@ case class BindingEnv[V](
   def allEmpty: Boolean = eval.isEmpty && agg.forall(_.isEmpty) && scan.forall(_.isEmpty)
 
   def promoteAgg: BindingEnv[V] = {
-    BindingEnv(agg.get)
+    BindingEnv(agg.get, scan = scan)
   }
 
   def promoteScan: BindingEnv[V] = {
-    BindingEnv(scan.get)
+    BindingEnv(scan.get, agg = agg)
   }
 
   def bindEval(name: String, v: V): BindingEnv[V] =

--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -62,7 +62,7 @@ object ContainsAgg {
     case l: AggLet => !l.isScan
     case _: TableAggregate => false
     case _: MatrixAggregate => false
-    case _: StreamAgg => true // this should be permitted, but causes problems elsewhere in the IR
+    case _: StreamAgg => false
     case _ => root.children.exists {
       case child: IR => ContainsAgg(child)
       case _ => false
@@ -111,7 +111,7 @@ object ContainsScan {
     case l: AggLet => l.isScan
     case _: TableAggregate => false
     case _: MatrixAggregate => false
-    case _: StreamAggScan => true // this should be permitted, but causes problems elsewhere in the IR
+    case _: StreamAggScan => false
     case _ => root.children.exists {
       case child: IR => ContainsScan(child)
       case _ => false

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -286,10 +286,8 @@ object TypeCheck {
         assert(body.typ == TVoid)
       case x@StreamAgg(a, name, query) =>
         assert(a.typ.isInstanceOf[TStream])
-        assert(env.agg.isEmpty)
       case x@StreamAggScan(a, name, query) =>
         assert(a.typ.isInstanceOf[TStream])
-        assert(env.scan.isEmpty)
         assert(x.typ.asInstanceOf[TStream].elementType == query.typ)
       case x@RunAgg(body, result, _) =>
         assert(x.typ == result.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -114,6 +114,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggStateSign
 object Extract {
   def liftScan(ir: IR): IR = ir match {
     case ApplyScanOp(init, seq, sig) => ApplyAggOp(init, seq, sig)
+    case StreamAggScan(a, name, query) => StreamAggScan(liftScan(a), name, query)
     case x => MapIR(liftScan)(x)
   }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -64,7 +64,7 @@ class Classx[C](val name: String, val superName: String) {
           else {
             /*
             if (l.method ne m) {
-              println(s"$l ${l.method} $m")
+              println(s"$l ${l.method} $m\n  ${l.stack.mkString("  \n")}")
             }
              */
             assert(l.method eq m)
@@ -317,6 +317,7 @@ class MethodLit(
 
 class Local(var method: Method, val name: String, val ti: TypeInfo[_]) {
   override def toString: String = f"t${ System.identityHashCode(this) }%08x/$name"
+//  val stack = Thread.currentThread().getStackTrace
 }
 
 class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(method, null, ti) {


### PR DESCRIPTION
Fixes #8325

Got rid of dummy_table logic, which is unnecessary with `parallelize`.

Agg/Scan envs were being mishandled in Extract/liftScan.