### PR TITLE
[query] Begin converting function registry from Code to PCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1159,14 +1159,14 @@ private class Emit[C](
         val value = Code(Code(ins), meth.invoke[Any]((coerce[Any](mb.getArg[Region](1).get) +: vars.map(_.get)): _*))
         strict(pt, value, codeArgs: _*)
       case x@ApplySeeded(fn, args, seed, rt) =>
-        val codeArgs = args.map(a => (a.pType, emit(a)))
+        val codeArgs = args.map(a => emit(a))
         val impl = x.implementation
         val unified = impl.unify(args.map(_.typ) :+ rt)
         assert(unified)
         impl.setSeed(seed)
         impl.apply(er, pt, codeArgs: _*)
       case x@ApplySpecial(_, args, rt) =>
-        val codeArgs = args.map(a => (a.pType, emit(a)))
+        val codeArgs = args.map(a => emit(a))
         val impl = x.implementation
         impl.argTypes.foreach(_.clear())
         val unified = impl.unify(args.map(_.typ) :+ rt)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -306,8 +306,9 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerCodeWithMissingness("corr", TArray(TFloat64), TArray(TFloat64), TFloat64, {
       (t1: PType, t2: PType) => PFloat64()
-    }) {
-      case (r, rt, (t1: PArray, EmitCode(setup1, m1, v1)), (t2: PArray, EmitCode(setup2, m2, v2))) =>
+    }) { case (r, rt, EmitCode(setup1, m1, v1), EmitCode(setup2, m2, v2)) =>
+        val t1 = v1.pt.asInstanceOf[PArray]
+        val t2 = v2.pt.asInstanceOf[PArray]
         val a1 = r.mb.newLocal[Long]()
         val a2 = r.mb.newLocal[Long]()
         val xSum = r.mb.newLocal[Double]()

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -335,9 +335,9 @@ object LocusFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("LocusInterval", TString, TBoolean, tinterval("T"), null) {
-      case (r: EmitRegion, rt: PInterval, (strT, ioff: EmitCode), (missingT, invalidMissing: EmitCode)) =>
+      case (r: EmitRegion, rt: PInterval, ioff: EmitCode, invalidMissing: EmitCode) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
-        val sinterval = asm4s.coerce[String](wrapArg(r, strT)(ioff.value[Long]))
+        val sinterval = asm4s.coerce[String](wrapArg(r, ioff.pt)(ioff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval](name="intervalObject")
         val interval = Code.invokeScalaObject[String, ReferenceGenome, Boolean, Interval](
           locusClass, "parseInterval", sinterval, rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
@@ -351,14 +351,14 @@ object LocusFunctions extends RegistryFunctions {
 
     registerCodeWithMissingness("LocusInterval", TString, TInt32, TInt32, TBoolean, TBoolean, TBoolean, tinterval("T"), null) {
       case (r: EmitRegion, rt: PInterval,
-      (locoffT, locoff: EmitCode),
-      (pos1T, pos1: EmitCode),
-      (pos2T, pos2: EmitCode),
-      (include1T, include1: EmitCode),
-      (include2T, include2: EmitCode),
-      (invalidMissingT, invalidMissing: EmitCode)) =>
+      locoff: EmitCode,
+      pos1: EmitCode,
+      pos2: EmitCode,
+      include1: EmitCode,
+      include2: EmitCode,
+      invalidMissing: EmitCode) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
-        val sloc = asm4s.coerce[String](wrapArg(r, locoffT)(locoff.value[Long]))
+        val sloc = asm4s.coerce[String](wrapArg(r, locoff.pt)(locoff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval]("intervalObject")
         val interval = Code.invokeScalaObject[String, Int, Int, Boolean, Boolean, ReferenceGenome, Boolean, Interval](
           locusClass, "makeInterval", sloc, pos1.value[Int], pos2.value[Int], include1.value[Boolean], include2.value[Boolean], rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
@@ -383,7 +383,8 @@ object LocusFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("liftoverLocus", tlocus("T"), TFloat64, TStruct("result" -> tv("U", "locus"), "is_negative_strand" -> TBoolean), null) {
-      case (r, rt: PStruct, (locT: PLocus, loc), (minMatchT, minMatch)) =>
+      case (r, rt: PStruct, loc, minMatch) =>
+        val locT = loc.pt.asInstanceOf[PLocus]
         val srcRG = locT.rg
         val destRG = rt.types(0).asInstanceOf[PLocus].rg
         val locus = Code.checkcast[Locus](asm4s.coerce[AnyRef](wrapArg(r, locT)(loc.value[Long])))
@@ -398,7 +399,8 @@ object LocusFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("liftoverLocusInterval", tinterval("T"), TFloat64, TStruct("result" -> tinterval("U"), "is_negative_strand" -> TBoolean), null) {
-      case (r, rt: PStruct, (iT: PInterval, i), (minMatchT, minMatch)) =>
+      case (r, rt: PStruct, i, minMatch) =>
+        val iT = i.pt.asInstanceOf[PInterval]
         val srcRG = iT.pointType.asInstanceOf[PLocus].rg
         val destRG = rt.types(0).asInstanceOf[PInterval].pointType.asInstanceOf[PLocus].rg
         val interval = Code.checkcast[Interval](asm4s.coerce[AnyRef](wrapArg(r, iT)(i.value[Long])))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -160,11 +160,11 @@ object UtilFunctions extends RegistryFunctions {
           Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)
       }
       registerCodeWithMissingness(s"to${name}OrMissing", TString, t, (xPT: PType) => rpt.setRequired(xPT.required)) {
-        case (r, rt, (xT: PString, x: EmitCode)) =>
+        case (r, rt, x) =>
           val s = r.mb.newLocal[String]()
           val m = r.mb.newLocal[Boolean]()
           EmitCode(
-            Code(x.setup, m := x.m, s := m.mux(Code._null[String], asm4s.coerce[String](wrapArg(r, xT)(x.v)))),
+            Code(x.setup, m := x.m, s := m.mux(Code._null[String], asm4s.coerce[String](wrapArg(r, x.pt)(x.v)))),
             (m || !Code.invokeScalaObject[String, Boolean](thisClass, s"isValid$name", s)),
             PCode(rt, Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)))
       }
@@ -222,37 +222,37 @@ object UtilFunctions extends RegistryFunctions {
       registerCodeWithMissingness(ignoreMissingName, TInt32, TInt32, TInt32, {
         case(t1: PType, t2: PType) => PInt32(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Int](rt, v1, v2, ignoreMissingName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Int](rt, v1, v2, ignoreMissingName)
       }
 
       registerCodeWithMissingness(ignoreMissingName, TInt64, TInt64, TInt64, {
         case(t1: PType, t2: PType) => PInt64(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Long](rt, v1, v2, ignoreMissingName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Long](rt, v1, v2, ignoreMissingName)
       }
 
       registerCodeWithMissingness(ignoreMissingName, TFloat32, TFloat32, TFloat32, {
         case(t1: PType, t2: PType) => PFloat32(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreMissingName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreMissingName)
       }
 
       registerCodeWithMissingness(ignoreMissingName, TFloat64, TFloat64, TFloat64, {
         case(t1: PType, t2: PType) => PFloat64(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreMissingName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreMissingName)
       }
 
       registerCodeWithMissingness(ignoreBothName, TFloat32, TFloat32, TFloat32, {
         case(t1: PType, t2: PType) => PFloat32(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreBothName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreBothName)
       }
 
       registerCodeWithMissingness(ignoreBothName, TFloat64, TFloat64, TFloat64, {
         case(t1: PType, t2: PType) => PFloat64(t1.required && t2.required)
       }) {
-        case (r, rt, (t1, v1), (t2, v2)) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreBothName)
+        case (r, rt, v1, v2) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreBothName)
       }
     }
 
@@ -268,7 +268,7 @@ object UtilFunctions extends RegistryFunctions {
     registerCodeWithMissingness("land", TBoolean, TBoolean, TBoolean, {
       case(_: PType, _: PType) => PBoolean()
     }) {
-      case (er, rt, (lT, l), (rT, r)) =>
+      case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]
 
@@ -300,7 +300,7 @@ object UtilFunctions extends RegistryFunctions {
     registerCodeWithMissingness("lor", TBoolean, TBoolean, TBoolean, {
       case(_: PType, _: PType) => PBoolean()
     }) {
-      case (er, rt, (lT, l), (rT, r)) =>
+      case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -37,7 +37,7 @@ object IRSuite {
 
   object TestFunctions extends RegistryFunctions {
 
-    def registerSeededWithMissingness(mname: String, aTypes: Array[Type], rType: Type, pt: Seq[PType] => PType)(impl: (EmitRegion, PType, Long, Array[(PType, EmitCode)]) => EmitCode) {
+    def registerSeededWithMissingness(mname: String, aTypes: Array[Type], rType: Type, pt: Seq[PType] => PType)(impl: (EmitRegion, PType, Long, Array[EmitCode]) => EmitCode) {
       IRFunctionRegistry.addIRFunction(new SeededIRFunction {
         val isDeterministic: Boolean = false
 
@@ -49,30 +49,30 @@ object IRSuite {
 
         override def returnPType(argTypes: Seq[PType], returnType: Type): PType = if (pt == null) PType.canonical(returnType) else pt(argTypes)
 
-        def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: (PType, EmitCode)*): EmitCode = {
-          unify(args.map(_._1.virtualType))
+        def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: EmitCode*): EmitCode = {
+          unify(args.map(_.pt.virtualType))
           impl(r, rpt, seed, args.toArray)
         }
       })
     }
 
-    def registerSeededWithMissingness(mname: String, mt1: Type, rType: Type, pt: PType => PType)(impl: (EmitRegion, PType, Long, (PType, EmitCode)) => EmitCode): Unit =
+    def registerSeededWithMissingness(mname: String, mt1: Type, rType: Type, pt: PType => PType)(impl: (EmitRegion, PType, Long, EmitCode) => EmitCode): Unit =
       registerSeededWithMissingness(mname, Array(mt1), rType, unwrappedApply(pt)) { case (r, rt, seed, Array(a1)) => impl(r, rt, seed, a1) }
 
     def registerAll() {
-      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, null) { case (mb, rt,  _, (lT, l)) =>
+      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, null) { case (mb, rt,  _, l) =>
         EmitCode(Code(Code.invokeScalaObject[Unit](outer.getClass, "incr"), l.setup),
           l.m,
           PCode(rt, l.v))
       }
 
-      registerSeededWithMissingness("incr_m", TBoolean, TBoolean, null) { case (mb, rt, _, (lT, l)) =>
+      registerSeededWithMissingness("incr_m", TBoolean, TBoolean, null) { case (mb, rt, _, l) =>
         EmitCode(l.setup,
           Code(Code.invokeScalaObject[Unit](outer.getClass, "incr"), l.m),
           PCode(rt, l.v))
       }
 
-      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, null) { case (mb, rt, _, (lT, l)) =>
+      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, null) { case (mb, rt, _, l) =>
         EmitCode(l.setup,
           l.m,
           PCode(rt, Code(Code.invokeScalaObject[Unit](outer.getClass, "incr"), l.v)))


### PR DESCRIPTION
This step is probably the easiest. Remove the `PType` from `(PType, EmitCode)` pairs. It should always agree with the `PType` on the corresponding `EmitCode`