### PR TITLE
[query] support emit-level parameters

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -135,10 +135,6 @@ dependencies {
     unbundled 'org.scala-lang:scala-library:' + scalaVersion
     unbundled 'org.scala-lang:scala-reflect:' + scalaVersion
 
-    bundled group: 'org.ow2.asm', name: 'asm', version: '7.3.1'
-    bundled group: 'org.ow2.asm', name: 'asm-util', version: '7.3.1'
-    bundled group: 'org.ow2.asm', name: 'asm-analysis', version: '7.3.1'
-
     unbundled('org.apache.spark:spark-core_' + scalaMajorVersion + ':' + sparkVersion) {
         exclude module: 'hadoop-client'
     }

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -134,6 +134,11 @@ configurations {
 dependencies {
     unbundled 'org.scala-lang:scala-library:' + scalaVersion
     unbundled 'org.scala-lang:scala-reflect:' + scalaVersion
+
+    bundled group: 'org.ow2.asm', name: 'asm', version: '7.3.1'
+    bundled group: 'org.ow2.asm', name: 'asm-util', version: '7.3.1'
+    bundled group: 'org.ow2.asm', name: 'asm-analysis', version: '7.3.1'
+
     unbundled('org.apache.spark:spark-core_' + scalaMajorVersion + ':' + sparkVersion) {
         exclude module: 'hadoop-client'
     }

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -361,7 +361,7 @@ class RegionValueBuilder(var region: Region) {
 
   def selectRegionValue(fromT: PStruct, fromFieldIdx: Array[Int], region: Region, offset: Long) {
     val t = fromT.typeAfterSelect(fromFieldIdx).fundamentalType
-    assert(currentType() == t)
+    assert(currentType().setRequired(true) == t.setRequired(true))
     assert(t.size == fromFieldIdx.length)
     startStruct()
     addFields(fromT, region, offset, fromFieldIdx)
@@ -376,7 +376,7 @@ class RegionValueBuilder(var region: Region) {
     val toT = currentType()
 
     if (typestk.isEmpty) {
-      val r = toT.copyFromType(region, t.fundamentalType, fromOff, region.ne(fromRegion))
+      val r = toT.copyFromAddress(region, t.fundamentalType, fromOff, region ne fromRegion)
       start = r
       return
     }

--- a/hail/src/main/scala/is/hail/asm4s/AsmFunction.scala
+++ b/hail/src/main/scala/is/hail/asm4s/AsmFunction.scala
@@ -1,5 +1,7 @@
 package is.hail.asm4s
 
+import is.hail.annotations.{Region, RegionValue}
+
 trait AsmFunction0[R] { def apply(): R }
 trait AsmFunction1[A,R] { def apply(a: A): R }
 trait AsmFunction2[A,B,R] { def apply(a: A, b: B): R }
@@ -17,3 +19,48 @@ trait AsmFunction12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,R] {
 trait AsmFunction13[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,R] {
   def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13): R
 }
+
+trait AsmFunction1RegionUnit {
+  def apply(r: Region): Unit
+}
+
+trait AsmFunction1RegionLong {
+  def apply(r: Region): Long
+}
+
+trait AsmFunction2RegionLongUnit {
+  def apply(r: Region, a: Long): Unit
+}
+
+trait AsmFunction2RegionLongInt {
+  def apply(r: Region, a: Long): Int
+}
+
+trait AsmFunction2RegionLongLong {
+  def apply(r: Region, a: Long): Long
+}
+
+trait AsmFunction3RegionLongBooleanLong {
+  def apply(r: Region, a: Long, b: Boolean): Long
+}
+
+trait AsmFunction3RegionLongLongUnit {
+  def apply(r: Region, a: Long, b: Long): Unit
+}
+
+trait AsmFunction3RegionLongLongBoolean {
+  def apply(r: Region, a: Long, b: Long): Boolean
+}
+
+trait AsmFunction3RegionLongIntLong {
+  def apply(r: Region, a: Long, b: Int): Long
+}
+
+trait AsmFunction3RegionLongLongLong {
+  def apply(r: Region, a: Long, b: Long): Long
+}
+
+trait AsmFunction3RegionIteratorRegionValueBooleanLong {
+  def apply(r: Region, a: Iterator[RegionValue], b: Boolean): Long
+}
+

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -18,6 +18,16 @@ package asm4s {
     def slots: Int = 1
 
     def newArray(): AbstractInsnNode
+
+    override def hashCode(): Int = desc.hashCode()
+
+    override def equals(that: Any): Boolean = that match {
+      case that: TypeInfo[_] =>
+        return desc == that.desc
+      case _ => false
+    }
+
+    override def toString: String = desc
   }
 
   class ClassInfo[C](className: String) extends TypeInfo[C] {

--- a/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
@@ -111,7 +111,7 @@ case class IndexedRVDSpec private(
   private val lRvdType = LegacyEncodedTypeParser.parseLegacyRVDType(rvdType)
 
   lazy val shim = IndexedRVDSpec2(lRvdType.key,
-    TypedCodecSpec(lRvdType.rowEType, lRvdType.rowType, codecSpec.child),
+    TypedCodecSpec(lRvdType.rowEType.setRequired(true), lRvdType.rowType, codecSpec.child),
     indexSpec.toIndexSpec2, partFiles, jRangeBounds, Map.empty[String, String])
 }
 
@@ -126,7 +126,7 @@ case class UnpartitionedRVDSpec private(
 
   def key: IndexedSeq[String] = FastIndexedSeq()
 
-  def typedCodecSpec: AbstractTypedCodecSpec = TypedCodecSpec(rowEType, rowVType, codecSpec.child)
+  def typedCodecSpec: AbstractTypedCodecSpec = TypedCodecSpec(rowEType.setRequired(true), rowVType, codecSpec.child)
 
   val attrs: Map[String, String] = Map.empty
 }
@@ -147,7 +147,7 @@ case class OrderedRVDSpec private(
       JSONAnnotationImpex.importAnnotation(jRangeBounds, rangeBoundsType, padNulls = false).asInstanceOf[IndexedSeq[Interval]])
   }
 
-  override def typedCodecSpec: AbstractTypedCodecSpec = TypedCodecSpec(lRvdType.rowEType, lRvdType.rowType, codecSpec.child)
+  override def typedCodecSpec: AbstractTypedCodecSpec = TypedCodecSpec(lRvdType.rowEType.setRequired(true), lRvdType.rowType, codecSpec.child)
 
   val attrs: Map[String, String] = Map.empty
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -9,15 +9,15 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   val ti: TypeInfo[_] = typeToTypeInfo(typ)
   val mb: EmitMethodBuilder[_] = r.mb
 
-  def sort(sorter: DependentEmitFunction[_]): Code[Unit] = {
+  def sort(sorter: DependentEmitFunctionBuilder[_]): Code[Unit] = {
     val localF = ti match {
       case BooleanInfo => mb.genFieldThisRef[AsmFunction2[Boolean, Boolean, Boolean]]()
       case IntInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
       case LongInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
-      case FloatInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
-      case DoubleInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
+      case FloatInfo => mb.genFieldThisRef[AsmFunction2[Long, Long, Boolean]]()
+      case DoubleInfo => mb.genFieldThisRef[AsmFunction2[Double, Double, Boolean]]()
     }
-    Code(localF.storeAny(sorter.newInstance(mb.mb)), array.sort(localF))
+    Code(localF.storeAny(Code.checkcast(sorter.newInstance(mb))(localF.ti)), array.sort(localF))
   }
 
   def toRegion(): Code[Long] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -18,37 +18,40 @@ case class CodeCacheValue(typ: PType, f: (Int, Region) => Any)
 object Compile {
   private[this] val codeCache: Cache[CodeCacheKey, CodeCacheValue] = new Cache(50)
 
-  private def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
+  def apply[F: TypeInfo](
     ctx: ExecuteContext,
-    print: Option[PrintWriter],
-    args: Seq[(String, PType, ClassTag[_])],
-    argTypeInfo: Array[MaybeGenericTypeInfo[_]],
+    params: IndexedSeq[(String, PType)],
+    expectedCodeParamTypes: IndexedSeq[TypeInfo[_]], expectedCodeReturnType: TypeInfo[_],
     body: IR,
-    optimize: Boolean
+    optimize: Boolean = true,
+    print: Option[PrintWriter] = None
   ): (PType, (Int, Region) => F) = {
+
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
-      Env(args.map { case (n, _, _) => n -> n }: _*))
-    val k = CodeCacheKey(FastIndexedSeq[AggStatePhysicalSignature](), args.map { case (n, pt, _) => (n, pt) }, normalizedBody)
+      Env(params.map { case (n, _) => n -> n }: _*))
+    val k = CodeCacheKey(FastIndexedSeq[AggStatePhysicalSignature](), params.map { case (n, pt) => (n, pt) }, normalizedBody)
     codeCache.get(k) match {
       case Some(v) =>
         return (v.typ, v.f.asInstanceOf[(Int, Region) => F])
       case None =>
     }
 
-    val fb = EmitFunctionBuilder[F]("Compiled", argTypeInfo, GenericTypeInfo[R]())
-
     var ir = body
-    ir = Subst(ir, BindingEnv(args
+    ir = Subst(ir, BindingEnv(params
       .zipWithIndex
-      .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }))
+      .foldLeft(Env.empty[IR]) { case (e, ((n, t), i)) => e.bind(n, In(i, t)) }))
     ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
 
     TypeCheck(ir, BindingEnv.empty)
 
-    InferPType(ir, Env(args.map { case (n, pt, _) => n -> pt}: _*))
+    InferPType(ir, Env(params.map { case (n, pt) => n -> pt}: _*))
+    val returnType = ir.pType
 
-    assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
+    val fb = EmitFunctionBuilder[F]("Compiled",
+      CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
+        EmitParamType(pt)
+      }, returnType)
 
     /*
     {
@@ -60,212 +63,57 @@ object Compile {
       }
 
       visit(ir)
-    } */
+    }
+     */
+
+    assert(fb.mb.parameterTypeInfo == expectedCodeParamTypes, s"expected $expectedCodeParamTypes, got ${ fb.mb.parameterTypeInfo }")
+    assert(fb.mb.returnTypeInfo == expectedCodeReturnType, s"expected $expectedCodeReturnType, got ${ fb.mb.returnTypeInfo }")
 
     Emit(ctx, ir, fb)
 
     val f = fb.resultWithIndex(print)
     codeCache += k -> CodeCacheValue(ir.pType, f)
 
-    (ir.pType, f)
-  }
-
-  def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    print: Option[PrintWriter],
-    args: Seq[(String, PType, ClassTag[_])],
-    body: IR,
-    optimize: Boolean
-  ): (PType, (Int, Region) => F) = {
-    assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
-
-    val ab = new ArrayBuilder[MaybeGenericTypeInfo[_]]()
-    ab += GenericTypeInfo[Region]()
-    args.foreach { case (_, t, _) =>
-      ab += GenericTypeInfo()(typeToTypeInfo(t))
-      ab += GenericTypeInfo[Boolean]()
-    }
-
-    val argTypeInfo: Array[MaybeGenericTypeInfo[_]] = ab.result()
-
-    Compile[F, R](ctx, print, args, argTypeInfo, body, optimize)
-  }
-
-  def apply[R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    body: IR,
-    print: Option[PrintWriter],
-    optimize: Boolean = true
-  ): (PType, (Int, Region) => AsmFunction1[Region, R]) = {
-    apply[AsmFunction1[Region, R], R](ctx, print, FastSeq[(String, PType, ClassTag[_])](), body, optimize)
-  }
-
-  def apply[T0: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    body: IR,
-    optimize: Boolean,
-    print: Option[PrintWriter]
-  ): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
-    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0])), body, optimize)
-  }
-
-  def apply[T0: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    body: IR,
-    optimize: Boolean): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) =
-    apply(ctx, name0, typ0, body, optimize, None)
-
-  def apply[T0: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) =
-    apply(ctx, name0, typ0, body, true)
-
-  def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    name1: String,
-    typ1: PType,
-    body: IR,
-    print: Option[PrintWriter]): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, optimize = true)
-  }
-
-  def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    name1: String,
-    typ1: PType,
-    body: IR,
-    print: Option[PrintWriter],
-    optimize: Boolean): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, print, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, optimize = optimize)
-  }
-
-  def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    name1: String,
-    typ1: PType,
-    body: IR): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) =
-    apply(ctx, name0, typ0, name1, typ1, body, None)
-
-  def apply[
-  T0: TypeInfo : ClassTag,
-  T1: TypeInfo : ClassTag,
-  T2: TypeInfo : ClassTag,
-  R: TypeInfo : ClassTag
-  ](ctx: ExecuteContext,
-    name0: String,
-    typ0: PType,
-    name1: String,
-    typ1: PType,
-    name2: String,
-    typ2: PType,
-    body: IR
-  ): (PType, (Int, Region) => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
-    apply[AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R], R](ctx, None, FastSeq(
-      (name0, typ0, classTag[T0]),
-      (name1, typ1, classTag[T1]),
-      (name2, typ2, classTag[T2])
-    ), body,
-      optimize = true)
-  }
-
-  def apply[
-  T0: TypeInfo : ClassTag,
-  T1: TypeInfo : ClassTag,
-  T2: TypeInfo : ClassTag,
-  T3: TypeInfo : ClassTag,
-  R: TypeInfo : ClassTag
-  ](ctx: ExecuteContext,
-    name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    name2: String, typ2: PType,
-    name3: String, typ3: PType,
-    body: IR
-  ): (PType, (Int, Region) => AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R]) = {
-    apply[AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R], R](ctx, None, FastSeq(
-      (name0, typ0, classTag[T0]),
-      (name1, typ1, classTag[T1]),
-      (name2, typ2, classTag[T2]),
-      (name3, typ3, classTag[T3])
-    ), body,
-      optimize = true)
-  }
-
-  def apply[
-  T0: ClassTag,
-  T1: ClassTag,
-  T2: ClassTag,
-  T3: ClassTag,
-  T4: ClassTag,
-  T5: ClassTag,
-  R: TypeInfo : ClassTag
-  ](ctx: ExecuteContext,
-    name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    name2: String, typ2: PType,
-    name3: String, typ3: PType,
-    name4: String, typ4: PType,
-    name5: String, typ5: PType,
-    body: IR
-  ): (PType, (Int, Region) => AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R]) = {
-
-    apply[AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R], R](ctx, None, FastSeq(
-      (name0, typ0, classTag[T0]),
-      (name1, typ1, classTag[T1]),
-      (name2, typ2, classTag[T2]),
-      (name3, typ3, classTag[T3]),
-      (name4, typ4, classTag[T4]),
-      (name5, typ5, classTag[T5])
-    ), body,
-      optimize = true)
+    (returnType, f)
   }
 }
 
 object CompileWithAggregators2 {
   private[this] val codeCache: Cache[CodeCacheKey, CodeCacheValue] = new Cache(50)
 
-  private def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
+  def apply[F: TypeInfo](
     ctx: ExecuteContext,
     aggSigs: Array[AggStatePhysicalSignature],
-    args: Seq[(String, PType, ClassTag[_])],
-    argTypeInfo: Array[MaybeGenericTypeInfo[_]],
+    params: IndexedSeq[(String, PType)],
+    expectedCodeParamTypes: IndexedSeq[TypeInfo[_]], expectedCodeReturnType: TypeInfo[_],
     body: IR,
-    optimize: Boolean
+    optimize: Boolean = true
   ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
-      Env(args.map { case (n, _, _) => n -> n }: _*))
-    val k = CodeCacheKey(aggSigs, args.map { case (n, pt, _) => (n, pt) }, normalizedBody)
+      Env(params.map { case (n, _) => n -> n }: _*))
+    val k = CodeCacheKey(aggSigs, params.map { case (n, pt) => (n, pt) }, normalizedBody)
     codeCache.get(k) match {
       case Some(v) =>
         return (v.typ, v.f.asInstanceOf[(Int, Region) => (F with FunctionWithAggRegion)])
       case None =>
     }
 
-    val fb = EmitFunctionBuilder[F]("CompiledWithAggs", argTypeInfo, GenericTypeInfo[R]())
-
     var ir = body
-    ir = Subst(ir, BindingEnv(args
+    ir = Subst(ir, BindingEnv(params
       .zipWithIndex
-      .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }))
+      .foldLeft(Env.empty[IR]) { case (e, ((n, t), i)) => e.bind(n, In(i, t)) }))
     ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
 
-    TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
+    TypeCheck(ir, BindingEnv(Env.fromSeq[Type](params.map { case (name, t) => name -> t.virtualType })))
 
-    InferPType(ir, Env(args.map { case (n, pt, _) => n -> pt}: _*), aggSigs, null, null)
+    InferPType(ir, Env(params.map { case (n, pt) => n -> pt}: _*), aggSigs, null, null)
 
-    assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
+    val returnType = ir.pType
+    val fb = EmitFunctionBuilder[F]("CompiledWithAggs",
+      CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
+        EmitParamType(pt)
+      }, returnType)
 
     Emit(ctx, ir, fb, Some(aggSigs))
 
@@ -273,53 +121,4 @@ object CompileWithAggregators2 {
     codeCache += k -> CodeCacheValue(ir.pType, f)
     (ir.pType, f.asInstanceOf[(Int, Region) => (F with FunctionWithAggRegion)])
   }
-
-  def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    aggSigs: Array[AggStatePhysicalSignature],
-    args: Seq[(String, PType, ClassTag[_])],
-    body: IR,
-    optimize: Boolean
-  ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
-    assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
-
-    val ab = new ArrayBuilder[MaybeGenericTypeInfo[_]]()
-    ab += GenericTypeInfo[Region]()
-    args.foreach { case (_, t, _) =>
-      ab += GenericTypeInfo()(typeToTypeInfo(t))
-      ab += GenericTypeInfo[Boolean]()
-    }
-
-    val argTypeInfo: Array[MaybeGenericTypeInfo[_]] = ab.result()
-
-    CompileWithAggregators2[F, R](ctx, aggSigs, args, argTypeInfo, body, optimize)
-  }
-
-  def apply[R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    aggSigs: Array[AggStatePhysicalSignature],
-    body: IR): (PType, (Int, Region) => AsmFunction1[Region, R] with FunctionWithAggRegion) = {
-
-    apply[AsmFunction1[Region, R], R](ctx, aggSigs, FastSeq[(String, PType, ClassTag[_])](), body, optimize = true)
-  }
-
-  def apply[T0: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    aggSigs: Array[AggStatePhysicalSignature],
-    name0: String, typ0: PType,
-    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R] with FunctionWithAggRegion) = {
-
-    apply[AsmFunction3[Region, T0, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0])), body, optimize = true)
-  }
-
-  def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
-    ctx: ExecuteContext,
-    aggSigs: Array[AggStatePhysicalSignature],
-    name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    body: IR): (PType, (Int, Region) => (AsmFunction5[Region, T0, Boolean, T1, Boolean, R] with FunctionWithAggRegion)) = {
-
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](ctx, aggSigs, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, optimize = true)
-  }
 }
-

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -1,10 +1,11 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.SafeRow
+import is.hail.annotations.{Region, SafeRow}
+import is.hail.asm4s._
 import is.hail.expr.ir.lowering.LoweringPipeline
-import is.hail.expr.types.physical.{PBaseStruct, PTuple, PType, PVoid}
+import is.hail.expr.types.physical.{PBaseStruct, PTuple}
 import is.hail.expr.types.virtual.TVoid
-import is.hail.utils.FastSeq
+import is.hail.utils.{FastIndexedSeq, FastSeq}
 
 object CompileAndEvaluate {
   def apply[T](ctx: ExecuteContext,
@@ -30,8 +31,11 @@ object CompileAndEvaluate {
       // void is not really supported by IR utilities
       return Left(())
 
-    val (resultPType: PTuple, f) = ctx.timer.time("Compile")(Compile[Long](ctx,
-      MakeTuple.ordered(FastSeq(ir)), None, optimize = false))
+    val (resultPType: PTuple, f) = ctx.timer.time("Compile")(Compile[AsmFunction1RegionLong](ctx,
+      FastIndexedSeq(),
+      FastIndexedSeq(classInfo[Region]), LongInfo,
+      MakeTuple.ordered(FastSeq(ir)),
+      print = None, optimize = false))
 
     val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(0, ctx.r))
     val resultAddress = ctx.timer.time("RunCompiledFunction")(fRunnable(ctx.r))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -550,7 +550,7 @@ object EmitStream {
     env0: Emit.E,
     container: Option[AggContainer]
   ): COption[SizedStream] =
-    emit(emitter, streamIR0, mb, mb.getArg[Region](1), env0, container)
+    emit(emitter, streamIR0, mb, mb.getCodeParam[Region](1), env0, container)
 
   private[ir] def emit[C](
     emitter: Emit[C],
@@ -687,13 +687,8 @@ object EmitStream {
         case In(n, PStream(eltType, _)) =>
           val xIter = mb.newLocal[Iterator[RegionValue]]()
 
-          new COption[Code[Iterator[RegionValue]]] {
-            def apply(none: Code[Ctrl], some: (Code[Iterator[RegionValue]]) => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = {
-              mb.getArg[Boolean](2 + 2 * n + 1).mux(
-                none,
-                some(mb.getArg[Iterator[RegionValue]](2 + 2 * n)))
-            }
-          }.map { iter =>
+          // this, Region, ...
+          mb.getStreamEmitParam(2 + n).map { iter =>
             val stream = unfold[Code[RegionValue]](
               Code._empty,
               Code._empty,

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -359,7 +359,7 @@ object GetFieldByIdx {
 final case class GetField(o: IR, name: String) extends IR
 
 object MakeTuple {
-  def ordered(types: Seq[IR]): MakeTuple = MakeTuple(types.iterator.zipWithIndex.map { case (ir, i) => (i, ir)}.toFastIndexedSeq)
+  def ordered(types: Seq[IR]): MakeTuple = MakeTuple(types.iterator.zipWithIndex.map { case (ir, i) => (i, ir) }.toFastIndexedSeq)
 }
 
 final case class MakeTuple(fields: Seq[(Int, IR)]) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -96,7 +96,7 @@ object LowerMatrixIR {
           irIf('row (Symbol(entries)).isNA) {
             irDie("missing entry array unsupported in 'to_matrix_table_row_major'", lc.typ.rowType)
           } {
-            irIf('row (Symbol(entries)).len.cne( 'global (Symbol(cols)).len)) {
+            irIf('row (Symbol(entries)).len.cne('global (Symbol(cols)).len)) {
               irDie("length mismatch between entry array and column array in 'to_matrix_table_row_major'", lc.typ.rowType)
             } {
               'row

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1374,11 +1374,11 @@ object PruneDeadFields {
         val keys2 = requestedType.key
         // fully upcast before shuffle
         if (!isSorted && keys2.nonEmpty)
-          child2 = upcastTable(child2, memo.requestedType.lookup(child).asInstanceOf[TableType])
+          child2 = upcastTable(child2, memo.requestedType.lookup(child).asInstanceOf[TableType], upcastGlobals = false)
         TableKeyBy(child2, keys2, isSorted)
       case TableOrderBy(child, sortFields) =>
         // fully upcast before shuffle
-        val child2 = upcastTable(rebuild(child, memo), memo.requestedType.lookup(child).asInstanceOf[TableType])
+        val child2 = upcastTable(rebuild(child, memo), memo.requestedType.lookup(child).asInstanceOf[TableType], upcastGlobals = false)
         TableOrderBy(child2, sortFields)
       case TableLeftJoinRightDistinct(left, right, root) =>
         if (requestedType.rowType.hasField(root))

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -3,11 +3,11 @@ package is.hail.expr.ir
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.TableAnnotationImpex
-import is.hail.expr.types.physical.{PCanonicalStruct, PStruct}
+import is.hail.expr.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PStruct}
 import is.hail.expr.types.virtual.{Field, TArray, TStruct}
 import is.hail.expr.types.{MatrixType, TableType}
 import is.hail.io.{BufferSpec, TypedCodecSpec, exportTypes}
-import is.hail.rvd.{AbstractRVDSpec, RVD, RVDContext, RVDType}
+import is.hail.rvd.{AbstractRVDSpec, RVD, RVDType}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
@@ -19,14 +19,16 @@ import org.json4s.jackson.JsonMethods
 
 object TableValue {
   def apply(ctx: ExecuteContext, rowType: PStruct, key: IndexedSeq[String], rdd: ContextRDD[RegionValue]): TableValue = {
+    assert(rowType.required)
     val tt = TableType(rowType.virtualType, key, TStruct.empty)
     TableValue(tt,
       BroadcastRow.empty(ctx),
       RVD.coerce(RVDType(rowType, key), rdd, ctx))
   }
 
-  def apply(ctx: ExecuteContext, rowType:  TStruct, key: IndexedSeq[String], rdd: RDD[Row], rowPType: Option[PStruct] = None): TableValue = {
-    val canonicalRowType = rowPType.getOrElse(PCanonicalStruct.canonical(rowType))
+  def apply(ctx: ExecuteContext, rowType: TStruct, key: IndexedSeq[String], rdd: RDD[Row], rowPType: Option[PStruct] = None): TableValue = {
+    val canonicalRowType = rowPType.getOrElse(PCanonicalStruct.canonical(rowType).setRequired(true).asInstanceOf[PStruct])
+    assert(canonicalRowType.required)
     val tt = TableType(rowType, key, TStruct.empty)
     TableValue(tt,
       BroadcastRow.empty(ctx),
@@ -44,6 +46,8 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     throw new RuntimeException(s"key mismatch:\n  typ: ${ typ.key }\n  rvd: ${ rvd.typ.key }")
   if (typ.globalType != globals.t.virtualType)
     throw new RuntimeException(s"globals mismatch:\n  typ: ${ typ.globalType.parsableString() }\n  val: ${ globals.t.virtualType.parsableString() }")
+  if (!globals.t.required)
+    throw new RuntimeException(s"globals not required; ${ globals.t }")
 
   def rdd: RDD[Row] =
     rvd.toRows
@@ -170,7 +174,34 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
       typ.rowType.deleteKey(entriesFieldName),
       typ.rowType.field(MatrixType.entriesIdentifier).typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct])
 
-    MatrixValue(mType, rename(
+    val globalsT = globals.t
+    val colsT = globalsT.field(colsFieldName).typ.asInstanceOf[PArray]
+
+    val globals2 =
+      if (colsT.required && colsT.elementType.required)
+        globals
+      else
+        globals.cast(
+          globalsT.insertFields(FastIndexedSeq(
+            colsFieldName -> PCanonicalArray(colsT.elementType.setRequired(true), true))))
+
+    val entriesT = rvd.rowPType.field(entriesFieldName).typ.asInstanceOf[PArray]
+    val rvd2 =
+      if (entriesT.required && entriesT.elementType.required)
+        rvd
+      else
+        rvd.cast(
+          PCanonicalStruct(true,
+            rvd.rowPType.fields.map { f =>
+              if (f.name == entriesFieldName)
+                entriesFieldName -> PCanonicalArray(entriesT.elementType.setRequired(true), true)
+              else
+                f.name -> f.typ
+            }: _*))
+
+    val newTV = TableValue(typ, globals2, rvd2)
+
+    MatrixValue(mType, newTV.rename(
       Map(colsFieldName -> LowerMatrixIR.colsFieldName),
       Map(entriesFieldName -> LowerMatrixIR.entriesFieldName)))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -185,21 +185,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
           globalsT.insertFields(FastIndexedSeq(
             colsFieldName -> PCanonicalArray(colsT.elementType.setRequired(true), true))))
 
-    val entriesT = rvd.rowPType.field(entriesFieldName).typ.asInstanceOf[PArray]
-    val rvd2 =
-      if (entriesT.required && entriesT.elementType.required)
-        rvd
-      else
-        rvd.cast(
-          PCanonicalStruct(true,
-            rvd.rowPType.fields.map { f =>
-              if (f.name == entriesFieldName)
-                entriesFieldName -> PCanonicalArray(entriesT.elementType.setRequired(true), true)
-              else
-                f.name -> f.typ
-            }: _*))
-
-    val newTV = TableValue(typ, globals2, rvd2)
+    val newTV = TableValue(typ, globals2, rvd)
 
     MatrixValue(mType, newTV.rename(
       Map(colsFieldName -> LowerMatrixIR.colsFieldName),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -74,12 +74,12 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
     }
 
   private val insert: EmitMethodBuilder[_] = {
-    val insertAt = cb.genEmitMethod("btree_insert", Array[TypeInfo[_]](typeInfo[Long], typeInfo[Int], typeInfo[Boolean], typeToTypeInfo(key.compType), typeInfo[Long]), typeInfo[Long])
-    val node: Value[Long] = insertAt.getArg[Long](1)
-    val insertIdx: Value[Int] = insertAt.getArg[Int](2)
-    val km: Value[Boolean] = insertAt.getArg[Boolean](3)
-    val kv: Value[_] = insertAt.getArg(4)(typeToTypeInfo(key.compType))
-    val child: Value[Long] = insertAt.getArg[Long](5)
+    val insertAt = cb.genEmitMethod("btree_insert", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Int], typeInfo[Boolean], key.compType.ti, typeInfo[Long]), typeInfo[Long])
+    val node: Value[Long] = insertAt.getCodeParam[Long](1)
+    val insertIdx: Value[Int] = insertAt.getCodeParam[Int](2)
+    val km: Value[Boolean] = insertAt.getCodeParam[Boolean](3)
+    val kv: Value[_] = insertAt.getCodeParam(4)(key.compType.ti)
+    val child: Value[Long] = insertAt.getCodeParam[Long](5)
 
     def parent: Code[Long] = getParent(node)
 
@@ -126,7 +126,7 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
         }
       Code((!isLeaf(node)).orEmpty(
         setChild(newNode, -1, c)),
-        insertAt.invoke[Long](parent, upperBound, m, v, newNode))
+        insertAt.invokeCode[Long](parent, upperBound, m, v, newNode))
     }
 
     def promote(idx: Int): Code[Unit] = {
@@ -141,7 +141,7 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
         Code((!isLeaf(node)).orEmpty(
           setChild(newNode, -1, loadChild(node, idx))),
           key.copy(loadKey(node, idx),
-            insertAt.invoke[Long](parent, upperBound, compKeyM, compKeyV, newNode)),
+            insertAt.invokeCode[Long](parent, upperBound, compKeyM, compKeyV, newNode)),
           setKeyMissing(node, idx))
       }
     }
@@ -154,29 +154,29 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
       (insertIdx > splitIdx).mux(
         Code(copyToNew(splitIdx + 1),
           promote(splitIdx),
-          insertAt.invoke(newNode, insertIdx - splitIdx - 1, km, kv, child)),
+          insertAt.invokeCode(newNode, insertIdx - splitIdx - 1, km, kv, child)),
         Code(
           copyToNew(splitIdx),
           insertIdx.ceq(splitIdx).mux(
             insertKey(km, kv, child),
             Code(promote(splitIdx - 1),
-              insertAt.invoke(node, insertIdx, km, kv, child))))))
+              insertAt.invokeCode(node, insertIdx, km, kv, child))))))
 
     insertAt.emit(isFull(node).mux(splitAndInsert, shiftAndInsert))
     insertAt
   }
 
   private val getF: EmitMethodBuilder[_] = {
-    val get = cb.genEmitMethod("btree_get", Array[TypeInfo[_]](typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(key.compType)), typeInfo[Long])
-    val node = get.getArg[Long](1)
-    val km = get.getArg[Boolean](2)
-    val kv = get.getArg(3)(typeToTypeInfo(key.compType))
+    val get = cb.genEmitMethod("btree_get", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Boolean], key.compType.ti), typeInfo[Long])
+    val node = get.getCodeParam[Long](1)
+    val km = get.getCodeParam[Boolean](2)
+    val kv = get.getCodeParam(3)(key.compType.ti)
 
     val cmp = get.newLocal[Int]()
     val keyV = get.newLocal[Long]()
 
     def insertOrGetAt(i: Int) = isLeaf(node).mux(
-      Code(keyV := insert.invoke[Long](node, i, km, kv, 0L), cmp := 0),
+      Code(keyV := insert.invokeCode[Long](node, const(i), km, kv, const(0L)), cmp := 0),
       node := loadChild(node, i - 1))
 
     get.emit(Code(
@@ -198,38 +198,38 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
   def init: Code[Unit] = createNode(root)
 
   def getOrElseInitialize(km: Code[Boolean], kv: Code[_]): Code[Long] =
-    getF.invoke(root, km, kv)
+    getF.invokeCode(root, km, kv)
 
   def foreach(visitor: Code[Long] => Code[Unit]): Code[Unit] = {
-    val f = cb.genEmitMethod("btree_foreach", Array[TypeInfo[_]](typeInfo[Long]), typeInfo[Unit])
-    val node = f.getArg[Long](1)
+    val f = cb.genEmitMethod("btree_foreach", FastIndexedSeq[ParamType](typeInfo[Long]), typeInfo[Unit])
+    val node = f.getCodeParam[Long](1)
     val i = f.newLocal[Int]("aobt_foreach_i")
 
     f.emit(Code(
-      (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, -1))),
+      (!isLeaf(node)).orEmpty(f.invokeCode(loadChild(node, -1))),
       i := 0,
       Array.range(0, maxElements)
         .foldRight(Code._empty) { (i, cont) =>
           hasKey(node, i).orEmpty(
             Code(
               visitor(loadKey(node, i)),
-              (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, i))),
+              (!isLeaf(node)).orEmpty(f.invokeCode(loadChild(node, i))),
               cont))
         }))
-    f.invoke(root)
+    f.invokeCode(root)
   }
 
   val deepCopy: Code[Long] => Code[Unit] = {
-    val f = cb.genEmitMethod("btree_deepCopy", Array[TypeInfo[_]](typeInfo[Long], typeInfo[Long]), typeInfo[Unit])
-    val destNode = f.getArg[Long](1)
-    val srcNode = f.getArg[Long](2)
+    val f = cb.genEmitMethod("btree_deepCopy", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Long]), typeInfo[Unit])
+    val destNode = f.getCodeParam[Long](1)
+    val srcNode = f.getCodeParam[Long](2)
 
     val er = EmitRegion(f, region)
     val newNode = f.newLocal[Long]()
 
     def copyChild(i: Int) =
       Code(createNode(newNode),
-        f.invoke[Unit](newNode, loadChild(srcNode, i)))
+        f.invokeCode[Unit](newNode, loadChild(srcNode, i)))
 
     val copyNodes = Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
       hasKey(srcNode, i).orEmpty(
@@ -247,31 +247,31 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
           setChild(destNode, -1, newNode))),
       copyNodes))
 
-    { srcRoot: Code[Long] => f.invoke(root, srcRoot) }
+    { srcRoot: Code[Long] => f.invokeCode(root, srcRoot) }
   }
 
   def bulkStore(obCode: Code[OutputBuffer])(keyStore: (Value[OutputBuffer], Code[Long]) => Code[Unit]): Code[Unit] = {
-    val f = cb.genEmitMethod("btree_bulkStore", Array[TypeInfo[_]](typeInfo[Long], typeInfo[OutputBuffer]), typeInfo[Unit])
-    val node = f.getArg[Long](1)
-    val ob = f.getArg[OutputBuffer](2)
+    val f = cb.genEmitMethod("btree_bulkStore", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[OutputBuffer]), typeInfo[Unit])
+    val node = f.getCodeParam[Long](1)
+    val ob = f.getCodeParam[OutputBuffer](2)
 
     f.emit(Code(
       ob.writeBoolean(!isLeaf(node)),
-      (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, -1), ob)),
+      (!isLeaf(node)).orEmpty(f.invokeCode(loadChild(node, -1), ob)),
       Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
         hasKey(node, i).mux(Code(
           ob.writeBoolean(true),
           keyStore(ob, loadKey(node, i)),
-          (!isLeaf(node)).orEmpty(f.invoke(loadChild(node, i), ob)),
+          (!isLeaf(node)).orEmpty(f.invokeCode(loadChild(node, i), ob)),
           cont),
           ob.writeBoolean(false)) }))
-    f.invoke(root, obCode)
+    f.invokeCode(root, obCode)
   }
 
   def bulkLoad(ibCode: Code[InputBuffer])(keyLoad: (Value[InputBuffer], Code[Long]) => Code[Unit]): Code[Unit] = {
-    val f = cb.genEmitMethod("btree_bulkLoad", Array[TypeInfo[_]](typeInfo[Long], typeInfo[InputBuffer]), typeInfo[Unit])
-    val node = f.getArg[Long](1)
-    val ib = f.getArg[InputBuffer](2)
+    val f = cb.genEmitMethod("btree_bulkLoad", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[InputBuffer]), typeInfo[Unit])
+    val node = f.getCodeParam[Long](1)
+    val ib = f.getCodeParam[InputBuffer](2)
     val newNode = f.newLocal[Long]()
     val isInternalNode = f.newLocal[Boolean]()
 
@@ -281,7 +281,7 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
         Code(
           createNode(newNode),
           setChild(node, -1, newNode),
-          f.invoke(newNode, ib)
+          f.invokeCode(newNode, ib)
       )),
       Array.range(0, maxElements).foldRight(Code._empty) { (i, cont) =>
         ib.readBoolean().orEmpty(Code(
@@ -290,9 +290,9 @@ class AppendOnlyBTree(cb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
           isInternalNode.orEmpty(
             Code(createNode(newNode),
             setChild(node, i, newNode),
-            f.invoke(newNode, ib))),
+            f.invokeCode(newNode, ib))),
           cont))
       }))
-    f.invoke(root, ibCode)
+    f.invokeCode(root, ibCode)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -128,7 +128,7 @@ class AppendOnlySetState(val cb: EmitClassBuilder[_], t: PType) extends PointerB
           Code(
             ob.writeBoolean(key.isKeyMissing(src)),
             (!key.isKeyMissing(src)).orEmpty(
-              kEnc.invoke(key.loadKey(src), ob)))
+              kEnc.invokeCode(key.loadKey(src), ob)))
         }
       }
     }
@@ -145,7 +145,7 @@ class AppendOnlySetState(val cb: EmitClassBuilder[_], t: PType) extends PointerB
         tree.bulkLoad(ib) { (ib, dest) =>
           Code(
             km := ib.readBoolean(),
-            (!km).orEmpty(kv.storeAny(kDec.invoke(region, ib))),
+            (!km).orEmpty(kv.storeAny(kDec.invokeCode(region, ib))),
             key.store(dest, km, kv),
             size := size + 1)
         })

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{CodeOrdering, Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitFunctionBuilder, EmitMethodBuilder, EmitRegion, defaultValue, typeToTypeInfo}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitFunctionBuilder, EmitMethodBuilder, EmitRegion, ParamType, defaultValue, typeToTypeInfo}
 import is.hail.expr.types.encoded.EType
 import is.hail.expr.types.physical._
 import is.hail.io._
@@ -17,16 +17,16 @@ class GroupedBTreeKey(kt: PType, cb: EmitClassBuilder[_], region: Value[Region],
   private val kcomp = cb.getCodeOrdering(kt, CodeOrdering.compare, ignoreMissingness = false)
 
   private val compLoader: EmitMethodBuilder[_] = {
-    val mb = cb.genEmitMethod("compWithKey", Array[TypeInfo[_]](typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(compType)), typeInfo[Int])
-    val off = mb.getArg[Long](1)
-    val m = mb.getArg[Boolean](2)
-    val v = mb.getArg(3)(typeToTypeInfo(compType))
+    val mb = cb.genEmitMethod("compWithKey", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Boolean], compType.ti), typeInfo[Int])
+    val off = mb.getCodeParam[Long](1)
+    val m = mb.getCodeParam[Boolean](2)
+    val v = mb.getCodeParam(3)(compType.ti)
     mb.emit(compKeys(isKeyMissing(off) -> loadKey(off), m.get -> v.get))
     mb
   }
 
   override def compWithKey(off: Code[Long], k: (Code[Boolean], Code[_])): Code[Int] =
-    compLoader.invoke[Int](off, k._1, k._2)
+    compLoader.invokeCode[Int](off, k._1, k._2)
 
   val regionIdx: Value[Int] = new Value[Int] {
     def get: Code[Int] = Region.loadInt(storageType.fieldOffset(offset, 1))
@@ -198,7 +198,7 @@ class DictState(val cb: EmitClassBuilder[_], val keyType: PType, val nested: Sta
             km := keyed.isKeyMissing(_elt),
             kv.storeAny(keyed.loadKey(_elt)),
             ob.writeBoolean(km),
-            (!km).orEmpty(kEnc.invoke(kv, ob)),
+            (!km).orEmpty(kEnc.invokeCode(kv, ob)),
             keyed.loadStates,
             nested.toCodeWithArgs(cb, "grouped_nested_serialize", Array[TypeInfo[_]](classInfo[OutputBuffer]),
               Array(ob.get),
@@ -226,7 +226,7 @@ class DictState(val cb: EmitClassBuilder[_], val keyType: PType, val nested: Sta
           Code(
             _elt := koff,
             km := ib.readBoolean(),
-            (!km).orEmpty(kv := kDec.invoke(region, ib)),
+            (!km).orEmpty(kv := kDec.invokeCode(region, ib)),
             initElement(_elt, km, kv),
             nested.toCodeWithArgs(cb, "grouped_nested_deserialize", Array[TypeInfo[_]](classInfo[InputBuffer]),
               FastIndexedSeq(ib),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -159,17 +159,17 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
   def push(region: Value[Region], elt: EmitCode): Code[Unit] = {
     val eltTI = typeToTypeInfo(elemType)
     val pushF = cb.genEmitMethod("blockLinkedListPush",
-      Array[TypeInfo[_]](typeInfo[Region], typeInfo[Boolean], eltTI),
+      FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[Boolean], eltTI),
       typeInfo[Unit])
     pushF.emit(push(pushF,
-      pushF.getArg[Region](1),
-      pushF.getArg[Boolean](2),
-      pushF.getArg(3)(eltTI)))
+      pushF.getCodeParam[Region](1),
+      pushF.getCodeParam[Boolean](2),
+      pushF.getCodeParam(3)(eltTI).get))
     Code(
       elt.setup,
       elt.m.mux(
-        pushF.invoke(region, true, defaultValue(elemType)),
-        pushF.invoke(region, false, elt.v)))
+        pushF.invokeCode(region, const(true), defaultValue(elemType)),
+        pushF.invokeCode(region, const(false), elt.v)))
   }
 
   def append(region: Value[Region], bll: StagedBlockLinkedList): Code[Unit] = {
@@ -177,17 +177,17 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
     assert(bll ne this)
     assert(bll.elemType.isOfType(elemType))
     val appF = cb.genEmitMethod("blockLinkedListAppend",
-      Array[TypeInfo[_]](typeInfo[Region]),
+      FastIndexedSeq[ParamType](typeInfo[Region]),
       typeInfo[Unit])
     appF.emit(bll.foreach(appF) { elt =>
-      push(appF, appF.getArg[Region](1), elt.m, elt.v)
+      push(appF, appF.getCodeParam[Region](1), elt.m, elt.v)
     })
-    appF.invoke(region)
+    appF.invokeCode(region)
   }
 
   def writeToSRVB(srvb: StagedRegionValueBuilder): Code[Unit] = {
     assert(srvb.typ.fundamentalType.isOfType(bufferType.fundamentalType), s"srvb: ${srvb.typ}, buf: ${bufferType.fundamentalType}")
-    val writeF = cb.genEmitMethod("blockLinkedListToSRVB", Array[TypeInfo[_]](), typeInfo[Unit])
+    val writeF = cb.genEmitMethod("blockLinkedListToSRVB", FastIndexedSeq[ParamType](), typeInfo[Unit])
     writeF.emit {
       Code(
         srvb.start(totalCount, init = true),
@@ -200,14 +200,14 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
             srvb.advance())
         })
     }
-    writeF.invoke()
+    writeF.invokeCode()
   }
 
   def serialize(region: Code[Region], outputBuffer: Code[OutputBuffer]): Code[Unit] = {
     val serF = cb.genEmitMethod("blockLinkedListSerialize",
-      Array[TypeInfo[_]](typeInfo[Region], typeInfo[OutputBuffer]),
+      FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[OutputBuffer]),
       typeInfo[Unit])
-    val ob = serF.getArg[OutputBuffer](2)
+    val ob = serF.getCodeParam[OutputBuffer](2)
     serF.emit {
       val n = serF.newLocal[Long]()
       val i = serF.newLocal[Int]()
@@ -220,15 +220,15 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
         },
         ob.writeBoolean(false))
     }
-    serF.invoke(region, outputBuffer)
+    serF.invokeCode(region, outputBuffer)
   }
 
   def deserialize(region: Code[Region], inputBuffer: Code[InputBuffer]): Code[Unit] = {
     val desF = cb.genEmitMethod("blockLinkedListDeserialize",
-      Array[TypeInfo[_]](typeInfo[Region], typeInfo[InputBuffer]),
+      FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[InputBuffer]),
       typeInfo[Unit])
-    val r = desF.getArg[Region](1)
-    val ib = desF.getArg[InputBuffer](2)
+    val r = desF.getCodeParam[Region](1)
+    val ib = desF.getCodeParam[InputBuffer](2)
     val array = desF.newLocal[Long]("array")
     val dec = bufferEType.buildDecoder(bufferType, desF.ecb)
     desF.emit(
@@ -236,7 +236,7 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
         array := dec(r, ib),
         appendShallow(desF, r, array))
     )
-    desF.invoke(region, inputBuffer)
+    desF.invokeCode[Unit](region, inputBuffer)
   }
 
   private def appendShallow(mb: EmitMethodBuilder[_], r: Code[Region], aoff: Code[Long]): Code[Unit] = {
@@ -259,9 +259,9 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
     assert(other ne this)
     assert(other.cb eq cb)
     val initF = cb.genEmitMethod("blockLinkedListDeepCopy",
-      Array[TypeInfo[_]](typeInfo[Region]),
+      FastIndexedSeq[ParamType](typeInfo[Region]),
       typeInfo[Unit])
-    val r = initF.getArg[Region](1)
+    val r = initF.getCodeParam[Region](1)
     initF.emit {
       val i = initF.newLocal[Int]()
       Code(
@@ -283,6 +283,6 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
             totalCount := other.totalCount)
         })
     }
-    initF.invoke(region)
+    initF.invokeCode(region)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -118,7 +118,7 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
         val partCounts = partition(n, nPartitionsAdj)
         val partStarts = partCounts.scanLeft(0)(_ + _)
 
-        val rvdType = RVDType(PType.canonical(tir.typ.rowType).asInstanceOf[PStruct], Array("idx"))
+        val rvdType = RVDType(PType.canonical(tir.typ.rowType).setRequired(true).asInstanceOf[PStruct], Array("idx"))
 
         val contextType = TStruct(
           "start" -> TInt32,

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -121,4 +121,16 @@ package object ir {
   implicit def toRichIndexedSeqEmitSettable(s: IndexedSeq[EmitSettable]): RichIndexedSeqEmitSettable = new RichIndexedSeqEmitSettable(s)
 
   implicit def emitValueToCode(ev: EmitValue): EmitCode = ev.get
+
+  implicit def toCodeParamType(ti: TypeInfo[_]): CodeParamType = CodeParamType(ti)
+
+  implicit def toEmitParamType(pt: PType): EmitParamType = EmitParamType(pt)
+
+  implicit def toCodeParam(c: Code[_]): CodeParam = CodeParam(c)
+
+  implicit def valueToCodeParam(v: Value[_]): CodeParam = CodeParam(v)
+
+  implicit def toEmitParam(ec: EmitCode): EmitParam = EmitParam(ec)
+
+  implicit def emitValueToEmitParam(ev: EmitValue): EmitParam = EmitParam(ev)
 }

--- a/hail/src/main/scala/is/hail/expr/types/BaseType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BaseType.scala
@@ -17,7 +17,7 @@ abstract class BaseType {
 
   def parsableString(): String = toPrettyString(0, compact = true)
 
-  def pyString(sb: StringBuilder) = pretty(sb, 0, compact = true)
+  def pyString(sb: StringBuilder): Unit = pretty(sb, 0, compact = true)
 }
 
 trait Requiredness {

--- a/hail/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TableType.scala
@@ -18,8 +18,8 @@ object TableType {
 }
 
 case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct) extends BaseType {
-  lazy val canonicalPType = PType.canonical(rowType).asInstanceOf[PStruct]
-  lazy val canonicalRVDType = RVDType(canonicalPType, key)
+  lazy val canonicalRowPType = PType.canonical(rowType).setRequired(true).asInstanceOf[PStruct]
+  lazy val canonicalRVDType = RVDType(canonicalRowPType, key)
 
   key.foreach {k =>
     if (!rowType.hasField(k))

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -159,4 +159,6 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     elementType.pretty(sb, indent, compact)
     sb.append("]")
   }
+
+  def setRequired(newRequired: Boolean): EArray = EArray(elementType, newRequired)
 }

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBinary.scala
@@ -56,6 +56,8 @@ class EBinary(override val required: Boolean) extends EType {
 
   def _asIdent = "binary"
   def _toPretty = "EBinary"
+
+  def setRequired(newRequired: Boolean): EBinary = EBinary(newRequired)
 }
 
 object EBinary {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBoolean.scala
@@ -32,6 +32,8 @@ class EBoolean(override val required: Boolean) extends EType {
 
   def _asIdent = "bool"
   def _toPretty = "EBoolean"
+
+  def setRequired(newRequired: Boolean): EBoolean = EBoolean(newRequired)
 }
 
 object EBoolean {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EFloat32.scala
@@ -32,6 +32,8 @@ class EFloat32(override val required: Boolean) extends EType {
 
   def _asIdent = "float32"
   def _toPretty = "EFloat32"
+
+  def setRequired(newRequired: Boolean): EFloat32 = EFloat32(newRequired)
 }
 
 object EFloat32 {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EFloat64.scala
@@ -32,6 +32,8 @@ class EFloat64(override val required: Boolean) extends EType {
 
   def _asIdent = "float64"
   def _toPretty = "EFloat64"
+
+  def setRequired(newRequired: Boolean): EFloat64 = EFloat64(newRequired)
 }
 
 object EFloat64 {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EInt32.scala
@@ -35,6 +35,8 @@ class EInt32(override val required: Boolean) extends EType {
 
   def _asIdent = "int32"
   def _toPretty = "EInt32"
+
+  def setRequired(newRequired: Boolean): EInt32 = EInt32(newRequired)
 }
 
 object EInt32 {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EInt64.scala
@@ -32,6 +32,8 @@ class EInt64(override val required: Boolean) extends EType {
 
   def _asIdent = "int64"
   def _toPretty = "EInt64"
+
+  def setRequired(newRequired: Boolean): EInt64 = EInt64(newRequired)
 }
 
 object EInt64 {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EPackedIntArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EPackedIntArray.scala
@@ -11,7 +11,7 @@ import is.hail.utils._
 
 final case class EPackedIntArray(
   override val required: Boolean = false,
-  val elementsRequired: Boolean
+  elementsRequired: Boolean
 ) extends EContainer {
   def elementType: EType = EInt32(elementsRequired)
 
@@ -128,4 +128,6 @@ final case class EPackedIntArray(
   private def getPacker(mb: EmitMethodBuilder[_]): Value[IntPacker] = {
     mb.getOrDefineLazyField[IntPacker](Code.newInstance[IntPacker], "thePacker")
   }
+
+  def setRequired(newRequired: Boolean): EPackedIntArray = EPackedIntArray(newRequired, elementsRequired)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/ComplexPType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/ComplexPType.scala
@@ -28,12 +28,9 @@ abstract class ComplexPType extends PType {
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =
     this.representation.copyFromTypeAndStackValue(mb, region, srcPType.asInstanceOf[ComplexPType].representation, stackValue, deepCopy)
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
-    assert(this isOfType srcPType)
-
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
     val srcRepPType = srcPType.asInstanceOf[ComplexPType].representation
-
-    this.representation.copyFromType(region, srcRepPType, srcAddress, deepCopy)
+    representation.copyFromAddress(region, srcRepPType, srcAddress, deepCopy)
   }
 
   def constructAtAddress(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
@@ -147,13 +147,13 @@ trait PArrayBackedContainer extends PContainer {
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =
     this.copyFromType(mb, region, srcPType, stackValue.asInstanceOf[Code[Long]], deepCopy)
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    this.arrayRep.copyFromType(region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
+    arrayRep.copyFromAddress(region, srcPType.asInstanceOf[PArrayBackedContainer].arrayRep, srcAddress, deepCopy)
 
-  def nextElementAddress(currentOffset: Long) =
+  def nextElementAddress(currentOffset: Long): Long =
     arrayRep.nextElementAddress(currentOffset)
 
-  def nextElementAddress(currentOffset: Code[Long]) =
+  def nextElementAddress(currentOffset: Code[Long]): Code[Long] =
     arrayRep.nextElementAddress(currentOffset)
 
   def constructAtAddress(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -459,7 +459,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
           setElementPresent(newAddr, i)
           elementType.constructAtAddress(elementOffset(newAddr, len, i), region, srcElementT, srcArrayT.loadElement(srcAddress, len, i), deepCopy)
         } else
-          assert(!required)
+          assert(!elementType.required)
 
         i += 1
       }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -213,7 +213,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
           types(idx).constructAtAddress(
             fieldOffset(addr, idx), region, srcStruct.types(idx), srcStruct.loadField(srcAddress, idx), deepCopy)
         } else
-          assert(!required)
+          assert(!fieldRequired(idx))
         idx += 1
       }
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalCall.scala
@@ -3,6 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.utils.FastIndexedSeq
 import is.hail.variant.Genotype
 
 final case class PCanonicalCall(required: Boolean = false) extends PCall {
@@ -62,6 +63,8 @@ class PCanonicalCallSettable(val pt: PCanonicalCall, call: Settable[Int]) extend
 
 class PCanonicalCallCode(val pt: PCanonicalCall, val call: Code[Int]) extends PCallCode {
   def code: Code[_] = call
+
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(call)
 
   def ploidy(): Code[Int] = (call >>> 1) & 0x3
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
 import is.hail.expr.types.virtual.{TInterval, Type}
+import is.hail.utils.FastIndexedSeq
 
 final case class PCanonicalInterval(pointType: PType, override val required: Boolean = false) extends PInterval {
     def _asIdent = s"interval_of_${pointType.asIdent}"
@@ -96,6 +97,8 @@ class PCanonicalIntervalSettable(
 
 class PCanonicalIntervalCode(val pt: PCanonicalInterval, val a: Code[Long]) extends PIntervalCode {
   def code: Code[_] = a
+
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
   def includesStart(): Code[Boolean] = pt.includesStart(a)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
@@ -3,6 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.utils.FastIndexedSeq
 import is.hail.variant._
 
 object PCanonicalLocus {
@@ -130,6 +131,8 @@ class PCanonicalLocusSettable(
 
 class PCanonicalLocusCode(val pt: PCanonicalLocus, val a: Code[Long]) extends PLocusCode {
   def code: Code[_] = a
+
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
   def contig(): PStringCode = new PCanonicalStringCode(pt.contigType, pt.contigAddr(a))
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -213,12 +213,10 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =
     this.copyFromType(mb, region, srcPType, stackValue.asInstanceOf[Code[Long]], deepCopy)
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  = {
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  = {
     val sourceNDPType = srcPType.asInstanceOf[PNDArray]
-
-    assert(this.elementType == sourceNDPType.elementType && this.nDims == sourceNDPType.nDims)
-
-    this.representation.copyFromType(region, sourceNDPType.representation, srcAddress, deepCopy)
+    assert(elementType == sourceNDPType.elementType && nDims == sourceNDPType.nDims)
+    representation.copyFromAddress(region, sourceNDPType.representation, srcAddress, deepCopy)
   }
 
   override def deepRename(t: Type) = deepRenameNDArray(t.asInstanceOf[TNDArray])

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
@@ -3,6 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, MethodBuilder, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.utils.FastIndexedSeq
 
 case object PCanonicalStringOptional extends PCanonicalString(false)
 case object PCanonicalStringRequired extends PCanonicalString(true)
@@ -25,11 +26,8 @@ class PCanonicalString(val required: Boolean) extends PString {
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =
     this.copyFromType(mb, region, srcPType, stackValue.asInstanceOf[Code[Long]], deepCopy)
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  = {
-    this.fundamentalType.copyFromType(
-      region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy
-    )
-  }
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long  =
+    fundamentalType.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
 
   override def containsPointers: Boolean = true
 
@@ -85,6 +83,8 @@ object PCanonicalString {
 
 class PCanonicalStringCode(val pt: PCanonicalString, a: Code[Long]) extends PStringCode {
   def code: Code[_] = a
+
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
   def loadLength(): Code[Int] = pt.loadLength(a)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -25,6 +25,8 @@ abstract class PCode { self =>
 
   def code: Code[_]
 
+  def codeTuple(): IndexedSeq[Code[_]]
+
   def typeInfo: TypeInfo[_] = typeToTypeInfo(pt)
 
   def tcode[T](implicit ti: TypeInfo[T]): Code[T] = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
@@ -29,7 +29,7 @@ final case class PStream(elementType: PType, required: Boolean = false) extends 
   def copyFromType(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean) =
     throw new UnsupportedOperationException("PStream copyFromType is currently undefined")
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean) =
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean) =
     throw new UnsupportedOperationException("PStream copyFromType is currently undefined")
 
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
@@ -18,7 +18,7 @@ case object PVoid extends PType {
   def copyFromType(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean) =
     throw new UnsupportedOperationException("PVoid copyFromType is currently undefined")
 
-  def copyFromType(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean) =
+  def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean) =
     throw new UnsupportedOperationException("PVoid copyFromType is currently undefined")
 
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
@@ -2,7 +2,6 @@ package is.hail.expr.types.virtual
 
 import is.hail.annotations.{Annotation, ExtendedOrdering}
 import is.hail.check.Gen
-import is.hail.expr.types.physical.PArray
 import org.json4s.jackson.JsonMethods
 
 import scala.reflect.{ClassTag, classTag}

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TTuple.scala
@@ -10,9 +10,7 @@ object TTuple {
 
   val empty: TTuple = TTuple()
 
-  def apply(required: Boolean, args: Type*): TTuple = TTuple(args.iterator.zipWithIndex.map { case (t, i) => TupleField(i, t)}.toArray)
-
-  def apply(args: Type*): TTuple = apply(false, args: _*)
+  def apply(args: Type*): TTuple = TTuple(args.iterator.zipWithIndex.map { case (t, i) => TupleField(i, t)}.toArray)
 }
 
 case class TupleField(index: Int, typ: Type)

--- a/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
@@ -1,10 +1,10 @@
 package is.hail.expr.types.virtual
 
 import is.hail.annotations._
+import is.hail.asm4s._
 import is.hail.check.{Arbitrary, Gen}
-import is.hail.expr.ir.IRParser
+import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.expr.types.physical.PType
 import is.hail.expr.{JSONAnnotationImpex, SparkAnnotationImpex}
 import is.hail.utils
 import is.hail.utils._
@@ -104,6 +104,8 @@ object Type {
 
 abstract class Type extends BaseType with Serializable {
   self =>
+
+  def ti: TypeInfo[_] = typeToTypeInfo(this)
 
   def children: Seq[Type] = FastSeq()
 

--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -17,8 +17,8 @@ object TypedCodecSpec {
 }
 
 final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: BufferSpec) extends AbstractTypedCodecSpec {
-  val encodedType: EType = _eType
-  val encodedVirtualType: Type = _vType
+  def encodedType: EType = _eType
+  def encodedVirtualType: Type = _vType
 
   def computeSubsetPType(requestedType: Type): PType = {
     _eType._decodedPType(requestedType)
@@ -41,11 +41,11 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
   def buildEmitDecoderF[T](requestedType: Type, cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) = {
     val rt = encodedType.decodedPType(requestedType)
     val mb = encodedType.buildDecoderMethod(rt, cb)
-    (rt, (region: Value[Region], buf: Value[InputBuffer]) => mb.invoke[T](region, buf))
+    (rt, (region: Value[Region], buf: Value[InputBuffer]) => mb.invokeCode[T](region, buf))
   }
 
   def buildEmitEncoderF[T](t: PType, cb: EmitClassBuilder[_]): StagedEncoderF[T] = {
     val mb = encodedType.buildEncoderMethod(t, cb)
-    (region: Value[Region], off: Value[T], buf: Value[OutputBuffer]) => mb.invoke[Unit](off, buf)
+    (region: Value[Region], off: Value[T], buf: Value[OutputBuffer]) => mb.invokeCode[Unit](off, buf)
   }
 }

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -35,13 +35,13 @@ object BgenSettings {
 
     val keyVType = indexKeyType(rg)
     val keyEType = EBaseStruct(FastIndexedSeq(
-      EField("locus", EBaseStruct(FastIndexedSeq(
-        EField("contig", EBinaryRequired, 0),
-        EField("position", EInt32Required, 1)
-      )), 0),
+      EField("locus",
+        EBaseStruct(FastIndexedSeq(
+          EField("contig", EBinaryRequired, 0),
+          EField("position", EInt32Required, 1))),
+        0),
       EField("alleles", EArray(EBinaryOptional, required = false), 1)),
-      required = false
-    )
+      required = true)
 
     val annotationVType = TStruct.empty
     val annotationEType = EBaseStruct(FastIndexedSeq(), required = true)
@@ -98,7 +98,7 @@ case class BgenSettings(
     .fieldOption(MatrixType.entriesIdentifier)
     .map(f => f.typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct])
 
-  val rowPType: PStruct = PCanonicalStruct(
+  val rowPType: PStruct = PCanonicalStruct(required = true,
     Array(
       "locus" -> PCanonicalLocus.schemaFromRG(rg),
       "alleles" -> PCanonicalArray(PCanonicalString()),
@@ -112,8 +112,7 @@ case class BgenSettings(
           "GP" -> PCanonicalArray(PFloat64Required, required = true),
           "dosage" -> PFloat64Required
         ).filter { case (name, _) => entryType.exists(t => t.hasField(name))
-        }: _*
-      )))
+        }: _*)))
       .filter { case (name, _) => requestedType.rowType.hasField(name) }: _*)
 
   assert(rowPType.virtualType == requestedType.rowType, s"${ rowPType.virtualType.parsableString() } vs ${ requestedType.rowType.parsableString() }")

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -35,13 +35,11 @@ object BgenSettings {
 
     val keyVType = indexKeyType(rg)
     val keyEType = EBaseStruct(FastIndexedSeq(
-      EField("locus",
-        EBaseStruct(FastIndexedSeq(
-          EField("contig", EBinaryRequired, 0),
-          EField("position", EInt32Required, 1))),
-        0),
+      EField("locus", EBaseStruct(FastIndexedSeq(
+        EField("contig", EBinaryRequired, 0),
+        EField("position", EInt32Required, 1))), 0),
       EField("alleles", EArray(EBinaryOptional, required = false), 1)),
-      required = true)
+      required = false)
 
     val annotationVType = TStruct.empty
     val annotationEType = EBaseStruct(FastIndexedSeq(), required = true)

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations.{Region, _}
 import is.hail.asm4s.{coerce, _}
 import is.hail.backend.BroadcastValue
-import is.hail.expr.ir.{EmitFunctionBuilder, EmitMethodBuilder, EmitRegion}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitMethodBuilder, EmitRegion, ParamType}
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PArray, PCanonicalArray, PStruct, PType}
@@ -177,10 +177,10 @@ object CompileDecoder {
   ): (Int, Region) => AsmFunction4[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long] = {
     val fb = EmitFunctionBuilder[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long]("bgen_rdd_decoder")
     val mb = fb.apply_method
-    val region = mb.getArg[Region](1)
-    val cp = mb.getArg[BgenPartition](2)
-    val cbfis = mb.getArg[HadoopFSDataBinaryReader](3)
-    val csettings = mb.getArg[BgenSettings](4)
+    val region = mb.getCodeParam[Region](1)
+    val cp = mb.getCodeParam[BgenPartition](2)
+    val cbfis = mb.getCodeParam[HadoopFSDataBinaryReader](3)
+    val csettings = mb.getCodeParam[BgenSettings](4)
 
     val regionField = mb.genFieldThisRef[Region]("region")
     val srvb = new StagedRegionValueBuilder(mb, settings.rowPType, regionField)
@@ -324,7 +324,7 @@ object CompileDecoder {
 
           val memoTyp = PCanonicalArray(entryType.setRequired(true), required = true)
           val memoizeAllValues: Code[Unit] = {
-            val memoMB = mb.genEmitMethod("memoizeEntries", Array[TypeInfo[_]](), UnitInfo)
+            val memoMB = mb.genEmitMethod("memoizeEntries", FastIndexedSeq[ParamType](), UnitInfo)
 
             val d0 = memoMB.newLocal[Int]("memoize_entries_d0")
             val d1 = memoMB.newLocal[Int]("memoize_entries_d1")
@@ -346,11 +346,11 @@ object CompileDecoder {
                         val addGT: Code[Unit] = if (includeGT) {
 
                           val addGtMB = mb.genEmitMethod("bgen_add_gt",
-                            Array[TypeInfo[_]](IntInfo, IntInfo, IntInfo),
+                            FastIndexedSeq[ParamType](IntInfo, IntInfo, IntInfo),
                             UnitInfo)
-                          val d0arg = addGtMB.getArg[Int](1)
-                          val d1arg = addGtMB.getArg[Int](2)
-                          val d2arg = addGtMB.getArg[Int](3)
+                          val d0arg = addGtMB.getCodeParam[Int](1)
+                          val d1arg = addGtMB.getCodeParam[Int](2)
+                          val d2arg = addGtMB.getCodeParam[Int](3)
 
                           addGtMB.emit(
                             Code(
@@ -369,17 +369,17 @@ object CompileDecoder {
                                     srvb.setMissing(),
                                     srvb.addInt(c1)))),
                               if (includeGP || includeDosage) srvb.advance() else Code._empty))
-                          addGtMB.invoke(d0, d1, d2)
+                          addGtMB.invokeCode(d0, d1, d2)
                         } else Code._empty
 
                         val addGP: Code[Unit] = if (includeGP) {
                           val addGpMB = mb.genEmitMethod("bgen_add_gp",
-                            Array[TypeInfo[_]](IntInfo, IntInfo, IntInfo),
+                            FastIndexedSeq[ParamType](IntInfo, IntInfo, IntInfo),
                             UnitInfo)
 
-                          val d0arg = addGpMB.getArg[Int](1)
-                          val d1arg = addGpMB.getArg[Int](2)
-                          val d2arg = addGpMB.getArg[Int](3)
+                          val d0arg = addGpMB.getCodeParam[Int](1)
+                          val d1arg = addGpMB.getCodeParam[Int](2)
+                          val d2arg = addGpMB.getCodeParam[Int](3)
 
                           val divisor = addGpMB.newLocal[Double]("divisor")
 
@@ -395,19 +395,19 @@ object CompileDecoder {
                                 srvb.addDouble(d2arg.toD / divisor))
                             }),
                             if (includeDosage) srvb.advance() else Code._empty))
-                          addGpMB.invoke(d0, d1, d2)
+                          addGpMB.invokeCode(d0, d1, d2)
                         } else Code._empty
 
                         val addDosage: Code[Unit] = if (includeDosage) {
                           val addDosageMB = mb.genEmitMethod("bgen_add_dosage",
-                            Array[TypeInfo[_]](IntInfo, IntInfo),
+                            FastIndexedSeq[ParamType](IntInfo, IntInfo),
                             UnitInfo)
 
-                          val d1arg = addDosageMB.getArg[Int](1)
-                          val d2arg = addDosageMB.getArg[Int](2)
+                          val d1arg = addDosageMB.getCodeParam[Int](1)
+                          val d2arg = addDosageMB.getCodeParam[Int](2)
 
                           addDosageMB.emit(srvb.addDouble((d1arg + (d2arg << 1)).toD / 255.0))
-                          addDosageMB.invoke(d1, d2)
+                          addDosageMB.invokeCode(d1, d2)
                         } else Code._empty
 
                         Code(srvb.start(), addGT, addGP, addDosage)
@@ -421,24 +421,24 @@ object CompileDecoder {
                 alreadyMemoized := true
               )
             ))
-            memoMB.invoke()
+            memoMB.invokeCode()
           }
 
           val lookupEntry: (Code[Int], Code[Int]) => Code[Long] = {
-            val lookupMB = mb.genEmitMethod("bgen_look_up_add_entry", Array[TypeInfo[_]](IntInfo, IntInfo), LongInfo)
+            val lookupMB = mb.genEmitMethod("bgen_look_up_add_entry", FastIndexedSeq[ParamType](IntInfo, IntInfo), LongInfo)
 
-            val d0 = lookupMB.getArg[Int](1)
-            val d1 = lookupMB.getArg[Int](2)
+            val d0 = lookupMB.getCodeParam[Int](1)
+            val d1 = lookupMB.getCodeParam[Int](2)
             lookupMB.emit(Code(
               Code._empty,
               memoTyp.elementOffset(memoizedEntryData, settings.nSamples, (d0 << 8) | d1)
             ))
-            lookupMB.invoke(_, _)
+            lookupMB.invokeCode(_, _)
           }
 
           val addEntries: Code[Array[Byte]] => Code[Unit] = {
-            val addEntriesMB = mb.genEmitMethod("bgen_add_entries", Array[TypeInfo[_]](typeInfo[Array[Byte]]), UnitInfo)
-            val data = addEntriesMB.getArg[Array[Byte]](1)
+            val addEntriesMB = mb.genEmitMethod("bgen_add_entries", FastIndexedSeq[ParamType](typeInfo[Array[Byte]]), UnitInfo)
+            val data = addEntriesMB.getCodeParam[Array[Byte]](1)
             val i = addEntriesMB.newLocal[Int]("i")
             val off = addEntriesMB.newLocal[Int]("off")
             val d0 = addEntriesMB.newLocal[Int]("d0")
@@ -462,7 +462,7 @@ object CompileDecoder {
                       i := i + 1))
                 })
             )
-            addEntriesMB.invoke(_)
+            addEntriesMB.invokeCode(_)
           }
 
           Code(FastIndexedSeq(

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.backend.BroadcastValue
 import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.TableType
-import is.hail.expr.types.physical.{PCanonicalStruct}
+import is.hail.expr.types.physical.{PCanonicalStruct, PStruct}
 import is.hail.expr.types.virtual._
 import is.hail.io.fs.FS
 import is.hail.io.index.{IndexWriter, InternalNodeBuilder, LeafNodeBuilder}
@@ -99,7 +99,7 @@ object IndexBgen {
     val offsetIdx = rowType.fieldIdx("offset")
     val fileIdxIdx = rowType.fieldIdx("file_idx")
     val (keyType, _) = rowType.virtualType.select(Array("file_idx", "locus", "alleles"))
-    val indexKeyType = rowType.selectFields(Array("locus", "alleles"))
+    val indexKeyType = rowType.selectFields(Array("locus", "alleles")).setRequired(false).asInstanceOf[PStruct]
 
     val attributes = Map("reference_genome" -> rg.orNull,
       "contig_recoding" -> recoding,

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -61,7 +61,6 @@ object ExportPlink {
 
   def apply(mv: MatrixValue, path: String): Unit = {
     val hc = HailContext.get
-    val sc = hc.sc
     val fs = hc.fs
 
     val tmpBedDir = fs.getTemporaryFile(hc.tmpDir)

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -211,7 +211,7 @@ case class MatrixPLINKReader(
           nPartitions.getOrElse(sc.defaultMinPartitions)))
 
       val kType = requestedType.canonicalRVDType.kType
-      val rvRowType = requestedType.canonicalPType
+      val rvRowType = requestedType.canonicalRowPType
 
       val hasRsid = requestedType.rowType.hasField("rsid")
       val hasCmPos = requestedType.rowType.hasField("cm_position")

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1549,7 +1549,7 @@ case class MatrixVCFReader(
 
   override lazy val fullType: TableType = fullMatrixType.canonicalTableType
 
-  val fullRVDType = RVDType(PCanonicalStruct(false,
+  val fullRVDType = RVDType(PCanonicalStruct(true,
     PCanonicalStruct.canonical(kType).fields.map { f => (f.name, f.typ) }
       ++ vaSignature.fields.map { f => (f.name, f.typ) }
       ++ Array(LowerMatrixIR.entriesFieldName -> PCanonicalArray(genotypeSignature)): _*),
@@ -1696,7 +1696,9 @@ class VCFsReader(
   val fullRVDType = RVDType(PCanonicalStruct(false,
     PCanonicalStruct.canonical(kType).fields.map { f => (f.name, f.typ) }
       ++ header1.vaSignature.fields.map { f => (f.name, f.typ) }
-      ++ Array(LowerMatrixIR.entriesFieldName -> PCanonicalArray(header1.genotypeSignature)): _*),
+      ++ Array(LowerMatrixIR.entriesFieldName -> PCanonicalArray(header1.genotypeSignature)): _*)
+    .setRequired(true)
+    .asInstanceOf[PStruct],
     typ.rowKey)
 
   val partitioner: RVDPartitioner = {

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1255,7 +1255,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   def entriesTable(ctx: ExecuteContext): TableValue = {
-    val rowType = PCanonicalStruct("i" -> PInt64Optional, "j" -> PInt64Optional, "entry" -> PFloat64Optional)
+    val rowType = PCanonicalStruct(true, "i" -> PInt64Optional, "j" -> PInt64Optional, "entry" -> PFloat64Optional)
     
     val entriesRDD = ContextRDD.weaken(blocks).cflatMap { case (ctx, ((blockRow, blockCol), block)) =>
       val rowOffset = blockRow * blockSize.toLong

--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -6,7 +6,6 @@ import is.hail.utils._
 import org.objectweb.asm.{ClassReader, ClassWriter}
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.tree._
-import org.objectweb.asm.tree.analysis.AnalyzerException
 import org.objectweb.asm.util.{CheckClassAdapter, Textifier, TraceClassVisitor}
 
 import scala.collection.JavaConverters._

--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -6,6 +6,7 @@ import is.hail.utils._
 import org.objectweb.asm.{ClassReader, ClassWriter}
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.tree._
+import org.objectweb.asm.tree.analysis.AnalyzerException
 import org.objectweb.asm.util.{CheckClassAdapter, Textifier, TraceClassVisitor}
 
 import scala.collection.JavaConverters._

--- a/hail/src/main/scala/is/hail/lir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/lir/Pretty.scala
@@ -124,7 +124,7 @@ object Pretty {
     case x: IfX => s"${ asm.util.Printer.OPCODES(x.op) } ${ x.Ltrue } ${ x.Lfalse }"
     case x: GotoX => x.L.toString
     case x: SwitchX => s"${ x.Ldefault } (${ x.Lcases.mkString(" ") })"
-    case x: LdcX => x.a.toString
+    case x: LdcX => s"${ x.a.toString } ${ x.ti }"
     case x: InsnX => asm.util.Printer.OPCODES(x.op)
     case x: StoreX => x.l.toString
     case x: IincX => s"${ x.l.toString } ${ x.i }"

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -94,6 +94,8 @@ class Classx[C](val name: String, val superName: String) {
       InitializeLocals(m)
     }
 
+    // println(Pretty(this))
+
     Emit(this,
       print
       // Some(new PrintWriter(System.out))
@@ -316,12 +318,12 @@ class MethodLit(
 ) extends MethodRef
 
 class Local(var method: Method, val name: String, val ti: TypeInfo[_]) {
-  override def toString: String = f"t${ System.identityHashCode(this) }%08x/$name"
-//  val stack = Thread.currentThread().getStackTrace
+  override def toString: String = f"t${ System.identityHashCode(this) }%08x/$name ${ ti.desc }"
+  // val stack = Thread.currentThread().getStackTrace
 }
 
 class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(method, null, ti) {
-  override def toString: String = s"arg:$i"
+  override def toString: String = s"arg:$i ${ ti.desc }"
 }
 
 class Block {
@@ -582,6 +584,14 @@ class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
       return _ti
 
     op match {
+      // Int + Boolean
+      case IAND =>
+        children.head.ti
+      case IOR =>
+        children.head.ti
+      case IXOR =>
+        children.head.ti
+
       // Int
       case INEG => IntInfo
       case IADD => IntInfo
@@ -589,9 +599,6 @@ class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
       case IMUL => IntInfo
       case IDIV => IntInfo
       case IREM => IntInfo
-      case IAND => IntInfo
-      case IOR => IntInfo
-      case IXOR => IntInfo
       case L2I => IntInfo
       case F2I => IntInfo
       case D2I => IntInfo

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -294,7 +294,8 @@ object IBD {
       }
   }
 
-  private val ibdPType = PCanonicalStruct(("i", PCanonicalString()), ("j", PCanonicalString())) ++ ExtendedIBDInfo.pType
+  private val ibdPType =
+    (PCanonicalStruct(("i", PCanonicalString()), ("j", PCanonicalString())) ++ ExtendedIBDInfo.pType).setRequired(true).asInstanceOf[PStruct]
   private val ibdKey = FastIndexedSeq("i", "j")
 
   private[methods] def generateComputeMaf(input: MatrixValue, fieldName: String): (RegionValue) => Double = {

--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -57,6 +57,8 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
     }
 
     val rowType = PCanonicalStruct.canonical(TStruct(mv.typ.rowKey.zip(mv.typ.rowKeyStruct.types): _*) ++ TStruct("loadings" -> TArray(TFloat64)))
+      .setRequired(true)
+      .asInstanceOf[PStruct]
     val rowKeysBc = HailContext.backend.broadcast(collectRowKeys())
     val localRowKeySignature = mv.typ.rowKeyStruct.types
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -39,7 +39,7 @@ object AbstractRVDSpec {
 
   def read(fs: is.hail.io.fs.FS, path: String): AbstractRVDSpec = {
     val metadataFile = path + "/metadata.json.gz"
-    val r = using(fs.open(metadataFile)) { in => JsonMethods.parse(in) }
+    using(fs.open(metadataFile)) { in => JsonMethods.parse(in) }
       .transformField { case ("orvdType", value) => ("rvdType", value) } // ugh
       .extract[AbstractRVDSpec]
   }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -39,7 +39,7 @@ object AbstractRVDSpec {
 
   def read(fs: is.hail.io.fs.FS, path: String): AbstractRVDSpec = {
     val metadataFile = path + "/metadata.json.gz"
-    using(fs.open(metadataFile)) { in => JsonMethods.parse(in) }
+    val r = using(fs.open(metadataFile)) { in => JsonMethods.parse(in) }
       .transformField { case ("orvdType", value) => ("rvdType", value) } // ugh
       .extract[AbstractRVDSpec]
   }
@@ -125,7 +125,7 @@ object AbstractRVDSpec {
     val parts = if (specLeft.key.isEmpty)
       specLeft.partFiles
     else
-      tmpPartitioner.rangeBounds.map { b => specLeft.partFiles(partitioner.lowerBoundInterval(b)) }.toArray
+      tmpPartitioner.rangeBounds.map { b => specLeft.partFiles(partitioner.lowerBoundInterval(b)) }
 
     val (isl, isr) = (specLeft, specRight) match {
       case (l: Indexed, r: Indexed) => (Some(l.indexSpec), Some(r.indexSpec))
@@ -308,12 +308,21 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
   _partFiles: Array[String],
   _jRangeBounds: JValue,
   _attrs: Map[String, String]) extends AbstractRVDSpec with Indexed {
-  def typedCodecSpec: AbstractTypedCodecSpec = _codecSpec
+
+  // some lagacy OrderedRVDSpec2 were written out without the toplevel encoder required
+  private val codecSpec2 = _codecSpec match {
+    case cs: TypedCodecSpec =>
+      TypedCodecSpec(cs._eType.setRequired(true), cs._vType, cs._bufferSpec)
+  }
+
+  require(codecSpec2.encodedType.required)
+
+  def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
 
   def indexSpec: AbstractIndexSpec = _indexSpec
 
   lazy val partitioner: RVDPartitioner = {
-    val keyType = _codecSpec.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
+    val keyType = codecSpec2.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
     val rangeBoundsType = TArray(TInterval(keyType))
     new RVDPartitioner(keyType,
       JSONAnnotationImpex.importAnnotation(_jRangeBounds, rangeBoundsType, padNulls = false).asInstanceOf[IndexedSeq[Interval]])
@@ -361,8 +370,17 @@ case class OrderedRVDSpec2(_key: IndexedSeq[String],
   _partFiles: Array[String],
   _jRangeBounds: JValue,
   _attrs: Map[String, String]) extends AbstractRVDSpec {
+
+  // some lagacy OrderedRVDSpec2 were written out without the toplevel encoder required
+  private val codecSpec2 = _codecSpec match {
+    case cs: TypedCodecSpec =>
+      TypedCodecSpec(cs._eType.setRequired(true), cs._vType, cs._bufferSpec)
+  }
+
+  require(codecSpec2.encodedType.required)
+
   lazy val partitioner: RVDPartitioner = {
-    val keyType = _codecSpec.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
+    val keyType = codecSpec2.encodedVirtualType.asInstanceOf[TStruct].select(key)._1
     val rangeBoundsType = TArray(TInterval(keyType))
     new RVDPartitioner(keyType,
       JSONAnnotationImpex.importAnnotation(_jRangeBounds, rangeBoundsType, padNulls = false).asInstanceOf[IndexedSeq[Interval]])
@@ -374,5 +392,5 @@ case class OrderedRVDSpec2(_key: IndexedSeq[String],
 
   val attrs: Map[String, String] = _attrs
 
-  def typedCodecSpec: AbstractTypedCodecSpec = _codecSpec
+  def typedCodecSpec: AbstractTypedCodecSpec = codecSpec2
 }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -955,10 +955,9 @@ class RVD(
     root: String): RVD = {
     assert(!typ.key.contains(root))
 
-    val valueStruct = right.typ.valueType
     val rightRowType = right.typ.rowType
 
-    val newRowType = rowPType.appendKey(root, right.typ.valueType)
+    val newRowType = rowPType.appendKey(root, right.typ.valueType.setRequired(false))
 
     val localRowType = rowPType
 
@@ -1439,7 +1438,7 @@ object RVD {
   }
 
   private def copyFromType(destPType: PType, srcPType: PType, srcRegionValue: RegionValue): RegionValue =
-    RegionValue(srcRegionValue.region, destPType.copyFromType(srcRegionValue.region, srcPType, srcRegionValue.offset, false))
+    RegionValue(srcRegionValue.region, destPType.copyFromAddress(srcRegionValue.region, srcPType, srcRegionValue.offset, false))
 
   def unify(rvds: Seq[RVD]): Seq[RVD] = {
     if (rvds.length == 1 || rvds.forall(_.rowPType == rvds.head.rowPType))
@@ -1447,11 +1446,11 @@ object RVD {
 
     val unifiedRowPType = InferPType.getNestedElementPTypesOfSameType(rvds.map(_.rowPType)).asInstanceOf[PStruct]
 
-    rvds.map(rvd => {
+    rvds.map { rvd =>
       val srcRowPType = rvd.rowPType
       val newRVDType = rvd.typ.copy(rowType = unifiedRowPType)
       rvd.map(newRVDType)(copyFromType(unifiedRowPType, srcRowPType, _))
-    })
+    }
   }
 
   def union(

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -66,6 +66,7 @@ class RVD(
     new RVD(newTyp, newPartitioner, crdd)
   }
 
+
   // Exporting
 
   def toRows: RDD[Row] = {

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -16,6 +16,7 @@ class RVDTypeSerializer extends CustomSerializer[RVDType](format => ( {
 
 final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
   extends Serializable {
+  require(rowType.required)
 
   val keySet: Set[String] = key.toSet
 

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -26,7 +26,7 @@ object LinearMixedModel {
       LMMData(gamma, residualSq, BDV(py), px, BDV(d), ydy, BDV(xdy), xdx, yOpt.map(BDV(_)), xOpt))
   }
   
-  private val rowType = PCanonicalStruct(
+  private val rowType = PCanonicalStruct(true,
       "idx" -> PInt64(),
       "beta" -> PFloat64(),
       "sigma_sq" -> PFloat64(),

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -161,7 +161,7 @@ trait Py4jUtils {
 
   def pyFromDF(df: DataFrame, jKey: java.util.List[String]): TableIR = {
     val key = jKey.asScala.toArray.toFastIndexedSeq
-    val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[PStruct]
+    val signature = SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
     ExecuteContext.scoped() { ctx =>
       TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)), ctx)
     }

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -357,7 +357,7 @@ case class TextTableReader(options: TextTableReaderOptions) extends TableReader 
     val rowTyp = tr.typ.rowType
     val nFieldOrig = fullType.rowType.size
     val rowFields = rowTyp.fields
-    val rowPType = PType.canonical(rowTyp).asInstanceOf[PStruct]
+    val rowPType = PType.canonical(rowTyp).setRequired(true).asInstanceOf[PStruct]
 
     val useColIndices = rowTyp.fields.map(f => fullType.rowType.fieldIdx(f.name))
 

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -25,7 +25,7 @@ class StagedRegionValueSuite extends HailSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addString(fb.getArg[String](2)),
+        srvb.addString(fb.getCodeParam[String](2)),
         srvb.end()
       )
     )
@@ -67,7 +67,7 @@ class StagedRegionValueSuite extends HailSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addInt(fb.getArg[Int](2)),
+        srvb.addInt(fb.getCodeParam[Int](2)),
         srvb.end()
       )
     )
@@ -105,7 +105,7 @@ class StagedRegionValueSuite extends HailSuite {
     fb.emit(
       Code(
         srvb.start(1),
-        srvb.addInt(fb.getArg[Int](2)),
+        srvb.addInt(fb.getCodeParam[Int](2)),
         srvb.advance(),
         srvb.end()
       )
@@ -147,7 +147,7 @@ class StagedRegionValueSuite extends HailSuite {
         srvb.start(),
         srvb.addString("hello"),
         srvb.advance(),
-        srvb.addInt(fb.getArg[Int](2)),
+        srvb.addInt(fb.getCodeParam[Int](2)),
         srvb.end()
       )
     )
@@ -189,7 +189,7 @@ class StagedRegionValueSuite extends HailSuite {
         ssb.start(),
         ssb.addInt(srvb.arrayIdx + 1),
         ssb.advance(),
-        ssb.addString(fb.getArg[String](2))
+        ssb.addString(fb.getCodeParam[String](2))
       )
     }
 
@@ -324,7 +324,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalStruct("a" -> PCanonicalString(), "b" -> PCanonicalArray(PInt32()))
     val input = "hello"
     val fb = EmitFunctionBuilder[Region, String, Long]("fb")
-    val codeInput = fb.getArg[String](2)
+    val codeInput = fb.getCodeParam[String](2)
     val srvb = new StagedRegionValueBuilder(fb, rt)
 
     val array = { sab: StagedRegionValueBuilder =>
@@ -389,7 +389,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalArray(PInt32())
     val input = 3
     val fb = EmitFunctionBuilder[Region, Int, Long]("fb")
-    val codeInput = fb.getArg[Int](2)
+    val codeInput = fb.getCodeParam[Int](2)
     val srvb = new StagedRegionValueBuilder(fb, rt)
 
     fb.emit(
@@ -439,11 +439,11 @@ class StagedRegionValueSuite extends HailSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addIRIntermediate(PInt32())(fb.getArg[Int](2)),
+        srvb.addIRIntermediate(PInt32())(fb.getCodeParam[Int](2)),
         srvb.advance(),
-        srvb.addIRIntermediate(PBoolean())(fb.getArg[Boolean](3)),
+        srvb.addIRIntermediate(PBoolean())(fb.getCodeParam[Boolean](3)),
         srvb.advance(),
-        srvb.addIRIntermediate(PFloat64())(fb.getArg[Double](4)),
+        srvb.addIRIntermediate(PFloat64())(fb.getCodeParam[Double](4)),
         srvb.advance(),
         srvb.end()
       )
@@ -479,7 +479,7 @@ class StagedRegionValueSuite extends HailSuite {
             StagedRegionValueBuilder.deepCopyFromOffset(
               EmitRegion.default(fb.apply_method),
               t,
-              fb.getArg[Long](2).load()))
+              fb.getCodeParam[Long](2)))
           val copyF = fb.resultWithIndex()(0, region)
           val newOff = copyF(region, src)
 

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -345,7 +345,7 @@ class ASM4SSuite extends TestNGSuite {
         intField.store(fb.getArg[Int](1)),
         longField.store(fb.getArg[Long](2)),
         booleanField.store(fb.getArg[Boolean](3)))
-
+      
       typeInfo[T] match {
         case IntInfo => fb.emit(Code(c, intField.load()))
         case LongInfo => fb.emit(Code(c, longField.load()))

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -98,13 +98,13 @@ class FunctionSuite extends HailSuite {
   def testFunctionBuilderGetOrDefine() {
     val fb = EmitFunctionBuilder[Int]("foo")
     val i = fb.genFieldThisRef[Int]()
-    val mb1 = fb.getOrGenMethod("foo", "foo", Array[TypeInfo[_]](), UnitInfo) { mb =>
+    val mb1 = fb.getOrGenEmitMethod("foo", "foo", FastIndexedSeq[ParamType](), UnitInfo) { mb =>
       mb.emit(i := i + 1)
     }
-    val mb2 = fb.getOrGenMethod("foo", "foo", Array[TypeInfo[_]](), UnitInfo) { mb =>
+    val mb2 = fb.getOrGenEmitMethod("foo", "foo", FastIndexedSeq[ParamType](), UnitInfo) { mb =>
       mb.emit(i := i - 100)
     }
-    fb.emit(Code(i := 0, mb1.invoke(), mb2.invoke(), i))
+    fb.emit(Code(i := 0, mb1.invokeCode(), mb2.invokeCode(), i))
     Region.scoped { r =>
 
       assert(fb.resultWithIndex().apply(0, r)() == 2)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -278,16 +278,16 @@ class IRSuite extends HailSuite {
 
   @Test def testCoalesceInferPType() {
     assertPType(Coalesce(FastSeq(In(0, PInt32()))), PInt32())
-    assertPType(Coalesce(FastSeq(In(0, PInt32()), In(0, PInt32(true)))), PInt32())
+    assertPType(Coalesce(FastSeq(In(0, PInt32()), In(0, PInt32(true)))), PInt32(true))
     assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true)))))), PCanonicalArray(PCanonicalArray(PInt32())))
     assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true), true))))), PCanonicalArray(PCanonicalArray(PInt32())))
-    assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true), true), true)))), PCanonicalArray(PCanonicalArray(PInt32())))
-    assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true), true), true)))), PCanonicalArray(PCanonicalArray(PInt32())))
+    assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true), true), true)))), PCanonicalArray(PCanonicalArray(PInt32()), true))
+    assertPType(Coalesce(FastSeq(In(0, PCanonicalArray(PCanonicalArray(PInt32()))), In(0, PCanonicalArray(PCanonicalArray(PInt32(true), true), true)))), PCanonicalArray(PCanonicalArray(PInt32()), true))
     assertPType(Coalesce(FastSeq(
       In(0, PCanonicalArray(PCanonicalArray(PInt32()))),
       In(0, PCanonicalArray(PCanonicalArray(PInt32(), true))),
       In(0, PCanonicalArray(PCanonicalArray(PInt32(true)), true))
-    )), PCanonicalArray(PCanonicalArray(PInt32())))
+    )), PCanonicalArray(PCanonicalArray(PInt32()), true))
   }
 
   val i32na = NA(TInt32)

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -35,8 +35,8 @@ class OrderingSuite extends HailSuite {
   ): AsmFunction3[Region, Long, Long, op.ReturnType] = {
     implicit val x = op.rtti
     val fb = EmitFunctionBuilder[Region, Long, Long, op.ReturnType]("lifted")
-    val cv1 = Region.getIRIntermediate(t)(fb.getArg[Long](2))
-    val cv2 = Region.getIRIntermediate(t)(fb.getArg[Long](3))
+    val cv1 = Region.getIRIntermediate(t)(fb.getCodeParam[Long](2))
+    val cv2 = Region.getIRIntermediate(t)(fb.getCodeParam[Long](3))
     fb.emit(fb.apply_method.getCodeOrdering(t, op)((const(false), cv1), (const(false), cv2)))
     fb.resultWithIndex()(0, r)
   }
@@ -291,9 +291,9 @@ class OrderingSuite extends HailSuite {
         val eoff = rvb.end()
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int]("binary_search")
-        val cregion = fb.getArg[Region](1).load()
-        val cset = fb.getArg[Long](2)
-        val cetuple = fb.getArg[Long](3)
+        val cregion = fb.getCodeParam[Region](1).load()
+        val cset = fb.getCodeParam[Long](2)
+        val cetuple = fb.getCodeParam[Long](3)
 
         val bs = new BinarySearch(fb.apply_method, pset, pset.elementType, keyOnly = false)
         fb.emit(bs.getClosestIndex(cset, false, Region.loadIRIntermediate(pt)(pTuple.fieldOffset(cetuple, 0))))
@@ -331,9 +331,9 @@ class OrderingSuite extends HailSuite {
         val eoff = rvb.end()
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int]("binary_search_dict")
-        val cregion = fb.getArg[Region](1).load()
-        val cdict = fb.getArg[Long](2)
-        val cktuple = fb.getArg[Long](3)
+        val cregion = fb.getCodeParam[Region](1)
+        val cdict = fb.getCodeParam[Long](2)
+        val cktuple = fb.getCodeParam[Long](3)
 
         val bs = new BinarySearch(fb.apply_method, pDict, pDict.keyType, keyOnly = true)
         val m = ptuple.isFieldMissing(cktuple, 0)

--- a/hail/src/test/scala/is/hail/expr/ir/PTypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PTypeSuite.scala
@@ -2,9 +2,12 @@ package is.hail.expr.ir
 
 import is.hail.HailSuite
 import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual
+import is.hail.expr.types.virtual.{TArray, TDict, TInt32, TInterval, TStruct}
 import is.hail.rvd.AbstractRVDSpec
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
+import org.apache.spark.sql.Row
 import org.json4s.jackson.Serialization
 import org.testng.annotations.{DataProvider, Test}
 
@@ -42,5 +45,24 @@ class PTypeSuite extends HailSuite {
     implicit val formats = AbstractRVDSpec.formats
     val s = Serialization.write(ptype)
     assert(Serialization.read[PType](s) == ptype)
+  }
+
+  @Test def testLiteralPType(): Unit = {
+    assert(PType.literalPType(TInt32, 5) == PInt32(true))
+    assert(PType.literalPType(TInt32, null) == PInt32())
+
+    assert(PType.literalPType(TArray(TInt32), null) == PCanonicalArray(PInt32(true)))
+    assert(PType.literalPType(TArray(TInt32), FastIndexedSeq(1, null)) == PCanonicalArray(PInt32(), true))
+    assert(PType.literalPType(TArray(TInt32), FastIndexedSeq(1, 5)) == PCanonicalArray(PInt32(true), true))
+
+    assert(PType.literalPType(TInterval(TInt32), Interval(5, null, false, true)) == PCanonicalInterval(PInt32(), true))
+
+    val p = TStruct("a" -> TInt32, "b" -> TInt32)
+    val d = TDict(p, p)
+    assert(PType.literalPType(d, Map(Row(3, null) -> Row(null, 3))) ==
+      PCanonicalDict(
+        PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32()),
+        PCanonicalStruct(true, "a" -> PInt32(), "b" -> PInt32(true)),
+        true))
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -14,7 +14,6 @@ import org.testng.annotations.{DataProvider, Test}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-/*
 class PruneSuite extends HailSuite {
   @Test def testUnionType() {
     val base = TStruct(
@@ -1261,6 +1260,3 @@ class PruneSuite extends HailSuite {
          | subtype:   ${ t2.toPrettyString(0, true) }""".stripMargin)
   }
 }
-
-
- */

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -14,6 +14,7 @@ import org.testng.annotations.{DataProvider, Test}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+/*
 class PruneSuite extends HailSuite {
   @Test def testUnionType() {
     val base = TStruct(
@@ -1260,3 +1261,6 @@ class PruneSuite extends HailSuite {
          | subtype:   ${ t2.toPrettyString(0, true) }""".stripMargin)
   }
 }
+
+
+ */

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -50,7 +50,7 @@ object BTreeBackedSet {
     val cb = fb.ecb
     val root = fb.genFieldThisRef[Long]()
     val r = fb.genFieldThisRef[Region]()
-    val ib = fb.getArg[InputBuffer](2)
+    val ib = fb.getCodeParam[InputBuffer](2)
     val ib2 = fb.genFieldThisRef[InputBuffer]()
 
     val km = fb.genFieldThisRef[Boolean]()
@@ -59,7 +59,7 @@ object BTreeBackedSet {
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
     fb.emit(Code(
-      r := fb.getArg[Region](1),
+      r := fb.getCodeParam[Region](1),
       btree.init,
       btree.bulkLoad(ib) { (ib, off) =>
         Code(
@@ -90,7 +90,7 @@ class BTreeBackedSet(region: Region, n: Int) {
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
     fb.emit(Code(
-      r := fb.getArg[Region](1),
+      r := fb.getCodeParam[Region](1),
       btree.init, root))
 
     fb.resultWithIndex()(0, region)
@@ -101,16 +101,16 @@ class BTreeBackedSet(region: Region, n: Int) {
     val cb = fb.ecb
     val root = fb.genFieldThisRef[Long]()
     val r = fb.genFieldThisRef[Region]()
-    val m = fb.getArg[Boolean](3)
-    val v = fb.getArg[Long](4)
+    val m = fb.getCodeParam[Boolean](3)
+    val v = fb.getCodeParam[Long](4)
     val elt = fb.newLocal[Long]()
 
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
 
     fb.emit(Code(
-      r := fb.getArg[Region](1),
-      root := fb.getArg[Long](2),
+      r := fb.getCodeParam[Region](1),
+      root := fb.getCodeParam[Long](2),
       elt := btree.getOrElseInitialize(m, v),
       key.isEmpty(elt).orEmpty(key.storeKey(elt, m, v)),
       root))
@@ -131,8 +131,8 @@ class BTreeBackedSet(region: Region, n: Int) {
     val returnArray = fb.newLocal[Array[java.lang.Long]]()
 
     fb.emit(Code(
-      r := fb.getArg[Region](1),
-      root := fb.getArg[Long](2),
+      r := fb.getCodeParam[Region](1),
+      root := fb.getCodeParam[Long](2),
       sab.clear,
       btree.foreach { koff =>
         Code.memoize(koff, "koff") { koff =>
@@ -158,14 +158,14 @@ class BTreeBackedSet(region: Region, n: Int) {
     val cb = fb.ecb
     val root = fb.genFieldThisRef[Long]()
     val r = fb.genFieldThisRef[Region]()
-    val ob = fb.getArg[OutputBuffer](2)
+    val ob = fb.getCodeParam[OutputBuffer](2)
     val ob2 = fb.genFieldThisRef[OutputBuffer]()
 
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
 
     fb.emit(Code(
-      root := fb.getArg[Long](1),
+      root := fb.getCodeParam[Long](1),
       ob2 := ob,
       btree.bulkStore(ob2) { (ob, off) =>
         Code.memoize(ob, "ob", off, "off") { (ob, off) =>

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -16,7 +16,7 @@ class TakeByAggregatorSuite extends HailSuite {
       val stringPT = PCanonicalString(true)
       val tba = new TakeByRVAS(PCanonicalString(true), PInt64Optional, PCanonicalArray(stringPT, required = true), cb)
       Region.scoped { r =>
-        val argR = fb.getArg[Region](1)
+        val argR = fb.getCodeParam[Region](1)
         val i = fb.genFieldThisRef[Long]()
         val off = fb.genFieldThisRef[Long]()
         val rt = tba.resultType
@@ -50,7 +50,7 @@ class TakeByAggregatorSuite extends HailSuite {
     val cb = fb.ecb
     val tba = new TakeByRVAS(PInt32Optional, PInt32Optional, PCanonicalArray(PInt32Optional, required = true), cb)
     Region.scoped { r =>
-      val argR = fb.getArg[Region](1)
+      val argR = fb.getCodeParam[Region](1)
       val rt = tba.resultType
 
       fb.emit(Code(Code(FastIndexedSeq(
@@ -81,7 +81,7 @@ class TakeByAggregatorSuite extends HailSuite {
       val cb = fb.ecb
 
       Region.scoped { r =>
-        val argR = fb.getArg[Region](1)
+        val argR = fb.getCodeParam[Region](1)
         val i = fb.genFieldThisRef[Int]()
         val random = fb.genFieldThisRef[Int]()
         val resultOff = fb.genFieldThisRef[Long]()

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -22,7 +22,7 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val sbll = new StagedBlockLinkedList(elemPType, cb)
 
       val ptr = fb.genFieldThisRef[Long]()
-      val r = fb.getArg[Region](1)
+      val r = fb.getCodeParam[Region](1)
       fb.emit(Code(
         ptr := r.allocate(sbll.storageType.alignment, sbll.storageType.byteSize),
         sbll.init(r),
@@ -37,9 +37,9 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val cb = fb.ecb
       val sbll = new StagedBlockLinkedList(elemPType, cb)
 
-      val r = fb.getArg[Region](1)
-      val ptr = fb.getArg[Long](2)
-      val eltOff = fb.getArg[Long](3)
+      val r = fb.getCodeParam[Region](1)
+      val ptr = fb.getCodeParam[Long](2)
+      val eltOff = fb.getCodeParam[Long](3)
       fb.emit(Code(
         sbll.load(ptr),
         sbll.push(r, EmitCode(Code._empty,
@@ -59,9 +59,9 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val sbll1 = new StagedBlockLinkedList(elemPType, cb)
       val sbll2 = new StagedBlockLinkedList(elemPType, cb)
 
-      val r = fb.getArg[Region](1)
-      val ptr1 = fb.getArg[Long](2)
-      val ptr2 = fb.getArg[Long](3)
+      val r = fb.getCodeParam[Region](1)
+      val ptr1 = fb.getCodeParam[Long](2)
+      val ptr2 = fb.getCodeParam[Long](3)
       fb.emit(Code(
         sbll1.load(ptr1),
         sbll2.load(ptr2),
@@ -80,8 +80,8 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val cb = fb.ecb
       val sbll = new StagedBlockLinkedList(elemPType, cb)
 
-      val rArg = fb.getArg[Region](1).load
-      val ptr = fb.getArg[Long](2).load
+      val rArg = fb.getCodeParam[Region](1)
+      val ptr = fb.getCodeParam[Long](2)
       val rField = fb.genFieldThisRef[Region]()
       val srvb = new StagedRegionValueBuilder(EmitRegion(fb.apply_method, rField), arrayPType)
       fb.emit(Code(
@@ -103,8 +103,8 @@ class StagedBlockLinkedListSuite extends TestNGSuite {
       val sbll2 = new StagedBlockLinkedList(elemPType, cb)
       val sbll1 = new StagedBlockLinkedList(elemPType, cb)
       val dstPtr = fb.genFieldThisRef[Long]()
-      val r = fb.getArg[Region](1)
-      val srcPtr = fb.getArg[Long](2)
+      val r = fb.getCodeParam[Region](1)
+      val srcPtr = fb.getCodeParam[Long](2)
       fb.emit(Code(
         dstPtr := r.allocate(sbll1.storageType.alignment, sbll1.storageType.byteSize),
         sbll2.load(srcPtr),

--- a/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
@@ -24,8 +24,8 @@ class PContainerTest extends HailSuite {
     log.info(s"Testing $data")
 
     val fb = EmitFunctionBuilder[Region, Long, Long]("not_empty")
-    val codeRegion = fb.getArg[Region](1)
-    val value = fb.getArg[Long](2)
+    val codeRegion = fb.getCodeParam[Region](1)
+    val value = fb.getCodeParam[Long](2)
 
     fb.emit(destType.checkedConvertFrom(fb.apply_method, codeRegion, value, sourceType, "ShouldHaveNoNull"))
 
@@ -55,7 +55,7 @@ class PContainerTest extends HailSuite {
     log.info(s"Testing $data")
 
     val fb = EmitFunctionBuilder[Long, Boolean]("not_empty")
-    val value = fb.getArg[Long](1)
+    val value = fb.getCodeParam[Long](1)
 
     fb.emit(Region.containsNonZeroBits(value + sourceType.lengthHeaderBytes, sourceType.loadLength(value).toL))
 
@@ -70,7 +70,7 @@ class PContainerTest extends HailSuite {
     log.info(s"\nTesting $data")
 
     val fb = EmitFunctionBuilder[Long, Boolean]("not_empty")
-    val value = fb.getArg[Long](1)
+    val value = fb.getCodeParam[Long](1)
 
     fb.emit(sourceType.hasMissingValues(value))
 

--- a/hail/src/test/scala/is/hail/expr/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PhysicalTestUtils.scala
@@ -13,9 +13,9 @@ object PhysicalTestUtils extends TestNGSuite {
 
     val srcAddress = ScalaToRegionValue(srcRegion, sourceType, sourceValue)
 
-    if(interpret) {
+    if (interpret) {
       try {
-        val copyOff = destType.fundamentalType.copyFromType(region, sourceType.fundamentalType, srcAddress, deepCopy = deepCopy)
+        val copyOff = destType.fundamentalType.copyFromAddress(region, sourceType.fundamentalType, srcAddress, deepCopy = deepCopy)
         val copy = UnsafeRow.read(destType, region, copyOff)
 
         log.info(s"Copied value: ${copy}, Source value: ${sourceValue}")
@@ -23,17 +23,16 @@ object PhysicalTestUtils extends TestNGSuite {
         region.clear()
         srcRegion.clear()
       } catch {
-        case e: AssertionError => {
+        case e: AssertionError =>
           srcRegion.clear()
           region.clear()
 
-          if(expectCompileErr) {
+          if (expectCompileErr) {
             log.info("OK: Caught expected compile-time error")
             return
           }
 
           throw new Error(e)
-        }
       }
 
       return
@@ -41,24 +40,23 @@ object PhysicalTestUtils extends TestNGSuite {
     
     var compileSuccess = false
     val fb = EmitFunctionBuilder[Region, Long, Long]("not_empty")
-    val codeRegion = fb.getArg[Region](1)
-    val value = fb.getArg[Long](2)
+    val codeRegion = fb.getCodeParam[Region](1)
+    val value = fb.getCodeParam[Long](2)
 
     try {
       fb.emit(destType.fundamentalType.copyFromType(fb.apply_method, codeRegion, sourceType.fundamentalType, value, deepCopy = deepCopy))
       compileSuccess = true
     } catch {
-      case e: AssertionError => {
+      case e: AssertionError =>
         srcRegion.clear()
         region.clear()
 
-        if(expectCompileErr) {
+        if (expectCompileErr) {
           log.info("OK: Caught expected compile-time error")
           return
         }
 
         throw new Error(e)
-      }
     }
 
     if(compileSuccess && expectCompileErr) {

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -157,7 +157,7 @@ class ReferenceGenomeSuite extends HailSuite {
     val fb = EmitFunctionBuilder[String, Boolean]("serialize_rg")
     val cb = fb.ecb
     val rgfield = fb.genLazyFieldThisRef(grch38.codeSetup(cb))
-    fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getArg[String](1)))
+    fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getCodeParam[String](1)))
 
     Region.scoped { r =>
       val f = fb.resultWithIndex()(0, r)
@@ -176,7 +176,7 @@ class ReferenceGenomeSuite extends HailSuite {
     val fb = EmitFunctionBuilder[String, Int, Int, Int, String]("serialize_rg")
     val cb = fb.ecb
     val rgfield = fb.genLazyFieldThisRef(rg.codeSetup(cb))
-    fb.emit(rgfield.invoke[String, Int, Int, Int, String]("getSequence", fb.getArg[String](1), fb.getArg[Int](2), fb.getArg[Int](3), fb.getArg[Int](4)))
+    fb.emit(rgfield.invoke[String, Int, Int, Int, String]("getSequence", fb.getCodeParam[String](1), fb.getCodeParam[Int](2), fb.getCodeParam[Int](3), fb.getCodeParam[Int](4)))
 
     Region.scoped { r =>
       val f = fb.resultWithIndex()(0, r)
@@ -193,7 +193,7 @@ class ReferenceGenomeSuite extends HailSuite {
     val fb = EmitFunctionBuilder[String, Locus, Double, (Locus, Boolean)]("serialize_with_liftover")
     val cb = fb.ecb
     val rgfield = fb.genLazyFieldThisRef(grch37.codeSetup(cb))
-    fb.emit(rgfield.invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus", fb.getArg[String](1), fb.getArg[Locus](2), fb.getArg[Double](3)))
+    fb.emit(rgfield.invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus", fb.getCodeParam[String](1), fb.getCodeParam[Locus](2), fb.getCodeParam[Double](3)))
 
     Region.scoped { r =>
       val f = fb.resultWithIndex()(0, r)


### PR DESCRIPTION
It might not look like it, but I promise, I'm trying to keep these as small as possible.

Summary of changes:
 - EmitMethodBuilder, etc. no longer implement WrappedMethodBuilder, etc. but they do proxy the necessary functions.
 - Emit method params and return values are now statically either: an Code[T] with type TypeInfo[T], or an EmitCode, with type PType.
 - Added ParamType to wrap the two parameter type options, and Param to wrap the two code options, with implicit conversions.
 - A bunch of methods now have emit and code variants: getEmitParam, getCodeParam, invokeCode, invokeEmit (where code, emit refer to the return value).
 - I made the minimal changes to get things working again.  Some code still code parameters to pass emit values.  I will fix these in a later PR.
 - Where possible, make the class implemented by Compile concrete rather than generic.  I think this can be pushed through the entire code base and we can remove the option to build generic methods.  We should have done this a long time ago.
 - ModuleBuilder can now create type-specialized tuple types.  This is used for EmitCode return values.  I'm not sure if this is actually used yet.
 - Require RVDType rowType to be required.  Require TypeValue global type to be required.  Fix lots of places to make this true.  In a few spots (e.g. TableMap{Rows, Globals}), I had to wrap the IR being compiled in a Coalesce with a Die to make sure the return type is required.
 - Cleaned up the dependent function interface to be closer to what we have now with MethodBuilder, etc.  DependentFunctionBuilder is now just an `apply_method: DependentMethodBuilder`, EmitFunctionBuilder analogously.  DependentMethodBuilder wraps a MethodBuilder, EmitMethodBuilder wraps a DependentMethodBuilder and an EmitMethodBuilder.
 - Add equality comparison to TypeInfo[_]
 - Add methods to convert IndexedSeq[Code[_]] to/from PCode and EmitCode.  These are used to pass EmitCode as arguments to method invocation.  If an emit parameter is required, the missingness boolean is omitted, otherwise it is present.

Furthermore, this change also adds requiredness to many things and improves ptype interfaces:
 - added PType.literalPType that infers PTypes from Scala literals, use in a few places (emit for Literal, BroadcastRegionValue constructor from annotation, etc.)
 - require Table global and row types to be required
 - same for MatrixValue, but also cols and entries (the entries array, not individual entries, which an be missing)
 - Don't upcast globals in TableKeyBy and TableOrderBy
 - added EType setRequired
 - AbstractCodecSpecs assert row and global etypes are present at the toplevel, and setRequired(true) if they are coming from encoders written by previous versions
 - rename PType.copyFromType to PType.copyFromAdddres.  Modify it so it can "downcast": convert to a PType with greater requiredness.  This is used in converting TableValues to MatrixValues to satisfy the requiredness assertions.
