### PR TITLE
Fix LiftMeOut bindingEnv in ChildEnvWithoutBindings

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -175,7 +175,7 @@ object ChildEnvWithoutBindings {
       case MatrixAggregate(_, _) => BindingEnv(Env.empty, agg = Some(Env.empty))
       case TableAggregate(_, _) => BindingEnv(Env.empty, agg = Some(Env.empty))
       case RelationalLet(_, _, _) => if (i == 0) BindingEnv.empty else env
-      case LiftMeOut(_) => BindingEnv.empty
+      case LiftMeOut(_) => BindingEnv(Env.empty[T], env.agg.map(_ => Env.empty), env.scan.map(_ => Env.empty))
       case _ => if (UsesAggEnv(ir, i)) env.promoteAgg else if (UsesScanEnv(ir, i)) env.promoteScan else env
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FreeVariables.scala
@@ -3,9 +3,6 @@ package is.hail.expr.ir
 object FreeVariables {
   def apply(ir: IR, supportsAgg: Boolean, supportsScan: Boolean): BindingEnv[Unit] = {
 
-    val defaultAgg = if (supportsAgg) Some(Env.empty[Unit]) else None
-    val defaultScan = if (supportsScan) Some(Env.empty[Unit]) else None
-
     def compute(ir1: IR, baseEnv: BindingEnv[Unit]): BindingEnv[Unit] = {
       ir1 match {
         case Ref(name, _) =>
@@ -15,11 +12,11 @@ object FreeVariables {
         case StreamAggScan(a, name, query) =>
           val aE = compute(a, baseEnv)
           val qE = compute(query, baseEnv.copy(scan = Some(Env.empty)))
-          aE.merge(qE.copy(eval = qE.eval.bindIterable(qE.scan.get.m - name), scan = defaultScan))
+          aE.merge(qE.copy(eval = qE.eval.bindIterable(qE.scan.get.m - name), scan = baseEnv.scan))
         case StreamAgg(a, name, query) =>
           val aE = compute(a, baseEnv)
           val qE = compute(query, baseEnv.copy(agg = Some(Env.empty)))
-          aE.merge(qE.copy(eval = qE.eval.bindIterable(qE.agg.get.m - name), agg = defaultAgg))
+          aE.merge(qE.copy(eval = qE.eval.bindIterable(qE.agg.get.m - name), agg = baseEnv.agg))
         case _ =>
           ir1.children
             .iterator
@@ -43,7 +40,7 @@ object FreeVariables {
     }
 
     compute(ir, BindingEnv(Env.empty,
-      defaultAgg,
-      defaultScan))
+      if (supportsAgg) Some(Env.empty[Unit]) else None,
+      if (supportsScan) Some(Env.empty[Unit]) else None))
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3229,6 +3229,26 @@ class IRSuite extends HailSuite {
     assert(!HasIRSharing(ir1.deepCopy()))
   }
 
+  @Test def freeVariablesAggScanBindingEnv(): Unit = {
+    def testFreeVarsHelper(ir: IR): Unit = {
+      val irFreeVarsTrue = FreeVariables.apply(ir, true, true)
+      assert(irFreeVarsTrue.agg.isDefined && irFreeVarsTrue.scan.isDefined)
+
+      val irFreeVarsFalse = FreeVariables.apply(ir, false, false)
+//      assert(irFreeVarsFalse.agg.isEmpty && irFreeVarsTrue.scan.isEmpty)
+    }
+
+    val liftIR = LiftMeOut(Ref("x", TInt32))
+    testFreeVarsHelper(liftIR)
+
+    val sumSig = AggSignature(Sum(), Seq(), Seq(TInt64))
+    val streamAggIR =  StreamAgg(
+      StreamMap(StreamRange(I32(0), I32(4), I32(1)), "x", Cast(Ref("x", TInt32), TInt64)),
+      "x",
+      ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(Ref("x", TInt64)), sumSig))
+    testFreeVarsHelper(streamAggIR)
+  }
+
   @DataProvider(name = "nonNullTypesAndValues")
   def nonNullTypesAndValues(): Array[Array[Any]] = Array(
     Array(PInt32(), 1),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3235,7 +3235,7 @@ class IRSuite extends HailSuite {
       assert(irFreeVarsTrue.agg.isDefined && irFreeVarsTrue.scan.isDefined)
 
       val irFreeVarsFalse = FreeVariables.apply(ir, false, false)
-//      assert(irFreeVarsFalse.agg.isEmpty && irFreeVarsTrue.scan.isEmpty)
+      assert(irFreeVarsFalse.agg.isEmpty && irFreeVarsFalse.scan.isEmpty)
     }
 
     val liftIR = LiftMeOut(Ref("x", TInt32))
@@ -3247,6 +3247,9 @@ class IRSuite extends HailSuite {
       "x",
       ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq(Ref("x", TInt64)), sumSig))
     testFreeVarsHelper(streamAggIR)
+
+    val streamScanIR = StreamAggScan(Ref("st", TStream(TInt32)), "x", ApplyScanOp(FastIndexedSeq.empty, FastIndexedSeq(Cast(Ref("x", TInt32), TInt64)), sumSig))
+    testFreeVarsHelper(streamScanIR)
   }
 
   @DataProvider(name = "nonNullTypesAndValues")


### PR DESCRIPTION
Fixes #8338 

The problem was that in `FreeVariables.scala`, we call `ChildEnvWithoutBindings` to create a new env. It's important that the new env we get has the same type of aggregation environments as the `baseEnv`.