### PR TITLE
[query] Improve BGzipInputStream.read

### DIFF
--- a/benchmark/python/benchmark_hail/run/resources.py
+++ b/benchmark/python/benchmark_hail/run/resources.py
@@ -243,6 +243,22 @@ class EmptyGVCF(ResourceGroup):
         return 'empty.g.vcf.bgz'
 
 
+class SingleGVCF(ResourceGroup):
+    def __init__(self):
+        super(SingleGVCF, self).__init__('NA20760.hg38.g.vcf.gz.tbi', 'NA20760.hg38.g.vcf.gz')
+    def name(self):
+        return 'single_gvcf'
+
+    def _create(self, resource_dir):
+        for f in self.files:
+            download(resource_dir, f)
+            logging.info(f'downloading {f}')
+
+    def path(self, resource):
+        if resource is not None:
+            raise KeyError(resource)
+        return 'NA20760.hg38.g.vcf.gz'
+
 profile_25 = Profile25()
 many_partitions_tables = ManyPartitionsTables()
 gnomad_dp_sim = GnomadDPSim()
@@ -251,6 +267,7 @@ many_ints_table = ManyIntsTable()
 sim_ukbb = SimUKBB()
 random_doubles = RandomDoublesMatrixTable()
 empty_gvcf = EmptyGVCF()
+single_gvcf = SingleGVCF()
 
 all_resources = profile_25, many_partitions_tables, gnomad_dp_sim, many_strings_table, many_ints_table, sim_ukbb, \
     random_doubles, empty_gvcf

--- a/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
+++ b/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
@@ -214,9 +214,19 @@ public class BGzipInputStream extends SplitCompressionInputStream {
     }
 
     public int read() throws IOException {
-        byte b[] = new byte[1];
-        int result = this.read(b, 0, 1);
-        return (result < 0) ? result : (b[0] & 0xff);
+        if (outputBufferSize == 0)
+            return -1; // EOF
+
+        if (outputBufferPos == 0)
+            currentPos = inputBufferInPos + 1;
+
+        int r = outputBuffer[outputBufferPos];
+        outputBufferPos += 1;
+
+        if (outputBufferPos == outputBufferSize)
+            decompressNextBlock();
+
+        return r & 0xff;
     }
 
     public void resetState() throws IOException {


### PR DESCRIPTION
Improves performance of GVCF import significantly:
```
           Benchmark Name      Ratio     Time 1     Time 2
           --------------      -----     ------     ------
  import_gvcf_force_count      81.2%     68.737     55.833
import_and_transform_gvcf      79.9%     75.692     60.464
----------------------
Harmonic mean: 80.5%
Geometric mean: 80.6%
Arithmetic mean: 80.6%
Median:  80.6%
```

Stacked on #8382