### PR TITLE
[query] more Backend cleanup

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2315,7 +2315,7 @@ def index_bgen(path,
         index_file_map = {}
     if contig_recoding is None:
         contig_recoding = {}
-    Env.hc()._jhc.indexBgen(wrap_to_list(path), index_file_map, joption(rg), contig_recoding, skip_invalid_loci)
+    Env.backend().index_bgen(wrap_to_list(path), index_file_map, rg, contig_recoding, skip_invalid_loci)
 
 
 @typecheck(path=str,

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -1,135 +1,18 @@
 package is.hail.backend
 
-import is.hail.annotations.UnsafeRow
-import is.hail.expr.ir.IRParser
-import is.hail.expr.types.encoded.EType
-import is.hail.expr.types.physical.{PBaseStruct, PType}
-import is.hail.io.{BufferSpec, TypedCodecSpec}
-import java.io.{ByteArrayInputStream, PrintWriter}
-
-import is.hail.HailContext
-import is.hail.annotations.{Region, SafeRow}
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.ir.lowering.{DArrayLowering, LowererUnsupportedOperation, LoweringPipeline}
-import is.hail.expr.ir.{BlockMatrixIR, Compilable, Compile, CompileAndEvaluate, ExecuteContext, IR, MakeTuple, Pretty, TypeCheck}
-import is.hail.expr.types.physical.PTuple
-import is.hail.expr.types.virtual.TVoid
-import is.hail.linalg.BlockMatrix
 import is.hail.utils._
-import org.json4s.DefaultFormats
-import org.json4s.jackson.{JsonMethods, Serialization}
 
 import scala.reflect.ClassTag
 
 abstract class BroadcastValue[T] { def value: T }
 
-abstract class ValueCache {
-  def persistBlockMatrix(id: String, value: BlockMatrix, storageLevel: String): Unit
-  def getPersistedBlockMatrix(id: String): BlockMatrix
-  def unpersistBlockMatrix(id: String): Unit
-}
-
 abstract class Backend {
-  def cache: ValueCache = asSpark().cache
-
   def broadcast[T: ClassTag](value: T): BroadcastValue[T]
 
   def parallelizeAndComputeWithIndex[T: ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U]
 
-  def clear(): Unit
-
-  private[this] def executionResultToAnnotation(ctx: ExecuteContext, result: Either[Unit, (PTuple, Long)]) = result match {
-    case Left(x) => x
-    case Right((pt, off)) => SafeRow(pt, off).get(0)
-  }
-
-  def jvmLowerAndExecute(ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Any, ExecutionTimer) =
-    ExecuteContext.scoped { ctx =>
-      val (l, r) = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
-      (executionResultToAnnotation(ctx, l), r)
-    }
-
-  private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
-    val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
-      case (true, true) => DArrayLowering.All
-      case (true, false) => DArrayLowering.TableOnly
-      case (false, true) => DArrayLowering.BMOnly
-      case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
-    }
-    val ir = LoweringPipeline.darrayLowerer(typesToLower).apply(ctx, ir0, optimize).asInstanceOf[IR]
-
-    if (!Compilable(ir))
-      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")
-
-    val res = ir.typ match {
-      case TVoid =>
-        val (_, f) = ctx.timer.time("Compile")(Compile[Unit](ctx, ir, print))
-        ctx.timer.time("Run")(Left(f(0, ctx.r)(ctx.r)))
-
-      case _ =>
-        val (pt: PTuple, f) = ctx.timer.time("Compile")(Compile[Long](ctx, MakeTuple.ordered(FastSeq(ir)), print))
-        ctx.timer.time("Run")(Right((pt, f(0, ctx.r)(ctx.r))))
-    }
-
-    (res, ctx.timer)
-  }
-
-  def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) =
-    ExecuteContext.scoped { ctx =>
-      val (l, r) = _execute(ctx, ir, optimize)
-      (executionResultToAnnotation(ctx, l), r)
-    }
-
-  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
-    TypeCheck(ir)
-    try {
-      val lowerTable = HailContext.get.flags.get("lower") != null
-      val lowerBM = HailContext.get.flags.get("lower_bm") != null
-      _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM)
-    } catch {
-      case _: LowererUnsupportedOperation =>
-        (CompileAndEvaluate._apply(ctx, ir, optimize = optimize), ctx.timer)
-    }
-  }
-
-  def executeJSON(ir: IR): String = {
-    val t = ir.typ
-    val (value, timings) = execute(ir, optimize = true)
-    val jsonValue = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
-    timings.finish()
-    timings.logInfo()
-
-    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
-  }
-
-  def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) = {
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    ExecuteContext.scoped { ctx =>
-      _execute(ctx, ir, true)._1 match {
-        case Left(_) => throw new RuntimeException("expression returned void")
-        case Right((t, off)) =>
-          assert(t.size == 1)
-          val elementType = t.fields(0).typ
-          val codec = TypedCodecSpec(
-            EType.defaultFromPType(elementType), elementType.virtualType, bs)
-          assert(t.isFieldDefined(off, 0))
-          (elementType.toString, codec.encode(elementType, ctx.r, t.loadField(off, 0)))
-      }
-    }
-  }
-
-  def decodeToJSON(ptypeString: String, b: Array[Byte], bufferSpecString: String): String = {
-    val t = IRParser.parsePType(ptypeString)
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    val codec = TypedCodecSpec(EType.defaultFromPType(t), t.virtualType, bs)
-    using(Region()) { r =>
-      val (pt, off) = codec.decode(t.virtualType, b, r)
-      assert(pt.virtualType == t.virtualType)
-      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
-        UnsafeRow.read(pt, r, off), pt.virtualType))
-    }
-  }
+  def stop(): Unit
 
   def asSpark(): SparkBackend = fatal("SparkBackend needed for this operation.")
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -1,14 +1,33 @@
 package is.hail.backend.spark
 
+import is.hail.annotations.UnsafeRow
+import is.hail.expr.ir.IRParser
+import is.hail.expr.types.encoded.EType
+import is.hail.io.{BufferSpec, TypedCodecSpec}
+import is.hail.HailContext
+import is.hail.annotations.{Region, SafeRow}
+import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.lowering._
+import is.hail.expr.ir._
+import is.hail.expr.types.physical.PTuple
+import is.hail.expr.types.virtual.TVoid
 import is.hail.backend.{Backend, BroadcastValue, HailTaskContext}
 import is.hail.io.fs.{FS, HadoopFS}
 import is.hail.utils._
+import is.hail.io.bgen.IndexBgen
+
+import org.json4s.DefaultFormats
+import org.json4s.jackson.{JsonMethods, Serialization}
+
 import org.apache.spark.{ProgressBarBuilder, SparkConf, SparkContext, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.reflect.ClassTag
+import java.io.PrintWriter
+
 
 class SparkBroadcastValue[T](bc: Broadcast[T]) extends BroadcastValue[T] with Serializable {
   def value: T = bc.value
@@ -174,7 +193,7 @@ object SparkBackend {
     theSparkBackend
   }
 
-  def clear(): Unit = synchronized {
+  def stop(): Unit = synchronized {
     if (theSparkBackend != null) {
       theSparkBackend.sc.stop()
       theSparkBackend = null
@@ -189,7 +208,7 @@ class SparkBackend(val sc: SparkContext) extends Backend {
 
   val fsBc: Broadcast[FS] = sc.broadcast(fs)
 
-  override val cache: SparkValueCache = SparkValueCache()
+  val bmCache: SparkBlockMatrixCache = SparkBlockMatrixCache()
 
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new SparkBroadcastValue[T](sc.broadcast(value))
 
@@ -210,5 +229,109 @@ class SparkBackend(val sc: SparkContext) extends Backend {
 
   override def asSpark(): SparkBackend = this
 
-  def clear(): Unit = SparkBackend.clear()
+  def stop(): Unit = SparkBackend.stop()
+
+  private[this] def executionResultToAnnotation(ctx: ExecuteContext, result: Either[Unit, (PTuple, Long)]) = result match {
+    case Left(x) => x
+    case Right((pt, off)) => SafeRow(pt, off).get(0)
+  }
+
+  def jvmLowerAndExecute(ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Any, ExecutionTimer) =
+    ExecuteContext.scoped() { ctx =>
+      val (l, r) = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
+      (executionResultToAnnotation(ctx, l), r)
+    }
+
+  private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+    val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
+      case (true, true) => DArrayLowering.All
+      case (true, false) => DArrayLowering.TableOnly
+      case (false, true) => DArrayLowering.BMOnly
+      case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
+    }
+    val ir = LoweringPipeline.darrayLowerer(typesToLower).apply(ctx, ir0, optimize).asInstanceOf[IR]
+
+    if (!Compilable(ir))
+      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")
+
+    val res = ir.typ match {
+      case TVoid =>
+        val (_, f) = ctx.timer.time("Compile")(Compile[Unit](ctx, ir, print))
+        ctx.timer.time("Run")(Left(f(0, ctx.r)(ctx.r)))
+
+      case _ =>
+        val (pt: PTuple, f) = ctx.timer.time("Compile")(Compile[Long](ctx, MakeTuple.ordered(FastSeq(ir)), print))
+        ctx.timer.time("Run")(Right((pt, f(0, ctx.r)(ctx.r))))
+    }
+
+    (res, ctx.timer)
+  }
+
+  def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) =
+    ExecuteContext.scoped() { ctx =>
+      val (l, r) = _execute(ctx, ir, optimize)
+      (executionResultToAnnotation(ctx, l), r)
+    }
+
+  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+    TypeCheck(ir)
+    try {
+      val lowerTable = HailContext.get.flags.get("lower") != null
+      val lowerBM = HailContext.get.flags.get("lower_bm") != null
+      _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM)
+    } catch {
+      case _: LowererUnsupportedOperation =>
+        (CompileAndEvaluate._apply(ctx, ir, optimize = optimize), ctx.timer)
+    }
+  }
+
+  def executeJSON(ir: IR): String = {
+    val t = ir.typ
+    val (value, timings) = execute(ir, optimize = true)
+    val jsonValue = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
+    timings.finish()
+    timings.logInfo()
+
+    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
+  }
+
+  def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) = {
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    ExecuteContext.scoped() { ctx =>
+      _execute(ctx, ir, true)._1 match {
+        case Left(_) => throw new RuntimeException("expression returned void")
+        case Right((t, off)) =>
+          assert(t.size == 1)
+          val elementType = t.fields(0).typ
+          val codec = TypedCodecSpec(
+            EType.defaultFromPType(elementType), elementType.virtualType, bs)
+          assert(t.isFieldDefined(off, 0))
+          (elementType.toString, codec.encode(elementType, ctx.r, t.loadField(off, 0)))
+      }
+    }
+  }
+
+  def decodeToJSON(ptypeString: String, b: Array[Byte], bufferSpecString: String): String = {
+    val t = IRParser.parsePType(ptypeString)
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    val codec = TypedCodecSpec(EType.defaultFromPType(t), t.virtualType, bs)
+    using(Region()) { r =>
+      val (pt, off) = codec.decode(t.virtualType, b, r)
+      assert(pt.virtualType == t.virtualType)
+      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
+        UnsafeRow.read(pt, r, off), pt.virtualType))
+    }
+  }
+
+  def pyIndexBgen(
+    files: java.util.List[String],
+    indexFileMap: java.util.Map[String, String],
+    rg: Option[String],
+    contigRecoding: java.util.Map[String, String],
+    skipInvalidLoci: Boolean) {
+    ExecuteContext.scoped(this, fs) { ctx =>
+      IndexBgen(ctx, files.asScala.toArray, indexFileMap.asScala.toMap, rg, contigRecoding.asScala.toMap, skipInvalidLoci)
+    }
+    info(s"Number of BGEN files indexed: ${ files.size() }")
+  }
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
@@ -1,11 +1,10 @@
 package is.hail.backend.spark
 
-import is.hail.backend.ValueCache
 import is.hail.linalg.BlockMatrix
 
 import scala.collection.mutable
 
-case class SparkValueCache() extends ValueCache {
+case class SparkBlockMatrixCache() {
   private[this] val blockmatrices: mutable.Map[String, BlockMatrix] = new mutable.HashMap()
 
   def persistBlockMatrix(id: String, value: BlockMatrix, storageLevel: String): Unit =

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -61,7 +61,7 @@ abstract sealed class BlockMatrixIR extends BaseIR {
   def typ: BlockMatrixType
 
   def pyExecute(): BlockMatrix = {
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       Interpret(this, ctx, optimize = true)
     }
   }
@@ -131,7 +131,7 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
 }
 
 case class BlockMatrixPersistReader(id: String) extends BlockMatrixReader {
-  lazy val bm: BlockMatrix = HailContext.backend.cache.getPersistedBlockMatrix(id)
+  lazy val bm: BlockMatrix = HailContext.sparkBackend().bmCache.getPersistedBlockMatrix(id)
   lazy val fullType: BlockMatrixType = BlockMatrixType.fromBlockMatrix(bm)
   def apply(ctx: ExecuteContext, hc: HailContext): BlockMatrix = bm
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -37,7 +37,7 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
 
 case class BlockMatrixPersistWriter(id: String, storageLevel: String) extends BlockMatrixWriter {
   def apply(hc: HailContext, bm: BlockMatrix): Unit =
-    HailContext.backend.cache.persistBlockMatrix(id, bm, storageLevel)
+    HailContext.sparkBackend().bmCache.persistBlockMatrix(id, bm, storageLevel)
 }
 
 case class BlockMatrixRectanglesWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -5,7 +5,7 @@ import is.hail.utils.HailException
 
 object FoldConstants {
   def apply(ir: BaseIR): BaseIR =
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       RewriteBottomUp(ir, {
         case _: Ref |
              _: In |

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -590,7 +590,7 @@ object Interpret {
       case BlockMatrixMultiWrite(blockMatrices, writer) =>
         writer(blockMatrices.map(_.execute(ctx)))
       case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id))) =>
-        HailContext.backend.cache.unpersistBlockMatrix(id)
+        HailContext.sparkBackend().bmCache.unpersistBlockMatrix(id)
       case _: UnpersistBlockMatrix =>
       case TableToValueApply(child, function) =>
         function.execute(ctx, child.execute(ctx))

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -43,7 +43,7 @@ abstract sealed class MatrixIR extends BaseIR {
   override def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR
 
   def persist(storageLevel: StorageLevel): MatrixIR = {
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       val tv = Interpret(this, ctx, optimize = true)
       MatrixLiteral(this.typ, TableLiteral(tv.persist(storageLevel), ctx))
     }
@@ -72,7 +72,7 @@ abstract sealed class MatrixIR extends BaseIR {
 object MatrixLiteral {
   def apply(typ: MatrixType, rvd: RVD, globals: Row, colValues: IndexedSeq[Row]): MatrixLiteral = {
     val tt = typ.canonicalTableType
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       MatrixLiteral(typ,
         TableLiteral(
           TableValue(tt,

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1548,18 +1548,18 @@ object IRParser {
         val blocksOnly = boolean_literal(it)
         punctuation(it, ")")
         val Row(starts: IndexedSeq[Long @unchecked], stops: IndexedSeq[Long @unchecked]) =
-          ExecuteContext.scoped[Row] { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped() { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
         RowIntervalSparsifier(blocksOnly, starts, stops)
       case "PyBandSparsifier" =>
         val blocksOnly = boolean_literal(it)
         punctuation(it, ")")
         val Row(l: Long, u: Long) =
-          ExecuteContext.scoped[Row] { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped() { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
         BandSparsifier(blocksOnly, l, u)
       case "PyRectangleSparsifier" =>
         punctuation(it, ")")
         val rectangles: IndexedSeq[Long] =
-          ExecuteContext.scoped { ctx => CompileAndEvaluate[IndexedSeq[Long]](ctx, ir_value_expr(env)(it)) }
+          ExecuteContext.scoped() { ctx => CompileAndEvaluate[IndexedSeq[Long]](ctx, ir_value_expr(env)(it)) }
         RectangleSparsifier(rectangles.grouped(4).toIndexedSeq)
       case "RowIntervalSparsifier" =>
         val blocksOnly = boolean_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -46,7 +46,7 @@ abstract sealed class TableIR extends BaseIR {
 
   def persist(storageLevel: StorageLevel): TableIR = {
     // FIXME: store table literal in cache, return ID
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       val tv = Interpret(this, ctx, optimize = true)
       TableLiteral(tv.persist(storageLevel), ctx)
     }
@@ -72,7 +72,7 @@ abstract sealed class TableIR extends BaseIR {
   def pyUnpersist(): TableIR = unpersist()
 
   def pyToDF(): DataFrame = {
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       Interpret(this, ctx).toDF()
     }
   }

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -164,7 +164,7 @@ private class BgenRDD(
           assert(keys == null)
           new IndexBgenRecordIterator(ctx, p, settings, f(p.partitionIndex, ctx.partitionRegion)).flatten
         case p: LoadBgenPartition =>
-          val index: IndexReader = indexBuilder(p.bcFS.value, p.indexPath, 8)
+          val index: IndexReader = indexBuilder(p.fsBc.value, p.indexPath, 8)
           context.addTaskCompletionListener { (context: TaskContext) =>
             index.close()
           }

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -377,7 +377,7 @@ case class MatrixBGENReader(
 
   val (indexKeyType, indexAnnotationType) = LoadBgen.getIndexTypes(fileMetadata)
 
-  val (maybePartitions, partitionRangeBounds) = BgenRDDPartitions(referenceGenome, fileMetadata,
+  val (maybePartitions, partitionRangeBounds) = BgenRDDPartitions(fs, referenceGenome, fileMetadata,
     if (nPartitions.isEmpty && blockSizeInMB.isEmpty)
     Some(128)
   else
@@ -390,7 +390,7 @@ case class MatrixBGENReader(
       assert(rowType.isPrefixOf(fullMatrixType.rowKeyStruct))
       assert(rowType.types.nonEmpty)
 
-      ExecuteContext.scoped { ctx =>
+      ExecuteContext.scoped() { ctx =>
         val rvd = Interpret(ir.TableDistinct(variantsTableIR), ctx).rvd
 
         val repartitioned = RepartitionedOrderedRDD2(rvd, partitionRangeBounds.map(_.coarsen(rowType.types.length)))

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -3,6 +3,8 @@ package is.hail.io.fs
 import java.io._
 import java.util
 
+import is.hail.HailContext
+import is.hail.backend.BroadcastValue
 import is.hail.utils._
 
 import scala.io.Source
@@ -117,4 +119,6 @@ trait FS extends Serializable {
         }
     }
   }
+
+  lazy val broadcast: BroadcastValue[FS] = HailContext.backend.broadcast(this)
 }

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -117,7 +117,7 @@ object ExportPlink {
     using(fs.create(tmpBimDir + "/_SUCCESS"))(out => ())
     fs.copyMerge(tmpBimDir, path + ".bim", nPartitions, header = false, partFilesOpt = Some(partFiles))
 
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       mv.colsTableValue(ctx).export(path + ".fam", header = false)
     }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -484,7 +484,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   def filterRowIntervalsIR(startsAndStops: IR, blocksOnly: Boolean): BlockMatrix = {
-    val Row(starts, stops) = ExecuteContext.scoped { ctx => CompileAndEvaluate[Row](ctx, startsAndStops) }
+    val Row(starts, stops) = ExecuteContext.scoped() { ctx => CompileAndEvaluate[Row](ctx, startsAndStops) }
 
     filterRowIntervals(
       starts.asInstanceOf[IndexedSeq[Int]].map(_.toLong).toArray,

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -36,7 +36,7 @@ object LinearMixedModel {
   private val tableType = TableType(rowType.virtualType, FastIndexedSeq("idx"), TStruct.empty)
 
   def toTableIR(rvd: RVD): TableIR = {
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       TableLiteral(TableValue(tableType, BroadcastRow.empty(ctx), rvd), ctx)
     }
   }

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -37,7 +37,7 @@ object Graph {
 
   def pyMaximalIndependentSet(edgesIR: IR, nodeTypeStr: String, tieBreaker: Option[String]): IR = {
     val nodeType = IRParser.parseType(nodeTypeStr)
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       val edges = Interpret[IndexedSeq[Row]](ctx, edgesIR).toArray
 
       val resultType = TSet(nodeType)

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -155,7 +155,7 @@ trait Py4jUtils {
   def pyFromDF(df: DataFrame, jKey: java.util.List[String]): TableIR = {
     val key = jKey.asScala.toArray.toFastIndexedSeq
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[PStruct]
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)), ctx)
     }
   }

--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -37,7 +37,7 @@ class HailSuite extends TestNGSuite {
 
   @BeforeClass def ensureHailContextInitialized() { hc }
 
-  val ctx = ExecuteContext(Region(), new ExecutionTimer) // will get cleaned up on suite GC
+  val ctx = new ExecuteContext(hc.backend, hc.fs, Region(), new ExecutionTimer) // will get cleaned up on suite GC
 
   def fs: FS = hc.fs
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -217,7 +217,7 @@ class EmitStreamSuite extends HailSuite {
     val ir = streamIR.deepCopy()
     InferPType(ir, Env.empty)
     val eltType = ir.pType.asInstanceOf[PStream].elementType
-    val stream = ExecuteContext.scoped { ctx =>
+    val stream = ExecuteContext.scoped() { ctx =>
       val s = ir match {
         case ToArray(s) => s
         case s => s
@@ -273,7 +273,7 @@ class EmitStreamSuite extends HailSuite {
     val mb = fb.apply_method
     val ir = streamIR.deepCopy()
     InferPType(ir, Env.empty)
-    val optStream = ExecuteContext.scoped { ctx =>
+    val optStream = ExecuteContext.scoped() { ctx =>
       TypeCheck(ir)
       EmitStream(new Emit(ctx, fb.ecb), mb, ir, Env.empty, EmitRegion.default(mb), None)
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -13,7 +13,7 @@ import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.expr.Nat
 import is.hail.expr.types.encoded.{EArray, EBaseStruct, EBinary, EField, EFloat32, EFloat64, EInt32, EInt64, EType}
-import is.hail.io.bgen.MatrixBGENReader
+import is.hail.io.bgen.{IndexBgen, MatrixBGENReader}
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.linalg.BlockMatrix
 import is.hail.methods._
@@ -2499,7 +2499,7 @@ class IRSuite extends HailSuite {
 
   @DataProvider(name = "valueIRs")
   def valueIRs(): Array[Array[IR]] = {
-    hc.indexBgen(FastIndexedSeq("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
+    IndexBgen(ctx, Array("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
 
     val b = True()
     val c = Ref("c", TBoolean)
@@ -2733,7 +2733,7 @@ class IRSuite extends HailSuite {
   @DataProvider(name = "matrixIRs")
   def matrixIRs(): Array[Array[MatrixIR]] = {
     try {
-      hc.indexBgen(FastIndexedSeq("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
+      IndexBgen(ctx, Array("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
 
       val tableRead = TableIR.read(hc, "src/test/resources/backward_compatability/1.0.0/table/0.ht")
       val read = MatrixIR.read(hc, "src/test/resources/backward_compatability/1.0.0/matrix_table/0.hmt")
@@ -3173,7 +3173,7 @@ class IRSuite extends HailSuite {
         |       (MakeStruct (locus  (Apply start Locus(GRCh37) (Ref __uid_3))))
         |       (MakeStruct (locus  (Apply end Locus(GRCh37) (Ref __uid_3)))) (True) (False))))
         |""".stripMargin)
-    val (v, _) = HailContext.backend.execute(ir, optimize = true)
+    val (v, _) = HailContext.sparkBackend().execute(ir, optimize = true)
     assert(
       ir.typ.ordering.equiv(
         FastIndexedSeq(

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -90,7 +90,7 @@ class RandomFunctionsSuite extends HailSuite {
       Interval(Row(10), Row(14), false, true))
     val newPartitioner = mapped.partitioner.copy(rangeBounds=newRangeBounds)
 
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       val repartitioned = mapped.repartition(newPartitioner, ctx)
       val cachedAndRepartitioned = mapped.cache().repartition(newPartitioner, ctx)
 

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -33,7 +33,7 @@ class PartitioningSuite extends HailSuite {
     val rvdType = nonEmptyRVD.typ
     val emptyRVD = RVD.empty(hc.sc, rvdType)
 
-    ExecuteContext.scoped { ctx =>
+    ExecuteContext.scoped() { ctx =>
       emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
       emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
       nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()


### PR DESCRIPTION
Summary of changes:
 - Added index_bgen to Python Backend
 - Move most Backend functions to SparkBackend.  Everything about the current code assumes a single user, but the ServiceBackend will have a different, mutli-user interface.
 - Added Backend and FS to ExecuteContext.
 - renamed Backend clear => stop
