### PR TITLE
Use -Wl,--as-needed in linking native libs

### DIFF
--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -126,7 +126,7 @@ endif
 CXXFLAGS += $(HAIL_OPT_FLAGS) $(CXXSTD) -I$(LIBSIMDPP) -Wall -Wextra
 CXXFLAGS += -fPIC -ggdb -fno-strict-aliasing
 CXXFLAGS += -I../resources/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(JAVA_MD)
-LIBFLAGS += -fvisibility=default
+LIBFLAGS += -Wl,--as-needed -fvisibility=default
 PREBUILT := ../../../prebuilt
 
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
Allows the addition of other libs easily via `LIBFLAGS`. Generally the
order of arguments is important when linking. If `foo.o` contains a symbol
in zlib, then `-lz` must appear on the command line after foo.o. Passing
`--as-needed` to the linker gets around this, at the cost of potentially more
cpu and memory use during linking.