### PR TITLE
[query] simplify fs interface

### DIFF
--- a/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
+++ b/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
@@ -281,7 +281,13 @@ public class BGzipInputStream extends SplitCompressionInputStream {
         final long compOff = BlockCompressedFilePointerUtil.getBlockAddress(pos);
         final int uncompOff = BlockCompressedFilePointerUtil.getBlockOffset(pos);
         if (inputBufferInPos != compOff) {
-            ((Seekable) in).seek(compOff);
+            if (in instanceof Seekable)
+                ((Seekable) in).seek(compOff);
+            else {
+                assert(in instanceof SeekableStream);
+                ((SeekableStream) in).seek(compOff);
+            }
+
             inputBufferSize = 0;
             inputBufferPos = 0;
             inputBufferInPos = compOff;

--- a/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
+++ b/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
@@ -1,6 +1,7 @@
 package is.hail.io.compress;
 
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import is.hail.io.fs.SeekableStream;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.io.compress.SplitCompressionInputStream;
 import org.apache.hadoop.io.compress.SplittableCompressionCodec;
@@ -101,7 +102,12 @@ public class BGzipInputStream extends SplitCompressionInputStream {
         super(in, start, end);
 
         assert (readMode == SplittableCompressionCodec.READ_MODE.BYBLOCK);
-        ((Seekable) in).seek(start);
+        if (in instanceof Seekable)
+            ((Seekable) in).seek(start);
+        else {
+            assert(in instanceof SeekableStream);
+            ((SeekableStream)in).seek(start);
+        }
         resetState();
         decompressNextBlock();
 
@@ -232,7 +238,13 @@ public class BGzipInputStream extends SplitCompressionInputStream {
     public void resetState() throws IOException {
         inputBufferSize = 0;
         inputBufferPos = 0;
-        inputBufferInPos = ((Seekable) in).getPos();
+
+        if (in instanceof Seekable)
+            inputBufferInPos = ((Seekable) in).getPos();
+        else {
+            assert (in instanceof SeekableStream);
+            inputBufferInPos = ((SeekableStream) in).getPosition();
+        }
 
         outputBufferSize = 0;
         outputBufferPos = 0;

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -676,7 +676,7 @@ class HailContext private(
       override def compute(split: Partition, context: TaskContext): Iterator[T] = {
         val p = split.asInstanceOf[FilePartition]
         val filename = path + "/parts/" + p.file
-        val in = localFS.value.unsafeReader(filename)
+        val in = localFS.value.open(filename)
         read(p.index, in, context.taskMetrics().inputMetrics)
       }
 
@@ -707,7 +707,7 @@ class HailContext private(
       val idxname = s"$path/$idxPath/${ p.file }.idx"
       val filename = s"$path/parts/${ p.file }"
       val idxr = mkIndexReader(fs, idxname, 8) // default cache capacity
-      val in = fs.unsafeReader(filename)
+      val in = fs.open(filename)
       (in, idxr, p.bounds, context.taskMetrics().inputMetrics)
     })
   }
@@ -795,8 +795,8 @@ class HailContext private(
         val idxname = s"$pathRows/${ indexSpecRows.get.relPath }/${ p.file }.idx"
         mk(fs, idxname, 8) // default cache capacity
       }
-      val inRows = fs.unsafeReader(s"$pathRows/parts/${ p.file }")
-      val inEntries = fs.unsafeReader(s"$pathEntries/parts/${ p.file }")
+      val inRows = fs.open(s"$pathRows/parts/${ p.file }")
+      val inEntries = fs.open(s"$pathEntries/parts/${ p.file }")
       (inRows, inEntries, idxr, p.bounds, context.taskMetrics().inputMetrics)
     })
 

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -30,7 +30,7 @@ object RelationalSpec {
     if (!hc.sFS.isDir(path))
       fatal(s"MatrixTable and Table files are directories; path '$path' is not a directory")
     val metadataFile = path + "/metadata.json.gz"
-    val jv = hc.sFS.readFile(metadataFile) { in => parse(in) }
+    val jv = using(hc.sFS.open(metadataFile)) { in => parse(in) }
 
     val fileVersion = jv \ "file_version" match {
       case JInt(rep) => SemanticVersion(rep.toInt)
@@ -84,7 +84,7 @@ abstract class RelationalSpec {
   def partitionCounts: Array[Long] = getComponent[PartitionCountsComponentSpec]("partition_counts").counts.toArray
 
   def write(fs: is.hail.io.fs.FS, path: String) {
-    fs.writeTextFile(path + "/metadata.json.gz") { out =>
+    using(fs.create(path + "/metadata.json.gz")) { out =>
       Serialization.write(this, out)(RelationalSpec.formats)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1876,7 +1876,7 @@ private class Emit[C](
       case x@ReadValue(path, spec, requestedType) =>
         val p = emit(path)
         val pathString = coerce[PString](path.pType).loadString(p.value[Long])
-        val rowBuf = spec.buildCodeInputBuffer(mb.getUnsafeReader(pathString, true))
+        val rowBuf = spec.buildCodeInputBuffer(mb.open(pathString, true))
         val (pt, dec) = spec.buildEmitDecoderF(requestedType, mb.ecb, typeToTypeInfo(x.pType))
         EmitCode(p.setup, p.m, PCode(pt,
           Code.memoize(rowBuf, "read_ib") { ib =>
@@ -1904,7 +1904,7 @@ private class Emit[C](
                   (!taskCtx.isNull).orEmpty(
                     pv := pv.concat("-").concat(taskCtx.invoke[String]("partSuffix")))
                 },
-                rb := spec.buildCodeOutputBuffer(mb.getUnsafeWriter(pv)),
+                rb := spec.buildCodeOutputBuffer(mb.create(pv)),
                 vti match {
                   case vti: TypeInfo[t] =>
                     val enc = spec.buildEmitEncoderF(value.pType, mb.ecb, vti)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -151,11 +151,11 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder with WrappedCl
     body: (EmitMethodBuilder[_], Code[A1], Code[A2]) => Code[R]
   ): (Code[A1], Code[A2]) => Code[R] = ecb.wrapInEmitMethod[A1, A2, R](baseName, body)
 
-  def getUnsafeReader(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
-    getFS.invoke[String, Boolean, InputStream]("unsafeReader", path, checkCodec)
+  def open(path: Code[String], checkCodec: Code[Boolean]): Code[InputStream] =
+    getFS.invoke[String, Boolean, InputStream]("open", path, checkCodec)
 
-  def getUnsafeWriter(path: Code[String]): Code[OutputStream] =
-    getFS.invoke[String, OutputStream]("unsafeWriter", path)
+  def create(path: Code[String]): Code[OutputStream] =
+    getFS.invoke[String, OutputStream]("create", path)
 
   def genDependentFunction[A1: TypeInfo, A2: TypeInfo, R: TypeInfo](
     baseName: String = null

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -665,7 +665,7 @@ object EmitStream {
               EmitCode.present(eltType, _),
               setup0 = None,
               setup = Some(xRowBuf := spec
-                .buildCodeInputBuffer(mb.getUnsafeReader(pathString, true))))
+                .buildCodeInputBuffer(mb.open(pathString, true))))
 
             SizedStream(stream, None)
           }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -95,7 +95,7 @@ case class MatrixValue(
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
     colsSpec.write(fs, path)
 
-    fs.writeTextFile(path + "/_SUCCESS")(out => ())
+    using(fs.create(path + "/_SUCCESS"))(out => ())
   }
 
   private def writeGlobals(fs: FS, path: String, bufferSpec: BufferSpec) {
@@ -113,7 +113,7 @@ case class MatrixValue(
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
     globalsSpec.write(fs, path)
 
-    fs.writeTextFile(path + "/_SUCCESS")(out => ())
+    using(fs.create(path + "/_SUCCESS"))(out => ())
   }
 
   private def finalizeWrite(
@@ -136,7 +136,7 @@ case class MatrixValue(
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
     rowsSpec.write(fs, path + "/rows")
 
-    fs.writeTextFile(path + "/rows/_SUCCESS")(out => ())
+    using(fs.create(path + "/rows/_SUCCESS"))(out => ())
 
     val entriesSpec = TableSpec(
       FileFormat.version.rep,
@@ -148,7 +148,7 @@ case class MatrixValue(
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
     entriesSpec.write(fs, path + "/entries")
 
-    fs.writeTextFile(path + "/entries/_SUCCESS")(out => ())
+    using(fs.create(path + "/entries/_SUCCESS"))(out => ())
 
     fs.mkDir(path + "/cols")
     writeCols(fs, path + "/cols", bufferSpec)
@@ -173,7 +173,7 @@ case class MatrixValue(
 
     writeNativeFileReadMe(path)
 
-    fs.writeTextFile(path + "/_SUCCESS")(out => ())
+    using(fs.create(path + "/_SUCCESS"))(out => ())
 
     val nRows = partitionCounts.sum
     info(s"wrote matrix table with $nRows ${ plural(nRows, "row") } " +

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream, InputStream}
+import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream}
 
 import is.hail.HailContext
 import is.hail.annotations._
@@ -14,8 +14,6 @@ import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, BlockMatrixReadRowBlock
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
-import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
-import org.apache.hadoop.io.IOUtils
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.storage.StorageLevel

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -102,7 +102,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
 
     writeNativeFileReadMe(path)
 
-    fs.writeTextFile(path + "/_SUCCESS")(out => ())
+    using(fs.create(path + "/_SUCCESS"))(out => ())
 
     val nRows = partitionCounts.sum
     info(s"wrote table with $nRows ${ plural(nRows, "row") } " +

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
@@ -1,5 +1,7 @@
 package is.hail.expr.ir.functions
 
+import java.io.DataOutputStream
+
 import is.hail.HailContext
 import is.hail.expr.ir.{ExecuteContext, MatrixValue}
 import is.hail.expr.types.MatrixType
@@ -49,7 +51,7 @@ case class MatrixWriteBlockMatrix(path: String,
     blockPartFiles.foreach { case (i, f) => partFiles(i) = f }
 
     // write metadata
-    fs.writeDataFile(path + BlockMatrix.metadataRelativePath) { os =>
+    using(new DataOutputStream(fs.create(path + BlockMatrix.metadataRelativePath))) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
         BlockMatrixMetadata(blockSize, nRows, localNCols, gp.maybeBlocks, partFiles),
@@ -59,7 +61,7 @@ case class MatrixWriteBlockMatrix(path: String,
     assert(blockCount == gp.numPartitions)
     info(s"Wrote all $blockCount blocks of $nRows x $localNCols matrix with block size $blockSize.")
 
-    fs.writeTextFile(path + "/_SUCCESS")(out => ())
+    using(fs.create(path + "/_SUCCESS"))(out => ())
 
     null
   }

--- a/hail/src/main/scala/is/hail/io/HadoopFSDataBinaryReader.scala
+++ b/hail/src/main/scala/is/hail/io/HadoopFSDataBinaryReader.scala
@@ -1,22 +1,18 @@
 package is.hail.io
 
-import java.io.InputStream
+import is.hail.io.fs.SeekableDataInputStream
 
-import org.apache.hadoop.fs.FSDataInputStream
-
-class HadoopFSDataBinaryReader(is: InputStream) extends AbstractBinaryReader {
-
-  val fis = new FSDataInputStream(is)
+class HadoopFSDataBinaryReader(fis: SeekableDataInputStream) extends AbstractBinaryReader with AutoCloseable {
 
   override def read(): Int = fis.read()
 
   override def read(byteArray: Array[Byte], hasRead: Int, toRead: Int): Int = fis.read(byteArray, hasRead, toRead)
 
-  def close() = fis.close()
+  def close(): Unit = fis.close()
 
-  def seek(pos: Long) = fis.seek(pos)
+  def seek(pos: Long): Unit = fis.seek(pos)
 
   def skipBytes(bytes: Long): Long = fis.skip(bytes)
 
-  def getPosition: Long = fis.getPos
+  def getPosition: Long = fis.getPosition
 }

--- a/hail/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/hail/src/main/scala/is/hail/io/IndexBTree.scala
@@ -1,6 +1,6 @@
 package is.hail.io
 
-import java.io.Closeable
+import java.io.{Closeable, DataOutputStream}
 import java.util.Arrays
 
 import is.hail.utils._
@@ -78,7 +78,7 @@ object IndexBTree {
     fileName: String,
     fs: FS,
     branchingFactor: Int = 1024
-  ): Unit = fs.writeDataFile(fileName) { w =>
+  ): Unit = using(new DataOutputStream(fs.create(fileName))) { w =>
     w.write(btreeBytes(arr, branchingFactor))
   }
 

--- a/hail/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/hail/src/main/scala/is/hail/io/IndexBTree.scala
@@ -5,6 +5,7 @@ import java.util.Arrays
 
 import is.hail.utils._
 import is.hail.io.fs.FS
+import org.apache.hadoop.fs.FSDataInputStream
 
 import scala.collection.mutable
 
@@ -90,13 +91,13 @@ object IndexBTree {
 
 class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) extends Closeable {
   val maxDepth = calcDepth()
-  private val fileSystem = try {
-    fs.fileSystem(indexFileName).open
+  private val is = try {
+    new FSDataInputStream(fs.open(indexFileName))
   } catch {
     case e: Exception => fatal(s"Could not find a BGEN .idx file at $indexFileName. Try running HailContext.index_bgen().", e)
   }
 
-  def close() = fileSystem.close()
+  def close(): Unit = is.close()
 
   def calcDepth(): Int =
     IndexBTree.calcDepth(fs.getFileSize(indexFileName) / 8, branchingFactor)
@@ -113,7 +114,7 @@ class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) ext
 
     def searchBlock(): Long = {
       def read(prevValue: Long, prevPos: Long): Long = {
-        val currValue = fileSystem.readLong()
+        val currValue = is.readLong()
 
         if (currentDepth != maxDepth && query >= prevValue && (query < currValue || currValue == -1L))
           prevPos
@@ -125,8 +126,8 @@ class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) ext
           read(currValue, prevPos + 8)
       }
 
-      fileSystem.seek(startIndex)
-      val firstValue = fileSystem.readLong()
+      is.seek(startIndex)
+      val firstValue = is.readLong()
       if (currentDepth != maxDepth && query >= 0L && query <= firstValue)
         startIndex
       else if (currentDepth == maxDepth && query >= 0L && query <= firstValue)
@@ -137,7 +138,7 @@ class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) ext
 
     def searchLastBlock(): (Long, Long) = {
       def read(prevValue: Long, prevPos: Long): (Long, Long) = {
-        val currValue = fileSystem.readLong()
+        val currValue = is.readLong()
 
         if (query <= currValue || currValue == -1L)
           (prevPos + 8, currValue)
@@ -147,8 +148,8 @@ class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) ext
           read(currValue, prevPos + 8)
       }
 
-      fileSystem.seek(startIndex)
-      val firstValue = fileSystem.readLong()
+      is.seek(startIndex)
+      val firstValue = is.readLong()
       if (query >= 0L && query <= firstValue)
         (startIndex, firstValue)
       else
@@ -221,9 +222,9 @@ class OnDiskBTreeIndexToValue(
 
   private[this] val layers = numLayers(fs.getFileSize(path) / 8)
   private[this] val junk = leadingElements(layers - 1)
-  private[this] var fileSystem = try {
+  private[this] var is = try {
     log.info("reading index file: " + path)
-    fs.fileSystem(path).open
+    new FSDataInputStream(fs.open(path))
   } catch {
     case e: Exception =>
       fatal(s"Could not find a BGEN .idx file at $path. Try running HailContext.index_bgen().", e)
@@ -236,8 +237,8 @@ class OnDiskBTreeIndexToValue(
       a
     } else {
       Arrays.sort(indices)
-      fileSystem.seek((junk + indices(0)) * 8)
-      a(0) = fileSystem.readLong()
+      is.seek((junk + indices(0)) * 8)
+      a(0) = is.readLong()
       assert(a(0) != -1)
       var i = 1
       while (i < indices.length) {
@@ -246,8 +247,8 @@ class OnDiskBTreeIndexToValue(
         } else {
           val jump = (indices(i) - indices(i - 1) - 1) * 8
           assert(jump >= 0)
-          fileSystem.skipBytes(jump)
-          a(i) = fileSystem.readLong()
+          is.skipBytes(jump)
+          a(i) = is.readLong()
           assert(a(i) != -1)
         }
         i += 1
@@ -257,9 +258,9 @@ class OnDiskBTreeIndexToValue(
   }
 
   override def close(): Unit = synchronized {
-    if (fileSystem != null) {
-      fileSystem.close()
-      fileSystem = null
+    if (is != null) {
+      is.close()
+      is = null
     }
   }
 }

--- a/hail/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/hail/src/main/scala/is/hail/io/IndexBTree.scala
@@ -92,7 +92,7 @@ object IndexBTree {
 class IndexBTree(indexFileName: String, fs: FS, branchingFactor: Int = 1024) extends Closeable {
   val maxDepth = calcDepth()
   private val is = try {
-    new FSDataInputStream(fs.open(indexFileName))
+    fs.openNoCompression(indexFileName)
   } catch {
     case e: Exception => fatal(s"Could not find a BGEN .idx file at $indexFileName. Try running HailContext.index_bgen().", e)
   }
@@ -224,7 +224,7 @@ class OnDiskBTreeIndexToValue(
   private[this] val junk = leadingElements(layers - 1)
   private[this] var is = try {
     log.info("reading index file: " + path)
-    new FSDataInputStream(fs.open(path))
+    fs.openNoCompression(path)
   } catch {
     case e: Exception =>
       fatal(s"Could not find a BGEN .idx file at $path. Try running HailContext.index_bgen().", e)

--- a/hail/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/hail/src/main/scala/is/hail/io/IndexBTree.scala
@@ -5,7 +5,6 @@ import java.util.Arrays
 
 import is.hail.utils._
 import is.hail.io.fs.FS
-import org.apache.hadoop.fs.FSDataInputStream
 
 import scala.collection.mutable
 

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -92,11 +92,11 @@ object RichContextRDDRegionValue {
       } else
         (finalRowsPartPath, finalEntriesPartPath, finalIdxPath)
 
-    val rowCount = fs.writeFile(rowsPartPath) { rowsOS =>
+    val rowCount = using(fs.create(rowsPartPath)) { rowsOS =>
       val trackedRowsOS = new ByteTrackingOutputStream(rowsOS)
       using(makeRowsEnc(trackedRowsOS)) { rowsEN =>
 
-        fs.writeFile(entriesPartPath) { entriesOS =>
+        using(fs.create(entriesPartPath)) { entriesOS =>
           val trackedEntriesOS = new ByteTrackingOutputStream(entriesOS)
           using(makeEntriesEnc(trackedEntriesOS)) { entriesEN =>
             using(makeIndexWriter(fs, idxPath)) { iw =>

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -43,7 +43,7 @@ object TextMatrixReader {
     nRowFields: Int,
     opts: TextMatrixReaderOptions
   ): HeaderInfo = {
-    val maybeFirstTwoLines = fs.readFile(file) { s =>
+    val maybeFirstTwoLines = using(fs.open(file)) { s =>
       Source.fromInputStream(s).getLines().filter(!opts.isComment(_)).take(2).toArray.toSeq }
 
     (opts.hasHeader, maybeFirstTwoLines) match {

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -28,7 +28,7 @@ trait BgenPartition extends Partition {
   def bcFS: Broadcast[FS]
 
   def makeInputStream: HadoopFSDataBinaryReader = {
-    new HadoopFSDataBinaryReader(bcFS.value.open(path))
+    new HadoopFSDataBinaryReader(bcFS.value.openNoCompression(path))
   }
 
   def recodeContig(contig: String): String = contigRecoding.getOrElse(contig, contig)

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -28,9 +28,7 @@ trait BgenPartition extends Partition {
   def bcFS: Broadcast[FS]
 
   def makeInputStream: HadoopFSDataBinaryReader = {
-    val fileSystem = bcFS.value.fileSystem(path)
-    val bfis = new HadoopFSDataBinaryReader(fileSystem.open)
-    bfis
+    new HadoopFSDataBinaryReader(bcFS.value.open(path))
   }
 
   def recodeContig(contig: String): String = contigRecoding.getOrElse(contig, contig)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -50,7 +50,7 @@ object LoadBgen {
   def readSamples(fs: is.hail.io.fs.FS, file: String): Array[String] = {
     val bState = readState(fs, file)
     if (bState.hasIds) {
-      fs.readFile(file) { is =>
+      using(fs.open(file)) { is =>
         val reader = new HadoopFSDataBinaryReader(is)
 
         reader.seek(bState.headerLength + 4)
@@ -75,7 +75,7 @@ object LoadBgen {
   }
 
   def readSampleFile(fs: is.hail.io.fs.FS, file: String): Array[String] = {
-    fs.readFile(file) { s =>
+    using(fs.open(file)) { s =>
       Source.fromInputStream(s)
         .getLines()
         .drop(2)
@@ -89,7 +89,7 @@ object LoadBgen {
   }
 
   def readState(fs: is.hail.io.fs.FS, file: String): BgenHeader = {
-    fs.readFile(file) { is =>
+    using(fs.open(file)) { is =>
       val reader = new HadoopFSDataBinaryReader(is)
       readState(reader, file, fs.getFileSize(file))
     }

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -7,6 +7,18 @@ import is.hail.utils._
 
 import scala.io.Source
 
+trait PositionedStream {
+  def getPosition: Long
+}
+
+trait SeekableStream extends PositionedStream {
+  def seek(pos: Long): Unit
+}
+
+abstract class SeekableDataInputStream(is: InputStream) extends DataInputStream(is) with SeekableStream
+
+abstract class PositionedDataOutputStream(os: OutputStream) extends DataOutputStream(os) with PositionedStream
+
 trait FileStatus {
   def getPath: String
   def getModificationTime: Long
@@ -23,11 +35,11 @@ trait FS extends Serializable {
 
   def getProperties: Iterator[util.Map.Entry[String, String]]
 
-  def openNoCompression(filename: String): InputStream
+  def openNoCompression(filename: String): SeekableDataInputStream
 
   def open(filename: String, checkCodec: Boolean = true): InputStream
 
-  def createNoCompression(filename: String): OutputStream
+  def createNoCompression(filename: String): PositionedDataOutputStream
 
   def create(filename: String): OutputStream
 

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -58,8 +58,6 @@ trait FS extends Serializable {
 
   def listStatus(filename: String): Array[FileStatus]
 
-  def getFileSize(filename: String): Long
-
   def getTemporaryFile(tmpdir: String, nChar: Int = 10,
     prefix: Option[String] = None, suffix: Option[String] = None): String
 
@@ -89,6 +87,8 @@ trait FS extends Serializable {
   def makeQualified(path: String): String
 
   def deleteOnExit(path: String): Unit
+
+  def getFileSize(filename: String): Long = fileStatus(filename).getLen
 
   def readLines[T](filename: String, filtAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace())(reader: Iterator[WithContext[String]] => T): T = {
     using(open(filename)) {

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -50,7 +50,7 @@ trait FS extends Serializable {
 
   def delete(filename: String, recursive: Boolean)
 
-  def exists(files: String*): Boolean
+  def exists(files: String): Boolean
 
   def isFile(filename: String): Boolean
 

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -6,21 +6,11 @@ import java.util
 import is.hail.utils.{TextInputFilterAndReplace, WithContext}
 import net.jpountz.lz4.LZ4Compressor
 import com.esotericsoftware.kryo.io.{Input, Output}
-import org.apache.hadoop.fs.{ FSDataInputStream, FSDataOutputStream }
+import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
 
-trait FileSystem {
-  def open: FSDataInputStream
-  def open(path: FilePath): FSDataInputStream
-  def open(path: String): FSDataInputStream
-
-  def getPath(path: String): FilePath
-  def makeQualified(path: String): FilePath
-  def makeQualified(path: FilePath): FilePath
-  def deleteOnExit(path: FilePath): Boolean
-}
 
 trait FileStatus {
-  def getPath: FilePath
+  def getPath: String
   def getModificationTime: Long
   def getLen: Long
   def isDirectory: Boolean
@@ -28,22 +18,15 @@ trait FileStatus {
   def getOwner: String
 }
 
-trait FilePath extends Serializable{
-  type Configuration
-
-  def toString: String
-  def getName: String
-  def getFileSystem(conf: Configuration): FileSystem
-}
-
-trait FS extends Serializable{
+trait FS extends Serializable {
   def getProperty(name: String): String
 
   def setProperty(name: String, value: String): Unit
 
   def getProperties: Iterator[util.Map.Entry[String, String]]
 
-  protected def open(filename: String, checkCodec: Boolean = true): InputStream
+  def open(filename: String, checkCodec: Boolean = true): InputStream
+
   /**
     * @return true if a new directory was created, false otherwise
     **/
@@ -59,8 +42,6 @@ trait FS extends Serializable{
 
   def listStatus(filename: String): Array[FileStatus]
 
-  def fileSystem(filename: String): FileSystem
-
   def getFileSize(filename: String): Long
 
   def getTemporaryFile(tmpdir: String, nChar: Int = 10,
@@ -74,12 +55,12 @@ trait FS extends Serializable{
 
   def copy(src: String, dst: String, deleteSource: Boolean = false): Unit
 
-  def copyMerge( sourceFolder: String,
-                 destinationFile: String,
-                 numPartFilesExpected: Int,
-                 deleteSource: Boolean = true,
-                 header: Boolean = true,
-                 partFilesOpt: Option[IndexedSeq[String]] = None ): Unit
+  def copyMerge(sourceFolder: String,
+    destinationFile: String,
+    numPartFilesExpected: Int,
+    deleteSource: Boolean = true,
+    header: Boolean = true,
+    partFilesOpt: Option[IndexedSeq[String]] = None): Unit
 
   def copyMergeList(srcFileStatuses: Array[FileStatus], destFilename: String, deleteSource: Boolean = true)
 
@@ -122,5 +103,8 @@ trait FS extends Serializable{
   def unsafeReader(filename: String, checkCodec: Boolean = true): InputStream
 
   def unsafeWriter(filename: String): OutputStream
-}
 
+  def makeQualified(path: String): String
+
+  def deleteOnExit(path: String): Unit
+}

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -103,9 +103,6 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
     new hadoop.fs.Path(filename).getFileSystem(conf.value)
   }
 
-  def getFileSize(filename: String): Long =
-    fileStatus(filename).getLen
-
   def listStatus(filename: String): Array[FileStatus] = {
     val fs = getFileSystem(filename)
     val hPath = new hadoop.fs.Path(filename)

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -124,8 +124,9 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
     fs.isFile(hPath)
   }
 
-  def exists(files: String*): Boolean = {
-    files.forall(filename => getFileSystem(filename).exists(new hadoop.fs.Path(filename)))
+  def exists(file: String): Boolean = {
+    val path = new hadoop.fs.Path(file)
+    path.getFileSystem(conf.value).exists(path)
   }
 
   /**

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -339,7 +339,7 @@ object ExportBGEN {
             partFile(d, i))
 
       var dropped = 0L
-      using(bcFS.value.unsafeWriter(pf)) { out =>
+      using(bcFS.value.create(pf)) { out =>
         val bpw = new BgenPartitionWriter(localRVRowPType, nSamples)
 
         if (exportType == ExportType.PARALLEL_HEADER_IN_SHARD) {
@@ -364,7 +364,7 @@ object ExportBGEN {
       warn(s"Set $dropped genotypes to missing: total GP probability did not lie in [0.999, 1.001].")
 
     if (exportType == ExportType.PARALLEL_SEPARATE_HEADER) {
-      using(fs.unsafeWriter(parallelOutputPath + "/header")) { out =>
+      using(fs.create(parallelOutputPath + "/header")) { out =>
         out.write(
           BgenWriter.headerBlock(sampleIds, nVariants))
       }
@@ -372,12 +372,12 @@ object ExportBGEN {
 
     if (exportType == ExportType.CONCATENATED) {
       val (_, dt) = time {
-        using(fs.unsafeWriter(path + ".bgen")) { out =>
+        using(fs.create(path + ".bgen")) { out =>
           out.write(
             BgenWriter.headerBlock(sampleIds, nVariants))
 
           files.foreach { f =>
-            using(fs.unsafeReader(f)) { in =>
+            using(fs.open(f)) { in =>
               IOUtils.copyBytes(in, out, 4096)
             }
           }

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -39,7 +39,7 @@ object IndexReaderBuilder {
 
 object IndexReader {
   def readUntyped(fs: FS, path: String): IndexMetadataUntypedJSON = {
-    val jv = fs.readFile(path + "/metadata.json.gz") { in =>
+    val jv = using(fs.open(path + "/metadata.json.gz")) { in =>
       JsonMethods.parse(in)
         .removeField{ case (f, _) => f == "keyType" || f == "annotationType" }
     }
@@ -53,7 +53,7 @@ object IndexReader {
   }
 
   def readTypes(fs: FS, path: String): (Type, Type) = {
-    val jv = fs.readFile(path + "/metadata.json.gz") { in => JsonMethods.parse(in) }
+    val jv = using(fs.open(path + "/metadata.json.gz")) { in => JsonMethods.parse(in) }
     implicit val formats: Formats = defaultJSONFormats + new TypeSerializer
     val metadata = jv.extract[IndexMetadata]
     metadata.keyType -> metadata.annotationType
@@ -79,7 +79,7 @@ class IndexReader(fs: FS,
   val indexRelativePath = metadata.indexPath
   val ordering = keyType.ordering
 
-  private val is = fs.unsafeReader(path + "/" + indexRelativePath).asInstanceOf[FSDataInputStream]
+  private val is = fs.open(path + "/" + indexRelativePath).asInstanceOf[FSDataInputStream]
   private val leafDecoder = leafDecoderBuilder(is)
   private val internalDecoder = internalDecoderBuilder(is)
 

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -79,7 +79,7 @@ class IndexReader(fs: FS,
   val indexRelativePath = metadata.indexPath
   val ordering = keyType.ordering
 
-  private val is = fs.open(path + "/" + indexRelativePath).asInstanceOf[FSDataInputStream]
+  private val is = fs.openNoCompression(path + "/" + indexRelativePath)
   private val leafDecoder = leafDecoderBuilder(is)
   private val internalDecoder = internalDecoderBuilder(is)
 

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -118,7 +118,7 @@ class IndexWriter(
   private val internalNodeBuilders = new ArrayBuilder[InternalNodeBuilder]()
   internalNodeBuilders += new InternalNodeBuilder(keyType, annotationType)
 
-  private val trackedOS = new ByteTrackingOutputStream(fs.unsafeWriter(path + "/index"))
+  private val trackedOS = new ByteTrackingOutputStream(fs.create(path + "/index"))
 
   private val leafEncoder = makeLeafEncoder(trackedOS)
   private val internalEncoder = makeInternalEncoder(trackedOS)
@@ -209,7 +209,7 @@ class IndexWriter(
   }
 
   private def writeMetadata(rootOffset: Long) = {
-    fs.writeTextFile(path + "/metadata.json.gz") { out =>
+    using(fs.create(path + "/metadata.json.gz")) { out =>
       val metadata = IndexMetadata(
         IndexWriter.version.rep,
         branchingFactor,

--- a/hail/src/main/scala/is/hail/io/package.scala
+++ b/hail/src/main/scala/is/hail/io/package.scala
@@ -1,5 +1,7 @@
 package is.hail
 
+import java.io.OutputStreamWriter
+
 import is.hail.expr.types.virtual.Type
 import is.hail.utils._
 import is.hail.io.fs.FS
@@ -11,7 +13,7 @@ package object io {
 
   def exportTypes(filename: String, fs: FS, info: Array[(String, Type)]) {
     val sb = new StringBuilder
-    fs.writeTextFile(filename) { out =>
+    using(new OutputStreamWriter(fs.create(filename))) { out =>
       info.foreachBetween { case (name, t) =>
         sb.append(prettyIdentifier(name))
         sb.append(":")

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -85,8 +85,8 @@ object ExportPlink {
       val bimPartPath = tmpBimDir + "/" + f
       var rowCount = 0L
 
-      fs.writeTextFile(bimPartPath) { bimOS =>
-        fs.writeFile(bedPartPath) { bedOS =>
+      using(new OutputStreamWriter(fs.create(bimPartPath))) { bimOS =>
+        using(fs.create(bedPartPath)) { bedOS =>
           val v = new RegionValueVariant(fullRowType)
           val a = new BimAnnotationView(fullRowType)
           val hcv = HardCallView(fullRowType)
@@ -110,11 +110,11 @@ object ExportPlink {
 
     val nRecordsWritten = nRecordsWrittenPerPartition.sum
 
-    fs.writeFile(tmpBedDir + "/_SUCCESS")(out => ())
-    fs.writeFile(tmpBedDir + "/header")(out => out.write(ExportPlink.bedHeader))
+    using(fs.create(tmpBedDir + "/_SUCCESS"))(out => ())
+    using(fs.create(tmpBedDir + "/header"))(out => out.write(ExportPlink.bedHeader))
     fs.copyMerge(tmpBedDir, path + ".bed", nPartitions, header = true, partFilesOpt = Some(partFiles))
 
-    fs.writeTextFile(tmpBimDir + "/_SUCCESS")(out => ())
+    using(fs.create(tmpBimDir + "/_SUCCESS"))(out => ())
     fs.copyMerge(tmpBimDir, path + ".bim", nPartitions, header = false, partFilesOpt = Some(partFiles))
 
     ExecuteContext.scoped { ctx =>

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -156,7 +156,7 @@ case class MatrixPLINKReader(
   info(s"Found $nSamples samples in fam file.")
   info(s"Found $nVariants variants in bim file.")
 
-  hc.sFS.readFile(bed) { dis =>
+  using(hc.sFS.open(bed)) { dis =>
     val b1 = dis.read()
     val b2 = dis.read()
     val b3 = dis.read()

--- a/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
+++ b/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
@@ -41,8 +41,8 @@ object FASTAReader {
     val localFastaFile = tmpDir.createLocalTempFile(extension = "fasta")
     val uriLocalFastaFile = uriPath(localFastaFile)
 
-    fs.readFile(fastaFile) { in =>
-      fs.writeFile(localFastaFile) { out =>
+    using(fs.open(fastaFile)) { in =>
+      using(fs.create(localFastaFile)) { out =>
         IOUtils.copy(in, out)
       }}
 

--- a/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
+++ b/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
@@ -27,8 +27,8 @@ object LiftOver {
     val tmpDir = TempDir(fs)
     val localChainFile = tmpDir.createLocalTempFile(extension = "chain")
 
-    fs.readFile(chainFile) { in =>
-      fs.writeFile(localChainFile) { out =>
+    using(fs.open(chainFile)) { in =>
+      using(fs.create(localChainFile)) { out =>
         IOUtils.copy(in, out)
       }}
 

--- a/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
+++ b/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
@@ -103,7 +103,7 @@ class TabixReader(val filePath: String, fs: FS, idxFilePath: Option[String] = No
         fatal(s"unknown file extension for tabix index: $s")
   }
 
-  val index: Tabix = fs.readFile(indexPath) { is =>
+  val index: Tabix = using(fs.open(indexPath)) { is =>
     var buf = new Array[Byte](4)
     is.read(buf, 0, 4) // read magic bytes "TBI\1"
     if (!(Magic sameElements buf))
@@ -322,7 +322,7 @@ class TabixLineIterator(
   private var i: Int = -1
   private var curOff: Long = 0 // virtual file offset, not real offset
   private var isEof = false
-  private var is = new BGzipInputStream(bcFS.value.unsafeReader(filePath, checkCodec = false))
+  private var is = new BGzipInputStream(bcFS.value.open(filePath, checkCodec = false))
 
   def next(): String = {
     var s: String = null

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -301,7 +301,7 @@ object ExportVCF {
       }
 
       append.foreach { f =>
-        fs.readFile(f) { s =>
+        using(fs.open(f)) { s =>
           Source.fromInputStream(s)
             .getLines()
             .filterNot(_.isEmpty)

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -214,7 +214,7 @@ class ReadBlocksAsRowsRDD(path: String,
               if (pi >= 0) {
                 val filename = path + "/parts/" + partFiles(pi)
 
-                val is = bcFS.value.unsafeReader(filename)
+                val is = bcFS.value.open(filename)
                 val in = BlockMatrix.bufferSpec.buildInputBuffer(is)
 
                 val nColsInBlock = gp.blockColNCols(blockCol)

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -57,7 +57,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
         val partFolder = partFileBase + partFile(d, i, TaskContext.get())
 
         val fileHandles = Array.tabulate(endIdx - startIdx) { j =>
-          new OutputStreamWriter(bcFS.value.unsafeWriter(partFolder + "/" + j.toString + extension), "UTF-8")
+          new OutputStreamWriter(bcFS.value.create(partFolder + "/" + j.toString + extension), "UTF-8")
         }
 
         if (i == 0) {

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -31,7 +31,7 @@ case class VEPConfiguration(
 
 object VEP {
   def readConfiguration(fs: FS, path: String): VEPConfiguration = {
-    val jv = fs.readFile(path) { in =>
+    val jv = using(fs.open(path)) { in =>
       JsonMethods.parse(in)
     }
     implicit val formats = defaultJSONFormats + new TStructSerializer

--- a/hail/src/main/scala/is/hail/misc/BGZipBlocks.scala
+++ b/hail/src/main/scala/is/hail/misc/BGZipBlocks.scala
@@ -39,10 +39,8 @@ object BGZipBlocks {
       f()
     }
 
-    val fileSystem = fs.fileSystem(file)
-
     // no decompression codec
-    val is = fileSystem.open(file)
+    val is = fs.open(file)
 
     fillBuf(is)
 

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -39,7 +39,7 @@ object AbstractRVDSpec {
 
   def read(fs: is.hail.io.fs.FS, path: String): AbstractRVDSpec = {
     val metadataFile = path + "/metadata.json.gz"
-    fs.readFile(metadataFile) { in => JsonMethods.parse(in) }
+    using(fs.open(metadataFile)) { in => JsonMethods.parse(in) }
       .transformField { case ("orvdType", value) => ("rvdType", value) } // ugh
       .extract[AbstractRVDSpec]
   }
@@ -59,7 +59,7 @@ object AbstractRVDSpec {
     val (rType: PStruct, dec) = enc.buildDecoder(requestedType)
 
     val f = partPath(path, partFiles(0))
-    fs.readFile(f) { in =>
+    using(fs.open(f)) { in =>
       val Array(rv) = HailContext.readRowsPartition(dec)(r, in).toArray
       (rType, rv.offset)
     }
@@ -84,7 +84,7 @@ object AbstractRVDSpec {
     val codecSpec = TypedCodecSpec(rowType, bufferSpec)
 
     val part0Count =
-      fs.writeFile(partsPath + "/" + filePath) { os =>
+      using(fs.create(partsPath + "/" + filePath)) { os =>
         using(RVDContext.default) { ctx =>
           val rvb = ctx.rvb
           val region = ctx.region
@@ -187,7 +187,7 @@ abstract class AbstractRVDSpec {
     AbstractRVDSpec.readLocal(hc, path, typedCodecSpec, partFiles, requestedType, r)
 
   def write(fs: FS, path: String) {
-    fs.writeTextFile(path + "/metadata.json.gz") { out =>
+    using(fs.create(path + "/metadata.json.gz")) { out =>
       import AbstractRVDSpec.formats
       Serialization.write(this, out)
     }

--- a/hail/src/main/scala/is/hail/utils/ByteTrackingInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ByteTrackingInputStream.scala
@@ -1,6 +1,8 @@
 package is.hail.utils
 
 import java.io.InputStream
+
+import is.hail.io.fs.SeekableStream
 import org.apache.hadoop.fs.Seekable
 
 class ByteTrackingInputStream(base: InputStream) extends InputStream {
@@ -31,5 +33,12 @@ class ByteTrackingInputStream(base: InputStream) extends InputStream {
 
   override def close(): Unit = base.close()
 
-  def seek(offset: Long) = base.asInstanceOf[Seekable].seek(offset)
+  def seek(offset: Long): Unit = {
+    base match {
+      case base: Seekable =>
+        base.seek(offset)
+      case base: SeekableStream =>
+        base.seek(offset)
+    }
+  }
 }

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -104,14 +104,14 @@ trait Py4jUtils {
     (n / factor.toDouble).formatted("%.1f")
   }
 
-  def readFile(path: String, hc: HailContext, buffSize: Int): HadoopPyReader = hc.sFS.readFile(path) { in =>
-    new HadoopPyReader(hc.sFS.unsafeReader(path), buffSize)
+  def readFile(path: String, hc: HailContext, buffSize: Int): HadoopPyReader = using(hc.sFS.open(path)) { in =>
+    new HadoopPyReader(hc.sFS.open(path), buffSize)
   }
 
   def writeFile(path: String, hc: HailContext, exclusive: Boolean): HadoopPyWriter = {
     if (exclusive && hc.sFS.exists(path))
       fatal(s"a file already exists at '$path'")
-    new HadoopPyWriter(hc.sFS.unsafeWriter(path))
+    new HadoopPyWriter(hc.sFS.create(path))
   }
 
   def copyFile(from: String, to: String, hc: HailContext) {

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -38,13 +38,13 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
     size += a.length
     if (size > sizeLimit) {
       val file = hc.getTemporaryFile()
-      using(new FSDataOutputStream(fs.createNoCompression(file))) { os =>
+      using(fs.createNoCompression(file)) { os =>
         var k = 0
         while (k < buf.length) {
           val vals = buf(k)
           if (vals != null) {
             buf(k) = null
-            val pos = os.getPos
+            val pos = os.getPosition
             val oos = new ObjectOutputStream(os)
             oos.writeInt(vals.length)
             var j = 0
@@ -73,7 +73,7 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
         buf(i) = null
       } else {
         val (filename, pos) = files(i)
-        using(new FSDataInputStream(fs.openNoCompression(filename))) { is =>
+        using(fs.openNoCompression(filename)) { is =>
           is.seek(pos)
           using(new ObjectInputStream(is)) { ois =>
             val length = ois.readInt()

--- a/hail/src/main/scala/is/hail/utils/TempDir.scala
+++ b/hail/src/main/scala/is/hail/utils/TempDir.scala
@@ -2,11 +2,9 @@ package is.hail.utils
 
 import java.io.IOException
 
-import org.apache.hadoop
-
 import scala.util.Random
 
-import is.hail.io.fs.{FS, FilePath}
+import is.hail.io.fs.FS
 
 object TempDir {
   def createTempDir(tmpdir: String, fs: FS): String = {
@@ -19,11 +17,10 @@ object TempDir {
         } else {
           fs.mkDir(dir)
 
-          val fileSystem = fs.fileSystem(tmpdir)
-          val qDir = fileSystem.makeQualified(dir)
-          fileSystem.deleteOnExit(qDir)
+          val qDir = fs.makeQualified(dir)
+          fs.deleteOnExit(qDir)
 
-          return qDir.toString
+          return qDir
         }
       } catch {
         case e: IOException =>

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -726,7 +726,7 @@ package object utils extends Logging
     val hc = HailContext.get
     val dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
 
-    hc.sFS.writeTextFile(path + "/README.txt") { out =>
+    using(new OutputStreamWriter(hc.sFS.create(path + "/README.txt"))) { out =>
       out.write(
         s"""This folder comprises a Hail (www.hail.is) native Table or MatrixTable.
            |  Written with version ${ hc.version }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichArray.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichArray.scala
@@ -15,7 +15,7 @@ object RichArray {
   }
   
   def importFromDoubles(hc: HailContext, path: String, a: Array[Double], bufSize: Int): Unit = {
-    hc.sFS.readFile(path) { is =>
+    using(hc.sFS.open(path)) { is =>
       val in = new DoubleInputBuffer(is, bufSize)
 
       in.readDoubles(a)
@@ -26,7 +26,7 @@ object RichArray {
     exportToDoubles(fs, path, a, defaultBufSize)
 
   def exportToDoubles(fs: FS, path: String, a: Array[Double], bufSize: Int): Unit = {
-    fs.writeFile(path) { os =>
+    using(fs.create(path)) { os =>
       val out = new DoubleOutputBuffer(os, bufSize)
 
       out.writeDoubles(a)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -59,7 +59,7 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
           partPath -> idxPath
         } else
           finalFilename -> finalIdxFilename
-      val os = fs.unsafeWriter(filename)
+      val os = fs.create(filename)
       val iw = mkIdxWriter(fs, idxFilename)
       val count = write(ctx, it, os, iw)
       if (iw != null)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -1,6 +1,6 @@
 package is.hail.utils.richUtils
 
-import java.io.OutputStream
+import java.io.{OutputStream, OutputStreamWriter}
 
 import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
@@ -69,7 +69,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
 
     if (exportType == ExportType.PARALLEL_SEPARATE_HEADER) {
       val headerExt = fs.getCodec(filename)
-      fs.writeTextFile(parallelOutputPath + "/header" + headerExt) { out =>
+      using(new OutputStreamWriter(fs.create(parallelOutputPath + "/header" + headerExt))) { out =>
         header.foreach { h =>
           out.write(h)
           out.write('\n')

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -450,7 +450,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   override def toString: String = name
 
   def write(fs: is.hail.io.fs.FS, file: String): Unit =
-    fs.writeTextFile(file) { out =>
+    using(fs.create(file)) { out =>
       val jrg = JSONExtractReferenceGenome(name,
         contigs.map(contig => JSONExtractContig(contig, contigLength(contig))),
         xContigs, yContigs, mtContigs,
@@ -579,7 +579,7 @@ object ReferenceGenome {
   }
 
   def fromFile(hc: HailContext, file: String): ReferenceGenome = {
-    val rg = hc.sFS.readFile(file)(read)
+    val rg = using(hc.sFS.open(file))(read)
     addReference(rg)
     rg
   }
@@ -651,7 +651,7 @@ object ReferenceGenome {
       val rgs = mutable.Set[ReferenceGenome]()
       refs.foreach { fileSystem =>
         val rgPath = fileSystem.getPath.toString
-        val rg = fs.readFile(rgPath)(read)
+        val rg = using(fs.open(rgPath))(read)
         val name = rg.name
         if (ReferenceGenome.hasReference(name) && ReferenceGenome.getReference(name) != rg)
           fatal(s"'$name' already exists and is not identical to the imported reference from '$rgPath'.")

--- a/hail/src/test/scala/is/hail/io/IndexBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexBTreeSuite.scala
@@ -4,7 +4,6 @@ import is.hail.HailSuite
 import is.hail.check.Gen._
 import is.hail.check.Prop._
 import is.hail.check.Properties
-import is.hail.utils._
 import org.testng.annotations.Test
 
 import scala.language.implicitConversions

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -63,8 +63,8 @@ class BGzipCodecSuite extends HailSuite {
     val uncompIS = sFS.open(uncompPath)
     val uncomp = IOUtils.toByteArray(uncompIS)
     uncompIS.close()
-
-    val decompIS = new BGzipInputStream(sFS.open(compPath))
+    
+    val decompIS = new BGzipInputStream(sFS.openNoCompression(compPath))
     val decomp = IOUtils.toByteArray(decompIS)
     decompIS.close()
 

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -6,6 +6,7 @@ import is.hail.check.Prop.forAll
 import is.hail.utils._
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil
 import org.apache.commons.io.IOUtils
+import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.{hadoop => hd}
 import org.testng.annotations.Test
 
@@ -59,13 +60,11 @@ class BGzipCodecSuite extends HailSuite {
      */
     val compPath = "src/test/resources/bgz.test.sample.vcf.bgz"
 
-    val fileSystem = sFS.fileSystem(uncompPath)
-
-    val uncompIS = fileSystem.open(uncompPath)
+    val uncompIS = sFS.open(uncompPath)
     val uncomp = IOUtils.toByteArray(uncompIS)
     uncompIS.close()
 
-    val decompIS = new BGzipInputStream(fileSystem.open(compPath))
+    val decompIS = new BGzipInputStream(sFS.open(compPath))
     val decomp = IOUtils.toByteArray(decompIS)
     decompIS.close()
 
@@ -126,10 +125,9 @@ class BGzipCodecSuite extends HailSuite {
     val uncompPath = "src/test/resources/sample.vcf"
     val compPath = "src/test/resources/sample.vcf.gz"
 
-    val fileSystem = sFS.fileSystem(uncompPath)
-    val compIS = fileSystem.open(compPath)
+    val compIS = sFS.open(compPath)
 
-    using (fileSystem.open(uncompPath)) { uncompIS => using (new BGzipInputStream(compIS)) { decompIS =>
+    using(new FSDataInputStream(sFS.open(uncompPath))) { uncompIS => using (new BGzipInputStream(compIS)) { decompIS =>
       val fromEnd = 48 // arbitrary number of bytes from the end of block to attempt to seek to
       for (((cOff, nOff), uOff) <- blockStarts.zip(uncompBlockStarts);
            e <- Seq(0, 1024, maxBlockSize - fromEnd)) {

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -125,9 +125,9 @@ class BGzipCodecSuite extends HailSuite {
     val uncompPath = "src/test/resources/sample.vcf"
     val compPath = "src/test/resources/sample.vcf.gz"
 
-    val compIS = sFS.open(compPath)
+    using(sFS.openNoCompression(uncompPath)) { uncompIS =>
+      using(new BGzipInputStream(sFS.openNoCompression(compPath))) { decompIS =>
 
-    using(new FSDataInputStream(sFS.open(uncompPath))) { uncompIS => using (new BGzipInputStream(compIS)) { decompIS =>
       val fromEnd = 48 // arbitrary number of bytes from the end of block to attempt to seek to
       for (((cOff, nOff), uOff) <- blockStarts.zip(uncompBlockStarts);
            e <- Seq(0, 1024, maxBlockSize - fromEnd)) {

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -63,7 +63,7 @@ class BGzipCodecSuite extends HailSuite {
     val uncompIS = sFS.open(uncompPath)
     val uncomp = IOUtils.toByteArray(uncompIS)
     uncompIS.close()
-    
+
     val decompIS = new BGzipInputStream(sFS.openNoCompression(compPath))
     val decomp = IOUtils.toByteArray(decompIS)
     decompIS.close()


### PR DESCRIPTION
It was too tightly coupled to the Hadoop interface (still is).  Remove fs.{FilePath, FileSystem}.