### PR TITLE
[batch][hail] pervasively retry transient errors in synchronous code

### DIFF
--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -1,10 +1,11 @@
 import os
 import threading
 import time
-
 import requests
 from werkzeug.serving import make_server
 from flask import Response
+
+from hailtop.utils import sync_retry_transient_errors
 
 
 class ServerThread(threading.Thread):
@@ -31,7 +32,7 @@ class ServerThread(threading.Thread):
         up = False
         while not up:
             try:
-                requests.get(ping_url)
+                sync_retry_transient_errors(requests.get, ping_url)
                 up = True
             except requests.exceptions.ConnectionError:
                 time.sleep(0.01)

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -4,6 +4,8 @@ import pkg_resources
 import requests
 import hail as hl
 
+from hailtop.utils import sync_retry_transient_errors
+
 from ..utils.java import Env
 from ..typecheck import typecheck_method, oneof
 from ..table import table_type
@@ -102,7 +104,7 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                response = requests.get(url)
+                response = sync_retry_transient_errors(requests.get, url)
                 config = response.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hail/utils/tutorial.py
+++ b/hail/python/hail/utils/tutorial.py
@@ -4,6 +4,7 @@ from .misc import local_path_uri, new_local_temp_dir
 import os
 import zipfile
 from urllib.request import urlretrieve
+from hailtop.utils import sync_retry_transient_errors
 
 __all__ = [
     'get_1kg',
@@ -67,7 +68,7 @@ def get_1kg(output_dir, overwrite: bool = False):
         source = resources['1kg_matrix_table']
         info(f'downloading 1KG VCF ...\n'
              f'  Source: {source}')
-        urlretrieve(resources['1kg_matrix_table'], tmp_vcf)
+        sync_retry_transient_errors(urlretrieve, resources['1kg_matrix_table'], tmp_vcf)
         cluster_readable_vcf = Env.jutils().copyToTmp(jhc, local_path_uri(tmp_vcf), 'vcf')
         info('importing VCF and writing to matrix table...')
         hl.import_vcf(cluster_readable_vcf, min_partitions=16).write(matrix_table_path, overwrite=True)
@@ -76,13 +77,13 @@ def get_1kg(output_dir, overwrite: bool = False):
         source = resources['1kg_annotations']
         info(f'downloading 1KG annotations ...\n'
              f'  Source: {source}')
-        urlretrieve(source, tmp_sample_annot)
+        sync_retry_transient_errors(urlretrieve, source, tmp_sample_annot)
 
         tmp_gene_annot = os.path.join(tmp_dir, 'ensembl_gene_annotations.txt')
         source = resources['ensembl_gene_annotations']
         info(f'downloading Ensembl gene annotations ...\n'
              f'  Source: {source}')
-        urlretrieve(source, tmp_gene_annot)
+        sync_retry_transient_errors(urlretrieve, source, tmp_gene_annot)
 
         hl.hadoop_copy(local_path_uri(tmp_sample_annot), sample_annotations_path)
         hl.hadoop_copy(local_path_uri(tmp_gene_annot), gene_annotations_path)
@@ -122,7 +123,7 @@ def get_movie_lens(output_dir, overwrite: bool = False):
         tmp_path = os.path.join(tmp_dir, 'ml-100k.zip')
         info(f'downloading MovieLens-100k data ...\n'
              f'  Source: {source}')
-        urlretrieve(source, tmp_path)
+        sync_retry_transient_errors(urlretrieve, source, tmp_path)
         with zipfile.ZipFile(tmp_path, 'r') as z:
             z.extractall(tmp_dir)
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -6,7 +6,7 @@ from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     retry_long_running, run_if_changed, LoggingTimer, \
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
-from .tqdm import tqdm, TQDM_DEFAULT_DISABLEn
+from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 
 __all__ = [
     'time_msecs',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -4,9 +4,9 @@ from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     request_retry_transient_errors, request_raise_transient_errors, \
     collect_agen, retry_all_errors, retry_transient_errors, \
     retry_long_running, run_if_changed, LoggingTimer, \
-    WaitableSharedPool, RETRY_FUNCTION_SCRIPT
+    WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
-from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
+from .tqdm import tqdm, TQDM_DEFAULT_DISABLEn
 
 __all__ = [
     'time_msecs',
@@ -34,5 +34,6 @@ __all__ = [
     'collect_agen',
     'tqdm',
     'TQDM_DEFAULT_DISABLE',
-    'RETRY_FUNCTION_SCRIPT'
+    'RETRY_FUNCTION_SCRIPT',
+    'sync_retry_transient_errors'
 ]


### PR DESCRIPTION
It was previously hard to retry transient errors from synchronous libraries like
requests because `hailtop` lacked a synchronous retry wrapper. This PR
implements such a function and uses it in every place that hail imports
`requests`. I also finally addressed the 1kg download issues.