### PR TITLE
[ci] add a retry button

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -86,9 +86,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
 
-@routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
-@web_authenticated_developers_only()
-async def get_pr(request, userdata):  # pylint: disable=unused-argument
+def wb_and_pr_from_request(request):
     watched_branch_index = int(request.match_info['watched_branch_index'])
     pr_number = int(request.match_info['pr_number'])
 
@@ -98,10 +96,17 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
 
     if not wb.prs or pr_number not in wb.prs:
         raise web.HTTPNotFound()
-    pr = wb.prs[pr_number]
+    return wb, wb.prs[pr_number]
+
+
+@routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
+@web_authenticated_developers_only()
+async def get_pr(request, userdata):  # pylint: disable=unused-argument
+    wb, pr = wb_and_pr_from_request(request)
 
     page_context = {}
     page_context['repo'] = wb.branch.repo.short_str()
+    page_context['wb'] = wb
     page_context['pr'] = pr
     # FIXME
     if pr.batch:
@@ -120,11 +125,45 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
 
     batch_client = request.app['batch_client']
     batches = batch_client.list_batches(
-        f'test=1 pr={pr_number}')
+        f'test=1 pr={pr.number}')
     batches = sorted([b async for b in batches], key=lambda b: b.id, reverse=True)
     page_context['history'] = [await b.status() for b in batches]
 
     return await render_template('ci', request, userdata, 'pr.html', page_context)
+
+
+async def retry_pr(wb, pr, request):
+    app = request.app
+    session = await aiohttp_session.get_session(request)
+
+    if pr.batch is None:
+        log.info('retry cannot be requested for PR #{pr.number} because it has no batch')
+        set_message(
+            session,
+            f'Retry cannot be requested for PR #{pr.number} because it has no batch.',
+            'error')
+        return
+
+    batch_id = pr.batch.id
+    dbpool = app['dbpool']
+    async with dbpool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute('INSERT INTO invalidated_batches (batch_id) VALUES (%s);', batch_id)
+    await wb.notify_batch_changed(app)
+
+    log.info(f'retry requested for PR: {pr.number}')
+    set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
+
+
+@routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
+@check_csrf_token
+@web_authenticated_developers_only(redirect=False)
+async def post_retry_pr(request, userdata):  # pylint: disable=unused-argument
+    wb, pr = wb_and_pr_from_request(request)
+
+    await asyncio.shield(retry_pr(wb, pr, request))
+    return web.HTTPFound(
+        deploy_config.url('ci', f'/watched_branches/{wb.index}/pr/{pr.number}'))
 
 
 @routes.get('/batches')
@@ -186,7 +225,8 @@ async def post_authorized_source_sha(request, userdata):  # pylint: disable=unus
     log.info(f'authorized sha: {sha}')
     session = await aiohttp_session.get_session(request)
     set_message(session, f'SHA {sha} authorized.', 'info')
-    raise web.HTTPFound(deploy_config.base_path('ci') + '/')
+    return web.HTTPFound(
+        deploy_config.url('ci', '/'))
 
 
 @routes.get('/healthcheck')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -459,10 +459,10 @@ mkdir -p {shq(repo_dir)}
             self.set_build_state(None)
         elif min_batch_status['complete']:
             if min_batch_status['state'] == 'success':
-                self.set_build_state = 'success'
+                self.set_build_state('success')
                 self.source_sha_failed = False
             else:
-                self.set_build_state = 'failure'
+                self.set_build_state('failure')
                 self.source_sha_failed = True
             self.target_branch.state_changed = True
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -289,7 +289,9 @@ class PR(Code):
 
         log.info(f'{self.short_str()}: notify github state: {gh_status}')
         if self.batch is None or isinstance(self.batch, MergeFailureBatch):
-            target_url = f'https://ci.hail.is/watched_branches/{self.target_branch.index}/pr/{self.number}'
+            target_url = deploy_config.external_url(
+                'ci',
+                f'/watched_branches/{self.target_branch.index}/pr/{self.number}')
         else:
             assert self.batch.id is not None
             target_url = deploy_config.external_url(
@@ -421,54 +423,48 @@ mkdir -p {shq(repo_dir)}
                 log.info(f'cancelling partial test batch {batch.id}')
                 await batch.cancel()
 
-    async def _update_batch(self, batch_client):
-        if self.build_state:
-            assert self.batch
-            return
+    @staticmethod
+    async def is_invalidated_batch(batch, dbpool):
+        assert batch is not None
+        async with dbpool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute('SELECT * from invalidated_batches WHERE batch_id = %s;', batch.id)
+                row = await cursor.fetchone()
+                return row is not None
 
-        if self.batch is None:
-            # find the latest non-cancelled batch for source
-            batches = batch_client.list_batches(
-                f'test=1 '
-                f'target_branch={self.target_branch.branch.short_str()} '
-                f'source_sha={self.source_sha}')
-
-            min_batch = None
-            failed = None
-            async for b in batches:
-                try:
-                    s = await b.status()
-                except Exception as err:
-                    log.info(f'failed to get the status for batch {b.id} due to error: {err}')
-                    raise
-                if s['state'] != 'cancelled':
-                    if min_batch is None or b.id > min_batch.id:
-                        min_batch = b
-
-                    if s['state'] == 'failure':
-                        failed = True
-                    elif failed is None:
-                        failed = False
-            self.batch = min_batch
-            self.source_sha_failed = failed
-
-        if self.batch:
+    async def _update_batch(self, batch_client, dbpool):
+        # find the latest non-cancelled batch for source
+        batches = batch_client.list_batches(
+            f'test=1 '
+            f'target_branch={self.target_branch.branch.short_str()} '
+            f'source_sha={self.source_sha}')
+        min_batch = None
+        min_batch_status = None
+        async for b in batches:
+            if self.is_invalidated_batch(b, dbpool):
+                continue
             try:
-                status = await self.batch.status()
-            except aiohttp.client_exceptions.ClientResponseError as exc:
-                if exc.status == 404:
-                    log.info(f'batch {self.batch.id} was deleted by someone')
-                    self.batch = None
-                    self.set_build_state(None)
-                    return
-                raise exc
-            if status['complete']:
-                if status['state'] == 'success':
-                    self.set_build_state('success')
-                else:
-                    self.set_build_state('failure')
-                    self.source_sha_failed = True
-                self.target_branch.state_changed = True
+                s = await b.status()
+            except Exception as err:
+                log.info(f'failed to get the status for batch {b.id} due to error: {err}')
+                raise
+            if s['state'] != 'cancelled':
+                if min_batch is None or b.id > min_batch.id:
+                    min_batch = b
+                    min_batch_status = s
+        self.batch = min_batch
+        self.source_sha_failed = None
+
+        if min_batch_status is None:
+            self.set_build_state(None)
+        elif min_batch_status['complete']:
+            if min_batch_status['state'] == 'success':
+                self.set_build_state = 'success'
+                self.source_sha_failed = False
+            else:
+                self.set_build_state = 'failure'
+                self.source_sha_failed = True
+            self.target_branch.state_changed = True
 
     async def _heal(self, batch_client, dbpool, on_deck, gh):
         # can't merge target if we don't know what it is
@@ -602,7 +598,7 @@ class WatchedBranch(Code):
 
                 if self.batch_changed:
                     self.batch_changed = False
-                    await self._update_batch(batch_client)
+                    await self._update_batch(batch_client, dbpool)
 
                 if self.state_changed:
                     self.state_changed = False
@@ -713,14 +709,14 @@ url: {url}
             async with repos_lock:
                 await self._start_deploy(batch_client)
 
-    async def _update_batch(self, batch_client):
+    async def _update_batch(self, batch_client, dbpool):
         log.info(f'update batch {self.short_str()}')
 
         if self.deployable:
             await self._update_deploy(batch_client)
 
         for pr in self.prs.values():
-            await pr._update_batch(batch_client)
+            await pr._update_batch(batch_client, dbpool)
 
     async def _heal(self, batch_client, dbpool, gh):
         log.info(f'heal {self.short_str()}')

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -13,6 +13,10 @@
       <div>{{ name }}: {{ value }}</div>
       {% endfor %}
     </div>
+    <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
+      <button type="submit">Retry</button>
+    </form>
     <h2>Jobs</h2>
     <table class="data-table" style="line-height: 175%">
       <thead>

--- a/ci/sql/estimated-current.txt
+++ b/ci/sql/estimated-current.txt
@@ -1,0 +1,11 @@
+CREATE TABLE authorized_shas (
+  sha VARCHAR(100) NOT NULL
+) ENGINE = InnoDB;
+
+CREATE INDEX authorized_shas_sha ON authorized_shas (sha);
+
+CREATE TABLE invalidated_batches (
+  batch_id BIGINT NOT NULL
+) ENGINE = InnoDB;
+
+CREATE INDEX invalidated_batches_batch_id ON invalidated_batches (batch_id);

--- a/ci/sql/invalidated-batches.sql
+++ b/ci/sql/invalidated-batches.sql
@@ -1,0 +1,5 @@
+CREATE TABLE invalidated_batches (
+  batch_id BIGINT NOT NULL
+) ENGINE = InnoDB;
+
+CREATE INDEX invalidated_batches_batch_id ON invalidated_batches (batch_id);


### PR DESCRIPTION
cc: @tpoterba 
![Screen Shot 2020-03-30 at 6 53 49 PM](https://user-images.githubusercontent.com/106194/77969485-cd780d00-72b7-11ea-96fc-4f529297c830.png)

Since my mind was already thinking about CI to address other issues, I thought it prudent to implement this longstanding request.

The key idea is that each batch now has a target sha, source sha, and an attempt id. When we refresh state from batch, we look for the oldest batch with the newest attempt_id. We increment attempt_id whenever we `_start_build` on a batch. If the source sha changes, we set the attempt id to zero. It will be incremented to one the next time we build. In this manner, we prevent CI from refreshing from batch and blowing away a retried batch even though it has a higher batch id (and we always prefer lower ids).

Retry is implemented in the standard a PR is noted as needing a retry and the watched branch is informed that its state has changed. The heal method of a PR checks for the retry flag, cancels any existing batch, and triggers a new build.

Miscellaneous changes/fixes:
- a developers only endpoint to force CI to update right now (convenient for dev deploy where the GitHub triggers are not configured)
- don't try to clean up a database that wasn't created
- correct URL for CI in a couple places