### PR TITLE
[ci] fix "GitHubAPI object has no attribute 'get'" error

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -324,7 +324,7 @@ class PR(Code):
 
     async def _update_last_known_github_status(self, gh):
         if self.source_sha:
-            source_sha_json = await gh.get(
+            source_sha_json = await gh.getitem(
                 f'/repos/{self.target_branch.branch.repo.short_str()}/commits/{self.source_sha}/status')
             last_known_github_status = PR._hail_github_status_from_statuses(source_sha_json)
             if last_known_github_status != self.last_known_github_status:


### PR DESCRIPTION
I never tested that PR that got merged (whoops!) and CI tests are insufficient
to catch this case (we should beef those up, asana task added).

The issue was that I thought the method to issue an HTTP get request was `get`,
but it was `getitem`. This PR fixes that. This error occured during `update` and
thus prevented all forward progress of CI.