### PR TITLE
[query] fix finding hail jar in pip package

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -636,18 +636,17 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
-     export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar --driver-memory 6g pyspark-shell"
-     export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=0
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /hail.jar
-       to: /io/hail.jar
-     - from: /hail.zip
-       to: /io/hail.zip
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -655,8 +654,8 @@ steps:
      - from: /data.tar.gz
        to: /io/data.tar.gz
    dependsOn:
-    - hail_run_image
-    - build_hail
+     - hail_run_image
+     - build_hail
  - kind: runImage
    name: test_hail_python_1
    image:
@@ -670,18 +669,17 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
-     export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar --driver-memory 6g pyspark-shell"
-     export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=1
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /hail.jar
-       to: /io/hail.jar
-     - from: /hail.zip
-       to: /io/hail.zip
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -704,18 +702,17 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
-     export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar --driver-memory 6g pyspark-shell"
-     export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=2
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /hail.jar
-       to: /io/hail.jar
-     - from: /hail.zip
-       to: /io/hail.zip
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -738,18 +735,17 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
-     export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar --driver-memory 6g pyspark-shell"
-     export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=3
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /hail.jar
-       to: /io/hail.jar
-     - from: /hail.zip
-       to: /io/hail.zip
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -772,18 +768,17 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
-     export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar --driver-memory 6g pyspark-shell"
-     export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=4
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /hail.jar
-       to: /io/hail.jar
-     - from: /hail.zip
-       to: /io/hail.zip
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -1263,7 +1258,7 @@ steps:
     - base_image
     - copy_files
     - deploy_batch
-   timeout: 1200   
+   timeout: 1200
    inputs:
     - from: /repo/hailtop
       to: /io/

--- a/build.yaml
+++ b/build.yaml
@@ -637,7 +637,7 @@ steps:
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
      tar xvf wheel-container.tar
-     pip install --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
@@ -670,7 +670,7 @@ steps:
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
      tar xvf wheel-container.tar
-     pip install --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
@@ -703,7 +703,7 @@ steps:
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
      tar xvf wheel-container.tar
-     pip install --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
@@ -736,7 +736,7 @@ steps:
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
      tar xvf wheel-container.tar
-     pip install --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
@@ -769,7 +769,7 @@ steps:
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
      tar xvf wheel-container.tar
-     pip install --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"

--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -2,10 +2,10 @@ python/.eggs
 python/README.md
 python/dist
 python/hail.egg-info
+python/hail/backend/hail-all-spark.jar
 python/hail/hail_pip_version
 python/hail/hail_version
 python/hail/docs/_build/*
-python/hail/hail-all-spark.jar
 python/hail/docs/_static/hail_version.js
 python/hailtop/hailctl/hail_version
 python/hailtop/hailctl/deploy.yaml

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -39,6 +39,7 @@ SCALA_BUILD_INFO := src/main/resources/build-info.properties
 
 SHADOW_JAR := build/libs/hail-all-spark.jar
 SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
+PYTHON_JAR := python/hail/backend/hail-all-spark.jar
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 
 .PHONY: shadowJar
@@ -98,12 +99,12 @@ python/hailtop/hailctl/hail_version: python/hail/hail_version
 python/README.md: ../README.md
 	cp ../README.md python/
 
-python/hail/hail-all-spark.jar: $(SHADOW_JAR)
+$(PYTHON_JAR): $(SHADOW_JAR)
 	cp -f $< $@
 
 .PHONY: pytest
 pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
-pytest: python/README.md python/hail/hail-all-spark.jar
+pytest: python/README.md $(PYTHON_JAR)
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
      --addopts "-v \
      --color=no \
@@ -115,7 +116,7 @@ pytest: python/README.md python/hail/hail-all-spark.jar
 
 .PHONY: doctest
 doctest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
-doctest: python/README.md python/hail/hail-all-spark.jar
+doctest: python/README.md $(PYTHON_JAR)
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
 	  --addopts "-v \
     --color=no \
@@ -139,7 +140,7 @@ doctest: python/README.md python/hail/hail-all-spark.jar
 .PHONY: wheel
 wheel: $(WHEEL)
 
-$(WHEEL): $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES)
+$(WHEEL): $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) $(PYTHON_JAR)
 	rm -rf build/deploy
 	mkdir -p build/deploy
 	mkdir -p build/deploy/src
@@ -152,7 +153,6 @@ $(WHEEL): $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES)
 	    --exclude 'test/' \
 	    --exclude '*.log' \
 	    python/ build/deploy/
-	cp build/libs/hail-all-spark.jar build/deploy/hail/
 	cd build/deploy; $(HAIL_PYTHON3) setup.py sdist bdist_wheel
 
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location
@@ -190,7 +190,7 @@ upload-artifacts: $(WHEEL)
 
 .PHONY: install-editable
 install-editable: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
-install-editable: python/README.md python/hail/hail-all-spark.jar
+install-editable: python/README.md $(PYTHON_JAR)
 	-$(PIP) uninstall -y hail
 	cd python && $(PIP) install -e .
 
@@ -378,7 +378,7 @@ native-lib-reset-prebuilt:
 clean: clean-env clean-docs native-lib-clean
 	./gradlew clean $(GRADLE_ARGS)
 	rm -rf build/
-	rm -rf python/hail/hail-all-spark.jar
+	rm -rf $(PYTHON_JAR)
 	rm -rf python/README.md
 	rm -rf $(SCALA_BUILD_INFO)
 	rm -rf $(PYTHON_VERSION_INFO)

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -90,7 +90,7 @@ class Backend(abc.ABC):
 
 
 class SparkBackend(Backend):
-    def __init__(self, idempotent, sc, app_name, master, local, min_block_size):
+    def __init__(self, idempotent, sc, spark_conf, app_name, master, local, min_block_size):
         if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
             hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
             assert os.path.exists(hail_jar_path), f'{hail_jar_path} does not exist'

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -48,7 +48,7 @@ class HailContext(object):
             if os.environ.get('HAIL_APISERVER_URL') is not None:
                 _backend = ServiceBackend()
             else:
-                _backend = SparkBackend(idempotent, sc, app_name, master, local, min_block_size)
+                _backend = SparkBackend(idempotent, sc, spark_conf, app_name, master, local, min_block_size)
         self._backend = _backend
         self._jbackend = _backend._jbackend
 

--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -27,10 +27,10 @@ setup(
         'hail': 'hail',
         'hailtop': 'hailtop'},
     package_data={
-        'hail': ['hail-all-spark.jar',
-                 'hail_pip_version',
+        'hail': ['hail_pip_version',
                  'hail_version',
                  'experimental/annotation_db.json'],
+        'hail.backend': ['hail-all-spark.jar'],
         'hailtop.hailctl': ['hail_version', 'deploy.yaml']},
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Move installed location of hail-all-spark.jar to from hail/ to
hail/backend/

We were not finding the jar properly with pkg_resources, and so were not
setting the paths appropriately for pip installs, causing 'JavaPackage
not callable' errors.