### PR TITLE
[ci] Fix external URLs in CI

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -187,7 +187,7 @@ async def post_authorized_source_sha(request, userdata):  # pylint: disable=unus
     log.info(f'authorized sha: {sha}')
     session = await aiohttp_session.get_session(request)
     set_message(session, f'SHA {sha} authorized.', 'info')
-    raise web.HTTPFound('/')
+    raise web.HTTPFound(deploy_config.base_path('ci') + '/')
 
 
 @routes.get('/healthcheck')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -291,7 +291,9 @@ class PR(Code):
         data = {
             'state': gh_status,
             # FIXME should be this build, not the pr
-            'target_url': f'https://ci.hail.is/watched_branches/{self.target_branch.index}/pr/{self.number}',
+            'target_url': deploy_config.external_url(
+                'ci',
+                f'/watched_branches/{self.target_branch.index}/pr/{self.number}'),
             # FIXME improve
             'description': gh_status,
             'context': GITHUB_STATUS_CONTEXT
@@ -682,6 +684,9 @@ class WatchedBranch(Code):
                     self.deploy_state = 'failure'
 
                 if not is_test_deployment and self.deploy_state == 'failure':
+                    url = deploy_config.external_url(
+                        'ci',
+                        f'/batches/{self.deploy_batch.id}')
                     request = {
                         'type': 'stream',
                         'to': 'team',
@@ -691,7 +696,7 @@ class WatchedBranch(Code):
 state: {self.deploy_state}
 branch: {self.branch.short_str()}
 sha: {self.sha}
-url: https://ci.hail.is/batches/{self.deploy_batch.id}
+url: {url}
 '''}
                     result = zulip_client.send_message(request)
                     log.info(result)


### PR DESCRIPTION
- Fix statuses for dev deploys.
- Fix zulip notify for dev deploys (not currently used).
- Fix HTTPFound for dev deploys and PRs.

We need to prefix the redirect with the base path
for this current CI instance. In my dev deploy case,
this prepends: `dking/ci` from which the web browser can
correctly redirect to: `https://internal.hail.is/dking/ci/`.