### PR TITLE
[ci] no clean up for non-created databases

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -910,7 +910,7 @@ python3 create_database.py {shq(json.dumps(create_database_config))}
                                     parents=self.deps_parents())
 
     def cleanup(self, batch, scope, parents):
-        if scope in ['deploy', 'dev']:
+        if scope in ['deploy', 'dev'] or self.cant_create_database:
             return
 
         cleanup_script = f'''


### PR DESCRIPTION
Databases that are not created fail currently without this change
because they try to connect to a database called None. This
is only visible in PR builds and dev deploys. PR builds do
not test this behavior, so I do not think anyone else
has observed it.