### PR TITLE
[hailctl] authenticated curl

### DIFF
--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -28,6 +28,9 @@ def print_help():
     subs.add_parser('batch',
                     help='Manage batches running on the batch service managed by the Hail team.',
                     description='Manage batches running on the batch service managed by the Hail team.')
+    subs.add_parser('curl',
+                    help='Issue authenticated curl requests to Hail infrastructure.',
+                    description='Issue authenticated curl requests to Hail infrastructure.')
 
     main_parser.print_help()
 
@@ -101,6 +104,9 @@ def main():
         elif module == 'batch':
             from hailtop.hailctl.batch import cli
             cli.main(args)
+        elif module == 'curl':
+            from hailtop.hailctl.curl import main
+            main(args)
         elif module in ('-h', '--help', 'help'):
             print_help()
         else:

--- a/hail/python/hailtop/hailctl/curl.py
+++ b/hail/python/hailtop/hailctl/curl.py
@@ -1,0 +1,22 @@
+import sys
+import subprocess
+
+from hailtop.auth import namespace_auth_headers
+from hailtop.config import get_deploy_config
+
+
+def main(args):
+    if len(args) < 3:
+        print('hailctl curl NAMESPACE SERVICE PATH [args] ...', file=sys.stderr)
+        sys.exit(1)
+    ns = args[0]
+    svc = args[1]
+    path = args[2]
+    deploy_config = get_deploy_config()
+    headers = namespace_auth_headers(deploy_config, ns)
+    headers = [x
+               for k, v in headers.items()
+               for x in ['-H', f'{k}: {v}']]
+    path = deploy_config.with_service(svc, ns).external_url(svc, path)
+    print('curl ' + ' '.join(headers) + ' ' + ' '.join(args[3:]) + ' ' + path)
+    subprocess.check_call(['curl', *headers, *args[3:], path])


### PR DESCRIPTION
This makes it easy to send authenticated HTTP requests to our
infrastructure. When developing a new service, you might not have an
existing (or working) client yet and want to explore the HTTP endpoints with
cURL.