### PR TITLE
RVDContext must own partitionRegion or it won't be cleaned up

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -21,6 +21,7 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
     assert(children.remove(child))
 
   own(r)
+  own(partitionRegion)
 
   def freshContext: RVDContext = {
     val ctx = new RVDContext(partitionRegion, Region())

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 object RVDContext {
   def default: RVDContext = {
     val partRegion = Region()
-    val ctx = new RVDContext(Region(), Region())
+    val ctx = new RVDContext(partRegion, Region())
     ctx.own(partRegion)
     ctx
   }
@@ -21,7 +21,6 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
     assert(children.remove(child))
 
   own(r)
-  own(partitionRegion)
 
   def freshContext: RVDContext = {
     val ctx = new RVDContext(partitionRegion, Region())


### PR DESCRIPTION
The biggest headaches always seem to have the smallest code changes to fix. 