### PR TITLE
[build.yaml] standardize on one location for sql-config.cnf

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -151,7 +151,7 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-     mysql --defaults-extra-file=/database-server-config/sql-config.cnf < /io/sql/delete-auth-tables.sql
+     mysql --defaults-extra-file=/sql-config/sql-config.cnf < /io/sql/delete-auth-tables.sql
    inputs:
     - from: /repo/auth/sql
       to: /io/
@@ -159,7 +159,7 @@ steps:
     - name: database-server-config
       namespace:
         valueFrom: default_ns.name
-      mountPath: /database-server-config
+      mountPath: /sql-config
    runIfRequested: true
    scopes:
     - dev
@@ -916,7 +916,7 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-     mysql --defaults-extra-file=/database-server-config/sql-config.cnf < /io/sql/delete-batch-tables.sql
+     mysql --defaults-extra-file=/sql-config/sql-config.cnf < /io/sql/delete-batch-tables.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/
@@ -924,7 +924,7 @@ steps:
     - name: database-server-config
       namespace:
         valueFrom: default_ns.name
-      mountPath: /database-server-config
+      mountPath: /sql-config
    runIfRequested: true
    scopes:
     - dev
@@ -938,7 +938,7 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-     mysql --defaults-extra-file=/database-server-config/sql-config.cnf < /io/sql/delete-ci-tables.sql
+     mysql --defaults-extra-file=/sql-config/sql-config.cnf < /io/sql/delete-ci-tables.sql
    inputs:
     - from: /repo/ci/sql
       to: /io/
@@ -946,7 +946,7 @@ steps:
     - name: database-server-config
       namespace:
         valueFrom: default_ns.name
-      mountPath: /database-server-config
+      mountPath: /sql-config
    runIfRequested: true
    scopes:
     - dev


### PR DESCRIPTION
Soon, I will add certificates and keys to the secrets and I want
to add configuration parameters that specify the paths to those
certificates and keys. Therefore, the mount locations of the
secrets must be the same everywhere so the paths are valid.