### PR TITLE
[vcf-combiner] Docs update and restructuring.

### DIFF
--- a/hail/python/hail/docs/experimental/index.rst
+++ b/hail/python/hail/docs/experimental/index.rst
@@ -49,8 +49,6 @@ Genetics Methods
     import_gtf
     get_gene_intervals
     export_entries_by_col
-    sparse_split_multi
-    densify
     pc_project
 
 `dplyr`-inspired Methods
@@ -79,9 +77,6 @@ Functions
 .. autofunction:: import_gtf
 .. autofunction:: get_gene_intervals
 .. autofunction:: export_entries_by_col
-.. autofunction:: sparse_split_multi
-.. autofunction:: densify
-.. autofunction:: lgt_to_gt
 .. autofunction:: gather
 .. autofunction:: separate
 .. autofunction:: spread

--- a/hail/python/hail/docs/experimental/vcf_combiner.rst
+++ b/hail/python/hail/docs/experimental/vcf_combiner.rst
@@ -144,12 +144,12 @@ example: ::
     DP: 9
     GQ: 77
     LA: [0, 2]
-    LGT: 0/2
+    LGT: 0/1
     LAD: [3, 6]
     LPL: [137, 0, 77]
     END: NA
 
-    equivalent GT: 0/1
+    equivalent GT: 0/2
     equivalent AD: [3, 0, 6]
     equivalent PL: [137, 137*, 137*, 0, 137*, 77]
 

--- a/hail/python/hail/docs/experimental/vcf_combiner.rst
+++ b/hail/python/hail/docs/experimental/vcf_combiner.rst
@@ -1,83 +1,190 @@
 VCF Combiner
 ============
 
-Library functions for combining GVCFS and sparse matrix tables into
-larger sparse matrix tables.
+Hail has functionality for combining single-sample GVCFs into a multi-sample
+matrix table. This process is sometimes called "joint calling", although the
+implementation in Hail does not use cohort-level information to reassign individual
+genotype calls.
 
-What this module provides:
-    - A Sensible way to transform input GVCFS.
-    - The combining function.
+The resulting matrix table is different from a matrix table imported from a project VCF;
+see below for a synopsis of how to use this object.
 
-What this module does not provide:
-    - Any way to repartition the data.
+Running the Hail GVCF combiner
+------------------------------
 
-There are three additional functions of note for working with sparse data in the main experimental
-module :func:`.sparse_split_multi`, which splits multi-alleleics in a sparse matrix table,
-:func:`.lgt_to_gt`, which converts from local alleles and genotypes to true(global) genotypes, and
-:func:`.densify`, which converts a sparse matrix table to a dense one.
+The :func:`.run_combiner` function is the primary entry point to running the Hail GVCF
+combiner. A typical script for running the combiner on Google Cloud Dataproc using
+``hailctl dataproc`` might look like the below::
 
-.. currentmodule:: hail.experimental.vcf_combiner
 
-.. autosummary::
+    import hail as hl
+    hl.init(log='/home/hail/combiner.log')
 
-    combine_gvcfs
-    transform_gvcf
+    path_to_input_list = 'gs://path/to/input_files.txt'  # a file with one GVCF path per line
 
-Sparse Matrix Tables
---------------------
+    inputs = []
+    with hl.hadoop_open(path_to_input_list, 'r') as f:
+        for line in f:
+            inputs.append(line.strip())
 
-Sparse matrix tables are a new method of representing VCF style data in a space efficient way. They
-are produced them using :func:`transform_gvcf` on an imported GVCF, or by using
-:func:`combine_gvcfs` on smaller sparse matrix tables. They have two components that differentiate
-them from matrix tables produced by importing VCFs.
+    output_file = 'gs://path/to/combined/output.mt'  # output destination
+    temp_bucket = 'gs://my-temp-bucket'  # bucket for storing intermediate files
+    hl.experimental.run_combiner(inputs, out_file=output_file, tmp_path=temp_bucket, reference_genome='GRCh38')
 
-* `Sample Level Reference Blocks`_
-* `Local Alleles`_
+
+A command-line tool is also provided as a convenient wrapper around this function. This
+tool can be run using the below syntax::
+
+    python3 -m hail.experimental.vcf_combiner SAMPLE_MAP OUT_FILE TMP_PATH [OPTIONAL ARGS...]
+
+The below command is equivalent to the Python pipeline above::
+
+    python3 -m hail.experimental.vcf_combiner \
+        gs://path/to/input_files.txt \
+        gs://path/to/combined/output.mt \
+        gs://my-temp-bucket \
+        --reference-genome GRCh38 \
+        --log /home/hail/combiner.log
+
+Pipeline structure
+^^^^^^^^^^^^^^^^^^
+
+The Hail GVCF combiner merges GVCFs hierarchically, parameterized by the `branch_factor`
+setting. The number of rounds of merges is defined as ``math.ceil(math.log(N_GVCFS, BRANCH_FACTOR))``.
+With the default branch factor of 100, merging between 101 and 10,000 inputs uses 2 rounds,
+and merging between 10,001 and 1,000,000 inputs requires 3 rounds.
+
+The combiner will print the execution plan before it runs: ::
+
+    2020-04-01 08:37:32 Hail: INFO: GVCF combiner plan:
+        Branch factor: 4
+        Batch size: 4
+        Combining 50 input files in 3 phases with 6 total jobs.
+            Phase 1: 4 jobs corresponding to 13 intermediate output files.
+            Phase 2: 1 job corresponding to 4 intermediate output files.
+            Phase 3: 1 job corresponding to 1 final output file.
+
+
+Pain points
+^^^^^^^^^^^
+
+The combiner can take some time on large numbers of GVCFs. This time is split
+between single-machine planning and compilation work that happens only on the
+driver machine, and jobs that take advantage of the entire cluster. For this
+reason, its is recommended that clusters with autoscaling functionality are
+used, to reduce the overall cost of the pipeline.
+
+Working with sparse matrix tables
+---------------------------------
+
+Sparse matrix tables are a new method of representing VCF-style data in a space
+efficient way. The 'sparse' modifier refers to the fact that these datasets
+contain sample-level reference blocks, just like the input GVCFs -- most of the
+entries in the matrix are missing, because that entry falls within a reference
+block defined at an earlier locus. While unfamiliar, this representation (1) is
+incrementally mergeable with other sparse matrix tables, and (2) scales with the
+``N_GVCFs``, not ``N_GVCFs^1.5`` as project VCFs do. The schema of a sparse
+matrix table also differs from the schema of a dense project VCF imported to
+matrix table. They do not have the same ``GT``, ``AD``, and ``PL`` fields found
+in a project VCF, but instead have ``LGT``, ``LAD``, ``LPL`` that provide the
+same information, but require additional functions to work with in combination
+with a sample's local alleles, ``LA``.
 
 Sample Level Reference Blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-GVCFs represent blocks of homozygous reference calls of similar qualities using one record. For
-example: ::
+GVCFs represent blocks of homozygous reference calls of similar qualities using
+one record. For example: ::
 
-    #CHROM  POS    ID  REF  ALT  INFO       FORMAT    S01
+    #CHROM  POS    ID  REF  ALT  INFO       FORMAT    SAMPLE_1
     chr1    14523  .   C    .    END=15000  GT:DP:GQ  0/0:19:40
 
-This record indicates that S01 is homozygous reference until position 15,000 with approximate ``GQ``
-of 40 across the few hundred base pair block.
+This record indicates that sample ``SAMPLE_1`` is homozygous reference until
+position 15,000 with approximate ``GQ`` of 40 across the ~500-base-pair. In
+short read sequencing, two adjacent loci in a sample's genome will be covered by
+mostly the same reads so the quality information about these two loci is highly
+correlated; reference blocks explicitly represent regions of reference alleles
+with similar quality information.
 
-A sparse matrix table has an entry field ``END`` that corresponds to the GVCF ``INFO`` field,
-``END``. It has the same meaning, but only for the single column where the END resides. In a sparse
-matrix table, there should be no present entries for this sample between ``chr1:14524`` and
-``chr1:15000``, inclusive.
+A sparse matrix table has an entry field ``END`` that corresponds to the GVCF
+``INFO`` field, ``END``. It has the same meaning, but only for the single column
+where the END resides. In a sparse matrix table, there will be no defined
+entries for this sample between ``chr1:14524`` and ``chr1:15000``, inclusive.
 
 Local Alleles
 ^^^^^^^^^^^^^
 
-Local alleles are used to reduce the size of arrays such as ``AD``, or most notably ``PL`` at
-multi-alleleic sites with many alternate alleles. To illustrate why such a thing is necessary,
-consider a site with around 4,000 alleles. A ``PL`` for this site would be ``(4,000 * 4,001)/2
-= 8,002,000`` elements long. In a joint cohort of 100,000 samples, if every sample had a ``PL`` at
-this position, there would be ``8,002,000 * 100,000 = 800,200,000,000`` elements, each of which is
-generally represented as a 4 byte integer, giving a full size of the ``PL`` arrays for this row of
-over 3 terabytes. Even if we only had the minimum required ``PL`` arrays materialized, we would
-still be looking at gigabytes for a single row.
+The ``LA`` field constitutes a record's **local alleles**, or the alleles that
+appeared in the original GVCF for that sample. ``LA`` is used to interpret the
+values of ``LGT`` (local genotype), ``LAD`` (local allele depth), and ``LPL``
+(local phred-scaled genotype likelihoods). This is best explained through
+example: ::
 
-A sparse matrix table solves this issue by creating new fields that are 'local'. It only stores
-information that was present in the imported GVCFs. The :func:`transform_gvcf` does this initial
-conversion. The fields ``GT``, ``AD``, ``PGT``, ``PL``, are converted to their local versions,
-``LGT``, ``LAD``, ``LPGT``, ``LPL``, and a ``LA`` (local alleles) array is added.  The ``LA`` field
-serves as the map between the ``alleles`` field and the local fields. For example (using VCF-like
-notation): ::
+    Variant Information
+    -------------------
+    locus: chr22:10678889
+    alleles: ["CAT", "C", "TAT"]
 
-    LGT:LA:LAD    1/2:0,7,5:0,19,21
+    Sample1 (reference block, CAT/CAT)
+    -------------------------
+    DP: 8
+    GQ: 21
+    LA: [0]
+    LGT: 0/0
+    LAD: NA
+    LPL: NA
+    END: 10678898
 
-For this genotype, the true ``GT`` is ``5/7``, and the depth of the ``5`` Allele is ``21`` and the
-depth of the ``7`` allele is ``19``. To get the appropriate ``LPL`` index one can still use
-:func:`hail.expr.CallExpression.unphased_diploid_gt_index` of ``LGT``.
+    equivalent GT: 0/0
+    equivalent AD: [8, 0, 0]
+    equivalent PL: [0, 21, 42*, 21, 42*, 42*]
+
+    Sample1 (called CAT/TAT)
+    -------------------------
+    DP: 9
+    GQ: 77
+    LA: [0, 2]
+    LGT: 0/2
+    LAD: [3, 6]
+    LPL: [137, 0, 77]
+    END: NA
+
+    equivalent GT: 0/1
+    equivalent AD: [3, 0, 6]
+    equivalent PL: [137, 137*, 137*, 0, 137*, 77]
+
+The ``LA`` field for the first sample only includes the reference allele (0),
+since this locus was the beginning of a reference block in the original GVCF. In
+a reference block, LA will typically be an array with only one value, ``0``. The
+``LA`` field for the second sample, which contains a variant allele, includes
+the reference and that allele (0 and 2, respectively). PL entries above marked
+with an asterisk refer to genotypes with alleles not observed in the original
+GVCF; the actual value produced by a tool like GATK will be large (a
+low-likelihood value), but not exactly the above. As with standard ``GT``
+fields, it is possible to use :meth:`.CallExpression.unphased_diploid_gt_index`
+to compute the ``LGT``'s corresponding index into the ``LPL`` array.
+
 
 Functions
----------
+~~~~~~~~~
 
-.. autofunction:: combine_gvcfs
-.. autofunction:: transform_gvcf
+There are a number of functions for working with sparse data. Of particular
+importance is :func:`densify`, which transforms a sparse matrix table to a dense
+project-VCF-like matrix table on the fly. While computationally expensive, this
+operation is necessary for many downstream analyses, and should be thought of as
+roughly costing as much as reading a matrix table created by importing a dense
+project VCF.
+
+.. currentmodule:: hail.experimental
+
+.. autosummary::
+
+    run_combiner
+    densify
+    sparse_split_multi
+    lgt_to_gt
+
+.. autofunction:: run_combiner
+.. autofunction:: densify
+.. autofunction:: sparse_split_multi
+.. autofunction:: lgt_to_gt

--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -9,8 +9,7 @@ from .datasets import load_dataset
 from .import_gtf import import_gtf, get_gene_intervals
 from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_block_matrices
 from .export_entries_by_col import export_entries_by_col
-from .densify import densify
-from .sparse_split_multi import sparse_split_multi
+from .vcf_combiner import sparse_split_multi, run_combiner, lgt_to_gt, densify
 from .function import define_function
 from .ldscsim import simulate_phenotypes
 from .full_outer_join_mt import full_outer_join_mt
@@ -18,7 +17,6 @@ from .tidyr import gather, separate, spread
 from .codec import encode, decode
 from .db import DB
 from .compile import compile_comparison_binary, compiled_compare
-from .sparse_mt_utils import lgt_to_gt
 from .loop import loop
 from .time import strftime, strptime
 from .pca import pc_project
@@ -41,8 +39,6 @@ __all__ = ['ld_score',
            'block_matrices_tofiles',
            'export_block_matrices',
            'export_entries_by_col',
-           'densify',
-           'sparse_split_multi',
            'define_function',
            'simulate_phenotypes',
            'full_outer_join_mt',
@@ -55,6 +51,9 @@ __all__ = ['ld_score',
            'compile_comparison_binary',
            'compiled_compare',
            'lgt_to_gt',
+           'run_combiner',
+           'sparse_split_multi',
+           'densify',
            'loop',
            'strptime',
            'strftime',

--- a/hail/python/hail/experimental/vcf_combiner/__init__.py
+++ b/hail/python/hail/experimental/vcf_combiner/__init__.py
@@ -1,0 +1,11 @@
+from .vcf_combiner import run_combiner
+from .sparse_split_multi import sparse_split_multi
+from .sparse_mt_utils import lgt_to_gt
+from .densify import densify
+
+__all__ = [
+    'run_combiner',
+    'sparse_split_multi',
+    'lgt_to_gt',
+    'densify',
+]

--- a/hail/python/hail/experimental/vcf_combiner/__init__.py
+++ b/hail/python/hail/experimental/vcf_combiner/__init__.py
@@ -5,9 +5,6 @@ from .densify import densify
 
 __all__ = [
     'run_combiner',
-    'transform_gvcf',
-    'transform_one',
-    'parse_as_fields',
     'sparse_split_multi',
     'lgt_to_gt',
     'densify',

--- a/hail/python/hail/experimental/vcf_combiner/__init__.py
+++ b/hail/python/hail/experimental/vcf_combiner/__init__.py
@@ -1,10 +1,13 @@
-from .vcf_combiner import run_combiner
+from .vcf_combiner import run_combiner, transform_gvcf, transform_one, parse_as_fields
 from .sparse_split_multi import sparse_split_multi
 from .sparse_mt_utils import lgt_to_gt
 from .densify import densify
 
 __all__ = [
     'run_combiner',
+    'transform_gvcf',
+    'transform_one',
+    'parse_as_fields',
     'sparse_split_multi',
     'lgt_to_gt',
     'densify',

--- a/hail/python/hail/experimental/vcf_combiner/__main__.py
+++ b/hail/python/hail/experimental/vcf_combiner/__main__.py
@@ -1,0 +1,48 @@
+import argparse
+
+import hail as hl
+from .vcf_combiner import CombinerConfig, run_combiner, parse_sample_mapping
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Driver for Hail's GVCF combiner",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('sample_map',
+                        help='Path to the sample map, a tab-separated file with two columns. '
+                             'The first column is the sample ID, and the second column '
+                             'is the GVCF path.')
+    parser.add_argument('out_file', help='Path to final combiner output.')
+    parser.add_argument('tmp_path', help='Path to folder for intermediate output '
+                                         '(should be an object store path, if running on the cloud).')
+    parser.add_argument('--log', help='Hail log path.')
+    parser.add_argument('--header',
+                        help='External header, must be readable by all executors. '
+                             'WARNING: if this option is used, the sample names in the '
+                             'GVCFs will be overridden by the names in sample map.',
+                        required=False)
+    parser.add_argument('--branch-factor', type=int, default=CombinerConfig.default_branch_factor, help='Branch factor.')
+    parser.add_argument('--batch-size', type=int, default=CombinerConfig.default_batch_size, help='Batch size.')
+    parser.add_argument('--target-records', type=int, default=CombinerConfig.default_target_records, help='Target records per partition.')
+    parser.add_argument('--overwrite', help='overwrite the output path', action='store_true')
+    parser.add_argument('--reference-genome', default='GRCh38', help='Reference genome.')
+    args = parser.parse_args()
+    hl.init(log=args.log)
+
+    if not args.overwrite and hl.utils.hadoop_exists(args.out_file):
+        raise FileExistsError(f"path '{args.out_file}' already exists, use --overwrite to overwrite this path")
+
+    sample_names, sample_paths = parse_sample_mapping(args.sample_map)
+    run_combiner(sample_paths,
+                 args.out_file,
+                 args.tmp_path,
+                 header=args.header,
+                 sample_names=sample_names,
+                 batch_size=args.batch_size,
+                 branch_factor=args.branch_factor,
+                 target_records=args.target_records,
+                 overwrite=args.overwrite,
+                 reference_genome=args.reference_genome)
+
+
+if __name__ == '__main__':
+    main()

--- a/hail/python/hail/experimental/vcf_combiner/densify.py
+++ b/hail/python/hail/experimental/vcf_combiner/densify.py
@@ -1,7 +1,7 @@
 import hail as hl
 
 def densify(sparse_mt):
-    """Convert sparse MatrixTable to a dense one.
+    """Convert sparse matrix table to a dense VCF-like representation by expanding reference blocks.
 
     Parameters
     ----------
@@ -15,6 +15,10 @@ def densify(sparse_mt):
     :class:`.MatrixTable`
         The densified MatrixTable.  The ``END`` entry field is dropped.
 
+    While computationally expensive, this
+    operation is necessary for many downstream analyses, and should be thought of as
+    roughly costing as much as reading a matrix table created by importing a dense
+    project VCF.
     """
     if list(sparse_mt.row_key)[0] != 'locus' or not isinstance(sparse_mt.locus.dtype, hl.tlocus):
         raise ValueError("first row key field must be named 'locus' and have type 'locus'")

--- a/hail/python/hail/experimental/vcf_combiner/sparse_mt_utils.py
+++ b/hail/python/hail/experimental/vcf_combiner/sparse_mt_utils.py
@@ -5,14 +5,14 @@ from hail.typecheck import typecheck
 
 @typecheck(lgt=expr_call, la=expr_array(expr_int32))
 def lgt_to_gt(lgt, la):
-    """Transforming Local GT and Local Alleles into the true GT
+    """Transform LGT into GT using local alleles array.
 
     Parameters
     ----------
     lgt : :class:`.CallExpression`
-        The LGT value
+        LGT value.
     la : :class:`.ArrayExpression`
-        The Local Alleles array
+        Local alleles array.
 
     Returns
     -------

--- a/hail/python/hail/experimental/vcf_combiner/sparse_split_multi.py
+++ b/hail/python/hail/experimental/vcf_combiner/sparse_split_multi.py
@@ -2,7 +2,10 @@ import hail as hl
 
 
 def sparse_split_multi(sparse_mt, *, filter_changed_loci=False):
-    """Splits multiallelic variants on a sparse MatrixTable.
+    """Splits multiallelic variants on a sparse matrix table.
+
+    Analogous to :func:`.split_multi_hts` (splits entry fields) for sparse
+    representations.
 
     Takes a dataset formatted like the output of :func:`.vcf_combiner`. The
     splitting will add `was_split` and `a_index` fields, as :func:`.split_multi`
@@ -75,8 +78,7 @@ def sparse_split_multi(sparse_mt, *, filter_changed_loci=False):
 
     Unlike the normal split_multi function. Sparse split multi will not filter
     ``*`` alleles. This is because a row with a bi-allelic spanning deletion
-    may contain ref blocks that start at this position for other samples. And filtering
-    the ref block will remove
+    may contain reference blocks that start at this position for other samples.
 
     Parameters
     ----------

--- a/hail/python/test/hail/experimental/test_vcf_combiner.py
+++ b/hail/python/test/hail/experimental/test_vcf_combiner.py
@@ -23,7 +23,7 @@ def test_1kg_chr22():
 
     sample_names = all_samples[:5]
     paths = [os.path.join(resource('gvcfs'), '1kg_chr22', f'{s}.hg38.g.vcf.gz') for s in sample_names]
-    vc.run_combiner(sample_names, paths,
+    vc.run_combiner(paths,
                     out_file=out_file,
                     tmp_path=Env.hc().tmp_dir,
                     branch_factor=2,

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -370,7 +370,7 @@ class VCFTests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_combiner_works(self):
-        from hail.experimental.vcf_combiner import transform_one, combine_gvcfs
+        from hail.experimental.vcf_combiner.vcf_combiner import transform_one, combine_gvcfs
         _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
         paths = [resource(p) for p in _paths]
         parts = [
@@ -395,7 +395,7 @@ class VCFTests(unittest.TestCase):
         comb._force_count_rows()
 
     def test_combiner_parse_as_annotations(self):
-        import hail.experimental.vcf_combiner as c
+        from hail.experimental.vcf_combiner.vcf_combiner import parse_as_fields
         infos = hl.array([
             hl.struct(
                 AS_QUALapprox="|1171|",
@@ -412,7 +412,7 @@ class VCFTests(unittest.TestCase):
                 AS_RAW_MQRankSum="|NaN|NaN",
                 AS_RAW_ReadPosRankSum="|NaN|NaN")])
 
-        output = hl.eval(infos.map(lambda info: c.parse_as_fields(info, False)))
+        output = hl.eval(infos.map(lambda info: parse_as_fields(info, False)))
         expected = [
             hl.Struct(
                 AS_QUALapprox=[None, 1171, None],


### PR DESCRIPTION
* Made vcf_combiner a module in experimental. Will probably
  move this out of experimental in the future.
* Fleshed out docs, and moved associated functions into
  the same file.
* Changed run_combiner to require sample_names only if
  the header argument is defined. Will change the command-line
  script to accept a file with one column of paths, too.

~Stacked on #8396~