### PR TITLE
[hail] fix binom_test, improve docs, improve testing

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1753,8 +1753,8 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     Test if a coin is biased towards heads after observing thirty-two heads out
     of fifty flips:
 
-    >>> hl.eval(hl.binom_test(32, 50, 0.4, 'greater'))
-    0.0005193012313665977
+    >>> hl.eval(hl.binom_test(32, 50, 0.5, 'greater'))
+    0.03245432353613613
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1727,11 +1727,6 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     - ``'greater'``: a one-tailed test of the significance of `x` or more successes, and
     - ``'two-sided'``: a two-tailed test of the significance of `x` or any equivalent or more unlikely outcome.
 
-    The alternatives are computed in this manner:
-    - ``'less'``: the value of the binomial cumulative density function evaluated at `x`
-    - ``'greater'``: the value of the binomial cumulative density function evaluated at `1 - x`
-    - ``'two-sided'``: the value of the binomial cumulative density function evaluated at `x` or `1 - x` (if `x` is below the mean or above, respectively) plus the value of the binomial cumulative density function evaluated at the equally likely or next most unlikely outcome on the other side of the distribution.
-
     Examples
     --------
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1742,7 +1742,7 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     out of ten flips:
 
     >>> hl.eval(hl.binom_test(2, 10, 0.5, 'two-sided'))
-    0.10937500000000003
+    0.10937499999999994
 
     Test if a coin is biased towards tails after observing four heads out of ten
     flips:
@@ -1754,7 +1754,7 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     of fifty flips:
 
     >>> hl.eval(hl.binom_test(32, 50, 0.4, 'greater'))
-    0.000519301231366599
+    0.0005193012313665977
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1730,11 +1730,7 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     The alternatives are computed in this manner:
     - ``'less'``: the value of the binomial cumulative density function evaluated at `x`
     - ``'greater'``: the value of the binomial cumulative density function evaluated at `1 - x`
-    - ``'two-sided'``: the value of the binomial cumulative density function
-      evaluated at `x` or `1 - x` (if `x` is below the mean or above,
-      respectively) plus the value of the binomial cumulative density function
-      evaluated at the equally likely or next most unlikely outcome on the other
-      side of the distribution.
+    - ``'two-sided'``: the value of the binomial cumulative density function evaluated at `x` or `1 - x` (if `x` is below the mean or above, respectively) plus the value of the binomial cumulative density function evaluated at the equally likely or next most unlikely outcome on the other side of the distribution.
 
     Examples
     --------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -10,7 +10,7 @@ from hail.expr.types import from_numpy
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
 from hail.ir import *
 from hail.typecheck import *
-from hail.utils.java import Env
+from hail.utils.java import Env, warn
 from hail.utils.misc import plural
 
 import numpy as np
@@ -1714,25 +1714,51 @@ def or_missing(predicate, value):
 
 
 @typecheck(x=expr_int32, n=expr_int32, p=expr_float64,
-           alternative=enumeration("two.sided", "greater", "less"))
+           alternative=enumeration("two.sided", "two-sided", "greater", "less"))
 def binom_test(x, n, p, alternative: str) -> Float64Expression:
     """Performs a binomial test on `p` given `x` successes in `n` trials.
-
-    Examples
-    --------
-
-    >>> hl.eval(hl.binom_test(5, 10, 0.5, 'less'))
-    0.6230468749999999
-
-    With alternative ``less``, the p-value is the probability of at most `x`
-    successes, i.e. the cumulative probability at `x` of the distribution
-    Binom(`n`, `p`). With ``greater``, the p-value is the probably of at least
-    `x` successes. With ``two.sided``, the p-value is the total probability of
-    all outcomes with probability at most that of `x`.
 
     Returns the p-value from the `exact binomial test
     <https://en.wikipedia.org/wiki/Binomial_test>`__ of the null hypothesis that
     success has probability `p`, given `x` successes in `n` trials.
+
+    The alternatives are interpreted as follows:
+    - ``'less'``: a one-tailed test of the significance of `x` or fewer successes,
+    - ``'greater'``: a one-tailed test of the significance of `x` or more successes, and
+    - ``'two-sided'``: a two-tailed test of the significance of `x` or any equivalent or more unlikely outcome.
+
+    The alternatives are computed in this manner:
+    - ``'less'``: the value of the binomial cumulative density function evaluated at `x`
+    - ``'greater'``: the value of the binomial cumulative density function evaluated at `1 - x`
+    - ``'two-sided'``: the value of the binomial cumulative density function
+      evaluated at `x` or `1 - x` (if `x` is below the mean or above,
+      respectively) plus the value of the binomial cumulative density function
+      evaluated at the equally likely or next most unlikely outcome on the other
+      side of the distribution.
+
+    Examples
+    --------
+
+    All the examples below use a fair coin as the null hypothesis. Zero is
+    interpreted as tail and one as heads.
+
+    Test if a coin is biased towards heads or tails after observing two heads
+    out of ten flips:
+
+    >>> hl.eval(hl.binom_test(2, 10, 0.5, 'two-sided'))
+    0.10937500000000003
+
+    Test if a coin is biased towards tails after observing four heads out of ten
+    flips:
+
+    >>> hl.eval(hl.binom_test(4, 10, 0.5, 'less'))
+    0.3769531250000001
+
+    Test if a coin is biased towards heads after observing thirty-two heads out
+    of fifty flips:
+
+    >>> hl.eval(hl.binom_test(32, 50, 0.4, 'greater'))
+    0.000519301231366599
 
     Parameters
     ----------
@@ -1743,7 +1769,7 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     p : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Probability of success, between 0 and 1.
     alternative
-        : One of, "two.sided", "greater", "less".
+        : One of, "two-sided", "greater", "less", (deprecated: "two.sided").
 
     Returns
     -------
@@ -1751,7 +1777,13 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
         p-value.
     """
 
-    alt_enum = {"two.sided": 0, "greater": 1, "less": 2}[alternative]
+    if alternative == 'two.sided':
+        warn('"two.sided" is a deprecated and will be removed in a future '
+             'release, please use "two-sided" for the `alternative` parameter '
+             'to hl.binom_test')
+        alternative = 'two-sided'
+
+    alt_enum = {"two-sided": 0, "less": 1, "greater": 2}[alternative]
     return _func("binomTest", tfloat64, x, n, p, to_expr(alt_enum))
 
 

--- a/hail/python/test/hail/expr/test_functions.py
+++ b/hail/python/test/hail/expr/test_functions.py
@@ -1,0 +1,16 @@
+import hail as hl
+import scipy.stats as spst
+import pytest
+
+
+def test_deprecated_binom_test():
+    assert hl.eval(hl.binom_test(2, 10, 0.5, 'two.sided')) == \
+        pytest.approx(spst.binom_test(2, 10, 0.5, 'two-sided'))
+
+
+def test_binom_test():
+    arglists = [[2, 10, 0.5, 'two-sided'],
+                [4, 10, 0.5, 'less'],
+                [32, 50, 0.4, 'greater']]
+    for args in arglists:
+        assert hl.eval(hl.binom_test(*args)) == pytest.approx(spst.binom_test(*args)), args

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -362,7 +362,7 @@ package object stats {
       case 0 => TestKind.TWO_SIDED
       case 1 => TestKind.LOWER
       case 2 => TestKind.GREATER
-      case _ => fatal(s"""Invalid alternative "$alternative". Must be "two_sided", "less" or "greater".""")
+      case _ => fatal(s"""Invalid alternative "$alternative". Must be "two-sided", "less" or "greater".""")
     }
 
     DistributionTest.binomial_test(nSuccess, n, p, kind)(1)

--- a/hail/src/test/scala/is/hail/stats/StatsSuite.scala
+++ b/hail/src/test/scala/is/hail/stats/StatsSuite.scala
@@ -80,14 +80,6 @@ class StatsSuite extends HailSuite {
 
   }
 
-  @Test def binomTestTest() {
-    //Compare against R
-    assert(D_==(binomTest(2, 10, 0.5, 0), 0.10937, tolerance = 1e-4))
-    assert(D_==(binomTest(4 ,10, 0.5, 1), 0.377, tolerance = 1e-3))
-    assert(D_==(binomTest(32, 50, 0.4, 2), 0.0005193, tolerance = 1e-4))
-
-  }
-
   @Test def entropyTest() {
     assert(D_==(entropy("accctg"), 1.79248, tolerance = 1e-5))
     assert(D_==(entropy(Array(2, 3, 4, 5, 6, 6, 4)), 2.23593, tolerance = 1e-5))


### PR DESCRIPTION
Changes:
- correct the interpretation of less and greater.
- improve the formatting and verbiage of the docs,
- expand upon the statistical definition alluded to previously in only the less
  case,
- add python tests which would have caught this error,
- add python tests which test against `scipy`,
- deprecate the use of `'two.sided'`, an R-ism, document the preferred use of
  `'two-sided'`, a Python-ism, and
- fix an error message in Scala that used yet another naming of the two sided test.

