### PR TITLE
[ci] fix ci bug when a PR hits a merge failure

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -288,13 +288,13 @@ class PR(Code):
         assert self.source_sha is not None
 
         log.info(f'{self.short_str()}: notify github state: {gh_status}')
-        if self.batch:
+        if self.batch is None or isinstance(self.batch, MergeFailureBatch):
+            target_url = f'https://ci.hail.is/watched_branches/{self.target_branch.index}/pr/{self.number}'
+        else:
             assert self.batch.id is not None
             target_url = deploy_config.external_url(
                 'ci',
                 f'/batches/{self.batch.id}')
-        else:
-            target_url = f'https://ci.hail.is/watched_branches/{self.target_branch.index}/pr/{self.number}'
         data = {
             'state': gh_status,
             'target_url': target_url,


### PR DESCRIPTION
A merge failure creates a funny batch that doesn't have an id. This handles that properly.