### PR TITLE
[ci][batch][notebook][auth] TLS DB connections

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -7,7 +7,6 @@ import concurrent.futures
 import aiohttp
 from aiohttp import web
 import aiohttp_session
-import aiomysql
 import uvloop
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
 from hailtop.utils import collect_agen, humanize_timedelta_msecs

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -15,7 +15,7 @@ from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, \
     rest_authenticated_developers_only, web_authenticated_developers_only, \
-    check_csrf_token, AccessLogger
+    check_csrf_token, AccessLogger, create_database_pool
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
 
@@ -341,17 +341,7 @@ async def on_startup(app):
         'ci',
         oauth_token=oauth_token)
     app['batch_client'] = await BatchClient('ci', session=session)
-
-    with open('/ci-user-secret/sql-config.json', 'r') as f:
-        config = json.loads(f.read().strip())
-        app['dbpool'] = await aiomysql.create_pool(host=config['host'],
-                                                   port=config['port'],
-                                                   db=config['db'],
-                                                   user=config['user'],
-                                                   password=config['password'],
-                                                   charset='utf8',
-                                                   cursorclass=aiomysql.cursors.DictCursor,
-                                                   autocommit=True)
+    app['dbpool'] = await create_database_pool()
 
     asyncio.ensure_future(update_loop(app))
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -26,7 +26,17 @@ async def write_user_config(namespace, database_name, user, config):
         f.write(json.dumps(config))
 
     with open(f'sql-config.cnf', 'w') as f:
-        f.write(f'[client]\n' + '\n'.join(f'{k}={v}' for k, v in config.items()))
+        f.write(f'''
+[client]
+host={config["host"]}
+user={config["user"]}
+password="{config["password"]}"
+database={config["db"]}
+ssl-ca={config["ssl-ca"]}
+ssl-cert={config["ssl-cert"]}
+ssl-key={config["ssl-key"]}
+ssl-mode={config["ssl-mode"]}
+''')
 
     shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
     shutil.copy('/sql-config/client-key.pem', 'client-key.pem')

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -32,6 +32,7 @@ user={config["user"]}
 password="{config["password"]}"
 database={config["db"]}
 ''')
+        files = ['sql-config.json', 'sql-config.cnf']
         if 'ssl-ca' in config:
             f.write(f'ssl-ca={config["ssl-ca"]}\n')
         if 'ssl-cert' in config:
@@ -43,17 +44,21 @@ database={config["db"]}
 
     if os.path.exists('/sql-config/server-ca.pem'):
         shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
+        files.append('server-ca.pem')
     if os.path.exists('/sql-config/client-key.pem'):
         shutil.copy('/sql-config/client-key.pem', 'client-key.pem')
+        files.append('client-key.pem')
     if os.path.exists('/sql-config/client-cert.pem'):
         shutil.copy('/sql-config/client-cert.pem', 'client-cert.pem')
+        files.append('client-cert.pem')
 
     secret_name = f'sql-{database_name}-{user}-config'
     print(f'creating secret {secret_name}')
+    from_files = ' '.join('--from-file={f}' for f in files)
     await check_shell(
         f'''
 kubectl -n {shq(namespace)} delete --ignore-not-found=true secret {shq(secret_name)}
-kubectl -n {shq(namespace)} create secret generic {shq(secret_name)} --from-file=sql-config.json --from-file=sql-config.cnf --from-file=server-ca.pem --from-file=client-key.pem --from-file=client-cert.pem
+kubectl -n {shq(namespace)} create secret generic {shq(secret_name)} {from_files}
 ''')
 
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -26,17 +26,20 @@ async def write_user_config(namespace, database_name, user, config):
         f.write(json.dumps(config))
 
     with open(f'sql-config.cnf', 'w') as f:
-        f.write(f'''
-[client]
+        f.write(f'''[client]
 host={config["host"]}
 user={config["user"]}
 password="{config["password"]}"
 database={config["db"]}
-ssl-ca={config["ssl-ca"]}
-ssl-cert={config["ssl-cert"]}
-ssl-key={config["ssl-key"]}
-ssl-mode={config["ssl-mode"]}
 ''')
+        if 'ssl-ca' in config:
+            f.write(f'ssl-ca={config["ssl-ca"]}\n')
+        if 'ssl-cert' in config:
+            f.write(f'ssl-cert={config["ssl-cert"]}\n')
+        if 'ssl-key' in config:
+            f.write(f'ssl-key={config["ssl-key"]}\n')
+        if 'ssl-mode' in config:
+            f.write(f'ssl-mode={config["ssl-mode"]}\n')
 
     shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
     shutil.copy('/sql-config/client-key.pem', 'client-key.pem')
@@ -105,10 +108,10 @@ GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON `{_name}`.* TO '{user_username}
         'user': admin_username,
         'password': admin_password,
         'db': _name,
-        'ssl-ca': sql_config['ssl-ca'],
-        'ssl-cert': sql_config['ssl-cert'],
-        'ssl-key': sql_config['ssl-key'],
-        'ssl-mode': sql_config['ssl-mode']
+        'ssl-ca': sql_config.get('ssl-ca'),
+        'ssl-cert': sql_config.get('ssl-cert'),
+        'ssl-key': sql_config.get('ssl-key'),
+        'ssl-mode': sql_config.get('ssl-mode')
     })
 
     await write_user_config(namespace, database_name, 'user', {
@@ -119,10 +122,10 @@ GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON `{_name}`.* TO '{user_username}
         'user': user_username,
         'password': user_password,
         'db': _name,
-        'ssl-ca': sql_config['ssl-ca'],
-        'ssl-cert': sql_config['ssl-cert'],
-        'ssl-key': sql_config['ssl-key'],
-        'ssl-mode': sql_config['ssl-mode']
+        'ssl-ca': sql_config.get('ssl-ca'),
+        'ssl-cert': sql_config.get('ssl-cert'),
+        'ssl-key': sql_config.get('ssl-key'),
+        'ssl-mode': sql_config.get('ssl-mode')
     })
 
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -53,7 +53,7 @@ database={config["db"]}
     await check_shell(
         f'''
 kubectl -n {shq(namespace)} delete --ignore-not-found=true secret {shq(secret_name)}
-kubectl -n {shq(namespace)} create secret generic {shq(secret_name)} --from-file=sql-config.json --from-file=sql-config.cnf
+kubectl -n {shq(namespace)} create secret generic {shq(secret_name)} --from-file=sql-config.json --from-file=sql-config.cnf --from-file=server-ca.pem --from-file=client-key.pem --from-file=client-cert.pem
 ''')
 
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -41,9 +41,12 @@ database={config["db"]}
         if 'ssl-mode' in config:
             f.write(f'ssl-mode={config["ssl-mode"]}\n')
 
-    shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
-    shutil.copy('/sql-config/client-key.pem', 'client-key.pem')
-    shutil.copy('/sql-config/client-cert.pem', 'client-cert.pem')
+    if os.path.exists('/sql-config/server-ca.pem'):
+        shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
+    if os.path.exists('/sql-config/client-key.pem'):
+        shutil.copy('/sql-config/client-key.pem', 'client-key.pem')
+    if os.path.exists('/sql-config/client-cert.pem'):
+        shutil.copy('/sql-config/client-cert.pem', 'client-cert.pem')
 
     secret_name = f'sql-{database_name}-{user}-config'
     print(f'creating secret {secret_name}')

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -76,6 +76,7 @@ async def create_database():
 
     db = Database()
     await db.async_init()
+
     if scope == 'deploy':
         assert _name == database_name
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -54,7 +54,7 @@ database={config["db"]}
 
     secret_name = f'sql-{database_name}-{user}-config'
     print(f'creating secret {secret_name}')
-    from_files = ' '.join('--from-file={f}' for f in files)
+    from_files = ' '.join(f'--from-file={f}' for f in files)
     await check_shell(
         f'''
 kubectl -n {shq(namespace)} delete --ignore-not-found=true secret {shq(secret_name)}

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -65,8 +65,8 @@ spec:
            - name: session-secret-key
              mountPath: /session-secret-key
              readOnly: true
-           - mountPath: /ci-user-secret
-             name: ci-user-secret
+           - mountPath: /sql-config
+             name: sql-config
              readOnly: true
            - mountPath: /secrets/oauth-token
              name: hail-ci-0-1-github-oauth-token
@@ -97,7 +97,7 @@ spec:
          secret:
            optional: false
            secretName: session-secret-key
-       - name: ci-user-secret
+       - name: sql-config
          secret:
            optional: false
            secretName: "{{ ci_database.user_secret_name }}"

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -4,6 +4,7 @@ import pymysql
 import aiomysql
 import logging
 import functools
+import ssl
 
 from hailtop.utils import sleep_and_backoff, LoggingTimer
 
@@ -52,7 +53,8 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
 
 
 @retry_transient_mysql_errors
-async def create_database_pool(config_file=None, autocommit=True, maxsize=10, ssl=True):
+async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
+    ssl_context = ssl.create_default_context(cafile='/sql-config/server-ca.pem')
     if config_file is None:
         config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
     with open(config_file, 'r') as f:
@@ -62,7 +64,7 @@ async def create_database_pool(config_file=None, autocommit=True, maxsize=10, ss
         # connection args
         host=sql_config['host'], user=sql_config['user'], password=sql_config['password'],
         db=sql_config.get('db'), port=sql_config['port'], charset='utf8',
-        ssl=ssl, cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
+        ssl=ssl_context, cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
 
 
 class TransactionAsyncContextManager:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -55,6 +55,7 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
 @retry_transient_mysql_errors
 async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
     ssl_context = ssl.create_default_context(cafile='/sql-config/server-ca.pem')
+    ssl_context.check_hostname = False
     if config_file is None:
         config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
     with open(config_file, 'r') as f:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -52,7 +52,7 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
 
 
 @retry_transient_mysql_errors
-async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
+async def create_database_pool(config_file=None, autocommit=True, maxsize=10, ssl=True):
     if config_file is None:
         config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
     with open(config_file, 'r') as f:
@@ -62,7 +62,7 @@ async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
         # connection args
         host=sql_config['host'], user=sql_config['user'], password=sql_config['password'],
         db=sql_config.get('db'), port=sql_config['port'], charset='utf8',
-        cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
+        ssl=ssl, cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
 
 
 class TransactionAsyncContextManager:

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -58,17 +58,17 @@ def ssl_context_from_sql_config(sql_config):
         # change to the following in a follow up PR
         # raise ValueError(f'cleartext database connections are not '
         #                  f'permitted. {json.dumps(sql_config)}')
-        log.warn(f'using a cleartext mysql connection')
+        log.warning(f'using a cleartext mysql connection')
 
         return False
-    elif ssl_mode == 'REQUIRED':
+    if ssl_mode == 'REQUIRED':
         # change to the following in a follow up PR
         # raise ValueError(f'unverified database connections are not '
         #                  f'permitted. {json.dumps(sql_config)}')
         assert 'ssl-cert' in sql_config
         assert 'ssl-key' in sql_config
 
-        log.warn(f'not verifying msyql server certificates')
+        log.warning(f'not verifying msyql server certificates')
 
         ssl_context = ssl.create_default_context()
         ssl_context.load_cert_chain(
@@ -76,7 +76,7 @@ def ssl_context_from_sql_config(sql_config):
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
         return ssl_context
-    elif ssl_mode == 'VERIFY_CA':
+    if ssl_mode == 'VERIFY_CA':
         assert 'ssl-cert' in sql_config
         assert 'ssl-key' in sql_config
         assert 'ssl-ca' in sql_config
@@ -88,9 +88,8 @@ def ssl_context_from_sql_config(sql_config):
             sql_config['ssl-cert'], keyfile=sql_config['ssl-key'], password=None)
         ssl_context.check_hostname = False
         return ssl_context
-    else:
-        raise ValueError(f'only DISABLED, REQURIED, and VERIFY_CA are '
-                         'supported for ssl-mode. {json.dumps(sql_config)}')
+    raise ValueError(f'only DISABLED, REQURIED, and VERIFY_CA are '
+                     'supported for ssl-mode. {json.dumps(sql_config)}')
 
 
 @retry_transient_mysql_errors

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -88,8 +88,9 @@ def ssl_context_from_sql_config(sql_config):
             sql_config['ssl-cert'], keyfile=sql_config['ssl-key'], password=None)
         ssl_context.check_hostname = False
         return ssl_context
-    raise ValueError(f'only DISABLED, REQURIED, and VERIFY_CA are '
-                     'supported for ssl-mode. {json.dumps(sql_config)}')
+    raise ValueError(f'Only DISABLED, REQURIED, and VERIFY_CA are '
+                     f'supported for ssl-mode. ssl-mode was set to '
+                     f'{sql_config.get("ssl-mode")}.')
 
 
 @retry_transient_mysql_errors


### PR DESCRIPTION
This PR teaches gear/database.py to respect four more MySQL configuration parameters: `ssl-mode`, `ssl-ca`, `ssl-cert`, `ssl-key`. In particular, we can now turn TLS on or off and rotate keys by simply changing secrets and restarting the services. Since all sql-config secrets (except those in my namespace) currently have no certs, no keys, and no ssl parameters, after this PR merges all services will still use plaintext communications to the database.

After this PR merges, I will update the root secret as well as all the service secrets (e.g. sql-auth-user-config) to have a shared client cert/key and our sql database's cert. Moreover I will set `ssl-mode` to `VERIFY_CA` which means (in our world, at least) verify the server's certificate but not the hostname (we use IPs to connect to our sql server) and present your own certificate for verification. Then I will restart all the services. Then I will ban plaintext connections to the database. Then I will PR a change that raises errors if we try to start a service with plaintext connections or unverified connections.

I also:
- updated `create_database.py` so that it will propagate these TLS settings, if present, to created secrets, and
- updated CI to use `gear/database.py` and standard sql-config locations.

All these parameters are defined by MySQL. We only support three options for [`ssl-mode`](https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#option_general_ssl-mode), the remainder are either unnecessary or not supported (e.g. we have no hostnames so `VERIFY_IDENTITY` is irrelevant).