### PR TITLE
[query] hl.init() against query backend without starting JVM/Spark

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -523,6 +523,16 @@ steps:
    dependsOn:
      - service_base_image
      - build_hail
+ - kind: runImage
+   name: check_query
+   image:
+     valueFrom: query_image.image
+   script: |
+     set -ex
+     python3 -m flake8 query
+     python3 -m pylint --rcfile pylintrc query
+   dependsOn:
+     - query_image
  - kind: deploy
    name: deploy_query
    namespace:

--- a/build.yaml
+++ b/build.yaml
@@ -519,7 +519,7 @@ steps:
    publishAs: query
    inputs:
      - from: /hail.jar
-       to: /hail.jar
+       to: /query/hail.jar
    dependsOn:
      - service_base_image
      - build_hail

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -18,6 +18,10 @@ from hailtop.utils import sync_retry_transient_errors
 
 class Backend(abc.ABC):
     @abc.abstractmethod
+    def stop(self):
+        pass
+
+    @abc.abstractmethod
     def execute(self, ir, timed=False):
         pass
 
@@ -178,6 +182,12 @@ class SparkBackend(Backend):
             connect_logger('localhost', 12888)
 
             self._jbackend.startProgressBar()
+
+    def stop(self):
+        self._jhc.stop()
+        self._jhc = None
+        self.sc.stop()
+        self.sc = None
 
     @property
     def fs(self):

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -290,8 +290,8 @@ class ServiceBackend(Backend):
 
         if not deploy_config:
             deploy_config = get_deploy_config()
-        self.url = deploy_config.base_url('apiserver')
-        self.headers = service_auth_headers(deploy_config, 'apiserver')
+        self.url = deploy_config.base_url('query')
+        self.headers = service_auth_headers(deploy_config, 'query')
         self._fs = None
 
     @property

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -106,9 +106,8 @@ class HailContext(object):
         return self._default_ref
 
     def stop(self):
-        Env.hail().HailContext.clear()
-        self.sc.stop()
-        self.sc = None
+        # HailContext.stop calls backend.stop() on the JVM backend
+        Env.hail().HailContext.stop()
         Env._jvm = None
         Env._hc = None
         uninstall_exception_handler()
@@ -273,7 +272,6 @@ def stop():
     """Stop the currently running Hail session."""
     if Env._hc:
         Env.hc().stop()
-        Env._hc = None
 
 def spark_context():
     """Returns the active Spark context.

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -346,11 +346,11 @@ def set_global_seed(seed):
 
 
 def _set_flags(**flags):
-    available = set(Env.hc()._jhc.flags().available())
+    available = set(Env.backend()._jhc.flags().available())
     invalid = []
     for flag, value in flags.items():
         if flag in available:
-            Env.hc()._jhc.flags().set(flag, value)
+            Env.backend()._jhc.flags().set(flag, value)
         else:
             invalid.append(flag)
     if len(invalid) != 0:
@@ -359,7 +359,7 @@ def _set_flags(**flags):
 
 
 def _get_flags(*flags):
-    return {flag: Env.hc()._jhc.flags().get(flag) for flag in flags}
+    return {flag: Env.backend()._jhc.flags().get(flag) for flag in flags}
 
 
 def debug_info():

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -106,8 +106,8 @@ class HailContext(object):
         return self._default_ref
 
     def stop(self):
-        # HailContext.stop calls backend.stop() on the JVM backend
-        Env.hail().HailContext.stop()
+        self._backend.stop()
+        self._backend = None
         Env._jvm = None
         Env._hc = None
         uninstall_exception_handler()

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -282,7 +282,7 @@ def spark_context():
     -------
     :class:`pyspark.SparkContext`
     """
-    return Env.hc().sc
+    return Env.backend().sc
 
 def current_backend():
     return Env.hc()._backend

--- a/hail/python/hail/experimental/codec.py
+++ b/hail/python/hail/experimental/codec.py
@@ -2,10 +2,10 @@ from hail.utils.java import Env
 
 
 def encode(expression, codec='{"name":"BlockingBufferSpec","blockSize":65536,"child":{"name":"StreamBlockBufferSpec"}}'):
-    v = Env.hc()._jhc.backend().encodeToBytes(Env.backend()._to_java_ir(expression._ir), codec)
+    v = Env.backend()._jbackend.encodeToBytes(Env.backend()._to_java_ir(expression._ir), codec)
     return (v._1(), v._2())
 
 
 def decode(typ, ptype_string, bytes, codec='{"name":"BlockingBufferSpec","blockSize":65536,"child":{"name":"StreamBlockBufferSpec"}}'):
     return typ._from_json(
-        Env.hc()._jhc.backend().decodeToJSON(ptype_string, bytes, codec))
+        Env.backend()._jbackend.decodeToJSON(ptype_string, bytes, codec))

--- a/hail/python/hail/experimental/compile.py
+++ b/hail/python/hail/experimental/compile.py
@@ -29,7 +29,7 @@ def load_libhail():
 
 
 def compile_comparison_binary(op, codecName, l_type, r_type):
-    return Env.hc()._jhc.backend().compileComparisonBinary(
+    return Env.backend()._jhc.backend().compileComparisonBinary(
         op, codecName, l_type, r_type)
 
 

--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -21,28 +21,28 @@ class HadoopFS(FS):
             return io.TextIOWrapper(handle, encoding='iso-8859-1')
 
     def copy(self, src: str, dest: str):
-        Env.jutils().copyFile(src, dest, Env.hc()._jhc)
+        Env.jutils().copyFile(src, dest, Env.backend()._jhc)
 
     def exists(self, path: str) -> bool:
-        return Env.jutils().exists(path, Env.hc()._jhc)
+        return Env.jutils().exists(path, Env.backend()._jhc)
 
     def is_file(self, path: str) -> bool:
-        return Env.jutils().isFile(path, Env.hc()._jhc)
+        return Env.jutils().isFile(path, Env.backend()._jhc)
 
     def is_dir(self, path: str) -> bool:
-        return Env.jutils().isDir(path, Env.hc()._jhc)
+        return Env.jutils().isDir(path, Env.backend()._jhc)
 
     def stat(self, path: str) -> Dict:
-        return json.loads(Env.jutils().stat(path, Env.hc()._jhc))
+        return json.loads(Env.jutils().stat(path, Env.backend()._jhc))
 
     def ls(self, path: str) -> List[Dict]:
-        r = Env.jutils().ls(path, Env.hc()._jhc)
+        r = Env.jutils().ls(path, Env.backend()._jhc)
         return json.loads(r)
 
 
 class HadoopReader(io.RawIOBase):
     def __init__(self, path, buffer_size):
-        self._jfile = Env.jutils().readFile(path, Env.hc()._jhc, buffer_size)
+        self._jfile = Env.jutils().readFile(path, Env.backend()._jhc, buffer_size)
         super(HadoopReader, self).__init__()
 
     def close(self):
@@ -60,7 +60,7 @@ class HadoopReader(io.RawIOBase):
 
 class HadoopWriter(io.RawIOBase):
     def __init__(self, path, exclusive=False):
-        self._jfile = Env.jutils().writeFile(path, Env.hc()._jhc, exclusive)
+        self._jfile = Env.jutils().writeFile(path, Env.backend()._jhc, exclusive)
         super(HadoopWriter, self).__init__()
 
     def writable(self):

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -377,7 +377,7 @@ class JIRVectorReference(object):
 
     def __del__(self):
         try:
-            Env.hc()._jhc.pyRemoveIrVector(self.jid)
+            Env.backend()._jhc.pyRemoveIrVector(self.jid)
         # there is only so much we can do if the attempt to remove the unused IR fails,
         # especially since this will often get called during interpreter shutdown.
         except Exception:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1817,7 +1817,7 @@ class BlockMatrix(object):
             Describes which entries to export. One of:
             ``'full'``, ``'lower'``, ``'strict_lower'``, ``'upper'``, ``'strict_upper'``.
         """
-        jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.hc()._jhc, path_in, joption(partition_size))
+        jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, path_in, joption(partition_size))
 
         export_type = Env.hail().utils.ExportType.getExportType(parallel)
 
@@ -2428,20 +2428,20 @@ def _jarray_from_ndarray(nd):
     path = new_local_temp_file()
     uri = local_path_uri(path)
     nd.tofile(path)
-    return Env.hail().utils.richUtils.RichArray.importFromDoubles(Env.hc()._jhc, uri, nd.size)
+    return Env.hail().utils.richUtils.RichArray.importFromDoubles(Env.backend()._jhc, uri, nd.size)
 
 
 def _ndarray_from_jarray(ja):
     path = new_local_temp_file()
     uri = local_path_uri(path)
-    Env.hail().utils.richUtils.RichArray.exportToDoubles(Env.hc()._jhc, uri, ja)
+    Env.hail().utils.richUtils.RichArray.exportToDoubles(Env.backend()._jhc, uri, ja)
     return np.fromfile(path)
 
 
 def _breeze_fromfile(uri, n_rows, n_cols):
     _check_entries_size(n_rows, n_cols)
 
-    return Env.hail().utils.richUtils.RichDenseMatrixDouble.importFromDoubles(Env.hc()._jhc, uri, n_rows, n_cols, True)
+    return Env.hail().utils.richUtils.RichDenseMatrixDouble.importFromDoubles(Env.backend()._jhc, uri, n_rows, n_cols, True)
 
 
 def _check_entries_size(n_rows, n_cols):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -21,7 +21,7 @@ from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativ
 from hail.table import Table
 from hail.typecheck import *
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
-from hail.utils.java import Env, jarray, joption
+from hail.utils.java import Env, joption
 
 block_matrix_type = lazy()
 
@@ -1898,8 +1898,7 @@ class BlockMatrix(object):
                 raise ValueError(f'rectangle {r} does not satisfy '
                                  f'0 <= r[0] <= r[1] <= n_rows and 0 <= r[2] <= r[3] <= n_cols')
 
-        flattened_rectangles = jarray(Env.jvm().long, list(itertools.chain(*rectangles)))
-        rectangles = hl.literal(flattened_rectangles, hl.tarray(hl.tint64))
+        rectangles = hl.literal(list(itertools.chain(*rectangles)), hl.tarray(hl.tint64))
         return BlockMatrix(
             BlockMatrixSparsify(self._bmir, rectangles._ir, RectangleSparsifier))
 

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -931,9 +931,9 @@ def grep(regex, path, max_count=100, *, show=True):
     :obj:`dict` of :obj:`str` to :obj:`list` of :obj:`str`
     """
     if show:
-        Env.hc()._jhc.grepPrint(regex, jindexed_seq_args(path), max_count)
+        Env.backend()._jhc.grepPrint(regex, jindexed_seq_args(path), max_count)
     else:
-        jarr = Env.hc()._jhc.grepReturn(regex, jindexed_seq_args(path), max_count)
+        jarr = Env.backend()._jhc.grepReturn(regex, jindexed_seq_args(path), max_count)
         return {x._1(): list(x._2()) for x in jarr}
 
 

--- a/hail/python/hail/stats/linear_mixed_model.py
+++ b/hail/python/hail/stats/linear_mixed_model.py
@@ -728,18 +728,18 @@ class LinearMixedModel(object):
             self._set_scala_model()
 
         if partition_size is None:
-            block_size = Env.hail().linalg.BlockMatrix.readMetadata(Env.hc()._jhc, pa_t_path).blockSize()
+            block_size = Env.hail().linalg.BlockMatrix.readMetadata(Env.backend()._jhc, pa_t_path).blockSize()
             partition_size = block_size
         elif partition_size <= 0:
             raise ValueError(f'partition_size must be positive, found {partition_size}')
 
-        jpa_t = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.hc()._jhc, pa_t_path, jsome(partition_size))
+        jpa_t = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, pa_t_path, jsome(partition_size))
 
         if a_t_path is None:
             maybe_ja_t = jnone()
         else:
             maybe_ja_t = jsome(
-                Env.hail().linalg.RowMatrix.readBlockMatrix(Env.hc()._jhc, a_t_path, jsome(partition_size)))
+                Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, a_t_path, jsome(partition_size)))
 
         return Table._from_java(self._scala_model.fit(jpa_t, maybe_ja_t))
 

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -46,13 +46,6 @@ class Env:
         return Env._hail_package
 
     @staticmethod
-    def gateway():
-        if not Env._gateway:
-            Env.hc()
-            assert Env._gateway is not None
-        return Env._gateway
-
-    @staticmethod
     def jutils():
         if not Env._jutils:
             Env._jutils = scala_package_object(Env.hail().utils)
@@ -107,13 +100,6 @@ class Env:
         if Env._seed_generator is None:
             Env.set_seed(None)
         return Env._seed_generator.next_seed()
-
-
-def jarray(jtype, lst):
-    jarr = Env.gateway().new_array(jtype, len(lst))
-    for i, s in enumerate(lst):
-        jarr[i] = s
-    return jarr
 
 
 def scala_object(jpackage, name):

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -80,7 +80,7 @@ class Env:
 
     @staticmethod
     def spark_session():
-        return Env.hc()._spark_session
+        return Env.backend()._spark_session
 
     _dummy_table = None
 

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -153,7 +153,7 @@ def local_path_uri(path):
 
 
 def new_temp_file(suffix=None, prefix=None, n_char=10):
-    return Env.hc()._jhc.getTemporaryFile(n_char, joption(prefix), joption(suffix))
+    return Env.backend()._jhc.getTemporaryFile(n_char, joption(prefix), joption(suffix))
 
 
 def new_local_temp_dir(suffix=None, prefix=None, dir=None):

--- a/hail/python/hail/utils/tutorial.py
+++ b/hail/python/hail/utils/tutorial.py
@@ -47,7 +47,7 @@ def get_1kg(output_dir, overwrite: bool = False):
     overwrite
         If ``True``, overwrite any existing files/directories at `output_dir`.
     """
-    jhc = Env.hc()._jhc
+    jhc = Env.backend()._jhc
 
     _mkdir(jhc, output_dir)
 
@@ -110,7 +110,7 @@ def get_movie_lens(output_dir, overwrite: bool = False):
         If ``True``, overwrite existing files/directories at those locations.
     """
 
-    jhc = Env.hc()._jhc
+    jhc = Env.backend()._jhc
 
     _mkdir(jhc, output_dir)
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -456,8 +456,11 @@ class HailContext private(
 
   def fsBc: Broadcast[FS] = sparkBackend().fsBc
 
-  val tmpDir: String = TempDir.createTempDir(tmpDirPath, fs)
-  info(s"Hail temporary directory: $tmpDir")
+  lazy val tmpDir: String = {
+    val tmpDir = TempDir.createTempDir(tmpDirPath, fs)
+    info(s"Hail temporary directory: $tmpDir")
+    tmpDir
+  }
 
   val flags: HailFeatureFlags = new HailFeatureFlags()
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -155,7 +155,7 @@ object HailContext {
     theContext
   }
 
-  def clear(): Unit = synchronized {
+  def stop(): Unit = synchronized {
     ReferenceGenome.reset()
     IRFunctionRegistry.clearUserFunctions()
     backend.stop()

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -448,6 +448,8 @@ class HailContext private(
   val tmpDirPath: String,
   val branchingFactor: Int,
   val optimizerIterations: Int) {
+  def stop(): Unit = HailContext.stop()
+
   def sparkBackend(): SparkBackend = backend.asSpark()
 
   def sc: SparkContext = sparkBackend().sc

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -16,3 +16,4 @@ abstract class Backend {
 
   def asSpark(): SparkBackend = fatal("SparkBackend needed for this operation.")
 }
+

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -4,7 +4,13 @@ import is.hail.backend.{Backend, BroadcastValue}
 
 import scala.reflect.ClassTag
 
-object ServiceBackend extends Backend {
+object ServiceBackend {
+  def apply(): ServiceBackend = {
+    new ServiceBackend()
+  }
+}
+
+class ServiceBackend() extends Backend {
   def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = new BroadcastValue[T] {
     def value: T = _value
   }
@@ -22,11 +28,5 @@ object ServiceBackend extends Backend {
 
   def stop(): Unit = ()
 
-  def apply(): ServiceBackend = {
-    new ServiceBackend()
-  }
-}
-
-class ServiceBackend() {
   def request(): Int = 5
 }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -1,6 +1,27 @@
 package is.hail.backend.service
 
-object ServiceBackend {
+import is.hail.backend.{Backend, BroadcastValue}
+
+import scala.reflect.ClassTag
+
+object ServiceBackend extends Backend {
+  def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = new BroadcastValue[T] {
+    def value: T = _value
+  }
+
+  def parallelizeAndComputeWithIndex[T: ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U] = {
+    val n = collection.length
+    val r = new Array[U](n)
+    var i = 0
+    while (i < n) {
+      r(i) = f(collection(i), i)
+      i += 1
+    }
+    r
+  }
+
+  def stop(): Unit = ()
+
   def apply(): ServiceBackend = {
     new ServiceBackend()
   }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -192,7 +192,7 @@ object SparkBackend {
     theSparkBackend = new SparkBackend(sc1)
     theSparkBackend
   }
-
+  
   def stop(): Unit = synchronized {
     if (theSparkBackend != null) {
       theSparkBackend.sc.stop()

--- a/query/Dockerfile
+++ b/query/Dockerfile
@@ -5,6 +5,6 @@ COPY query/query /query/query/
 RUN pip3 install --no-cache-dir /query && \
   rm -rf /query
 
-COPY hail.jar /
+COPY query/hail.jar /
 
 EXPOSE 5000

--- a/query/Makefile
+++ b/query/Makefile
@@ -16,7 +16,7 @@ build:
 	make -C ../docker build
 	make -C ../hail shadowJar
 # janky
-	cp ../hail/build/libs/hail-all-spark.jar .
+	cp ../hail/build/libs/hail-all-spark.jar ./hail.jar
 	-docker pull $(QUERY_LATEST)
 	python3 ../ci/jinja2_render.py '{"service_base_image":{"image":"service-base"}}' Dockerfile Dockerfile.out
 	docker build -t query -f Dockerfile.out --cache-from query,$(QUERY_LATEST),service-base ..

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -3,7 +3,6 @@ import concurrent
 import uvloop
 from aiohttp import web
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
-from hail.utils import FatalError
 from hailtop.utils import blocking_to_async
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, rest_authenticated_users_only
@@ -38,14 +37,10 @@ def blocking_get_reference(app, data):
 async def get_reference(request, userdata):  # pylint: disable=unused-argument
     app = request.app
     thread_pool = app['thread_pool']
-    try:
-        data = await request.json()
-        result = await blocking_to_async(thread_pool, blocking_get_reference, app, data)
-        return web.json_response(result)
-    except FatalError as e:
-        return web.json_response({
-            'message': e.args[0]
-        }, status=400)
+    data = await request.json()
+    # FIXME error handling
+    result = await blocking_to_async(thread_pool, blocking_get_reference, app, data)
+    return web.json_response(result)
 
 
 async def on_startup(app):


### PR DESCRIPTION
This changes allow `hl.init()` to run against the query service without starting JVM/Spark on the client:

```
$ python3
Python 3.7.3 (default, Oct  7 2019, 12:56:13) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import hail as hl
>>> hl.init(_backend=hl.backend.ServiceBackend())
Welcome to
     __  __     <>__
    / /_/ /__  __/ /
   / __  / _ `/ / /
  /_/ /_/\_,_/_/_/   version 0.2.34-0ef20f14e0c1
LOGGING: writing to /home/cotton/hail/hail-20200402-0120-0.2.34-0ef20f14e0c1.log
```

Summary of changes:
 - Move initialization of Java HailContext from init to SparkBackend ctor.  There is no JVM or Java HailContext when using the service backend.
 - Env no longer carries the gateway.  (Next: jvm)
 - make Java HailContext.tmpDir construction lazy.  It requires a fs, but HailContext will only carry an fs for the SparkBackend.  This will have to get rethought.
 - Make Java ServiceBackend extend Backend.
 - Construct a HailContext in the query service.
 - Implement /references/get in query backend which is needed by hl.init to get the builtin reference genomes on startup.