### PR TITLE
[query/pcode] Convert `hamming` string function to registerPCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -3,7 +3,9 @@ package is.hail.expr.types.physical
 import is.hail.annotations.CodeOrdering
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.check.Arbitrary._
+import is.hail.check.Gen
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.TBinary
 
 abstract class PBinary extends PType {
@@ -99,12 +101,22 @@ abstract class PBinary extends PType {
   def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit]
 }
 
+abstract class PBinaryValue extends PValue {
+  def loadLength(): Code[Int]
+
+  def loadBytes(): Code[Array[Byte]]
+
+  def loadByte(i: Code[Int]): Code[Byte]
+}
+
 abstract class PBinaryCode extends PCode {
   def pt: PBinary
 
   def loadLength(): Code[Int]
 
-  def bytesAddress(): Code[Long]
-
   def loadBytes(): Code[Array[Byte]]
+
+  def memoize(cb: EmitCodeBuilder, name: String): PBinaryValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): PBinaryValue
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
@@ -163,6 +163,8 @@ class PCanonicalBinarySettable(val pt: PCanonicalBinary, a: Settable[Long]) exte
 class PCanonicalBinaryCode(val pt: PCanonicalBinary, val a: Code[Long]) extends PBinaryCode {
   def code: Code[_] = a
 
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
+
   def loadLength(): Code[Int] = pt.loadLength(a)
 
   def loadBytes(): Code[Array[Byte]] = pt.loadBytes(a)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBinary.scala
@@ -141,7 +141,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 }
 
 object PCanonicalBinary {
-  def apply(required: Boolean = false): PBinary = if (required) PCanonicalBinaryRequired else PCanonicalBinaryOptional
+  def apply(required: Boolean = false): PCanonicalBinary = if (required) PCanonicalBinaryRequired else PCanonicalBinaryOptional
 
   def unapply(t: PBinary): Option[Boolean] = Option(t.required)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
@@ -82,8 +82,6 @@ class PCanonicalStringCode(val pt: PCanonicalString, a: Code[Long]) extends PStr
 
   def loadLength(): Code[Int] = pt.loadLength(a)
 
-  def bytesAddress(): Code[Long] = pt.bytesAddress(a)
-
   def loadString(): Code[String] = pt.loadString(a)
 
   def asBytes(): PBinaryCode = new PCanonicalBinaryCode(pt.binaryFundamentalType, a)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
@@ -15,7 +15,7 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   override def byteSize: Long = 8
 
-  lazy val binaryFundamentalType: PBinary = PCanonicalBinary(required)
+  lazy val binaryFundamentalType: PCanonicalBinary = PCanonicalBinary(required)
 
   def copyFromType(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Long] = {
     this.fundamentalType.copyFromType(

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
@@ -31,12 +31,6 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   override def containsPointers: Boolean = true
 
-  def bytesAddress(boff: Long): Long =
-    this.fundamentalType.bytesAddress(boff)
-
-  def bytesAddress(boff: Code[Long]): Code[Long] =
-    this.fundamentalType.bytesAddress(boff)
-
   def loadLength(boff: Long): Int =
     this.fundamentalType.loadLength(boff)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalString.scala
@@ -92,6 +92,8 @@ class PCanonicalStringCode(val pt: PCanonicalString, a: Code[Long]) extends PStr
 
   def loadString(): Code[String] = pt.loadString(a)
 
+  def asBytes(): PBinaryCode = new PCanonicalBinaryCode(pt.binaryFundamentalType, a)
+
   def memoize(cb: EmitCodeBuilder, name: String): PValue = defaultMemoizeImpl(cb, name)
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PValue = defaultMemoizeFieldImpl(cb, name)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -19,10 +19,6 @@ abstract class PString extends PType {
   protected val binaryFundamentalType: PBinary
   override lazy val fundamentalType: PBinary = binaryFundamentalType
 
-  def bytesAddress(boff: Long): Long
-
-  def bytesAddress(boff: Code[Long]): Code[Long]
-
   def loadLength(boff: Long): Int
 
   def loadLength(boff: Code[Long]): Code[Int]

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -37,8 +37,6 @@ abstract class PStringCode extends PCode {
 
   def loadLength(): Code[Int]
 
-  def bytesAddress(): Code[Long]
-
   def loadString(): Code[String]
 
   def asBytes(): PBinaryCode

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -44,4 +44,6 @@ abstract class PStringCode extends PCode {
   def bytesAddress(): Code[Long]
 
   def loadString(): Code[String]
+
+  def asBytes(): PBinaryCode
 }


### PR DESCRIPTION
Also make various PCode/PTypes improvements, notably removing `bytesAddress`
from `PString`, and adding a proper `PBinaryValue` class for byte indexing as a `PCode`.