### PR TITLE
[query] don't test GoogleStorageFS by default

### DIFF
--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -216,35 +216,10 @@ trait FSSuite {
   }
 }
 
-class TestHadoopFS extends HailSuite with FSSuite {
+class HadoopFSSuite extends HailSuite with FSSuite {
   val root: String = "file:/"
   
   lazy val fsResourcesRoot: String = "file:" + new java.io.File("./src/test/resources/fs").getCanonicalPath
   
   lazy val tmpdir: String = tmpDir.createTempFile()
-}
-
-class TestGoogleStorageFS extends TestNGSuite with FSSuite {
-  val bucket: String = "hail-test-dmk9z"
-  
-  val root: String = s"gs://$bucket"
-  
-  val fsResourcesRoot: String = System.getenv("HAIL_GS_FS_TEST_RESOURCES")
-
-  private val keyFile = "/test-gsa-key/key.json"
-  
-  lazy val fs = new GoogleStorageFS(
-    new String(IOUtils.toByteArray(new FileInputStream(keyFile))))
-
-  lazy val tmpdir: String = s"gs://$bucket/tmp"
-
-  @Test def testDropTailingSlash(): Unit = {
-    import GoogleStorageFS._
-
-    assert(dropTrailingSlash("") == "")
-    assert(dropTrailingSlash("/foo/bar") == "/foo/bar")
-    assert(dropTrailingSlash("foo/bar/") == "foo/bar")
-    assert(dropTrailingSlash("/foo///") == "/foo")
-    assert(dropTrailingSlash("///") == "")
-  }
 }

--- a/hail/src/test/scala/is/hail/fs/gs/GoogleStorageFSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/gs/GoogleStorageFSSuite.scala
@@ -1,0 +1,34 @@
+package is.hail.fs.gs
+
+import java.io.FileInputStream
+
+import is.hail.fs.FSSuite
+import is.hail.io.fs.GoogleStorageFS
+import org.apache.commons.io.IOUtils
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class GoogleStorageFSSuite extends TestNGSuite with FSSuite {
+  val bucket: String = "hail-test-dmk9z"
+
+  val root: String = s"gs://$bucket"
+
+  val fsResourcesRoot: String = System.getenv("HAIL_GS_FS_TEST_RESOURCES")
+
+  private val keyFile = "/test-gsa-key/key.json"
+
+  lazy val fs = new GoogleStorageFS(
+    new String(IOUtils.toByteArray(new FileInputStream(keyFile))))
+
+  lazy val tmpdir: String = s"gs://$bucket/tmp"
+
+  @Test def testDropTailingSlash(): Unit = {
+    import GoogleStorageFS._
+
+    assert(dropTrailingSlash("") == "")
+    assert(dropTrailingSlash("/foo/bar") == "/foo/bar")
+    assert(dropTrailingSlash("foo/bar/") == "foo/bar")
+    assert(dropTrailingSlash("/foo///") == "/foo")
+    assert(dropTrailingSlash("///") == "")
+  }
+}

--- a/hail/testng.xml
+++ b/hail/testng.xml
@@ -2,7 +2,7 @@
     <test name="TestAll">
         <packages>
           <package name="is.hail.*">
-            <exclude name="is.hail.fs.TestGoogleStorageFS"></exclude>
+            <exclude name="is.hail.fs.gs"></exclude>
 	  </package>
         </packages>
     </test>

--- a/hail/testng.xml
+++ b/hail/testng.xml
@@ -2,6 +2,7 @@
     <test name="TestAll">
         <packages>
           <package name="is.hail.*">
+            <exclude name="is.hail.fs.TestGoogleStorageFS"></exclude>
 	  </package>
         </packages>
     </test>


### PR DESCRIPTION
There is a `testng-build.xml` that is used by build.yaml and tests the google storage fs.