### PR TITLE
[query] cleanup redundent MethodBuilders in Emit

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -543,7 +543,16 @@ object EmitStream {
     }
   }
 
-  private[ir] def apply[C](
+  private[ir] def emit[C](
+    emitter: Emit[C],
+    streamIR0: IR,
+    mb: EmitMethodBuilder[C],
+    env0: Emit.E,
+    container: Option[AggContainer]
+  ): COption[SizedStream] =
+    emit(emitter, streamIR0, mb, mb.getArg[Region](1), env0, container)
+
+  private[ir] def emit[C](
     emitter: Emit[C],
     streamIR0: IR,
     mb: EmitMethodBuilder[C],
@@ -557,9 +566,9 @@ object EmitStream {
       def emitIR(ir: IR, env: Emit.E = env, region: Value[Region] = region, container: Option[AggContainer] = container): EmitCode =
         emitter.emitWithRegion(ir, mb, region, env, container)
 
-      def emitVoidIR(ir: IR, mb:  EmitMethodBuilder[C] = mb, env: Emit.E = env, container: Option[AggContainer] = container): Code[Unit] = {
+      def emitVoidIR(ir: IR, env: Emit.E = env, container: Option[AggContainer] = container): Code[Unit] = {
         EmitCodeBuilder.scopedVoid(mb) { cb =>
-          emitter.emitVoid(cb, ir, mb, env, EmitRegion(mb, region), container, None)
+          emitter.emitVoid(cb, ir, mb, region, env, container, None)
         }
       }
 

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -223,7 +223,7 @@ class EmitStreamSuite extends HailSuite {
         case s => s
       }
       TypeCheck(s)
-      EmitStream(new Emit(ctx, fb.ecb), s, mb, mb.getArg[Region](1), Env.empty, None)
+      EmitStream.emit(new Emit(ctx, fb.ecb), s, mb, Env.empty, None)
     }
     mb.emit {
       val arrayt = EmitStream.toArray(mb, PArray(eltType), stream)
@@ -275,7 +275,7 @@ class EmitStreamSuite extends HailSuite {
     InferPType(ir, Env.empty)
     val optStream = ExecuteContext.scoped() { ctx =>
       TypeCheck(ir)
-      EmitStream(new Emit(ctx, fb.ecb), ir, mb, mb.getArg[Region](1), Env.empty, None)
+      EmitStream.emit(new Emit(ctx, fb.ecb), ir, mb, Env.empty, None)
     }
     val L = CodeLabel()
     val len = mb.newLocal[Int]()

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -223,7 +223,7 @@ class EmitStreamSuite extends HailSuite {
         case s => s
       }
       TypeCheck(s)
-      EmitStream(new Emit(ctx, fb.ecb), mb, s, Env.empty, EmitRegion.default(mb), None)
+      EmitStream(new Emit(ctx, fb.ecb), s, mb, mb.getArg[Region](1), Env.empty, None)
     }
     mb.emit {
       val arrayt = EmitStream.toArray(mb, PArray(eltType), stream)
@@ -275,7 +275,7 @@ class EmitStreamSuite extends HailSuite {
     InferPType(ir, Env.empty)
     val optStream = ExecuteContext.scoped() { ctx =>
       TypeCheck(ir)
-      EmitStream(new Emit(ctx, fb.ecb), mb, ir, Env.empty, EmitRegion.default(mb), None)
+      EmitStream(new Emit(ctx, fb.ecb), ir, mb, mb.getArg[Region](1), Env.empty, None)
     }
     val L = CodeLabel()
     val len = mb.newLocal[Int]()


### PR DESCRIPTION
Emit was taking two MethodBuilder arguments, one directly and one embedded in an EmitRegion. This PR replaces the EmitRegion argument with a Value[Region]. It also makes a couple other simple refactorings that were personally helpful in understanding the structure of Emit.