### PR TITLE
[query] Pull unused fields out of NDArray

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1316,8 +1316,8 @@ private class Emit[C](
               val childStrides = new CodePTuple(childPType.strides.pType, childStridesAddr)
 
               x.pType.construct(
-                childPType.flags.load(childAddress),
-                childPType.offset.load(childAddress),
+                0,
+                0,
                 { srvb =>
                   Code(
                     srvb.start(),

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -188,8 +188,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     }
   }
 
-  override def construct(flags: Code[Int], offset: Code[Int], shapeBuilder: (StagedRegionValueBuilder => Code[Unit]),
-    stridesBuilder: (StagedRegionValueBuilder => Code[Unit]), data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long] = {
+  override def construct(shapeBuilder: StagedRegionValueBuilder => Code[Unit], stridesBuilder: StagedRegionValueBuilder => Code[Unit], data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long] = {
     val srvb = new StagedRegionValueBuilder(mb, this.representation)
 
     Code(Code(FastIndexedSeq(

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -52,6 +52,5 @@ abstract class PNDArray extends PType {
 
   def copyColumnMajorToRowMajor(colMajorAddress: Code[Long], targetAddress: Code[Long], nRows: Code[Long], nCols: Code[Long], mb: EmitMethodBuilder[_]): Code[Unit]
 
-  def construct(flags: Code[Int], offset: Code[Int], shapeBuilder: (StagedRegionValueBuilder => Code[Unit]),
-    stridesBuilder: (StagedRegionValueBuilder => Code[Unit]), data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long]
+  def construct(shapeBuilder: StagedRegionValueBuilder => Code[Unit], stridesBuilder: StagedRegionValueBuilder => Code[Unit], data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long]
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -24,8 +24,6 @@ abstract class PNDArray extends PType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering = throw new UnsupportedOperationException
 
-  val flags: StaticallyKnownField[PInt32Required.type, Int]
-  val offset: StaticallyKnownField[PInt32Required.type, Int]
   val shape: StaticallyKnownField[PTuple, Long]
   val strides: StaticallyKnownField[PTuple, Long]
   val data: StaticallyKnownField[PArray, Long]

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -47,8 +47,8 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
   override def str(a: Annotation): String = {
     if (a == null) "NA" else {
       val a_row = a.asInstanceOf[Row]
-      val shape = a_row(2).asInstanceOf[Row].toSeq.asInstanceOf[Seq[Long]].map(_.toInt)
-      val data = a_row(4).asInstanceOf[UnsafeIndexedSeq]
+      val shape = a_row(this.representation.fieldIdx("shape")).asInstanceOf[Row].toSeq.asInstanceOf[Seq[Long]].map(_.toInt)
+      val data = a_row(this.representation.fieldIdx("data")).asInstanceOf[UnsafeIndexedSeq]
 
       def dataToNestedString(data: Iterator[Annotation], shape: Seq[Int], sb: StringBuilder):Unit  = {
         if (shape.isEmpty) {
@@ -99,8 +99,6 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
   val ordering: ExtendedOrdering = null
 
   lazy val representation = TStruct(
-    ("flags", TInt32),
-    ("offset", TInt32),
     ("shape", TTuple(Array.tabulate(nDims)(_ => TInt64):_*)),
     ("strides", TTuple(Array.tabulate(nDims)(_ => TInt64):_*)),
     ("data", TArray(elementType))

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -106,7 +106,7 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
     "org.apache.hadoop.io.compress.GzipCodec")
 
   @transient private var codecs: IndexedSeq[hadoop.io.compress.CompressionCodec] = _
-  
+
   def createCodecs(): Unit = {
     if (codecs != null)
       return

--- a/hail/src/test/scala/is/hail/expr/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PNDArraySuite.scala
@@ -10,7 +10,7 @@ import org.testng.annotations.Test
 class PNDArraySuite extends HailSuite {
   @Test def copyTests() {
     def runTests(deepCopy: Boolean, interpret: Boolean = false) {
-      PhysicalTestUtils.copyTestExecutor(PNDArray(PInt64(true), 1), PNDArray(PInt64(true), 1), Annotation(0, 1, Annotation(1L), Annotation(1L), IndexedSeq(4L,5L,6L)),
+      PhysicalTestUtils.copyTestExecutor(PNDArray(PInt64(true), 1), PNDArray(PInt64(true), 1), Annotation(Annotation(1L), Annotation(1L), IndexedSeq(4L,5L,6L)),
         deepCopy = deepCopy, interpret = interpret)
     }
 

--- a/hail/www/index.md
+++ b/hail/www/index.md
@@ -23,15 +23,6 @@ Hail is maintained by a team in the [Neale lab](https://nealelab.is/) at the [St
 
 Contact the Hail team at <a href="mailto:hail@broadinstitute.org"><code>hail@broadinstitute.org</code></a>.
 
-<dl>
-  <dt>Definition list</dt>
-  <dd>Is something people use sometimes.</dd>
-
-  <dt>Markdown in HTML</dt>
-  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
-</dl>
-
-
 ### Citing Hail
 
 If you use Hail for published work, please cite the software. You can get a citation for the version of Hail you installed by executing:

--- a/hail/www/index.md
+++ b/hail/www/index.md
@@ -23,6 +23,15 @@ Hail is maintained by a team in the [Neale lab](https://nealelab.is/) at the [St
 
 Contact the Hail team at <a href="mailto:hail@broadinstitute.org"><code>hail@broadinstitute.org</code></a>.
 
+<dl>
+  <dt>Definition list</dt>
+  <dd>Is something people use sometimes.</dd>
+
+  <dt>Markdown in HTML</dt>
+  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
+</dl>
+
+
 ### Citing Hail
 
 If you use Hail for published work, please cite the software. You can get a citation for the version of Hail you installed by executing:


### PR DESCRIPTION
This PR gets rid of the vestigial `flags` and `offset` fields in `PNDArray` and `TNDArray`