### PR TITLE
Add Libraries to Sidebar

### DIFF
--- a/hail/python/hail/docs/index.rst
+++ b/hail/python/hail/docs/index.rst
@@ -21,10 +21,11 @@ Contents
     Tutorials <tutorials-landing>
     Reference (Python API) <api>
     Overview <overview/index>
-    Datasets <datasets>
-    Annotation Database <annotation_database_ui>
     How-To Guides <guides>
     Cheatsheets <cheatsheets>
+    Datasets <datasets>
+    Annotation Database <annotation_database_ui>
+    Libraries <libraries>
     For Software Developers <getting_started_developing>
     Other Resources <other_resources>
     Change Log <change_log>

--- a/hail/python/hail/docs/libraries.rst
+++ b/hail/python/hail/docs/libraries.rst
@@ -10,10 +10,12 @@ questions about them, but they may provide useful functions not included in base
 
 --------
 
-Hail utilities for gnomAD
---------------------------
+gnomad (Hail Utilities for gnomAD)
+----------------------------------
 
 This repo contains a number of Hail utility functions and scripts for the `gnomAD <https://gnomad.broadinstitute.org>`_ project and the `MacArthur lab <https://macarthurlab.org/>`_.
 
-`PyPI <https://pypi.org/project/gnomad/>`_ and `API Reference <https://broadinstitute.github.io/gnomad_methods/api_reference/>`_
+Install with ``pip install gnomad``.
+
+More info can be found here: `PyPI <https://pypi.org/project/gnomad/>`_ and `API Reference <https://broadinstitute.github.io/gnomad_methods/api_reference/>`_
 

--- a/hail/python/hail/docs/libraries.rst
+++ b/hail/python/hail/docs/libraries.rst
@@ -1,0 +1,19 @@
+.. _sec-libraries:
+
+
+===================
+Libraries
+===================
+
+This pages lists any external libraries we are aware of that are built on top of hail. These libraries are not developed by hail team so we cannot necessarily answer 
+questions about them, but they may provide useful functions not included in base hail.
+
+--------
+
+Hail utilities for gnomAD
+--------------------------
+
+This repo contains a number of Hail utility functions and scripts for the `gnomAD <https://gnomad.broadinstitute.org>`_ project and the `MacArthur lab <https://macarthurlab.org/>`_.
+
+`PyPI <https://pypi.org/project/gnomad/>`_ and `API Reference <https://broadinstitute.github.io/gnomad_methods/api_reference/>`_
+


### PR DESCRIPTION
I added libraries to the sidebar, added a libraries page, and moved up "cheat sheets" and "how to guides" about "Datasets" and "Annotation Database". I figure documentation should be together, as opposed to split up by datasets

Looks like: 
<img width="1579" alt="Screen Shot 2020-04-03 at 2 30 41 PM" src="https://user-images.githubusercontent.com/13773586/78395546-aa9d6f80-75bb-11ea-8235-ec18db91c541.png">

