### PR TITLE
[query] Don't create java objects in TableParallelize

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, DataOutputStream}
 
 import is.hail.HailContext
 import is.hail.annotations._
@@ -312,25 +312,44 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
 
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     val hc = HailContext.get
-    val (ptype, res) = CompileAndEvaluate._apply(ctx, rowsAndGlobal, optimize = false) match {
-      case Right((t, off)) => (t.fields(0).typ, SafeRow(t, off).getAs[Row](0))
+    val (ptype: PStruct, res) = CompileAndEvaluate._apply(ctx, rowsAndGlobal, optimize = false) match {
+      case Right((t: PTuple, off)) => (t.fields(0).typ, t.loadField(off, 0))
     }
 
-    val Row(_rows: IndexedSeq[_], globals: Row) = res
+    val globalsT = ptype.types(1).asInstanceOf[PStruct]
+    val globals = BroadcastRow(RegionValue(ctx.r, ptype.loadField(res, 1)), globalsT, ctx.backend)
 
-    val rows = _rows.asInstanceOf[IndexedSeq[Row]]
-    rows.zipWithIndex.foreach { case (r, idx) =>
-      if (r == null)
-        fatal(s"cannot parallelize null values: found null value at index $idx")
+    val rowsT = ptype.types(0).asInstanceOf[PArray]
+    val rowT = rowsT.elementType.asInstanceOf[PStruct]
+    val spec = TypedCodecSpec(rowT, BufferSpec.wireSpec)
+
+    val makeEnc = spec.buildEncoder(rowT)
+    val rowsAddr = ptype.loadField(res, 0)
+    val nRows = rowsT.loadLength(rowsAddr)
+
+    val encRows = Array.tabulate(nRows) { i =>
+      if (rowsT.isElementMissing(rowsAddr, i))
+        fatal(s"cannot parallelize null values: found null value at index $i")
+      val baos = new ByteArrayOutputStream()
+      makeEnc(baos).writeRegionValue(ctx.r, rowsT.loadElement(rowsAddr, i))
+      baos.toByteArray
     }
 
-    log.info(s"parallelized ${ rows.length } rows")
+    val (resultRowType: PStruct, makeDec) = spec.buildDecoder(typ.rowType)
+    assert(resultRowType.virtualType == typ.rowType)
 
-    val rowPType = PType.canonical(ptype).asInstanceOf[PStruct].field("rows").typ.asInstanceOf[PArray].elementType.setRequired(true).asInstanceOf[PStruct]
-    assert(rowPType.virtualType == typ.rowType)
-    val rvd = ContextRDD.parallelize(hc.sc, rows, nPartitions)
-      .cmapPartitions((ctx, it) => it.toRegionValueIterator(ctx.region, rowPType))
-    TableValue(typ, BroadcastRow(ctx, globals, typ.globalType), RVD.unkeyed(rowPType, rvd))
+    log.info(s"parallelized ${ nRows } rows")
+
+    val rvd = ContextRDD.parallelize(hc.sc, encRows, nPartitions)
+      .cmapPartitions { (ctx, it) =>
+        val rv = RegionValue(ctx.region)
+        it.map { arr =>
+          val bais = new ByteArrayInputStream(arr)
+          rv.setOffset(makeDec(bais).readRegionValue(ctx.region))
+          rv
+        }
+      }
+    TableValue(typ, globals, RVD.unkeyed(resultRowType, rvd))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -320,7 +320,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
     val globals = BroadcastRow(RegionValue(ctx.r, ptype.loadField(res, 1)), globalsT, ctx.backend)
 
     val rowsT = ptype.types(0).asInstanceOf[PArray]
-    val rowT = rowsT.elementType.asInstanceOf[PStruct]
+    val rowT = rowsT.elementType.asInstanceOf[PStruct].setRequired(true)
     val spec = TypedCodecSpec(rowT, BufferSpec.wireSpec)
 
     val makeEnc = spec.buildEncoder(rowT)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -327,8 +327,8 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
     val rowsAddr = ptype.loadField(res, 0)
     val nRows = rowsT.loadLength(rowsAddr)
 
-    val parts = partition(nRows, nPartitions.getOrElse(16))
-    val nSplits = parts.length
+    val nSplits = math.min(nPartitions.getOrElse(16), nRows)
+    val parts = partition(nRows, nSplits)
 
     val bae = new ByteArrayEncoder(makeEnc)
     var idx = 0

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -327,7 +327,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
     val rowsAddr = ptype.loadField(res, 0)
     val nRows = rowsT.loadLength(rowsAddr)
 
-    val nSplits = math.min(nPartitions.getOrElse(16), nRows)
+    val nSplits = math.min(nPartitions.getOrElse(16), math.max(nRows, 1))
     val parts = partition(nRows, nSplits)
 
     val bae = new ByteArrayEncoder(makeEnc)

--- a/hail/src/main/scala/is/hail/io/Decoder.scala
+++ b/hail/src/main/scala/is/hail/io/Decoder.scala
@@ -44,7 +44,13 @@ final class ByteArrayDecoder(
   }
 
   def regionValueFromBytes(region: Region, bytes: Array[Byte]): Long = {
+    set(bytes)
+    readValue(region)
+  }
+
+  def readValue(region: Region): Long = dec.readRegionValue(region)
+
+  def set(bytes: Array[Byte]) {
     bais.restart(bytes)
-    dec.readRegionValue(region)
   }
 }

--- a/hail/src/main/scala/is/hail/io/Encoder.scala
+++ b/hail/src/main/scala/is/hail/io/Encoder.scala
@@ -51,9 +51,15 @@ final class ByteArrayEncoder(
   }
 
   def regionValueToBytes(region: Region, offset: Long): Array[Byte] = {
-    baos.reset()
-    enc.writeRegionValue(region, offset)
+    reset()
+    writeRegionValue(region, offset)
+    result()
+  }
+
+  def reset(): Unit = baos.reset()
+  def writeRegionValue(region: Region, offset: Long): Unit = enc.writeRegionValue(region, offset)
+  def result(): Array[Byte] = {
     enc.flush()
-    baos.toByteArray()
+    baos.toByteArray
   }
 }


### PR DESCRIPTION
Don't love allocating input/outputstreams per row, but still better than before.