### PR TITLE
[query/docs] fix table join description.

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2315,17 +2315,17 @@ class Table(ExprContainer):
         join strategy:
 
         - **inner** -- Only rows with a matching key in the opposite table are included
-        in the resulting table.
+          in the resulting table.
         - **left** -- All rows from the left table are included in the resulting table.
-        If a row in the left table has no match in the right table, then the fields
-        derived from the right table will be missing.
+          If a row in the left table has no match in the right table, then the fields
+          derived from the right table will be missing.
         - **right** -- All rows from the right table are included in the resulting table.
-        If a row in the right table has no match in the left table, then the fields
-        derived from the left table will be missing.
+          If a row in the right table has no match in the left table, then the fields
+          derived from the left table will be missing.
         - **outer** -- All rows are included in the resulting table. If a row in the right
-        table has no match in the left table, then the fields derived from the left
-        table will be missing. If a row in the right table has no match in the left table,
-        then the fields derived from the left table will be missing.
+          table has no match in the left table, then the fields derived from the left
+          table will be missing. If a row in the right table has no match in the left table,
+          then the fields derived from the left table will be missing.
 
         Both tables must have the same number of keys and the corresponding
         types of each key must be the same (order matters), but the key names

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2310,17 +2310,16 @@ class Table(ExprContainer):
 
         Notes
         -----
-        Hail supports four types of joins specified by `how`:
+        Hail supports four types of joins specified by `how`.
 
-        - **inner** -- Key must be present in both the left and right tables.
-        - **outer** -- Key present in either the left or the right. For keys
-          only in the left table, the right table's fields will be missing.
-          For keys only in the right table, the left table's fields will be
-          missing.
-        - **left** -- Key present in the left table. For keys not found on
-          the right, the right table's fields will be missing.
-        - **right** -- Key present in the right table. For keys not found on
-          the right, the right table's fields will be missing.
+        - **inner** -- Key values must match in both the left and right tables for a record to be in the joined table.
+        - **outer** -- Joined table contains all rows from both tables. For key values found only in the left table, the
+          right table's fields will be missing in the joined table. For key values found only in the right table, the
+          left table's fields will be missing.
+        - **left** -- All rows from the left table returned. Where left table key values have no match in the right table,
+          the right table's fields will be missing.
+        - **right** -- All rows from the right table returned. Where right table key values have no match in the left table,
+          the left table's fields will be missing.
 
         Both tables must have the same number of keys and the corresponding
         types of each key must be the same (order matters), but the key names
@@ -2333,6 +2332,8 @@ class Table(ExprContainer):
         The key fields and order from the left table are preserved,
         while the key fields from the right table are not present in
         the result.
+
+        Missing (NA) keys never match.
 
         Note
         ----

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2310,17 +2310,22 @@ class Table(ExprContainer):
 
         Notes
         -----
-        Tables are joined by comparing the values of their "Key" fields, row by row.
-        How this comparison is made depends on the join strategy:
+        Tables are joined at rows whose key fields have equal values.
+        The inclusion of a row with no match in the opposite table depends on the
+        join strategy:
 
-        - **inner** -- Key values must match in both the left and right tables.
-        - **outer** -- All rows from both tables are kept in the joined table. For key values found only in the left table, the
-          right table's fields will be missing in the joined table. For key values found only in the right table, the
-          left table's fields will be missing.
-        - **left** -- All rows from the left table are kept. For left table key values with no match in the right table,
-          the right table's fields will be missing.
-        - **right** -- All rows from the right table are kept. For right table key values with no match in the left table,
-          the left table's fields will be missing.
+        - **inner** -- Only rows with a matching key in the opposite table are included
+        in the resulting table.
+        - **left** -- All rows from the left table are included in the resulting table.
+        If a row in the left table has no match in the right table, then the fields
+        derived from the right table will be missing.
+        - **right** -- All rows from the right table are included in the resulting table.
+        If a row in the right table has no match in the left table, then the fields
+        derived from the left table will be missing.
+        - **outer** -- All rows are included in the resulting table. If a row in the right
+        table has no match in the left table, then the fields derived from the left
+        table will be missing. If a row in the right table has no match in the left table,
+        then the fields derived from the left table will be missing.
 
         Both tables must have the same number of keys and the corresponding
         types of each key must be the same (order matters), but the key names

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2310,7 +2310,7 @@ class Table(ExprContainer):
 
         Notes
         -----
-        Tables are joined at rows whose key fields have equal values.
+        Tables are joined at rows whose key fields have equal values. Missing values never match.
         The inclusion of a row with no match in the opposite table depends on the
         join strategy:
 
@@ -2338,8 +2338,6 @@ class Table(ExprContainer):
         The key fields and order from the left table are preserved,
         while the key fields from the right table are not present in
         the result.
-
-        Missing (NA) keys never match.
 
         Note
         ----

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2312,7 +2312,7 @@ class Table(ExprContainer):
         -----
         Tables are joined at rows whose key fields have equal values. Missing values never match.
         The inclusion of a row with no match in the opposite table depends on the
-        join strategy:
+        join type:
 
         - **inner** -- Only rows with a matching key in the opposite table are included
           in the resulting table.
@@ -2350,9 +2350,9 @@ class Table(ExprContainer):
         Parameters
         ----------
         right : :class:`.Table`
-            Table with which to join.
+            Table to join.
         how : :obj:`str`
-            Join type. One of "inner", "outer", "left", "right".
+            Join type. One of "inner", "left", "right", "outer"
 
         Returns
         -------

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2310,15 +2310,16 @@ class Table(ExprContainer):
 
         Notes
         -----
-        Hail supports four types of joins specified by `how`.
+        Tables are joined by comparing the values of their "Key" fields, row by row.
+        How this comparison is made depends on the join strategy:
 
-        - **inner** -- Key values must match in both the left and right tables for a record to be in the joined table.
-        - **outer** -- Joined table contains all rows from both tables. For key values found only in the left table, the
+        - **inner** -- Key values must match in both the left and right tables.
+        - **outer** -- All rows from both tables are kept in the joined table. For key values found only in the left table, the
           right table's fields will be missing in the joined table. For key values found only in the right table, the
           left table's fields will be missing.
-        - **left** -- All rows from the left table returned. Where left table key values have no match in the right table,
+        - **left** -- All rows from the left table are kept. For left table key values with no match in the right table,
           the right table's fields will be missing.
-        - **right** -- All rows from the right table returned. Where right table key values have no match in the left table,
+        - **right** -- All rows from the right table are kept. For right table key values with no match in the left table,
           the left table's fields will be missing.
 
         Both tables must have the same number of keys and the corresponding


### PR DESCRIPTION
This fixes one mistake (right join does not set fields in the right table to missing), and makes the join table to be more precise. Keys are arrays of columns/fields of the table. They need to be present (they must be of same length and type for a join to be performed). The values are what are considered. The description also doesn't give a clear idea that left/right join is really about returning all rows from left/right table, and then joining the right/left table's fields depending on matches.