### PR TITLE
[query] minimally functional query service

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -544,6 +544,7 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - batch_pods_ns
     - query_image
  - kind: buildImage
    name: hail_repl_image

--- a/build.yaml
+++ b/build.yaml
@@ -534,6 +534,22 @@ steps:
    dependsOn:
      - query_image
  - kind: deploy
+   name: deploy_query_sa
+   namespace:
+     valueFrom: default_ns.name
+   config: query/service-account.yaml
+   dependsOn:
+    - default_ns
+ - kind: deploy
+   name: deploy_query_sa_batch_pods
+   namespace:
+     valueFrom: batch_pods_ns.name
+   config: query/service-account-batch-pods.yaml
+   dependsOn:
+    - default_ns
+    - batch_pods_ns
+    - deploy_query_sa
+ - kind: deploy
    name: deploy_query
    namespace:
      valueFrom: default_ns.name
@@ -546,6 +562,8 @@ steps:
     - default_ns
     - batch_pods_ns
     - query_image
+    - deploy_query_sa
+    - deploy_query_sa_batch_pods
  - kind: buildImage
    name: hail_repl_image
    dockerFile: hail/Dockerfile.hail-repl

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -311,6 +311,9 @@ class ServiceBackend(Backend):
             self._fs = GoogleCloudStorageFS()
         return self._fs
 
+    def stop(self):
+        pass
+
     def _render(self, ir):
         r = CSERenderer()
         assert len(r.jirs) == 0
@@ -325,14 +328,12 @@ class ServiceBackend(Backend):
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
         resp.raise_for_status()
-
         resp_json = resp.json()
         typ = dtype(resp_json['type'])
-        result = json.loads(resp_json['result'])
-        value = typ._from_json(result['value'])
-        timings = result['timings']
+        value = typ._convert_from_json_na(resp_json['value'])
+        # FIXME put back timings
 
-        return (value, timings) if timed else value
+        return (value, None) if timed else value
 
     def _request_type(self, ir, kind):
         code = self._render(ir)

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -412,7 +412,8 @@ class ServiceBackend(Backend):
         return resp.json()
 
     def load_references_from_dataset(self, path):
-        raise NotImplementedError
+        # FIXME
+        return []
 
     def add_sequence(self, name, fasta_file, index_file):
         resp = sync_retry_transient_errors(

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -8,6 +8,8 @@ import scala.reflect.ClassTag
 abstract class BroadcastValue[T] { def value: T }
 
 abstract class Backend {
+  def defaultParallelism: Int
+
   def broadcast[T: ClassTag](value: T): BroadcastValue[T]
 
   def parallelizeAndComputeWithIndex[T: ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U]

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -1,7 +1,17 @@
 package is.hail.backend.service
 
+import is.hail.annotations.UnsafeRow
 import is.hail.backend.{Backend, BroadcastValue}
+import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.lowering.{DArrayLowering, LoweringPipeline}
+import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, MakeTuple}
+import is.hail.expr.types.physical.PBaseStruct
+import is.hail.io.fs.GoogleStorageFS
+import is.hail.utils.FastIndexedSeq
+import org.json4s.JsonAST.{JObject, JString}
+import org.json4s.jackson.JsonMethods
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 object ServiceBackend {
@@ -10,7 +20,23 @@ object ServiceBackend {
   }
 }
 
+class User(
+  val username: String,
+  val fs: GoogleStorageFS)
+
 class ServiceBackend() extends Backend {
+  private[this] val users = mutable.Map[String, User]()
+
+  def addUser(username: String, key: String): Unit = {
+    assert(!users.contains(username))
+    users += username -> new User(username, new GoogleStorageFS(key))
+  }
+
+  def removeUser(username: String): Unit = {
+    assert(users.contains(username))
+    users -= username
+  }
+
   def broadcast[T: ClassTag](_value: T): BroadcastValue[T] = new BroadcastValue[T] {
     def value: T = _value
   }
@@ -28,5 +54,40 @@ class ServiceBackend() extends Backend {
 
   def stop(): Unit = ()
 
-  def request(): Int = 5
+  def valueType(username: String, s: String): String = {
+    val x = IRParser.parse_value_ir(s)
+    x.typ.toString
+  }
+
+  def tableType(username: String, s: String): String = {
+    val x = IRParser.parse_table_ir(s)
+    x.typ.toString
+  }
+
+  def matrixTableType(username: String, s: String): String = {
+    val x = IRParser.parse_matrix_ir(s)
+    x.typ.toString
+  }
+
+  def blockMatrixType(username: String, s: String): String = {
+    val x = IRParser.parse_blockmatrix_ir(s)
+    x.typ.toString
+  }
+
+  def execute(username: String, s: String): String = {
+    val user = users(username)
+    ExecuteContext.scoped(this, user.fs) { ctx =>
+      var x = IRParser.parse_value_ir(s)
+      x = LoweringPipeline.darrayLowerer(DArrayLowering.All).apply(ctx, x, optimize = true)
+        .asInstanceOf[IR]
+      val (pt, f) = Compile[Long](ctx, MakeTuple.ordered(FastIndexedSeq(x)), None, optimize = true)
+
+      val a = f(0, ctx.r)(ctx.r)
+      val v = new UnsafeRow(pt.asInstanceOf[PBaseStruct], ctx.r, a)
+
+      JsonMethods.compact(
+        JObject(List("value" -> JSONAnnotationImpex.exportAnnotation(v.get(0), x.typ),
+          "type" -> JString(pt.virtualType.toString))))
+    }
+  }
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -221,14 +221,15 @@ class SparkBackend(val sc: SparkContext) extends Backend {
     }.collect()
   }
 
-
-  def startProgressBar() {
-    ProgressBarBuilder.build(sc)
-  }
+  def defaultParallelism: Int = sc.defaultParallelism
 
   override def asSpark(): SparkBackend = this
 
   def stop(): Unit = SparkBackend.stop()
+
+  def startProgressBar() {
+    ProgressBarBuilder.build(sc)
+  }
 
   private[this] def executionResultToAnnotation(ctx: ExecuteContext, result: Either[Unit, (PTuple, Long)]) = result match {
     case Left(x) => x

--- a/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
@@ -15,6 +15,13 @@ object ExecuteContext {
       f(ctx)
     }
   }
+
+  def scopedNewRegion[T](ctx: ExecuteContext)(f: ExecuteContext => T): T = {
+    Region.scoped { r =>
+      val newCtx = new ExecuteContext(ctx.backend, ctx.fs, r, ctx.timer)
+      f(newCtx)
+    }
+  }
 }
 
 class ExecuteContext(

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -6,41 +6,49 @@ import is.hail.utils.HailException
 object FoldConstants {
   def apply(ir: BaseIR): BaseIR =
     ExecuteContext.scoped() { ctx =>
-      RewriteBottomUp(ir, {
-        case _: Ref |
-             _: In |
-             _: RelationalRef |
-             _: RelationalLet |
-             _: ApplySeeded |
-             _: ApplyAggOp |
-             _: ApplyScanOp |
-             _: Begin |
-             _: MakeNDArray |
-             _: NDArrayShape |
-             _: NDArrayReshape |
-             _: NDArrayConcat |
-             _: NDArraySlice |
-             _: NDArrayFilter |
-             _: NDArrayMap |
-             _: NDArrayMap2 |
-             _: NDArrayReindex |
-             _: NDArrayAgg |
-             _: NDArrayWrite |
-             _: NDArrayMatMul |
-             _: Die => None
-        case ir: IR if ir.typ.isInstanceOf[TStream] => None
-        case ir: IR if !IsConstant(ir) &&
-          Interpretable(ir) &&
-          ir.children.forall {
-            case c: IR => IsConstant(c)
-            case _ => false
-          } =>
-          try {
-            Some(Literal.coerce(ir.typ, Interpret.alreadyLowered(ctx, ir)))
-          } catch {
-            case _: HailException => None
-          }
-        case _ => None
-      })
+      foldConstants(ctx, ir)
     }
+
+  def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+    ExecuteContext.scopedNewRegion(ctx) { ctx =>
+      foldConstants(ctx, ir)
+    }
+
+  private def foldConstants(ctx: ExecuteContext, ir: BaseIR): BaseIR =
+    RewriteBottomUp(ir, {
+      case _: Ref |
+           _: In |
+           _: RelationalRef |
+           _: RelationalLet |
+           _: ApplySeeded |
+           _: ApplyAggOp |
+           _: ApplyScanOp |
+           _: Begin |
+           _: MakeNDArray |
+           _: NDArrayShape |
+           _: NDArrayReshape |
+           _: NDArrayConcat |
+           _: NDArraySlice |
+           _: NDArrayFilter |
+           _: NDArrayMap |
+           _: NDArrayMap2 |
+           _: NDArrayReindex |
+           _: NDArrayAgg |
+           _: NDArrayWrite |
+           _: NDArrayMatMul |
+           _: Die => None
+      case ir: IR if ir.typ.isInstanceOf[TStream] => None
+      case ir: IR if !IsConstant(ir) &&
+        Interpretable(ir) &&
+        ir.children.forall {
+          case c: IR => IsConstant(c)
+          case _ => false
+        } =>
+        try {
+          Some(Literal.coerce(ir.typ, Interpret.alreadyLowered(ctx, ir)))
+        } catch {
+          case _: HailException => None
+        }
+      case _ => None
+    })
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -256,16 +256,14 @@ case class MatrixRangeReader(nRows: Int, nCols: Int, nPartitions: Option[Int]) e
   val columnCount: Option[Int] = Some(nCols)
 
   lazy val partitionCounts: Option[IndexedSeq[Long]] = {
-    val nPartitionsAdj = math.min(nRows, nPartitions.getOrElse(HailContext.get.sc.defaultParallelism))
+    val nPartitionsAdj = math.min(nRows, nPartitions.getOrElse(HailContext.backend.defaultParallelism))
     Some(partition(nRows, nPartitionsAdj).map(_.toLong))
   }
 
   override def lower(mr: MatrixRead): TableIR = {
-    val uid1 = Symbol(genUID())
-
     val nRowsAdj = if (mr.dropRows) 0 else nRows
     val nColsAdj = if (mr.dropCols) 0 else nCols
-    TableRange(nRowsAdj, nPartitions.getOrElse(HailContext.get.sc.defaultParallelism))
+    TableRange(nRowsAdj, nPartitions.getOrElse(HailContext.backend.defaultParallelism))
       .rename(Map("idx" -> "row_idx"))
       .mapGlobals(makeStruct(LowerMatrixIR.colsField ->
         irRange(0, nColsAdj).map('i ~> makeStruct('col_idx -> 'i))))

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -20,7 +20,7 @@ object Optimize {
     ctx.timer.time("Optimize") {
       while (iter < maxIter && ir != last) {
         last = ir
-        runOpt(FoldConstants(_), iter, "FoldConstants")
+        runOpt(FoldConstants(ctx, _), iter, "FoldConstants")
         runOpt(ExtractIntervalFilters(_), iter, "ExtractIntervalFilters")
         runOpt(Simplify(_), iter, "Simplify")
         runOpt(ForwardLets(_), iter, "ForwardLets")

--- a/query/.gitignore
+++ b/query/.gitignore
@@ -1,2 +1,3 @@
 /Dockerfile.out
 /deployment.yaml.out
+/service-account-batch-pods.yaml.out

--- a/query/Makefile
+++ b/query/Makefile
@@ -30,5 +30,5 @@ push: build
 
 .PHONY: deploy
 deploy: push
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"query_image":{"image":"$(QUERY_IMAGE)"},"batch_pods_ns":{"name":"batch-pods"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out

--- a/query/Makefile
+++ b/query/Makefile
@@ -30,5 +30,8 @@ push: build
 
 .PHONY: deploy
 deploy: push
+	kubectl -n default apply -f service-account.yaml
+	python3 ../ci/jinja2_render.py '{"default_ns":{"name":"default"}}' service-account-batch-pods.yaml service-account-batch-pods.yaml.out
+	kubectl -n batch-pods apply -f service-account-batch-pods.yaml.out
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"query_image":{"image":"$(QUERY_IMAGE)"},"batch_pods_ns":{"name":"batch-pods"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: query
         hail.is/sha: "{{ code.sha }}"
     spec:
+      serviceAccountName: query
 {% if deploy %}
       priorityClassName: production
 {% endif %}
@@ -31,8 +32,8 @@ spec:
              value: "{{ global.domain }}"
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
-	   - name: HAIL_BATCH_PODS_NAMESPACE
-	     value: "{{ batch_pods_ns.name }}"
+           - name: HAIL_BATCH_PODS_NAMESPACE
+             value: "{{ batch_pods_ns.name }}"
            - name: HAIL_SHA
              value: "{{ code.sha }}"
           ports:

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -31,6 +31,8 @@ spec:
              value: "{{ global.domain }}"
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
+	   - name: HAIL_BATCH_PODS_NAMESPACE
+	     value: "{{ batch_pods_ns.name }}"
            - name: HAIL_SHA
              value: "{{ code.sha }}"
           ports:

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -1,3 +1,4 @@
+import os
 import json
 import base64
 import concurrent
@@ -12,8 +13,8 @@ from gear import setup_aiohttp_session, rest_authenticated_users_only
 
 uvloop.install()
 
+BATCH_PODS_NAMESPACE = os.environ['HAIL_BATCH_PODS_NAMESPACE']
 log = logging.getLogger('batch')
-
 routes = web.RouteTableDef()
 
 
@@ -29,7 +30,7 @@ def add_user(app, userdata):
         k8s_client.read_namespaced_secret,
         userdata['gsa_key_secret_name'],
         # FIXME parameterize
-        'batch-pods',
+        BATCH_PODS_NAMESPACE,
         _request_timeout=5.0)
     gsa_key = base64.b64decode(gsa_key_secret['key.json']).decode()
     jbackend.addUser(username, gsa_key)

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -1,17 +1,39 @@
 import json
+import base64
 import concurrent
+import logging
 import uvloop
 from aiohttp import web
+import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
-from hailtop.utils import blocking_to_async
+from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
 from gear import setup_aiohttp_session, rest_authenticated_users_only
 
 uvloop.install()
 
+log = logging.getLogger('batch')
+
 routes = web.RouteTableDef()
 
-deploy_config = get_deploy_config()
+
+def add_user(app, userdata):
+    username = userdata['username']
+    users = app['users']
+    if username in users:
+        return
+
+    jbackend = app['jbackend']
+    k8s_client = app['k8s_client']
+    gsa_key_secret = await retry_transient_errors(
+        k8s_client.read_namespaced_secret,
+        userdata['gsa_key_secret_name'],
+        # FIXME parameterize
+        'batch-pods',
+        _request_timeout=5.0)
+    gsa_key = base64.b64decode(gsa_key_secret['key.json']).decode()
+    jbackend.addUser(username, gsa_key)
+    users.add(username)
 
 
 @routes.get('/healthcheck')
@@ -19,11 +41,94 @@ async def healthcheck(request):  # pylint: disable=unused-argument
     return web.Response()
 
 
-@routes.get('/request')
-async def request(request):
-    jbackend = request.app['jbackend']
-    resp = jbackend.request()
-    return web.json_response({'value': resp})
+def blocking_execute(jbackend, username, code):
+    return jbackend.execute(username, code)
+
+
+@routes.post('/execute')
+@rest_authenticated_users_only
+async def execute(request, userdata):
+    app = request.app
+    thread_pool = app['thread_pool']
+    jbackend = app['thread_pool']
+    code = await request.json()
+    log.info(f'execute: {code}')
+    add_user(app, userdata)
+    result = await blocking_to_async(thread_pool, blocking_execute, jbackend, userdata['username'], code)
+    log.info(f'result: {result}')
+    return web.json_response(result)
+
+
+def blocking_value_type(jbackend, username, code):
+    return jbackend.valueType(username, code)
+
+
+@routes.post('/type/value')
+@rest_authenticated_users_only
+async def value_type(request, userdata):
+    app = request.app
+    thread_pool = app['thread_pool']
+    jbackend = app['thread_pool']
+    code = await request.json()
+    log.info(f'value type: {code}')
+    add_user(app, userdata)
+    result = await blocking_to_async(thread_pool, blocking_value_type, jbackend, userdata['username'], code)
+    log.info(f'result: {result}')
+    return web.json_response(result)
+
+
+def blocking_table_type(jbackend, username, code):
+    return jbackend.tableType(username, code)
+
+
+@routes.post('/type/table')
+@rest_authenticated_users_only
+async def table_type(request, userdata):
+    app = request.app
+    thread_pool = app['thread_pool']
+    jbackend = app['thread_pool']
+    code = await request.json()
+    log.info(f'table type: {code}')
+    add_user(app, userdata)
+    result = await blocking_to_async(thread_pool, blocking_table_type, jbackend, userdata['username'], code)
+    log.info(f'result: {result}')
+    return web.json_response(result)
+
+
+def blocking_matrix_type(jbackend, username, code):
+    return jbackend.matrixTableType(username, code)
+
+
+@routes.post('/type/matrix')
+@rest_authenticated_users_only
+async def matrix_type(request, userdata):
+    app = request.app
+    thread_pool = app['thread_pool']
+    jbackend = app['thread_pool']
+    code = await request.json()
+    log.info(f'matrix type: {code}')
+    add_user(app, userdata)
+    result = await blocking_to_async(thread_pool, blocking_matrix_type, jbackend, userdata['username'], code)
+    log.info(f'result: {result}')
+    return web.json_response(result)
+
+
+def blocking_blockmatrix_type(jbackend, username, code):
+    return jbackend.blockMatrixType(username, code)
+
+
+@routes.post('/type/blockmatrix')
+@rest_authenticated_users_only
+async def blockmatrix_type(request, userdata):
+    app = request.app
+    thread_pool = app['thread_pool']
+    jbackend = app['thread_pool']
+    code = await request.json()
+    log.info(f'blockmatrix type: {code}')
+    add_user(app, userdata)
+    result = await blocking_to_async(thread_pool, blocking_blockmatrix_type, jbackend, userdata['username'], code)
+    log.info(f'result: {result}')
+    return web.json_response(result)
 
 
 def blocking_get_reference(app, data):
@@ -38,7 +143,6 @@ async def get_reference(request, userdata):  # pylint: disable=unused-argument
     app = request.app
     thread_pool = app['thread_pool']
     data = await request.json()
-    # FIXME error handling
     result = await blocking_to_async(thread_pool, blocking_get_reference, app, data)
     return web.json_response(result)
 
@@ -66,6 +170,12 @@ async def on_startup(app):
         jbackend, 'hail.log', False, False, 50, "/tmp", 3)
     app['jhc'] = jhc
 
+    app['users'] = set()
+
+    kube.config.load_incluster_config()
+    k8s_client = kube.client.CoreV1Api()
+    app['k8s_client'] = k8s_client
+
 
 def run():
     app = web.Application()
@@ -76,6 +186,7 @@ def run():
 
     app.on_startup.append(on_startup)
 
+    deploy_config = get_deploy_config()
     web.run_app(
         deploy_config.prefix_application(app, 'query'),
         host='0.0.0.0',

--- a/query/service-account-batch-pods.yaml
+++ b/query/service-account-batch-pods.yaml
@@ -1,0 +1,21 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: query
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: query
+subjects:
+- kind: ServiceAccount
+  name: query
+  namespace: {{ default_ns.name }}
+roleRef:
+  kind: Role
+  name: query
+  apiGroup: rbac.authorization.k8s.io

--- a/query/service-account.yaml
+++ b/query/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: query


### PR DESCRIPTION
It is able to execute a trivial pipeline without the JVM on the client.  The countdown down to a fully functional Hail Query service begins now.  I will start running the Python tests against the service to benchmark our progress.

The main blockers are:
 - Table lowering @tpoterba @patrick-schultz @catoverdrive 
 - The shuffle service @tpoterba @danking 
 - Reading, writing and threading the (per-user, for the query service) filesystem through execution.  I'll be working on this.
 - A Batch backend for distributed execution.  I will do this once there is enough functionality to execute something big/interesting.

It's happening!