### PR TITLE
[www] remove id from links, make location.pathname comply w/ RFC2616

### DIFF
--- a/hail/www/template.xslt
+++ b/hail/www/template.xslt
@@ -56,28 +56,28 @@
 
                         <div class="collapse navbar-collapse" id="hail-navbar-collapse">
                             <ul class="nav navbar-nav navbar-right" id="hail-menu">
-                                <li id="docs" class="nav-item">
+                                <li class="nav-item">
                                     <a href="/docs/0.2/index.html">Docs</a>
                                 </li>
-                                <li id="forum" class="nav-item">
+                                <li class="nav-item">
                                     <a href="http://discuss.hail.is">Forum</a>
                                 </li>
-                                <li id="chat" class="nav-item">
+                                <li class="nav-item">
                                     <a href="http://hail.zulipchat.com">Chat</a>
                                 </li>
-                                <li id="code" class="nav-item">
+                                <li class="nav-item">
                                     <a href="https://github.com/hail-is/hail">Code</a>
                                 </li>
-                                <li id='powered-science' class="nav-item">
+                                <li class="nav-item">
                                     <a href="/references.html">Powered-Science</a>
                                 </li>
-                                <li id='blog' class="nav-item">
+                                <li class="nav-item">
                                     <a href="https://blog.hail.is/">Blog</a>
                                 </li>
-                                <li id='workshop' class="nav-item">
+                                <li class="nav-item">
                                     <a href="https://workshop.hail.is">Workshop</a>
                                 </li>
-                                <li id='about' class="nav-item">
+                                <li class="nav-item">
                                     <a href="/about.html">About</a>
                                 </li>
                             </ul>
@@ -94,7 +94,7 @@
                         (function () {
                             var cpage = location.pathname;
 
-                            if (cpage === "" || cpage === "/" || cpage === "/index.html") {
+                            if (cpage === "/" || cpage === "/index.html") {
                                 document.getElementById('hail-navbar-brand').className = "active";
                                 return;
                             };
@@ -102,9 +102,7 @@
                             var menuItems = document.querySelectorAll('#hail-menu a');
 
                             for (var i = 0; i < menuItems.length; i++) {
-                                var href = menuItems[i].pathname;
-
-                                if (href === cpage) {
+                                if (menuItems[i].pathname === cpage && menuItems[i].host == location.host) {
                                     menuItems[i].className = "active";
                                     return;
                                 }


### PR DESCRIPTION
Removed id from anchor tags. Unneeded (all anchor tags should have same style, or determined by nesting level in menu, and now not used to make active links), less for Kumar to remember to do when adding pages.

Also removed cpage == "" check. By RFC2616, cannot have empty pathname; if none is provided "/" is defaulted to.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html

"The most common form of Request-URI is that used to identify a resource on an origin server or gateway. In this case the absolute path of the URI MUST be transmitted (see section 3.2.1, abs_path) as the Request-URI, and the network location of the URI (authority) MUST be transmitted in a Host header field."

and 

"The absoluteURI form is REQUIRED when the request is being made to a proxy. "

Also verified in chrome/safari/edge
