### PR TITLE
[query] fix ptype inference for CollectDistributedArray

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -512,7 +512,7 @@ object InferPType {
       case x@CollectDistributedArray(contextsIR, globalsIR, contextsName, globalsName, bodyIR) =>
         infer(contextsIR)
         infer(globalsIR)
-        infer(bodyIR, env.bind(contextsName -> x.decodedContextPType, globalsName -> x.decodedContextPType))
+        infer(bodyIR, env.bind(contextsName -> x.decodedContextPType, globalsName -> x.decodedGlobalPType))
         PCanonicalArray(x.decodedBodyPType, contextsIR.pType.required)
       case ReadPartition(rowIR, codecSpec, rowType) =>
         infer(rowIR)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -509,12 +509,11 @@ object InferPType {
         else
           pt
       case In(_, pType: PType) => pType
-      case CollectDistributedArray(contextsIR, globalsIR, contextsName, globalsName, bodyIR) =>
+      case x@CollectDistributedArray(contextsIR, globalsIR, contextsName, globalsName, bodyIR) =>
         infer(contextsIR)
         infer(globalsIR)
-        infer(bodyIR, env.bind(contextsName -> coerce[PStream](contextsIR.pType).elementType, globalsName -> globalsIR.pType))
-
-        PCanonicalArray(bodyIR.pType, contextsIR.pType.required)
+        infer(bodyIR, env.bind(contextsName -> x.decodedContextPType, globalsName -> x.decodedContextPType))
+        PCanonicalArray(x.decodedBodyPType, contextsIR.pType.required)
       case ReadPartition(rowIR, codecSpec, rowType) =>
         infer(rowIR)
         val child = codecSpec.buildDecoder(rowType)._1


### PR DESCRIPTION
The current ptype inference doesn't account for the fact that we're serializing through en EType and could potentially generate a different PType when decoded. I pulled out a bunch of the type/codec stuff onto the IR node since we'll use it in InferPTypes and also in Emit.