### PR TITLE
[ci] better errors on bad github response and fix too many status updates

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -9,73 +9,7 @@ from aiohttp import web
 import aiohttp_session
 import aiomysql
 import uvloop
-import gidgethub
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
-from gidgethub import (BadRequest, GitHubBroken, HTTPException, InvalidField,
-                       RateLimitExceeded, RedirectionException)
-from typing import Any, Dict, Mapping, Optional, Tuple, Type
-
-
-def decipher_response(status_code: int, headers: Mapping,
-                      body: bytes) -> Tuple[Any, Optional[gidgethub.sansio.RateLimit], Optional[str]]:
-    """Decipher an HTTP response for a GitHub API request.
-    The mapping providing the headers is expected to support lowercase keys.
-    The parameters of this function correspond to the three main parts
-    of an HTTP response: the status code, headers, and body. Assuming
-    no errors which lead to an exception being raised, a 3-item tuple
-    is returned. The first item is the decoded body (typically a JSON
-    object, but possibly None or a string depending on the content
-    type of the body). The second item is an instance of RateLimit
-    based on what the response specified.
-    The last item of the tuple is the URL where to request the next
-    part of results. If there are no more results then None is
-    returned. Do be aware that the URL can be a URI template and so
-    may need to be expanded.
-    If the status code is anything other than 200, 201, or 204, then
-    an HTTPException is raised.
-    """
-    data = gidgethub.sansio._decode_body(headers.get("content-type"), body)
-    if status_code in {200, 201, 204}:
-        return data, gidgethub.sansio.RateLimit.from_http(headers), gidgethub.sansio._next_link(headers.get("link"))
-    else:
-        try:
-            message = data["message"]
-        except (TypeError, KeyError):
-            message = None
-        exc_type: Type[HTTPException]
-        if status_code >= 500:
-            exc_type = GitHubBroken
-        elif status_code >= 400:
-            exc_type = BadRequest
-            if status_code == 403:
-                rate_limit = gidgethub.sansio.RateLimit.from_http(headers)
-                if rate_limit and not rate_limit.remaining:
-                    raise RateLimitExceeded(rate_limit, message)
-            elif status_code == 422:
-                errors = data.get("errors", None)
-                log.info(f'fml {body.decode()} {errors}')
-                if errors:
-                    fields = ", ".join(repr(e["field"]) for e in errors)
-                    message = f"{message} for {fields}"
-                else:
-                    message = data["message"]
-                raise InvalidField(errors, message)
-        elif status_code >= 300:
-            exc_type = RedirectionException
-        else:
-            exc_type = HTTPException
-        import http
-        status_code_enum = http.HTTPStatus(status_code)
-        args: Tuple
-        if message:
-            args = status_code_enum, message
-        else:
-            args = status_code_enum,
-        raise exc_type(*args)
-
-gidgethub.sansio.decipher_response = decipher_response
-
-
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -323,7 +323,11 @@ async def on_startup(app):
         raise_for_status=True,
         timeout=aiohttp.ClientTimeout(total=60))
     app['client_session'] = session
-    app['github_client'] = gh_aiohttp.GitHubAPI(session, 'ci', oauth_token=oauth_token)
+    app['github_client'] = gh_aiohttp.GitHubAPI(
+        aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=60)),
+        'ci',
+        oauth_token=oauth_token)
     app['batch_client'] = await BatchClient('ci', session=session)
 
     with open('/ci-user-secret/sql-config.json', 'r') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -306,8 +306,6 @@ class PR(Code):
             await gh_client.post(
                 f'/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}',
                 data=data)
-        except KeyError as e:
-            log.exception(f'{self.short_str()}: notify github of build state failed due to exception: {data} {e}')
         except gidgethub.HTTPException as e:
             log.info(f'{self.short_str()}: notify github of build state failed due to exception: {data} {e}')
         except aiohttp.client_exceptions.ClientResponseError as e:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -306,8 +306,10 @@ class PR(Code):
             await gh_client.post(
                 f'/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}',
                 data=data)
+        except KeyError as e:
+            log.exception(f'{self.short_str()}: notify github of build state failed due to exception: {data} {e}')
         except gidgethub.HTTPException as e:
-            log.info(f'{self.short_str()}: notify github of build state failed due to exception: {e}')
+            log.info(f'{self.short_str()}: notify github of build state failed due to exception: {data} {e}')
         except aiohttp.client_exceptions.ClientResponseError as e:
             log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data} {e}')
 
@@ -323,7 +325,7 @@ class PR(Code):
         if n_hail_status == 0:
             return None
         if n_hail_status == 1:
-            return hail_status[0]
+            return hail_status[0]['state']
         raise ValueError(
             f'github sent multiple status summaries for our one '
             'context {GITHUB_STATUS_CONTEXT}: {hail_status}\n\n{statuses_json}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -309,7 +309,7 @@ class PR(Code):
         except gidgethub.HTTPException as e:
             log.info(f'{self.short_str()}: notify github of build state failed due to exception: {e}')
         except aiohttp.client_exceptions.ClientResponseError as e:
-            log.error(f'{self.short_str()}: Unexpected exception in post to github: {e}')
+            log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data} {e}')
 
     async def _update_github(self, gh):
         await self._update_last_known_github_status(gh)


### PR DESCRIPTION
CI was getting 422s from GitHub. Using a
`raise_for_status=True` ClientSession circumvented gidgethubs native
error handling logic smothering the HTTP response body where github
places critical debugging information. Aiohttp is aware that
`raise_for_status` provides no access to the response body. They addressed
this in https://github.com/aio-libs/aiohttp/pulls/3892, but that has not
been released because 4.0.0 has not yet been released.

Moreover, `gidgethub` incorrectly handles the too many statuses response. I'll PR a fix into their repo. For now, I've added a bit more information the logs and fixed the main issue, the missing `['status']`.

Another relevant issue: https://github.com/aio-libs/aiohttp/issues/4600.