### PR TITLE
[query] Don't call into JVM for parallel/export_type

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -11,7 +11,7 @@ from hail.expr.nat import NatBase, NatLiteral
 from hail.expr.type_parsing import type_grammar, type_node_visitor
 from hail.genetics.reference_genome import reference_genome_type
 from hail.typecheck import *
-from hail.utils.java import scala_object, jset, Env, escape_parsable
+from hail.utils.java import escape_parsable
 
 __all__ = [
     'dtype',

--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -2,7 +2,7 @@ import json
 import re
 from hail.typecheck import *
 from hail.utils import wrap_to_list
-from hail.utils.java import jiterable_to_list, Env, joption
+from hail.utils.java import Env
 from hail.typecheck import oneof, transformed
 import hail as hl
 

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -1,3 +1,4 @@
+from .export_type import *
 from .base_ir import *
 from .ir import *
 from .register_functions import *

--- a/hail/python/hail/ir/export_type.py
+++ b/hail/python/hail/ir/export_type.py
@@ -1,11 +1,14 @@
 from hail.typecheck import *
 
 class ExportType:
-    checker = enumeration('separate_header', 'header_per_shard')
-
     CONCATENATED = "concatenated"
     PARALLEL_SEPARATE_HEADER = "separate_header"
     PARALLEL_HEADER_IN_SHARD = "header_per_shard"
+
+    checker = enumeration(
+        ExportType.CONCATENATED,
+        ExportType.PARALLEL_SEPARATE_HEADER,
+        ExporType.PARALLEL_HEADER_IN_SHARD)
 
     @staticmethod
     def default(export_type):

--- a/hail/python/hail/ir/export_type.py
+++ b/hail/python/hail/ir/export_type.py
@@ -1,0 +1,14 @@
+from hail.typecheck import *
+
+class ExportType:
+    checker = enumeration('separate_header', 'header_per_shard')
+
+    CONCATENATED = "concatenated"
+    PARALLEL_SEPARATE_HEADER = "separate_header"
+    PARALLEL_HEADER_IN_SHARD = "header_per_shard"
+
+    def default(export_type):
+        if export_type is None:
+            return CONCATENATED
+        else:
+            return export_type

--- a/hail/python/hail/ir/export_type.py
+++ b/hail/python/hail/ir/export_type.py
@@ -7,8 +7,9 @@ class ExportType:
     PARALLEL_SEPARATE_HEADER = "separate_header"
     PARALLEL_HEADER_IN_SHARD = "header_per_shard"
 
+    @staticmethod
     def default(export_type):
         if export_type is None:
-            return CONCATENATED
+            return ExportType.CONCATENATED
         else:
             return export_type

--- a/hail/python/hail/ir/export_type.py
+++ b/hail/python/hail/ir/export_type.py
@@ -8,7 +8,7 @@ class ExportType:
     checker = enumeration(
         ExportType.CONCATENATED,
         ExportType.PARALLEL_SEPARATE_HEADER,
-        ExporType.PARALLEL_HEADER_IN_SHARD)
+        ExportType.PARALLEL_HEADER_IN_SHARD)
 
     @staticmethod
     def default(export_type):

--- a/hail/python/hail/ir/export_type.py
+++ b/hail/python/hail/ir/export_type.py
@@ -5,10 +5,7 @@ class ExportType:
     PARALLEL_SEPARATE_HEADER = "separate_header"
     PARALLEL_HEADER_IN_SHARD = "header_per_shard"
 
-    checker = enumeration(
-        ExportType.CONCATENATED,
-        ExportType.PARALLEL_SEPARATE_HEADER,
-        ExportType.PARALLEL_HEADER_IN_SHARD)
+    checker = enumeration("concatenated", "separate_header", "header_per_shard")
 
     @staticmethod
     def default(export_type):

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -3,6 +3,7 @@ import json
 from hail.expr.types import hail_type
 from ..typecheck import *
 from ..utils.misc import escape_str
+from .export_type import ExportType
 
 
 class MatrixWriter(object):
@@ -54,7 +55,7 @@ class MatrixNativeWriter(MatrixWriter):
 class MatrixVCFWriter(MatrixWriter):
     @typecheck_method(path=str,
                       append=nullable(str),
-                      export_type=str,
+                      export_type=ExportType.checker,
                       metadata=nullable(dictof(str, dictof(str, dictof(str, str)))))
     def __init__(self, path, append, export_type, metadata):
         self.path = path
@@ -98,7 +99,7 @@ class MatrixGENWriter(MatrixWriter):
 
 
 class MatrixBGENWriter(MatrixWriter):
-    @typecheck_method(path=str, export_type=str)
+    @typecheck_method(path=str, export_type=ExportType.checker)
     def __init__(self, path, export_type):
         self.path = path
         self.export_type = export_type

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -54,7 +54,7 @@ class MatrixNativeWriter(MatrixWriter):
 class MatrixVCFWriter(MatrixWriter):
     @typecheck_method(path=str,
                       append=nullable(str),
-                      export_type=int,
+                      export_type=str,
                       metadata=nullable(dictof(str, dictof(str, dictof(str, str)))))
     def __init__(self, path, append, export_type, metadata):
         self.path = path
@@ -98,7 +98,7 @@ class MatrixGENWriter(MatrixWriter):
 
 
 class MatrixBGENWriter(MatrixWriter):
-    @typecheck_method(path=str, export_type=int)
+    @typecheck_method(path=str, export_type=str)
     def __init__(self, path, export_type):
         self.path = path
         self.export_type = export_type

--- a/hail/python/hail/ir/table_writer.py
+++ b/hail/python/hail/ir/table_writer.py
@@ -46,7 +46,7 @@ class TableTextWriter(TableWriter):
     @typecheck_method(path=str,
                       types_file=nullable(str),
                       header=bool,
-                      export_type=int,
+                      export_type=str,
                       delimiter=str)
     def __init__(self, path, types_file, header, export_type, delimiter):
         super(TableTextWriter, self).__init__()

--- a/hail/python/hail/ir/table_writer.py
+++ b/hail/python/hail/ir/table_writer.py
@@ -2,6 +2,7 @@ import abc
 import json
 from ..typecheck import *
 from ..utils.misc import escape_str
+from .export_type import ExportType
 
 
 class TableWriter(object):
@@ -46,7 +47,7 @@ class TableTextWriter(TableWriter):
     @typecheck_method(path=str,
                       types_file=nullable(str),
                       header=bool,
-                      export_type=str,
+                      export_type=ExportType.checker,
                       delimiter=str)
     def __init__(self, path, types_file, header, export_type, delimiter):
         super(TableTextWriter, self).__init__()

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1819,7 +1819,9 @@ class BlockMatrix(object):
         """
         jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, path_in, joption(partition_size))
 
-        export_type = Env.hail().utils.ExportType.getExportType(parallel)
+        if parallel is None:
+            parallel = 'concatenated
+        export_type = parallel
 
         if entries == 'full':
             jrm.export(path_out, delimiter, joption(header), add_index, export_type)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -18,6 +18,7 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F
     RowIntervalSparsifier, BandSparsifier, UnpersistBlockMatrix
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader, BlockMatrixPersistReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter, BlockMatrixPersistWriter
+from hail.ir import ExportType
 from hail.table import Table
 from hail.typecheck import *
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
@@ -1667,7 +1668,7 @@ class BlockMatrix(object):
                delimiter=str,
                header=nullable(str),
                add_index=bool,
-               parallel=nullable(enumeration('separate_header', 'header_per_shard')),
+               parallel=nullable(ExportType.checker),
                partition_size=nullable(int),
                entries=enumeration('full', 'lower', 'strict_lower', 'upper', 'strict_upper'))
     def export(path_in, path_out, delimiter='\t', header=None, add_index=False, parallel=None,
@@ -1819,9 +1820,7 @@ class BlockMatrix(object):
         """
         jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, path_in, joption(partition_size))
 
-        if parallel is None:
-            parallel = 'concatenated'
-        export_type = parallel
+        export_type = ExportType.default(parallel)
 
         if entries == 'full':
             jrm.export(path_out, delimiter, joption(header), add_index, export_type)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1820,7 +1820,7 @@ class BlockMatrix(object):
         jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.backend()._jhc, path_in, joption(partition_size))
 
         if parallel is None:
-            parallel = 'concatenated
+            parallel = 'concatenated'
         export_type = parallel
 
         if entries == 'full':

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -166,7 +166,7 @@ def export_gen(dataset, output, precision=4, gp=None, id1=None, id2=None,
            gp=nullable(expr_array(expr_float64)),
            varid=nullable(expr_str),
            rsid=nullable(expr_str),
-           parallel=nullable(str))
+           parallel=nullable(ExportType.checker))
 def export_bgen(mt, output, gp=None, varid=None, rsid=None, parallel=None):
     """Export MatrixTable as :class:`.MatrixTable` as BGEN 1.2 file with 8
     bits of per probability.  Also writes SAMPLE file.
@@ -216,8 +216,7 @@ def export_bgen(mt, output, gp=None, varid=None, rsid=None, parallel=None):
         if 'rsid' in mt.row and mt.rsid.dtype == tstr:
             rsid = mt.rsid
 
-    if parallel is None:
-        parallel = 'concatenated'
+    parallel = ExportType.default(parallel)
 
     l = mt.locus
     a = mt.alleles
@@ -383,7 +382,7 @@ def export_plink(dataset, output, call=None, fam_id=None, ind_id=None, pat_id=No
 @typecheck(dataset=MatrixTable,
            output=str,
            append_to_header=nullable(str),
-           parallel=nullable(enumeration('separate_header', 'header_per_shard')),
+           parallel=nullable(ExportType.checker),
            metadata=nullable(dictof(str, dictof(str, dictof(str, str)))))
 def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=None):
     """Export a :class:`.MatrixTable` as a VCF file.
@@ -510,8 +509,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
         hl.utils.java.warn('export_vcf: ignored the following fields:' + ignored_str)
         dataset = dataset.drop(*(f for f, _ in fields_dropped))
 
-    if parallel is None:
-        parallel = 'concatenated'
+    parallel = ExportType.default(parallel)
 
     writer = MatrixVCFWriter(output,
                              append_to_header,

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -29,9 +29,6 @@ class Ascending(object):
     def __ne__(self, other):
         return not self == other
 
-    def _j_obj(self):
-        return scala_package_object(Env.hail().table).asc(self.col)
-
 
 class Descending(object):
     def __init__(self, col):
@@ -42,9 +39,6 @@ class Descending(object):
 
     def __ne__(self, other):
         return not self == other
-
-    def _j_obj(self):
-        return scala_package_object(Env.hail().table).desc(self.col)
 
 
 @typecheck(col=oneof(Expression, str))
@@ -1007,10 +1001,10 @@ class Table(ExprContainer):
         delimiter : :obj:`str`
             Field delimiter.
         """
-
+        if parallel is None:
+            parallel = 'concatenated'
         Env.backend().execute(
-            TableWrite(self._tir, TableTextWriter(output, types_file, header,
-                                                  Env.hail().utils.ExportType.getExportType(parallel), delimiter)))
+            TableWrite(self._tir, TableTextWriter(output, types_file, header, parallel, delimiter)))
 
     def group_by(self, *exprs, **named_exprs) -> 'GroupedTable':
         """Group by a new key for use with :meth:`.GroupedTable.aggregate`.

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -962,7 +962,7 @@ class Table(ExprContainer):
     @typecheck_method(output=str,
                       types_file=nullable(str),
                       header=bool,
-                      parallel=nullable(enumeration('separate_header', 'header_per_shard')),
+                      parallel=nullable(ExportType.checker),
                       delimiter=str)
     def export(self, output, types_file=None, header=True, parallel=None, delimiter='\t'):
         """Export to a TSV file.
@@ -1001,8 +1001,7 @@ class Table(ExprContainer):
         delimiter : :obj:`str`
             Field delimiter.
         """
-        if parallel is None:
-            parallel = 'concatenated'
+        parallel = ExportType.default(parallel)
         Env.backend().execute(
             TableWrite(self._tir, TableTextWriter(output, types_file, header, parallel, delimiter)))
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -107,7 +107,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "",
                                                               '[{"start":{"row_idx":0},"end":{"row_idx": 10},"includeStart":true,"includeEnd":false}]',
                                                               hl.dtype('array<interval<struct{row_idx:int32}>>'))),
-            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, False, None)),
+            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, 'concatenate', None)),
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -101,7 +101,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixToValueApply(matrix_read, {'name': 'ForceCountMatrixTable'}),
             ir.TableAggregate(table, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], [ir.I32(0)]))])),
             ir.TableWrite(table, ir.TableNativeWriter(new_temp_file(), False, True, "fake_codec_spec$$")),
-            ir.TableWrite(table, ir.TableTextWriter(new_temp_file(), None, True, 0, ",")),
+            ir.TableWrite(table, ir.TableTextWriter(new_temp_file(), None, True, "concatenated", ",")),
             ir.MatrixAggregate(matrix_read, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], [ir.I32(0)]))])),
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "", None, None)),
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "",

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -107,7 +107,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "",
                                                               '[{"start":{"row_idx":0},"end":{"row_idx": 10},"includeStart":true,"includeEnd":false}]',
                                                               hl.dtype('array<interval<struct{row_idx:int32}>>'))),
-            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, 'concatenate', None)),
+            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, ir.ExportType.CONCATENATED, None)),
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -42,7 +42,7 @@ case class MatrixNativeWriter(
 case class MatrixVCFWriter(
   path: String,
   append: Option[String] = None,
-  exportType: Int = ExportType.CONCATENATED,
+  exportType: String = ExportType.CONCATENATED,
   metadata: Option[VCFMetadata] = None
 ) extends MatrixWriter {
   def apply(mv: MatrixValue): Unit = ExportVCF(mv, path, append, exportType, metadata)
@@ -57,7 +57,7 @@ case class MatrixGENWriter(
 
 case class MatrixBGENWriter(
   path: String,
-  exportType: Int
+  exportType: String
 ) extends MatrixWriter {
   def apply(mv: MatrixValue): Unit = ExportBGEN(mv, path, exportType)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -114,7 +114,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
       s"to $path")
   }
 
-  def export(path: String, typesFile: String = null, header: Boolean = true, exportType: Int = ExportType.CONCATENATED, delimiter: String = "\t") {
+  def export(path: String, typesFile: String = null, header: Boolean = true, exportType: String = ExportType.CONCATENATED, delimiter: String = "\t") {
     val hc = HailContext.get
     hc.fs.delete(path, recursive = true)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -29,7 +29,7 @@ case class TableTextWriter(
   path: String,
   typesFile: String = null,
   header: Boolean = true,
-  exportType: Int = ExportType.CONCATENATED,
+  exportType: String = ExportType.CONCATENATED,
   delimiter: String
 ) extends TableWriter {
   def apply(tv: TableValue): Unit = tv.export(path, typesFile, header, exportType, delimiter)

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -299,7 +299,7 @@ class BgenPartitionWriter(rowPType: PStruct, nSamples: Int) {
 }
 
 object ExportBGEN {
-  def apply(mv: MatrixValue, path: String, exportType: Int): Unit = {
+  def apply(mv: MatrixValue, path: String, exportType: String): Unit = {
     val colValues = mv.colValues.javaValue
 
     val sampleIds = colValues.map(_.asInstanceOf[Row].getString(0))

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -217,7 +217,7 @@ object ExportVCF {
     getAttributes(k1, attributes).flatMap(_.get(k2))
 
   def apply(mv: MatrixValue, path: String, append: Option[String],
-    exportType: Int, metadata: Option[VCFMetadata]) {
+    exportType: String, metadata: Option[VCFMetadata]) {
 
     mv.typ.requireColKeyString()
     mv.typ.requireRowKeyVariant()

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -96,29 +96,29 @@ class RowMatrix(val hc: HailContext,
     new DenseMatrix[Double](nRowsInt, nCols, a.flatten, 0, nCols, isTranspose = true)
   }
   
-  def export(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
+  def export(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, _ => localNCols)
   }
 
   // includes the diagonal
-  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
+  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, i => math.min(i + 1, localNCols.toLong).toInt)
   }
 
-  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
+  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, i => math.min(i, localNCols.toLong).toInt)
   }
 
   // includes the diagonal
-  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
+  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i, localNCols.toLong).toInt, _ => localNCols)
   }  
   
-  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
+  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: String) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i + 1, localNCols.toLong).toInt, _ => localNCols)
   }
@@ -129,7 +129,7 @@ class RowMatrix(val hc: HailContext,
     columnDelimiter: String,
     header: Option[String],
     addIndex: Boolean,
-    exportType: Int, 
+    exportType: String,
     start: (Long) => Int, 
     end: (Long) => Int) {
     
@@ -154,7 +154,7 @@ class RowMatrix(val hc: HailContext,
   def genericExport(
     path: String, 
     header: Option[String], 
-    exportType: Int, 
+    exportType: String,
     writeRow: (StringBuilder, Long, Array[Double]) => Unit) {
     
     rows.mapPartitions { it =>

--- a/hail/src/main/scala/is/hail/utils/ExportType.scala
+++ b/hail/src/main/scala/is/hail/utils/ExportType.scala
@@ -1,16 +1,7 @@
 package is.hail.utils
 
 object ExportType {
-  val CONCATENATED = 0
-  val PARALLEL_SEPARATE_HEADER = 1
-  val PARALLEL_HEADER_IN_SHARD = 2
-
-  def getExportType(typ: String): Int = {
-    typ match {
-      case null => CONCATENATED
-      case "separate_header" => PARALLEL_SEPARATE_HEADER
-      case "header_per_shard" => PARALLEL_HEADER_IN_SHARD
-      case _ => fatal(s"Unknown export type: '$typ'")
-    }
-  }
+  val CONCATENATED = "concatenated"
+  val PARALLEL_SEPARATE_HEADER = "separate_header"
+  val PARALLEL_HEADER_IN_SHARD = "header_per_shard"
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -28,7 +28,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     Iterator(it.exists(p))
   }.fold(false)(_ || _)
 
-  def writeTable(fs: FS, filename: String, tmpDir: String, header: Option[String] = None, exportType: Int = ExportType.CONCATENATED) {
+  def writeTable(fs: FS, filename: String, tmpDir: String, header: Option[String] = None, exportType: String = ExportType.CONCATENATED) {
     val hConf = r.sparkContext.hadoopConfiguration
     val codecFactory = new CompressionCodecFactory(hConf)
     val codec = Option(codecFactory.getCodec(new hadoop.fs.Path(filename)))


### PR DESCRIPTION
Use strings instead of ints.