### PR TITLE
[query service] example read_table works

### DIFF
--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -52,7 +52,7 @@ class TableNativeReader(TableReader):
                 'name': 'NativeReaderOptions',
                 'intervals': self._interval_type._convert_to_json(self.intervals),
                 'intervalPointType': self._interval_type.element_type.point_type._parsable_string(),
-                'filterIntervals': self.filter_intervals,
+                'filterIntervals': self.filter_intervals
             }
         return escape_str(json.dumps(reader))
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -168,12 +168,12 @@ case class MatrixNativeReader(
   _spec: AbstractMatrixTableSpec = null
 ) extends MatrixReader {
   lazy val spec: AbstractMatrixTableSpec = Option(_spec).getOrElse(
-    (RelationalSpec.read(HailContext.get, path): @unchecked) match {
+    (RelationalSpec.read(HailContext.fs, path): @unchecked) match {
       case mts: AbstractMatrixTableSpec => mts
       case _: AbstractTableSpec => fatal(s"file is a Table, not a MatrixTable: '$path'")
     })
 
-  lazy val columnCount: Option[Int] = Some(RelationalSpec.read(HailContext.get, path + "/cols")
+  lazy val columnCount: Option[Int] = Some(RelationalSpec.read(HailContext.fs, path + "/cols")
     .asInstanceOf[AbstractTableSpec]
     .partitionCounts
     .sum
@@ -197,7 +197,7 @@ case class MatrixNativeReader(
 
     if (mr.dropCols) {
       val tt = TableType(mr.typ.rowType, mr.typ.rowKey, mr.typ.globalType)
-      val trdr: TableReader = TableNativeReader(rowsPath, options, _spec = spec.rowsTableSpec(rowsPath))
+      val trdr: TableReader = TableNativeReader(rowsPath, options, spec.rowsTableSpec(rowsPath))
       var tr: TableIR = TableRead(tt, mr.dropRows, trdr)
       tr = TableMapGlobals(
         tr,

--- a/hail/src/main/scala/is/hail/expr/ir/NativeReaderOptions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NativeReaderOptions.scala
@@ -29,17 +29,17 @@ class NativeReaderOptionsSerializer() extends CustomSerializer[NativeReaderOptio
 )
 
 object NativeReaderOptions {
-  def fromJson(jv: JObject): NativeReaderOptions = {
+  def fromJson(optionsJV: JObject): NativeReaderOptions = {
     implicit val formats: Formats = DefaultFormats
 
-    val filterIntervals = (jv \ "filterIntervals").extract[Boolean]
-    val intervalPointType = IRParser.parseType((jv \ "intervalPointType").extract[String])
+    val filterIntervals = (optionsJV \ "filterIntervals").extract[Boolean]
+    val intervalPointType = IRParser.parseType((optionsJV \ "intervalPointType").extract[String])
     val intervals = {
-      val jvIntervals = jv \ "intervals"
+      val jvIntervals = optionsJV \ "intervals"
       val ty = TArray(TInterval(intervalPointType))
       JSONAnnotationImpex.importAnnotation(jvIntervals, ty).asInstanceOf[IndexedSeq[Interval]]
     }
-    new NativeReaderOptions(intervals, intervalPointType, filterIntervals)
+    NativeReaderOptions(intervals, intervalPointType, filterIntervals)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/NativeReaderOptions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NativeReaderOptions.scala
@@ -1,13 +1,10 @@
 package is.hail.expr.ir
 
-import is.hail.annotations._
 import is.hail.expr.types.virtual._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.utils._
-import org.json4s.{Formats, ShortTypeHints, CustomSerializer, JObject}
-import org.json4s.JsonAST.{JArray, JInt, JNull, JString, JField, JNothing}
+import org.json4s.{CustomSerializer, DefaultFormats, Formats, JObject, JValue}
 import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods
 
 class NativeReaderOptionsSerializer() extends CustomSerializer[NativeReaderOptions](
   format =>
@@ -31,8 +28,31 @@ class NativeReaderOptionsSerializer() extends CustomSerializer[NativeReaderOptio
     })
 )
 
+object NativeReaderOptions {
+  def fromJson(jv: JObject): NativeReaderOptions = {
+    implicit val formats: Formats = DefaultFormats
+
+    val filterIntervals = (jv \ "filterIntervals").extract[Boolean]
+    val intervalPointType = IRParser.parseType((jv \ "intervalPointType").extract[String])
+    val intervals = {
+      val jvIntervals = jv \ "intervals"
+      val ty = TArray(TInterval(intervalPointType))
+      JSONAnnotationImpex.importAnnotation(jvIntervals, ty).asInstanceOf[IndexedSeq[Interval]]
+    }
+    new NativeReaderOptions(intervals, intervalPointType, filterIntervals)
+  }
+}
+
 case class NativeReaderOptions(
   intervals: IndexedSeq[Interval],
   intervalPointType: Type,
-  filterIntervals: Boolean = false
-)
+  filterIntervals: Boolean = false) {
+  def toJson: JValue = {
+    val ty = TArray(TInterval(intervalPointType))
+    JObject(
+      "name" -> "NativeReaderOptions",
+      "intervals" -> JSONAnnotationImpex.exportAnnotation(intervals, ty),
+      "intervalPointType" -> intervalPointType.parsableString(),
+      "filterIntervals" -> filterIntervals)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -11,6 +11,7 @@ import is.hail.expr.types._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.io._
+import is.hail.io.fs.FS
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, BlockMatrixReadRowBlockedRDD}
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
@@ -18,17 +19,18 @@ import is.hail.utils._
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.storage.StorageLevel
-import org.json4s.{Formats, ShortTypeHints}
+import org.json4s.JsonAST.{JNothing, JString}
+import org.json4s.{Formats, JObject, ShortTypeHints}
 
 import scala.reflect.ClassTag
 
 object TableIR {
-  def read(hc: HailContext, path: String, dropRows: Boolean = false, requestedType: Option[TableType] = None): TableIR = {
+  def read(fs: FS, path: String, dropRows: Boolean = false, requestedType: Option[TableType] = None): TableIR = {
     val successFile = path + "/_SUCCESS"
-    if (!hc.fs.exists(path + "/_SUCCESS"))
+    if (!fs.exists(path + "/_SUCCESS"))
       fatal(s"write failed: file not found: $successFile")
 
-    val tr = TableNativeReader(path)
+    val tr = TableNativeReader.read(fs, path, None)
     TableRead(requestedType.getOrElse(tr.fullType), dropRows = dropRows, tr)
   }
 }
@@ -111,12 +113,18 @@ case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, e
 
 object TableReader {
   implicit val formats: Formats = RelationalSpec.formats + ShortTypeHints(
-    List(classOf[TableNativeReader],
-      classOf[TableNativeZippedReader],
+    List(classOf[TableNativeZippedReader],
       classOf[TextTableReader],
       classOf[TextInputFilterAndReplace],
       classOf[TableFromBlockMatrixNativeReader])
     ) + new NativeReaderOptionsSerializer()
+
+  def fromJson(fs: FS, jv: JObject): TableReader = {
+    (jv \ "name").extract[String] match {
+      case "TableNativeReader" => TableNativeReader.fromJson(fs, jv)
+      case _ => jv.extract[TableReader]
+    }
+  }
 }
 
 abstract class TableReader {
@@ -127,19 +135,36 @@ abstract class TableReader {
   def fullType: TableType
 }
 
-case class TableNativeReader(
-  path: String,
-  options: Option[NativeReaderOptions] = None,
-  var _spec: AbstractTableSpec = null
-) extends TableReader {
-  lazy val spec = if (_spec != null)
-    _spec
-  else
-    (RelationalSpec.read(HailContext.get, path): @unchecked) match {
+object TableNativeReader {
+  def read(fs: FS, path: String, options: Option[NativeReaderOptions]): TableNativeReader = {
+    val spec = (RelationalSpec.read(fs, path): @unchecked) match {
       case ts: AbstractTableSpec => ts
       case _: AbstractMatrixTableSpec => fatal(s"file is a MatrixTable, not a Table: '$path'")
     }
 
+    TableNativeReader(path, options, spec)
+  }
+
+  def fromJson(fs: FS, jv: JObject): TableNativeReader = {
+    val path = jv \ "path" match {
+      case JString(s) => s
+    }
+
+    val options = jv \ "options" match {
+      case optionsJV: JObject =>
+        Some(NativeReaderOptions.fromJson(jv))
+      case JNothing => None
+    }
+
+    read(fs, path, options)
+  }
+}
+
+case class TableNativeReader(
+  path: String,
+  options: Option[NativeReaderOptions],
+  spec: AbstractTableSpec
+) extends TableReader {
   def partitionCounts: Option[IndexedSeq[Long]] = if (intervals.isEmpty) Some(spec.partitionCounts) else None
 
   override lazy val fullType: TableType = spec.table_type
@@ -182,7 +207,7 @@ case class TableNativeZippedReader(
   var _specLeft: AbstractTableSpec = null,
   var _specRight: AbstractTableSpec = null
 ) extends TableReader {
-  private def getSpec(path: String) = (RelationalSpec.read(HailContext.get, path): @unchecked) match {
+  private def getSpec(path: String) = (RelationalSpec.read(HailContext.fs, path): @unchecked) match {
     case ts: AbstractTableSpec => ts
     case _: AbstractMatrixTableSpec => fatal(s"file is a MatrixTable, not a Table: '$path'")
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -121,7 +121,6 @@ object TableReader {
     ) + new NativeReaderOptionsSerializer()
 
   def fromJson(fs: FS, jv: JObject): TableReader = {
-    println(jv)
     (jv \ "name").extract[String] match {
       case "TableNativeReader" => TableNativeReader.fromJson(fs, jv)
       case _ => jv.extract[TableReader]
@@ -147,14 +146,14 @@ object TableNativeReader {
     TableNativeReader(path, options, spec)
   }
 
-  def fromJson(fs: FS, jv: JObject): TableNativeReader = {
-    val path = jv \ "path" match {
+  def fromJson(fs: FS, readerJV: JObject): TableNativeReader = {
+    val path = readerJV \ "path" match {
       case JString(s) => s
     }
 
-    val options = jv \ "options" match {
+    val options = readerJV \ "options" match {
       case optionsJV: JObject =>
-        Some(NativeReaderOptions.fromJson(jv))
+        Some(NativeReaderOptions.fromJson(optionsJV))
       case JNothing => None
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -113,13 +113,15 @@ case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, e
 
 object TableReader {
   implicit val formats: Formats = RelationalSpec.formats + ShortTypeHints(
-    List(classOf[TableNativeZippedReader],
+    List(classOf[TableNativeReader],
+      classOf[TableNativeZippedReader],
       classOf[TextTableReader],
       classOf[TextInputFilterAndReplace],
       classOf[TableFromBlockMatrixNativeReader])
     ) + new NativeReaderOptionsSerializer()
 
   def fromJson(fs: FS, jv: JObject): TableReader = {
+    println(jv)
     (jv \ "name").extract[String] match {
       case "TableNativeReader" => TableNativeReader.fromJson(fs, jv)
       case _ => jv.extract[TableReader]

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -57,9 +57,10 @@ object Graph {
     val wrappedNodeType = PCanonicalTuple(true, PType.canonical(nodeType))
     val refMap = Map("l" -> wrappedNodeType.virtualType, "r" -> wrappedNodeType.virtualType)
 
-    Region.scoped { region =>
+    ExecuteContext.scoped() { ctx =>
+      val region = ctx.r
       val tieBreakerF = tieBreaker.map { e =>
-        val ir = IRParser.parse_value_ir(e, IRParserEnvironment(refMap))
+        val ir = IRParser.parse_value_ir(e, IRParserEnvironment(ctx, refMap = refMap))
         val (t, f) = Compile[AsmFunction3RegionLongLongLong](ctx,
           IndexedSeq(("l", wrappedNodeType), ("r", wrappedNodeType)),
           FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -588,7 +588,7 @@ object ReferenceGenome {
   }
 
   def fromHailDataset(path: String): String = {
-    val references = RelationalSpec.readReferences(HailContext.get, path)
+    val references = RelationalSpec.readReferences(HailContext.fs, path)
     implicit val formats: Formats = defaultJSONFormats
     Serialization.write(references.map(_.toJSON).toFastIndexedSeq)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2888,6 +2888,7 @@ class IRSuite extends HailSuite {
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
     val s = Pretty(x, elideLiterals = false)
+    println(s)
     val x2 = IRParser.parse_matrix_ir(s)
     assert(x2 == x)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2888,7 +2888,6 @@ class IRSuite extends HailSuite {
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
     val s = Pretty(x, elideLiterals = false)
-    println(s)
     val x2 = IRParser.parse_matrix_ir(s)
     assert(x2 == x)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -33,8 +33,8 @@ class TableIRSuite extends HailSuite {
     val path = tmpDir.createTempFile()
     CompileAndEvaluate[Unit](ctx, TableWrite(original, TableNativeWriter(path, overwrite = true)), false)
 
-    val read = TableIR.read(hc, path, false, None)
-    val droppedRows = TableIR.read(hc, path, true, None)
+    val read = TableIR.read(fs, path, false, None)
+    val droppedRows = TableIR.read(fs, path, true, None)
 
     val expectedRows = Array.tabulate(10)(i => Row(i)).toFastIndexedSeq
     val expectedGlobals = Row(57)
@@ -415,7 +415,7 @@ class TableIRSuite extends HailSuite {
     val path = tmpDir.createLocalTempFile(extension = "ht")
     Interpret[Unit](ctx, TableWrite(table, TableNativeWriter(path)))
     val before = table.execute(ctx)
-    val after = Interpret(TableIR.read(hc, path), ctx, false)
+    val after = Interpret(TableIR.read(fs, path), ctx, false)
     assert(before.globals.javaValue == after.globals.javaValue)
     assert(before.rdd.collect().toFastIndexedSeq == after.rdd.collect().toFastIndexedSeq)
   }


### PR DESCRIPTION
@danking @tpoterba I wasn't sure if this should go to compilers or services team.  I randomly picked Dan.  Who "owns" GoogleStorageFS?  ServiceBackend?  Let's discuss in staff meeting this week.

Summary of changes:
 - ExecuteContext aded to IRParserEnvironment (maybe should be renamed IRParserContext now?)
 - TableReader in general will need the filesystem for construct.  This breaks the json4s de/serializer model.  I started expanding the serializers and writing them by hand.  Just did the TableNativeReader for now.  We might reconsider the mix of custom and JSON in the printed format at some point in the future.
 - A bunch of functions take a hc but only need an fs.  More of this to come.

```
hl.init(_backend=hl.backend.ServiceBackend())
t = hl.read_table('gs://hail-cseed-k0ox4/sample_rows.ht')
print(t.count())
```

```
Welcome to
     __  __     <>__
    / /_/ /__  __/ /
   / __  / _ `/ / /
  /_/ /_/\_,_/_/_/   version 0.2.36-75a0f869d72d
LOGGING: writing to /home/cotton/hail-20200407-1502-0.2.36-75a0f869d72d.log
346
```
