### PR TITLE
[query] Fix dosage length check.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -570,7 +570,7 @@ object Interpret {
             SafeRow(rt.asInstanceOf[PTuple], resultOffset).get(0)
           } catch {
             case e: Exception =>
-              fatal(s"error while calling '${ ir.implementation.name }'", e)
+              fatal(s"error while calling '${ ir.implementation.name }': ${ e.getMessage }", e)
           }
         }
       case TableCount(child) =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -45,7 +45,7 @@ object GenotypeFunctions extends RegistryFunctions {
           val gpv = gpc.memoize(cb, "dosage_gp")
 
           cb.ifx(gpv.loadLength().cne(3),
-            Code._fatal[Unit](const("length of gp array must be 3, got ").concat(gpv.loadLength().toS)))
+            cb._fatal(const("length of gp array must be 3, got ").concat(gpv.loadLength().toS)))
 
           gpv.loadElement(cb, 1).flatMap(cb) { (_1: PCode) =>
             gpv.loadElement(cb, 2).map { (_2: PCode) =>

--- a/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
@@ -30,7 +30,7 @@ class GenotypeFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("dosage", TFloat64, toIRDoubleArray(gp)), expected)
   }
 
-  def testDosageLength() {
+  @Test def testDosageLength() {
     assertFatal(invoke("dosage", TFloat64, IRDoubleArray(1.0, 1.5)), "length")
     assertFatal(invoke("dosage", TFloat64, IRDoubleArray(1.0, 1.5, 0.0, 0.0)), "length")
   }


### PR DESCRIPTION
This illustrates one of the footguns in using CodeBuilder. When using
functionality like ifx, we must be sure to actually put the resultant
code on the CodeBuilder in the block we pass to ifx. Otherwise we won't
add any code and the behavior may be surprising.

This is basically equivalent to storing some Code in a variable and then
never passing that variable into a returned Code, so it is never
executed.