### PR TITLE
[internal-gateway][router-resolver] get optional TLS running

### DIFF
--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -10,11 +10,22 @@ map $http_x_forwarded_proto $updated_scheme {
 
 limit_req_zone global zone=limit:1m rate=83r/s;
 
+map $maybe_router_scheme $router_scheme {
+    default $maybe_router_scheme;
+    ''      http;
+}
+
 server {
     server_name internal.hail;
     client_max_body_size 50m;
     listen 80;
     listen [::]:80;
+
+    location = /router_scheme {
+        internal;
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://router-resolver.default.svc.cluster.local/router-scheme/$namespace;
+    }
 
     location ~ ^/([^/]+)/([^/]+) {
     	limit_req zone=limit burst=20 nodelay;
@@ -22,8 +33,11 @@ server {
         set $namespace $1;
         set $service $2;
 
+        auth_request /router_scheme;
+        auth_request_set $maybe_router_scheme $upstream_http_x_router_scheme;
+
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://router.$namespace.svc.cluster.local;
+        proxy_pass $router_scheme://router.$namespace.svc.cluster.local;
 
         proxy_set_header Host $service.internal;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This change is temporary. I do not intend to keep the extra hop to `auth` on all internal-gateway requests.

Once all the TLS changes go in and everything in the cluster is TLS-secured, then I can switch the internal gateway to unconditionally use HTTPS and remove the router-resolver's extra endpoint.

I've already deployed this (I need it to get batch tests to pass in my namespace.