### PR TITLE
[site] actually check that site is alive

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -895,6 +895,10 @@ steps:
    namespace:
      valueFrom: default_ns.name
    config: site/deployment.yaml
+   wait:
+    - kind: Service
+      name: site
+      for: alive
    dependsOn:
     - default_ns
     - site_image

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: site-deployment
+  name: site
   labels:
     app: site
     hail.is/sha: "{{ code.sha }}"


### PR DESCRIPTION
This change brings the site deployment naming scheme in line with
our other k8s Deployments and also adds a `wait` to build.yaml so
that we check that the site has come up successfully.