### PR TITLE
[ci] fix for waiting on a pod with multiple containers

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -721,7 +721,7 @@ set +e
 kubectl -n {self.namespace} rollout status --timeout=1h deployment {name} && \
   kubectl -n {self.namespace} wait --timeout=1h --for=condition=available deployment {name}
 EC=$?
-kubectl -n {self.namespace} logs --tail=999999 -l app={name} | {pretty_print_log}
+kubectl -n {self.namespace} logs --tail=999999 -l app={name} --all-containers=true | {pretty_print_log}
 set -e
 (exit $EC)
 '''


### PR DESCRIPTION
The error message you get is this:
```
Error from server (BadRequest): a container name must be specified for pod blog-0, choose one of: [nginx blog]
```

This option is described in `kubectl logs --help` as:
> --all-containers=false: Get all containers logs in the pod(s).