### PR TITLE
NDArray Map Method Builder Scoping

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -695,3 +695,10 @@ def test_numpy_interop():
                           np.array([[6, 9], [10, 15]]))
     assert np.array_equal(hl.eval(np.array(b) @ hl.nd.array(a)),
                           np.array([[6, 9], [10, 15]]))
+
+
+def test_ndarray_emitter_extract():
+    np_mat = np.array([0, 1, 2, 1, 0])
+    mat = hl.nd.array(np_mat)
+    mapped_mat = mat.map(lambda x: hl.array([3, 4, 5])[hl.int(x)])
+    assert hl.eval(hl.range(5).map(lambda i: mapped_mat[i])) == [3, 4, 5, 4, 3]

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1542,20 +1542,3 @@ class Tests(unittest.TestCase):
         mt = mt.key_cols_by(col_id = hl.str(mt.col_idx))
         mt = mt.add_col_index()
         mt.show()
-
-    def test_ndarray_extract_failure(self):
-        import numpy as np
-
-        mt = hl.utils.range_matrix_table(10, 10)
-        mt = mt.annotate_cols(phenotype_boolean=hl.rand_bool(.5))
-
-        np_pheno = np.array(mt.phenotype_boolean.collect())
-        np_pheno[np_pheno == None] = 2
-        np_pheno = np_pheno.astype(int)
-        np_pheno_mat = np.repeat(np_pheno, 1).reshape(np_pheno.size, 1)
-        np.random.shuffle(np_pheno_mat[:,0])
-        mt = mt.annotate_globals(pheno_perm = np_pheno_mat)
-        mt = mt.annotate_globals(pheno_perm = mt.pheno_perm.map(
-            lambda x: { hl.array([False, True, hl.null(hl.tbool)])[hl.int(x)] }))
-
-        mt._force_count_rows()

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1543,3 +1543,19 @@ class Tests(unittest.TestCase):
         mt = mt.add_col_index()
         mt.show()
 
+    def test_ndarray_extract_failure(self):
+        import numpy as np
+
+        mt = hl.utils.range_matrix_table(10, 10)
+        mt = mt.annotate_cols(phenotype_boolean=hl.rand_bool(.5))
+
+        np_pheno = np.array(mt.phenotype_boolean.collect())
+        np_pheno[np_pheno == None] = 2
+        np_pheno = np_pheno.astype(int)
+        np_pheno_mat = np.repeat(np_pheno, 1).reshape(np_pheno.size, 1)
+        np.random.shuffle(np_pheno_mat[:,0])
+        mt = mt.annotate_globals(pheno_perm = np_pheno_mat)
+        mt = mt.annotate_globals(pheno_perm = mt.pheno_perm.map(
+            lambda x: { hl.array([False, True, hl.null(hl.tbool)])[hl.int(x)] }))
+
+        mt._force_count_rows()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2078,7 +2078,7 @@ private class Emit[C](
       case NDArrayMap(child, elemName, body) =>
         val childP = child.pType.asInstanceOf[PNDArray]
         val elemPType = childP.elementType
-        val elemRef = mb.newPresentEmitField(elemPType) // FIXME elemName
+        val elemRef = mb.newPresentEmitField("ndarray_map_element_name", elemPType)
         val bodyEnv = env.bind(elemName, elemRef)
         val bodyt = emit(body, env = bodyEnv)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2580,7 +2580,7 @@ abstract class NDArrayEmitter[C](
   }
 
   private def emitLoops(mb: EmitMethodBuilder[C], outputShapeVariables: IndexedSeq[Value[Long]], srvb: StagedRegionValueBuilder): Code[Unit] = {
-    val innerMethod = mb.genEmitMethod("ndaLoop", mb.emitParamTypes, CodeParamType(UnitInfo))
+    val innerMethod = mb.genEmitMethod("ndaLoop", mb.emitParamTypes, UnitInfo)
 
     val idxVars = Array.tabulate(nDims) { _ => mb.genFieldThisRef[Long]() }.toFastIndexedSeq
     val storeElement = innerMethod.newLocal("nda_elem_out")(typeToTypeInfo(outputElementPType.virtualType))
@@ -2601,6 +2601,6 @@ abstract class NDArrayEmitter[C](
       )
     }
     innerMethod.emit(loops)
-    innerMethod.invokeCode[Unit](mb.getParamsList():_*)
+    innerMethod.invokeCode[Unit](mb.getParamsList(): _*)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -325,11 +325,7 @@ object EmitUtils {
       newMB.emit(Code(c.map(_.emit(newMB))))
       new EstimableEmitter[C] {
         def emit(mb: EmitMethodBuilder[C]): Code[Unit] = {
-          newMB.invokeCode[Unit](
-            mb.emitParamTypes.toFastIndexedSeq.zipWithIndex.map {
-              case (CodeParamType(ti), i) => CodeParam(mb.getCodeParam(i + 1)(ti)): Param
-              case (EmitParamType(pt), i) => EmitParam(mb.getEmitParam(i + 1)): Param
-            }: _*)
+          newMB.invokeCode[Unit](mb.getParamsList():_*)
         }
 
         def estimatedSize: Int = 5
@@ -2606,11 +2602,6 @@ abstract class NDArrayEmitter[C](
       )
     }
     innerMethod.emit(loops)
-
-    val mbParams = mb.emitParamTypes.toFastIndexedSeq.zipWithIndex.map {
-      case (CodeParamType(ti), i) => CodeParam(mb.getCodeParam(i + 1)(ti)): Param
-      case (EmitParamType(pt), i) => EmitParam(mb.getEmitParam(i + 1)): Param
-    }
-    innerMethod.invokeCode[Unit](mbParams:_*)
+    innerMethod.invokeCode[Unit](mb.getParamsList():_*)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2098,13 +2098,6 @@ private class Emit[C](
         val lP = coerce[PNDArray](lChild.pType)
         val rP = coerce[PNDArray](rChild.pType)
 
-        val lElemRef = mb.newPresentEmitField(lName, lP.elementType)
-        val rElemRef = mb.newPresentEmitField(rName, rP.elementType)
-
-        val bodyEnv = env.bind(lName, lElemRef)
-          .bind(rName, rElemRef)
-        val bodyt = emit(body, env = bodyEnv)
-
         val leftChildEmitter = deforest(lChild)
         val rightChildEmitter = deforest(rChild)
 
@@ -2115,6 +2108,12 @@ private class Emit[C](
 
         new NDArrayEmitter[C](lP.shape.pType.size, shapeArray, lP.shape.pType, body.pType, setupShape, setupMissing, leftChildEmitter.missing || rightChildEmitter.missing) {
           override def outputElement(elemMB: EmitMethodBuilder[C], idxVars: IndexedSeq[Value[Long]]): Code[_] = {
+            val lElemRef = elemMB.newPresentEmitField(lName, lP.elementType)
+            val rElemRef = elemMB.newPresentEmitField(rName, rP.elementType)
+
+            val bodyEnv = env.bind(lName, lElemRef)
+              .bind(rName, rElemRef)
+            val bodyt = emitSelf.emit(body, elemMB, bodyEnv, None)
 
             val lIdxVars2 = NDArrayEmitter.zeroBroadcastedDims2(elemMB, idxVars, nDims, leftChildEmitter.outputShape)
             val rIdxVars2 = NDArrayEmitter.zeroBroadcastedDims2(elemMB, idxVars, nDims, rightChildEmitter.outputShape)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -877,7 +877,7 @@ class EmitMethodBuilder[C](
     }
   }
 
-  def getParamsList(): Seq[Param] = {
+  def getParamsList(): IndexedSeq[Param] = {
     emitParamTypes.toFastIndexedSeq.zipWithIndex.map {
       case (CodeParamType(ti), i) => CodeParam(this.getCodeParam(i + 1)(ti)): Param
       case (EmitParamType(pt), i) => EmitParam(this.getEmitParam(i + 1)): Param

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -877,6 +877,13 @@ class EmitMethodBuilder[C](
     }
   }
 
+  def getParamsList(): Seq[Param] = {
+    emitParamTypes.toFastIndexedSeq.zipWithIndex.map {
+      case (CodeParamType(ti), i) => CodeParam(this.getCodeParam(i + 1)(ti)): Param
+      case (EmitParamType(pt), i) => EmitParam(this.getEmitParam(i + 1)): Param
+    }
+  }
+
   def invokeCode[T](args: Param*): Code[T] = {
     assert(emitReturnType.isInstanceOf[CodeParamType])
     mb.invoke(args.flatMap {


### PR DESCRIPTION
It was wrong for the `elemRef` values in the emit code `NDArrayMap` and `NDArrayMap2` to use `mb` as opposed to `elemMB`. They were being emitted in a different method builder than they were being used in. In order to fix this, I had to fix `NDArrayEmitter` to take an `EmitMethodBuilder[C]` instead of `EmitMethodBuilder[_]`, so I did that. I also had to pass the arguments along from the `mb` method builder to the `innerMethod` method builder in the `NDArrayEmitter` emit method. Factored out `mb.getParamsList()` to make that easier.

I also added a new test that is remedied by this change.