### PR TITLE
[query] Fix subtle hamming performance regression/bug

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -149,11 +149,13 @@ abstract class EmitValue {
 }
 
 object IEmitCode {
-  def apply(cb: EmitCodeBuilder, m: Code[Boolean], pc: PCode): IEmitCode = {
+  def apply(cb: EmitCodeBuilder, m: Code[Boolean], pc: => PCode): IEmitCode = {
     val Lmissing = CodeLabel()
     val Lpresent = CodeLabel()
-    cb.ifx(m, { cb.goto(Lmissing) }, { cb.goto(Lpresent) })
-    IEmitCode(Lmissing, Lpresent, pc)
+    cb.ifx(m, { cb.goto(Lmissing) })
+    val resPc: PCode = pc
+    cb.goto(Lpresent)
+    IEmitCode(Lmissing, Lpresent, resPc)
   }
 }
 
@@ -600,7 +602,7 @@ private class Emit[C](
     // working towards removing this
     if (pt == PVoid)
       return new EmitCode(emitVoid(ir), const(false), PCode(pt, Code._empty))
-    
+
     (ir: @unchecked) match {
       case I32(x) =>
         present(pt, const(x))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -252,13 +252,14 @@ object StringFunctions extends RegistryFunctions {
 
             val m = v1.loadLength().cne(v2.loadLength())
 
-            cb.whileLoop(i < v1.loadLength(), {
-              cb.ifx(v1.loadByte(i).cne(v2.loadByte(i)),
-                cb.assign(n, n + 1))
-              cb.assign(i, i + 1)
+            IEmitCode(cb, m, {
+              cb.whileLoop(i < v1.loadLength(), {
+                cb.ifx(v1.loadByte(i).cne(v2.loadByte(i)),
+                  cb.assign(n, n + 1))
+                cb.assign(i, i + 1)
+              })
+              PCode(rt, n)
             })
-
-            IEmitCode(cb, m, PCode(rt, n))
           }
         }
       }


### PR DESCRIPTION
This change alters the signature of IEmitCode's apply method to take
a thunk returning a PCode, rather than a PCode. This was an issue
because the CodeBuilder is built up in strict append order. In an idiom
like:

    EmitCode.fromI(mb) { cb =>
      cb += setupIsMissing
      val isMissing = missingExpr
      cb += setupThePCode
      val pc = pcodeExpr
      IEmitCode(cb, isMissing, pc)
    }

We were running all of the Code added to the CodeBuilder as a sort of
"setup" before computing the missingness expression. There was no way to
sequence this such that the Code needed to produce the PCode was not
also run in the setup, thus potentially leading to extra work, even when
the result would be missing, like in hamming.

By changing the signature of apply to take a thunk that produces
a PCode, we give callers the ability to control if code is executed
before or after the missingness check.

Co-Authored-By: Patrick Schultz <pschultz@broadinstitute.org>