### PR TITLE
[ci] fix create_database

### DIFF
--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -33,13 +33,13 @@ password="{config["password"]}"
 database={config["db"]}
 ''')
         files = ['sql-config.json', 'sql-config.cnf']
-        if 'ssl-ca' in config:
+        if config.get('ssl-ca') is not None:
             f.write(f'ssl-ca={config["ssl-ca"]}\n')
-        if 'ssl-cert' in config:
+        if config.get('ssl-cert') is not None:
             f.write(f'ssl-cert={config["ssl-cert"]}\n')
-        if 'ssl-key' in config:
+        if config.get('ssl-key') is not None:
             f.write(f'ssl-key={config["ssl-key"]}\n')
-        if 'ssl-mode' in config:
+        if config.get('ssl-mode') is not None:
             f.write(f'ssl-mode={config["ssl-mode"]}\n')
 
     if os.path.exists('/sql-config/server-ca.pem'):


### PR DESCRIPTION
If you look in the body of create_database, you will see that I copy the
keys from an existing sql-config using `get`. This propagates the `None`s
rather than leaving the keys missing. This fix changes `write_user_config`
to filter out keys set to None. Such keys should not appear in normal
configs because we never use `null` in our configs.