### PR TITLE
[ci] fix PR number link

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -101,7 +101,6 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
     pr = wb.prs[pr_number]
 
     page_context = {}
-    page_context['wb'] = wb
     page_context['repo'] = wb.branch.repo.short_str()
     page_context['pr'] = pr
     # FIXME

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block title %}PR {{ number }}{% endblock %}
 {% block content %}
-    <h1>{{ pr.title }} <a href="https://github.com/{{ wb.repo }}/pull/{{ pr.number }}"><span class="gh-number">#{{ pr.number }}</span></a></h1>
+    <h1>{{ pr.title }} <a href="https://github.com/{{ repo }}/pull/{{ pr.number }}"><span class="gh-number">#{{ pr.number }}</span></a></h1>
     {% if batch is defined %}
     <div class="attributes">
       <div>batch: <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></div>


### PR DESCRIPTION
`wb.repo` is not a thing, the thing is `repo` which is `hail-is/hail`.