### PR TITLE
[router] ensure the router comes up during deployment

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -883,6 +883,10 @@ steps:
    namespace:
      valueFrom: default_ns.name
    config: router/deployment.yaml
+   wait:
+     - kind: Service
+       name: router
+       for: alive
    link:
     - www
     - notebook


### PR DESCRIPTION
The `wait` directive tells CI to wait for the service to come up before
continuing with deployment. If the service fails to come up (including
failing to respond to the readiness checks) then CI will fail the build.