### PR TITLE
[router] remove duplicate batch service

### DIFF
--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -44,20 +44,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: batch
-  labels:
-    app: batch
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    targetPort: 5000
-  selector:
-    app: batch
----
-apiVersion: v1
-kind: Service
-metadata:
   name: batch-driver
   labels:
     app: batch-driver


### PR DESCRIPTION
The two entries are the same so we never noticed. I saw it when I was switching ports to 443.