### PR TITLE
Fix `IEmitCode.map`, Rewrite `MakeNDArray` in `CodeBuilder` style

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -650,7 +650,6 @@ class tndarray(HailType):
         return f'NDArray[{self._element_type._parsable_string()},{self.ndim}]'
 
     def _convert_from_json(self, x):
-        print(x)
         np_type = self.element_type.to_numpy()
         return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
 

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -650,6 +650,7 @@ class tndarray(HailType):
         return f'NDArray[{self._element_type._parsable_string()},{self.ndim}]'
 
     def _convert_from_json(self, x):
+        print(x)
         np_type = self.element_type.to_numpy()
         return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
 

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -334,8 +334,13 @@ object Code {
     newC
   }
 
-  def _println(c: Code[AnyRef]): Code[Unit] =
-    Code.invokeScalaObject[AnyRef, Unit](scala.Console.getClass, "println", c)
+  def _println(c: Code[AnyRef]): Code[Unit] = {
+    Code(
+      Code.invokeScalaObject[AnyRef, Unit](scala.Console.getClass, "println", c),
+      Code.invokeScalaObject[Unit](scala.Console.getClass, "flush")
+    )
+  }
+
 
   def checkcast[T](v: Code[_])(implicit tti: TypeInfo[T]): Code[T] =
     Code(v, lir.checkcast(tti.iname))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -233,8 +233,7 @@ case class EmitCode(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
     cb.append(Code._println("Pre setup"))
     cb += setup
     cb.append(Code._println("Post setup"))
-    cb.ifx(m, {cb.append(Code._println("Was missing")); cb.goto(Lmissing) },
-      {cb.append(Code._println("Was present")); cb.goto(Lpresent) })
+    cb.ifx(m, { cb.goto(Lmissing) }, { cb.goto(Lpresent) })
     IEmitCode(Lmissing, Lpresent, pv)
   }
 
@@ -1297,7 +1296,7 @@ private class Emit[C](
             datat.toI(cb).map(cb) { case dataCode: PIndexableCode =>
               val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
               val dataValue = dataCode.memoize(cb, "make_ndarray_data")
-              val dataPtr = dataValue.get.code.asInstanceOf[Code[Long]]
+              val dataPtr = dataValue.get.tcode[Long]
               val requiredData = dataPType.checkedConvertFrom(mb, region, dataPtr, coerce[PArray](dataContainer), "NDArray cannot have missing data")
 
               (0 until nDims).foreach { index =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1292,61 +1292,36 @@ private class Emit[C](
         val shapet = emit(shapeIR)
         val rowMajort = emit(rowMajorIR)
 
-        val shapeAddress = mb.genFieldThisRef[Long]()
-
-        val oldShapeTuple = new CodePTuple(shapePType, shapeAddress)
-
-        val shapeVariables = (0 until nDims).map(_ => mb.newLocal[Long]()).toArray
-
-        def shapeBuilder(srvb: StagedRegionValueBuilder): Code[Unit] = {
-          Code(
-            srvb.start(),
-            Code.foreach(0 until nDims) { index =>
-              Code(
-                srvb.addLong(shapeVariables(index)),
-                srvb.advance())
-            })
-        }
-
-        val newResult = EmitCode.fromI(mb) { cb =>
-          cb.append(Code._println("Started making an ndarray"))
-
+        EmitCode.fromI(mb) { cb =>
           shapet.toI(cb).flatMap(cb) { case shapeTupleCode: PBaseStructCode =>
-            cb.append(Code._println("Flatmapped once"))
             datat.toI(cb).map(cb) { case dataCode: PIndexableCode =>
-              cb.append(Code._println("Mapped!"))
               val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
               val dataValue = dataCode.memoize(cb, "make_ndarray_data")
               val dataPtr = dataValue.get.code.asInstanceOf[Code[Long]]
-              cb.append(Code._println("Made it this far"))
               val requiredData = dataPType.checkedConvertFrom(mb, region, dataPtr, coerce[PArray](dataContainer), "NDArray cannot have missing data")
 
               (0 until nDims).foreach { index =>
                 cb.ifx(shapeTupleValue.isFieldMissing(index),
-                  Code._fatal[Unit](s"shape missing at index $index"),
-                  shapeVariables(index) := shapeTupleValue(index))
+                  cb.append(Code._fatal[Unit](s"shape missing at index $index")))
               }
 
-              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb))
+              val shapeCodeSeq = (0 until nDims).map(shapeTupleValue[Long](_).get)
+
+              def shapeBuilder(srvb: StagedRegionValueBuilder): Code[Unit] = {
+                Code(
+                  srvb.start(),
+                  Code.foreach(0 until nDims) { index =>
+                    Code(
+                      srvb.addLong(shapeTupleValue(index)),
+                      srvb.advance())
+                  })
+              }
+
+              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
             }
           }
         }
-        newResult
 
-//        val setup = Code(
-//          shapet.setup,
-//          datat.setup,
-//          rowMajort.setup)
-//
-//        val result = Code(
-//          shapeAddress := shapet.value[Long],
-//          Code.foreach(0 until nDims) { index =>
-//            oldShapeTuple.isMissing(index).mux[Unit](
-//              Code._fatal[Unit](s"shape missing at index $index"),
-//              shapeVariables(index) := oldShapeTuple(index))
-//          },
-//          xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb))
-//        EmitCode(setup, datat.m || shapet.m, PCode(pt, result))
       case NDArrayShape(ndIR) =>
         val ndt = emit(ndIR)
         val ndP = ndIR.pType.asInstanceOf[PNDArray]

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -229,10 +229,7 @@ case class EmitCode(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
   def toI(cb: EmitCodeBuilder): IEmitCode = {
     val Lmissing = CodeLabel()
     val Lpresent = CodeLabel()
-    cb.append(Code._println(s"PType is: ${pt.toString}"))
-    cb.append(Code._println("Pre setup"))
     cb += setup
-    cb.append(Code._println("Post setup"))
     cb.ifx(m, { cb.goto(Lmissing) }, { cb.goto(Lpresent) })
     IEmitCode(Lmissing, Lpresent, pv)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1302,6 +1302,12 @@ private class Emit[C](
             })
         }
 
+        val newResult = EmitCode.fromI(mb) { cb =>
+          val shapeValue = cb.memoize(shapet, "foo")
+
+          ???
+        }
+
         val setup = Code(
           shapet.setup,
           datat.setup,
@@ -1312,7 +1318,7 @@ private class Emit[C](
           Code.foreach(0 until nDims) { index =>
             shapeTuple.isFieldMissing(index).mux[Unit](
               Code._fatal[Unit](s"shape missing at index $index"),
-              shapeVariables(index) := shapeTuple(index))
+              shapeVariables(index) := oldShapeTuple(index))
           },
           xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb))
         EmitCode(setup, datat.m || shapet.m, PCode(pt, result))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1312,7 +1312,7 @@ private class Emit[C](
           Code.foreach(0 until nDims) { index =>
             shapeTuple.isFieldMissing(index).mux[Unit](
               Code._fatal[Unit](s"shape missing at index $index"),
-              shapeVariables(index) := oldShapeTuple(index))
+              shapeVariables(index) := shapeTuple(index))
           },
           xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb))
         EmitCode(setup, datat.m || shapet.m, PCode(pt, result))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -7,6 +7,7 @@ import is.hail.asm4s.joinpoint.Ctrl
 import is.hail.asm4s._
 import is.hail.backend.HailTaskContext
 import is.hail.expr.ir.functions.StringFunctions
+import is.hail.expr.types.physical
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
@@ -1287,7 +1288,8 @@ private class Emit[C](
         val requiredData = dataPType.checkedConvertFrom(mb, region, datat.value[Long], coerce[PArray](dataContainer), "NDArray cannot have missing data")
         val shapeAddress = mb.genFieldThisRef[Long]()
 
-        val shapeTuple = new CodePTuple(shapePType, shapeAddress)
+        //val shapeTuple = new CodePTuple(shapePType, shapeAddress)
+        val shapeTuple: PBaseStructCode = shapePType.load(shapeAddress)
 
         val shapeVariables = (0 until nDims).map(_ => mb.newLocal[Long]()).toArray
 
@@ -1305,10 +1307,21 @@ private class Emit[C](
           shapet.setup,
           datat.setup,
           rowMajort.setup)
+
+//        val newResult = EmitCode.fromI(mb) { cb =>
+//          val newShapeAddress = cb.memoize(shapet, "make_nd_shape")
+//
+//
+//          IEmitCode(cb, ???, {
+//            val newRes = xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb)
+//            PCode(pt, ???)
+//          })
+//        }
+
         val result = Code(
           shapeAddress := shapet.value[Long],
           Code.foreach(0 until nDims) { index =>
-            shapeTuple.isMissing(index).mux[Unit](
+            shapeTuple.isFieldMissing(index).mux[Unit](
               Code._fatal[Unit](s"shape missing at index $index"),
               shapeVariables(index) := shapeTuple(index))
           },

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1287,6 +1287,7 @@ private class Emit[C](
         val requiredData = dataPType.checkedConvertFrom(mb, region, datat.value[Long], coerce[PArray](dataContainer), "NDArray cannot have missing data")
         val shapeAddress = mb.genFieldThisRef[Long]()
 
+        val oldShapeTuple = new CodePTuple(shapePType, shapeAddress)
         val shapeTuple: PBaseStructCode = shapePType.load(shapeAddress)
 
         val shapeVariables = (0 until nDims).map(_ => mb.newLocal[Long]()).toArray
@@ -1311,7 +1312,7 @@ private class Emit[C](
           Code.foreach(0 until nDims) { index =>
             shapeTuple.isFieldMissing(index).mux[Unit](
               Code._fatal[Unit](s"shape missing at index $index"),
-              shapeVariables(index) := shapeTuple(index))
+              shapeVariables(index) := oldShapeTuple(index))
           },
           xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb))
         EmitCode(setup, datat.m || shapet.m, PCode(pt, result))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -7,7 +7,6 @@ import is.hail.asm4s.joinpoint.Ctrl
 import is.hail.asm4s._
 import is.hail.backend.HailTaskContext
 import is.hail.expr.ir.functions.StringFunctions
-import is.hail.expr.types.physical
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
@@ -1288,7 +1287,6 @@ private class Emit[C](
         val requiredData = dataPType.checkedConvertFrom(mb, region, datat.value[Long], coerce[PArray](dataContainer), "NDArray cannot have missing data")
         val shapeAddress = mb.genFieldThisRef[Long]()
 
-        //val shapeTuple = new CodePTuple(shapePType, shapeAddress)
         val shapeTuple: PBaseStructCode = shapePType.load(shapeAddress)
 
         val shapeVariables = (0 until nDims).map(_ => mb.newLocal[Long]()).toArray
@@ -1307,16 +1305,6 @@ private class Emit[C](
           shapet.setup,
           datat.setup,
           rowMajort.setup)
-
-//        val newResult = EmitCode.fromI(mb) { cb =>
-//          val newShapeAddress = cb.memoize(shapet, "make_nd_shape")
-//
-//
-//          IEmitCode(cb, ???, {
-//            val newRes = xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb)
-//            PCode(pt, ???)
-//          })
-//        }
 
         val result = Code(
           shapeAddress := shapet.value[Long],

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -48,7 +48,7 @@ object GenotypeFunctions extends RegistryFunctions {
             cb._fatal(const("length of gp array must be 3, got ").concat(gpv.loadLength().toS)))
 
           gpv.loadElement(cb, 1).flatMap(cb) { (_1: PCode) =>
-            gpv.loadElement(cb, 2).map { (_2: PCode) =>
+            gpv.loadElement(cb, 2).map(cb) { (_2: PCode) =>
               PCode(rt, _1.tcode[Double] + _2.tcode[Double] * 2.0)
             }
           }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -187,6 +187,8 @@ abstract class PBaseStruct extends PType {
 }
 
 abstract class PBaseStructValue extends PValue {
+  def apply[T](i: Int): Value[T]
+
   def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode
 
   def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.asInstanceOf[PBaseStruct].fieldIdx(fieldName))
@@ -196,11 +198,6 @@ abstract class PBaseStructCode extends PCode {
   def pt: PBaseStruct
 
   val a: Code[Long]
-
-  def apply[T](i: Int): Value[T] =
-    new Value[T] {
-      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
-    }
 
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -199,8 +199,6 @@ abstract class PBaseStructValue extends PValue {
 abstract class PBaseStructCode extends PCode {
   def pt: PBaseStruct
 
-  val a: Code[Long]
-
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PBaseStructValue

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -182,6 +182,8 @@ abstract class PBaseStruct extends PType {
     } else
       Gen.uniformSequence(types.map(t => t.genValue)).map(a => Annotation(a: _*))
   }
+
+  override def load(src: Code[Long]): PBaseStructCode = ???
 }
 
 abstract class PBaseStructValue extends PValue {
@@ -193,7 +195,18 @@ abstract class PBaseStructValue extends PValue {
 abstract class PBaseStructCode extends PCode {
   def pt: PBaseStruct
 
+  val a: Code[Long]
+
+  def apply[T](i: Int): Value[T] =
+    new Value[T] {
+      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
+    }
+
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PBaseStructValue
+
+  def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
+    this.pt.isFieldMissing(a, fieldIdx)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -189,6 +189,8 @@ abstract class PBaseStruct extends PType {
 abstract class PBaseStructValue extends PValue {
   def apply[T](i: Int): Value[T]
 
+  def isFieldMissing(fieldIdx: Int): Code[Boolean]
+
   def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode
 
   def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.asInstanceOf[PBaseStruct].fieldIdx(fieldName))
@@ -202,8 +204,4 @@ abstract class PBaseStructCode extends PCode {
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PBaseStructValue
-
-  def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
-    this.pt.isFieldMissing(a, fieldIdx)
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -249,6 +249,10 @@ class PCanonicalBaseStructSettable(
     new Value[T] {
       def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
     }
+
+  def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
+    this.pt.isFieldMissing(a, fieldIdx)
+  }
 }
 
 class PCanonicalBaseStructCode(val pt: PCanonicalBaseStruct, val a: Code[Long]) extends PBaseStructCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -244,6 +244,11 @@ class PCanonicalBaseStructSettable(
   def store(pv: PCode): Code[Unit] = {
     a := pv.asInstanceOf[PCanonicalBaseStructCode].a
   }
+
+  def apply[T](i: Int): Value[T] =
+    new Value[T] {
+      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
+    }
 }
 
 class PCanonicalBaseStructCode(val pt: PCanonicalBaseStruct, val a: Code[Long]) extends PBaseStructCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -219,18 +219,18 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     }
   }
 
-  override def load(src: Code[Long]): PCode =
+  override def load(src: Code[Long]): PCanonicalBaseStructCode =
     new PCanonicalBaseStructCode(this, src)
 }
 
 object PCanonicalBaseStructSettable {
-  def apply(cb: EmitCodeBuilder, pt: PBaseStruct, name: String, sb: SettableBuilder): PCanonicalBaseStructSettable = {
+  def apply(cb: EmitCodeBuilder, pt: PCanonicalBaseStruct, name: String, sb: SettableBuilder): PCanonicalBaseStructSettable = {
     new PCanonicalBaseStructSettable(pt, sb.newSettable(name))
   }
 }
 
 class PCanonicalBaseStructSettable(
-  val pt: PBaseStruct,
+  val pt: PCanonicalBaseStruct,
   val a: Settable[Long]
 ) extends PBaseStructValue with PSettable {
   def get: PBaseStructCode = new PCanonicalBaseStructCode(pt, a)
@@ -246,7 +246,7 @@ class PCanonicalBaseStructSettable(
   }
 }
 
-class PCanonicalBaseStructCode(val pt: PBaseStruct, val a: Code[Long]) extends PBaseStructCode {
+class PCanonicalBaseStructCode(val pt: PCanonicalBaseStruct, val a: Code[Long]) extends PBaseStructCode {
   def code: Code[_] = a
 
   def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)


### PR DESCRIPTION
My intention is to start to replace my custom `CodePTuple` thing with the new standard `PBaseStructCode`. I've rewritten `MakeNDArray` to start doing this. 

This also fixes `IEmitCode.map`, which was broken in cases where the `CodeBuilder` ended in jumps.

