### PR TITLE
[query] refactor stream length tracking

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -728,6 +728,12 @@ class CodeInt(val lhs: Code[Int]) extends AnyVal {
 
   def %(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, lir.insn2(IREM))
 
+  def max(rhs: Code[Int]): Code[Int] =
+    Code.invokeStatic[Math, Int, Int, Int]("max", lhs, rhs)
+
+  def min(rhs: Code[Int]): Code[Int] =
+    Code.invokeStatic[Math, Int, Int, Int]("min", lhs, rhs)
+
   def compare(op: Int, rhs: Code[Int]): Code[Boolean] = {
     val Ltrue = new lir.Block()
     val Lfalse = new lir.Block()

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -278,9 +278,8 @@ class EmitStreamSuite extends HailSuite {
     fb.emit(
       Code(
         optStream(
-          Code(len := 0, L.goto), { stream =>
-            stream.length.map[Code[Ctrl]] { case (s, l) => Code(s, len := l, L.goto) }.getOrElse[Code[Ctrl]](
-              Code(len := -1, L.goto))
+          Code(len := 0, L.goto), { case EmitStream.SizedStream(setup, _, length) =>
+            Code(setup, len := length.getOrElse(-1), L.goto)
           }),
         L,
         len))


### PR DESCRIPTION
I had to modify the way stream lengths are tracked in the emitter to be able to handle StreamTake. The new way is also simpler, and moves in the direction of the new CodeBuilder style.

Now `SizedStream` is 
```
case class SizedStream(setup: Code[Unit], stream: Stream[EmitCode], length: Option[Code[Int]])
```
The `setup` must be emitted before either the `stream` or the `length` are used. This allows the length and stream to share setup code.