### PR TITLE
[query] Refactor PStruct to avoid abstract methods

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -94,16 +94,11 @@ abstract class PBaseStruct extends PType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder]): CodeOrdering
 
-  def isIsomorphicTo(other: PBaseStruct): Boolean =
-    size == other.size && isCompatibleWith(other)
-
   def isPrefixOf(other: PBaseStruct): Boolean =
     size <= other.size && isCompatibleWith(other)
 
   def isCompatibleWith(other: PBaseStruct): Boolean =
     fields.zip(other.fields).forall{ case (l, r) => l.typ isOfType r.typ }
-
-  def truncate(newSize: Int): PBaseStruct
 
   override def unsafeOrdering(): UnsafeOrdering =
     unsafeOrdering(this)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalTuple.scala
@@ -13,9 +13,6 @@ final case class PCanonicalTuple(_types: IndexedSeq[PTupleField], override val r
 
   def setRequired(required: Boolean) = if(required == this.required) this else PCanonicalTuple(_types, required)
 
-  override def truncate(newSize: Int): PTuple =
-    PCanonicalTuple(_types.take(newSize), required)
-
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     sb.append("PCTuple[")
     _types.foreachBetween { fd =>

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
@@ -18,21 +18,35 @@ trait PStruct extends PBaseStruct {
     CodeOrdering.rowOrdering(this, other.asInstanceOf[PStruct], mb, so)
   }
 
-  def deleteField(key: String): PStruct
+  final def deleteField(key: String): PCanonicalStruct = {
+    assert(fieldIdx.contains(key))
+    val index = fieldIdx(key)
+    val newFields = Array.fill[PField](fields.length - 1)(null)
+    for (i <- 0 until index)
+      newFields(i) = fields(i)
+    for (i <- index + 1 until fields.length)
+      newFields(i - 1) = fields(i).copy(index = i - 1)
+    PCanonicalStruct(newFields, required)
+  }
 
-  def appendKey(key: String, sig: PType): PStruct
+  final def appendKey(key: String, sig: PType): PCanonicalStruct = {
+    assert(!fieldIdx.contains(key))
+    val newFields = Array.fill[PField](fields.length + 1)(null)
+    for (i <- fields.indices)
+      newFields(i) = fields(i)
+    newFields(fields.length) = PField(key, sig, fields.length)
+    PCanonicalStruct(newFields, required)
+  }
 
   def rename(m: Map[String, String]): PStruct
 
-  def ++(that: PStruct): PStruct
-
   def identBase: String = "tuple"
 
-  def selectFields(names: Seq[String]): PStruct
+  final def selectFields(names: Seq[String]): PCanonicalStruct = PCanonicalStruct(required, names.map(f => f -> field(f).typ): _*)
 
-  def dropFields(names: Set[String]): PStruct
+  final def dropFields(names: Set[String]): PCanonicalStruct = selectFields(fieldNames.filter(!names.contains(_)))
 
-  def typeAfterSelect(keep: IndexedSeq[Int]): PStruct
+  final def typeAfterSelect(keep: IndexedSeq[Int]): PCanonicalStruct = PCanonicalStruct(required, keep.map(i => fieldNames(i) -> types(i)): _*)
 
   protected val structFundamentalType: PStruct
   override lazy val fundamentalType: PStruct = structFundamentalType

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -293,7 +293,7 @@ object IBD {
   }
 
   private val ibdPType =
-    (PCanonicalStruct(("i", PCanonicalString()), ("j", PCanonicalString())) ++ ExtendedIBDInfo.pType).setRequired(true).asInstanceOf[PStruct]
+    PCanonicalStruct(required = true, Array(("i", PCanonicalString()), ("j", PCanonicalString())) ++ ExtendedIBDInfo.pType.fields.map(f => (f.name, f.typ)): _*)
   private val ibdKey = FastIndexedSeq("i", "j")
 
   private[methods] def generateComputeMaf(input: MatrixValue, fieldName: String): (RegionValue) => Double = {


### PR DESCRIPTION
In looking at your PSelectFieldsStruct PR, I got a bit angry at the number of abstract methods on PStruct. This cleanup should make your PR smaller and simpler. We'll sort out the constructible methods at some point too.

All the methods I changed were ones that are always used to do type-level manipulation to return a new constructible type that is fed into an RVB. Returning a PCanonicalStruct to these usages is the correct thing.