### PR TITLE
[query] Begin moving from EmitCode to IEmitCode in Emit

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -137,5 +137,9 @@ class CodeBuilder(val mb: MethodBuilder[_], var code: Code[Unit]) extends CodeBu
     code = Code(code, c)
   }
 
-  def result(): Code[Unit] = code
+  def result(): Code[Unit] = {
+    val tmp = code
+    code = Code._empty
+    tmp
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -617,6 +617,14 @@ private class Emit[C](
       case CastRename(v, _typ) =>
         emitI(v)
 
+      case NA(typ) =>
+        IEmitCode(cb, const(true), pt.defaultValue)
+      case IsNA(v) =>
+        val iec = emitI(v)
+        val m = new CCode(cb.result().start, iec.Lmissing.start, iec.Lpresent.start)
+        // ^ XXX is there a better way to do this?
+        presentI(cb, pt, m)
+
       case x@ArrayRef(a, i, s) =>
         val errorTransformer: Code[String] => Code[String] = s match {
           case Str("") =>
@@ -787,12 +795,6 @@ private class Emit[C](
       return new EmitCode(emitVoid(ir), const(false), PCode._empty)
 
     (ir: @unchecked) match {
-      case NA(typ) =>
-        EmitCode(Code._empty, const(true), pt.defaultValue)
-      case IsNA(v) =>
-        val codeV = emit(v)
-        EmitCode(codeV.setup, const(false), PCode(pt, codeV.m))
-
       case Coalesce(values) =>
         val mout = mb.newLocal[Boolean]()
         val out = mb.newPLocal(pt)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -165,6 +165,14 @@ class EmitUnrealizableValue(val pt: PType, private val ec: EmitCode) extends Emi
   }
 }
 
+/**
+ * Notes on IEmitCode;
+ *  1. It is the responsibility of the producers of IEmitCode to emit the relevant
+ *     jumps for the Lmissing and Lpresent labels (cb.goto or similar)
+ *  2. It is the responsibility of consumers to define these labels and to
+ *     prevent the pcode from being used on any code path taken as a result of
+ *     jumping to Lmissing.
+ */
 object IEmitCode {
   def apply(cb: EmitCodeBuilder, m: Code[Boolean], pc: => PCode): IEmitCode = {
     val Lmissing = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -645,30 +645,6 @@ private class Emit[C](
         emitI(v).consume(cb, cb.assign(m, const(true)), { _ => cb.assign(m, const(false)) })
         presentC(m)
 
-      /* FIXME
-      case If(cond, cnsq, altr) =>
-        assert(cnsq.typ == altr.typ)
-
-        emitI(cond).flatMap(cb) { cond =>
-          val out = mb.newPLocal("emitI_if_out", pt)
-          val m = cb.newLocal("emitI_if_m", const(false))
-          cb.ifx(cond.tcode[Boolean], {
-            emitI(cnsq).consume(cb, {
-              cb.assign(m, const(true))
-            }, { pc =>
-              cb.assign(out, pc)
-            })
-          }, {
-            emitI(altr).consume(cb, {
-              cb.assign(m, const(true))
-            }, { pc =>
-              cb.assign(out, pc)
-            })
-          })
-          IEmitCode(cb, m, out.load())
-        }
-      */
-
       case x@ArrayRef(a, i, s) =>
         val errorTransformer: Code[String] => Code[String] = s match {
           case Str("") =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -625,6 +625,30 @@ private class Emit[C](
         emitI(v).consume(cb, cb.assign(m, const(true)), { _ => cb.assign(m, const(false)) })
         presentI(cb, pt, m)
 
+      /* FIXME
+      case If(cond, cnsq, altr) =>
+        assert(cnsq.typ == altr.typ)
+
+        emitI(cond).flatMap(cb) { cond =>
+          val out = mb.newPLocal("emitI_if_out", pt)
+          val m = cb.newLocal("emitI_if_m", const(false))
+          cb.ifx(cond.tcode[Boolean], {
+            emitI(cnsq).consume(cb, {
+              cb.assign(m, const(true))
+            }, { pc =>
+              cb.assign(out, pc)
+            })
+          }, {
+            emitI(altr).consume(cb, {
+              cb.assign(m, const(true))
+            }, { pc =>
+              cb.assign(out, pc)
+            })
+          })
+          IEmitCode(cb, m, out.load())
+        }
+      */
+
       case x@ArrayRef(a, i, s) =>
         val errorTransformer: Code[String] => Code[String] = s match {
           case Str("") =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -399,11 +399,10 @@ private class Emit[C](
         def estimatedSize: Int = ir.size * opSize
 
         def emit(mb: EmitMethodBuilder[C]): Code[Unit] = {
-          val (setup, _) = EmitCodeBuilder.scoped(mb) { cb =>
+          EmitCodeBuilder.scopedVoid(mb) { cb =>
             // wrapped methods can't contain uses of Recur
             emitSelf.emitVoid(cb, ir, mb, env, container)
           }
-          setup
         }
       }
     }
@@ -630,7 +629,7 @@ private class Emit[C](
     // ideally, emit would not be called with void values, but initOp args can be void
     // working towards removing this
     if (pt == PVoid)
-      return new EmitCode(emitVoid(ir), const(false), PCode(pt, Code._empty))
+      return new EmitCode(emitVoid(ir), const(false), PCode._empty)
 
     (ir: @unchecked) match {
       case I32(x) =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -37,7 +37,11 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     code = Code(code, c)
   }
 
-  def result(): Code[Unit] = code
+  def result(): Code[Unit] = {
+    val tmp = code
+    code = Code._empty
+    tmp
+  }
 
   def assign(s: PSettable, v: PCode): Unit = {
     append(s := v)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -25,7 +25,7 @@ object EmitCodeBuilder {
   }
 }
 
-class EmitCodeBuilder(emb: EmitMethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
+class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
   def isOpenEnded: Boolean = {
     val last = code.end.last
     (last == null) || !last.isInstanceOf[is.hail.lir.ControlX]

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -986,6 +986,8 @@ trait WrappedEmitMethodBuilder[C] extends WrappedEmitClassBuilder[C] {
   // FIXME needs to code and emit variants
   def emit(body: Code[_]): Unit = mb.emit(body)
 
+  def emitWithBuilder[T](f: (EmitCodeBuilder) => Code[T]): Unit = emb.emitWithBuilder(f)
+
   // EmitMethodBuilder methods
   def getCodeParam[T: TypeInfo](emitIndex: Int): Settable[T] = emb.getCodeParam[T](emitIndex)
 


### PR DESCRIPTION
Replace, the top level entry into `emit` with `emitI`. Move anything that had
already been converted, as well as constants/literals, into `emitI`. Added the
necessary fallbacks.

