### PR TITLE
[docker] add a hail and a genetics image and publish them

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1556,3 +1556,6 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
+   # FIXME
+   # scopes:
+   #   - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1569,5 +1569,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   # scopes:
-   #   - deploy
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1539,6 +1539,7 @@ steps:
      docker tag {{ genetics_public_image.image }} hailgenetics/genetics:$(cat hail_pip_version)
      docker push hailgenetics/genetics:$(cat hail_pip_version)
    dependsOn:
+    - default_ns
     - ci_utils_image
     - genetics_public_image
     - hail_public_image
@@ -1555,3 +1556,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1486,8 +1486,8 @@ steps:
    dockerFile: docker/hail/Dockerfile
    contextPath: docker/hail/
    publishAs: hail_public
-   dependsOn:
-    - build_hail
+   # dependsOn:
+   #  - build_hail
    inputs:
      - from: /wheel-container.tar
        to: /wheel-container.tar
@@ -1548,8 +1548,8 @@ steps:
          fi
      }
 
-     push_if_absent {{ hail_public_image.image }} hailgenetics/hail:$(cat hail_pip_version)
-     push_if_absent {{ genetics_public_image.image }} hailgenetics/genetics:$(cat hail_pip_version)
+     push_if_absent {{ hail_public_image.image }} hailgenetics/garbage1:$(cat hail_pip_version)
+     push_if_absent {{ genetics_public_image.image }} hailgenetics/garbage2:$(cat hail_pip_version)
    dependsOn:
     - default_ns
     - ci_utils_image

--- a/build.yaml
+++ b/build.yaml
@@ -1552,6 +1552,7 @@ steps:
      push_if_absent {{ genetics_public_image.image }} hailgenetics/garbage2:$(cat hail_pip_version)
    dependsOn:
     - default_ns
+    - batch_pods_ns
     - ci_utils_image
     - genetics_public_image
     - hail_public_image

--- a/build.yaml
+++ b/build.yaml
@@ -1491,6 +1491,15 @@ steps:
    inputs:
      - from: hail_pip_version
        to: hail_pip_version
+ - kind: runImage
+   name: test_hail_public_image
+   image:
+     valueFrom: hail_public_image.image
+   script: |
+     set -ex
+     python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+     python3 -c 'import numpy; import pandas import sklearn; import matplotlib;import scipy'
+     gcloud --version
  - kind: buildImage
    name: genetics_public_image
    dockerFile: docker/genetics/Dockerfile
@@ -1498,6 +1507,16 @@ steps:
    publishAs: genetics
    dependsOn:
     - hail_public_image
+ - kind: runImage
+   name: test_genetics_public_image
+   image:
+     valueFrom: genetics_public_image.image
+   script: |
+     set -ex
+     bcftools --version
+     plink --version
+     plink2 --version
+     king --version
  - kind: runImage
    name: push_to_docker_hub
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -1566,5 +1566,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   scopes:
-     - deploy
+   # scopes:
+   #   - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1498,7 +1498,7 @@ steps:
    script: |
      set -ex
      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
-     python3 -c 'import numpy; import pandas import sklearn; import matplotlib; import scipy'
+     python3 -c 'import numpy; import pandas; import sklearn; import matplotlib; import scipy'
      gcloud --version
    dependsOn:
      - hail_public_image
@@ -1515,10 +1515,9 @@ steps:
      valueFrom: genetics_public_image.image
    script: |
      set -ex
-     bcftools --version
+     samtools --version
      plink --version
      plink2 --version
-     king --version
    dependsOn:
      - genetics_public_image
  - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -90,7 +90,7 @@ steps:
      mkdir repo
      cd repo
      {{ code.checkout_script }}
-     make python/hail/hail_pip_version
+     make -C hail python/hail/hail_pip_version
    outputs:
      - from: /io/repo/auth/sql
        to: /repo/auth/
@@ -1556,5 +1556,3 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   scopes:
-     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1487,10 +1487,7 @@ steps:
    contextPath: docker/hail/
    publishAs: hail_public
    dependsOn:
-    - copy_files
-   inputs:
-     - from: hail_pip_version
-       to: hail_pip_version
+    - build_hail
  - kind: runImage
    name: test_hail_public_image
    image:
@@ -1566,5 +1563,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   scopes:
-     - deploy
+   # scopes:
+   #   - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1568,5 +1568,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   # scopes:
-   #   - deploy
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -107,7 +107,7 @@ steps:
      - from: /io/repo/hail/python/hailtop
        to: /repo/hailtop/
      - from: /io/repo/hail/python/hail/hail_pip_version
-       to: hail_pip_version
+       to: /hail_pip_version
    dependsOn:
      - base_image
  - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -1500,6 +1500,8 @@ steps:
      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
      python3 -c 'import numpy; import pandas import sklearn; import matplotlib;import scipy'
      gcloud --version
+   dependsOn:
+     - hail_public_image
  - kind: buildImage
    name: genetics_public_image
    dockerFile: docker/genetics/Dockerfile
@@ -1517,6 +1519,8 @@ steps:
      plink --version
      plink2 --version
      king --version
+   dependsOn:
+     - genetics_public_image
  - kind: runImage
    name: push_to_docker_hub
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -1488,6 +1488,9 @@ steps:
    publishAs: hail_public
    dependsOn:
     - build_hail
+   inputs:
+     - from: /wheel-container.tar
+       to: /wheel-container.tar
  - kind: runImage
    name: test_hail_public_image
    image:
@@ -1563,5 +1566,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   # scopes:
-   #   - deploy
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1498,7 +1498,7 @@ steps:
    script: |
      set -ex
      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
-     python3 -c 'import numpy; import pandas import sklearn; import matplotlib;import scipy'
+     python3 -c 'import numpy; import pandas import sklearn; import matplotlib; import scipy'
      gcloud --version
    dependsOn:
      - hail_public_image

--- a/build.yaml
+++ b/build.yaml
@@ -1570,3 +1570,4 @@ steps:
       mountPath: /test-gsa-key
    scopes:
      - deploy
+     - dev  # FIXME: revert this

--- a/build.yaml
+++ b/build.yaml
@@ -1566,7 +1566,7 @@ steps:
       mountPath: /docker-hub-hailgenetics
     - name: test-gsa-key
       namespace:
-        valueFrom: default_ns.name
+        valueFrom: batch_pods_ns.name
       mountPath: /test-gsa-key
    scopes:
      - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1566,6 +1566,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   # FIXME
-   # scopes:
-   #   - deploy
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1566,5 +1566,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   # scopes:
-   #   - deploy
+   scopes:
+     - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1529,7 +1529,9 @@ steps:
 
      cd /io
 
-     gcloud auth activate-service-account --key-file=/secrets/test-gsa-key
+     gcloud -q auth activate-service-account \
+       --key-file=/gcr-pull-service-account-key/gcr-pull-service-account-key.json
+     gcloud -q auth configure-docker
      gcloud auth configure-docker
      cat /docker-hub-hailgenetics/password | docker login --username hailgenetics --password-stdin
 
@@ -1565,10 +1567,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /docker-hub-hailgenetics
-    - name: test-gsa-key
+    - name: gcr-pull-service-account-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /test-gsa-key
+      mountPath: /gcr-pull-service-account-key
    scopes:
      - deploy
      - dev  # FIXME: revert this

--- a/build.yaml
+++ b/build.yaml
@@ -1568,5 +1568,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   scopes:
-     - deploy
+   # scopes:
+   #   - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -90,6 +90,7 @@ steps:
      mkdir repo
      cd repo
      {{ code.checkout_script }}
+     make python/hail/hail_pip_version
    outputs:
      - from: /io/repo/auth/sql
        to: /repo/auth/
@@ -105,6 +106,8 @@ steps:
        to: /repo/notebook/
      - from: /io/repo/hail/python/hailtop
        to: /repo/hailtop/
+     - from: /io/repo/hail/python/hail/hail_pip_version
+       to: hail_pip_version
    dependsOn:
      - base_image
  - kind: runImage
@@ -1478,3 +1481,54 @@ steps:
     - test_batch
     - test_ci
     - test_pipeline
+ - kind: buildImage
+   name: hail_public_image
+   dockerFile: docker/hail/Dockerfile
+   contextPath: docker/hail/
+   publishAs: hail_public
+   dependsOn:
+    - copy_files
+   inputs:
+     - from: hail_pip_version
+       to: hail_pip_version
+ - kind: buildImage
+   name: genetics_public_image
+   dockerFile: docker/genetics/Dockerfile
+   contextPath: docker/genetics/
+   publishAs: genetics
+   dependsOn:
+    - hail_public_image
+ - kind: runImage
+   name: push_to_docker_hub
+   image:
+     valueFrom: ci_utils_image.image
+   script: |
+     set -ex
+     gcloud auth activate-service-account --key-file=/secrets/test-gsa-key
+     gcloud auth configure-docker
+     cat /docker-hub-hailgenetics/password | docker login --username hailgenetics --password-stdin
+
+     docker pull {{ hail_public_image.name }}
+     docker tag {{ hail_public_image.name }} hailgenetics/hail:$(cat hail_pip_version)
+     docker push hailgenetics/hail:$(cat hail_pip_version)
+
+     docker pull {{ genetics_public_image.name }}
+     docker tag {{ genetics_public_image.name }} hailgenetics/genetics:$(cat hail_pip_version)
+     docker push hailgenetics/genetics:$(cat hail_pip_version)
+   dependsOn:
+    - ci_utils_image
+    - genetics_public_image
+    - hail_public_image
+    - copy_files
+   inputs:
+     - from: hail_pip_version
+       to: hail_pip_version
+   secrets:
+    - name: docker-hub-hailgenetics
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /docker-hub-hailgenetics
+    - name: test-gsa-key
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /test-gsa-key

--- a/build.yaml
+++ b/build.yaml
@@ -1488,9 +1488,9 @@ steps:
    publishAs: hail_public
    # dependsOn:
    #  - build_hail
-   inputs:
-     - from: /wheel-container.tar
-       to: /wheel-container.tar
+   # inputs:
+   #   - from: /wheel-container.tar
+   #     to: /wheel-container.tar
  - kind: runImage
    name: test_hail_public_image
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -1527,6 +1527,9 @@ steps:
      valueFrom: ci_utils_image.image
    script: |
      set -ex
+
+     cd /io
+
      gcloud auth activate-service-account --key-file=/secrets/test-gsa-key
      gcloud auth configure-docker
      cat /docker-hub-hailgenetics/password | docker login --username hailgenetics --password-stdin
@@ -1555,8 +1558,8 @@ steps:
     - hail_public_image
     - copy_files
    inputs:
-     - from: hail_pip_version
-       to: hail_pip_version
+     - from: /hail_pip_version
+       to: /io/hail_pip_version
    secrets:
     - name: docker-hub-hailgenetics
       namespace:
@@ -1566,5 +1569,5 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /test-gsa-key
-   scopes:
-     - deploy
+   # scopes:
+   #   - deploy

--- a/build.yaml
+++ b/build.yaml
@@ -1531,12 +1531,12 @@ steps:
      gcloud auth configure-docker
      cat /docker-hub-hailgenetics/password | docker login --username hailgenetics --password-stdin
 
-     docker pull {{ hail_public_image.name }}
-     docker tag {{ hail_public_image.name }} hailgenetics/hail:$(cat hail_pip_version)
+     docker pull {{ hail_public_image.image }}
+     docker tag {{ hail_public_image.image }} hailgenetics/hail:$(cat hail_pip_version)
      docker push hailgenetics/hail:$(cat hail_pip_version)
 
-     docker pull {{ genetics_public_image.name }}
-     docker tag {{ genetics_public_image.name }} hailgenetics/genetics:$(cat hail_pip_version)
+     docker pull {{ genetics_public_image.image }}
+     docker tag {{ genetics_public_image.image }} hailgenetics/genetics:$(cat hail_pip_version)
      docker push hailgenetics/genetics:$(cat hail_pip_version)
    dependsOn:
     - ci_utils_image

--- a/build.yaml
+++ b/build.yaml
@@ -1531,13 +1531,23 @@ steps:
      gcloud auth configure-docker
      cat /docker-hub-hailgenetics/password | docker login --username hailgenetics --password-stdin
 
-     docker pull {{ hail_public_image.image }}
-     docker tag {{ hail_public_image.image }} hailgenetics/hail:$(cat hail_pip_version)
-     docker push hailgenetics/hail:$(cat hail_pip_version)
+     function image_exists() {
+         NAME=$(echo $1 | sed 's/:.*//')
+         TAG=$(echo $1 | sed 's/.*://')
+         curl -sfL https://index.docker.io/v1/repositories/$NAME/tags/$TAG > /dev/null
+     }
 
-     docker pull {{ genetics_public_image.image }}
-     docker tag {{ genetics_public_image.image }} hailgenetics/genetics:$(cat hail_pip_version)
-     docker push hailgenetics/genetics:$(cat hail_pip_version)
+     function push_if_absent() {
+         if ! image_exists $2
+         then
+             docker pull $1
+             docker tag $1 $2
+             docker push $2
+         fi
+     }
+
+     push_if_absent {{ hail_public_image.image }} hailgenetics/hail:$(cat hail_pip_version)
+     push_if_absent {{ genetics_public_image.image }} hailgenetics/genetics:$(cat hail_pip_version)
    dependsOn:
     - default_ns
     - ci_utils_image

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,6 +21,18 @@ service-base:
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base ..
 
+.PHONY: hail-public-image
+hail-public-image:
+	make -C ../hail wheel
+	cp ../hail/build/deploy/dist/hail-*-py3-none-any.whl hail/
+	cd hail && tar -cvf wheel-container.tar hail-*-py3-none-any.whl
+	docker build hail -f hail/Dockerfile -t hail-public-image
+
+.PHONY: genetics-public-image
+genetics-public-image: hail-public-image
+	python3 ../ci/jinja2_render.py '{"hail_public_image":{"image":"hail-public-image"}}' genetics/Dockerfile genetics/Dockerfile.out
+	docker build genetics -f genetics/Dockerfile -t genetics-public-image
+
 .PHONY: push
 push: build
 	docker tag base $(BASE_LATEST)

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -58,4 +58,3 @@ RUN find \
       king \
       -type f -executable \
     | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'
-

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,0 +1,44 @@
+FROM {{ hail_public_image.image }}
+
+RUN mkdir samtools && \
+    (cd samtools && \
+     wget https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
+     tar -xf samtools-1.9.tar.bz2 && \
+     rm -rf samtools-1.9.tar.bz2 && \
+     cd samtools-1.9 && \
+     ./configure && \
+     make && \
+     make install)
+RUN git clone --recursive https://github.com/vcflib/vcflib.git && \
+    (cd vcflib && make)
+RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_latest.zip && \
+    unzip plink2_linux_avx2_latest.zip && \
+    mv plink2 /bin/ && \
+    rm -rf plink2_linux_avx2_latest.zip
+RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink_linux_x86_64_latest.zip && \
+    unzip plink_linux_x86_64_latest.zip && \
+    mv plink /bin/ && \
+    rm -rf plink_linux_x86_64_latest.zip
+RUN mkdir king && \
+    (cd king && \
+     wget http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
+     tar -xf Linux-king.tar.gz)
+RUN mkdir gcta && \
+    (cd gcta && \
+pp     wget http://cnsgenomics.com/software/gcta/gcta_1.91.7beta.zip && \
+     unzip gcta_1.91.7beta.zip && \
+     rm -rf gcta_1.91.7beta.zip)
+RUN mkdir eigenstrat && \
+    (cd eigenstrat && \
+     git clone https://github.com/DReichLab/EIG.git && \
+     cd EIG && \
+     cd src && \
+     LDLIBS="-llapacke" make && \
+     make install)
+RUN find \
+      eigenstrat/EIG/bin \
+      gcta/gcta_1.91.7beta \
+      king \
+      -type f -executable \
+    | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'
+

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,60 +1,60 @@
 FROM {{ hail_public_image.image }}
 
-RUN apt-get update && \
-  apt-get -y install \
-    cmake \
-    libbz2-dev \
-    libcurl4-openssl-dev \
-    liblzma-dev \
-    zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && \
+#   apt-get -y install \
+#     cmake \
+#     libbz2-dev \
+#     libcurl4-openssl-dev \
+#     liblzma-dev \
+#     zlib1g-dev \
+#   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir samtools && \
-    (cd samtools && \
-     curl -LO https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
-     tar -xf samtools-1.9.tar.bz2 && \
-     rm -rf samtools-1.9.tar.bz2 && \
-     cd samtools-1.9 && \
-     ./configure --without-curses && \
-     make && \
-     make install)
-RUN git clone --recursive https://github.com/vcflib/vcflib.git && \
-    (cd vcflib && make)
-RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_latest.zip && \
-    unzip plink2_linux_avx2_latest.zip && \
-    mv plink2 /bin/ && \
-    rm -rf plink2_linux_avx2_latest.zip
-RUN curl -LO http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_latest.zip && \
-    unzip plink_linux_x86_64_latest.zip && \
-    mv plink /bin/ && \
-    rm -rf plink_linux_x86_64_latest.zip
-RUN mkdir king && \
-    (cd king && \
-     curl -LO http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
-     tar -xf Linux-king.tar.gz)
-RUN mkdir gcta && \
-    (cd gcta && \
-     curl -LO https://cnsgenomics.com/software/gcta/bin/gcta_1.93.1beta.zip && \
-     unzip gcta_1.93.1beta.zip && \
-     rm -rf gcta_1.93.1beta.zip)
+# RUN mkdir samtools && \
+#     (cd samtools && \
+#      curl -LO https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
+#      tar -xf samtools-1.9.tar.bz2 && \
+#      rm -rf samtools-1.9.tar.bz2 && \
+#      cd samtools-1.9 && \
+#      ./configure --without-curses && \
+#      make && \
+#      make install)
+# RUN git clone --recursive https://github.com/vcflib/vcflib.git && \
+#     (cd vcflib && make)
+# RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_latest.zip && \
+#     unzip plink2_linux_avx2_latest.zip && \
+#     mv plink2 /bin/ && \
+#     rm -rf plink2_linux_avx2_latest.zip
+# RUN curl -LO http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_latest.zip && \
+#     unzip plink_linux_x86_64_latest.zip && \
+#     mv plink /bin/ && \
+#     rm -rf plink_linux_x86_64_latest.zip
+# RUN mkdir king && \
+#     (cd king && \
+#      curl -LO http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
+#      tar -xf Linux-king.tar.gz)
+# RUN mkdir gcta && \
+#     (cd gcta && \
+#      curl -LO https://cnsgenomics.com/software/gcta/bin/gcta_1.93.1beta.zip && \
+#      unzip gcta_1.93.1beta.zip && \
+#      rm -rf gcta_1.93.1beta.zip)
 
-RUN apt-get update && \
-  apt-get -y install \
-    libgsl-dev \
-    liblapacke-dev \
-    libopenblas-dev \
-  && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && \
+#   apt-get -y install \
+#     libgsl-dev \
+#     liblapacke-dev \
+#     libopenblas-dev \
+#   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir eigenstrat && \
-    (cd eigenstrat && \
-     git clone https://github.com/DReichLab/EIG.git && \
-     cd EIG && \
-     cd src && \
-     LDLIBS="-llapacke" make && \
-     make install)
-RUN find \
-      eigenstrat/EIG/bin \
-      gcta/gcta_1.91.7beta \
-      king \
-      -type f -executable \
-    | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'
+# RUN mkdir eigenstrat && \
+#     (cd eigenstrat && \
+#      git clone https://github.com/DReichLab/EIG.git && \
+#      cd EIG && \
+#      cd src && \
+#      LDLIBS="-llapacke" make && \
+#      make install)
+# RUN find \
+#       eigenstrat/EIG/bin \
+#       gcta/gcta_1.91.7beta \
+#       king \
+#       -type f -executable \
+#     | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,4 +1,4 @@
-FROM 5c8432c11ea6
+FROM {{ hail_public_image.image }}
 
 RUN apt-get update && \
   apt-get -y install \

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,12 +1,22 @@
 FROM {{ hail_public_image.image }}
 
+RUN apt-get update && \
+  apt-get -y install \
+    cmake \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    libgsl-dev \
+    liblzma-dev \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir samtools && \
     (cd samtools && \
-     wget https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
+     curl -LO https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
      tar -xf samtools-1.9.tar.bz2 && \
      rm -rf samtools-1.9.tar.bz2 && \
      cd samtools-1.9 && \
-     ./configure && \
+     ./configure --without-curses && \
      make && \
      make install)
 RUN git clone --recursive https://github.com/vcflib/vcflib.git && \
@@ -15,19 +25,19 @@ RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_latest.zip 
     unzip plink2_linux_avx2_latest.zip && \
     mv plink2 /bin/ && \
     rm -rf plink2_linux_avx2_latest.zip
-RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink_linux_x86_64_latest.zip && \
+RUN curl -LO http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_latest.zip && \
     unzip plink_linux_x86_64_latest.zip && \
     mv plink /bin/ && \
     rm -rf plink_linux_x86_64_latest.zip
 RUN mkdir king && \
     (cd king && \
-     wget http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
+     curl -LO http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
      tar -xf Linux-king.tar.gz)
 RUN mkdir gcta && \
     (cd gcta && \
-pp     wget http://cnsgenomics.com/software/gcta/gcta_1.91.7beta.zip && \
-     unzip gcta_1.91.7beta.zip && \
-     rm -rf gcta_1.91.7beta.zip)
+     curl -LO https://cnsgenomics.com/software/gcta/bin/gcta_1.93.1beta.zip && \
+     unzip gcta_1.93.1beta.zip && \
+     rm -rf gcta_1.93.1beta.zip)
 RUN mkdir eigenstrat && \
     (cd eigenstrat && \
      git clone https://github.com/DReichLab/EIG.git && \

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,11 +1,10 @@
-FROM {{ hail_public_image.image }}
+FROM 5c8432c11ea6
 
 RUN apt-get update && \
   apt-get -y install \
     cmake \
     libbz2-dev \
     libcurl4-openssl-dev \
-    libgsl-dev \
     liblzma-dev \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
@@ -38,6 +37,14 @@ RUN mkdir gcta && \
      curl -LO https://cnsgenomics.com/software/gcta/bin/gcta_1.93.1beta.zip && \
      unzip gcta_1.93.1beta.zip && \
      rm -rf gcta_1.93.1beta.zip)
+
+RUN apt-get update && \
+  apt-get -y install \
+    libgsl-dev \
+    liblapacke-dev \
+    libopenblas-dev \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir eigenstrat && \
     (cd eigenstrat && \
      git clone https://github.com/DReichLab/EIG.git && \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:18.04
+
+ENV LANG C.UTF-8
+ENV MAKEFLAGS -j2
+
+COPY hail_pip_version .
+
+RUN apt-get update && \
+  apt-get -y install \
+    curl \
+    git \
+    liblapack3 \
+    openjdk-8-jre-headless \
+    python3 python3-pip \
+    rsync \
+    unzip bzip2 zip tar \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 --no-cache-dir install \
+      hail==$(cat hail_pip_version) \
+      ipython \
+      numpy \
+      scipy \
+      scikit-learn \
+      matplotlib \
+      pandas
+RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+         > $(find_spark_home)/jars/gcs-connector-hadoop2-2.0.1.jar && \
+    mkdir -p $(find_spark_home)/conf && \
+    touch $(find_spark_home)/spark-defaults.conf && \
+    sed -i $(find_spark_home)/spark-defaults.conf \
+        's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true' \
+        's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json'
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
+    mv /root/google-cloud-sdk /

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ENV LANG C.UTF-8
 ENV MAKEFLAGS -j2
 
-COPY hail_pip_version .
+COPY wheel-container.tar .
 
 RUN apt-get update && \
   apt-get -y install \
@@ -16,8 +16,9 @@ RUN apt-get update && \
     unzip bzip2 zip tar \
     vim \
   && rm -rf /var/lib/apt/lists/*
-RUN pip3 --no-cache-dir install \
-      hail==$(cat hail_pip_version) \
+RUN tar xvf wheel-container.tar && \
+    pip3 --no-cache-dir install \
+      hail-*-py3-none-any.whl \
       ipython \
       matplotlib \
       numpy \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -25,6 +25,7 @@ RUN tar xvf wheel-container.tar && \
       pandas \
       scikit-learn \
       scipy \
+    && rm -rf hail-*-py3-none-any.whl
 RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
          > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
     mkdir -p $(find_spark_home.py)/conf && \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -33,4 +33,4 @@ RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0
         's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
-    mv /root/google-cloud-sdk /
+    mv /root/google-cloud-sdk && \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -3,37 +3,37 @@ FROM ubuntu:18.04
 ENV LANG C.UTF-8
 ENV MAKEFLAGS -j2
 
-COPY wheel-container.tar .
+# COPY wheel-container.tar .
 
-RUN apt-get update && \
-  apt-get -y install \
-    curl \
-    git \
-    liblapack3 \
-    openjdk-8-jre-headless \
-    python3 python3-pip \
-    rsync \
-    unzip bzip2 zip tar \
-    vim \
-  && rm -rf /var/lib/apt/lists/*
-RUN tar xvf wheel-container.tar && \
-    pip3 --no-cache-dir install \
-      hail-*-py3-none-any.whl \
-      ipython \
-      matplotlib \
-      numpy \
-      pandas \
-      scikit-learn \
-      scipy \
-    && rm -rf hail-*-py3-none-any.whl
-RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
-    mkdir -p $(find_spark_home.py)/conf && \
-    touch $(find_spark_home.py)/spark-defaults.conf && \
-    sed -i $(find_spark_home.py)/spark-defaults.conf \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
-# source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN curl https://sdk.cloud.google.com | bash && \
-    echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
-    echo 'source /root/google-cloud-sdk/path.bash.inc' >> ~/.profile
+# RUN apt-get update && \
+#   apt-get -y install \
+#     curl \
+#     git \
+#     liblapack3 \
+#     openjdk-8-jre-headless \
+#     python3 python3-pip \
+#     rsync \
+#     unzip bzip2 zip tar \
+#     vim \
+#   && rm -rf /var/lib/apt/lists/*
+# RUN tar xvf wheel-container.tar && \
+#     pip3 --no-cache-dir install \
+#       hail-*-py3-none-any.whl \
+#       ipython \
+#       matplotlib \
+#       numpy \
+#       pandas \
+#       scikit-learn \
+#       scipy \
+#     && rm -rf hail-*-py3-none-any.whl
+# RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+#          > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
+#     mkdir -p $(find_spark_home.py)/conf && \
+#     touch $(find_spark_home.py)/spark-defaults.conf && \
+#     sed -i $(find_spark_home.py)/spark-defaults.conf \
+#         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
+#         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
+# # source: https://cloud.google.com/storage/docs/gsutil_install#linux
+# RUN curl https://sdk.cloud.google.com | bash && \
+#     echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
+#     echo 'source /root/google-cloud-sdk/path.bash.inc' >> ~/.profile

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 --no-cache-dir install \
       ipython \
       matplotlib \
       numpy \
-      pandas
+      pandas \
       scikit-learn \
       scipy \
 RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -29,8 +29,9 @@ RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0
     mkdir -p $(find_spark_home.py)/conf && \
     touch $(find_spark_home.py)/spark-defaults.conf && \
     sed -i $(find_spark_home.py)/spark-defaults.conf \
-        's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true' \
-        's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json'
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
-    mv /root/google-cloud-sdk && \
+RUN curl https://sdk.cloud.google.com | bash && \
+    echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
+    echo 'source /root/google-cloud-sdk/path.bash.inc' >> ~/.profile

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -25,10 +25,10 @@ RUN pip3 --no-cache-dir install \
       matplotlib \
       pandas
 RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         > $(find_spark_home)/jars/gcs-connector-hadoop2-2.0.1.jar && \
-    mkdir -p $(find_spark_home)/conf && \
-    touch $(find_spark_home)/spark-defaults.conf && \
-    sed -i $(find_spark_home)/spark-defaults.conf \
+         > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
+    mkdir -p $(find_spark_home.py)/conf && \
+    touch $(find_spark_home.py)/spark-defaults.conf && \
+    sed -i $(find_spark_home.py)/spark-defaults.conf \
         's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true' \
         's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -19,11 +19,11 @@ RUN apt-get update && \
 RUN pip3 --no-cache-dir install \
       hail==$(cat hail_pip_version) \
       ipython \
-      numpy \
-      scipy \
-      scikit-learn \
       matplotlib \
+      numpy \
       pandas
+      scikit-learn \
+      scipy \
 RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
          > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
     mkdir -p $(find_spark_home.py)/conf && \


### PR DESCRIPTION
cc: @cseed 

In preparation for the terra integration prototype, I've modified build.yaml to build and publish two public images. Both are versioned by the hail_pip_version. The first, `hailgenetics/hail`, contains hail, common python libraries, and the google cloud sdk. The second, `hailgenetics/genetics`, contains a slew of genetics tools that were used by the CCG Workshop.

There is no R in any of these images. That is intentional.

The image push step is scoped to deploy (but I tested it in my dev environment), so it only runs on deploy. Ergo, we should only update the image during deploy. I also added a safety check that doesn't overwrite an extant tag, if, for example, a deploy partially ran. Maybe we should update the image? I'm not sure. It seems better to not change the image automatically.