### PR TITLE
[hail] automate deploy in build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1469,6 +1469,7 @@ steps:
 
      cd /io
 
+     ls -al
      mkdir -p python
      mv cluster-tests python/cluster-tests
 
@@ -1484,7 +1485,7 @@ steps:
      - default_ns
    inputs:
      - from: /repo/hail/python/cluster-tests
-       to: /io/cluster-tests
+       to: /io/
      - from: /wheel-container.tar
        to: /io/wheel-container.tar
      - from: /test-dataproc.sh

--- a/build.yaml
+++ b/build.yaml
@@ -1476,6 +1476,8 @@ steps:
      tar xvf wheel-container.tar
      python3 -m pip install -U hail-*-py3-none-any.whl
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
+     gcloud config set project hail-vdc
+     gcloud config set zone us-central1-a
 
      bash test-dataproc.sh
    dependsOn:

--- a/build.yaml
+++ b/build.yaml
@@ -1475,7 +1475,7 @@ steps:
 
      # tar xvf wheel-container.tar
      # python3 -m pip install -U hail-*-py3-none-any.whl
-     pip install -U hail==0.2.35
+     python3 -m pip install -U hail==0.2.35
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
      gcloud config set project hail-vdc
      gcloud config set dataproc/region us-central1

--- a/build.yaml
+++ b/build.yaml
@@ -1489,8 +1489,8 @@ steps:
    inputs:
      - from: /repo/hail/python/cluster-tests
        to: /io/
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     # - from: /wheel-container.tar
+     #   to: /io/wheel-container.tar
      - from: /test-dataproc.sh
        to: /io/test-dataproc.sh
    secrets:

--- a/build.yaml
+++ b/build.yaml
@@ -108,6 +108,8 @@ steps:
        to: /repo/hailtop/
      - from: /io/repo/hail/python/test
        to: /repo/test/
+     - from: /io/repo/hail/python/cluster-tests/
+       to: /repo/hail/python/cluster-tests
      - from: /io/repo/hail/python/hail/hail_version
        to: /hail_version
      - from: /io/repo/git_version
@@ -1478,6 +1480,8 @@ steps:
      - build_hail
      - default_ns
    inputs:
+     - from: /repo/hail/python/cluster-tests
+       to: /io/python/cluster-tests
      - from: /wheel-container.tar
        to: /io/wheel-container.tar
      - from: /test-dataproc.sh

--- a/build.yaml
+++ b/build.yaml
@@ -1506,6 +1506,9 @@ steps:
    script: |
      set -ex
      cd /io
+
+     {{ code.checkout_script }}
+
      gcloud auth activate-service-account --key-file=/ci-deploy-0-1--hail-is-hail/ci-deploy-0-1--hail-is-hail.json
      tar xvf wheel-container.tar
      cp /pypi-credentials/pypirc $HOME/.pypirc

--- a/build.yaml
+++ b/build.yaml
@@ -116,6 +116,8 @@ steps:
        to: /hail_pip_version
      - from: /io/repo/hail/spark_version
        to: /spark_version
+     - from: /io/repo/hail/test-dataproc.sh
+       to: /test-dataproc.sh
    dependsOn:
      - base_image
  - kind: runImage
@@ -1457,6 +1459,36 @@ steps:
     - test_ci
     - test_hailtop_batch
  - kind: runImage
+   name: test_dataproc
+   image:
+     valueFrom: ci_utils_image.image
+   script: |
+     set -ex
+
+     cd /io
+
+     tar xvf wheel-container.tar
+     python3 -m pip install -U --no-dependencies hail-*-py3-none-any.whl
+     gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
+
+     bash test-dataproc.sh
+   dependsOn:
+     - copy_files
+     - build_hail
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test-dataproc.sh
+       to: /io/test-dataproc.sh
+   secrets:
+     - name: test-dataproc-service-account-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-dataproc-service-account-key
+   scopes:
+     - deploy
+     - dev
+ - kind: runImage
    name: deploy
    image:
      valueFrom: ci_utils_image.image
@@ -1499,6 +1531,7 @@ steps:
    scopes:
     - deploy
    dependsOn:
+    - test_dataproc
     - default_ns
     - copy_files
     - ci_utils_image

--- a/build.yaml
+++ b/build.yaml
@@ -90,6 +90,9 @@ steps:
      mkdir repo
      cd repo
      {{ code.checkout_script }}
+     make -C hail python/hail/hail_version python/hail/hail_pip_version
+     make -C hail spark_version
+     git rev-parse HEAD > git_version
    outputs:
      - from: /io/repo/auth/sql
        to: /repo/auth/
@@ -105,6 +108,14 @@ steps:
        to: /repo/hailtop/
      - from: /io/repo/hail/python/test
        to: /repo/test/
+     - from: /io/repo/hail/python/hail/hail_version
+       to: /hail_version
+     - from: /io/repo/git_version
+       to: /git_version
+     - from: /io/repo/hail/python/hail/hail_pip_version
+       to: /hail_pip_version
+     - from: /io/repo/hail/spark_version
+       to: /spark_version
    dependsOn:
      - base_image
  - kind: runImage
@@ -1445,3 +1456,50 @@ steps:
     - test_batch
     - test_ci
     - test_hailtop_batch
+ - kind: runImage
+   name: deploy
+   image:
+     valueFrom: ci_utils_image.image
+   script: |
+     set -ex
+     cd /io
+     gcloud auth activate-service-account --key-file=/ci-deploy-0-1--hail-is-hail/ci-deploy-0-1--hail-is-hail.json
+     tar xvf wheel-container.tar
+     cp /pypi-credentials/pypirc $HOME/.pypirc
+     printf 'Authorization: token ' > github-oauth
+     cat /hail-ci-0-1-github-oauth-token/oauth-token >>github-oauth
+     ./deploy.sh $(cat hail_pip_version) \
+                 $(cat hail_version) \
+                 $(cat git_version) \
+                 origin \
+                 hail-*-py3-none-any.whl \
+                 github-oauth
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /hail_version
+       to: /io/hail_version
+     - from: /hail_pip_version
+       to: /io/hail_pip_version
+     - from: /git_version
+       to: /io/git_version
+   secrets:
+    - name: pypi-credentials
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /pypi-credentials
+    - name: ci-deploy-0-1--hail-is-hail
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /ci-deploy-0-1--hail-is-hail
+    - name: hail-ci-0-1-github-oauth-token
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /hail-ci-0-1-github-oauth-token
+   scopes:
+    - deploy
+   dependsOn:
+    - default_ns
+    - copy_files
+    - ci_utils_image
+    - build_hail

--- a/build.yaml
+++ b/build.yaml
@@ -1476,6 +1476,7 @@ steps:
      - ci_utils_image
      - copy_files
      - build_hail
+     - default_ns
    inputs:
      - from: /wheel-container.tar
        to: /io/wheel-container.tar

--- a/build.yaml
+++ b/build.yaml
@@ -1469,6 +1469,9 @@ steps:
 
      cd /io
 
+     mkdir -p python
+     mv cluster-tests python/cluster-tests
+
      tar xvf wheel-container.tar
      python3 -m pip install -U hail-*-py3-none-any.whl
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
@@ -1481,7 +1484,7 @@ steps:
      - default_ns
    inputs:
      - from: /repo/hail/python/cluster-tests
-       to: /io/python/cluster-tests
+       to: /io/cluster-tests
      - from: /wheel-container.tar
        to: /io/wheel-container.tar
      - from: /test-dataproc.sh

--- a/build.yaml
+++ b/build.yaml
@@ -1468,7 +1468,7 @@ steps:
      cd /io
 
      tar xvf wheel-container.tar
-     python3 -m pip install -U --no-dependencies hail-*-py3-none-any.whl
+     python3 -m pip install -U hail-*-py3-none-any.whl
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
 
      bash test-dataproc.sh

--- a/build.yaml
+++ b/build.yaml
@@ -1489,7 +1489,7 @@ steps:
      gcloud config set project hail-vdc
      gcloud config set dataproc/region us-central1
 
-     ./test-dataproc.sh
+     bash test-dataproc.sh
    dependsOn:
      - ci_utils_image
      - copy_files
@@ -1527,12 +1527,12 @@ steps:
      cp /pypi-credentials/pypirc $HOME/.pypirc
      printf 'Authorization: token ' > github-oauth
      cat /hail-ci-0-1-github-oauth-token/oauth-token >>github-oauth
-     ./deploy.sh $(cat hail_pip_version) \
-                 $(cat hail_version) \
-                 $(cat git_version) \
-                 origin \
-                 hail-*-py3-none-any.whl \
-                 github-oauth
+     bash deploy.sh $(cat hail_pip_version) \
+                    $(cat hail_version) \
+                    $(cat git_version) \
+                    origin \
+                    hail-*-py3-none-any.whl \
+                    github-oauth
    inputs:
      - from: /wheel-container.tar
        to: /io/wheel-container.tar

--- a/build.yaml
+++ b/build.yaml
@@ -1473,6 +1473,7 @@ steps:
 
      bash test-dataproc.sh
    dependsOn:
+     - ci_utils_image
      - copy_files
      - build_hail
    inputs:

--- a/build.yaml
+++ b/build.yaml
@@ -110,16 +110,16 @@ steps:
        to: /repo/test/
      - from: /io/repo/hail/python/cluster-tests/
        to: /repo/hail/python/cluster-tests
+     - from: /io/repo/hail/test-dataproc.sh
+       to: /test-dataproc.sh
      - from: /io/repo/hail/python/hail/hail_version
        to: /hail_version
-     - from: /io/repo/git_version
-       to: /git_version
      - from: /io/repo/hail/python/hail/hail_pip_version
        to: /hail_pip_version
      - from: /io/repo/hail/spark_version
        to: /spark_version
-     - from: /io/repo/hail/test-dataproc.sh
-       to: /test-dataproc.sh
+     - from: /io/repo/git_version
+       to: /git_version
    dependsOn:
      - base_image
  - kind: runImage
@@ -1469,28 +1469,26 @@ steps:
 
      cd /io
 
-     ls -al
      mkdir -p python
      mv cluster-tests python/cluster-tests
 
-     # tar xvf wheel-container.tar
-     # python3 -m pip install -U hail-*-py3-none-any.whl
-     python3 -m pip install -U hail==0.2.35
+     tar xvf wheel-container.tar
+     python3 -m pip install -U hail-*-py3-none-any.whl
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
      gcloud config set project hail-vdc
      gcloud config set dataproc/region us-central1
 
-     bash test-dataproc.sh
+     ./test-dataproc.sh
    dependsOn:
      - ci_utils_image
      - copy_files
-     # - build_hail
+     - build_hail
      - default_ns
    inputs:
      - from: /repo/hail/python/cluster-tests
        to: /io/
-     # - from: /wheel-container.tar
-     #   to: /io/wheel-container.tar
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
      - from: /test-dataproc.sh
        to: /io/test-dataproc.sh
    secrets:
@@ -1543,6 +1541,7 @@ steps:
       mountPath: /hail-ci-0-1-github-oauth-token
    scopes:
     - deploy
+    - dev
    dependsOn:
     - test_dataproc
     - default_ns

--- a/build.yaml
+++ b/build.yaml
@@ -1467,6 +1467,17 @@ steps:
    script: |
      set -ex
 
+     mkdir -p repo
+     cd repo
+     {{ code.checkout_script }}
+     if git ls-remote --exit-code --tags origin $(cat /io/hail_pip_version)
+     then
+         echo "tag $HAIL_PIP_VERSION already exists"
+         exit 0
+     fi
+     cd ..
+     rm -rf repo
+
      cd /io
 
      mkdir -p python
@@ -1491,6 +1502,8 @@ steps:
        to: /io/wheel-container.tar
      - from: /test-dataproc.sh
        to: /io/test-dataproc.sh
+     - from: /hail_pip_version
+       to: /io/hail_pip_version
    secrets:
      - name: test-dataproc-service-account-key
        namespace:

--- a/build.yaml
+++ b/build.yaml
@@ -1473,17 +1473,18 @@ steps:
      mkdir -p python
      mv cluster-tests python/cluster-tests
 
-     tar xvf wheel-container.tar
-     python3 -m pip install -U hail-*-py3-none-any.whl
+     # tar xvf wheel-container.tar
+     # python3 -m pip install -U hail-*-py3-none-any.whl
+     pip install -U hail==0.2.35
      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
      gcloud config set project hail-vdc
-     gcloud config set zone us-central1-a
+     gcloud config set dataproc/region us-central1
 
      bash test-dataproc.sh
    dependsOn:
      - ci_utils_image
      - copy_files
-     - build_hail
+     # - build_hail
      - default_ns
    inputs:
      - from: /repo/hail/python/cluster-tests

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -4,6 +4,8 @@ RUN apt-get update && \
   apt-get -y install docker.io && \
   rm -rf /var/lib/apt/lists/*
 
+RUN pip3 --no-cache-dir install twine
+
 COPY jinja2_render.py .
 COPY wait-for.py .
 COPY create_database.py .

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -84,7 +84,7 @@ src/main/resources/build-info.properties: Makefile
 .PHONY: python-version-info
 python-version-info: $(PYTHON_VERSION_INFO)
 
-spark_version: $(SPARK_VERSION)
+spark_version: env/SPARK_VERSION
 	echo $(SPARK_VERSION) > spark_version
 
 python/hail/hail_version: env/SHORT_REVISION env/HAIL_PIP_VERSION

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -212,19 +212,9 @@ install-on-cluster: $(WHEEL)
 .PHONY: install-hailctl
 install-hailctl: install upload-artifacts
 
-cluster_name_37 := cluster-$(shell whoami)-$(shell LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
-cluster_name_38 := cluster-$(shell whoami)-$(shell LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
-cluster_test_files := $(wildcard python/cluster-tests/*.py)
-cluster_37_test_files := $(filter-out python/cluster-tests/cluster-vep-check-GRCh38.py, $(cluster_test_files))
-cluster_38_test_files := $(filter-out python/cluster-tests/cluster-vep-check-GRCh37.py, $(cluster_test_files))
 .PHONY: test-dataproc
 test-dataproc: install-hailctl
-	hailctl dataproc start $(cluster_name_37) --max-idle 10m --vep GRCh37 --requester-pays-allow-buckets hail-us-vep
-	for FILE in $(cluster_37_test_files); do \
-	  hailctl dataproc submit $(cluster_name_37) $$FILE || exit 1; done || exit
-	hailctl dataproc start $(cluster_name_38) --max-idle 10m --vep GRCh38 --requester-pays-allow-buckets hail-us-vep
-	for FILE in $(cluster_38_test_files); do \
-	  hailctl dataproc submit $(cluster_name_38) $$FILE || exit 1; done || exit
+	bash test-dataproc.sh
 
 # use curl version >=7.55.0
 # set DEPLOY_REMOTE to the hail-is/hail remote

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -13,6 +13,7 @@ SPARK_VERSION := 2.4.0
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 36
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)
+HAIL_VERSION := $(HAIL_PIP_VERSION)-$(SHORT_REVISION)
 
 $(eval $(call ENV_VAR,REVISION))
 $(eval $(call ENV_VAR,SHORT_REVISION))
@@ -83,8 +84,11 @@ src/main/resources/build-info.properties: Makefile
 .PHONY: python-version-info
 python-version-info: $(PYTHON_VERSION_INFO)
 
+spark_version: $(SPARK_VERSION)
+	echo $(SPARK_VERSION) > spark_version
+
 python/hail/hail_version: env/SHORT_REVISION env/HAIL_PIP_VERSION
-	echo $(HAIL_PIP_VERSION)-$(SHORT_REVISION) > $@
+	echo $(HAIL_VERSION) > $@
 
 python/hail/hail_pip_version: env/HAIL_PIP_VERSION
 	echo $(HAIL_PIP_VERSION) > $@
@@ -222,59 +226,14 @@ test-dataproc: install-hailctl
 	for FILE in $(cluster_38_test_files); do \
 	  hailctl dataproc submit $(cluster_name_38) $$FILE || exit 1; done || exit
 
-
-DEPLOYED_VERSION = $(shell \
-  $(PIP) --no-cache-dir search hail \
-   | grep '^hail ' \
-   | sed 's/hail (//' \
-   | sed 's/).*//')
-.PHONY: check-pypi
-check-pypi:
-	if [ -z "$$DEPLOY_REMOTE" ]; then \
-	  echo "ERROR: DEPLOY_REMOTE must be set to deploy to PyPI"; exit 1; fi
-	if [ "$(DEPLOYED_VERSION)" = "$(HAIL_PIP_VERSION)" ]; then \
-	  echo "ERROR: version $(HAIL_PIP_VERSION) already deployed"; exit 1; fi
-
-HAIL_TWINE_CREDS_FOLDER ?= /secrets/
-
-.PHONY: pypi-deploy
-pypi-deploy: check-pypi test-dataproc set-docs-sha
-	TWINE_USERNAME=$(shell cat $(HAIL_TWINE_CREDS_FOLDER)/pypi-username) \
-	TWINE_PASSWORD=$(shell cat $(HAIL_TWINE_CREDS_FOLDER)/pypi-password) \
-	twine upload build/deploy/dist/*
-
-TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION) || echo "does not exist")
-.PHONY: check-tag
-check-tag:
-	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
-
-GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
-.PHONY: tag
-tag: check-tag pypi-deploy
-	git tag $(HAIL_PIP_VERSION) -m "Hail version $(HAIL_PIP_VERSION)"
-	git push $(DEPLOY_REMOTE) $(HAIL_PIP_VERSION)
-	@echo Please make a release: $(GITHUB_RELEASE_URL)
-	if [ `uname` == "Darwin" ]; then open $(GITHUB_RELEASE_URL); fi
-
-annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)-$(SHORT_REVISION)/annotation_db.json
-.PHONY: deploy-annotation-db
-deploy-annotation-db:
-	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
-	gsutil -m retention temp set $(annotation_db_json_url)
-
-docs_location := gs://hail-common/builds/0.2/docs/hail-0.2-docs-$(REVISION).tar.gz
-local_sha_location := build/deploy/latest-hash-spark-$(SPARK_VERSION).txt
-cloud_sha_location := gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.4.0.txt
-.PHONY: set-docs-sha
-set-docs-sha: deploy-annotation-db
-	mkdir -p $(dir $(local_sha_location))
-	gsutil ls $(docs_location)  # make sure file exists
-	echo "$(REVISION)" > $(local_sha_location)
-	gsutil cp $(local_sha_location) $(cloud_sha_location)
-	gsutil acl set public-read $(cloud_sha_location)
-
+# use curl version >=7.55.0
+# set DEPLOY_REMOTE to the hail-is/hail remote
+# create an access token with full repo privileges at https://github.com/settings/tokens
+# create a file that contains "Authorization: token YOUR_ACCESS_TOKEN_HERE"
+# set GITHUB_OAUTH_HEADER_FILE to that filename
 .PHONY: deploy
-deploy: tag
+deploy: test-dataproc $(WHEEL)
+	bash deploy.sh $(HAIL_PIP_VERSION) $(HAIL_VERSION) $(REVISION) $(DEPLOY_REMOTE) $(WHEEL) $(GITHUB_OAUTH_HEADER_FILE)
 
 .PHONY: install-dev-deps
 install-dev-deps:

--- a/hail/deploy.sh
+++ b/hail/deploy.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -ex
+
+[[ $1 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+[[ $2 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+[[ $3 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+git cat-file -e $3^{commit} || (echo "bad sha $3" ; exit 1)
+[[ $4 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+[[ $5 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+[[ $6 ]] || (echo "./deploy.sh HAIL_PIP_VERSION HAIL_VERSION GIT_VERSION REMOTE WHEEL GITHUB_OAUTH_HEADER_FILE" ; exit 1)
+
+HAIL_PIP_VERSION=$1
+HAIL_VERSION=$2
+GIT_VERSION=$3
+REMOTE=$4
+WHEEL=$5
+GITHUB_OAUTH_HEADER_FILE=$6
+
+if git ls-remote --exit-code --tags $REMOTE $HAIL_PIP_VERSION
+then
+    echo "tag $HAIL_PIP_VERSION already exists"
+    exit 0
+fi
+
+pip install hail== 2>&1 \
+    | head -n 1 \
+    | sed 's/.*versions: //' \
+    | sed 's/)//' \
+    | sed 's/ //g' \
+    | tr ',' '\n' \
+         > pip_versions
+
+if grep -q -e $HAIL_PIP_VERSION pip_versions
+then
+    echo "package $HAIL_PIP_VERSION already exists"
+    exit 1
+fi
+
+if curl -sf https://github.com/hail-is/hail/releases/tag/$HAIL_PIP_VERSION >/dev/null
+then
+    echo "release $HAIL_PIP_VERSOIN already exists"
+    exit 1
+fi
+
+docs_location=gs://hail-common/builds/0.2/docs/hail-0.2-docs-$GIT_VERSION.tar.gz
+
+if ! gsutil ls $docs_location
+then
+    echo "docs for $GIT_VERSION do not exist"
+    exit 1
+fi
+
+
+# push git tag
+git tag $HAIL_PIP_VERSION -m "Hail version $HAIL_PIP_VERSION."
+git push origin $HAIL_PIP_VERSION
+
+# make GitHub release
+curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/hail/releases -d '{
+  "tag_name": "'$HAIL_PIP_VERSION'",
+  "target_commitish": "master",
+  "name": "'$HAIL_PIP_VERSION'",
+  "body": "Hail version '$HAIL_PIP_VERSION'",
+  "draft": false,
+  "prerelease": false
+}'
+
+# deploy to PyPI
+twine upload $WHEEL
+
+# update docs sha
+cloud_sha_location=gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.4.0.txt
+gsutil cp $docs_location $cloud_sha_location
+gsutil acl set public-read $cloud_sha_location
+
+# deploy annotation db json
+annotation_db_json_url=gs://hail-common/annotationdb/$HAIL_VERSION/annotation_db.json
+gsutil cp python/hail/experimental/annotation_db.json $annotation_db_json_url
+gsutil -m retention temp set $annotation_db_json_url

--- a/hail/deploy.sh
+++ b/hail/deploy.sh
@@ -39,7 +39,7 @@ fi
 
 if curl -sf https://github.com/hail-is/hail/releases/tag/$HAIL_PIP_VERSION >/dev/null
 then
-    echo "release $HAIL_PIP_VERSOIN already exists"
+    echo "release $HAIL_PIP_VERSION already exists"
     exit 1
 fi
 

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -ex
+
+cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
+cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
+
+stop_dataproc () {
+    exit_code=$?
+
+    set +e
+
+    hailctl dataproc stop $cluster_name_37
+    hailctl dataproc stop $cluster_name_38
+
+    exit $exit_code
+}
+trap stop_dataproc EXIT
+
+cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
+cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
+
+hailctl dataproc start $cluster_name_37 --max-idle 10m --vep GRCh37 --requester-pays-allow-buckets hail-us-vep
+for file in $cluster_37_test_files
+do
+    hailctl dataproc submit $cluster_name_37 $file
+done
+
+hailctl dataproc start $cluster_name_38 --max-idle 10m --vep GRCh38 --requester-pays-allow-buckets hail-us-vep
+for file in $cluster_38_test_files
+do
+    hailctl dataproc submit $cluster_name_38 $filen
+done

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -12,8 +12,14 @@ stop_dataproc () {
 
     set +e
 
-    hailctl dataproc stop $cluster_name_37
-    hailctl dataproc stop $cluster_name_38
+    hailctl dataproc \
+            --project $project \
+            --zone $zone \
+            stop $cluster_name_37
+    hailctl dataproc
+            --project $project \
+            --zone $zone \
+            stop $cluster_name_38
 
     exit $exit_code
 }
@@ -31,9 +37,10 @@ hailctl dataproc \
         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_37_test_files
 do
-    hailctl --project $project \
+    hailctl dataproc \
+            --project $project \
             --zone $zone \
-            dataproc submit \
+            submit \
             $cluster_name_37 $file
 done
 
@@ -46,8 +53,9 @@ hailctl dataproc \
         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_38_test_files
 do
-    hailctl --project $project \
+    hailctl dataproc \
+            --project $project \
             --zone $zone \
-            dataproc submit \
+            submit \
             $cluster_name_38 $filen
 done

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-project=hail-vdc
-zone=us-central-1a
 cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
@@ -12,14 +10,8 @@ stop_dataproc () {
 
     set +e
 
-    hailctl dataproc \
-            --project $project \
-            --zone $zone \
-            stop $cluster_name_37
-    hailctl dataproc
-            --project $project \
-            --zone $zone \
-            stop $cluster_name_38
+    hailctl dataproc stop $cluster_name_37
+    hailctl dataproc stop $cluster_name_38
 
     exit $exit_code
 }
@@ -29,8 +21,6 @@ cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
 
 hailctl dataproc \
-        --project $project \
-        --zone $zone \
         start $cluster_name_37 \
         --max-idle 10m \
         --vep GRCh37 \
@@ -38,15 +28,11 @@ hailctl dataproc \
 for file in $cluster_37_test_files
 do
     hailctl dataproc \
-            --project $project \
-            --zone $zone \
             submit \
             $cluster_name_37 $file
 done
 
 hailctl dataproc \
-        --project $project \
-        --zone $zone \
         start $cluster_name_38 \
         --max-idle 10m \
         --vep GRCh38 \
@@ -54,8 +40,6 @@ hailctl dataproc \
 for file in $cluster_38_test_files
 do
     hailctl dataproc \
-            --project $project \
-            --zone $zone \
             submit \
             $cluster_name_38 $filen
 done

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -10,8 +10,8 @@ stop_dataproc () {
 
     set +e
 
-    hailctl dataproc stop $cluster_name_37 || true  # max idle is 10m anyway
-    hailctl dataproc stop $cluster_name_38 || true  # max idle is 10m anyway
+    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
 
     exit $exit_code
 }

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+project=hail-vdc
+zone=us-central-1a
 cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
@@ -20,14 +22,32 @@ trap stop_dataproc EXIT
 cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
 
-hailctl dataproc start $cluster_name_37 --max-idle 10m --vep GRCh37 --requester-pays-allow-buckets hail-us-vep
+hailctl dataproc \
+        --project $project \
+        --zone $zone \
+        start $cluster_name_37 \
+        --max-idle 10m \
+        --vep GRCh37 \
+        --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_37_test_files
 do
-    hailctl dataproc submit $cluster_name_37 $file
+    hailctl --project $project \
+            --zone $zone \
+            dataproc submit \
+            $cluster_name_37 $file
 done
 
-hailctl dataproc start $cluster_name_38 --max-idle 10m --vep GRCh38 --requester-pays-allow-buckets hail-us-vep
+hailctl dataproc \
+        --project $project \
+        --zone $zone \
+        start $cluster_name_38 \
+        --max-idle 10m \
+        --vep GRCh38 \
+        --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_38_test_files
 do
-    hailctl dataproc submit $cluster_name_38 $filen
+    hailctl --project $project \
+            --zone $zone \
+            dataproc submit \
+            $cluster_name_38 $filen
 done

--- a/hail/test-dataproc.sh
+++ b/hail/test-dataproc.sh
@@ -10,8 +10,8 @@ stop_dataproc () {
 
     set +e
 
-    hailctl dataproc stop $cluster_name_37
-    hailctl dataproc stop $cluster_name_38
+    hailctl dataproc stop $cluster_name_37 || true  # max idle is 10m anyway
+    hailctl dataproc stop $cluster_name_38 || true  # max idle is 10m anyway
 
     exit $exit_code
 }
@@ -23,6 +23,7 @@ cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-
 hailctl dataproc \
         start $cluster_name_37 \
         --max-idle 10m \
+        --max-age 120m \
         --vep GRCh37 \
         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_37_test_files
@@ -35,11 +36,12 @@ done
 hailctl dataproc \
         start $cluster_name_38 \
         --max-idle 10m \
+        --max-age 120m \
         --vep GRCh38 \
         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_38_test_files
 do
     hailctl dataproc \
             submit \
-            $cluster_name_38 $filen
+            $cluster_name_38 $file
 done


### PR DESCRIPTION
I have not tested this, though I faithfully copied the commands from existing
deploy scripts (except for creating a github release).

A change that I think is valuable regardless of automation is the conversion of
deploy from a series of Makefile targets to a bash script.

I also add a deploy build.yaml step which simply calls the deploy script,
setting up appropriate credentials.

I only had to add one set of credentials: the PyPI credentials. I've already
created that secret in the cluster.

Hand deploys are still very easy. You need curl >=7.55.0 (that version
implemented reading headers from a file). You need to set up two things:
1. create $HOME/.pypirc and put this there:
```
[pypi]
username: hailteam
password: GET_THIS_FROM_THE_USUAL_PLACE
```
2. get a github access token with repo
   privileges (https://github.com/settings/tokens), create
   $HOME/.github-oauth-header, and put this there:
```
Authorization: token YOUR_ACCESS_TOKEN_HERE
```
Now, to do a hand deploy run:
```
make deploy GITHUB_OAUTH_HEADER_FILE=$HOME/.github-oauth-header DEPLOY_REMOTE=THE_REMOTE_FOR_hail-is/hail
```

The github credentials are used to create a GitHub release.