### PR TITLE
[query] fix incorrect method lookup

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -630,7 +630,7 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
       lhs.v match {
         case v: lir.LdcX =>
           lhs.end.append(lir.goto(
-            if (v.a.asInstanceOf[Boolean])
+            if (v.a.asInstanceOf[Int] != 0)
               Ltrue
             else
               Lfalse))

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -380,7 +380,7 @@ object Code {
       c.v match {
         case v: lir.LdcX =>
           val t = new Value[T] {
-            def get: Code[T] = Code(lir.ldcInsn(v.a))
+            def get: Code[T] = Code(lir.ldcInsn(v.a, v.ti))
           }
           return f(t)
         // You can't forward local references here because the local might have changed
@@ -554,9 +554,9 @@ class CCode(
       val c = new lir.Local(null, "bool", BooleanInfo)
       _start = _entry
       _end = new lir.Block()
-      _Ltrue.append(lir.store(c, lir.ldcInsn(1)))
+      _Ltrue.append(lir.store(c, lir.ldcInsn(1, BooleanInfo)))
       _Ltrue.append(lir.goto(_end))
-      _Lfalse.append(lir.store(c, lir.ldcInsn(0)))
+      _Lfalse.append(lir.store(c, lir.ldcInsn(0, BooleanInfo)))
       _Lfalse.append(lir.goto(_end))
       _v = lir.load(c)
 

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -315,7 +315,14 @@ package object asm4s {
   implicit def toLocalRefInt(f: LocalRef[Int]): LocalRefInt = new LocalRefInt(f)
 
   def _const[T](a: T): Value[T] = new Value[T] {
-    def get: Code[T] = Code(lir.ldcInsn(a))
+    def get: Code[T] = {
+      a match {
+        case a: Boolean =>
+          Code(lir.ldcInsn(if (a) 1 else 0))
+        case _ =>
+          Code(lir.ldcInsn(a))
+      }
+    }
   }
 
   implicit def const(s: String): Value[String] = _const(s)

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -314,46 +314,40 @@ package object asm4s {
 
   implicit def toLocalRefInt(f: LocalRef[Int]): LocalRefInt = new LocalRefInt(f)
 
-  def _const[T](a: T): Value[T] = new Value[T] {
-    def get: Code[T] = {
-      a match {
-        case a: Boolean =>
-          Code(lir.ldcInsn(if (a) 1 else 0))
-        case _ =>
-          Code(lir.ldcInsn(a))
-      }
+  def _const[T](a: Any, ti: TypeInfo[T]): Value[T] =
+    new Value[T] {
+      def get: Code[T] = Code(lir.ldcInsn(a, ti))
     }
-  }
 
-  implicit def const(s: String): Value[String] = _const(s)
+  implicit def const(s: String): Value[String] = _const(s, classInfo[String])
 
-  implicit def const(b: Boolean): Value[Boolean] = _const(b)
+  implicit def const(b: Boolean): Value[Boolean] = _const(if (b) 1 else 0, BooleanInfo)
 
-  implicit def const(i: Int): Value[Int] = _const(i)
+  implicit def const(i: Int): Value[Int] = _const(i, IntInfo)
 
-  implicit def const(l: Long): Value[Long] = _const(l)
+  implicit def const(l: Long): Value[Long] = _const(l, LongInfo)
 
-  implicit def const(f: Float): Value[Float] = _const(f)
+  implicit def const(f: Float): Value[Float] = _const(f, FloatInfo)
 
-  implicit def const(d: Double): Value[Double] = _const(d)
+  implicit def const(d: Double): Value[Double] = _const(d, DoubleInfo)
 
-  implicit def const(c: Char): Value[Char] = _const(c)
+  implicit def const(c: Char): Value[Char] = _const(c, CharInfo)
 
-  implicit def const(b: Byte): Value[Byte] = _const(b)
+  implicit def const(b: Byte): Value[Byte] = _const(b, ByteInfo)
 
-  implicit def strToCode(s: String): Code[String] = _const(s)
+  implicit def strToCode(s: String): Code[String] = const(s)
 
-  implicit def boolToCode(b: Boolean): Code[Boolean] = _const(b)
+  implicit def boolToCode(b: Boolean): Code[Boolean] = const(b)
 
-  implicit def intToCode(i: Int): Code[Int] = _const(i)
+  implicit def intToCode(i: Int): Code[Int] = const(i)
 
-  implicit def longToCode(l: Long): Code[Long] = _const(l)
+  implicit def longToCode(l: Long): Code[Long] = const(l)
 
-  implicit def floatToCode(f: Float): Code[Float] = _const(f)
+  implicit def floatToCode(f: Float): Code[Float] = const(f)
 
-  implicit def doubleToCode(d: Double): Code[Double] = _const(d)
+  implicit def doubleToCode(d: Double): Code[Double] = const(d)
 
-  implicit def charToCode(c: Char): Code[Char] = _const(c)
+  implicit def charToCode(c: Char): Code[Char] = const(c)
 
-  implicit def byteToCode(b: Byte): Code[Byte] = _const(b)
+  implicit def byteToCode(b: Byte): Code[Byte] = const(b)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -343,7 +343,7 @@ private class Emit[C](
   val ctx: ExecuteContext,
   val cb: EmitClassBuilder[C]) { emitSelf =>
 
-  val methods: mutable.Map[String, Seq[(Seq[PType], PType, EmitMethodBuilder[C])]] = mutable.Map().withDefaultValue(FastSeq())
+  val methods: mutable.Map[(String, Seq[PType], PType), EmitMethodBuilder[C]] = mutable.Map()
 
   import Emit.E
 
@@ -1241,16 +1241,15 @@ private class Emit[C](
         assert(unified)
 
         val argPTypes = args.map(_.pType)
+        val k = (fn, argPTypes, pt)
         val meth =
-          methods(fn).filter { case (argt, rtExpected, _) =>
-            argt == argPTypes && rtExpected == ir.pType
-          } match {
-            case Seq((_, _, funcMB)) =>
+          methods.get(k) match {
+            case Some(funcMB) =>
               funcMB
-            case Seq() =>
-              val methodbuilder = impl.getAsMethod(mb.ecb, pt, argPTypes: _*)
-              methods.update(fn, methods(fn) :+ ((argPTypes, pt, methodbuilder)))
-              methodbuilder
+            case None =>
+              val funcMB = impl.getAsMethod(mb.ecb, pt, argPTypes: _*)
+              methods.update(k, funcMB)
+              funcMB
           }
         val codeArgs = args.map(emit(_))
         val vars = args.map { a => coerce[Any](mb.newLocal()(typeToTypeInfo(a.typ))) }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1243,8 +1243,7 @@ private class Emit[C](
         val argPTypes = args.map(_.pType)
         val meth =
           methods(fn).filter { case (argt, rtExpected, _) =>
-            argt.zip(argPTypes).forall { case (t1, t2) => t1 == t2 } &&
-              rtExpected == ir.pType
+            argt == argPTypes && rtExpected == ir.pType
           } match {
             case Seq((_, _, funcMB)) =>
               funcMB

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -181,15 +181,13 @@ object StringFunctions extends RegistryFunctions {
     })(thisClass, "concat")
 
     registerWrappedScalaFunction("split", TString, TString, TArray(TString), {
-      case (_: Type, _: PType, _: PType) => {
+      case (_: Type, _: PType, _: PType) =>
         PCanonicalArray(PCanonicalString(true))
-      }
     })(thisClass, "split")
 
     registerWrappedScalaFunction("split", TString, TString, TInt32, TArray(TString), {
-      case (_: Type, _: PType, _: PType, _: PType) => {
+      case (_: Type, _: PType, _: PType, _: PType) =>
         PCanonicalArray(PCanonicalString(true))
-      }
     })(thisClass, "splitLimited")
 
     registerWrappedScalaFunction("replace", TString, TString, TString, TString, {

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -653,19 +653,7 @@ class NewArrayX(val eti: TypeInfo[_]) extends ValueX {
 
 class NewInstanceX(val ti: TypeInfo[_]) extends ValueX
 
-class LdcX(val a: Any) extends ValueX {
-  val ti: TypeInfo[_] = a match {
-    case _: Boolean => BooleanInfo
-    case _: Byte => ByteInfo
-    case _: Short => ShortInfo
-    case _: Int => IntInfo
-    case _: Long => LongInfo
-    case _: Char => CharInfo
-    case _: Float => FloatInfo
-    case _: Double => DoubleInfo
-    case _: String => classInfo[String]
-  }
-}
+class LdcX(val a: Any, val ti: TypeInfo[_]) extends ValueX
 
 class MethodX(val op: Int, val method: MethodRef) extends ValueX {
   def ti: TypeInfo[_] = method.returnTypeInfo

--- a/hail/src/main/scala/is/hail/lir/package.scala
+++ b/hail/src/main/scala/is/hail/lir/package.scala
@@ -215,7 +215,7 @@ package object lir {
     x
   }
 
-  def ldcInsn(a: Any): ValueX = new LdcX(a)
+  def ldcInsn(a: Any, ti: TypeInfo[_]): ValueX = new LdcX(a, ti)
 
   def returnx(): ControlX = new ReturnX()
 
@@ -244,11 +244,11 @@ package object lir {
   }
 
   def defaultValue(ti: TypeInfo[_]): ValueX = ti match {
-    case BooleanInfo => ldcInsn(false)
-    case IntInfo => ldcInsn(0)
-    case LongInfo => ldcInsn(0L)
-    case FloatInfo => ldcInsn(0.0f)
-    case DoubleInfo => ldcInsn(0.0)
+    case BooleanInfo => ldcInsn(0, ti)
+    case IntInfo => ldcInsn(0, ti)
+    case LongInfo => ldcInsn(0L, ti)
+    case FloatInfo => ldcInsn(0.0f, ti)
+    case DoubleInfo => ldcInsn(0.0, ti)
     case _: ClassInfo[_] => insn(ACONST_NULL, ti)
     case _: ArrayInfo[_] => insn(ACONST_NULL, ti)
   }


### PR DESCRIPTION
Plus:
 - Boolean ldc (load constant) instructions need an int, not a boolean.  JVM seems OK with it, but the asm bytecode verifier rejects it.
 - In Apply codegen, the zip in function lookup was potentially truncating the arguments, selecting an incorrect function.  Fix, and simplify the definition of `methods`.
 - Fix/simplify asm error reporting from asm in lir Emit.  The old code was crashing inside asm.  I used the new code to debug some bytecode issues, it works well.
 - compute max locals/stack, needed by the asm verifier (CheckClass).

@konradjk This fixes your class not found issue.