### PR TITLE
[site] fix matches

### DIFF
--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -32,6 +32,7 @@ server {
     }
 
     location ~ ^/docs/batch(|/.*)$ {
+        root /var/www/html;
         try_files /docs/pipeline$1 /docs/batch$1 =404;
     }
 

--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -32,7 +32,7 @@ server {
     }
 
     location ~ ^/docs/batch(|/.*)$ {
-        try_files /docs/pipeline$1 /docs/batch$1;
+        try_files /docs/pipeline$1 /docs/batch$1 =404;
     }
 
     error_page 404 /404.html;

--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -27,14 +27,14 @@ server {
         return 301 $scheme://$http_host/docs/0.2$1;
     }
 
-    location /docs/pipeline {
-        return 301 $scheme://$http_host/docs/batch;
+    location ~ ^/docs/pipeline(|/.*)$ {
+        return 301 $scheme://$http_host/docs/batch$1;
     }
 
-    location ~ ^/docs/batch(.*)$ {
+    location ~ ^/docs/batch(|/.*)$ {
         try_files /var/www/html/docs/pipeline$1 /var/www/html/docs/batch$1;
     }
-    
+
     error_page 404 /404.html;
 
     location / {

--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -32,7 +32,7 @@ server {
     }
 
     location ~ ^/docs/batch(|/.*)$ {
-        try_files /var/www/html/docs/pipeline$1 /var/www/html/docs/batch$1;
+        try_files /docs/pipeline$1 /docs/batch$1;
     }
 
     error_page 404 /404.html;


### PR DESCRIPTION
The previous location directive redirected every URL matching that prefix to `/batch`, thus losing the suffix. I'm testing right now.