### PR TITLE
[query] refactor Stream to top-level class

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -447,7 +447,7 @@ private class Emit[C](
 
         cb += streamOpt.cases(mb)(
           Code._empty,
-          _.getStream.forEach(mb)(forBody))
+          _.getStream.forEach(mb, forBody))
 
       case x@InitOp(i, args, _, op) =>
         val AggContainer(aggs, sc) = container.get
@@ -1879,11 +1879,10 @@ private class Emit[C](
         }
 
         def addContexts(ctxStream: SizedStream): Code[Unit] = ctxStream match {
-          case SizedStream(setup, stream, len) =>
-          Code(
+          case SizedStream(setup, stream, len) => Code(
             setup,
             ctxab.invoke[Int, Unit]("ensureCapacity", len.getOrElse(16)),
-            stream.map(etToTuple(_, ctxType)).forEach(mb) { offset =>
+            stream.map(etToTuple(_, ctxType)).forEach(mb, { offset =>
               Code(
                 baos.invoke[Unit]("reset"),
                 Code.memoize(offset, "cda_add_contexts_addr") { offset =>
@@ -1891,8 +1890,8 @@ private class Emit[C](
                 },
                 buf.invoke[Unit]("flush"),
                 ctxab.invoke[Array[Byte], Unit]("add", baos.invoke[Array[Byte]]("toByteArray")))
-            })
-        }
+            }))
+          }
 
         val addGlobals = Code(
           Code.memoize(etToTuple(globalsT, gType), "cda_g") { g =>

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -37,22 +37,22 @@ class EmitStreamSuite extends HailSuite {
     asmFn.apply
   }
 
-  def range(start: Code[Int], stop: Code[Int], name: String)(implicit ctx: EmitStreamContext): CodeStream.Stream[Code[Int]] =
-    CodeStream.map(CodeStream.range(ctx.mb, start, 1, stop - start))(
+  def range(start: Code[Int], stop: Code[Int], name: String)(implicit ctx: EmitStreamContext): Stream[Code[Int]] =
+    Stream.range(ctx.mb, start, 1, stop - start).map(
       a => a,
       setup0 = Some(Code._println(const(s"$name setup0"))),
       setup = Some(Code._println(const(s"$name setup"))),
       close0 = Some(Code._println(const(s"$name close0"))),
       close = Some(Code._println(const(s"$name close"))))
 
-  class CheckedStream[T](_stream: CodeStream.Stream[T], name: String, mb: EmitMethodBuilder[_]) {
+  class CheckedStream[T](_stream: Stream[T], name: String, mb: EmitMethodBuilder[_]) {
     val outerBit = mb.newLocal[Boolean]()
     val innerBit = mb.newLocal[Boolean]()
     val innerCount = mb.newLocal[Int]()
 
     def init: Code[Unit] = Code(outerBit := false, innerBit := false, innerCount := 0)
 
-    val stream: CodeStream.Stream[T] = _stream.mapCPS(
+    val stream: Stream[T] = _stream.mapCPS(
       (ctx, a, k) => (outerBit & innerBit).mux(
         k(a),
         Code._fatal[Unit](s"$name: pulled from when not setup")),
@@ -92,7 +92,7 @@ class EmitStreamSuite extends HailSuite {
   def checkedRange(start: Code[Int], stop: Code[Int], name: String, mb: EmitMethodBuilder[_]): CheckedStream[Code[Int]] = {
     val tstart = mb.newLocal[Int]()
     val len = mb.newLocal[Int]()
-    val s = CodeStream.range(mb, tstart, 1, len)
+    val s = Stream.range(mb, tstart, 1, len)
       .map(
         f = x => x,
         setup0 = Some(Code(tstart := 0, len := 0)),
@@ -106,7 +106,7 @@ class EmitStreamSuite extends HailSuite {
 
       Code(
         r.init,
-        r.stream.forEach(mb)(i => Code._println(i.toS)),
+        r.stream.forEach(mb, i => Code._println(i.toS)),
         r.assertClosed(1))
     }
     for (i <- 0 to 2) { f(i) }
@@ -116,11 +116,11 @@ class EmitStreamSuite extends HailSuite {
     val f = compile2[Int, Int, Unit] { (mb, m, n) =>
       val l = checkedRange(0, m, "left", mb)
       val r = checkedRange(0, n, "right", mb)
-      val z = CodeStream.zip(l.stream, r.stream)
+      val z = Stream.zip(l.stream, r.stream)
 
       Code(
         l.init, r.init,
-        z.forEach(mb)(x => Code._println(const("(").concat(x._1.toS).concat(", ").concat(x._2.toS).concat(")"))),
+        z.forEach(mb, x => Code._println(const("(").concat(x._1.toS).concat(", ").concat(x._2.toS).concat(")"))),
         l.assertClosed(1), r.assertClosed(1))
     }
     for {
@@ -139,7 +139,7 @@ class EmitStreamSuite extends HailSuite {
         inner = checkedRange(0, i, "inner", mb)
         inner.stream
       }
-      val run = outer.stream.flatMap(f).forEach(mb)(i => Code._println(i.toS))
+      val run = outer.stream.flatMap(f).forEach(mb, i => Code._println(i.toS))
 
       Code(
         outer.init, inner.init,
@@ -161,8 +161,9 @@ class EmitStreamSuite extends HailSuite {
         rInner = checkedRange(0, i, "right inner", mb)
         rInner.stream
       }
-      val run = CodeStream.zip(l.stream, rOuter.stream.flatMap(f))
-                          .forEach(mb)(x => Code._println(const("(").concat(x._1.toS).concat(", ").concat(x._2.toS).concat(")")))
+      val run = Stream
+        .zip(l.stream, rOuter.stream.flatMap(f))
+        .forEach(mb, x => Code._println(const("(").concat(x._1.toS).concat(", ").concat(x._2.toS).concat(")")))
 
       Code(
         l.init, rOuter.init, rInner.init,
@@ -185,11 +186,11 @@ class EmitStreamSuite extends HailSuite {
       val s1 = checkedRange(0, n1, "s1", mb)
       val s2 = checkedRange(0, n2, "s2", mb)
       val s3 = checkedRange(0, n3, "s3", mb)
-      val z = CodeStream.multiZip(IndexedSeq(s1.stream, s2.stream, s3.stream)).asInstanceOf[CodeStream.Stream[IndexedSeq[Code[Int]]]]
+      val z = Stream.multiZip(IndexedSeq(s1.stream, s2.stream, s3.stream)).asInstanceOf[Stream[IndexedSeq[Code[Int]]]]
 
       Code(
         s1.init, s2.init, s3.init,
-        z.forEach(mb)(x => Code._println(const("(").concat(x(0).toS).concat(", ").concat(x(1).toS).concat(", ").concat(x(2).toS).concat(")"))),
+        z.forEach(mb, x => Code._println(const("(").concat(x(0).toS).concat(", ").concat(x(1).toS).concat(", ").concat(x(2).toS).concat(")"))),
         s1.assertClosed(1),
         s2.assertClosed(1),
         s3.assertClosed(1))


### PR DESCRIPTION
This is a simple refactor, that moves `Stream[A]` to a top-level class. Some of my wip depends on this, so it will be helpful to get it merged. This should also simplify merging `Stream` with the PType infrastructure, where `Stream` should become a `PCode`.