### PR TITLE
[infra/docs] Add setup.py project urls.

### DIFF
--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -22,6 +22,10 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://hail.is",
+    project_urls={
+        'Documentation': 'https://hail.is/docs/0.2/',
+        'Repository': 'https://github.com/hail-is/hail',
+    },
     packages=find_packages('.'),
     package_dir={
         'hail': 'hail',


### PR DESCRIPTION
Documentation for this field's use is availible at the end of the linked
section. We can maybe version the docs url in order to host the docs to
the released versions.

https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords