### PR TITLE
NDArrays Default to Column Major

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -659,8 +659,8 @@ class tndarray(HailType):
 
         strides = []
         axis_one_step_byte_size = x.itemsize
-        for dimension_size in reversed(x.shape):
-            strides.insert(0, axis_one_step_byte_size)
+        for dimension_size in x.shape:
+            strides.append(axis_one_step_byte_size)
             axis_one_step_byte_size *= (dimension_size if dimension_size > 0 else 1)
 
         json_dict = {

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -650,11 +650,12 @@ class tndarray(HailType):
         return f'NDArray[{self._element_type._parsable_string()},{self.ndim}]'
 
     def _convert_from_json(self, x):
+        print(x)
         np_type = self.element_type.to_numpy()
         return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
 
     def _convert_to_json(self, x):
-        data = x.reshape(x.size).tolist()
+        data = x.flatten("F").tolist()
 
         strides = []
         axis_one_step_byte_size = x.itemsize
@@ -669,6 +670,9 @@ class tndarray(HailType):
             "data": data,
             "offset": 0
         }
+        print("Sending data:")
+        print(json_dict)
+
         return json_dict
 
     def clear(self):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -650,7 +650,6 @@ class tndarray(HailType):
         return f'NDArray[{self._element_type._parsable_string()},{self.ndim}]'
 
     def _convert_from_json(self, x):
-        print(x)
         np_type = self.element_type.to_numpy()
         return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
 
@@ -670,9 +669,6 @@ class tndarray(HailType):
             "data": data,
             "offset": 0
         }
-        print("Sending data:")
-        print(json_dict)
-
         return json_dict
 
     def clear(self):

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1534,6 +1534,9 @@ private class Emit[C](
         val ndt = emit(nd)
         val ndAddress = mb.genFieldThisRef[Long]()
         val ndPType = nd.pType.asInstanceOf[PNDArray]
+        // This does a lot of byte level copying currently, so only trust
+        // the PCanonicalNDArray representation.
+        assert(ndPType.isInstanceOf[PCanonicalNDArray])
 
         val shapeAddress: Value[Long] = new Value[Long] {
           def get: Code[Long] = ndPType.shape.load(ndAddress)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1307,7 +1307,7 @@ private class Emit[C](
                   })
               }
 
-              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
+              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultColumnMajorStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
             }
           }
         }
@@ -1501,7 +1501,7 @@ private class Emit[C](
             Code.invokeStatic[Memory, Long, Unit]("free", leftColumnMajorAddress.load()),
             Code.invokeStatic[Memory, Long, Unit]("free", rightColumnMajorAddress.load()),
             Code.invokeStatic[Memory, Long, Unit]("free", answerColumnMajorAddress.load()))),
-            outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeDefaultStridesBuilder(IndexedSeq(M, N), mb), answerRowMajorPArrayAddress, mb)
+            outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeDefaultRowMajorStridesBuilder(IndexedSeq(M, N), mb), answerRowMajorPArrayAddress, mb)
           )
 
           EmitCode(missingSetup, isMissing, PCode(pt, multiplyViaDGEMM))
@@ -1630,10 +1630,10 @@ private class Emit[C](
 
           val hShapeArray = FastIndexedSeq[Value[Long]](N, M)
           val hShapeBuilder = hPType.makeShapeBuilder(hShapeArray.map(_.get))
-          val hStridesBuilder = hPType.makeDefaultStridesBuilder(hShapeArray.map(_.get), mb)
+          val hStridesBuilder = hPType.makeDefaultRowMajorStridesBuilder(hShapeArray.map(_.get), mb)
 
           val tauShapeBuilder = tauPType.makeShapeBuilder(FastIndexedSeq(K.get))
-          val tauStridesBuilder = tauPType.makeDefaultStridesBuilder(FastIndexedSeq(K.get), mb)
+          val tauStridesBuilder = tauPType.makeDefaultRowMajorStridesBuilder(FastIndexedSeq(K.get), mb)
 
           val h = hPType.construct(hShapeBuilder, hStridesBuilder, aAddressDGEQRF, mb)
           val tau = tauPType.construct(tauShapeBuilder, tauStridesBuilder, tauAddress, mb)
@@ -1667,7 +1667,7 @@ private class Emit[C](
           }
 
           val rShapeBuilder = rPType.makeShapeBuilder(rShapeArray.map(_.get))
-          val rStridesBuilder = rPType.makeDefaultStridesBuilder(rShapeArray.map(_.get), mb)
+          val rStridesBuilder = rPType.makeDefaultRowMajorStridesBuilder(rShapeArray.map(_.get), mb)
 
           //This block assumes rDataAddress is a row major ndarray.
           val zeroOutLowerTriangle =
@@ -1705,7 +1705,7 @@ private class Emit[C](
             val qPType = crPType.types(0).asInstanceOf[PNDArray]
             val qShapeArray = if (mode == "complete") Array(M, M) else Array(M, K)
             val qShapeBuilder = qPType.makeShapeBuilder(qShapeArray.map(_.get))
-            val qStridesBuilder = qPType.makeDefaultStridesBuilder(qShapeArray.map(_.get), mb)
+            val qStridesBuilder = qPType.makeDefaultRowMajorStridesBuilder(qShapeArray.map(_.get), mb)
 
             val rNDArrayAddress = mb.genFieldThisRef[Long]()
             val qDataAddress = mb.genFieldThisRef[Long]()
@@ -2577,7 +2577,7 @@ abstract class NDArrayEmitter[C](
           Code.foreach(0 until nDims)(index => outputShapeVariables(index) := outputShape(index)))))
 
     EmitCode(fullSetup, m,
-      PCode(targetType, targetType.construct(shapeBuilder, targetType.makeDefaultStridesBuilder(outputShapeVariables.map(_.load()), mb), dataAddress, mb)))
+      PCode(targetType, targetType.construct(shapeBuilder, targetType.makeDefaultColumnMajorStridesBuilder(outputShapeVariables.map(_.load()), mb), dataAddress, mb)))
   }
 
   private def emitLoops(mb: EmitMethodBuilder[C], outputShapeVariables: IndexedSeq[Value[Long]], srvb: StagedRegionValueBuilder): Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1531,7 +1531,7 @@ private class Emit[C](
 
       case x@NDArrayQR(nd, mode) =>
         // See here to understand different modes: https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.qr.html
-        val ndt = emit(nd)
+        val ndt = emitNDArrayStandardStrides(nd)
         val ndAddress = mb.genFieldThisRef[Long]()
         val ndPType = nd.pType.asInstanceOf[PNDArray]
         // This does a lot of byte level copying currently, so only trust

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1307,7 +1307,7 @@ private class Emit[C](
                   })
               }
 
-              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultRowMajorStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
+              PCode(pt, xP.construct(shapeBuilder, xP.makeRowMajorStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
             }
           }
         }
@@ -1484,7 +1484,7 @@ private class Emit[C](
                   LDC.toI
                 )
             },
-            outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeDefaultColumnMajorStridesBuilder(IndexedSeq(M, N), mb), answerPArrayAddress, mb)
+            outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeColumnMajorStridesBuilder(IndexedSeq(M, N), mb), answerPArrayAddress, mb)
           )
 
           EmitCode(missingSetup, isMissing, PCode(pt, multiplyViaDGEMM))
@@ -1615,10 +1615,10 @@ private class Emit[C](
 
           val hShapeArray = FastIndexedSeq[Value[Long]](N, M)
           val hShapeBuilder = hPType.makeShapeBuilder(hShapeArray.map(_.get))
-          val hStridesBuilder = hPType.makeDefaultRowMajorStridesBuilder(hShapeArray.map(_.get), mb)
+          val hStridesBuilder = hPType.makeRowMajorStridesBuilder(hShapeArray.map(_.get), mb)
 
           val tauShapeBuilder = tauPType.makeShapeBuilder(FastIndexedSeq(K.get))
-          val tauStridesBuilder = tauPType.makeDefaultRowMajorStridesBuilder(FastIndexedSeq(K.get), mb)
+          val tauStridesBuilder = tauPType.makeRowMajorStridesBuilder(FastIndexedSeq(K.get), mb)
 
           val h = hPType.construct(hShapeBuilder, hStridesBuilder, aAddressDGEQRF, mb)
           val tau = tauPType.construct(tauShapeBuilder, tauStridesBuilder, tauAddress, mb)
@@ -1654,7 +1654,7 @@ private class Emit[C](
           val rShapeArray = FastIndexedSeq[Value[Long]](rRows, rCols)
 
           val rShapeBuilder = rPType.makeShapeBuilder(rShapeArray.map(_.get))
-          val rStridesBuilder = rPType.makeDefaultColumnMajorStridesBuilder(rShapeArray.map(_.get), mb)
+          val rStridesBuilder = rPType.makeColumnMajorStridesBuilder(rShapeArray.map(_.get), mb)
 
           // This block assumes that `rDataAddress` and `aAddressDGEQRF` point to column major arrays.
           // TODO: Abstract this into ndarray ptype/pcode interface methods.
@@ -1690,7 +1690,7 @@ private class Emit[C](
             val qPType = crPType.types(0).asInstanceOf[PNDArray]
             val qShapeArray = if (mode == "complete") Array(M, M) else Array(M, K)
             val qShapeBuilder = qPType.makeShapeBuilder(qShapeArray.map(_.get))
-            val qStridesBuilder = qPType.makeDefaultColumnMajorStridesBuilder(qShapeArray.map(_.get), mb)
+            val qStridesBuilder = qPType.makeColumnMajorStridesBuilder(qShapeArray.map(_.get), mb)
 
             val rNDArrayAddress = mb.genFieldThisRef[Long]()
             val qDataAddress = mb.genFieldThisRef[Long]()
@@ -2562,7 +2562,7 @@ abstract class NDArrayEmitter[C](
           Code.foreach(0 until nDims)(index => outputShapeVariables(index) := outputShape(index)))))
 
     EmitCode(fullSetup, m,
-      PCode(targetType, targetType.construct(shapeBuilder, targetType.makeDefaultColumnMajorStridesBuilder(outputShapeVariables.map(_.load()), mb), dataAddress, mb)))
+      PCode(targetType, targetType.construct(shapeBuilder, targetType.makeColumnMajorStridesBuilder(outputShapeVariables.map(_.load()), mb), dataAddress, mb)))
   }
 
   private def emitLoops(mb: EmitMethodBuilder[C], outputShapeVariables: IndexedSeq[Value[Long]], srvb: StagedRegionValueBuilder): Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1307,7 +1307,7 @@ private class Emit[C](
                   })
               }
 
-              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultColumnMajorStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
+              PCode(pt, xP.construct(shapeBuilder, xP.makeDefaultRowMajorStridesBuilder(shapeCodeSeq, mb), requiredData, mb))
             }
           }
         }
@@ -2592,7 +2592,8 @@ abstract class NDArrayEmitter[C](
         srvb.addIRIntermediate(outputElementPType)(storeElement),
         srvb.advance()
       )
-    val loops = idxVars.zipWithIndex.foldRight(body) { case ((dimVar, dimIdx), innerLoops) =>
+
+    val columnMajorLoops = idxVars.zipWithIndex.foldLeft(body) { case (innerLoops, (dimVar, dimIdx)) =>
       Code(
         dimVar := 0L,
         Code.whileLoop(dimVar < outputShapeVariables(dimIdx),
@@ -2601,7 +2602,7 @@ abstract class NDArrayEmitter[C](
         )
       )
     }
-    innerMethod.emit(loops)
+    innerMethod.emit(columnMajorLoops)
     innerMethod.invokeCode[Unit](mb.getParamsList(): _*)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -67,23 +67,17 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def makeDefaultColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb =>
     val runningProduct = mb.newLocal[Long]()
     val tempShapeStorage = mb.newLocal[Long]()
-    val computedStrides = (0 until nDims).map(_ => mb.genFieldThisRef[Long]())
     Code(
       srvb.start(),
       runningProduct := elementType.byteSize,
       Code.foreach(0 until nDims){ index =>
         Code(
-          computedStrides(index) := runningProduct,
+          srvb.addLong(runningProduct),
+          srvb.advance(),
           tempShapeStorage := sourceShapeArray(index),
           runningProduct := runningProduct * (tempShapeStorage > 0L).mux(tempShapeStorage, 1L)
         )
-      },
-      Code.foreach(0 until nDims)(index =>
-        Code(
-          srvb.addLong(computedStrides(index)),
-          srvb.advance()
-        )
-      )
+      }
     )
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -64,7 +64,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     ))
   }
 
-  def makeDefaultColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb =>
+  def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb =>
     val runningProduct = mb.newLocal[Long]()
     val tempShapeStorage = mb.newLocal[Long]()
     Code(
@@ -81,7 +81,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     )
   }
 
-  def makeDefaultRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb =>
+  def makeRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb =>
     val runningProduct = mb.newLocal[Long]()
     val tempShapeStorage = mb.newLocal[Long]()
     val computedStrides = (0 until nDims).map(_ => mb.genFieldThisRef[Long]())

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -46,9 +46,5 @@ abstract class PNDArray extends PType {
 
   def unlinearizeIndexRowMajor(index: Code[Long], shapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): (Code[Unit], IndexedSeq[Value[Long]])
 
-  def copyRowMajorToColumnMajor(rowMajorAddress: Code[Long], targetAddress: Code[Long], nRows: Code[Long], nCols: Code[Long], mb: EmitMethodBuilder[_]): Code[Unit]
-
-  def copyColumnMajorToRowMajor(colMajorAddress: Code[Long], targetAddress: Code[Long], nRows: Code[Long], nCols: Code[Long], mb: EmitMethodBuilder[_]): Code[Unit]
-
   def construct(shapeBuilder: StagedRegionValueBuilder => Code[Unit], stridesBuilder: StagedRegionValueBuilder => Code[Unit], data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long]
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -34,7 +34,9 @@ abstract class PNDArray extends PType {
 
   def makeShapeBuilder(shapeArray: IndexedSeq[Code[Long]]): StagedRegionValueBuilder => Code[Unit]
 
-  def makeDefaultStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+  def makeDefaultRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+
+  def makeDefaultColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
 
   def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], mb: EmitMethodBuilder[_]): Code[_]
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -34,9 +34,9 @@ abstract class PNDArray extends PType {
 
   def makeShapeBuilder(shapeArray: IndexedSeq[Code[Long]]): StagedRegionValueBuilder => Code[Unit]
 
-  def makeDefaultRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+  def makeRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
 
-  def makeDefaultColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+  def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Code[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
 
   def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], mb: EmitMethodBuilder[_]): Code[_]
 


### PR DESCRIPTION
This PR switches the `NDArrayEmitter` to emit column major data by default. However, it still allows things like the result of `MakeNDArray` to come back as row major. This simplifies code that calls BLAS considerably, since we no longer have to manually flip to column major and then flip back. 

There's still unnecessary copying going on, just less. `emitNDArrayStandardStrides` is not a very smart method, always copies the data even if it's already in the right format. At some point a smarter version of this should check if the ndarray exists in memory with the proper striding already. 