### PR TITLE
[hailctl][batch] add hailctl config & make tests work locally

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1266,7 +1266,7 @@ steps:
  - kind: runImage
    name: test_batch_docs
    image:
-     valueFrom: base_image.image
+     valueFrom: service_base_image.image
    script: |
      set -ex
 
@@ -1289,7 +1289,7 @@ steps:
    dependsOn:
     - default_ns
     - batch_pods_ns
-    - base_image
+    - service_base_image
     - copy_files
     - deploy_batch
    timeout: 1200

--- a/build.yaml
+++ b/build.yaml
@@ -1235,8 +1235,10 @@ steps:
    image:
      valueFrom: service_base_image.image
    script: |
+     set -ex
+
      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
-     python3 -m hailctl config set batch/billing_project test
+     python3 -m hailtop.hailctl config set batch/billing_project test
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail /io/test/test/hailtop/batch/
    inputs:
     - from: /repo/test
@@ -1267,8 +1269,10 @@ steps:
      valueFrom: base_image.image
    script: |
      set -ex
+
      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      cd /io/hailtop/hailtop/batch
+     python3 -m hailtop.hailctl config set batch/billing_project test
      python3 -m pytest --instafail \
        --doctest-modules \
        --doctest-glob='*.rst' \

--- a/build.yaml
+++ b/build.yaml
@@ -1236,7 +1236,7 @@ steps:
      valueFrom: service_base_image.image
    script: |
      export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
-     export SCRATCH=gs://hail-test-dmk9z/{{ token }}/batch
+     python3 -m hailctl config set batch/billing_project test
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail /io/test/test/hailtop/batch/
    inputs:
     - from: /repo/test
@@ -1254,7 +1254,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /test-gsa-key      
+      mountPath: /test-gsa-key
    dependsOn:
     - default_ns
     - batch_pods_ns

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -6,7 +6,7 @@ import time
 import copy
 from shlex import quote as shq
 import webbrowser
-from hailtop.config import get_deploy_config
+from hailtop.config import get_deploy_config, get_user_config
 from hailtop.batch_client.client import BatchClient
 
 from .resource import InputResourceFile, JobResourceFile
@@ -220,7 +220,14 @@ class ServiceBackend(Backend):
         Name of billing project to use.
     """
 
-    def __init__(self, billing_project):
+    def __init__(self, billing_project=None):
+        if billing_project is None:
+            billing_project = get_user_config().get('batch', 'billing_project')
+        if billing_project is None:
+            raise ValueError(
+                f'you must specify the billing_project parameter of '
+                f'ServiceBackend or set "batch/billing_project" using hailctl '
+                f'config set')
         self._batch_client = BatchClient(billing_project)
 
     def close(self):

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -203,13 +203,21 @@ class LocalBackend(Backend):
 
 
 class ServiceBackend(Backend):
-    """
-    Backend that executes batches on Hail's Batch Service on Google Cloud.
+    """Backend that executes batches on Hail's Batch Service on Google Cloud.
 
     Examples
     --------
 
     >>> service_backend = ServiceBackend('test')
+    >>> b = Batch(backend=service_backend)
+    >>> b.run() # doctest: +SKIP
+    >>> service_backend.close()
+
+    If the Hail configuration parameter batch/billing_project was previously set
+    with ``hailctl config set``, then one may elide the billing_project
+    parameter.
+
+    >>> service_backend = ServiceBackend()
     >>> b = Batch(backend=service_backend)
     >>> b.run() # doctest: +SKIP
     >>> service_backend.close()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -225,9 +225,9 @@ class ServiceBackend(Backend):
             billing_project = get_user_config().get('batch', 'billing_project')
         if billing_project is None:
             raise ValueError(
-                f'you must specify the billing_project parameter of '
-                f'ServiceBackend or set "batch/billing_project" using hailctl '
-                f'config set')
+                f'the billing_project parameter of ServiceBackend must be set '
+                f'or run hailctl config set batch/billing_project '
+                f'YOUR_BILLING_PROJECT')
         self._batch_client = BatchClient(billing_project)
 
     def close(self):

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -234,8 +234,8 @@ class ServiceBackend(Backend):
         if billing_project is None:
             raise ValueError(
                 f'the billing_project parameter of ServiceBackend must be set '
-                f'or run hailctl config set batch/billing_project '
-                f'YOUR_BILLING_PROJECT')
+                f'or run `hailctl config set batch/billing_project '
+                f'YOUR_BILLING_PROJECT`')
         self._batch_client = BatchClient(billing_project)
 
     def close(self):

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -127,8 +127,8 @@ You can open iPython or a Jupyter notebook and execute the following batch:
     >>> j.command('echo "hello world"')
     >>> b.run(open=True)
 
-You may elide the ``billing_project`` parameter if you set a default billing
-project with ``hailctl``:
+You may elide the ``billing_project`` parameter if you have previously set a
+billing project with ``hailctl``:
 
 .. code-block:: sh
 

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -127,6 +127,12 @@ You can open iPython or a Jupyter notebook and execute the following batch:
     >>> j.command('echo "hello world"')
     >>> b.run(open=True)
 
+You may elide the ``billing_project`` parameter if you set a default billing
+project with ``hailctl``:
+
+.. code-block:: sh
+
+    hailctl config set batch/billing_project hail
 
 Using the UI
 ------------

--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -1,6 +1,9 @@
+from .user_config import get_user_config, get_user_config_path
 from .deploy_config import get_deploy_config, DeployConfig
 
 __all__ = [
     'get_deploy_config',
+    'get_user_config',
+    'get_user_config_path',
     'DeployConfig'
 ]

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -1,0 +1,20 @@
+import os
+import configparser
+
+user_config = None
+
+
+def get_user_config_path():
+    config_file = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')) + '/hail/config.yaml'
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
+    return config_file
+
+
+def get_user_config():
+    global user_config
+    if user_config is None:
+        user_config = configparser.ConfigParser()
+        config_file = get_user_config_path()
+        if os.path.exists(config_file):
+            user_config.read(config_file)
+    return user_config

--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -5,9 +5,8 @@ user_config = None
 
 
 def get_user_config_path():
-    config_file = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')) + '/hail/config.yaml'
-    os.makedirs(os.path.dirname(config_file), exist_ok=True)
-    return config_file
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+    return xdg_config_home + '/hail/config.yaml'
 
 
 def get_user_config():
@@ -15,6 +14,7 @@ def get_user_config():
     if user_config is None:
         user_config = configparser.ConfigParser()
         config_file = get_user_config_path()
-        if os.path.exists(config_file):
-            user_config.read(config_file)
+        os.makedirs(os.path.dirname(config_file), exist_ok=True)
+        open(config_file, 'a').close()
+        user_config.read(config_file)
     return user_config

--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -31,6 +31,9 @@ def print_help():
     subs.add_parser('curl',
                     help='Issue authenticated curl requests to Hail infrastructure.',
                     description='Issue authenticated curl requests to Hail infrastructure.')
+    subs.add_parser('config',
+                    help='Manage Hail configuration.',
+                    description='Manage Hail configuration.')
 
     main_parser.print_help()
 
@@ -107,6 +110,9 @@ def main():
         elif module == 'curl':
             from hailtop.hailctl.curl import main
             main(args)
+        elif module == 'config':
+            from hailtop.hailctl.config import cli
+            cli.main(args)
         elif module in ('-h', '--help', 'help'):
             print_help()
         else:

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -50,7 +50,7 @@ def main(args):
     if not args:
         parser().print_help()
         sys.exit(0)
-    args, pass_through_args = parser().parse_known_args(args=args)
+    args = parser().parse_args(args=args)
 
     config_file = get_user_config_path()
     if args.module == 'config-location':

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -97,4 +97,3 @@ A parameter with more than one slash is invalid, for example:
         sys.exit(0)
     print(f'bad module name: {args.module}')
     sys.exit(1)
-

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -78,6 +78,7 @@ A parameter with more than one slash is invalid, for example:
 "batch/billing/project".
 '''.lstrip('\n'), file=sys.stderr)
         sys.exit(1)
+
     if args.module == 'set':
         if section not in config:
             config[section] = dict()

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -1,0 +1,100 @@
+import sys
+import argparse
+
+from hailtop.config import get_user_config, get_user_config_path
+
+
+def parser():
+    main_parser = argparse.ArgumentParser(
+        prog='hailctl config',
+        description='Manage Hail configuration.')
+    subparsers = main_parser.add_subparsers()
+
+    set_parser = subparsers.add_parser(
+        'set',
+        help='Set a Hail configuration parameter.',
+        description='Set a Hail configuration parameter.')
+    unset_parser = subparsers.add_parser(
+        'unset',
+        help='Unset a Hail configuration parameter (restore to default behavior).',
+        description='Unset a hail configuration parameter (restore to default behavior).')
+    get_parser = subparsers.add_parser(
+        'get',
+        help='Get the value of a Hail configuration parameter.',
+        description='Get the value of a Hail configuration parameter.')
+    config_location_parser = subparsers.add_parser(
+        'config-location',
+        help='Print the location of the config file',
+        description='Print the location of the config file')
+
+    set_parser.set_defaults(module='set')
+    set_parser.add_argument("parameter", type=str,
+                            help="A hail configuration parameter.")
+    set_parser.add_argument("value", type=str,
+                            help="A value.")
+
+    unset_parser.set_defaults(module='unset')
+    unset_parser.add_argument("parameter", type=str,
+                              help="A hail configuration parameter.")
+
+    get_parser.set_defaults(module='get')
+    get_parser.add_argument("parameter", type=str,
+                            help="A hail configuration parameter.")
+
+    config_location_parser.set_defaults(module='config-location')
+
+    return main_parser
+
+
+def main(args):
+    if not args:
+        parser().print_help()
+        sys.exit(0)
+    args, pass_through_args = parser().parse_known_args(args=args)
+
+    config_file = get_user_config_path()
+    if args.module == 'config-location':
+        print(config_file)
+        sys.exit(0)
+
+    config = get_user_config()
+
+    path = args.parameter.split('/')
+    if len(path) == 1:
+        section = 'global'
+        key = path[0]
+    elif len(path) == 2:
+        section = path[0]
+        key = path[1]
+    else:
+        print(f'''
+Paramters must contain at most one slash separating the configuration section
+from the configuration parameter, for example: "batch/billing_project".
+
+Parameters may also have no slahes, indicating the parameter is a global
+parameter, for example: "email".
+
+A parameter with more than one slash is invalid, for example:
+"batch/billing/project".
+'''.lstrip('\n'), file=sys.stderr)
+        sys.exit(1)
+    if args.module == 'set':
+        if section not in config:
+            config[section] = dict()
+        config[section][key] = args.value
+        with open(config_file, 'w') as f:
+            config.write(f)
+        sys.exit(0)
+    if args.module == 'unset':
+        if section in config and key in config[section]:
+            del config[section][key]
+            with open(config_file, 'w') as f:
+                config.write(f)
+        sys.exit(0)
+    if args.module == 'get':
+        if section in config and key in config[section]:
+            print(config[section][key])
+        sys.exit(0)
+    print(f'bad module name: {args.module}')
+    sys.exit(1)
+

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -3,10 +3,12 @@ import os
 import subprocess as sp
 import tempfile
 from shlex import quote as shq
+import uuid
 
 from hailtop.batch import Batch, ServiceBackend, LocalBackend
 from hailtop.batch.utils import arg_max
 from hailtop.utils import grouped
+from hailtop.auth import get_userinfo
 
 
 class LocalTests(unittest.TestCase):
@@ -293,7 +295,9 @@ class BatchTests(unittest.TestCase):
     def setUp(self):
         self.backend = ServiceBackend()
         self.gcs_input_dir = 'gs://hail-services/batch-testing/resources'
-        self.gcs_output_dir = os.environ.get('SCRATCH').rstrip('/') + '/output'
+        bucket_name = get_userinfo()['bucket_name']
+        token = uuid.uuid4()
+        self.gcs_output_dir = f'gs://{bucket_name}/batch-tests/{token}'
 
     def tearDown(self):
         self.backend.close()

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -301,14 +301,17 @@ class BatchTests(unittest.TestCase):
         self.gcs_output_dir = f'gs://{bucket_name}/batch-tests/{token}'
         gcs_client = google.cloud.storage.Client(project='hail-vdc')
         bucket = gcs_client.bucket(bucket_name)
-        if not bucket.blob('/batch-tests/resources/hello (foo) spaces.txt').exists():
-            bucket.blob('/batch-tests/resources/random_file_512mb').upload_from_string(
+        if not bucket.blob('batch-tests/resources/hello (foo) spaces.txt').exists():
+            print('uploading 512 MB to GCS, this may take some time, but only '
+                  'happens once per-user')
+            bucket.blob('batch-tests/resources/random_file_512mb').upload_from_string(
                 os.urandom(512 * 1024 * 1024))
-            bucket.blob('/batch-tests/resources/hello.txt').upload_from_string(
+            print('done.')
+            bucket.blob('batch-tests/resources/hello.txt').upload_from_string(
                 'hello world')
-            bucket.blob('/batch-tests/resources/hello spaces.txt').upload_from_string(
+            bucket.blob('batch-tests/resources/hello spaces.txt').upload_from_string(
                 'hello')
-            bucket.blob('/batch-tests/resources/hello (foo) spaces.txt').upload_from_string(
+            bucket.blob('batch-tests/resources/hello (foo) spaces.txt').upload_from_string(
                 'hello')
 
     def tearDown(self):

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -306,11 +306,6 @@ class BatchTests(unittest.TestCase):
                 '/test-gsa-key/key.json'))
         bucket = gcs_client.bucket(bucket_name)
         if not bucket.blob('batch-tests/resources/hello (foo) spaces.txt').exists():
-            print('uploading 512 MB to GCS, this may take some time, but only '
-                  'happens once per-user')
-            bucket.blob('batch-tests/resources/random_file_512mb').upload_from_string(
-                os.urandom(512 * 1024 * 1024))
-            print('done.')
             bucket.blob('batch-tests/resources/hello.txt').upload_from_string(
                 'hello world')
             bucket.blob('batch-tests/resources/hello spaces.txt').upload_from_string(

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -291,7 +291,7 @@ class LocalTests(unittest.TestCase):
 
 class BatchTests(unittest.TestCase):
     def setUp(self):
-        self.backend = ServiceBackend('test')
+        self.backend = ServiceBackend()
         self.gcs_input_dir = 'gs://hail-services/batch-testing/resources'
         self.gcs_output_dir = os.environ.get('SCRATCH').rstrip('/') + '/output'
 

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -4,6 +4,7 @@ import subprocess as sp
 import tempfile
 from shlex import quote as shq
 import uuid
+import google.oauth2.service_account
 import google.cloud.storage
 
 from hailtop.batch import Batch, ServiceBackend, LocalBackend
@@ -299,7 +300,10 @@ class BatchTests(unittest.TestCase):
         token = uuid.uuid4()
         self.gcs_input_dir = f'gs://{bucket_name}/batch-tests/resources'
         self.gcs_output_dir = f'gs://{bucket_name}/batch-tests/{token}'
-        gcs_client = google.cloud.storage.Client(project='hail-vdc')
+        gcs_client = google.cloud.storage.Client(
+            project='hail-vdc',
+            credentials=google.oauth2.service_account.Credentials.from_service_account_file(
+                '/test-gsa-key/key.json'))
         bucket = gcs_client.bucket(bucket_name)
         if not bucket.blob('batch-tests/resources/hello (foo) spaces.txt').exists():
             print('uploading 512 MB to GCS, this may take some time, but only '


### PR DESCRIPTION
Currently, the test_batch fails for local users.

These changes enable test_batch to work for local users with minimal configuration. The only necessary step is for a user to execute:
```
hailctl config set batch/billing_project hail
```
All other steps are handled by the test suite, including uploading test data if it does not already exist. I believe this obsoletes `hail-services` bucket. Is that correct?

The main change necessary to support this was a Hail configuration system. There is now a file stored in an [XDG acceptable](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) location to which we can read and write sectioned key-value pairs. The `ServiceBackend` looks in this configuration file if the billing_project is unspecified. The file format is defined by the INI-like configuration file library, [`configparser`](https://docs.python.org/3/library/configparser.html#). `configparser` is included in Python.

cc: @cseed your thoughts on `hailctl config` appreciated. I think we'll use this for the query service as well.