### PR TITLE
[hail] automatically build two bioinformatics images 

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1551,3 +1551,42 @@ steps:
     - copy_files
     - ci_utils_image
     - build_hail
+ - kind: buildImage
+   name: hail_public_image
+   dockerFile: docker/hail/Dockerfile
+   contextPath: docker/hail/
+   publishAs: hail_public
+   dependsOn:
+    - build_hail
+   inputs:
+     - from: /wheel-container.tar
+       to: /wheel-container.tar
+ - kind: runImage
+   name: test_hail_public_image
+   image:
+     valueFrom: hail_public_image.image
+   script: |
+     set -ex
+     python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
+     python3 -c 'import numpy; import pandas; import sklearn; import matplotlib; import scipy'
+     gcloud --version
+   dependsOn:
+     - hail_public_image
+ - kind: buildImage
+   name: genetics_public_image
+   dockerFile: docker/genetics/Dockerfile
+   contextPath: docker/genetics/
+   publishAs: genetics
+   dependsOn:
+    - hail_public_image
+ - kind: runImage
+   name: test_genetics_public_image
+   image:
+     valueFrom: genetics_public_image.image
+   script: |
+     set -ex
+     samtools --version
+     plink --version
+     plink2 --version
+   dependsOn:
+     - genetics_public_image

--- a/build.yaml
+++ b/build.yaml
@@ -1555,7 +1555,7 @@ steps:
    name: hail_public_image
    dockerFile: docker/hail/Dockerfile
    contextPath: docker/hail/
-   publishAs: hail_public
+   publishAs: hail-public
    dependsOn:
     - build_hail
    inputs:
@@ -1576,7 +1576,7 @@ steps:
    name: genetics_public_image
    dockerFile: docker/genetics/Dockerfile
    contextPath: docker/genetics/
-   publishAs: genetics
+   publishAs: genetics-public
    dependsOn:
     - hail_public_image
  - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -1569,7 +1569,7 @@ steps:
      set -ex
      python3 -c 'import hail as hl; hl.balding_nichols_model(3, 100, 100)._force_count_rows()'
      python3 -c 'import numpy; import pandas; import sklearn; import matplotlib; import scipy'
-     gcloud --version
+     gsutil --version
    dependsOn:
      - hail_public_image
  - kind: buildImage

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,6 +9,12 @@ BASE_IMAGE = gcr.io/$(PROJECT)/base:$(shell docker images -q --no-trunc base:lat
 SERVICE_BASE_LATEST = gcr.io/$(PROJECT)/service-base:latest
 SERVICE_BASE_IMAGE = gcr.io/$(PROJECT)/service-base:$(shell docker images -q --no-trunc service-base:latest | sed -e 's,[^:]*:,,')
 
+HAIL_PUBLIC_LATEST = gcr.io/$(PROJECT)/hail-public:latest
+HAIL_PUBLIC_IMAGE = gcr.io/$(PROJECT)/hail-public:$(shell docker images -q --no-trunc hail-public:latest | sed -e 's,[^:]*:,,')
+
+GENETICS_PUBLIC_LATEST = gcr.io/$(PROJECT)/genetics-public:latest
+GENETICS_PUBLIC_IMAGE = gcr.io/$(PROJECT)/genetics-public:$(shell docker images -q --no-trunc genetics-public:latest | sed -e 's,[^:]*:,,')
+
 base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull ubuntu:18.04
 	-docker pull $(BASE_LATEST)
@@ -26,12 +32,18 @@ hail-public-image:
 	make -C ../hail wheel
 	cp ../hail/build/deploy/dist/hail-*-py3-none-any.whl hail/
 	cd hail && tar -cvf wheel-container.tar hail-*-py3-none-any.whl
-	docker build hail -f hail/Dockerfile -t hail-public-image
+	-docker pull $(HAIL_PUBLIC_LATEST)
+	docker build hail -f hail/Dockerfile -t hail-public \
+     --cache-from hail-public,$(HAIL_PUBLIC_LATEST),ubuntu:18.04 \
+     hail
 
 .PHONY: genetics-public-image
 genetics-public-image: hail-public-image
 	python3 ../ci/jinja2_render.py '{"hail_public_image":{"image":"hail-public-image"}}' genetics/Dockerfile genetics/Dockerfile.out
-	docker build genetics -f genetics/Dockerfile.out -t genetics-public-image
+	-docker pull $(GENETICS_PUBLIC_LATEST)
+	docker build genetics -f genetics/Dockerfile.out -t genetics-public \
+    --cache-from genetics-public,$(GENETICS_PUBLIC_LATEST),hail-public,$(HAIL_PUBLIC_LATEST) \
+    genetics
 
 .PHONY: push
 push: build

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,6 +21,18 @@ service-base:
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base ..
 
+.PHONY: hail-public-image
+hail-public-image:
+	make -C ../hail wheel
+	cp ../hail/build/deploy/dist/hail-*-py3-none-any.whl hail/
+	cd hail && tar -cvf wheel-container.tar hail-*-py3-none-any.whl
+	docker build hail -f hail/Dockerfile -t hail-public-image
+
+.PHONY: genetics-public-image
+genetics-public-image: hail-public-image
+	python3 ../ci/jinja2_render.py '{"hail_public_image":{"image":"hail-public-image"}}' genetics/Dockerfile genetics/Dockerfile.out
+	docker build genetics -f genetics/Dockerfile.out -t genetics-public-image
+
 .PHONY: push
 push: build
 	docker tag base $(BASE_LATEST)

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,0 +1,60 @@
+FROM {{ hail_public_image.image }}
+
+RUN apt-get update && \
+  apt-get -y install \
+    cmake \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    liblzma-dev \
+    zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir samtools && \
+    (cd samtools && \
+     curl -LO https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 && \
+     tar -xf samtools-1.9.tar.bz2 && \
+     rm -rf samtools-1.9.tar.bz2 && \
+     cd samtools-1.9 && \
+     ./configure --without-curses && \
+     make && \
+     make install)
+RUN git clone --recursive https://github.com/vcflib/vcflib.git && \
+    (cd vcflib && make)
+RUN curl -LO http://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_latest.zip && \
+    unzip plink2_linux_avx2_latest.zip && \
+    mv plink2 /bin/ && \
+    rm -rf plink2_linux_avx2_latest.zip
+RUN curl -LO http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_latest.zip && \
+    unzip plink_linux_x86_64_latest.zip && \
+    mv plink /bin/ && \
+    rm -rf plink_linux_x86_64_latest.zip
+RUN mkdir king && \
+    (cd king && \
+     curl -LO http://people.virginia.edu/~wc9c/KING/Linux-king.tar.gz && \
+     tar -xf Linux-king.tar.gz)
+RUN mkdir gcta && \
+    (cd gcta && \
+     curl -LO https://cnsgenomics.com/software/gcta/bin/gcta_1.93.1beta.zip && \
+     unzip gcta_1.93.1beta.zip && \
+     rm -rf gcta_1.93.1beta.zip)
+
+RUN apt-get update && \
+  apt-get -y install \
+    libgsl-dev \
+    liblapacke-dev \
+    libopenblas-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir eigenstrat && \
+    (cd eigenstrat && \
+     git clone https://github.com/DReichLab/EIG.git && \
+     cd EIG && \
+     cd src && \
+     LDLIBS="-llapacke" make && \
+     make install)
+RUN find \
+      eigenstrat/EIG/bin \
+      gcta/gcta_1.91.7beta \
+      king \
+      -type f -executable \
+    | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:18.04
+
+ENV LANG C.UTF-8
+ENV MAKEFLAGS -j2
+
+COPY wheel-container.tar .
+
+RUN apt-get update && \
+  apt-get -y install \
+    curl \
+    git \
+    liblapack3 \
+    openjdk-8-jre-headless \
+    python3 python3-pip \
+    rsync \
+    unzip bzip2 zip tar \
+    vim \
+  && rm -rf /var/lib/apt/lists/*
+RUN tar xvf wheel-container.tar && \
+    pip3 --no-cache-dir install \
+      hail-*-py3-none-any.whl \
+      ipython \
+      matplotlib \
+      numpy \
+      pandas \
+      scikit-learn \
+      scipy \
+    && rm -rf hail-*-py3-none-any.whl
+RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+         > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
+    mkdir -p $(find_spark_home.py)/conf && \
+    touch $(find_spark_home.py)/spark-defaults.conf && \
+    sed -i $(find_spark_home.py)/spark-defaults.conf \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
+        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN curl https://sdk.cloud.google.com | bash && \
+    echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
+    echo 'source /root/google-cloud-sdk/path.bash.inc' >> ~/.profile

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -28,7 +28,7 @@ RUN tar xvf wheel-container.tar && \
     && rm -rf hail-*-py3-none-any.whl
 RUN export SPARK_HOME=$(find_spark_home.py) && \
     curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         >$SPARK_HOME /jars/gcs-connector-hadoop2-2.0.1.jar && \
+         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.0.1.jar && \
     mkdir -p $SPARK_HOME/conf && \
     touch $SPARK_HOME/conf/spark-defaults.conf && \
     sed -i $SPARK_HOME/conf/spark-defaults.conf \

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -35,5 +35,7 @@ RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl https://sdk.cloud.google.com | bash && \
-    echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
-    echo 'source /root/google-cloud-sdk/path.bash.inc' >> ~/.profile
+    echo '. /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
+    echo '. /root/google-cloud-sdk/path.bash.inc' >> ~/.profile && \
+    echo '. /root/google-cloud-sdk/completion.bash.inc' >> ~/.bashrc && \
+    echo '. /root/google-cloud-sdk/path.bash.inc' >> ~/.bashrc

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -30,8 +30,8 @@ RUN export SPARK_HOME=$(find_spark_home.py) && \
     curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
          >$SPARK_HOME /jars/gcs-connector-hadoop2-2.0.1.jar && \
     mkdir -p $SPARK_HOME/conf && \
-    touch $SPARK_HOME/spark-defaults.conf && \
-    sed -i $SPARK_HOME/spark-defaults.conf \
+    touch $SPARK_HOME/conf/spark-defaults.conf && \
+    sed -i $SPARK_HOME/conf/spark-defaults.conf \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -35,7 +35,7 @@ RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl https://sdk.cloud.google.com | bash && \
-    echo '. /root/google-cloud-sdk/completion.bash.inc' >> ~/.profile && \
-    echo '. /root/google-cloud-sdk/path.bash.inc' >> ~/.profile && \
-    echo '. /root/google-cloud-sdk/completion.bash.inc' >> ~/.bashrc && \
-    echo '. /root/google-cloud-sdk/path.bash.inc' >> ~/.bashrc
+    find \
+      /root/google-cloud-sdk/bin/ \
+      -type f -executable \
+    | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)'

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -26,11 +26,12 @@ RUN tar xvf wheel-container.tar && \
       scikit-learn \
       scipy \
     && rm -rf hail-*-py3-none-any.whl
-RUN curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         > $(find_spark_home.py)/jars/gcs-connector-hadoop2-2.0.1.jar && \
-    mkdir -p $(find_spark_home.py)/conf && \
-    touch $(find_spark_home.py)/spark-defaults.conf && \
-    sed -i $(find_spark_home.py)/spark-defaults.conf \
+RUN export SPARK_HOME=$(find_spark_home.py) && \
+    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
+         >$SPARK_HOME /jars/gcs-connector-hadoop2-2.0.1.jar && \
+    mkdir -p $SPARK_HOME/conf && \
+    touch $SPARK_HOME/spark-defaults.conf && \
+    sed -i $SPARK_HOME/spark-defaults.conf \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
         -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux


### PR DESCRIPTION
This adds two new Dockerfiles. The first has gsutil and pip-wheel-installed
Hail. The second builds on the first adding a number of bioinformatics tools
that were included in the CCG Tutorial.

Deployment to dockerhub is not trivial because, unfortunately, I need to mount
the docker socket even to download and then upload an image (never starting a
container). I'll design and implement some extension to CI that lets me deploy
images to docker hub later. For now, I used dev deploy to build
these (https://ci.hail.is/batches/33294) and then manually pulled them and
uploaded them to PyPI as hailgenetics/hail:0.2.37 and
hailgenetics/genetics:0.2.37. I particularly appreciate criticism of the names.
