### PR TITLE
[query] Add StreamGrouped node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -85,6 +85,8 @@ object Children {
       Array(a, len)
     case StreamDrop(a, len) =>
       Array(a, len)
+    case StreamGrouped(a, size) =>
+      Array(a, size)
     case StreamMap(a, name, body) =>
       Array(a, body)
     case StreamZip(as, names, body, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -141,6 +141,9 @@ object Copy {
       case StreamDrop(_, _) =>
         assert(newChildren.length == 2)
         StreamDrop(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
+      case StreamGrouped(_, _) =>
+        assert(newChildren.length == 2)
+        StreamGrouped(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case StreamMap(_, name, _) =>
         assert(newChildren.length == 2)
         StreamMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -474,13 +474,24 @@ private class Emit[C](
 
         emitI(cond).consume(cb, {}, m => cb.ifx(m.tcode[Boolean], emitVoid(cnsq), emitVoid(altr)))
 
-      case Let(name, value, body) =>
-        val x = mb.newEmitField(name, value.pType)
-        val storeV = wrapToMethod(FastIndexedSeq(value)) { (_, _, ecV) =>
-          x := ecV
-        }
-        cb += storeV
-        emitVoid(body, env = env.bind(name, x))
+      case Let(name, value, body) => value.pType match {
+        case streamType: PCanonicalStream =>
+          val valuet = COption.toEmitCode(
+            emitStream(value)
+              .map(ss => PCanonicalStreamCode(streamType, ss.getStream)),
+            mb)
+          val bodyEnv = env.bind(name -> new EmitUnrealizableValue(streamType, valuet))
+
+          emitVoid(body, env = bodyEnv)
+
+        case valueType =>
+          val x = mb.newEmitField(name, valueType)
+          val storeV = wrapToMethod(FastIndexedSeq(value)) { (_, _, ecV) =>
+            x := ecV
+          }
+          cb += storeV
+          emitVoid(body, env = env.bind(name, x))
+      }
 
       case StreamFor(a, valueName, body) =>
         val eltType = a.pType.asInstanceOf[PStream].elementType
@@ -862,18 +873,27 @@ private class Emit[C](
 
         EmitCode(setup, mout, out.load())
 
-      case Let(name, value, body) =>
-        val x = mb.newEmitField(name, value.pType)
-        val storeV = wrapToMethod(FastIndexedSeq(value)) { (_, _, ecV) =>
-          x := ecV
-        }
-        val bodyenv = env.bind(name, x)
-        val codeBody = emit(body, env = bodyenv)
-        val setup = Code(
-          storeV,
-          codeBody.setup)
+      case Let(name, value, body) => value.pType match {
+        case streamType: PCanonicalStream =>
+          val valuet = COption.toEmitCode(
+            emitStream(value)
+              .map(ss => PCanonicalStreamCode(streamType, ss.getStream)),
+            mb)
+          val bodyEnv = env.bind(name -> new EmitUnrealizableValue(streamType, valuet))
 
-        EmitCode(setup, codeBody.m, codeBody.pv)
+          emit(body, env = bodyEnv)
+
+        case valueType =>
+          val x = mb.newEmitField(name, valueType)
+          val storeV = wrapToMethod(FastIndexedSeq(value)) { (_, _, ecV) =>
+            x := ecV
+          }
+          val bodyenv = env.bind(name, x)
+          val codeBody = emit(body, env = bodyenv)
+
+          EmitCode(storeV, codeBody)
+      }
+
       case Ref(name, _) =>
         val ev = env.lookup(name)
         if (ev.pt != pt)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -664,6 +664,15 @@ object EmitStream {
             coerce[PCanonicalStream](x.pType).defaultValue.stream,
             Some(0)))
 
+        case x@Ref(name, _) =>
+          val typ = coerce[PStream](x.pType)
+          val ev = env.lookup(name)
+          if (ev.pt != typ)
+            throw new RuntimeException(s"PValue type did not match inferred ptype:\n name: $name\n  pv: ${ ev.pt }\n  ir: $typ")
+          COption.fromEmitCode(ev.get).map { pc =>
+            SizedStream.unsized(pc.asStream.stream)
+          }
+
         case x@StreamRange(startIR, stopIR, stepIR) =>
           val eltType = coerce[PStream](x.pType).elementType
           val step = mb.genFieldThisRef[Int]("sr_step")
@@ -820,22 +829,55 @@ object EmitStream {
             }
           }
 
+        case x@StreamGrouped(a, size) =>
+          val innerType = coerce[PCanonicalStream](coerce[PStream](x.pType).elementType)
+          val optStream = emitStream(a, env)
+          val optSize = COption.fromEmitCode(emitIR(size))
+          val xS = mb.newLocal[Int]("st_n")
+          optStream.flatMap { case SizedStream(setup, stream, len) =>
+            optSize.map { s =>
+              val newStream = stream.grouped(xS).map(inner => EmitCode(Code._empty, false, PCanonicalStreamCode(innerType, inner)))
+              SizedStream(
+                Code(setup, xS := s.tcode[Int], (xS <= 0).orEmpty(Code._fatal[Unit](const("StreamGrouped: nonpositive size")))),
+                newStream,
+                len.map(l => ((l.toL + xS.toL - 1L) / xS.toL).toI)) // rounding up integer division
+            }
+          }
+
         case StreamMap(childIR, name, bodyIR) =>
-          val childEltType = coerce[PStream](childIR.pType).elementType
+          val eltType = coerce[PStream](childIR.pType).elementType
 
           val optStream = emitStream(childIR, env)
           optStream.map { case SizedStream(setup, stream, len) =>
-            val newStream = stream.map { eltt =>
-              val xElt = mb.newEmitField(name, childEltType)
-              val bodyenv = env.bind(name -> xElt)
-              val bodyt = emitIR(bodyIR, env = bodyenv)
+            val newStream = stream.map { eltt => (eltType, bodyIR.pType) match {
+              case (eltType: PCanonicalStream, bodyType: PCanonicalStream) =>
+                val bodyenv = env.bind(name -> new EmitUnrealizableValue(eltType, eltt))
 
-              EmitCode(
-                Code(xElt := eltt,
-                     bodyt.setup),
-                bodyt.m,
-                bodyt.pv)
-            }
+                COption.toEmitCode(
+                  emitStream(bodyIR, env = bodyenv)
+                    .map(ss => PCanonicalStreamCode(bodyType, ss.getStream)),
+                  mb)
+              case (eltType: PCanonicalStream, _) =>
+                val bodyenv = env.bind(name -> new EmitUnrealizableValue(eltType, eltt))
+
+                emitIR(bodyIR, env = bodyenv)
+              case (_, bodyType: PCanonicalStream) =>
+                val xElt = mb.newEmitField(name, eltType)
+                val bodyenv = env.bind(name -> xElt)
+
+                EmitCode(
+                  xElt := eltt,
+                  COption.toEmitCode(
+                    emitStream(bodyIR, env = bodyenv)
+                      .map(ss => PCanonicalStreamCode(bodyType, ss.getStream)),
+                    mb))
+              case _ =>
+                val xElt = mb.newEmitField(name, eltType)
+                val bodyenv = env.bind(name -> xElt)
+                val bodyt = emitIR(bodyIR, env = bodyenv)
+
+                EmitCode(xElt := eltt, bodyt)
+            }}
 
             SizedStream(setup, newStream, len)
           }
@@ -870,6 +912,7 @@ object EmitStream {
           }
 
         case StreamZip(as, names, bodyIR, behavior) =>
+          // FIXME: should make StreamZip support unrealizable element types
           val eltTypes = {
             val types = as.map(ir => coerce[PStream](ir.pType).elementType)
             behavior match {
@@ -1014,14 +1057,19 @@ object EmitStream {
           val optOuter = emitStream(outerIR, env)
 
           optOuter.map { outer =>
-            val nested = outer.getStream.mapCPS[COption[Stream[EmitCode]]] { (ctx, elt, k) =>
-              val xElt = mb.newEmitField(name, outerEltType)
-              val innerEnv = env.bind(name -> xElt)
-              val optInner = emitStream(innerIR, innerEnv).map(ss => ss.stream.addSetup(ss.setup))
+            val nested = outer.getStream.map[COption[Stream[EmitCode]]] { elt =>
+              if (outerEltType.isRealizable) {
+                val xElt = mb.newEmitField(name, outerEltType)
+                val innerEnv = env.bind(name -> xElt)
+                val optInner = emitStream(innerIR, innerEnv).map(_.getStream)
 
-              Code(
-                xElt := elt,
-                k(optInner))
+                optInner.addSetup(xElt := elt)
+              } else {
+                val innerEnv = env.bind(name -> new EmitUnrealizableValue(outerEltType, elt))
+
+                emitStream(innerIR, innerEnv).map(_.getStream)
+              }
+
             }
 
             SizedStream.unsized(nested.flatten.flatten)
@@ -1035,7 +1083,6 @@ object EmitStream {
           val optLeftStream = emitStream(thn, env)
           val optRightStream = emitStream(els, env)
 
-          // TODO: set xCond in setup of choose, don't need CPS
           condT.flatMap[SizedStream] { cond =>
             val newOptStream = COption.choose[SizedStream](
               xCond,
@@ -1059,12 +1106,19 @@ object EmitStream {
 
         case Let(name, valueIR, bodyIR) =>
           val valueType = valueIR.pType
-          val xValue = mb.newEmitField(name, valueType)
-
           val valuet = emitIR(valueIR)
-          val bodyEnv = env.bind(name -> xValue)
 
-          emitStream(bodyIR, bodyEnv).addSetup(xValue := valuet)
+          if (valueType.isRealizable) {
+            val xValue = mb.newEmitField(name, valueType)
+
+            val bodyEnv = env.bind(name -> xValue)
+
+            emitStream(bodyIR, bodyEnv).addSetup(xValue := valuet)
+          } else {
+            val bodyEnv = env.bind(name -> new EmitUnrealizableValue(valueType, valuet))
+
+            emitStream(bodyIR, bodyEnv)
+          }
 
         case x@StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
           val eltType = coerce[PStream](childIR.pType).elementType

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -201,6 +201,8 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 
 final case class GroupByKey(collection: IR) extends IR
 
+final case class StreamGrouped(a: IR, groupSize: IR) extends IR
+
 final case class StreamMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TStream = coerce[TStream](super.typ)
   def elementTyp: Type = typ.elementType

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -287,6 +287,12 @@ object InferPType {
         assert(len.pType isOfType PInt32())
         assert(a.pType.isInstanceOf[PStream])
         a.pType.orMissing(len.pType.required)
+      case StreamGrouped(a, size) =>
+        infer(a)
+        infer(size)
+        assert(size.pType isOfType PInt32())
+        assert(a.pType.isInstanceOf[PStream])
+        PCanonicalStream(a.pType.setRequired(true)).orMissing(a.pType.required && size.pType.required)
       case StreamMap(a, name, body) =>
         infer(a)
         infer(body, env.bind(name, a.pType.asInstanceOf[PStream].elementType))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -102,6 +102,8 @@ object InferType {
         a.typ
       case StreamDrop(a, _) =>
         a.typ
+      case StreamGrouped(a, _) =>
+        TStream(a.typ)
       case StreamMap(a, name, body) =>
         TStream(body.typ)
       case StreamZip(as, _, body, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -362,6 +362,16 @@ object Interpret {
           if (n < 0) fatal("StreamDrop: negative num")
           aValue.asInstanceOf[IndexedSeq[Any]].drop(n)
         }
+      case StreamGrouped(a, size) =>
+        val aValue = interpret(a, env, args)
+        val sizeValue = interpret(size, env, args)
+        if (aValue == null || sizeValue == null)
+          null
+        else {
+          val size = sizeValue.asInstanceOf[Int]
+          if (size <= 0) fatal("StreamGrouped: nonpositive size")
+          aValue.asInstanceOf[IndexedSeq[Any]].grouped(size).toFastIndexedSeq
+        }
       case StreamMap(a, name, body) =>
         val aValue = interpret(a, env, args)
         if (aValue == null)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -957,6 +957,10 @@ object PruneDeadFields {
           bodyEnv.deleteEval(name),
           memoizeValueIR(a, TStream(valueType), memo)
         )
+      case StreamGrouped(a, size) =>
+        unifyEnvs(
+          memoizeValueIR(a, requestedType.asInstanceOf[TStream].elementType, memo),
+          memoizeValueIR(size, size.typ, memo))
       case StreamZip(as, names, body, behavior) =>
         val bodyEnv = memoizeValueIR(body,
           requestedType.asInstanceOf[TStream].elementType,

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -265,6 +265,11 @@ object TypeCheck {
         assert(a.typ.isInstanceOf[TStream])
         assert(x.typ == a.typ)
         assert(num.typ == TInt32)
+      case x@StreamGrouped(a, size) =>
+        val ts = coerce[TStream](x.typ)
+        assert(a.typ.isInstanceOf[TStream])
+        assert(ts.elementType == a.typ)
+        assert(size.typ == TInt32)
       case x@StreamMap(a, name, body) =>
         assert(a.typ.isInstanceOf[TStream])
         assert(x.elementTyp == body.typ)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -832,6 +832,17 @@ class IRSuite extends HailSuite {
         "x", Ref("x", TInt32) + Ref("q", TInt32))),
         "y", Ref("y", TInt32) + I32(3))),
       FastIndexedSeq(5, 6, 7, 8, 9))
+
+    // test let binding streams
+    assertEvalsTo(Let("s", MakeStream(Seq(I32(0), I32(5)), TStream(TInt32)), ToArray(Ref("s", TStream(TInt32)))),
+                  FastIndexedSeq(0, 5))
+    assertEvalsTo(Let("s", NA(TStream(TInt32)), ToArray(Ref("s", TStream(TInt32)))),
+                  null)
+    assertEvalsTo(
+      ToArray(Let("s",
+                  MakeStream(Seq(I32(0), I32(5)), TStream(TInt32)),
+                  StreamTake(Ref("s", TStream(TInt32)), I32(1)))),
+      FastIndexedSeq(0))
   }
 
   @Test def testMakeArray() {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -584,6 +584,11 @@ class PruneSuite extends HailSuite {
       TStream(justB), Array(TStream(justB), null))
   }
 
+  @Test def testStreamGroupedMemo() {
+    checkMemo(StreamGrouped(st, I32(2)),
+              TStream(TStream(justB)), Array(TStream(justB), null))
+  }
+
   @Test def testStreamZipMemo() {
     val a2 = st.deepCopy()
     val a3 = st.deepCopy()
@@ -1086,6 +1091,14 @@ class PruneSuite extends HailSuite {
     checkRebuild(StreamMap(MakeStream(Seq(NA(ts)), TStream(ts)), "x", Ref("x", ts)), TStream(subsetTS("b")),
       (_: BaseIR, r: BaseIR) => {
         val ir = r.asInstanceOf[StreamMap]
+        ir.a.typ == TStream(subsetTS("b"))
+      })
+  }
+
+  @Test def testStreamGroupedRebuild() {
+    checkRebuild(StreamGrouped(MakeStream(Seq(NA(ts)), TStream(ts)), I32(2)), TStream(TStream(subsetTS("b"))),
+      (_: BaseIR, r: BaseIR) => {
+        val ir = r.asInstanceOf[StreamGrouped]
         ir.a.typ == TStream(subsetTS("b"))
       })
   }


### PR DESCRIPTION
~~Stacked on #8564~~

Adds a `StreamGrouped` node, which groups a stream into equal size substreams.

Finishes adding support for nested streams in `EmitStream`:
* the element types in `StreamMap` and `StreamFlatMap` may be streams
* for `StreamMap` the resulting element type may also be a stream (`StreamFlapMap` handles that case automatically)
* `Let` may bind streams, whether the body type is stream, value, or void.