### PR TITLE
[query] PNDArrayCode / NDArrayRef CodeBuilder

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -483,7 +483,7 @@ class VCode[+T](
 
   def check(): Unit = {
     /*
-    if (start == null) {
+    if (_start == null) {
       println(clearStack.mkString("\n"))
       println("-----")
       println(stack.mkString("\n"))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -202,6 +202,25 @@ object EmitCode {
     newEC
   }
 
+  def mapN(ecs: IndexedSeq[EmitCode], cb: EmitCodeBuilder)(f: IndexedSeq[PCode] => PCode): EmitCode = {
+    val emptySeq = IndexedSeq[PCode]()
+
+    def helper(i: Int, pcs: IndexedSeq[PCode]): EmitCode = {
+      if (i == ecs.length - 1) {
+        ecs(i).map { pc =>
+          f(pcs :+ pc)
+        }
+      }
+      else {
+        ecs(i).map { pc =>
+          helper(i + 1, pcs :+ pc)
+        }
+      }
+    }
+
+    helper(0, emptySeq)
+  }
+
   def codeTupleTypes(pt: PType): IndexedSeq[TypeInfo[_]] = {
     val ts = pt.codeTupleTypes()
     if (pt.required)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1348,9 +1348,8 @@ private class Emit[C](
 
               val ndValue = ndCode.memoize(cb, "reffed_ndarray")
               val idxValues = memoizedIndices.map(_.value.asInstanceOf[Value[Long]])
-
-              cb.append(ndPType.outOfBounds(idxValues, ndValue.a, mb)
-                .orEmpty(Code._fatal[Unit]("Index out of bounds")))
+              cb.append(ndValue.outOfBounds(idxValues, mb)
+                      .orEmpty(Code._fatal[Unit]("Index out of bounds")))
 
               PCode(ndPType.elementType, ndValue.apply(idxValues, mb))
             }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1338,6 +1338,12 @@ private class Emit[C](
             overallMissing := overallMissing || idxMissingness
           }))
 
+        val newValue = EmitCode.fromI(mb) { cb =>
+          ndt.toI(cb).flatMap(cb) { case ndCode: PNDArrayCode =>
+            IEmitCode(cb, false, ndCode)
+          }
+        }
+
         val value = Code(
           ndAddress := ndt.value[Long],
           idxFieldsBinding,

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -229,7 +229,14 @@ object PCanonicalNDArraySettable {
 }
 
 class PCanonicalNDArraySettable(val pt: PCanonicalNDArray, val a: Settable[Long]) extends PNDArrayValue with PSettable {
-  override def get: PCode = ???
+  //FIXME: Rewrite apply to not require a methodBuilder, meaning also rewrite loadElementToIRIntermediate
+  def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_] = {
+    new Value[Any] {
+      override def get: Code[Any] = pt.loadElementToIRIntermediate(indices, a, mb)
+    }
+  }
+
+  override def get: PCode = new PCanonicalNDArrayCode(pt, a)
 
   override def store(pv: PCode): Code[Unit] = a := pv.asInstanceOf[PCanonicalNDArrayCode].a
 }
@@ -246,7 +253,6 @@ class PCanonicalNDArrayCode(val pt: PCanonicalNDArray, val a: Code[Long]) extend
     val s = PCanonicalNDArraySettable(cb, pt, name, sb)
     cb.assign(s, this)
     s
-    ???
   }
 
   override def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue = memoize(cb, name, cb.localBuilder)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -237,6 +237,8 @@ class PCanonicalNDArraySettable(val pt: PCanonicalNDArray, val a: Settable[Long]
     }
   }
 
+  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
+
   override def get: PCode = new PCanonicalNDArrayCode(pt, a)
 
   override def store(pv: PCode): Code[Unit] = a := pv.asInstanceOf[PCanonicalNDArrayCode].a

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -240,6 +240,8 @@ class PCanonicalNDArraySettable(val pt: PCanonicalNDArray, val a: Settable[Long]
   override def get: PCode = new PCanonicalNDArrayCode(pt, a)
 
   override def store(pv: PCode): Code[Unit] = a := pv.asInstanceOf[PCanonicalNDArrayCode].a
+
+  override def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[Boolean] = ???
 }
 
 class PCanonicalNDArrayCode(val pt: PCanonicalNDArray, val a: Code[Long]) extends PNDArrayCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -127,7 +127,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     Region.loadIRIntermediate(data.pType.elementType)(getElementAddress(indices, ndAddress, mb))
   }
 
-  def outOfBounds(indices: IndexedSeq[Code[Long]], nd: Value[Long], mb: EmitMethodBuilder[_]): Code[Boolean] = {
+  def outOfBounds(indices: IndexedSeq[Value[Long]], nd: Value[Long], mb: EmitMethodBuilder[_]): Code[Boolean] = {
     val shapeTuple = new CodePTuple(shape.pType, new Value[Long] {
       def get: Code[Long] = shape.load(nd)
     })

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder, UnsafeOrdering}
 import is.hail.asm4s.{Code, MethodBuilder, _}
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.{TNDArray, Type}
 import is.hail.utils.FastIndexedSeq
 
@@ -220,4 +220,17 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def constructAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
     throw new NotImplementedError("constructAtAddress should only be called on fundamental types; PCanonicalNDarray is not fundamental")
+}
+
+class PCanonicalNDArrayCode(val pt: PCanonicalNDArray, val a: Code[Long]) extends PNDArrayCode {
+
+  def code: Code[_] = a
+
+  def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
+
+  override def store(mb: EmitMethodBuilder[_], r: Value[Region], dst: Code[Long]): Code[Unit] = ???
+
+  override def memoize(cb: EmitCodeBuilder, name: String): PValue = ???
+
+  override def memoizeField(cb: EmitCodeBuilder, name: String): PValue = ???
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -241,7 +241,9 @@ class PCanonicalNDArraySettable(val pt: PCanonicalNDArray, val a: Settable[Long]
 
   override def store(pv: PCode): Code[Unit] = a := pv.asInstanceOf[PCanonicalNDArrayCode].a
 
-  override def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[Boolean] = ???
+  override def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Boolean] = {
+    pt.outOfBounds(indices, a, mb)
+  }
 }
 
 class PCanonicalNDArrayCode(val pt: PCanonicalNDArray, val a: Code[Long]) extends PNDArrayCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalNDArray.scala
@@ -231,6 +231,7 @@ object PCanonicalNDArraySettable {
 class PCanonicalNDArraySettable(val pt: PCanonicalNDArray, val a: Settable[Long]) extends PNDArrayValue with PSettable {
   //FIXME: Rewrite apply to not require a methodBuilder, meaning also rewrite loadElementToIRIntermediate
   def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_] = {
+    assert(indices.size == pt.nDims)
     new Value[Any] {
       override def get: Code[Any] = pt.loadElementToIRIntermediate(indices, a, mb)
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -109,7 +109,8 @@ object PCode {
       new PCanonicalLocusCode(pt, coerce[Long](code))
     case pt: PCanonicalCall =>
       new PCanonicalCallCode(pt, coerce[Int](code))
-
+    case pt: PCanonicalNDArray =>
+      new PCanonicalNDArrayCode(pt, coerce[Long](code))
     case _ =>
       new PPrimitiveCode(pt, code)
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -6,10 +6,16 @@ import is.hail.expr.ir._
 import is.hail.utils._
 import is.hail.variant.Genotype
 
-trait PValue {
+trait PValue { pValueSelf =>
   def pt: PType
 
   def get: PCode
+
+  def value: Value[_] = {
+    new Value[Any] {
+      override def get: Code[Any] = pValueSelf.get.code
+    }
+  }
 }
 
 trait PSettable extends PValue {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -53,6 +53,8 @@ abstract class PNDArrayValue extends PValue {
   val a: Value[Long]
 
   def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_]
+
+  def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[Boolean]
 }
 
 abstract class PNDArrayCode extends PCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -48,3 +48,7 @@ abstract class PNDArray extends PType {
 
   def construct(shapeBuilder: StagedRegionValueBuilder => Code[Unit], stridesBuilder: StagedRegionValueBuilder => Code[Unit], data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long]
 }
+
+abstract class PNDArrayCode extends PCode {
+
+}

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -40,7 +40,7 @@ abstract class PNDArray extends PType {
 
   def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], mb: EmitMethodBuilder[_]): Code[_]
 
-  def outOfBounds(indices: IndexedSeq[Code[Long]], nd: Value[Long], mb: EmitMethodBuilder[_]): Code[Boolean]
+  def outOfBounds(indices: IndexedSeq[Value[Long]], nd: Value[Long], mb: EmitMethodBuilder[_]): Code[Boolean]
 
   def linearizeIndicesRowMajor(indices: IndexedSeq[Code[Long]], shapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Long]
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -49,6 +49,10 @@ abstract class PNDArray extends PType {
   def construct(shapeBuilder: StagedRegionValueBuilder => Code[Unit], stridesBuilder: StagedRegionValueBuilder => Code[Unit], data: Code[Long], mb: EmitMethodBuilder[_]): Code[Long]
 }
 
+abstract class PNDArrayValue extends PValue {
+
+}
+
 abstract class PNDArrayCode extends PCode {
 
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -3,7 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.Nat
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.TNDArray
 
 final class StaticallyKnownField[T, U](
@@ -50,9 +50,11 @@ abstract class PNDArray extends PType {
 }
 
 abstract class PNDArrayValue extends PValue {
+  val a: Value[Long]
 
+  def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_]
 }
 
 abstract class PNDArrayCode extends PCode {
-
+  def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -50,11 +50,9 @@ abstract class PNDArray extends PType {
 }
 
 abstract class PNDArrayValue extends PValue {
-  val a: Value[Long]
-
   def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_]
 
-  def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[Boolean]
+  def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Boolean]
 }
 
 abstract class PNDArrayCode extends PCode {


### PR DESCRIPTION
Simplified `NDArrayRef` considerably by switching to `CodeBuilder` interface, adding `EmitCode.mapN`, and adding `PNDArrayCode`. 

Thanks @patrick-schultz for contributing code for `EmitCode.mapN`. 