### PR TITLE
[query] add checks to CodeBuilder

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
-import is.hail.asm4s.{Code, CodeBuilderLike, MethodBuilder, TypeInfo, Value}
-import is.hail.expr.types.physical.{PCode, PValue, PSettable}
+import is.hail.asm4s.{Code, CodeBuilderLike, MethodBuilder}
+import is.hail.expr.types.physical.{PCode, PSettable, PValue}
 
 object EmitCodeBuilder {
   def apply(mb: EmitMethodBuilder[_]): EmitCodeBuilder = new EmitCodeBuilder(mb, Code._empty)
@@ -26,9 +26,14 @@ object EmitCodeBuilder {
 }
 
 class EmitCodeBuilder(emb: EmitMethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
+  def isOpenEnded: Boolean = {
+    val last = code.end.last
+    (last == null) || !last.isInstanceOf[is.hail.lir.ControlX]
+  }
+
   def mb: MethodBuilder[_] = emb.mb
 
-  def append(c: Code[Unit]): Unit = {
+  def uncheckedAppend(c: Code[Unit]): Unit = {
     code = Code(code, c)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -20,9 +20,9 @@ object GenotypeFunctions extends RegistryFunctions {
 
         cb.whileLoop(i < pl.loadLength(), {
           val iec = pl.loadElement(cb, i)
-          cb += iec.Lmissing
+          cb.define(iec.Lmissing)
           cb += Code._fatal[Unit]("PL cannot have missing elements.")
-          cb += iec.Lpresent
+          cb.define(iec.Lpresent)
           val pli = cb.newLocal[Int]("pli", iec.pc.tcode[Int])
           cb.ifx(pli < m, {
             cb.assign(m2, m)


### PR DESCRIPTION
@johnc1231 I realized there's a really easy way to catch the kinds of dead-code-after-a-goto bugs we were running into, so I went ahead and did it.

The basic idea is: most operations on a CodeBuilder (which ultimately call `append`) assert that the current `code` doesn't end in a `ControlX`, such as a jump. `CodeBuilder.define` is the escape hatch, which works whether `code` ends in a jump, or doesn't, in which case the previous code falls through to the new label.