### PR TITLE
[query] Refactor function registry to not use overloading

### DIFF
--- a/hail/src/main/scala/is/hail/experimental/ExperimentalFunctions.scala
+++ b/hail/src/main/scala/is/hail/experimental/ExperimentalFunctions.scala
@@ -10,6 +10,6 @@ object ExperimentalFunctions extends RegistryFunctions {
     val experimentalPackageClass = Class.forName("is.hail.experimental.package$")
 
     registerScalaFunction("filtering_allele_frequency", Array(TInt32, TInt32, TFloat64), TFloat64, (_: Type, pt: Seq[PType]) => PFloat64())(experimentalPackageClass, "calcFilterAlleleFreq")
-    registerWrappedScalaFunction("haplotype_freq_em", TArray(TInt32), TArray(TFloat64), (_: Type, pt: PType) => PCanonicalArray(PFloat64(true)))(experimentalPackageClass, "haplotypeFreqEM")
+    registerWrappedScalaFunction1("haplotype_freq_em", TArray(TInt32), TArray(TFloat64), (_: Type, pt: PType) => PCanonicalArray(PFloat64(true)))(experimentalPackageClass, "haplotypeFreqEM")
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -88,28 +88,28 @@ object ArrayFunctions extends RegistryFunctions {
   }
 
   def registerAll() {
-    registerIR("isEmpty", TArray(tv("T")), TBoolean)((_, a) => isEmpty(a))
+    registerIR1("isEmpty", TArray(tv("T")), TBoolean)((_, a) => isEmpty(a))
 
-    registerIR("extend", TArray(tv("T")), TArray(tv("T")), TArray(tv("T")))((_, a, b) => extend(a, b))
+    registerIR2("extend", TArray(tv("T")), TArray(tv("T")), TArray(tv("T")))((_, a, b) => extend(a, b))
 
-    registerIR("append", TArray(tv("T")), tv("T"), TArray(tv("T"))) { (_, a, c) =>
+    registerIR2("append", TArray(tv("T")), tv("T"), TArray(tv("T"))) { (_, a, c) =>
       extend(a, MakeArray(Seq(c), TArray(c.typ)))
     }
 
-    registerIR("contains", TArray(tv("T")), tv("T"), TBoolean) { (_, a, e) => contains(a, e) }
+    registerIR2("contains", TArray(tv("T")), tv("T"), TBoolean) { (_, a, e) => contains(a, e) }
 
     for ((stringOp, argType, retType, irOp) <- arrayOps) {
-      registerIR(stringOp, TArray(argType), argType, TArray(retType)) { (_, a, c) =>
+      registerIR2(stringOp, TArray(argType), argType, TArray(retType)) { (_, a, c) =>
         val i = genUID()
         ToArray(StreamMap(ToStream(a), i, irOp(Ref(i, c.typ), c)))
       }
 
-      registerIR(stringOp, argType, TArray(argType), TArray(retType)) { (_, c, a) =>
+      registerIR2(stringOp, argType, TArray(argType), TArray(retType)) { (_, c, a) =>
         val i = genUID()
         ToArray(StreamMap(ToStream(a), i, irOp(c, Ref(i, c.typ))))
       }
 
-      registerIR(stringOp, TArray(argType), TArray(argType), TArray(retType)) { (_, array1, array2) =>
+      registerIR2(stringOp, TArray(argType), TArray(argType), TArray(retType)) { (_, array1, array2) =>
         val a1id = genUID()
         val e1 = Ref(a1id, coerce[TArray](array1.typ).elementType)
         val a2id = genUID()
@@ -118,9 +118,9 @@ object ArrayFunctions extends RegistryFunctions {
       }
     }
 
-    registerIR("sum", TArray(tnum("T")), tv("T"))((_, a) => sum(a))
+    registerIR1("sum", TArray(tnum("T")), tv("T"))((_, a) => sum(a))
 
-    registerIR("product", TArray(tnum("T")), tv("T"))((_, a) => product(a))
+    registerIR1("product", TArray(tnum("T")), tv("T"))((_, a) => product(a))
 
     def makeMinMaxOp(op: String): Seq[IR] => IR = {
       { case Seq(a) =>
@@ -146,7 +146,7 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerIR("mean", Array(TArray(tnum("T"))), TFloat64, inline = true)((_, a) => mean(a))
 
-    registerIR("median", TArray(tnum("T")), tv("T")) { (_, array) =>
+    registerIR1("median", TArray(tnum("T")), tv("T")) { (_, array) =>
       val t = array.typ.asInstanceOf[TArray].elementType
       val v = Ref(genUID(), t)
       val a = Ref(genUID(), TArray(t))
@@ -198,9 +198,9 @@ object ArrayFunctions extends RegistryFunctions {
       ), "midx")
     }
 
-    registerIR("argmin", TArray(tv("T")), TInt32)((_, a) => argF(a, LT(_)))
+    registerIR1("argmin", TArray(tv("T")), TInt32)((_, a) => argF(a, LT(_)))
 
-    registerIR("argmax", TArray(tv("T")), TInt32)((_, a) => argF(a, GT(_)))
+    registerIR1("argmax", TArray(tv("T")), TInt32)((_, a) => argF(a, GT(_)))
 
     def uniqueIndex(a: IR, op: (Type) => ComparisonOp[Boolean]): IR = {
       val t = coerce[TArray](a.typ).elementType
@@ -241,11 +241,11 @@ object ArrayFunctions extends RegistryFunctions {
         NA(TInt32)))
     }
 
-    registerIR("uniqueMinIndex", TArray(tv("T")), TInt32)((_, a) => uniqueIndex(a, LT(_)))
+    registerIR1("uniqueMinIndex", TArray(tv("T")), TInt32)((_, a) => uniqueIndex(a, LT(_)))
 
-    registerIR("uniqueMaxIndex", TArray(tv("T")), TInt32)((_, a) => uniqueIndex(a, GT(_)))
+    registerIR1("uniqueMaxIndex", TArray(tv("T")), TInt32)((_, a) => uniqueIndex(a, GT(_)))
 
-    registerIR("indexArray", TArray(tv("T")), TInt32, TString, tv("T")) { (_, a, i, s) =>
+    registerIR3("indexArray", TArray(tv("T")), TInt32, TString, tv("T")) { (_, a, i, s) =>
       ArrayRef(
         a,
         If(ApplyComparisonOp(LT(TInt32), i, I32(0)),
@@ -253,7 +253,7 @@ object ArrayFunctions extends RegistryFunctions {
           i), s)
     }
 
-    registerIR("sliceRight", TArray(tv("T")), TInt32, TArray(tv("T"))) { (_, a, i) =>
+    registerIR2("sliceRight", TArray(tv("T")), TInt32, TArray(tv("T"))) { (_, a, i) =>
       val idx = genUID()
       ToArray(StreamMap(
         StreamRange(
@@ -268,7 +268,7 @@ object ArrayFunctions extends RegistryFunctions {
         ArrayRef(a, Ref(idx, TInt32))))
     }
 
-    registerIR("sliceLeft", TArray(tv("T")), TInt32, TArray(tv("T"))) { (_, a, i) =>
+    registerIR2("sliceLeft", TArray(tv("T")), TInt32, TArray(tv("T"))) { (_, a, i) =>
       val idx = genUID()
       If(IsNA(a), a,
         ToArray(StreamMap(
@@ -282,7 +282,7 @@ object ArrayFunctions extends RegistryFunctions {
           ArrayRef(a, Ref(idx, TInt32)))))
     }
 
-    registerIR("slice", TArray(tv("T")), TInt32, TInt32, TArray(tv("T"))) { case(_, a, i, j) =>
+    registerIR3("slice", TArray(tv("T")), TInt32, TInt32, TArray(tv("T"))) { case(_, a, i, j) =>
       val idx = genUID()
       ToArray(StreamMap(
         StreamRange(
@@ -299,12 +299,12 @@ object ArrayFunctions extends RegistryFunctions {
         ArrayRef(a, Ref(idx, TInt32))))
     }
 
-    registerIR("flatten", TArray(TArray(tv("T"))), TArray(tv("T"))) { (_, a) =>
+    registerIR1("flatten", TArray(TArray(tv("T"))), TArray(tv("T"))) { (_, a) =>
       val elt = Ref(genUID(), coerce[TArray](a.typ).elementType)
       ToArray(StreamFlatMap(ToStream(a), elt.name, ToStream(elt)))
     }
 
-    registerEmitCode("corr", TArray(TFloat64), TArray(TFloat64), TFloat64, {
+    registerEmitCode2("corr", TArray(TFloat64), TArray(TFloat64), TFloat64, {
       (_: Type, _: PType, _: PType) => PFloat64()
     }) { case (r, rt, EmitCode(setup1, m1, v1), EmitCode(setup2, m2, v2)) =>
         val t1 = v1.pt.asInstanceOf[PArray]

--- a/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -9,7 +9,7 @@ import is.hail.variant._
 
 object CallFunctions extends RegistryFunctions {
   def registerAll() {
-    registerWrappedScalaFunction("Call", TString, TCall, (rt: Type, _: PType) => PCanonicalCall())(Call.getClass, "parse")
+    registerWrappedScalaFunction1("Call", TString, TCall, (rt: Type, _: PType) => PCanonicalCall())(Call.getClass, "parse")
 
     registerScalaFunction("Call", Array(TBoolean), TCall, (rt: Type, _: Seq[PType]) => PCanonicalCall())(Call0.getClass, "apply")
 
@@ -19,7 +19,7 @@ object CallFunctions extends RegistryFunctions {
 
     registerScalaFunction("UnphasedDiploidGtIndexCall", Array(TInt32), TCall, (rt: Type, _: Seq[PType]) => PCanonicalCall())(Call2.getClass, "fromUnphasedDiploidGtIndex")
 
-    registerWrappedScalaFunction("Call", TArray(TInt32), TBoolean, TCall, {
+    registerWrappedScalaFunction2("Call", TArray(TInt32), TBoolean, TCall, {
       case(rt: Type, _: PType, _: PType) => PCanonicalCall()
     })(CallN.getClass, "apply")
 
@@ -37,7 +37,7 @@ object CallFunctions extends RegistryFunctions {
 
     registerScalaFunction("downcode", Array(TCall, TInt32), TCall, (rt: Type, _: Seq[PType]) => PCanonicalCall())(Call.getClass, "downcode")
 
-    registerWrappedScalaFunction("oneHotAlleles", TCall, TInt32, TArray(TInt32), {
+    registerWrappedScalaFunction2("oneHotAlleles", TCall, TInt32, TArray(TInt32), {
       case(rt: Type, _: PType, _: PType) => PCanonicalArray(PInt32(true))
     })(Call.getClass, "oneHotAlleles")
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -38,18 +38,18 @@ object DictFunctions extends RegistryFunctions {
   val tdict = TDict(tv("key"), tv("value"))
 
   def registerAll() {
-    registerIR("isEmpty", tdict, TBoolean) { (_, d) =>
+    registerIR1("isEmpty", tdict, TBoolean) { (_, d) =>
       ArrayFunctions.isEmpty(CastToArray(d))
     }
 
-    registerIR("contains", tdict, tv("key"), TBoolean)((_, a, b) => contains(a, b))
+    registerIR2("contains", tdict, tv("key"), TBoolean)((_, a, b) => contains(a, b))
 
-    registerIR("get", tdict, tv("key"), tv("value"), tv("value"))((_, a, b, c) => get(a, b, c))
-    registerIR("get", tdict, tv("key"), tv("tvalue")) { (_, d, k) =>
+    registerIR3("get", tdict, tv("key"), tv("value"), tv("value"))((_, a, b, c) => get(a, b, c))
+    registerIR2("get", tdict, tv("key"), tv("tvalue")) { (_, d, k) =>
       get(d, k, NA(types.coerce[TDict](d.typ).valueType))
     }
 
-    registerIR("index", tdict, tv("key"), tv("value")) { (_, d, k) =>
+    registerIR2("index", tdict, tv("key"), tv("value")) { (_, d, k) =>
       val vtype = types.coerce[TBaseStruct](types.coerce[TContainer](d.typ).elementType).types(1)
       val errormsg = invoke("concat", TString,
         Str("Key '"),
@@ -61,7 +61,7 @@ object DictFunctions extends RegistryFunctions {
       get(d, k, Die(errormsg, vtype))
     }
 
-    registerIR("dictToArray", tdict, TArray(TStruct("key" -> tv("key"), "value" -> tv("value")))) { (_, d) =>
+    registerIR1("dictToArray", tdict, TArray(TStruct("key" -> tv("key"), "value" -> tv("value")))) { (_, d) =>
       val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(
         ToStream(d),
@@ -69,21 +69,21 @@ object DictFunctions extends RegistryFunctions {
         MakeTuple.ordered(Seq(GetField(elt, "key"), GetField(elt, "value")))))
     }
 
-    registerIR("keySet", tdict, TSet(tv("key"))) { (_, d) =>
+    registerIR1("keySet", tdict, TSet(tv("key"))) { (_, d) =>
       val pairs = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
       ToSet(StreamMap(ToStream(d), pairs.name, GetField(pairs, "key")))
     }
 
-    registerIR("dict", TSet(TTuple(tv("key"), tv("value"))), tdict)((_, s) => ToDict(ToStream(s)))
+    registerIR1("dict", TSet(TTuple(tv("key"), tv("value"))), tdict)((_, s) => ToDict(ToStream(s)))
 
-    registerIR("dict", TArray(TTuple(tv("key"), tv("value"))), tdict)((_, a) => ToDict(ToStream(a)))
+    registerIR1("dict", TArray(TTuple(tv("key"), tv("value"))), tdict)((_, a) => ToDict(ToStream(a)))
 
-    registerIR("keys", tdict, TArray(tv("key"))) { (_, d) =>
+    registerIR1("keys", tdict, TArray(tv("key"))) { (_, d) =>
       val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(ToStream(d), elt.name, GetField(elt, "key")))
     }
 
-    registerIR("values", tdict, TArray(tv("value"))) { (_, d) =>
+    registerIR1("values", tdict, TArray(tv("value"))) { (_, d) =>
       val elt = Ref(genUID(), types.coerce[TContainer](d.typ).elementType)
       ToArray(StreamMap(ToStream(d), elt.name, GetField(elt, "value")))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -18,7 +18,7 @@ object IRFunctionRegistry {
   private val userAddedFunctions: mutable.Set[(String, (Type, Seq[Type], Seq[Type]))] = mutable.HashSet.empty
 
   def clearUserFunctions() {
-    userAddedFunctions.foreach { case (name, (rt, typeArgs, argTypes)) => removeIRFunction(name, rt, typeArgs, argTypes) }
+    userAddedFunctions.foreach { case (name, (rt, typeParams, argTypes)) => removeIRFunction(name, rt, typeParams, argTypes) }
     userAddedFunctions.clear()
   }
 
@@ -33,16 +33,16 @@ object IRFunctionRegistry {
     codeRegistry.addBinding(f.name, f)
   }
 
-  def addIR(name: String, typeArgs: Seq[Type], argTypes: Seq[Type], retType: Type, alwaysInline: Boolean, f: (Seq[Type], Seq[IR]) => IR): Unit = {
+  def addIR(name: String, typeParams: Seq[Type], argTypes: Seq[Type], retType: Type, alwaysInline: Boolean, f: (Seq[Type], Seq[IR]) => IR): Unit = {
     if (!isJavaIdentifier(name))
       throw new IllegalArgumentException(s"Illegal function name, not Java identifier: $name")
 
     val m = irRegistry.getOrElseUpdate(name, new mutable.HashMap())
-    m.update((typeArgs, argTypes, retType, alwaysInline), f)
+    m.update((typeParams, argTypes, retType, alwaysInline), f)
   }
 
   def pyRegisterIR(mname: String,
-    typeArgStrs: java.util.ArrayList[String],
+    typeParamStrs: java.util.ArrayList[String],
     argNames: java.util.ArrayList[String],
     argTypeStrs: java.util.ArrayList[String],
     retType: String,
@@ -50,37 +50,37 @@ object IRFunctionRegistry {
     if (!isJavaIdentifier(mname))
       throw new IllegalArgumentException(s"Illegal function name, not Java identifier: $mname")
 
-    val typeArgs = typeArgStrs.asScala.map(IRParser.parseType).toFastIndexedSeq
+    val typeParams = typeParamStrs.asScala.map(IRParser.parseType).toFastIndexedSeq
     val argTypes = argTypeStrs.asScala.map(IRParser.parseType).toFastIndexedSeq
-    userAddedFunctions += ((mname, (body.typ, typeArgs, argTypes)))
+    userAddedFunctions += ((mname, (body.typ, typeParams, argTypes)))
     addIR(mname,
-      typeArgs,
+      typeParams,
       argTypes, IRParser.parseType(retType), false, { (_, args) =>
         Subst(body,
           BindingEnv(Env[IR](argNames.asScala.zip(args): _*)))
       })
   }
 
-  def removeIRFunction(name: String, rt: Type, typeArgs: Seq[Type], argTypes: Seq[Type]): Unit = {
+  def removeIRFunction(name: String, rt: Type, typeParams: Seq[Type], argTypes: Seq[Type]): Unit = {
     val functions = codeRegistry(name)
-    val toRemove = functions.filter(_.unify(typeArgs, argTypes, rt)).toArray
+    val toRemove = functions.filter(_.unify(typeParams, argTypes, rt)).toArray
     assert(toRemove.length == 1)
     codeRegistry.removeBinding(name, toRemove.head)
   }
 
-  def lookupFunction(name: String, rt: Type, typeArgs: Seq[Type], argTypes: Seq[Type]): Option[IRFunction] = {
-    codeRegistry.lift(name).map { fs => fs.filter(t => t.unify(typeArgs, argTypes, rt)).toSeq }.getOrElse(FastSeq()) match {
+  def lookupFunction(name: String, rt: Type, typeParams: Seq[Type], argTypes: Seq[Type]): Option[IRFunction] = {
+    codeRegistry.lift(name).map { fs => fs.filter(t => t.unify(typeParams, argTypes, rt)).toSeq }.getOrElse(FastSeq()) match {
       case Seq() => None
       case Seq(f) => Some(f)
       case _ => fatal(s"Multiple functions found that satisfy $name(${ argTypes.mkString(",") }).")
     }
   }
 
-  def lookupIR(name: String, rt: Type, typeArgs: Seq[Type], argTypes: Seq[Type]): Option[((Seq[Type], Seq[Type], Type, Boolean), (Seq[Type], Seq[IR]) => IR)] = {
-    irRegistry.getOrElse(name, Map.empty).filter { case ((typeArgsFound: Seq[Type], argTypesFound: Seq[Type], _, _), _) =>
-      typeArgsFound.length == typeArgs.length && {
-        typeArgsFound.foreach(_.clear())
-        (typeArgsFound, typeArgs).zipped.forall(_.unify(_))
+  def lookupIR(name: String, rt: Type, typeParams: Seq[Type], argTypes: Seq[Type]): Option[((Seq[Type], Seq[Type], Type, Boolean), (Seq[Type], Seq[IR]) => IR)] = {
+    irRegistry.getOrElse(name, Map.empty).filter { case ((typeParamsFound: Seq[Type], argTypesFound: Seq[Type], _, _), _) =>
+      typeParamsFound.length == typeParams.length && {
+        typeParamsFound.foreach(_.clear())
+        (typeParamsFound, typeParams).zipped.forall(_.unify(_))
       } && argTypesFound.length == argTypes.length && {
         argTypesFound.foreach(_.clear())
         (argTypesFound, argTypes).zipped.forall(_.unify(_))
@@ -95,21 +95,21 @@ object IRFunctionRegistry {
   def lookupConversion(name: String, rt: Type, args: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] =
     lookupConversion(name, rt, Array.empty[Type], args)
 
-  def lookupConversion(name: String, rt: Type, typeArgs: Seq[Type], args: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] = {
-    val validIR: Option[(Seq[Type], Seq[IR]) => IR] = lookupIR(name, rt, typeArgs, args).map {
-      case ((_, _, _, inline), conversion) => (typeArgsPassed, args) =>
-        val x = ApplyIR(name, typeArgsPassed, args)
+  def lookupConversion(name: String, rt: Type, typeParams: Seq[Type], args: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] = {
+    val validIR: Option[(Seq[Type], Seq[IR]) => IR] = lookupIR(name, rt, typeParams, args).map {
+      case ((_, _, _, inline), conversion) => (typeParamsPassed, args) =>
+        val x = ApplyIR(name, typeParamsPassed, args)
         x.conversion = conversion
         x.inline = inline
         x
     }
 
-    val validMethods = lookupFunction(name, rt, typeArgs, args).map { f => { (irTypeArgs: Seq[Type], irArgs: Seq[IR]) =>
+    val validMethods = lookupFunction(name, rt, typeParams, args).map { f => { (irtypeParams: Seq[Type], irArgs: Seq[IR]) =>
       f match {
         case _: SeededIRFunction =>
           ApplySeeded(name, irArgs.init, irArgs.last.asInstanceOf[I64].x, f.returnType.subst())
-        case _: IRFunctionWithoutMissingness => Apply(name, irTypeArgs, irArgs, f.returnType.subst())
-        case _: IRFunctionWithMissingness => ApplySpecial(name, irTypeArgs, irArgs, f.returnType.subst())
+        case _: IRFunctionWithoutMissingness => Apply(name, irtypeParams, irArgs, f.returnType.subst())
+        case _: IRFunctionWithMissingness => ApplySpecial(name, irtypeParams, irArgs, f.returnType.subst())
       }
     } }
 
@@ -143,8 +143,8 @@ object IRFunctionRegistry {
     def dtype(t: Type): String = s"""dtype("${ StringEscapeUtils.escapeString(t.toString) }\")"""
 
     irRegistry.foreach { case (name, fns) =>
-        fns.foreach { case ((typeArgs, argTypes, retType, _), f) =>
-          println(s"""register_function("${ StringEscapeUtils.escapeString(name) }", (${ typeArgs.map(dtype).mkString(",") }), (${ argTypes.map(dtype).mkString(",") }), ${ dtype(retType) })""")
+        fns.foreach { case ((typeParams, argTypes, retType, _), f) =>
+          println(s"""register_function("${ StringEscapeUtils.escapeString(name) }", (${ typeParams.map(dtype).mkString(",") }), (${ argTypes.map(dtype).mkString(",") }), ${ dtype(retType) })""")
         }
     }
 
@@ -155,7 +155,7 @@ object IRFunctionRegistry {
               "register_seeded_function"
             else
               "register_function"
-          }("${ StringEscapeUtils.escapeString(name) }", (${ f.typeArgs.map(dtype).mkString(",") }), (${ f.argTypes.map(dtype).mkString(",") }), ${ dtype(f.returnType) })""")
+          }("${ StringEscapeUtils.escapeString(name) }", (${ f.typeParams.map(dtype).mkString(",") }), (${ f.argTypes.map(dtype).mkString(",") }), ${ dtype(f.returnType) })""")
         }
     }
   }
@@ -281,12 +281,13 @@ abstract class RegistryFunctions {
 
   def registerPCode(mname: String, aTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType, typeParams: Array[Type] = Array.empty)
     (impl: (EmitRegion, PType, Array[PCode]) => PCode) {
+    val _typeParams = typeParams
     IRFunctionRegistry.addIRFunction(new IRFunctionWithoutMissingness {
       override val name: String = mname
 
       override val argTypes: Seq[Type] = aTypes
 
-      override val typeArgs: Seq[Type] = typeParams
+      override val typeParams: Seq[Type] = _typeParams
 
       override val returnType: Type = rType
 
@@ -297,21 +298,22 @@ abstract class RegistryFunctions {
         p.setRequired(argTypes.forall(_.required))
       }
 
-      override def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: PCode*): PCode = impl(r, returnPType, args.toArray)
+      override def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: PCode*): PCode = impl(r, returnPType, args.toArray)
 
-      override def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: (PType, Code[_])*): Code[_] = {
-        assert(unify(typeArgs, args.map(_._1.virtualType), returnPType.virtualType))
-        apply(r, returnPType, typeArgs, args.map { case (t, a) => PCode(t, a) }: _*).code
+      override def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: (PType, Code[_])*): Code[_] = {
+        assert(unify(typeParams, args.map(_._1.virtualType), returnPType.virtualType))
+        apply(r, returnPType, typeParams, args.map { case (t, a) => PCode(t, a) }: _*).code
       }
     })
   }
 
   def registerCode(mname: String, aTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType, typeParams: Array[Type] = Array.empty)
     (impl: (EmitRegion, PType, Array[Type], Array[(PType, Code[_])]) => Code[_]) {
+    val _typeParams = typeParams
     IRFunctionRegistry.addIRFunction(new IRFunctionWithoutMissingness {
       override val name: String = mname
 
-      override val typeArgs: Seq[Type] = typeParams
+      override val typeParams: Seq[Type] = _typeParams
 
       override val argTypes: Seq[Type] = aTypes
 
@@ -324,19 +326,20 @@ abstract class RegistryFunctions {
         p.setRequired(argTypes.forall(_.required))
       }
 
-      override def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: (PType, Code[_])*): Code[_] = {
-        assert(unify(typeArgs, args.map(_._1.virtualType), returnPType.virtualType))
-        impl(r, returnPType, typeArgs.toArray, args.toArray)
+      override def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: (PType, Code[_])*): Code[_] = {
+        assert(unify(typeParams, args.map(_._1.virtualType), returnPType.virtualType))
+        impl(r, returnPType, typeParams.toArray, args.toArray)
       }
     })
   }
 
   def registerEmitCode(mname: String, aTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType, typeParams: Array[Type] = Array.empty)
     (impl: (EmitRegion, PType, Array[EmitCode]) => EmitCode) {
+    val _typeParams = typeParams
     IRFunctionRegistry.addIRFunction(new IRFunctionWithMissingness {
       override val name: String = mname
 
-      override val typeArgs: Seq[Type] = typeParams
+      override val typeParams: Seq[Type] = _typeParams
 
       override val argTypes: Seq[Type] = aTypes
 
@@ -345,15 +348,15 @@ abstract class RegistryFunctions {
       override def returnPType(argTypes: Seq[PType], returnType: Type): PType =
         if (pt == null) PType.canonical(returnType) else pt(returnType, argTypes)
 
-      override def apply(r: EmitRegion, rpt: PType, typeArgs: Seq[Type], args: EmitCode*): EmitCode = {
-        assert(unify(typeArgs, args.map(_.pt.virtualType), rpt.virtualType))
+      override def apply(r: EmitRegion, rpt: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode = {
+        assert(unify(typeParams, args.map(_.pt.virtualType), rpt.virtualType))
         impl(r, rpt, args.toArray)
       }
     })
   }
 
-  def registerScalaFunction(mname: String, argTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType, typeParams: Array[Type] = Array.empty)(cls: Class[_], method: String) {
-    registerCode(mname, argTypes, rType, pt, typeParams) { case (r, rt, _, args) =>
+  def registerScalaFunction(mname: String, argTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType)(cls: Class[_], method: String) {
+    registerCode(mname, argTypes, rType, pt) { case (r, rt, _, args) =>
       val cts = argTypes.map(TypeToIRIntermediateClassTag(_).runtimeClass)
       Code.invokeScalaObject(cls, method, cts, args.map(_._2))(TypeToIRIntermediateClassTag(rType))
     }
@@ -414,8 +417,8 @@ abstract class RegistryFunctions {
       case (r, rt, _, Array(a1: (PType, Code[A1]) @unchecked)) => impl(r, rt, a1)
     }
 
-  def registerCode1t[A1](mname: String, typeArg: Type, mt1: Type, rt: Type, pt: (Type, PType) => PType)(impl: (EmitRegion, PType, Type, (PType, Code[A1])) => Code[_]): Unit =
-    registerCode(mname, Array(mt1), rt, unwrappedApply(pt)) {
+  def registerCode1t[A1](mname: String, typeParam: Type, mt1: Type, rt: Type, pt: (Type, PType) => PType)(impl: (EmitRegion, PType, Type, (PType, Code[A1])) => Code[_]): Unit =
+    registerCode(mname, Array(mt1), rt, unwrappedApply(pt), typeParams = Array(typeParam)) {
       case (r, rt, Array(t), Array(a1: (PType, Code[A1]) @unchecked)) => impl(r, rt, t, a1)
     }
 
@@ -428,9 +431,9 @@ abstract class RegistryFunctions {
       a2: (PType, Code[A2]) @unchecked)) => impl(r, rt, a1, a2)
     }
 
-  def registerCode2t[A1, A2](mname: String, typeArg1: Type, arg1: Type, arg2: Type, rt: Type, pt: (Type, PType, PType) => PType)
+  def registerCode2t[A1, A2](mname: String, typeParam1: Type, arg1: Type, arg2: Type, rt: Type, pt: (Type, PType, PType) => PType)
     (impl: (EmitRegion, PType, Type, (PType, Code[A1]), (PType, Code[A2])) => Code[_]): Unit =
-    registerCode(mname, Array(arg1, arg2), rt, unwrappedApply(pt), Array(typeArg1)) {
+    registerCode(mname, Array(arg1, arg2), rt, unwrappedApply(pt), Array(typeParam1)) {
       case (r, rt, Array(t1), Array(a1: (PType, Code[A1]) @unchecked, a2: (PType, Code[A2]) @unchecked)) => impl(r, rt, t1, a1, a2)
     }
 
@@ -453,9 +456,9 @@ abstract class RegistryFunctions {
       a4: (PType, Code[A4]) @unchecked)) => impl(r, rt, a1, a2, a3, a4)
     }
 
-  def registerCode4t[A1, A2, A3, A4](mname: String, typeArg1: Type, arg1: Type, arg2: Type, arg3: Type, arg4: Type, rt: Type, pt: (Type, PType, PType, PType, PType) => PType)
+  def registerCode4t[A1, A2, A3, A4](mname: String, typeParam1: Type, arg1: Type, arg2: Type, arg3: Type, arg4: Type, rt: Type, pt: (Type, PType, PType, PType, PType) => PType)
     (impl: (EmitRegion, PType, Type, (PType, Code[A1]), (PType, Code[A2]), (PType, Code[A3]), (PType, Code[A4])) => Code[_]): Unit =
-    registerCode(mname, Array(arg1, arg2, arg3, arg4), rt, unwrappedApply(pt), Array(typeArg1)) {
+    registerCode(mname, Array(arg1, arg2, arg3, arg4), rt, unwrappedApply(pt), Array(typeParam1)) {
       case (r, rt, Array(t1), Array(
       a1: (PType, Code[A1]) @unchecked,
       a2: (PType, Code[A2]) @unchecked,
@@ -494,17 +497,17 @@ abstract class RegistryFunctions {
     (impl: (EmitRegion, PType, EmitCode, EmitCode, EmitCode, EmitCode, EmitCode, EmitCode) => EmitCode): Unit =
     registerEmitCode(mname, Array(mt1, mt2, mt3, mt4, mt5, mt6), rt, unwrappedApply(pt)) { case (r, rt, Array(a1, a2, a3, a4, a5, a6)) => impl(r, rt, a1, a2, a3, a4, a5, a6) }
 
-  def registerIR1(mname: String, mt1: Type, retType: Type, typeArgs: Array[Type] = Array.empty)(f: (Seq[Type], IR) => IR): Unit =
-    registerIR(mname, Array(mt1), retType, typeParams = typeArgs) { case (t, Seq(a1)) => f(t, a1) }
+  def registerIR1(mname: String, mt1: Type, retType: Type, typeParams: Array[Type] = Array.empty)(f: (Seq[Type], IR) => IR): Unit =
+    registerIR(mname, Array(mt1), retType, typeParams = typeParams) { case (t, Seq(a1)) => f(t, a1) }
 
-  def registerIR2(mname: String, mt1: Type, mt2: Type, retType: Type, typeArgs: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2), retType, typeParams = typeArgs) { case (t, Seq(a1, a2)) => f(t, a1, a2) }
+  def registerIR2(mname: String, mt1: Type, mt2: Type, retType: Type, typeParams: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2), retType, typeParams = typeParams) { case (t, Seq(a1, a2)) => f(t, a1, a2) }
 
-  def registerIR3(mname: String, mt1: Type, mt2: Type, mt3: Type, retType: Type, typeArgs: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2, mt3), retType, typeParams = typeArgs) { case (t, Seq(a1, a2, a3)) => f(t, a1, a2, a3) }
+  def registerIR3(mname: String, mt1: Type, mt2: Type, mt3: Type, retType: Type, typeParams: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2, mt3), retType, typeParams = typeParams) { case (t, Seq(a1, a2, a3)) => f(t, a1, a2, a3) }
 
-  def registerIR4(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, retType: Type, typeArgs: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR, IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2, mt3, mt4), retType, typeParams = typeArgs) { case (t, Seq(a1, a2, a3, a4)) => f(t, a1, a2, a3, a4) }
+  def registerIR4(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, retType: Type, typeParams: Array[Type] = Array.empty)(f: (Seq[Type], IR, IR, IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2, mt3, mt4), retType, typeParams = typeParams) { case (t, Seq(a1, a2, a3, a4)) => f(t, a1, a2, a3, a4) }
 
   def registerSeeded(mname: String, aTypes: Array[Type], rType: Type, pt: (Type, Seq[PType]) => PType)
     (impl: (EmitRegion, PType, Long, Array[(PType, Code[_])]) => Code[_]) {
@@ -572,13 +575,13 @@ abstract class RegistryFunctions {
 sealed abstract class IRFunction {
   def name: String
 
-  def typeArgs: Seq[Type]
+  def typeParams: Seq[Type]
 
   def argTypes: Seq[Type]
 
-  def apply(mb: EmitRegion, returnType: PType, typeArgs: Seq[Type], args: EmitCode*): EmitCode
+  def apply(mb: EmitRegion, returnType: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode
 
-  def getAsMethod[C](cb: EmitClassBuilder[C], rpt: PType, typeArgs: Seq[Type], args: PType*): EmitMethodBuilder[C] = ???
+  def getAsMethod[C](cb: EmitClassBuilder[C], rpt: PType, typeParams: Seq[Type], args: PType*): EmitMethodBuilder[C] = ???
 
   def returnType: Type
 
@@ -586,9 +589,9 @@ sealed abstract class IRFunction {
 
   override def toString: String = s"$name(${ argTypes.mkString(", ") }, ${ argTypes.mkString(", ") }): $returnType"
 
-  def unify(typeArgsIn: Seq[Type], argTypesIn: Seq[Type], returnTypeIn: Type): Boolean = {
-    val concrete = (typeArgsIn ++ argTypesIn) :+ returnTypeIn
-    val types = (typeArgs ++ argTypes) :+ returnType
+  def unify(typeParamsIn: Seq[Type], argTypesIn: Seq[Type], returnTypeIn: Type): Boolean = {
+    val concrete = (typeParamsIn ++ argTypesIn) :+ returnTypeIn
+    val types = (typeParams ++ argTypes) :+ returnType
     types.length == concrete.length && {
       types.foreach(_.clear())
       types.zip(concrete).forall { case (i, j) => i.unify(j) }
@@ -599,31 +602,31 @@ sealed abstract class IRFunction {
 abstract class IRFunctionWithoutMissingness extends IRFunction {
   def name: String
 
-  def typeArgs: Seq[Type]
+  def typeParams: Seq[Type]
 
   def argTypes: Seq[Type]
 
-  def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: (PType, Code[_])*): Code[_]
+  def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: (PType, Code[_])*): Code[_]
 
-  def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: PCode*): PCode =
-    PCode(returnPType, apply(r, returnPType, typeArgs, args.map(pc => pc.pt -> pc.code): _*))
+  def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: PCode*): PCode =
+    PCode(returnPType, apply(r, returnPType, typeParams, args.map(pc => pc.pt -> pc.code): _*))
 
-  def apply(r: EmitRegion, returnPType: PType, typeArgs: Seq[Type], args: EmitCode*): EmitCode = {
+  def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode = {
     val setup = Code(args.map(_.setup))
     val missing = args.map(_.m).reduce(_ || _)
-    val value = apply(r, returnPType, typeArgs, args.map { a => (a.pt, a.v) }: _*)
+    val value = apply(r, returnPType, typeParams, args.map { a => (a.pt, a.v) }: _*)
 
     EmitCode(setup, missing, PCode(returnPType, value))
   }
 
-  override def getAsMethod[C](cb: EmitClassBuilder[C], rpt: PType, typeArgs: Seq[Type], args: PType*): EmitMethodBuilder[C] = {
-    val unified = unify(typeArgs, args.map(_.virtualType), rpt.virtualType)
+  override def getAsMethod[C](cb: EmitClassBuilder[C], rpt: PType, typeParams: Seq[Type], args: PType*): EmitMethodBuilder[C] = {
+    val unified = unify(typeParams, args.map(_.virtualType), rpt.virtualType)
     assert(unified)
     val argTIs = argTypes.toFastIndexedSeq.map(t => t.subst().ti)
     val methodbuilder = cb.genEmitMethod(name, (typeInfo[Region] +: argTIs).map(ti => ti: CodeParamType), typeToTypeInfo(rpt))
     methodbuilder.emit(apply(EmitRegion.default(methodbuilder),
       rpt,
-      typeArgs,
+      typeParams,
       args.zip(argTIs.zipWithIndex.map { case (ti, i) =>
         methodbuilder.getCodeParam(i + 2)(ti).get
       }): _*))
@@ -636,11 +639,11 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
 abstract class IRFunctionWithMissingness extends IRFunction {
   def name: String
 
-  def typeArgs: Seq[Type]
+  def typeParams: Seq[Type]
 
   def argTypes: Seq[Type]
 
-  def apply(r: EmitRegion, rpt: PType, typeArgs: Seq[Type], args: EmitCode*): EmitCode
+  def apply(r: EmitRegion, rpt: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode
 
   def returnType: Type
 }
@@ -650,7 +653,7 @@ abstract class SeededIRFunction extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def typeArgs: Seq[Type] = Seq.empty[Type]
+  def typeParams: Seq[Type] = Seq.empty[Type]
 
   private[this] var seed: Long = _
 
@@ -658,7 +661,7 @@ abstract class SeededIRFunction extends IRFunction {
 
   def applySeeded(seed: Long, region: EmitRegion, rpt: PType, args: EmitCode*): EmitCode
 
-  def apply(region: EmitRegion, rpt: PType, typeArgs: Seq[Type], args: EmitCode*): EmitCode =
+  def apply(region: EmitRegion, rpt: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode =
     applySeeded(seed, region, rpt, args: _*)
 
   def apply(region: EmitRegion, rpt: PType, args: EmitCode*): EmitCode =

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -10,7 +10,7 @@ import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32, Type}
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerPCode("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: PType) => PInt32())
+    registerPCode1("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: PType) => PInt32())
     { case (r, rt, _pl: PIndexableCode) =>
       val code = EmitCodeBuilder.scopedCode(r.mb) { cb =>
         val pl = _pl.memoize(cb, "plv")
@@ -38,7 +38,7 @@ object GenotypeFunctions extends RegistryFunctions {
       PCode(rt, code)
     }
 
-    registerEmitCode("dosage", TArray(tv("N", "float64")), TFloat64,  (_: Type, _: PType) => PFloat64()
+    registerEmitCode1("dosage", TArray(tv("N", "float64")), TFloat64,  (_: Type, _: PType) => PFloat64()
     ) { case (r, rt, gp) =>
       EmitCode.fromI(r.mb) { cb =>
         gp.toI(cb).flatMap(cb) { case (gpc: PIndexableCode) =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -11,7 +11,7 @@ object IntervalFunctions extends RegistryFunctions {
 
   def registerAll(): Unit = {
 
-    registerEmitCode("Interval", tv("T"), tv("T"), TBoolean, TBoolean, TInterval(tv("T")),
+    registerEmitCode4("Interval", tv("T"), tv("T"), TBoolean, TBoolean, TInterval(tv("T")),
       { case (_: Type, startpt, endpt, includesStartPT, includesEndPT) =>
         PCanonicalInterval(
           InferPType.getNestedElementPTypes(Seq(startpt, endpt)),
@@ -52,7 +52,7 @@ object IntervalFunctions extends RegistryFunctions {
           PCode(rt, vv))
     }
 
-    registerEmitCode("start", TInterval(tv("T")), tv("T"),
+    registerEmitCode1("start", TInterval(tv("T")), tv("T"),
       (_: Type, x: PType) => x.asInstanceOf[PInterval].pointType.orMissing(x.required)) {
       case (r, rt, interval) =>
         val intervalT = interval.pt.asInstanceOf[PInterval]
@@ -64,7 +64,7 @@ object IntervalFunctions extends RegistryFunctions {
         )
     }
 
-    registerEmitCode("end", TInterval(tv("T")), tv("T"),
+    registerEmitCode1("end", TInterval(tv("T")), tv("T"),
       (_: Type, x: PType) => x.asInstanceOf[PInterval].pointType.orMissing(x.required)) {
       case (r, rt, interval) =>
         val intervalT = interval.pt.asInstanceOf[PInterval]
@@ -76,19 +76,19 @@ object IntervalFunctions extends RegistryFunctions {
         )
     }
 
-    registerPCode("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: PType) =>
+    registerPCode1("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: PType) =>
       PBoolean(x.required)
     ) {
       case (r, rt, interval: PIntervalCode) => PCode(rt, interval.includesStart())
     }
 
-    registerPCode("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: PType) =>
+    registerPCode1("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: PType) =>
       PBoolean(x.required)
     ) {
       case (r, rt, interval: PIntervalCode) => PCode(rt, interval.includesEnd())
     }
 
-    registerEmitCode("contains", TInterval(tv("T")), tv("T"), TBoolean, {
+    registerEmitCode2("contains", TInterval(tv("T")), tv("T"), TBoolean, {
       case(_: Type, intervalT: PInterval, _: PType) => PBoolean(intervalT.required)
     }) {
       case (r, rt, int, point) =>
@@ -114,7 +114,7 @@ object IntervalFunctions extends RegistryFunctions {
           PCode(rt, contains))
     }
 
-    registerCode("isEmpty", TInterval(tv("T")), TBoolean, (_: Type, pt: PType) => PBoolean(pt.required)) {
+    registerCode1("isEmpty", TInterval(tv("T")), TBoolean, (_: Type, pt: PType) => PBoolean(pt.required)) {
       case (r, rt, (intervalT: PInterval, intOff)) =>
         val interval = new IRInterval(r, intervalT, intOff)
 
@@ -124,7 +124,7 @@ object IntervalFunctions extends RegistryFunctions {
         )
     }
 
-    registerCode("overlaps", TInterval(tv("T")), TInterval(tv("T")), TBoolean, (_: Type, i1t: PType, i2t: PType) => PBoolean(i1t.required && i2t.required)) {
+    registerCode2("overlaps", TInterval(tv("T")), TInterval(tv("T")), TBoolean, (_: Type, i1t: PType, i2t: PType) => PBoolean(i1t.required && i2t.required)) {
       case (r, rt, (i1t: PInterval, iOff1), (i2t: PInterval, iOff2)) =>
         val interval1 = new IRInterval(r, i1t, iOff1)
         val interval2 = new IRInterval(r, i2t, iOff2)
@@ -138,7 +138,7 @@ object IntervalFunctions extends RegistryFunctions {
         )
     }
 
-    registerIR("sortedNonOverlappingIntervalsContain",
+    registerIR2("sortedNonOverlappingIntervalsContain",
       TArray(TInterval(tv("T"))), tv("T"), TBoolean) { case (_, intervals, value) =>
       val uid = genUID()
       val uid2 = genUID()

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -133,7 +133,7 @@ object LocusFunctions extends RegistryFunctions {
   }
 
   def registerLocusCode(methodName: String)(f: IR => IR): Unit =
-    registerIR(methodName, tlocus("T"), TBoolean)((_, a) => f(a))
+    registerIR1(methodName, tlocus("T"), TBoolean)((_, a) => f(a))
 
   def inX(locus: IR): IR = {
     val xContigs = Literal(TSet(TString), locus.typ.asInstanceOf[TLocus].rg.xContigs)
@@ -160,13 +160,13 @@ object LocusFunctions extends RegistryFunctions {
   def registerAll() {
     val locusClass = Locus.getClass
 
-    registerPCode("contig", tlocus("T"), TString,
+    registerPCode1("contig", tlocus("T"), TString,
       (_: Type, x: PType) => x.asInstanceOf[PLocus].contigType) {
       case (r, rt, locus: PLocusCode) =>
         locus.contig()
     }
 
-    registerCode("position", tlocus("T"), TInt32, (_: Type, x: PType) => x.asInstanceOf[PLocus].positionType) {
+    registerCode1("position", tlocus("T"), TInt32, (_: Type, x: PType) => x.asInstanceOf[PLocus].positionType) {
       case (r, rt, (locusT: PLocus, locus: Code[Long])) =>
         locusT.position(locus)
     }
@@ -180,7 +180,7 @@ object LocusFunctions extends RegistryFunctions {
     registerLocusCode("inXNonPar") { locus => inX(locus) && !inPar(locus) }
     registerLocusCode("inYNonPar") { locus => inY(locus) && !inPar(locus) }
 
-    registerPCode("min_rep", tlocus("T"), TArray(TString), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString)), {
+    registerPCode2("min_rep", tlocus("T"), TArray(TString), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString)), {
       (returnType: Type, _: PType, _: PType) => {
         val locusPT = PCanonicalLocus(returnType.asInstanceOf[TStruct].field("locus").typ.asInstanceOf[TLocus].rg, true)
         PCanonicalStruct("locus" -> locusPT, "alleles" -> PCanonicalArray(PCanonicalString(true), true))
@@ -223,7 +223,7 @@ object LocusFunctions extends RegistryFunctions {
         PCode(rt, code)
     }
 
-    registerCode("locus_windows_per_contig", TArray(TArray(TFloat64)), TFloat64, TTuple(TArray(TInt32), TArray(TInt32)), {
+    registerCode2("locus_windows_per_contig", TArray(TArray(TFloat64)), TFloat64, TTuple(TArray(TInt32), TArray(TInt32)), {
       (_: Type, _: PType, _: PType) =>
         PCanonicalTuple(false, PCanonicalArray(PInt32(true), true), PCanonicalArray(PInt32(true), true))
     }) {
@@ -299,7 +299,7 @@ object LocusFunctions extends RegistryFunctions {
           srvb.end())
     }
 
-    registerCode("Locus", TString, tlocus("T"), {
+    registerCode1("Locus", TString, tlocus("T"), {
       (returnType: Type, _: PType) => PCanonicalLocus(returnType.asInstanceOf[TLocus].rg)
     }) {
       case (r, rt: PLocus, (strT, locusoff: Code[Long])) =>
@@ -310,7 +310,7 @@ object LocusFunctions extends RegistryFunctions {
         emitLocus(r, locus, rt)
     }
 
-    registerCode("Locus", TString, TInt32, tlocus("T"), {
+    registerCode2("Locus", TString, TInt32, tlocus("T"), {
       (returnType: Type, _: PType, _: PType) => PCanonicalLocus(returnType.asInstanceOf[TLocus].rg)
     }) {
       case (r, rt: PLocus, (contigT, contig: Code[Long]), (posT, pos: Code[Int])) =>
@@ -327,7 +327,7 @@ object LocusFunctions extends RegistryFunctions {
         }
     }
 
-    registerCode("LocusAlleles", TString, tvariant("T"), {
+    registerCode1("LocusAlleles", TString, tvariant("T"), {
       (returnType: Type, _: PType) => {
         val lTyp = returnType.asInstanceOf[TStruct].field("locus").typ.asInstanceOf[TLocus]
         PCanonicalStruct("locus" -> PCanonicalLocus(lTyp.rg, true), "alleles" -> PCanonicalArray(PCanonicalString(true), true))
@@ -342,7 +342,7 @@ object LocusFunctions extends RegistryFunctions {
         emitVariant(r, variant, rt)
     }
 
-    registerEmitCode("LocusInterval", TString, TBoolean, tinterval("T"), {
+    registerEmitCode2("LocusInterval", TString, TBoolean, tinterval("T"), {
       (returnType: Type, _: PType, _: PType) => {
         val lPTyp = returnType.asInstanceOf[TInterval].pointType.asInstanceOf[TLocus]
         PCanonicalInterval(PCanonicalLocus(lPTyp.asInstanceOf[TLocus].rg))
@@ -362,7 +362,7 @@ object LocusFunctions extends RegistryFunctions {
         )
     }
 
-    registerEmitCode("LocusInterval", TString, TInt32, TInt32, TBoolean, TBoolean, TBoolean, tinterval("T"), {
+    registerEmitCode6("LocusInterval", TString, TInt32, TInt32, TBoolean, TBoolean, TBoolean, tinterval("T"), {
       (returnType: Type, _: PType, _: PType, _: PType, _: PType, _: PType, _: PType) => {
         val lPTyp = returnType.asInstanceOf[TInterval].pointType.asInstanceOf[TLocus]
         PCanonicalInterval(PCanonicalLocus(lPTyp.rg))
@@ -388,7 +388,7 @@ object LocusFunctions extends RegistryFunctions {
         )
     }
 
-    registerCode("globalPosToLocus", TInt64, tlocus("T"), {
+    registerCode1("globalPosToLocus", TInt64, tlocus("T"), {
       (returnType: Type, _: PType) =>
         PCanonicalLocus(returnType.asInstanceOf[TLocus].rg)
     }) {
@@ -397,13 +397,13 @@ object LocusFunctions extends RegistryFunctions {
         emitLocus(r, locus, rt)
     }
 
-    registerCode("locusToGlobalPos", tlocus("T"), TInt64, (_: Type, _: PType) => PInt64()) {
+    registerCode1("locusToGlobalPos", tlocus("T"), TInt64, (_: Type, _: PType) => PInt64()) {
       case (r, rt, (locusT: PLocus, locus: Code[Long])) =>
         val locusObject = Code.checkcast[Locus](wrapArg(r, locusT)(locus).asInstanceOf[Code[AnyRef]])
         unwrapReturn(r, rt)(rgCode(r.mb, locusT.rg).invoke[Locus, Long]("locusToGlobalPos", locusObject))
     }
 
-    registerEmitCode("liftoverLocus", tlocus("T"), TFloat64, TStruct("result" -> tv("U", "locus"), "is_negative_strand" -> TBoolean), {
+    registerEmitCode2("liftoverLocus", tlocus("T"), TFloat64, TStruct("result" -> tv("U", "locus"), "is_negative_strand" -> TBoolean), {
       (returnType: Type, _: PType, _: PType) => {
         val lTyp = returnType.asInstanceOf[TStruct].field("result").typ.asInstanceOf[TLocus]
         PCanonicalStruct("result" -> PCanonicalLocus(lTyp.rg, true), "is_negative_strand" -> PBoolean(true))
@@ -425,7 +425,7 @@ object LocusFunctions extends RegistryFunctions {
         )
     }
 
-    registerEmitCode("liftoverLocusInterval", tinterval("T"), TFloat64, TStruct("result" -> tinterval("U"), "is_negative_strand" -> TBoolean), {
+    registerEmitCode2("liftoverLocusInterval", tinterval("T"), TFloat64, TStruct("result" -> tinterval("U"), "is_negative_strand" -> TBoolean), {
       (returnType: Type, _: PType, _: PType) => {
         val lTyp = returnType.asInstanceOf[TStruct].field("result").typ.asInstanceOf[TInterval].pointType.asInstanceOf[TLocus]
         PCanonicalStruct("result" -> PCanonicalInterval(PCanonicalLocus(lTyp.rg, true), true), "is_negative_strand" -> PBoolean(true))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -93,10 +93,10 @@ object MathFunctions extends RegistryFunctions {
     val jDoubleClass = classOf[java.lang.Double]    
 
     // numeric conversions
-    registerIR("toInt32", tnum("T"), TInt32)((_, x) => Cast((x), TInt32))
-    registerIR("toInt64", tnum("T"), TInt64)((_, x) => Cast(x, TInt64))
-    registerIR("toFloat32", tnum("T"), TFloat32)((_, x) => Cast(x, TFloat32))
-    registerIR("toFloat64", tnum("T"), TFloat64)((_, x) => Cast(x, TFloat64))
+    registerIR1("toInt32", tnum("T"), TInt32)((_, x) => Cast((x), TInt32))
+    registerIR1("toInt64", tnum("T"), TInt64)((_, x) => Cast(x, TInt64))
+    registerIR1("toFloat32", tnum("T"), TFloat32)((_, x) => Cast(x, TFloat32))
+    registerIR1("toFloat64", tnum("T"), TFloat64)((_, x) => Cast(x, TFloat64))
     
     registerScalaFunction("abs", Array(TInt32), TInt32, (_: Type, _: Seq[PType]) => PInt32())(mathPackageClass, "abs")
     registerScalaFunction("abs", Array(TInt64), TInt64, (_: Type, _: Seq[PType]) => PInt64())(mathPackageClass, "abs")
@@ -163,9 +163,9 @@ object MathFunctions extends RegistryFunctions {
     
     registerScalaFunction("approxEqual", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TBoolean, (_: Type, _: Seq[PType]) => PBoolean())(thisClass, "approxEqual")
 
-    registerWrappedScalaFunction("entropy", TString, TFloat64, (_: Type, _: PType) => PFloat64())(thisClass, "irentropy")
+    registerWrappedScalaFunction1("entropy", TString, TFloat64, (_: Type, _: PType) => PFloat64())(thisClass, "irentropy")
 
-    registerCode("fisher_exact_test", TInt32, TInt32, TInt32, TInt32, fetStruct.virtualType,
+    registerCode4("fisher_exact_test", TInt32, TInt32, TInt32, TInt32, fetStruct.virtualType,
       (_, _, _, _, _) => fetStruct
     ){ case (r, rt, (at, a), (bt, b), (ct, c), (dt, d)) =>
       val res = r.mb.newLocal[Array[Double]]()
@@ -184,7 +184,7 @@ object MathFunctions extends RegistryFunctions {
         srvb.offset)
     }
     
-    registerCode("chi_squared_test", TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
+    registerCode4("chi_squared_test", TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
       (_, _, _, _, _) => chisqStruct
     ){ case (r, rt, (at, a), (bt, b), (ct, c), (dt, d))  =>
       val res = r.mb.newLocal[Array[Double]]()
@@ -200,7 +200,7 @@ object MathFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("contingency_table_test", TInt32, TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
+    registerCode5("contingency_table_test", TInt32, TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
       (_, _, _, _, _, _) => chisqStruct
     ){ case (r, rt, (at, a), (bt, b), (ct, c), (dt, d), (mccT, min_cell_count)) =>
       val res = r.mb.newLocal[Array[Double]]()
@@ -216,7 +216,7 @@ object MathFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("hardy_weinberg_test", TInt32, TInt32, TInt32,
+    registerCode3("hardy_weinberg_test", TInt32, TInt32, TInt32,
       hweStruct.virtualType, (_, _, _, _) => hweStruct) { case (r, rt, (nhrT, nHomRef), (nhT, nHet), (nhvT, nHomVar)) =>
       val res = r.mb.newLocal[Array[Double]]()
       val srvb = new StagedRegionValueBuilder(r, rt)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -9,17 +9,17 @@ object NDArrayFunctions extends RegistryFunctions {
   override def registerAll() {
     for ((stringOp, argType, retType, irOp) <- ArrayFunctions.arrayOps) {
       val nDimVar = NatVariable()
-      registerIR(stringOp, TNDArray(argType, nDimVar), argType, TNDArray(retType, nDimVar)) { (_, a, c) =>
+      registerIR2(stringOp, TNDArray(argType, nDimVar), argType, TNDArray(retType, nDimVar)) { (_, a, c) =>
         val i = genUID()
         NDArrayMap(a, i, irOp(Ref(i, c.typ), c))
       }
 
-      registerIR(stringOp, argType, TNDArray(argType, nDimVar), TNDArray(retType, nDimVar)) { (_, c, a) =>
+      registerIR2(stringOp, argType, TNDArray(argType, nDimVar), TNDArray(retType, nDimVar)) { (_, c, a) =>
         val i = genUID()
         NDArrayMap(a, i, irOp(c, Ref(i, c.typ)))
       }
 
-      registerIR(stringOp, TNDArray(argType, nDimVar), TNDArray(argType, nDimVar), TNDArray(retType, nDimVar)) { (_, l, r) =>
+      registerIR2(stringOp, TNDArray(argType, nDimVar), TNDArray(argType, nDimVar), TNDArray(retType, nDimVar)) { (_, l, r) =>
         val lid = genUID()
         val rid = genUID()
         val lElemRef = Ref(lid, coerce[TNDArray](l.typ).elementType)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -56,27 +56,27 @@ class IRRandomness(seed: Long) {
 object RandomSeededFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerSeeded("rand_unif", TFloat64, TFloat64, TFloat64, {
+    registerSeeded2("rand_unif", TFloat64, TFloat64, TFloat64, {
       case(_: Type, _: PType, _: PType) => PFloat64()
     }) { case (r, rt, seed, (minT, min), (maxT, max)) =>
       r.mb.newRNG(seed).invoke[Double, Double, Double]("runif", min, max)
     }
 
-    registerSeeded("rand_norm", TFloat64, TFloat64, TFloat64, {
+    registerSeeded2("rand_norm", TFloat64, TFloat64, TFloat64, {
       case(_: Type, _: PType, _: PType) => PFloat64()
     }) { case (r, rt, seed, (meanT, mean), (sdT, sd)) =>
       r.mb.newRNG(seed).invoke[Double, Double, Double]("rnorm", mean, sd)
     }
 
-    registerSeeded("rand_bool", TFloat64, TBoolean, (_: Type, _: PType) => PBoolean()) { case (r, rt, seed, (pT, p)) =>
+    registerSeeded1("rand_bool", TFloat64, TBoolean, (_: Type, _: PType) => PBoolean()) { case (r, rt, seed, (pT, p)) =>
       r.mb.newRNG(seed).invoke[Double, Boolean]("rcoin", p)
     }
 
-    registerSeeded("rand_pois", TFloat64, TFloat64, (_: Type, _: PType) => PFloat64()) { case (r, rt, seed, (lambdaT, lambda)) =>
+    registerSeeded1("rand_pois", TFloat64, TFloat64, (_: Type, _: PType) => PFloat64()) { case (r, rt, seed, (lambdaT, lambda)) =>
       r.mb.newRNG(seed).invoke[Double, Double]("rpois", lambda)
     }
 
-    registerSeeded("rand_pois", TInt32, TFloat64, TArray(TFloat64), {
+    registerSeeded2("rand_pois", TInt32, TFloat64, TArray(TFloat64), {
       case(_: Type, _: PType, _: PType) => PCanonicalArray(PFloat64(true))
     }) { case (r, rt, seed, (nT, n), (lambdaT, lambda)) =>
       val length = r.mb.newLocal[Int]()
@@ -91,13 +91,13 @@ object RandomSeededFunctions extends RegistryFunctions {
         srvb.offset)
     }
 
-    registerSeeded("rand_beta", TFloat64, TFloat64, TFloat64, {
+    registerSeeded2("rand_beta", TFloat64, TFloat64, TFloat64, {
       case(_: Type, _: PType, _: PType) => PFloat64()
     }) { case (r, rt, seed, (aT, a), (bT, b)) =>
       r.mb.newRNG(seed).invoke[Double, Double, Double]("rbeta", a, b)
     }
 
-    registerSeeded("rand_beta", TFloat64, TFloat64, TFloat64, TFloat64, TFloat64, {
+    registerSeeded4("rand_beta", TFloat64, TFloat64, TFloat64, TFloat64, TFloat64, {
       case(_: Type, _: PType, _: PType, _: PType, _: PType) => PFloat64()
     }) {
       case (r, rt, seed, (aT, a), (bT, b), (minT, min), (maxT, max)) =>
@@ -118,13 +118,13 @@ object RandomSeededFunctions extends RegistryFunctions {
           value)
     }
 
-    registerSeeded("rand_gamma", TFloat64, TFloat64, TFloat64, {
+    registerSeeded2("rand_gamma", TFloat64, TFloat64, TFloat64, {
       case(_: Type, _: PType, _: PType) => PFloat64()
     }) { case (r, rt, seed, (aT, a), (scaleT, scale)) =>
       r.mb.newRNG(seed).invoke[Double, Double, Double]("rgamma", a, scale)
     }
 
-    registerSeeded("rand_cat", TArray(TFloat64), TInt32, (_: Type, _: PType) => PInt32()) { case (r, rt, seed, (aT: PArray, a)) =>
+    registerSeeded1("rand_cat", TArray(TFloat64), TInt32, (_: Type, _: PType) => PInt32()) { case (r, rt, seed, (aT: PArray, a)) =>
       val array = r.mb.newLocal[Array[Double]]()
       val aoff = r.mb.newLocal[Long]()
       val length = r.mb.newLocal[Int]()

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -11,33 +11,32 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
   def rgCode(mb: EmitMethodBuilder[_], rg: ReferenceGenome): Code[ReferenceGenome] = mb.getReferenceGenome(rg)
 
   def registerAll() {
-    registerCode("isValidContig", LocusFunctions.tlocus("R"), TString, TBoolean, (_: Type, _: PType) => PBoolean()) {
+    registerCode1t("isValidContig", LocusFunctions.tlocus("R"), TString, TBoolean, (_: Type, _: PType) => PBoolean()) {
       case (r, rt, tlocus, (contigT, contig: Code[Long])) => {}
         val scontig = asm4s.coerce[String](wrapArg(r, contigT)(contig))
         rgCode(r.mb, tlocus.asInstanceOf[TLocus].rg).invoke[String, Boolean]("isValidContig", scontig)
     }
 
-    registerCode("isValidLocus", LocusFunctions.tlocus("R"), TString, TInt32, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
+    registerCode2t("isValidLocus", LocusFunctions.tlocus("R"), TString, TInt32, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
       case (r, rt, typeArg: TLocus, (contigT, contig: Code[Long]), (posT, pos: Code[Int])) =>
         val scontig = asm4s.coerce[String](wrapArg(r, contigT)(contig))
         rgCode(r.mb, typeArg.rg).invoke[String, Int, Boolean]("isValidLocus", scontig, pos)
     }
 
-    registerCode("getReferenceSequenceFromValidLocus", LocusFunctions.tlocus("R"), TString, TInt32, TInt32, TInt32, TString, (_: Type, _: PType, _: PType, _: PType, _: PType) => PCanonicalString()) {
+    registerCode4t("getReferenceSequenceFromValidLocus", LocusFunctions.tlocus("R"), TString, TInt32, TInt32, TInt32, TString, (_: Type, _: PType, _: PType, _: PType, _: PType) => PCanonicalString()) {
       case (r, rt, typeArg: TLocus, (contigT, contig: Code[Long]), (posT, pos: Code[Int]), (beforeT, before: Code[Int]), (afterT, after: Code[Int])) =>
         val scontig = asm4s.coerce[String](wrapArg(r, contigT)(contig))
         unwrapReturn(r, rt)(rgCode(r.mb, typeArg.rg).invoke[String, Int, Int, Int, String]("getSequence", scontig, pos, before, after))
     }
 
-    registerCode("contigLength", LocusFunctions.tlocus("R"), TString, TInt32, (_: Type, _: PType) => PInt32()) {
+    registerCode1t("contigLength", LocusFunctions.tlocus("R"), TString, TInt32, (_: Type, _: PType) => PInt32()) {
       case (r, rt, typeArg: TLocus, (contigT, contig: Code[Long])) =>
         val scontig = asm4s.coerce[String](wrapArg(r, contigT)(contig))
         rgCode(r.mb, typeArg.rg).invoke[String, Int]("contigLength", scontig)
     }
 
-    registerIR("getReferenceSequence", LocusFunctions.tlocus("R"), TString, TInt32, TInt32, TInt32, TString) {
-      (tlocus, contig, pos, before, after) =>
-        val tl = Seq(tlocus)
+    registerIR("getReferenceSequence", Array(TString, TInt32, TInt32, TInt32), TString, typeParams = Array(LocusFunctions.tlocus("R"))) {
+      case (tl, Seq(tlocus, contig, pos, before, after)) =>
         val getRef = IRFunctionRegistry.lookupConversion(
           name = "getReferenceSequenceFromValidLocus",
           rt = TString,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -40,12 +40,12 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
         val getRef = IRFunctionRegistry.lookupConversion(
           name = "getReferenceSequenceFromValidLocus",
           rt = TString,
-          typeArgs = tl,
+          typeParams = tl,
           args = Seq(TString, TInt32, TInt32, TInt32)).get
         val isValid = IRFunctionRegistry.lookupConversion(
           "isValidLocus",
           TBoolean,
-          typeArgs = tl,
+          typeParams = tl,
           Seq(TString, TInt32)).get
 
         val r = isValid(tl, Seq(contig, pos))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -36,7 +36,7 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
     }
 
     registerIR("getReferenceSequence", Array(TString, TInt32, TInt32, TInt32), TString, typeParams = Array(LocusFunctions.tlocus("R"))) {
-      case (tl, Seq(tlocus, contig, pos, before, after)) =>
+      case (tl, Seq(contig, pos, before, after)) =>
         val getRef = IRFunctionRegistry.lookupConversion(
           name = "getReferenceSequenceFromValidLocus",
           rt = TString,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -18,17 +18,17 @@ object SetFunctions extends RegistryFunctions {
   }
 
   def registerAll() {
-    registerIR("toSet", TArray(tv("T")), TSet(tv("T"))) { (_, a) =>
+    registerIR1("toSet", TArray(tv("T")), TSet(tv("T"))) { (_, a) =>
       ToSet(ToStream(a))
     }
 
-    registerIR("isEmpty", TSet(tv("T")), TBoolean) { (_, s) =>
+    registerIR1("isEmpty", TSet(tv("T")), TBoolean) { (_, s) =>
       ArrayFunctions.isEmpty(CastToArray(s))
     }
 
-    registerIR("contains", TSet(tv("T")), tv("T"), TBoolean)((_, a, b) => contains(a, b))
+    registerIR2("contains", TSet(tv("T")), tv("T"), TBoolean)((_, a, b) => contains(a, b))
 
-    registerIR("remove", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v) =>
+    registerIR2("remove", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v) =>
       val t = v.typ
       val x = genUID()
       ToSet(
@@ -38,7 +38,7 @@ object SetFunctions extends RegistryFunctions {
           ApplyComparisonOp(NEQWithNA(t), Ref(x, t), v)))
     }
 
-    registerIR("add", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v) =>
+    registerIR2("add", TSet(tv("T")), tv("T"), TSet(tv("T"))) { (_, s, v) =>
       val t = v.typ
       val x = genUID()
       ToSet(
@@ -48,7 +48,7 @@ object SetFunctions extends RegistryFunctions {
           ToStream(Ref(x, TArray(t)))))
     }
 
-    registerIR("union", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
+    registerIR2("union", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
       val t = s1.typ.asInstanceOf[TSet].elementType
       val x = genUID()
       ToSet(
@@ -58,7 +58,7 @@ object SetFunctions extends RegistryFunctions {
           ToStream(Ref(x, TArray(t)))))
     }
 
-    registerIR("intersection", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
+    registerIR2("intersection", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
       val t = s1.typ.asInstanceOf[TSet].elementType
       val x = genUID()
       ToSet(
@@ -66,7 +66,7 @@ object SetFunctions extends RegistryFunctions {
           contains(s2, Ref(x, t))))
     }
 
-    registerIR("difference", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
+    registerIR2("difference", TSet(tv("T")), TSet(tv("T")), TSet(tv("T"))) { (_, s1, s2) =>
       val t = s1.typ.asInstanceOf[TSet].elementType
       val x = genUID()
       ToSet(
@@ -74,7 +74,7 @@ object SetFunctions extends RegistryFunctions {
           ApplyUnaryPrimOp(Bang(), contains(s2, Ref(x, t)))))
     }
 
-    registerIR("isSubset", TSet(tv("T")), TSet(tv("T")), TBoolean) { (_, s, w) =>
+    registerIR2("isSubset", TSet(tv("T")), TSet(tv("T")), TBoolean) { (_, s, w) =>
       val t = s.typ.asInstanceOf[TSet].elementType
       val a = genUID()
       val x = genUID()
@@ -83,7 +83,7 @@ object SetFunctions extends RegistryFunctions {
         ApplySpecial("land", FastSeq(), FastSeq(Ref(a, TBoolean), contains(w, Ref(x, t))), TBoolean))
     }
 
-    registerIR("median", TSet(tnum("T")), tv("T")) { (_, s) =>
+    registerIR1("median", TSet(tnum("T")), tv("T")) { (_, s) =>
       val t = s.typ.asInstanceOf[TSet].elementType
       val a = Ref(genUID(), TArray(t))
       val size = Ref(genUID(), TInt32)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -96,18 +96,18 @@ object StringFunctions extends RegistryFunctions {
   def registerAll(): Unit = {
     val thisClass = getClass
 
-    registerPCode("length", TString, TInt32, (_: Type, _: PType) => PInt32()) { case (r: EmitRegion, rt, s: PStringCode) =>
+    registerPCode1("length", TString, TInt32, (_: Type, _: PType) => PInt32()) { case (r: EmitRegion, rt, s: PStringCode) =>
       PCode(rt, s.loadString().invoke[Int]("length"))
     }
 
-    registerCode("substring", TString, TInt32, TInt32, TString, {
+    registerCode3("substring", TString, TInt32, TInt32, TString, {
       (_: Type, _: PType, _: PType, _: PType) => PCanonicalString()
     }) {
       case (r: EmitRegion, rt, (sT: PString, s: Code[Long]), (startT, start: Code[Int]), (endT, end: Code[Int])) =>
       unwrapReturn(r, rt)(asm4s.coerce[String](wrapArg(r, sT)(s)).invoke[Int, Int, String]("substring", start, end))
     }
 
-    registerIR("slice", TString, TInt32, TInt32, TString) { (_, str, start, end) =>
+    registerIR3("slice", TString, TInt32, TInt32, TString) { (_, str, start, end) =>
       val len = Ref(genUID(), TInt32)
       val s = Ref(genUID(), TInt32)
       val e = Ref(genUID(), TInt32)
@@ -117,7 +117,7 @@ object StringFunctions extends RegistryFunctions {
             invoke("substring", TString, str, s, If(e < s, s, e)))))
     }
 
-    registerIR("index", TString, TInt32, TString) { (_, s, i) =>
+    registerIR2("index", TString, TInt32, TString) { (_, s, i) =>
       val len = Ref(genUID(), TInt32)
       val idx = Ref(genUID(), TInt32)
       Let(len.name, invoke("length", TInt32, s),
@@ -132,16 +132,16 @@ object StringFunctions extends RegistryFunctions {
         invoke("substring", TString, s, idx, idx + 1)))
     }
 
-    registerIR("sliceRight", TString, TInt32, TString) { (_, s, start) => invoke("slice", TString, s, start, invoke("length", TInt32, s)) }
-    registerIR("sliceLeft", TString, TInt32, TString) { (_, s, end) => invoke("slice", TString, s, I32(0), end) }
+    registerIR2("sliceRight", TString, TInt32, TString) { (_, s, start) => invoke("slice", TString, s, start, invoke("length", TInt32, s)) }
+    registerIR2("sliceLeft", TString, TInt32, TString) { (_, s, end) => invoke("slice", TString, s, I32(0), end) }
 
-    registerCode("str", tv("T"), TString, (_: Type, _: PType) => PCanonicalString()) { case (r, rt, (aT, a)) =>
+    registerCode1("str", tv("T"), TString, (_: Type, _: PType) => PCanonicalString()) { case (r, rt, (aT, a)) =>
       val annotation = boxArg(r, aT)(a)
       val str = r.mb.getType(aT.virtualType).invoke[Any, String]("str", annotation)
       unwrapReturn(r, rt)(str)
     }
 
-    registerEmitCode("showStr", tv("T"), TInt32, TString, {
+    registerEmitCode2("showStr", tv("T"), TInt32, TString, {
       (_: Type, _: PType, truncType: PType) => PCanonicalString(truncType.required)
     }) { case (r, rt, a, trunc) =>
       val annotation = Code(a.setup, a.m).muxAny(Code._null(boxedTypeInfo(a.pt)), boxArg(r, a.pt)(a.v))
@@ -149,7 +149,7 @@ object StringFunctions extends RegistryFunctions {
       EmitCode(trunc.setup, trunc.m, PCode(rt, unwrapReturn(r, rt)(str)))
     }
 
-    registerEmitCode("json", tv("T"), TString, (_: Type, _: PType) => PCanonicalString(true)) { case (r, rt, a) =>
+    registerEmitCode1("json", tv("T"), TString, (_: Type, _: PType) => PCanonicalString(true)) { case (r, rt, a) =>
       val bti = boxedTypeInfo(a.pt)
       val annotation = Code(a.setup, a.m).muxAny(Code._null(bti), boxArg(r, a.pt)(a.v))
       val json = r.mb.getType(a.pt.virtualType).invoke[Any, JValue]("toJSON", annotation)
@@ -157,52 +157,52 @@ object StringFunctions extends RegistryFunctions {
       EmitCode(Code._empty, false, PCode(rt, unwrapReturn(r, rt)(str)))
     }
 
-    registerWrappedScalaFunction("reverse", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"reverse")
-    registerWrappedScalaFunction("upper", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"upper")
-    registerWrappedScalaFunction("lower", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"lower")
-    registerWrappedScalaFunction("strip", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"strip")
-    registerWrappedScalaFunction("contains", TString, TString, TBoolean, {
+    registerWrappedScalaFunction1("reverse", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"reverse")
+    registerWrappedScalaFunction1("upper", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"upper")
+    registerWrappedScalaFunction1("lower", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"lower")
+    registerWrappedScalaFunction1("strip", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass,"strip")
+    registerWrappedScalaFunction2("contains", TString, TString, TBoolean, {
       case (_: Type, _: PType, _: PType) => PBoolean()
     })(thisClass, "contains")
-    registerWrappedScalaFunction("translate", TString, TDict(TString, TString), TString, {
+    registerWrappedScalaFunction2("translate", TString, TDict(TString, TString), TString, {
       case (_: Type, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "translate")
-    registerWrappedScalaFunction("startswith", TString, TString, TBoolean, {
+    registerWrappedScalaFunction2("startswith", TString, TString, TBoolean, {
       case (_: Type, _: PType, _: PType) => PBoolean()
     })(thisClass, "startswith")
-    registerWrappedScalaFunction("endswith", TString, TString, TBoolean, {
+    registerWrappedScalaFunction2("endswith", TString, TString, TBoolean, {
       case (_: Type, _: PType, _: PType) => PBoolean()
     })(thisClass, "endswith")
-    registerWrappedScalaFunction("regexMatch", TString, TString, TBoolean, {
+    registerWrappedScalaFunction2("regexMatch", TString, TString, TBoolean, {
       case (_: Type, _: PType, _: PType) => PBoolean()
     })(thisClass, "regexMatch")
-    registerWrappedScalaFunction("concat", TString, TString, TString, {
+    registerWrappedScalaFunction2("concat", TString, TString, TString, {
       case (_: Type, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "concat")
 
-    registerWrappedScalaFunction("split", TString, TString, TArray(TString), {
+    registerWrappedScalaFunction2("split", TString, TString, TArray(TString), {
       case (_: Type, _: PType, _: PType) =>
         PCanonicalArray(PCanonicalString(true))
     })(thisClass, "split")
 
-    registerWrappedScalaFunction("split", TString, TString, TInt32, TArray(TString), {
+    registerWrappedScalaFunction3("split", TString, TString, TInt32, TArray(TString), {
       case (_: Type, _: PType, _: PType, _: PType) =>
         PCanonicalArray(PCanonicalString(true))
     })(thisClass, "splitLimited")
 
-    registerWrappedScalaFunction("replace", TString, TString, TString, TString, {
+    registerWrappedScalaFunction3("replace", TString, TString, TString, TString, {
       case (_: Type, _: PType, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "replace")
 
-    registerWrappedScalaFunction("mkString", TSet(TString), TString, TString, {
+    registerWrappedScalaFunction2("mkString", TSet(TString), TString, TString, {
       case (_: Type, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "setMkString")
 
-    registerWrappedScalaFunction("mkString", TArray(TString), TString, TString, {
+    registerWrappedScalaFunction2("mkString", TArray(TString), TString, TString, {
       case (_: Type, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "arrayMkString")
 
-    registerEmitCode("firstMatchIn", TString, TString, TArray(TString), {
+    registerEmitCode2("firstMatchIn", TString, TString, TArray(TString), {
       case(_: Type, _: PType, _: PType) => PCanonicalArray(PCanonicalString(true))
     }) {
       case (er: EmitRegion, rt: PArray, s: EmitCode, r: EmitCode) =>
@@ -236,7 +236,7 @@ object StringFunctions extends RegistryFunctions {
       EmitCode(setup, missing, PCode(rt, value))
     }
 
-    registerEmitCode("hamming", TString, TString, TInt32, {
+    registerEmitCode2("hamming", TString, TString, TInt32, {
       case(_: Type, _: PType, _: PType) => PInt32()
     }) { case (r: EmitRegion, rt, e1: EmitCode, e2: EmitCode) =>
       EmitCode.fromI(r.mb) { cb =>
@@ -263,11 +263,11 @@ object StringFunctions extends RegistryFunctions {
       }
     }
 
-    registerWrappedScalaFunction("escapeString", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass, "escapeString")
-    registerWrappedScalaFunction("strftime", TString, TInt64, TString, TString, {
+    registerWrappedScalaFunction1("escapeString", TString, TString, (_: Type, _: PType) => PCanonicalString())(thisClass, "escapeString")
+    registerWrappedScalaFunction3("strftime", TString, TInt64, TString, TString, {
       case(_: Type, _: PType, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "strftime")
-    registerWrappedScalaFunction("strptime", TString, TString, TString, TInt64, {
+    registerWrappedScalaFunction3("strptime", TString, TString, TString, TInt64, {
       case(_: Type, _: PType, _: PType, _: PType) => PInt64()
     })(thisClass, "strptime")
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -125,7 +125,7 @@ object UtilFunctions extends RegistryFunctions {
   def registerAll() {
     val thisClass = getClass
 
-    registerCode("valuesSimilar", tv("T"), tv("U"), TFloat64, TBoolean, TBoolean, {
+    registerCode4("valuesSimilar", tv("T"), tv("U"), TFloat64, TBoolean, TBoolean, {
       case(_: Type, _: PType, _: PType, _: PType, _: PType) => PBoolean()
     }) {
       case (er, rt, (lT, l), (rT, r), (tolT, tolerance), (absT, absolute)) =>
@@ -135,16 +135,16 @@ object UtilFunctions extends RegistryFunctions {
         er.mb.getType(lT.virtualType).invoke[Any, Any, Double, Boolean, Boolean]("valuesSimilar", lb, rb, tolerance, absolute)
     }
 
-    registerCode[Int]("triangle", TInt32, TInt32, (_: Type, n: PType) => n) { case (_, rt, (nT, n: Code[Int])) =>
+    registerCode1[Int]("triangle", TInt32, TInt32, (_: Type, n: PType) => n) { case (_, rt, (nT, n: Code[Int])) =>
       Code.memoize(n, "triangle_n") { n =>
         (n * (n + 1)) / 2
       }
     }
 
-    registerCode[Boolean]("toInt32", TBoolean, TInt32, (_: Type, _: PType) => PInt32()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI }
-    registerCode[Boolean]("toInt64", TBoolean, TInt64, (_: Type, _: PType) => PInt64()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toL }
-    registerCode[Boolean]("toFloat32", TBoolean, TFloat32, (_: Type, _: PType) => PFloat32()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toF }
-    registerCode[Boolean]("toFloat64", TBoolean, TFloat64, (_: Type, _: PType) => PFloat64()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toD }
+    registerCode1[Boolean]("toInt32", TBoolean, TInt32, (_: Type, _: PType) => PInt32()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI }
+    registerCode1[Boolean]("toInt64", TBoolean, TInt64, (_: Type, _: PType) => PInt64()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toL }
+    registerCode1[Boolean]("toFloat32", TBoolean, TFloat32, (_: Type, _: PType) => PFloat32()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toF }
+    registerCode1[Boolean]("toFloat64", TBoolean, TFloat64, (_: Type, _: PType) => PFloat64()) { case (_, rt, (xT, x: Code[Boolean])) => x.toI.toD }
 
     for ((name, t, rpt, ct) <- Seq[(String, Type, PType, ClassTag[_])](
       ("Boolean", TBoolean, PBoolean(), implicitly[ClassTag[Boolean]]),
@@ -154,12 +154,12 @@ object UtilFunctions extends RegistryFunctions {
       ("Float32", TFloat32, PFloat32(), implicitly[ClassTag[Float]])
     )) {
       val ctString: ClassTag[String] = implicitly
-      registerCode(s"to$name", TString, t, (_: Type, _: PType) => rpt) {
+      registerCode1(s"to$name", TString, t, (_: Type, _: PType) => rpt) {
         case (r, rt, (xT: PString, x: Code[Long])) =>
           val s = asm4s.coerce[String](wrapArg(r, xT)(x))
           Code.invokeScalaObject(thisClass, s"parse$name", s)(ctString, ct)
       }
-      registerEmitCode(s"to${name}OrMissing", TString, t, (_: Type, xPT: PType) => rpt.setRequired(xPT.required)) {
+      registerEmitCode1(s"to${name}OrMissing", TString, t, (_: Type, xPT: PType) => rpt.setRequired(xPT.required)) {
         case (r, rt, x) =>
           val s = r.mb.newLocal[String]()
           val m = r.mb.newLocal[Boolean]()
@@ -171,17 +171,17 @@ object UtilFunctions extends RegistryFunctions {
     }
 
     Array(TInt32, TInt64).foreach { t =>
-      registerIR("min", t, t, t)((_, a, b) => intMin(a, b))
-      registerIR("max", t, t, t)((_, a, b) => intMax(a, b))
+      registerIR2("min", t, t, t)((_, a, b) => intMin(a, b))
+      registerIR2("max", t, t, t)((_, a, b) => intMax(a, b))
     }
 
     Array("min", "max").foreach { name =>
-      registerCode(name, TFloat32, TFloat32, TFloat32, (_: Type, _: PType, _: PType) => PFloat32()) {
+      registerCode2(name, TFloat32, TFloat32, TFloat32, (_: Type, _: PType, _: PType) => PFloat32()) {
         case (r, rt, (t1, v1: Code[Float]), (t2, v2: Code[Float])) =>
           Code.invokeStatic[Math, Float, Float, Float](name, v1, v2)
       }
 
-      registerCode(name, TFloat64, TFloat64, TFloat64, (_: Type, _: PType, _: PType) => PFloat64()) {
+      registerCode2(name, TFloat64, TFloat64, TFloat64, (_: Type, _: PType, _: PType) => PFloat64()) {
         case (r, rt, (t1, v1: Code[Double]), (t2, v2: Code[Double])) =>
           Code.invokeStatic[Math, Double, Double, Double](name, v1, v2)
       }
@@ -190,12 +190,12 @@ object UtilFunctions extends RegistryFunctions {
       val ignoreNanName = "nan" + name
       val ignoreBothName = ignoreNanName + "_ignore_missing"
 
-      registerCode(ignoreNanName, TFloat32, TFloat32, TFloat32, (_: Type, _: PType, _: PType) => PFloat32()) {
+      registerCode2(ignoreNanName, TFloat32, TFloat32, TFloat32, (_: Type, _: PType, _: PType) => PFloat32()) {
         case (r, rt, (t1, v1: Code[Float]), (t2, v2: Code[Float])) =>
           Code.invokeScalaObject[Float, Float, Float](thisClass, ignoreNanName, v1, v2)
       }
 
-      registerCode(ignoreNanName, TFloat64, TFloat64, TFloat64, (_: Type, _: PType, _: PType) => PFloat64()) {
+      registerCode2(ignoreNanName, TFloat64, TFloat64, TFloat64, (_: Type, _: PType, _: PType) => PFloat64()) {
         case (r, rt, (t1, v1: Code[Double]), (t2, v2: Code[Double])) =>
           Code.invokeScalaObject[Double, Double, Double](thisClass, ignoreNanName, v1, v2)
       }
@@ -211,39 +211,39 @@ object UtilFunctions extends RegistryFunctions {
             m2.mux(coerce[T](defaultValue(ti)), v2.value[T]), m2)))
       }
 
-      registerEmitCode(ignoreMissingName, TInt32, TInt32, TInt32, (_: Type, t1: PType, t2: PType) => PInt32(t1.required && t2.required)) {
+      registerEmitCode2(ignoreMissingName, TInt32, TInt32, TInt32, (_: Type, t1: PType, t2: PType) => PInt32(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Int](rt, v1, v2, ignoreMissingName)
       }
 
-      registerEmitCode(ignoreMissingName, TInt64, TInt64, TInt64, (_: Type, t1: PType, t2: PType) => PInt64(t1.required && t2.required)) {
+      registerEmitCode2(ignoreMissingName, TInt64, TInt64, TInt64, (_: Type, t1: PType, t2: PType) => PInt64(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Long](rt, v1, v2, ignoreMissingName)
       }
 
-      registerEmitCode(ignoreMissingName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
+      registerEmitCode2(ignoreMissingName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreMissingName)
       }
 
-      registerEmitCode(ignoreMissingName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
+      registerEmitCode2(ignoreMissingName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreMissingName)
       }
 
-      registerEmitCode(ignoreBothName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
+      registerEmitCode2(ignoreBothName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Float](rt, v1, v2, ignoreBothName)
       }
 
-      registerEmitCode(ignoreBothName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
+      registerEmitCode2(ignoreBothName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
         case (r, rt, v1, v2) => ignoreMissingTriplet[Double](rt, v1, v2, ignoreBothName)
       }
     }
 
-    registerCode("format", TString, tv("T", "tuple"), TString, (_: Type, _: PType, _: PType) => PCanonicalString()) {
+    registerCode2("format", TString, tv("T", "tuple"), TString, (_: Type, _: PType, _: PType) => PCanonicalString()) {
       case (r, rt, (fmtT: PString, format: Code[Long]), (argsT: PTuple, args: Code[Long])) =>
         unwrapReturn(r, rt)(Code.invokeScalaObject[String, Row, String](thisClass, "format",
           asm4s.coerce[String](wrapArg(r, fmtT)(format)),
           Code.checkcast[Row](asm4s.coerce[java.lang.Object](wrapArg(r, argsT)(args)))))
     }
 
-    registerEmitCode("land", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
+    registerEmitCode2("land", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
       case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]
@@ -273,7 +273,7 @@ object UtilFunctions extends RegistryFunctions {
           PCode(rt, w.ceq(10)))
     }
 
-    registerEmitCode("lor", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
+    registerEmitCode2("lor", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
       case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -27,14 +27,14 @@ class ScalaTestCompanion {
 
 object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
-    registerIR("addone", TInt32, TInt32)((_, a) => ApplyBinaryPrimOp(Add(), a, I32(1)))
+    registerIR1("addone", TInt32, TInt32)((_, a) => ApplyBinaryPrimOp(Add(), a, I32(1)))
     registerJavaStaticFunction("compare", Array(TInt32, TInt32), TInt32, null)(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", Array(), TInt32, null)(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", Array(), TInt32, null)(ScalaTestCompanion.getClass, "testFunction")
-    registerCode[Int, Int]("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x"), null) {
+    registerCode2[Int, Int]("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x"), null) {
       case (_, rt, (aT, a: Code[Int]), (bT, b: Code[Int])) => a + b
     }
-    registerCode("testCodeUnification2", tv("x"), tv("x"), null) { case (_, rt, (aT, a: Code[Long])) => a }
+    registerCode1("testCodeUnification2", tv("x"), tv("x"), null) { case (_, rt, (aT, a: Code[Long])) => a }
   }
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -50,7 +50,7 @@ object IRSuite {
         override def returnPType(argTypes: Seq[PType], returnType: Type): PType = if (pt == null) PType.canonical(returnType) else pt(returnType, argTypes)
 
         def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: EmitCode*): EmitCode = {
-          assert(unify(super.typeArgs, args.map(_.pt.virtualType), rpt.virtualType))
+          assert(unify(FastSeq(), args.map(_.pt.virtualType), rpt.virtualType))
           impl(r, rpt, seed, args.toArray)
         }
       })

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -34,15 +34,15 @@ object TestRandomFunctions extends RegistryFunctions {
   }
 
   def registerAll() {
-    registerSeeded("counter_seeded", TInt32, PInt32(true)) { case (r, rt, seed) =>
+    registerSeeded0("counter_seeded", TInt32, PInt32(true)) { case (r, rt, seed) =>
       getTestRNG(r.mb, seed).invoke[Int]("counter")
     }
 
-    registerSeeded("seed_seeded", TInt64, PInt64(true)) { case (r, rt, seed) =>
+    registerSeeded0("seed_seeded", TInt64, PInt64(true)) { case (r, rt, seed) =>
       getTestRNG(r.mb, seed).invoke[Long]("seed")
     }
 
-    registerSeeded("pi_seeded", TInt32, PInt32(true)) { case (r, rt, seed) =>
+    registerSeeded0("pi_seeded", TInt32, PInt32(true)) { case (r, rt, seed) =>
       getTestRNG(r.mb, seed).invoke[Int]("partitionIndex")
     }
   }


### PR DESCRIPTION
The overloading made development a huge headache. I think we should consider overloading more than ~2-way bad practice and try to avoid it.