### PR TITLE
Provide option to skip log4j configuration

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -179,7 +179,9 @@ dependencies {
     unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
-    bundled 'com.indeed:lsmtree-core:1.0.7'
+    bundled('com.indeed:lsmtree-core:1.0.7') {
+        transitive = false
+    }
     bundled 'com.indeed:util-serialization:1.0.30'
 }
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -179,9 +179,7 @@ dependencies {
     unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
-    bundled('com.indeed:lsmtree-core:1.0.7') {
-        transitive = false
-    }
+    bundled 'com.indeed:lsmtree-core:1.0.7'
     bundled 'com.indeed:util-serialization:1.0.30'
 }
 

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -124,9 +124,8 @@ class SparkBackend(Backend):
             conf.set('spark.executor.extraClassPath', './hail-all-spark.jar')
             if sc is None:
                 SparkContext._ensure_initialized(conf=conf)
-            else:
-                import warnings
-                warnings.warn(
+            elif not quiet:
+                sys.stderr.write(
                     'pip-installed Hail requires additional configuration options in Spark referring\n'
                     '  to the path to the Hail Python module directory HAIL_DIR,\n'
                     '  e.g. /path/to/python/site-packages/hail:\n'

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -102,7 +102,7 @@ class Backend(abc.ABC):
 class SparkBackend(Backend):
     def __init__(self, idempotent, sc, spark_conf, app_name, master,
                  local, log, quiet, append, min_block_size,
-                 branching_factor, tmp_dir, configure_logger, optimizer_iterations):
+                 branching_factor, tmp_dir, skip_logging_configuration, optimizer_iterations):
         if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
             hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
             assert os.path.exists(hail_jar_path), f'{hail_jar_path} does not exist'
@@ -151,12 +151,12 @@ class SparkBackend(Backend):
             self._jbackend = hail.backend.spark.SparkBackend.getOrCreate(
                 jsc, app_name, master, local, True, min_block_size)
             self._jhc = hail.HailContext.getOrCreate(
-                self._jbackend, log, True, append, branching_factor, tmp_dir, configure_logger, optimizer_iterations)
+                self._jbackend, log, True, append, branching_factor, tmp_dir, skip_logging_configuration, optimizer_iterations)
         else:
             self._jbackend = hail.backend.spark.SparkBackend.apply(
                 jsc, app_name, master, local, True, min_block_size)
             self._jhc = hail.HailContext.apply(
-                self._jbackend, log, True, append, branching_factor, tmp_dir, configure_logger, optimizer_iterations)
+                self._jbackend, log, True, append, branching_factor, tmp_dir, skip_logging_configuration, optimizer_iterations)
 
         self._jsc = self._jhc.sc()
         self.sc = sc if sc else SparkContext(gateway=self._gateway, jsc=self._jvm.JavaSparkContext(self._jsc))

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -102,7 +102,7 @@ class Backend(abc.ABC):
 class SparkBackend(Backend):
     def __init__(self, idempotent, sc, spark_conf, app_name, master,
                  local, log, quiet, append, min_block_size,
-                 branching_factor, tmp_dir, optimizer_iterations):
+                 branching_factor, tmp_dir, configure_logger, optimizer_iterations):
         if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
             hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
             assert os.path.exists(hail_jar_path), f'{hail_jar_path} does not exist'
@@ -151,12 +151,12 @@ class SparkBackend(Backend):
             self._jbackend = hail.backend.spark.SparkBackend.getOrCreate(
                 jsc, app_name, master, local, True, min_block_size)
             self._jhc = hail.HailContext.getOrCreate(
-                self._jbackend, log, True, append, branching_factor, tmp_dir, optimizer_iterations)
+                self._jbackend, log, True, append, branching_factor, tmp_dir, configure_logger, optimizer_iterations)
         else:
             self._jbackend = hail.backend.spark.SparkBackend.apply(
                 jsc, app_name, master, local, True, min_block_size)
             self._jhc = hail.HailContext.apply(
-                self._jbackend, log, True, append, branching_factor, tmp_dir, optimizer_iterations)
+                self._jbackend, log, True, append, branching_factor, tmp_dir, configure_logger, optimizer_iterations)
 
         self._jsc = self._jhc.sc()
         self.sc = sc if sc else SparkContext(gateway=self._gateway, jsc=self._jvm.JavaSparkContext(self._jsc))

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -27,7 +27,7 @@ class HailContext(object):
                       idempotent=bool,
                       global_seed=nullable(int),
                       spark_conf=nullable(dictof(str, str)),
-                      configure_logger=nullable(bool),
+                      skip_logging_configuration=bool,
                       optimizer_iterations=nullable(int),
                       _backend=nullable(Backend))
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
@@ -35,7 +35,7 @@ class HailContext(object):
                  min_block_size=1, branching_factor=50, tmp_dir=None,
                  default_reference="GRCh37", idempotent=False,
                  global_seed=6348563392232659379, spark_conf=None,
-                 configure_logger=None, optimizer_iterations=None=None, _backend=None):
+                 skip_logging_configuration=False, optimizer_iterations=None, _backend=None):
 
         if Env._hc:
             if idempotent:
@@ -63,7 +63,7 @@ class HailContext(object):
                 _backend = SparkBackend(
                     idempotent, sc, spark_conf, app_name, master, local, log,
                     quiet, append, min_block_size, branching_factor, tmp_dir,
-                    configure_logger, optimizer_iterations)
+                    skip_logging_configuration, optimizer_iterations)
         self._backend = _backend
 
         self._warn_cols_order = True
@@ -132,7 +132,7 @@ class HailContext(object):
            idempotent=bool,
            global_seed=nullable(int),
            spark_conf=nullable(dictof(str, str)),
-           configure_logger=nullable(bool),
+           skip_logging_configuration=bool,
            _optimizer_iterations=nullable(int),
            _backend=nullable(Backend))
 def init(sc=None, app_name='Hail', master=None, local='local[*]',
@@ -141,7 +141,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
          default_reference='GRCh37', idempotent=False,
          global_seed=6348563392232659379,
          spark_conf=None,
-         configure_logger=None,
+         skip_logging_configuration=False,
          _optimizer_iterations=None,
          _backend=None):
     """Initialize Hail and Spark.
@@ -213,13 +213,13 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
         Global random seed.
     spark_conf : :obj:`dict[str, str]`, optional
         Spark configuration parameters.
-    configure_logger : :obj:`bool`, optional
-        Whether to configure the logger.
+    skip_logging_configuration : :obj:`bool`
+        Skip logging configuration.
     """
     HailContext(sc, app_name, master, local, log, quiet, append,
                 min_block_size, branching_factor, tmp_dir,
                 default_reference, idempotent, global_seed, spark_conf,
-                configure_logger,_optimizer_iterations,_backend)
+                skip_logging_configuration,_optimizer_iterations,_backend)
 
 
 def version():

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -27,6 +27,7 @@ class HailContext(object):
                       idempotent=bool,
                       global_seed=nullable(int),
                       spark_conf=nullable(dictof(str, str)),
+                      configure_logger=nullable(bool),
                       optimizer_iterations=nullable(int),
                       _backend=nullable(Backend))
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
@@ -34,7 +35,7 @@ class HailContext(object):
                  min_block_size=1, branching_factor=50, tmp_dir=None,
                  default_reference="GRCh37", idempotent=False,
                  global_seed=6348563392232659379, spark_conf=None,
-                 optimizer_iterations=None, _backend=None):
+                 configure_logger=None, optimizer_iterations=None=None, _backend=None):
 
         if Env._hc:
             if idempotent:
@@ -62,7 +63,7 @@ class HailContext(object):
                 _backend = SparkBackend(
                     idempotent, sc, spark_conf, app_name, master, local, log,
                     quiet, append, min_block_size, branching_factor, tmp_dir,
-                    optimizer_iterations)
+                    configure_logger, optimizer_iterations)
         self._backend = _backend
 
         self._warn_cols_order = True
@@ -131,6 +132,7 @@ class HailContext(object):
            idempotent=bool,
            global_seed=nullable(int),
            spark_conf=nullable(dictof(str, str)),
+           configure_logger=nullable(bool),
            _optimizer_iterations=nullable(int),
            _backend=nullable(Backend))
 def init(sc=None, app_name='Hail', master=None, local='local[*]',
@@ -139,6 +141,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
          default_reference='GRCh37', idempotent=False,
          global_seed=6348563392232659379,
          spark_conf=None,
+         configure_logger=None,
          _optimizer_iterations=None,
          _backend=None):
     """Initialize Hail and Spark.
@@ -210,11 +213,13 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
         Global random seed.
     spark_conf : :obj:`dict[str, str]`, optional
         Spark configuration parameters.
+    configure_logger : :obj:`bool`, optional
+        Whether to configure the logger.
     """
     HailContext(sc, app_name, master, local, log, quiet, append,
                 min_block_size, branching_factor, tmp_dir,
                 default_reference, idempotent, global_seed, spark_conf,
-                _optimizer_iterations,_backend)
+                configure_logger,_optimizer_iterations,_backend)
 
 
 def version():

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -219,7 +219,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
     HailContext(sc, app_name, master, local, log, quiet, append,
                 min_block_size, branching_factor, tmp_dir,
                 default_reference, idempotent, global_seed, spark_conf,
-                skip_logging_configuration,_optimizer_iterations,_backend)
+                skip_logging_configuration, _optimizer_iterations, _backend)
 
 
 def version():

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -65,19 +65,21 @@ object HailContext {
 
   def sc: SparkContext = get.sc
 
-  def configureLogging(logFile: String, quiet: Boolean, append: Boolean) {
-    val logProps = new Properties()
+  def configureLogging(logFile: String, quiet: Boolean, append: Boolean, skipLoggingConfiguration: Boolean) {
+    if (!skipLoggingConfiguration) {
+      val logProps = new Properties()
 
-    logProps.put("log4j.rootLogger", "INFO, logfile")
-    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
-    logProps.put("log4j.appender.logfile.append", append.toString)
-    logProps.put("log4j.appender.logfile.file", logFile)
-    logProps.put("log4j.appender.logfile.threshold", "INFO")
-    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
-    logProps.put("log4j.appender.logfile.layout.ConversionPattern", HailContext.logFormat)
+      logProps.put("log4j.rootLogger", "INFO, logfile")
+      logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
+      logProps.put("log4j.appender.logfile.append", append.toString)
+      logProps.put("log4j.appender.logfile.file", logFile)
+      logProps.put("log4j.appender.logfile.threshold", "INFO")
+      logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
+      logProps.put("log4j.appender.logfile.layout.ConversionPattern", HailContext.logFormat)
 
-    LogManager.resetConfiguration()
-    PropertyConfigurator.configure(logProps)
+      LogManager.resetConfiguration()
+      PropertyConfigurator.configure(logProps)
+    }
 
     if (!quiet)
       consoleLog.addAppender(new ConsoleAppender(new PatternLayout(HailContext.logFormat), "System.err"))
@@ -146,9 +148,7 @@ object HailContext {
         DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD)
     }
 
-    if (!skipLoggingConfiguration) {
-      configureLogging(logFile, quiet, append)
-    }
+    configureLogging(logFile, quiet, append, skipLoggingConfiguration)
 
     theContext = new HailContext(backend, logFile, tmpDir, branchingFactor, optimizerIterations)
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -107,10 +107,10 @@ object HailContext {
     append: Boolean = false,
     branchingFactor: Int = 50,
     tmpDir: String = "/tmp",
-    configureLogger: Boolean = true,
+    skipLoggingConfiguration: Boolean = false,
     optimizerIterations: Int = 3): HailContext = {
     if (theContext == null)
-      return HailContext(backend, logFile, quiet, append, branchingFactor, tmpDir, configureLogger, optimizerIterations)
+      return HailContext(backend, logFile, quiet, append, branchingFactor, tmpDir, skipLoggingConfiguration, optimizerIterations)
 
     if (theContext.logFile != logFile)
       warn(s"Requested tmpDir $logFile, but already initialized to ${ theContext.logFile }.  Ignoring requested setting.")
@@ -133,7 +133,7 @@ object HailContext {
     append: Boolean = false,
     branchingFactor: Int = 50,
     tmpDir: String = "/tmp",
-    configureLogger: Boolean = true,
+    skipLoggingConfiguration: Boolean = false,
     optimizerIterations: Int = 3): HailContext = synchronized {
     require(theContext == null)
     checkJavaVersion()
@@ -146,7 +146,7 @@ object HailContext {
         DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD)
     }
 
-    if (configureLogger) {
+    if (!skipLoggingConfiguration) {
       configureLogging(logFile, quiet, append)
     }
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -107,9 +107,10 @@ object HailContext {
     append: Boolean = false,
     branchingFactor: Int = 50,
     tmpDir: String = "/tmp",
+    configureLogger: Boolean = true,
     optimizerIterations: Int = 3): HailContext = {
     if (theContext == null)
-      return HailContext(backend, logFile, quiet, append, branchingFactor, tmpDir, optimizerIterations)
+      return HailContext(backend, logFile, quiet, append, branchingFactor, tmpDir, configureLogger, optimizerIterations)
 
     if (theContext.logFile != logFile)
       warn(s"Requested tmpDir $logFile, but already initialized to ${ theContext.logFile }.  Ignoring requested setting.")
@@ -132,6 +133,7 @@ object HailContext {
     append: Boolean = false,
     branchingFactor: Int = 50,
     tmpDir: String = "/tmp",
+    configureLogger: Boolean = true,
     optimizerIterations: Int = 3): HailContext = synchronized {
     require(theContext == null)
     checkJavaVersion()
@@ -144,7 +146,9 @@ object HailContext {
         DenseMatrix.implOpMulMatrix_DMD_DVD_eq_DVD)
     }
 
-    configureLogging(logFile, quiet, append)
+    if (configureLogger) {
+      configureLogging(logFile, quiet, append)
+    }
 
     theContext = new HailContext(backend, logFile, tmpDir, branchingFactor, optimizerIterations)
 

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -165,7 +165,7 @@ async def on_startup(app):
     app['jbackend'] = jbackend
 
     jhc = hail_pkg.HailContext.apply(
-        jbackend, 'hail.log', False, False, 50, "/tmp", 3)
+        jbackend, 'hail.log', False, False, 50, "/tmp", False, 3)
     app['jhc'] = jhc
 
     app['users'] = set()


### PR DESCRIPTION
HailContext initialization overrides any existing log4j configuration, which can lead to the logs ending up in an unexpected location. This PR adds an option to HailContext initialization to skip this configuration step.

I also included two unrelated changes to this PR:
- Not bundling the transitive dependencies for `com.indeed:lsmtree-core:1.0.7`, which don't seem to be needed and can lead to classpath conflicts.
- Allowing the `quiet` option during initialization to silence the warning issued when initializing with pip-installed Hail.