### PR TITLE
[query] fix linreg aggregator correctness bug

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -989,6 +989,17 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(r.multiple_p_value, 0.6331017)
         self.assertAlmostEqual(r.n, 5)
 
+        # swapping the intercept and t.x
+        r = t.aggregate(hl.struct(linreg=hl.agg.linreg(t.y, [t.x, 1]))).linreg
+        self.assertAlmostEqual(r.beta[1], 0.14069227)
+        self.assertAlmostEqual(r.beta[0], 0.32744807)
+        self.assertAlmostEqual(r.standard_error[1], 0.59410817)
+        self.assertAlmostEqual(r.standard_error[0], 0.61833778)
+        self.assertAlmostEqual(r.t_stat[1], 0.23681254)
+        self.assertAlmostEqual(r.t_stat[0], 0.52956181)
+        self.assertAlmostEqual(r.p_value[1], 0.82805147)
+        self.assertAlmostEqual(r.p_value[0], 0.63310173)
+
         # weighted OLS
         t = t.add_index()
         r = t.aggregate(hl.struct(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -159,7 +159,7 @@ class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends Stag
           i += 1,
           xptr := xptr + scalar.byteSize))))
 
-      xt.anyMissing(mb, x).mux(Code._empty, body)
+      xt.hasMissingValues(x).mux(Code._empty, body)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArrayBackedContainer.scala
@@ -117,9 +117,6 @@ trait PArrayBackedContainer extends PContainer {
   def zeroes(mb: EmitMethodBuilder[_], region: Value[Region], length: Code[Int]): Code[Long] =
     arrayRep.zeroes(mb, region, length)
 
-  def anyMissing(mb: EmitMethodBuilder[_], aoff: Code[Long]): Code[Boolean] =
-    arrayRep.anyMissing(mb, aoff)
-
   def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] =
     arrayRep.forEach(mb, aoff, body)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -257,33 +257,6 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
   }
 
-  def anyMissing(mb: EmitMethodBuilder[_], aoff: Code[Long]): Code[Boolean] =
-    if (elementType.required)
-      false
-    else {
-      val n = mb.newLocal[Long]()
-      val ret = mb.newLocal[Boolean]()
-      val ptr = mb.newLocal[Long]()
-      val L = CodeLabel()
-      Code.memoize(aoff,"pcarr_any_missing_aoff") { aoff =>
-        Code(
-          n := aoff + ((loadLength(aoff) >>> 5) * 4 + 4).toL,
-          ptr := aoff + 4L,
-          L,
-          (ptr < n).mux(
-            Region.loadInt(ptr).cne(0).mux(
-              ret := true,
-              Code(
-                ptr := ptr + 4L,
-                L.goto)),
-            (Region.loadByte(ptr) >>>
-              (const(32) - (loadLength(aoff) | 31))).cne(0).mux(
-              ret := true,
-              ret := false)),
-          ret.load())
-      }
-    }
-
   def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] = {
     val i = mb.newLocal[Int]()
     val n = mb.newLocal[Int]()

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -83,8 +83,6 @@ abstract class PContainer extends PIterable {
 
   def zeroes(mb: EmitMethodBuilder[_], region: Value[Region], length: Code[Int]): Code[Long]
 
-  def anyMissing(mb: EmitMethodBuilder[_], aoff: Code[Long]): Code[Boolean]
-
   def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit]
 
   def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean]

--- a/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
@@ -78,6 +78,21 @@ class PContainerTest extends HailSuite {
     res
   }
 
+  def testAnyMissing(sourceType: PCanonicalArray, data: IndexedSeq[Any]) = {
+    val srcRegion = Region()
+    val src = ScalaToRegionValue(srcRegion, sourceType, data)
+
+    log.info(s"\nTesting $data")
+
+    val fb = EmitFunctionBuilder[Long, Boolean]("not_empty")
+    val value = fb.getCodeParam[Long](1)
+
+    fb.emit(sourceType.anyMissing(fb.apply_method, value))
+
+    val res = fb.result()()(src)
+    res
+  }
+
   @Test def checkFirstNonZeroByte() {
     val sourceType = PCanonicalArray(PInt64(false))
 
@@ -132,6 +147,12 @@ class PContainerTest extends HailSuite {
 
     assert(testHasMissingValues(sourceType, nullInByte(1, 0)) == false)
     assert(testHasMissingValues(sourceType, nullInByte(1, 1)) == true)
+    assert(testHasMissingValues(sourceType, nullInByte(2, 1)) == true)
+
+    for {
+      num <- Seq(2, 16, 31, 32, 33, 50, 63, 64, 65, 90, 127, 128, 129)
+        missing <- 1 to num
+    } assert(testHasMissingValues(sourceType, nullInByte(num, missing)) == true)
   }
 
   @Test def checkedConvertFromTest() {

--- a/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/expr/types/physical/PContainerTest.scala
@@ -78,21 +78,6 @@ class PContainerTest extends HailSuite {
     res
   }
 
-  def testAnyMissing(sourceType: PCanonicalArray, data: IndexedSeq[Any]) = {
-    val srcRegion = Region()
-    val src = ScalaToRegionValue(srcRegion, sourceType, data)
-
-    log.info(s"\nTesting $data")
-
-    val fb = EmitFunctionBuilder[Long, Boolean]("not_empty")
-    val value = fb.getCodeParam[Long](1)
-
-    fb.emit(sourceType.anyMissing(fb.apply_method, value))
-
-    val res = fb.result()()(src)
-    res
-  }
-
   @Test def checkFirstNonZeroByte() {
     val sourceType = PCanonicalArray(PInt64(false))
 


### PR DESCRIPTION
Fixes #8349.

The `anyMissing` implementation on `PArray` was wrong, and could return false if the only missing elements were in the last aligned 32 bits containing the end of the missing bits. This in turn let some rows be included in the regression even if some of the covariates were missing.