### PR TITLE
[hail] Shade most of our bundled dependencies

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     hailTest 'org.testng:testng:6.8.21'
     hailTest 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 
-    bundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
     bundled group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
 
@@ -251,7 +251,7 @@ tasks.withType(ShadowJar) {
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
-    relocate 'org.apache.commons', 'is.hail.relocated.org.apache.commons'
+    relocate 'org.apache.commons.lang3', 'is.hail.relocated.org.apache.commons.lang3'
     relocate 'org.apache.httpcomponents', 'is.hail.relocated.org.apache.httpcomponents'
     relocate 'com.indeed', 'is.hail.relocated.com.indeed'
     relocate 'com.google.cloud', 'is.hail.relocated.com.google.cloud'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     }
     unbundled('org.apache.hadoop:hadoop-client:2.7.1') {
         exclude module: 'servlet-api'
-	exclude module: 'asm'
+        exclude module: 'asm'
     }
     unbundled 'org.apache.spark:spark-sql_' + scalaMajorVersion + ':' + sparkVersion
     unbundled 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
@@ -251,6 +251,13 @@ tasks.withType(ShadowJar) {
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
+    relocate 'org.apache.commons', 'is.hail.relocated.org.apache.commons'
+    relocate 'org.apache.httpcomponents', 'is.hail.relocated.org.apache.httpcomponents'
+    relocate 'com.indeed', 'is.hail.relocated.com.indeed'
+    relocate 'com.google.cloud', 'is.hail.relocated.com.google.cloud'
+    relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
+    relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
+    relocate 'org.lz4', 'is.hail.relocated.org.lz4'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -181,7 +181,8 @@ dependencies {
     bundled group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
 
     bundled 'com.indeed:lsmtree-core:1.0.7'
-    bundled 'com.indeed:util-serialization:1.0.30'
+    bundled 'com.indeed:util-serialization:1.0.31'
+    bundled 'com.indeed:util-mmap:1.0.31'
     bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.14'
 }
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -248,14 +248,15 @@ tasks.withType(ShadowJar) {
     baseName = project.name + '-all'
     mergeServiceFiles()
     zip64 true
-    // conflict with version in default Hadoop/Spark install
+
     relocate 'org.apache.http', 'is.hail.relocated.org.apache.http'
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
     relocate 'org.apache.commons.lang3', 'is.hail.relocated.org.apache.commons.lang3'
     relocate 'org.apache.httpcomponents', 'is.hail.relocated.org.apache.httpcomponents'
-    relocate 'com.indeed', 'is.hail.relocated.com.indeed'
+    // we should really shade indeed, but it has native libraries
+    // relocate 'com.indeed', 'is.hail.relocated.com.indeed'
     relocate 'com.google.cloud', 'is.hail.relocated.com.google.cloud'
     relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -11,13 +11,12 @@ plugins {
   id 'scala'
   id 'idea'
   id 'maven'
-  id 'com.github.johnrengelman.shadow' version '5.0.0'
+  id 'com.github.johnrengelman.shadow' version "5.0.0"
   id "de.undercouch.download" version "3.2.0"
   id 'eclipse'
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
 repositories {
     mavenCentral()
@@ -177,8 +176,9 @@ dependencies {
     hailTest 'org.testng:testng:6.8.21'
     hailTest 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 
-    unbundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    bundled group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     bundled group: 'commons-codec', name: 'commons-codec', version: '1.11'
+    bundled group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
 
     bundled 'com.indeed:lsmtree-core:1.0.7'
     bundled 'com.indeed:util-serialization:1.0.30'
@@ -238,14 +238,6 @@ task testAll(type: Exec) {
     commandLine 'sh', '-c', 'echo "use make test; gradle is being phased out"; exit 1'
 }
 
-task relocateShadowJar(type: ConfigureShadowRelocation) {
-    target = tasks.shadowJar
-    prefix = "is.hail.auto.relocated"
-
-}
-
-tasks.shadowJar.dependsOn tasks.relocateShadowJar
-
 tasks.withType(ShadowJar) {
     manifest {
         attributes 'Implementation-Title': 'Hail',
@@ -258,6 +250,7 @@ tasks.withType(ShadowJar) {
     relocate 'org.apache.http', 'is.hail.relocated.org.apache.http'
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
+    relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -17,6 +17,7 @@ plugins {
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
 repositories {
     mavenCentral()
@@ -236,6 +237,14 @@ task doctest(type: Exec) {
 task testAll(type: Exec) {
     commandLine 'sh', '-c', 'echo "use make test; gradle is being phased out"; exit 1'
 }
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+    target = tasks.shadowJar
+    prefix = "is.hail.auto.relocated"
+
+}
+
+tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
 tasks.withType(ShadowJar) {
     manifest {

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -182,6 +182,7 @@ dependencies {
 
     bundled 'com.indeed:lsmtree-core:1.0.7'
     bundled 'com.indeed:util-serialization:1.0.30'
+    bundled group: 'org.freemarker', name: 'freemarker', version: '2.3.14'
 }
 
 task(checkSettings) doLast {
@@ -258,6 +259,7 @@ tasks.withType(ShadowJar) {
     relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'
+    relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -11,7 +11,7 @@ plugins {
   id 'scala'
   id 'idea'
   id 'maven'
-  id 'com.github.johnrengelman.shadow' version "5.0.0"
+  id 'com.github.johnrengelman.shadow' version '5.0.0'
   id "de.undercouch.download" version "3.2.0"
   id 'eclipse'
 }

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -5,17 +5,17 @@ set -ex
 cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
-stop_dataproc () {
-    exit_code=$?
+# stop_dataproc () {
+#     exit_code=$?
 
-    set +e
+#     set +e
 
-    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
-    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
+#     hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
+#     hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
 
-    exit $exit_code
-}
-trap stop_dataproc EXIT
+#     exit $exit_code
+# }
+# trap stop_dataproc EXIT
 
 cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -2,30 +2,30 @@
 
 set -ex
 
-cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
+cluster_name_37=cluster-dking-gihlua # cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
-stop_dataproc () {
-    exit_code=$?
+# stop_dataproc () {
+#     exit_code=$?
 
-    set +e
+#     set +e
 
-    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
-    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
+#     hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
+#     hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
 
-    exit $exit_code
-}
-trap stop_dataproc EXIT
+#     exit $exit_code
+# }
+# trap stop_dataproc EXIT
 
 cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
 
-hailctl dataproc \
-        start $cluster_name_37 \
-        --max-idle 10m \
-        --max-age 120m \
-        --vep GRCh37 \
-        --requester-pays-allow-buckets hail-us-vep
+# hailctl dataproc \
+#         start $cluster_name_37 \
+#         --max-idle 10m \
+#         --max-age 120m \
+#         --vep GRCh37 \
+#         --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_37_test_files
 do
     hailctl dataproc \

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -2,30 +2,30 @@
 
 set -ex
 
-cluster_name_37=cluster-dking-gihlua # cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
+cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
-# stop_dataproc () {
-#     exit_code=$?
+stop_dataproc () {
+    exit_code=$?
 
-#     set +e
+    set +e
 
-#     hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
-#     hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
 
-#     exit $exit_code
-# }
-# trap stop_dataproc EXIT
+    exit $exit_code
+}
+trap stop_dataproc EXIT
 
 cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')
 
-# hailctl dataproc \
-#         start $cluster_name_37 \
-#         --max-idle 10m \
-#         --max-age 120m \
-#         --vep GRCh37 \
-#         --requester-pays-allow-buckets hail-us-vep
+hailctl dataproc \
+        start $cluster_name_37 \
+        --max-idle 10m \
+        --max-age 120m \
+        --vep GRCh37 \
+        --requester-pays-allow-buckets hail-us-vep
 for file in $cluster_37_test_files
 do
     hailctl dataproc \

--- a/hail/scripts/test-dataproc.sh
+++ b/hail/scripts/test-dataproc.sh
@@ -5,17 +5,17 @@ set -ex
 cluster_name_37=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 cluster_name_38=cluster-$(whoami)-$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 6)
 
-# stop_dataproc () {
-#     exit_code=$?
+stop_dataproc () {
+    exit_code=$?
 
-#     set +e
+    set +e
 
-#     hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
-#     hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name_37 || true  # max-idle or max-age will delete it
+    hailctl dataproc stop $cluster_name_38 || true  # max-idle or max-age will delete it
 
-#     exit $exit_code
-# }
-# trap stop_dataproc EXIT
+    exit $exit_code
+}
+trap stop_dataproc EXIT
 
 cluster_37_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh38.py')
 cluster_38_test_files=$(ls python/cluster-tests/*.py | grep -ve 'python/cluster-tests/cluster-vep-check-GRCh37.py')


### PR DESCRIPTION
Our public interface is python. The public interface of Spark that we use, AFAICT, does not depend on any non-Spark-defined classes. Ergo, we should hide away all our dependencies.

I intended to shade every bundled package except for breeze-natives, because I think we want to take that from the cluster (and we're willing to lock into Spark's version). `RandBasis` (a breeze class) takes as argument a random generator from `math3`, so I keep the Apache Commons Math3 library unbundled and not shaded. Everything else should now be shaded.