### PR TITLE
[deploy-config] add service deploy-config location to defaults

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -273,7 +273,6 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-     export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      # create accounts
      mkdir /user-tokens
      cat > create-session.py <<EOF
@@ -1104,7 +1103,6 @@ steps:
    image:
      valueFrom: service_base_image.image
    script: |
-     export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
@@ -1212,7 +1210,6 @@ steps:
      valueFrom: test_ci_image.image
    script: |
      set -ex
-     export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      export ORGANIZATION=hail-ci-test
      export REPO_NAME=ci-test-"{{ create_ci_test_repo.token }}"
      export NAMESPACE="{{ default_ns.name }}"
@@ -1247,7 +1244,6 @@ steps:
    script: |
      set -ex
 
-     export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      python3 -m hailtop.hailctl config set batch/billing_project test
      python3 -m pytest --log-cli-level=INFO -s -vv --instafail /io/test/test/hailtop/batch/
    inputs:
@@ -1279,8 +1275,6 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-
-     export HAIL_DEPLOY_CONFIG_FILE=/deploy-config/deploy-config.json
      cd /io/hailtop/hailtop/batch
      python3 -m hailtop.hailctl config set batch/billing_project test
      python3 -m pytest --instafail \

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 from aiohttp import web
+from hailtop.utils import first_extant_file
 
 log = logging.getLogger('gear')
 
@@ -13,10 +14,12 @@ class DeployConfig:
 
     @staticmethod
     def from_config_file(config_file=None):
-        if not config_file:
-            config_file = os.environ.get(
-                'HAIL_DEPLOY_CONFIG_FILE', os.path.expanduser('~/.hail/deploy-config.json'))
-        if os.path.isfile(config_file):
+        config_file = first_extant_file(
+            config_file,
+            os.environ.get('HAIL_DEPLOY_CONFIG_FILE'),
+            os.path.expanduser('~/.hail/deploy-config.json'),
+            '/deploy-config/deploy-config.json')
+        if config_file is not None:
             with open(config_file, 'r') as f:
                 config = json.loads(f.read())
         else:

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -6,7 +6,8 @@ from .utils import (
     collect_agen, retry_all_errors, retry_transient_errors,
     retry_long_running, run_if_changed, LoggingTimer,
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
-    retry_response_returning_functions)
+    retry_response_returning_functions,
+    first_extant_file)
 from .process import CalledProcessError, check_shell, check_shell_output
 from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 
@@ -38,5 +39,6 @@ __all__ = [
     'TQDM_DEFAULT_DISABLE',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
-    'retry_response_returning_functions'
+    'retry_response_returning_functions',
+    'first_extant_file'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -23,6 +23,13 @@ RETRY_FUNCTION_SCRIPT = """function retry() {
 }"""
 
 
+def first_extant_file(*files):
+    for f in files:
+        if f is not None and os.path.isfile(f):
+            return f
+    return None
+
+
 def grouped(n, ls):
     while len(ls) != 0:
         group = ls[:n]


### PR DESCRIPTION
In the words of Camille Fournier: "An Engineer II rarely makes the same mistake twice."

I will be damned if I ever forget to `export HAIL_DEPLOY_CONFIG_FILE=...` ever again.