### PR TITLE
[hailtop.curl] curl should use localized url

### DIFF
--- a/hail/python/hailtop/hailctl/curl.py
+++ b/hail/python/hailtop/hailctl/curl.py
@@ -17,6 +17,6 @@ def main(args):
     headers = [x
                for k, v in headers.items()
                for x in ['-H', f'{k}: {v}']]
-    path = deploy_config.with_service(svc, ns).external_url(svc, path)
+    path = deploy_config.with_service(svc, ns).url(svc, path)
     print('curl ' + ' '.join(headers) + ' ' + ' '.join(args[3:]) + ' ' + path)
     subprocess.check_call(['curl', *headers, *args[3:], path])


### PR DESCRIPTION
Currently, `hailctl curl` uses `external_url` instead of `url`. As a result,
if `hailctl curl` is used inside a GCE VM or on a k8s pod, the url will always
be `....hail.is` to which GCE VMs and k8s pods likely lack credentials.

This was a mistake when I first wrote curl. At that time, I was only using it for
local testing. It will still work for local testing because our deploy configs are
all `external`.