### PR TITLE
Lower TableParallelize

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -26,7 +26,7 @@ sealed trait IR extends BaseIR {
       try {
         _typ = InferType(this)
       } catch {
-        case e: Throwable => throw new RuntimeException(s"typ: inference failure", e)
+        case e: Throwable => throw new RuntimeException(s"typ: inference failure: ${e.getMessage}", e)
       }
     _typ
   }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -125,16 +125,16 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
           val numRows = ArrayLen(GetField(loweredRowsAndGlobal, "rows"))
           val numNonEmptyPartitions = If(numRows < nPartitionsAdj, numRows, nPartitionsAdj)
           val q = numRows floorDiv numNonEmptyPartitions
-          val m = numRows - q * numNonEmptyPartitions
+          val remainder = numRows - q * numNonEmptyPartitions
           val length = If(numNonEmptyPartitions >= partIdx,
-            If(m > 0,
-              If(m > partIdx, q + 1, q),
+            If(remainder > 0,
+              If(remainder > partIdx, q + 1, q),
               q),
             0
           )
           val start = If(numNonEmptyPartitions >= partIdx,
-            If(m > 0,
-              If(m < partIdx, (q + 1) * m + (-m + partIdx) * q, (q + 1) * partIdx),
+            If(remainder > 0,
+              If(remainder < partIdx, (q + 1) * remainder + (-remainder + partIdx) * q, (q + 1) * partIdx),
               q * partIdx
             ),
             0

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -134,7 +134,7 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
           )
           val start = If(numNonEmptyPartitions >= partIdx,
             If(remainder > 0,
-              If(remainder < partIdx, (q + 1) * remainder + (-remainder + partIdx) * q, (q + 1) * partIdx),
+              If(remainder < partIdx, q * partIdx + remainder, (q + 1) * partIdx),
               q * partIdx
             ),
             0

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -383,7 +383,23 @@ class TableIRSuite extends HailSuite {
           ))), value)
   }
 
-  @Test def testShuffleAndJoinDoesntMemoryLeak() {
+  @Test def testTableParallelizeLowering() {
+    implicit val execStrats = ExecStrategy.lowering
+    val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
+    val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
+
+    assertEvalsTo(
+      TableCount(
+        TableParallelize(
+          Literal(
+            t,
+            value
+          ))),
+      2L
+    )
+  }
+
+    @Test def testShuffleAndJoinDoesntMemoryLeak() {
     implicit val execStrats = ExecStrategy.interpretOnly
     val row = Ref("row", TStruct("idx" -> TInt32))
     val t1 = TableRename(TableRange(1, 1), Map("idx" -> "idx_"), Map.empty)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -15,6 +15,7 @@ class TableIRSuite extends HailSuite {
   def rangeKT: TableIR = TableKeyBy(TableRange(20, 4), FastIndexedSeq())
 
   def collect(tir: TableIR): TableCollect = TableCollect(TableKeyBy(tir, FastIndexedSeq()))
+  def collectNoKey(tir: TableIR): TableCollect = TableCollect(tir)
 
   implicit val execStrats: Set[ExecStrategy] = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
 
@@ -370,12 +371,12 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableParallelize() {
-    implicit val execStrats = ExecStrategy.interpretOnly
+    implicit val execStrats = ExecStrategy.allRelational
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
 
     assertEvalsTo(
-      collect(
+      collectNoKey(
         TableParallelize(
           Literal(
             t,
@@ -383,8 +384,8 @@ class TableIRSuite extends HailSuite {
           ))), value)
   }
 
-  @Test def testTableParallelizeLowering() {
-    implicit val execStrats = ExecStrategy.lowering
+  @Test def testTableParallelizeCount() {
+    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.allRelational
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
 

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -374,8 +374,7 @@ class TableIRSuite extends HailSuite {
     implicit val execStrats = ExecStrategy.allRelational
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     Array(1, 10, 17, 34, 103).foreach { length =>
-      val mySeq = FastIndexedSeq((0 until length): _*).map(i => Row(i, "row" + i))
-      val value = Row(mySeq, Row("global"))
+      val value = Row(FastIndexedSeq(0 until length: _*).map(i => Row(i, "row" + i)), Row("global"))
       assertEvalsTo(
         collectNoKey(
           TableParallelize(

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -373,15 +373,17 @@ class TableIRSuite extends HailSuite {
   @Test def testTableParallelize() {
     implicit val execStrats = ExecStrategy.allRelational
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
-    val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
-
-    assertEvalsTo(
-      collectNoKey(
-        TableParallelize(
-          Literal(
-            t,
-            value
-          ))), value)
+    Array(1, 10, 17, 34, 103).foreach { length =>
+      val mySeq = FastIndexedSeq((0 until length): _*).map(i => Row(i, "row" + i))
+      val value = Row(mySeq, Row("global"))
+      assertEvalsTo(
+        collectNoKey(
+          TableParallelize(
+            Literal(
+              t,
+              value
+            ))), value)
+    }
   }
 
   @Test def testTableParallelizeCount() {


### PR DESCRIPTION
This PR lowers `TableParallelize` and beefs up the tests for parallelize a bit. If you see a simpler formulation of the math to compute `start` and `length` let me know. 