### PR TITLE
TableParallelize Lowering Adjustments

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -129,20 +129,23 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
           val (rowsId, rowsRef) = idAndRef(elementsType)
           val numRows = ArrayLen(rowsRef)
           val numNonEmptyPartitions = If(numRows < nPartitionsAdj, numRows, nPartitionsAdj)
-          val q = numRows floorDiv numNonEmptyPartitions
+          val (numNonEmptyPartsId, numNonEmptyPartsRef) = idAndRef(TInt32)
+          val q = numRows floorDiv numNonEmptyPartsRef
           val (qId, qRef) = idAndRef(TInt32)
-          val remainder = numRows - qRef * numNonEmptyPartitions
+          val remainder = numRows - qRef * numNonEmptyPartsRef
           val (remainderId, remainderRef) = idAndRef(TInt32)
           val length = (numRows - partIdx + nPartitionsAdj - 1) floorDiv nPartitionsAdj
           val start =
-            Let(qId, q,
-              Let(remainderId, remainder,
-                If(numNonEmptyPartitions >= partIdx,
-                  If(remainderRef > 0,
-                    If(remainderRef < partIdx, qRef * partIdx + remainderRef, (qRef + 1) * partIdx),
-                    qRef * partIdx
-                  ),
-                  0
+            Let(numNonEmptyPartsId, numNonEmptyPartitions,
+              Let(qId, q,
+                Let(remainderId, remainder,
+                  If(numNonEmptyPartsRef >= partIdx,
+                    If(remainderRef > 0,
+                      If(remainderRef < partIdx, qRef * partIdx + remainderRef, (qRef + 1) * partIdx),
+                      qRef * partIdx
+                    ),
+                    0
+                  )
                 )
               )
             )

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -126,12 +126,7 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
           val numNonEmptyPartitions = If(numRows < nPartitionsAdj, numRows, nPartitionsAdj)
           val q = numRows floorDiv numNonEmptyPartitions
           val remainder = numRows - q * numNonEmptyPartitions
-          val length = If(numNonEmptyPartitions >= partIdx,
-            If(remainder > 0,
-              If(remainder > partIdx, q + 1, q),
-              q),
-            0
-          )
+          val length = (numRows - partIdx + nPartitionsAdj - 1) floorDiv nPartitionsAdj
           val start = If(numNonEmptyPartitions >= partIdx,
             If(remainder > 0,
               If(remainder < partIdx, q * partIdx + remainder, (q + 1) * partIdx),


### PR DESCRIPTION
This PR makes some adjustments recommend by @cseed to the `LowerTableIR` lowering for `TableParallelize`. The only one I haven't done yet since we are still discussing it is modify the code to broadcast the entire `loweredRowsAndGlobal` value.