### PR TITLE
[query] lift requiredness inference into separate pass

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -69,7 +69,7 @@ case class PhysicalAggSignature(
 
   lazy val virtual: AggSignature = AggSignature(op, physicalInitOpArgs.map(_.virtualType), physicalSeqOpArgs.map(_.virtualType))
   lazy val singletonContainer: AggStatePhysicalSignature = AggStatePhysicalSignature(Map(op -> this), op, None)
-
+  def returnType: PType = singletonContainer.resultType
 }
 
 sealed trait AggOp {}

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -44,8 +44,7 @@ object Compile {
     ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
 
     TypeCheck(ir, BindingEnv.empty)
-
-    InferPType(ir, Env(params.map { case (n, pt) => n -> pt}: _*))
+    InferPType(ir, Env.empty[PType])
     val returnType = ir.pType
 
     val fb = EmitFunctionBuilder[F](ctx, "Compiled",
@@ -107,7 +106,7 @@ object CompileWithAggregators2 {
 
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](params.map { case (name, t) => name -> t.virtualType })))
 
-    InferPType(ir, Env(params.map { case (n, pt) => n -> pt}: _*), aggSigs, null, null)
+    InferPType(ir, Env.empty[PType], aggSigs, null, null)
 
     val returnType = ir.pType
     val fb = EmitFunctionBuilder[F](ctx, "CompiledWithAggs",

--- a/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
@@ -2,14 +2,15 @@ package is.hail.expr.ir
 
 import scala.collection.mutable
 
-case class UsesAndDefs(uses: Memo[mutable.Set[RefEquality[BaseRef]]], defs: Memo[BaseIR])
+case class UsesAndDefs(uses: Memo[mutable.Set[RefEquality[BaseRef]]], defs: Memo[BaseIR], free: mutable.Set[RefEquality[BaseRef]])
 
 object ComputeUsesAndDefs {
-  def apply(ir0: BaseIR, errorIfFreeVariables: Boolean = true, includeApplyIR: Boolean = false): UsesAndDefs = {
+  def apply(ir0: BaseIR, errorIfFreeVariables: Boolean = true): UsesAndDefs = {
     val uses = Memo.empty[mutable.Set[RefEquality[BaseRef]]]
     val defs = Memo.empty[BaseIR]
+    val free = if (errorIfFreeVariables) null else mutable.Set[RefEquality[BaseRef]]()
 
-    def computeTable(tir: TableIR, includeApplyIR: Boolean): Unit = tir.children
+    def computeTable(tir: TableIR): Unit = tir.children
       .iterator
       .zipWithIndex
       .foreach {
@@ -17,13 +18,13 @@ object ComputeUsesAndDefs {
           val b = NewBindings(tir, i).mapValues[BaseIR](_ => tir)
           if (!b.allEmpty && !uses.contains(tir))
             uses.bind(tir, mutable.Set.empty[RefEquality[BaseRef]])
-          computeIR(child, b, includeApplyIR)
-        case (child: TableIR, _) => computeTable(child, includeApplyIR)
-        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
+          computeIR(child, b)
+        case (child: TableIR, _) => computeTable(child)
+        case (child: MatrixIR, _) => computeMatrix(child)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
       }
 
-    def computeMatrix(mir: MatrixIR, includeApplyIR: Boolean): Unit = mir.children
+    def computeMatrix(mir: MatrixIR): Unit = mir.children
       .iterator
       .zipWithIndex
       .foreach {
@@ -31,13 +32,13 @@ object ComputeUsesAndDefs {
           val b = NewBindings(mir, i).mapValues[BaseIR](_ => mir)
           if (!b.allEmpty && !uses.contains(mir))
             uses.bind(mir, mutable.Set.empty[RefEquality[BaseRef]])
-          computeIR(child, b, includeApplyIR)
-        case (child: TableIR, _) => computeTable(child, includeApplyIR)
-        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
+          computeIR(child, b)
+        case (child: TableIR, _) => computeTable(child)
+        case (child: MatrixIR, _) => computeMatrix(child)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
       }
 
-    def computeBlockMatrix(bmir: BlockMatrixIR, includeApplyIR: Boolean): Unit = bmir.children
+    def computeBlockMatrix(bmir: BlockMatrixIR): Unit = bmir.children
       .iterator
       .zipWithIndex
       .foreach {
@@ -45,13 +46,13 @@ object ComputeUsesAndDefs {
           val b = NewBindings(bmir, i).mapValues[BaseIR](_ => bmir)
           if (!b.allEmpty && !uses.contains(bmir))
             uses.bind(bmir, mutable.Set.empty[RefEquality[BaseRef]])
-          computeIR(child, b, includeApplyIR)
-        case (child: TableIR, _) => computeTable(child, includeApplyIR)
-        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
+          computeIR(child, b)
+        case (child: TableIR, _) => computeTable(child)
+        case (child: MatrixIR, _) => computeMatrix(child)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
       }
 
-    def computeIR(ir: IR, env: BindingEnv[BaseIR], includeApplyIR: Boolean) {
+    def computeIR(ir: IR, env: BindingEnv[BaseIR]) {
       ir match {
         case r: BaseRef =>
           env.eval.lookupOption(r.name) match {
@@ -62,39 +63,37 @@ object ComputeUsesAndDefs {
             case None =>
               if (errorIfFreeVariables)
                 throw new RuntimeException(s"found variable with no definition: ${ r.name }")
+              else
+                free += RefEquality(r)
           }
         case _ =>
       }
-      ir match {
-        case x: ApplyIR if includeApplyIR => computeIR(x.explicitNode, env, includeApplyIR)
-        case _: IR =>
-          ir.children.iterator.zipWithIndex
-            .foreach {
-              case (ir1: IR, i) =>
-                val e = ChildEnvWithoutBindings(ir, i, env)
-                val newBindings = NewBindings(ir, i, e)
+      ir.children.iterator.zipWithIndex
+        .foreach {
+          case (ir1: IR, i) =>
+            val e = ChildEnvWithoutBindings(ir, i, env)
+            val newBindings = NewBindings(ir, i, e)
 
-                if (newBindings.allEmpty)
-                  computeIR(ir1, e, includeApplyIR)
-                else {
-                  if (!uses.contains(ir))
-                    uses.bind(ir, mutable.Set.empty[RefEquality[BaseRef]])
-                  computeIR(ir1, e.merge(newBindings.mapValues(_ => ir)), includeApplyIR)
-                }
-              case (tir: TableIR, _) => computeTable(tir, includeApplyIR)
-              case (mir: MatrixIR, _) => computeMatrix(mir, includeApplyIR)
-              case (bmir: BlockMatrixIR, _) => computeBlockMatrix(bmir, includeApplyIR)
+            if (newBindings.allEmpty)
+              computeIR(ir1, e)
+            else {
+              if (!uses.contains(ir))
+                uses.bind(ir, mutable.Set.empty[RefEquality[BaseRef]])
+              computeIR(ir1, e.merge(newBindings.mapValues(_ => ir)))
             }
-      }
+              case (tir: TableIR, _) => computeTable(tir)
+              case (mir: MatrixIR, _) => computeMatrix(mir)
+              case (bmir: BlockMatrixIR, _) => computeBlockMatrix(bmir)
+            }
     }
 
     ir0 match {
-      case ir: IR => computeIR(ir, BindingEnv(Env.empty, Some(Env.empty), Some(Env.empty)), includeApplyIR)
-      case tir: TableIR => computeTable(tir, includeApplyIR)
-      case mir: MatrixIR => computeMatrix(mir, includeApplyIR)
-      case bmir: BlockMatrixIR => computeBlockMatrix(bmir, includeApplyIR)
+      case ir: IR => computeIR(ir, BindingEnv(Env.empty, Some(Env.empty), Some(Env.empty)))
+      case tir: TableIR => computeTable(tir)
+      case mir: MatrixIR => computeMatrix(mir)
+      case bmir: BlockMatrixIR => computeBlockMatrix(bmir)
     }
 
-    UsesAndDefs(uses, defs)
+    UsesAndDefs(uses, defs, free)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
@@ -2,95 +2,97 @@ package is.hail.expr.ir
 
 import scala.collection.mutable
 
-case class UsesAndDefs(uses: Memo[mutable.Set[RefEquality[Ref]]], defs: Memo[BaseIR])
+case class UsesAndDefs(uses: Memo[mutable.Set[RefEquality[BaseRef]]], defs: Memo[BaseIR])
 
 object ComputeUsesAndDefs {
-  def apply(ir0: BaseIR, errorIfFreeVariables: Boolean = true): UsesAndDefs = {
-    val uses = Memo.empty[mutable.Set[RefEquality[Ref]]]
+  def apply(ir0: BaseIR, errorIfFreeVariables: Boolean = true, includeApplyIR: Boolean = false): UsesAndDefs = {
+    val uses = Memo.empty[mutable.Set[RefEquality[BaseRef]]]
     val defs = Memo.empty[BaseIR]
 
-    def computeTable(tir: TableIR): Unit = tir.children
+    def computeTable(tir: TableIR, includeApplyIR: Boolean): Unit = tir.children
       .iterator
       .zipWithIndex
       .foreach {
         case (child: IR, i) =>
           val b = NewBindings(tir, i).mapValues[BaseIR](_ => tir)
           if (!b.allEmpty && !uses.contains(tir))
-            uses.bind(tir, mutable.Set.empty[RefEquality[Ref]])
-          computeIR(child, b)
-        case (child: TableIR, _) => computeTable(child)
-        case (child: MatrixIR, _) => computeMatrix(child)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
+            uses.bind(tir, mutable.Set.empty[RefEquality[BaseRef]])
+          computeIR(child, b, includeApplyIR)
+        case (child: TableIR, _) => computeTable(child, includeApplyIR)
+        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
       }
 
-    def computeMatrix(mir: MatrixIR): Unit = mir.children
+    def computeMatrix(mir: MatrixIR, includeApplyIR: Boolean): Unit = mir.children
       .iterator
       .zipWithIndex
       .foreach {
         case (child: IR, i) =>
           val b = NewBindings(mir, i).mapValues[BaseIR](_ => mir)
           if (!b.allEmpty && !uses.contains(mir))
-            uses.bind(mir, mutable.Set.empty[RefEquality[Ref]])
-          computeIR(child, b)
-        case (child: TableIR, _) => computeTable(child)
-        case (child: MatrixIR, _) => computeMatrix(child)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
+            uses.bind(mir, mutable.Set.empty[RefEquality[BaseRef]])
+          computeIR(child, b, includeApplyIR)
+        case (child: TableIR, _) => computeTable(child, includeApplyIR)
+        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
       }
 
-    def computeBlockMatrix(bmir: BlockMatrixIR): Unit = bmir.children
+    def computeBlockMatrix(bmir: BlockMatrixIR, includeApplyIR: Boolean): Unit = bmir.children
       .iterator
       .zipWithIndex
       .foreach {
         case (child: IR, i) =>
           val b = NewBindings(bmir, i).mapValues[BaseIR](_ => bmir)
           if (!b.allEmpty && !uses.contains(bmir))
-            uses.bind(bmir, mutable.Set.empty[RefEquality[Ref]])
-          computeIR(child, b)
-        case (child: TableIR, _) => computeTable(child)
-        case (child: MatrixIR, _) => computeMatrix(child)
-        case (child: BlockMatrixIR, _) => computeBlockMatrix(child)
+            uses.bind(bmir, mutable.Set.empty[RefEquality[BaseRef]])
+          computeIR(child, b, includeApplyIR)
+        case (child: TableIR, _) => computeTable(child, includeApplyIR)
+        case (child: MatrixIR, _) => computeMatrix(child, includeApplyIR)
+        case (child: BlockMatrixIR, _) => computeBlockMatrix(child, includeApplyIR)
       }
 
-    def computeIR(ir: IR, env: BindingEnv[BaseIR]) {
+    def computeIR(ir: IR, env: BindingEnv[BaseIR], includeApplyIR: Boolean) {
       ir match {
-        case r@Ref(name, _) =>
-          env.eval.lookupOption(name) match {
+        case r: BaseRef =>
+          env.eval.lookupOption(r.name) match {
             case Some(decl) =>
               val re = RefEquality(r)
               uses.lookup(decl) += re
               defs.bind(re, decl)
             case None =>
               if (errorIfFreeVariables)
-                throw new RuntimeException(s"found variable with no definition: $name")
+                throw new RuntimeException(s"found variable with no definition: ${ r.name }")
           }
+        case _ =>
+      }
+      ir match {
+        case x: ApplyIR if includeApplyIR => computeIR(x.explicitNode, env, includeApplyIR)
         case _: IR =>
-          ir.children
-            .iterator
-            .zipWithIndex
+          ir.children.iterator.zipWithIndex
             .foreach {
               case (ir1: IR, i) =>
                 val e = ChildEnvWithoutBindings(ir, i, env)
                 val newBindings = NewBindings(ir, i, e)
 
                 if (newBindings.allEmpty)
-                  computeIR(ir1, e)
+                  computeIR(ir1, e, includeApplyIR)
                 else {
                   if (!uses.contains(ir))
-                    uses.bind(ir, mutable.Set.empty[RefEquality[Ref]])
-                  computeIR(ir1, e.merge(newBindings.mapValues(_ => ir)))
+                    uses.bind(ir, mutable.Set.empty[RefEquality[BaseRef]])
+                  computeIR(ir1, e.merge(newBindings.mapValues(_ => ir)), includeApplyIR)
                 }
-              case (tir: TableIR, _) => computeTable(tir)
-              case (mir: MatrixIR, _) => computeMatrix(mir)
-              case (bmir: BlockMatrixIR, _) => computeBlockMatrix(bmir)
+              case (tir: TableIR, _) => computeTable(tir, includeApplyIR)
+              case (mir: MatrixIR, _) => computeMatrix(mir, includeApplyIR)
+              case (bmir: BlockMatrixIR, _) => computeBlockMatrix(bmir, includeApplyIR)
             }
       }
     }
 
     ir0 match {
-      case ir: IR => computeIR(ir, BindingEnv(Env.empty, Some(Env.empty), Some(Env.empty)))
-      case tir: TableIR => computeTable(tir)
-      case mir: MatrixIR => computeMatrix(mir)
-      case bmir: BlockMatrixIR => computeBlockMatrix(bmir)
+      case ir: IR => computeIR(ir, BindingEnv(Env.empty, Some(Env.empty), Some(Env.empty)), includeApplyIR)
+      case tir: TableIR => computeTable(tir, includeApplyIR)
+      case mir: MatrixIR => computeMatrix(mir, includeApplyIR)
+      case bmir: BlockMatrixIR => computeBlockMatrix(bmir, includeApplyIR)
     }
 
     UsesAndDefs(uses, defs)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -340,12 +340,13 @@ object LoopRef {
     val (loopArgs, tmpLoopArgs) = args.zipWithIndex.map { case ((name, pt), i) =>
       (mb.newEmitField(s"$name$i", pt), mb.newEmitField(s"tmp$name$i", pt))
     }.unzip
-    LoopRef(L, loopArgs, tmpLoopArgs)
+    LoopRef(L, args.map(_._2), loopArgs, tmpLoopArgs)
   }
 }
 
 case class LoopRef(
   L: CodeLabel,
+  loopTypes: IndexedSeq[PType],
   loopArgs: IndexedSeq[EmitSettable],
   tmpLoopArgs: IndexedSeq[EmitSettable])
 
@@ -1168,8 +1169,11 @@ class Emit[C](
         EmitCode(lengthTriplet.setup, lengthTriplet.m, PCode(pt, result))
 
       case x@StreamFold(a, zero, accumName, valueName, body) =>
+        println(a.pType)
+        println(zero.pType)
+        println(body.pType)
         val eltType = coerce[PStream](a.pType).elementType
-        val accType = ir.pType
+        val accType = x.accPType
 
         val streamOpt = emitStream(a)
         val resOpt: COption[PCode] = streamOpt.flatMapCPS { (ss, _ctx, ret) =>
@@ -2024,7 +2028,8 @@ class Emit[C](
 
       case x@TailLoop(name, args, body) =>
         val label = CodeLabel()
-        val loopRef = LoopRef(mb, label, args.map { case (name, x) => (name, x.pType) })
+        val inits = args.zip(x.argPTypes)
+        val loopRef = LoopRef(mb, label, inits.map { case ((name, _), pt) => (name, pt) })
 
         val m = mb.genFieldThisRef[Boolean]()
         val v = mb.newPField(x.pType)
@@ -2038,16 +2043,19 @@ class Emit[C](
           bodyT.setup,
           m := bodyT.m,
           (!m).orEmpty(v := bodyT.pv))
+        val initArgs = loopRef.loopArgs := inits.map { case ((_, x), pt) =>
+          emit(x).castTo(mb, region, pt)
+        }
 
-        EmitCode(Code(loopRef.loopArgs := args.map { case (_, x) => emit(x) }, label, bodyF), m, v.load())
+        EmitCode(Code(initArgs, label, bodyF), m, v.load())
 
       case Recur(name, args, _) =>
         val loopRef = loopEnv.get.lookup(name)
 
         EmitCode(
           Code(
-            loopRef.tmpLoopArgs := args.map { arg =>
-              emit(arg, loopEnv = None)
+            loopRef.tmpLoopArgs := loopRef.loopTypes.zip(args).map { case (pt, arg) =>
+              emit(arg, loopEnv = None).castTo(mb, region, pt)
             },
             loopRef.loopArgs := loopRef.tmpLoopArgs.load(),
             loopRef.L.goto),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1169,9 +1169,6 @@ class Emit[C](
         EmitCode(lengthTriplet.setup, lengthTriplet.m, PCode(pt, result))
 
       case x@StreamFold(a, zero, accumName, valueName, body) =>
-        println(a.pType)
-        println(zero.pType)
-        println(body.pType)
         val eltType = coerce[PStream](a.pType).elementType
         val accType = x.accPType
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1197,7 +1197,7 @@ object EmitStream {
 
         case x@StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
           val eltType = coerce[PStream](childIR.pType).elementType
-          val accType = x.accPType
+          val accType = coerce[PStream](x.pType).elementType
 
           val streamOpt = emitStream(childIR, env)
           streamOpt.map { case SizedStream(setup, stream, len) =>

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -45,7 +45,7 @@ object ForwardLets {
 
     def rewrite(ir: IR, env: BindingEnv[IR]): IR = {
 
-      def shouldForward(value: IR, refs: mutable.Set[RefEquality[Ref]], base: IR): Boolean = {
+      def shouldForward(value: IR, refs: mutable.Set[RefEquality[BaseRef]], base: IR): Boolean = {
         value.isInstanceOf[Ref] ||
         value.isInstanceOf[In] ||
           (IsConstant(value) && !value.isInstanceOf[Str]) ||

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 object ForwardLets {
   def apply[T <: BaseIR](ir0: T): T = {
     val ir1 = new NormalizeNames(_ => genUID(), allowFreeVariables = true).apply(ir0)
-    val UsesAndDefs(uses, defs) = ComputeUsesAndDefs(ir1, errorIfFreeVariables = false)
+    val UsesAndDefs(uses, defs, _) = ComputeUsesAndDefs(ir1, errorIfFreeVariables = false)
     val nestingDepth = NestingDepth(ir1)
 
     def rewriteTable(tir: TableIR): BaseIR = tir.copy(tir

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -401,8 +401,9 @@ final case class ApplyIR(function: String, typeArgs: Seq[Type], args: Seq[IR]) e
   var conversion: (Seq[Type], Seq[IR]) => IR = _
   var inline: Boolean = _
 
-  lazy val refs = args.map(a => Ref(genUID(), a.typ)).toArray
+  private lazy val refs = args.map(a => Ref(genUID(), a.typ)).toArray
   lazy val body: IR = conversion(typeArgs, refs).deepCopy()
+  lazy val refIdx: Map[String, Int] = refs.map(_.name).zipWithIndex.toMap
 
   lazy val explicitNode: IR = {
     // foldRight because arg1 should be at the top so it is evaluated first

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -122,7 +122,9 @@ final case class Ref(name: String, var _typ: Type) extends BaseRef
 
 // Recur can't exist outside of loop
 // Loops can be nested, but we can't call outer loops in terms of inner loops so there can only be one loop "active" in a given context
-final case class TailLoop(name: String, params: IndexedSeq[(String, IR)], body: IR) extends IR
+final case class TailLoop(name: String, params: IndexedSeq[(String, IR)], body: IR) extends IR {
+  var argPTypes: IndexedSeq[PType] = null
+}
 final case class Recur(name: String, args: IndexedSeq[IR], _typ: Type) extends BaseRef
 
 final case class RelationalLet(name: String, value: IR, body: IR) extends IR
@@ -239,7 +241,9 @@ final case class StreamFilter(a: IR, name: String, cond: IR) extends IR {
 final case class StreamFlatMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TStream = coerce[TStream](super.typ)
 }
-final case class StreamFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
+final case class StreamFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR {
+  var accPType: PType = null
+}
 
 object StreamFold2 {
   def apply(a: StreamFold): StreamFold2 = {
@@ -253,9 +257,7 @@ final case class StreamFold2(a: IR, accum: IndexedSeq[(String, IR)], valueName: 
   var accPTypes: IndexedSeq[PType] = null
 }
 
-final case class StreamScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR {
-  var accPType: PType = null
-}
+final case class StreamScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
 
 final case class StreamFor(a: IR, valueName: String, body: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -401,7 +401,7 @@ final case class ApplyIR(function: String, typeArgs: Seq[Type], args: Seq[IR]) e
   var conversion: (Seq[Type], Seq[IR]) => IR = _
   var inline: Boolean = _
 
-  private lazy val refs = args.map(a => Ref(genUID(), a.typ)).toArray
+  lazy val refs = args.map(a => Ref(genUID(), a.typ)).toArray
   lazy val body: IR = conversion(typeArgs, refs).deepCopy()
 
   lazy val explicitNode: IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -156,7 +156,7 @@ object InferPType {
       case x: IR if requiredness.r.contains(x) => x match {
         case a: AbstractApplyNode[_] =>
           val pt = a.implementation.returnPType(a.args.map(_.pType), a.returnType)
-          assert(coerce[TypeWithRequiredness](requiredness.r.lookup(node)).validPType(pt))
+          assert(coerce[TypeWithRequiredness](requiredness.r.lookup(node)).matchesPType(pt))
           pt
         case x@StreamFold(a, zero, accumName, valueName, body) =>
           x.accPType = requiredness.states.lookup(x).head.canonicalPType(zero.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -119,20 +119,23 @@ object InferPType {
   def newBuilder[T](n: Int): AAB[T] = Array.fill(n)(new ArrayBuilder[RecursiveArrayBuilderElement[T]])
 
   def apply(ir: IR, env: Env[PType], aggs: Array[AggStatePhysicalSignature], inits: AAB[InitOp], seqs: AAB[SeqOp]): Unit = {
-    if (aggs == null && inits == null && seqs == null) {
+    try {
+      if (aggs != null || inits != null || seqs != null)
+          throw new NotImplementedError
       val r = Requiredness.apply(ir, null) // Value IR inference doesn't need context
       _inferWithRequiredness(ir, r)
-    } else {
-      try {
-        _apply(ir, env, aggs, inits, seqs)
-      } catch {
-        case e: Exception =>
-          throw new RuntimeException(s"error while inferring IR:\n${Pretty(ir)}", e)
-      }
-      VisitIR(ir) { case (node: IR) =>
-        if (node._pType == null)
-          throw new RuntimeException(s"ptype inference failure: node not inferred:\n${Pretty(node)}\n ** Full IR: **\n${Pretty(ir)}")
-      }
+    } catch {
+      case _: NotImplementedError =>
+        try {
+          _apply(ir, env, aggs, inits, seqs)
+        } catch {
+          case e: Exception =>
+            throw new RuntimeException(s"error while inferring IR:\n${Pretty(ir)}", e)
+        }
+        VisitIR(ir) { case (node: IR) =>
+          if (node._pType == null)
+            throw new RuntimeException(s"ptype inference failure: node not inferred:\n${Pretty(node)}\n ** Full IR: **\n${Pretty(ir)}")
+        }
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -123,11 +123,6 @@ object InferPType {
       if (aggs != null || inits != null || seqs != null || !env.isEmpty)
           throw new NotImplementedError
       val requiredness = Requiredness.apply(ir, null) // Value IR inference doesn't need context
-      requiredness.r.m.foreach { case (re, req) =>
-          println()
-          println(req)
-          println(Pretty(re.t))
-      }
       _inferWithRequiredness(ir, requiredness)
     } catch {
       case _: NotImplementedError =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -133,7 +133,7 @@ object InferType {
         TStream(join.typ)
       case NDArrayShape(nd) =>
         val ndType = nd.typ.asInstanceOf[TNDArray]
-        ndType.representation.fieldType("shape").asInstanceOf[TTuple]
+        ndType.shapeType
       case NDArrayReshape(nd, shape) =>
         TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case NDArrayConcat(nds, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -45,11 +45,11 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         usesAndDefs.uses.bind(re, xUses.free)
         dependents.getOrElseUpdate(x.body, mutable.Set[RefEquality[BaseIR]]()) += re
       case _ =>
-        node.children.foreach { c =>
-          initializeState(c)
-          if (node.typ != TVoid)
-            dependents.getOrElseUpdate(c, mutable.Set[RefEquality[BaseIR]]()) += re
-        }
+    }
+    node.children.foreach { c =>
+      initializeState(c)
+      if (node.typ != TVoid)
+        dependents.getOrElseUpdate(c, mutable.Set[RefEquality[BaseIR]]()) += re
     }
     if (node.typ != TVoid) {
       cache.bind(node, BaseTypeWithRequiredness(node.typ))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -388,6 +388,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => requiredness.fromPType(t)
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
+      case _: ResultOp | _: RunAgg | _: RunAggScan | _: CombOpValue | _: AggStateValue => ???
+
     }
     requiredness.probeChangedAndReset()
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -194,7 +194,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       // always required
       case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>
       case x if x.typ == TVoid =>
-      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) =>
+      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) | ApplyComparisonOp(Compare(_, _), _, _) =>
       case ApplyComparisonOp(op, l, r) =>
         fatal(s"non-strict comparison op $op must have explicit case")
       case TableCount(t) =>
@@ -238,9 +238,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         coerce[RDict](requiredness).keyType.unionFrom(keyType)
         coerce[RDict](requiredness).valueType.unionFrom(valueType)
       case LowerBoundOnOrderedCollection(collection, elem, _) =>
-        val cReq = lookupAs[RIterable](collection)
-        requiredness.unionFrom(cReq.elementType)
-        requiredness.union(cReq.required)
+        requiredness.union(lookup(collection).required)
       case GroupByKey(c) =>
         val cReq = lookupAs[RIterable](c)
         val Seq(k, v) = coerce[RBaseStruct](cReq.elementType).children

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -1,0 +1,396 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types._
+import is.hail.expr.types.virtual._
+import is.hail.utils._
+
+import scala.collection.mutable
+
+object Requiredness {
+  def apply(node: BaseIR, ctx: ExecuteContext): Memo[BaseTypeWithRequiredness] = {
+    val usesAndDefs = ComputeUsesAndDefs(node, includeApplyIR = true)
+    val pass = new Requiredness(usesAndDefs, ctx)
+    pass.initialize(node)
+    pass.run()
+    pass.result()
+  }
+}
+
+class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
+  type State = Memo[BaseTypeWithRequiredness]
+  private val cache = Memo.empty[BaseTypeWithRequiredness]
+  private val dependents = Memo.empty[mutable.Set[RefEquality[BaseIR]]]
+  private val q = mutable.Set[RefEquality[BaseIR]]()
+
+  private val defs = Memo.empty[Array[BaseTypeWithRequiredness]]
+
+  def result(): Memo[BaseTypeWithRequiredness] = cache
+
+  def lookup(node: IR): TypeWithRequiredness = coerce[TypeWithRequiredness](cache(node))
+  def lookupAs[T <: TypeWithRequiredness](node: IR): T = coerce[T](cache(node))
+
+  private def initializeState(node: BaseIR): Unit = {
+    val re = RefEquality(node)
+    node match {
+      case x: ApplyIR =>
+        initializeState(x.explicitNode)
+        dependents.getOrElseUpdate(x.explicitNode, mutable.Set[RefEquality[BaseIR]]()) += re
+      case _ =>
+        node.children.foreach { c =>
+          initializeState(c)
+          if (node.typ != TVoid)
+            dependents.getOrElseUpdate(c, mutable.Set[RefEquality[BaseIR]]()) += re
+        }
+    }
+    if (node.typ != TVoid) {
+      cache.bind(node, BaseTypeWithRequiredness(node.typ))
+      q += re
+    }
+  }
+
+  def initialize(node: BaseIR): Unit = {
+    initializeState(node)
+    usesAndDefs.uses.m.keys.foreach(n => addBindingRelations(n.t))
+  }
+
+  def run(): Unit = {
+    while (q.nonEmpty) {
+      val node = q.head
+      q -= node
+      if (analyze(node.t) && dependents.contains(node)) {
+        q ++= dependents.lookup(node)
+      }
+    }
+  }
+
+  def addBindingRelations(node: BaseIR): Unit = {
+    val refMap = usesAndDefs.uses(node).toArray.groupBy(_.t.name).mapValues(_.asInstanceOf[Array[RefEquality[BaseIR]]])
+    def addElementBinding(name: String, d: IR, makeOptional: Boolean = false): Unit = {
+      if (refMap.contains(name)) {
+        val uses = refMap(name)
+        val eltReq = coerce[RIterable](lookup(d)).elementType
+        val req = if (makeOptional) {
+          val optional = eltReq.copy(eltReq.children)
+          optional.union(false)
+          optional
+        } else eltReq
+        uses.foreach { u => defs.bind(u, Array(req)) }
+        dependents.getOrElseUpdate(d, mutable.Set[RefEquality[BaseIR]]()) ++= uses
+      }
+    }
+
+    def addBindings(name: String, ds: Array[IR]): Unit = {
+      if (refMap.contains(name)) {
+        val uses = refMap(name)
+        uses.foreach { u => defs.bind(u, ds.map(lookup).toArray[BaseTypeWithRequiredness]) }
+        ds.foreach { d => dependents.getOrElseUpdate(d, mutable.Set[RefEquality[BaseIR]]()) ++= uses }
+      }
+    }
+
+    def addBinding(name: String, ds: IR): Unit =
+      addBindings(name, Array(ds))
+
+    node match {
+      case Let(name, value, body) => addBinding(name, value)
+      case TailLoop(loopName, params, body) =>
+        addBinding(loopName, body)
+        val argDefs = Array.fill(params.length)(new ArrayBuilder[IR]())
+        refMap(loopName).map(_.t).foreach { case Recur(_, args, _) =>
+          argDefs.zip(args).foreach { case (ab, d) => ab += d }
+        }
+        var i = 0
+        while (i < params.length) {
+          val (name, init) = params(i)
+          addBindings(name, argDefs(i).result() :+ init)
+          i += 1
+        }
+      case ArraySort(a, l, r, c) =>
+        addElementBinding(l, a)
+        addElementBinding(r, a)
+      case StreamMap(a, name, body) =>
+        addElementBinding(name, a)
+      case x@StreamZip(as, names, body, behavior) =>
+        var i = 0
+        while (i < names.length) {
+          addElementBinding(names(i), as(i),
+            makeOptional = behavior == ArrayZipBehavior.ExtendNA)
+          i += 1
+        }
+      case StreamFilter(a, name, cond) => addElementBinding(name, a)
+      case StreamFlatMap(a, name, body) => addElementBinding(name, a)
+      case StreamFor(a, name, _) => addElementBinding(name, a)
+      case StreamFold(a, zero, accumName, valueName, body) =>
+        addElementBinding(valueName, a)
+        addBindings(accumName, Array[IR](zero, body))
+      case StreamScan(a, zero, accumName, valueName, body) =>
+        addElementBinding(valueName, a)
+        addBindings(accumName, Array[IR](zero, body))
+      case StreamFold2(a, accums, valueName, seq, result) =>
+        addElementBinding(valueName, a)
+        var i = 0
+        while (i < accums.length) {
+          val (n, z) = accums(i)
+          addBindings(n, Array[IR](z, seq(i)))
+          i += 1
+        }
+      case StreamLeftJoinDistinct(left, right, l, r, keyf, joinf) =>
+        addElementBinding(l, left)
+        addElementBinding(r, right)
+      case StreamAgg(a, name, query) =>
+        addElementBinding(name, a)
+      case StreamAggScan(a, name, query) =>
+        addElementBinding(name, a)
+      case RunAggScan(a, name, init, seqs, result, signature) =>
+        addElementBinding(name, a)
+      case AggExplode(a, name, aggBody, isScan) =>
+        addElementBinding(name, a)
+      case AggArrayPerElement(a, elt, idx, body, knownLength, isScan) =>
+        addElementBinding(elt, a)
+      //idx is always required Int32
+      case NDArrayMap(nd, name, body) =>
+        addElementBinding(name, nd)
+      case NDArrayMap2(left, right, l, r, body) =>
+        addElementBinding(l, left)
+        addElementBinding(r, right)
+      case CollectDistributedArray(ctxs, globs, c, g, body) =>
+        addElementBinding(c, ctxs)
+        addBinding(g, globs)
+    }
+  }
+
+  def analyze(node: BaseIR): Boolean = node match {
+    case x: IR => analyzeIR(x)
+    case x: TableIR => fatal("Table nodes not yet supported.")
+    case x: BlockMatrixIR => fatal("BM nodes not yet supported.")
+    case _ =>
+      fatal("MatrixTable must be lowered first.")
+  }
+
+  def analyzeIR(node: IR): Boolean = {
+    val requiredness = lookup(node)
+    node match {
+      // union all
+      case _: Cast |
+           _: CastRename |
+           _: ToSet |
+           _: CastToArray |
+           _: ToArray |
+           _: ToStream |
+           _: NDArrayReindex |
+           _: NDArrayAgg =>
+        node.children.foreach { case c: IR => requiredness.unionFrom(lookup(c)) }
+
+      // union top-level
+      case _: ApplyBinaryPrimOp |
+           _: ApplyUnaryPrimOp |
+           _: ArrayLen |
+           _: ArrayZeros |
+           _: StreamRange |
+           _: WriteValue =>
+        requiredness.union(node.children.forall(c => cache(c).required))
+      case x: ApplyComparisonOp if x.op.strict =>
+        requiredness.union(node.children.forall(c => cache(c).required))
+
+      // always required
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>
+      case x if x.typ == TVoid =>
+      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) =>
+      case ApplyComparisonOp(op, l, r) =>
+        fatal(s"non-strict comparison op $op must have explicit case")
+      case TableCount(t) =>
+
+      case _: NA => requiredness.union(false)
+      case Literal(t, a) => requiredness.unionLiteral(a)
+
+      case Coalesce(values) =>
+        val reqs = values.map(lookup)
+        requiredness.union(reqs.exists(_.required))
+        reqs.foreach(r => requiredness.children.zip(r.children).foreach { case (r1, r2) => r1.unionFrom(r2) })
+      case If(cond, cnsq, altr) =>
+        requiredness.union(lookup(cond).required)
+        requiredness.unionFrom(lookup(cnsq))
+        requiredness.unionFrom(lookup(altr))
+
+      case AggLet(name, value, body, isScan) =>
+        requiredness.unionFrom(lookup(body))
+      case Let(name, value, body) =>
+        requiredness.unionFrom(lookup(body))
+      case RelationalLet(name, value, body) =>
+        requiredness.unionFrom(lookup(body))
+      case TailLoop(name, params, body) =>
+        requiredness.unionFrom(lookup(body))
+      case x: BaseRef =>
+        requiredness.unionFrom(defs(node).map(coerce[TypeWithRequiredness]))
+
+      case MakeArray(args, _) =>
+        coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
+      case MakeStream(args, _) =>
+        coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
+      case ArrayRef(a, i, _) =>
+        val aReq = lookupAs[RIterable](a)
+        requiredness.unionFrom(aReq.elementType)
+        requiredness.union(lookup(i).required && aReq.required)
+      case ArraySort(a, l, r, c) =>
+        requiredness.unionFrom(lookup(a))
+      case ToDict(a) =>
+        val aReq = lookupAs[RIterable](a)
+        val Seq(keyType, valueType) = coerce[RBaseStruct](aReq.elementType).children
+        coerce[RDict](requiredness).keyType.unionFrom(keyType)
+        coerce[RDict](requiredness).valueType.unionFrom(valueType)
+      case LowerBoundOnOrderedCollection(collection, elem, _) =>
+        val cReq = lookupAs[RIterable](collection)
+        requiredness.unionFrom(cReq.elementType)
+        requiredness.union(cReq.required)
+      case GroupByKey(c) =>
+        val cReq = lookupAs[RIterable](c)
+        val Seq(k, v) = coerce[RBaseStruct](cReq.elementType).children
+        coerce[RDict](requiredness).keyType.unionFrom(k)
+        coerce[RIterable](coerce[RDict](requiredness).valueType).elementType.unionFrom(v)
+        requiredness.union(cReq.required)
+      case StreamMap(a, name, body) =>
+        requiredness.union(lookup(a).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+      case StreamTake(a, n) =>
+        requiredness.union(lookup(n).required)
+        requiredness.unionFrom(lookup(a))
+      case StreamDrop(a, n) =>
+        requiredness.union(lookup(n).required)
+        requiredness.unionFrom(lookup(a))
+      case StreamZip(as, names, body, behavior) =>
+        requiredness.union(as.forall(lookup(_).required))
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+      case StreamFilter(a, name, cond) =>
+        requiredness.unionFrom(lookup(a))
+      case StreamFlatMap(a, name, body) =>
+        requiredness.union(lookup(a).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookupAs[RIterable](body).elementType)
+      case StreamFold(a, zero, accumName, valueName, body) =>
+        requiredness.union(lookup(a).required)
+        requiredness.unionFrom(lookup(body))
+      case StreamScan(a, zero, accumName, valueName, body) =>
+        requiredness.union(lookup(a).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+      case StreamFold2(a, accums, valueName, seq, result) =>
+        requiredness.union(lookup(a).required)
+        requiredness.unionFrom(lookup(result))
+
+      case StreamLeftJoinDistinct(left, right, _, _, keyf, joinf) =>
+        requiredness.union(lookup(left).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(joinf))
+      case StreamAgg(a, name, query) =>
+        requiredness.union(lookup(a).required)
+        requiredness.unionFrom(lookup(query))
+      case StreamAggScan(a, name, query) =>
+        requiredness.union(lookup(a).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(query))
+      case AggFilter(cond, aggIR, isScan) =>
+        requiredness.unionFrom(lookup(aggIR))
+      case AggExplode(array, name, aggBody, isScan) =>
+        requiredness.unionFrom(lookup(aggBody))
+      case AggGroupBy(key, aggIR, isScan) =>
+        val rdict = coerce[RDict](requiredness)
+        rdict.keyType.unionFrom(lookup(key))
+        rdict.valueType.unionFrom(lookup(aggIR))
+      case AggArrayPerElement(a, _, _, body, knownLength, isScan) =>
+        val rit = coerce[RIterable](requiredness)
+        rit.union(lookup(a).required)
+        rit.elementType.unionFrom(lookup(body))
+      case ApplyAggOp(initOpArgs, seqOpArgs, aggSig) => //FIXME round-tripping through ptype
+        val initPTypes = initOpArgs.map(a => lookup(a).canonicalPType(a.typ))
+        val seqPTypes = seqOpArgs.map(a => lookup(a).canonicalPType(a.typ))
+        requiredness.fromPType(aggSig.toPhysical(initPTypes, seqPTypes).returnType)
+      case ApplyScanOp(initOpArgs, seqOpArgs, aggSig) =>
+        val initPTypes = initOpArgs.map(a => lookup(a).canonicalPType(a.typ))
+        val seqPTypes = seqOpArgs.map(a => lookup(a).canonicalPType(a.typ))
+        requiredness.fromPType(aggSig.toPhysical(initPTypes, seqPTypes).returnType)
+
+      case MakeNDArray(data, shape, rowMajor) =>
+        requiredness.unionFrom(lookup(data))
+        requiredness.union(lookup(shape).required)
+      case NDArrayShape(nd) =>
+        requiredness.union(lookup(nd).required)
+      case NDArrayReshape(nd, shape) =>
+        val sReq = lookupAs[RBaseStruct](shape)
+        val ndReq = lookup(nd)
+        requiredness.unionFrom(ndReq)
+        requiredness.union(sReq.required && sReq.children.forall(_.required))
+      case NDArrayConcat(nds, axis) =>
+        val ndsReq = lookupAs[RIterable](nds)
+        requiredness.unionFrom(ndsReq.elementType)
+        requiredness.union(ndsReq.required)
+      case NDArrayRef(nd, idxs) =>
+        val ndReq = lookupAs[RNDArray](nd)
+        requiredness.unionFrom(ndReq.elementType)
+        requiredness.union(ndReq.required && idxs.forall(lookup(_).required))
+      case NDArraySlice(nd, slices) =>
+        val slicesReq = lookupAs[RTuple](slices)
+        val allSlicesRequired = slicesReq.types.forall {
+          case r: RTuple => r.required && r.types.forall(_.required)
+          case r => r.required
+        }
+        requiredness.unionFrom(lookup(nd))
+        requiredness.union(slicesReq.required && allSlicesRequired)
+      case NDArrayFilter(nd, keep) =>
+        requiredness.unionFrom(lookup(nd))
+      case NDArrayMap(nd, name, body) =>
+        requiredness.union(lookup(nd).required)
+        coerce[RNDArray](requiredness).unionElement(lookup(body))
+      case NDArrayMap2(l, r, _, _, body) =>
+        requiredness.union(lookup(l).required && lookup(r).required)
+        coerce[RNDArray](requiredness).unionElement(lookup(body))
+      case NDArrayMatMul(l, r) =>
+        requiredness.unionFrom(lookup(l))
+        requiredness.union(lookup(r).required)
+      case NDArrayQR(nd, mode) => requiredness.maximize()
+      case MakeStruct(fields) =>
+        fields.foreach { case (n, f) =>
+          coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
+        }
+      case MakeTuple(fields) =>
+        fields.foreach { case (i, f) =>
+          coerce[RTuple](requiredness).types(i).unionFrom(lookup(f))
+        }
+      case SelectFields(old, fields) =>
+        val oldReq = lookupAs[RStruct](old)
+        fields.foreach { n =>
+          coerce[RStruct](requiredness).field(n).unionFrom(oldReq.field(n))
+        }
+      case InsertFields(old, fields, _) =>
+        lookup(old) match {
+          case oldReq: RStruct =>
+            requiredness.union(oldReq.required)
+            val fieldMap = fields.toMap.mapValues(lookup)
+            coerce[RStruct](requiredness).fields.foreach { f =>
+              f.typ.unionFrom(fieldMap.getOrElse(f.name, oldReq.field(f.name)))
+            }
+          case _ => fields.foreach { case (n, f) =>
+            coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))
+          }
+        }
+      case GetField(o, name) =>
+        val oldReq = lookupAs[RStruct](o)
+        requiredness.union(oldReq.required)
+        requiredness.unionFrom(oldReq.field(name))
+      case GetTupleElement(o, idx) =>
+        val oldReq = lookupAs[RTuple](o)
+        requiredness.union(oldReq.required)
+        requiredness.unionFrom(oldReq.fields(idx).typ)
+      case x: ApplyIR => requiredness.unionFrom(lookup(x.explicitNode))
+      case x: AbstractApplyNode[_] => //FIXME: round-tripping via PTypes.
+        val argP = x.args.map(a => lookup(a).canonicalPType(a.typ))
+        requiredness.fromPType(x.implementation.returnPType(argP, x.returnType))
+      case CollectDistributedArray(ctxs, globs, _, _, body) =>
+        requiredness.union(lookup(ctxs).required)
+        coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+      case ReadPartition(context, rowType, reader) =>
+        requiredness.union(lookup(context).required)
+        coerce[RIterable](requiredness).elementType.fromPType(reader.rowPType(rowType))
+      case ReadValue(path, spec, rt) =>
+        requiredness.union(lookup(path).required)
+        requiredness.fromPType(spec.encodedType.decodedPType(rt))
+      case In(_, t) => requiredness.fromPType(t)
+      case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
+    }
+    requiredness.probeChangedAndReset()
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -243,7 +243,7 @@ object UtilFunctions extends RegistryFunctions {
           Code.checkcast[Row](asm4s.coerce[java.lang.Object](wrapArg(r, argsT)(args)))))
     }
 
-    registerEmitCode2("land", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
+    registerEmitCode2("land", TBoolean, TBoolean, TBoolean, (_: Type, tl: PType, tr: PType) => PBoolean(tl.required && tr.required)) {
       case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]
@@ -273,7 +273,7 @@ object UtilFunctions extends RegistryFunctions {
           PCode(rt, w.ceq(10)))
     }
 
-    registerEmitCode2("lor", TBoolean, TBoolean, TBoolean, (_: Type, _: PType, _: PType) => PBoolean()) {
+    registerEmitCode2("lor", TBoolean, TBoolean, TBoolean, (_: Type, tl: PType, tr: PType) => PBoolean(tl.required && tr.required)) {
       case (er, rt, l, r) =>
         val lv = l.value[Boolean]
         val rv = r.value[Boolean]

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -79,6 +79,8 @@ package object ir {
 
   private[ir] def coerce[T <: PType](x: PType): T = types.coerce[T](x)
 
+  private[ir] def coerce[T <: BaseTypeWithRequiredness](x: BaseTypeWithRequiredness): T = types.coerce[T](x)
+
   def invoke(name: String, rt: Type, typeArgs: Array[Type], args: IR*): IR = IRFunctionRegistry.lookupConversion(name, rt, typeArgs, args.map(_.typ)) match {
     case Some(f) => f(typeArgs, args)
     case None => fatal(s"no conversion found for $name(${typeArgs.mkString(", ")}, ${args.map(_.typ).mkString(", ")}) => $rt")

--- a/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
@@ -77,11 +77,8 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
   def _unionLiteral(a: Annotation): Unit
   def _unionPType(pType: PType): Unit
   def _validPType(pt: PType): Boolean
-  def unionLiteral(a: Annotation): Unit = {
-    if (a == null)
-      maximize()
-    _unionLiteral(a)
-  }
+  def unionLiteral(a: Annotation): Unit =
+    if (a == null) union(true) else _unionLiteral(a)
 
   def fromPType(pType: PType): Unit = {
     union(pType.required)

--- a/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
@@ -6,9 +6,19 @@ import is.hail.expr.types.virtual._
 import is.hail.utils.{FastSeq, Interval}
 import org.apache.spark.sql.Row
 
+object BaseTypeWithRequiredness {
+  def apply(typ: BaseType): BaseTypeWithRequiredness = typ match {
+    case t: Type => TypeWithRequiredness(t)
+    case t: TableType => RTable(
+      t.rowType.fields.map(f => f.name -> TypeWithRequiredness(f.typ)),
+      t.globalType.fields.map(f => f.name -> TypeWithRequiredness(f.typ)),
+      t.key)
+  }
+}
+
 object TypeWithRequiredness {
   def apply(typ: Type): TypeWithRequiredness = typ match {
-    case TInt32 | TInt64 | TFloat32 | TFloat64 | TBinary | TString | TCall | TVoid | _: TLocus => RPrimitive()
+    case TBoolean | TInt32 | TInt64 | TFloat32 | TFloat64 | TBinary | TString | TCall | TVoid | _: TLocus => RPrimitive()
     case t: TArray => RIterable(apply(t.elementType))
     case t: TSet => RIterable(apply(t.elementType))
     case t: TStream => RIterable(apply(t.elementType))
@@ -19,31 +29,31 @@ object TypeWithRequiredness {
     case t: TTuple => RTuple(t.fields.map(f => apply(f.typ)))
     case t: TUnion => RUnion(t.cases.map(c => c.name -> apply(c.typ)))
   }
-
-  def apply(t: TableType): RTable = RTable(
-    t.rowType.fields.map(f => f.name -> apply(f.typ)),
-    t.globalType.fields.map(f => f.name -> apply(f.typ)),
-    t.key)
 }
-
 
 sealed abstract class BaseTypeWithRequiredness {
   private[this] var _required: Boolean = true
   private[this] var change = false
 
-  def required: Boolean = _required
+  def required: Boolean = _required & !change
   def children: Seq[BaseTypeWithRequiredness]
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): BaseTypeWithRequiredness
+  def toString: String
+
+  def deepCopy(): BaseTypeWithRequiredness =
+    copy(children.map(_.deepCopy()))
 
   protected[this] def _maximizeChildren(): Unit = children.foreach(_.maximize())
   protected[this] def _unionChildren(newChildren: Seq[BaseTypeWithRequiredness]): Unit = {
     assert(children.length == newChildren.length)
-    children.zip(newChildren).foreach { case (r1, r2) => r1.unionFrom(r2) }
+    children.zip(newChildren).foreach { case (r1, r2) =>
+      r1.unionFrom(r2)
+    }
   }
 
-  final def union(r: Boolean): Unit = { change = !r && required }
+  final def union(r: Boolean): Unit = { change |= !r && required }
   final def maximize(): Unit = {
-    change = required
+    change |= required
     _maximizeChildren()
   }
 
@@ -76,6 +86,10 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
     union(pType.required)
     _unionPType(pType)
   }
+
+  def canonicalPType(t: Type): PType
+  def _toString: String
+  override def toString: String = if (required) "+" + _toString else _toString
 }
 
 final case class RPrimitive() extends TypeWithRequiredness {
@@ -86,6 +100,8 @@ final case class RPrimitive() extends TypeWithRequiredness {
     assert(newChildren.isEmpty)
     RPrimitive()
   }
+  def canonicalPType(t: Type): PType = PType.canonical(t, required)
+  def _toString: String = "RPrimitive"
 }
 
 object RIterable {
@@ -98,6 +114,7 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
   def _unionLiteral(a: Annotation): Unit =
     a.asInstanceOf[Iterable[_]].foreach(elt => elementType.unionLiteral(elt))
   def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PIterable].elementType)
+  def _toString: String = s"RIterable[${ elementType.toString }]"
 
   override def _maximizeChildren(): Unit = {
     if (eltRequired)
@@ -105,15 +122,29 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
     else elementType.maximize()
   }
 
-  override def _unionChildren(req: Seq[BaseTypeWithRequiredness]): Unit = {
-    val Seq(newEltReq) = req
+  override def _unionChildren(newChildren: Seq[BaseTypeWithRequiredness]): Unit = {
+    val Seq(newEltReq) = newChildren
+    unionElement(newEltReq)
+  }
+
+  def unionElement(newElement: BaseTypeWithRequiredness): Unit = {
     if (eltRequired)
-      elementType.children.zip(newEltReq.children).foreach { case (r1, r2) => r1.unionFrom(r2) }
+      elementType.children.zip(newElement.children).foreach { case (r1, r2) => r1.unionFrom(r2) }
+    else
+      elementType.unionFrom(newElement)
   }
 
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RIterable = {
     val Seq(newElt: TypeWithRequiredness) = newChildren
     RIterable(newElt)
+  }
+  def canonicalPType(t: Type): PType = {
+    val elt = elementType.canonicalPType(coerce[TIterable](t).elementType)
+    t match {
+      case _: TArray => PCanonicalArray(elt, required = required)
+      case _: TSet => PCanonicalSet(elt, required = required)
+      case _: TStream => PCanonicalStream(elt, required = required)
+    }
   }
 }
 case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
@@ -127,6 +158,12 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
     val Seq(newElt: RStruct) = newChildren
     RDict(newElt.field("key"), newElt.field("value"))
   }
+  override def canonicalPType(t: Type): PType =
+    PCanonicalDict(
+      keyType.canonicalPType(coerce[TDict](t).keyType),
+      valueType.canonicalPType(coerce[TDict](t).valueType),
+      required = required)
+  override def _toString: String = s"RDict[${ keyType.toString }, ${ valueType.toString }]"
 }
 case class RNDArray(override val elementType: TypeWithRequiredness) extends RIterable(elementType, true) {
   override def _unionLiteral(a: Annotation): Unit = ???
@@ -135,6 +172,11 @@ case class RNDArray(override val elementType: TypeWithRequiredness) extends RIte
     val Seq(newElt: TypeWithRequiredness) = newChildren
     RNDArray(newElt)
   }
+  override def canonicalPType(t: Type): PType = {
+    val tnd = coerce[TNDArray](t)
+    PCanonicalNDArray(elementType.canonicalPType(tnd.elementType), tnd.nDims, required = required)
+  }
+  override def _toString: String = s"RNDArray[${ elementType.toString }]"
 }
 
 case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredness) extends TypeWithRequiredness {
@@ -151,6 +193,14 @@ case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredn
     val Seq(newStart: TypeWithRequiredness, newEnd: TypeWithRequiredness) = newChildren
     RInterval(newStart, newEnd)
   }
+
+  def canonicalPType(t: Type): PType = t match {
+    case TInterval(pointType) =>
+      val unified = startType.deepCopy().asInstanceOf[TypeWithRequiredness]
+      unified.unionFrom(endType)
+      PCanonicalInterval(unified.canonicalPType(pointType), required = required)
+  }
+  def _toString: String = s"RInterval[${ startType.toString }, ${ endType.toString }]"
 }
 
 
@@ -162,6 +212,14 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
     children.zip(a.asInstanceOf[Row].toSeq).foreach { case (r, f) => r.unionLiteral(f) }
   def _unionPType(pType: PType): Unit =
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
+  def canonicalPType(t: Type): PType = t match {
+    case ts: TStruct =>
+      PCanonicalStruct(required = required,
+        fields.map(f => f.name -> f.typ.canonicalPType(ts.fieldType(f.name))): _*)
+    case ts: TTuple =>
+      PCanonicalTuple(required = required,
+        fields.map(f => f.typ.canonicalPType(ts.types(f.index))): _*)
+  }
 }
 
 object RStruct {
@@ -176,6 +234,7 @@ case class RStruct(fields: IndexedSeq[RField]) extends RBaseStruct {
     assert(newChildren.length == fields.length)
     RStruct(Array.tabulate(fields.length)(i => fields(i).name -> coerce[TypeWithRequiredness](newChildren(i))))
   }
+  def _toString: String = s"RStruct[${ fields.map(f => s"${ f.name }: ${ f.typ.toString }").mkString(",") }]"
 }
 
 object RTuple {
@@ -184,11 +243,13 @@ object RTuple {
 }
 
 case class RTuple(fields: IndexedSeq[RField]) extends RBaseStruct {
+  assert(fields.zipWithIndex.forall { case (actual, expected) => actual.index == expected })
   val types: Seq[TypeWithRequiredness] = fields.map(_.typ)
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RTuple = {
     assert(newChildren.length == fields.length)
     RTuple(newChildren.map(coerce[TypeWithRequiredness]))
   }
+  def _toString: String = s"RTuple[${ fields.map(f => f.typ.toString).mkString(",") }]"
 }
 
 case class RUnion(cases: Seq[(String, TypeWithRequiredness)]) extends TypeWithRequiredness {
@@ -199,6 +260,8 @@ case class RUnion(cases: Seq[(String, TypeWithRequiredness)]) extends TypeWithRe
     assert(newChildren.length == cases.length)
     RUnion(Array.tabulate(cases.length)(i => cases(i)._1 -> coerce[TypeWithRequiredness](newChildren(i))))
   }
+  def canonicalPType(t: Type): PType = ???
+  def _toString: String = s"RStruct[${ cases.map { case (n, t) => s"${ n }: ${ t.toString }" }.mkString(",") }]"
 }
 
 case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: Seq[(String, TypeWithRequiredness)], key: Seq[String]) extends BaseTypeWithRequiredness {
@@ -235,5 +298,8 @@ case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: 
     val newRowFields = rowFields.zip(newChildren.take(rowFields.length)).map { case ((n, _), r: TypeWithRequiredness) => n -> r }
     val newGlobalFields = globalFields.zip(newChildren.drop(rowFields.length)).map { case ((n, _), r: TypeWithRequiredness) => n -> r }
     RTable(newRowFields, newGlobalFields, key)
+  }
+  override def toString: String = {
+    s"RTable[\n  row:${ rowType.toString }\n  global:${ globalType.toString }]"
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
@@ -76,6 +76,7 @@ sealed abstract class BaseTypeWithRequiredness {
 sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
   def _unionLiteral(a: Annotation): Unit
   def _unionPType(pType: PType): Unit
+  def _validPType(pt: PType): Boolean
   def unionLiteral(a: Annotation): Unit = {
     if (a == null)
       maximize()
@@ -86,21 +87,31 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
     union(pType.required)
     _unionPType(pType)
   }
-
   def canonicalPType(t: Type): PType
+  def validPType(pt: PType): Boolean = pt.required == required && _validPType(pt)
   def _toString: String
   override def toString: String = if (required) "+" + _toString else _toString
 }
 
+object RPrimitive {
+  val supportedTypes: Set[Type] = Set(TBoolean, TInt32, TInt64, TFloat32, TFloat64, TBinary, TString, TCall, TVoid)
+}
+
 final case class RPrimitive() extends TypeWithRequiredness {
   val children: Seq[TypeWithRequiredness] = FastSeq.empty
+
+  def typeSupported(t: Type): Boolean = RPrimitive.supportedTypes.contains(t) || t.isInstanceOf[TLocus]
   def _unionLiteral(a: Annotation): Unit = ()
-  def _unionPType(pType: PType): Unit = ()
+  def _validPType(pt: PType): Boolean = typeSupported(pt.virtualType)
+  def _unionPType(pType: PType): Unit = assert(validPType(pType))
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RPrimitive = {
     assert(newChildren.isEmpty)
     RPrimitive()
   }
-  def canonicalPType(t: Type): PType = PType.canonical(t, required)
+  def canonicalPType(t: Type): PType = {
+    assert(typeSupported(t))
+    PType.canonical(t, required)
+  }
   def _toString: String = "RPrimitive"
 }
 
@@ -113,6 +124,7 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
   val children: Seq[TypeWithRequiredness] = FastSeq(elementType)
   def _unionLiteral(a: Annotation): Unit =
     a.asInstanceOf[Iterable[_]].foreach(elt => elementType.unionLiteral(elt))
+  def _validPType(pt: PType): Boolean = elementType.validPType(coerce[PIterable](pt).elementType)
   def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PIterable].elementType)
   def _toString: String = s"RIterable[${ elementType.toString }]"
 
@@ -167,6 +179,7 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
 }
 case class RNDArray(override val elementType: TypeWithRequiredness) extends RIterable(elementType, true) {
   override def _unionLiteral(a: Annotation): Unit = ???
+  override def _validPType(pt: PType): Boolean = elementType.validPType(coerce[PNDArray](pt).elementType)
   override def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PNDArray].elementType)
   override def copy(newChildren: Seq[BaseTypeWithRequiredness]): RNDArray = {
     val Seq(newElt: TypeWithRequiredness) = newChildren
@@ -185,6 +198,9 @@ case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredn
     startType.unionLiteral(a.asInstanceOf[Interval].start)
     endType.unionLiteral(a.asInstanceOf[Interval].end)
   }
+  def _validPType(pt: PType): Boolean =
+    startType.validPType(coerce[PInterval](pt).pointType) &&
+      endType.validPType(coerce[PInterval](pt).pointType)
   def _unionPType(pType: PType): Unit = {
     startType.fromPType(pType.asInstanceOf[PInterval].pointType)
     endType.fromPType(pType.asInstanceOf[PInterval].pointType)
@@ -210,6 +226,8 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
   val children: Seq[TypeWithRequiredness] = fields.map(_.typ)
   def _unionLiteral(a: Annotation): Unit =
     children.zip(a.asInstanceOf[Row].toSeq).foreach { case (r, f) => r.unionLiteral(f) }
+  def _validPType(pt: PType): Boolean =
+    coerce[PBaseStruct](pt).fields.forall(f => children(f.index).validPType(f.typ))
   def _unionPType(pType: PType): Unit =
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
   def canonicalPType(t: Type): PType = t match {
@@ -255,6 +273,7 @@ case class RTuple(fields: IndexedSeq[RField]) extends RBaseStruct {
 case class RUnion(cases: Seq[(String, TypeWithRequiredness)]) extends TypeWithRequiredness {
   val children: Seq[TypeWithRequiredness] = cases.map(_._2)
   def _unionLiteral(a: Annotation): Unit = ???
+  def _validPType(pt: PType): Boolean = ???
   def _unionPType(pType: PType): Unit = ???
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RUnion = {
     assert(newChildren.length == cases.length)

--- a/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
@@ -78,7 +78,7 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
   def _unionPType(pType: PType): Unit
   def _validPType(pt: PType): Boolean
   def unionLiteral(a: Annotation): Unit =
-    if (a == null) union(true) else _unionLiteral(a)
+    if (a == null) union(false) else _unionLiteral(a)
 
   def fromPType(pType: PType): Unit = {
     union(pType.required)

--- a/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TypeWithRequiredness.scala
@@ -40,8 +40,14 @@ sealed abstract class BaseTypeWithRequiredness {
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): BaseTypeWithRequiredness
   def toString: String
 
-  def deepCopy(): BaseTypeWithRequiredness =
-    copy(children.map(_.deepCopy()))
+  def minimalCopy(): BaseTypeWithRequiredness =
+    copy(children.map(_.minimalCopy()))
+
+  def deepCopy(): BaseTypeWithRequiredness = {
+    val r = minimalCopy()
+    r.unionFrom(this)
+    r
+  }
 
   protected[this] def _maximizeChildren(): Unit = children.foreach(_.maximize())
   protected[this] def _unionChildren(newChildren: Seq[BaseTypeWithRequiredness]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -98,8 +98,10 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   val ordering: ExtendedOrdering = null
 
+  lazy val shapeType: TTuple = TTuple(Array.fill(nDims)(TInt64): _*)
+
   lazy val representation = TStruct(
-    ("shape", TTuple(Array.fill(nDims)(TInt64): _*)),
+    ("shape", shapeType),
     ("strides", TTuple(Array.fill(nDims)(TInt64): _*)),
     ("data", TArray(elementType))
   )

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -148,10 +148,10 @@ package object stats {
   }
   
   val fetStruct = PCanonicalStruct(
-    "p_value" -> PFloat64(),
-    "odds_ratio" -> PFloat64(),
-    "ci_95_lower" -> PFloat64(),
-    "ci_95_upper" -> PFloat64())
+    "p_value" -> PFloat64(required = true),
+    "odds_ratio" -> PFloat64(required = true),
+    "ci_95_lower" -> PFloat64(required = true),
+    "ci_95_upper" -> PFloat64(required = true))
 
   def fisherExactTest(a: Int, b: Int, c: Int, d: Int): Array[Double] =
     fisherExactTest(a, b, c, d, 1.0, 0.95, "two.sided")

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -249,8 +249,8 @@ class RequirednessSuite extends HailSuite {
   @Test(dataProvider = "valueIR")
   def testRequiredness(node: IR, expected: PType): Unit = {
     TypeCheck(node)
-    val (m, _) = Requiredness.apply(node, ctx)
-    val actual = m.lookup(node).asInstanceOf[TypeWithRequiredness]
+    val res = Requiredness.apply(node, ctx)
+    val actual = res.r.lookup(node).asInstanceOf[TypeWithRequiredness]
     assert(actual.canonicalPType(node.typ) == expected, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(m) }")
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -1,0 +1,256 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import is.hail.expr.Nat
+import is.hail.expr.types.encoded.EBaseStruct
+import is.hail.expr.types.{BaseTypeWithRequiredness, TypeWithRequiredness}
+import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual._
+import is.hail.io.{BufferSpec, TypedCodecSpec}
+import is.hail.stats.fetStruct
+import is.hail.utils.{ArrayBuilder, FastIndexedSeq}
+import is.hail.variant.Locus
+import org.apache.spark.sql.Row
+import org.testng.annotations.{DataProvider, Test}
+
+class RequirednessSuite extends HailSuite {
+  val required: Boolean = true
+  val optional: Boolean = false
+
+  @DataProvider(name="valueIR")
+  def valueIR(): Array[Array[Any]] = {
+    val nodes = new ArrayBuilder[Array[Any]](50)
+
+    val allRequired = Array(
+      I32(5), I64(5), F32(3.14f), F64(3.14), Str("foo"), True(), False(),
+      IsNA(I32(5)),
+      Cast(I32(5), TFloat64),
+      Die("mumblefoo", TFloat64),
+      Literal(TStruct("x" -> TInt32), Row(1)),
+      MakeArray(FastIndexedSeq(I32(4)), TArray(TInt32)),
+      MakeStruct(FastIndexedSeq("x" -> I32(4), "y" -> Str("foo"))),
+      MakeTuple.ordered(FastIndexedSeq(I32(5), Str("bar"))))
+
+    allRequired.foreach { n =>
+      nodes += Array(n, PType.canonical(n.typ, required).deepInnerRequired(required))
+    }
+
+    val tarray = TArray(TInt32)
+    val tstream = TStream(TInt32)
+    val tstruct = TStruct("x" -> TInt32, "y" -> TArray(TInt32))
+    val ttuple = TTuple(TInt32, TArray(TInt32))
+    val tnd = TNDArray(TInt32, Nat(2))
+    val tnestednd = TNDArray(tarray, Nat(2))
+    val tnestedarray = TArray(tarray)
+    val tnestedstream = TStream(tarray)
+
+    def int(r: Boolean): IR = if (r) I32(5) else NA(TInt32)
+
+    def stream(r: Boolean, elt: Boolean): IR = {
+      if (r)
+        MakeStream(FastIndexedSeq(int(elt), int(required)), tstream)
+      else
+        mapIR(NA(tstream))(x => x + int(elt))
+    }
+
+    def array(r: Boolean, elt: Boolean): IR = ToArray(stream(r, elt))
+
+
+    def struct(r: Boolean, i: Boolean, a: Boolean, elt: Boolean): IR = {
+      val fields = FastIndexedSeq("x" -> int(i), "y" -> array(a, elt))
+      if (r) MakeStruct(fields) else InsertFields(NA(tstruct), fields)
+    }
+
+    def tuple(r: Boolean, i: Boolean, a: Boolean, elt: Boolean): IR = {
+      val t = MakeTuple.ordered(FastIndexedSeq(int(i), array(a, elt)))
+      if (r) t else If(True(), NA(ttuple), t)
+    }
+
+    def nd(r: Boolean): IR =
+      if (r) MakeNDArray.fill(int(optional), FastIndexedSeq(1, 2), True()) else NA(tnd)
+
+    def nestednd(r: Boolean, aelt: Boolean): IR = {
+      if (r)
+        MakeNDArray.fill(array(optional, aelt), FastIndexedSeq(1, 2), True())
+      else
+        NDArrayMap(NA(tnestednd), genUID(), array(optional, aelt))
+    }
+
+    def nestedstream(r: Boolean, a: Boolean, aelt: Boolean): IR = {
+      if (r)
+        MakeStream(FastIndexedSeq(array(a, required), array(required, aelt)), tnestedstream)
+      else
+        mapIR(NA(tnestedstream))(x => array(a, aelt))
+    }
+    def nestedarray(r: Boolean, a: Boolean, aelt: Boolean): IR = ToArray(nestedstream(r, a, aelt))
+
+    val bools = Array(true, false)
+    for (r1 <- bools) {
+      val pint = PInt32(r1)
+      nodes += Array(int(r1), pint)
+      nodes += Array(nd(r1), PCanonicalNDArray(PInt32(required), 2, r1))
+      for (r2 <- bools) {
+        val parray = PCanonicalArray(pint, r2)
+        nodes += Array(array(r2, r1), parray)
+        nodes += Array(nestednd(r2, r1), PCanonicalNDArray(PCanonicalArray(pint, required), 2, r2))
+        for (r3 <- bools) {
+          nodes += Array(nestedarray(r3, r2, r1), PCanonicalArray(parray, r3))
+          for (r4 <- bools) {
+            nodes += Array(tuple(r4, r3, r2, r1), PCanonicalTuple(r4, PInt32(r3), parray))
+            nodes += Array(struct(r4, r3, r2, r1), PCanonicalStruct(r4, "x" -> PInt32(r3), "y" -> parray))
+          }
+        }
+      }
+    }
+
+    // test coalesce
+    nodes += Array(Coalesce(FastIndexedSeq(
+      array(required, optional),
+      array(optional, required))),
+      PCanonicalArray(PInt32(optional), required))
+
+    nodes += Array(Coalesce(FastIndexedSeq(
+      array(optional, optional),
+      array(optional, required))),
+      PCanonicalArray(PInt32(optional), optional))
+
+    // test read/write
+    val pDisc = PCanonicalStruct(required,
+      "a" -> PInt32(optional),
+      "b" -> PCanonicalArray(PInt32(required), required),
+      "c" -> PCanonicalArray(PCanonicalStruct(required,
+        "x" -> PInt32(required),
+        "y" -> PCanonicalArray(PInt32(required), optional)
+      ), required)
+    )
+
+    val spec = TypedCodecSpec(pDisc, BufferSpec.default)
+    val pr = PartitionNativeReader(spec)
+    val rt1 = TStruct("a" -> TInt32, "b" -> TArray(TInt32))
+    val rt2 = TStruct("a" -> TInt32, "c" -> TArray(TStruct("x" -> TInt32)))
+    Array(Str("foo") -> pDisc,
+      NA(TString) -> pDisc,
+      Str("foo") -> pDisc.subsetTo(rt1),
+      Str("foo") -> pDisc.subsetTo(rt2)).foreach { case (path, pt) =>
+      nodes += Array(ReadPartition(path, pt.virtualType, pr), PCanonicalStream(pt).setRequired(path.isInstanceOf[Str]))
+      nodes += Array(ReadValue(path, spec, pt.virtualType), pt.setRequired(path.isInstanceOf[Str]))
+    }
+
+    val value = Literal(pDisc.virtualType, Row(null, IndexedSeq(1), IndexedSeq(Row(1, IndexedSeq(1)))))
+    nodes += Array(WriteValue(value, Str("foo"), spec), PCanonicalString(required))
+    nodes += Array(WriteValue(NA(pDisc.virtualType), Str("foo"), spec), PCanonicalString(optional))
+    nodes += Array(WriteValue(value, NA(TString), spec), PCanonicalString(optional))
+
+    // test bindings
+    nodes += Array(bindIR(nestedarray(required, optional, optional)) { v => ArrayRef(v, I32(0)) },
+      PCanonicalArray(PInt32(optional), optional))
+    // filter
+    nodes += Array(StreamFilter(stream(optional, optional), "x", Ref("x", TInt32).ceq(0)),
+      PCanonicalStream(PInt32(optional), optional))
+    // StreamFold
+    nodes += Array(StreamFold(
+      nestedstream(optional, optional, optional),
+      I32(0), "a", "b",
+      ArrayRef(Ref("b", tarray), Ref("a", TInt32))
+    ), PInt32(optional))
+    // StreamFold2
+    nodes += Array(StreamFold2(
+      nestedstream(optional, optional, optional),
+      FastIndexedSeq("b" -> I32(0)), "a",
+      FastIndexedSeq(ArrayRef(Ref("a", tarray), Ref("b", TInt32))),
+      Ref("b", TInt32)
+    ), PInt32(optional))
+    // StreamScan
+      nodes += Array(StreamScan(
+        nestedstream(optional, optional, optional),
+        I32(0), "a", "b",
+        ArrayRef(Ref("b", tarray), Ref("a", TInt32))
+      ), PCanonicalStream(PInt32(optional), optional))
+    // TailLoop
+    val param1 = Ref(genUID(), tarray)
+    val param2 = Ref(genUID(), TInt32)
+    val loop = TailLoop("loop", FastIndexedSeq(
+      param1.name -> array(required, required),
+      param2.name -> int(required)),
+      If(False(), // required
+        MakeArray(FastIndexedSeq(param1), tnestedarray), // required
+        If(param2 <= I32(1), // possibly missing
+          Recur("loop", FastIndexedSeq(
+            array(required, optional),
+            int(required)), tnestedarray),
+          Recur("loop", FastIndexedSeq(
+            array(optional, required),
+            int(optional)), tnestedarray))))
+    nodes += Array(loop, PCanonicalArray(PCanonicalArray(PInt32(optional), optional), optional))
+    // ArrayZip
+    val s1 = Ref(genUID(), TInt32)
+    val s2 = Ref(genUID(), TInt32)
+    val notExtendNA = StreamZip(
+      FastIndexedSeq(stream(required, optional), stream(required, required)),
+      FastIndexedSeq(s1.name, s2.name),
+      s1 + s2, ArrayZipBehavior.TakeMinLength)
+    val extendNA = StreamZip(
+      FastIndexedSeq(stream(required, required), stream(required, required)),
+      FastIndexedSeq(s1.name, s2.name),
+      s1 + s2, ArrayZipBehavior.ExtendNA)
+    nodes += Array(notExtendNA, PCanonicalStream(PInt32(optional), required))
+    nodes += Array(extendNA, PCanonicalStream(PInt32(optional), required))
+    // ArraySort
+    nodes += Array(ArraySort(stream(optional, required), s1.name, s2.name, True()), PCanonicalArray(PInt32(required), optional))
+    // CollectDistributedArray
+    nodes += Array(CollectDistributedArray(
+      stream(optional, required),
+      int(optional),
+      s1.name, s2.name,
+      s1 + s2), PCanonicalArray(PInt32(optional), optional))
+
+    // ApplyIR
+    nodes += Array(
+      invoke("argmin", TInt32, array(required, required)),
+      PInt32(optional))
+    nodes += Array(
+      invoke("argmin", TInt32, array(required, optional)),
+      PInt32(optional))
+    nodes += Array(
+      invoke("argmin", TInt32, array(optional, required)),
+      PInt32(optional))
+    // Apply
+    nodes += Array(
+      invoke("fisher_exact_test", fetStruct.virtualType,
+        int(required), int(required), int(required), int(required)),
+      fetStruct.setRequired(required))
+    nodes += Array(
+      invoke("fisher_exact_test", fetStruct.virtualType,
+        int(optional), int(required), int(required), int(required)),
+      fetStruct.setRequired(optional))
+    nodes += Array(
+      invoke("Interval", TInterval(TArray(TInt32)),
+        array(required, optional), array(required, required), True(), NA(TBoolean)),
+      PCanonicalInterval(PCanonicalArray(PInt32(optional), required), optional))
+    nodes.result()
+  }
+
+  @Test
+  def testDataProviders(): Unit = {
+    val s = new ArrayBuilder[String]()
+    valueIR().map(v => v(0) -> v(1))foreach { case (n: IR, t: PType) =>
+      if (n.typ != t.virtualType)
+        s += s"${ n.typ } != ${ t.virtualType }: \n${ Pretty(n) }"
+    }
+    assert(s.size == 0, s.result().mkString("\n\n"))
+  }
+
+  def dump(m: Memo[BaseTypeWithRequiredness]): String = {
+    m.m.map { case (node, t) =>
+        s"${Pretty(node.t)}: \n$t"
+    }.mkString("\n\n")
+  }
+
+  @Test(dataProvider = "valueIR")
+  def testRequiredness(node: IR, expected: PType): Unit = {
+    TypeCheck(node)
+    val m = Requiredness.apply(node, ctx)
+    val actual = m.lookup(node).asInstanceOf[TypeWithRequiredness]
+    assert(actual.canonicalPType(node.typ) == expected, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(m) }")
+  }
+}

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -251,6 +251,6 @@ class RequirednessSuite extends HailSuite {
     TypeCheck(node)
     val res = Requiredness.apply(node, ctx)
     val actual = res.r.lookup(node).asInstanceOf[TypeWithRequiredness]
-    assert(actual.canonicalPType(node.typ) == expected, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(m) }")
+    assert(actual.canonicalPType(node.typ) == expected, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(res.r) }")
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -249,7 +249,7 @@ class RequirednessSuite extends HailSuite {
   @Test(dataProvider = "valueIR")
   def testRequiredness(node: IR, expected: PType): Unit = {
     TypeCheck(node)
-    val m = Requiredness.apply(node, ctx)
+    val (m, _) = Requiredness.apply(node, ctx)
     val actual = m.lookup(node).asInstanceOf[TypeWithRequiredness]
     assert(actual.canonicalPType(node.typ) == expected, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(m) }")
   }


### PR DESCRIPTION
This PR is already getting kind of massive, so I think I'm going to plan on implementing (extracted) aggregator support separately.

I may also pull out the TableIR stuff into a separate PR and leave this as just implementations of pure value IR nodes, since I ended up needing to add a bunch of stuff to be able to pull minimal PTypes out of reads.

I've written tests for most of the values nodes, but not all of them.