### PR TITLE
Lower TableRename

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -26,7 +26,7 @@ sealed trait IR extends BaseIR {
       try {
         _typ = InferType(this)
       } catch {
-        case e: Throwable => throw new RuntimeException(s"typ: inference failure: ${e.getMessage}", e)
+        case e: Throwable => throw new RuntimeException(s"typ: inference failure:", e)
       }
     _typ
   }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -233,8 +233,11 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
 
       case TableRename(child, rowMap, globalMap) =>
         val loweredChild = lower(child)
-        
-        loweredChild
+        val oldPart = loweredChild.partitioner
+        loweredChild.copy(
+          globalsField = globalMap.getOrElse(loweredChild.globalsField, loweredChild.globalsField),
+          partitioner = oldPart.copy(kType = oldPart.kType.rename(rowMap))
+        )
 
       case node =>
         throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -234,7 +234,7 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
       case TableRename(child, rowMap, globalMap) =>
         val loweredChild = lower(child)
         
-        ???
+        loweredChild
 
       case node =>
         throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -231,6 +231,11 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
 
         loweredChild.copy(body = StreamFlatMap(loweredChild.body, row.name, StreamMap(fieldRef, elt.name, newRow)))
 
+      case TableRename(child, rowMap, globalMap) =>
+        val loweredChild = lower(child)
+        
+        ???
+
       case node =>
         throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")
     }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -234,9 +234,14 @@ class LowerTableIR(val typesToLower: DArrayLowering.Type) extends AnyVal {
       case TableRename(child, rowMap, globalMap) =>
         val loweredChild = lower(child)
         val oldPart = loweredChild.partitioner
+        val structId = genUID()
+        val oldStructType = loweredChild.body.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]
+        val newStructType = oldStructType.rename(rowMap)
+
         loweredChild.copy(
-          globalsField = globalMap.getOrElse(loweredChild.globalsField, loweredChild.globalsField),
-          partitioner = oldPart.copy(kType = oldPart.kType.rename(rowMap))
+          //globalsField = globalMap.getOrElse(loweredChild.globalsField, loweredChild.globalsField),
+          partitioner = oldPart.copy(kType = oldPart.kType.rename(rowMap)),
+          body = StreamMap(loweredChild.body, structId, CastRename(Ref(structId, oldStructType), newStructType))
         )
 
       case node =>

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -441,10 +441,13 @@ class TableIRSuite extends HailSuite {
             value
           )),
         Map[String, String]("a" -> "c"),
-        Map[String, String]("x" -> "q")
+        Map.empty[String, String]
       )
+
+    println(renameIR.typ.rowType)
     val newRow = MakeStruct(Seq(("foo", GetField(Ref("row", renameIR.typ.rowType), "c")), ("bar", GetField(Ref("row", renameIR.typ.rowType), "b"))))
     val mapped = TableMapRows(renameIR, newRow)
+    println(mapped.typ.rowType)
 
     // Check that values haven't changed.
     assertEvalsTo(

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -3,7 +3,6 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
-import is.hail.expr.ir.lowering.{DArrayLowering, LowerTableIR}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.rvd.RVDPartitioner


### PR DESCRIPTION
This PR lowers `TableRename`. The only thing that is not really tested is the renaming of key fields, because we don't support lowering `TableKeyBy` yet. 