### PR TITLE
[deploy] deploy rebuilds wheel from scratch and uploads artifacts

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1480,7 +1480,7 @@ steps:
      fi
 
      cd hail
-     make test-dataproc DEV_CLARIFIER=ci_test_dataproc
+     make test-dataproc DEV_CLARIFIER=ci_test_dataproc/
    dependsOn:
      - ci_utils_image
      - copy_files

--- a/build.yaml
+++ b/build.yaml
@@ -1519,15 +1519,15 @@ steps:
      {{ code.checkout_script }}
      cd hail
 
+     make wheel upload-artifacts DEPLOY_REMOTE=origin
+
      bash scripts/deploy.sh $(cat /io/hail_pip_version) \
                             $(cat /io/hail_version) \
                             $(cat /io/git_version) \
                             origin \
-                            /io/hail-*-py3-none-any.whl \
+                            /io/repo/hail/build/deploy/dist/hail-*-py3-none-any.whl \
                             /io/github-oauth
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
      - from: /hail_version
        to: /io/hail_version
      - from: /hail_pip_version

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -159,7 +159,7 @@ $(WHEEL): $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) $(PYT
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location
 ifndef DEPLOY_REMOTE
 DEV_CLARIFIER ?= $(shell whoami)-dev/
-CLOUD_SUB_FOLDER := $(HAIL_PIP_VERSION)-$(SHORT_REVISION)
+CLOUD_SUB_FOLDER := $(HAIL_VERSION)
 UPLOAD_RETENTION =
 else
 CLOUD_SUB_FOLDER := $(HAIL_PIP_VERSION)

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -29,21 +29,6 @@ then
     exit 1
 fi
 
-hailctl_candidate_location=gs://hail-common/hailctl/dataproc/ci_test-dataproc/$HAIL_VERSION/
-hailctl_release_location=gs://hail-common/hailctl/dataproc/$HAIL_PIP_VERSION/
-
-if ! gsutil ls $hailctl_candidate_location
-then
-    echo "hailctl candidate resources do not exist at $hailctl_candidate_location"
-    exit 1
-fi
-
-if gsutil ls $hailctl_release_location
-then
-    echo "hailctl resources already present at $hailctl_release_location"
-    exit 1
-fi
-
 pip_versions_file=$(mktemp)
 pip install hail== 2>&1 \
     | head -n 1 \
@@ -86,12 +71,6 @@ curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/h
   "draft": false,
   "prerelease": false
 }'
-
-# deploy hailctl resources
-gsutil -m cp -r $hailctl_candidate_location $hailctl_release_location
-gsutil -m cp -r $WHEEL ${cloud_base}
-gsutil -m acl set -r public-read ${cloud_base}
-gsutil -m retention temp set ${cloud_base}*
 
 # deploy to PyPI
 twine upload $WHEEL

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -58,6 +58,7 @@ then
     exit 1
 fi
 
+
 # push git tag
 git tag $HAIL_PIP_VERSION -m "Hail version $HAIL_PIP_VERSION."
 git push origin $HAIL_PIP_VERSION


### PR DESCRIPTION
This pains me. As currently set up, there's no way to deploy the wheel that we tested because that wheel is tightly coupled with a bunch of "temporary" file paths. I'm not confident I can untangle all this into a clean promote-what-you-test deploy right now. This PR should get us back to correct deploys until I can take the time to get us to proper promote-what-you-test deploys.