### PR TITLE
Add Support for NDArrays with Zero elements

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -626,7 +626,7 @@ class tndarray(HailType):
 
     def _traverse(self, obj, f):
         if f(self, obj):
-            for elt in np.nditer(obj):
+            for elt in np.nditer(obj, ['zerosize_ok']):
                 self.element_type._traverse(elt.item(), f)
 
     def _typecheck_one_level(self, annotation):

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -248,11 +248,11 @@ def test_ndarray_reshape():
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((0, 2, 2)))
-    assert "must contain only positive numbers or -1" in str(exc)
+    assert "requested shape is incompatible with number of elements" in str(exc)
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((2, 2, -2)))
-    assert "must contain only positive numbers or -1" in str(exc)
+    assert "must contain only nonnegative numbers or -1" in str(exc)
 
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -595,10 +595,15 @@ def test_ndarray_qr():
         ndarray_h, ndarray_tau = hl.eval(hl.nd.qr(hl_ndarray, mode="raw"))
         np_ndarray_h, np_ndarray_tau = np.linalg.qr(np_ndarray, mode="raw")
 
-        rank = np.linalg.matrix_rank(np_ndarray)
+        # Can't ask for the rank of something that has a 0 in its shape.
+        if 0 in np_ndarray.shape:
+            assert ndarray_h.shape == np_ndarray_h.shape
+            assert ndarray_tau.shape == np_ndarray_tau.shape
+        else:
+            rank = np.linalg.matrix_rank(np_ndarray)
 
-        assert np.allclose(ndarray_h[:, :rank], np_ndarray_h[:, :rank])
-        assert np.allclose(ndarray_tau[:rank], np_ndarray_tau[:rank])
+            assert np.allclose(ndarray_h[:, :rank], np_ndarray_h[:, :rank])
+            assert np.allclose(ndarray_tau[:rank], np_ndarray_tau[:rank])
 
     def assert_r_equivalence(hl_ndarray, np_ndarray):
         assert np.allclose(hl.eval(hl.nd.qr(hl_ndarray, mode="r")), np.linalg.qr(np_ndarray, mode="r"))
@@ -607,21 +612,31 @@ def test_ndarray_qr():
         q, r = hl.eval(hl.nd.qr(hl_ndarray, mode="reduced"))
         nq, nr = np.linalg.qr(np_ndarray, mode="reduced")
 
-        rank = np.linalg.matrix_rank(np_ndarray)
+        # Can't ask for the rank of something that has a 0 in its shape.
+        if 0 in np_ndarray.shape:
+            assert q.shape == nq.shape
+            assert r.shape == nr.shape
+        else:
+            rank = np.linalg.matrix_rank(np_ndarray)
 
-        assert np.allclose(q[:, :rank], nq[:, :rank])
-        assert np.allclose(r, nr)
-        assert np.allclose(q @ r, np_ndarray)
+            assert np.allclose(q[:, :rank], nq[:, :rank])
+            assert np.allclose(r, nr)
+            assert np.allclose(q @ r, np_ndarray)
 
     def assert_complete_equivalence(hl_ndarray, np_ndarray):
         q, r = hl.eval(hl.nd.qr(hl_ndarray, mode="complete"))
         nq, nr = np.linalg.qr(np_ndarray, mode="complete")
 
-        rank = np.linalg.matrix_rank(np_ndarray)
+        # Can't ask for the rank of something that has a 0 in its shape.
+        if 0 in np_ndarray.shape:
+            assert q.shape == nq.shape
+            assert r.shape == nr.shape
+        else:
+            rank = np.linalg.matrix_rank(np_ndarray)
 
-        assert np.allclose(q[:, :rank], nq[:, :rank])
-        assert np.allclose(r, nr)
-        assert np.allclose(q @ r, np_ndarray)
+            assert np.allclose(q[:, :rank], nq[:, :rank])
+            assert np.allclose(r, nr)
+            assert np.allclose(q @ r, np_ndarray)
 
     def assert_same_qr(hl_ndarray, np_ndarray):
         assert_raw_equivalence(hl_ndarray, np_ndarray)
@@ -665,6 +680,11 @@ def test_ndarray_qr():
     single_element = hl.nd.array([1]).reshape((1, 1))
 
     assert_same_qr(single_element, np_single_element)
+
+    np_no_elements = np.array([]).reshape((0, 10))
+    no_elements = hl.nd.array(np_no_elements)
+
+    assert_same_qr(no_elements, np_no_elements)
 
     with pytest.raises(ValueError) as exc:
         hl.nd.qr(wiki_example, mode="invalid")

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -208,6 +208,9 @@ def test_ndarray_reshape():
     np_hypercube = np.arange(3 * 5 * 7 * 9).reshape((3, 5, 7, 9))
     hypercube = hl.nd.array(np_hypercube)
 
+    np_shape_zero = np.array([])
+    shape_zero = hl.nd.array(np_shape_zero)
+
     assert_ndarrays_eq(
         (single.reshape(()), np_single.reshape(())),
         (zero_dim.reshape(()), np_zero_dim.reshape(())),
@@ -220,7 +223,8 @@ def test_ndarray_reshape():
         (cube_to_rect, np_cube_to_rect),
         (cube_t_to_rect, np_cube_t_to_rect),
         (hypercube.reshape((5, 7, 9, 3)).reshape((7, 9, 3, 5)), np_hypercube.reshape((7, 9, 3, 5))),
-        (hypercube.reshape(hl.tuple([5, 7, 9, 3])), np_hypercube.reshape((5, 7, 9, 3)))
+        (hypercube.reshape(hl.tuple([5, 7, 9, 3])), np_hypercube.reshape((5, 7, 9, 3))),
+        (shape_zero.reshape((0, 5)), np_shape_zero.reshape((0, 5)))
     )
 
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat, 2)).reshape((4, 5))) is None
@@ -457,6 +461,7 @@ def test_ndarray_matmul():
     np_five_dim_tensor = np.arange(7 * 5 * 1 * 5 * 3).reshape((7, 5, 1, 5, 3))
     np_ones_int32 = np.ones((4, 4), dtype=np.int32)
     np_ones_float64 = np.ones((4, 4), dtype=np.float64)
+    np_zero_by_four = np.array([]).reshape((0, 4))
 
     v = hl.nd.array(np_v)
     y = hl.nd.array(np_y)
@@ -473,6 +478,7 @@ def test_ndarray_matmul():
     five_dim_tensor = hl.nd.array(np_five_dim_tensor)
     ones_int32 = hl.nd.array(np_ones_int32)
     ones_float64 = hl.nd.array(np_ones_float64)
+    zero_by_four = hl.nd.array(np_zero_by_four)
 
     assert_ndarrays_eq(
         (v @ v, np_v @ np_v),
@@ -497,7 +503,8 @@ def test_ndarray_matmul():
         (m @ rect_prism, np_m @ np_rect_prism),
         (m @ rect_prism.T, np_m @ np_rect_prism.T),
         (broadcasted_mat @ rect_prism, np_broadcasted_mat @ np_rect_prism),
-        (six_dim_tensor @ five_dim_tensor, np_six_dim_tensor @ np_five_dim_tensor)
+        (six_dim_tensor @ five_dim_tensor, np_six_dim_tensor @ np_five_dim_tensor),
+        (zero_by_four @ ones_float64, np_zero_by_four, np_ones_float64)
     )
 
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat64, 2)) @ hl.null(hl.tndarray(hl.tfloat64, 2))) is None

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -224,7 +224,8 @@ def test_ndarray_reshape():
         (cube_t_to_rect, np_cube_t_to_rect),
         (hypercube.reshape((5, 7, 9, 3)).reshape((7, 9, 3, 5)), np_hypercube.reshape((7, 9, 3, 5))),
         (hypercube.reshape(hl.tuple([5, 7, 9, 3])), np_hypercube.reshape((5, 7, 9, 3))),
-        (shape_zero.reshape((0, 5)), np_shape_zero.reshape((0, 5)))
+        (shape_zero.reshape((0, 5)), np_shape_zero.reshape((0, 5))),
+        (shape_zero.reshape((-1, 5)), np_shape_zero.reshape((-1, 5)))
     )
 
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat, 2)).reshape((4, 5))) is None
@@ -253,6 +254,10 @@ def test_ndarray_reshape():
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((2, 2, -2)))
     assert "must contain only nonnegative numbers or -1" in str(exc)
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(shape_zero.reshape((0, -1)))
+    assert "Can't reshape" in str(exc)
 
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -461,7 +461,7 @@ def test_ndarray_matmul():
     np_five_dim_tensor = np.arange(7 * 5 * 1 * 5 * 3).reshape((7, 5, 1, 5, 3))
     np_ones_int32 = np.ones((4, 4), dtype=np.int32)
     np_ones_float64 = np.ones((4, 4), dtype=np.float64)
-    np_zero_by_four = np.array([]).reshape((0, 4))
+    np_zero_by_four = np.array([], dtype=np.float64).reshape((0, 4))
 
     v = hl.nd.array(np_v)
     y = hl.nd.array(np_y)
@@ -504,7 +504,8 @@ def test_ndarray_matmul():
         (m @ rect_prism.T, np_m @ np_rect_prism.T),
         (broadcasted_mat @ rect_prism, np_broadcasted_mat @ np_rect_prism),
         (six_dim_tensor @ five_dim_tensor, np_six_dim_tensor @ np_five_dim_tensor),
-        (zero_by_four @ ones_float64, np_zero_by_four, np_ones_float64)
+        (zero_by_four @ ones_float64, np_zero_by_four, np_ones_float64),
+        (zero_by_four.transpose() @ zero_by_four, np_zero_by_four.transpose() @ np_zero_by_four)
     )
 
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat64, 2)) @ hl.null(hl.tndarray(hl.tfloat64, 2))) is None

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1634,7 +1634,9 @@ class Emit[C](
         val K = new Value[Long] {
           def get: Code[Long] = (M < N).mux(M, N)
         }
-        val LDA = M // Possible stride tricks could change this in the future.
+        val LDA = new Value[Long] {
+          override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
+        }
 
         def LWORK = Region.loadDouble(LWORKAddress).toI
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2255,7 +2255,7 @@ class Emit[C](
               )
             ) },
             (runningProduct ceq 0L).mux(
-              hasNegativeOne.mux(
+              (hasNegativeOne || (runningProduct cne numElements)).mux(
                 Code._fatal[Unit]("Can't reshape since requested shape is incompatible with number of elements"),
                 Code(newShapeVars.zip(requestedShape).map { case (variable, shapeElement) => variable := shapeElement})
               ),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1576,8 +1576,6 @@ class Emit[C](
               val element = coerce[Any](elemMB.genFieldThisRef("matmul_element")(eVti))
               val k = elemMB.genFieldThisRef[Long]()
 
-              val innerMethod = elemMB.genEmitMethod("ndaMatMulLoop", FastIndexedSeq.empty[ParamType], eVti)
-
               val (lIndices: IndexedSeq[Value[Long]], rIndices: IndexedSeq[Value[Long]]) = (lPType.nDims, rPType.nDims, idxVars) match {
                 case (1, 1, Seq()) => (IndexedSeq(k), IndexedSeq(k))
                 case (1, _, stack :+ m) =>
@@ -1592,8 +1590,8 @@ class Emit[C](
                   (lStackVars :+ n :+ k, rStackVars :+ k :+  m)
               }
 
-              val lElem = lPType.loadElementToIRIntermediate(lIndices, leftND, innerMethod)
-              val rElem = rPType.loadElementToIRIntermediate(rIndices, rightND, innerMethod)
+              val lElem = lPType.loadElementToIRIntermediate(lIndices, leftND, elemMB)
+              val rElem = rPType.loadElementToIRIntermediate(rIndices, rightND, elemMB)
               val kLen = elemMB.genFieldThisRef[Long]()
 
               val loopCode = Code(
@@ -1604,8 +1602,7 @@ class Emit[C](
                   element := numericElementType.add(numericElementType.multiply(lElem, rElem), element),
                   k := k + 1L),
                 element)
-              innerMethod.emit(loopCode)
-              innerMethod.invokeCode[Unit]()
+              loopCode
             }
           }
           emitter.emit(mb, outputPType)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1530,10 +1530,10 @@ class Emit[C](
 
           val multiplyViaDGEMM = Code(
             shapeSetup,
-            answerPArrayAddress := outputPType.data.pType.allocate(region, (M * N).toI),
-            outputPType.data.pType.stagedInitialize(answerPArrayAddress, (M * N).toI),
 
-            ((M cne 0L) && (N cne 0L) && (K cne 0L)).orEmpty(
+            ((M cne 0L) && (N cne 0L) && (K cne 0L)).mux(Code(
+              answerPArrayAddress := outputPType.data.pType.allocate(region, (M * N).toI),
+              outputPType.data.pType.stagedInitialize(answerPArrayAddress, (M * N).toI),
               lPType.elementType match {
                 case PFloat32(_) =>
                   Code.invokeScalaObject13[String, String, Int, Int, Int, Float, Long, Int, Long, Int, Float, Long, Int, Unit](BLAS.getClass, method="sgemm",
@@ -1568,6 +1568,8 @@ class Emit[C](
                     LDC.toI
                   )
               }),
+              answerPArrayAddress := outputPType.data.pType.zeroes(mb, region, (M * N).toI)
+            ),
             outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeColumnMajorStridesBuilder(IndexedSeq(M, N), mb), answerPArrayAddress, mb)
           )
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1532,40 +1532,42 @@ class Emit[C](
             shapeSetup,
             answerPArrayAddress := outputPType.data.pType.allocate(region, (M * N).toI),
             outputPType.data.pType.stagedInitialize(answerPArrayAddress, (M * N).toI),
-            lPType.elementType match {
-              case PFloat32(_) =>
-                Code.invokeScalaObject13[String, String, Int, Int, Int, Float, Long, Int, Long, Int, Float, Long, Int, Unit](BLAS.getClass, method="sgemm",
-                  "N",
-                  "N",
-                  M.toI,
-                  N.toI,
-                  K.toI,
-                  1.0f,
-                  lPType.data.pType.firstElementOffset(leftDataAddress),
-                  LDA.toI,
-                  rPType.data.pType.firstElementOffset(rightDataAddress),
-                  LDB.toI,
-                  0.0f,
-                  outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),
-                  LDC.toI
-                )
-              case PFloat64(_) =>
-                Code.invokeScalaObject13[String, String, Int, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, method="dgemm",
-                  "N",
-                  "N",
-                  M.toI,
-                  N.toI,
-                  K.toI,
-                  1.0,
-                  lPType.data.pType.firstElementOffset(leftDataAddress),
-                  LDA.toI,
-                  rPType.data.pType.firstElementOffset(rightDataAddress),
-                  LDB.toI,
-                  0.0,
-                  outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),
-                  LDC.toI
-                )
-            },
+            
+            ((M cne 0L) && (N cne 0L) && (K cne 0L)).orEmpty(
+              lPType.elementType match {
+                case PFloat32(_) =>
+                  Code.invokeScalaObject13[String, String, Int, Int, Int, Float, Long, Int, Long, Int, Float, Long, Int, Unit](BLAS.getClass, method="sgemm",
+                    "N",
+                    "N",
+                    M.toI,
+                    N.toI,
+                    K.toI,
+                    1.0f,
+                    lPType.data.pType.firstElementOffset(leftDataAddress),
+                    LDA.toI,
+                    rPType.data.pType.firstElementOffset(rightDataAddress),
+                    LDB.toI,
+                    0.0f,
+                    outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),
+                    LDC.toI
+                  )
+                case PFloat64(_) =>
+                  Code.invokeScalaObject13[String, String, Int, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, method="dgemm",
+                    "N",
+                    "N",
+                    M.toI,
+                    N.toI,
+                    K.toI,
+                    1.0,
+                    lPType.data.pType.firstElementOffset(leftDataAddress),
+                    LDA.toI,
+                    rPType.data.pType.firstElementOffset(rightDataAddress),
+                    LDB.toI,
+                    0.0,
+                    outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),
+                    LDC.toI
+                  )
+              }),
             outputPType.construct(outputPType.makeShapeBuilder(IndexedSeq(M, N)), outputPType.makeColumnMajorStridesBuilder(IndexedSeq(M, N), mb), answerPArrayAddress, mb)
           )
 


### PR DESCRIPTION
This PR:

- Fixes it so that we can pass numpy ndarray literals with no elements.
- Makes sure we don't call BLAS when shape contains a 0. 
- Allows reshapes that contain a 0.