### PR TITLE
[lowering] TableStage Refactor / TableParallelize Lowering Improvement

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -29,7 +29,7 @@ sealed trait IR extends BaseIR {
       try {
         _typ = InferType(this)
       } catch {
-        case e: Throwable => throw new RuntimeException(s"typ: inference failure: ${e.getMessage}", e)
+        case e: Throwable => throw new RuntimeException(s"typ: inference failure:", e)
       }
     _typ
   }

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -61,12 +61,8 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         case (child: BlockMatrixIR, _) => normalizeBlockMatrix(child)
       }.toFastIndexedSeq)
   }
-  var done = false
+
   private def normalizeIR(ir: IR, env: BindingEnv[String]): IR = {
-//    if (!done) {
-//      println(Pretty(ir))
-//      done = true
-//    }
 
     def normalize(ir: IR, env: BindingEnv[String] = env): IR = normalizeIR(ir, env)
 

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -63,10 +63,10 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
   }
   var done = false
   private def normalizeIR(ir: IR, env: BindingEnv[String]): IR = {
-    if (!done) {
-      println(Pretty(ir))
-      done = true
-    }
+//    if (!done) {
+//      println(Pretty(ir))
+//      done = true
+//    }
 
     def normalize(ir: IR, env: BindingEnv[String] = env): IR = normalizeIR(ir, env)
 

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -61,8 +61,12 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         case (child: BlockMatrixIR, _) => normalizeBlockMatrix(child)
       }.toFastIndexedSeq)
   }
-
+  var done = false
   private def normalizeIR(ir: IR, env: BindingEnv[String]): IR = {
+    if (!done) {
+      println(Pretty(ir))
+      done = true
+    }
 
     def normalize(ir: IR, env: BindingEnv[String] = env): IR = normalizeIR(ir, env)
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -195,20 +195,20 @@ object LowerTableIR {
               GetField(Ref("context", contextType), "end"),
               I32(1)), i.name, MakeStruct(FastSeq("idx" -> i))))
 
-//        case TableMapGlobals(child, newGlobals) =>
-//          val loweredChild = lower(child)
-//          val oldbroadcast = Ref(genUID(), loweredChild.broadcastVals.typ)
-//          val newGlobRef = genUID()
-//          val newBroadvastVals =
-//            Let(
-//              oldbroadcast.name,
-//              loweredChild.broadcastVals,
-//              InsertFields(oldbroadcast,
-//                FastIndexedSeq(newGlobRef ->
-//                  Subst(lowerIR(newGlobals),
-//                    BindingEnv.eval("global" -> GetField(oldbroadcast, loweredChild.globalsField))))))
-//
-//          loweredChild.copy(broadcastVals = newBroadvastVals, globalsField = newGlobRef)
+        case TableMapGlobals(child, newGlobals) =>
+          val loweredChild = lower(child)
+          val oldbroadcast = Ref(genUID(), loweredChild.broadcastVals.typ)
+          val newGlobRef = genUID()
+          val newBroadvastVals =
+            Let(
+              oldbroadcast.name,
+              loweredChild.broadcastVals,
+              InsertFields(oldbroadcast,
+                FastIndexedSeq(newGlobRef ->
+                  Subst(lowerIR(newGlobals),
+                    BindingEnv.eval("global" -> GetField(oldbroadcast, loweredChild.globalsField))))))
+
+          loweredChild.copy(broadcastVals = newBroadvastVals, globalsField = newGlobRef)
 
         case TableFilter(child, cond) =>
           val loweredChild = lower(child)
@@ -263,7 +263,7 @@ object LowerTableIR {
         val cda = lowered.toIR(x => ToArray(x))
         lowered.wrapInBindings(MakeStruct(FastIndexedSeq(
           "rows" -> ToArray(StreamFlatMap(ToStream(cda), elt, ToStream(Ref(elt, cda.typ.asInstanceOf[TArray].elementType)))),
-          "global" -> GetField(lowered.broadcastRef, lowered.globalsField))))
+          "global" -> Ref(lowered.globalsField, child.typ.globalType))))
 
       case node if node.children.exists(_.isInstanceOf[TableIR]) =>
         throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -111,6 +111,10 @@ package object ir {
     case TFloat64 => F64(0d)
   }
 
+  def bindIR(v: IR)(body: Ref => IR): IR = {
+    val ref = Ref(genUID(), v.typ)
+    Let(ref.name, v, body(ref))
+  }
 
   def mapIR(stream: IR)(f: IR => IR): IR = {
     val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -427,7 +427,6 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableMapGlobals(): Unit = {
-    implicit val execStrats = ExecStrategy.lowering
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     val innerRowRef = Ref("row", t.field("rows").typ.asInstanceOf[TArray].elementType)
     val innerGlobalRef = Ref("global", t.field("global").typ)


### PR DESCRIPTION
Addressing what we discussed in lowering meeting yesterday. I've refactored TableStage to accumulate a bunch of let bindings that can be wrapped around the IR you want to generate with `TableStage.wrapInBindings`. See `TableCollect` for an example of this.

This definitely generates the IR we wanted, but I'd be very open to suggestions about how to make this more ergonomic to use (had to generate a lot of UIDs and Refs manually for `TableParallelize`). 

cc @cseed @tpoterba 