### PR TITLE
[query] fix bug in TableNativeReader.partitionCounts.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -197,7 +197,7 @@ class TableNativeReader(
 
   val filterIntervals: Boolean = params.options.map(_.filterIntervals).getOrElse(false)
 
-  def partitionCounts: Option[IndexedSeq[Long]] = if (filterIntervals) Some(spec.partitionCounts) else None
+  def partitionCounts: Option[IndexedSeq[Long]] = if (filterIntervals) None else Some(spec.partitionCounts)
 
   def fullType: TableType = spec.table_type
 


### PR DESCRIPTION
My change https://github.com/hail-is/hail/pull/8581 introduced a bug, count of native reads with pushed down intervals could give the wrong answer. 