### PR TITLE
[query] fix two requiredness issues

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -115,6 +115,19 @@ object CompileWithAggregators2 {
         EmitParamType(pt)
       }, returnType)
 
+    /*
+    {
+      def visit(x: IR): Unit = {
+        println(f"${ System.identityHashCode(x) }%08x    ${ x.getClass.getSimpleName } ${ x.pType }")
+        Children(x).foreach {
+          case c: IR => visit(c)
+        }
+      }
+
+      visit(ir)
+    }
+     */
+
     Emit(ctx, ir, fb, Some(aggSigs))
 
     val f = fb.resultWithIndex()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1226,7 +1226,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
           extracted.postAggIR,
           Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ)))))
     assert(rTyp.virtualType == newRow.typ)
-
+    
     // 1. init op on all aggs and write out to initPath
     val initAgg = Region.scoped { aggRegion =>
       Region.scoped { fRegion =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -192,7 +192,7 @@ object Extract {
     case PhysicalAggSignature(AggElements(), _, _) =>
       new ArrayElementwiseOpAggregator(aggSig.nested.get.map(a => getAgg(a, a.default)).toArray)
     case PhysicalAggSignature(PrevNonnull(), _, Seq(t)) =>
-      new PrevNonNullAggregator(t)
+      new PrevNonNullAggregator(t.setRequired(false))
     case PhysicalAggSignature(Group(), _, Seq(kt, PVoid)) =>
       new GroupedAggregator(PType.canonical(kt), aggSig.nested.get.map(a => getAgg(a, a.default)).toArray)
     case PhysicalAggSignature(CollectAsSet(), _, Seq(t)) =>

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalLocus.scala
@@ -17,7 +17,7 @@ object PCanonicalLocus {
     "position" -> PInt32(required = true))
 
   def schemaFromRG(rg: Option[ReferenceGenome], required: Boolean = false): PType = rg match {
-    case Some(ref) => PCanonicalLocus(ref)
+    case Some(ref) => PCanonicalLocus(ref, required)
     case None => representation(required)
   }
 }


### PR DESCRIPTION
PCLocus wasn't honoring requested requiredness
prev nonnull aggregator requiredness was wrong