### PR TITLE
[query] fix hl.spark_context for query backend

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -304,7 +304,7 @@ def spark_context():
     -------
     :class:`pyspark.SparkContext`
     """
-    return Env.backend().sc
+    return Env.spark_backend('spark_context').sc
 
 def current_backend():
     return Env.hc()._backend

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -8,6 +8,7 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
+    @skip_unless_spark_backend()
     def test_init_hail_context_twice(self):
         hl.init(idempotent=True)  # Should be no error
         hl.stop()

--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -1,7 +1,7 @@
 import unittest
 
 import hail as hl
-from .helpers import startTestHailContext, stopTestHailContext
+from .helpers import startTestHailContext, stopTestHailContext, skip_unless_spark_backend
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext


### PR DESCRIPTION
- generate appropriate error message
- don't test