### PR TITLE
[query] move Python parser entrypoints to SparkBackend

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -253,7 +253,7 @@ class SparkBackend(Backend):
         return dtype(jir.typ().toString())
 
     def table_type(self, tir):
-        jir = self._to_java_type_ir(tir)
+        jir = self._to_java_table_ir(tir)
         return ttable._from_java(jir.typ())
 
     def matrix_type(self, mir):

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -199,6 +199,21 @@ class SparkBackend(Backend):
         self.sc.stop()
         self.sc = None
 
+    def _parse_value_ir(self, code, ref_map={}, ir_map={}):
+        return self._jbackend.parse_value_ir(
+            code,
+            {k: t._parsable_string() for k, t in ref_map.items()},
+            ir_map)
+
+    def _parse_table_ir(self, code, ref_map={}, ir_map={}):
+        return self._jbackend.parse_table_ir(code, ref_map, ir_map)
+
+    def _parse_matrix_ir(self, code, ref_map={}, ir_map={}):
+        return self._jbackend.parse_matrix_ir(code, ref_map, ir_map)
+
+    def _parse_blockmatrix_ir(self, code, ref_map={}, ir_map={}):
+        return self._jbackend.parse_blockmatrix_ir(code, ref_map, ir_map)
+
     @property
     def fs(self):
         if self._fs is None:
@@ -206,15 +221,27 @@ class SparkBackend(Backend):
             self._fs = HadoopFS(self._utils_package_object, self._jbackend.fs())
         return self._fs
 
-    def _to_java_ir(self, ir):
+    def _to_java_ir(self, ir, parse):
         if not hasattr(ir, '_jir'):
             r = CSERenderer(stop_at_jir=True)
             # FIXME parse should be static
-            ir._jir = ir.parse(r(ir), ir_map=r.jirs)
+            ir._jir = parse(r(ir), ir_map=r.jirs)
         return ir._jir
 
+    def _to_java_value_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_value_ir)
+
+    def _to_java_table_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_table_ir)
+
+    def _to_java_matrix_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_matrix_ir)
+
+    def _to_java_blockmatrix_ir(self, ir):
+        return self._to_java_ir(ir, self._parse_blockmatrix_ir)
+
     def execute(self, ir, timed=False):
-        jir = self._to_java_ir(ir)
+        jir = self._to_java_value_ir(ir)
         result = json.loads(self._jhc.backend().executeJSON(jir))
         value = ir.typ._from_json(result['value'])
         timings = result['timings']
@@ -222,31 +249,31 @@ class SparkBackend(Backend):
         return (value, timings) if timed else value
 
     def value_type(self, ir):
-        jir = self._to_java_ir(ir)
+        jir = self._to_java_value_ir(ir)
         return dtype(jir.typ().toString())
 
     def table_type(self, tir):
-        jir = self._to_java_ir(tir)
+        jir = self._to_java_type_ir(tir)
         return ttable._from_java(jir.typ())
 
     def matrix_type(self, mir):
-        jir = self._to_java_ir(mir)
+        jir = self._to_java_matrix_ir(mir)
         return tmatrix._from_java(jir.typ())
 
     def persist_table(self, t, storage_level):
-        return Table._from_java(self._jbackend.pyPersistTable(storage_level, self._to_java_ir(t._tir)))
+        return Table._from_java(self._jbackend.pyPersistTable(storage_level, self._to_java_table_ir(t._tir)))
 
     def unpersist_table(self, t):
-        return Table._from_java(self._to_java_ir(t._tir).pyUnpersist())
+        return Table._from_java(self._to_java_table_ir(t._tir).pyUnpersist())
 
     def persist_matrix_table(self, mt, storage_level):
-        return MatrixTable._from_java(self._jbackend.pyPersistMatrix(storage_level, self._to_java_ir(mt._mir)))
+        return MatrixTable._from_java(self._jbackend.pyPersistMatrix(storage_level, self._to_java_matrix_ir(mt._mir)))
 
     def unpersist_matrix_table(self, mt):
-        return MatrixTable._from_java(self._to_java_ir(mt._mir).pyUnpersist())
+        return MatrixTable._from_java(self._to_java_matrix_ir(mt._mir).pyUnpersist())
 
     def blockmatrix_type(self, bmir):
-        jir = self._to_java_ir(bmir)
+        jir = self._to_java_blockmatrix_ir(bmir)
         return tblockmatrix._from_java(jir.typ())
 
     def from_spark(self, df, key):
@@ -256,7 +283,7 @@ class SparkBackend(Backend):
         t = t.expand_types()
         if flatten:
             t = t.flatten()
-        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_ir(t._tir)), Env.spark_session()._wrapped)
+        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_table_ir(t._tir)), Env.spark_session()._wrapped)
 
     def to_pandas(self, t, flatten):
         return self.to_spark(t, flatten).toPandas()

--- a/hail/python/hail/experimental/codec.py
+++ b/hail/python/hail/experimental/codec.py
@@ -2,10 +2,10 @@ from hail.utils.java import Env
 
 
 def encode(expression, codec='{"name":"BlockingBufferSpec","blockSize":65536,"child":{"name":"StreamBlockBufferSpec"}}'):
-    v = Env.backend()._jbackend.encodeToBytes(Env.backend()._to_java_ir(expression._ir), codec)
+    v = Env.spark_backend('encode')._jbackend.encodeToBytes(Env.backend()._to_java_value_ir(expression._ir), codec)
     return (v._1(), v._2())
 
 
 def decode(typ, ptype_string, bytes, codec='{"name":"BlockingBufferSpec","blockSize":65536,"child":{"name":"StreamBlockBufferSpec"}}'):
     return typ._from_json(
-        Env.backend()._jbackend.decodeToJSON(ptype_string, bytes, codec))
+        Env.spark_backend('decode')._jbackend.decodeToJSON(ptype_string, bytes, codec))

--- a/hail/python/hail/experimental/function.py
+++ b/hail/python/hail/experimental/function.py
@@ -26,7 +26,8 @@ def define_function(f, *param_types, _name=None, type_args=()):
 
     r = CSERenderer(stop_at_jir=True)
     code = r(body._ir)
-    jbody = body._ir.parse(code, ref_map=dict(zip(param_names, param_types)), ir_map=r.jirs)
+    jbody = (Env.spark_backend('define_function')
+             ._parse_value_ir(code, ref_map=dict(zip(param_names, param_types)), ir_map=r.jirs))
 
     Env.hail().expr.ir.functions.IRFunctionRegistry.pyRegisterIR(
         mname,

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -53,10 +53,6 @@ class BaseIR(Renderable):
         """
         return ''
 
-    @abc.abstractmethod
-    def parse(self, code, ref_map, ir_map):
-        return
-
     @property
     @abc.abstractmethod
     def typ(self):
@@ -237,12 +233,6 @@ class IR(BaseIR):
     def _compute_type(self, env, agg_env):
         raise NotImplementedError(self)
 
-    def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.ir.IRParser.parse_value_ir(
-            code,
-            {k: t._parsable_string() for k, t in ref_map.items()},
-            ir_map)
-
     @property
     def free_vars(self):
         def vars_from_child(i):
@@ -307,9 +297,6 @@ class TableIR(BaseIR):
     def renderable_new_block(self, i: int) -> bool:
         return True
 
-    def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.ir.IRParser.parse_table_ir(code, ref_map, ir_map)
-
     global_env = {'global'}
     row_env = {'global', 'row'}
 
@@ -331,9 +318,6 @@ class MatrixIR(BaseIR):
 
     def renderable_new_block(self, i: int) -> bool:
         return True
-
-    def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.ir.IRParser.parse_matrix_ir(code, ref_map, ir_map)
 
     global_env = {'global'}
     row_env = {'global', 'va'}
@@ -358,9 +342,6 @@ class BlockMatrixIR(BaseIR):
 
     def renderable_new_block(self, i: int) -> bool:
         return True
-
-    def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.ir.IRParser.parse_blockmatrix_ir(code, ref_map, ir_map)
 
     def unpersisted(self):
         return self

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -228,7 +228,7 @@ class BlockMatrix(object):
         if self._cached_jbm is not None:
             return self._cached_jbm
         else:
-            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).pyExecute()
+            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_blockmatrix_ir(self._bmir).pyExecute()
             return self._cached_jbm
 
     @classmethod
@@ -1194,7 +1194,7 @@ class BlockMatrix(object):
         -------
         :obj:`bool`
         """
-        return Env.backend()._to_java_ir(self._bmir).typ().isSparse()
+        return Env.backend()._to_java_blockmatrix_ir(self._bmir).typ().isSparse()
 
     @property
     def T(self):

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -150,7 +150,7 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None, keyed=True) -> Ta
     edges = hl.read_table(edges_path)
 
     mis_nodes = construct_expr(JavaIR(Env.hail().utils.Graph.pyMaximalIndependentSet(
-        Env.spark_backend('maximal_independent_set')._to_java_ir(edges.collect(_localize=False)._ir),
+        Env.spark_backend('maximal_independent_set')._to_java_value_ir(edges.collect(_localize=False)._ir),
         node_t._parsable_string(),
         joption(tie_breaker_str))),
                                hl.tset(node_t))

--- a/hail/python/test/hail/experimental/test_codec.py
+++ b/hail/python/test/hail/experimental/test_codec.py
@@ -1,4 +1,5 @@
 import hail as hl
+from test.hail.helpers import *
 
 
 UNBLOCKED_UNBUFFERED_SPEC = '{"name":"StreamBufferSpec"}'
@@ -17,6 +18,7 @@ def assert_round_trip_all_specs(exp):
     assert_round_trip(exp, BLOCKED_UNBUFFERED_SPEC)
 
 
+@skip_unless_spark_backend()
 def test_encode_basics():
     (_, b) = hl.experimental.encode(hl.literal(1), codec='{"name":"StreamBufferSpec"}')
     assert b.hex() == '01000000'
@@ -25,6 +27,7 @@ def test_encode_basics():
     assert b.hex() == 'ffffffff'
 
 
+@skip_unless_spark_backend()
 def test_decode_basics():
     result = hl.experimental.decode(hl.tint32,
                                     'PInt32',
@@ -39,10 +42,12 @@ def test_decode_basics():
     assert result == -1
 
 
+@skip_unless_spark_backend()
 def test_round_trip_basics():
     assert_round_trip_all_specs(hl.literal(1))
 
 
+@skip_unless_spark_backend()
 def test_complex_round_trips():
     assert_round_trip_all_specs(hl.struct())
     assert_round_trip_all_specs(hl.empty_array(hl.tint32))

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -119,6 +119,7 @@ class ValueIRTests(unittest.TestCase):
 
         return value_irs
 
+    @skip_unless_spark_backend()
     def test_parses(self):
         env = {'c': hl.tbool,
                'a': hl.tarray(hl.tint32),
@@ -132,9 +133,8 @@ class ValueIRTests(unittest.TestCase):
                't': hl.ttuple(hl.tint32, hl.tint64, hl.tfloat64),
                'call': hl.tcall,
                'x': hl.tint32}
-        env = {name: t._parsable_string() for name, t in env.items()}
         for x in self.value_irs():
-            Env.hail().expr.ir.IRParser.parse_value_ir(str(x), env, {})
+            Env.spark_backend('ValueIRTests.test_parses')._parse_value_ir(str(x), env)
 
     def test_copies(self):
         for x in self.value_irs():
@@ -144,7 +144,6 @@ class ValueIRTests(unittest.TestCase):
 
 
 class TableIRTests(unittest.TestCase):
-
     def table_irs(self):
         b = ir.TrueIR()
         table_read = ir.TableRead(
@@ -209,9 +208,10 @@ class TableIRTests(unittest.TestCase):
 
         return table_irs
 
+    @skip_unless_spark_backend()
     def test_parses(self):
         for x in self.table_irs():
-            Env.hail().expr.ir.IRParser.parse_table_ir(str(x))
+            Env.spark_backend('TableIRTests.test_parses')._parse_table_ir(str(x))
 
 
 class MatrixIRTests(unittest.TestCase):
@@ -269,10 +269,11 @@ class MatrixIRTests(unittest.TestCase):
 
         return matrix_irs
 
+    @skip_unless_spark_backend()
     def test_parses(self):
         for x in self.matrix_irs():
             try:
-                Env.hail().expr.ir.IRParser.parse_matrix_ir(str(x))
+                Env.spark_backend('MatrixIRTests.test_parses')._parse_matrix_ir(str(x))
             except Exception as e:
                 raise ValueError(str(x)) from e
 
@@ -344,9 +345,10 @@ class BlockMatrixIRTests(unittest.TestCase):
             slice_bm
         ]
 
+    @skip_unless_spark_backend()
     def test_parses(self):
         for x in self.blockmatrix_irs():
-            Env.hail().expr.ir.IRParser.parse_blockmatrix_ir(str(x))
+            Env.spark_backend('BlockMatrixIRTests.test_parses')._parse_blockmatrix_ir(str(x))
 
 
 class ValueTests(unittest.TestCase):

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -501,4 +501,30 @@ class SparkBackend(
       lmm.fit(ctx, pa_t, Option(a_t))
     }
   }
+
+  def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_blockmatrix_ir(
+    s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
+  ): BlockMatrixIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1676,31 +1676,7 @@ object IRParser {
     parse_value_ir(s, IRParserEnvironment(ctx))
   }
 
-  def parse_value_ir(s: String): IR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_value_ir(ctx, s)
-    }
-  }
-
-  def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(parseType), irMap.asScala.toMap))
-    }
-  }
-
   def parse_table_ir(ctx: ExecuteContext, s: String): TableIR = parse_table_ir(s, IRParserEnvironment(ctx))
-
-  def parse_table_ir(s: String): TableIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_table_ir(ctx, s)
-    }
-  }
-
-  def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(parseType), irMap.asScala.toMap))
-    }
-  }
 
   def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parse(s, table_ir(env))
 
@@ -1708,35 +1684,9 @@ object IRParser {
 
   def parse_matrix_ir(ctx: ExecuteContext, s: String): MatrixIR = parse_matrix_ir(s, IRParserEnvironment(ctx))
 
-  def parse_matrix_ir(s: String): MatrixIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_matrix_ir(ctx, s)
-    }
-  }
-
-  def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(parseType), irMap.asScala.toMap))
-    }
-  }
-
   def parse_blockmatrix_ir(s: String, env: IRParserEnvironment): BlockMatrixIR = parse(s, blockmatrix_ir(env))
 
   def parse_blockmatrix_ir(ctx: ExecuteContext, s: String): BlockMatrixIR = parse_blockmatrix_ir(s, IRParserEnvironment(ctx))
-
-  def parse_blockmatrix_ir(s: String): BlockMatrixIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_blockmatrix_ir(ctx, s)
-    }
-  }
-
-  def parse_blockmatrix_ir(
-    s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
-  ): BlockMatrixIR = {
-    ExecuteContext.scoped() { ctx =>
-      parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(parseType), irMap.asScala.toMap))
-    }
-  }
 
   def parseType(code: String, env: TypeParserEnvironment): Type = parse(code, type_expr(env))
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2929,21 +2929,21 @@ class IRSuite extends HailSuite {
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
     val s = Pretty(x, elideLiterals = false)
-    val x2 = IRParser.parse_table_ir(s)
+    val x2 = IRParser.parse_table_ir(ctx, s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
     val s = Pretty(x, elideLiterals = false)
-    val x2 = IRParser.parse_matrix_ir(s)
+    val x2 = IRParser.parse_matrix_ir(ctx, s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "blockMatrixIRs")
   def testBlockMatrixIRParser(x: BlockMatrixIR) {
     val s = Pretty(x, elideLiterals = false)
-    val x2 = IRParser.parse_blockmatrix_ir(s)
+    val x2 = IRParser.parse_blockmatrix_ir(ctx, s)
     assert(x2 == x)
   }
 
@@ -3218,12 +3218,12 @@ class IRSuite extends HailSuite {
     val lit = Literal(t, Row(1L))
 
     assert(IRParser.parseType(t.parsableString()) == t)
-    assert(IRParser.parse_value_ir(Pretty(lit, elideLiterals = false)) == lit)
+    assert(IRParser.parse_value_ir(ctx, Pretty(lit, elideLiterals = false)) == lit)
   }
 
   def regressionTestUnifyBug(): Unit = {
     // failed due to misuse of Type.unify
-    val ir = IRParser.parse_value_ir(
+    val ir = IRParser.parse_value_ir(ctx,
       """
         |(ToArray (StreamMap __uid_3
         |    (ToStream (Literal Array[Interval[Locus(GRCh37)]] "[{\"start\": {\"contig\": \"20\", \"position\": 10277621}, \"end\": {\"contig\": \"20\", \"position\": 11898992}, \"includeStart\": true, \"includeEnd\": false}]"))


### PR DESCRIPTION
- SparkBackend has the right context
- skip the parser tests unless on Spark backend
