### PR TITLE
[query] remove call to ExecuteContext.scoped from FoldConstants

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -4,11 +4,6 @@ import is.hail.expr.types.virtual.TStream
 import is.hail.utils.HailException
 
 object FoldConstants {
-  def apply(ir: BaseIR): BaseIR =
-    ExecuteContext.scoped() { ctx =>
-      foldConstants(ctx, ir)
-    }
-
   def apply(ctx: ExecuteContext, ir: BaseIR): BaseIR =
     ExecuteContext.scopedNewRegion(ctx) { ctx =>
       foldConstants(ctx, ir)

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -5,7 +5,7 @@ import is.hail.utils._
 import scala.collection.mutable
 
 object ForwardLets {
-  def apply(ir0: BaseIR): BaseIR = {
+  def apply[T <: BaseIR](ir0: T): T = {
     val ir1 = new NormalizeNames(_ => genUID(), allowFreeVariables = true).apply(ir0)
     val UsesAndDefs(uses, defs) = ComputeUsesAndDefs(ir1, allowFreeVariables = false)
     val nestingDepth = NestingDepth(ir1)
@@ -93,11 +93,11 @@ object ForwardLets {
       }
     }
 
-    ir1 match {
+    (ir1 match {
       case ir: IR => rewrite(ir, BindingEnv(Env.empty, Some(Env.empty), Some(Env.empty)))
       case tir: TableIR => rewriteTable(tir)
       case mir: MatrixIR => rewriteMatrix(mir)
       case bmir: BlockMatrixIR => rewriteBlockMatrix(bmir)
-    }
+    }).asInstanceOf[T]
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -4,6 +4,9 @@ import is.hail.HailContext
 import is.hail.utils._
 
 object Optimize {
+  def apply[T <: BaseIR](ctx: ExecuteContext, ir: T): T =
+    Optimize(ir, false, "direct", ctx)
+
   def apply[T <: BaseIR](ir0: T, noisy: Boolean, context: String, ctx: ExecuteContext): T = {
     if (noisy)
       log.info(s"optimize $context: before: IR size ${ IRSize(ir0) }: \n" + Pretty(ir0, elideLiterals = true))

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -324,10 +324,9 @@ object Simplify {
           }.toFastIndexedSeq)
       }
 
-      val rw = fieldNames.foldLeft[IR](Let(name, old, rewrite(body))) { case (comb, fieldName) =>
+      fieldNames.foldLeft[IR](Let(name, old, rewrite(body))) { case (comb, fieldName) =>
         Let(newFieldRefs(fieldName).name, newFieldMap(fieldName), comb)
       }
-      FoldConstants(ForwardLets(rw)).asInstanceOf[IR]
 
     case SelectFields(old, fields) if coerce[TStruct](old.typ).fieldNames sameElements fields =>
       old

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -324,9 +324,10 @@ object Simplify {
           }.toFastIndexedSeq)
       }
 
-      fieldNames.foldLeft[IR](Let(name, old, rewrite(body))) { case (comb, fieldName) =>
+      val rw = fieldNames.foldLeft[IR](Let(name, old, rewrite(body))) { case (comb, fieldName) =>
         Let(newFieldRefs(fieldName).name, newFieldMap(fieldName), comb)
       }
+      ForwardLets[IR](rw)
 
     case SelectFields(old, fields) if coerce[TStruct](old.typ).fieldNames sameElements fields =>
       old

--- a/hail/src/test/scala/is/hail/expr/ir/FoldConstantsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FoldConstantsSuite.scala
@@ -1,18 +1,19 @@
 package is.hail.expr.ir
 
+import is.hail.HailSuite
 import is.hail.expr.types.virtual.{TFloat64, TInt32, TTuple}
 import org.apache.spark.sql.Row
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
-class FoldConstantsSuite extends TestNGSuite {
+class FoldConstantsSuite extends HailSuite {
   @Test def testRandomBlocksFolding() {
     val x = ApplySeeded("rand_norm", Seq(F64(0d), F64(0d)), 0L, TFloat64)
-    assert(FoldConstants(x) == x)
+    assert(FoldConstants(ctx, x) == x)
   }
 
   @Test def testErrorCatching() {
     val ir = invoke("toInt32", TInt32, Str(""))
-    assert(FoldConstants(ir) == ir)
+    assert(FoldConstants(ctx, ir) == ir)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -116,12 +116,12 @@ class ForwardLetsSuite extends HailSuite {
 
   @Test def testLetNoMention(): Unit = {
     val ir = Let("x", I32(1), I32(2))
-    assert(ForwardLets(ir) == I32(2))
+    assert(ForwardLets[IR](ir) == I32(2))
   }
 
   @Test def testLetRefRewrite(): Unit = {
     val ir = Let("x", I32(1), Ref("x", TInt32))
-    assert(ForwardLets(ir) == I32(1))
+    assert(ForwardLets[IR](ir) == I32(1))
   }
 
   @Test def testAggregators(): Unit = {

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -98,7 +98,8 @@ class SimplifySuite extends HailSuite {
 
     assert(Simplify(ir1) == InsertFields(r, FastSeq(("y", F64(0)), ("z", GetField(r, "x").toD)), Some(FastIndexedSeq("x", "y", "z"))))
     assert(Simplify(ir2) == InsertFields(r, FastSeq(("y", F64(0.0)), ("z", GetField(r, "x").toD + F64(0.0))), Some(FastIndexedSeq("x", "y", "z"))))
-    assert(Simplify(ir3) == InsertFields(Ref("something_else", TStruct.empty), FastSeq(("z", I32(0)))))
+
+    assert(Optimize[IR](ctx, ir3) == InsertFields(Ref("something_else", TStruct.empty), FastSeq(("z", I32(0)))))
 
     val shouldNotRewrite = Let("row2", InsertFields(r, FastSeq(("y", Ref("other", TFloat64)))), InsertFields(r2, FastSeq(("z", invoke("str", TString, r2)))))
 


### PR DESCRIPTION
ExecuteContext.scoped() depends on the Spark backend, and all uses of it need to get removed.  A separate PR removes it from the IRParser.  The remaining uses are in BlockMatrix and the Graph/maximal independent set stuff.