### PR TITLE
[query] move BlockMatrixIR.pyExecute to SparkBackend

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -225,11 +225,10 @@ class BlockMatrix(object):
 
     @property
     def _jbm(self):
-        if self._cached_jbm is not None:
-            return self._cached_jbm
-        else:
-            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_blockmatrix_ir(self._bmir).pyExecute()
-            return self._cached_jbm
+        if self._cached_jbm is None:
+            self._cached_jbm = (Env.spark_backend('BlockMatrix._jbm')._jbackend
+                                .pyBlockMatrixExecute(self._bmir))
+        return self._cached_jbm
 
     @classmethod
     @typecheck_method(path=str)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -525,6 +525,8 @@ class SparkBackend(
   ): BlockMatrixIR = {
     withExecuteContext() { ctx =>
       IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
 
   def pyBlockMatrixExecute(bm: BlockMatrixIR): BlockMatrix = {
     withExecuteContext() { ctx =>

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -29,7 +29,7 @@ import scala.collection.JavaConverters._
 import java.io.PrintWriter
 
 import is.hail.io.vcf.VCFsReader
-import is.hail.linalg.RowMatrix
+import is.hail.linalg.{BlockMatrix, RowMatrix}
 import is.hail.stats.LinearMixedModel
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.storage.StorageLevel
@@ -525,6 +525,10 @@ class SparkBackend(
   ): BlockMatrixIR = {
     withExecuteContext() { ctx =>
       IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+
+  def pyBlockMatrixExecute(bm: BlockMatrixIR): BlockMatrix = {
+    withExecuteContext() { ctx =>
+      Interpret(bm, ctx, optimize = true)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -61,12 +61,6 @@ object BlockMatrixIR {
 abstract sealed class BlockMatrixIR extends BaseIR {
   def typ: BlockMatrixType
 
-  def pyExecute(): BlockMatrix = {
-    ExecuteContext.scoped() { ctx =>
-      Interpret(this, ctx, optimize = true)
-    }
-  }
-
   protected[ir] def execute(ctx: ExecuteContext): BlockMatrix =
     fatal("tried to execute unexecutable IR:\n" + Pretty(this))
 


### PR DESCRIPTION
When BM gets de-Sparked, this will go away an the structure will be analogous to Table and MatrixTable.

Also, this removes a use of ExecuteContext.scoped(), which is deprecated.
