### PR TITLE
[batch] give a reasonable error message when no batch billing project is set

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -230,7 +230,7 @@ class ServiceBackend(Backend):
 
     def __init__(self, billing_project=None):
         if billing_project is None:
-            billing_project = get_user_config().get('batch', 'billing_project')
+            billing_project = get_user_config().get('batch', 'billing_project', fallback=None)
         if billing_project is None:
             raise ValueError(
                 f'the billing_project parameter of ServiceBackend must be set '


### PR DESCRIPTION
The default behavior, is, apparently, to error, not to return `None`. This change makes the missing value case return `None` which triggers the ValueError on the next line.