### PR TITLE
typecheck literal

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -665,9 +665,7 @@ class tndarray(HailType):
         json_dict = {
             "shape": x.shape,
             "strides": strides,
-            "flags": 0,
-            "data": data,
-            "offset": 0
+            "data": data
         }
         return json_dict
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -85,6 +85,7 @@ object Literal {
 final case class Literal(_typ: Type, value: Annotation) extends IR {
   require(!CanEmit(_typ))
   require(value != null)
+  require(_typ.typeCheck(value))
 }
 
 final case class I32(x: Int) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -85,7 +85,7 @@ object Literal {
 final case class Literal(_typ: Type, value: Annotation) extends IR {
   require(!CanEmit(_typ))
   require(value != null)
-  require(_typ.typeCheck(value))
+  // require(_typ.typeCheck(value))
 }
 
 final case class I32(x: Int) extends IR

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TNDArray.scala
@@ -94,13 +94,13 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
-  def _typeCheck(a: Any): Boolean = throw new UnsupportedOperationException
+  def _typeCheck(a: Any): Boolean = representation._typeCheck(a)
 
   val ordering: ExtendedOrdering = null
 
   lazy val representation = TStruct(
-    ("shape", TTuple(Array.tabulate(nDims)(_ => TInt64):_*)),
-    ("strides", TTuple(Array.tabulate(nDims)(_ => TInt64):_*)),
+    ("shape", TTuple(Array.fill(nDims)(TInt64): _*)),
+    ("strides", TTuple(Array.fill(nDims)(TInt64): _*)),
     ("data", TArray(elementType))
   )
 }

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -264,19 +264,22 @@ class ExtractIntervalFiltersSuite extends HailSuite {
 
   @Test def testIntervalListFold() {
     val inIntervals = FastIndexedSeq(
-      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(10, -1)),
+      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(10, -1)),
       null,
-      Interval(wrappedIntervalEndpoint(20, -1), wrappedIntervalEndpoint(25, -1)),
-      Interval(wrappedIntervalEndpoint(-10, -1), wrappedIntervalEndpoint(5, -1))
+      Interval(IntervalEndpoint(20, -1), IntervalEndpoint(25, -1)),
+      Interval(IntervalEndpoint(-10, -1), IntervalEndpoint(5, -1))
     )
 
     val ir = StreamFold(
-      Literal(TArray(TInterval(TInt32)), inIntervals),
+      ToStream(Literal(TArray(TInterval(TInt32)), inIntervals)),
       False(),
       "acc",
       "elt",
-      invoke("lor", TBoolean, Ref("acc", TBoolean), invoke("contains", TBoolean, Ref("elt", TInterval(TInt32)), k1))
-    )
+      invoke("lor", TBoolean,
+        Ref("acc", TBoolean),
+        invoke("contains", TBoolean, Ref("elt", TInterval(TInt32)), k1)))
+    TypeCheck(ir, BindingEnv(Env(ref1.name -> ref1.typ)))
+
     val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(ir, ref1, ref1Key).get
     assert(rw == True())
     assert(intervals.toSeq == FastSeq(


### PR DESCRIPTION
Fix bugs that show up when we typecheck the literal value on construction.  The assert is commented out for now because it is expensive.  Later, I'll add a flag to control expensive checks like this and checkRVDKeys and the tests should be run with expensive checks turned on.