### PR TITLE
[query] refactor TableStage.context for ease of use and better scoping

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -116,9 +116,20 @@ package object ir {
     Let(ref.name, v, body(ref))
   }
 
-  def mapIR(stream: IR)(f: IR => IR): IR = {
+  def mapIR(stream: IR)(f: Ref => IR): IR = {
     val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)
     StreamMap(stream, ref.name, f(ref))
+  }
+
+  def flatMapIR(stream: IR)(f: Ref => IR): IR = {
+    val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)
+    StreamFlatMap(stream, ref.name, f(ref))
+  }
+
+  def foldIR(stream: IR, zero: IR)(f: (Ref, Ref) => IR): IR = {
+    val elt = Ref(genUID(), coerce[TStream](stream.typ).elementType)
+    val accum = Ref(genUID(), zero.typ)
+    StreamFold(stream, zero, accum.name, elt.name, f(accum, elt))
   }
 
   def rangeIR(n: IR): IR = StreamRange(0, n, 1)


### PR DESCRIPTION
Some light refactoring of TableStage to change how context/body is defined; this is pretty similar to how BlockMatrixStage currently handles contexts.

I prefer this way of defining the body of a partition because I think it will make writing table joins more natural and lead to less boilerplate ref generation; I think BlockMatrixDot provides a pretty good illustration of what a join body will look like, in general. (The context handling is different, and I don't think we want to do what BlockMatrixStage does w.r.t contexts right now.) This is slightly different from the code in master; I've rewritten `blockBody` to make use of `bindIR` and (currently non-existent) `foldIR` instead of manually generating refs to better illustrate flow.

```
      case x@BlockMatrixDot(leftIR, rightIR) =>
        val left = lower(leftIR)
        val right = lower(rightIR)
        val newCtxType = TArray(TTuple(left.ctxType, right.ctxType))
        new BlockMatrixStage(left.globalVals ++ right.globalVals, newCtxType) {
          def blockContext(idx: (Int, Int)): IR = {
            val (i, j) = idx
            MakeArray(Array.tabulate[Option[IR]](leftIR.typ.nColBlocks) { k =>
              if (leftIR.typ.hasBlock(i -> k) && rightIR.typ.hasBlock(k -> j))
                Some(MakeTuple.ordered(FastSeq(
                  left.blockContext(i -> k), right.blockContext(k -> j))))
              else None
            }.flatten[IR], newCtxType)
          }

          def blockBody(ctxRef: Ref): IR = {
            def blockMultiply(elt: Ref) =
              bindIR(GetTupleElement(elt, 0)) { leftElt =>
                bindIR(GetTupleElement(elt, 1)) { rightElt =>
                  NDArrayMatMul(left.blockBody(leftElt), right.blockBody(rightElt))
                }
              }
            foldIR(ToStream(invoke("sliceRight", ctxType, ctxRef, I32(1))),
              bindIR(ArrayRef(ctxRef, 0))(blockMultiply)) { (sum, elt) =>
              NDArrayMap2(sum, blockMultiply(elt), "l", "r",
                Ref("l", x.typ.elementType) + Ref("r", x.typ.elementType))
            }
          }
        }
```