### PR TITLE
[query] remove BlockMatrix._jbm from python

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -221,14 +221,6 @@ class BlockMatrix(object):
 
     def __init__(self, bmir):
         self._bmir = bmir
-        self._cached_jbm = None
-
-    @property
-    def _jbm(self):
-        if self._cached_jbm is None:
-            self._cached_jbm = (Env.spark_backend('BlockMatrix._jbm')._jbackend
-                                .pyBlockMatrixExecute(self._bmir))
-        return self._cached_jbm
 
     @classmethod
     @typecheck_method(path=str)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -29,7 +29,7 @@ import scala.collection.JavaConverters._
 import java.io.PrintWriter
 
 import is.hail.io.vcf.VCFsReader
-import is.hail.linalg.{BlockMatrix, RowMatrix}
+import is.hail.linalg.RowMatrix
 import is.hail.stats.LinearMixedModel
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.storage.StorageLevel
@@ -524,12 +524,6 @@ class SparkBackend(
   ): BlockMatrixIR = {
     withExecuteContext() { ctx =>
       IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
-    }
-  }
-
-  def pyBlockMatrixExecute(bm: BlockMatrixIR): BlockMatrix = {
-    withExecuteContext() { ctx =>
-      Interpret(bm, ctx, optimize = true)
     }
   }
 }


### PR DESCRIPTION
@cseed following up on my comment from #8642.

There's no need to keep java block matrices as a python concept anymore, since there's no operation that isn't encoded in the IR.

I checked with Konrad and Jacob before removing, although it turns out that I'd at some point previously already removed the Scala function that they were calling through `_jbm`, so the `._jbm.filterRowIntervalsIR` call hasn't worked for a while now, anyways.