### PR TITLE
[query/debug] add print parameter back to classesBytes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -608,7 +608,7 @@ class EmitClassBuilder[C](
       "FunctionBuilder emission should happen on master, but happened on worker")
 
     val n = cb.className.replace("/", ".")
-    val classesBytes = modb.classesBytes()
+    val classesBytes = modb.classesBytes(print)
 
     new ((Int, Region) => C) with java.io.Serializable {
       @transient @volatile private var theClass: Class[_] = null


### PR DESCRIPTION
There was no way to get the class printout from resultWithIndex.
Must have been droped at some point