### PR TITLE
[query] add GenericLines

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -52,8 +52,11 @@ object GenericLines {
         private var bufMark = 0
         private var bufPos = 0
 
-        // end really means first block >= end
-        private var endBlock = -1L
+        private var realEnd =
+          if (splitCompressed)
+            -1L  // end really means first block >= end
+          else
+            end
 
         private def loadBuffer(): Unit = {
           // compressed blocks can be empty
@@ -68,8 +71,8 @@ object GenericLines {
               bufMark = nRead
               assert(!splitCompressed || virtualOffsetBlockOffset(bufOffset) == 0)
 
-              if (endBlock == -1 && bufOffset >= end)
-                endBlock = bufOffset
+              if (realEnd == -1 && bufOffset >= end)
+                realEnd = bufOffset
             }
           }
         }
@@ -91,7 +94,7 @@ object GenericLines {
           assert(bufPos < bufMark)
 
           val offset = bufOffset + bufPos
-          if (split && endBlock != -1L && offset > endBlock) {
+          if (split && realEnd != -1L && offset > realEnd) {
             line = null
             return
           }
@@ -254,7 +257,7 @@ object GenericLines {
           fatal(s"Cowardly refusing to read file serially: ${ status.getPath }.")
 
         Iterator.single {
-          Row(0, status.getPath, 0, size, false)
+          Row(0, status.getPath, 0L, size, false)
         }
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -1,0 +1,298 @@
+package is.hail.expr.ir
+
+import is.hail.utils._
+import is.hail.expr.types.virtual.{TBoolean, TInt32, TInt64, TString, TStruct, Type}
+import is.hail.io.compress.{BGzipCodec, BGzipInputStream}
+import is.hail.io.fs.{FS, Positioned, PositionedInputStream, SeekableInputStream}
+import org.apache.commons.io.input.{CountingInputStream, ProxyInputStream}
+import org.apache.hadoop.io.compress.SplittableCompressionCodec
+import org.apache.spark.sql.Row
+
+abstract class CloseableIterator[T] extends Iterator[T] with AutoCloseable
+
+object GenericLines {
+  def read(fs: FS, contexts: IndexedSeq[Any]): GenericLines = {
+
+    val fsBc = fs.broadcast
+    val body: (Any) => CloseableIterator[GenericLine] = { (context: Any) =>
+      val contextRow = context.asInstanceOf[Row]
+      val index = contextRow.getAs[Int](0)
+      val file = contextRow.getAs[String](1)
+      val start = contextRow.getAs[Long](2)
+      val end = contextRow.getAs[Long](3)
+      val split = contextRow.getAs[Boolean](4)
+
+      new CloseableIterator[GenericLine] {
+        private var splitCompressed = false
+        private val is: PositionedInputStream = {
+          val fs = fsBc.value
+          val rawIS = fs.openNoCompression(file)
+          val codec = fs.getCodec(file)
+          if (codec == null) {
+            rawIS.seek(start)
+            rawIS
+          } else if (codec.isInstanceOf[BGzipCodec]) {
+            splitCompressed = true
+            val bgzIS = new BGzipInputStream(rawIS, start, end, SplittableCompressionCodec.READ_MODE.BYBLOCK)
+            new ProxyInputStream(bgzIS) with Positioned {
+              def getPosition: Long = bgzIS.getVirtualOffset
+            }
+          } else {
+            assert(!split)
+            new CountingInputStream(codec.createInputStream(rawIS)) with Positioned {
+              def getPosition: Long = getByteCount
+            }
+          }
+        }
+
+        private var eof = false
+
+        private var buf = new Array[Byte](64 * 1024)
+        private var bufOffset = 0L
+        private var bufMark = 0
+        private var bufPos = 0
+
+        // end really means first block >= end
+        private var endBlock = -1L
+
+        private def loadBuffer(): Unit = {
+          // compressed blocks can be empty
+          while (bufPos == bufMark && !eof) {
+            // load new block
+            bufOffset = is.getPosition
+            val nRead = is.read(buf)
+            if (nRead == -1)
+              eof = true
+            else {
+              bufPos = 0
+              bufMark = nRead
+              assert(!splitCompressed || virtualOffsetBlockOffset(bufOffset) == 0)
+
+              if (endBlock == -1 && bufOffset >= end)
+                endBlock = bufOffset
+            }
+          }
+        }
+
+        loadBuffer()
+
+        private var lineData = new Array[Byte](1024)
+
+        private var line = new GenericLine(file)
+        line.data = lineData
+
+        private def readLine(): Unit = {
+          assert(line != null)
+
+          if (eof) {
+            line = null
+            return
+          }
+          assert(bufPos < bufMark)
+
+          val offset = bufOffset + bufPos
+          if (split && endBlock != -1L && offset > endBlock) {
+            line = null
+            return
+          }
+
+          line.offset = offset
+
+          var sawcr = false
+          var linePos = 0
+
+          while (true) {
+            if (eof) {
+              assert(linePos > 0)
+              line.lineLength = linePos
+              return
+            }
+
+            assert(bufPos < bufMark)
+
+            val begin = bufPos
+            var eol = false
+
+            if (sawcr) {
+              val c = buf(bufPos)
+              if (c == '\n')
+                bufPos += 1
+              eol = true
+            } else {
+              // look for end of line in buf
+              while (bufPos < bufMark && {
+                val c = buf(bufPos)
+                c != '\n' && c != '\r'
+              })
+                bufPos += 1
+
+              if (bufPos < bufMark) {
+                val c = buf(bufPos)
+                if (c == '\n') {
+                  bufPos += 1
+                  eol = true
+                } else {
+                  assert(c == '\r')
+
+                  bufPos += 1
+                  if (bufPos < bufMark) {
+                    val c2 = buf(bufPos)
+                    if (c2 == '\n')
+                      bufPos += 1
+                    eol = true
+                  } else
+                    sawcr = true
+                }
+              }
+            }
+
+            // move scanned input from buf to lineData
+            val n = bufPos - begin
+            if (linePos + n > lineData.length) {
+              val newLineData = new Array[Byte]((linePos + n) * 2)
+              System.arraycopy(lineData, 0, newLineData, 0, linePos)
+              lineData = newLineData
+              line.data = newLineData
+            }
+            System.arraycopy(buf, begin, lineData, linePos, n)
+            linePos += n
+
+            if (bufPos == bufMark)
+              loadBuffer()
+
+            if (eol) {
+              assert(linePos > 0)
+              line.lineLength = linePos
+              return
+            }
+          }
+        }
+
+        readLine()
+        // the first line begins at most at start
+        // belongs to previous partition
+        if (index > 0 && line != null)
+          readLine()
+
+        private var consumed = false
+
+        def hasNext: Boolean = {
+          if (consumed) {
+            readLine()
+            consumed = false
+          }
+          line != null
+        }
+
+        def next(): GenericLine = {
+          if (consumed)
+            readLine()
+          assert(line != null)
+          assert(line.lineLength > 0)
+          consumed = true
+          line
+        }
+
+        def close(): Unit = {
+          is.close()
+        }
+      }
+    }
+
+    val contextType = TStruct(
+      "index" -> TInt32,
+      "file" -> TString,
+      "start" -> TInt64,
+      "end" -> TInt64,
+      "split" -> TBoolean)
+    new GenericLines(
+      contextType,
+      contexts,
+      body)
+  }
+
+
+  def read(
+    fs: FS,
+    files: IndexedSeq[String],
+    blockSizeInMB: Option[Int],
+    nPartitions: Option[Int],
+    allowSerialRead: Boolean
+  ): GenericLines = {
+    val statuses = fs.globAllStatuses(files)
+      .filter(_.getLen > 0)
+    val totalSize = statuses.map(_.getLen).sum
+
+    val contexts = statuses.flatMap { status =>
+      val size = status.getLen
+      val codec = fs.getCodec(status.getPath)
+
+      val splittable = codec == null || codec.isInstanceOf[BGzipCodec]
+      if (splittable) {
+        var fileNParts = nPartitions match {
+          case Some(nPartitions) =>
+            ((nPartitions.toDouble * size) / totalSize + 0.5).toInt
+          case None =>
+            val blockSizeInB = blockSizeInMB.getOrElse(128) * 1024 * 1024
+            (size.toDouble / blockSizeInB + 0.5).toInt
+        }
+        if (fileNParts == 0)
+          fileNParts = 1
+
+        val parts = partition(size, fileNParts)
+        val partScan = parts.scanLeft(0L)(_ + _)
+        Iterator.range(0, fileNParts)
+          .map { i =>
+            var start = partScan(i)
+            var end = partScan(i + 1)
+            if (codec != null)
+              end = makeVirtualOffset(end, 0)
+            Row(i, status.getPath, start, end, true)
+          }
+      } else {
+        if (!allowSerialRead)
+          fatal(s"Cowardly refusing to read file serially: ${ status.getPath }.")
+
+        Iterator.single {
+          Row(0, status.getPath, 0, size, false)
+        }
+      }
+    }
+
+    GenericLines.read(fs, contexts)
+  }
+
+  def collect(lines: GenericLines): IndexedSeq[String] = {
+    lines.contexts.flatMap { context =>
+      using(lines.body(context)) { it =>
+        it.map { line =>
+          var n = line.lineLength
+          assert(n > 0)
+          val lineData = line.data
+          // strip line delimiter to match behavior of Spark textFile
+          if (lineData(n - 1) == '\n') {
+            n -= 1
+            if (n > 0 && lineData(n - 1) == '\r')
+              n -= 1
+          } else if (lineData(n - 1) == '\r')
+            n -= 1
+          new String(lineData, 0, n)
+        }.toArray
+      }
+    }
+  }
+}
+
+class GenericLine(
+  val file: String,
+  // possibly virtual
+  var offset: Long,
+  var data: Array[Byte],
+  var lineLength: Int) {
+  def this(file: String) = this(file, 0, null, 0)
+}
+
+class GenericLines(
+  val contextType: Type,
+  val contexts: IndexedSeq[Any],
+  val body: (Any) => CloseableIterator[GenericLine])

--- a/hail/src/main/scala/is/hail/io/fs/package.scala
+++ b/hail/src/main/scala/is/hail/io/fs/package.scala
@@ -3,6 +3,8 @@ package is.hail.io
 import java.io.{DataInputStream, DataOutputStream, InputStream, OutputStream}
 
 package object fs {
+  type PositionedInputStream = InputStream with Positioned
+
   type SeekableInputStream = InputStream with Seekable
 
   type SeekableDataInputStream = DataInputStream with Seekable

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -642,6 +642,20 @@ package object utils extends Logging
     parts
   }
 
+  def partition(n: Long, k: Int): Array[Long] = {
+    if (k == 0) {
+      assert(n == 0)
+      return Array.empty[Long]
+    }
+
+    assert(n >= 0)
+    assert(k > 0)
+    val parts = Array.tabulate(k)(i => (n - i + k - 1) / k)
+    assert(parts.sum == n)
+    assert(parts.max - parts.min <= 1)
+    parts
+  }
+
   def matchErrorToNone[T, U](f: (T) => U): (T) => Option[U] = (x: T) => {
     try {
       Some(f(x))
@@ -825,6 +839,21 @@ package object utils extends Logging
   def decomposeWithName(v: Any, name: String)(implicit formats: Formats): JObject = {
     val jo = Extraction.decompose(v).asInstanceOf[JObject]
     jo.merge(JObject("name" -> JString(name)))
+  }
+
+  def makeVirtualOffset(fileOffset: Long, blockOffset: Int): Long = {
+    assert(fileOffset >= 0)
+    assert(blockOffset >= 0)
+    assert(blockOffset < 64 * 1024)
+    (fileOffset << 16) | blockOffset
+  }
+
+  def virtualOffsetBlockOffset(offset: Long): Int = {
+    (offset & 0xFFFF).toInt
+  }
+
+  def virtualOffsetCompressedOffset(offset: Long): Long = {
+    offset >> 16
   }
 }
 

--- a/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -5,8 +5,10 @@ import is.hail.check.Gen
 import is.hail.check.Prop.forAll
 import is.hail.utils._
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil
+import is.hail.expr.ir.GenericLines
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.spark.sql.Row
 import org.apache.{hadoop => hd}
 import org.testng.annotations.Test
 
@@ -19,7 +21,6 @@ class TestFileInputFormat extends hd.mapreduce.lib.input.TextInputFormat {
     val hConf = job.getConfiguration
 
     val splitPoints = hConf.get("bgz.test.splits").split(",").map(_.toLong)
-    println(splitPoints.toSeq)
 
     val splits = new mutable.ArrayBuffer[hd.mapreduce.InputSplit]
     val files = listStatus(job).asScala
@@ -45,20 +46,92 @@ class TestFileInputFormat extends hd.mapreduce.lib.input.TextInputFormat {
 }
 
 class BGzipCodecSuite extends HailSuite {
+  val uncompPath = "src/test/resources/sample.vcf"
+
+  // is actually a bgz file
+  val gzPath = "src/test/resources/sample.vcf.gz"
+
+  /*
+   * bgz.test.sample.vcf.bgz was created as follows:
+   *  - split sample.vcf into 60-line chunks: `split -l 60 sample.vcf sample.vcf.`
+   *  - move the line boundary on two chunks by 1 character in different directions
+   *  - bgzip compressed the chunks
+   *  - stripped the empty terminate block in chunks except ad and ag (the last)
+   *  - concatenated the chunks
+   */
+  val compPath = "src/test/resources/bgz.test.sample.vcf.bgz"
+
+  @Test def testGenericLinesSimpleUncompressed() {
+    val lines = Source.fromFile(uncompPath).getLines().toFastIndexedSeq
+
+    var i = 0
+    while (i < 16) {
+      val lines2 = GenericLines.collect(
+        GenericLines.read(fs, Array(uncompPath), None, Some(i), false))
+      assert(lines2 == lines)
+      i += 1
+    }
+  }
+
+  @Test def testGenericLinesSimpleBGZ() {
+    val lines = Source.fromFile(uncompPath).getLines().toFastIndexedSeq
+
+    var i = 0
+    while (i < 16) {
+      val lines2 = GenericLines.collect(
+        GenericLines.read(fs, Array(compPath), None, Some(i), false))
+      assert(lines2 == lines)
+      i += 1
+    }
+  }
+
+  @Test def testGenericLinesSimpleGZ() {
+    val lines = Source.fromFile(uncompPath).getLines().toFastIndexedSeq
+
+    // won't split, just run once
+    val lines2 = GenericLines.collect(
+      GenericLines.read(fs, Array(gzPath), None, Some(7), false))
+    assert(lines2 == lines)
+  }
+
+  @Test def testGenericLinesRandom() {
+    val lines = Source.fromFile(uncompPath).getLines().toFastIndexedSeq
+
+    val compLength = 195353
+    val compSplits = Array[Long](6566, 20290, 33438, 41165, 56691, 70278, 77419, 92522, 106310, 112477, 112505, 124593,
+      136405, 144293, 157375, 169172, 175174, 186973, 195325)
+
+    val g = for (n <- Gen.oneOfGen(
+      Gen.choose(0, 10),
+      Gen.choose(0, 100));
+      rawSplits <- Gen.buildableOfN[Array](n,
+        Gen.oneOfGen(Gen.choose(0L, compLength),
+          Gen.applyGen(Gen.oneOf[(Long) => Long](identity, _ - 1, _ + 1),
+            Gen.oneOfSeq(compSplits)))))
+      yield
+        (Array(0L, compLength) ++ rawSplits).distinct.sorted
+
+    val p = forAll(g) { splits =>
+
+      val contexts = (0 until (splits.length - 1))
+        .map { i =>
+          val end = makeVirtualOffset(splits(i + 1), 0)
+          Row(i, compPath, splits(i), end, true)
+        }
+      val lines2 = GenericLines.collect(GenericLines.read(fs, contexts))
+      if (lines2.length != lines.length) {
+        println(lines.length)
+        println(lines2.length)
+        println(contexts)
+      }
+      assert(lines2 == lines)
+      true
+    }
+    p.check()
+  }
+
   @Test def test() {
     sc.hadoopConfiguration.setLong("mapreduce.input.fileinputformat.split.minsize", 1L)
-
-    val uncompPath = "src/test/resources/sample.vcf"
-
-    /*
-     * bgz.test.sample.vcf.bgz was created as follows:
-     *  - split sample.vcf into 60-line chunks: `split -l 60 sample.vcf sample.vcf.`
-     *  - move the line boundary on two chunks by 1 character in different directions
-     *  - bgzip compressed the chunks
-     *  - stripped the empty terminate block in chunks except ad and ag (the last)
-     *  - concatenated the chunks
-     */
-    val compPath = "src/test/resources/bgz.test.sample.vcf.bgz"
 
     val uncompIS = fs.open(uncompPath)
     val uncomp = IOUtils.toByteArray(uncompIS)


### PR DESCRIPTION
Write loading lines from text files in a way that can be used by Spark or table lowering.  This will be to lower the VCF and text file importers.

This handles three cases:
 - an (splittable) uncompressed file,
 - a (splittable) bgzip compressed file, and
 - an non-splittable compressed file compressed by some other codec.  In this case, it will be loaded as a single partition.

I test each of the three cases.  I also ported the prexisting partition test that generates random splittings and tests that in the bgzip case.  I tested with the number of tests turned up to 10,000.

Two ideas here:

Each line has a fixed offset depending on the case (file offset, virtual offset, or decompressed offset).  The split defines a partition of the offset spaces. For a partition (start, end), and line with offset x, the line belongs in the partition if x lies in the range (start, end] or, if it is the first partition, [start, end].

This is because, if at the beginning of a split, you can't tell if the line started earlier or not.

The second idea is to copy the blocks one at a time into buf.  bgzip blocks are max 64KB.  `read` on a BGzipInputStream doesn't return data that spans blocks.  So buf always contains the entire data for a block.  This is used to track the offset o the beginning of the line.