### PR TITLE
Lower TableGroupWithinPartitions

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -226,7 +226,7 @@ object LowerTableIR {
 
         case TableGroupWithinPartitions(child, groupedStructName, n) =>
           val loweredChild = lower(child)
-          val keyFields = FastIndexedSeq(loweredChild.partitioner.kType.fieldNames: _*)
+          val keyFields = FastIndexedSeq(child.typ.keyType.fieldNames: _*)
           loweredChild.mapPartition { part =>
             val grouped =  StreamGrouped(part, n)
             val groupedArrays = mapIR(grouped) (group => ToArray(group))

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -224,6 +224,14 @@ object LowerTableIR {
             Subst(newRow, BindingEnv(env, scan = Some(env)))
           })
 
+        case TableGroupWithinPartitions(child, name, n) =>
+          val loweredChild = lower(child)
+          loweredChild.mapPartition { part =>
+            val grouped =  StreamGrouped(part, n)
+            ???
+          }
+          ???
+
         case TableExplode(child, path) =>
           lower(child).mapPartition { rows =>
             flatMapIR(rows) { row: Ref =>

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -522,7 +522,6 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableGroupWithinPartitions(): Unit = {
-    implicit val execStrats = ExecStrategy.interpretOnly
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     val length = 6
     val value = Row(FastIndexedSeq(0 until length: _*).map(i => Row(i, "row" + i)), Row("global"))


### PR DESCRIPTION
This PR lowers `TableGroupWithinPartitions` and adds a test for it. 