### PR TITLE
[ci] Make git clone resilient to failure 

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -142,6 +142,9 @@ def clone_or_fetch_script(repo):
 function clone() {{ ( set -e
     dir=$(mktemp -d)
     git clone {shq(repo)} $dir
+    echo $?
+    (cd $dir && g status)  # verify the clone actually worked
+    echo $?
     for x in $(ls -A $dir); do
         mv -- "$dir/$x" ./
     done

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -143,7 +143,7 @@ function clone() {{ ( set -e
     dir=$(mktemp -d)
     git clone {shq(repo)} $dir
     echo $?
-    (cd $dir && g status)  # verify the clone actually worked
+    (cd $dir && git status)  # verify the clone actually worked
     echo $?
     for x in $(ls -A $dir); do
         mv -- "$dir/$x" ./


### PR DESCRIPTION
As currently written, if `git clone` returns a non-zero exit code, the script
should exit immediately. I am not sure why this GnuTLS recv error (pasted below)
does not trigger a non-zero exit code from git clone. This change both
explicitly echoes the exit code so we can be sure of our sanity and adds a check
that I'm confident will fail if no git repository was cloned (`git status`).

```
+ date
Wed Apr 29 21:15:15 UTC 2020
+ rm -rf repo
+ mkdir repo
+ cd repo
+ '[' '!' -d .git ']'
+ retry clone
+ clone
+ set -e
++ mktemp -d
+ dir=/tmp/tmp.5R5aJAlgEm
+ git clone https://github.com/hail-is/hail.git /tmp/tmp.5R5aJAlgEm
Cloning into '/tmp/tmp.5R5aJAlgEm'...
error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
++ ls -A /tmp/tmp.5R5aJAlgEm

real	0m0.998s
user	0m0.008s
sys	0m0.017s
+ git config user.email ci@hail.is
fatal: not in a git directory
```
