### PR TITLE
[query] Run setup and test missingness when invoking an EmitParam

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -920,30 +920,25 @@ class EmitMethodBuilder[C](
   }
 
   private def _invoke[T](_args: Param*): Code[T] = {
-    val args = _args.map {
-      case cp: CodeParam =>
-        cp
-      case ep@EmitParam(EmitCode(setup, m, pv)) =>
-        if (pv.pt.required) {
-          ep
-        } else {
-          // Why can't this be a local? aren't we invoking it right after?
-          val mv = genFieldThisRef[Boolean](s"emitparam_m_${pv.pt._asIdent}")
-          EmitParam(EmitCode(Code(setup, mv := m), mv, PCode(pv.pt, mv.mux(defaultValue(pv.pt), pv.code))))
-        }
-    }
-
-    val setup = Code(args.map {
-      case CodeParam(_) => Code._empty
-      case EmitParam(ec) => ec.setup
-    })
-    Code(
-      setup,
+    EmitCodeBuilder.scopedCode(this) { cb =>
+      val args = _args.map {
+        case cp: CodeParam =>
+          cp
+        case EmitParam(EmitCode(setup, m, pv)) =>
+          cb += setup
+          if (pv.pt.required) {
+            cb += Code.toUnit(m) // side effects???, is this even possible
+            EmitParam(EmitCode.present(pv))
+          } else {
+            val mv = cb.newField[Boolean](s"emitparam_m_${pv.pt._asIdent}", m)
+            EmitParam(EmitCode(Code._empty, mv, PCode(pv.pt, mv.mux(defaultValue(pv.pt), pv.code))))
+          }
+      }
       mb.invoke(args.flatMap {
         case CodeParam(c) => FastIndexedSeq(c)
-        case EmitParam(ec) =>
-          ec.codeTuple()
-      }: _*))
+        case EmitParam(ec) => ec.codeTuple()
+      }: _*)
+    }
   }
 
   def invokeCode[T](args: Param*): Code[T] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -377,44 +377,39 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
       rebalanceUp(ab.size - 1))
   }
 
-  val seqOp: (Code[Boolean], Code[_], Code[Boolean], Code[_]) => Code[Unit] = {
-    val ki = typeToTypeInfo(keyType)
-    val vi = typeToTypeInfo(valueType)
+  val seqOp: (EmitCode, EmitCode) => Code[Unit] = {
     val mb = cb.genEmitMethod("take_by_seqop",
-      FastIndexedSeq[ParamType](BooleanInfo, vi, BooleanInfo, ki),
+      FastIndexedSeq[ParamType](valueType, keyType),
       UnitInfo)
 
-    val valueM = mb.getCodeParam[Boolean](1)
-    val value = mb.getCodeParam(2)(vi)
-    val keyM = mb.getCodeParam[Boolean](3)
-    val key = mb.getCodeParam(4)(ki)
+    val value = mb.getEmitParam(1)
+    val key = mb.getEmitParam(2)
 
     mb.emit(
       (maxSize > 0).orEmpty(
         (ab.size < maxSize).mux(
           Code(
-            stageAndIndexKey(keyM, key),
-            copyToStaging(value, valueM, keyStage),
+            stageAndIndexKey(key.m, key.v),
+            copyToStaging(value.v, value.m, keyStage),
             enqueueStaging()),
           Code(
             tempPtr := eltTuple.loadField(elementOffset(0), 0),
-            (compareKey((keyM, key), loadKey(tempPtr)) < 0)
+            (compareKey((key.m, key.v), loadKey(tempPtr)) < 0)
               .orEmpty(Code(
-                stageAndIndexKey(keyM, key),
-                copyToStaging(value, valueM, keyStage),
+                stageAndIndexKey(key.m, key.v),
+                copyToStaging(value.v, value.m, keyStage),
                 swapStaging(),
                 gc()))))))
 
-    val kmVar = cb.genFieldThisRef[Boolean]("km")
-    val vmVar = cb.genFieldThisRef[Boolean]("vm")
 
-    { (vm: Code[Boolean], v: Code[_], km: Code[Boolean], k: Code[_]) =>
-      Code(
-        vmVar := vm,
-        kmVar := km,
-        mb.invokeCode(vmVar, vmVar.mux(defaultValue(valueType), v), kmVar, kmVar.mux(defaultValue(keyType), k))
-      )
-    }
+    (v: EmitCode, k: EmitCode) => mb.invokeCode(v, k)
+  }
+
+  // for tests
+  def seqOp(vm: Code[Boolean], v: Code[_], km: Code[Boolean], k: Code[_]): Code[Unit] = {
+    val vec = EmitCode(Code._empty, vm, PCode(valueType, v))
+    val kec = EmitCode(Code._empty, km, PCode(keyType, k))
+    seqOp(vec, kec)
   }
 
   def combine(other: TakeByRVAS, dummy: Boolean): Code[Unit] = {
@@ -591,11 +586,7 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
     val Array(value: EmitCode, key: EmitCode) = seq
     assert(value.pv.pt == valueType)
     assert(key.pv.pt == keyType)
-    Code(
-      value.setup,
-      key.setup,
-      state.seqOp(value.m, value.v, key.m, key.v)
-    )
+    state.seqOp(value, key)
   }
 
   def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = state.combine(other, dummy)

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -254,6 +254,7 @@ class Aggregators2Suite extends HailSuite {
   }
 
   @Test def testTakeBy() {
+    /* FIXME only the last test here is failing with the change, will remove before merge
     val t = TStruct(
       "a" -> TStruct("x" -> TInt32, "y" -> TInt64),
       "b" -> TInt32,
@@ -354,6 +355,7 @@ class Aggregators2Suite extends HailSuite {
       seqOpArgs2,
       expected = rows2.take(17),
       args = FastIndexedSeq(("rows", (TArray(t2), rows2.reverse))))
+    */
 
     // test inside of aggregation
     val tr = TableRange(10000, 5)

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -254,7 +254,6 @@ class Aggregators2Suite extends HailSuite {
   }
 
   @Test def testTakeBy() {
-    /* FIXME only the last test here is failing with the change, will remove before merge
     val t = TStruct(
       "a" -> TStruct("x" -> TInt32, "y" -> TInt64),
       "b" -> TInt32,
@@ -355,7 +354,6 @@ class Aggregators2Suite extends HailSuite {
       seqOpArgs2,
       expected = rows2.take(17),
       args = FastIndexedSeq(("rows", (TArray(t2), rows2.reverse))))
-    */
 
     // test inside of aggregation
     val tr = TableRange(10000, 5)


### PR DESCRIPTION
We previously were just passing the Code in EmitParams to method
invocations without testing missingness. This change fixes this by
wrapping the PCode in a missingness that will return a default value if
the original EmitCode is missing.