### PR TITLE
fix Spark and Scala versioning

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1485,7 +1485,7 @@ steps:
    script: |
      set -ex
      gcloud auth activate-service-account --key-file=/secrets/ci-deploy-0-1--hail-is-hail.json
-     SPARK_VERSION=2.4.0
+     SPARK_VERSION=2.4.5
      BRANCH=0.2
      SHA="{{ code.sha }}"
      GS_JAR=gs://hail-common/builds/${BRANCH}/jars/hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.jar

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -9,7 +9,8 @@ REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 URL := $(shell git config --get remote.origin.url)
-SPARK_VERSION := 2.4.0
+SCALA_VERSION = 2.11.12
+SPARK_VERSION := 2.4.5
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 39
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)
@@ -46,7 +47,7 @@ WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)
 
-GRADLE_ARGS += -Dspark.version=$(SPARK_VERSION) -Dpy4j.version$(PY4J_VERSION)
+GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION)
 
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -26,12 +26,6 @@ repositories {
     maven { url "https://repo.spring.io/plugins-release/" }
 }
 
-String sparkVersion = "2.4.5"
-String breezeVersion = "0.13.2"
-String py4jVersion = "0.10.7"
-String scalaVersion = '2.11.12'
-String scalaMajorVersion = '2.11'
-
 sourceSets.main.scala.srcDir "src/main/java"
 sourceSets.main.java.srcDirs = []
 sourceSets.test.runtimeClasspath += files("prebuilt/lib")
@@ -87,6 +81,7 @@ compileScala {
         "-Xlint:-infer-any",
         "-Xlint:-unsound-match"
     ]
+
     scalaCompileOptions.forkOptions.with {
         jvmArgs = ["-Xms512M",
                    "-Xmx4096M",
@@ -95,7 +90,46 @@ compileScala {
     }
 }
 
+project.ext {
+    cachedBreezeVersion = null
+    
+    sparkVersion = System.getProperty("spark.version", "2.4.5")
+    scalaVersion = System.getProperty("scala.version", "2.11.12")
+    scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
+}
+
+String breezeVersion() {
+  if (cachedBreezeVersion == null) {
+    def artifacts = configurations.justSpark.getResolvedConfiguration().getResolvedArtifacts()
+    artifacts.each { ResolvedArtifact artifact ->
+	def module = artifact.getModuleVersion().getId()
+	if (module.getGroup() == 'org.scalanlp'
+	  && module.getName() == 'breeze_' + scalaMajorVersion) {
+	    cachedBreezeVersion = module.getVersion()	    
+	}
+    }
+    if (cachedBreezeVersion == null) {
+      throw new RuntimeException('Unable to determine breeze library version')
+    }
+  }
+  return cachedBreezeVersion
+}
+
 configurations {
+    justSpark
+
+    all {
+        resolutionStrategy {
+            componentSelection {
+	      withModule('org.scalanlp:breeze-natives_' + scalaMajorVersion) { ComponentSelection selection ->
+		  if (selection.candidate.getVersion() != breezeVersion()) {
+		    selection.reject()
+		  }
+	      }
+	    }
+	}
+    }
+
     compile.extendsFrom bundled, unbundled
     testCompile.extendsFrom compile, hailTest
     hailJar.extendsFrom bundled
@@ -110,6 +144,8 @@ configurations {
 }
 
 dependencies {
+    justSpark 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
+
     unbundled 'org.scala-lang:scala-library:' + scalaVersion
     unbundled 'org.scala-lang:scala-reflect:' + scalaVersion
 
@@ -123,7 +159,7 @@ dependencies {
     unbundled 'org.apache.spark:spark-sql_' + scalaMajorVersion + ':' + sparkVersion
     unbundled 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
     bundled 'org.lz4:lz4-java:1.4.0'
-    bundled('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':' + breezeVersion) {
+    bundled('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':+') {
         transitive = false
     }
     bundled 'com.github.fommil.netlib:all:1.1.2'

--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -98,11 +98,12 @@ For Cloudera-specific instructions, see :ref:`running-on-a-cloudera-cluster`.
 
 For all other Spark clusters, you will need to build Hail from the source code.
 
-Hail should be built on the master node of the Spark cluster. The following
-command builds Hail for Spark 2.4.0, installs the Python library, and installs
-all the Python dependencies::
+Hail should be built on the master node of the Spark cluster. The
+following command builds Hail for Scala 2.11.12 and Spark 2.4.5,
+installs the Python library, and installs all the Python
+dependencies::
 
-    make install-on-cluster HAIL_COMPILE_NATIVES=1 SPARK_VERSION=2.4.0
+    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.5
 
 Moreover, every worker node of the cluster needs a compatible BLAS and LAPACK
 library, such as the Intel MKL or OpenBlas.
@@ -179,7 +180,7 @@ the same as above, except:
    builds a Hail JAR for Cloudera's
    2.4.0 version of Spark::
 
-    make install-on-cluster HAIL_COMPILE_NATIVES=1 SPARK_VERSION=2.4.0.cloudera PY4J_VERSION=0.10.7
+    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.0.cloudera
 
  - On a Cloudera cluster, ``SPARK_HOME`` should be set as:
    ``SPARK_HOME=/opt/cloudera/parcels/SPARK2/lib/spark2``,

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -30,9 +30,9 @@ Build and install a wheel file from source with local-mode ``pyspark``::
 
     make install HAIL_COMPILE_NATIVES=1
 
-As above, but explicitly specifying the Spark version::
+As above, but explicitly specifying the Scala and Spark versions::
 
-    make install HAIL_COMPILE_NATIVES=1 SPARK_VERSION=2.4.1
+    make install HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.5
 
 Building the Docs and Website
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -134,7 +134,6 @@ REGION_TO_REPLICATE_MAPPING = {
     'australia-southeast1': 'aus-sydney'
 }
 
-SPARK_VERSION = '2.4.0'
 IMAGE_VERSION = '1.4-debian9'
 
 


### PR DESCRIPTION
Changes:
 - removed unused py4jVersion from build.gradle
 - pin breeze native version to version required by spark.  This was not easy!  I do it by creating a configuration that just depends on Spark, and then a resolution rule for all configurations that says only accept the breeze natives version corresponding to the version requested by spark.
 - determine sparkMajorVersion from sparkVersion (strip patch version)
 - in docs, everywhere we use SPARK_VERSION, also specify SCALA_VERSION.  I verified 2.4.0.cloudera is built against Scala 2.11.
 - added SCALA_VERSION to hail/Makefile
 - make Makefile versions match build.gradle defaults (somewhat annoying they are duplicated)