### PR TITLE
[query/agg] Remove unused `dummy` parameters

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -113,7 +113,7 @@ class ApproxCDFAggregator extends StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State = new ApproxCDFState(cb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     val Array(k) = init
     Code(
       k.setup,
@@ -123,7 +123,7 @@ class ApproxCDFAggregator extends StagedAggregator {
       ))
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(x) = seq
     Code(
       x.setup,
@@ -133,12 +133,12 @@ class ApproxCDFAggregator extends StagedAggregator {
       ))
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     state.comb(other)
   }
 
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     state.result(srvb)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -98,7 +98,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State = new CallStatsState(cb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     val Array(nAlleles) = init
     val addr = state.cb.genFieldThisRef[Long]()
     val n = state.cb.genFieldThisRef[Int]()
@@ -127,7 +127,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
     ))
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(call) = seq
     assert(t == call.pv.pt)
 
@@ -158,7 +158,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
       mb.invokeCode(call.v)))
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     val i = state.cb.genFieldThisRef[Int]()
     Code(
       other.nAlleles.cne(state.nAlleles).orEmpty(Code._fatal[Unit]("length mismatch")),
@@ -172,7 +172,7 @@ class CallStatsAggregator(t: PCall) extends StagedAggregator {
   }
 
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     val alleleNumber = state.cb.genFieldThisRef[Int]()
     val i = state.cb.genFieldThisRef[Int]()
     val x = state.cb.genFieldThisRef[Int]()

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -57,17 +57,17 @@ class CollectAggregator(val elemType: PType) extends StagedAggregator {
   def createState(cb: EmitClassBuilder[_]): State =
     new State(cb)
 
-  def initOp(state: State, args: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, args: Array[EmitCode]): Code[Unit] = {
     assert(args.isEmpty)
     state.bll.init(state.region)
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] =
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] =
     state.bll.push(state.region, seq(0))
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] =
+  protected def _combOp(state: State, other: State): Code[Unit] =
     state.bll.append(state.region, other.bll)
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] =
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] =
     srvb.addArray(resultType, state.bll.writeToSRVB(_))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -161,20 +161,20 @@ class CollectAsSetAggregator(t: PType) extends StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State = new AppendOnlySetState(cb, t)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 0)
     state.init
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(elt) = seq
     Code(elt.setup, state.insert(elt.m, elt.v))
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] =
+  protected def _combOp(state: State, other: State): Code[Unit] =
     other.foreach { (km, kv) => state.insert(km, kv) }
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] =
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] =
     srvb.addArray(resultType.arrayFundamentalType, sab =>
       Code(
         sab.start(state.size),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -12,27 +12,26 @@ object CountAggregator extends StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State = new PrimitiveRVAState(Array(PInt64(true)), cb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 0)
     val (_, v, _) = state.fields(0)
     v.storeAny(0L)
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     assert(seq.length == 0)
     val (_, v, _) = state.fields(0)
     v.storeAny(coerce[Long](v) + 1L)
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     val (_, v1, _) = state.fields(0)
     val (_, v2, _) = other.fields(0)
     v1.storeAny(coerce[Long](v1) + coerce[Long](v2))
   }
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     val (_, v, _) = state.fields(0)
     srvb.addLong(coerce[Long](v))
   }
 }
-

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -539,7 +539,7 @@ class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State = new DownsampleState(cb, arrayType)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     val Array(nDivisions) = init
     Code(
       nDivisions.setup,
@@ -550,7 +550,7 @@ class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(x, y, label) = seq
 
     Code(
@@ -563,7 +563,7 @@ class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
     )
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = state.merge(other)
+  protected def _combOp(state: State, other: State): Code[Unit] = state.merge(other)
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = state.result(srvb, resultType)
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = state.result(srvb, resultType)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -110,7 +110,7 @@ class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends Stag
           k0))
     }
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     val _initOpF = state.cb.wrapInEmitMethod[Int, Int, Unit]("linregInitOp", initOpF(state))
     val Array(kt, k0t) = init
     (Code(kt.setup, kt.m) || Code(k0t.setup, k0t.m)).mux(
@@ -163,7 +163,7 @@ class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends Stag
     }
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val _seqOpF = state.cb.wrapInEmitMethod[Double, Long, Unit]("linregSeqOp", seqOpF(state))
     val Array(y, x) = seq
     (Code(y.setup, y.m) || Code(x.setup, x.m)).mux(
@@ -207,11 +207,11 @@ class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends Stag
         optr := optr + scalar.byteSize))))
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     state.cb.wrapInEmitMethod[Unit]("linregCombOp", combOpF(state, other))
   }
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     val res = state.cb.genFieldThisRef[Long]()
     coerce[Unit](Code(
       res := Code.invokeScalaObject4[Region, Long, Long, Int, Long](LinearRegressionAggregator.getClass, "computeResult",

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -23,7 +23,7 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
   def createState(cb: EmitClassBuilder[_]): State =
     new PrimitiveRVAState(Array(typ.setRequired(monoid.neutral.isDefined)), cb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 0)
     val (mOpt, v, _) = state.fields(0)
     (mOpt, monoid.neutral) match {
@@ -32,7 +32,7 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     }
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(elt) = seq
     val (mOpt, v, _) = state.fields(0)
     val eltm = state.cb.genFieldThisRef[Boolean]()
@@ -44,13 +44,13 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     )
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     val (m1, v1, _) = state.fields(0)
     val (m2, v2, _) = other.fields(0)
     combine(m1, v1, m2.map(_.load), v2.load)
   }
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     val (mOpt, v, _) = state.fields(0)
     mOpt match {
       case None => srvb.addIRIntermediate(typ)(v)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -14,12 +14,12 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
   def createState(cb: EmitClassBuilder[_]): State =
     new TypedRegionBackedAggState(typ.setRequired(false), cb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 0)
     state.storeMissing()
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(elt: EmitCode) = seq
     val v = state.cb.genFieldThisRef()(typeToTypeInfo(typ))
     Code(
@@ -29,7 +29,7 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
     )
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+  protected def _combOp(state: State, other: State): Code[Unit] = {
     val t = other.get()
     val v = state.cb.genFieldThisRef()(typeToTypeInfo(typ))
     Code(
@@ -38,7 +38,7 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
         Code(v := t.value, state.storeNonmissing(v))))
   }
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = {
     val t = state.get()
     Code(
       t.setup,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -12,16 +12,16 @@ abstract class StagedAggregator {
 
   def createState(cb: EmitClassBuilder[_]): State
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit]
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit]
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit]
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit]
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit]
+  protected def _combOp(state: State, other: State): Code[Unit]
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit]
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit]
 
-  def initOp(state: AggregatorState, init: Array[EmitCode]): Code[Unit] = initOp(state.asInstanceOf[State], init, dummy = true)
-  def seqOp(state: AggregatorState, seq: Array[EmitCode]): Code[Unit] = seqOp(state.asInstanceOf[State], seq, dummy = true)
-  def combOp(state: AggregatorState, other: AggregatorState): Code[Unit] = combOp(state.asInstanceOf[State], other.asInstanceOf[State], dummy = true)
-  def result(state: AggregatorState, srvb: StagedRegionValueBuilder): Code[Unit] = result(state.asInstanceOf[State], srvb, dummy = true)
+  def initOp(state: AggregatorState, init: Array[EmitCode]): Code[Unit] = _initOp(state.asInstanceOf[State], init)
+  def seqOp(state: AggregatorState, seq: Array[EmitCode]): Code[Unit] = _seqOp(state.asInstanceOf[State], seq)
+  def combOp(state: AggregatorState, other: AggregatorState): Code[Unit] = _combOp(state.asInstanceOf[State], other.asInstanceOf[State])
+  def result(state: AggregatorState, srvb: StagedRegionValueBuilder): Code[Unit] = _result(state.asInstanceOf[State], srvb)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -75,7 +75,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val cb: EmitClassBuil
     )
   }
 
-  def combine(other: TakeRVAS, dummy: Boolean): Code[Unit] = {
+  def combine(other: TakeRVAS): Code[Unit] = {
     val j = cb.genFieldThisRef[Int]()
     val (eltJMissing, eltJ) = other.builder.loadElement(j)
 
@@ -91,7 +91,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val cb: EmitClassBuil
     )
   }
 
-  def result(srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
+  def result(srvb: StagedRegionValueBuilder): Code[Unit] = {
     srvb.addArray(resultType, { rvb =>
       val (eltIMissing, eltOffset) = builder.elementOffset(rvb.arrayIdx)
       Code(
@@ -124,7 +124,7 @@ class TakeAggregator(typ: PType) extends StagedAggregator {
   def createState(fb: EmitClassBuilder[_]): State =
     new TakeRVAS(typ, resultType, fb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     Code(
@@ -134,12 +134,12 @@ class TakeAggregator(typ: PType) extends StagedAggregator {
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(elt: EmitCode) = seq
     state.seqOp(elt)
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = state.combine(other, dummy)
+  protected def _combOp(state: State, other: State): Code[Unit] = state.combine(other)
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = state.result(srvb, dummy)
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] = state.result(srvb)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -417,7 +417,7 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     }
   }
 
-  def combine(other: TakeByRVAS, dummy: Boolean): Code[Unit] = {
+  def combine(other: TakeByRVAS): Code[Unit] = {
     val mb = cb.genEmitMethod("take_by_combop", FastIndexedSeq[ParamType](), UnitInfo)
 
     val i = mb.newLocal[Int]("combine_i")
@@ -577,7 +577,7 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
   def createState(fb: EmitClassBuilder[_]): State =
     new TakeByRVAS(valueType, keyType, resultType, fb)
 
-  def initOp(state: State, init: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _initOp(state: State, init: Array[EmitCode]): Code[Unit] = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
     Code(
@@ -587,7 +587,7 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
     )
   }
 
-  def seqOp(state: State, seq: Array[EmitCode], dummy: Boolean): Code[Unit] = {
+  protected def _seqOp(state: State, seq: Array[EmitCode]): Code[Unit] = {
     val Array(value: EmitCode, key: EmitCode) = seq
     assert(value.pv.pt == valueType)
     assert(key.pv.pt == keyType)
@@ -598,8 +598,8 @@ class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregato
     )
   }
 
-  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = state.combine(other, dummy)
+  protected def _combOp(state: State, other: State): Code[Unit] = state.combine(other)
 
-  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] =
+  protected def _result(state: State, srvb: StagedRegionValueBuilder): Code[Unit] =
     srvb.addIRIntermediate(resultType)(state.result(srvb.region, resultType))
 }


### PR DESCRIPTION
Also protect and rename the internal agg methods.