### PR TITLE
[hail] fix sbt, support bloop

### DIFF
--- a/hail/build.sbt
+++ b/hail/build.sbt
@@ -27,7 +27,8 @@ lazy val root = (project in file(".")).
       "-deprecation",
       "-unchecked",
       "-Xlint:-infer-any",
-      "-Xlint:-unsound-match"
+      "-Xlint:-unsound-match",
+      "-target:jvm-1.8"
     ),
     libraryDependencies ++= Seq(
           "org.scalatest" %% "scalatest" % "3.0.3" % Test

--- a/hail/project/plugins.sbt
+++ b/hail/project/plugins.sbt
@@ -2,3 +2,4 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 resolvers += Resolver.bintrayIvyRepo("s22s", "sbt-plugins")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")


### PR DESCRIPTION
The date time changes added `-target:jvm-1.8` to build.gradle which quietly
broke SBT. It wasn't a problem for me because I wasn't hacking on Hail until
recently.

Moreover, [Ensime](https://ensime.github.io) is dead, so I'm switching over to
bloop. This plugin is necessary for SBT to generate bloop configuration files.