### PR TITLE
[many] Fixes needed to get TLS working for CI, Batch, & Auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .*.crc
 *.pyc
 **/hail-*.log
+hail/.bloop/
 hail/.gradle/
 hail/.idea/
 hail/.pytest_cache/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,6 +21,11 @@ base: base-stmp
 base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull ubuntu:18.04
 	-docker pull $(BASE_LATEST)
+	[ "$(shell bash stat-permissions.sh Dockerfile.base)" = "644" ]
+	[ "$(shell bash stat-permissions.sh core-site.xml)" = "644" ]
+	[ "$(shell bash stat-permissions.sh requirements.txt)" = "644" ]
+	[ "$(shell bash stat-permissions.sh ../pylintrc)" = "644" ]
+	[ "$(shell bash stat-permissions.sh ../setup.cfg)" = "644" ]
 	docker build -t base -f Dockerfile.base --cache-from base,$(BASE_LATEST),ubuntu:18.04 ..
 	touch base-stmp
 
@@ -28,6 +33,8 @@ base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.c
 service-base: base-stmp
 	-docker pull $(SERVICE_BASE_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
+	[ "$(shell bash stat-permissions.sh Dockerfile.service-base.out)" = "644" ]
+	[ "$(shell bash stat-permissions.sh service-base-requirements.txt)" = "644" ]
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base,ubuntu:18.04 ..
 
 .PHONY: hail-public-image

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,11 +21,6 @@ base: base-stmp
 base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull ubuntu:18.04
 	-docker pull $(BASE_LATEST)
-	[ "$(shell ./stat-permissons.sh Dockerfile.base)" = "644" ]
-	[ "$(shell ./stat-permissons.sh core-site.xml)" = "644" ]
-	[ "$(shell ./stat-permissons.sh requirements.txt)" = "644" ]
-	[ "$(shell ./stat-permissons.sh ../pylintrc)" = "644" ]
-	[ "$(shell ./stat-permissons.sh ../setup.cfg)" = "644" ]
 	docker build -t base -f Dockerfile.base --cache-from base,$(BASE_LATEST),ubuntu:18.04 ..
 	touch base-stmp
 
@@ -33,8 +28,6 @@ base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.c
 service-base: base-stmp
 	-docker pull $(SERVICE_BASE_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
-	[ "$(shell ./stat-permissons.sh Dockerfile.service-base.out)" = "644" ]
-	[ "$(shell ./stat-permissons.sh service-base-requirements.txt)" = "644" ]
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base,ubuntu:18.04 ..
 
 .PHONY: hail-public-image

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,11 +21,11 @@ base: base-stmp
 base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull ubuntu:18.04
 	-docker pull $(BASE_LATEST)
-	[ "$(shell stat -c "%a" Dockerfile.base)" = "644" ]
-	[ "$(shell stat -c "%a" core-site.xml)" = "644" ]
-	[ "$(shell stat -c "%a" requirements.txt)" = "644" ]
-	[ "$(shell stat -c "%a" ../pylintrc)" = "644" ]
-	[ "$(shell stat -c "%a" ../setup.cfg)" = "644" ]
+	[ "$(shell ./stat-permissons.sh Dockerfile.base)" = "644" ]
+	[ "$(shell ./stat-permissons.sh core-site.xml)" = "644" ]
+	[ "$(shell ./stat-permissons.sh requirements.txt)" = "644" ]
+	[ "$(shell ./stat-permissons.sh ../pylintrc)" = "644" ]
+	[ "$(shell ./stat-permissons.sh ../setup.cfg)" = "644" ]
 	docker build -t base -f Dockerfile.base --cache-from base,$(BASE_LATEST),ubuntu:18.04 ..
 	touch base-stmp
 
@@ -33,8 +33,8 @@ base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.c
 service-base: base-stmp
 	-docker pull $(SERVICE_BASE_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
-	[ "$(shell stat -c "%a" Dockerfile.service-base.out)" = "644" ]
-	[ "$(shell stat -c "%a" service-base-requirements.txt)" = "644" ]
+	[ "$(shell ./stat-permissons.sh Dockerfile.service-base.out)" = "644" ]
+	[ "$(shell ./stat-permissons.sh service-base-requirements.txt)" = "644" ]
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base,ubuntu:18.04 ..
 
 .PHONY: hail-public-image

--- a/docker/stat-permissions.sh
+++ b/docker/stat-permissions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+uname=$(uname -s)
+
+if [ $uname = "Linux" ]
+     stat -c "%a" $1
+then
+elif [ $uname = "Darwin" ]
+     stat -f "%A" $1
+else
+    echo "unsupported OS $uname"
+    exit 1
+fi

--- a/docker/stat-permissions.sh
+++ b/docker/stat-permissions.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 uname=$(uname -s)
 
 if [ $uname = "Linux" ]
-     stat -c "%a" $1
 then
+     stat -c "%a" $1
 elif [ $uname = "Darwin" ]
+then
      stat -f "%A" $1
 else
     echo "unsupported OS $uname"

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -45,7 +45,7 @@ spec:
          volumeMounts:
           - mountPath: /etc/letsencrypt
             name: letsencrypt-config
-          - name: ssl-config-gatewayx
+          - name: ssl-config-gateway
             mountPath: /ssl-config
             readOnly: true
       volumes:

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -1,4 +1,4 @@
-include /ssl-config/ssl-config-http.conf
+include /ssl-config/ssl-config-http.conf;
 
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -37,7 +37,7 @@ server {
         internal;
         resolver kube-dns.kube-system.svc.cluster.local;
         proxy_pass https://router-resolver.default.svc.cluster.local/auth/$namespace;
-        include /ssl-config/ssl-config-proxy.conf
+        include /ssl-config/ssl-config-proxy.conf;
     }
 
     location ~ ^/([^/]+)/([^/]+) {
@@ -88,7 +88,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        include /ssl-config/ssl-config-proxy.conf
+        include /ssl-config/ssl-config-proxy.conf;
     }
 
     listen [::]:443 ssl default_server;

--- a/internal-gateway/service.yaml
+++ b/internal-gateway/service.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 443
+    port: 80
     protocol: TCP
-    targetPort: 443
+    targetPort: 80
   selector:
     app: internal-gateway
   loadBalancerIP: "{{ global.internal_ip }}"

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -108,7 +108,7 @@ metadata:
     app: router-resolver
 spec:
   ports:
-   - port: 80
+   - port: 443
      protocol: TCP
      targetPort: 5000
   selector:


### PR DESCRIPTION
- `stat -c` doesn't work on Mac
- I have a bloop directory now (related to metals which is a Scala Emacs IDE)
- I had a rogue x in the definition of gateway's deployment
- I had missing semicolons in gateway's deployment
- the router resolver *is* TLS enabled
- the internal-gateway is *not* TLS enabled