### PR TITLE
Shade org.apache.commons.io

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -267,7 +267,7 @@ tasks.withType(ShadowJar) {
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
-    relocate 'org.apache.commons.lang3', 'is.hail.relocated.org.apache.commons.lang3'
+    relocate 'org.apache.commons', 'is.hail.relocated.org.apache.commons'
     relocate 'org.apache.httpcomponents', 'is.hail.relocated.org.apache.httpcomponents'
     // we should really shade indeed, but it has native libraries
     // relocate 'com.indeed', 'is.hail.relocated.com.indeed'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -267,7 +267,8 @@ tasks.withType(ShadowJar) {
     relocate 'com.google.common', 'is.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'is.hail.relocated.org.objectweb'
     relocate 'org.codehaus.jackson', 'is.hail.relocated.org.codehaus.jackson'
-    relocate 'org.apache.commons', 'is.hail.relocated.org.apache.commons'
+    relocate 'org.apache.commons.lang3', 'is.hail.relocated.org.apache.commons.lang3'
+    relocate 'org.apache.commons.io', 'is.hail.relocated.org.apache.commons.io'
     relocate 'org.apache.httpcomponents', 'is.hail.relocated.org.apache.httpcomponents'
     // we should really shade indeed, but it has native libraries
     // relocate 'com.indeed', 'is.hail.relocated.com.indeed'


### PR DESCRIPTION
In our use case, the shaded Hail jar runs into dependency conflicts due to `org.apache.commons.io`, which is pulled in by `com.indeed:lsmtree-core`. This PR shades `org.apache.commons.io`; unfortunately, shading all of `org.apache.commons` was problematic.