### PR TITLE
[ci, query, scorecard] reduce k8s requests

### DIFF
--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           resources:
             requests:
               memory: "1G"
+              cpu: "400m"
+            limits:
+              memory: "1G"
               cpu: "1"
           env:
            - name: HAIL_DEPLOY_CONFIG_FILE

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -48,7 +48,10 @@ spec:
           resources:
             requests:
               memory: "3.75G"
-              cpu: "1"
+              cpu: "800m"
+	    limits:
+	      memory: "3.75G"
+	      cpu: "1"
           readinessProbe:
             httpGet:
               path: /healthcheck

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -49,9 +49,9 @@ spec:
             requests:
               memory: "3.75G"
               cpu: "800m"
-	    limits:
-	      memory: "3.75G"
-	      cpu: "1"
+            limits:
+              memory: "3.75G"
+              cpu: "1"
           readinessProbe:
             httpGet:
               path: /healthcheck

--- a/scorecard/deployment.yaml
+++ b/scorecard/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         resources:
           requests:
             memory: "500M"
-            cpu: "500m"
+            cpu: "100m"
         ports:
         - containerPort: 5000
         volumeMounts:


### PR DESCRIPTION
to be a little more in line with need, and to make the non-preemptible pods more packable.

The ukbb-rg pods are pretty slow, so I didn't reduce them.
