### PR TITLE
[hail][ir] improve Stream.unfold signature

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -44,15 +44,15 @@ class PartitionIteratorLongReader(
       val it = mb.newLocal[Iterator[java.lang.Long]]("pilr_it")
 
       SizedStream.unsized(Stream.unfold[Code[Long]](
-        Code._empty,
-        it := mb.getObject(body(requestedType))
-          .invoke[java.lang.Object, java.lang.Object, Iterator[java.lang.Long]]("apply",
-            region,
-            Code.invokeScalaObject3[PType, Region, Long, java.lang.Object](UnsafeRow.getClass, "read",
-              mb.getPType(contextPC.pt), region, contextPC.tcode[Long])),
         (_, k) => k(COption(
           !it.get.hasNext,
-          Code.longValue(it.get.next()))))
+          Code.longValue(it.get.next()))),
+        setup = Some(
+          it := mb.getObject(body(requestedType))
+            .invoke[java.lang.Object, java.lang.Object, Iterator[java.lang.Long]]("apply",
+              region,
+              Code.invokeScalaObject3[PType, Region, Long, java.lang.Object](UnsafeRow.getClass, "read",
+                mb.getPType(contextPC.pt), region, contextPC.tcode[Long]))))
       .map(rv => EmitCode.present(eltPType, Region.loadIRIntermediate(eltPType)(rv))))
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -179,8 +179,6 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec) extends Partition
       val pathString = path.asString.loadString()
       val xRowBuf = mb.newLocal[InputBuffer]()
       val stream = Stream.unfold[Code[Long]](
-        Code._empty,
-        Code._empty,
         (_, k) =>
           k(COption(
             !xRowBuf.load().readByte().toZ,


### PR DESCRIPTION
- Teach `unfold` to accept close and close0.
- Teach `unfold` to use the language of `Stream`, i.e. `setup0` and `setup`.
- Teach `unfold` to not require `setup` and `setup0`.
