### PR TITLE
[hail][ir] teach function registry to raise helpful errors

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -406,9 +406,8 @@ sealed abstract class AbstractApplyNode[F <: IRFunction] extends IR {
   def returnType: Type
   def typeArgs: Seq[Type]
   def argTypes: Seq[Type] = args.map(_.typ)
-  lazy val implementation: F = IRFunctionRegistry.lookupFunction(function, returnType, typeArgs, argTypes)
-    .getOrElse(throw new RuntimeException(s"no function match for $function: ${ argTypes.map(_.parsableString()).mkString(", ") }"))
-      .asInstanceOf[F]
+  lazy val implementation: F = IRFunctionRegistry.lookupFunctionOrFail(function, returnType, typeArgs, argTypes)
+    .asInstanceOf[F]
 }
 
 final case class Apply(function: String, typeArgs: Seq[Type], args: Seq[IR], returnType: Type) extends AbstractApplyNode[IRFunctionWithoutMissingness]


### PR DESCRIPTION
When you screw up an `Apply` IR, you previously received no information as
to why. This change teaches the function registry to display all signatures
that match the function name but not the types, assisting a developer in
diagnosing whether they got the name wrong or the types wrong.