### PR TITLE
[hail][ir] fix & improve IRFunction.toString

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -635,7 +635,7 @@ sealed abstract class IRFunction {
 
   def returnPType(argTypes: Seq[PType], returnType: Type): PType
 
-  override def toString: String = s"$name(${ argTypes.mkString(", ") }, ${ argTypes.mkString(", ") }): $returnType"
+  override def toString: String = s"$name[${ typeParams.mkString(", ") }](${ argTypes.mkString(", ") }): $returnType"
 
   def unify(typeParamsIn: Seq[Type], argTypesIn: Seq[Type], returnTypeIn: Type): Boolean = {
     val concrete = (typeParamsIn ++ argTypesIn) :+ returnTypeIn


### PR DESCRIPTION
The argTypes were duplicated. That is just wrong. Moreover, the typeParams are
printed as if they are the types of parameters, not formal parameters themselves.
This uses the well-understood, Scala-style square-bracket notation.