### PR TITLE
[hail][io] Teach TypedCodecSpec to create decoders without a VType

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1949,7 +1949,7 @@ class Emit[C](
 
         val cEnc = x.contextSpec.buildEmitEncoderF[Long](x.contextPTuple, parentCB)
         val gEnc = x.globalSpec.buildEmitEncoderF[Long](x.globalPTuple, parentCB)
-        val (bRetPType, bDec) = x.bodySpec.buildEmitDecoderF[Long](x, parentCB)
+        val (bRetPType, bDec) = x.bodySpec.buildEmitDecoderF[Long](parentCB)
         assert(bRetPType == x.decodedBodyPTuple)
 
         val baos = mb.genFieldThisRef[ByteArrayOutputStream]()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1891,9 +1891,9 @@ class Emit[C](
             Array[ParamType](typeInfo[Region], ctxType, gType),
             typeInfo[Long])
 
-          val (cRetPtype, cDec) = x.contextSpec.buildEmitDecoderF[Long](x.contextPTuple.virtualType, bodyFB.ecb)
+          val (cRetPtype, cDec) = x.contextSpec.buildEmitDecoderF[Long](bodyFB.ecb)
           assert(cRetPtype == x.decodedContextPTuple)
-          val (gRetPtype, gDec) = x.globalSpec.buildEmitDecoderF[Long](x.globalPTuple.virtualType, bodyFB.ecb)
+          val (gRetPtype, gDec) = x.globalSpec.buildEmitDecoderF[Long](bodyFB.ecb)
           assert(gRetPtype == x.decodedGlobalPTuple)
           val bEnc = x.bodySpec.buildEmitEncoderF[Long](x.bodyPTuple, bodyFB.ecb)
           val bOB = bodyFB.genFieldThisRef[OutputBuffer]()
@@ -1949,7 +1949,7 @@ class Emit[C](
 
         val cEnc = x.contextSpec.buildEmitEncoderF[Long](x.contextPTuple, parentCB)
         val gEnc = x.globalSpec.buildEmitEncoderF[Long](x.globalPTuple, parentCB)
-        val (bRetPType, bDec) = x.bodySpec.buildEmitDecoderF[Long](x.bodyPTuple.virtualType, parentCB)
+        val (bRetPType, bDec) = x.bodySpec.buildEmitDecoderF[Long](x, parentCB)
         assert(bRetPType == x.decodedBodyPTuple)
 
         val baos = mb.genFieldThisRef[ByteArrayOutputStream]()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -272,7 +272,7 @@ class EmitClassBuilder[C](
     val litType = PCanonicalTuple(true, literals.map(_._1._1): _*)
     val spec = TypedCodecSpec(litType, BufferSpec.defaultUncompressed)
 
-    val (litRType, dec) = spec.buildEmitDecoderF[Long](litType.virtualType, this)
+    val (litRType, dec) = spec.buildEmitDecoderF[Long](this)
     assert(litRType == litType)
     cb.addInterface(typeInfo[FunctionWithLiterals].iname)
     val mb2 = newEmitMethod("addLiterals", FastIndexedSeq[ParamType](typeInfo[Array[Byte]]), typeInfo[Unit])

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -72,7 +72,7 @@ class CallStatsState(val cb: EmitClassBuilder[_]) extends PointerBasedRVAState {
 
   def deserialize(codec: BufferSpec): Value[InputBuffer] => Code[Unit] = {
     val (decType, dec) = TypedCodecSpec(CallStatsState.stateType, codec)
-      .buildEmitDecoderF[Long](CallStatsState.stateType.virtualType, cb)
+      .buildEmitDecoderF[Long](cb)
     assert(decType == CallStatsState.stateType)
 
     { ib: Value[InputBuffer] =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -69,7 +69,7 @@ class StagedArrayBuilder(eltType: PType, cb: EmitClassBuilder[_], region: Value[
   }
 
   def deserialize(codec: BufferSpec): Value[InputBuffer] => Code[Unit] = {
-    val (decType, dec) = TypedCodecSpec(eltArray, codec).buildEmitDecoderF[Long](eltArray.virtualType, cb)
+    val (decType, dec) = TypedCodecSpec(eltArray, codec).buildEmitDecoderF[Long](cb)
     assert(decType == eltArray)
 
     { (ib: Value[InputBuffer]) =>

--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -53,6 +53,9 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
     (rt, (region: Value[Region], buf: Value[InputBuffer]) => mb.invokeCode[T](region, buf))
   }
 
+  def buildEmitDecoderF[T](cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) =
+    buildEmitDecoderF(_vType, cb)
+
   def buildEmitEncoderF[T](t: PType, cb: EmitClassBuilder[_]): StagedEncoderF[T] = {
     val mb = encodedType.buildEncoderMethod(t, cb)
     (region: Value[Region], off: Value[T], buf: Value[OutputBuffer]) => mb.invokeCode[Unit](off, buf)


### PR DESCRIPTION
A TypedCodecSpec has a reasonable VType on hand: `_vType`. In the Shuffler, I have
found myself repeating myself too often. This seems generally useful.