### PR TITLE
[hail] teach MemoryBuffer to act like ByteArray(In|Out)putStream

### DIFF
--- a/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
+++ b/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
@@ -20,6 +20,18 @@ final class MemoryBuffer extends Serializable {
     pos = 0
   }
 
+  def set(bytes: Array[Byte]): Unit = {
+     mem = bytes
+     pos = 0
+     end = bytes.length
+   }
+
+   def toByteArray(): Array[Byte] = {
+     val dst = new Array[Byte](end)
+     System.arraycopy(mem, 0, dst, 0, end);
+     dst
+   }
+
   def grow(n: Int) {
     mem = util.Arrays.copyOf(mem, math.max(capacity * 2, end + n))
   }

--- a/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
+++ b/hail/src/main/scala/is/hail/io/MemoryBuffer.scala
@@ -21,16 +21,16 @@ final class MemoryBuffer extends Serializable {
   }
 
   def set(bytes: Array[Byte]): Unit = {
-     mem = bytes
-     pos = 0
-     end = bytes.length
-   }
+    mem = bytes
+    pos = 0
+    end = bytes.length
+  }
 
-   def toByteArray(): Array[Byte] = {
-     val dst = new Array[Byte](end)
-     System.arraycopy(mem, 0, dst, 0, end);
-     dst
-   }
+  def toByteArray(): Array[Byte] = {
+    val dst = new Array[Byte](end)
+    System.arraycopy(mem, 0, dst, 0, end);
+    dst
+  }
 
   def grow(n: Int) {
     mem = util.Arrays.copyOf(mem, math.max(capacity * 2, end + n))


### PR DESCRIPTION
The Shuffler uses MemoryBuffer to apply Hail encoders and decoders on byte arrays. For
example, I need to serialize the ETypes into generated bytecode so I can send it to the
Shuffler at run-time. I serialize the EType object to bytes using an encoder and MemoryBuffer
Then, I base64 encode it and store it as a JVM constant pool String. When I need to start
a Shuffle I base64 decode the string, stuff the bytes in a MemoryBuffer and decode it.