### PR TITLE
[query, wip] Proposed additions to PCode/CodeBuilder APIs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -214,7 +214,10 @@ case class EmitCode(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
 
   def toI(cb: EmitCodeBuilder): COptionCode = {
     cb += setup
-    COptionCode(cb, m, pv)
+    if (cb.isOpenEnded)
+      COptionCode(cb, m, pv)
+    else
+      COption(valueType).dummy
   }
 
   def castTo(mb: EmitMethodBuilder[_], region: Value[Region], destType: PType): EmitCode = {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -1,22 +1,27 @@
 package is.hail.expr.ir
 
-import is.hail.asm4s.{Code, CodeBuilderLike, MethodBuilder}
-import is.hail.expr.types.physical.{PCode, PSettable, PValue}
+import is.hail.asm4s.{Code, CodeBuilder, CodeLabel, VCode}
+import is.hail.expr.types.physical
+import is.hail.expr.types.physical.{CRetCode, CUnitCode, PCode, PSettable, PThunk, PThunkCode, PValue}
+import is.hail.lir
 
 object EmitCodeBuilder {
-  def apply(mb: EmitMethodBuilder[_]): EmitCodeBuilder = new EmitCodeBuilder(mb, Code._empty)
-
-  def apply(mb: EmitMethodBuilder[_], code: Code[Unit]): EmitCodeBuilder = new EmitCodeBuilder(mb, code)
-
   def scoped[T](mb: EmitMethodBuilder[_])(f: (EmitCodeBuilder) => T): (Code[Unit], T) = {
-    val cb = EmitCodeBuilder(mb)
+    val start = new lir.Block
+    val cb = new EmitCodeBuilder(mb, start)
     val t = f(cb)
-    (cb.result(), t)
+
+    (new VCode(start, cb.getEnd, null), t)
   }
 
   def scopedCode[T](mb: EmitMethodBuilder[_])(f: (EmitCodeBuilder) => Code[T]): Code[T] = {
     val (cbcode, retcode) = EmitCodeBuilder.scoped(mb)(f)
     Code(cbcode, retcode)
+  }
+
+  def scopedPCode(mb: EmitMethodBuilder[_])(f: (EmitCodeBuilder) => PCode): PCode = {
+    val (cbcode, retcode) = EmitCodeBuilder.scoped(mb)(f)
+    PCode(retcode.pt, Code(cbcode, retcode.code))
   }
 
   def scopedVoid(mb: EmitMethodBuilder[_])(f: (EmitCodeBuilder) => Unit): Code[Unit] = {
@@ -25,30 +30,52 @@ object EmitCodeBuilder {
   }
 }
 
-class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) extends CodeBuilderLike {
-  def isOpenEnded: Boolean = {
-    val last = code.end.last
-    (last == null) || !last.isInstanceOf[is.hail.lir.ControlX]
-  }
-
-  def mb: MethodBuilder[_] = emb.mb
-
-  def uncheckedAppend(c: Code[Unit]): Unit = {
-    code = Code(code, c)
-  }
-
-  def result(): Code[Unit] = {
-    val tmp = code
-    code = Code._empty
-    tmp
-  }
-
+class EmitCodeBuilder(val emb: EmitMethodBuilder[_], _end: lir.Block) extends CodeBuilder(emb.mb, _end) {
   def assign(s: PSettable, v: PCode): Unit = {
     append(s := v)
   }
 
   def assign(s: EmitSettable, v: EmitCode): Unit = {
     append(s := v)
+  }
+
+  def ife[R <: physical.CCode](c: Code[Boolean], emitThen: => R, emitElse: => R): R = {
+    val Ltrue = CodeLabel()
+    val Lfalse = CodeLabel()
+    append(c.mux(Ltrue.goto, Lfalse.goto))
+    define(Ltrue)
+    val t = emitThen
+    clear()
+    define(Lfalse)
+    val f = emitElse
+    physical.CCode.merge(emb, t, f)
+  }
+
+  def ifr(c: Code[Boolean], emitThen: => CRetCode, emitElse: => CRetCode): PCode = {
+    val ret = ife(c, emitThen, emitElse)
+    define(ret.end)
+    ret.value
+  }
+
+  def ret(value: PCode): CRetCode = CRetCode(this, value)
+
+  def ret(): CUnitCode = CUnitCode(this)
+
+  def force[R <: physical.CCode](thunk: PCode): R = {
+    assert(isOpenEnded)
+    end.append(lir.goto(thunk.asInstanceOf[PThunkCode].start))
+    clear()
+    thunk.asInstanceOf[PThunkCode].end.asInstanceOf[R]
+  }
+
+  def define(u: CUnitCode): Unit = {
+    assert(!isOpenEnded)
+    end = u.end
+  }
+
+  def extract(r: CRetCode): PCode = {
+    define(r.end)
+    r.value
   }
 
   def memoize[T](pc: PCode, name: String): PValue = pc.memoize(this, name)
@@ -60,13 +87,13 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   }
 
   def memoize[T](ec: EmitCode, name: String): EmitValue = {
-    val l = emb.newEmitLocal(name, ec.pt)
+    val l = emb.newEmitLocal(name, ec.valueType)
     append(l := ec)
     l
   }
 
   def memoizeField[T](ec: EmitCode, name: String): EmitValue = {
-    val l = emb.newEmitField(name, ec.pt)
+    val l = emb.newEmitField(name, ec.valueType)
     append(l := ec)
     l
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -866,14 +866,14 @@ class EmitMethodBuilder[C](
     }
   }
 
-  def getStreamEmitParam(emitIndex: Int): COption[Code[Iterator[RegionValue]]] = {
+  def getStreamEmitParam(emitIndex: Int): COptionOld[Code[Iterator[RegionValue]]] = {
     assert(emitIndex != 0)
 
     val pt = emitParamTypes(emitIndex - 1).asInstanceOf[EmitParamType].pt
     assert(pt.isInstanceOf[PStream])
     val codeIndex = emitParamCodeIndex(emitIndex - 1)
 
-    new COption[Code[Iterator[RegionValue]]] {
+    new COptionOld[Code[Iterator[RegionValue]]] {
       def apply(none: Code[Ctrl], some: (Code[Iterator[RegionValue]]) => Code[Ctrl])(implicit ctx: EmitStreamContext): Code[Ctrl] = {
         mb.getArg[Boolean](codeIndex + 1).mux(
           none,
@@ -1079,7 +1079,7 @@ class DependentEmitFunctionBuilder[F](
   }
 
   def newDepEmitField(ec: EmitCode): EmitValue = {
-    val _pt = ec.pt
+    val _pt = ec.valueType
     val ti = typeToTypeInfo(_pt)
     val m = genFieldThisRef[Boolean]()
     val v = genFieldThisRef()(ti)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -349,7 +349,7 @@ abstract class RegistryFunctions {
         if (pt == null) PType.canonical(returnType) else pt(returnType, argTypes)
 
       override def apply(r: EmitRegion, rpt: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode = {
-        assert(unify(typeParams, args.map(_.pt.virtualType), rpt.virtualType))
+        assert(unify(typeParams, args.map(_.valueType.virtualType), rpt.virtualType))
         impl(r, rpt, args.toArray)
       }
     })
@@ -535,9 +535,9 @@ abstract class RegistryFunctions {
 
       def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: EmitCode*): EmitCode = {
         val setup = Code(args.map(_.setup))
-        val rpt = returnPType(args.map(_.pt), returnType)
+        val rpt = returnPType(args.map(_.valueType), returnType)
         val missing: Code[Boolean] = if (args.isEmpty) false else args.map(_.m).reduce(_ || _)
-        val value = applySeeded(seed, r, rpt, args.map { a => (a.pt, a.v) }: _*)
+        val value = applySeeded(seed, r, rpt, args.map { a => (a.valueType, a.v) }: _*)
 
         EmitCode(setup, missing, PCode(rpt, value))
       }
@@ -614,7 +614,7 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
   def apply(r: EmitRegion, returnPType: PType, typeParams: Seq[Type], args: EmitCode*): EmitCode = {
     val setup = Code(args.map(_.setup))
     val missing = args.map(_.m).reduce(_ || _)
-    val value = apply(r, returnPType, typeParams, args.map { a => (a.pt, a.v) }: _*)
+    val value = apply(r, returnPType, typeParams, args.map { a => (a.valueType, a.v) }: _*)
 
     EmitCode(setup, missing, PCode(returnPType, value))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -19,11 +19,9 @@ object GenotypeFunctions extends RegistryFunctions {
         val i = cb.newLocal[Int]("i", 0)
 
         cb.whileLoop(i < pl.loadLength(), {
-          val iec = pl.loadElement(cb, i)
-          cb.define(iec.Lmissing)
-          cb += Code._fatal[Unit]("PL cannot have missing elements.")
-          cb.define(iec.Lpresent)
-          val pli = cb.newLocal[Int]("pli", iec.pc.tcode[Int])
+          val value = pl.loadElement(cb, i)
+            .handle(cb, cb += Code._fatal[Unit]("PL cannot have missing elements."))
+          val pli = cb.newLocal[Int]("pli", value.tcode[Int])
           cb.ifx(pli < m, {
             cb.assign(m2, m)
             cb.assign(m, pli)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -33,11 +33,11 @@ object IntervalFunctions extends RegistryFunctions {
               srvb.start(),
               start.m.mux(
                 srvb.setMissing(),
-                srvb.addIRIntermediate(start.pt)(start.v)),
+                srvb.addIRIntermediate(start.valueType)(start.v)),
               srvb.advance(),
               end.m.mux(
                 srvb.setMissing(),
-                srvb.addIRIntermediate(end.pt)(end.v)),
+                srvb.addIRIntermediate(end.valueType)(end.v)),
               srvb.advance(),
               srvb.addBoolean(includesStart.value[Boolean]),
               srvb.advance(),
@@ -55,7 +55,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerEmitCode1("start", TInterval(tv("T")), tv("T"),
       (_: Type, x: PType) => x.asInstanceOf[PInterval].pointType.orMissing(x.required)) {
       case (r, rt, interval) =>
-        val intervalT = interval.pt.asInstanceOf[PInterval]
+        val intervalT = interval.valueType.asInstanceOf[PInterval]
         val iv = r.mb.newLocal[Long]()
         EmitCode(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
@@ -67,7 +67,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerEmitCode1("end", TInterval(tv("T")), tv("T"),
       (_: Type, x: PType) => x.asInstanceOf[PInterval].pointType.orMissing(x.required)) {
       case (r, rt, interval) =>
-        val intervalT = interval.pt.asInstanceOf[PInterval]
+        val intervalT = interval.valueType.asInstanceOf[PInterval]
         val iv = r.mb.newLocal[Long]()
         EmitCode(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
@@ -93,10 +93,10 @@ object IntervalFunctions extends RegistryFunctions {
     }) {
       case (r, rt, int, point) =>
         val mPoint = r.mb.newLocal[Boolean]()
-        val vPoint = r.mb.newLocal()(typeToTypeInfo(point.pt))
+        val vPoint = r.mb.newLocal()(typeToTypeInfo(point.valueType))
 
         val cmp = r.mb.newLocal[Int]()
-        val interval = new IRInterval(r, int.pt.asInstanceOf[PInterval], int.value[Long])
+        val interval = new IRInterval(r, int.valueType.asInstanceOf[PInterval], int.value[Long])
         val compare = interval.ordering(CodeOrdering.compare)
 
         val contains = Code(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -350,7 +350,7 @@ object LocusFunctions extends RegistryFunctions {
     }) {
       case (r: EmitRegion, rt: PInterval, ioff: EmitCode, invalidMissing: EmitCode) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
-        val sinterval = asm4s.coerce[String](wrapArg(r, ioff.pt)(ioff.value[Long]))
+        val sinterval = asm4s.coerce[String](wrapArg(r, ioff.valueType)(ioff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval](name="intervalObject")
         val interval = Code.invokeScalaObject3[String, ReferenceGenome, Boolean, Interval](
           locusClass, "parseInterval", sinterval, rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
@@ -376,7 +376,7 @@ object LocusFunctions extends RegistryFunctions {
       include2: EmitCode,
       invalidMissing: EmitCode) =>
         val plocus = rt.pointType.asInstanceOf[PLocus]
-        val sloc = asm4s.coerce[String](wrapArg(r, locoff.pt)(locoff.value[Long]))
+        val sloc = asm4s.coerce[String](wrapArg(r, locoff.valueType)(locoff.value[Long]))
         val intervalLocal = r.mb.newLocal[Interval]("intervalObject")
         val interval = Code.invokeScalaObject7[String, Int, Int, Boolean, Boolean, ReferenceGenome, Boolean, Interval](
           locusClass, "makeInterval", sloc, pos1.value[Int], pos2.value[Int], include1.value[Boolean], include2.value[Boolean], rgCode(r.mb, plocus.rg), invalidMissing.value[Boolean])
@@ -410,7 +410,7 @@ object LocusFunctions extends RegistryFunctions {
       }
     }) {
       case (r, rt: PStruct, loc, minMatch) =>
-        val locT = loc.pt.asInstanceOf[PLocus]
+        val locT = loc.valueType.asInstanceOf[PLocus]
         val srcRG = locT.rg
 
         val destRG = rt.types(0).asInstanceOf[PLocus].rg
@@ -432,7 +432,7 @@ object LocusFunctions extends RegistryFunctions {
       }
     }) {
       case (r, rt: PStruct, i, minMatch) =>
-        val iT = i.pt.asInstanceOf[PInterval]
+        val iT = i.valueType.asInstanceOf[PInterval]
         val srcRG = iT.pointType.asInstanceOf[PLocus].rg
         val destRG = rt.types(0).asInstanceOf[PInterval].pointType.asInstanceOf[PLocus].rg
         val interval = Code.checkcast[Interval](asm4s.coerce[AnyRef](wrapArg(r, iT)(i.value[Long])))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -164,7 +164,7 @@ object UtilFunctions extends RegistryFunctions {
           val s = r.mb.newLocal[String]()
           val m = r.mb.newLocal[Boolean]()
           EmitCode(
-            Code(x.setup, m := x.m, s := m.mux(Code._null[String], asm4s.coerce[String](wrapArg(r, x.pt)(x.v)))),
+            Code(x.setup, m := x.m, s := m.mux(Code._null[String], asm4s.coerce[String](wrapArg(r, x.valueType)(x.v)))),
             (m || !Code.invokeScalaObject1[String, Boolean](thisClass, s"isValid$name", s)),
             PCode(rt, Code.invokeScalaObject1(thisClass, s"parse$name", s)(ctString, ct)))
       }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -3,7 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.check.Gen
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
 import is.hail.utils._
 
 object PBaseStruct {
@@ -186,9 +186,9 @@ abstract class PBaseStructValue extends PValue {
 
   def isFieldMissing(fieldIdx: Int): Code[Boolean]
 
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): COptionCode
 
-  def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.asInstanceOf[PBaseStruct].fieldIdx(fieldName))
+  def loadField(cb: EmitCodeBuilder, fieldName: String): COptionCode = loadField(cb, pt.asInstanceOf[PBaseStruct].fieldIdx(fieldName))
 }
 
 abstract class PBaseStructCode extends PCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalArray.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s.Code
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.asm4s.joinpoint._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.{TArray, Type}
 import is.hail.utils._
 
@@ -545,9 +545,9 @@ class PCanonicalIndexableSettable(
 
   def loadLength(): Value[Int] = length
 
-  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode = {
+  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): COptionCode = {
     val iv = cb.newLocal("pcindval_i", i)
-    IEmitCode(cb,
+    COptionCode(cb,
       pt.isElementMissing(a, iv),
       pt.elementType.load(elementsAddress + iv.toL * pt.elementByteSize))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.BaseStruct
 import is.hail.utils._
 
@@ -239,8 +239,8 @@ class PCanonicalBaseStructSettable(
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
-    IEmitCode(cb,
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): COptionCode = {
+    COptionCode(cb,
       pt.isFieldMissing(a, fieldIdx),
       pt.fields(fieldIdx).typ.load(pt.fieldOffset(a, fieldIdx)))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalInterval.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.{TInterval, Type}
 import is.hail.utils.FastIndexedSeq
 
@@ -79,13 +79,13 @@ class PCanonicalIntervalSettable(
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, includesStart, includesEnd)
 
-  def loadStart(cb: EmitCodeBuilder): IEmitCode =
-    IEmitCode(cb,
+  def loadStart(cb: EmitCodeBuilder): COptionCode =
+    COptionCode(cb,
       !(pt.startDefined(a)),
       pt.pointType.load(pt.loadStart(a)))
 
-  def loadEnd(cb: EmitCodeBuilder): IEmitCode =
-    IEmitCode(cb,
+  def loadEnd(cb: EmitCodeBuilder): COptionCode =
+    COptionCode(cb,
       !(pt.endDefined(a)),
       pt.pointType.load(pt.loadEnd(a)))
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalStream.scala
@@ -1,9 +1,17 @@
 package is.hail.expr.types.physical
 
+import is.hail.asm4s.Code
 import is.hail.expr.types.virtual.{TStream, Type}
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitUnrealizableValue, Stream}
+import is.hail.expr.ir.{EmitCode, EmitMethodBuilder, EmitStream, Stream}
 
 final case class PCanonicalStream(elementType: PType, required: Boolean = false) extends PStream {
+  def mux(mb: EmitMethodBuilder[_], cond: Code[Boolean], ifT: PUnrealizableCode, ifF: PUnrealizableCode): PUnrealizableCode =
+    (ifT, ifF) match {
+      case (PCanonicalStreamCode(tTyp, tStream), PCanonicalStreamCode(fTyp, fStream)) =>
+        assert(tTyp == fTyp)
+        PCanonicalStreamCode(tTyp, EmitStream.mux(mb, elementType, cond, tStream, fStream))
+    }
+
   override val fundamentalType: PStream = {
     if (elementType == elementType.fundamentalType)
       this
@@ -28,14 +36,4 @@ final case class PCanonicalStream(elementType: PType, required: Boolean = false)
   def setRequired(required: Boolean): PCanonicalStream = if(required == this.required) this else this.copy(required = required)
 }
 
-final case class PCanonicalStreamCode(pt: PCanonicalStream, stream: Stream[EmitCode]) extends PStreamCode { self =>
-  def memoize(cb: EmitCodeBuilder, name: String): PValue = new PValue {
-    val pt = self.pt
-    var used: Boolean = false
-    def get: PCode = {
-      assert(!used)
-      used = true
-      self
-    }
-  }
-}
+final case class PCanonicalStreamCode(pt: PCanonicalStream, stream: Stream[EmitCode]) extends PStreamCode

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 
 abstract class PContainer extends PIterable {
   override def containsPointers: Boolean = true
@@ -97,7 +97,7 @@ abstract class PContainer extends PIterable {
 abstract class PIndexableValue extends PValue {
   def loadLength(): Value[Int]
 
-  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode
+  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): COptionCode
 }
 
 abstract class PIndexableCode extends PCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -3,7 +3,7 @@ package is.hail.expr.types.physical
 import is.hail.annotations.{CodeOrdering, _}
 import is.hail.asm4s._
 import is.hail.check.Gen
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.virtual.TInterval
 import is.hail.utils._
 
@@ -109,9 +109,9 @@ abstract class PIntervalValue extends PValue {
 
   def includesEnd(): Value[Boolean]
 
-  def loadStart(cb: EmitCodeBuilder): IEmitCode
+  def loadStart(cb: EmitCodeBuilder): COptionCode
 
-  def loadEnd(cb: EmitCodeBuilder): IEmitCode
+  def loadEnd(cb: EmitCodeBuilder): COptionCode
 }
 
 abstract class PIntervalCode extends PCode {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
@@ -2,6 +2,13 @@ package is.hail.expr.types.physical
 
 import is.hail.expr.types.virtual.TStream
 
+object PStream {
+  def unapply(arg: PType): Option[PType] = arg match {
+    case PCanonicalStream(eltType, _) => Some(eltType)
+    case _ => None
+  }
+}
+
 abstract class PStream extends PIterable with PUnrealizable {
   lazy val virtualType: TStream = TStream(elementType.virtualType)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PSubsetStruct.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s.{Code, Settable, SettableBuilder, Value, coerce, const}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.expr.types.BaseStruct
 import is.hail.expr.types.virtual.TStruct
 import is.hail.utils._
@@ -163,8 +163,8 @@ class PSubsetStructSettable(val pt: PSubsetStruct, a: Settable[Long]) extends PB
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
-    IEmitCode(cb,
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): COptionCode = {
+    COptionCode(cb,
       pt.isFieldMissing(a, fieldIdx),
       pt.fields(fieldIdx).typ.load(pt.fieldOffset(a, fieldIdx)))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PUnrealizable.scala
@@ -612,4 +612,7 @@ case class COptionCode(missing: CUnitCode, present: CRetCode) extends CCode {
 
   def getOrElse(cb: EmitCodeBuilder, orElse: PCode): PCode =
     consumeR(cb, orElse, v => v)
+
+  def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: PType): COptionCode =
+    map(cb)(_.castTo(cb.emb, region, destType))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PUnrealizable.scala
@@ -1,10 +1,15 @@
 package is.hail.expr.types.physical
 
 import is.hail.annotations.{CodeOrdering, Region}
-import is.hail.asm4s.{Code, TypeInfo, Value}
-import is.hail.expr.ir.{Ascending, Descending, EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.asm4s._
+import is.hail.expr.ir.{Ascending, Descending, EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitValue, SortOrder, Stream}
+import is.hail.expr.types.virtual.{TThunk, Type}
+import is.hail.{asm4s, lir}
+import is.hail.utils.FastIndexedSeq
 
 trait PUnrealizable extends PType {
+  def mux(mb: EmitMethodBuilder[_], cond: Code[Boolean], ifT: PUnrealizableCode, ifF: PUnrealizableCode): PUnrealizableCode
+
   private def unsupported: Nothing =
     throw new UnsupportedOperationException(s"$this is not realizable")
 
@@ -42,7 +47,17 @@ trait PUnrealizable extends PType {
     unsupported
 }
 
-trait PUnrealizableCode extends PCode {
+trait PUnrealizableCode extends PCode { self =>
+  def memoize(cb: EmitCodeBuilder, name: String): PValue = new PValue {
+    val pt = self.pt
+    var used: Boolean = false
+    def get: PCode = {
+      assert(!used)
+      used = true
+      self
+    }
+  }
+
   private def unsupported: Nothing =
     throw new UnsupportedOperationException(s"$pt is not realizable")
 
@@ -61,4 +76,540 @@ trait PUnrealizableCode extends PCode {
     unsupported
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PValue = unsupported
+}
+
+final case class PThunk(ct: CType) extends PType with PUnrealizable {
+  def required = true
+  def virtualType: Type = TThunk(ct)
+
+  def apply(emb: EmitMethodBuilder[_])(f: EmitCodeBuilder => CCode): PThunkCode = {
+    val start = new lir.Block
+    val cb = new EmitCodeBuilder(emb, start)
+    val end = f(cb)
+    assert(end.typ == ct)
+    PThunkCode(start, end)
+  }
+
+  def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "PCStream["
+    ct.pretty(sb, indent, compact)
+    sb += ']'
+  }
+  def setRequired(required: Boolean): PType = {
+    assert(required)
+    this
+  }
+  def mux(mb: EmitMethodBuilder[_], cond: Code[Boolean], ifT: PUnrealizableCode, ifF: PUnrealizableCode): PUnrealizableCode = {
+    val branch = cond.toCCode
+    branch.Ltrue.append(lir.goto(ifT.asInstanceOf[PThunkCode].start))
+    branch.Lfalse.append(lir.goto(ifF.asInstanceOf[PThunkCode].start))
+    PThunkCode(branch.start, ct.merge(mb, ifT.asInstanceOf[PThunkCode].end, ifF.asInstanceOf[PThunkCode].end))
+  }
+  def _asIdent = s"thunk_of_${ct.asIdent}"
+}
+
+object PThunkCode {
+  def apply(start: lir.Block, end: CCode): PThunkCode =
+    new PThunkCode(start, end)
+
+  def apply(emb: EmitMethodBuilder[_])(f: EmitCodeBuilder => CCode): PThunkCode = {
+    val start = new lir.Block
+    val cb = new EmitCodeBuilder(emb, start)
+    val end = f(cb)
+    PThunkCode(start, end)
+  }
+}
+
+class PThunkCode(val start: lir.Block, val end: CCode) extends PCode with PUnrealizableCode { self =>
+  val pt: PThunk = PThunk(end.typ)
+
+  def force(cb: EmitCodeBuilder): CCode = {
+    cb.end.append(lir.goto(start))
+    cb.define(CUnitCode(start))
+    end
+  }
+
+  def addSetup(setup: Code[Unit]): PThunkCode = {
+    val newStart = setup.start
+    setup.end.append(lir.goto(start))
+    PThunkCode(newStart, end)
+  }
+
+  def map(f: CCode => CCode): PThunkCode =
+    PThunkCode(start, f(end))
+}
+
+object POptionCode {
+  def present(pt: PType, v: Code[_]): POptionCode = {
+    val start = new lir.Block
+    POptionCode(start, COption.present(CRetCode(CUnitCode(start), PCode(pt, v))))
+  }
+
+  def missing(pt: PType): POptionCode = {
+    val start = new lir.Block
+    POptionCode(start, COption.missing(pt, CUnitCode(start)))
+  }
+
+  def define(mb: EmitMethodBuilder[_])(f: (EmitCodeBuilder) => COptionCode): POptionCode = {
+    val start = new lir.Block
+    val cb = new EmitCodeBuilder(mb, start)
+    POptionCode(start, f(cb))
+  }
+
+  def define(cb: EmitCodeBuilder)(f: => COptionCode): POptionCode = {
+    val start = new lir.Block
+    cb.define(CUnitCode(start))
+    POptionCode(start, f)
+  }
+
+  def mapN(ecs: IndexedSeq[POptionCode], cb: EmitCodeBuilder)(f: IndexedSeq[PCode] => PCode): COptionCode =
+    COptionCode.mapN(ecs.map(ec => () => ec.force(cb)), cb)(f)
+//
+//  def codeTupleTypes(pt: PType): IndexedSeq[TypeInfo[_]] = {
+//    val ts = pt.codeTupleTypes()
+//    if (pt.required)
+//      ts
+//    else
+//      ts :+ BooleanInfo
+//  }
+//
+//  def fromCodeTuple(pt: PType, ct: IndexedSeq[Code[_]]): POptionCode = {
+//    if (pt.required)
+//      POptionCode(Code._empty, const(false), pt.fromCodeTuple(ct))
+//    else
+//      POptionCode(Code._empty, coerce[Boolean](ct.last), pt.fromCodeTuple(ct.init))
+//  }
+}
+
+case class POptionCode(start: lir.Block, end: COptionCode) extends PCode with PUnrealizableCode {
+  val pt: PThunk = PThunk(end.typ)
+
+  def valueType: PType = end.typ.valueType
+
+  def force(cb: EmitCodeBuilder): COptionCode = {
+    cb.define(CUnitCode(start))
+    end
+  }
+
+  def v: Code[_] = end.present.value.code
+
+  def value[T: TypeInfo]: Code[T] = end.present.value.tcode[T]
+
+  def map(f: PCode => PCode): POptionCode =
+    copy(end = end.copy(present = end.present.copy(value = f(end.present.value))))
+
+  def toEmitCode: EmitCode = EmitCode(
+    Code._empty,
+    new asm4s.CCode(start, end.missing.end, end.present.end.end),
+    end.present.value)
+}
+
+
+abstract class CType {
+  def dummy: CCode
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CCode
+  def merge(mb: EmitMethodBuilder[_], l: CCode, r: CCode): CCode = {
+    lazy val inL: Settable[Boolean] = Code.newLocal[Boolean]("ct_merge_inL")
+    mergeWithFlag(mb, l, r, Left(inL))
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false): Unit
+  def asIdent: String
+}
+
+object CCode {
+  def merge[R <: CCode](mb: EmitMethodBuilder[_], l: R, r: R): R = {
+    assert(l.typ == r.typ)
+    l.typ.merge(mb, l, r).asInstanceOf[R]
+  }
+}
+
+abstract class CCode {
+  val typ: CType
+  def appendAll(c: => Code[Unit]): Unit
+}
+
+case object CUnit extends CType {
+  def dummy: CUnitCode = CUnitCode(new lir.Block)
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CUnitCode = {
+    val newEnd = new lir.Block
+    l.asInstanceOf[CUnitCode].end.append(lir.goto(newEnd))
+    r.asInstanceOf[CUnitCode].end.append(lir.goto(newEnd))
+    CUnitCode(newEnd)
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "Unit"
+  }
+  def asIdent: String = "cunit"
+}
+
+object CUnitCode {
+  def apply(cb: EmitCodeBuilder): CUnitCode = CUnitCode(cb.getEnd)
+}
+
+case class CUnitCode(var end: lir.Block) extends CCode {
+  val typ: CType = CUnit
+
+  def append(c: Code[Unit]): Unit = {
+    end.append(lir.goto(c.start))
+    end = c.end
+    c.clear()
+  }
+
+  def appendAll(c: => Code[Unit]): Unit = append(c)
+
+  def consume[R <: CCode](cb: EmitCodeBuilder, body: => R): R = {
+    cb.setEnd(end)
+    end = null
+    val ret = body
+    assert(!cb.isOpenEnded)
+    ret
+  }
+
+  def consumeR(cb: EmitCodeBuilder, body: => PCode): PCode = {
+    cb.setEnd(end)
+    end = null
+    val ret = body
+    assert(cb.isOpenEnded)
+    ret
+  }
+
+  def consumeU(cb: EmitCodeBuilder, body: => Unit): Unit = {
+    cb.setEnd(end)
+    end = null
+    body
+    assert(cb.isOpenEnded)
+  }
+}
+
+case object CNothing extends CType {
+  def apply(): CNothingCode = dummy
+  def dummy: CNothingCode = CCanonicalNothingCode
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CNothingCode = {
+    assert(l.typ == CNothing)
+    assert(r.typ == CNothing)
+    CCanonicalNothingCode
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "CNothing"
+  }
+  def asIdent: String = "cnothing"
+}
+
+abstract class CNothingCode extends CCode {
+  val typ: CNothing.type = CNothing
+  def appendAll(c: => Code[Unit]): Unit = {}
+}
+
+case object CCanonicalNothingCode extends CNothingCode
+
+case class CProd(endType: CType, valueType: PType) extends CType {
+  def dummy: CProdCode = CProdCode(endType.dummy, valueType.defaultValue)
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CProdCode = {
+    assert(l.typ == r.typ, s"${l.typ} != ${r.typ}")
+    assert(l.typ == this)
+    (l, r) match {
+      case (CProdCode(lEnd, lValue: PUnrealizableCode), CProdCode(rEnd, rValue: PUnrealizableCode)) =>
+        val inLv: Value[Boolean] = inL match {
+          case Left(inL) =>
+            lEnd.appendAll(inL := true)
+            rEnd.appendAll(inL := false)
+            inL
+          case Right(inL) =>
+            inL
+        }
+        CProdCode(
+          endType.mergeWithFlag(mb, lEnd, rEnd, Right(inLv)),
+          valueType.asInstanceOf[PUnrealizable].mux(mb, inLv, lValue, rValue))
+      case (CProdCode(lEnd, lValue), CProdCode(rEnd, rValue)) =>
+        val x = mb.newPLocal(valueType)
+        lEnd.appendAll(x := lValue)
+        rEnd.appendAll(x := rValue)
+        CProdCode(endType.mergeWithFlag(mb, lEnd, rEnd, inL), x)
+    }
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "CProd["
+    endType.pretty(sb, indent, compact)
+    if (compact)
+      sb += ','
+    else
+      sb ++= ", "
+    valueType.pretty(sb, indent, compact)
+    sb += ']'
+  }
+  def asIdent: String = s"cret_of_${valueType.asIdent}"
+}
+
+case class CProdCode(end: CCode, value: PCode) extends CCode {
+  val valueType: PType = value.pt
+  val endType: CType = end.typ
+
+  val typ: CProd = CProd(endType, valueType)
+
+  def appendAll(c: => Code[Unit]): Unit = end.appendAll(c)
+}
+
+case class CRet(valueType: PType) extends CType {
+  def dummy: CRetCode = new CRetCode(CUnit.dummy, valueType.defaultValue)
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CRetCode = {
+    assert(l.typ == r.typ, s"${l.typ} != ${r.typ}")
+    assert(l.typ == this)
+    (l, r) match {
+      case (CRetCode(lEnd, lValue: PUnrealizableCode), CRetCode(rEnd, rValue: PUnrealizableCode)) =>
+        val inLv: Value[Boolean] = inL match {
+          case Left(inL) =>
+            lEnd.append(inL := true)
+            rEnd.append(inL := false)
+            inL
+          case Right(inL) =>
+            inL
+        }
+        CRetCode(
+          CUnit.mergeWithFlag(mb, lEnd, rEnd, Right(inLv)),
+          valueType.asInstanceOf[PUnrealizable].mux(mb, inLv, lValue, rValue))
+      case (CRetCode(lEnd, lValue), CRetCode(rEnd, rValue)) =>
+        val x = mb.newPLocal(valueType)
+        lEnd.append(x := lValue)
+        rEnd.append(x := rValue)
+        CRetCode(CUnit.mergeWithFlag(mb, lEnd, rEnd, inL), x)
+    }
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "CRet["
+    valueType.pretty(sb, indent, compact)
+    sb += ']'
+  }
+  def asIdent: String = s"cret_of_${valueType.asIdent}"
+}
+
+object CRetCode {
+  def apply(cb: EmitCodeBuilder, value: PCode): CRetCode =
+    CRetCode(CUnitCode(cb.getEnd), value)
+}
+
+case class CRetCode(end: CUnitCode, value: PCode) extends CCode {
+  val valueType: PType = value.pt
+
+  val typ: CRet = CRet(valueType)
+
+  def appendAll(c: => Code[Unit]): Unit = end.appendAll(c)
+
+  def consume[R <: CCode](cb: EmitCodeBuilder, f: PCode => R): R =
+    end.consume(cb, f(value))
+
+  def consumeR(cb: EmitCodeBuilder, f: PCode => PCode): PCode =
+    end.consumeR(cb, f(value))
+
+  def consumeU(cb: EmitCodeBuilder, f: PCode => Unit): Unit =
+    end.consumeU(cb, f(value))
+}
+
+case class CRet2(t1: PType, t2: PType) extends CType {
+  def dummy: CRet2Code = new CRet2Code(CUnit.dummy, t1.defaultValue, t2.defaultValue)
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): CRet2Code = {
+    assert(l.typ == r.typ, s"${l.typ} != ${r.typ}")
+    assert(l.typ == this)
+    (l, r) match {
+      case (CRet2Code(lEnd, lv1, lv2), CRet2Code(rEnd, rv1, rv2)) =>
+        val (lv: PCode, inL2) = if (t1.isRealizable) {
+          val x = mb.newPLocal(t1)
+          lEnd.append(x := lv1)
+          rEnd.append(x := rv1)
+          (x, () => inL)
+        } else {
+          val inLv: Value[Boolean] = inL match {
+            case Left(inL) =>
+              lEnd.append(inL := true)
+              rEnd.append(inL := false)
+              inL
+            case Right(inL) =>
+              inL
+          }
+          (t1.asInstanceOf[PUnrealizable].mux(mb, inLv, lv1.asInstanceOf[PUnrealizableCode], rv1.asInstanceOf[PUnrealizableCode]), () => Right(inLv))
+        }
+        val rv: PCode = if (t2.isRealizable) {
+          val x = mb.newPLocal(t2)
+          lEnd.append(x := lv2)
+          rEnd.append(x := rv2)
+          x
+        } else {
+          val inLv: Value[Boolean] = inL2() match {
+            case Left(inL) =>
+              lEnd.append(inL := true)
+              rEnd.append(inL := false)
+              inL
+            case Right(inL) =>
+              inL
+          }
+          t1.asInstanceOf[PUnrealizable].mux(mb, inLv, lv1.asInstanceOf[PUnrealizableCode], rv1.asInstanceOf[PUnrealizableCode])
+        }
+
+        CRet2Code(CUnit.mergeWithFlag(mb, lEnd, rEnd, inL), lv, rv)
+    }
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "CRet2["
+    t1.pretty(sb, indent, compact)
+    if (compact)
+      sb += ','
+    else
+      sb ++= ", "
+    t2.pretty(sb, indent, compact)
+    sb += ']'
+  }
+  def asIdent: String = s"cret2_of_${t1.asIdent}_and_${t2.asIdent}"
+}
+
+object CRet2Code {
+  def apply(cb: EmitCodeBuilder, value1: PCode, value2: PCode): CRet2Code =
+    CRet2Code(CUnitCode(cb.getEnd), value1, value2)
+}
+
+case class CRet2Code(end: CUnitCode, value1: PCode, value2: PCode) extends CCode {
+  val typ: CRet2 = CRet2(value1.pt, value2.pt)
+
+  def appendAll(c: => Code[Unit]): Unit = end.appendAll(c)
+
+  def consume[R <: CCode](cb: EmitCodeBuilder, f: (PCode, PCode) => R): R =
+    end.consume(cb, f(value1, value2))
+
+  def consumeR(cb: EmitCodeBuilder, f: (PCode, PCode) => PCode): PCode =
+    end.consumeR(cb, f(value1, value2))
+
+  def consumeU(cb: EmitCodeBuilder, f: (PCode, PCode) => Unit): Unit =
+    end.consumeU(cb, f(value1, value2))
+}
+
+object COption {
+  def missing(valueType: PType, end: CUnitCode): COptionCode =
+    COptionCode(end, CRet(valueType).dummy)
+  def missing(cb: EmitCodeBuilder, valueType: PType): COptionCode =
+    missing(valueType, CUnitCode(cb.getEnd))
+  def present(ret: CRetCode): COptionCode =
+    COptionCode(CUnit.dummy, ret)
+  def present(cb: EmitCodeBuilder, value: PCode): COptionCode =
+    present(CRetCode(cb, value))
+}
+
+case class COption(valueType: PType) extends CType {
+  def dummy: COptionCode = COptionCode(CUnit.dummy, CRet(valueType).dummy)
+  def mergeWithFlag(mb: EmitMethodBuilder[_], l: CCode, r: CCode, inL: => Either[Settable[Boolean], Value[Boolean]]): COptionCode = {
+    assert(l.typ == r.typ)
+    (l, r) match {
+      case (COptionCode(lMissing, lPresent), COptionCode(rMissing, rPresent)) =>
+        COptionCode(
+          CUnit.mergeWithFlag(mb, lMissing, rMissing, inL),
+          CRet(valueType).mergeWithFlag(mb, lPresent, rPresent, inL))
+    }
+  }
+  def pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb ++= "COption["
+    valueType.pretty(sb, indent, compact)
+    sb += ']'
+  }
+  def asIdent: String = s"coption_of_${valueType.asIdent}"
+}
+
+object COptionCode {
+  def apply(cb: EmitCodeBuilder, m: Code[Boolean], pc: => PCode): COptionCode = {
+    val Lmissing = CodeLabel()
+    val Lpresent = CodeLabel()
+    cb.append(m.mux(Lmissing.goto, Lpresent.goto))
+    cb.define(Lpresent)
+    val present = COption.present(CRetCode(cb, pc))
+    cb.clear()
+    cb.define(Lmissing)
+    val missing = COption.missing(cb, present.typ.valueType)
+    cb.clear()
+
+    CCode.merge(cb.emb, present, missing)
+  }
+
+  def mapN(ecs: IndexedSeq[() => COptionCode], cb: EmitCodeBuilder)(f: IndexedSeq[PCode] => PCode): COptionCode = {
+    if (ecs.isEmpty)
+      COption.present(CRetCode(cb, f(FastIndexedSeq())))
+    else
+      ecs.head().flatMap(cb)(pc => mapN(ecs.tail, cb)(pcs => f(pc +: pcs)))
+  }
+//
+//  def mapN(ecs: IndexedSeq[POptionCode], cb: EmitCodeBuilder)(f: IndexedSeq[PCode] => PCode): COptionCode = {
+//    if (ecs.isEmpty)
+//      COption.present(CRetCode(cb, f(FastIndexedSeq())))
+//    else
+//      ecs.head.force(cb).flatMap(cb)(pc => mapN(ecs.tail, cb)(pcs => f(pc +: pcs)))
+//  }
+
+  def map2(cb: EmitCodeBuilder, opt1: => COptionCode, opt2: => COptionCode)(f: (PCode, PCode) => PCode): COptionCode =
+    opt1.flatMap(cb)(pc1 => opt2.map(cb)(pc2 => f(pc1, pc2)))
+
+  def firstPresent(cb: EmitCodeBuilder, valueType: PType, opts: IndexedSeq[COptionCode]): COptionCode = {
+    if (opts.isEmpty)
+      COption.missing(cb, valueType)
+    else
+      opts.head.consume(cb, {
+        firstPresent(cb, valueType, opts.tail)
+      }, { pc =>
+        COption.present(CRetCode(cb, pc))
+      })
+  }
+
+  def firstPresent(cb: EmitCodeBuilder, opts: IndexedSeq[COptionCode]): COptionCode = {
+    assert(opts.nonEmpty)
+    if (opts.length == 1)
+      opts.head
+    else
+      opts.head.consume(cb, {
+        firstPresent(cb, opts.tail)
+      }, { pc =>
+        COption.present(CRetCode(cb, pc))
+      })
+  }
+}
+
+case class COptionCode(missing: CUnitCode, present: CRetCode) extends CCode {
+  val typ: COption = COption(present.valueType)
+
+  def appendAll(c: => Code[Unit]): Unit = {
+    missing.append(c)
+    present.appendAll(c)
+  }
+
+  def consume[R <: CCode](cb: EmitCodeBuilder, ifMissing: => R, ifPresent: PCode => R): R = {
+    val m = missing.consume(cb, ifMissing)
+    val p = present.consume(cb, ifPresent)
+    CCode.merge(cb.emb, m, p)
+  }
+
+  def consumeU(cb: EmitCodeBuilder, ifMissing: => Unit, ifPresent: PCode => Unit): Unit =
+    cb.define(consume(cb, { ifMissing; cb.ret() }, pc => { ifPresent(pc); cb.ret() }))
+
+  def consumeR(cb: EmitCodeBuilder, ifMissing: => PCode, ifPresent: PCode => PCode): PCode =
+    cb.extract(consume(cb, cb.ret(ifMissing), v => cb.ret(ifPresent(v))))
+
+  def flatMap(cb: EmitCodeBuilder)(f: PCode => COptionCode): COptionCode = {
+    val p = present.consume(cb, f)
+    val m = missing.consume(cb, COption.missing(cb, p.typ.valueType))
+    CCode.merge(cb.emb, m, p)
+  }
+
+  def map(cb: EmitCodeBuilder)(f: PCode => PCode): COptionCode =
+    flatMap(cb)(value => COption.present(CRetCode(cb, f(value))))
+
+  def handle(cb: EmitCodeBuilder, ifMissing: => Unit): PCode = {
+    val ret = consume(cb, {
+      ifMissing
+      assert(!cb.isOpenEnded)
+      CRet(typ.valueType).dummy
+    }, { value =>
+      CRetCode(cb, value)
+    })
+    cb.end = ret.end.end
+    ret.value
+  }
+
+  def ifPresent(cb: EmitCodeBuilder, f: PCode => Unit): Unit =
+    consumeU(cb, {}, f)
+
+  def getOrElse(cb: EmitCodeBuilder, orElse: PCode): PCode =
+    consumeR(cb, orElse, v => v)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
@@ -14,4 +14,8 @@ case object PVoid extends PType with PUnrealizable {
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = sb.append("PVoid")
 
   def setRequired(required: Boolean) = PVoid
+
+  def mux(mb: EmitMethodBuilder[_], cond: Code[Boolean], ifT: PUnrealizableCode, ifF: PUnrealizableCode): PUnrealizableCode = {
+    ???
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TThunk.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TThunk.scala
@@ -1,0 +1,16 @@
+package is.hail.expr.types.virtual
+
+import is.hail.annotations.ExtendedOrdering
+import is.hail.expr.types.physical.CType
+
+import scala.reflect.ClassTag
+
+case class TThunk(ct: CType) extends Type {
+  def ordering: ExtendedOrdering = ???
+
+  def _typeCheck(a: Any): Boolean = ???
+
+  def _toPretty = s"Thunk[$ct]"
+
+  def scalaClassTag: ClassTag[_ <: AnyRef] = ???
+}

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -321,17 +321,15 @@ class EmitStreamSuite extends HailSuite {
       TypeCheck(ir)
       EmitStream.emit(new Emit(ctx, fb.ecb), ir, mb, Env.empty, None)
     }
-    val L = CodeLabel()
-    val len = mb.newLocal[Int]()
+    val len: Settable[Int] = mb.newLocal[Int]()
     implicit val ctx = EmitStreamContext(mb)
     fb.emit(
       Code(
-        optStream(
-          Code(len := 0, L.goto),
+        optStream.cases(mb)(
+          len := 0,
           { case EmitStream.SizedStream(setup, _, length) =>
-            Code(setup, len := length.getOrElse(-1), L.goto)
+            Code(setup, len := length.getOrElse(-1))
           }),
-        L,
         len))
     val f = fb.resultWithIndex()
     Region.scoped { r =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -50,7 +50,7 @@ object IRSuite {
         override def returnPType(argTypes: Seq[PType], returnType: Type): PType = if (pt == null) PType.canonical(returnType) else pt(returnType, argTypes)
 
         def applySeeded(seed: Long, r: EmitRegion, rpt: PType, args: EmitCode*): EmitCode = {
-          assert(unify(FastSeq(), args.map(_.pt.virtualType), rpt.virtualType))
+          assert(unify(FastSeq(), args.map(_.valueType.virtualType), rpt.virtualType))
           impl(r, rpt, seed, args.toArray)
         }
       })


### PR DESCRIPTION
I'm sharing this in the hopes of spurring discussion around what the eventual PValue/CodeBuilder world should look like.

There's a lot of noise here from a couple of renames, mostly `COption` -> `COptionOld` and `IEmitCode` to `COptionCode`. The important changes are in (Emit)CodeBuilder, Emit, and PUnrealizable.

This introduces a `PThunk` unrealizable ptype, which uses the new `CType` and `CCode` class hierarchies. This is all currently lumped in PUnrealizable.scala, but I'd want to split it into separate files before this is done.

This also makes some tweaks and additions to (Emit)CodeBuilder to use CCode. To demonstrate the use of these additions, I replaced `IEmitCode` with `COptionCode`, and I moved the `If` emit case to `emitI`, following earlier discussion.