### PR TITLE
[query] TableRead readers statically know ptypes for a requested ptype

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -120,6 +120,8 @@ abstract class TableReader {
 
   def fullType: TableType
 
+  def rowAndGlobalPTypes(ctx: ExecuteContext, requestedType: TableType): (PStruct, PStruct)
+
   def toJValue: JValue = {
     Extraction.decompose(this)(TableReader.formats)
   }
@@ -212,6 +214,13 @@ class TableNativeReader(
 
   def fullType: TableType = spec.table_type
 
+  def rowAndGlobalPTypes(ctx: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = {
+    coerce[PStruct](spec.rowsComponent.rvdSpec(ctx.fs, params.path)
+      .typedCodecSpec.encodedType.decodedPType(requestedType.rowType)) ->
+      coerce[PStruct](spec.globalsComponent.rvdSpec(ctx.fs, params.path)
+        .typedCodecSpec.encodedType.decodedPType(requestedType.globalType))
+  }
+
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val (globalType, globalsOffset) = spec.globalsComponent.readLocalSingleRow(ctx, params.path, tr.typ.globalType)
     val rvd = if (tr.dropRows) {
@@ -293,6 +302,39 @@ case class TableNativeZippedReader(
   def partitionCounts: Option[IndexedSeq[Long]] = if (intervals.isEmpty) Some(specLeft.partitionCounts) else None
 
   override lazy val fullType: TableType = specLeft.table_type.copy(rowType = specLeft.table_type.rowType ++ specRight.table_type.rowType)
+  private val leftFieldSet = specLeft.table_type.rowType.fieldNames.toSet
+  private val rightFieldSet = specRight.table_type.rowType.fieldNames.toSet
+
+  def leftRType(requestedType: TStruct): TStruct =
+    requestedType.filter(f => leftFieldSet.contains(f.name))._1
+
+  def rightRType(requestedType: TStruct): TStruct =
+    requestedType.filter(f => rightFieldSet.contains(f.name))._1
+
+  def leftPType(ctx: ExecuteContext, leftRType: TStruct): PStruct =
+    coerce[PStruct](specLeft.rowsComponent.rvdSpec(ctx.fs, pathLeft)
+      .typedCodecSpec.encodedType.decodedPType(leftRType))
+
+  def rightPType(ctx: ExecuteContext, rightRType: TStruct): PStruct =
+    coerce[PStruct](specRight.rowsComponent.rvdSpec(ctx.fs, pathRight)
+      .typedCodecSpec.encodedType.decodedPType(rightRType))
+
+  def rowAndGlobalPTypes(ctx: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = {
+    fieldInserter(ctx, leftPType(ctx, leftRType(requestedType.rowType)),
+      rightPType(ctx, rightRType(requestedType.rowType)))._1 ->
+      coerce[PStruct](specLeft.globalsComponent.rvdSpec(ctx.fs, pathLeft)
+        .typedCodecSpec.encodedType.decodedPType(requestedType.globalType))
+  }
+
+  def fieldInserter(ctx: ExecuteContext, pLeft: PStruct, pRight: PStruct): (PStruct, (Int, Region) => AsmFunction3RegionLongLongLong) = {
+    val (t: PStruct, mk) = ir.Compile[AsmFunction3RegionLongLongLong](ctx,
+      FastIndexedSeq("left" -> pLeft, "right" -> pRight),
+      FastIndexedSeq(typeInfo[Region], LongInfo, LongInfo), LongInfo,
+      InsertFields(Ref("left", pLeft.virtualType),
+        pRight.fieldNames.map(f =>
+          f -> GetField(Ref("right", pRight.virtualType), f))))
+    (t, mk)
+  }
 
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val fs = ctx.fs
@@ -304,8 +346,6 @@ case class TableNativeZippedReader(
         intervals.map(i => RVDPartitioner.union(tr.typ.keyType, i, tr.typ.key.length - 1))
       else
         intervals.map(i => new RVDPartitioner(tr.typ.keyType, i))
-      val leftFieldSet = specLeft.table_type.rowType.fieldNames.toSet
-      val rightFieldSet = specRight.table_type.rowType.fieldNames.toSet
       if (tr.typ.rowType.fieldNames.forall(f => !rightFieldSet.contains(f))) {
         specLeft.rowsComponent.read(ctx, pathLeft, tr.typ.rowType, partitioner, filterIntervals)
       } else if (tr.typ.rowType.fieldNames.forall(f => !leftFieldSet.contains(f))) {
@@ -318,12 +358,15 @@ case class TableNativeZippedReader(
 
         val leftRType = tr.typ.rowType.filter(f => leftFieldSet.contains(f.name))._1
         val rightRType = tr.typ.rowType.filter(f => rightFieldSet.contains(f.name))._1
+
         AbstractRVDSpec.readZipped(ctx,
           rvdSpecLeft, rvdSpecRight,
           rvdPathLeft, rvdPathRight,
+          partitioner, filterIntervals,
           tr.typ.rowType,
           leftRType, rightRType,
-          partitioner, filterIntervals)
+          tr.typ.key,
+          fieldInserter)
       }
     }
 
@@ -370,13 +413,19 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
     TableType(rowType, Array("row_idx"), TStruct.empty)
   }
 
+  def rowAndGlobalPTypes(context: ExecuteContext, tableType: TableType): (PStruct, PStruct) = {
+    PType.canonical(tableType.rowType, required = true).asInstanceOf[PStruct] ->
+      PCanonicalStruct.empty(required = true)
+  }
+
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val rowsRDD = new BlockMatrixReadRowBlockedRDD(ctx.fsBc, params.path, partitionRanges, metadata)
 
     val partitionBounds = partitionRanges.map { r => Interval(Row(r.start), Row(r.end), true, false) }
     val partitioner = new RVDPartitioner(fullType.keyType, partitionBounds)
 
-    val rvd = RVD(fullType.canonicalRVDType, partitioner, ContextRDD(rowsRDD))
+    val rowTyp = rowAndGlobalPTypes(ctx, tr.typ)._1
+    val rvd = RVD(RVDType(rowTyp, fullType.key.filter(rowTyp.hasField)), partitioner, ContextRDD(rowsRDD))
     TableValue(ctx, fullType, BroadcastRow.empty(ctx), rvd)
   }
 

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -305,6 +305,11 @@ class TextMatrixReader(
 
   def partitionCounts = Some(_partitionCounts)
 
+  def rowAndGlobalPTypes(context: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = {
+    PType.canonical(requestedType.rowType, required = true).asInstanceOf[PStruct] ->
+      PType.canonical(requestedType.globalType, required = true).asInstanceOf[PStruct]
+  }
+
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val requestedType = tr.typ
     val compiledLineParser = new CompiledLineParser(ctx,
@@ -323,7 +328,7 @@ class TextMatrixReader(
     val rvd = if (tr.dropRows)
       RVD.empty(requestedType.canonicalRVDType)
     else
-      RVD.unkeyed(PCanonicalStruct.canonical(requestedType.rowType).setRequired(true).asInstanceOf[PStruct], rdd)
+      RVD.unkeyed(rowAndGlobalPTypes(ctx, requestedType)._1, rdd)
     val globalValue = makeGlobalValue(ctx, requestedType.globalType, headerInfo.columnIdentifiers.map(Row(_)))
     TableValue(ctx, tr.typ, globalValue, rvd)
   }

--- a/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -5,7 +5,8 @@ import is.hail.annotations._
 import is.hail.backend.BroadcastValue
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.{ExecuteContext, LowerMatrixIR, MatrixHybridReader, MatrixRead, MatrixReader, MatrixValue, TableRead, TableValue}
-import is.hail.expr.types.MatrixType
+import is.hail.expr.types.{MatrixType, TableType}
+import is.hail.expr.types.physical.{PStruct, PType}
 import is.hail.expr.types.virtual._
 import is.hail.io.bgen.LoadBgen
 import is.hail.io.vcf.LoadVCF
@@ -189,6 +190,10 @@ class MatrixGENReader(
   def columnCount: Option[Int] = Some(nSamples)
 
   def partitionCounts: Option[IndexedSeq[Long]] = None
+
+  def rowAndGlobalPTypes(context: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = {
+    requestedType.canonicalRowPType -> PType.canonical(requestedType.globalType).asInstanceOf[PStruct]
+  }
 
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val sc = SparkBackend.sparkContext("MatrixGENReader.apply")

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -295,6 +295,10 @@ class MatrixPLINKReader(
 
   val partitionCounts: Option[IndexedSeq[Long]] = None
 
+  def rowAndGlobalPTypes(context: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = {
+    requestedType.canonicalRowPType -> PType.canonical(requestedType.globalType).asInstanceOf[PStruct]
+  }
+
   def executeGeneric(ctx: ExecuteContext): GenericTableValue = {
     val fsBc = ctx.fsBc
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.HailSuite
 import is.hail.expr.Nat
 import is.hail.expr.types._
+import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.methods.{ForceCountMatrixTable, ForceCountTable}
 import is.hail.rvd.RVD
@@ -95,6 +96,8 @@ class PruneSuite extends HailSuite {
     def apply(tr: TableRead, ctx: ExecuteContext): TableValue = ???
 
     def partitionCounts: Option[IndexedSeq[Long]] = ???
+
+    def rowAndGlobalPTypes(ctx: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = ???
 
     def fullType: TableType = tab.typ
   })

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -4,6 +4,7 @@ import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types._
+import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.rvd.RVDPartitioner
 import is.hail.utils._
@@ -515,6 +516,8 @@ class TableIRSuite extends HailSuite {
       override def apply(tr: TableRead, ctx: ExecuteContext): TableValue = ???
 
       override def partitionCounts: Option[IndexedSeq[Long]] = Some(FastIndexedSeq(1, 2, 3, 4))
+
+      def rowAndGlobalPTypes(ctx: ExecuteContext, requestedType: TableType): (PStruct, PStruct) = ???
 
       override def fullType: TableType = TableType(TStruct.empty, FastIndexedSeq(), TStruct.empty)
     }


### PR DESCRIPTION
This adds the function to TableReader:
```
rowAndGlobalPTypes(ctx: ExecuteContext, requrestedType: Type): (PStruct, PStruct)
```

(The context is necessary for native readers to be able to get the filesystem in order to read the metadata.)

I'm not sure if this is the best way to implement this, but it feels like TableReaders ought to be able to tell you what PType they expect to be decoding into at compile time, since we can use this information to make decisions about requiredness, etc. on IRs that contain TableReads.

I rely on this to extend the requiredness analysis to TableIR nodes; I think it's probably reasonable to have one function that goes from requestedType => PType instead of separate functions for requiredness and other analyses we might want to do un the future, since I don't think we have imminent plans to decode directly into different PTypes.