### PR TITLE
TableGroupWithinPartitions Memory Fix

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1463,6 +1463,13 @@ def test_group_within_partitions_after_explode():
     t = t._group_within_partitions("grouped_fields", 10)
     assert(t._force_count() == 20)
 
+def test_group_within_partitions_after_import_vcf():
+    gt_mt = hl.import_vcf(resource('small-gt.vcf'))
+    ht = gt_mt.rows()
+    ht = ht._group_within_partitions("grouped_fields", 16)
+    ht.collect() # Just testing import without segault
+    assert True
+
 
 def test_range_annotate_range():
     # tests left join right distinct requiredness

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -30,6 +30,19 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
     jObjects(idx)
   }
 
+  def dumpMemoryInfo(): String = {
+    s"""
+       |Blocks Used = ${usedBlocks.size}, Chunks used = ${bigChunks.size}
+       |Block Info:
+       |  BlockSize = ${blockSize} ($blockByteSize bytes)
+       |  Current Block Info:
+       |    Current Block Address: ${currentBlock}
+       |    Offset Within Block:   ${offsetWithinBlock}
+       |  Used Blocks Info:
+       |    BlockStarts: ${usedBlocks.result().toIndexedSeq}
+       |""".stripMargin
+  }
+
   def allocateNewBlock(): Unit = {
     if (currentBlock != 0)
       usedBlocks += currentBlock

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2047,7 +2047,7 @@ case class TableGroupWithinPartitions(child: TableIR, name: String, n: Int) exte
 
           val offsetArray = new Array[Long](blockSize) // May be longer than the amount of data
           var childIterationCount = 0
-          while (it.hasNext && childIterationCount != blockSize) {
+          while (childIterationCount != blockSize && it.hasNext) {
             val nextPtr = it.next()
             offsetArray(childIterationCount) = nextPtr
             childIterationCount += 1


### PR DESCRIPTION
It was wrong for me to check `hasNext` before checking `childIterationCount != blockSize`. If you look at https://github.com/hail-is/hail/blob/master/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala#L1306, you can see that `LoadVCF`'s `hasNext` loads values into memory. By calling `hasNext` and then not actually processing that value, I was loading a value into memory and then invalidating the pointer before it processed in the next group of rows. 

Thanks to @tpoterba  for helping me figure this out. 