### PR TITLE
[query] Lower TableTail

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -337,8 +337,6 @@ object LowerTableIR {
           ) {
             override def partition(ctxRef: Ref): IR = {
               bindIR(GetField(ctxRef, "old")) { oldRef =>
-                //ToStream(MakeArray(FastIndexedSeq(MakeStruct(FastIndexedSeq("a" -> GetField(ctxRef, "numberToDrop"), "b" -> Str("foo")))), TArray(TStruct("a" -> TInt32, "b" -> TString))))
-
                 StreamDrop(loweredChild.partition(oldRef), GetField(ctxRef, "numberToDrop"))
               }
             }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -124,6 +124,14 @@ package object ir {
     Let(ref.name, v, body(ref))
   }
 
+  def maxIR(a: IR, b: IR): IR = {
+    If(a > b, a, b)
+  }
+
+  def minIR(a: IR, b: IR): IR = {
+    If(a < b, a, b)
+  }
+
   def mapIR(stream: IR)(f: Ref => IR): IR = {
     val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)
     StreamMap(stream, ref.name, f(ref))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -430,7 +430,6 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableTail(): Unit = {
-    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.lowering
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
     val numRowsToTakeArray = Array(0, 2, 7, 10, 12)
     val numInitialPartitionsArray = Array(1, 3, 6, 10, 13)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -432,8 +432,8 @@ class TableIRSuite extends HailSuite {
   @Test def testTableTail(): Unit = {
     implicit val execStrats: Set[ExecStrategy] = ExecStrategy.lowering
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
-    val numRowsToTakeArray = Array(2)
-    val numInitialPartitionsArray = Array(10) //, 13)
+    val numRowsToTakeArray = Array(0, 2, 7, 10, 12)
+    val numInitialPartitionsArray = Array(1, 3, 6, 10, 13)
     val initialDataLength = 10
     def makeData(length: Int): Row = {
       Row(FastIndexedSeq((initialDataLength - length) until initialDataLength: _*).map(i => Row(i, "row" + i)), Row("global"))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -430,10 +430,10 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testTableTail(): Unit = {
-    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.interpretOnly
+    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.lowering
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)), "global" -> TStruct("x" -> TString))
-    val numRowsToTakeArray = Array(0, 4, 7, 12)
-    val numInitialPartitionsArray = Array(1, 2, 6, 10, 13)
+    val numRowsToTakeArray = Array(2)
+    val numInitialPartitionsArray = Array(10) //, 13)
     val initialDataLength = 10
     def makeData(length: Int): Row = {
       Row(FastIndexedSeq((initialDataLength - length) until initialDataLength: _*).map(i => Row(i, "row" + i)), Row("global"))


### PR DESCRIPTION
This PR lowers `TableTail`. It's very similar to `TableHead`'s lowering, and `TableHead` is less confusing, so may be helpful to look at that one first (this one does a lot of subtracting lengths from total lengths to figure out how many to drop). 