### PR TITLE
[gear] add new retry for database

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -14,7 +14,8 @@ log = logging.getLogger('gear.database')
 
 # 1213 - Deadlock found when trying to get lock; try restarting transaction
 # 2003 - Can't connect to MySQL server on ...
-retry_codes = (1213, 2003)
+# 2013 - Lost connection to MySQL server during query ([Errno 104] Connection reset by peer)
+retry_codes = (1213, 2003, 2013)
 
 
 def retry_transient_mysql_errors(f):


### PR DESCRIPTION
Got this error in a migration step when dev deploying.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 598, in _read_bytes
    data = await self._reader.readexactly(num_bytes)
  File "/usr/lib/python3.7/asyncio/streams.py", line 679, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/lib/python3.7/asyncio/streams.py", line 473, in _wait_for_data
    await self._waiter
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 804, in _read_ready__data_received
    data = self._sock.recv(self.max_size)
ConnectionResetError: [Errno 104] Connection reset by peer

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "create_database.py", line 263, in <module>
    loop.run_until_complete(async_main())
  File "/usr/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
    return future.result()
  File "create_database.py", line 259, in async_main
    await migrate(database_name, db, i, m)
  File "create_database.py", line 201, in migrate
    (to_version, to_version, name, script_sha1))
  File "/usr/local/lib/python3.7/dist-packages/gear/database.py", line 26, in wrapper
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/gear/database.py", line 229, in just_execute
    async with self.start() as tx:
  File "/usr/local/lib/python3.7/dist-packages/gear/database.py", line 114, in __aenter__
    await tx.async_init(self.db_pool, self.read_only)
  File "/usr/local/lib/python3.7/dist-packages/gear/database.py", line 135, in async_init
    await cursor.execute('START TRANSACTION;')
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/cursors.py", line 239, in execute
    await self._query(query)
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/cursors.py", line 457, in _query
    await conn.query(q)
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 428, in query
    await self._read_query_result(unbuffered=unbuffered)
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 622, in _read_query_result
    await result.read()
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 1105, in read
    first_packet = await self.connection._read_packet()
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 561, in _read_packet
    packet_header = await self._read_bytes(4)
  File "/usr/local/lib/python3.7/dist-packages/aiomysql/connection.py", line 604, in _read_bytes
    raise OperationalError(2013, msg) from e
pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query ([Errno 104] Connection reset by peer)')
```