### PR TITLE
[hail][internal] teach EType to preserve XStruct

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EType.scala
@@ -7,7 +7,7 @@ import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitFunctionBuilder, EmitMethodBuilder, ExecuteContext, IRParser, ParamType, PunctuationToken, TokenIterator, typeToTypeInfo}
 import is.hail.expr.types.physical._
-import is.hail.expr.types.virtual.Type
+import is.hail.expr.types.virtual._
 import is.hail.expr.types.{BaseType, Requiredness}
 import is.hail.io._
 import is.hail.utils._
@@ -35,6 +35,11 @@ abstract class EType extends BaseType with Serializable with Requiredness {
   final def buildDecoder(ctx: ExecuteContext, requestedType: Type): (PType, (InputBuffer) => Decoder) = {
     val (rt, f) = EType.buildDecoder(ctx, this, requestedType)
     (rt, (in: InputBuffer) => new CompiledDecoder(in, f))
+  }
+
+  final def buildStructDecoder(ctx: ExecuteContext, requestedType: TStruct): (PStruct, (InputBuffer) => Decoder) = {
+    val (pType: PStruct, makeDec) = buildDecoder(ctx, requestedType)
+    pType -> makeDec
   }
 
   final def buildEncoder(pt: PType, cb: EmitClassBuilder[_]): StagedEncoder = {


### PR DESCRIPTION
This mirrors the functionality available on `TypedCodecSpec`. In some cases (the shuffler),
you might be handed a buffer that is already configured, but you still want to create a
decoder whose PType is known to be a subtype of PStruct.