### PR TITLE
[hail][internal] Teach TypedCodecSpec to supply decodedPType

### DIFF
--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -33,6 +33,10 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
     encodedType.decodedPType(requestedType)
   }
 
+  def decodedPType(): PType = {
+    encodedType.decodedPType(_vType)
+  }
+
   def buildDecoder(ctx: ExecuteContext, requestedType: Type): (PType, (InputStream) => Decoder) = {
     val (rt, bufferToDecoder) = encodedType.buildDecoder(ctx, requestedType)
     (rt, (in: InputStream) => bufferToDecoder(_bufferSpec.buildInputBuffer(in)))


### PR DESCRIPTION
Just as `buildEmitDecoderF` need not accept a virtual type, we might want to know
the PType that the natural decoder would produce. This PR implements that.