### PR TITLE
Annotation DB Requester Pays

### DIFF
--- a/hail/python/hail/docs/annotation_database_ui.rst
+++ b/hail/python/hail/docs/annotation_database_ui.rst
@@ -15,7 +15,7 @@ To access these buckets on a cluster started with ``hailctl dataproc``, you can 
 
 .. code-block:: text
 
-    hailctl dataproc start  my-cluster --requester-pays-allow-annotation-db
+    hailctl dataproc start my-cluster --requester-pays-allow-annotation-db
 
 --------------
 

--- a/hail/python/hail/docs/annotation_database_ui.rst
+++ b/hail/python/hail/docs/annotation_database_ui.rst
@@ -9,6 +9,14 @@ This database contains a curated collection of variant annotations in an accessi
 
 To incorporate these annotations in your own Hail analysis pipeline, select which annotations you would like to query from the table below and then copy-and-paste the Hail generated code into your own analysis script.
 
+Note that most of these annotations are stored in :ref:`Requester Pays<GCP Requester Pays>` buckets. These buckets are all stored in the US, so egress charges
+may apply if your cluster is outside of the US.
+To access these buckets on a cluster started with ``hailctl dataproc``, you can use the additional argument ``--requester-pays-annotation-db`` as follows:
+
+.. code-block:: text
+
+    hailctl dataproc start  my-cluster --requester-pays-allow-annotation-db
+
 --------------
 
 Database Query

--- a/hail/python/hail/docs/cloud/google_cloud.rst
+++ b/hail/python/hail/docs/cloud/google_cloud.rst
@@ -72,6 +72,8 @@ run the following script from your command line:
 
 After this is installed, you'll be able to read from paths beginning with ``gs`` directly from you laptop.
 
+.. _GCP Requester Pays:
+
 Requester Pays
 --------------
 
@@ -95,6 +97,11 @@ To make it easier to avoid accidentally reading from a requester pays bucket, we
 .. code-block:: text
 
     hailctl dataproc start  my-cluster --requester-pays-allow-buckets hail-bucket,big-data
+
+Users of the :ref:`Annotation Database` will find that many of the files are stored in requester pays buckets.
+In order to allow the dataproc cluster to read from them, you can either use ``--requester-pays-allow-all`` from above
+or use the special ``--requester-pays-allow-annotation-db`` to enable the specific list of buckets that the annotation database
+relies on.
 
 Variant Effect Predictor (VEP)
 ------------------------------

--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -3,52 +3,52 @@
   "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4341060/",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/DANN.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/DANN.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-common/datasets/1/DANN.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/DANN.GRCh38.ht",
      "version": "GRCh38"}]},
  "CADD":
  {"description": "CADD: an algorithm designed to annotate both coding and non-coding variants.",
   "url": "http://europepmc.org/abstract/med/11384848",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/CADD.v1.4.GRCh37.ht",
      "version": "1.4-GRCh37"},
-    {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/CADD.v1.4.GRCh38.ht",
      "version": "1.4-GRCh38"}]},
  "Ensembl_homo_sapiens_reference_genome":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
      "version": "95-GRCh37"},
-    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
      "version": "95-GRCh38"}]},
  "Ensembl_homo_sapiens_low_complexity_regions":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
      "version": "95-GRCh37"},
-    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
      "version": "95-GRCh38"}]},
  "gencode":
  {"description": "GENCODE: aims to identify all gene features in the human genome using a combination of computational analysis, manual annotation, and experimental validation.",
   "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431492/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/gencode.v19.annotation.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/gencode.v19.annotation.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-common/datasets/1/gencode.v31.annotation.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/gencode.v31.annotation.GRCh38.ht",
      "version": "GRCh38"}]},
  "gnomad_lof_metrics":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
   "url": "https://gnomad.broadinstitute.org/",
   "key_properties": ["gene"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/gnomad_v2.1.1_lof_metrics_by_gene.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/gnomad_v2.1.1_lof_metrics_by_gene.ht",
      "version": "2.1.1"}]},
  "gnomad_exome_sites":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
@@ -73,49 +73,49 @@
   "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
   "key_properties": ["gene", "unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/gene_specific_summary_2019-07.txt.gz.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/gene_specific_summary_2019-07.txt.gz.ht",
      "version": "2019-07"}]},
  "clinvar_variant_summary":
  {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
   "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
      "version": "2019-07-GRCh37"},
-    {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
      "version": "2019-07-GRCh38"}]},
  "dbNSFP_variants":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp4.0a.GRCh37.ht",
      "version": "4.0-GRCh37"},
-    {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp4.0a.GRCh38.ht",
      "version": "4.0-GRCh38"}]},
  "dbNSFP_genes":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
   "key_properties": ["gene", "unique"],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
      "version": "4.0"}]},
  "gerp_scores":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
   "key_properties": ["unique"],
   "versions": [
-    {"url": "gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh37.ht",
+    {"url": "gs://hail-datasets-us/datasets/1/GERP_scores.GERP++.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/GERP_scores.GERP++.GRCh38.ht",
      "version": "GRCh38"}]},
  "gerp_elements":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh37.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/GERP_elements.GERP++.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh38.ht",
+    {"url":"gs://hail-datasets-us/datasets/1/GERP_elements.GERP++.GRCh38.ht",
      "version": "GRCh38"}]}
 }

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -116,7 +116,7 @@ class DB:
                           for k, v in config.items()}
 
     def available_databases(self):
-        return self._by_name().keys()
+        return self.__by_name.keys()
 
     @staticmethod
     def _row_lens(rel):

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -134,6 +134,8 @@ REGION_TO_REPLICATE_MAPPING = {
     'australia-southeast1': 'aus-sydney'
 }
 
+ANNOTATION_DB_BUCKETS = ["hail-datasets-us"]
+
 IMAGE_VERSION = '1.4-debian9'
 
 
@@ -240,6 +242,8 @@ def main(args, pass_through_args):
             requester_pays_bucket_sources = []
             if args.requester_pays_allow_buckets:
                 requester_pays_bucket_sources.append(args.requester_pays_allow_buckets)
+            if args.requester_pays_allow_annotation_db:
+                requester_pays_bucket_sources.extend(ANNOTATION_DB_BUCKETS)
 
             conf.extend_flag("properties", {"spark:spark.hadoop.fs.gs.requester.pays.buckets": ",".join(requester_pays_bucket_sources)})
 


### PR DESCRIPTION
I've copied the Annotation DB data into a requester pays bucket and added a new `hailctl` argument to enable reading from that bucket.

Please also ensure that this new bucket is globally visible and marked as requester pays as part of the review process.