### PR TITLE
[query] fix router rule for query service

### DIFF
--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -239,7 +239,7 @@ server {
     server_name query.*;
 
     location / {
-        proxy_pass http://query/;
+        proxy_pass https://query/;
         include /etc/nginx/proxy.conf;
     }
 


### PR DESCRIPTION
Missed one.  Hand deployed, verified it works end-to-end with this.