### PR TITLE
Correct documented type for ReferenceGenome.lengths

### DIFF
--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -158,7 +158,7 @@ class ReferenceGenome(object):
 
         Returns
         -------
-        :obj:`list` of :obj:`str`
+        :obj:`dict` of :obj:`str` to :obj:`int`
         """
         return self._lengths
 


### PR DESCRIPTION
ReferenceGenome's `lengths` property is currently documented as returning a list of strings. However, it actually returns a dict of strings to ints.