### PR TITLE
Correct documented return type for ReferenceGenome.remove_sequence

### DIFF
--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -369,12 +369,7 @@ class ReferenceGenome(object):
         return self._sequence_files is not None
 
     def remove_sequence(self):
-        """Remove the reference sequence.
-
-        Returns
-        -------
-        :obj:`bool`
-        """
+        """Remove the reference sequence."""
         self._sequence_files = None
         Env.backend().remove_sequence(self.name)
 


### PR DESCRIPTION
ReferenceGenome's `remove_sequence` method is currently documented as returning a bool. However, it doesn't actually return anything.