### PR TITLE
Format VEP CLI arguments in GCP docs

### DIFF
--- a/hail/python/hail/docs/cloud/google_cloud.rst
+++ b/hail/python/hail/docs/cloud/google_cloud.rst
@@ -107,6 +107,6 @@ variant in a dataset containing GRCh37 variants:
     hailctl dataproc start NAME --vep GRCh37
 
 Hail also supports VEP for GRCh38 variants, but you must start a cluster with
-the argument `--vep GRCh38`. A cluster started without the `--vep` argument is
+the argument ``--vep GRCh38``. A cluster started without the ``--vep`` argument is
 unable to run VEP and cannot be modified to run VEP. You must start a new
-cluster using `--vep`.
+cluster using ``--vep``.


### PR DESCRIPTION
Elsewhere, CLI arguments are formatted with double backticks.