### PR TITLE
TableDistinct Lowering + Tests

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1235,6 +1235,7 @@ class Emit[C](
               case Some(len) => Code(ss.setup, len)
               case None =>
                 Code(
+                  count := 0,
                   ss.getStream.forEach(mb, _ => count := count + 1),
                   count.get
                 )
@@ -1261,7 +1262,8 @@ class Emit[C](
             val codeB = emit(body, env = bodyenv)
             Code(xElt := elt,
               tmpAcc := codeB.map(v => accType.copyFromPValue(mb, region, PCode(body.pType, codeB.v))),
-              xAcc := tmpAcc)
+              xAcc := tmpAcc
+            )
           }
 
           val codeZ = emit(zero).map(accType.copyFromPValue(mb, region, _))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -970,6 +970,10 @@ class EmitMethodBuilder[C](
   def newPField(name: String, pt: PType): PSettable = newPSettable(fieldBuilder, pt, name)
 
   def newEmitSettable(_pt: PType, ms: Settable[Boolean], vs: PSettable): EmitSettable = new EmitSettable {
+    if (!_pt.isRealizable) {
+      throw new UnsupportedOperationException(s"newEmitSettable can only be called on realizable PTypes. Called on ${_pt}")
+    }
+
     def pt: PType = _pt
 
     def get: EmitCode = EmitCode(Code._empty,

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -194,6 +194,7 @@ object Simplify {
     case ArrayLen(MakeArray(args, _)) => I32(args.length)
 
     case StreamLen(StreamMap(s, _, _)) => StreamLen(s)
+    case StreamLen(StreamFlatMap(a, name, body)) => streamSumIR(StreamMap(a, name, StreamLen(body)))
       
     case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => StreamLen(s)
     case ArrayLen(StreamFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -194,8 +194,7 @@ object Simplify {
     case ArrayLen(MakeArray(args, _)) => I32(args.length)
 
     case StreamLen(StreamMap(s, _, _)) => StreamLen(s)
-    case StreamLen(StreamFlatMap(a, name, body)) => streamSumIR(StreamMap(a, name, StreamLen(body)))
-
+      
     case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => StreamLen(s)
     case ArrayLen(StreamFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
 
@@ -210,7 +209,8 @@ object Simplify {
 
     case StreamFor(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
 
-    case StreamFold(StreamMap(a, n1, b), zero, accumName, valueName, body) => StreamFold(a, zero, accumName, n1, Let(valueName, b, body))
+    // FIXME: Unqualify when StreamFold supports folding over stream of streams
+    case StreamFold(StreamMap(a, n1, b), zero, accumName, valueName, body) if a.typ.asInstanceOf[TStream].elementType.isRealizable => StreamFold(a, zero, accumName, n1, Let(valueName, b, body))
 
     case StreamFlatMap(StreamMap(a, n1, b1), n2, b2) =>
       StreamFlatMap(a, n1, Let(n2, b1, b2))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -293,6 +293,7 @@ object TypeCheck {
         assert(body.typ.isInstanceOf[TStream])
       case x@StreamFold(a, zero, accumName, valueName, body) =>
         assert(a.typ.isInstanceOf[TStream])
+        assert(a.typ.asInstanceOf[TStream].elementType.isRealizable, Pretty(x))
         assert(body.typ == zero.typ)
         assert(x.typ == zero.typ)
       case x@StreamFold2(a, accum, valueName, seq, res) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -290,8 +290,8 @@ object LowerTableIR {
 
           loweredChild.repartitionNoShuffle(loweredChild.partitioner.coarsen(child.typ.key.length).strictify)
             .mapPartition { partition =>
-              mapIR(StreamGroupByKey(partition, child.typ.key)) { groupRef =>
-                ArrayRef(ToArray(StreamTake(groupRef, 1)), 0)
+              flatMapIR(StreamGroupByKey(partition, child.typ.key)) { groupRef =>
+                StreamTake(groupRef, 1)
               }
             }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -119,10 +119,9 @@ object PCode {
       new PCanonicalCallCode(pt, coerce[Int](code))
     case pt: PCanonicalNDArray =>
       new PCanonicalNDArrayCode(pt, coerce[Long](code))
+    case pt: PCanonicalStream =>
+      throw new UnsupportedOperationException(s"Can't PCode.apply unrealizable PType: $pt")
     case _ =>
-      if (!pt.isRealizable) {
-        throw new UnsupportedOperationException(s"Can't PCode.apply an unrealizable PType: $pt")
-      }
       new PPrimitiveCode(pt, code)
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -119,6 +119,8 @@ object PCode {
       new PCanonicalCallCode(pt, coerce[Int](code))
     case pt: PCanonicalNDArray =>
       new PCanonicalNDArrayCode(pt, coerce[Long](code))
+    case pt: PCanonicalStream =>
+      throw new UnsupportedOperationException("Can't PCode.apply a PCanonicalStream")
     case _ =>
       new PPrimitiveCode(pt, code)
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCode.scala
@@ -119,9 +119,10 @@ object PCode {
       new PCanonicalCallCode(pt, coerce[Int](code))
     case pt: PCanonicalNDArray =>
       new PCanonicalNDArrayCode(pt, coerce[Long](code))
-    case pt: PCanonicalStream =>
-      throw new UnsupportedOperationException("Can't PCode.apply a PCanonicalStream")
     case _ =>
+      if (!pt.isRealizable) {
+        throw new UnsupportedOperationException(s"Can't PCode.apply an unrealizable PType: $pt")
+      }
       new PPrimitiveCode(pt, code)
   }
 


### PR DESCRIPTION
I'm PRing this because it's done / short / adds a good test, but it may be possible to eliminate `TableDistinct` in the future in favor of just `TableAggregateByKey`