### PR TITLE
[query][ptypes] fix InferPType to work with requiredness pass

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -44,7 +44,7 @@ object Compile {
     ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
 
     TypeCheck(ir, BindingEnv.empty)
-    InferPType(ir, Env.empty[PType])
+    InferPType(ir)
     val returnType = ir.pType
 
     val fb = EmitFunctionBuilder[F](ctx, "Compiled",

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1181,7 +1181,10 @@ class Emit[C](
                 i := 1,
                 nab.add(1),
                 Code.whileLoop(i < eab.size,
-                  isSame.invokeCode[Boolean](region, eab.applyEV(mb, i-1), eab.applyEV(mb, i)).mux(
+                  EmitCodeBuilder.scopedCode[Boolean](mb) { cb =>
+                    cb.invokeCode[Boolean](isSame, region,
+                      eab.applyEV(mb, i-1), eab.applyEV(mb, i))
+                  }.mux(
                     nab.update(nab.size - 1, coerce[Int](nab(nab.size - 1)) + 1),
                     nab.add(1)),
                   i += 1),

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1196,7 +1196,7 @@ object EmitStream {
 
         case x@StreamScan(childIR, zeroIR, accName, eltName, bodyIR) =>
           val eltType = coerce[PStream](childIR.pType).elementType
-          val accType = coerce[PStream](x.pType).elementType
+          val accType = x.accPType
 
           val streamOpt = emitStream(childIR, env)
           streamOpt.map { case SizedStream(setup, stream, len) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -82,7 +82,7 @@ object InferPType {
   }
 
   def unifyPTypes(pTypes: Seq[PType], result: TypeWithRequiredness): PType = {
-    assert(pTypes.tail.forall(pt => pt.virtualType == pTypes.head.virtualType))
+    assert(pTypes.isEmpty || pTypes.tail.forall(pt => pt.virtualType == pTypes.head.virtualType))
     if (pTypes.nonEmpty && pTypes.tail.forall(pt => pt == pTypes.head))
       pTypes.head
     else result.canonicalPType(pTypes.head.virtualType)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -194,7 +194,7 @@ object InferPType {
             if (seqs != null)
               seqs(i) += RecursiveArrayBuilderElement(x, None)
         }
-      case _ => _inferAggs(node, inits, seqs)
+      case _ => node.children.foreach(c => _inferAggs(c.asInstanceOf[IR], inits, seqs))
     }
 
   private def _inferWithRequiredness(node: IR, env: Env[PType], requiredness: RequirednessAnalysis, usesAndDefs: UsesAndDefs, aggs: Array[AggStatePhysicalSignature] = null): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -153,6 +153,7 @@ object InferPType {
 
   private def _inferAggs(node: IR, inits: AAB[InitOp] = null, seqs: AAB[SeqOp] = null): Unit =
     node match {
+      case _: RunAgg | _: RunAggScan =>
       case x@InitOp(i, args, sig, op) =>
         op match {
           case Group() =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -171,7 +171,9 @@ object InferPType {
         }
         if (inits != null) {
           val argTypes = x.args.map { a =>
-            r.map(m => coerce[TypeWithRequiredness](m.lookup(a)).canonicalPType(a.typ)).getOrElse(a.pType)
+            if (a.typ != TVoid)
+              r.map(m => coerce[TypeWithRequiredness](m.lookup(a)).canonicalPType(a.typ)).getOrElse(a.pType)
+            else PVoid
           }
           inits(i) += RecursiveArrayBuilderElement(x.op -> argTypes, nested)
         }
@@ -194,7 +196,9 @@ object InferPType {
         }
         if (seqs != null) {
           val argTypes = x.args.map { a =>
-            r.map(m => coerce[TypeWithRequiredness](m.lookup(a)).canonicalPType(a.typ)).getOrElse(a.pType)
+            if (a.typ != TVoid)
+              r.map(m => coerce[TypeWithRequiredness](m.lookup(a)).canonicalPType(a.typ)).getOrElse(a.pType)
+            else PVoid
           }
           seqs(i) += RecursiveArrayBuilderElement(x.op -> argTypes, nested)
         }

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -239,7 +239,7 @@ object InferPType {
         lookup(x.name, requiredness(node), usesAndDefs.defs.lookup(node).asInstanceOf[IR])
       case MakeNDArray(data, shape, rowMajor) =>
         val nElem = shape.pType.asInstanceOf[PTuple].size
-        PCanonicalNDArray(coerce[PArray](data.pType).elementType.setRequired(true), nElem, data.pType.required && shape.pType.required)
+        PCanonicalNDArray(coerce[PArray](data.pType).elementType.setRequired(true), nElem, requiredness(node).required)
       case StreamRange(start: IR, stop: IR, step: IR) =>
         assert(start.pType isOfType stop.pType)
         assert(start.pType isOfType step.pType)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -188,7 +188,7 @@ object InferPType {
             None
         }
         if (seqs != null)
-          seqs(i) += RecursiveArrayBuilderElement(x, nested)
+          seqs(i) += RecursiveArrayBuilderElement(x.op -> x.args.map(_.pType), nested)
       case _ => node.children.foreach(c => _extractAggOps(c.asInstanceOf[IR], inits, seqs))
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -99,7 +99,7 @@ object InferPType {
   def apply(ir: IR, env: Env[PType], aggs: Array[AggStatePhysicalSignature], inits: AAB[InitOp], seqs: AAB[SeqOp]): Unit = {
     try {
       val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
-      val requiredness = Requiredness.apply(ir, usesAndDefs, null) // Value IR inference doesn't need context
+      val requiredness = Requiredness.apply(ir, usesAndDefs, null, env) // Value IR inference doesn't need context
       requiredness.states.m.foreach { case (ir, types) =>
         ir.t match {
           case x: StreamFold => x.accPTypes = types.map(r => r.canonicalPType(x.zero.typ))

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -144,10 +144,11 @@ object InferPType {
     case StreamLeftJoinDistinct(_, right, _, `name`, _, _) => coerce[PStream](right.pType).elementType.setRequired(false)
     case RunAggScan(a, `name`, _, _, _, _) => coerce[PStream](a.pType).elementType
     case NDArrayMap(nd, `name`, _) => coerce[PNDArray](nd.pType).elementType
-    case NDArrayMap2(left, _, `name`, _, _) => coerce[PNDArray](left.pType).elementType
+    case NDArrayMap2(left, _, `name`, _, _) => coerce[PNDArray](left.pType  ).elementType
     case NDArrayMap2(_, right, _, `name`, _) => coerce[PNDArray](right.pType).elementType
     case x@CollectDistributedArray(_, _, `name`, _, _) => x.decodedContextPType
     case x@CollectDistributedArray(_, _, _, `name`, _) => x.decodedGlobalPType
+    case _ => throw new RuntimeException(s"$name not found in definition \n${ Pretty(defNode) }")
   }
 
   private def _inferAggs(node: IR, inits: AAB[InitOp] = null, seqs: AAB[SeqOp] = null): Unit =

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -4,7 +4,7 @@ import is.hail.types.physical._
 import is.hail.types.virtual.{TNDArray, TVoid}
 import is.hail.utils._
 import is.hail.HailContext
-import is.hail.types.{BaseTypeWithRequiredness, TypeWithRequiredness}
+import is.hail.types.{BaseTypeWithRequiredness, RDict, RIterable, TypeWithRequiredness}
 
 object InferPType {
 
@@ -68,49 +68,27 @@ object InferPType {
         assert(inits.forall(_.nested.isEmpty))
         assert(seqs.forall(_.nested.isEmpty))
         val initArgTypes = inits.map(i => i.value.args.map(_.pType).toArray).transpose
-          .map(ts => getNestedElementPTypes(ts))
+          .map(ts => unifyPTypes(ts))
         val seqArgTypes = seqs.map(i => i.value.args.map(_.pType).toArray).transpose
-          .map(ts => getNestedElementPTypes(ts))
+          .map(ts => unifyPTypes(ts))
         virt.defaultSignature.toPhysical(initArgTypes, seqArgTypes).singletonContainer
     }
   }
 
-  def getNestedElementPTypes(ptypes: Seq[PType]): PType = {
-    assert(ptypes.forall(_.virtualType == ptypes.head.virtualType))
-    getNestedElementPTypesOfSameType(ptypes)
+  def unifyPTypes(pTypes: Seq[PType]): PType = {
+    val r = TypeWithRequiredness.apply(pTypes.head.virtualType)
+    pTypes.foreach(r.fromPType)
+    unifyPTypes(pTypes, r)
   }
 
-  def getNestedElementPTypesOfSameType(ptypes: Seq[PType]): PType = {
-    ptypes.head match {
-      case _: PStream =>
-        val elementType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PStream].elementType))
-        PCanonicalStream(elementType, ptypes.forall(_.required))
-      case _: PCanonicalArray =>
-        val elementType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PArray].elementType))
-        PCanonicalArray(elementType, ptypes.forall(_.required))
-      case _: PCanonicalSet =>
-        val elementType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PSet].elementType))
-        PCanonicalSet(elementType, ptypes.forall(_.required))
-      case x: PStruct =>
-        PCanonicalStruct(ptypes.forall(_.required), x.fieldNames.map(fieldName =>
-          fieldName -> getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PStruct].field(fieldName).typ))
-        ): _*)
-      case x: PCanonicalTuple =>
-        PCanonicalTuple(x._types.map(pTupleField =>
-          pTupleField.copy(typ = getNestedElementPTypesOfSameType(ptypes.map { case t: PTuple => t._types(t.fieldIndex(pTupleField.index)).typ }))
-        ), ptypes.forall(_.required))
-      case _: PCanonicalDict =>
-        val keyType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PDict].keyType))
-        val valueType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PDict].valueType))
-        PCanonicalDict(keyType, valueType, ptypes.forall(_.required))
-      case _: PCanonicalInterval =>
-        val pointType = getNestedElementPTypesOfSameType(ptypes.map(_.asInstanceOf[PInterval].pointType))
-        PCanonicalInterval(pointType, ptypes.forall(_.required))
-      case _ => ptypes.head.setRequired(ptypes.forall(_.required))
-    }
+  def unifyPTypes(pTypes: Seq[PType], result: TypeWithRequiredness): PType = {
+    assert(pTypes.tail.forall(pt => pt.virtualType == pTypes.head.virtualType))
+    if (pTypes.nonEmpty && pTypes.tail.forall(pt => pt == pTypes.head))
+      pTypes.head
+    else result.canonicalPType(pTypes.head.virtualType)
   }
 
-  def apply(ir: IR, env: Env[PType]): Unit = apply(ir, env, null, null, null)
+  def apply(ir: IR): Unit = apply(ir, Env.empty, null, null, null)
 
   private type AAB[T] = Array[ArrayBuilder[RecursiveArrayBuilderElement[T]]]
 
@@ -120,399 +98,241 @@ object InferPType {
 
   def apply(ir: IR, env: Env[PType], aggs: Array[AggStatePhysicalSignature], inits: AAB[InitOp], seqs: AAB[SeqOp]): Unit = {
     try {
-      if (aggs != null || inits != null || seqs != null || !env.isEmpty)
-          throw new NotImplementedError
-      val requiredness = Requiredness.apply(ir, null) // Value IR inference doesn't need context
-      _inferWithRequiredness(ir, requiredness)
+      val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
+      val requiredness = Requiredness.apply(ir, usesAndDefs, null) // Value IR inference doesn't need context
+      requiredness.states.m.foreach { case (ir, types) =>
+        ir.t match {
+          case x: StreamFold => x.accPTypes = types.map(r => r.canonicalPType(x.zero.typ))
+          case x: StreamScan => x.accPTypes = types.map(r => r.canonicalPType(x.zero.typ))
+          case x: StreamFold2 =>
+            x.accPTypes = x.accum.zip(types).map { case ((_, arg), r) => r.canonicalPType(arg.typ) }.toArray
+          case x: TailLoop =>
+            x.accPTypes = x.params.zip(types).map { case ((_, arg), r) => r.canonicalPType(arg.typ) }.toArray
+        }
+      }
+      _inferWithRequiredness(ir, env, requiredness, usesAndDefs, aggs)
+      if (inits != null || seqs != null)
+        _inferAggs(ir, inits, seqs)
     } catch {
-      case _: NotImplementedError =>
-        try {
-          _apply(ir, env, aggs, inits, seqs)
-        } catch {
-          case e: Exception =>
-            throw new RuntimeException(s"error while inferring IR:\n${Pretty(ir)}", e)
-        }
-        VisitIR(ir) { case (node: IR) =>
-          if (node._pType == null)
-            throw new RuntimeException(s"ptype inference failure: node not inferred:\n${Pretty(node)}\n ** Full IR: **\n${Pretty(ir)}")
-        }
+      case e: Exception =>
+        throw new RuntimeException(s"error while inferring IR:\n${Pretty(ir)}", e)
+    }
+    VisitIR(ir) { case (node: IR) =>
+      if (node._pType == null)
+        throw new RuntimeException(s"ptype inference failure: node not inferred:\n${Pretty(node)}\n ** Full IR: **\n${Pretty(ir)}")
     }
   }
 
-  private def _inferWithRequiredness(node: IR, requiredness: RequirednessAnalysis): Unit = {
+  private def lookup(name: String, r: TypeWithRequiredness, defNode: IR): PType = defNode match {
+    case Let(`name`, value, _) => value.pType
+    case TailLoop(`name`, _, body) => r.canonicalPType(body.typ)
+    case x: TailLoop => x.accPTypes(x.paramIdx(name))
+    case ArraySort(a, l, r, c) => coerce[PStream](a.pType).elementType
+    case StreamMap(a, `name`, _) => coerce[PStream](a.pType).elementType
+    case x@StreamZip(as, _, _, _) =>
+      coerce[PStream](as(x.nameIdx(name)).pType).elementType.setRequired(r.required)
+    case StreamFilter(a, `name`, _) => coerce[PStream](a.pType).elementType
+    case StreamFlatMap(a, `name`, _) => coerce[PStream](a.pType).elementType
+    case StreamFor(a, `name`, _) => coerce[PStream](a.pType).elementType
+    case StreamFold(a, _, _, `name`, _) => coerce[PStream](a.pType).elementType
+    case x: StreamFold => x.accPType
+    case StreamScan(a, _, _, `name`, _) => coerce[PStream](a.pType).elementType
+    case x: StreamScan => x.accPType
+    case StreamFold2(a, _, `name`, _, _) => coerce[PStream](a.pType).elementType
+    case x: StreamFold2 => x.accPTypes(x.nameIdx(name))
+    case StreamLeftJoinDistinct(left, _, `name`, _, _, _) => coerce[PStream](left.pType).elementType
+    case StreamLeftJoinDistinct(_, right, _, `name`, _, _) => coerce[PStream](right.pType).elementType.setRequired(false)
+    case RunAggScan(a, `name`, _, _, _, _) => coerce[PStream](a.pType).elementType
+    case NDArrayMap(nd, `name`, _) => coerce[PNDArray](nd.pType).elementType
+    case NDArrayMap2(left, _, `name`, _, _) => coerce[PNDArray](left.pType).elementType
+    case NDArrayMap2(_, right, _, `name`, _) => coerce[PNDArray](right.pType).elementType
+    case x@CollectDistributedArray(_, _, `name`, _, _) => x.decodedContextPType
+    case x@CollectDistributedArray(_, _, _, `name`, _) => x.decodedGlobalPType
+  }
+
+  private def _inferAggs(node: IR, inits: AAB[InitOp] = null, seqs: AAB[SeqOp] = null): Unit =
+    node match {
+      case x@InitOp(i, args, sig, op) =>
+        op match {
+          case Group() =>
+            val newInits = newBuilder[InitOp](sig.nested.get.length)
+            val IndexedSeq(initArg) = args
+            _inferAggs(initArg, inits = newInits, seqs = null)
+            if (inits != null)
+              inits(i) += RecursiveArrayBuilderElement(x, Some(newInits))
+          case AggElementsLengthCheck() =>
+            val newInits = newBuilder[InitOp](sig.nested.get.length)
+            val initArg = args.last
+            _inferAggs(initArg, inits = newInits, seqs = null)
+            if (inits != null)
+              inits(i) += RecursiveArrayBuilderElement(x, Some(newInits))
+          case _ =>
+            assert(sig.nested.isEmpty)
+            if (inits != null)
+              inits(i) += RecursiveArrayBuilderElement(x, None)
+        }
+      case x@SeqOp(i, args, sig, op) =>
+        op match {
+          case Group() =>
+            val newSeqs = newBuilder[SeqOp](sig.nested.get.length)
+            val IndexedSeq(_, seqArg) = args
+            _inferAggs(seqArg, inits = null, seqs = newSeqs)
+            if (seqs != null)
+              seqs(i) += RecursiveArrayBuilderElement(x, Some(newSeqs))
+          case AggElements() =>
+            val newSeqs = newBuilder[SeqOp](sig.nested.get.length)
+            val IndexedSeq(_, seqArg) = args
+            _inferAggs(seqArg, inits = null, seqs = newSeqs)
+            if (seqs != null)
+              seqs(i) += RecursiveArrayBuilderElement(x, Some(newSeqs))
+          case AggElementsLengthCheck() =>
+            if (seqs != null)
+              seqs(i) += RecursiveArrayBuilderElement(x, None)
+          case _ =>
+            assert(sig.nested.isEmpty)
+            if (seqs != null)
+              seqs(i) += RecursiveArrayBuilderElement(x, None)
+        }
+    }
+
+  private def _inferWithRequiredness(node: IR, env: Env[PType], requiredness: RequirednessAnalysis, usesAndDefs: UsesAndDefs, aggs: Array[AggStatePhysicalSignature] = null): Unit = {
     if (node._pType != null)
       throw new RuntimeException(node.toString)
-    node.children.foreach {
-      case x: IR => _inferWithRequiredness(x, requiredness)
-      case c => throw new RuntimeException(s"unsupported node:\n${Pretty(c)}")
+    node match {
+      case x@RunAgg(body, result, signature) =>
+        _inferWithRequiredness(body, env, requiredness, usesAndDefs)
+        val inits = newBuilder[InitOp](signature.length)
+        val seqs = newBuilder[SeqOp](signature.length)
+        _inferAggs(body, inits = inits, seqs = seqs)
+        val sigs = signature.indices.map { i => computePhysicalAgg(signature(i), inits(i), seqs(i)) }.toArray
+        x.physicalSignatures = sigs
+        _inferWithRequiredness(result, env, requiredness, usesAndDefs, x.physicalSignatures)
+      case x@RunAggScan(array, name, init, seq, result, signature) =>
+        _inferWithRequiredness(array, env, requiredness, usesAndDefs)
+        _inferWithRequiredness(init, env, requiredness, usesAndDefs)
+        _inferWithRequiredness(seq, env, requiredness, usesAndDefs)
+        val inits = newBuilder[InitOp](signature.length)
+        val seqs = newBuilder[SeqOp](signature.length)
+        _inferAggs(init, inits = inits, seqs = null)
+        _inferAggs(seq, inits = null, seqs = seqs)
+        val sigs = signature.indices.map { i => computePhysicalAgg(signature(i), inits(i), seqs(i)) }.toArray
+        x.physicalSignatures = sigs
+        _inferWithRequiredness(result, env, requiredness, usesAndDefs, x.physicalSignatures)
+      case _ =>
+        node.children.foreach {
+          case x: IR => _inferWithRequiredness(x, env, requiredness, usesAndDefs, aggs)
+          case c => throw new RuntimeException(s"unsupported node:\n${Pretty(c)}")
+        }
     }
     node._pType = node match {
-      case x: IR if x.typ == TVoid => PVoid
-      case x: IR if requiredness.r.contains(x) => x match {
-        case a: AbstractApplyNode[_] =>
-          val pt = a.implementation.returnPType(a.returnType, a.args.map(_.pType))
-          assert(coerce[TypeWithRequiredness](requiredness.r.lookup(node)).matchesPType(pt))
-          pt
-        case x@StreamFold(a, zero, accumName, valueName, body) =>
-          x.accPType = requiredness.states.lookup(x).head.canonicalPType(zero.typ)
-          coerce[TypeWithRequiredness](requiredness.r.lookup(node)).canonicalPType(x.typ)
-        case x@StreamFold2(a, accum, valueName, seqs, result) =>
-          x.accPTypes = accum.zip(requiredness.states.lookup(x)).map { case ((_, z), r) =>
-              r.canonicalPType(z.typ)
-          }
-          coerce[TypeWithRequiredness](requiredness.r.lookup(node)).canonicalPType(x.typ)
-        case x@TailLoop(name, args, body) =>
-          x.argPTypes = args.zip(requiredness.states.lookup(x)).map { case ((_, i), r) =>
-            r.canonicalPType(i.typ)
-          }
-          coerce[TypeWithRequiredness](requiredness.r.lookup(node)).canonicalPType(x.typ)
-        case _ => coerce[TypeWithRequiredness](requiredness.r.lookup(node)).canonicalPType(x.typ)
-      }
-      case _ => throw new RuntimeException(s"unsupported node:\n${Pretty(node)}")
-    }
-  }
-  private def _apply(ir: IR, env: Env[PType], aggs: Array[AggStatePhysicalSignature], inits: AAB[InitOp], seqs: AAB[SeqOp]): Unit = {
-    if (ir._pType != null)
-      throw new RuntimeException(ir.toString)
-
-    def infer(ir: IR, env: Env[PType] = env, aggs: Array[AggStatePhysicalSignature] = aggs,
-      inits: AAB[InitOp] = inits, seqs: AAB[SeqOp] = seqs): Unit = _apply(ir, env, aggs, inits, seqs)
-
-    ir._pType = ir match {
-      case I32(_) => PInt32(true)
-      case I64(_) => PInt64(true)
-      case F32(_) => PFloat32(true)
-      case F64(_) => PFloat64(true)
-      case Str(_) => PCanonicalString(true)
-      case Literal(t, a) => PType.literalPType(t, a)
-      case True() | False() => PBoolean(true)
-      case Cast(ir, t) =>
-        infer(ir)
-        PType.canonical(t, ir.pType.required)
-      case CastRename(ir, t) =>
-        infer(ir)
-        ir.pType.deepRename(t)
-      case NA(t) =>
-        PType.canonical(t).deepInnerRequired(false)
-      case Die(msg, t) =>
-        infer(msg)
-        PType.canonical(t).deepInnerRequired(true)
-      case IsNA(ir) =>
-        infer(ir)
-        PBoolean(true)
-      case Ref(name, _) => env.lookup(name)
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: Literal | _: True | _: False
+           | _: Cast | _: NA | _: Die | _: IsNA | _: ArrayZeros | _: ArrayLen | _: StreamLen
+           | _: LowerBoundOnOrderedCollection | _: ApplyBinaryPrimOp
+           | _: ApplyUnaryPrimOp | _: ApplyComparisonOp | _: WriteValue
+           | _: NDArrayAgg | _: ShuffleWrite | _: ShuffleStart | _: AggStateValue =>
+        requiredness(node).canonicalPType(node.typ)
+      case x: BaseRef if usesAndDefs.free.contains(RefEquality(x)) =>
+        env.lookup(x.name)
+      case x: BaseRef =>
+        lookup(x.name, requiredness(node), usesAndDefs.defs.lookup(node).asInstanceOf[IR])
       case MakeNDArray(data, shape, rowMajor) =>
-        infer(data)
-        infer(shape)
-        infer(rowMajor)
-
         val nElem = shape.pType.asInstanceOf[PTuple].size
-
         PCanonicalNDArray(coerce[PArray](data.pType).elementType.setRequired(true), nElem, data.pType.required && shape.pType.required)
       case StreamRange(start: IR, stop: IR, step: IR) =>
-        infer(start)
-        infer(stop)
-        infer(step)
-
         assert(start.pType isOfType stop.pType)
         assert(start.pType isOfType step.pType)
-
-        val allRequired = start.pType.required && stop.pType.required && step.pType.required
-        PCanonicalStream(start.pType.setRequired(true), allRequired)
-      case ArrayZeros(length) =>
-        infer(length)
-        PCanonicalArray(PInt32(true), length.pType.required)
-      case ArrayLen(a: IR) =>
-        infer(a)
-
-        PInt32(a.pType.required)
-      case LowerBoundOnOrderedCollection(orderedCollection: IR, bound: IR, _) =>
-        infer(orderedCollection)
-        infer(bound)
-
-        PInt32(orderedCollection.pType.required)
-      case Let(name, value, body) =>
-        infer(value)
-        infer(body, env.bind(name, value.pType))
-        body.pType
-      case TailLoop(_, args, body) =>
-        args.foreach { case (_, ir) => infer(ir) }
-        infer(body, env.bind(args.map { case (n, ir) => n -> ir.pType }: _*))
-        body.pType
-      case Recur(_, args, typ) =>
-        args.foreach { a => infer(a) }
-        PType.canonical(typ)
-      case ApplyBinaryPrimOp(op, l, r) =>
-        infer(l)
-        infer(r)
-
-        val vType = BinaryOp.getReturnType(op, l.pType.virtualType, r.pType.virtualType)
-        PType.canonical(vType, l.pType.required && r.pType.required)
-      case ApplyUnaryPrimOp(op, v) =>
-        infer(v)
-        PType.canonical(UnaryOp.getReturnType(op, v.pType.virtualType)).setRequired(v.pType.required)
-      case ApplyComparisonOp(op, l, r) =>
-        infer(l)
-        infer(r)
-
-        assert(l.pType isOfType r.pType)
-        op match {
-          case _: Compare => PInt32(l.pType.required && r.pType.required)
-          case _ => PBoolean(l.pType.required && r.pType.required)
-        }
-      case a: AbstractApplyNode[_] =>
-        val pTypes = a.args.map(i => {
-          infer(i)
-          i.pType
-        })
-        a.implementation.returnPType(a.returnType, pTypes)
+        PCanonicalStream(start.pType.setRequired(true), requiredness(node).required)
+      case Let(_, _, body) => body.pType
+      case TailLoop(_, _, body) => body.pType
+      case a: AbstractApplyNode[_] => a.implementation.returnPType(a.returnType, a.args.map(_.pType))
       case ArrayRef(a, i, s) =>
-        infer(a)
-        infer(i)
-        infer(s)
         assert(i.pType isOfType PInt32())
-
-        val aType = coerce[PArray](a.pType)
-        val elemType = aType.elementType
-        elemType.orMissing(a.pType.required && i.pType.required)
+        coerce[PArray](a.pType).elementType.setRequired(requiredness(node).required)
       case ArraySort(a, leftName, rightName, lessThan) =>
-        infer(a)
-        val et = coerce[PStream](a.pType).elementType
-
-        infer(lessThan, env.bind(leftName -> et, rightName -> et))
         assert(lessThan.pType.isOfType(PBoolean()))
-
-        PCanonicalArray(et, a.pType.required)
+        PCanonicalArray(coerce[PIterable](a.pType).elementType, requiredness(node).required)
       case ToSet(a) =>
-        infer(a)
-        val et = coerce[PIterable](a.pType).elementType
-        PCanonicalSet(et, a.pType.required)
+        PCanonicalSet(coerce[PIterable](a.pType).elementType, requiredness(node).required)
       case ToDict(a) =>
-        infer(a)
         val elt = coerce[PBaseStruct](coerce[PIterable](a.pType).elementType)
-        // Dict key/value types don't depend on PIterable's requiredeness because we have an interface guarantee that
-        // null PIterables are filtered out before dict construction
-        val keyRequired = elt.types(0).required
-        val valRequired = elt.types(1).required
-        PCanonicalDict(elt.types(0).setRequired(keyRequired), elt.types(1).setRequired(valRequired), a.pType.required)
+        PCanonicalDict(elt.types(0), elt.types(1), requiredness(node).required)
       case ToArray(a) =>
-        infer(a)
         val elt = coerce[PIterable](a.pType).elementType
-        PCanonicalArray(elt, a.pType.required)
+        PCanonicalArray(elt, requiredness(node).required)
       case CastToArray(a) =>
-        infer(a)
         val elt = coerce[PIterable](a.pType).elementType
-        PCanonicalArray(elt, a.pType.required)
+        PCanonicalArray(elt, requiredness(node).required)
       case ToStream(a) =>
-        infer(a)
         val elt = coerce[PIterable](a.pType).elementType
-        PCanonicalStream(elt, a.pType.required)
+        PCanonicalStream(elt, requiredness(node).required)
       case GroupByKey(collection) =>
-        infer(collection)
+        val r = coerce[RDict](requiredness(node))
         val elt = coerce[PBaseStruct](coerce[PStream](collection.pType).elementType)
-        PCanonicalDict(elt.types(0), PCanonicalArray(elt.types(1)), collection.pType.required)
-      case StreamLen(a) =>
-        infer(a)
-        PInt32(a.pType.required)
+        PCanonicalDict(elt.types(0), PCanonicalArray(elt.types(1), r.valueType.required), r.required)
       case StreamTake(a, len) =>
-        infer(a)
-        infer(len)
-        assert(len.pType isOfType PInt32())
-        assert(a.pType.isInstanceOf[PStream])
-        a.pType.orMissing(len.pType.required)
+        a.pType.setRequired(requiredness(node).required)
       case StreamDrop(a, len) =>
-        infer(a)
-        infer(len)
-        assert(len.pType isOfType PInt32())
-        assert(a.pType.isInstanceOf[PStream])
-        a.pType.orMissing(len.pType.required)
+        a.pType.setRequired(requiredness(node).required)
       case StreamGrouped(a, size) =>
-        infer(a)
-        infer(size)
+        val r = coerce[RIterable](requiredness(node))
         assert(size.pType isOfType PInt32())
         assert(a.pType.isInstanceOf[PStream])
-        PCanonicalStream(a.pType.setRequired(true), a.pType.required && size.pType.required)
+        PCanonicalStream(a.pType.setRequired(r.elementType.required), r.required)
       case StreamGroupByKey(a, key) =>
-        infer(a)
+        val r = coerce[RIterable](requiredness(node))
         val structType = a.pType.asInstanceOf[PStream].elementType.asInstanceOf[PStruct]
         assert(structType.required)
-        assert(key.forall { k =>
-          structType.fieldType(k).required
-        })
-        PCanonicalStream(a.pType.setRequired(true), a.pType.required)
+        assert(key.forall { k => structType.fieldType(k).required })
+        PCanonicalStream(a.pType.setRequired(r.elementType.required), r.required)
       case StreamMap(a, name, body) =>
-        infer(a)
-        infer(body, env.bind(name, a.pType.asInstanceOf[PStream].elementType))
-        PCanonicalStream(body.pType, a.pType.required)
+        PCanonicalStream(body.pType, requiredness(node).required)
       case StreamZip(as, names, body, behavior) =>
-        as.foreach(infer(_))
-        val e = behavior match {
-          case ArrayZipBehavior.ExtendNA =>
-            env.bindIterable(names.zip(as.map(a => -a.pType.asInstanceOf[PStream].elementType)))
-          case _ =>
-            env.bindIterable(names.zip(as.map(a => a.pType.asInstanceOf[PStream].elementType)))
-        }
-        infer(body, e)
-        PCanonicalStream(body.pType, as.forall(_.pType.required))
-      case StreamFilter(a, name, cond) =>
-        infer(a)
-        infer(cond, env = env.bind(name, a.pType.asInstanceOf[PStream].elementType))
-        a.pType
+        PCanonicalStream(body.pType, requiredness(node).required)
+      case StreamFilter(a, name, cond) => a.pType
       case StreamFlatMap(a, name, body) =>
-        infer(a)
-        infer(body, env.bind(name, a.pType.asInstanceOf[PStream].elementType))
-
-        // Whether an array must return depends on a, but element requiredeness depends on body (null a elements elided)
-        PCanonicalStream(coerce[PIterable](body.pType).elementType, a.pType.required)
-      case x@StreamFold(a, zero, accumName, valueName, body) =>
-        infer(zero)
-        infer(a)
-        val initAccType = zero.pType
-        infer(body, env.bind(accumName -> initAccType, valueName -> a.pType.asInstanceOf[PStream].elementType))
-        x.accPType = if (body.pType != initAccType) {
-          val resPType = InferPType.getNestedElementPTypes(FastSeq(body.pType, initAccType))
-          // the below does a two-pass inference to unify the accumulator with the body ptype.
-          // this is not ideal, may cause problems in the future.
-          clearPTypes(body)
-          infer(body, env.bind(accumName -> resPType, valueName -> a.pType.asInstanceOf[PStream].elementType))
-          resPType
-        } else initAccType
-        x.accPType.orMissing(a.pType.required)
-      case StreamFor(a, value, body) =>
-        infer(a)
-        infer(body, env.bind(value -> a.pType.asInstanceOf[PStream].elementType))
-        PVoid
-      case x@StreamFold2(a, acc, valueName, seq, res) =>
-        infer(a)
-        acc.foreach { case (_, accIR) => infer(accIR) }
-        var seqEnv = env.bind(acc.map { case (name, accIR) => (name, accIR.pType) }: _*)
-          .bind(valueName -> a.pType.asInstanceOf[PStream].elementType)
-        var anyMismatch = false
-        x.accPTypes = seq.zip(acc.map(_._1)).map { case (seqIR, name) =>
-          infer(seqIR, seqEnv)
-          if (seqIR.pType != seqEnv.lookup(name)) {
-            anyMismatch = true
-            val resPType = InferPType.getNestedElementPTypes(FastSeq(seqIR.pType, seqEnv.lookup(name)))
-            seqEnv = seqEnv.bind(name, resPType)
-            // the below does a two-pass inference to unify the accumulator with the body ptype.
-            // this is not ideal, may cause problems in the future.
-            resPType
-          } else seqIR.pType
-        }
-
-        acc.indices.foreach {i =>
-          clearPTypes(seq(i))
-          infer(seq(i), seqEnv)
-        }
-
-        infer(res, seqEnv.delete(valueName))
-        res.pType.setRequired(res.pType.required && a.pType.required)
-      case x@StreamScan(a, zero, accumName, valueName, body) =>
-        infer(zero)
-
-        infer(a)
-        infer(body, env.bind(accumName -> zero.pType, valueName -> a.pType.asInstanceOf[PStream].elementType))
-        val accPType = if (body.pType != zero.pType) {
-          val resPType = InferPType.getNestedElementPTypes(FastSeq(body.pType, zero.pType))
-          // the below does a two-pass inference to unify the accumulator with the body ptype.
-          // this is not ideal, may cause problems in the future.
-          clearPTypes(body)
-          infer(body, env.bind(accumName -> resPType, valueName -> a.pType.asInstanceOf[PStream].elementType))
-          resPType
-        } else zero.pType
-
-        PCanonicalStream(elementType = accPType)
-      case StreamLeftJoinDistinct(lIR, rIR, lName, rName, compare, join) =>
-        infer(lIR)
-        infer(rIR)
-        val e = env.bind(lName -> lIR.pType.asInstanceOf[PStream].elementType, rName -> -rIR.pType.asInstanceOf[PStream].elementType)
-
-        infer(compare, e)
-        infer(join, e)
-
-        PCanonicalStream(join.pType, lIR.pType.required)
+        PCanonicalStream(coerce[PIterable](body.pType).elementType, requiredness(node).required)
+      case x: StreamFold =>
+        x.accPType.setRequired(requiredness(node).required)
+      case x: StreamFold2 =>
+        x.result.pType.setRequired(requiredness(node).required)
+      case x: StreamScan =>
+        val r = coerce[RIterable](requiredness(node))
+        PCanonicalStream(x.accPType.setRequired(r.elementType.required), r.required)
+      case StreamLeftJoinDistinct(_, _, _, _, _, join) =>
+        PCanonicalStream(join.pType, requiredness(node).required)
       case NDArrayShape(nd) =>
-        infer(nd)
         val r = nd.pType.asInstanceOf[PNDArray].shape.pType
-        r.setRequired(r.required && nd.pType.required)
+        r.setRequired(requiredness(node).required)
       case NDArrayReshape(nd, shape) =>
-        infer(nd)
-        infer(shape)
-
         val shapeT = shape.pType.asInstanceOf[PTuple]
         PCanonicalNDArray(coerce[PNDArray](nd.pType).elementType, shapeT.size,
-          nd.pType.required && shapeT.required && shapeT.types.forall(_.required))
+          requiredness(node).required)
       case NDArrayConcat(nds, _) =>
-        infer(nds)
         val ndtyp = coerce[PNDArray](coerce[PArray](nds.pType).elementType)
-        ndtyp.setRequired(nds.pType.required && ndtyp.required)
+        ndtyp.setRequired(requiredness(node).required)
       case NDArrayMap(nd, name, body) =>
-        infer(nd)
         val ndPType = nd.pType.asInstanceOf[PNDArray]
-        infer(body, env.bind(name -> ndPType.elementType))
-
-        PCanonicalNDArray(body.pType.setRequired(true), ndPType.nDims, nd.pType.required)
+        PCanonicalNDArray(body.pType.setRequired(true), ndPType.nDims, requiredness(node).required)
       case NDArrayMap2(l, r, lName, rName, body) =>
-        infer(l)
-        infer(r)
-
         val lPType = l.pType.asInstanceOf[PNDArray]
-        val rPType = r.pType.asInstanceOf[PNDArray]
-
-        InferPType(body, env.bind(lName -> lPType.elementType, rName -> rPType.elementType))
-
-        PCanonicalNDArray(body.pType.setRequired(true), lPType.nDims, l.pType.required && r.pType.required)
+        PCanonicalNDArray(body.pType.setRequired(true), lPType.nDims, requiredness(node).required)
       case NDArrayReindex(nd, indexExpr) =>
-        infer(nd)
-
-        PCanonicalNDArray(coerce[PNDArray](nd.pType).elementType, indexExpr.length, nd.pType.required)
+        PCanonicalNDArray(coerce[PNDArray](nd.pType).elementType, indexExpr.length, requiredness(node).required)
       case NDArrayRef(nd, idxs) =>
-        infer(nd)
-
-        var allRequired = nd.pType.required
-        val it = idxs.iterator
-        while (it.hasNext) {
-          val idxIR = it.next()
-          infer(idxIR)
-          assert(idxIR.pType.isOfType(PInt64()) || idxIR.pType.isOfType(PInt32()))
-          if (allRequired && !idxIR.pType.required) {
-            allRequired = false
-          }
-        }
-
-        coerce[PNDArray](nd.pType).elementType.setRequired(allRequired)
+        coerce[PNDArray](nd.pType).elementType.setRequired(requiredness(node).required)
       case NDArraySlice(nd, slices) =>
-        infer(nd)
-        infer(slices)
-        val slicesPT = coerce[PTuple](slices.pType)
-        val remainingDims = slicesPT.types.filter(_.isInstanceOf[PTuple])
-        PCanonicalNDArray(coerce[PNDArray](nd.pType).elementType, remainingDims.length,
-          slicesPT.required && slicesPT.types.forall(_.required)
-            && remainingDims.iterator.flatMap(t => coerce[PTuple](t).types).forall(_.required) && nd.pType.required)
-      case NDArrayFilter(nd, filters) =>
-        infer(nd)
-        filters.foreach(infer(_))
-        coerce[PNDArray](nd.pType)
+        val remainingDims = coerce[PTuple](slices.pType).types.filter(_.isInstanceOf[PTuple])
+        PCanonicalNDArray(coerce[PNDArray](nd.pType).elementType, remainingDims.length, requiredness(node).required)
+      case NDArrayFilter(nd, filters) => coerce[PNDArray](nd.pType)
       case NDArrayMatMul(l, r) =>
-        infer(l)
-        infer(r)
         val lTyp = coerce[PNDArray](l.pType)
         val rTyp = coerce[PNDArray](r.pType)
-        PCanonicalNDArray(lTyp.elementType, TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims), lTyp.required && rTyp.required)
-      case NDArrayQR(nd, mode) =>
-        infer(nd)
-        mode match {
-          case "r" => PCanonicalNDArray(PFloat64Required, 2)
-          case "raw" => PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 1))
-          case "reduced" | "complete" => PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 2))
-        }
+        PCanonicalNDArray(lTyp.elementType, TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims), requiredness(node).required)
+      case NDArrayQR(nd, mode) => NDArrayQR.pTypes(mode)
       case MakeStruct(fields) =>
-        PCanonicalStruct(true, fields.map { case (name, a) =>
-          infer(a)
-          (name, a.pType)
-        }: _ *)
+        PCanonicalStruct(requiredness(node).required,
+          fields.map { case (name, a) => (name, a.pType) }: _ *)
       case SelectFields(old, fields) =>
-        infer(old)
         if(HailContext.getFlag("use_spicy_ptypes") != null) {
           PSubsetStruct(coerce[PStruct](old.pType), fields:_*)
         } else {
@@ -520,192 +340,60 @@ object InferPType {
           tbs.selectFields(fields.toFastIndexedSeq)
         }
       case InsertFields(old, fields, fieldOrder) =>
-        infer(old)
         val tbs = coerce[PStruct](old.pType)
-
-        val s = tbs.insertFields(fields.map(f => {
-          infer(f._2)
-          (f._1, f._2.pType)
-        }))
-
+        val s = tbs.insertFields(fields.map(f => { (f._1, f._2.pType) }))
         fieldOrder.map { fds =>
           assert(fds.length == s.size)
           PCanonicalStruct(tbs.required, fds.map(f => f -> s.fieldType(f)): _*)
         }.getOrElse(s)
       case GetField(o, name) =>
-        infer(o)
         val t = coerce[PStruct](o.pType)
         if (t.index(name).isEmpty)
           throw new RuntimeException(s"$name not in $t")
-        val fd = t.field(name).typ
-        fd.setRequired(t.required && fd.required)
+        t.field(name).typ.setRequired(requiredness(node).required)
       case MakeTuple(values) =>
         PCanonicalTuple(values.map { case (idx, v) =>
-          infer(v)
           PTupleField(idx, v.pType)
-        }.toFastIndexedSeq, true)
+        }.toFastIndexedSeq, requiredness(node).required)
       case MakeArray(irs, t) =>
-        if (irs.isEmpty) {
-          PType.canonical(t, true).deepInnerRequired(true)
-        } else {
-          val elementTypes = irs.map { elt =>
-            infer(elt)
-            elt.pType
-          }
-
-          val inferredElementType = getNestedElementPTypes(elementTypes)
-          PCanonicalArray(inferredElementType, true)
-        }
+        val r = coerce[RIterable](requiredness(node))
+        PCanonicalArray(unifyPTypes(irs.map(_.pType), r.elementType), r.required)
       case GetTupleElement(o, idx) =>
-        infer(o)
         val t = coerce[PTuple](o.pType)
-        val fd = t.fields(t.fieldIndex(idx)).typ
-        fd.setRequired(t.required && fd.required)
+        t.fields(t.fieldIndex(idx)).typ.setRequired(requiredness(node).required)
       case If(cond, cnsq, altr) =>
-        infer(cond)
-        infer(cnsq)
-        infer(altr)
-
         assert(cond.pType isOfType PBoolean())
-
-        val branchType = getNestedElementPTypes(IndexedSeq(cnsq.pType, altr.pType))
-
-        branchType.setRequired(branchType.required && cond.pType.required)
+        val r = requiredness(node)
+        unifyPTypes(FastIndexedSeq(cnsq.pType, altr.pType), r).setRequired(r.required)
       case Coalesce(values) =>
-        values.foreach(v => infer(v))
-        val pt = getNestedElementPTypes(values.map(_.pType))
-        if (values.exists(_.pType.required))
-          pt.setRequired(true)
-        else
-          pt
+        val r = requiredness(node)
+        unifyPTypes(values.map(_.pType), r).setRequired(r.required)
       case In(_, pType: PType) => pType
-      case x@CollectDistributedArray(contextsIR, globalsIR, contextsName, globalsName, bodyIR) =>
-        infer(contextsIR)
-        infer(globalsIR)
-        infer(bodyIR, env.bind(contextsName -> x.decodedContextPType, globalsName -> x.decodedGlobalPType))
-        PCanonicalArray(x.decodedBodyPType, contextsIR.pType.required)
+      case x: CollectDistributedArray =>
+        PCanonicalArray(x.decodedBodyPType, requiredness(node).required)
       case ReadPartition(context, rowType, reader) =>
-        infer(context)
         val child = reader.rowPType(rowType)
-        PCanonicalStream(child, child.required)
+        PCanonicalStream(child, requiredness(node).required)
       case ReadValue(path, spec, requestedType) =>
-        infer(path)
-        spec.decodedPType(requestedType)
-      case WriteValue(value, pathPrefix, spec) =>
-        infer(value)
-        infer(pathPrefix)
-        PCanonicalString(pathPrefix.pType.required && value.pType.required)
+        spec.decodedPType(requestedType).setRequired(requiredness(node).required)
       case MakeStream(irs, t) =>
-        if (irs.isEmpty) {
-          PType.canonical(t, true).deepInnerRequired(true)
-        } else {
-          PCanonicalStream(getNestedElementPTypes(irs.map(theIR => {
-            infer(theIR)
-            theIR.pType
-          })), true)
-        }
-      case x@InitOp(i, args, sig, op) =>
-        op match {
-          case Group() =>
-            val nested = sig.nested.get
-            val newInits = newBuilder[InitOp](nested.length)
-            val IndexedSeq(initArg) = args
-            infer(initArg, env, null, inits = newInits, seqs = null)
-            if (inits != null)
-              inits(i) += RecursiveArrayBuilderElement(x, Some(newInits))
-          case AggElementsLengthCheck() =>
-            val nested = sig.nested.get
-            val newInits = newBuilder[InitOp](nested.length)
-            val initArg = args match {
-              case Seq(len, initArg) =>
-                infer(len, env, null, null, null)
-                initArg
-              case Seq(initArg) => initArg
-            }
-            infer(initArg, env, null, inits = newInits, seqs = null)
-            if (inits != null)
-              inits(i) += RecursiveArrayBuilderElement(x, Some(newInits))
-          case _ =>
-            assert(sig.nested.isEmpty)
-            args.foreach(infer(_, env, null, null, null))
-            if (inits != null)
-              inits(i) += RecursiveArrayBuilderElement(x, None)
-        }
-        PVoid
-      case x@SeqOp(i, args, sig, op) =>
-        op match {
-          case Group() =>
-            val nested = sig.nested.get
-            val newSeqs = newBuilder[SeqOp](nested.length)
-            val IndexedSeq(k, seqArg) = args
-            infer(k, env, null, inits = null, seqs = null)
-            infer(seqArg, env, null, inits = null, seqs = newSeqs)
-            if (seqs != null)
-              seqs(i) += RecursiveArrayBuilderElement(x, Some(newSeqs))
-          case AggElements() =>
-            val nested = sig.nested.get
-            val newSeqs = newBuilder[SeqOp](nested.length)
-            val IndexedSeq(idx, seqArg) = args
-            infer(idx, env, null, inits = null, seqs = null)
-            infer(seqArg, env, null, inits = null, seqs = newSeqs)
-            if (seqs != null)
-              seqs(i) += RecursiveArrayBuilderElement(x, Some(newSeqs))
-          case AggElementsLengthCheck() =>
-            val nested = sig.nested.get
-            val IndexedSeq(idx) = args
-            infer(idx, env, null, inits = null, seqs = null)
-            if (seqs != null)
-              seqs(i) += RecursiveArrayBuilderElement(x, None)
-          case _ =>
-            assert(sig.nested.isEmpty)
-            args.foreach(infer(_, env, null, null, null))
-            if (seqs != null)
-              seqs(i) += RecursiveArrayBuilderElement(x, None)
-        }
-        PVoid
+        val r = coerce[RIterable](requiredness(node))
+        PCanonicalStream(unifyPTypes(irs.map(_.pType), r.elementType), r.required)
       case x@ResultOp(resultIdx, sigs) =>
         PCanonicalTuple(true, (resultIdx until resultIdx + sigs.length).map(i => aggs(i).resultType): _*)
-      case x@RunAgg(body, result, signature) =>
-        val inits = newBuilder[InitOp](signature.length)
-        val seqs = newBuilder[SeqOp](signature.length)
-        infer(body, env, inits = inits, seqs = seqs, aggs = null)
-        val sigs = signature.indices.map { i => computePhysicalAgg(signature(i), inits(i), seqs(i)) }.toArray
-        infer(result, env, aggs = sigs, inits = null, seqs = null)
-        x.physicalSignatures = sigs
-        result.pType
+      case x@RunAgg(body, result, signature) => result.pType
       case x@RunAggScan(array, name, init, seq, result, signature) =>
-        infer(array)
-        val e2 = env.bind(name, coerce[PStream](array.pType).elementType)
-        val inits = newBuilder[InitOp](signature.length)
-        val seqs = newBuilder[SeqOp](signature.length)
-        infer(init, env = e2, inits = inits, seqs = null, aggs = null)
-        infer(seq, env = e2, inits = null, seqs = seqs, aggs = null)
-        val sigs = signature.indices.map { i => computePhysicalAgg(signature(i), inits(i), seqs(i)) }.toArray
-        infer(result, env = e2, aggs = sigs, inits = null, seqs = null)
-        x.physicalSignatures = sigs
-        PCanonicalStream(result.pType, array.pType.required)
-      case AggStateValue(i, sig) => PCanonicalBinary(true)
-      case x if x.typ == TVoid =>
-        x.children.foreach(c => infer(c.asInstanceOf[IR]))
-        PVoid
-      case NDArrayAgg(nd, _) =>
-        infer(nd)
-        PType.canonical(ir.typ)
-      case ShuffleStart(_, _, _, _) =>
-        PCanonicalBinary(true)
-      case ShuffleWrite(_, _, _) =>
-        PCanonicalBinary(true)
+        PCanonicalStream(result.pType, requiredness(node).required)
       case ShuffleGetPartitionBounds(_, _, keyFields, rowType, keyEType) =>
         val keyPType = keyEType.decodedPType(rowType.typeAfterSelectNames(keyFields.map(_.field)))
-        PCanonicalArray(keyPType, true)
+        PCanonicalArray(keyPType, requiredness(node).required)
       case ShuffleRead(_, _, rowType, rowEType) =>
         val rowPType = rowEType.decodedPType(rowType)
-        PCanonicalStream(rowPType, true)
-      case x if x.typ == TVoid =>
-        x.children.foreach(c => infer(c.asInstanceOf[IR]))
-        PVoid
+        PCanonicalStream(rowPType, requiredness(node).required)
+      case x if x.typ == TVoid => PVoid
+      case _ => throw new RuntimeException(s"unsupported node:\n${Pretty(node)}")
     }
-    if (ir.pType.virtualType != ir.typ)
-      throw new RuntimeException(s"pType.virtualType: ${ir.pType.virtualType}, vType = ${ir.typ}\n  ir=$ir")
+    if (node.pType.virtualType != node.typ)
+      throw new RuntimeException(s"pType.virtualType: ${node.pType.virtualType}, vType = ${node.typ}\n  ir=$node")
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -386,7 +386,7 @@ object InferPType {
         PCanonicalTuple(true, (resultIdx until resultIdx + sigs.length).map(i => aggs(i).resultType): _*)
       case x@RunAgg(body, result, signature) => result.pType
       case x@RunAggScan(array, name, init, seq, result, signature) =>
-        PCanonicalStream(result.pType, requiredness(node).required)
+        PCanonicalStream(result.pType, array.pType.required)
       case ShuffleGetPartitionBounds(_, _, keyFields, rowType, keyEType) =>
         val keyPType = keyEType.decodedPType(rowType.typeAfterSelectNames(keyFields.map(_.field)))
         PCanonicalArray(keyPType, requiredness(node).required)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -81,16 +81,16 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case x@InitOp(_, args, _, _) =>
         aggStateMemo.bind(node, wrapped)
         q += RefEquality(x)
-        dependents.getOrElseUpdate(x, mutable.Set[RefEquality[BaseIR]]()) ++= args.map(RefEquality(_))
+        args.foreach(a => dependents.getOrElseUpdate(a, mutable.Set[RefEquality[BaseIR]]()) += RefEquality(x))
         if (wrapped.scope != null)
-          dependents(x) += wrapped.scope
+          dependents.getOrElseUpdate(x, mutable.Set[RefEquality[BaseIR]]()) += wrapped.scope
         node.children.foreach(initializeAggStates(_, wrapped))
       case x@SeqOp(_, args, _, _) =>
         aggStateMemo.bind(node, wrapped)
         q += RefEquality(x)
-        dependents.getOrElseUpdate(x, mutable.Set[RefEquality[BaseIR]]()) ++= args.map(RefEquality(_))
+        args.foreach(a => dependents.getOrElseUpdate(a, mutable.Set[RefEquality[BaseIR]]()) += RefEquality(x))
         if (wrapped.scope != null)
-          dependents(x) += wrapped.scope
+          dependents.getOrElseUpdate(x, mutable.Set[RefEquality[BaseIR]]()) += wrapped.scope
         node.children.foreach(initializeAggStates(_, wrapped))
       case x: ResultOp =>
         aggStateMemo.bind(node, wrapped)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -438,7 +438,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => requiredness.fromPType(t)
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
-      case _: ResultOp | _: RunAgg | _: RunAggScan => ???
+      case _: ResultOp | _: RunAgg | _: RunAggScan => //FIXME: this needs an implementation; for now unused in InferPType
     }
     requiredness.probeChangedAndReset()
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -52,16 +52,16 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
     def sig: Array[AggStatePhysicalSignature] = _sig
   }
 
-  private val aggStateMemo = Memo.empty[WrappedAggState]
+  private[this] val aggStateMemo = Memo.empty[WrappedAggState]
 
-  def computeAggState(sigs: IndexedSeq[AggStateSignature], irs: Seq[IR]): Array[AggStatePhysicalSignature] = {
+  private[this] def computeAggState(sigs: IndexedSeq[AggStateSignature], irs: Seq[IR]): Array[AggStatePhysicalSignature] = {
     val initsAB = InferPType.newBuilder[(AggOp, Seq[PType])](sigs.length)
     val seqsAB = InferPType.newBuilder[(AggOp, Seq[PType])](sigs.length)
     irs.foreach { ir => InferPType._extractAggOps(ir, inits = initsAB, seqs = seqsAB) }
     Array.tabulate(sigs.length) { i => InferPType.computePhysicalAgg(sigs(i), initsAB(i), seqsAB(i)) }
   }
 
-  def initializeAggStates(node: BaseIR, wrapped: WrappedAggState): Unit = {
+  private[this] def initializeAggStates(node: BaseIR, wrapped: WrappedAggState): Unit = {
     node match {
       case x@RunAgg(body, result, signature) =>
         val next = new WrappedAggState(RefEquality[IR](x), null)
@@ -87,7 +87,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
     }
   }
 
-  def lookupAggState(ir: IR): WrappedAggState = aggStateMemo(ir)
+  private[this] def lookupAggState(ir: IR): WrappedAggState = aggStateMemo(ir)
 
   def result(): RequirednessAnalysis = RequirednessAnalysis(cache, states)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -226,6 +226,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
       // always required
       case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>
+      case _: CombOpValue | _: AggStateValue =>
       case x if x.typ == TVoid =>
       case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) | ApplyComparisonOp(Compare(_, _), _, _) =>
       case ApplyComparisonOp(op, l, r) =>
@@ -433,8 +434,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => requiredness.fromPType(t)
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
-      case _: ResultOp | _: RunAgg | _: RunAggScan | _: CombOpValue | _: AggStateValue => ???
-
+      case _: ResultOp | _: RunAgg | _: RunAggScan => ???
     }
     requiredness.probeChangedAndReset()
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -438,7 +438,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => requiredness.fromPType(t)
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
-      case _: ResultOp | _: RunAgg | _: RunAggScan => //FIXME: this needs an implementation; for now unused in InferPType
+      case _: ResultOp | _: RunAgg | _: RunAggScan =>
+        requiredness.maximize()
+        //FIXME: this needs an implementation; for now unused in InferPType
     }
     requiredness.probeChangedAndReset()
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -154,6 +154,10 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case StreamScan(a, zero, accumName, valueName, body) =>
         addElementBinding(valueName, a)
         addBindings(accumName, Array[IR](zero, body))
+        states.bind(node, Array[TypeWithRequiredness](lookup(
+          refMap.get(accumName)
+            .flatMap(refs => refs.headOption.map(_.t.asInstanceOf[IR]))
+            .getOrElse(zero))))
       case StreamFold2(a, accums, valueName, seq, result) =>
         addElementBinding(valueName, a)
         val s = Array.fill[TypeWithRequiredness](accums.length)(null)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -503,14 +503,14 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case x@RunAgg(body, result, signature) =>
         val wrapped = lookupAggState(x)
         val newAggSig = computeAggState(signature, FastSeq(body))
-        if (newAggSig sameElements wrapped.sig)
+        if (!(newAggSig sameElements wrapped.sig))
           wrapped.setSignature(newAggSig)
         else
           requiredness.unionFrom(lookup(result))
       case x@RunAggScan(array, name, init, seqs, result, signature) =>
         val wrapped = lookupAggState(x)
         val newAggSig = computeAggState(signature, FastSeq(init, seqs))
-        if (newAggSig sameElements wrapped.sig)
+        if (!(newAggSig sameElements wrapped.sig))
           wrapped.setSignature(newAggSig)
         else
           requiredness.unionFrom(lookup(result))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -57,7 +57,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
   private[this] def computeAggState(sigs: IndexedSeq[AggStateSignature], irs: Seq[IR]): Array[AggStatePhysicalSignature] = {
     val initsAB = InferPType.newBuilder[(AggOp, Seq[PType])](sigs.length)
     val seqsAB = InferPType.newBuilder[(AggOp, Seq[PType])](sigs.length)
-    irs.foreach { ir => InferPType._extractAggOps(ir, inits = initsAB, seqs = seqsAB) }
+    irs.foreach { ir => InferPType._extractAggOps(ir, inits = initsAB, seqs = seqsAB, Some(cache)) }
     Array.tabulate(sigs.length) { i => InferPType.computePhysicalAgg(sigs(i), initsAB(i), seqsAB(i)) }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1097,7 +1097,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
 
     def unionFieldPTypes(ps: PStruct, ps2: PStruct): IndexedSeq[(String, PType)] =
       ps.fields.zip(ps2.fields).map { case(pf1, pf2) =>
-        (pf1.name, InferPType.unifyPTypes(Seq(pf1.typ, pf2.typ)))
+        (pf1.name, InferPType.getCompatiblePType(Seq(pf1.typ, pf2.typ)))
       }
 
     def castFieldRequiredeness(ps: PStruct, required: Boolean): IndexedSeq[(String, PType)] =

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1096,9 +1096,9 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
       pfs.map(pf => (pf.name, pf.typ))
 
     def unionFieldPTypes(ps: PStruct, ps2: PStruct): IndexedSeq[(String, PType)] =
-      ps.fields.zip(ps2.fields).map({
-        case(pf1, pf2) => (pf1.name, InferPType.unifyPTypes(Seq(pf1.typ, pf2.typ)))
-      })
+      ps.fields.zip(ps2.fields).map { case(pf1, pf2) =>
+        (pf1.name, InferPType.unifyPTypes(Seq(pf1.typ, pf2.typ)))
+      }
 
     def castFieldRequiredeness(ps: PStruct, required: Boolean): IndexedSeq[(String, PType)] =
       ps.fields.map(pf => (pf.name, pf.typ.setRequired(required)))

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1097,7 +1097,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
 
     def unionFieldPTypes(ps: PStruct, ps2: PStruct): IndexedSeq[(String, PType)] =
       ps.fields.zip(ps2.fields).map({
-        case(pf1, pf2) => (pf1.name, InferPType.getNestedElementPTypes(Seq(pf1.typ, pf2.typ)))
+        case(pf1, pf2) => (pf1.name, InferPType.unifyPTypes(Seq(pf1.typ, pf2.typ)))
       })
 
     def castFieldRequiredeness(ps: PStruct, required: Boolean): IndexedSeq[(String, PType)] =

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -174,13 +174,13 @@ object Extract {
 
   def getAgg(aggSig: AggStatePhysicalSignature, op: AggOp): StagedAggregator = aggSig.lookup(op) match {
     case PhysicalAggSignature(Sum(), _, Seq(t)) =>
-      new SumAggregator(t)
+      new SumAggregator(t.setRequired(true))
     case PhysicalAggSignature(Product(), _, Seq(t)) =>
-      new ProductAggregator(t)
+      new ProductAggregator(t.setRequired(true))
     case PhysicalAggSignature(Min(), _, Seq(t)) =>
-      new MinAggregator(t)
+      new MinAggregator(t.setRequired(false))
     case PhysicalAggSignature(Max(), _, Seq(t)) =>
-      new MaxAggregator(t)
+      new MaxAggregator(t.setRequired(false))
     case PhysicalAggSignature(Count(), _, _) =>
       CountAggregator
     case PhysicalAggSignature(Take(), _, Seq(t)) => new TakeAggregator(t)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -102,10 +102,10 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggStateSign
   def results: IR = ResultOp(0, aggs)
 
   def getPhysicalAggs(ctx: ExecuteContext, initBindings: Env[PType], seqBindings: Env[PType]): Array[AggStatePhysicalSignature] = {
-    val initsAB = InferPType.newBuilder[InitOp](aggs.length)
-    val seqsAB = InferPType.newBuilder[SeqOp](aggs.length)
     val init2 = LoweringPipeline.compileLowerer.apply(ctx, init, false).asInstanceOf[IR].noSharing
     val seq2 = LoweringPipeline.compileLowerer.apply(ctx, seqPerElt, false).asInstanceOf[IR].noSharing
+    val initsAB = InferPType.newBuilder[(AggOp, Seq[PType])](aggs.length)
+    val seqsAB = InferPType.newBuilder[(AggOp, Seq[PType])](aggs.length)
     InferPType(init2, initBindings, null, inits = initsAB, null)
     InferPType(seq2, seqBindings, null, null, seqs = seqsAB)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -14,7 +14,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerEmitCode4("Interval", tv("T"), tv("T"), TBoolean, TBoolean, TInterval(tv("T")),
       { case (_: Type, startpt, endpt, includesStartPT, includesEndPT) =>
         PCanonicalInterval(
-          InferPType.getNestedElementPTypes(Seq(startpt, endpt)),
+          InferPType.unifyPTypes(Seq(startpt, endpt)),
           required = includesStartPT.required && includesEndPT.required
         )
       }) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -14,7 +14,7 @@ object IntervalFunctions extends RegistryFunctions {
     registerEmitCode4("Interval", tv("T"), tv("T"), TBoolean, TBoolean, TInterval(tv("T")),
       { case (_: Type, startpt, endpt, includesStartPT, includesEndPT) =>
         PCanonicalInterval(
-          InferPType.unifyPTypes(Seq(startpt, endpt)),
+          InferPType.getCompatiblePType(Seq(startpt, endpt)),
           required = includesStartPT.required && includesEndPT.required
         )
       }) {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1427,7 +1427,7 @@ object RVD {
     if (rvds.length == 1 || rvds.forall(_.rowPType == rvds.head.rowPType))
       return rvds
 
-    val unifiedRowPType = InferPType.unifyPTypes(rvds.map(_.rowPType)).asInstanceOf[PStruct]
+    val unifiedRowPType = InferPType.getCompatiblePType(rvds.map(_.rowPType)).asInstanceOf[PStruct]
     val unifiedKey = rvds.map(_.typ.key).reduce((l, r) => commonPrefix(l, r))
     rvds.map { rvd =>
       val srcRowPType = rvd.rowPType

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1427,7 +1427,7 @@ object RVD {
     if (rvds.length == 1 || rvds.forall(_.rowPType == rvds.head.rowPType))
       return rvds
 
-    val unifiedRowPType = InferPType.getNestedElementPTypesOfSameType(rvds.map(_.rowPType)).asInstanceOf[PStruct]
+    val unifiedRowPType = InferPType.unifyPTypes(rvds.map(_.rowPType)).asInstanceOf[PStruct]
     val unifiedKey = rvds.map(_.typ.key).reduce((l, r) => commonPrefix(l, r))
     rvds.map { rvd =>
       val srcRowPType = rvd.rowPType

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -185,7 +185,13 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
   override def _toString: String = s"RDict[${ keyType.toString }, ${ valueType.toString }]"
 }
 case class RNDArray(override val elementType: TypeWithRequiredness) extends RIterable(elementType, true) {
-  override def _unionLiteral(a: Annotation): Unit = ???
+  override def _unionLiteral(a: Annotation): Unit = {
+    val data = a.asInstanceOf[Row].getAs[Iterable[Any]](2)
+    data.asInstanceOf[Iterable[_]].foreach { elt =>
+      if (elt != null)
+        elementType.unionLiteral(elt)
+    }
+  }
   override def _matchesPType(pt: PType): Boolean = elementType.matchesPType(coerce[PNDArray](pt).elementType)
   override def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PNDArray].elementType)
   override def copy(newChildren: Seq[BaseTypeWithRequiredness]): RNDArray = {

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -110,7 +110,7 @@ final case class RPrimitive() extends TypeWithRequiredness {
 
   def _unionLiteral(a: Annotation): Unit = ()
   def _matchesPType(pt: PType): Boolean = RPrimitive.typeSupported(pt.virtualType)
-  def _unionPType(pType: PType): Unit = assert(matchesPType(pType))
+  def _unionPType(pType: PType): Unit = assert(RPrimitive.typeSupported(pType.virtualType))
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RPrimitive = {
     assert(newChildren.isEmpty)
     RPrimitive()

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -262,7 +262,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[F](ctx, "F", (classInfo[Region]: ParamType) +: inputTypes.map(pt => EmitParamType(pt): ParamType), LongInfo)
     val mb = fb.apply_method
     val ir = streamIR.deepCopy()
-    InferPType(ir, Env.empty)
+    InferPType(ir)
     val eltType = ir.pType.asInstanceOf[PStream].elementType
     val stream = ExecuteContext.scoped() { ctx =>
       val s = ir match {
@@ -319,7 +319,7 @@ class EmitStreamSuite extends HailSuite {
     val fb = EmitFunctionBuilder[Region, Int](ctx, "eval_stream_len")
     val mb = fb.apply_method
     val ir = streamIR.deepCopy()
-    InferPType(ir, Env.empty)
+    InferPType(ir)
     val optStream = ExecuteContext.scoped() { ctx =>
       TypeCheck(ir)
       EmitStream.emit(new Emit(ctx, fb.ecb), ir, mb, Env.empty, None)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -882,571 +882,571 @@ class IRSuite extends HailSuite {
 
   @Test def testGetNestedElementPTypesI32() {
     var types = Seq(PInt32(true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PInt32(true))
 
     types = Seq(PInt32(false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt32(false))
 
     types = Seq(PInt32(false), PInt32(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt32(false))
 
     types = Seq(PInt32(true), PInt32(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt32(true))
   }
 
   @Test def testGetNestedElementPTypesI64() {
     var types = Seq(PInt64(true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PInt64(true))
 
     types = Seq(PInt64(false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt64(false))
 
     types = Seq(PInt64(false), PInt64(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt64(false))
 
     types = Seq(PInt64(true), PInt64(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PInt64(true))
   }
 
   @Test def testGetNestedElementPFloat32() {
     var types = Seq(PFloat32(true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat32(true))
 
     types = Seq(PFloat32(false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat32(false))
 
     types = Seq(PFloat32(false), PFloat32(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat32(false))
 
     types = Seq(PFloat32(true), PFloat32(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat32(true))
   }
 
   @Test def testGetNestedElementPFloat64() {
     var types = Seq(PFloat64(true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat64(true))
 
     types = Seq(PFloat64(false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat64(false))
 
     types = Seq(PFloat64(false), PFloat64(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat64(false))
 
     types = Seq(PFloat64(true), PFloat64(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PFloat64(true))
   }
 
   @Test def testGetNestedElementPCanonicalString() {
     var types = Seq(PCanonicalString(true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalString(true))
 
     types = Seq(PCanonicalString(false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalString(false))
 
     types = Seq(PCanonicalString(false), PCanonicalString(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalString(false))
 
     types = Seq(PCanonicalString(true), PCanonicalString(true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalString(true))
   }
 
   @Test def testGetNestedPCanonicalArray() {
     var types = Seq(PCanonicalArray(PInt32(true), true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(true), true))
 
     types = Seq(PCanonicalArray(PInt32(true), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(true), false))
 
     types = Seq(PCanonicalArray(PInt32(false), true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(false), true))
 
     types = Seq(PCanonicalArray(PInt32(false), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(false), false))
 
     types = Seq(
       PCanonicalArray(PInt32(true), true),
       PCanonicalArray(PInt32(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(true), true))
 
     types = Seq(
       PCanonicalArray(PInt32(false), true),
       PCanonicalArray(PInt32(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(false), true))
 
     types = Seq(
       PCanonicalArray(PInt32(false), true),
       PCanonicalArray(PInt32(true), false)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PInt32(false), false))
 
     types = Seq(
       PCanonicalArray(PCanonicalArray(PInt32(true), true), true),
       PCanonicalArray(PCanonicalArray(PInt32(true), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PCanonicalArray(PInt32(true), true), true))
 
     types = Seq(
       PCanonicalArray(PCanonicalArray(PInt32(true), true), true),
       PCanonicalArray(PCanonicalArray(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PCanonicalArray(PInt32(false), true), true))
 
     types = Seq(
       PCanonicalArray(PCanonicalArray(PInt32(true), false), true),
       PCanonicalArray(PCanonicalArray(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PCanonicalArray(PInt32(false), false), true))
 
     types = Seq(
       PCanonicalArray(PCanonicalArray(PInt32(true), false), false),
       PCanonicalArray(PCanonicalArray(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalArray(PCanonicalArray(PInt32(false), false), false))
   }
 
   @Test def testGetNestedPStream() {
     var types = Seq(PCanonicalStream(PInt32(true), true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(true), true))
 
     types = Seq(PCanonicalStream(PInt32(true), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(true), false))
 
     types = Seq(PCanonicalStream(PInt32(false), true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(false), true))
 
     types = Seq(PCanonicalStream(PInt32(false), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(false), false))
 
     types = Seq(
       PCanonicalStream(PInt32(true), true),
       PCanonicalStream(PInt32(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(true), true))
 
     types = Seq(
       PCanonicalStream(PInt32(false), true),
       PCanonicalStream(PInt32(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(false), true))
 
     types = Seq(
       PCanonicalStream(PInt32(false), true),
       PCanonicalStream(PInt32(true), false)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PInt32(false), false))
 
     types = Seq(
       PCanonicalStream(PCanonicalStream(PInt32(true), true), true),
       PCanonicalStream(PCanonicalStream(PInt32(true), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PCanonicalStream(PInt32(true), true), true))
 
     types = Seq(
       PCanonicalStream(PCanonicalStream(PInt32(true), true), true),
       PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), true), true))
 
     types = Seq(
       PCanonicalStream(PCanonicalStream(PInt32(true), false), true),
       PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), false), true))
 
     types = Seq(
       PCanonicalStream(PCanonicalStream(PInt32(true), false), false),
       PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), false), false))
   }
 
   @Test def testGetNestedElementPCanonicalDict() {
     var types = Seq(PCanonicalDict(PInt32(true), PCanonicalString(true), true))
-    var res  = InferPType.unifyPTypes(types)
+    var res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalString(true), true))
 
     types = Seq(PCanonicalDict(PInt32(false), PCanonicalString(true), true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(false), PCanonicalString(true), true))
 
     types = Seq(PCanonicalDict(PInt32(true), PCanonicalString(false), true))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalString(false), true))
 
     types = Seq(PCanonicalDict(PInt32(true), PCanonicalString(true), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalString(true), false))
 
     types = Seq(PCanonicalDict(PInt32(false), PCanonicalString(false), false))
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(false), PCanonicalString(false), false))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalString(true), true),
       PCanonicalDict(PInt32(true), PCanonicalString(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalString(true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalString(true), false),
       PCanonicalDict(PInt32(true), PCanonicalString(true), false)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalString(true), false))
 
     types = Seq(
       PCanonicalDict(PInt32(false), PCanonicalString(true), true),
       PCanonicalDict(PInt32(true), PCanonicalString(true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(false), PCanonicalString(true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(false), PCanonicalString(true), true),
       PCanonicalDict(PInt32(true), PCanonicalString(false), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(false), PCanonicalString(false), true))
 
     types = Seq(
       PCanonicalDict(PInt32(false), PCanonicalString(true), false),
       PCanonicalDict(PInt32(true), PCanonicalString(false), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(false), PCanonicalString(false), false))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(true), true), true),
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(true), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(true), true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(true), true), true),
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(true), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(true), true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(true), true), true),
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(false), true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(true), true), true),
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(false), true), true))
 
     types = Seq(
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(true), false), true),
       PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(true), PCanonicalString(false), true), true)
     )
-    res  = InferPType.unifyPTypes(types)
+    res  = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalDict(PInt32(true), PCanonicalDict(PInt32(false), PCanonicalString(false), false), true))
   }
 
   @Test def testGetNestedElementPCanonicalStruct() {
     var types = Seq(PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
-    var res = InferPType.unifyPTypes(types)
+    var res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(PCanonicalStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(PCanonicalStruct(true, "a" -> PInt32(false), "b" -> PInt32(true)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PInt32(false), "b" -> PInt32(true)))
 
     types = Seq(PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(false)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(false)))
 
     types = Seq(PCanonicalStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)),
       PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32(true)),
       PCanonicalStruct(true, "a" -> PInt32(false), "b" -> PInt32(false))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PCanonicalStruct(false, "a" -> PInt32(true), "b" -> PInt32(true)),
       PCanonicalStruct(true, "a" -> PInt32(false), "b" -> PInt32(false))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(false, "a" -> PInt32(false), "b" -> PInt32(false)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)),"b" -> PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(false), "d" -> PInt32(true)),"b" -> PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(false), "d" -> PInt32(true)), "b" -> PInt32(true)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)),
       PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)))
 
     types = Seq(
       PCanonicalStruct(true, "a" -> PCanonicalStruct(false, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)),
       PCanonicalStruct(true, "a" -> PCanonicalStruct(true, "c" -> PInt32(true), "d" -> PInt32(true)), "b" -> PInt32(true)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalStruct(true, "a" -> PCanonicalStruct(false, "c" -> PInt32(false), "d" -> PInt32(false)), "b" -> PInt32(true)))
   }
 
   @Test def testGetNestedElementPCanonicalTuple() {
     var types = Seq(PCanonicalTuple(true, PInt32(true)))
-    var res = InferPType.unifyPTypes(types)
+    var res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(true, PInt32(true)))
 
     types = Seq(PCanonicalTuple(false, PInt32(true)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(false, PInt32(true)))
 
     types = Seq(PCanonicalTuple(true, PInt32(false)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(true, PInt32(false)))
 
     types = Seq(PCanonicalTuple(false, PInt32(false)))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(false, PInt32(false)))
 
     types = Seq(
       PCanonicalTuple(true, PInt32(true)),
       PCanonicalTuple(true, PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(true, PInt32(true)))
 
     types = Seq(
       PCanonicalTuple(true, PInt32(true)),
       PCanonicalTuple(false, PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(false, PInt32(true)))
 
     types = Seq(
       PCanonicalTuple(true, PInt32(false)),
       PCanonicalTuple(false, PInt32(true))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(false, PInt32(false)))
 
     types = Seq(
       PCanonicalTuple(true, PCanonicalTuple(true, PInt32(true))),
       PCanonicalTuple(true, PCanonicalTuple(true, PInt32(false)))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(true, PCanonicalTuple(true, PInt32(false))))
 
     types = Seq(
       PCanonicalTuple(true, PCanonicalTuple(false, PInt32(true))),
       PCanonicalTuple(true, PCanonicalTuple(true, PInt32(false)))
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalTuple(true, PCanonicalTuple(false, PInt32(false))))
   }
 
   @Test def testGetNestedElementPCanonicalSet() {
     var types = Seq(PCanonicalSet(PInt32(true), true))
-    var res = InferPType.unifyPTypes(types)
+    var res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(true), true))
 
     types = Seq(PCanonicalSet(PInt32(true), false))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(true), false))
 
     types = Seq(PCanonicalSet(PInt32(false), true))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(false), true))
 
     types = Seq(PCanonicalSet(PInt32(false), false))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(false), false))
 
     types = Seq(
       PCanonicalSet(PInt32(true), true),
       PCanonicalSet(PInt32(true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(true), true))
 
     types = Seq(
       PCanonicalSet(PInt32(false), true),
       PCanonicalSet(PInt32(true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(false), true))
 
     types = Seq(
       PCanonicalSet(PInt32(false), true),
       PCanonicalSet(PInt32(true), false)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PInt32(false), false))
 
     types = Seq(
       PCanonicalSet(PCanonicalSet(PInt32(true), true), true),
       PCanonicalSet(PCanonicalSet(PInt32(true), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PCanonicalSet(PInt32(true), true), true))
 
     types = Seq(
       PCanonicalSet(PCanonicalSet(PInt32(true), true), true),
       PCanonicalSet(PCanonicalSet(PInt32(false), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PCanonicalSet(PInt32(false), true), true))
 
     types = Seq(
       PCanonicalSet(PCanonicalSet(PInt32(true), false), true),
       PCanonicalSet(PCanonicalSet(PInt32(false), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalSet(PCanonicalSet(PInt32(false), false), true))
   }
 
   @Test def testGetNestedElementPCanonicalInterval() {
     var types = Seq(PCanonicalInterval(PInt32(true), true))
-    var res = InferPType.unifyPTypes(types)
+    var res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(true), true))
 
     types = Seq(PCanonicalInterval(PInt32(true), false))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(true), false))
 
     types = Seq(PCanonicalInterval(PInt32(false), true))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(false), true))
 
     types = Seq(PCanonicalInterval(PInt32(false), false))
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(false), false))
 
     types = Seq(
       PCanonicalInterval(PInt32(true), true),
       PCanonicalInterval(PInt32(true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(true), true))
 
     types = Seq(
       PCanonicalInterval(PInt32(false), true),
       PCanonicalInterval(PInt32(true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(false), true))
 
     types = Seq(
       PCanonicalInterval(PInt32(true), true),
       PCanonicalInterval(PInt32(true), false)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(true), false))
 
     types = Seq(
       PCanonicalInterval(PInt32(false), true),
       PCanonicalInterval(PInt32(true), false)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PInt32(false), false))
 
     types = Seq(
       PCanonicalInterval(PCanonicalInterval(PInt32(true), true), true),
       PCanonicalInterval(PCanonicalInterval(PInt32(true), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PCanonicalInterval(PInt32(true), true), true))
 
     types = Seq(
       PCanonicalInterval(PCanonicalInterval(PInt32(true), false), true),
       PCanonicalInterval(PCanonicalInterval(PInt32(true), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PCanonicalInterval(PInt32(true), false), true))
 
     types = Seq(
       PCanonicalInterval(PCanonicalInterval(PInt32(false), true), true),
       PCanonicalInterval(PCanonicalInterval(PInt32(true), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PCanonicalInterval(PInt32(false), true), true))
 
     types = Seq(
       PCanonicalInterval(PCanonicalInterval(PInt32(true), false), true),
       PCanonicalInterval(PCanonicalInterval(PInt32(false), true), true)
     )
-    res = InferPType.unifyPTypes(types)
+    res = InferPType.getCompatiblePType(types)
     assert(res == PCanonicalInterval(PCanonicalInterval(PInt32(false), false), true))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -136,20 +136,6 @@ class IRSuite extends HailSuite {
     assertPType(False(), PBoolean(true))
   }
 
-  @Test def testRefInferPtype() {
-    val env = Env[PType](
-      "1" -> PCanonicalStruct(true, "a" -> PCanonicalArray(PCanonicalArray(PInt32(false), true), false), "b" -> PInt32(true), "c" -> PCanonicalDict(PInt32(false), PCanonicalString(false), false)),
-      "2" -> PCanonicalStruct(true, "a" -> PCanonicalArray(PCanonicalArray(PInt32(true), true), true), "b" -> PInt32(true), "c" -> PCanonicalDict(PInt32(true), PCanonicalString(true), true))
-    )
-
-    var ir = Ref("1", TStruct("a" -> TArray(TArray(TInt32)), "b" -> TInt32, "c" -> TDict(TInt32, TString)))
-
-    assertPType(ir, PCanonicalStruct(true, "a" -> PCanonicalArray(PCanonicalArray(PInt32(false), true), false), "b" -> PInt32(true), "c" -> PCanonicalDict(PInt32(false), PCanonicalString(false), false)), env)
-
-    ir = Ref("2", TStruct("a" -> TArray(TArray(TInt32)), "b" -> TInt32, "c" -> TDict(TInt32, TString)))
-    assertPType(ir, PCanonicalStruct(true, "a" -> PCanonicalArray(PCanonicalArray(PInt32(true), true), true), "b" -> PInt32(true), "c" -> PCanonicalDict(PInt32(true), PCanonicalString(true), true)), env)
-  }
-
   // FIXME Void() doesn't work because we can't handle a void type in a tuple
 
   @Test def testCast() {


### PR DESCRIPTION
Fixing the InferPType pass with requiredness to correctly handle nested non-canonical PTypes, as discussed.

I ended up merging the new pass and the old pass, since the new pass *should* now be able to handle aggregator nodes using the existing agg inference stuff.