### PR TITLE
StreamLen node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -81,6 +81,8 @@ object Children {
       Array(orderedCollection, elem)
     case GroupByKey(collection) =>
       Array(collection)
+    case StreamLen(a) =>
+      Array(a)
     case StreamTake(a, len) =>
       Array(a, len)
     case StreamDrop(a, len) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -81,7 +81,7 @@ object Children {
       Array(orderedCollection, elem)
     case GroupByKey(collection) =>
       Array(collection)
-    case StreamLen(a) =>
+    case StreamLength(a) =>
       Array(a)
     case StreamTake(a, len) =>
       Array(a, len)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -81,7 +81,7 @@ object Children {
       Array(orderedCollection, elem)
     case GroupByKey(collection) =>
       Array(collection)
-    case StreamLength(a) =>
+    case StreamLen(a) =>
       Array(a)
     case StreamTake(a, len) =>
       Array(a, len)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -135,8 +135,8 @@ object Copy {
       case GroupByKey(_) =>
         assert(newChildren.length == 1)
         GroupByKey(newChildren(0).asInstanceOf[IR])
-      case StreamLength(_) =>
-        StreamLength(newChildren(0).asInstanceOf[IR])
+      case StreamLen(_) =>
+        StreamLen(newChildren(0).asInstanceOf[IR])
       case StreamTake(_, _) =>
         assert(newChildren.length == 2)
         StreamTake(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -135,8 +135,8 @@ object Copy {
       case GroupByKey(_) =>
         assert(newChildren.length == 1)
         GroupByKey(newChildren(0).asInstanceOf[IR])
-      case StreamLen(_) =>
-        StreamLen(newChildren(0).asInstanceOf[IR])
+      case StreamLength(_) =>
+        StreamLength(newChildren(0).asInstanceOf[IR])
       case StreamTake(_, _) =>
         assert(newChildren.length == 2)
         StreamTake(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -135,6 +135,8 @@ object Copy {
       case GroupByKey(_) =>
         assert(newChildren.length == 1)
         GroupByKey(newChildren(0).asInstanceOf[IR])
+      case StreamLen(_) =>
+        StreamLen(newChildren(0).asInstanceOf[IR])
       case StreamTake(_, _) =>
         assert(newChildren.length == 2)
         StreamTake(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1231,10 +1231,10 @@ class Emit[C](
         val lenOpt = streamOpt.map { ss =>
           val count = mb.newLocal[Int]("stream_length")
           val lenCode = Code(
-            const(ss.length.isDefined).mux(
-              count := ss.length.get,
-              ss.getStream.forEach(mb, _ => count := count + 1)
-            ),
+            count := 0,
+            ss.getStream.forEach(mb, _ => count := count + 1),
+            Code._println("Computed length ="),
+            Code._println(count.get.toS),
             count.get
           )
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1230,14 +1230,15 @@ class Emit[C](
         val streamOpt = emitStream(a)
         val lenOpt = streamOpt.map { ss =>
           val count = mb.newLocal[Int]("stream_length")
-          val lenCode = Code(
-            count := 0,
-            ss.getStream.forEach(mb, _ => count := count + 1),
-            Code._println("Computed length ="),
-            Code._println(count.get.toS),
-            count.get
-          )
-
+          val lenCode =
+            ss.length match {
+              case Some(len) => Code(ss.setup, len)
+              case None =>
+                Code(
+                  ss.getStream.forEach(mb, _ => count := count + 1),
+                  count.get
+                )
+            }
           PCode(x.pType, lenCode)
         }
         COption.toEmitCode(lenOpt, mb)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1229,13 +1229,15 @@ class Emit[C](
       case x@StreamLength(a) =>
         val streamOpt = emitStream(a)
         val lenOpt = streamOpt.map { ss =>
-          val lenCode = ss.length.getOrElse {
-            val count = mb.newLocal[Int]("stream_length")
-            Code(
-              ss.getStream.forEach(mb, _ => count := count + 1),
-              count.get
-            )
-          }
+          val count = mb.newLocal[Int]("stream_length")
+          val lenCode = Code(
+            const(ss.length.isDefined).mux(
+              count := ss.length.get,
+              ss.getStream.forEach(mb, _ => count := count + 1)
+            ),
+            count.get
+          )
+
           PCode(x.pType, lenCode)
         }
         COption.toEmitCode(lenOpt, mb)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1226,7 +1226,7 @@ class Emit[C](
         )
         EmitCode(lengthTriplet.setup, lengthTriplet.m, PCode(pt, result))
 
-      case x@StreamLen(a) =>
+      case x@StreamLength(a) =>
         val streamOpt = emitStream(a)
         val lenOpt = streamOpt.map { ss =>
           val lenCode = ss.length.getOrElse {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1226,7 +1226,7 @@ class Emit[C](
         )
         EmitCode(lengthTriplet.setup, lengthTriplet.m, PCode(pt, result))
 
-      case x@StreamLength(a) =>
+      case x@StreamLen(a) =>
         val streamOpt = emitStream(a)
         val lenOpt = streamOpt.map { ss =>
           val count = mb.newLocal[Int]("stream_length")

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -773,6 +773,7 @@ object EmitStream {
                 (startt.m || stopt.m || stept.m).mux[Unit](
                   none,
                   Code(
+                    Code._println("Making a StreamRange"),
                     start := startt.value,
                     stop := stopt.value,
                     step := stept.value,
@@ -783,7 +784,12 @@ object EmitStream {
                     (llen > const(Int.MaxValue.toLong)).mux[Unit](
                       Code._fatal[Unit]("Array range cannot have more than MAXINT elements."),
                       some(SizedStream(
-                        len := llen.toI,
+                        Code(
+                          Code._println("Going to set len"),
+                          len := llen.toI,
+                          Code._println("len just set"),
+                          Code._println(len.get.toS)
+                        ),
                         range(mb, start, step, len)
                           .map(i => EmitCode(Code._empty, const(false), PCode(eltType, i))),
                         Some(len)))))))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -773,7 +773,6 @@ object EmitStream {
                 (startt.m || stopt.m || stept.m).mux[Unit](
                   none,
                   Code(
-                    Code._println("Making a StreamRange"),
                     start := startt.value,
                     stop := stopt.value,
                     step := stept.value,
@@ -784,12 +783,7 @@ object EmitStream {
                     (llen > const(Int.MaxValue.toLong)).mux[Unit](
                       Code._fatal[Unit]("Array range cannot have more than MAXINT elements."),
                       some(SizedStream(
-                        Code(
-                          Code._println("Going to set len"),
-                          len := llen.toI,
-                          Code._println("len just set"),
-                          Code._println(len.get.toS)
-                        ),
+                        len := llen.toI,
                         range(mb, start, step, len)
                           .map(i => EmitCode(Code._empty, const(false), PCode(eltType, i))),
                         Some(len)))))))

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -213,7 +213,7 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 
 final case class GroupByKey(collection: IR) extends IR
 
-final case class StreamLen(a: IR) extends IR
+final case class StreamLength(a: IR) extends IR
 
 final case class StreamGrouped(a: IR, groupSize: IR) extends IR
 final case class StreamGroupByKey(a: IR, key: IndexedSeq[String]) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -213,6 +213,8 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 
 final case class GroupByKey(collection: IR) extends IR
 
+final case class StreamLen(a: IR) extends IR
+
 final case class StreamGrouped(a: IR, groupSize: IR) extends IR
 final case class StreamGroupByKey(a: IR, key: IndexedSeq[String]) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -213,7 +213,7 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 
 final case class GroupByKey(collection: IR) extends IR
 
-final case class StreamLength(a: IR) extends IR
+final case class StreamLen(a: IR) extends IR
 
 final case class StreamGrouped(a: IR, groupSize: IR) extends IR
 final case class StreamGroupByKey(a: IR, key: IndexedSeq[String]) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -311,7 +311,7 @@ object InferPType {
         infer(collection)
         val elt = coerce[PBaseStruct](coerce[PStream](collection.pType).elementType)
         PCanonicalDict(elt.types(0), PCanonicalArray(elt.types(1)), collection.pType.required)
-      case StreamLength(a) =>
+      case StreamLen(a) =>
         infer(a)
         PInt32(a.pType.required)
       case StreamTake(a, len) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -311,7 +311,7 @@ object InferPType {
         infer(collection)
         val elt = coerce[PBaseStruct](coerce[PStream](collection.pType).elementType)
         PCanonicalDict(elt.types(0), PCanonicalArray(elt.types(1)), collection.pType.required)
-      case StreamLen(a) =>
+      case StreamLength(a) =>
         infer(a)
         PInt32(a.pType.required)
       case StreamTake(a, len) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -311,6 +311,9 @@ object InferPType {
         infer(collection)
         val elt = coerce[PBaseStruct](coerce[PStream](collection.pType).elementType)
         PCanonicalDict(elt.types(0), PCanonicalArray(elt.types(1)), collection.pType.required)
+      case StreamLen(a) =>
+        infer(a)
+        PInt32(a.pType.required)
       case StreamTake(a, len) =>
         infer(a)
         infer(len)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -95,7 +95,7 @@ object InferType {
       case ToStream(a) =>
         val elt = coerce[TIterable](a.typ).elementType
         TStream(elt)
-      case StreamLength(a) => TInt32
+      case StreamLen(a) => TInt32
       case GroupByKey(collection) =>
         val elt = coerce[TBaseStruct](coerce[TStream](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -95,6 +95,7 @@ object InferType {
       case ToStream(a) =>
         val elt = coerce[TIterable](a.typ).elementType
         TStream(elt)
+      case StreamLen(a) => TInt32
       case GroupByKey(collection) =>
         val elt = coerce[TBaseStruct](coerce[TStream](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -95,7 +95,7 @@ object InferType {
       case ToStream(a) =>
         val elt = coerce[TIterable](a.typ).elementType
         TStream(elt)
-      case StreamLen(a) => TInt32
+      case StreamLength(a) => TInt32
       case GroupByKey(collection) =>
         val elt = coerce[TBaseStruct](coerce[TStream](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -252,6 +252,12 @@ object Interpret {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Any]].length
+      case StreamLen(a) =>
+        val aValue = interpret(a, env, args)
+        if (aValue == null)
+          null
+        else
+          aValue.asInstanceOf[IndexedSeq[Any]].length
       case StreamRange(start, stop, step) =>
         val startValue = interpret(start, env, args)
         val stopValue = interpret(stop, env, args)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -252,7 +252,7 @@ object Interpret {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Any]].length
-      case StreamLen(a) =>
+      case StreamLength(a) =>
         val aValue = interpret(a, env, args)
         if (aValue == null)
           null

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -252,7 +252,7 @@ object Interpret {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Any]].length
-      case StreamLength(a) =>
+      case StreamLen(a) =>
         val aValue = interpret(a, env, args)
         if (aValue == null)
           null

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -779,6 +779,7 @@ object IRParser {
         val s = ir_value_expr(env)(it)
         ArrayRef(a, i, s)
       case "ArrayLen" => ArrayLen(ir_value_expr(env)(it))
+      case "StreamLen" => StreamLen(ir_value_expr(env)(it))
       case "StreamRange" =>
         val start = ir_value_expr(env)(it)
         val stop = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -205,6 +205,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case _: ApplyBinaryPrimOp |
            _: ApplyUnaryPrimOp |
            _: ArrayLen |
+           _: StreamLen |
            _: ArrayZeros |
            _: StreamRange |
            _: WriteValue =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -205,7 +205,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case _: ApplyBinaryPrimOp |
            _: ApplyUnaryPrimOp |
            _: ArrayLen |
-           _: StreamLength |
+           _: StreamLen |
            _: ArrayZeros |
            _: StreamRange |
            _: WriteValue =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -205,7 +205,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case _: ApplyBinaryPrimOp |
            _: ApplyUnaryPrimOp |
            _: ArrayLen |
-           _: StreamLen |
+           _: StreamLength |
            _: ArrayZeros |
            _: StreamRange |
            _: WriteValue =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -193,14 +193,16 @@ object Simplify {
 
     case ArrayLen(MakeArray(args, _)) => I32(args.length)
 
-    case ArrayLen(ToArray(StreamMap(s, _, _))) => ArrayLen(ToArray(s))
+    case ArrayLen(ToArray(StreamMap(s, _, _))) => StreamLen(s)
+    case StreamLen(StreamMap(s, _, _)) => StreamLen(s)
 
     case ArrayLen(StreamFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
 
     case ArrayLen(ArraySort(a, _, _, _)) => ArrayLen(ToArray(a))
 
     case ArrayLen(ToArray(MakeStream(args, _))) => I32(args.length)
-      
+    case StreamLen(MakeStream(args, _)) => I32(args.length)
+
     case ArrayRef(MakeArray(args, _), I32(i), _) if i >= 0 && i < args.length => args(i)
 
     case StreamFilter(a, _, True()) => a
@@ -229,7 +231,7 @@ object Simplify {
 
     case ToStream(Let(name, value, ToArray(x))) if x.typ.isInstanceOf[TStream] => Let(name, value, x)
 
-    case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => foldIR(s, 0){ case (acc, _) => acc + 1}
+    case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => StreamLen(s)
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -195,6 +195,7 @@ object Simplify {
 
     case ArrayLen(ToArray(StreamMap(s, _, _))) => StreamLen(s)
     case StreamLen(StreamMap(s, _, _)) => StreamLen(s)
+    case StreamLen(StreamFlatMap(a, name, body)) => streamSumIR(StreamMap(a, name, StreamLen(body)))
 
     case ArrayLen(StreamFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -193,10 +193,10 @@ object Simplify {
 
     case ArrayLen(MakeArray(args, _)) => I32(args.length)
 
-    case ArrayLen(ToArray(StreamMap(s, _, _))) => StreamLen(s)
     case StreamLen(StreamMap(s, _, _)) => StreamLen(s)
     case StreamLen(StreamFlatMap(a, name, body)) => streamSumIR(StreamMap(a, name, StreamLen(body)))
 
+    case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => StreamLen(s)
     case ArrayLen(StreamFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
 
     case ArrayLen(ArraySort(a, _, _, _)) => ArrayLen(ToArray(a))
@@ -231,8 +231,6 @@ object Simplify {
     case ToStream(ToArray(s)) if s.typ.isInstanceOf[TStream] => s
 
     case ToStream(Let(name, value, ToArray(x))) if x.typ.isInstanceOf[TStream] => Let(name, value, x)
-
-    case ArrayLen(ToArray(s)) if s.typ.isInstanceOf[TStream] => StreamLen(s)
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -257,7 +257,7 @@ object TypeCheck {
         val td = coerce[TDict](x.typ)
         assert(td.keyType == telt.types(0))
         assert(td.valueType == TArray(telt.types(1)))
-      case StreamLen(a) =>
+      case StreamLength(a) =>
         assert(a.typ.isInstanceOf[TStream])
       case x@StreamTake(a, num) =>
         assert(a.typ.isInstanceOf[TStream])

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -257,7 +257,7 @@ object TypeCheck {
         val td = coerce[TDict](x.typ)
         assert(td.keyType == telt.types(0))
         assert(td.valueType == TArray(telt.types(1)))
-      case StreamLength(a) =>
+      case StreamLen(a) =>
         assert(a.typ.isInstanceOf[TStream])
       case x@StreamTake(a, num) =>
         assert(a.typ.isInstanceOf[TStream])

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -257,6 +257,8 @@ object TypeCheck {
         val td = coerce[TDict](x.typ)
         assert(td.keyType == telt.types(0))
         assert(td.valueType == TArray(telt.types(1)))
+      case StreamLen(a) =>
+        assert(a.typ.isInstanceOf[TStream])
       case x@StreamTake(a, num) =>
         assert(a.typ.isInstanceOf[TStream])
         assert(x.typ == a.typ)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -22,6 +22,7 @@ object ExecStrategy extends Enumeration {
   type ExecStrategy = Value
   val Interpret, InterpretUnoptimized, JvmCompile, LoweredJVMCompile, JvmCompileUnoptimized = Value
 
+  val unoptimizedCompileOnly: Set[ExecStrategy] = Set(JvmCompileUnoptimized)
   val compileOnly: Set[ExecStrategy] = Set(JvmCompile, JvmCompileUnoptimized)
   val javaOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile, JvmCompileUnoptimized)
   val interpretOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1752,11 +1752,11 @@ class IRSuite extends HailSuite {
     assertEvalsTo(LowerBoundOnOrderedCollection(dwoutna, NA(TInt32), onKey = true), 2)
   }
 
-  @Test def testStreamLength(): Unit = {
-    val a = StreamLength(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
+  @Test def testStreamLen(): Unit = {
+    val a = StreamLen(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
     assertEvalsTo(a, 3)
 
-    val range1 = StreamLength(StreamRange(1, 12, 1))
+    val range1 = StreamLen(StreamRange(1, 12, 1))
     assertEvalsTo(range1, 11)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1770,6 +1770,9 @@ class IRSuite extends HailSuite {
 
     val streamOfStreams = mapIR(rangeIR(5)) { elementRef => rangeIR(elementRef) }
     assertEvalsTo(StreamLen(flatMapIR(streamOfStreams){ x => x}), 4 + 3 + 2 + 1)
+
+    val filteredRange = StreamLen(StreamFilter(rangeIR(12), "x", irToPrimitiveIR(Ref("x", TInt32)) < 5))
+    assertEvalsTo(filteredRange, 5)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1755,6 +1755,9 @@ class IRSuite extends HailSuite {
   @Test def testStreamLength(): Unit = {
     val a = StreamLength(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
     assertEvalsTo(a, 3)
+
+    val range1 = StreamLength(StreamRange(0, 12, 1))
+    assertEvalsTo(range1, 12)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1765,6 +1765,8 @@ class IRSuite extends HailSuite {
     assertEvalsTo(range2, 10)
     val range3 = StreamLen(StreamRange(-10, 5, 1))
     assertEvalsTo(range3, 15)
+    val mappedRange = StreamLen(mapIR(StreamRange(2, 7, 1)) { ref => maxIR(ref, 3)})
+    assertEvalsTo(mappedRange, 5)
 
     val streamOfStreams = mapIR(rangeIR(5)) { elementRef => rangeIR(elementRef) }
     assertEvalsTo(StreamLen(flatMapIR(streamOfStreams){ x => x}), 4 + 3 + 2 + 1)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1756,8 +1756,8 @@ class IRSuite extends HailSuite {
     val a = StreamLength(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
     assertEvalsTo(a, 3)
 
-    val range1 = StreamLength(StreamRange(0, 12, 1))
-    assertEvalsTo(range1, 12)
+    val range1 = StreamLength(StreamRange(1, 12, 1))
+    assertEvalsTo(range1, 11)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1752,6 +1752,11 @@ class IRSuite extends HailSuite {
     assertEvalsTo(LowerBoundOnOrderedCollection(dwoutna, NA(TInt32), onKey = true), 2)
   }
 
+  @Test def testStreamLength(): Unit = {
+    val a = StreamLen(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
+    assertEvalsTo(a, 3)
+  }
+
   @Test def testStreamTake() {
     val naa = NA(TStream(TInt32))
     val a = MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1765,6 +1765,9 @@ class IRSuite extends HailSuite {
     assertEvalsTo(range2, 10)
     val range3 = StreamLen(StreamRange(-10, 5, 1))
     assertEvalsTo(range3, 15)
+
+    val streamOfStreams = mapIR(rangeIR(5)) { elementRef => rangeIR(elementRef) }
+    assertEvalsTo(StreamLen(flatMapIR(streamOfStreams){ x => x}), 4 + 3 + 2 + 1)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1756,8 +1756,15 @@ class IRSuite extends HailSuite {
     val a = StreamLen(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
     assertEvalsTo(a, 3)
 
-    val range1 = StreamLen(StreamRange(1, 12, 1))
-    assertEvalsTo(range1, 11)
+    val missing = StreamLen(NA(TStream(TInt64)))
+    assertEvalsTo(missing, null)
+
+    val range1 = StreamLen(StreamRange(1, 11, 1))
+    assertEvalsTo(range1, 10)
+    val range2 = StreamLen(StreamRange(20, 40, 2))
+    assertEvalsTo(range2, 10)
+    val range3 = StreamLen(StreamRange(-10, 5, 1))
+    assertEvalsTo(range3, 15)
   }
 
   @Test def testStreamTake() {
@@ -2699,6 +2706,7 @@ class IRSuite extends HailSuite {
       NDArrayFilter(nd, FastIndexedSeq(NA(TArray(TInt64)), NA(TArray(TInt64)))),
       ArrayRef(a, i),
       ArrayLen(a),
+      StreamLen(st),
       StreamRange(I32(0), I32(5), I32(1)),
       StreamRange(I32(0), I32(5), I32(1)),
       ArraySort(st, b),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1753,7 +1753,7 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testStreamLength(): Unit = {
-    val a = StreamLen(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
+    val a = StreamLength(MakeStream(Seq(I32(3), NA(TInt32), I32(7)), TStream(TInt32)))
     assertEvalsTo(a, 3)
   }
 


### PR DESCRIPTION
I added a `StreamLen` IR node. The justification for this were optimization issues in `Simplify` situations like

```
case ArrayLen(ToArray(StreamMap(s, _, _))) => ArrayLen(ToArray(s))
```

The above is not a valid optimization in all cases because if the elements of `s` are not realizable, the optimization will have created an invalid IR that will fail at emit time since elements of an array must be realizable.