### PR TITLE
[batch] fix exit code if error is in container execution

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -468,6 +468,7 @@ echo $HAIL_BATCH_WORKER_IP
         self.assertEqual(status['state'], 'Error', (status, j.log()))
         error_msg = j._get_error(status, 'main')
         assert error_msg and 'JobTimeoutError' in error_msg
+        assert j.exit_code(status) is None, status
 
     def test_client_max_size(self):
         builder = self.client.create_batch()

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -67,6 +67,10 @@ class Job:
 
     @staticmethod
     def _get_container_status_exit_code(container_status):
+        error = container_status.get('error')
+        if error is not None:
+            return None
+
         docker_container_status = container_status.get('container_status')
         if not docker_container_status:
             return None


### PR DESCRIPTION
There are two errors in the status returned by the worker: one is caught when executing the job and the other is when executing the container (such as uploading log to google storage or timeout error). We were only handling job-level errors correctly.