### PR TITLE
[query][bugfix] fix handling of subsetted tuples in Requiredness

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -354,8 +354,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(ndReq.required && idxs.forall(lookup(_).required))
       case NDArraySlice(nd, slices) =>
         val slicesReq = lookupAs[RTuple](slices)
-        val allSlicesRequired = slicesReq.types.forall {
-          case r: RTuple => r.required && r.types.forall(_.required)
+        val allSlicesRequired = slicesReq.fields.map(_.typ).forall {
+          case r: RTuple => r.required && r.fields.forall(_.typ.required)
           case r => r.required
         }
         requiredness.unionFrom(lookup(nd))
@@ -378,7 +378,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         }
       case MakeTuple(fields) =>
         fields.foreach { case (i, f) =>
-          coerce[RTuple](requiredness).types(i).unionFrom(lookup(f))
+          coerce[RTuple](requiredness).field(i).unionFrom(lookup(f))
         }
       case SelectFields(old, fields) =>
         val oldReq = lookupAs[RStruct](old)
@@ -405,7 +405,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case GetTupleElement(o, idx) =>
         val oldReq = lookupAs[RTuple](o)
         requiredness.union(oldReq.required)
-        requiredness.unionFrom(oldReq.fields(idx).typ)
+        requiredness.unionFrom(oldReq.field(idx))
       case x: ApplyIR => requiredness.unionFrom(lookup(x.body))
       case x: AbstractApplyNode[_] => //FIXME: round-tripping via PTypes.
         val argP = x.args.map(a => lookup(a).canonicalPType(a.typ))


### PR DESCRIPTION
Requiredness stuff was assuming that tuples were well-ordered and contiguously indexed, which is wrong because the pruner can prune tuple elements.

See https://discuss.hail.is/t/arrayindexoutofboundsexception-error-in-hail-0-2-40/1413/5