### PR TITLE
Use configured compute zone as default for hailctl dataproc

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -13,8 +13,7 @@ def init_parser(parser):
                         help='Web service to launch.')
     parser.add_argument('--port', '-p', default='10000', type=str,
                         help='Local port to use for SSH tunnel to master node (default: %(default)s).')
-    parser.add_argument('--zone', '-z', default='us-central1-b', type=str,
-                        help='Compute zone for Dataproc cluster (default: %(default)s).')
+    parser.add_argument('--zone', '-z', type=str, help='Compute zone for Dataproc cluster.')
     parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
 
@@ -37,11 +36,19 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     }
     connect_port_and_path = dataproc_port_and_path[service]
 
+    if args.zone:
+        zone = args.zone
+    else:
+        zone = sp.check_output(["gcloud", "config", "get-value", "compute/zone"], stderr=sp.DEVNULL).decode().strip()
+
+    if not zone:
+        raise RuntimeError("Could not determine compute zone. Use --zone argument to hailctl, or use `gcloud config set compute/zone <my-zone>` to set a default.")
+
     cmd = ['gcloud',
            'compute',
            'ssh',
            '{}-m'.format(args.name),
-           '--zone={}'.format(args.zone),
+           '--zone={}'.format(zone),
            '--ssh-flag=-D {}'.format(args.port),
            '--ssh-flag=-N',
            '--ssh-flag=-f',


### PR DESCRIPTION
`hailctl dataproc connect` and `hailctl dataproc modify` hard-code a default compute zone of us-central1-b. This changes those two commands to use the `compute/zone` value from the user's gcloud configuration if a zone argument is not provided.

@johnc1231 [mentioned this in Zulip](https://hail.zulipchat.com/#narrow/stream/128581-Cloud-support/topic/Unable.20to.20launch.20notebook) the other day.