### PR TITLE
Improve error message for starting a cluster without a region

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -247,9 +247,12 @@ def main(args, pass_through_args):
         project_region = args.region
     else:
         try:
-            project_region = sp.check_output(['gcloud', 'config', 'get-value', 'dataproc/region']).decode().strip()
+            project_region = sp.check_output(['gcloud', 'config', 'get-value', 'dataproc/region'], stderr=sp.DEVNULL).decode().strip()
         except sp.CalledProcessError:
-            raise RuntimeError("Could not determine dataproc region. Use --region argument to hailctl, or use `gcloud config set dataproc/region <my-region>` to set a default.")
+            project_region = None
+
+    if not project_region:
+        raise RuntimeError("Could not determine dataproc region. Use --region argument to hailctl, or use `gcloud config set dataproc/region <my-region>` to set a default.")
 
     # add VEP init script
     if args.vep:


### PR DESCRIPTION
Currently, attempting to start a Dataproc cluster without either a region argument or a configured `dataproc/region` results in a long error message `subprocess.CalledProcessError: Command '['gcloud', 'dataproc', 'clusters', 'create', ... ]' returned non-zero exit status 1` with the actual cause obscured above the traceback. That cause is:
```
Failed to find attribute [region]. The attribute can be set in the following ways:
- provide the argument [--region] on the command line
- set the property [dataproc/region]
```

There is some logic to show a nicer error message if no region is provided. However, that is only shown if `gcloud config get-value dataproc/region` fails. When `dataproc/region` is not set, that command succeeds and outputs an empty string. This change handles that case and shows the nicer error message.

