### PR TITLE
[batch] fix memory, storage requests

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -66,7 +66,9 @@ def parse_memory_in_bytes(memory_string):
     if match:
         number = float(match.group(1))
         suffix = match.group(2)
-        return int(number * conv_factor[suffix])
+        if suffix:
+            return math.ceil(number * conv_factor[suffix])
+        return math.ceil(number)
     return None
 
 

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -1,4 +1,4 @@
-from batch.utils import adjust_cores_for_packability
+from batch.utils import adjust_cores_for_packability, parse_memory_in_bytes
 
 
 def test_packability():
@@ -16,3 +16,9 @@ def test_packability():
     assert adjust_cores_for_packability(4000) == 4000
     assert adjust_cores_for_packability(4001) == 8000
     assert adjust_cores_for_packability(8001) == 16000
+
+
+def test_memory_str_to_bytes():
+    assert parse_memory_in_bytes('7') == 7
+    assert parse_memory_in_bytes('1K') == 1000
+    assert parse_memory_in_bytes('1Ki') == 1024

--- a/hail/python/hailtop/batch/docs/change_log.rst
+++ b/hail/python/hailtop/batch/docs/change_log.rst
@@ -1,0 +1,8 @@
+.. _sec-change-log:
+
+Change Log
+==========
+
+**Version 0.2.42**
+
+- Fixed memory and storage requests to have default units in bytes

--- a/hail/python/hailtop/batch/docs/change_log.rst
+++ b/hail/python/hailtop/batch/docs/change_log.rst
@@ -5,4 +5,4 @@ Change Log
 
 **Version 0.2.42**
 
-- Fixed memory and storage requests to have default units in bytes
+- Fixed the documentation for job memory and storage requests to have default units in bytes.

--- a/hail/python/hailtop/batch/docs/change_log.rst
+++ b/hail/python/hailtop/batch/docs/change_log.rst
@@ -1,8 +1,0 @@
-.. _sec-change-log:
-
-Change Log
-==========
-
-**Version 0.2.42**
-
-- Fixed memory and storage requests to have default units in bytes

--- a/hail/python/hailtop/batch/docs/index.rst
+++ b/hail/python/hailtop/batch/docs/index.rst
@@ -21,7 +21,6 @@ Contents
    Docker Resources <docker_resources>
    Batch Service <service>
    Reference (Python API) <api>
-   Change Log <change_log>
 
 
 Indices and tables

--- a/hail/python/hailtop/batch/docs/index.rst
+++ b/hail/python/hailtop/batch/docs/index.rst
@@ -21,6 +21,7 @@ Contents
    Docker Resources <docker_resources>
    Batch Service <service>
    Reference (Python API) <api>
+   Change Log <change_log>
 
 
 Indices and tables

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -327,16 +327,26 @@ class Job:
         ...   .command(f'echo "hello"'))
         >>> b.run()
 
+        Notes
+        -----
+
+        The storage expression must be of the form {number}{suffix}
+        where valid optional suffixes are *K*, *Ki*, *M*, *Mi*,
+        *G*, *Gi*, *T*, *Ti*, *P*, and *Pi*. Omitting a suffix means
+        the value is in bytes.
+
         Parameters
         ----------
-        storage: :obj:`str`
+        storage: :obj:`str` or :obj:`int`
+            Units are in bytes if `storage` is an :obj:`int`.
 
         Returns
         -------
         :class:`.Job`
             Same job object with storage set.
         """
-        self._storage = storage
+
+        self._storage = str(storage)
         return self
 
     def memory(self, memory):
@@ -346,24 +356,33 @@ class Job:
         Examples
         --------
 
-        Set the job's memory requirement to 5GB:
+        Set the job's memory requirement to be 3Gi:
 
         >>> b = Batch()
         >>> j = b.new_job()
-        >>> (j.memory(5)
+        >>> (j.memory('3Gi')
         ...   .command(f'echo "hello"'))
         >>> b.run()
 
+        Notes
+        -----
+
+        The memory expression must be of the form {number}{suffix}
+        where valid optional suffixes are *K*, *Ki*, *M*, *Mi*,
+        *G*, *Gi*, *T*, *Ti*, *P*, and *Pi*. Omitting a suffix means
+        the value is in bytes.
+
         Parameters
         ----------
-        memory: :obj:`str` or :obj:`float` or :obj:`int`
-            Value is in GB.
+        memory: :obj:`str` or :obj:`int`
+            Units are in bytes if `memory` is an :obj:`int`.
 
         Returns
         -------
         :class:`.Job`
             Same job object with memory requirements set.
         """
+
         self._memory = str(memory)
         return self
 
@@ -371,20 +390,28 @@ class Job:
         """
         Set the job's CPU requirements.
 
+        Notes
+        -----
+
+        The string expression must be of the form {number}{suffix}
+        where the optional suffix is *m* representing millicpu.
+        Omitting a suffix means the value is in cpu.
+
         Examples
         --------
 
-        Set the job's CPU requirement to 0.1 cores:
+        Set the job's CPU requirement to 250 millicpu:
 
         >>> b = Batch()
         >>> j = b.new_job()
-        >>> (j.cpu(0.1)
+        >>> (j.cpu('250m')
         ...   .command(f'echo "hello"'))
         >>> b.run()
 
         Parameters
         ----------
-        cores: :obj:`str` or :obj:`float` or :obj:`int`
+        cores: :obj:`str` or :obj:`int` or :obj:`float`
+            Units are in cpu if `cores` is numeric.
 
         Returns
         -------


### PR DESCRIPTION
Fixes #8793 

This is a breaking change as numeric values for storage and memory are in bytes rather than GiB.

CHANGELOG: Fixed the documentation for job memory and storage requests to have default units in bytes.