### PR TITLE
[query] Fix bad tuple indexing on PCanonicalBaseStructSettable

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -724,7 +724,7 @@ class Emit[C](
           ov.loadField(cb, name)
         }
 
-      case gte@GetTupleElement(o, i) =>
+      case GetTupleElement(o, i) =>
         emitI(o).flatMap(cb) { oc =>
           val ov = oc.asBaseStruct.memoize(cb, "get_tup_elem_o")
           ov.loadField(cb, oc.pt.asInstanceOf[PTuple].fieldIndex(i))
@@ -1440,7 +1440,7 @@ class Emit[C](
       case In(i, expectedPType) =>
         // this, Code[Region], ...
         val ev = mb.getEmitParam(2 + i)
-        assert(ev.pt == expectedPType, s"${ev.pt} not equal to specified $expectedPType")
+        assert(ev.pt == expectedPType)
         ev
       case Die(m, typ) =>
         val cm = emit(m)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -727,23 +727,6 @@ class Emit[C](
       case gte@GetTupleElement(o, i) =>
         emitI(o).flatMap(cb) { oc =>
           val ov = oc.asBaseStruct.memoize(cb, "get_tup_elem_o")
-          if (oc.pt.isInstanceOf[PStruct]) {
-            val pstruct = oc.pt.asInstanceOf[PStruct]
-            println(s"gte.o.pType = ${gte.o.pType}, oc.pt = ${oc.pt}")
-
-            println("Bad pcode stack trace")
-            oc.stackTrace.foreach(x => println(x))
-
-//            println("Bad GetTupleElement stack trace")
-//            gte.stackTrace.foreach{x =>
-//              println(x)
-//            }
-//
-//            println("Stack trace")
-//            pstruct.stackTrace.foreach {x =>
-//              println(x)
-//            }
-          }
           ov.loadField(cb, oc.pt.asInstanceOf[PTuple].fieldIndex(i))
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1049,8 +1049,6 @@ class Emit[C](
             }
             val discardNext = mb.genEmitMethod("discardNext",
               FastIndexedSeq[ParamType](typeInfo[Region], eltType, eltType), typeInfo[Boolean])
-            val cmp2PreCopy = ApplyComparisonOp(EQWithNA(keyType.virtualType), k0, k1)
-            InferPType(cmp2PreCopy, Env.empty)
 
             val cmp2 = ApplyComparisonOp(EQWithNA(keyType.virtualType), k0, k1).deepCopy()
             InferPType(cmp2, Env.empty)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -727,7 +727,7 @@ class Emit[C](
       case GetTupleElement(o, i) =>
         emitI(o).flatMap(cb) { oc =>
           val ov = oc.asBaseStruct.memoize(cb, "get_tup_elem_o")
-          ov.loadField(cb, i)
+          ov.loadField(cb, oc.pt.asInstanceOf[PTuple].fieldIndex(i))
         }
 
       case x@MakeNDArray(dataIR, shapeIR, rowMajorIR) =>

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -242,23 +242,30 @@ class PCanonicalBaseStructSettable(
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
+  def loadField(cb: EmitCodeBuilder, i: Int): IEmitCode = {
+    val ptTuple = pt.asInstanceOf[PTuple]
+    val trueIndex = ptTuple.fieldIndex(i)
     IEmitCode(cb,
-      pt.isFieldMissing(a, fieldIdx),
-      pt.fields(fieldIdx).typ.load(pt.fieldOffset(a, fieldIdx)))
+      ptTuple.isFieldMissing(a, trueIndex),
+      ptTuple.fields(trueIndex).typ.load(pt.fieldOffset(a, trueIndex)))
   }
 
   def store(pv: PCode): Code[Unit] = {
     a := pv.asInstanceOf[PCanonicalBaseStructCode].a
   }
 
-  def apply[T](i: Int): Value[T] =
+  def apply[T](i: Int): Value[T] = {
+    val ptTuple = pt.asInstanceOf[PTuple]
+    val trueIndex = ptTuple.fieldIndex(i)
     new Value[T] {
-      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
+      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(trueIndex))(pt.loadField(a, trueIndex)))
     }
+  }
 
-  def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
-    this.pt.isFieldMissing(a, fieldIdx)
+  def isFieldMissing(i: Int): Code[Boolean] = {
+    val ptTuple = pt.asInstanceOf[PTuple]
+    val trueIndex = ptTuple.fieldIndex(i)
+    this.pt.isFieldMissing(a, trueIndex)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCanonicalBaseStruct.scala
@@ -242,30 +242,23 @@ class PCanonicalBaseStructSettable(
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  def loadField(cb: EmitCodeBuilder, i: Int): IEmitCode = {
-    val ptTuple = pt.asInstanceOf[PTuple]
-    val trueIndex = ptTuple.fieldIndex(i)
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     IEmitCode(cb,
-      ptTuple.isFieldMissing(a, trueIndex),
-      ptTuple.fields(trueIndex).typ.load(pt.fieldOffset(a, trueIndex)))
+      pt.isFieldMissing(a, fieldIdx),
+      pt.fields(fieldIdx).typ.load(pt.fieldOffset(a, fieldIdx)))
   }
 
   def store(pv: PCode): Code[Unit] = {
     a := pv.asInstanceOf[PCanonicalBaseStructCode].a
   }
 
-  def apply[T](i: Int): Value[T] = {
-    val ptTuple = pt.asInstanceOf[PTuple]
-    val trueIndex = ptTuple.fieldIndex(i)
+  def apply[T](i: Int): Value[T] =
     new Value[T] {
-      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(trueIndex))(pt.loadField(a, trueIndex)))
+      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
     }
-  }
 
-  def isFieldMissing(i: Int): Code[Boolean] = {
-    val ptTuple = pt.asInstanceOf[PTuple]
-    val trueIndex = ptTuple.fieldIndex(i)
-    this.pt.isFieldMissing(a, trueIndex)
+  def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
+    this.pt.isFieldMissing(a, fieldIdx)
   }
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.ExecStrategy
+import is.hail.{ExecStrategy, HailSuite}
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types.virtual._
@@ -9,7 +9,7 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
-class DictFunctionsSuite extends TestNGSuite {
+class DictFunctionsSuite extends HailSuite {
   def tuplesToMap(a: Seq[(Integer, Integer)]): Map[Integer, Integer] =
     Option(a).map(_.filter(_ != null).toMap).orNull
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1537,6 +1537,17 @@ class IRSuite extends HailSuite {
     assertEvalsTo(GetTupleElement(na, 0), null)
   }
 
+    @Test def testLetBoundPrunedTuple(): Unit = {
+    implicit val execStrats = ExecStrategy.unoptimizedCompileOnly
+    val t2 = MakeTuple(FastSeq((2, I32(5))))
+
+    val letBoundTuple = bindIR(t2) { tupleRef =>
+      GetTupleElement(tupleRef, 2)
+    }
+
+    assertEvalsTo(letBoundTuple, 5)
+  }
+
   @Test def testArrayRef() {
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(0)), 5)
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(1)), null)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1537,6 +1537,17 @@ class IRSuite extends HailSuite {
     assertEvalsTo(GetTupleElement(na, 0), null)
   }
 
+  @Test def testLetBoundPrunedTuple(): Unit = {
+    implicit val execStrats = ExecStrategy.unoptimizedCompileOnly
+    val t2 = MakeTuple(FastSeq((2, I32(5))))
+
+    val letBoundTuple = bindIR(t2) { tupleRef =>
+      GetTupleElement(tupleRef, 2)
+    }
+
+    assertEvalsTo(letBoundTuple, 5)
+  }
+
   @Test def testArrayRef() {
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(0)), 5)
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(1)), null)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1537,17 +1537,6 @@ class IRSuite extends HailSuite {
     assertEvalsTo(GetTupleElement(na, 0), null)
   }
 
-  @Test def testLetBoundPrunedTuple(): Unit = {
-    implicit val execStrats = ExecStrategy.unoptimizedCompileOnly
-    val t2 = MakeTuple(FastSeq((2, I32(5))))
-
-    val letBoundTuple = bindIR(t2) { tupleRef =>
-      GetTupleElement(tupleRef, 2)
-    }
-
-    assertEvalsTo(letBoundTuple, 5)
-  }
-
   @Test def testArrayRef() {
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(0)), 5)
     assertEvalsTo(ArrayRef(MakeArray(FastIndexedSeq(I32(5), NA(TInt32)), TArray(TInt32)), I32(1)), null)

--- a/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.ExecStrategy
+import is.hail.{ExecStrategy, HailSuite}
 import is.hail.expr.types._
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
@@ -9,7 +9,7 @@ import is.hail.utils.FastSeq
 import org.testng.annotations.Test
 import org.scalatest.testng.TestNGSuite
 
-class SetFunctionsSuite extends TestNGSuite {
+class SetFunctionsSuite extends HailSuite {
   val naa = NA(TArray(TInt32))
   val nas = NA(TSet(TInt32))
 


### PR DESCRIPTION
This should fix Julia's bug here: https://discuss.hail.is/t/arrayindexoutofboundsexception-error-in-hail-0-2-40/1413/11

I will make a follow up PR tomorrow splitting things up and making a `PCanonicalTupleCode`. I just wanted to get rid of this blatantly wrong thing. 