### PR TITLE
[services/Java] retry retryable http client errors

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -320,13 +320,11 @@ async def retry_transient_errors(f, *args, **kwargs):
         try:
             return await f(*args, **kwargs)
         except Exception as e:
+            if not is_transient_error(e):
+                raise
             errors += 1
             if errors % 10 == 0:
                 log.warning(f'encountered {errors} errors, most recent one was {e}', exc_info=True)
-            if is_transient_error(e):
-                pass
-            else:
-                raise
         delay = await sleep_and_backoff(delay)
 
 

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -1,9 +1,9 @@
 package is.hail.services.batch_client
 
-import java.nio.charset.{Charset, StandardCharsets}
-import java.util.Random
+import java.nio.charset.StandardCharsets
 
 import is.hail.utils._
+import is.hail.services._
 import is.hail.services.{DeployConfig, Tokens}
 import org.apache.commons.io.IOUtils
 import org.apache.http.{HttpEntity, HttpEntityEnclosingRequest}
@@ -11,9 +11,10 @@ import org.apache.http.client.methods.{HttpDelete, HttpGet, HttpPatch, HttpPost,
 import org.apache.http.entity.{ByteArrayEntity, ContentType, StringEntity}
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
 import org.apache.http.util.EntityUtils
-import org.json4s.JsonAST.JNull
 import org.json4s.{DefaultFormats, Formats, JObject, JValue}
 import org.json4s.jackson.JsonMethods
+
+import scala.util.Random
 
 class NoBodyException(message: String, cause: Throwable) extends Exception(message, cause) {
   def this() = this(null, null)
@@ -21,7 +22,11 @@ class NoBodyException(message: String, cause: Throwable) extends Exception(messa
   def this(message: String) = this(message, null)
 }
 
-class ClientResponseException(statusCode: Int, message: String, cause: Throwable) extends Exception(message, cause) {
+class ClientResponseException(
+  val status: Int,
+  message: String,
+  cause: Throwable
+) extends Exception(message, cause) {
   def this(statusCode: Int) = this(statusCode, null, null)
 
   def this(statusCode: Int, message: String) = this(statusCode, message, null)
@@ -36,28 +41,31 @@ class BatchClient extends AutoCloseable {
     if (body != null)
       req.asInstanceOf[HttpEntityEnclosingRequest].setEntity(body)
     Tokens.get.addServiceAuthHeaders("batch", req)
-    using(httpClient.execute(req)) { resp =>
-      val statusCode = resp.getStatusLine.getStatusCode
-      if (statusCode < 200 || statusCode >= 300) {
-        val entity = resp.getEntity
-        val message =
-          if (entity != null)
-            EntityUtils.toString(entity)
-          else
-            null
-        throw new ClientResponseException(statusCode, message)
-      }
-      val entity: HttpEntity = resp.getEntity
-      if (entity != null) {
-        using(entity.getContent) { content =>
-          val s = IOUtils.toByteArray(content)
-          if (s.isEmpty)
-            null
-          else
-            JsonMethods.parse(new String(s))
+    
+    retryTransientErrors {
+      using(httpClient.execute(req)) { resp =>
+        val statusCode = resp.getStatusLine.getStatusCode
+        if (statusCode < 200 || statusCode >= 300) {
+          val entity = resp.getEntity
+          val message =
+            if (entity != null)
+              EntityUtils.toString(entity)
+            else
+              null
+          throw new ClientResponseException(statusCode, message)
         }
-      } else
-        null
+        val entity: HttpEntity = resp.getEntity
+        if (entity != null) {
+          using(entity.getContent) { content =>
+            val s = IOUtils.toByteArray(content)
+            if (s.isEmpty)
+              null
+            else
+              JsonMethods.parse(new String(s))
+          }
+        } else
+          null
+      }
     }
   }
 
@@ -134,7 +142,6 @@ class BatchClient extends AutoCloseable {
   def waitForBatch(batchID: Long): JValue = {
     implicit val formats: Formats = DefaultFormats
 
-    val random = new Random()
     val start = System.nanoTime()
 
     while (true) {
@@ -149,7 +156,7 @@ class BatchClient extends AutoCloseable {
       val elapsed = now - start
       var d = math.max(
         math.min(
-          (0.1 * (0.8 + random.nextFloat() * 0.4) * (elapsed / 1000.0 / 1000)).toInt,
+          (0.1 * (0.8 + Random.nextFloat() * 0.4) * (elapsed / 1000.0 / 1000)).toInt,
           5000),
         50)
       Thread.sleep(d)

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -41,7 +41,7 @@ class BatchClient extends AutoCloseable {
     if (body != null)
       req.asInstanceOf[HttpEntityEnclosingRequest].setEntity(body)
     Tokens.get.addServiceAuthHeaders("batch", req)
-    
+
     retryTransientErrors {
       using(httpClient.execute(req)) { resp =>
         val statusCode = resp.getStatusLine.getStatusCode

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -1,0 +1,52 @@
+package is.hail
+
+import is.hail.services.batch_client.ClientResponseException
+import org.apache.log4j.{LogManager, Logger}
+
+import scala.util.Random
+
+package object services {
+  lazy val log: Logger = LogManager.getLogger("is.hail.services")
+
+  val RETRYABLE_HTTP_STATUS_CODES: Set[Int] = {
+    var s = Set(408, 500, 502, 503, 504)
+    if (System.getenv("HAIL_DONT_RETRY_500") == "1")
+      s = s - 500
+    s
+  }
+
+  def sleepAndBackoff(delay: Double): Double = {
+    val t = delay * Random.nextDouble()
+    Thread.sleep((t * 1000).toInt)  // in ms
+    math.min(delay * 2, 60.0)
+  }
+
+  def isTransientError(e: Exception): Boolean = {
+    e match {
+      case e: ClientResponseException =>
+        RETRYABLE_HTTP_STATUS_CODES.contains(e.status)
+      case _ =>
+        false
+    }
+  }
+
+  def retryTransientErrors[T](f: => T): T = {
+    var delay = 0.1
+    var errors = 0
+    while (true) {
+      try {
+        return f
+      } catch {
+        case e: Exception =>
+          if (!isTransientError(e))
+            throw e
+          errors += 1
+          if (errors % 10 == 0)
+            log.warn(s"encountered $errors errors, most recent one was $e")
+      }
+      delay = sleepAndBackoff(delay)
+    }
+
+    throw new AssertionError("unreachable")
+  }
+}

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -9,10 +9,11 @@ package object services {
   lazy val log: Logger = LogManager.getLogger("is.hail.services")
 
   val RETRYABLE_HTTP_STATUS_CODES: Set[Int] = {
-    var s = Set(408, 500, 502, 503, 504)
+    val s = Set(408, 500, 502, 503, 504)
     if (System.getenv("HAIL_DONT_RETRY_500") == "1")
-      s = s - 500
-    s
+      s - 500
+    else
+      s
   }
 
   def sleepAndBackoff(delay: Double): Double = {
@@ -42,7 +43,7 @@ package object services {
             throw e
           errors += 1
           if (errors % 10 == 0)
-            log.warn(s"encountered $errors errors, most recent one was $e")
+            log.warn(s"encountered $errors transient errors, most recent one was $e")
       }
       delay = sleepAndBackoff(delay)
     }


### PR DESCRIPTION
Add retry infrastructure mirroring Python.

This will hopefully fix the deploy issue.  I think we'll have to grow another set of transient errors to retry related to lower-level networking issues.
