### PR TITLE
[hail][sbt] bloop 1.4.0 has a bug that breaks Java 8 compatibility

### DIFF
--- a/hail/project/plugins.sbt
+++ b/hail/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 resolvers += Resolver.bintrayIvyRepo("s22s", "sbt-plugins")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.1")


### PR DESCRIPTION
Fix is to upgrade to Bloop 1.4.1. https://github.com/scalacenter/bloop/issues/1276