### PR TITLE
[batch] focus search box

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
 {% block title %}Batch {{ batch['id'] }}{% endblock %}
+{% block head %}
+  <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
+{% endblock %}
 {% block content %}
   <h1>Batch {{ batch['id'] }}</h1>
   {% if 'attributes' in batch %}
@@ -11,7 +14,7 @@
   <div class="flex-col" style="width: 100%; min-width: 653px; max-width: 1024px;">
 	<div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches/{{ batch['id'] }}">
-	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
+	  <input style="vertical-align:text-bottom;" id="searchBar" name="q" size=30 type="text"
 		 {% if q %}
 	         value="{{ q }}"
 		 {% else %}
@@ -102,4 +105,7 @@
       {% endif %}
     </div>
   </div>
+  <script type="text/javascript">
+    focusOnSlash("searchBar");
+  </script>
 {% endblock %}

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -1,11 +1,14 @@
 {% extends "layout.html" %}
 {% block title %}Batches{% endblock %}
+{% block head %}
+  <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
+{% endblock %}
 {% block content %}
   <h1>Batches</h1>
   <div class="flex-col" style="width: 100%; min-width: 653px; max-width: 1024px;">
     <div class="flex-col-align-right">
 	<form method="GET" action="{{ base_path }}/batches">
-	  <input style="vertical-align:text-bottom;" name="q" size=30 type="text"
+	  <input style="vertical-align:text-bottom;" id="searchBar" name="q" size=30 type="text"
 		 {% if q %}
 	         value="{{ q }}"
 		 {% else %}
@@ -125,4 +128,7 @@
       </form>
       {% endif %}
   </div>
+  <script type="text/javascript">
+    focusOnSlash("searchBar");
+  </script>
 {% endblock %}

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -2,6 +2,7 @@
 {% block title %}CI{% endblock %}
 {% block head %}
     <script src="{{ base_path }}/common_static/search_bar.js"></script>
+    <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
 {% endblock %}
 {% block content %}
     <h1>CI</h1>
@@ -88,6 +89,6 @@
       <button type="submit">Authorize</button>
     </form>
     <script type="text/javascript">
-      document.getElementById("searchBar").focus();
+      focusOnSlash("searchBar");
     </script>
 {% endblock %}

--- a/web_common/web_common/static/focus_on_keyup.js
+++ b/web_common/web_common/static/focus_on_keyup.js
@@ -1,0 +1,7 @@
+function focusOnSlash(name) {
+  document.body.onkeyup = function(e){
+    if (e.keyCode == 191){
+      document.getElementById(name).focus();
+    }
+  }
+}


### PR DESCRIPTION
FYI @konradjk 

I tested this with dev deploy for the batch pages. I assume the ci page is the same. This changes the behavior of CI focus to require to enter slash first. I think it's better to be consistent.