### PR TITLE
Respect dry run arg when modifying wheel on Dataproc cluster

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -116,7 +116,8 @@ def main(args, pass_through_args):
 
         for cmd in cmds:
             print(cmd)
-            sp.check_call(cmd)
+            if not args.dry_run:
+                sp.check_call(cmd)
 
     if not wheel and not modify_args and pass_through_args:
         sys.stderr.write('ERROR: found pass-through arguments but not known modification args.')


### PR DESCRIPTION
`hailctl dataproc modify` has a `--dry-run` argument. That argument is checked before resizing the cluster but not before modifying the wheel.