### PR TITLE
[ci] fix table row highlighting when using on-page filter

### DIFF
--- a/web_common/web_common/static/search_bar.js
+++ b/web_common/web_common/static/search_bar.js
@@ -4,9 +4,7 @@ function searchTable(table_name, search_bar_name) {
   var table = document.getElementById(table_name);
   var tableRecords = table.getElementsByTagName("tr");
 
-  console.log(tableRecords)
   for (var i = 1; i < tableRecords.length; ++i) {
-    console.log(i)
     var record = tableRecords[i];
     var tds = record.getElementsByTagName("td");
     var anyMatch = false;

--- a/web_common/web_common/static/search_bar.js
+++ b/web_common/web_common/static/search_bar.js
@@ -4,7 +4,9 @@ function searchTable(table_name, search_bar_name) {
   var table = document.getElementById(table_name);
   var tableRecords = table.getElementsByTagName("tr");
 
+  console.log(tableRecords)
   for (var i = 1; i < tableRecords.length; ++i) {
+    console.log(i)
     var record = tableRecords[i];
     var tds = record.getElementsByTagName("td");
     var anyMatch = false;
@@ -15,9 +17,25 @@ function searchTable(table_name, search_bar_name) {
         break;
       }
     }
-    if (anyMatch)
-      record.style.display = "";
-    else
-      record.style.display = "none";
+    if (anyMatch) {
+      if (record.parentNode.style.display == "none") {
+        wrapper = record.parentNode
+
+        row_container = wrapper.parentNode
+        row_container.insertBefore(record, wrapper)
+        row_container.removeChild(wrapper)
+      }
+    } else {
+      if (record.parentNode.style.display != "none") {
+        wrapper = document.createElement('div')
+        wrapper.style.display = "none"
+
+        row_container = record.parentNode
+        row_container.insertBefore(wrapper, record)
+        row_container.removeChild(record)
+
+        wrapper.appendChild(record)
+      }
+    }
   }
 }

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -60,7 +60,7 @@ a {
     &:hover {
         text-decoration: underline;
         /* color: #3af */
-        
+
     }
 }
 
@@ -233,7 +233,7 @@ a {
     }
 
     tr {
-        &:nth-child(even) {
+        &:nth-type-of(even) {
             background-color: #f2f2f2;
         }
     }


### PR DESCRIPTION
The main issue is that `nth-child-of` still sees the hidden elements. We can instead
use `nth-of-type` and wrap hidden `tr`s in a `div`. Because the `div` is not a `tr`,
it does not appear as part of the `nth-of-type` calculation. The content is still
present on the page, so we can restore it by removing the `display: none` div.