### PR TITLE
[hail][change_log] fix change log syntax

### DIFF
--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -28,7 +28,7 @@ Released 2020-05-15
 
 ### Bug fixes
 
-- (hail#8799, hail#8786) Fix ArrayIndexOutOfBoundsException seen in pipelines that reuse a tuple value.
+- (hail#8799)(hail#8786) Fix ArrayIndexOutOfBoundsException seen in pipelines that reuse a tuple value.
 
 ### hailctl dataproc
 


### PR DESCRIPTION
The change log only supports (#NNNN) for PRs and issues, not a comma separated
list of #NNNNs inside parentheses. See: https://hail.is/docs/0.2/change_log.html#bug-fixes
for the issue currently. A sed rule in the makefile implements this syntax.