### PR TITLE
[ci] teach CI to issue 400s on bad dev deploys

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -334,20 +334,41 @@ async def post_update(request, userdata):  # pylint: disable=unused-argument
 @rest_authenticated_developers_only
 async def dev_deploy_branch(request, userdata):
     app = request.app
-    params = await request.json()
-    branch = FQBranch.from_short_str(params['branch'])
-    steps = params['steps']
+    try:
+        params = await request.json()
+    except Exception:
+        message = 'could not read body as JSON'
+        log.info('dev deploy failed: ' + message, exc_info=True)
+        raise web.HTTPBadRequest(text=message)
+
+    try:
+        branch = FQBranch.from_short_str(params['branch'])
+        steps = params['steps']
+    except Exception:
+        message = f'parameters are wrong; check the branch and steps syntax.\n\n{params}'
+        log.info('dev deploy failed: ' + message, exc_info=True)
+        raise web.HTTPBadRequest(text=message)
 
     gh = app['github_client']
     request_string = f'/repos/{branch.repo.owner}/{branch.repo.name}/git/refs/heads/{branch.name}'
-    branch_gh_json = await gh.getitem(request_string)
-    sha = branch_gh_json['object']['sha']
+
+    try:
+        branch_gh_json = await gh.getitem(request_string)
+        sha = branch_gh_json['object']['sha']
+    except Exception:
+        message = f'error finding {branch} at GitHub'
+        log.info('dev deploy failed: ' + message, exc_info=True)
+        raise web.HTTPBadRequest(text=message)
 
     unwatched_branch = UnwatchedBranch(branch, sha, userdata)
 
     batch_client = app['batch_client']
 
-    batch_id = await unwatched_branch.deploy(batch_client, steps)
+    try:
+        batch_id = await unwatched_branch.deploy(batch_client, steps)
+    except Exception as e:  # pylint: disable=broad-except
+        raise web.HTTPBadGateway(
+            text=f'starting the deploy failed due to {e}')
     return web.json_response({'sha': sha, 'batch_id': batch_id})
 
 


### PR DESCRIPTION
I avoid printing the full exception into the body in most cases. Seems prudent to not expose too much about our internals.

CI already uses a broad except and prints the full message when building PRs so I adopted that for building the branch (`unwatched_branch.deploy`) in dev deploy.