### PR TITLE
[batch] Issue a 400 for batches with jobs with duplicated parents

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -732,6 +732,8 @@ VALUES (%s, %s, %s);
 
             try:
                 await insert()  # pylint: disable=no-value-for-parameter
+            except aiohttp.web.HTTPException:
+                raise
             except Exception as err:
                 raise ValueError(f'encountered exception while inserting a bunch'
                                  f'jobs_args={json.dumps(jobs_args)}'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -544,7 +544,6 @@ echo $HAIL_BATCH_WORKER_IP
         try:
             batch = batch.submit()
         except aiohttp.ClientResponseError as e:
-            assert e.status == 400 and 'bunch contains job with duplicated parents' in e.message, \
-                f'bad status or error message {e} {e.status} {e.message}'
+            assert e.status == 400
         else:
             assert False, f'should receive a 400 Bad Request {batch.id}'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -544,5 +544,7 @@ echo $HAIL_BATCH_WORKER_IP
         try:
             batch = batch.submit()
         except aiohttp.ClientResponseError as e:
-            assert e.status == 400, 'bunch contains job with duplicated parents' in e.message
-        assert False, 'should receive a 400 Bad Request'
+            assert e.status == 400 and 'bunch contains job with duplicated parents' in e.message, \
+                f'bad status or error message {e} {e.status} {e.message}'
+        else:
+            assert False, f'should receive a 400 Bad Request {batch.id}'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -536,3 +536,13 @@ echo $HAIL_BATCH_WORKER_IP
                 allow_redirects=True,
                 headers=headers)
             assert r.status_code == 400, (config, r)
+
+    def test_duplicate_parents(self):
+        batch = self.client.create_batch()
+        head = batch.create_job('ubuntu:18.04', command=['echo', 'head'])
+        batch.create_job('ubuntu:18.04', command=['echo', 'tail'], parents=[head, head])
+        try:
+            batch = batch.submit()
+        except aiohttp.ClientResponseError as e:
+            assert e.status == 400, 'bunch contains job with duplicated parents' in e.message
+        assert False, 'should receive a 400 Bad Request'


### PR DESCRIPTION
If a batch contains a job who lists the same parent twice, Batch will encounter
[integrity errors from
MySQL](https://hail.zulipchat.com/#narrow/stream/127527-team/topic/ci.20broken/near/195236580). For
example, this error was raised when I duplicated a parent in build.yaml:

    pymysql.err.IntegrityError: (1062, "Duplicate entry '35921-13-1' for key 'PRIMARY'")"}

This change catches the integrity error and raises a more useful 400 bad request
error message.