### PR TITLE
[query] Add StreamJoinRightDistinct node

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1239,23 +1239,29 @@ class StreamScan(IR):
 
 
 class StreamJoinRightDistinct(IR):
-    @typecheck_method(left=IR, right=IR, l_name=str, r_name=str, compare=IR, join=IR, join_type=str)
-    def __init__(self, left, right, l_name, r_name, compare, join, join_type):
+    @typecheck_method(left=IR, right=IR, l_key=sequenceof(str), r_key=sequenceof(str), l_name=str, r_name=str, join=IR, join_type=str)
+    def __init__(self, left, right, l_key, r_key, l_name, r_name, join, join_type):
         super().__init__(left, right, compare, join)
         self.left = left
         self.right = right
+        self.l_key = l_key
+        self.r_key = r_key
         self.l_name = l_name
         self.r_name = r_name
-        self.compare = compare
         self.join = join
         self.join_type = join_type
 
     @typecheck_method(left=IR, right=IR, compare=IR, join=IR)
     def copy(self, left, right, compare, join):
-        return StreamJoinRightDistinct(left, right, self.l_name, self.r_name, compare, join, self.join_type)
+        return StreamJoinRightDistinct(left, right, self.l_key, self.r_key, self.l_name, self.r_name, join, self.join_type)
 
     def head_str(self):
-        return f'{escape_id(self.l_name)} {escape_id(self.r_name)} {self.join_type}'
+        return '{} {} ({}) ({}) {}'.format(
+            self.l_name,
+            self.r_name,
+            ' '.join([escape_id(x) for x in self.l_key]),
+            ' '.join([escape_id(x) for x in self.r_key]),
+            self.join_type)
 
     def _eq(self, other):
         return other.l_name == self.l_name and \

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1238,9 +1238,9 @@ class StreamScan(IR):
             return {}
 
 
-class StreamLeftJoinDistinct(IR):
-    @typecheck_method(left=IR, right=IR, l_name=str, r_name=str, compare=IR, join=IR)
-    def __init__(self, left, right, l_name, r_name, compare, join):
+class StreamJoinRightDistinct(IR):
+    @typecheck_method(left=IR, right=IR, l_name=str, r_name=str, compare=IR, join=IR, join_type=str)
+    def __init__(self, left, right, l_name, r_name, compare, join, join_type):
         super().__init__(left, right, compare, join)
         self.left = left
         self.right = right
@@ -1248,17 +1248,19 @@ class StreamLeftJoinDistinct(IR):
         self.r_name = r_name
         self.compare = compare
         self.join = join
+        self.join_type = join_type
 
     @typecheck_method(left=IR, right=IR, compare=IR, join=IR)
     def copy(self, left, right, compare, join):
-        return StreamLeftJoinDistinct(left, right, self.l_name, self.r_name, compare, join)
+        return StreamJoinRightDistinct(left, right, self.l_name, self.r_name, compare, join, self.join_type)
 
     def head_str(self):
-        return f'{escape_id(self.l_name)} {escape_id(self.r_name)}'
+        return f'{escape_id(self.l_name)} {escape_id(self.r_name)} {self.join_type}'
 
     def _eq(self, other):
         return other.l_name == self.l_name and \
-            other.r_name == self.r_name
+            other.r_name == self.r_name and \
+            other.join_type == self.join_type
 
     @property
     def bound_variables(self):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1241,7 +1241,7 @@ class StreamScan(IR):
 class StreamJoinRightDistinct(IR):
     @typecheck_method(left=IR, right=IR, l_key=sequenceof(str), r_key=sequenceof(str), l_name=str, r_name=str, join=IR, join_type=str)
     def __init__(self, left, right, l_key, r_key, l_name, r_name, join, join_type):
-        super().__init__(left, right, compare, join)
+        super().__init__(left, right, join)
         self.left = left
         self.right = right
         self.l_key = l_key
@@ -1251,16 +1251,16 @@ class StreamJoinRightDistinct(IR):
         self.join = join
         self.join_type = join_type
 
-    @typecheck_method(left=IR, right=IR, compare=IR, join=IR)
-    def copy(self, left, right, compare, join):
+    @typecheck_method(left=IR, right=IR, join=IR)
+    def copy(self, left, right, join):
         return StreamJoinRightDistinct(left, right, self.l_key, self.r_key, self.l_name, self.r_name, join, self.join_type)
 
     def head_str(self):
-        return '{} {} ({}) ({}) {}'.format(
-            self.l_name,
-            self.r_name,
+        return '({}) ({}) {} {} {}'.format(
             ' '.join([escape_id(x) for x in self.l_key]),
             ' '.join([escape_id(x) for x in self.r_key]),
+            self.l_name,
+            self.r_name,
             self.join_type)
 
     def _eq(self, other):
@@ -1273,7 +1273,7 @@ class StreamJoinRightDistinct(IR):
         return {self.l_name, self.r_name} | super().bound_variables
 
     def renderable_bindings(self, i, default_value=None):
-        if i == 2 or i == 3:
+        if i == 2:
             if default_value is None:
                 return {self.l_name: self.left.typ.element_type,
                         self.r_name: self.right.typ.element_type}

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -73,7 +73,7 @@ class ValueIRTests(unittest.TestCase):
             ir.StreamFlatMap(sta, 'v', ir.ToStream(v)),
             ir.StreamFold(st, ir.I32(0), 'x', 'v', v),
             ir.StreamScan(st, ir.I32(0), 'x', 'v', v),
-            ir.StreamLeftJoinDistinct(st, st, 'l', 'r', ir.I32(0), ir.I32(1)),
+            ir.StreamJoinRightDistinct(st, st, 'l', 'r', ir.I32(0), ir.I32(1), "left"),
             ir.StreamFor(st, 'v', ir.Void()),
             ir.AggFilter(ir.TrueIR(), ir.I32(0), False),
             ir.AggExplode(ir.StreamRange(ir.I32(0), ir.I32(2), ir.I32(1)), 'x', ir.I32(0), False),

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -73,7 +73,7 @@ class ValueIRTests(unittest.TestCase):
             ir.StreamFlatMap(sta, 'v', ir.ToStream(v)),
             ir.StreamFold(st, ir.I32(0), 'x', 'v', v),
             ir.StreamScan(st, ir.I32(0), 'x', 'v', v),
-            ir.StreamJoinRightDistinct(st, st, 'l', 'r', ir.I32(0), ir.I32(1), "left"),
+            ir.StreamJoinRightDistinct(st, st, ['k'], ['k'], 'l', 'r', ir.I32(1), "left"),
             ir.StreamFor(st, 'v', ir.Void()),
             ir.AggFilter(ir.TrueIR(), ir.I32(0), False),
             ir.AggExplode(ir.StreamRange(ir.I32(0), ir.I32(2), ir.I32(1)), 'x', ir.I32(0), False),

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -31,7 +31,7 @@ object Bindings {
     case RunAggScan(a, name, _, _, _, _) => if (i == 2 || i == 3) Array(name -> coerce[TStream](a.typ).elementType) else empty
     case StreamScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> coerce[TStream](a.typ).elementType) else empty
     case StreamAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStream].elementType) else empty
-    case StreamLeftJoinDistinct(ll, rr, l, r, _, _) => if (i == 2 || i == 3) Array(l -> coerce[TStream](ll.typ).elementType, r -> coerce[TStream](rr.typ).elementType) else empty
+    case StreamJoinRightDistinct(ll, rr, l, r, _, _, _) => if (i == 2 || i == 3) Array(l -> coerce[TStream](ll.typ).elementType, r -> coerce[TStream](rr.typ).elementType) else empty
     case ArraySort(a, left, right, _) => if (i == 1) Array(left -> coerce[TStream](a.typ).elementType, right -> coerce[TStream](a.typ).elementType) else empty
     case AggArrayPerElement(a, _, indexName, _, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32) else empty
     case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> coerce[TNDArray](nd.typ).elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -31,7 +31,7 @@ object Bindings {
     case RunAggScan(a, name, _, _, _, _) => if (i == 2 || i == 3) Array(name -> coerce[TStream](a.typ).elementType) else empty
     case StreamScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> coerce[TStream](a.typ).elementType) else empty
     case StreamAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStream].elementType) else empty
-    case StreamJoinRightDistinct(ll, rr, l, r, _, _, _) => if (i == 2 || i == 3) Array(l -> coerce[TStream](ll.typ).elementType, r -> coerce[TStream](rr.typ).elementType) else empty
+    case StreamJoinRightDistinct(ll, rr, _, _, l, r, _, _) => if (i == 2) Array(l -> coerce[TStream](ll.typ).elementType, r -> coerce[TStream](rr.typ).elementType) else empty
     case ArraySort(a, left, right, _) => if (i == 1) Array(left -> coerce[TStream](a.typ).elementType, right -> coerce[TStream](a.typ).elementType) else empty
     case AggArrayPerElement(a, _, indexName, _, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32) else empty
     case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> coerce[TNDArray](nd.typ).elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -105,8 +105,8 @@ object Children {
       Array(a) ++ accum.map(_._2) ++ seq ++ Array(result)
     case StreamScan(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
-    case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
-      Array(left, right, compare, join)
+    case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, joinType) =>
+      Array(left, right, join)
     case StreamFor(a, valueName, body) =>
       Array(a, body)
     case StreamAgg(a, name, query) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -105,7 +105,7 @@ object Children {
       Array(a) ++ accum.map(_._2) ++ seq ++ Array(result)
     case StreamScan(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
-    case StreamLeftJoinDistinct(left, right, l, r, compare, join) =>
+    case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
       Array(left, right, compare, join)
     case StreamFor(a, valueName, body) =>
       Array(a, body)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -174,9 +174,9 @@ object Copy {
       case StreamScan(_, _, accumName, valueName, _) =>
         assert(newChildren.length == 3)
         StreamScan(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(2).asInstanceOf[IR])
-      case StreamJoinRightDistinct(_, _, l, r, _, _, joinType) =>
-        assert(newChildren.length == 4)
-        StreamJoinRightDistinct(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], l, r, newChildren(2).asInstanceOf[IR], newChildren(3).asInstanceOf[IR], joinType)
+      case StreamJoinRightDistinct(_, _, lKey, rKey, l, r, _, joinType) =>
+        assert(newChildren.length == 3)
+        StreamJoinRightDistinct(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], lKey, rKey, l, r, newChildren(2).asInstanceOf[IR], joinType)
       case StreamFor(_, valueName, _) =>
         assert(newChildren.length == 2)
         StreamFor(newChildren(0).asInstanceOf[IR], valueName, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -174,9 +174,9 @@ object Copy {
       case StreamScan(_, _, accumName, valueName, _) =>
         assert(newChildren.length == 3)
         StreamScan(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(2).asInstanceOf[IR])
-      case StreamLeftJoinDistinct(_, _, l, r, _, _) =>
+      case StreamJoinRightDistinct(_, _, l, r, _, _, joinType) =>
         assert(newChildren.length == 4)
-        StreamLeftJoinDistinct(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], l, r, newChildren(2).asInstanceOf[IR], newChildren(3).asInstanceOf[IR])
+        StreamJoinRightDistinct(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], l, r, newChildren(2).asInstanceOf[IR], newChildren(3).asInstanceOf[IR], joinType)
       case StreamFor(_, valueName, _) =>
         assert(newChildren.length == 2)
         StreamFor(newChildren(0).asInstanceOf[IR], valueName, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -329,6 +329,18 @@ case class EmitCode(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
     else
       tc :+ m
   }
+
+  def missingIf(mb: EmitMethodBuilder[_], cond: Code[Boolean]): EmitCode =
+    EmitCode.fromI(mb) { cb =>
+      val Ltrue = CodeLabel()
+      val Lfalse = CodeLabel()
+      cb.ifx(cond, cb.goto(Ltrue), cb.goto(Lfalse))
+      cb.define(Lfalse)
+      val eci = toI(cb)
+      cb.define(Ltrue)
+      cb.goto(eci.Lmissing)
+      eci
+    }
 }
 
 abstract class EmitSettable extends EmitValue {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -468,7 +468,7 @@ object Stream {
       val rightEOS = mb.newLocal[Boolean]()
       val lx = mb.newEmitLocal(lElemType) // last value received from left
       val rx = mb.newEmitLocal(rElemType) // last value received from right
-      val rxOut = mb.newEmitLocal(rElemType) // B value to push (may be rNil while xB is not)
+      val rxOut = mb.newEmitLocal(rElemType.setRequired(false)) // right value to push (may be missing while rx is not)
 
       var rightSource: Source[EmitCode] = null
       val leftSource = left(
@@ -506,6 +506,98 @@ object Stream {
         setup = Code(pulledRight := false, rightEOS := false, leftSource.setup, rightSource.setup),
         close = Code(leftSource.close, rightSource.close),
         pull = leftSource.pull)
+    }
+  }
+
+  def outerJoinRightDistinct(
+    mb: EmitMethodBuilder[_],
+    lElemType: PType, left: Stream[EmitCode],
+    rElemType: PType, right: Stream[EmitCode],
+    comp: (EmitCode, EmitCode) => Code[Int]
+  ): Stream[(EmitCode, EmitCode)] = new Stream[(EmitCode, EmitCode)] {
+    def apply(eos: Code[Ctrl], push: ((EmitCode, EmitCode)) => Code[Ctrl])(implicit ctx: EmitStreamContext): Source[(EmitCode, EmitCode)] = {
+      val pulledRight = mb.newLocal[Boolean]()
+      val rightEOS = mb.newLocal[Boolean]()
+      val leftEOS = mb.newLocal[Boolean]()
+      val lx = mb.newEmitLocal(lElemType) // last value received from left
+      val rx = mb.newEmitLocal(rElemType) // last value received from right
+      val lOutMissing = mb.newLocal[Boolean]("ojrd_lom")
+      val rOutMissing = mb.newLocal[Boolean]("ojrd_rom")
+      val c = mb.newLocal[Int]()
+
+      val Leos = CodeLabel()
+      Code(Leos, eos)
+      val LpullRight = CodeLabel()
+      val LpullLeft = CodeLabel()
+      val Lpush = CodeLabel()
+
+      var rightSource: Source[EmitCode] = null
+      val leftSource = left(
+        eos = rightEOS.mux(
+          Leos.goto,
+          Code(
+            leftEOS := true,
+            lOutMissing := true,
+            rOutMissing := false,
+            (pulledRight && c.cne(0)).mux(
+              Lpush.goto,
+              Code(
+                pulledRight := true,
+                LpullRight.goto)))),
+        push = a => {
+          val Lcompare = CodeLabel()
+
+          Code(Lcompare,
+            c := comp(lx, rx),
+            lOutMissing := false,
+            rOutMissing := false,
+            (c > 0).mux(
+              pulledRight.mux(
+                Code(lOutMissing := true, Lpush.goto),
+                Code(pulledRight := true, LpullRight.goto)
+              ),
+              (c < 0).mux(
+                Code(rOutMissing := true, Lpush.goto),
+                Code(
+                  (lOutMissing || rOutMissing).orEmpty(Code._fatal[Unit]("")),
+                  pulledRight := true,
+                  Lpush.goto)))
+          )
+
+          rightSource = right(
+            eos = leftEOS.mux(
+              Leos.goto,
+              Code(rightEOS := true, lOutMissing := false, rOutMissing := true, Lpush.goto)
+            ),
+            push = b => Code(
+              rx := b,
+              leftEOS.mux(
+                Code((!lOutMissing || rOutMissing).orEmpty(Code._fatal[Unit]("")), Lpush.goto),
+                Lcompare.goto
+              )))
+
+          Code(Lpush, push((lx.missingIf(mb, lOutMissing), rx.missingIf(mb, rOutMissing))))
+          Code(LpullRight, rightSource.pull)
+
+          Code(
+            lx := a,
+            pulledRight.mux[Unit](
+              rightEOS.mux[Ctrl](
+                Code((lOutMissing || !rOutMissing).orEmpty(Code._fatal[Unit]("")), Lpush.goto),
+                Code(
+                  c.ceq(0).orEmpty(pulledRight := false),
+                  Lcompare.goto)),
+              Code(pulledRight := true, LpullRight.goto)))
+        })
+
+      Code(LpullLeft, leftSource.pull)
+
+      Source[(EmitCode, EmitCode)](
+        setup0 = Code(leftSource.setup0, rightSource.setup0),
+        close0 = Code(leftSource.close0, rightSource.close0),
+        setup = Code(pulledRight := false, leftEOS := false, rightEOS := false, c := 0, leftSource.setup, rightSource.setup),
+        close = Code(leftSource.close, rightSource.close),
+        pull = leftEOS.mux(LpullRight.goto, rightEOS.mux(LpullLeft.goto, (c <= 0).mux(LpullLeft.goto, LpullRight.goto))))
     }
   }
 }
@@ -1266,41 +1358,50 @@ object EmitStream {
             SizedStream(setup, newStream, len)
           }
 
-        case StreamLeftJoinDistinct(leftIR, rightIR, leftName, rightName, compIR, joinIR) =>
+        case StreamJoinRightDistinct(leftIR, rightIR, leftName, rightName, compIR, joinIR, joinType) =>
+          assert(joinType == "left" || joinType == "outer")
           val lEltType = coerce[PStream](leftIR.pType).elementType
-          val rEltType = coerce[PStream](rightIR.pType).elementType.setRequired(false)
-          val xLElt = mb.newEmitField("join_lelt", lEltType)
-          val xRElt = mb.newEmitField("join_relt", rEltType)
-
-          val env2 = env.bind(leftName -> xLElt, rightName -> xRElt)
+          val rEltType = coerce[PStream](rightIR.pType).elementType
+          val xLElt = mb.newEmitField("join_lelt", lEltType.orMissing(joinType == "left"))
+          val xRElt = mb.newEmitField("join_relt", rEltType.setRequired(false))
+          val newEnv = env.bind(leftName -> xLElt, rightName -> xRElt)
 
           def compare(lelt: EmitCode, relt: EmitCode): Code[Int] = {
-            val compt = emitIR(compIR, env = env2)
+            val compt = emitIR(compIR, newEnv)
             Code(
               xLElt := lelt,
               xRElt := relt,
               compt.setup,
-              compt.m.orEmpty(Code._fatal[Unit]("StreamLeftJoinDistinct: comp can't be missing")),
+              compt.m.orEmpty(Code._fatal[Unit]("StreamJoinRightDistinct: comp can't be missing")),
               coerce[Int](compt.v))
+          }
+          def joinF: ((EmitCode, EmitCode)) => EmitCode = { case (lelt, relt) =>
+            val joint = emitIR(joinIR, newEnv)
+            EmitCode(
+              Code(xLElt := lelt, xRElt := relt, joint.setup),
+              joint.m,
+              joint.pv)
           }
 
           emitStream(leftIR, env).flatMap { case SizedStream(leftSetup, leftStream, leftLen) =>
             emitStream(rightIR, env).map { ss =>
               val rightStream = ss.getStream
-              val newStream = leftJoinRightDistinct(
-                mb,
-                lEltType, leftStream,
-                rEltType, rightStream,
-                compare)
-                .map { case (lelt, relt) =>
-                  val joint = emitIR(joinIR, env = env2)
-                  EmitCode(
-                    Code(xLElt := lelt, xRElt := relt, joint.setup),
-                    joint.m,
-                    joint.pv)
-                }
+              val newStream = if (joinType == "left")
+                leftJoinRightDistinct(
+                  mb,
+                  lEltType, leftStream,
+                  rEltType, rightStream,
+                  compare)
+                  .map(joinF)
+              else
+                outerJoinRightDistinct(
+                  mb,
+                  lEltType, leftStream,
+                  rEltType, rightStream,
+                  compare)
+                  .map(joinF)
 
-              SizedStream(leftSetup, newStream, leftLen)
+              SizedStream(leftSetup, newStream, if (joinType == "left") leftLen else None)
             }
           }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -280,7 +280,7 @@ trait InferredPhysicalAggSignature {
 final case class RunAgg(body: IR, result: IR, signature: IndexedSeq[AggStateSignature]) extends IR with InferredPhysicalAggSignature
 final case class RunAggScan(array: IR, name: String, init: IR, seqs: IR, result: IR, signature: IndexedSeq[AggStateSignature]) extends IR with InferredPhysicalAggSignature
 
-final case class StreamJoinRightDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR, joinType: String) extends IR
+final case class StreamJoinRightDistinct(left: IR, right: IR, lKey: IndexedSeq[String], rKey: IndexedSeq[String], l: String, r: String, joinF: IR, joinType: String) extends IR
 
 sealed trait NDArrayIR extends TypedIR[TNDArray, PNDArray] {
   def elementTyp: Type = typ.elementType

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -280,7 +280,7 @@ trait InferredPhysicalAggSignature {
 final case class RunAgg(body: IR, result: IR, signature: IndexedSeq[AggStateSignature]) extends IR with InferredPhysicalAggSignature
 final case class RunAggScan(array: IR, name: String, init: IR, seqs: IR, result: IR, signature: IndexedSeq[AggStateSignature]) extends IR with InferredPhysicalAggSignature
 
-final case class StreamLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
+final case class StreamJoinRightDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR, joinType: String) extends IR
 
 sealed trait NDArrayIR extends TypedIR[TNDArray, PNDArray] {
   def elementTyp: Type = typ.elementType

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -140,7 +140,7 @@ object InferPType {
     case StreamFold2(a, _, `name`, _, _) => coerce[PStream](a.pType).elementType
     case x: StreamFold2 => x.accPTypes(x.nameIdx(name))
     case StreamJoinRightDistinct(left, _, _, _, `name`, _, _, joinType) =>
-      coerce[PStream](left.pType).elementType.setRequired(joinType == "left")
+      coerce[PStream](left.pType).elementType.orMissing(joinType == "left")
     case StreamJoinRightDistinct(_, right, _, _, _, `name`, _, _) =>
       coerce[PStream](right.pType).elementType.setRequired(false)
     case RunAggScan(a, `name`, _, _, _, _) => coerce[PStream](a.pType).elementType

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -139,8 +139,8 @@ object InferPType {
     case x: StreamScan => x.accPType
     case StreamFold2(a, _, `name`, _, _) => coerce[PStream](a.pType).elementType
     case x: StreamFold2 => x.accPTypes(x.nameIdx(name))
-    case StreamLeftJoinDistinct(left, _, `name`, _, _, _) => coerce[PStream](left.pType).elementType
-    case StreamLeftJoinDistinct(_, right, _, `name`, _, _) => coerce[PStream](right.pType).elementType.setRequired(false)
+    case StreamJoinRightDistinct(left, _, `name`, _, _, _, joinType) => coerce[PStream](left.pType).elementType.setRequired(joinType == "left")
+    case StreamJoinRightDistinct(_, right, _, `name`, _, _, _) => coerce[PStream](right.pType).elementType.setRequired(false)
     case RunAggScan(a, `name`, _, _, _, _) => coerce[PStream](a.pType).elementType
     case NDArrayMap(nd, `name`, _) => coerce[PNDArray](nd.pType).elementType
     case NDArrayMap2(left, _, `name`, _, _) => coerce[PNDArray](left.pType  ).elementType
@@ -310,7 +310,7 @@ object InferPType {
       case x: StreamScan =>
         val r = coerce[RIterable](requiredness(node))
         PCanonicalStream(x.accPType.setRequired(r.elementType.required), r.required)
-      case StreamLeftJoinDistinct(_, _, _, _, _, join) =>
+      case StreamJoinRightDistinct(_, _, _, _, _, join, _) =>
         PCanonicalStream(join.pType, requiredness(node).required)
       case NDArrayShape(nd) =>
         val r = nd.pType.asInstanceOf[PNDArray].shape.pType

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -139,8 +139,10 @@ object InferPType {
     case x: StreamScan => x.accPType
     case StreamFold2(a, _, `name`, _, _) => coerce[PStream](a.pType).elementType
     case x: StreamFold2 => x.accPTypes(x.nameIdx(name))
-    case StreamJoinRightDistinct(left, _, `name`, _, _, _, joinType) => coerce[PStream](left.pType).elementType.setRequired(joinType == "left")
-    case StreamJoinRightDistinct(_, right, _, `name`, _, _, _) => coerce[PStream](right.pType).elementType.setRequired(false)
+    case StreamJoinRightDistinct(left, _, _, _, `name`, _, _, joinType) =>
+      coerce[PStream](left.pType).elementType.setRequired(joinType == "left")
+    case StreamJoinRightDistinct(_, right, _, _, _, `name`, _, _) =>
+      coerce[PStream](right.pType).elementType.setRequired(false)
     case RunAggScan(a, `name`, _, _, _, _) => coerce[PStream](a.pType).elementType
     case NDArrayMap(nd, `name`, _) => coerce[PNDArray](nd.pType).elementType
     case NDArrayMap2(left, _, `name`, _, _) => coerce[PNDArray](left.pType  ).elementType
@@ -310,7 +312,7 @@ object InferPType {
       case x: StreamScan =>
         val r = coerce[RIterable](requiredness(node))
         PCanonicalStream(x.accPType.setRequired(r.elementType.required), r.required)
-      case StreamJoinRightDistinct(_, _, _, _, _, join, _) =>
+      case StreamJoinRightDistinct(_, _, _, _, _, _, join, _) =>
         PCanonicalStream(join.pType, requiredness(node).required)
       case NDArrayShape(nd) =>
         val r = nd.pType.asInstanceOf[PNDArray].shape.pType

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -130,7 +130,7 @@ object InferType {
         result.typ
       case RunAggScan(_, _, _, _, result, _) =>
         TStream(result.typ)
-      case StreamLeftJoinDistinct(left, right, l, r, compare, join) =>
+      case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
         TStream(join.typ)
       case NDArrayShape(nd) =>
         val ndType = nd.typ.asInstanceOf[TNDArray]

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -130,7 +130,7 @@ object InferType {
         result.typ
       case RunAggScan(_, _, _, _, result, _) =>
         TStream(result.typ)
-      case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
+      case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, joinType) =>
         TStream(join.typ)
       case NDArrayShape(nd) =>
         val ndType = nd.typ.asInstanceOf[TNDArray]

--- a/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
@@ -70,7 +70,7 @@ object NestingDepth {
           computeIR(a, depth)
           computeIR(zero, depth)
           computeIR(body, depth.incrementEval)
-        case StreamLeftJoinDistinct(left, right, l, r, keyF, joinF) =>
+        case StreamJoinRightDistinct(left, right, l, r, keyF, joinF, joinType) =>
           computeIR(left, depth)
           computeIR(right, depth)
           computeIR(keyF, depth.incrementEval)

--- a/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NestingDepth.scala
@@ -70,10 +70,9 @@ object NestingDepth {
           computeIR(a, depth)
           computeIR(zero, depth)
           computeIR(body, depth.incrementEval)
-        case StreamJoinRightDistinct(left, right, l, r, keyF, joinF, joinType) =>
+        case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, joinF, joinType) =>
           computeIR(left, depth)
           computeIR(right, depth)
-          computeIR(keyF, depth.incrementEval)
           computeIR(joinF, depth.incrementEval)
         case TailLoop(_, params, body) =>
           params.foreach { case (_, p) => computeIR(p, depth) }

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -153,11 +153,11 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         val newName = gen()
         val newEnv = env.eval.bind(name, newName)
         StreamAggScan(normalize(a), newName, normalize(body, env.copy(eval = newEnv, scan = Some(newEnv))))
-      case StreamJoinRightDistinct(left, right, l, r, keyF, joinF, joinType) =>
+      case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, joinF, joinType) =>
         val newL = gen()
         val newR = gen()
         val newEnv = env.bindEval(l -> newL, r -> newR)
-        StreamJoinRightDistinct(normalize(left), normalize(right), newL, newR, normalize(keyF, newEnv), normalize(joinF, newEnv), joinType)
+        StreamJoinRightDistinct(normalize(left), normalize(right), lKey, rKey, newL, newR, normalize(joinF, newEnv), joinType)
       case NDArrayMap(nd, name, body) =>
         val newName = gen()
         NDArrayMap(normalize(nd), newName, normalize(body, env.bindEval(name -> newName)))

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -153,11 +153,11 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         val newName = gen()
         val newEnv = env.eval.bind(name, newName)
         StreamAggScan(normalize(a), newName, normalize(body, env.copy(eval = newEnv, scan = Some(newEnv))))
-      case StreamLeftJoinDistinct(left, right, l, r, keyF, joinF) =>
+      case StreamJoinRightDistinct(left, right, l, r, keyF, joinF, joinType) =>
         val newL = gen()
         val newR = gen()
         val newEnv = env.bindEval(l -> newL, r -> newR)
-        StreamLeftJoinDistinct(normalize(left), normalize(right), newL, newR, normalize(keyF, newEnv), normalize(joinF, newEnv))
+        StreamJoinRightDistinct(normalize(left), normalize(right), newL, newR, normalize(keyF, newEnv), normalize(joinF, newEnv), joinType)
       case NDArrayMap(nd, name, body) =>
         val newName = gen()
         NDArrayMap(normalize(nd), newName, normalize(body, env.bindEval(name -> newName)))

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -929,16 +929,17 @@ object IRParser {
         val eltType = coerce[TStream](a.typ).elementType
         val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
         StreamScan(a, zero, accumName, valueName, body)
-      case "StreamLeftJoinDistinct" =>
+      case "StreamJoinRightDistinct" =>
         val l = identifier(it)
         val r = identifier(it)
+        val joinType = identifier(it)
         val left = ir_value_expr(env)(it)
         val right = ir_value_expr(env)(it)
         val lelt = coerce[TStream](left.typ).elementType
         val relt = coerce[TStream](right.typ).elementType
         val comp = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
         val join = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
-        StreamLeftJoinDistinct(left, right, l, r, comp, join)
+        StreamJoinRightDistinct(left, right, l, r, comp, join, joinType)
       case "StreamFor" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -930,6 +930,8 @@ object IRParser {
         val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
         StreamScan(a, zero, accumName, valueName, body)
       case "StreamJoinRightDistinct" =>
+        val lKey = identifiers(it)
+        val rKey = identifiers(it)
         val l = identifier(it)
         val r = identifier(it)
         val joinType = identifier(it)
@@ -937,9 +939,8 @@ object IRParser {
         val right = ir_value_expr(env)(it)
         val lelt = coerce[TStream](left.typ).elementType
         val relt = coerce[TStream](right.typ).elementType
-        val comp = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
         val join = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
-        StreamJoinRightDistinct(left, right, l, r, comp, join, joinType)
+        StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, joinType)
       case "StreamFor" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -275,7 +275,7 @@ object Pretty {
             case StreamFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
             case StreamFold2(_, acc, valueName, _, _) => prettyIdentifiers(acc.map(_._1)) + " " + prettyIdentifier(valueName)
             case StreamScan(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
-            case StreamLeftJoinDistinct(_, _, l, r, _, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
+            case StreamJoinRightDistinct(_, _, l, r, _, _, joinType) => prettyIdentifier(l) + " " + prettyIdentifier(r) + " " + joinType
             case StreamFor(_, valueName, _) => prettyIdentifier(valueName)
             case StreamAgg(a, name, query) => prettyIdentifier(name)
             case StreamAggScan(a, name, query) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -275,7 +275,8 @@ object Pretty {
             case StreamFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
             case StreamFold2(_, acc, valueName, _, _) => prettyIdentifiers(acc.map(_._1)) + " " + prettyIdentifier(valueName)
             case StreamScan(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
-            case StreamJoinRightDistinct(_, _, l, r, _, _, joinType) => prettyIdentifier(l) + " " + prettyIdentifier(r) + " " + joinType
+            case StreamJoinRightDistinct(_, _, lKey, rKey, l, r, _, joinType) =>
+              s"${prettyIdentifiers(lKey)} ${prettyIdentifiers(rKey)} ${prettyIdentifier(l)} ${prettyIdentifier(r)} $joinType"
             case StreamFor(_, valueName, _) => prettyIdentifier(valueName)
             case StreamAgg(a, name, query) => prettyIdentifier(name)
             case StreamAggScan(a, name, query) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1035,7 +1035,7 @@ object PruneDeadFields {
           bodyEnv.deleteEval(valueName).deleteEval(accumName),
           memoizeValueIR(a, TStream(valueType), memo)
         )
-      case StreamLeftJoinDistinct(left, right, l, r, compare, join) =>
+      case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
         val lType = left.typ.asInstanceOf[TStream]
         val rType = right.typ.asInstanceOf[TStream]
 
@@ -1702,16 +1702,17 @@ object PruneDeadFields {
           valueName,
           rebuildIR(body, env.bindEval(accumName -> z2.typ, valueName -> a2.typ.asInstanceOf[TStream].elementType), memo)
         )
-      case StreamLeftJoinDistinct(left, right, l, r, compare, join) =>
+      case StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
         val left2 = rebuildIR(left, env, memo)
         val right2 = rebuildIR(right, env, memo)
 
         val ltyp = left2.typ.asInstanceOf[TStream]
         val rtyp = right2.typ.asInstanceOf[TStream]
-        StreamLeftJoinDistinct(
+        StreamJoinRightDistinct(
           left2, right2, l, r,
           rebuildIR(compare, env.bindEval(l -> ltyp.elementType, r -> rtyp.elementType), memo),
-          rebuildIR(join, env.bindEval(l -> ltyp.elementType, r -> rtyp.elementType), memo))
+          rebuildIR(join, env.bindEval(l -> ltyp.elementType, r -> rtyp.elementType), memo),
+          joinType)
       case StreamFor(a, valueName, body) =>
         val a2 = rebuildIR(a, env, memo)
         val body2 = rebuildIR(body, env.bindEval(valueName -> a2.typ.asInstanceOf[TStream].elementType), memo)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -238,7 +238,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           i += 1
         }
         states.bind(node, s)
-      case StreamJoinRightDistinct(left, right, l, r, keyf, joinf, joinType) =>
+      case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, joinf, joinType) =>
         addElementBinding(l, left, makeOptional = (joinType == "outer"))
         addElementBinding(r, right, makeOptional = true)
       case StreamAgg(a, name, query) =>
@@ -392,8 +392,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case StreamFold2(a, accums, valueName, seq, result) =>
         requiredness.union(lookup(a).required)
         requiredness.unionFrom(lookup(result))
-      case StreamJoinRightDistinct(left, right, _, _, keyf, joinf, joinType) =>
-        requiredness.union(lookup(left).required)
+      case StreamJoinRightDistinct(left, right, _, _, _, _, joinf, joinType) =>
+        requiredness.union(lookup(left).required && lookup(right).required)
         coerce[RIterable](requiredness).elementType.unionFrom(lookup(joinf))
       case StreamAgg(a, name, query) =>
         requiredness.union(lookup(a).required)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -238,8 +238,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           i += 1
         }
         states.bind(node, s)
-      case StreamLeftJoinDistinct(left, right, l, r, keyf, joinf) =>
-        addElementBinding(l, left)
+      case StreamJoinRightDistinct(left, right, l, r, keyf, joinf, joinType) =>
+        addElementBinding(l, left, makeOptional = (joinType == "outer"))
         addElementBinding(r, right, makeOptional = true)
       case StreamAgg(a, name, query) =>
         addElementBinding(name, a)
@@ -392,7 +392,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case StreamFold2(a, accums, valueName, seq, result) =>
         requiredness.union(lookup(a).required)
         requiredness.unionFrom(lookup(result))
-      case StreamLeftJoinDistinct(left, right, _, _, keyf, joinf) =>
+      case StreamJoinRightDistinct(left, right, _, _, keyf, joinf, joinType) =>
         requiredness.union(lookup(left).required)
         coerce[RIterable](requiredness).elementType.unionFrom(lookup(joinf))
       case StreamAgg(a, name, query) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -305,7 +305,7 @@ object TypeCheck {
         assert(body.typ == zero.typ)
         assert(coerce[TStream](x.typ).elementType == zero.typ)
         assert(zero.typ.isRealizable)
-      case x@StreamLeftJoinDistinct(left, right, l, r, compare, join) =>
+      case x@StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
         val ltyp = coerce[TStream](left.typ)
         val rtyp = coerce[TStream](right.typ)
         assert(compare.typ == TInt32)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -305,11 +305,12 @@ object TypeCheck {
         assert(body.typ == zero.typ)
         assert(coerce[TStream](x.typ).elementType == zero.typ)
         assert(zero.typ.isRealizable)
-      case x@StreamJoinRightDistinct(left, right, l, r, compare, join, joinType) =>
-        val ltyp = coerce[TStream](left.typ)
-        val rtyp = coerce[TStream](right.typ)
-        assert(compare.typ == TInt32)
+      case x@StreamJoinRightDistinct(left, right, lKey, rKey, l, r, join, joinType) =>
+        val lEltTyp = coerce[TStruct](coerce[TStream](left.typ).elementType)
+        val rEltTyp = coerce[TStruct](coerce[TStream](right.typ).elementType)
         assert(coerce[TStream](x.typ).elementType == join.typ)
+        assert(lKey.forall(lEltTyp.hasField))
+        assert(rKey.forall(rEltTyp.hasField))
       case x@StreamFor(a, valueName, body) =>
         assert(a.typ.isInstanceOf[TStream])
         assert(body.typ == TVoid)

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -651,12 +651,14 @@ class PruneSuite extends HailSuite {
     val l = Ref("l", ref.typ)
     val r = Ref("r", ref.typ)
     checkMemo(
-      StreamJoinRightDistinct(st, st, "l", "r",
-        ApplyComparisonOp(LT(TInt32), GetField(l, "a"), GetField(r, "a")),
+      StreamJoinRightDistinct(st, st, FastIndexedSeq("a"), FastIndexedSeq("a"), "l", "r",
         MakeStruct(FastIndexedSeq("a" -> GetField(l, "a"), "b" -> GetField(l, "b"), "c" -> GetField(l, "c"), "d" -> GetField(r, "b"), "e" -> GetField(r, "c"))),
-                              "left"),
-      TStream(justA),
-      Array(TStream(justA), TStream(justA), null, justA))
+        "left"),
+      TStream(TStruct("b" -> TInt32, "d" -> TInt32)),
+      Array(
+        TStream(TStruct("a" -> TInt32, "b" -> TInt32)),
+        TStream(TStruct("a" -> TInt32, "b" -> TInt32)),
+        TStruct("b" -> TInt32, "d" -> TInt32)))
   }
 
   @Test def testStreamForMemo() {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -647,12 +647,14 @@ class PruneSuite extends HailSuite {
       Array(TStream(justA), null, null))
   }
 
-  @Test def testStreamLeftJoinDistinct() {
+  @Test def testStreamJoinRightDistinct() {
     val l = Ref("l", ref.typ)
     val r = Ref("r", ref.typ)
-    checkMemo(StreamLeftJoinDistinct(st, st, "l", "r",
-      ApplyComparisonOp(LT(TInt32), GetField(l, "a"), GetField(r, "a")),
-      MakeStruct(FastIndexedSeq("a" -> GetField(l, "a"), "b" -> GetField(l, "b"), "c" -> GetField(l, "c"), "d" -> GetField(r, "b"), "e" -> GetField(r, "c")))),
+    checkMemo(
+      StreamJoinRightDistinct(st, st, "l", "r",
+        ApplyComparisonOp(LT(TInt32), GetField(l, "a"), GetField(r, "a")),
+        MakeStruct(FastIndexedSeq("a" -> GetField(l, "a"), "b" -> GetField(l, "b"), "c" -> GetField(l, "c"), "d" -> GetField(r, "b"), "e" -> GetField(r, "c"))),
+                              "left"),
       TStream(justA),
       Array(TStream(justA), TStream(justA), null, justA))
   }


### PR DESCRIPTION
This replaces StreamLeftJoinDistinct, and supports a `joinType` flag like `TableJoin`. The plan is to lower `TableJoin` using this, by first doing a `StreamGroupByKey` on the right table to end up in the "right distinct" case, and then exploding after the join.

For now this only adds an implementation for the "outer" case to the existing "left".