### PR TITLE
[query] Fix NDArrayExpression._getitem_ to remember its source

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3581,7 +3581,10 @@ class NDArrayExpression(Expression):
                                   self._indices,
                                   self._aggregations)
 
-        return construct_expr(ir.NDArrayRef(self._ir, [idx._ir for idx in item]), self._type.element_type)
+        return construct_expr(ir.NDArrayRef(self._ir, [idx._ir for idx in item]),
+                              self._type.element_type,
+                              self._indices,
+                              self._aggregations)
 
     @typecheck_method(shape=oneof(expr_int64, tupleof(expr_int64), expr_tuple()))
     def reshape(self, shape):

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -735,3 +735,10 @@ def test_ndarray_emitter_extract():
     mat = hl.nd.array(np_mat)
     mapped_mat = mat.map(lambda x: hl.array([3, 4, 5])[hl.int(x)])
     assert hl.eval(hl.range(5).map(lambda i: mapped_mat[i])) == [3, 4, 5, 4, 3]
+
+
+def test_ndarrays_transmute_ops():
+    u = hl.utils.range_table(10, n_partitions=10)
+    u = u.annotate(x=hl.nd.array([u.idx]), y=hl.nd.array([u.idx]))
+    u = u.transmute(xxx=u.x @ u.y)
+    assert u.xxx.collect() == [x * x for x in range(10)]


### PR DESCRIPTION
CHANGELOG: Fixed issue where accessing an element of an ndarray in a call to Table.transmute would fail.

Because `_indices` was not being set, transmute would fail when it tried to see which row fields to delete. 