### PR TITLE
[query] Replace recursive BTree foreach with iterative version

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -201,30 +201,70 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
     getF.invokeCode(root, km, kv)
 
   def foreach(cb: EmitCodeBuilder)(visitor: (EmitCodeBuilder, Code[Long]) => Unit): Unit = {
-    val f = kb.genEmitMethod("btree_foreach", FastIndexedSeq[ParamType](typeInfo[Long]), typeInfo[Unit])
-    val node = f.getCodeParam[Long](1)
-    val i = f.newLocal[Int]("aobt_foreach_i")
-
+    // This emit should be removable once method splitting has been done properly
+    val f = kb.genEmitMethod("btree_foreach", FastIndexedSeq(), typeInfo[Unit])
     f.emitWithBuilder { cb =>
+
+    val stackI = cb.newLocal[Int]("btree_foreach_stack_i", -1)
+    val nodeStack = cb.newLocal("btree_foreach_node_stack", Code.newArray[Long](const(128)))
+    val idxStack = cb.newLocal("btree_foreach_index_stack", Code.newArray[Int](const(128)))
+
+    def stackPush(node: Code[Long]) = {
+      cb.assign(stackI, stackI + 1)
+      cb += nodeStack.update(stackI, node)
+      cb += idxStack.update(stackI, -1)
+    }
+    def stackUpdateIdx(newIdx: Code[Int]) = {
+      cb += idxStack.update(stackI, newIdx)
+    }
+    def stackPop() = {
+      cb.assign(stackI, stackI - 1)
+    }
+
+    val maxStackI = cb.newLocal("max_stackI", -1)
+    stackPush(root)
+    cb.whileLoop(stackI >= 0, { (Lstart) =>
+      cb.ifx(stackI > maxStackI, cb.assign(maxStackI, stackI))
+      val node = cb.newLocal("btree_foreach_node", nodeStack(stackI))
+      val idx = cb.newLocal("btree_foreach_idx", idxStack(stackI))
+      val Lend = CodeLabel()
+      val Lminus1 = CodeLabel()
+      val labels = Array.fill[CodeLabel](maxElements)(CodeLabel())
+      // this should probably be a switch, don't know how to make it one though
+      // furthermore, we should be able to do the lookups at runtime
+      // FIXME, clean this up once we have fixed arrays
+      cb.ifx(idx.ceq(-1), cb.goto(Lminus1))
+      (0 until maxElements).zip(labels).foreach { case (i, l) =>
+        cb.ifx(idx.ceq(i), cb.goto(l))
+      }
+      cb.goto(Lend)
+
+      cb.define(Lminus1)
       cb.ifx(!isLeaf(node), {
-        cb += f.invokeCode(loadChild(node, -1))
+        stackUpdateIdx(0)
+        stackPush(loadChild(node, -1))
+        cb.goto(Lstart)
       })
-      cb.assign(i, 0)
-      val Lexit = CodeLabel()
       (0 until maxElements).foreach { i =>
+        cb.define(labels(i))
         cb.ifx(hasKey(node, i), {
           visitor(cb, loadKey(node, i))
           cb.ifx(!isLeaf(node), {
-            cb += f.invokeCode(loadChild(node, i))
+            stackUpdateIdx(i + 1)
+            stackPush(loadChild(node, i))
+            cb.goto(Lstart)
           })
         }, {
-          cb.goto(Lexit)
+          cb.goto(Lend)
         })
       }
-      cb.define(Lexit)
-      Code._empty
+
+      cb.define(Lend)
+      stackPop()
+    })
+    Code._empty
     }
-    cb += f.invokeCode(root)
+    cb.invokeVoid(f)
   }
 
   val deepCopy: Code[Long] => Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -174,7 +174,7 @@ class CollectAsSetAggregator(t: PType) extends StagedAggregator {
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit =
     cb += srvb.addArray(resultType.arrayFundamentalType, { sab =>
-      EmitCodeBuilder.scopedVoid(sab.mb) { cb =>
+      EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
         cb += sab.start(state.size)
         state.foreach(cb) { (cb, km, kv) =>
           cb.ifx(km, {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -286,14 +286,14 @@ class GroupedAggregator(kt: PType, nestedAggs: Array[StagedAggregator]) extends 
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
-    cb += srvb.addArray(resultType.arrayFundamentalType, sab => EmitCodeBuilder.scopedVoid(sab.mb) { cb =>
+    cb += srvb.addArray(resultType.arrayFundamentalType, sab => EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
       cb += sab.start(state.size)
       state.foreach(cb) { (cb, km, kv) =>
-        cb += sab.addBaseStruct(resultType.elementType, ssb => EmitCodeBuilder.scopedVoid(ssb.mb) { cb =>
+        cb += sab.addBaseStruct(resultType.elementType, ssb => EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
           cb += ssb.start
           cb.ifx(km, cb += ssb.setMissing(), cb += ssb.addWithDeepCopy(kt, kv))
           cb += ssb.advance()
-          cb += ssb.addBaseStruct(resultEltType, svb => EmitCodeBuilder.scopedVoid(svb.mb) { cb =>
+          cb += ssb.addBaseStruct(resultEltType, svb => EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
             cb += svb.start()
             state.nested.toCode(cb, "grouped_result", { (cb, i, s) =>
               nestedAggs(i).result(cb, s, svb)


### PR DESCRIPTION
Allocate a fixed stack, as it was the simplest thing I could do.  128 stack
slots should be more than enough for this implementation as it requires one
stack slot per level of the tree.

There are many improvements that can be made here, but hopefully this should
unblock some amount of the method splitting work.
