### PR TITLE
Lower Force Count

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -23,6 +23,7 @@ object Children {
     case IsNA(value) =>
       Array(value)
     case Coalesce(values) => values.toFastIndexedSeq
+    case Consume(value) => FastIndexedSeq(value)
     case If(cond, cnsq, altr) =>
       Array(cond, cnsq, altr)
     case Let(name, value, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -24,6 +24,8 @@ object Copy {
         IsNA(newChildren(0).asInstanceOf[IR])
       case Coalesce(_) =>
         Coalesce(newChildren.map(_.asInstanceOf[IR]))
+      case Consume(_) =>
+        Consume(newChildren(0).asInstanceOf[IR])
       case If(_, _, _) =>
         assert(newChildren.length == 3)
         If(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -675,6 +675,13 @@ class Emit[C](
         presentC(const(true))
       case False() =>
         presentC(const(false))
+      case Consume(value) => {
+        val iec = emitI(value)
+        iec.map(cb){pc =>
+          // Ignore pc, just return a 1
+          PCode(ir.pType, 1L)
+        }
+      }
 
       case Cast(v, typ) =>
         val iec = emitI(v)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -676,13 +676,12 @@ class Emit[C](
       case False() =>
         presentC(const(false))
       case Consume(value) => {
-        val iec = emitI(value)
-        iec.map(cb){pc =>
+        emitI(value).map(cb){pc =>
+          cb.memoizeField(pc, "consumed_field")
           // Ignore pc, just return a 1
           PCode(ir.pType, 1L)
         }
       }
-
       case Cast(v, typ) =>
         val iec = emitI(v)
         val cast = Casts.get(v.typ, typ)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -107,6 +107,8 @@ final case class Coalesce(values: Seq[IR]) extends IR {
   require(values.nonEmpty)
 }
 
+final case class Consume(value: IR) extends IR
+
 final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 
 final case class AggLet(name: String, value: IR, body: IR, isScan: Boolean) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -21,6 +21,7 @@ object InferType {
       case NA(t) => t
       case IsNA(_) => TBoolean
       case Coalesce(values) => values.head.typ
+      case Consume(_) => TInt64
       case Ref(_, t) => t
       case RelationalRef(_, t) => t
       case RelationalLet(_, _, body) => body.typ

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -867,6 +867,7 @@ object PruneDeadFields {
           memoizeValueIR(alt, requestedType, memo)
         )
       case Coalesce(values) => unifyEnvsSeq(values.map(memoizeValueIR(_, requestedType, memo)))
+      case Consume(value) => memoizeValueIR(value, value.typ, memo)
       case Let(name, value, body) =>
         val bodyEnv = memoizeValueIR(body, requestedType, memo)
         val valueType = bodyEnv.eval.lookupOption(name) match {
@@ -1636,6 +1637,10 @@ object PruneDeadFields {
           Coalesce(values2)
         else
           Coalesce(values2.map(upcast(_, requestedType)))
+      case Consume(value) => {
+        val value2 = rebuildIR(value, env, memo)
+        Consume(value2)
+      }
       case Let(name, value, body) =>
         val value2 = rebuildIR(value, env, memo)
         Let(

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.methods.ForceCountTable
 import is.hail.types._
 import is.hail.types.physical.PType
 import is.hail.types.virtual._
@@ -307,6 +308,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case ApplyComparisonOp(op, l, r) =>
         fatal(s"non-strict comparison op $op must have explicit case")
       case TableCount(t) =>
+      case TableToValueApply(t, ForceCountTable()) =>
 
       case _: NA => requiredness.union(false)
       case Literal(t, a) => requiredness.unionLiteral(a)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.expr.ir._
 import is.hail.types
 import is.hail.types.virtual._
-import is.hail.methods.NPartitionsTable
+import is.hail.methods.{ForceCountTable, NPartitionsTable}
 import is.hail.rvd.{AbstractRVDSpec, RVDPartitioner}
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -607,6 +607,10 @@ object LowerTableIR {
       case TableCount(tableIR) =>
         invoke("sum", TInt64,
           lower(tableIR).mapPartition(rows => Cast(StreamLen(rows), TInt64)).collect())
+
+      case TableToValueApply(child, ForceCountTable()) =>
+        invoke("sum", TInt64,
+          lower(child).mapPartition(rows => Cast(StreamLen(mapIR(rows)(row => Consume(row))), TInt64)).collect())
 
       case TableGetGlobals(child) =>
         val stage = lower(child)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
+import is.hail.methods.ForceCountTable
 import is.hail.types._
 import is.hail.types.physical.PStruct
 import is.hail.types.virtual._
@@ -27,6 +28,11 @@ class TableIRSuite extends HailSuite {
     assertEvalsTo(node1, 10L)
     assertEvalsTo(node2, 15L)
     assertEvalsTo(node, 25L)
+  }
+
+  @Test def testRangeForceCount(): Unit = {
+    val forceCountRange = TableToValueApply(TableRange(100, 2), ForceCountTable())
+    assertEvalsTo(forceCountRange, 100L)
   }
 
   @Test def testRangeRead() {

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -30,9 +30,11 @@ class TableIRSuite extends HailSuite {
     assertEvalsTo(node, 25L)
   }
 
-  @Test def testRangeForceCount(): Unit = {
-    val forceCountRange = TableToValueApply(TableRange(100, 2), ForceCountTable())
-    assertEvalsTo(forceCountRange, 100L)
+  @Test def testForceCount(): Unit = {
+    implicit val execStrats = ExecStrategy.interpretOnly
+    val tableRangeSize = Int.MaxValue / 20
+    val forceCountRange = TableToValueApply(TableRange(tableRangeSize, 2), ForceCountTable())
+    assertEvalsTo(forceCountRange, tableRangeSize.toLong)
   }
 
   @Test def testRangeRead() {


### PR DESCRIPTION
Added a `Consume` IR that just emits its body and then returns a 1. I think I did the `IEmitCode` bit right such that it should emit all of the inner code, then ignore it and return 1, but I'd appreciate a second set of eyes. The lowering rule is trivial given that `Consume` exists. 

In the future, may be better to delete `ForceCountTable` entirely, and just use `Consume` from Python. 

cc @tpoterba 