### PR TITLE
[query] bugfix in TableFilterIntervals.execute

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2313,7 +2313,7 @@ case class TableFilterIntervals(child: TableIR, intervals: IndexedSeq[Interval],
     val partitioner = RVDPartitioner.union(
       tv.typ.keyType,
       intervals,
-      tv.rvd.typ.key.length - 1)
+      tv.typ.keyType.size - 1)
     TableValue(ctx, tv.typ, tv.globals, tv.rvd.filterIntervals(partitioner, keep))
   }
 }


### PR DESCRIPTION
If `tv.rvd.typ.key` is longer than `tv.typ.key`, then this would create a partitioner with `allowedOverlap` > the length of the partitioner key.