### PR TITLE
[query] fix converting iterator/buffer to stream

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -7,7 +7,7 @@ import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.EmitStream.SizedStream
 import is.hail.expr.ir.lowering.TableStage
 import is.hail.types.TableType
-import is.hail.types.physical.{PCode, PInt64Optional, PStruct, PType}
+import is.hail.types.physical.{PStruct, PType}
 import is.hail.types.virtual.{TArray, TStruct, Type}
 import is.hail.rvd.{RVD, RVDCoercer, RVDContext, RVDPartitioner, RVDType}
 import is.hail.sparkextras.ContextRDD
@@ -49,6 +49,7 @@ class PartitionIteratorLongReader(
       SizedStream.unsized(Stream.unfold[Code[Long]](
         (_, k) =>
           Code(
+            Code._fatal[Unit](""),
             hasNext := it.get.hasNext,
             hasNext.orEmpty(next := Code.longValue(it.get.next())),
             k(COption(!hasNext, next))),

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -602,6 +602,11 @@ class EmitStreamSuite extends HailSuite {
       ), intsPType)
     assert(f2(Seq(1, 5, 2, 9).iterator) == IndexedSeq(1, 5, 2, 9).flatMap(0 until _))
     assert(f2(null) == null)
+
+    val f3 = compileStreamWithIter(
+      StreamRange(0, StreamLen(In(0, intsPType)), 1), intsPType)
+    assert(f3(Seq(1, 5, 2, 9).iterator) == IndexedSeq(0, 1, 2, 3))
+    assert(f3(Seq().iterator) == IndexedSeq())
   }
 
   @Test def testEmitIf() {

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -45,6 +45,12 @@ class TableIRSuite extends HailSuite {
     assertEvalsTo(TableCollect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))
   }
 
+  @Test def testCountRead(): Unit = {
+    implicit val execStrats = ExecStrategy.lowering
+    val tir: TableIR = TableRead.native(fs, "src/test/resources/three_key.ht")
+    assertEvalsTo(TableCount(tir), 120L)
+  }
+
   @Test def testRangeCollect() {
     implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)


### PR DESCRIPTION
In several places constructing a stream from in iterator or buffer, the side effect of advancing the input was packaged with the value passed to the stream consumer. If that value was never used, the input wasn't advanced properly.

I fixed this pattern every place I could think of: the two `PartitionReader`s, and the `In` node allowing a java iterator to be passed as a stream argument to a compiled function.