### PR TITLE
[query][ptypes] allow requiredness to handle shared nodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComputeUsesAndDefs.scala
@@ -57,9 +57,11 @@ object ComputeUsesAndDefs {
         case r: BaseRef =>
           env.eval.lookupOption(r.name) match {
             case Some(decl) =>
-              val re = RefEquality(r)
-              uses.lookup(decl) += re
-              defs.bind(re, decl)
+              if (!defs.contains(r)) {
+                val re = RefEquality(r)
+                uses.lookup(decl) += re
+                defs.bind(re, decl)
+              }
             case None =>
               if (errorIfFreeVariables)
                 throw new RuntimeException(s"found variable with no definition: ${ r.name }")

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -107,7 +107,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
   def lookup(node: IR): TypeWithRequiredness = coerce[TypeWithRequiredness](cache(node))
   def lookupAs[T <: TypeWithRequiredness](node: IR): T = coerce[T](cache(node))
 
-  private def initializeState(node: BaseIR): Unit = {
+  private def initializeState(node: BaseIR): Unit = if (!cache.contains(node)) {
     val re = RefEquality(node)
     node match {
       case x: ApplyIR =>
@@ -295,9 +295,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
            _: ArrayZeros |
            _: StreamRange |
            _: WriteValue =>
-        requiredness.union(node.children.forall(c => cache(c).required))
+        requiredness.union(node.children.forall { case c: IR => lookup(c).required }
       case x: ApplyComparisonOp if x.op.strict =>
-        requiredness.union(node.children.forall(c => cache(c).required))
+        requiredness.union(node.children.forall { case c: IR => lookup(c).required }
 
       // always required
       case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -295,9 +295,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
            _: ArrayZeros |
            _: StreamRange |
            _: WriteValue =>
-        requiredness.union(node.children.forall { case c: IR => lookup(c).required }
+        requiredness.union(node.children.forall { case c: IR => lookup(c).required })
       case x: ApplyComparisonOp if x.op.strict =>
-        requiredness.union(node.children.forall { case c: IR => lookup(c).required }
+        requiredness.union(node.children.forall { case c: IR => lookup(c).required })
 
       // always required
       case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>


### PR DESCRIPTION
Although we generally want unshared IRs for downstream passes, there are many instances where we construct IRs with shared nodes (common case: using the same Ref for the table row in TableMapRows expressions). 

Requiredness correctness should not be affected by node-sharing, and deduplicating every time we want to run the requiredness analysis is potentially very expensive since the goal is to be able to run it at arbitrary points in the lowering stack, so I'm going to allow Requiredness to handle shared nodes.

This could potentially mess up if there are instances where a ref is created and used to represent two separate values for whatever reason, but I think we should consider that to be a bug---e.g.
```
val r = Ref("foo", TInt32)
If(…, 
    Let("foo", NA(TInt32), r + 3)
    Let("foo", I32(5), r + 5))
```
should never exist.

I've done the same for ComputeUsesAndDefs, which Requiredness needs, but same comment applies---correctness should not be affected by node sharing, unless we have improperly constructed IR with scoping issues.