### PR TITLE
[query] Local backend

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -6,7 +6,7 @@ import socket
 import socketserver
 from threading import Thread
 import py4j
-import pyspark
+from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 
 import hail
 from hail.utils.java import FatalError, Env, scala_package_object, scala_object
@@ -20,11 +20,11 @@ from hail.matrixtable import MatrixTable
 
 from .py4j_backend import Py4JBackend
 from ..hail_logging import Logger
+from ..fs.local_fs import LocalFS
 
 
 def handle_java_exception(f):
     def deco(*args, **kwargs):
-        import pyspark
         try:
             return f(*args, **kwargs)
         except py4j.protocol.Py4JJavaError as e:
@@ -39,10 +39,6 @@ def handle_java_exception(f):
             raise FatalError('%s\n\nJava stack trace:\n%s\n'
                              'Hail version: %s\n'
                              'Error summary: %s' % (deepest, full, hail.__version__, deepest)) from None
-        except pyspark.sql.utils.CapturedException as e:
-            raise FatalError('%s\n\nJava stack trace:\n%s\n'
-                             'Hail version: %s\n'
-                             'Error summary: %s' % (e.desc, e.stackTrace, hail.__version__, e.desc)) from None
 
     return deco
 
@@ -137,70 +133,30 @@ class Log4jLogger(Logger):
         self._log_pkg.info(msg)
 
 
-class SparkBackend(Py4JBackend):
-    def __init__(self, idempotent, sc, spark_conf, app_name, master,
-                 local, log, quiet, append, min_block_size,
-                 branching_factor, tmpdir, local_tmpdir, skip_logging_configuration, optimizer_iterations):
-        if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
-            hail_jar_path = pkg_resources.resource_filename(__name__, "hail-all-spark.jar")
-            assert os.path.exists(hail_jar_path), f'{hail_jar_path} does not exist'
-            conf = pyspark.SparkConf()
-
-            base_conf = spark_conf or {}
-            for k, v in base_conf.items():
-                conf.set(k, v)
-
-            jars = [hail_jar_path]
-
-            if os.environ.get('HAIL_SPARK_MONITOR'):
-                import sparkmonitor
-                jars.append(os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar'))
-                conf.set("spark.extraListeners", "sparkmonitor.listener.JupyterSparkMonitorListener")
-
-            conf.set('spark.jars', ','.join(jars))
-            conf.set('spark.driver.extraClassPath', ','.join(jars))
-            conf.set('spark.executor.extraClassPath', './hail-all-spark.jar')
-            if sc is None:
-                pyspark.SparkContext._ensure_initialized(conf=conf)
-            elif not quiet:
-                sys.stderr.write(
-                    'pip-installed Hail requires additional configuration options in Spark referring\n'
-                    '  to the path to the Hail Python module directory HAIL_DIR,\n'
-                    '  e.g. /path/to/python/site-packages/hail:\n'
-                    '    spark.jars=HAIL_DIR/hail-all-spark.jar\n'
-                    '    spark.driver.extraClassPath=HAIL_DIR/hail-all-spark.jar\n'
-                    '    spark.executor.extraClassPath=./hail-all-spark.jar')
-        else:
-            pyspark.SparkContext._ensure_initialized()
-
-        self._gateway = pyspark.SparkContext._gateway
-        self._jvm = pyspark.SparkContext._jvm
+class LocalBackend(Py4JBackend):
+    def __init__(self, tmpdir, log, quiet, append, branching_factor,
+                 skip_logging_configuration, optimizer_iterations):
+        print('in LocalBackend.__init__')
+        SPARK_HOME = os.environ['SPARK_HOME']
+        HAIL_HOME = os.environ['HAIL_HOME']
+        port = launch_gateway(
+            redirect_stdout=sys.stdout,
+            redirect_stderr=sys.stderr,
+            jarpath=f'{SPARK_HOME}/jars/py4j-0.10.7.jar',
+            classpath=f'{SPARK_HOME}/jars/*:{HAIL_HOME}/hail/build/libs/hail-all-spark.jar',
+            die_on_exit=True)
+        self._gateway = JavaGateway(
+            gateway_parameters=GatewayParameters(port=port, auto_convert=True))
+        self._jvm = self._gateway.jvm
 
         hail_package = getattr(self._jvm, 'is').hail
 
         self._hail_package = hail_package
         self._utils_package_object = scala_package_object(hail_package.utils)
 
-        jsc = sc._jsc.sc() if sc else None
-
-        if idempotent:
-            self._jbackend = hail_package.backend.spark.SparkBackend.getOrCreate(
-                jsc, app_name, master, local, True, min_block_size, tmpdir, local_tmpdir)
-            self._jhc = hail_package.HailContext.getOrCreate(
-                self._jbackend, log, True, append, branching_factor, skip_logging_configuration, optimizer_iterations)
-        else:
-            self._jbackend = hail_package.backend.spark.SparkBackend.apply(
-                jsc, app_name, master, local, True, min_block_size, tmpdir, local_tmpdir)
-            self._jhc = hail_package.HailContext.apply(
-                self._jbackend, log, True, append, branching_factor, skip_logging_configuration, optimizer_iterations)
-
-        self._jsc = self._jbackend.sc()
-        if sc:
-            self.sc = sc
-        else:
-            self.sc = pyspark.SparkContext(gateway=self._gateway, jsc=self._jvm.JavaSparkContext(self._jsc))
-        self._jspark_session = self._jbackend.sparkSession()
-        self._spark_session = pyspark.sql.SparkSession(self.sc, self._jspark_session)
+        self._jbackend = hail_package.backend.local.LocalBackend.apply(tmpdir)
+        self._jhc = hail_package.HailContext.apply(
+            self._jbackend, log, True, append, branching_factor, skip_logging_configuration, optimizer_iterations)
 
         # This has to go after creating the SparkSession. Unclear why.
         # Maybe it does its own patch?
@@ -215,17 +171,11 @@ class SparkBackend(Py4JBackend):
                                f"  JAR:    {jar_version}\n"
                                f"  Python: {py_version}")
 
-        self._fs = None
+        self._fs = LocalFS()
         self._logger = None
 
         if not quiet:
-            sys.stderr.write('Running on Apache Spark version {}\n'.format(self.sc.version))
-            if self._jsc.uiWebUrl().isDefined():
-                sys.stderr.write('SparkUI available at {}\n'.format(self._jsc.uiWebUrl().get()))
-
             connect_logger(self._utils_package_object, 'localhost', 12888)
-
-            self._jbackend.startProgressBar()
 
     def jvm(self):
         return self._jvm
@@ -239,8 +189,7 @@ class SparkBackend(Py4JBackend):
     def stop(self):
         self._jhc.stop()
         self._jhc = None
-        self.sc.stop()
-        self.sc = None
+        # FIXME stop gateway?
         uninstall_exception_handler()
 
     def _parse_value_ir(self, code, ref_map={}, ir_map={}):
@@ -253,6 +202,10 @@ class SparkBackend(Py4JBackend):
         return self._jbackend.parse_table_ir(code, ref_map, ir_map)
 
     def _parse_matrix_ir(self, code, ref_map={}, ir_map={}):
+        print(type(code))
+        print(code)
+        print(ref_map)
+        print(ir_map)
         return self._jbackend.parse_matrix_ir(code, ref_map, ir_map)
 
     def _parse_blockmatrix_ir(self, code, ref_map={}, ir_map={}):
@@ -266,9 +219,6 @@ class SparkBackend(Py4JBackend):
 
     @property
     def fs(self):
-        if self._fs is None:
-            from hail.fs.hadoop_fs import HadoopFS
-            self._fs = HadoopFS(self._utils_package_object, self._jbackend.fs())
         return self._fs
 
     def _to_java_ir(self, ir, parse):
@@ -327,48 +277,33 @@ class SparkBackend(Py4JBackend):
         jir = self._to_java_blockmatrix_ir(bmir)
         return tblockmatrix._from_java(jir.typ())
 
-    def from_spark(self, df, key):
-        return Table._from_java(self._jbackend.pyFromDF(df._jdf, key))
-
-    def to_spark(self, t, flatten):
-        t = t.expand_types()
-        if flatten:
-            t = t.flatten()
-        return pyspark.sql.DataFrame(self._jbackend.pyToDF(self._to_java_table_ir(t._tir)), Env.spark_session()._wrapped)
-
-    def to_pandas(self, t, flatten):
-        return self.to_spark(t, flatten).toPandas()
-
-    def from_pandas(self, df, key):
-        return Table.from_spark(Env.spark_session().createDataFrame(df), key)
-
     def add_reference(self, config):
-        Env.hail().variant.ReferenceGenome.fromJSON(json.dumps(config))
+        self._hail_package.variant.ReferenceGenome.fromJSON(json.dumps(config))
 
     def load_references_from_dataset(self, path):
-        return json.loads(Env.hail().variant.ReferenceGenome.fromHailDataset(self.fs._jfs, path))
+        return json.loads(self._hail_package.variant.ReferenceGenome.fromHailDataset(self.fs._jfs, path))
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
         self._jbackend.pyFromFASTAFile(
             name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par)
 
     def remove_reference(self, name):
-        Env.hail().variant.ReferenceGenome.removeReference(name)
+        self._hail_package.variant.ReferenceGenome.removeReference(name)
 
     def get_reference(self, name):
-        return json.loads(Env.hail().variant.ReferenceGenome.getReference(name).toJSONString())
+        return json.loads(self._hail_package.variant.ReferenceGenome.getReference(name).toJSONString())
 
     def add_sequence(self, name, fasta_file, index_file):
         self._jbackend.pyAddSequence(name, fasta_file, index_file)
 
     def remove_sequence(self, name):
-        scala_object(Env.hail().variant, 'ReferenceGenome').removeSequence(name)
+        scala_object(self._hail_package.variant, 'ReferenceGenome').removeSequence(name)
 
     def add_liftover(self, name, chain_file, dest_reference_genome):
         self._jbackend.pyReferenceAddLiftover(name, chain_file, dest_reference_genome)
 
     def remove_liftover(self, name, dest_reference_genome):
-        scala_object(Env.hail().variant, 'ReferenceGenome').referenceRemoveLiftover(
+        scala_object(self._hail_package.variant, 'ReferenceGenome').referenceRemoveLiftover(
             name, dest_reference_genome)
 
     def parse_vcf_metadata(self, path):

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -1,4 +1,3 @@
-import pkg_resources
 import sys
 import os
 import json
@@ -136,7 +135,6 @@ class Log4jLogger(Logger):
 class LocalBackend(Py4JBackend):
     def __init__(self, tmpdir, log, quiet, append, branching_factor,
                  skip_logging_configuration, optimizer_iterations):
-        print('in LocalBackend.__init__')
         SPARK_HOME = os.environ['SPARK_HOME']
         HAIL_HOME = os.environ['HAIL_HOME']
         port = launch_gateway(

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,0 +1,16 @@
+import abc
+from .backend import Backend
+
+
+class Py4JBackend(Backend):
+    @abc.abstractmethod
+    def jvm(self):
+        pass
+    
+    @abc.abstractmethod
+    def hail_package(self):
+        pass
+
+    @abc.abstractmethod
+    def utils_package_object(self):
+        pass

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -6,7 +6,7 @@ class Py4JBackend(Backend):
     @abc.abstractmethod
     def jvm(self):
         pass
-    
+
     @abc.abstractmethod
     def hail_package(self):
         pass

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -262,6 +262,41 @@ def init_service(
         global_seed, backend)
 
 
+@typecheck(
+    log=nullable(str),
+    quiet=bool,
+    append=bool,
+    branching_factor=int,
+    tmpdir=nullable(str),
+    default_reference=enumeration('GRCh37', 'GRCh38', 'GRCm38', 'CanFam3'),
+    global_seed=nullable(int),
+    skip_logging_configuration=bool,
+    _optimizer_iterations=nullable(int))
+def init_local(
+        log=None,
+        quiet=False,
+        append=False,
+        branching_factor=50,
+        tmpdir=None,
+        default_reference='GRCh37',
+        global_seed=6348563392232659379,
+        skip_logging_configuration=False,
+        _optimizer_iterations=None):
+    from hail.backend.local_backend import LocalBackend
+
+    log = _get_log(log)
+    tmpdir = _get_tmpdir(tmpdir)
+    optimizer_iterations = get_env_or_default(_optimizer_iterations, 'HAIL_OPTIMIZER_ITERATIONS', 3)
+
+    backend = LocalBackend(
+        tmpdir, log, quiet, append, branching_factor,
+        skip_logging_configuration, optimizer_iterations)
+
+    HailContext(
+        log, quiet, append, tmpdir, tmpdir, default_reference,
+        global_seed, backend)
+
+
 def version():
     """Get the installed hail version.
 

--- a/hail/python/hail/fs/local_fs.py
+++ b/hail/python/hail/fs/local_fs.py
@@ -1,0 +1,59 @@
+import os
+from stat import S_ISREG, S_ISDIR
+from typing import Dict, List
+from hurry.filesize import size
+from shutil import copy2
+
+from .fs import FS
+
+
+class LocalFS(FS):
+    def __init__(self):
+        pass
+
+    def open(self, path: str, mode: str = 'r'):
+        return open(path, mode)
+
+    def copy(self, src: str, dest: str):
+        dst_w_file = dest
+        if os.path.isdir(dst_w_file):
+            dst_w_file = os.path.join(dest, os.path.basename(src))
+
+        copy2(src, dst_w_file)
+        stats = os.stat(src)
+
+        os.chown(dst_w_file, stats.st_uid, stats.st_gid)
+
+    def exists(self, path: str) -> bool:
+        return os.path.exists(path)
+
+    def is_file(self, path: str) -> bool:
+        try:
+            return S_ISREG(os.stat(path).st_mode)
+        except FileNotFoundError:
+            return False
+
+    def is_dir(self, path: str) -> bool:
+        try:
+            return self._stat_is_local_dir(os.stat(path))
+        except FileNotFoundError:
+            return False
+
+    def stat(self, path: str) -> Dict:
+        return self._format_stat_local_file(os.stat(path), path)
+
+    def _format_stat_local_file(self, stats: os.stat_result, path: str) -> Dict:
+        return {
+            'is_dir': self._stat_is_local_dir(stats),
+            'size_bytes': stats.st_size,
+            'size': size(stats.st_size),
+            'path': path,
+            'owner': stats.st_uid,
+            'modification_time': stats.st_mtime,
+        }
+
+    def _stat_is_local_dir(self, stats: os.stat_result) -> bool:
+        return S_ISDIR(stats.st_mode)
+
+    def ls(self, path: str) -> List[Dict]:
+        return [self._format_stat_local_file(os.stat(file), file) for file in os.listdir(path)]

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -26,11 +26,11 @@ class Env:
 
     @staticmethod
     def hail():
-        return Env.spark_backend('Env.hail').hail_package()
+        return Env.py4j_backend('Env.hail').hail_package()
 
     @staticmethod
     def jutils():
-        return Env.spark_backend('Env.jutils').utils_package_object()
+        return Env.py4j_backend('Env.jutils').utils_package_object()
 
     @staticmethod
     def hc():
@@ -44,6 +44,11 @@ class Env:
             elif backend_name == 'spark':
                 from hail.context import init
                 init()
+            elif backend_name == 'local':
+                from hail.context import init_local
+                init_local()
+            else:
+                raise ValueError(f'unknown Hail Query backend: {backend_name}')
 
         assert Env._hc is not None
         return Env._hc
@@ -51,6 +56,16 @@ class Env:
     @staticmethod
     def backend():
         return Env.hc()._backend
+
+    @staticmethod
+    def py4j_backend(op):
+        from hail.backend.py4j_backend import Py4JBackend
+        b = Env.backend()
+        if isinstance(b, Py4JBackend):
+            return b
+        else:
+            raise NotImplementedError(
+                f"{b.__class__.__name__} doesn't support {op}, only Py4JBackend")
 
     @staticmethod
     def spark_backend(op):

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -3,6 +3,7 @@ from timeit import default_timer as timer
 import unittest
 from decorator import decorator
 
+from hail.utils.java import Env
 import hail as hl
 
 _initialized = False
@@ -11,7 +12,11 @@ _initialized = False
 def startTestHailContext():
     global _initialized
     if not _initialized:
-        hl.init(master='local[1]', min_block_size=0, quiet=True)
+        backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
+        if backend_name == 'spark':
+            hl.init(master='local[1]', min_block_size=0, quiet=True)
+        else:
+            Env.hc()  # force initialization
         _initialized = True
 
 

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -1,0 +1,208 @@
+package is.hail.backend.local
+
+import is.hail.annotations.UnsafeRow
+import is.hail.asm4s._
+import is.hail.expr.ir.IRParser
+import is.hail.types.encoded.EType
+import is.hail.io.{BufferSpec, TypedCodecSpec}
+import is.hail.annotations.{Region, SafeRow}
+import is.hail.expr.{JSONAnnotationImpex, Validate}
+import is.hail.expr.ir.lowering._
+import is.hail.expr.ir._
+import is.hail.types.physical.{PTuple, PType}
+import is.hail.types.virtual.TVoid
+import is.hail.backend.{Backend, BroadcastValue}
+import is.hail.io.fs.{FS, HadoopFS}
+import is.hail.utils._
+import is.hail.io.bgen.IndexBgen
+import is.hail.variant.ReferenceGenome
+
+import org.apache.hadoop
+import org.json4s.DefaultFormats
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
+import java.io.PrintWriter
+
+class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T]
+
+object LocalBackend {
+  private var theLocalBackend: LocalBackend = _
+
+  def apply(tmpdir: String): LocalBackend = synchronized {
+    require(theLocalBackend == null)
+
+    theLocalBackend = new LocalBackend(tmpdir)
+    theLocalBackend
+  }
+
+  def stop(): Unit = synchronized {
+    if (theLocalBackend != null) {
+      theLocalBackend = null
+    }
+  }
+}
+
+class LocalBackend(
+  val tmpdir: String
+) extends Backend {
+  // FIXME don't rely on hadoop
+  val hadoopConf = new hadoop.conf.Configuration()
+  hadoopConf.set(
+    "hadoop.io.compression.codecs",
+    "org.apache.hadoop.io.compress.DefaultCodec,"
+      + "is.hail.io.compress.BGzipCodec,"
+      + "is.hail.io.compress.BGzipCodecTbi,"
+      + "org.apache.hadoop.io.compress.GzipCodec")
+  
+  val fs: FS = new HadoopFS(new SerializableHadoopConfiguration(hadoopConf))
+
+  def withExecuteContext[T]()(f: ExecuteContext => T): T = {
+    ExecuteContext.scoped(tmpdir, tmpdir, this, fs)(f)
+  }
+
+  def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new LocalBroadcastValue[T](value)
+
+  def parallelizeAndComputeWithIndex[T : ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U] = {
+    collection.zipWithIndex.map { case (c, i) =>
+      f(c, i)
+    }
+  }
+
+  def defaultParallelism: Int = 1
+
+  def stop(): Unit = LocalBackend.stop()
+
+  private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir0: IR, print: Option[PrintWriter] = None): (PTuple, Long) = {
+    val ir = LoweringPipeline.darrayLowerer(DArrayLowering.All).apply(ctx, ir0, optimize = true).asInstanceOf[IR]
+
+    if (!Compilable(ir))
+      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")
+
+    assert(ir.typ != TVoid)
+
+    val (pt: PTuple, f) = ctx.timer.time("Compile") {
+      Compile[AsmFunction1RegionLong](ctx,
+        FastIndexedSeq[(String, PType)](),
+        FastIndexedSeq(classInfo[Region]), LongInfo,
+        MakeTuple.ordered(FastSeq(ir)),
+        print = print)
+    }
+
+    ctx.timer.time("Run") {
+      (pt, f(0, ctx.r).apply(ctx.r))
+    }
+  }
+
+  private[this] def _execute(ctx: ExecuteContext, ir: IR): (PTuple, Long) = {
+    TypeCheck(ir)
+    Validate(ir)
+    _jvmLowerAndExecute(ctx, ir)
+  }
+
+  def execute(ir: IR): (Any, ExecutionTimer) =
+    withExecuteContext() { ctx =>
+      val (pt, a) = _execute(ctx, ir)
+      (SafeRow(pt, a).get(0), ctx.timer)
+    }
+
+  def executeJSON(ir: IR): String = {
+    val t = ir.typ
+    val (value, timings) = execute(ir)
+    val jsonValue = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
+    timings.finish()
+    timings.logInfo()
+
+    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
+  }
+
+  def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) = {
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    withExecuteContext() { ctx =>
+      val (pt, a) = _execute(ctx, ir)
+      assert(pt.size == 1)
+      val elementType = pt.fields(0).typ
+      val codec = TypedCodecSpec(
+        EType.defaultFromPType(elementType), elementType.virtualType, bs)
+      assert(pt.isFieldDefined(a, 0))
+      (elementType.toString, codec.encode(ctx, elementType, pt.loadField(a, 0)))
+    }
+  }
+
+  def decodeToJSON(ptypeString: String, b: Array[Byte], bufferSpecString: String): String = {
+    val t = IRParser.parsePType(ptypeString)
+    val bs = BufferSpec.parseOrDefault(bufferSpecString)
+    val codec = TypedCodecSpec(EType.defaultFromPType(t), t.virtualType, bs)
+    withExecuteContext() { ctx =>
+      val (pt, off) = codec.decode(ctx, t.virtualType, b, ctx.r)
+      assert(pt.virtualType == t.virtualType)
+      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
+        UnsafeRow.read(pt, ctx.r, off), pt.virtualType))
+    }
+  }
+
+  def pyIndexBgen(
+    files: java.util.List[String],
+    indexFileMap: java.util.Map[String, String],
+    rg: String,
+    contigRecoding: java.util.Map[String, String],
+    skipInvalidLoci: Boolean) {
+    withExecuteContext() { ctx =>
+      IndexBgen(ctx, files.asScala.toArray, indexFileMap.asScala.toMap, Option(rg), contigRecoding.asScala.toMap, skipInvalidLoci)
+    }
+    info(s"Number of BGEN files indexed: ${ files.size() }")
+  }
+
+  def pyReferenceAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
+    withExecuteContext() { ctx =>
+      ReferenceGenome.referenceAddLiftover(ctx, name, chainFile, destRGName)
+    }
+  }
+
+  def pyFromFASTAFile(name: String, fastaFile: String, indexFile: String,
+    xContigs: java.util.List[String], yContigs: java.util.List[String], mtContigs: java.util.List[String],
+    parInput: java.util.List[String]): ReferenceGenome = {
+    withExecuteContext() { ctx =>
+      ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
+        xContigs.asScala.toArray, yContigs.asScala.toArray, mtContigs.asScala.toArray, parInput.asScala.toArray)
+    }
+  }
+
+  def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit = {
+    withExecuteContext() { ctx =>
+      ReferenceGenome.addSequence(ctx, name, fastaFile, indexFile)
+    }
+  }
+
+  def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def parse_blockmatrix_ir(
+    s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
+  ): BlockMatrixIR = {
+    withExecuteContext() { ctx =>
+      IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    }
+  }
+
+  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage = {
+    // Use a local sort for the moment to enable larger pipelines to run
+    LowerDistributedSort.localSort(ctx, stage, sortFields)
+  }
+}


### PR DESCRIPTION
Bascially grabbed the relevant bits from SparkBackend and ServiceBackend.  Enabled by setting HAIL_QUERY_BACKEND=local.  Needs HAIL_HOME and SPARK_HOME set to find jars, and hardcodes the py4j jar version that comes with Spark 2.4.x.  Will have to work on ripping out Spark dependency. Currently uses HadoopFS for the file system in Java.  GoogleFS in Python works with gs:// or local files, I just copied it and ripped out the Google stuff.  Some some rough ideas from some of your old work, @johnc1231 (py4jbackend).  Current results on the Python tests:

 > == 470 failed, 245 passed, 87 skipped, 15 warnings, 1 error in 270.61 seconds ==
