### PR TITLE
[query] Add `hl.die` function for error checking.

### DIFF
--- a/hail/python/hail/docs/functions/core.rst
+++ b/hail/python/hail/docs/functions/core.rst
@@ -12,6 +12,7 @@ Core language functions
     bind
     rbind
     null
+    die
     str
     is_missing
     is_defined
@@ -29,6 +30,7 @@ Core language functions
 .. autofunction:: bind
 .. autofunction:: rbind
 .. autofunction:: null
+.. autofunction:: die
 .. autofunction:: str
 .. autofunction:: is_missing
 .. autofunction:: is_defined

--- a/hail/python/hail/docs/functions/index.rst
+++ b/hail/python/hail/docs/functions/index.rst
@@ -31,6 +31,7 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     bind
     rbind
     null
+    die
     is_missing
     is_defined
     coalesce

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -44,7 +44,7 @@ from .functions import literal, chi_squared_test, if_else, cond, switch, case, \
     parse_int32, parse_int64, bool, get_sequence, reverse_complement, \
     is_valid_contig, is_valid_locus, contig_length, liftover, min_rep, \
     uniroot, format, approx_equal, reversed, bit_and, bit_or, bit_xor, \
-    bit_lshift, bit_rshift, bit_not, binary_search, \
+    bit_lshift, bit_rshift, bit_not, binary_search, die, \
     _values_similar, _showstr, _sort_by, _compare, _locus_windows_per_contig
 
 __all__ = ['HailType',
@@ -126,6 +126,7 @@ __all__ = ['HailType',
            'log',
            'log10',
            'null',
+           'die',
            'or_else',
            'coalesce',
            'or_missing',

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -139,6 +139,28 @@ def null(t: Union[HailType, str]):
     """
     return construct_expr(ir.NA(t), t)
 
+@typecheck(msg=expr_str, t=hail_type)
+def die(msg, t: Union[HailType, str]):
+    """Creates an expression representing a fatal exception.
+
+    Notes
+    -----
+    This method is useful for constructing an expression that includes error checking,
+    with :func:`.cond`, :func:`.case`, or :func:`.switch`.
+
+    Parameters
+    ----------
+    msg : :class:`.StringExpression`
+        Exception message.
+    t : :obj:`str` or :class:`.HailType`
+        Type of the expression.
+
+    Returns
+    -------
+    :class:`.Expression`
+    """
+    return construct_expr(ir.Die(msg._ir, t), t)
+
 
 @typecheck(x=anytype, dtype=nullable(hail_type))
 def literal(x: Any, dtype: Optional[Union[HailType, str]] = None):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3354,3 +3354,7 @@ class Tests(unittest.TestCase):
             hl.tuple([1, 2, 'str'])
         ]
         assert hl.eval(hl._compare(hl.tuple(values), hl.tuple(hl.parse_json(hl.json(v), v.dtype) for v in values)) == 0)
+
+    def test_die(self):
+        with pytest.raises(hl.utils.FatalError, match='Foo'):
+            hl.eval(hl.die('Foo', 'int'))


### PR DESCRIPTION
CHANGELOG: Add `hl.die` function that can be used to generate errors. Useful in data validation.