### PR TITLE
BlockMatrix Transpose Sparsity Fix

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -42,7 +42,7 @@ from .matrix_ir import MatrixAggregateRowsByKey, MatrixRead, MatrixFilterRows, \
 from .blockmatrix_ir import BlockMatrixRead, BlockMatrixMap, BlockMatrixMap2, \
     BlockMatrixDot, BlockMatrixBroadcast, BlockMatrixAgg, BlockMatrixFilter, \
     BlockMatrixDensify, BlockMatrixSparsifier, BandSparsifier, \
-    RowIntervalSparsifier, RectangleSparsifier, BlockMatrixSparsify, \
+    RowIntervalSparsifier, RectangleSparsifier, PerBlockSparsifier, BlockMatrixSparsify, \
     BlockMatrixSlice, ValueToBlockMatrix, BlockMatrixRandom, JavaBlockMatrix, \
     tensor_shape_to_matrix_shape
 from .utils import filter_predicate_with_keep, make_filter_and_replace

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -98,6 +98,7 @@ __all__ = [
     'BandSparsifier',
     'RowIntervalSparsifier',
     'RectangleSparsifier',
+    'PerBlockSparsifier',
     'BlockMatrixSparsify',
     'BlockMatrixSlice',
     'ValueToBlockMatrix',

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -259,6 +259,14 @@ class _RectangleSparsifier(BlockMatrixSparsifier):
 RectangleSparsifier = _RectangleSparsifier()
 
 
+class PerBlockSparsifier(BlockMatrixSparsifier):
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return '(PyPerBlockSparsifier)'
+
+
 class BlockMatrixSparsify(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, value=IR, sparsifier=BlockMatrixSparsifier)
     def __init__(self, child, value, sparsifier):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -9,13 +9,13 @@ import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr import construct_expr, construct_variable
 from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed, \
-    expr_tuple, expr_array, expr_int64
+    expr_tuple, expr_array, expr_int32, expr_int64
 from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryPrimOp, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter, TableFromBlockMatrixNativeReader, TableRead, \
     BlockMatrixSlice, BlockMatrixSparsify, BlockMatrixDensify, RectangleSparsifier, \
-    RowIntervalSparsifier, BandSparsifier, UnpersistBlockMatrix
+    RowIntervalSparsifier, BandSparsifier, PerBlockSparsifier, UnpersistBlockMatrix
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader, BlockMatrixPersistReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter, BlockMatrixPersistWriter
 from hail.ir import ExportType
@@ -1004,6 +1004,12 @@ class BlockMatrix(object):
         return BlockMatrix(
             BlockMatrixSparsify(self._bmir, intervals._ir,
                                 RowIntervalSparsifier(blocks_only)))
+
+    @typecheck_method(indices=expr_array(expr_int32))
+    def _sparsify_blocks(self, indices):
+        return BlockMatrix(
+            BlockMatrixSparsify(self._bmir, indices._ir,
+                                PerBlockSparsifier()))
 
     @typecheck_method(starts=oneof(sequenceof(int), np.ndarray),
                       stops=oneof(sequenceof(int), np.ndarray),

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1028,6 +1028,12 @@ class Tests(unittest.TestCase):
         bm = bm._sparsify_blocks(block_list)
         sparse_numpy = sparsify_numpy(np_square, block_size, block_list)
         assert np.array_equal(bm.to_numpy(), sparse_numpy)
+        assert np.array_equal(
+            sparse_numpy,
+            np.array([[0,  0,  3, 4],
+                      [0,  0,  7, 8],
+                      [9,  10, 0, 0],
+                      [13, 14, 0, 0]]))
 
         block_list = [4, 8, 10, 12, 13, 14]
         np_square = np.arange(225, dtype=np.float64).reshape((15, 15))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1039,8 +1039,32 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_sparse_transposition(self):
+        block_list = [1, 2]
+        np_square = np.arange(16, dtype=np.float64).reshape((4, 4))
+        block_size = 2
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        sparse_bm = bm._sparsify_blocks(block_list).T
+        sparse_np = sparsify_numpy(np_square, block_size, block_list).T
+        assert np.array_equal(sparse_bm.to_numpy(), sparse_np)
+
         block_list = [4, 8, 10, 12, 13, 14]
         np_square = np.arange(225, dtype=np.float64).reshape((15, 15))
+        block_size = 4
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        sparse_bm = bm._sparsify_blocks(block_list).T
+        sparse_np = sparsify_numpy(np_square, block_size, block_list).T
+        assert np.array_equal(sparse_bm.to_numpy(), sparse_np)
+
+        block_list = [2, 5, 8, 10, 11]
+        np_square = np.arange(150, dtype=np.float64).reshape((10, 15))
+        block_size = 4
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        sparse_bm = bm._sparsify_blocks(block_list).T
+        sparse_np = sparsify_numpy(np_square, block_size, block_list).T
+        assert np.array_equal(sparse_bm.to_numpy(), sparse_np)
+
+        block_list = [2, 5, 8, 10, 11]
+        np_square = np.arange(165, dtype=np.float64).reshape((15, 11))
         block_size = 4
         bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
         sparse_bm = bm._sparsify_blocks(block_list).T

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1030,10 +1030,10 @@ class Tests(unittest.TestCase):
         assert np.array_equal(bm.to_numpy(), sparse_numpy)
         assert np.array_equal(
             sparse_numpy,
-            np.array([[0,  0,  3, 4],
-                      [0,  0,  7, 8],
-                      [9,  10, 0, 0],
-                      [13, 14, 0, 0]]))
+            np.array([[0,  0,  2, 3],
+                      [0,  0,  6, 7],
+                      [8,  9,  0, 0],
+                      [12, 13, 0, 0]]))
 
         block_list = [4, 8, 10, 12, 13, 14]
         np_square = np.arange(225, dtype=np.float64).reshape((15, 15))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1027,7 +1027,7 @@ class Tests(unittest.TestCase):
         bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
         bm = bm._sparsify_blocks(block_list)
         sparse_numpy = sparsify_numpy(np_square, block_size, block_list)
-        assert (np.array_equal(bm.to_numpy(), sparse_numpy))
+        assert np.array_equal(bm.to_numpy(), sparse_numpy)
 
         block_list = [4, 8, 10, 12, 13, 14]
         np_square = np.arange(225, dtype=np.float64).reshape((15, 15))
@@ -1035,5 +1035,14 @@ class Tests(unittest.TestCase):
         bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
         bm = bm._sparsify_blocks(block_list)
         sparse_numpy = sparsify_numpy(np_square, block_size, block_list)
-        assert (np.array_equal(bm.to_numpy(), sparse_numpy))
+        assert np.array_equal(bm.to_numpy(), sparse_numpy)
 
+    @skip_unless_spark_backend()
+    def test_sparse_transposition(self):
+        block_list = [4, 8, 10, 12, 13, 14]
+        np_square = np.arange(225, dtype=np.float64).reshape((15, 15))
+        block_size = 4
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        sparse_bm = bm._sparsify_blocks(block_list).T
+        sparse_np = sparsify_numpy(np_square, block_size, block_list).T
+        assert np.array_equal(sparse_bm.to_numpy(), sparse_np)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -5,10 +5,36 @@ from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalE
 from ..helpers import *
 import numpy as np
 import tempfile
+import math
 from hail.expr.expressions import ExpressionException
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext
+
+
+def sparsify_numpy(np_mat, block_size, blocks_to_sparsify):
+    n_rows, n_cols = np_mat.shape
+    target_mat = np.zeros((n_rows, n_cols))
+    n_block_rows = math.ceil(n_rows / block_size)
+    n_block_cols = math.ceil(n_cols / block_size)
+    n_rows_last_block = block_size if (n_rows % block_size) == 0 else n_rows % block_size
+    n_cols_last_block = block_size if (n_cols % block_size) == 0 else n_cols % block_size
+
+    for block in blocks_to_sparsify:
+        block_row_idx = block % n_block_rows
+        block_col_idx = block // n_block_rows
+        rows_to_copy = block_size if block_row_idx != (n_block_rows - 1) else n_rows_last_block
+        cols_to_copy = block_size if block_col_idx != (n_block_cols - 1) else n_cols_last_block
+        starting_row_idx = block_row_idx * block_size
+        starting_col_idx = block_col_idx * block_size
+
+        a = starting_row_idx
+        b = starting_row_idx + rows_to_copy
+        c = starting_col_idx
+        d = starting_col_idx + cols_to_copy
+        target_mat[a:b, c:d] = np_mat[a:b, c:d]
+
+    return target_mat
 
 
 class Tests(unittest.TestCase):
@@ -991,3 +1017,23 @@ class Tests(unittest.TestCase):
         with pytest.raises(ValueError) as exc:
             bm.filter_rows([0]).filter_rows([3]).to_numpy()
         assert "index" in str(exc)
+
+
+    @skip_unless_spark_backend()
+    def test_sparsify_blocks(self):
+        block_list = [1, 2]
+        np_square = np.arange(16, dtype=np.float64).reshape((4, 4))
+        block_size = 2
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        bm = bm._sparsify_blocks(block_list)
+        sparse_numpy = sparsify_numpy(np_square, block_size, block_list)
+        assert (np.array_equal(bm.to_numpy(), sparse_numpy))
+
+        block_list = [4, 8, 10, 12, 13, 14]
+        np_square = np.arange(225, dtype=np.float64).reshape((15, 15))
+        block_size = 4
+        bm = BlockMatrix.from_numpy(np_square, block_size=block_size)
+        bm = bm._sparsify_blocks(block_list)
+        sparse_numpy = sparsify_numpy(np_square, block_size, block_list)
+        assert (np.array_equal(bm.to_numpy(), sparse_numpy))
+

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -484,8 +484,6 @@ case class BlockMatrixBroadcast(
           case IndexedSeq(1, 0) => // transpose
             assert(child.typ.blockSize == blockSize)
             BlockMatrixSparsity(child.typ.sparsity.definedBlocks.map(seq => seq.map { case (i, j) => (j, i)}))
-
-            //BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.//child.typ.hasBlock(j -> i))
           case IndexedSeq(0, 1) =>
             assert(child.typ.blockSize == blockSize)
             child.typ.sparsity

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -741,27 +741,11 @@ case class RectangleSparsifier(rectangles: IndexedSeq[IndexedSeq[Long]]) extends
 case class PerBlockSparsifier(blocks: IndexedSeq[Int]) extends BlockMatrixSparsifier {
   override def typ: Type = TArray(TInt32)
 
-  var definedBlocksST = IndexedSeq[StackTraceElement]()
-
   val blockSet = blocks.toSet
 
   override def definedBlocks(childType: BlockMatrixType): BlockMatrixSparsity = {
-    //definedBlocksST = Thread.currentThread().getStackTrace.toIndexedSeq
-    //info(definedBlocksST.take(10).toString())
-//    log.info("Defining blocks")
-//    info("Defining blocks")
-//    val x = blocks.map { blockIndex =>
-//      // TODO: Is this really right?
-//      val blockRow = blockIndex % childType.nRowBlocks
-//      val blockCol = blockIndex / childType.nColBlocks
-//      (blockRow, blockCol)
-//    }
-//    log.info("Defined blocks")
-//    info("Defined blocks")
-    val nRowBlocks = childType.nRowBlocks
-    val nColBlocks = childType.nColBlocks
-    BlockMatrixSparsity(nRowBlocks, nColBlocks){ case(i: Int, j: Int) =>
-      blockSet.contains(i + j * nRowBlocks)
+    BlockMatrixSparsity(childType.nRowBlocks, childType.nColBlocks){ case(i: Int, j: Int) =>
+      blockSet.contains(i + j * childType.nRowBlocks)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1563,6 +1563,11 @@ object IRParser {
         val Row(l: Long, u: Long) =
           ExecuteContext.scoped() { ctx => CompileAndEvaluate[Row](ctx, ir_value_expr(env)(it)) }
         BandSparsifier(blocksOnly, l, u)
+      case "PyPerBlockSparsifier" =>
+        punctuation(it, ")")
+        val indices: IndexedSeq[Int] =
+          ExecuteContext.scoped() { ctx => CompileAndEvaluate[IndexedSeq[Int]](ctx, ir_value_expr(env)(it)) }
+        PerBlockSparsifier(indices)
       case "PyRectangleSparsifier" =>
         punctuation(it, ")")
         val rectangles: IndexedSeq[Long] =

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
@@ -52,7 +52,7 @@ case class MatrixWriteBlockMatrix(path: String,
     using(new DataOutputStream(fs.create(path + BlockMatrix.metadataRelativePath))) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, nRows, localNCols, gp.maybeBlocks, partFiles),
+        BlockMatrixMetadata(blockSize, nRows, localNCols, gp.partitionIndexToBlockIndex, partFiles),
         os)
     }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1605,9 +1605,26 @@ private class BlockMatrixUnionOpRDD(
 
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
     val (i, j) = gp.partCoordinates(split.index)
-    val lm = op(block(l, lParts, lGP, context, i, j) -> block(r, rParts, rGP, context, i, j))
-    
-    Iterator.single(((i, j), lm))
+    val left = block(l, lParts, lGP, context, i, j)
+    val right = block(r, rParts, rGP, context, i, j)
+    try {
+      val lm = op(left -> right)
+
+      Iterator.single(((i, j), lm))
+    } catch {
+      case e: Throwable => {
+        throw new IllegalArgumentException(
+          s"""
+             | split.index = ${split.index}
+             | coordinates = ${(i, j)}
+             | left.shape = ${left.map(dm => (dm.rows, dm.cols))}
+             | right.shape = ${right.map(dm => (dm.rows, dm.cols))}
+             | leftBM.shape = ${(l.nRows, l.nCols)}
+             | rightBM.shape = ${(r.nRows, r.nCols)}
+             |""".stripMargin, e)
+      }
+    }
+
   }
 
   protected def getPartitions: Array[Partition] = Array.tabulate(gp.numPartitions)(pi =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -347,7 +347,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   
   require(gp.blockSize == blockSize && gp.nRows == nRows && gp.nCols == nCols)
   
-  val isSparse: Boolean = gp.maybeBlocks.isDefined
+  val isSparse: Boolean = gp.partitionIndexToBlockIndex.isDefined
   
   def requireDense(name: String): Unit =
     if (isSparse)
@@ -363,7 +363,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   // if Some(bis), unrealized blocks in bis are replaced with zero blocks
   // if None, all unrealized blocks are replaced with zero blocks
   def realizeBlocks(maybeBlocksToRealize: Option[IndexedSeq[Int]]): BlockMatrix = {
-    val realizeGP = gp.copy(maybeBlocks =
+    val realizeGP = gp.copy(partitionIndexToBlockIndex =
       if (maybeBlocksToRealize.exists(_.length == gp.maxNBlocks)) None else maybeBlocksToRealize)
 
     val newGP = gp.union(realizeGP)
@@ -376,7 +376,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         val lm = (BDM.zeros[Double] _).tupled(newGP.blockDims(bi))
         Iterator.single((newGP.blockCoordinates(bi), lm))
       }
-      val oldToNewPI = gp.maybeBlocks.get.map(newGP.blockToPartition)
+      val oldToNewPI = gp.partitionIndexToBlockIndex.get.map(newGP.blockToPartition)
       val newBlocks = blocks.supersetPartitions(oldToNewPI, newGP.numPartitions, newPIPartition, Some(newGP))
 
       new BlockMatrix(newBlocks, blockSize, nRows, nCols)
@@ -387,15 +387,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     if (blocksToKeep.length == gp.maxNBlocks)
       this
     else
-      subsetBlocks(gp.intersect(gp.copy(maybeBlocks = Some(blocksToKeep))))
+      subsetBlocks(gp.intersect(gp.copy(partitionIndexToBlockIndex = Some(blocksToKeep))))
     
   // assumes subsetGP blocks are subset of gp blocks, as with subsetGP = gp.intersect(gp2)
   def subsetBlocks(subsetGP: GridPartitioner): BlockMatrix = {
     if (subsetGP.numPartitions == gp.numPartitions)
       this
     else {
-      assert(subsetGP.maybeBlocks.isDefined)
-      new BlockMatrix(blocks.subsetPartitions(subsetGP.maybeBlocks.get.map(gp.blockToPartition), Some(subsetGP)),
+      assert(subsetGP.partitionIndexToBlockIndex.isDefined)
+      new BlockMatrix(blocks.subsetPartitions(subsetGP.partitionIndexToBlockIndex.get.map(gp.blockToPartition), Some(subsetGP)),
         blockSize, nRows, nCols)
     }
   }
@@ -790,7 +790,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     using(new DataOutputStream(fs.create(uri + metadataRelativePath))) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, nRows, nCols, gp.maybeBlocks, partFiles),
+        BlockMatrixMetadata(blockSize, nRows, nCols, gp.partitionIndexToBlockIndex, partFiles),
         os)
     }
 
@@ -869,7 +869,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
   
   private def sameBlocks(that: M): Boolean = {
-    (gp.maybeBlocks, that.gp.maybeBlocks) match {
+    (gp.partitionIndexToBlockIndex, that.gp.partitionIndexToBlockIndex) match {
       case (Some(bis), Some(bis2)) => bis sameElements bis2
       case (None, None) => true
       case _ => false
@@ -1354,7 +1354,7 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
   private val allBlockColRanges: Array[Array[(Int, Array[Int], Array[Int])]] =
     BlockMatrixFilterRDD.computeAllBlockColRanges(keepCols, originalGP, tempDenseGP)
 
-  private val originalMaybeBlocksSet = originalGP.maybeBlocks.map(_.toSet)
+  private val originalMaybeBlocksSet = originalGP.partitionIndexToBlockIndex.map(_.toSet)
 
   private val blockParentMap = (0 until tempDenseGP.numPartitions).map {blockId =>
     val (newBlockRow, newBlockCol) = tempDenseGP.blockCoordinates(blockId)
@@ -1374,7 +1374,7 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
 
   private val blockIndices = blockParentMap.keys.toArray.sorted
   private val newGPMaybeBlocks: Option[IndexedSeq[Int]] = if (blockIndices.length == tempDenseGP.maxNBlocks) None else Some(blockIndices)
-  private val newGP = tempDenseGP.copy(maybeBlocks = newGPMaybeBlocks)
+  private val newGP = tempDenseGP.copy(partitionIndexToBlockIndex = newGPMaybeBlocks)
 
   log.info(s"Finished constructing block matrix filter RDD. Total time ${(System.nanoTime() - t0).toDouble / 1000000000}")
 
@@ -1470,7 +1470,7 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
   private val allBlockColRanges: Array[Array[(Int, Array[Int], Array[Int])]] =
     BlockMatrixFilterRDD.computeAllBlockColRanges(keep, originalGP, tempDenseGP)
 
-  private val originalMaybeBlocksSet = originalGP.maybeBlocks.map(_.toSet)
+  private val originalMaybeBlocksSet = originalGP.partitionIndexToBlockIndex.map(_.toSet)
 
   //Map the denseGP blocks to the blocks of parents they depend on, temporarily pretending they are all there.
   //Then delete the parents that aren't in originalGP.maybeBlocks, then delete the pairs
@@ -1490,7 +1490,7 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
 
   private val blockIndices = blockParentMap.keys.toFastIndexedSeq.sorted
   private val newGPMaybeBlocks = if (blockIndices.length == tempDenseGP.maxNBlocks)  None else Some(blockIndices)
-  private val newGP = tempDenseGP.copy(maybeBlocks = newGPMaybeBlocks)
+  private val newGP = tempDenseGP.copy(partitionIndexToBlockIndex = newGPMaybeBlocks)
 
   protected def getPartitions: Array[Partition] = {
     Array.tabulate(newGP.numPartitions) { partitionIndex: Int =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1623,24 +1623,9 @@ private class BlockMatrixUnionOpRDD(
     val (i, j) = gp.partCoordinates(split.index)
     val left = block(l, lParts, lGP, context, i, j)
     val right = block(r, rParts, rGP, context, i, j)
-    try {
-      val lm = op(left -> right)
+    val lm = op(left -> right)
 
-      Iterator.single(((i, j), lm))
-    } catch {
-      case e: Throwable => {
-        throw new IllegalArgumentException(
-          s"""
-             | split.index = ${split.index}
-             | coordinates = ${(i, j)}
-             | left.shape = ${left.map(dm => (dm.rows, dm.cols))}
-             | right.shape = ${right.map(dm => (dm.rows, dm.cols))}
-             | leftBM.shape = ${(l.nRows, l.nCols)}
-             | rightBM.shape = ${(r.nRows, r.nCols)}
-             |""".stripMargin, e)
-      }
-    }
-
+    Iterator.single(((i, j), lm))
   }
 
   protected def getPartitions: Array[Partition] = Array.tabulate(gp.numPartitions)(pi =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -193,9 +193,7 @@ object BlockMatrix {
     i: Int, j: Int): Option[BDM[Double]] = {
     val pi = gp.coordinatesPart(i, j)
     if (pi >= 0) {
-      val partition = parts(pi)
-      assert(partition.index == pi)
-      val it = bm.blocks.iterator(partition, context)
+      val it = bm.blocks.iterator(parts(pi), context)
       assert(it.hasNext)
       val (_, lm) = it.next()
       assert(!it.hasNext)
@@ -1565,15 +1563,7 @@ private class BlockMatrixTransposeRDD(bm: BlockMatrix)
         val parent = inverseTransposePI(partitionId)
         val (oldI, oldJ) = bm.gp.partCoordinates(parent)
         val (newI, newJ) = newGP.partCoordinates(partitionId)
-        assert(newI == oldJ && newJ == oldI,
-          s"""
-           |${(oldI, oldJ)} doesn't map to ${(newI, newJ)}
-           | computedParentPartitionID = $parent
-           | partitionId = $partitionId
-           | gp.maybeBlocks = ${bm.gp.maybeBlocks}
-           | newGP.maybeBlocks = ${newGP.maybeBlocks}
-           | bm shape ${(bm.nRows, bm.nCols)}
-           """.stripMargin)
+        assert(newI == oldJ && newJ == oldI)
         Array(parent)
       }
     })

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -193,7 +193,9 @@ object BlockMatrix {
     i: Int, j: Int): Option[BDM[Double]] = {
     val pi = gp.coordinatesPart(i, j)
     if (pi >= 0) {
-      val it = bm.blocks.iterator(parts(pi), context)
+      val partition = parts(pi)
+      assert(partition.index == pi)
+      val it = bm.blocks.iterator(partition, context)
       assert(it.hasNext)
       val (_, lm) = it.next()
       assert(!it.hasNext)
@@ -1559,7 +1561,21 @@ private class BlockMatrixTransposeRDD(bm: BlockMatrix)
 
   override def getDependencies: Seq[Dependency[_]] = Array[Dependency[_]](
     new NarrowDependency(bm.blocks) {
-      def getParents(partitionId: Int): Seq[Int] = Array(inverseTransposePI(partitionId))
+      def getParents(partitionId: Int): Seq[Int] = {
+        val parent = inverseTransposePI(partitionId)
+        val (oldI, oldJ) = bm.gp.partCoordinates(parent)
+        val (newI, newJ) = newGP.partCoordinates(partitionId)
+        assert(newI == oldJ && newJ == oldI,
+          s"""
+           |${(oldI, oldJ)} doesn't map to ${(newI, newJ)}
+           | computedParentPartitionID = $parent
+           | partitionId = $partitionId
+           | gp.maybeBlocks = ${bm.gp.maybeBlocks}
+           | newGP.maybeBlocks = ${newGP.maybeBlocks}
+           | bm shape ${(bm.nRows, bm.nCols)}
+           """.stripMargin)
+        Array(parent)
+      }
     })
 
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] =

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1621,9 +1621,7 @@ private class BlockMatrixUnionOpRDD(
 
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
     val (i, j) = gp.partCoordinates(split.index)
-    val left = block(l, lParts, lGP, context, i, j)
-    val right = block(r, rParts, rGP, context, i, j)
-    val lm = op(left -> right)
+    val lm = op(block(l, lParts, lGP, context, i, j) -> block(r, rParts, rGP, context, i, j))
 
     Iterator.single(((i, j), lm))
   }

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -124,8 +124,8 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
         
         (GridPartitioner(blockSize, nCols, nRows, Some(biTranspose)), newPIToOldPI.apply)
       case None => {
-        def inverseTransposeBI(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
-        (gpT, inverseTransposeBI)
+        def newBIToOldBI(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
+        (gpT, newBIToOldBI)
       }
     }
   }

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -117,15 +117,17 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     */
   def transpose: (GridPartitioner, Int => Int) = {
     val gpT = GridPartitioner(blockSize, nCols, nRows)
-    def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
     maybeBlocks match {
       case Some(bis) =>
+        def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
+
         val (biTranspose, newPIToOldPI) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
-        
-        (GridPartitioner(blockSize, nCols, nRows, Some(biTranspose)), newPIToOldPI.apply)
+        val transposedPartitionIndicesToParentPartitions = newPIToOldPI.apply(_)
+
+        (GridPartitioner(blockSize, nCols, nRows, Some(biTranspose)), transposedPartitionIndicesToParentPartitions)
       case None => {
-        def newBIToOldBI(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
-        (gpT, newBIToOldBI)
+        def transposedBlockIndicesToParentBlocks(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
+        (gpT, transposedBlockIndicesToParentBlocks)
       }
     }
   }

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -12,17 +12,17 @@ import scala.collection.mutable
   * @param blockSize
   * @param nRows
   * @param nCols
-  * @param maybeBlocks If exists, matrix is sparse and this contains a list of indices of blocks that are not all zero
+  * @param partitionIndexToBlockIndex If exists, matrix is sparse and this contains a list of indices of blocks that are not all zero
   */
-case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks: Option[IndexedSeq[Int]] = None) extends Partitioner {
+case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, partitionIndexToBlockIndex: Option[IndexedSeq[Int]] = None) extends Partitioner {
   if (nRows == 0)
     fatal("block matrix must have at least one row")
   if (nCols == 0)
     fatal("block matrix must have at least one column")
-  
+
   require(nRows <= Int.MaxValue.toLong * blockSize)
   require(nCols <= Int.MaxValue.toLong * blockSize)
-  
+
   def indexBlockIndex(index: Long): Int = (index / blockSize).toInt
 
   def indexBlockOffset(index: Long): Int = (index % blockSize).toInt
@@ -31,13 +31,13 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   val nBlockCols: Int = indexBlockIndex(nCols - 1) + 1
 
   val maxNBlocks: Long = nBlockRows.toLong * nBlockCols
-  
-  if (!maybeBlocks.forall(bis => bis.isEmpty ||
+
+  if (!partitionIndexToBlockIndex.forall(bis => bis.isEmpty ||
     (bis.isIncreasing && bis.head >= 0 && bis.last < maxNBlocks &&
       bis.length < maxNBlocks))) // a block-sparse matrix cannot have all blocks present
-    throw new IllegalArgumentException(s"requirement failed: Sparse blocks sequence was ${maybeBlocks.toIndexedSeq}")
+    throw new IllegalArgumentException(s"requirement failed: Sparse blocks sequence was ${partitionIndexToBlockIndex.toIndexedSeq}")
 
-  val blockToPartitionMap = maybeBlocks.map(_.zipWithIndex.toMap.withDefaultValue(-1))
+  val blockToPartitionMap = partitionIndexToBlockIndex.map(_.zipWithIndex.toMap.withDefaultValue(-1))
 
   val lastBlockRowNRows: Int = indexBlockOffset(nRows - 1) + 1
   val lastBlockColNCols: Int = indexBlockOffset(nCols - 1) + 1
@@ -50,7 +50,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
 
   def blockDims(bi: Int): (Int, Int) = (blockRowNRows(blockBlockRow(bi)), blockColNCols(blockBlockCol(bi)))
 
-  def nBlocks: Int = maybeBlocks.map(_.length).getOrElse(nBlockRows * nBlockCols)
+  def nBlocks: Int = partitionIndexToBlockIndex.map(_.length).getOrElse(nBlockRows * nBlockCols)
 
   def blockCoordinates(bi: Int): (Int, Int) = (blockBlockRow(bi), blockBlockCol(bi))
 
@@ -61,7 +61,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   }
 
   def intersect(that: GridPartitioner): GridPartitioner = {
-    copy(maybeBlocks = (maybeBlocks, that.maybeBlocks) match {
+    copy(partitionIndexToBlockIndex = (partitionIndexToBlockIndex, that.partitionIndexToBlockIndex) match {
       case (Some(bis), Some(bis2)) => Some(bis.filter(bis2.toSet))
       case (Some(bis), None) => Some(bis)
       case (None, Some(bis2)) => Some(bis2)
@@ -70,7 +70,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   }
 
   def union(that: GridPartitioner): GridPartitioner = {
-    copy(maybeBlocks = (maybeBlocks, that.maybeBlocks) match {
+    copy(partitionIndexToBlockIndex = (partitionIndexToBlockIndex, that.partitionIndexToBlockIndex) match {
       case (Some(bis), Some(bis2)) =>
         val union = (bis ++ bis2).distinct
         if (union.length == maxNBlocks)
@@ -81,14 +81,14 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     })
   }
 
-  override val numPartitions: Int = maybeBlocks match {
+  override val numPartitions: Int = partitionIndexToBlockIndex match {
     case Some(bis) => bis.length
     case None =>
       assert(maxNBlocks < Int.MaxValue)
       maxNBlocks.toInt
   }
 
-  def partitionToBlock(pi: Int): Int = maybeBlocks match {
+  def partitionToBlock(pi: Int): Int = partitionIndexToBlockIndex match {
     case Some(bis) =>
       assert(pi >= 0 && pi < bis.length)
       bis(pi)
@@ -101,7 +101,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     case Some(bpMap) => bpMap(blockId)
     case None =>  blockId
   }
-  
+
   def partCoordinates(pi: Int): (Int, Int) = blockCoordinates(partitionToBlock(pi))
 
   def coordinatesPart(i: Int, j: Int): Int = blockToPartition(coordinatesBlock(i, j))
@@ -113,18 +113,18 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   /**
     *
     * @return A transposed GridPartitioner and a function that maps partitions in the new partitioner to partitions
-    *         in the old partitioner. 
+    *         in the old partitioner.
     */
   def transpose: (GridPartitioner, Int => Int) = {
     val gpT = GridPartitioner(blockSize, nCols, nRows)
-    maybeBlocks match {
+    partitionIndexToBlockIndex match {
       case Some(bis) =>
         def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
 
-        val (biTranspose, newPIToOldPI) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
-        val transposedPartitionIndicesToParentPartitions = newPIToOldPI.apply(_)
+        val (partIdxToBlockIdxT, partIdxTToPartIdx) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
+        val transposedPartitionIndicesToParentPartitions = partIdxTToPartIdx.apply(_)
 
-        (GridPartitioner(blockSize, nCols, nRows, Some(biTranspose)), transposedPartitionIndicesToParentPartitions)
+        (GridPartitioner(blockSize, nCols, nRows, Some(partIdxToBlockIdxT)), transposedPartitionIndicesToParentPartitions)
       case None => {
         def transposedBlockIndicesToParentBlocks(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
         (gpT, transposedBlockIndicesToParentBlocks)
@@ -136,14 +136,14 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     val firstRow = i * blockSize
     v(firstRow until firstRow + blockRowNRows(i))
   }
-  
+
   def vectorOnBlockCol(v: BDV[Double], j: Int): BDV[Double] = {
     val firstCol = j * blockSize
     v(firstCol until firstCol + blockColNCols(j))
   }
 
   def maybeBlockRows(): Option[IndexedSeq[Int]] =
-    maybeBlocks match {
+    partitionIndexToBlockIndex match {
       case Some(bis) =>
         val bisRow = bis.map(blockBlockRow).distinct
         if (bisRow.length < nBlockRows) Some(bisRow) else None
@@ -151,7 +151,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     }
 
   def maybeBlockCols(): Option[IndexedSeq[Int]] =
-    maybeBlocks match {
+    partitionIndexToBlockIndex match {
       case Some(bis) =>
         val bisCol = bis.map(blockBlockCol).distinct
         if (bisCol.length < nBlockCols) Some(bisCol) else None

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -112,8 +112,8 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, partitionIn
 
   /**
     *
-    * @return A transposed GridPartitioner and a function that maps partitions in the new partitioner to partitions
-    *         in the old partitioner.
+    * @return A transposed GridPartitioner and a function that maps partitions in the new transposed partitioner to
+    *         the parent partitions in the old partitioner.
     */
   def transpose: (GridPartitioner, Int => Int) = {
     val gpT = GridPartitioner(blockSize, nCols, nRows)

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -121,10 +121,10 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, partitionIn
       case Some(bis) =>
         def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
 
-        val (partIdxToBlockIdxT, partIdxTToPartIdx) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
+        val (partIdxTToBlockIdxT, partIdxTToPartIdx) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
         val transposedPartitionIndicesToParentPartitions = partIdxTToPartIdx.apply(_)
 
-        (GridPartitioner(blockSize, nCols, nRows, Some(partIdxToBlockIdxT)), transposedPartitionIndicesToParentPartitions)
+        (GridPartitioner(blockSize, nCols, nRows, Some(partIdxTToBlockIdxT)), transposedPartitionIndicesToParentPartitions)
       case None => {
         def transposedBlockIndicesToParentBlocks(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
         (gpT, transposedBlockIndicesToParentBlocks)

--- a/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
@@ -96,7 +96,7 @@ object BlockMatrixType {
   }
 
   def fromBlockMatrix(value: BlockMatrix): BlockMatrixType = {
-    val sparsity = BlockMatrixSparsity.fromLinearBlocks(value.nRows, value.nCols, value.blockSize, value.gp.maybeBlocks)
+    val sparsity = BlockMatrixSparsity.fromLinearBlocks(value.nRows, value.nCols, value.blockSize, value.gp.partitionIndexToBlockIndex)
     val (shape, isRowVector) = matrixToTensorShape(value.nRows, value.nCols)
     BlockMatrixType(TFloat64, shape, isRowVector, value.blockSize, sparsity)
   }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -142,7 +142,7 @@ class RichDenseMatrixDouble(val m: BDM[Double]) extends AnyVal {
     using(new DataOutputStream(fs.create(path + BlockMatrix.metadataRelativePath))) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, m.rows, m.cols, gp.maybeBlocks, partFiles),
+        BlockMatrixMetadata(blockSize, m.rows, m.cols, gp.partitionIndexToBlockIndex, partFiles),
         os)
     }
 

--- a/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -801,7 +801,7 @@ class BlockMatrixSuite extends HailSuite {
     val lm = new BDM[Double](9, 12, (0 to 107).map(_.toDouble).toArray)
     val bm = toBM(lm, blockSize = 3)
     val sparse = bm.filterBand(0, 0, true)
-    assert(sparse.transpose().gp.maybeBlocks.get.toIndexedSeq == IndexedSeq(0, 5, 10))
+    assert(sparse.transpose().gp.partitionIndexToBlockIndex.get.toIndexedSeq == IndexedSeq(0, 5, 10))
   }
 
   @Test


### PR DESCRIPTION
CHANGELOG: Fix a major correctness bug ocurring when calling  `BlockMatrix.transpose` on sparse BlockMatrices. Symmetric matrices are not affected.

It seems like `BlockMatrix.transpose` has been broken for a while when the matrix is sparse. 

I added `PerBlockMatrixSparsifier` as a way to sparsify particular blocks of a `BlockMatrix` from python. This is just so we can write tests / diagnose user errors based on sparsity patterns. I also wrote a helper function to sparsify numpy matrices for testing purposes. 

The crucial fix here is to `GridPartitioner.transpose`. That function is supposed to return a pair of the form `(GridPartitioner, Int => Int)`, where the first of the pair is the new `GridPartitioner` for the transposed thing, and the second of the pair is a function that takes in a partition number and returns the partition number of its parent partition. Crucially, it's a function from new partition ids to old partition ids. I believe that code I'm removing did the opposite.

Refresher on `GridPartitioner`: There are 3 coordinate systems:

There's "coordinate", which is (row, column)

There's "blockIndex", which is the column major numbering of all blocks

And there's "partitionIndex", which is similar to numbering by blockIndex but it skips the sparse blocks