### PR TITLE
[query] CodeOrdering support for missing-nonequal comparisons

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/PartitionBoundOrdering.scala
+++ b/hail/src/main/scala/is/hail/rvd/PartitionBoundOrdering.scala
@@ -12,6 +12,9 @@ object PartitionBoundOrdering {
 
     new ExtendedOrdering {
       outer =>
+
+      val missingEqual = true
+
       override def compareNonnull(x: T, y: T): Int = {
         val rx = x.asInstanceOf[Row]
         val ry = y.asInstanceOf[Row]

--- a/hail/src/main/scala/is/hail/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TArray.scala
@@ -52,8 +52,10 @@ final case class TArray(elementType: Type) extends TContainer {
   override def genNonmissingValue: Gen[IndexedSeq[Annotation]] =
     Gen.buildableOf[Array](elementType.genValue).map(x => x: IndexedSeq[Annotation])
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.iterableOrdering(elementType.ordering)
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.iterableOrdering(elementType.ordering, missingEqual)
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
 

--- a/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
@@ -15,8 +15,11 @@ object TBaseStruct {
     * of types of r is a prefix of types, or types is a prefix of the list of
     * types of r.
     */
-  def getOrdering(types: Array[Type]): ExtendedOrdering =
-    ExtendedOrdering.rowOrdering(types.map(_.ordering))
+  def getOrdering(types: Array[Type], missingEqual: Boolean = true): ExtendedOrdering =
+    ExtendedOrdering.rowOrdering(types.map(_.ordering), missingEqual)
+
+  def getJoinOrdering(types: Array[Type]): ExtendedOrdering =
+    ExtendedOrdering.rowOrdering(types.map(_.mkOrdering(missingEqual = false)), _missingEqual = false)
 }
 
 abstract class TBaseStruct extends Type {

--- a/hail/src/main/scala/is/hail/types/virtual/TBinary.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBinary.scala
@@ -16,10 +16,14 @@ case object TBinary extends Type {
 
   override def scalaClassTag: ClassTag[Array[Byte]] = classTag[Array[Byte]]
 
-  val ordering: ExtendedOrdering = ExtendedOrdering.iterableOrdering(new ExtendedOrdering {
+  def mkOrdering(_missingEqual: Boolean = true): ExtendedOrdering = ExtendedOrdering.iterableOrdering(new ExtendedOrdering {
+    val missingEqual = _missingEqual
+
     override def compareNonnull(x: Any, y: Any): Int =
       java.lang.Integer.compare(
         java.lang.Byte.toUnsignedInt(x.asInstanceOf[Byte]),
         java.lang.Byte.toUnsignedInt(y.asInstanceOf[Byte]))
   })
+
+  override val ordering: ExtendedOrdering = mkOrdering()
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBoolean.scala
@@ -22,6 +22,8 @@ case object TBoolean extends Type {
 
   override def scalaClassTag: ClassTag[java.lang.Boolean] = classTag[java.lang.Boolean]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TCall.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TCall.scala
@@ -24,6 +24,8 @@ case object TCall extends ComplexType {
 
   override def str(a: Annotation): String = if (a == null) "NA" else Call.toString(a.asInstanceOf[Call])
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TDict.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TDict.scala
@@ -72,8 +72,10 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
 
   override def scalaClassTag: ClassTag[Map[_, _]] = classTag[Map[_, _]]
 
-  lazy val ordering: ExtendedOrdering =
-    ExtendedOrdering.mapOrdering(elementType.ordering)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.mapOrdering(elementType.ordering, missingEqual)
 
   override def valueSubsetter(subtype: Type): Any => Any = {
     val subdict = subtype.asInstanceOf[TDict]

--- a/hail/src/main/scala/is/hail/types/virtual/TFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TFloat32.scala
@@ -39,7 +39,9 @@ case object TFloat32 extends TNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Float]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Float]], missingEqual)
 }
 

--- a/hail/src/main/scala/is/hail/types/virtual/TFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TFloat64.scala
@@ -39,6 +39,8 @@ case object TFloat64 extends TNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Double]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Double]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TInt32.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInt32.scala
@@ -22,6 +22,8 @@ case object TInt32 extends TIntegral {
 
   override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TInt64.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInt64.scala
@@ -20,7 +20,9 @@ case object TInt64 extends TIntegral {
 
   override def scalaClassTag: ClassTag[java.lang.Long] = classTag[java.lang.Long]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Long]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Long]], missingEqual)
 }
 

--- a/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
@@ -32,7 +32,10 @@ case class TInterval(pointType: Type) extends ComplexType {
 
   override def scalaClassTag: ClassTag[Interval] = classTag[Interval]
 
-  lazy val ordering: ExtendedOrdering = Interval.ordering(pointType.ordering, startPrimary=true)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    Interval.ordering(pointType.ordering, startPrimary=true, missingEqual)
 
   lazy val representation: TStruct = {
     TStruct(

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -40,8 +40,10 @@ case class TLocus(rgBc: BroadcastRG) extends ComplexType {
 
   override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
-  lazy val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(rg.locusOrdering)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(rg.locusOrdering, missingEqual)
 
   lazy val representation: TStruct = TLocus.representation
 

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -96,7 +96,7 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   def _typeCheck(a: Any): Boolean = representation._typeCheck(a)
 
-  val ordering: ExtendedOrdering = null
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
 
   lazy val shapeType: TTuple = TTuple(Array.fill(nDims)(TInt64): _*)
 

--- a/hail/src/main/scala/is/hail/types/virtual/TSet.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TSet.scala
@@ -40,7 +40,10 @@ final case class TSet(elementType: Type) extends TContainer {
     sb.append("]")
   }
 
-  lazy val ordering: ExtendedOrdering = ExtendedOrdering.setOrdering(elementType.ordering)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.setOrdering(elementType.ordering, missingEqual)
 
   override def _showStr(a: Annotation): String =
     a.asInstanceOf[Set[Annotation]]

--- a/hail/src/main/scala/is/hail/types/virtual/TStream.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStream.scala
@@ -47,7 +47,7 @@ final case class TStream(elementType: Type) extends TIterable {
   override def genNonmissingValue: Gen[Annotation] =
     throw new UnsupportedOperationException("Streams don't have associated annotations.")
 
-  lazy val ordering: ExtendedOrdering =
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
     throw new UnsupportedOperationException("Stream comparison is currently undefined.")
 
   override def scalaClassTag: ClassTag[Iterator[AnyRef]] = classTag[Iterator[AnyRef]]

--- a/hail/src/main/scala/is/hail/types/virtual/TString.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TString.scala
@@ -23,8 +23,10 @@ case object TString extends Type {
 
   override def scalaClassTag: ClassTag[String] = classTag[String]
 
-  val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[String]])
+  override val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[String]], missingEqual)
 
   override def fundamentalType: Type = TBinary
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -47,7 +47,10 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
   override def truncate(newSize: Int): TStruct = TStruct(fields.take(newSize))
 
-  lazy val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    TBaseStruct.getOrdering(types, missingEqual)
 
   override def canCompare(other: Type): Boolean = other match {
     case t: TStruct => size == t.size && fields.zip(t.fields).forall { case (f1, f2) =>

--- a/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
@@ -19,7 +19,10 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
 
   lazy val fieldIndex: Map[Int, Int] = _types.zipWithIndex.map { case (tf, idx) => tf.index -> idx }.toMap
 
-  lazy val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
+  override lazy val ordering: ExtendedOrdering = mkOrdering()
+
+  override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
+    TBaseStruct.getOrdering(types, missingEqual)
 
   override lazy val _isCanonical: Boolean = _types.indices.forall(i => i == _types(i).index)
 

--- a/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
@@ -132,5 +132,5 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
 
   override def scalaClassTag: ClassTag[AnyRef] = ???
 
-  def ordering: ExtendedOrdering = ???
+  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = ???
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TVariable.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TVariable.scala
@@ -73,5 +73,5 @@ final case class TVariable(name: String, cond: String = null) extends Type {
 
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TVariable is not realizable")
 
-  val ordering: ExtendedOrdering = null
+  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TVoid.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TVoid.scala
@@ -10,7 +10,7 @@ case object TVoid extends Type {
     sb.append("void")
   }
 
-  val ordering: ExtendedOrdering = null
+  def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
 
   override def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = throw new UnsupportedOperationException("No ClassTag for Void")
 

--- a/hail/src/main/scala/is/hail/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/Type.scala
@@ -194,7 +194,9 @@ abstract class Type extends BaseType with Serializable {
 
   def canCompare(other: Type): Boolean = this == other
 
-  def ordering: ExtendedOrdering
+  def mkOrdering(missingEqual: Boolean = true): ExtendedOrdering
+
+  def ordering: ExtendedOrdering = mkOrdering()
 
   def jsonReader: JSONReader[Annotation] = new JSONReader[Annotation] {
     def fromJSON(a: JValue): Annotation = JSONAnnotationImpex.importAnnotation(a, self)

--- a/hail/src/main/scala/is/hail/utils/Interval.scala
+++ b/hail/src/main/scala/is/hail/utils/Interval.scala
@@ -214,7 +214,9 @@ object Interval {
           Interval(y, x, s, e)
       }
 
-  def ordering(pord: ExtendedOrdering, startPrimary: Boolean): ExtendedOrdering = new ExtendedOrdering {
+  def ordering(pord: ExtendedOrdering, startPrimary: Boolean, _missingEqual: Boolean = true): ExtendedOrdering = new ExtendedOrdering {
+    val missingEqual = _missingEqual
+
     override def compareNonnull(x: Any, y: Any): Int = {
       val xi = x.asInstanceOf[Interval]
       val yi = y.asInstanceOf[Interval]


### PR DESCRIPTION
This is needed to implement stream joins and groupByKey in Interpret.