### PR TITLE
[query] Fix handling of missing keys in stream joins and GroupByKey

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -716,7 +716,7 @@ object EmitStream {
     def apply(outerEos: Code[Ctrl], outerPush: Stream[PCode] => Code[Ctrl])(implicit ctx: EmitStreamContext): Source[Stream[PCode]] = {
       val keyType = eltType.selectFields(key)
       val keyViewType = PSubsetStruct(eltType, key)
-      val ordering = keyType.codeOrdering(mb, keyViewType).asInstanceOf[CodeOrdering { type T = Long }]
+      val ordering = keyType.codeOrdering(mb, keyViewType, missingFieldsEqual = false).asInstanceOf[CodeOrdering { type T = Long }]
 
       val xCurKey = ctx.mb.newPLocal("st_grpby_curkey", keyType)
       val xCurElt = ctx.mb.newPLocal("st_grpby_curelt", eltType)
@@ -1385,7 +1385,7 @@ object EmitStream {
 
           val lKeyViewType = PSubsetStruct(lEltType, lKey: _*)
           val rKeyViewType = PSubsetStruct(rEltType, rKey: _*)
-          val ordering = lKeyViewType.codeOrdering(mb, rKeyViewType).asInstanceOf[CodeOrdering { type T = Long }]
+          val ordering = lKeyViewType.codeOrdering(mb, rKeyViewType, missingFieldsEqual = false).asInstanceOf[CodeOrdering { type T = Long }]
 
           def compare(lelt: EmitValue, relt: EmitValue): Code[Int] = {
             assert(lelt.pt == lEltType)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -160,7 +160,6 @@ object InferPType {
         val r = coerce[RIterable](requiredness(node))
         val structType = a.pType.asInstanceOf[PStream].elementType.asInstanceOf[PStruct]
         assert(structType.required)
-        assert(key.forall { k => structType.fieldType(k).required })
         PCanonicalStream(a.pType.setRequired(r.elementType.required), r.required)
       case StreamMap(a, name, body) =>
         PCanonicalStream(body.pType, requiredness(node).required)

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -93,10 +93,16 @@ abstract class PBaseStruct extends PType {
     sb.result()
   }
 
-  def codeOrdering(mb: EmitMethodBuilder[_], so: Array[SortOrder]): CodeOrdering =
-    codeOrdering(mb, this, so)
+  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering =
+    codeOrdering(mb, other, null, true)
 
-  def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder]): CodeOrdering
+  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, missingFieldsEqual: Boolean): CodeOrdering =
+    codeOrdering(mb, other, null, missingFieldsEqual)
+
+  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder]): CodeOrdering =
+    codeOrdering(mb, other, so, true)
+
+  def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder], missingFieldsEqual: Boolean): CodeOrdering
 
   def isPrefixOf(other: PBaseStruct): Boolean =
     size <= other.size && isCompatibleWith(other)

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -8,13 +8,10 @@ import is.hail.types.virtual.{Field, TStruct}
 trait PStruct extends PBaseStruct {
   lazy val virtualType: TStruct = TStruct(fields.map(f => Field(f.name, f.typ.virtualType, f.index)))
 
-  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering =
-    codeOrdering(mb, other, null)
-
-  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder]): CodeOrdering = {
+  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder], missingFieldsEqual: Boolean): CodeOrdering = {
     assert(other.asInstanceOf[PStruct].isIsomorphicTo(this))
     assert(so == null || so.size == types.size)
-    CodeOrdering.rowOrdering(this, other.asInstanceOf[PStruct], mb, so)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[PStruct], mb, so, missingFieldsEqual)
   }
 
   final def deleteField(key: String): PCanonicalStruct = {

--- a/hail/src/main/scala/is/hail/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PTuple.scala
@@ -20,13 +20,10 @@ trait PTuple extends PBaseStruct {
   protected val tupleFundamentalType: PTuple
   override lazy val fundamentalType: PTuple = tupleFundamentalType
 
-  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering =
-    codeOrdering(mb, other, null)
-
-  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder]): CodeOrdering = {
+  final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder], missingFieldsEqual: Boolean): CodeOrdering = {
     assert(other isOfType this)
     assert(so == null || so.size == types.size)
-    CodeOrdering.rowOrdering(this, other.asInstanceOf[PTuple], mb, so)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[PTuple], mb, so, missingFieldsEqual)
   }
 
   def identBase: String = "tuple"

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1872,7 +1872,7 @@ class IRSuite extends HailSuite {
     assertEvalsTo(toNestedArray(group(MakeStream(Seq(), TStream(structType)))), FastIndexedSeq())
 
     // test when inner streams are unused
-    assertEvalsTo(streamForceCount(group(a)), 3)
+    assertEvalsTo(streamForceCount(group(a)), 5)
 
     def takeFromEach(stream: IR, take: IR): IR = {
       val innerType = coerce[TStream](stream.typ)


### PR DESCRIPTION
~Stacked on #8873~