### PR TITLE
[query] fix unconsumed inner streams

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -152,6 +152,9 @@ package object ir {
     foldIR(stream, 0){ case (accum, elt) => accum + elt}
   }
 
+  def streamForceCount(stream: IR): IR =
+    streamSumIR(mapIR(stream)(_ => I32(1)))
+
   def rangeIR(n: IR): IR = StreamRange(0, n, 1)
 
   def rangeIR(start: IR, stop: IR): IR = StreamRange(start, stop, 1)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1830,7 +1830,10 @@ class IRSuite extends HailSuite {
     assertEvalsTo(toNestedArray(StreamGrouped(a, I32(5))), FastIndexedSeq(FastIndexedSeq(3, null, 7)))
     assertFatal(toNestedArray(StreamGrouped(a, I32(0))), "StreamGrouped: nonpositive size")
 
-    val r = StreamRange(I32(0), I32(10), I32(1))
+    val r = rangeIR(10)
+
+    // test when inner streams are unused
+    assertEvalsTo(streamForceCount(StreamGrouped(rangeIR(10), 2)), 5)
 
     assertEvalsTo(StreamLen(StreamGrouped(r, 2)), 5)
 
@@ -1867,6 +1870,9 @@ class IRSuite extends HailSuite {
                                  FastIndexedSeq(Row(1, 2), Row(1, 4), Row(1, 6)),
                                  FastIndexedSeq(Row(4, null))))
     assertEvalsTo(toNestedArray(group(MakeStream(Seq(), TStream(structType)))), FastIndexedSeq())
+
+    // test when inner streams are unused
+    assertEvalsTo(streamForceCount(group(a)), 3)
 
     def takeFromEach(stream: IR, take: IR): IR = {
       val innerType = coerce[TStream](stream.typ)


### PR DESCRIPTION
Allow the inner stream in a `StreamGrouped` or `StreamGroupByKey` to be unused, by recognizing when the `apply` method on the inner stream is never called, and calling it ourselves with a dummy consumer which just asserts the contained code paths are unreachable.