### PR TITLE
[query] add UUID4 IR node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -11,6 +11,7 @@ object Children {
     case F32(x) => none
     case F64(x) => none
     case Str(x) => none
+    case UUID4(_) => none
     case True() => none
     case False() => none
     case Literal(_, _) => none

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -8,6 +8,7 @@ object Copy {
       case F32(value) => F32(value)
       case F64(value) => F64(value)
       case Str(value) => Str(value)
+      case UUID4(id) => UUID4(id)
       case True() => True()
       case False() => False()
       case Literal(typ, value) => Literal(typ, value)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -671,6 +671,10 @@ class Emit[C](
         presentC(const(x))
       case s@Str(x) =>
         presentPC(mb.addLiteral(x, coerce[PString](s.pType)))
+      case x@UUID4(_) =>
+        presentPC(PCode(x.pType, coerce[PString](x.pType).
+          allocateAndStoreString(mb, region, Code.invokeScalaObject0[String](
+            Class.forName("is.hail.expr.ir.package$"), "uuid4"))))
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
       case True() =>

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -16,6 +16,7 @@ object FoldConstants {
            _: RelationalRef |
            _: RelationalLet |
            _: ApplySeeded |
+           _: UUID4 |
            _: ApplyAggOp |
            _: ApplyScanOp |
            _: Begin |

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -97,6 +97,17 @@ final case class True() extends IR
 final case class False() extends IR
 final case class Void() extends IR
 
+object UUID4 {
+  def apply(): UUID4 = UUID4(genUID())
+}
+
+// WARNING! This node can only be used when trying to append a one-off,
+// random string that will not be reused elsewhere in the pipeline.
+// Any other uses will need to write and then read again; this node is
+// non-deterministic and will not e.g. exhibit the correct semantics when
+// self-joining on streams.
+final case class UUID4(id: String) extends IR
+
 final case class Cast(v: IR, _typ: Type) extends IR
 final case class CastRename(v: IR, _typ: Type) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -238,7 +238,7 @@ object InferPType {
     }
     node._pType = node match {
       case x if x.typ == TVoid => PVoid
-      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: Literal | _: True | _: False
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: UUID4 | _: Literal | _: True | _: False
            | _: Cast | _: NA | _: Die | _: IsNA | _: ArrayZeros | _: ArrayLen | _: StreamLen
            | _: LowerBoundOnOrderedCollection | _: ApplyBinaryPrimOp
            | _: ApplyUnaryPrimOp | _: ApplyComparisonOp | _: WriteValue

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -13,6 +13,7 @@ object InferType {
       case F32(_) => TFloat32
       case F64(_) => TFloat64
       case Str(_) => TString
+      case UUID4(_) => TString
       case Literal(t, _) => t
       case True() | False() => TBoolean
       case Void() => TVoid

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -835,7 +835,8 @@ object Interpret {
         Region.scoped { r =>
           SafeRow.read(rt, makeFunction(0, r)(r)).asInstanceOf[Row](0)
         }
-
+      case UUID4(_) =>
+         uuid4()
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -690,6 +690,7 @@ object IRParser {
       case "F32" => F32(float32_literal(it))
       case "F64" => F64(float64_literal(it))
       case "Str" => Str(string_literal(it))
+      case "UUID4" => UUID4(identifier(it))
       case "True" => True()
       case "False" => False()
       case "Literal" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -238,6 +238,7 @@ object Pretty {
             case F32(x) => x.toString
             case F64(x) => x.toString
             case Str(x) => prettyStringLiteral(if (elideLiterals && x.length > 13) x.take(10) + "..." else x)
+            case UUID4(id) => prettyIdentifier(id)
             case Cast(_, typ) => typ.parsableString()
             case CastRename(_, typ) => typ.parsableString()
             case NA(typ) => typ.parsableString()

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -456,7 +456,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(node.children.forall { case c: IR => lookup(c).required })
 
       // always required
-      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die =>
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die | _: UUID4 =>
       case _: CombOpValue | _: AggStateValue =>
       case x if x.typ == TVoid =>
       case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) | ApplyComparisonOp(Compare(_, _), _, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -85,6 +85,7 @@ object TypeCheck {
       case True() =>
       case False() =>
       case Str(x) =>
+      case UUID4(_) =>
       case Literal(_, _) =>
       case Void() =>
       case Cast(v, typ) => if (!Casts.valid(v.typ, typ))

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -12,6 +12,8 @@ import is.hail.utils._
 
 import scala.language.implicitConversions
 
+import java.util.UUID
+
 package object ir {
   type TokenIterator = BufferedIterator[Token]
 
@@ -22,6 +24,8 @@ package object ir {
     uidCounter += 1
     uid
   }
+
+  def uuid4(): String = UUID.randomUUID().toString
 
   def genSym(base: String): Sym = Sym.gen(base)
 
@@ -141,6 +145,10 @@ package object ir {
     val ref = Ref(genUID(), coerce[TStream](stream.typ).elementType)
     StreamFlatMap(stream, ref.name, f(ref))
   }
+
+  def flatten(stream: IR): IR = flatMapIR(stream) { elt =>
+      if (elt.typ.isInstanceOf[TStream]) elt else ToStream(elt)
+    }
 
   def foldIR(stream: IR, zero: IR)(f: (Ref, Ref) => IR): IR = {
     val elt = Ref(genUID(), coerce[TStream](stream.typ).elementType)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2805,6 +2805,7 @@ class IRSuite extends HailSuite {
 
     val irs = Array(
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),
+      UUID4(),
       Cast(i, TFloat64),
       CastRename(NA(TStruct("a" -> TInt32)), TStruct("b" -> TInt32)),
       NA(TInt32), IsNA(i),
@@ -3574,5 +3575,30 @@ class IRSuite extends HailSuite {
     for (v <- Array(value, null)) {
       assertEvalsTo(ToArray(readArray), FastIndexedSeq(v -> pt.virtualType), Array.fill(10)(v).toFastIndexedSeq)
     }
+  }
+
+  @Test def testUUID4() {
+    val single = UUID4()
+    val hex = "[0-9a-f]"
+    val format = s"$hex{8}-$hex{4}-$hex{4}-$hex{4}-$hex{12}"
+    // 12345678-1234-5678-1234-567812345678
+    assertEvalsTo(
+      bindIR(single){ s =>
+        invoke("regexMatch", TBoolean, Str(format), s) &&
+          invoke("length", TInt32, s).ceq(I32(36))
+      }, true)
+
+    val stream = mapIR(rangeIR(5)) { _ => single }
+
+    def selfZip(s: IR, n: Int) = StreamZip(Array.fill(n)(s), Array.tabulate(n)(i => s"$i"),
+      MakeArray(Array.tabulate(n)(i => Ref(s"$i", TString)), TArray(TString)),
+      ArrayZipBehavior.AssumeSameLength)
+
+    def assertNumDistinct(s: IR, expected: Int) =
+      assertEvalsTo(ArrayLen(CastToArray(ToSet(s))), expected)
+
+    assertNumDistinct(stream, 5)
+    assertNumDistinct(flatten(selfZip(stream, 2)), 10)
+    assertNumDistinct(bindIR(ToArray(stream))(a => selfZip(ToStream(a), 2)), 5)
   }
 }


### PR DESCRIPTION
I'd like to introduce a function to generate UUIDs in our code. The use case I have in mind is currently to append unique identifiers to partition file names for write to mimic our current behavior, but the ability to generate uuids in our IR seems pretty nice, in general.

I added it as an IR node, but there's several problems arising from the fact that UUID is non-deterministic, and we can't effectively seed it. 

The fact that UUID4 is non-idempotent is actually the feature I'm looking for here---running the exact same IR twice should get me two different results, because if my WritePartition fails with a certain UUID I want to retry the execution, generating a new UUID. 

We can put a "seed" in the node to effectively treat each UUID4() node as non-equal to avoid any theoretical CSEing that might get done.

I don't think we need to worry about other forms of let binding; we treat it as non-constant, and we already don't push lets inside of nested array scopes, so the only time we'd ever forward a binding with UUID4 is if we have one usage of the binding within the same array scoping as its definition, which is perfectly valid.

The part that I'm having trouble with is related to the following concept: What happens when I make a stream of uuids, and then try to do a self-join? Let's look at the example of zipping a stream with itself, and just concatenating the two elements into an array.
```
val stream = mapIR(rangeIR(5)) { _ => UUID4() }
val zipped = StreamZip(Array(stream, stream), Array("1", "2"),
      MakeArray(Array(Ref("1", TString), Ref("1", TString)), TArray(TString)),
      ArrayZipBehavior.AssumeSameLength)
```
In the general case, we'd expect the zipped stream to be composed of arrays of duplicated elements---we rely on this being true when lowering, for example, a TableJoin against itself or a slightly transformed version of itself. Neither `zipped` nor `boundAndZipped` will exhibit that behavior here---since we process each stream independently, the UUIDs generated will all be different from each other. We don't see this problem with other random functions, because they're all seeded and therefore deterministic within a certain context. 

As per the note I've left on the class definition, we'd need to be careful to only use it when we can guarantee it won't be passed to another function that will use it in an invalid way. I think my use case in TableWrite fits this criteria, since it's a terminal operation; any other use cases would need to be able to guarantee the same until we can handle this node more generally.