### PR TITLE
[query] run seeded functions through IEmitCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -167,7 +167,7 @@ object LoweredTableReader {
         "key",
         MakeStruct(FastIndexedSeq(
           "key" -> Ref("key", keyType),
-          "token" -> invokeSeeded("rand_unif", TFloat64, F64(0.0), F64(1.0), I64(1)),
+          "token" -> invokeSeeded("rand_unif", 1, TFloat64, F64(0.0), F64(1.0)),
           "prevkey" -> ApplyScanOp(FastIndexedSeq(), FastIndexedSeq(Ref("key", keyType)), prevkey)))),
       "x",
       Let("n", ApplyAggOp(FastIndexedSeq(), FastIndexedSeq(), count),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -147,10 +147,43 @@ object IRFunctionRegistry {
     }
   }
 
-  def lookupConversion(name: String, returnType: Type, arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] =
-    lookupConversion(name, returnType, Array.empty[Type], arguments)
+  def lookupSeeded(name: String, returnType: Type, arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] =
 
-  def lookupConversion(name: String, returnType: Type, typeParameters: Seq[Type], arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] = {
+  def lookupUnseeded(name: String, returnType: Type, typeParameters: Seq[Type], arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] = {
+    val validIR: Option[(Seq[Type], Seq[IR]) => IR] = lookupIR(name, returnType, typeParameters, arguments).map {
+      case ((_, _, _, inline), conversion) => (typeParametersPassed, args) =>
+        val x = ApplyIR(name, typeParametersPassed, args)
+        x.conversion = conversion
+        x.inline = inline
+        x
+    }
+
+    val validMethods = lookupFunction(name, returnType, typeParameters, arguments)
+      .map { f =>
+      { (irValueParametersTypes: Seq[Type], irArguments: Seq[IR]) =>
+        f match {
+          case _: SeededJVMFunction =>
+            ApplySeeded(name, irArguments.init, irArguments.last.asInstanceOf[I64].x, f.returnType.subst())
+          case _: UnseededMissingnessObliviousJVMFunction =>
+            Apply(name, irValueParametersTypes, irArguments, f.returnType.subst())
+          case _: UnseededMissingnessAwareJVMFunction =>
+            ApplySpecial(name, irValueParametersTypes, irArguments, f.returnType.subst())
+        }
+      }
+      }
+
+    (validIR, validMethods) match {
+      case (None   , None)    => None
+      case (None   , Some(x)) => Some(x)
+      case (Some(x), None)    => Some(x)
+      case _ => fatal(s"Multiple methods found that satisfy $name(${ arguments.mkString(",") }).")
+    }
+  }
+
+  def lookupUnseeded(name: String, returnType: Type, arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] =
+    lookupUnseeded(name, returnType, Array.empty[Type], arguments)
+
+  def lookupUnseeded(name: String, returnType: Type, typeParameters: Seq[Type], arguments: Seq[Type]): Option[(Seq[Type], Seq[IR]) => IR] = {
     val validIR: Option[(Seq[Type], Seq[IR]) => IR] = lookupIR(name, returnType, typeParameters, arguments).map {
       case ((_, _, _, inline), conversion) => (typeParametersPassed, args) =>
         val x = ApplyIR(name, typeParametersPassed, args)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -37,12 +37,12 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
 
     registerIR("getReferenceSequence", Array(TString, TInt32, TInt32, TInt32), TString, typeParameters = Array(LocusFunctions.tlocus("R"))) {
       case (tl, Seq(contig, pos, before, after)) =>
-        val getRef = IRFunctionRegistry.lookupConversion(
+        val getRef = IRFunctionRegistry.lookupUnseeded(
           name = "getReferenceSequenceFromValidLocus",
           returnType = TString,
           typeParameters = tl,
           arguments = Seq(TString, TInt32, TInt32, TInt32)).get
-        val isValid = IRFunctionRegistry.lookupConversion(
+        val isValid = IRFunctionRegistry.lookupUnseeded(
           "isValidLocus",
           TBoolean,
           typeParameters = tl,

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -89,9 +89,9 @@ package object ir {
   def invoke(name: String, rt: Type, args: IR*): IR =
     invoke(name, rt, Array.empty[Type], args:_*)
 
-  def invokeSeeded(name: String, rt: Type, args: IR*): IR = IRFunctionRegistry.lookupUnseeded(name, rt, Array.empty[Type], args.init.map(_.typ)) match {
-    case Some(f) => f(Array.empty[Type], args)
-    case None => fatal(s"no conversion found for $name(${args.map(_.typ).mkString(", ")}) => $rt")
+  def invokeSeeded(name: String, seed: Long, rt: Type, args: IR*): IR = IRFunctionRegistry.lookupSeeded(name, seed, rt, args.map(_.typ)) match {
+    case Some(f) => f(args)
+    case None => fatal(s"no seeded function found for $name(${args.map(_.typ).mkString(", ")}) => $rt")
   }
 
   implicit def irToPrimitiveIR(ir: IR): PrimitiveIR = new PrimitiveIR(ir)

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -81,7 +81,7 @@ package object ir {
 
   private[ir] def coerce[T <: BaseTypeWithRequiredness](x: BaseTypeWithRequiredness): T = tycoerce[T](x)
 
-  def invoke(name: String, rt: Type, typeArgs: Array[Type], args: IR*): IR = IRFunctionRegistry.lookupConversion(name, rt, typeArgs, args.map(_.typ)) match {
+  def invoke(name: String, rt: Type, typeArgs: Array[Type], args: IR*): IR = IRFunctionRegistry.lookupUnseeded(name, rt, typeArgs, args.map(_.typ)) match {
     case Some(f) => f(typeArgs, args)
     case None => fatal(s"no conversion found for $name(${typeArgs.mkString(", ")}, ${args.map(_.typ).mkString(", ")}) => $rt")
   }
@@ -89,7 +89,7 @@ package object ir {
   def invoke(name: String, rt: Type, args: IR*): IR =
     invoke(name, rt, Array.empty[Type], args:_*)
 
-  def invokeSeeded(name: String, rt: Type, args: IR*): IR = IRFunctionRegistry.lookupConversion(name, rt, Array.empty[Type], args.init.map(_.typ)) match {
+  def invokeSeeded(name: String, rt: Type, args: IR*): IR = IRFunctionRegistry.lookupUnseeded(name, rt, Array.empty[Type], args.init.map(_.typ)) match {
     case Some(f) => f(Array.empty[Type], args)
     case None => fatal(s"no conversion found for $name(${args.map(_.typ).mkString(", ")}) => $rt")
   }

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -46,7 +46,7 @@ class FunctionSuite extends HailSuite {
   TestRegisterFunctions.registerAll()
 
   def lookup(meth: String, rt: Type, types: Type*)(irs: IR*): IR = {
-    val l = IRFunctionRegistry.lookupConversion(meth, rt, types).get
+    val l = IRFunctionRegistry.lookupUnseeded(meth, rt, types).get
     l(Seq(), irs)
   }
 
@@ -83,10 +83,10 @@ class FunctionSuite extends HailSuite {
 
   @Test
   def testVariableUnification() {
-    assert(IRFunctionRegistry.lookupConversion("testCodeUnification", TInt32, Seq(TInt32, TInt32)).isDefined)
-    assert(IRFunctionRegistry.lookupConversion("testCodeUnification", TInt32, Seq(TInt64, TInt32)).isEmpty)
-    assert(IRFunctionRegistry.lookupConversion("testCodeUnification", TInt64, Seq(TInt32, TInt32)).isEmpty)
-    assert(IRFunctionRegistry.lookupConversion("testCodeUnification2", TArray(TInt32), Seq(TArray(TInt32))).isDefined)
+    assert(IRFunctionRegistry.lookupUnseeded("testCodeUnification", TInt32, Seq(TInt32, TInt32)).isDefined)
+    assert(IRFunctionRegistry.lookupUnseeded("testCodeUnification", TInt32, Seq(TInt64, TInt32)).isEmpty)
+    assert(IRFunctionRegistry.lookupUnseeded("testCodeUnification", TInt64, Seq(TInt32, TInt32)).isEmpty)
+    assert(IRFunctionRegistry.lookupUnseeded("testCodeUnification2", TArray(TInt32), Seq(TArray(TInt32))).isDefined)
   }
 
   @Test

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -42,14 +42,14 @@ object IRSuite {
       returnType: Type,
       calculateReturnType: (Type, Seq[PType]) => PType
     )(
-      impl: (EmitRegion, PType, Long, Array[EmitCode]) => EmitCode
+      impl: (EmitCodeBuilder, EmitRegion, PType, Long, Array[() => IEmitCode]) => IEmitCode
     ) {
       IRFunctionRegistry.addJVMFunction(
         new SeededMissingnessAwareJVMFunction(name, valueParameterTypes, returnType, calculateReturnType) {
           val isDeterministic: Boolean = false
-          def applySeeded(seed: Long, r: EmitRegion, returnPType: PType, args: EmitCode*): EmitCode = {
-            assert(unify(FastSeq(), args.map(_.pt.virtualType), returnPType.virtualType))
-            impl(r, returnPType, seed, args.toArray)
+          def applySeededI(seed: Long, cb: EmitCodeBuilder, r: EmitRegion, returnPType: PType, args: (PType, () => IEmitCode)*): IEmitCode = {
+            assert(unify(FastSeq(), args.map(_._1.virtualType), returnPType.virtualType))
+            impl(cb, r, returnPType, seed, args.map(a => a._2).toArray)
           }
         }
       )
@@ -61,28 +61,23 @@ object IRSuite {
       returnType: Type,
       calculateReturnType: (Type, PType) => PType
     )(
-      impl: (EmitRegion, PType, Long, EmitCode) => EmitCode
+      impl: (EmitCodeBuilder, EmitRegion, PType, Long, () => IEmitCode) => IEmitCode
     ): Unit =
       registerSeededWithMissingness(name, Array(valueParameterType), returnType, unwrappedApply(calculateReturnType)) {
-        case (r, rt, seed, Array(a1)) => impl(r, rt, seed, a1) }
+        case (cb, r, rt, seed, Array(a1)) => impl(cb, r, rt, seed, a1)
+      }
 
     def registerAll() {
-      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, null) { case (mb, rt,  _, l) =>
-        EmitCode(Code(Code.invokeScalaObject0[Unit](outer.getClass, "incr"), l.setup),
-          l.m,
-          PCode(rt, l.v))
+      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, null) { case (cb, mb, rt,  _, l) =>
+        cb += Code.invokeScalaObject0[Unit](outer.getClass, "incr")
+        l()
       }
 
-      registerSeededWithMissingness("incr_m", TBoolean, TBoolean, null) { case (mb, rt, _, l) =>
-        EmitCode(l.setup,
-          Code(Code.invokeScalaObject0[Unit](outer.getClass, "incr"), l.m),
-          PCode(rt, l.v))
-      }
-
-      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, null) { case (mb, rt, _, l) =>
-        EmitCode(l.setup,
-          l.m,
-          PCode(rt, Code(Code.invokeScalaObject0[Unit](outer.getClass, "incr"), l.v)))
+      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, null) { case (cb, mb, rt, _, l) =>
+        l().map(cb) { pc =>
+          cb += Code.invokeScalaObject0[Unit](outer.getClass, "incr")
+          pc
+        }
       }
     }
   }
@@ -3250,12 +3245,6 @@ class IRSuite extends HailSuite {
 
     def sm = ApplySeeded("incr_s", FastSeq(NA(TBoolean)), 0L, TBoolean)
 
-    def mt = ApplySeeded("incr_m", FastSeq(True()), 0L, TBoolean)
-
-    def mf = ApplySeeded("incr_m", FastSeq(True()), 0L, TBoolean)
-
-    def mm = ApplySeeded("incr_m", FastSeq(NA(TBoolean)), 0L, TBoolean)
-
     def vt = ApplySeeded("incr_v", FastSeq(True()), 0L, TBoolean)
 
     def vf = ApplySeeded("incr_v", FastSeq(True()), 0L, TBoolean)
@@ -3264,7 +3253,6 @@ class IRSuite extends HailSuite {
 
     // baseline
     test(st, true, 1); test(sf, true, 1); test(sm, true, 1)
-    test(mt, true, 1); test(mf, true, 1); test(mm, true, 1)
     test(vt, true, 1); test(vf, true, 1); test(vm, true, 0)
 
     // if
@@ -3272,10 +3260,6 @@ class IRSuite extends HailSuite {
     test(If(st, i, True()), true, 1)
     test(If(sf, i, True()), true, 1)
     test(If(sm, i, True()), true, 1)
-
-    test(If(mt, i, True()), true, 1)
-    test(If(mf, i, True()), true, 1)
-    test(If(mm, i, True()), true, 1)
 
     test(If(vt, i, True()), true, 1)
     test(If(vf, i, True()), true, 1)
@@ -3286,10 +3270,6 @@ class IRSuite extends HailSuite {
     test(If(i, sf, True()), true, 1)
     test(If(i, sm, True()), true, 1)
 
-    test(If(i, mt, True()), true, 1)
-    test(If(i, mf, True()), true, 1)
-    test(If(i, mm, True()), true, 1)
-
     test(If(i, vt, True()), true, 1)
     test(If(i, vf, True()), true, 1)
     test(If(i, vm, True()), true, 0)
@@ -3298,10 +3278,6 @@ class IRSuite extends HailSuite {
     test(If(i, True(), st), false, 1)
     test(If(i, True(), sf), false, 1)
     test(If(i, True(), sm), false, 1)
-
-    test(If(i, True(), mt), false, 1)
-    test(If(i, True(), mf), false, 1)
-    test(If(i, True(), mm), false, 1)
 
     test(If(i, True(), vt), false, 1)
     test(If(i, True(), vf), false, 1)

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -141,10 +141,10 @@ class RandomFunctionsSuite extends HailSuite {
   }
 
   @Test def testRandCat() {
-    val seed = I64(5L)
-    assertEvalsTo(invokeSeeded("rand_cat", TInt32, MakeArray(IndexedSeq[IR](0.1), TArray(TFloat64)), seed), 0)
-    assertEvalsTo(invokeSeeded("rand_cat", TInt32, MakeArray(IndexedSeq[IR](0.3, 0.2, 0.95, 0.05), TArray(TFloat64)), seed), 1)
-    assertEvalsTo(invokeSeeded("rand_cat", TInt32, NA(TArray(TFloat64)), seed), null)
-    assertFatal(invokeSeeded("rand_cat", TInt32, MakeArray(IndexedSeq[IR](0.3, NA(TFloat64)), TArray(TFloat64)), seed), "rand_cat")
+    val seed = 5L
+    assertEvalsTo(invokeSeeded("rand_cat", seed, TInt32, MakeArray(IndexedSeq[IR](0.1), TArray(TFloat64))), 0)
+    assertEvalsTo(invokeSeeded("rand_cat", seed, TInt32, MakeArray(IndexedSeq[IR](0.3, 0.2, 0.95, 0.05), TArray(TFloat64))), 1)
+    assertEvalsTo(invokeSeeded("rand_cat", seed, TInt32, NA(TArray(TFloat64))), null)
+    assertFatal(invokeSeeded("rand_cat", seed, TInt32, MakeArray(IndexedSeq[IR](0.3, NA(TFloat64)), TArray(TFloat64))), "rand_cat")
   }
 }


### PR DESCRIPTION
Use `emitI` to emit `ApplySeeded` nodes and port the seeded function implementations to rely on IEmitCode instead of EmitCode

The changes in IRSuite are arguably to a test that's no longer relevant---it was a regression test for a bug where we were occasionally double-emitting some part of the EmitTriplet in some cases.

On the other hand, it feels kind of useful to keep as an illustration of how to thread IEmitCode through the function registry in a way that allows us to have weird interactions between the setup code of various IEmitCode args and the function itself. It was certainly instructive for me to work through how to translate the test functions in a way that made sense.

I've removed one of the functions since we no longer have a single notion for "this code should be run after all the IEmitCode setup but before the missingness is calculated"---they've been kind of merged into one concept.