### PR TITLE
Fix type annotations and checks in functions.py

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5717,8 +5717,8 @@ def _locus_windows_per_contig(coords, radius):
 
 
 @typecheck(a=expr_array(),
-           seed=nullable(int))
-def shuffle(a, seed: int = None) -> ArrayExpression:
+           seed=nullable(builtins.int))
+def shuffle(a, seed: builtins.int = None) -> ArrayExpression:
     """Randomly permute an array
 
     Example

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4029,7 +4029,7 @@ def set(collection) -> SetExpression:
 
 
 @typecheck(t=hail_type)
-def empty_set(t: Union[HailType, str]) -> SetExpression:
+def empty_set(t: Union[HailType, builtins.str]) -> SetExpression:
     """Returns an empty set of elements of a type `t`.
 
     Examples
@@ -4080,7 +4080,7 @@ def array(collection) -> ArrayExpression:
 
 
 @typecheck(t=hail_type)
-def empty_array(t: Union[HailType, str]) -> ArrayExpression:
+def empty_array(t: Union[HailType, builtins.str]) -> ArrayExpression:
     """Returns an empty array of elements of a type `t`.
 
     Examples
@@ -4200,7 +4200,7 @@ def _ndarray(collection, row_major=None):
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)
-def empty_dict(key_type: Union[HailType, str], value_type: Union[HailType, str]) -> DictExpression:
+def empty_dict(key_type: Union[HailType, builtins.str], value_type: Union[HailType, builtins.str]) -> DictExpression:
     """Returns an empty dictionary with key type `key_type` and value type
     `value_type`.
 


### PR DESCRIPTION
hail/python/hail/expr/functions.py defines functions `str`, `int`, etc. There are a few uses of `str` or `int` in functions.py that refer to `hail.expr.functions.str` and `hail.expr.functions.int` where they are intended to refer to `builtins.str` or `builtins.int`.

Empty collection constructors are currently documented as accepting either a Hail type object or a `hail.expr.functions.str` instead of a `builtins.str` for the type name.
https://hail.is/docs/0.2/functions/constructors.html#hail.expr.functions.empty_array

In the case of `shuffle`, the type check as well as the type annotation is incorrect. Currently, attempting to call `hl.shuffle` with a `seed` argument throws an exception `TypeError: int() missing 1 required positional argument: 'x'`.

---

There is also a more widespread but much less impactful issue with the docstrings in functions.py.   Sphinx interprets ``:obj:`str` `` in a docstring in functions.py to refer to `hail.expr.functions.str`, so the documentation for many parameters of builtin types links to `hail.expr.functions` functions. For example, `str` in the description of the `reference_genome` parameter for `hl.locus` links to `hl.expr.functions.str`, though that parameter is actually of type `builtin.str`.
https://hail.is/docs/0.2/functions/genetics.html#hail.expr.functions.locus