### PR TITLE
Documentation fixups

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -204,7 +204,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
         Spark configuration parameters.
     skip_logging_configuration : :obj:`bool`
         Skip logging configuration in java and python.
-    local_tmpdir : obj:`str`, optional
+    local_tmpdir : :obj:`str`, optional
         Local temporary directory.  Used on driver and executor nodes.
         Must use the file scheme.  Defaults to TMPDIR, or /tmp.
     """

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -10,7 +10,7 @@ Requirements
   Note: it *must* be Java **8**. Hail does not support versions 9+ due to our
   dependency on Spark.
 
-- The Python and non-pip installation requiremenets in `Getting Started <getting_started.html>`_
+- The Python and non-pip installation requirements in `Getting Started <getting_started.html>`_
 
 
 Building Hail


### PR DESCRIPTION
A couple of small fixes for docs:
* Correct spelling of "requirements" in getting started developing
* Fix reST syntax for type of `local_tmpdir` parameter to `hl.init`