### PR TITLE
Add ENDArray

### DIFF
--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -37,7 +37,7 @@ final case class EBlockMatrixNDArray(elementType: EType, override val required: 
     assert(pnd.elementType.required)
     val ndarray = coerce[Long](v)
     val i = mb.newLocal[Long]("i")
-    val j = mb.newLocal[Long]("i")
+    val j = mb.newLocal[Long]("j")
     val r = mb.newLocal[Long]("r")
     val c = mb.newLocal[Long]("c")
     val writeElemF = elementType.buildEncoder(pnd.elementType, mb.ecb)

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
@@ -1,0 +1,26 @@
+package is.hail.types.encoded
+import is.hail.annotations.Region
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.io.{InputBuffer, OutputBuffer}
+import is.hail.types.physical.PType
+import is.hail.types.virtual.Type
+
+class ENDArray(val elementType: EType) extends EContainer {
+
+  override def _buildEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = ???
+
+  override def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = ???
+
+  override def _buildSkip(mb: EmitMethodBuilder[_], r: Value[Region], in: Value[InputBuffer]): Code[Unit] = ???
+
+  override def _asIdent: String = ???
+
+  override def _toPretty: String = ???
+
+  override def _decodedPType(requestedType: Type): PType = ???
+
+  override def setRequired(required: Boolean): EType = ???
+
+  override def required: Boolean = ???
+}

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
@@ -58,7 +58,12 @@ case class ENDArray(elementType: EType, nDims: Int, required: Boolean = false) e
   }
 
   override def _buildSkip(mb: EmitMethodBuilder[_], r: Value[Region], in: Value[InputBuffer]): Code[Unit] = {
-    ???
+    val arraySkipper = EArray(elementType, true).buildSkip(mb)
+
+    Code(
+      Code((0 until nDims * 2).map(_ => in.skipLong())),
+      arraySkipper(r, in)
+    )
   }
 
   def _decodedPType(requestedType: Type): PType = {

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
@@ -8,31 +8,42 @@ import is.hail.types.virtual.{TNDArray, Type}
 import is.hail.utils._
 
 case class ENDArray(elementType: EType, required: Boolean = false) extends EContainer {
-
   override def _buildEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
     val pnd = pt.asInstanceOf[PCanonicalNDArray]
     assert(pnd.elementType.required)
     val ndarray = coerce[Long](v)
 
-    val shapeVariables: IndexedSeq[LocalRef[Long]] = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"shape_$i"))
-    val readShapes = shapeVariables.zipWithIndex.map{ case (shapeVar, i) => shapeVar := pnd.loadShape(ndarray, i)}
-    val writeShapes = shapeVariables.map(shapeVar => out.get.writeLong(shapeVar))
+    val writeShapes = (0 until pnd.nDims).map(i => out.get.writeLong(pnd.loadShape(ndarray, i)))
+    // Note, encoded strides is in terms of indices into ndarray, not bytes.
+    val writeStrides = (0 until pnd.nDims).map(i => out.get.writeLong(pnd.loadStride(ndarray, i) / pnd.elementType.byteSize))
 
-    val loopVariables: IndexedSeq[LocalRef[Long]] = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"index_$i"))
+    val dataArrayType = EArray(elementType, required)
+    val writeData = dataArrayType.buildEncoder(pnd.data.pType, mb.ecb)
 
-
-    val writeElemF = elementType.buildEncoder(pnd.elementType, mb.ecb)
-    val code = Code(
-      Code(readShapes),
+    Code(
       Code(writeShapes),
-      Code(loopVariables.map(loopVar => loopVar := 0L))
+      Code(writeStrides),
+      writeData(pnd.data.load(ndarray.get), out)
     )
-    ???
   }
 
-  override def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = ???
+  override def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = {
+    val pnd = pt.asInstanceOf[PCanonicalNDArray]
+    val shapeVars = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"shape_$i"))
+    val strideVars = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"stride_$i"))
+    val data = pnd.data.load(in.readLong())
 
-  override def _buildSkip(mb: EmitMethodBuilder[_], r: Value[Region], in: Value[InputBuffer]): Code[Unit] = ???
+    Code(
+      Code(shapeVars.map(shapeVar => shapeVar := in.readLong())),
+      Code(strideVars.map(strideVar => strideVar := in.readLong() * pt.byteSize)),
+      pnd.construct(pnd.makeShapeBuilder(shapeVars), pnd.makeShapeBuilder(strideVars), data, mb)
+    )
+  }
+
+  override def _buildSkip(mb: EmitMethodBuilder[_], r: Value[Region], in: Value[InputBuffer]): Code[Unit] = {
+    
+    ???
+  }
 
   def _decodedPType(requestedType: Type): PType = {
     val requestedTNDArray = requestedType.asInstanceOf[TNDArray]

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
@@ -75,10 +75,4 @@ case class ENDArray(elementType: EType, nDims: Int, required: Boolean = false) e
 
   override def _asIdent = s"ndarray_of_${elementType.asIdent}"
   override def _toPretty = s"ENDArray[$elementType,$nDims]"
-
-  override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
-    sb.append("ENDArray[")
-    elementType.pretty(sb, indent, compact)
-    sb.append("]")
-  }
 }

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArray.scala
@@ -1,26 +1,52 @@
 package is.hail.types.encoded
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, Value}
+import is.hail.asm4s.{Code, LocalRef, Value, coerce}
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.io.{InputBuffer, OutputBuffer}
-import is.hail.types.physical.PType
-import is.hail.types.virtual.Type
+import is.hail.types.physical.{PCanonicalNDArray, PType}
+import is.hail.types.virtual.{TNDArray, Type}
+import is.hail.utils._
 
-class ENDArray(val elementType: EType) extends EContainer {
+case class ENDArray(elementType: EType, required: Boolean = false) extends EContainer {
 
-  override def _buildEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = ???
+  override def _buildEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
+    val pnd = pt.asInstanceOf[PCanonicalNDArray]
+    assert(pnd.elementType.required)
+    val ndarray = coerce[Long](v)
+
+    val shapeVariables: IndexedSeq[LocalRef[Long]] = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"shape_$i"))
+    val readShapes = shapeVariables.zipWithIndex.map{ case (shapeVar, i) => shapeVar := pnd.loadShape(ndarray, i)}
+    val writeShapes = shapeVariables.map(shapeVar => out.get.writeLong(shapeVar))
+
+    val loopVariables: IndexedSeq[LocalRef[Long]] = (0 until pnd.nDims).map(i => mb.newLocal[Long](s"index_$i"))
+
+
+    val writeElemF = elementType.buildEncoder(pnd.elementType, mb.ecb)
+    val code = Code(
+      Code(readShapes),
+      Code(writeShapes),
+      Code(loopVariables.map(loopVar => loopVar := 0L))
+    )
+    ???
+  }
 
   override def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = ???
 
   override def _buildSkip(mb: EmitMethodBuilder[_], r: Value[Region], in: Value[InputBuffer]): Code[Unit] = ???
 
-  override def _asIdent: String = ???
+  def _decodedPType(requestedType: Type): PType = {
+    val requestedTNDArray = requestedType.asInstanceOf[TNDArray]
+    val elementPType = elementType.decodedPType(requestedTNDArray.elementType)
+    PCanonicalNDArray(elementPType, requestedTNDArray.nDims, required)
+  }
+  override def setRequired(required: Boolean): EType = ENDArray(elementType, required)
 
-  override def _toPretty: String = ???
+  override def _asIdent = s"ndarray_of_${elementType.asIdent}"
+  override def _toPretty = s"ENDArray[$elementType]"
 
-  override def _decodedPType(requestedType: Type): PType = ???
-
-  override def setRequired(required: Boolean): EType = ???
-
-  override def required: Boolean = ???
+  override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
+    sb.append("ENDArray[")
+    elementType.pretty(sb, indent, compact)
+    sb.append("]")
+  }
 }

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -277,7 +277,7 @@ object EType {
   def defaultFromPType(pt: PType): EType = {
     if (pt.isInstanceOf[PNDArray]) {
       val pnd = pt.asInstanceOf[PNDArray]
-      ENDArray(defaultFromPType(pnd.elementType), pt.required)
+      ENDArray(defaultFromPType(pnd.elementType), pnd.nDims, pnd.required)
     }
     else pt.fundamentalType match {
       case t: PInt32 => EInt32(t.required)
@@ -346,8 +346,10 @@ object EType {
       case "ENDArray" =>
         IRParser.punctuation(it, "[")
         val elementType = eTypeParser(it)
+        IRParser.punctuation(it, ",")
+        val nDims = IRParser.int32_literal(it)
         IRParser.punctuation(it, "]")
-        ENDArray(elementType, req)
+        ENDArray(elementType, nDims,  req)
       case x => throw new UnsupportedOperationException(s"Couldn't parse $x ${it.toIndexedSeq}")
 
     }

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -275,11 +275,7 @@ object EType {
   }
 
   def defaultFromPType(pt: PType): EType = {
-    if (pt.isInstanceOf[PNDArray]) {
-      val pnd = pt.asInstanceOf[PNDArray]
-      ENDArray(defaultFromPType(pnd.elementType), pnd.nDims, pnd.required)
-    }
-    else pt.fundamentalType match {
+    pt.fundamentalType match {
       case t: PInt32 => EInt32(t.required)
       case t: PInt64 => EInt64(t.required)
       case t: PFloat32 => EFloat32(t.required)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -25,6 +25,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def loadShape(off: Code[Long], idx: Int): Code[Long] =
     shape.pType.types(idx).load(shape.pType.fieldOffset(shape.load(off), idx)).tcode[Long]
 
+  def loadStride(off: Code[Long], idx: Int): Code[Long] =
+    strides.pType.types(idx).load(strides.pType.fieldOffset(strides.load(off), idx)).tcode[Long]
+
   @transient lazy val strides = new StaticallyKnownField(
     PCanonicalTuple(true, Array.tabulate(nDims)(_ => PInt64Required):_*): PTuple,
     (off) => representation.loadField(off, "strides")

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -30,7 +30,8 @@ class ETypeSuite extends HailSuite {
       EArray(EInt32Required, required = false),
       EArray(EArray(EInt32Optional, required = true), required = true),
       EBaseStruct(FastIndexedSeq(), required = true),
-      EBaseStruct(FastIndexedSeq(EField("x", EBinaryRequired, 0), EField("y", EFloat64Optional, 1)), required = true)
+      EBaseStruct(FastIndexedSeq(EField("x", EBinaryRequired, 0), EField("y", EFloat64Optional, 1)), required = true),
+      ENDArray(EArray(EFloat64Required,true))
     ).map(t => Array(t: Any))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -31,7 +31,7 @@ class ETypeSuite extends HailSuite {
       EArray(EArray(EInt32Optional, required = true), required = true),
       EBaseStruct(FastIndexedSeq(), required = true),
       EBaseStruct(FastIndexedSeq(EField("x", EBinaryRequired, 0), EField("y", EFloat64Optional, 1)), required = true),
-      ENDArray(EArray(EFloat64Required,true))
+      ENDArray(EArray(EFloat64Required, true), 3)
     ).map(t => Array(t: Any))
   }
 
@@ -112,7 +112,7 @@ class ETypeSuite extends HailSuite {
 
   @Test def testNDArrayEncodeDecode(): Unit = {
     val pType = PCanonicalNDArray(PInt32Required, 2, true)
-    val eType = ENDArray(EInt32Required, true)
+    val eType = ENDArray(EInt32Required, 2, true)
     val data = Row(Row(2L, 2L), Row(16L, 8L), FastIndexedSeq(1, 2, 3, 4))
 
     assertEqualEncodeDecode(pType, eType, pType, data)

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -31,7 +31,7 @@ class ETypeSuite extends HailSuite {
       EArray(EArray(EInt32Optional, required = true), required = true),
       EBaseStruct(FastIndexedSeq(), required = true),
       EBaseStruct(FastIndexedSeq(EField("x", EBinaryRequired, 0), EField("y", EFloat64Optional, 1)), required = true),
-      ENDArray(EArray(EFloat64Required, true), 3)
+      ENDArray(EFloat64Required , 3)
     ).map(t => Array(t: Any))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.HailSuite
 import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
 import is.hail.types.encoded._
-import is.hail.types.physical.{PCanonicalArray, PCanonicalNDArray, PCanonicalStringOptional, PCanonicalStringRequired, PCanonicalStruct, PInt32Optional, PInt32Required, PInt64Optional, PInt64Required, PType}
+import is.hail.types.physical.{PCanonicalArray, PCanonicalNDArray, PCanonicalStringOptional, PCanonicalStringRequired, PCanonicalStruct, PFloat64Required, PInt32Optional, PInt32Required, PInt64Optional, PInt64Required, PType}
 import is.hail.io.{InputBuffer, MemoryBuffer, MemoryInputBuffer, MemoryOutputBuffer, OutputBuffer}
 import is.hail.rvd.AbstractRVDSpec
 import is.hail.utils._
@@ -111,11 +111,16 @@ class ETypeSuite extends HailSuite {
   }
 
   @Test def testNDArrayEncodeDecode(): Unit = {
-    val pType = PCanonicalNDArray(PInt32Required, 2, true)
-    val eType = ENDArray(EInt32Required, 2, true)
-    val data = Row(Row(2L, 2L), Row(16L, 8L), FastIndexedSeq(1, 2, 3, 4))
+    val pTypeInt2 = PCanonicalNDArray(PInt32Required, 2, true)
+    val eTypeInt2 = ENDArray(EInt32Required, 2, true)
+    val dataInt2 = Row(Row(2L, 2L), Row(16L, 8L), FastIndexedSeq(1, 2, 3, 4))
 
-    assertEqualEncodeDecode(pType, eType, pType, data)
+    assertEqualEncodeDecode(pTypeInt2, eTypeInt2, pTypeInt2, dataInt2)
+
+    val pTypeFloat3 = PCanonicalNDArray(PFloat64Required, 3, false)
+    val eTypeFloat3 = ENDArray(EFloat64Required, 3, false)
+    val dataFloat3 = Row(Row(3L, 2L, 1L), Row(32L, 16L, 16L), FastIndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+
+    assertEqualEncodeDecode(pTypeFloat3, eTypeFloat3, pTypeFloat3, dataFloat3)
   }
-
 }


### PR DESCRIPTION
This PR introduces and tests a new `EType`, `ENDArray`. It is not used anywhere yet except for tests, as there are some issues with `fundamentalType` and backcompatibility to be worked out, but in the interest of smaller PRs I figured I'd get the type implementation in first and do a follow up where we start using it. 