### PR TITLE
[query] Extend `hl.export_vcf` to work on Table

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -280,6 +280,15 @@ class VCFTests(unittest.TestCase):
         mt2 = hl.import_vcf(tmp, reference_genome='GRCh38')
         self.assertTrue(mt._same(mt2))
 
+    def test_export_sites_only_from_table(self):
+        mt = hl.import_vcf(resource('sample.vcf.bgz'))\
+            .select_entries()\
+            .filter_cols(False)
+
+        tmp = new_temp_file(extension="vcf")
+        hl.export_vcf(mt.rows(), tmp)
+        assert hl.import_vcf(tmp)._same(mt)
+
     @skip_unless_spark_backend()
     def test_import_gvcfs(self):
         path = resource('sample.vcf.bgz')


### PR DESCRIPTION
When you have a sites only dataset (like gnomad), you shouldn't have to convert to a `MatrixTable` just to make a VCF. This fixes that problem by internally converting tables to MatrixTables for export. 