### PR TITLE
[query] Some refactoring of TableStage

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -56,17 +56,14 @@ object LowerDistributedSort {
         Interval(first, last, includesStart = true, includesEnd = true)
       }.toIndexedSeq)
 
-    new TableStage(letBindings = FastIndexedSeq.empty, Set(),
+    TableStage(
       globals = Literal(resultPType.fieldType("global").virtualType, rowsAndGlobal.get(1)),
       partitioner = partitioner,
       contexts = mapIR(
         StreamGrouped(
           ToStream(Literal(rowsType.virtualType, sortedRows)),
-          I32(itemsPerPartition))) { s =>
-        ToArray(s)
-      }
-    ) {
-      def partition(ctxRef: Ref): IR = ToStream(ctxRef)
-    }
+          I32(itemsPerPartition))
+        )(ToArray(_)),
+      ctxRef => ToStream(ctxRef))
   }
 }


### PR DESCRIPTION
~Stacked on #8874, not by necessity, but because the following PR lowering TableJoin depends on both this and that.~

* Before, `TableStage` defined it's per-partition behavior in an abstract method `def partition(ctxRef: Ref): IR`. This makes defining a new `TableStage` a bit heavy syntactically, and means we can't inspect the type of the partition IR without apply the function to something.

  This PR replaces the abstract method with two fields `ctxRefName: String` and `partitionIR: IR`. It defines a method `def partition(ctx: IR): IR` using these, which is more ergonomic to use because the context isn't forced to be a `Ref`.

* With the type of the partition result accessible, this PR requires that type to be a `TStream<TStruct>`. Without this requirement, there is no clear connection between the partitioner and the rest of the `TableStage`. The only violation of this requirement was mapping to some other type right before collecting; this use is accommodated by a `mapCollect` method which combines the steps.

* The binding structure of `TableStage` has been slightly reorganized. The `letBindings`, which are used on the master, and the `broadcastVals` which are used on the driver (previously, they had to also be usable on master), have been teased apart. In the new structure:
  * `letBindings` are as before: a sequence of bindings which are evaluated in sequence on the master, whose bindings are visible in the `contexts` expression and in the `broadcastVals`
  * `broadcastVals` are now a separate sequence of bindings, which are evaluated on the master in parallel (each broadcast binding sees only the `letBindings`, no previous `broadcastVals`), and whose bindings are visible only in the `partitionIR`
  * `globals` is now required to be a `Ref`, which is defined in `letBindings` and redefined in `broadcastVals`, so that the `Ref` is valid in later `letBindings`, in `contexts`, as well as in the `partitionIR`. This does mean that `globals` is always broadcast, even when it's just an empty struct. But since we're generating a `CollectDistributedArray` which always broadcasts a struct, adding a nested required empty struct shouldn't have any overhead.

  I think this more layered organization has a clearer semantics than before, where `broadcastVals` were a subset of the `letBindings`, and `globals` was an arbitrary IR in the `broadcastVals` scope. It's also closer to the structure of the resulting `CollectDistributedArray`.

  I tried to pull `letBindings` out of `TableStage`, letting them be built up imperatively in the lowering pass, similar to what we do in `LowerMatrixIR`. I had it mostly working, but was blocked by `localSort`, which compiles and executes an intermediate `TableStage`. This needs to be able to compile only those bindings needed in that intermediate stage, and to throw out those used bindings, neither of which is easy when the bindings are accumulated in a single list throughout the lowering pass.

@catoverdrive Would appreciate if you could take a quick look as well.