### PR TITLE
[query] Lower TableJoin

### DIFF
--- a/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
+++ b/hail/python/hail/docs/tutorials/07-matrixtable.ipynb
@@ -457,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -187,7 +187,8 @@ object ExtendedOrdering {
         val rx = x.asInstanceOf[Row]
         val ry = y.asInstanceOf[Row]
         val rLen = rx.length
-        assert(rLen == ry.length)
+        assert(rLen == fieldOrd.length)
+        assert(ry.length == fieldOrd.length)
 
         var i = 0
         while (i < rLen) {

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -322,7 +322,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         }
 
         if (joinType == "inner")
-          requiredness.key.zipWithIndex.foreach { case (k, i) =>
+          requiredness.key.take(joinKey).zipWithIndex.foreach { case (k, i) =>
             requiredness.field(k).unionWithIntersection(FastSeq(
               leftReq.field(leftReq.key(i)),
               rightReq.field(rightReq.key(i))))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -300,29 +300,55 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionKeys(lookup(child))
         requiredness.unionValues(lookupAs[RStruct](expr))
         requiredness.unionGlobals(lookup(child))
-      case TableJoin(left, right, joinType, _) =>
+      case TableJoin(left, right, joinType, joinKey) =>
         val leftReq = lookup(left)
         val rightReq = lookup(right)
 
-        requiredness.unionValues(leftReq)
-        requiredness.unionValues(rightReq)
-
-        if (joinType == "outer" || joinType == "zip" || joinType == "left") {
-          requiredness.unionKeys(leftReq)
-          rightReq.valueFields.foreach(n => requiredness.field(n).union(r = false))
-        }
-
-        if (joinType == "outer" || joinType == "zip" || joinType == "right") {
-          requiredness.unionKeys(rightReq)
-          leftReq.valueFields.foreach(n => requiredness.field(n).union(r = false))
-        }
-
-        if (joinType == "inner")
-          requiredness.key.zipWithIndex.foreach { case (k, i) =>
-            requiredness.field(k).unionWithIntersection(FastSeq(
-              leftReq.field(leftReq.key(i)),
-              rightReq.field(rightReq.key(i))))
+        if (joinType == "left") {
+          val leftFields = left.typ.rowType.fieldNames.toSet
+          requiredness.rowFields.foreach { case (f, t) =>
+            if (leftFields contains f)
+              t.unionFrom(leftReq.field(f))
+            else
+              t.union(r = false)
           }
+        }
+
+        if (joinType == "right") {
+          val rightFields = right.typ.rowType.fieldNames.toSet
+          val keyMap = left.typ.key.zip(right.typ.key).take(joinKey).toMap
+          requiredness.rowFields.foreach { case (f, t) =>
+            if (keyMap.contains(f))
+              t.unionFrom(rightReq.field(keyMap(f)))
+            else if (rightFields.contains(f))
+              t.unionFrom(rightReq.field(f))
+            else
+              t.union(r = false)
+          }
+        }
+
+        if (joinType == "outer" || joinType == "zip") {
+          val keyMap = left.typ.key.zip(right.typ.key).take(joinKey).toMap
+          requiredness.rowFields.foreach { case (f, t) =>
+            if (keyMap.contains(f)) {
+              t.unionFrom(leftReq.field(f))
+              t.unionFrom(rightReq.field(keyMap(f)))
+            } else
+              t.union(r = false)
+          }
+        }
+
+        if (joinType == "inner") {
+          val keyMap = left.typ.key.zip(right.typ.key).take(joinKey).toMap
+          requiredness.rowFields.foreach { case (f, t) =>
+            if (keyMap.contains(f))
+              t.unionWithIntersection(FastSeq(leftReq.field(f), rightReq.field(keyMap(f))))
+            else if (leftReq.fieldMap.contains(f))
+              t.unionFrom(leftReq.field(f))
+            else
+              t.unionFrom(rightReq.field(f))
+          }
+        }
 
         requiredness.unionGlobals(leftReq.globalType)
         requiredness.unionGlobals(rightReq.globalType)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -697,9 +697,10 @@ object LowerTableIR {
           require(!isSorted || nPreservedFields > 0 || newKey.isEmpty)
 
           if (nPreservedFields == newKey.length || isSorted)
+            // TODO: should this add a runtime check that keys are within the
+            // partition bounds, like in RVD?
             loweredChild.changePartitionerNoRepartition(loweredChild.partitioner.coarsen(nPreservedFields))
               .extendKeyPreservesPartitioning(newKey)
-          //        .checkKeyOrdering()
           else {
             val sorted = ctx.backend.lowerDistributedSort(
               ctx, loweredChild, newKey.map(k => SortField(k, Ascending)))

--- a/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
@@ -55,6 +55,7 @@ class KeyedRVD(val rvd: RVD, val key: Int) {
         case "right" => rightPart
         case "inner" => leftPart.intersect(rightPart)
         case "outer" => RVDPartitioner.generate(
+          kType.fieldNames,
           realType.kType.virtualType,
           leftPart.rangeBounds ++ rightPart.rangeBounds)
       }

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -339,12 +339,16 @@ case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: 
 
   def unionKeys(req: RStruct): Unit = key.foreach { n => field(n).unionFrom(req.field(n)) }
   def unionKeys(req: RTable): Unit = {
+    if (key.length > req.key.length)
+      println()
     assert(key.length <= req.key.length)
     key.zip(req.key).foreach { case (k, rk) => field(k).unionFrom(req.field(rk)) }
   }
 
   def unionValues(req: RStruct): Unit = valueFields.foreach { n => if (req.hasField(n)) field(n).unionFrom(req.field(n)) }
   def unionValues(req: RTable): Unit = unionValues(req.rowType)
+
+  def changeKey(key: Seq[String]): RTable = RTable(rowFields, globalFields, key)
 
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RTable = {
     assert(newChildren.length == rowFields.length + globalFields.length)

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -339,8 +339,6 @@ case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: 
 
   def unionKeys(req: RStruct): Unit = key.foreach { n => field(n).unionFrom(req.field(n)) }
   def unionKeys(req: RTable): Unit = {
-    if (key.length > req.key.length)
-      println()
     assert(key.length <= req.key.length)
     key.zip(req.key).foreach { case (k, rk) => field(k).unionFrom(req.field(rk)) }
   }

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -366,7 +366,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   }
 
   def typeAfterSelectNames(keep: IndexedSeq[String]): TStruct =
-    new TStruct(keep.map(i => fields(fieldIdx(i))))
+    TStruct(keep.map(n => n -> fieldType(n)): _*)
 
   def typeAfterSelect(keep: IndexedSeq[Int]): TStruct =
     TStruct(keep.map(i => fieldNames(i) -> types(i)): _*)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -373,7 +373,7 @@ object TestUtils {
               loweredExecute(x, env, args, agg)
           }
           if (t != TVoid) {
-            assert(t.typeCheck(res))
+            assert(t.typeCheck(res), s"\n  t=$t\n  result=$res\n  strategy=$strat")
             assert(t.valuesSimilar(res, expected), s"\n  result=$res\n  expect=$expected\n  strategy=$strat)")
           }
         } catch {

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -489,8 +489,6 @@ class RequirednessSuite extends HailSuite {
   def testTableRequiredness(node: TableIR, row: PType, global: PType): Unit = {
     val res = Requiredness.apply(node, ctx)
     val actual = res.r.lookup(node).asInstanceOf[RTable]
-    if (actual.rowType.canonicalPType(node.typ.rowType) != row)
-      println()
     assert(actual.rowType.canonicalPType(node.typ.rowType) == row, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(res.r) }")
     assert(actual.globalType.canonicalPType(node.typ.globalType) == global, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(res.r) }")
   }

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -489,6 +489,8 @@ class RequirednessSuite extends HailSuite {
   def testTableRequiredness(node: TableIR, row: PType, global: PType): Unit = {
     val res = Requiredness.apply(node, ctx)
     val actual = res.r.lookup(node).asInstanceOf[RTable]
+    if (actual.rowType.canonicalPType(node.typ.rowType) != row)
+      println()
     assert(actual.rowType.canonicalPType(node.typ.rowType) == row, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(res.r) }")
     assert(actual.globalType.canonicalPType(node.typ.globalType) == global, s"\n\n${Pretty(node)}: \n$actual\n\n${ dump(res.r) }")
   }

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -326,7 +326,6 @@ class TableIRSuite extends HailSuite {
     leftProject: Set[Int],
     rightProject: Set[Int]
   ) {
-    implicit val execStrats = ExecStrategy.allRelational
     val (leftType, leftProjectF) = rowType.filter(f => !leftProject.contains(f.index))
     val left = TableKeyBy(
       TableParallelize(

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -309,64 +309,55 @@ class TableIRSuite extends HailSuite {
   @DataProvider(name = "join")
   def joinData(): Array[Array[Any]] =
     for {
-      l <- leftPartitioners
-      r <- rightPartitioners
+      lParts <- Array[Integer](1, 2, 3)
+      rParts <- Array[Integer](1, 2, 3)
       (j, p) <- joinTypes
       leftProject <- Seq[Set[Int]](Set(), Set(1), Set(2), Set(1, 2))
       rightProject <- Seq[Set[Int]](Set(), Set(1), Set(2), Set(1, 2))
       if !leftProject.contains(1) || rightProject.contains(1)
-    } yield Array[Any](l, r, j, p, leftProject, rightProject)
+    } yield Array[Any](lParts, rParts, j, p, leftProject, rightProject)
 
   @Test(dataProvider = "join")
   def testTableJoin(
-    leftPart: RVDPartitioner,
-    rightPart: RVDPartitioner,
+    lParts: Int,
+    rParts: Int,
     joinType: String,
     pred: Row => Boolean,
     leftProject: Set[Int],
     rightProject: Set[Int]
   ) {
-    implicit val execStrats = ExecStrategy.interpretOnly
+    implicit val execStrats = ExecStrategy.allRelational
     val (leftType, leftProjectF) = rowType.filter(f => !leftProject.contains(f.index))
-    val left = Interpret(TableKeyBy(
+    val left = TableKeyBy(
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(leftType), "global" -> TStruct.empty),
           Row(leftData.map(leftProjectF.asInstanceOf[Row => Row]), Row())),
-        Some(1)),
-      if (!leftProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A")),
-      ctx,
-      optimize = false)
-    val partitionedLeft = left.copy(rvd = left.rvd
-      .repartition(ctx, if (!leftProject.contains(1)) leftPart else leftPart.coarsen(1))
-    )
+        Some(lParts)),
+      if (!leftProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A"))
 
     val (rightType, rightProjectF) = rowType.filter(f => !rightProject.contains(f.index))
-    val right = Interpret(TableKeyBy(
+    val right = TableKeyBy(
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rightType), "global" -> TStruct.empty),
           Row(rightData.map(rightProjectF.asInstanceOf[Row => Row]), Row())),
         Some(1)),
-      if (!rightProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A")),
-      ctx,
-      optimize = false)
-    val partitionedRight = right.copy(
-      rvd = right.rvd
-        .repartition(ctx, if (!rightProject.contains(1)) rightPart else rightPart.coarsen(1)))
+      if (!rightProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A"))
 
     val (_, joinProjectF) = joinedType.filter(f => !leftProject.contains(f.index) && !rightProject.contains(f.index - 2))
     val joined = collect(
       TableJoin(
-        TableLiteral(partitionedLeft),
+        left,
         TableRename(
-          TableLiteral(partitionedRight),
+          right,
           Array("A", "B", "C")
-            .filter(partitionedRight.typ.rowType.hasField)
+            .filter(right.typ.rowType.hasField)
             .map(a => a -> (a + "_"))
             .toMap,
           Map.empty),
         joinType, 1))
+
     assertEvalsTo(joined, Row(expected.filter(pred).map(joinProjectF).toFastIndexedSeq, Row()))
   }
 
@@ -717,7 +708,7 @@ class TableIRSuite extends HailSuite {
   val value1 = Row(FastIndexedSeq(0 until parTable1Length: _*).map(i => Row("row" + i, i * i, s"t1_${i}")), Row("global"))
   val table1 = TableParallelize(Literal(parTable1Type, value1), Some(2))
 
-  val parTable2Length = 13
+  val parTable2Length = 9
   val parTable2Type = TStruct("rows" -> TArray(TStruct("a2" -> TString, "b2" -> TInt32, "c2" -> TString)), "global" -> TStruct("y"-> TInt32))
   val value2 = Row(FastIndexedSeq(0 until parTable2Length: _*).map(i => Row("row" + i, -2 * i, s"t2_${i}")), Row(15))
   val table2 = TableParallelize(Literal(parTable2Type, value2), Some(3))
@@ -741,7 +732,7 @@ class TableIRSuite extends HailSuite {
     val joinedParKeyedByAAndB = TableLeftJoinRightDistinct(table1KeyedByAAndB, table2KeyedByA, "joinRoot")
 
     assertEvalsTo(TableCount(joinedParKeyedByAAndB), parTable1Length.toLong)
-    assertEvalsTo(collect(joinedParKeyedByA), Row(FastIndexedSeq(0 until parTable1Length: _*).map(i =>
+    assertEvalsTo(collect(joinedParKeyedByAAndB), Row(FastIndexedSeq(0 until parTable1Length: _*).map(i =>
       Row("row" + i, i * i, s"t1_${i}", Row(-2 * i, s"t2_${i}"))), Row("global"))
     )
   }


### PR DESCRIPTION
~Stacked on #8917~

Adds `zipPartitions`, `extendKeyPreservesPartitioning`, `orderedJoin`, and `alignAndZipPartitions` methods to `TableStage`, trying to mirror the `RVD` implementation, especially concerning the partitioning logic.

Adds lowering case for `TableJoin`.