### PR TITLE
[site] fixes for dev deploys

### DIFF
--- a/hail/python/hail/docs/_templates/layout.html
+++ b/hail/python/hail/docs/_templates/layout.html
@@ -215,7 +215,13 @@
   {% endif %}
 
   <script type="text/javascript">
-    $.get('/index.html', function(data) {
+    let hostname = window.location.hostname
+    let prefix = if (hostname == "internal.hail.is") {
+      window.location.pathname.split("/").slice(0, 3).join("/")
+    } else {
+      ""
+    }
+    $.get(prefix + '/index.html', function(data) {
       $("#hail-navbar").replaceWith($("<div>").html(data).find("#hail-navbar").addClass('documentation-view'));
     });
   </script> 

--- a/site/site.sh
+++ b/site/site.sh
@@ -14,8 +14,8 @@ EOF
 else
     prefix="/$HAIL_DEFAULT_NAMESPACE/site"
     cat >$rewrite_conf_location <<EOF
-subs_filter href="/([^/]) href="/$HAIL_DEFAULT_NAMESPACE/site/\$1 gr;
-subs_filter src="/([^/]) src="/$HAIL_DEFAULT_NAMESPACE/site/\$1 gr;
+subs_filter href=(['"])/([^/]) href=\$1/$HAIL_DEFAULT_NAMESPACE/site/\$2 gr;
+subs_filter src=(['"])/([^/]) src=\$1/$HAIL_DEFAULT_NAMESPACE/site/\$2 gr;
 EOF
 fi
 


### PR DESCRIPTION
1. When dev deploying or PR deploying, the root URL is not the usual one. We fix `layout.html` to produce the correct url when prefixed.
2. The NGINX rule which fixes paths in dev deploys or PR deploys incorrectly assumed only double quotes were permissible around HTML attributes. Single quotoes are also permissible.

The layout changes will not take effect until we next deploy the Hail docs. Until then, dev deploy's will not have a nav bar on the docs.