### PR TITLE
[query] refactor MakeRVDSpec to have intermediate with no partFiles

### DIFF
--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -163,12 +163,11 @@ object RichContextRDDRegionValue {
     partFiles: Array[String],
     partitioner: RVDPartitioner
   ) {
-    val rowsSpec = MakeRVDSpec(t.key, rowsCodecSpec, partFiles, partitioner, rowsIndexSpec)
+    val rowsSpec = MakeRVDSpec(rowsCodecSpec, partFiles, partitioner, rowsIndexSpec)
     rowsSpec.write(fs, path + "/rows/rows")
 
-    val entriesSpec = MakeRVDSpec(
-      FastIndexedSeq(), entriesCodecSpec, partFiles, RVDPartitioner.unkeyed(partitioner.numPartitions),
-      entriesIndexSpec)
+    val entriesSpec = MakeRVDSpec(entriesCodecSpec, partFiles,
+      RVDPartitioner.unkeyed(partitioner.numPartitions), entriesIndexSpec)
     entriesSpec.write(fs, path + "/entries/rows")
   }
 }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -99,7 +99,7 @@ object AbstractRVDSpec {
         }
       }
 
-    val spec = MakeRVDSpec(FastIndexedSeq(), codecSpec, Array(filePath), RVDPartitioner.unkeyed(1))
+    val spec = MakeRVDSpec(codecSpec, Array(filePath), RVDPartitioner.unkeyed(1))
     spec.write(fs, path)
 
     Array(part0Count)
@@ -261,7 +261,6 @@ object IndexSpec {
 
 object MakeRVDSpec {
   def apply(
-    key: IndexedSeq[String],
     codecSpec: AbstractTypedCodecSpec,
     partFiles: Array[String],
     partitioner: RVDPartitioner,
@@ -271,23 +270,33 @@ object MakeRVDSpec {
     val partJV = JSONAnnotationImpex.exportAnnotation(
       partitioner.rangeBounds.toFastSeq,
       partitioner.rangeBoundsType)
+    RVDSpecMaker(codecSpec, partitioner.kType.fieldNames, partJV, indexSpec, attrs)(partFiles)
+  }
+}
+
+case class RVDSpecMaker(
+  codecSpec: AbstractTypedCodecSpec,
+  key: Array[String],
+  bounds: JValue,
+  indexSpec: AbstractIndexSpec,
+  attrs: Map[String, String]) {
+  def apply(partFiles: Array[String]): AbstractRVDSpec =
     Option(indexSpec) match {
       case Some(ais) => IndexedRVDSpec2(
         key,
         codecSpec,
         ais,
         partFiles,
-        partJV,
+        bounds,
         attrs)
       case None => OrderedRVDSpec2(
         key,
         codecSpec,
         partFiles,
-        partJV,
+        bounds,
         attrs
       )
     }
-  }
 }
 
 object IndexedRVDSpec2 {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -760,7 +760,7 @@ class RVD(
 
   def write(ctx: ExecuteContext, path: String, idxRelPath: String, stageLocally: Boolean, codecSpec: AbstractTypedCodecSpec): Array[Long] = {
     val (partFiles, partitionCounts) = crdd.writeRows(ctx, path, idxRelPath, typ, stageLocally, codecSpec)
-    val spec = MakeRVDSpec(typ.key, codecSpec, partFiles, partitioner, IndexSpec.emptyAnnotation(idxRelPath, typ.kType))
+    val spec = MakeRVDSpec(codecSpec, partFiles, partitioner, IndexSpec.emptyAnnotation(idxRelPath, typ.kType))
     spec.write(ctx.fs, path)
     partitionCounts
   }


### PR DESCRIPTION
the lowered TableWrite should be able to represent the pre-write RVDSpec in a concise way.