### PR TITLE
[query] WritePartition and WriteMetadata IR node definitions

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -206,6 +206,8 @@ object Children {
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
     case ReadPartition(path, _, _) => Array(path)
+    case WritePartition(stream, ctx, _) => Array(stream, ctx)
+    case WriteMetadata(writeAnnotations, _) => Array(writeAnnotations)
     case ReadValue(path, _, _) => Array(path)
     case WriteValue(value, pathPrefix, spec) => Array(value, pathPrefix)
     case LiftMeOut(child) => Array(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -331,6 +331,12 @@ object Copy {
       case ReadPartition(context, rowType, reader) =>
         assert(newChildren.length == 1)
         ReadPartition(newChildren(0).asInstanceOf[IR], rowType, reader)
+      case WritePartition(stream, ctx, writer) =>
+        assert(newChildren.length == 2)
+        WritePartition(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], writer)
+      case WriteMetadata(ctx, writer) =>
+        assert(newChildren.length == 1)
+        WriteMetadata(newChildren(0).asInstanceOf[IR], writer)
       case ReadValue(path, spec, requestedType) =>
         assert(newChildren.length == 1)
         ReadValue(newChildren(0).asInstanceOf[IR], spec, requestedType)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -252,6 +252,8 @@ object InferPType {
       case ReadPartition(context, rowType, reader) =>
         val child = reader.rowPType(rowType)
         PCanonicalStream(child, requiredness(node).required)
+      case WritePartition(value, writeCtx, writer) =>
+        writer.returnPType(writeCtx.pType, coerce[PStream](value.pType))
       case ReadValue(path, spec, requestedType) =>
         spec.decodedPType(requestedType).setRequired(requiredness(node).required)
       case MakeStream(irs, t) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -233,6 +233,8 @@ object InferType {
       case BlockMatrixToValueApply(child, function) => function.typ(child.typ)
       case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
       case ReadPartition(_, rowType, _) => TStream(rowType)
+      case WritePartition(value, writeCtx, writer) => writer.returnType
+      case _: WriteMetadata => TVoid
       case ReadValue(_, _, typ) => typ
       case WriteValue(value, pathPrefix, spec) => TString
       case LiftMeOut(child) => child.typ

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -34,6 +34,8 @@ object Interpretable {
         _: TailLoop |
         _: Recur |
         _: ReadPartition |
+        _: WritePartition |
+        _: WriteMetadata |
         _: ReadValue |
         _: WriteValue |
         _: NDArrayWrite => false

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1219,6 +1219,17 @@ object IRParser {
         val reader = JsonMethods.parse(string_literal(it)).extract[PartitionReader]
         val context = ir_value_expr(env)(it)
         ReadPartition(context, rowType, reader)
+      case "WritePartition" =>
+        import PartitionWriter.formats
+        val writer = JsonMethods.parse(string_literal(it)).extract[PartitionWriter]
+        val stream = ir_value_expr(env)(it)
+        val ctx = ir_value_expr(env)(it)
+        WritePartition(stream, ctx, writer)
+      case "WriteMetadata" =>
+        import MetadataWriter.formats
+        val writer = JsonMethods.parse(string_literal(it)).extract[MetadataWriter]
+        val ctx = ir_value_expr(env)(it)
+        WriteMetadata(ctx, writer)
       case "ReadValue" =>
         import AbstractRVDSpec.formats
         val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -433,6 +433,10 @@ object Pretty {
             case RelationalLetBlockMatrix(name, _, _) => prettyIdentifier(name)
             case ReadPartition(_, rowType, reader) =>
               s"${ rowType.parsableString() } ${ prettyStringLiteral(JsonMethods.compact(reader.toJValue)) }"
+            case WritePartition(value, writeCtx, writer) =>
+              prettyStringLiteral(JsonMethods.compact(writer.toJValue))
+            case WriteMetadata(writeAnnotations, writer) =>
+              prettyStringLiteral(JsonMethods.compact(writer.toJValue))
             case ReadValue(_, spec, reqType) =>
               s"${ prettyStringLiteral(spec.toString) } ${ reqType.parsableString() }"
             case WriteValue(_, _, spec) => prettyStringLiteral(spec.toString)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.expr.ir.functions.GetElement
 import is.hail.methods.ForceCountTable
 import is.hail.types._
-import is.hail.types.physical.PType
+import is.hail.types.physical.{PStream, PType}
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -604,6 +604,10 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case ReadPartition(context, rowType, reader) =>
         requiredness.union(lookup(context).required)
         coerce[RIterable](requiredness).elementType.fromPType(reader.rowPType(rowType))
+      case WritePartition(value, writeCtx, writer) =>
+        val sType = coerce[PStream](lookup(value).canonicalPType(value.typ))
+        val ctxType = lookup(writeCtx).canonicalPType(writeCtx.typ)
+        requiredness.fromPType(writer.returnPType(ctxType, sType))
       case ReadValue(path, spec, rt) =>
         requiredness.union(lookup(path).required)
         requiredness.fromPType(spec.encodedType.decodedPType(rt))

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -69,51 +69,6 @@ case class TableValue(ctx: ExecuteContext, typ: TableType, globals: BroadcastRow
     filterWithPartitionOp((_, _) => ())((_, ctx, ptr, glob) => p(ctx, ptr, glob))
   }
 
-  def write(ctx: ExecuteContext, path: String, overwrite: Boolean, stageLocally: Boolean, codecSpecJSON: String) {
-    assert(typ.isCanonical)
-    val fs = ctx.fs
-
-    val bufferSpec = BufferSpec.parseOrDefault(codecSpecJSON)
-
-    if (overwrite)
-      fs.delete(path, recursive = true)
-    else if (fs.exists(path))
-      fatal(s"file already exists: $path")
-
-    fs.mkDir(path)
-
-    val globalsPath = path + "/globals"
-    fs.mkDir(globalsPath)
-    AbstractRVDSpec.writeSingle(ctx, globalsPath, globals.t, bufferSpec, Array(globals.javaValue))
-
-    val codecSpec = TypedCodecSpec(rvd.rowPType, bufferSpec)
-    val partitionCounts = rvd.write(ctx, path + "/rows", "../index", stageLocally, codecSpec)
-
-    val referencesPath = path + "/references"
-    fs.mkDir(referencesPath)
-    ReferenceGenome.exportReferences(fs, referencesPath, typ.rowType)
-    ReferenceGenome.exportReferences(fs, referencesPath, typ.globalType)
-
-    val spec = TableSpecParameters(
-      FileFormat.version.rep,
-      is.hail.HAIL_PRETTY_VERSION,
-      "references",
-      typ,
-      Map("globals" -> RVDComponentSpec("globals"),
-        "rows" -> RVDComponentSpec("rows"),
-        "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
-    spec.write(fs, path)
-
-    writeNativeFileReadMe(fs, path)
-
-    using(fs.create(path + "/_SUCCESS"))(_ => ())
-
-    val nRows = partitionCounts.sum
-    info(s"wrote table with $nRows ${ plural(nRows, "row") } " +
-      s"in ${ partitionCounts.length } ${ plural(partitionCounts.length, "partition") } " +
-      s"to $path")
-  }
-
   def export(ctx: ExecuteContext, path: String, typesFile: String = null, header: Boolean = true, exportType: String = ExportType.CONCATENATED, delimiter: String = "\t") {
     val fs = ctx.fs
     fs.delete(path, recursive = true)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -1,9 +1,17 @@
 package is.hail.expr.ir
 
-import java.io.OutputStream
-
 import is.hail.GenericIndexedSeqSerializer
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.ir.EmitStream.SizedStream
+import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage}
+import is.hail.types.virtual._
+import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, TypedCodecSpec}
+import is.hail.rvd.{AbstractRVDSpec, RVDPartitioner, RVDSpecMaker}
+import is.hail.types.{RTable, TableType}
+import is.hail.types.physical.{PCanonicalString, PCanonicalStruct, PInt64, PStream, PStruct, PType}
 import is.hail.utils._
+import is.hail.variant.ReferenceGenome
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 
 object TableWriter {
@@ -25,7 +33,93 @@ case class TableNativeWriter(
   stageLocally: Boolean = false,
   codecSpecJSONStr: String = null
 ) extends TableWriter {
-  def apply(ctx: ExecuteContext, tv: TableValue): Unit = tv.write(ctx, path, overwrite, stageLocally, codecSpecJSONStr)
+  def apply(ctx: ExecuteContext, tv: TableValue): Unit = {
+    val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
+    assert(tv.typ.isCanonical)
+    val fs = ctx.fs
+
+    if (overwrite)
+      fs.delete(path, recursive = true)
+    else if (fs.exists(path))
+      fatal(s"file already exists: $path")
+
+    fs.mkDir(path)
+
+    val globalsPath = path + "/globals"
+    fs.mkDir(globalsPath)
+    AbstractRVDSpec.writeSingle(ctx, globalsPath, tv.globals.t, bufferSpec, Array(tv.globals.javaValue))
+
+    val codecSpec = TypedCodecSpec(tv.rvd.rowPType, bufferSpec)
+    val partitionCounts = tv.rvd.write(ctx, path + "/rows", "../index", stageLocally, codecSpec)
+
+    val referencesPath = path + "/references"
+    fs.mkDir(referencesPath)
+    ReferenceGenome.exportReferences(fs, referencesPath, tv.typ.rowType)
+    ReferenceGenome.exportReferences(fs, referencesPath, tv.typ.globalType)
+
+    val spec = TableSpecParameters(
+      FileFormat.version.rep,
+      is.hail.HAIL_PRETTY_VERSION,
+      "references",
+      tv.typ,
+      Map("globals" -> RVDComponentSpec("globals"),
+        "rows" -> RVDComponentSpec("rows"),
+        "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
+    spec.write(fs, path)
+
+    writeNativeFileReadMe(fs, path)
+
+    using(fs.create(path + "/_SUCCESS"))(_ => ())
+
+    val nRows = partitionCounts.sum
+    info(s"wrote table with $nRows ${ plural(nRows, "row") } " +
+      s"in ${ partitionCounts.length } ${ plural(partitionCounts.length, "partition") } " +
+      s"to $path")
+  }
+}
+
+case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: String, index: Option[(String, PStruct)], localDir: Option[String]) extends PartitionWriter {
+  def stageLocally: Boolean = localDir.isDefined
+  def hasIndex: Boolean = index.isDefined
+  val filenameType = PCanonicalString(required = true)
+  def pContextType = PCanonicalString()
+  def pResultType: PCanonicalStruct =
+    PCanonicalStruct(required=true, "filePath" -> filenameType, "partitionCounts" -> PInt64(required=true))
+
+  def ctxType: Type = TString
+  def returnType: Type = pResultType.virtualType
+  def returnPType(ctxType: PType, streamType: PStream): PType = pResultType
+
+  if (stageLocally)
+    throw new LowererUnsupportedOperation("stageLocally option not yet implemented")
+
+  def ifIndexedCode(code: => Code[Unit]): Code[Unit] = if (hasIndex) code else Code._empty
+  def ifIndexed[T >: Null](obj: => T): T = if (hasIndex) obj else null
+
+  def consumeStream(
+    context: EmitCode,
+    eltType: PStruct,
+    mb: EmitMethodBuilder[_],
+    region: Value[Region],
+    stream: SizedStream): EmitCode = ???
+}
+
+case class MetadataNativeWriter(
+  path: String,
+  overwrite: Boolean,
+  rowsSpec: RVDSpecMaker,
+  globalsSpec: RVDSpecMaker,
+  typ: TableType) extends MetadataWriter {
+  def annotationType: Type = TStruct(
+    "global" -> TString,
+    "partitions" -> TArray(TStruct(
+      "filePath" -> TString,
+      "partitionCounts" -> TInt64)))
+
+  def writeMetadata(
+    writeAnnotations: => IEmitCode,
+    cb: EmitCodeBuilder,
+    region: Value[Region]): Unit = ???
 }
 
 case class TableTextWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -431,6 +431,12 @@ object TypeCheck {
         assert(context.typ == reader.contextType)
         assert(x.typ == TStream(rowType))
         assert(PruneDeadFields.isSupertype(rowType, reader.fullRowType))
+      case x@WritePartition(value, writeCtx, writer) =>
+        assert(value.typ.isInstanceOf[TStream])
+        assert(writeCtx.typ == writer.ctxType)
+        assert(x.typ == writer.returnType)
+      case WriteMetadata(writeAnnotations, writer) =>
+        assert(writeAnnotations.typ == writer.annotationType)
       case x@ReadValue(path, spec, requestedType) =>
         assert(path.typ == TString)
         assert(spec.encodedType.decodedPType(requestedType).virtualType == requestedType)

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -266,12 +266,22 @@ object MakeRVDSpec {
     partitioner: RVDPartitioner,
     indexSpec: AbstractIndexSpec = null,
     attrs: Map[String, String] = Map.empty
-  ): AbstractRVDSpec = {
-    val partJV = JSONAnnotationImpex.exportAnnotation(
+  ): AbstractRVDSpec =
+    RVDSpecMaker(codecSpec, partitioner, indexSpec, attrs)(partFiles)
+}
+
+object RVDSpecMaker {
+  def apply(codecSpec: AbstractTypedCodecSpec,
+    partitioner: RVDPartitioner,
+    indexSpec: AbstractIndexSpec = null,
+    attrs: Map[String, String] =  Map.empty): RVDSpecMaker = RVDSpecMaker(
+    codecSpec,
+    partitioner.kType.fieldNames,
+    JSONAnnotationImpex.exportAnnotation(
       partitioner.rangeBounds.toFastSeq,
-      partitioner.rangeBoundsType)
-    RVDSpecMaker(codecSpec, partitioner.kType.fieldNames, partJV, indexSpec, attrs)(partFiles)
-  }
+      partitioner.rangeBoundsType),
+    indexSpec,
+    attrs)
 }
 
 case class RVDSpecMaker(

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -286,7 +286,7 @@ object RVDSpecMaker {
 
 case class RVDSpecMaker(
   codecSpec: AbstractTypedCodecSpec,
-  key: Array[String],
+  key: IndexedSeq[String],
   bounds: JValue,
   indexSpec: AbstractIndexSpec,
   attrs: Map[String, String]) {

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -17,6 +17,9 @@ class PTypeSerializer extends CustomSerializer[PType](format => (
   { case JString(s) => PType.canonical(IRParser.parsePType(s)) },
   { case t: PType => JString(t.toString) }))
 
+class PStructSerializer extends CustomSerializer[PStruct](format => (
+  { case JString(s) => IRParser.parsePType(s).asInstanceOf[PStruct] },
+  { case t: PStruct => JString(t.toString) }))
 
 object PType {
   def genScalar(required: Boolean): Gen[PType] =

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -17,7 +17,7 @@ import is.hail.io.bgen.{IndexBgen, MatrixBGENReader}
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.linalg.BlockMatrix
 import is.hail.methods._
-import is.hail.rvd.RVD
+import is.hail.rvd.{RVD, RVDPartitioner, RVDSpecMaker}
 import is.hail.utils.{FastIndexedSeq, _}
 import is.hail.variant.{Call2, Locus}
 import is.hail.{ExecStrategy, HailContext, HailSuite}
@@ -2935,6 +2935,20 @@ class IRSuite extends HailSuite {
       ReadPartition(Str("foo"),
         TStruct("foo" -> TInt32),
         PartitionNativeReader(TypedCodecSpec(PCanonicalStruct("foo" -> PInt32(), "bar" -> PCanonicalString()), BufferSpec.default))),
+      WritePartition(
+        MakeStream(FastSeq(), TStream(TStruct())), NA(TString),
+        PartitionNativeWriter(TypedCodecSpec(PType.canonical(TStruct()), BufferSpec.default), "path", None, None)),
+      WriteMetadata(
+        NA(TStruct("global" -> TString, "partitions" -> TStruct("filePath" -> TString, "partitionCounts" -> TInt64))),
+        MetadataNativeWriter("path", overwrite = false,
+          RVDSpecMaker(
+            TypedCodecSpec(PType.canonical(TStruct("a" -> TInt32)), BufferSpec.default),
+            RVDPartitioner.unkeyed(1)),
+          RVDSpecMaker(
+            TypedCodecSpec(PType.canonical(TStruct()), BufferSpec.default),
+            new RVDPartitioner(TStruct("a" -> TInt32), Array[Interval](), 1)),
+          TableType(TStruct("a" -> PInt32()), FastIndexedSeq("a"), TStruct()))
+      ),
       ReadValue(Str("foo"), TypedCodecSpec(PCanonicalStruct("foo" -> PInt32(), "bar" -> PCanonicalString()), BufferSpec.default), TStruct("foo" -> TInt32)),
       WriteValue(I32(1), Str("foo"), TypedCodecSpec(PInt32(), BufferSpec.default)),
       LiftMeOut(I32(1)),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2947,7 +2947,7 @@ class IRSuite extends HailSuite {
           RVDSpecMaker(
             TypedCodecSpec(PType.canonical(TStruct()), BufferSpec.default),
             new RVDPartitioner(TStruct("a" -> TInt32), Array[Interval](), 1)),
-          TableType(TStruct("a" -> PInt32()), FastIndexedSeq("a"), TStruct()))
+          TableType(TStruct("a" -> TInt32), FastIndexedSeq("a"), TStruct()))
       ),
       ReadValue(Str("foo"), TypedCodecSpec(PCanonicalStruct("foo" -> PInt32(), "bar" -> PCanonicalString()), BufferSpec.default), TStruct("foo" -> TInt32)),
       WriteValue(I32(1), Str("foo"), TypedCodecSpec(PInt32(), BufferSpec.default)),


### PR DESCRIPTION
Defines (but doesn't implement) WritePartition and WriteMetadata nodes as well as stub classes for the writers needed for native TableWrite lowering.

WriteMetadata uses IEmitCode; WritePartition is implemented with EmitCode because it consumes a stream.