### PR TITLE
[query][lowering] lower TableWrite with native reader

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -620,6 +620,9 @@ class Emit[C](
         val msg = cb.newLocal[String]("exmsg", "<exception message missing>")
         cm.consume(cb, {}, s => cb.assign(msg, s.asString.loadString()))
         cb._throw(Code.newInstance[HailException, String](msg))
+
+      case x@WriteMetadata(annotations, writer) =>
+        writer.writeMetadata(emitI(annotations), cb, region)
     }
   }
 
@@ -2121,6 +2124,15 @@ class Emit[C](
             loopRef.L.goto),
           // dead code
           const(true), pt.defaultValue)
+
+      case x@WritePartition(stream, ctx, writer) =>
+        val ctxCode = emit(ctx)
+        val eltType = coerce[PStruct](coerce[PStream](stream.pType).elementType)
+        COption.toEmitCode(
+          emitStream(stream).flatMap { s =>
+            COption.fromEmitCode(writer.consumeStream(ctxCode, eltType, mb, region, s))
+          }, mb)
+
       case x@ReadValue(path, spec, requestedType) =>
         val p = emit(path)
         val pathString = coerce[PString](path.pType).loadString(p.value[Long])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -194,6 +194,12 @@ object IEmitCode {
     IEmitCode(Lmissing, Lpresent, resPc)
   }
 
+  def present(cb: EmitCodeBuilder, pc: => PCode): IEmitCode = {
+    val Lpresent = CodeLabel()
+    cb.goto(Lpresent)
+    IEmitCode(CodeLabel(), Lpresent, pc)
+  }
+
   def sequence[T](seq: IndexedSeq[T], toIec: T => IEmitCode, cb: EmitCodeBuilder)
       (f: IndexedSeq[PCode] => PCode): IEmitCode = {
     val Lmissing = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -1,16 +1,23 @@
 package is.hail.expr.ir
 
+import java.io.OutputStream
+
 import is.hail.GenericIndexedSeqSerializer
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitStream.SizedStream
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage}
+import is.hail.io.fs.FS
+import is.hail.io.index.StagedIndexWriter
 import is.hail.types.virtual._
-import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, TypedCodecSpec}
-import is.hail.rvd.{AbstractRVDSpec, RVDPartitioner, RVDSpecMaker}
+
+import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, OutputBuffer, TypedCodecSpec}
+import is.hail.rvd.{AbstractRVDSpec, IndexSpec, RVDPartitioner, RVDSpecMaker}
 import is.hail.types.{RTable, TableType}
-import is.hail.types.physical.{PCanonicalString, PCanonicalStruct, PInt64, PStream, PStruct, PType}
+import is.hail.types.encoded.EType
+import is.hail.types.physical.{PArray, PCanonicalString, PCanonicalStruct, PCode, PInt64, PStream, PString, PStruct, PType}
 import is.hail.utils._
+import is.hail.utils.richUtils.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 
@@ -25,6 +32,8 @@ object TableWriter {
 abstract class TableWriter {
   def path: String
   def apply(ctx: ExecuteContext, mv: TableValue): Unit
+  def lower(ctx: ExecuteContext, ts: TableStage, t: TableIR, r: RTable): IR =
+    throw new LowererUnsupportedOperation(s"${ this.getClass } does not have defined lowering!")
 }
 
 case class TableNativeWriter(
@@ -33,6 +42,44 @@ case class TableNativeWriter(
   stageLocally: Boolean = false,
   codecSpecJSONStr: String = null
 ) extends TableWriter {
+
+  override def lower(ctx: ExecuteContext, ts: TableStage, t: TableIR, r: RTable): IR = {
+    val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
+    val rowSpec = TypedCodecSpec(EType.fromTypeAndAnalysis(t.typ.rowType, r.rowType), t.typ.rowType, bufferSpec)
+    val globalSpec = TypedCodecSpec(EType.fromTypeAndAnalysis(t.typ.globalType, r.globalType), t.typ.globalType, bufferSpec)
+
+    // write out partitioner key, which may be stricter than table key
+    val partitioner = ts.partitioner
+    val pKey: PStruct = coerce[PStruct](rowSpec.decodedPType(partitioner.kType))
+    val rowWriter = PartitionNativeWriter(rowSpec, s"$path/rows/parts/", Some(s"$path/index/parts/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
+    val globalWriter = PartitionNativeWriter(globalSpec, s"$path/globals/parts/", None, None)
+    val metadataWriter = MetadataNativeWriter(path, overwrite,
+      RVDSpecMaker(rowSpec, partitioner, IndexSpec.emptyAnnotation("../index", coerce[PStruct](pKey))),
+      RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(1)),
+      t.typ)
+
+    val writePartitions = ts.mapContexts { oldCtx =>
+      val d = digitsNeeded(ts.numPartitions)
+      val partFiles = Array.tabulate(ts.numPartitions)(i => Str(s"${ partFile(d, i) }-"))
+
+      zip2(oldCtx, MakeStream(partFiles, TStream(TString)), ArrayZipBehavior.AssertSameLength) { (ctxElt, pf) =>
+        MakeStruct(FastSeq(
+          "oldCtx" -> ctxElt,
+          "writeCtx" -> pf))
+      }
+    }(GetField(_, "oldCtx")).mapPartitionWithContext { (rows, ctxRef) =>
+      val file = GetField(ctxRef, "writeCtx")
+      WritePartition(rows, file + UUID4(), rowWriter)
+    }.collect(bind=false)
+
+    val writeGlobals = WritePartition(MakeStream(FastSeq(ts.globals), TStream(ts.globals.typ)),
+      Str(partFile(1, 0)), globalWriter)
+
+    WriteMetadata(ts.wrapInBindings(makestruct(
+      "global" -> GetField(writeGlobals, "filePath"),
+      "partitions" -> writePartitions)), metadataWriter)
+  }
+
   def apply(ctx: ExecuteContext, tv: TableValue): Unit = {
     val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
     assert(tv.typ.isCanonical)
@@ -101,7 +148,111 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
     region: Value[Region],
-    stream: SizedStream): EmitCode = ???
+    stream: SizedStream): EmitCode = {
+    val enc = spec.buildEmitEncoderF(eltType, mb.ecb, typeInfo[Long]) //(Value[Region], Value[T], Value[OutputBuffer]) => Code[Unit]
+
+    val keyType = ifIndexed { index.get._2 }
+    val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(keyType, mb.ecb).streamCompatible() }
+
+    context.map { ctxCode: PCode =>
+      val ctx = mb.newLocal[Long]("ctx")
+      val result = mb.newLocal[Long]("write_result")
+
+      val filename = mb.newLocal[String]("filename")
+      val indexFile = ifIndexed { mb.newLocal[String]("indexFile") }
+
+      val os = mb.newLocal[ByteTrackingOutputStream]("write_os")
+      val ob = mb.newLocal[OutputBuffer]("write_ob")
+      val n = mb.newLocal[Long]("partition_count")
+      val keyRVB = ifIndexed { new StagedRegionValueBuilder(mb, keyType) }
+      val row = mb.newLocal[Long]("row")
+
+      val init = Code(
+        ctx := ctxCode.tcode[Long],
+        filename := pContextType.loadString(ctx),
+        ifIndexedCode {
+          Code(indexFile := const(index.get._1).concat(filename),
+            indexWriter.init(indexFile))
+        },
+        filename := const(partPrefix).concat(filename),
+        os := Code.newInstance[ByteTrackingOutputStream, OutputStream](mb.create(filename)),
+        ob := spec.buildCodeOutputBuffer(Code.checkcast[OutputStream](os)),
+        n := 0L)
+
+      def writeFile(codeRow: EmitCode): Code[Unit] = {
+        val rowType = coerce[PStruct](codeRow.pt)
+        Code(
+          codeRow.setup,
+          codeRow.m.mux(
+            Code._fatal[Unit]("row can't be missing"),
+            Code(
+              row := codeRow.value[Long],
+              ifIndexedCode {
+                val annotation = EmitCode.present(+PCanonicalStruct(), 0L)
+                Code(
+                  keyRVB.start(),
+                  Code(keyType.fields.map { f =>
+                    keyRVB.addIRIntermediate(f.typ)(Region.loadIRIntermediate(f.typ)(rowType.fieldOffset(row, f.name)))
+                  }),
+                  indexWriter.add(EmitCode.present(keyType, keyRVB.offset), ob.invoke[Long]("indexOffset"), annotation))
+              },
+              ob.writeByte(1.asInstanceOf[Byte]),
+              enc(region, row, ob),
+              n := n + 1L)))
+      }
+
+      PCode(pResultType,
+        Code.sequence1(FastIndexedSeq(
+          init,
+          stream.getStream.forEach(mb, writeFile),
+          ob.writeByte(0.asInstanceOf[Byte]),
+          result := pResultType.allocate(region),
+          ifIndexedCode { indexWriter.close() },
+          ob.flush(),
+          os.invoke[Unit]("close"),
+          Region.storeIRIntermediate(filenameType)(
+            pResultType.fieldOffset(result, "filePath"), ctx),
+          Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)),
+          result))
+    }
+  }
+}
+
+class NativeTableMetadata(path: String, typ: TableType, rowsSpec: RVDSpecMaker, globalSpec: RVDSpecMaker) {
+  val globalsPath = s"$path/globals"
+  val rowsPath = s"$path/rows"
+
+  def write(fs: FS, globalPath: String, partFiles: Array[String], partitionCounts: Array[Long]): Unit = {
+    // globalMetadata
+    globalSpec(Array(globalPath)).write(fs, globalsPath)
+
+    // rowMetadata
+    rowsSpec(partFiles).write(fs, rowsPath)
+
+    val referencesPath = path + "/references"
+    fs.mkDir(referencesPath)
+    ReferenceGenome.exportReferences(fs, referencesPath, typ.rowType)
+    ReferenceGenome.exportReferences(fs, referencesPath, typ.globalType)
+
+    val spec = TableSpecParameters(
+      FileFormat.version.rep,
+      is.hail.HAIL_PRETTY_VERSION,
+      "references",
+      typ,
+      Map("globals" -> RVDComponentSpec("globals"),
+        "rows" -> RVDComponentSpec("rows"),
+        "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
+    spec.write(fs, path)
+
+    writeNativeFileReadMe(fs, path)
+
+    using(fs.create(path + "/_SUCCESS"))(_ => ())
+
+    val nRows = partitionCounts.sum
+    info(s"wrote table with $nRows ${ plural(nRows, "row") } " +
+      s"in ${ partitionCounts.length } ${ plural(partitionCounts.length, "partition") } " +
+      s"to $path")
+  }
 }
 
 case class MetadataNativeWriter(
@@ -116,10 +267,57 @@ case class MetadataNativeWriter(
       "filePath" -> TString,
       "partitionCounts" -> TInt64)))
 
+  val metadata = new NativeTableMetadata(path, typ, rowsSpec, globalsSpec)
   def writeMetadata(
     writeAnnotations: => IEmitCode,
     cb: EmitCodeBuilder,
-    region: Value[Region]): Unit = ???
+    region: Value[Region]): Unit = {
+    if (overwrite)
+      cb += cb.emb.getFS.invoke[String, Boolean, Unit]("delete", path, true)
+    else
+      cb.ifx(cb.emb.getFS.invoke[String, Boolean]("exists", path), cb._fatal(s"file already exists: $path"))
+
+    cb += cb.emb.getFS.invoke[String, Unit]("mkDir", path)
+    cb += cb.emb.getFS.invoke[String, Unit]("mkDir", s"$path/globals")
+    cb += cb.emb.getFS.invoke[String, Unit]("mkDir", s"$path/rows")
+
+    writeAnnotations.consume(cb,
+      { cb._fatal("write annotations can't be missing!") },
+      { pc =>
+        val v = pc.memoize(cb, "write_annotations")
+        val aType = coerce[PStruct](v.pt)
+        val partType = coerce[PArray](aType.fieldType("partitions"))
+        val eltType = coerce[PStruct](partType.elementType)
+
+        // global: (filename, pcount)
+        // row: Array[(filename, pcount)]
+
+        val globalFile = cb.newLocal[String]("global_file")
+        val partFiles = cb.newLocal[Array[String]]("partFiles")
+        val partCounts = cb.newLocal[Array[Long]]("partCounts")
+
+        val aoff = cb.newLocal[Long]("aoff")
+        val eltOff = cb.newLocal[Long]("eltOff")
+        val n = cb.newLocal[Int]("n")
+        val i = cb.newLocal[Int]("i")
+
+        cb.assign(globalFile, coerce[PString](aType.fieldType("global"))
+          .loadString(aType.loadField(coerce[Long](v.value), "global")))
+
+        cb.assign(aoff, aType.loadField(coerce[Long](v.value), "partitions"))
+        cb.assign(i, 0)
+        cb.assign(n, partType.loadLength(aoff))
+        cb.assign(partFiles, Code.newArray[String](n))
+        cb.assign(partCounts, Code.newArray[Long](n))
+        cb.whileLoop(i < n, {
+          cb.assign(eltOff, partType.loadElement(aoff, n, i))
+          cb += partFiles.update(i, coerce[PString](eltType.fieldType("filePath")).loadString(eltType.loadField(eltOff, "filePath")))
+          cb += partCounts.update(i, Region.loadLong(eltType.fieldOffset(eltOff, "partitionCounts")))
+          cb.assign(i, i + 1)
+        })
+        cb += cb.emb.getObject(metadata).invoke[FS, String, Array[String], Array[Long], Unit]("write", cb.emb.getFS, globalFile, partFiles, partCounts)
+      })
+  }
 }
 
 case class TableTextWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -207,9 +207,9 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
           indexWriter.close(cb)
         cb += ob.flush()
         cb += os.invoke[Unit]("close")
-        Region.storeIRIntermediate(filenameType)(
-          pResultType.fieldOffset(result, "filePath"), ctx),
-        Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)),
+        cb += Region.storeIRIntermediate(filenameType)(
+          pResultType.fieldOffset(result, "filePath"), ctx)
+        cb += Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)
         result.get
       })
     }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -170,6 +170,12 @@ package object ir {
   def insertIR(old: IR, fields: (String, IR)*): InsertFields = InsertFields(old, fields)
   def selectIR(old: IR, fields: String*): SelectFields = SelectFields(old, fields)
 
+  def zip2(s1: IR, s2: IR, behavior: ArrayZipBehavior.ArrayZipBehavior)(f: (Ref, Ref) => IR): IR = {
+    val r1 = Ref(genUID(), coerce[TStream](s1.typ).elementType)
+    val r2 = Ref(genUID(), coerce[TStream](s2.typ).elementType)
+    StreamZip(FastSeq(s1, s2), FastSeq(r1.name, r2.name), f(r1, r2), behavior)
+  }
+
   def makestruct(fields: (String, IR)*): MakeStruct = MakeStruct(fields)
 
   implicit def toRichIndexedSeqEmitSettable(s: IndexedSeq[EmitSettable]): RichIndexedSeqEmitSettable = new RichIndexedSeqEmitSettable(s)

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -38,7 +38,7 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
     sb, region,
     LeafNodeBuilder.arrayType(keyType, annotationType))
 
-  val pType: PCanonicalStruct = LeafNodeBuilder.typ(keyType, annotationType)
+  private val pType: PCanonicalStruct = LeafNodeBuilder.typ(keyType, annotationType)
   private val node = new PCanonicalBaseStructSettable(pType, sb.newSettable[Long]("lef_node_addr"))
 
   def close(cb: EmitCodeBuilder): Unit = cb.ifx(!region.isNull, cb += region.invalidate())

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -240,6 +240,7 @@ case class IndexSpec2(_relPath: String,
 
 
 object IndexSpec {
+
   def fromKeyAndValuePTypes(relPath: String, keyPType: PType, annotationPType: PType, offsetFieldName: Option[String]): AbstractIndexSpec = {
     val leafType = LeafNodeBuilder.typ(keyPType, annotationPType)
     val leafNodeSpec = TypedCodecSpec(leafType, BufferSpec.default)

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -1,12 +1,13 @@
 package is.hail.types.physical
 
 import is.hail.annotations._
+import is.hail.asm4s
 import is.hail.asm4s._
 import is.hail.check.{Arbitrary, Gen}
 import is.hail.expr.ir
 import is.hail.expr.ir._
 import is.hail.types.virtual._
-import is.hail.types.Requiredness
+import is.hail.types.{coerce, Requiredness}
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
@@ -18,7 +19,7 @@ class PTypeSerializer extends CustomSerializer[PType](format => (
   { case t: PType => JString(t.toString) }))
 
 class PStructSerializer extends CustomSerializer[PStruct](format => (
-  { case JString(s) => IRParser.parsePType(s).asInstanceOf[PStruct] },
+  { case JString(s) => coerce[PStruct](IRParser.parsePType(s)) },
   { case t: PStruct => JString(t.toString) }))
 
 object PType {
@@ -451,7 +452,7 @@ abstract class PType extends Serializable with Requiredness {
 
   def constructAtAddress(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit]
   def constructAtAddressFromValue(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, src: Code[_], deepCopy: Boolean): Code[Unit]
-    = constructAtAddress(mb, addr, region, srcPType, coerce[Long](src), deepCopy)
+    = constructAtAddress(mb, addr, region, srcPType, asm4s.coerce[Long](src), deepCopy)
 
   def constructAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit
 

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -329,7 +329,7 @@ object TestUtils {
     TypeCheck(x, BindingEnv(env.mapValues(_._2), agg = agg.map(_._2.toEnv)))
 
     val t = x.typ
-    assert(t.typeCheck(expected), s"$t, $expected")
+    assert(t == TVoid || t.typeCheck(expected), s"$t, $expected")
 
     ExecuteContext.scoped() { ctx =>
       val filteredExecStrats: Set[ExecStrategy] =
@@ -372,8 +372,10 @@ object TestUtils {
             case ExecStrategy.LoweredJVMCompile =>
               loweredExecute(x, env, args, agg)
           }
-          assert(t.typeCheck(res))
-          assert(t.valuesSimilar(res, expected), s"\n  result=$res\n  expect=$expected\n  strategy=$strat)")
+          if (t != TVoid) {
+            assert(t.typeCheck(res))
+            assert(t.valuesSimilar(res, expected), s"\n  result=$res\n  expect=$expected\n  strategy=$strat)")
+          }
         } catch {
           case e: Exception =>
             error(s"error from strategy $strat")

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -38,11 +38,12 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testRangeRead() {
+    implicit val execStrats = ExecStrategy.lowering
     val original = TableKeyBy(TableMapGlobals(TableRange(10, 3), MakeStruct(FastIndexedSeq("foo" -> I32(57)))), FastIndexedSeq())
 
     val path = ctx.createTmpPath("test-range-read", "ht")
-    CompileAndEvaluate[Unit](ctx, TableWrite(original, TableNativeWriter(path, overwrite = true)), false)
-
+    val write = TableWrite(original, TableNativeWriter(path, overwrite = true))
+    assertEvalsTo(write, ())
     val read = TableIR.read(fs, path, false, None)
     val droppedRows = TableIR.read(fs, path, true, None)
 


### PR DESCRIPTION
This implementation lowers TableWrite with a TableNativeReader.

Punting on the `stageLocally` path for now (it'll throw a lowering error) since our current implementation adds a task listener to the spark task to clean up files, and I'm not sure how we want to handle that in the general case.