### PR TITLE
[query] Make VEP on Dataproc not require a config

### DIFF
--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -553,7 +553,7 @@ def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='
      - ``GRCh37``: ``gs://hail-us-vep/vep85-loftee-gcloud.json``
      - ``GRCh38``: ``gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json``
 
-     If no config file is specified, this function will check the to see if `VEP_CONFIG_URI` is set with a path to a config file.
+     If no config file is specified, this function will check to see if environment variable `VEP_CONFIG_URI` is set with a path to a config file.
 
     **Annotations**
 

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -1,7 +1,8 @@
 import hail as hl
 from collections import Counter
+import os
 from typing import Tuple, List, Union
-from hail.typecheck import typecheck, oneof, anytype
+from hail.typecheck import typecheck, oneof, anytype, nullable
 from hail.utils.java import Env, info
 from hail.utils.misc import divide_null
 from hail.matrixtable import MatrixTable
@@ -478,11 +479,11 @@ def concordance(left, right, *, _localize_global_statistics=True) -> Tuple[List[
 
 
 @typecheck(dataset=oneof(Table, MatrixTable),
-           config=str,
+           config=nullable(str),
            block_size=int,
            name=str,
            csq=bool)
-def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep', csq=False):
+def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='vep', csq=False):
     """Annotate variants with VEP.
 
     .. include:: ../_templates/req_tvariant.rst
@@ -581,6 +582,13 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
         Dataset with new row-indexed field `name` containing VEP annotations.
 
     """
+    if config is None:
+        maybe_config = os.getenv("HAIL_VEP_CONFIG")
+        if maybe_config is not None:
+            config = maybe_config
+        else:
+            raise ValueError("No config set and HAIL_VEP_CONFIG was not set.")
+    
     if isinstance(dataset, MatrixTable):
         require_row_key_variant(dataset, 'vep')
         ht = dataset.select_rows().rows()

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -553,6 +553,8 @@ def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='
      - ``GRCh37``: ``gs://hail-us-vep/vep85-loftee-gcloud.json``
      - ``GRCh38``: ``gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json``
 
+     If no config file is specified, this function will check the to see if `VEP_CONFIG_URI` is set with a path to a config file.
+
     **Annotations**
 
     A new row field is added in the location specified by `name` with type given

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -583,12 +583,12 @@ def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='
 
     """
     if config is None:
-        maybe_config = os.getenv("HAIL_VEP_CONFIG")
+        maybe_config = os.getenv("VEP_CONFIG_URI")
         if maybe_config is not None:
             config = maybe_config
         else:
-            raise ValueError("No config set and HAIL_VEP_CONFIG was not set.")
-    
+            raise ValueError("No config set and VEP_CONFIG_URI was not set.")
+
     if isinstance(dataset, MatrixTable):
         require_row_key_variant(dataset, 'vep')
         ht = dataset.select_rows().rows()

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -86,6 +86,15 @@ if role == 'Master':
         'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',
     }
 
+    # VEP ENV
+    try:
+        vep_config_uri = get_metadata('VEP_CONFIG_URI')
+    except Exception:
+        pass
+    else:
+        env_to_set["VEP_CONFIG_URI"] = vep_config_uri
+
+
     print('setting environment')
 
     for e, value in env_to_set.items():

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -94,7 +94,6 @@ if role == 'Master':
     else:
         env_to_set["VEP_CONFIG_URI"] = vep_config_uri
 
-
     print('setting environment')
 
     for e, value in env_to_set.items():

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
@@ -2,8 +2,8 @@
 
 export PROJECT="$(gcloud config get-value project)"
 export ASSEMBLY=GRCh37
+export VEP_CONFIG_PATH="/vep_data/vep-gcloud.json"
 export VEP_REPLICATE="$(/usr/share/google/get_metadata_value attributes/VEP_REPLICATE)"
-export HAIL_VEP_CONFIG="file:///vep_data/vep85-gcloud.json"
 export VEP_BUCKET=hail-${VEP_REPLICATE}-vep
 export VEP_DOCKER_IMAGE=konradjk/vep85_loftee:1.0.3
 
@@ -25,8 +25,8 @@ apt-get update
 apt-get install -y --allow-unauthenticated docker-ce
 
 # Get VEP cache and LOFTEE data
-gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json $HAIL_VEP_CONFIG
-ln -s /vep_data/vep85-gcloud.json /vep_data/vep-gcloud.json
+gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json /vep_data/vep85-gcloud.json
+ln -s /vep_data/vep85-gcloud.json VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
@@ -3,6 +3,7 @@
 export PROJECT="$(gcloud config get-value project)"
 export ASSEMBLY=GRCh37
 export VEP_REPLICATE="$(/usr/share/google/get_metadata_value attributes/VEP_REPLICATE)"
+export HAIL_VEP_CONFIG="file:///vep_data/vep85-gcloud.json"
 export VEP_BUCKET=hail-${VEP_REPLICATE}-vep
 export VEP_DOCKER_IMAGE=konradjk/vep85_loftee:1.0.3
 
@@ -24,7 +25,7 @@ apt-get update
 apt-get install -y --allow-unauthenticated docker-ce
 
 # Get VEP cache and LOFTEE data
-gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json /vep_data/vep85-gcloud.json
+gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json $HAIL_VEP_CONFIG
 ln -s /vep_data/vep85-gcloud.json /vep_data/vep-gcloud.json
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
@@ -2,7 +2,7 @@
 
 export PROJECT="$(gcloud config get-value project)"
 export ASSEMBLY=GRCh37
-export VEP_CONFIG_PATH="/vep_data/vep-gcloud.json"
+export VEP_CONFIG_PATH="$(/usr/share/google/get_metadata_value attributes/VEP_CONFIG_PATH)"
 export VEP_REPLICATE="$(/usr/share/google/get_metadata_value attributes/VEP_REPLICATE)"
 export VEP_BUCKET=hail-${VEP_REPLICATE}-vep
 export VEP_DOCKER_IMAGE=konradjk/vep85_loftee:1.0.3
@@ -26,7 +26,7 @@ apt-get install -y --allow-unauthenticated docker-ce
 
 # Get VEP cache and LOFTEE data
 gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json /vep_data/vep85-gcloud.json
-ln -s /vep_data/vep85-gcloud.json VEP_CONFIG_PATH
+ln -s /vep_data/vep85-gcloud.json $VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export PROJECT="$(gcloud config get-value project)"
+export VEP_CONFIG_PATH="/vep_data/vep-gcloud.json"
 export VEP_REPLICATE="$(/usr/share/google/get_metadata_value attributes/VEP_REPLICATE)"
 export VEP_BUCKET=hail-${VEP_REPLICATE}-vep
 export ASSEMBLY=GRCh38
@@ -25,7 +26,7 @@ apt-get install -y --allow-unauthenticated docker-ce
 
 # Get VEP cache and LOFTEE data
 gsutil -u $PROJECT cp gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json /vep_data/vep95-GRCh38-gcloud.json
-ln -s /vep_data/vep95-GRCh38-gcloud.json /vep_data/vep-gcloud.json
+ln -s /vep_data/vep95-GRCh38-gcloud.json VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data/ &
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PROJECT="$(gcloud config get-value project)"
-export VEP_CONFIG_PATH="/vep_data/vep-gcloud.json"
+export VEP_CONFIG_PATH="$(/usr/share/google/get_metadata_value attributes/VEP_CONFIG_PATH)"
 export VEP_REPLICATE="$(/usr/share/google/get_metadata_value attributes/VEP_REPLICATE)"
 export VEP_BUCKET=hail-${VEP_REPLICATE}-vep
 export ASSEMBLY=GRCh38
@@ -26,7 +26,7 @@ apt-get install -y --allow-unauthenticated docker-ce
 
 # Get VEP cache and LOFTEE data
 gsutil -u $PROJECT cp gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json /vep_data/vep95-GRCh38-gcloud.json
-ln -s /vep_data/vep95-GRCh38-gcloud.json VEP_CONFIG_PATH
+ln -s /vep_data/vep95-GRCh38-gcloud.json $VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data/ &
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -276,6 +276,8 @@ def main(args, pass_through_args):
                                f"  Supported regions: {', '.join(REGION_TO_REPLICATE_MAPPING.keys())}")
         print(f"Pulling VEP data from bucket in {replicate}.")
         conf.extend_flag('metadata', {"VEP_REPLICATE": replicate})
+        vep_config_path = "/vep_data/vep-gcloud.json"
+        conf.extend_flag('metadata', {"VEP_CONFIG_PATH": vep_config_path, "VEP_CONFIG_URI": f"file://{vep_config_path}"})
         conf.extend_flag('initialization-actions', [deploy_metadata[f'vep-{args.vep}.sh']])
     # add custom init scripts
     if args.init:


### PR DESCRIPTION
VEP will now automatically look for a config file in environment variable `VEP_CONFIG_URI` if one isn't specified. This environment variable is prepopulated on dataproc clusters started with `hailctl dataproc`