### PR TITLE
[ukbb-rg] fix rainbowvis.js

### DIFF
--- a/ukbb-rg/Dockerfile.browser
+++ b/ukbb-rg/Dockerfile.browser
@@ -18,7 +18,7 @@ RUN wget -nv -O shiny-server-1.5.9.923-amd64.deb https://download3.rstudio.org/u
 
 COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
 COPY app/app.R /srv/shiny-server/rg_browser/
-COPY app/www/rainbowvis.js /srv/shiny-server/static/
+COPY app/www/rainbowvis.js /srv/shiny-server/rg_browser/www/rainbowvis.js
 
 RUN ln -s /ukbb-rg-browser/Rdata_outputs /srv/shiny-server/rg_browser/Rdata_outputs
 


### PR DESCRIPTION
I do not know where `static` came from. The shiny docs indicate that static files
should be placed inside a `www` directory which is a sibling to the `app.R` file.

Already deployed.