### PR TITLE
[batch] change how files are named in the user interface

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -396,7 +396,7 @@ class ServiceBackend(Backend):
 
             symlinks = [x for r in job._mentioned for x in symlink_input_resource_group(r)]
 
-            env_vars = {r._uid: shq(r._get_path(local_tmpdir)) for r in job._mentioned}
+            env_vars = {r._uid: r._get_path(local_tmpdir) for r in job._mentioned}
 
             if job._image is None:
                 if verbose:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -149,7 +149,7 @@ class LocalBackend(Backend):
                 for name, irf in r._resources.items():
                     src = irf._get_path(tmpdir)
                     dest = f'{r._get_path(tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {src} {dest}')
+                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
             return symlinks
 
         write_inputs = [x for r in batch._input_resources for x in copy_external_output(r)]
@@ -364,7 +364,7 @@ class ServiceBackend(Backend):
                 for name, irf in r._resources.items():
                     src = irf._get_path(local_tmpdir)
                     dest = f'{r._get_path(local_tmpdir)}.{name}'
-                    symlinks.append(f'ln -sf {src} {dest}')
+                    symlinks.append(f'ln -sf {shq(src)} {shq(dest)}')
             return symlinks
 
         write_external_inputs = [x for r in batch._input_resources for x in copy_external_output(r)]
@@ -372,8 +372,11 @@ class ServiceBackend(Backend):
             def _cp(src, dst):
                 return f'gsutil -m cp -R {src} {dst}'
 
-            write_cmd = bash_flags + activate_service_account + ' && ' + \
-                ' && '.join([_cp(*files) for files in write_external_inputs])
+            write_cmd = f'''
+{bash_flags}
+{activate_service_account}
+{' && '.join([_cp(*files) for files in write_external_inputs])}
+'''
 
             if dry_run:
                 commands.append(write_cmd)

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -181,8 +181,7 @@ class LocalBackend(Backend):
                            f"{memory} "
                            f"{cpu} "
                            f"{job._image} /bin/bash "
-                           f"-c {shq(defs + cmd)}",
-                           '\n']
+                           f"-c {shq(defs + cmd)}"]
             else:
                 script += resource_defs
                 script += job._command

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -1,7 +1,6 @@
 import os
 
 import re
-import uuid
 from typing import Optional, Dict, Union
 
 from hailtop.utils import secret_alnum_string

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -4,6 +4,8 @@ import re
 import uuid
 from typing import Optional, Dict, Union
 
+from hailtop.utils import secret_alnum_string
+
 from .backend import Backend, LocalBackend
 from .job import Job
 from .resource import Resource, InputResourceFile, JobResourceFile, ResourceGroup
@@ -158,34 +160,27 @@ class Batch:
         self._jobs.append(j)
         return j
 
-    def _tmp_file(self, prefix=None, suffix=None):
-        def _get_random_file():
-            file = '{}{}{}'.format(prefix if prefix else '',
-                                   uuid.uuid4().hex[:8],
-                                   suffix if suffix else '')
-            if file not in self._allocated_files:
-                self._allocated_files.add(file)
-                return file
-            return _get_random_file()
-
-        return _get_random_file()
-
     def _new_job_resource_file(self, source, value=None):
-        jrf = JobResourceFile(value if value else self._tmp_file())
+        if value is None:
+            value = secret_alnum_string(5)
+        jrf = JobResourceFile(value)
         jrf._add_source(source)
         self._resource_map[jrf._uid] = jrf  # pylint: disable=no-member
         return jrf
 
     def _new_input_resource_file(self, input_path, value=None):
-        irf = InputResourceFile(value if value else self._tmp_file())
+        if value is None:
+            value = f'{secret_alnum_string(5)}/{os.path.basename(input_path)}'
+        irf = InputResourceFile(value)
         irf._add_input_path(input_path)
         self._resource_map[irf._uid] = irf  # pylint: disable=no-member
         self._input_resources.add(irf)
         return irf
 
-    def _new_resource_group(self, source, mappings):
+    def _new_resource_group(self, source, mappings, root=None):
         assert isinstance(mappings, dict)
-        root = self._tmp_file()
+        if root is None:
+            root = secret_alnum_string(5)
         d = {}
         new_resource_map = {}
         for name, code in mappings.items():
@@ -290,8 +285,9 @@ class Batch:
         :class:`.InputResourceFile`
         """
 
-        root = self._tmp_file()
-        new_resources = {name: self._new_input_resource_file(file, root + '.' + name) for name, file in kwargs.items()}
+        root = secret_alnum_string(5)
+        new_resources = {name: self._new_input_resource_file(file, value=f'{root}/{os.path.basename(file)}')
+                         for name, file in kwargs.items()}
         rg = ResourceGroup(None, root, **new_resources)
         self._resource_map.update({rg._uid: rg})
         return rg
@@ -411,9 +407,10 @@ class Batch:
 
         assert len(seen) == len(self._jobs)
 
-        job_index = {j: i for i, j in enumerate(ordered_jobs)}
+        job_index = {j: i for i, j in enumerate(ordered_jobs, start=1)}
         for j in ordered_jobs:
             i = job_index[j]
+            j._job_id = i
             for d in j._dependencies:
                 j = job_index[d]
                 if j >= i:

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -194,7 +194,7 @@ class Batch:
         self._resource_map.update({rg._uid: rg})
         return rg
 
-    def read_input(self, path, extension=None):
+    def read_input(self, path):
         """
         Create a new input resource file object representing a single file.
 
@@ -222,8 +222,6 @@ class Batch:
         """
 
         irf = self._new_input_resource_file(path)
-        if extension is not None:
-            irf.add_extension(extension)
         return irf
 
     def read_input_group(self, **kwargs):

--- a/hail/python/hailtop/batch/docs/tutorial.rst
+++ b/hail/python/hailtop/batch/docs/tutorial.rst
@@ -423,8 +423,8 @@ you can reference a specific input file such as `bfile.fam`.
 Resource File Extensions
 ------------------------
 
-If your tool requires a specific extension for the input files to have such
-as the file is gzipped, then you'd need to create the resource group as follows:
+If your tool requires a specific extension for the input files in a resource group,
+then you'd need to create the resource group as follows:
 
 .. code-block:: python
 

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -77,7 +77,7 @@ class ResourceFile(Resource, str):
         return self._resource_group
 
     def __str__(self):
-        return self._uid  # pylint: disable=no-member
+        return f'"{self._uid}"'  # pylint: disable=no-member
 
     def __repr__(self):
         return self._uid  # pylint: disable=no-member
@@ -109,7 +109,7 @@ class InputResourceFile(ResourceFile):
 
     def _get_path(self, directory):
         assert self._value is not None
-        return shq(directory + '/inputs/' + self._value)
+        return directory + '/inputs/' + self._value
 
 
 class JobResourceFile(ResourceFile):
@@ -139,7 +139,7 @@ class JobResourceFile(ResourceFile):
     def _get_path(self, directory):
         assert self._source is not None
         assert self._value is not None
-        return shq(f'{directory}/{self._source._job_id}/{self._value}')
+        return f'{directory}/{self._source._job_id}/{self._value}'
 
     def add_extension(self, extension):
         """
@@ -271,4 +271,4 @@ class ResourceGroup(Resource):
         return other + str(self._uid)
 
     def __str__(self):
-        return self._uid
+        return f'"{self._uid}"'

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -120,6 +120,7 @@ class LocalTests(unittest.TestCase):
                                        in2=input_file2.name)
             j = b.new_job()
             j.command(f'cat {input.in1} {input.in2} > {j.ofile}')
+            j.command(f'cat {input}.in1 {input}.in2')
             b.write_output(j.ofile, output_file.name)
             b.run()
 
@@ -349,6 +350,7 @@ class BatchTests(unittest.TestCase):
         j = b.new_job()
         j.storage('0.25Gi')
         j.command(f'cat {input.foo}')
+        j.command(f'cat {input}.foo')
         assert b.run().status()['state'] == 'success'
 
     def test_single_task_output(self):

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -262,9 +262,7 @@ class LocalTests(unittest.TestCase):
     def test_add_extension_input_resource_file(self):
         input_file1 = '/tmp/data/example1.txt.bgz.foo'
         b = self.batch()
-        in1 = b.read_input(input_file1, extension='.txt.bgz.foo')
-        with self.assertRaises(Exception):
-            in1.add_extension('.baz')
+        in1 = b.read_input(input_file1)
         assert in1._value.endswith('.txt.bgz.foo')
 
     def test_file_name_space(self):


### PR DESCRIPTION
There might be additional PRs, but for now this PR does the following:

- Names folders for jobs based on the job_id computed after ordering the jobs
- Gets rid of double slashes in path names
- Names JobResourceFiles based on the name of the attribute.
Example: j.ofile => /batch/1/ofile
- Names resource groups from jobs as follows:
Example: j.declare_resource_group(ofile={'bed': '{root}.bed'})
/batch/1/ofile.bed
- Names input resource files based on the file name
/batch/inputs/{uid}/my_vcf.bgz
- Names input resource groups two-ways
input = batch.declare_resource_group(vcf=...)
/batch/inputs/{uid}/my_vcf.bgz
/batch/inputs/{uid}.vcf

I tested this locally and on the service to make sure it's doing what I want.