### PR TITLE
[query] store job configuration in user bucket

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -353,7 +353,6 @@ steps:
      # batch, auth gsa keys
      kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "auth-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "batch-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
-     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "query-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
      # create ci
      N=$(kubectl -n {{ default_ns.name }} get secret --ignore-not-found=true --no-headers ci-tokens | wc -l | tr -d '[:space:]')
      if [[ $N = 0 ]]; then

--- a/build.yaml
+++ b/build.yaml
@@ -1347,6 +1347,7 @@ steps:
      cd /io
      tar xvf wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     hailctl config set batch/bucket hail-test-dmk9z
      cat > test.py <<EOF
      import hail as hl
      t = hl.utils.range_table(50, 3)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -17,7 +17,7 @@ from ..hail_logging import PythonOnlyLogger
 
 
 class ServiceBackend(Backend):
-    def __init__(self, billing_project: str = None, bucket: str = None, deploy_config=None, skip_logging_configuration: bool = False):
+    def __init__(self, billing_project: str = None, bucket: str = None, *, deploy_config=None, skip_logging_configuration: bool = False):
         if billing_project is None:
             billing_project = get_user_config().get('batch', 'billing_project', fallback=None)
         if billing_project is None:

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -244,6 +244,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
     skip_logging_configuration=bool)
 def init_service(
         billing_project: str = None,
+        bucket: str = None,
         log=None,
         quiet=False,
         append=False,
@@ -253,7 +254,7 @@ def init_service(
         global_seed=6348563392232659379,
         skip_logging_configuration=False):
     from hail.backend.service_backend import ServiceBackend
-    backend = ServiceBackend(billing_project, skip_logging_configuration)
+    backend = ServiceBackend(billing_project, bucket, skip_logging_configuration=skip_logging_configuration)
 
     log = _get_log(log)
     tmpdir = _get_tmpdir(tmpdir)

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -234,6 +234,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
 
 @typecheck(
     billing_project=nullable(str),
+    bucket=nullable(str),
     log=nullable(str),
     quiet=bool,
     append=bool,

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -233,7 +233,7 @@ class ServiceBackend(Backend):
 
     """
 
-    def __init__(self, billing_project=None, bucket=None):
+    def __init__(self, billing_project: str = None, bucket: str = None):
         if billing_project is None:
             billing_project = get_user_config().get('batch', 'billing_project', fallback=None)
         if billing_project is None:

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -54,9 +54,6 @@ spec:
            - name: session-secret-key
              mountPath: /session-secret-key
              readOnly: true
-           - name: gsa-key
-             mountPath: /gsa-key
-             readOnly: true
            - name: ssl-config
              mountPath: /ssl-config
              readOnly: true
@@ -79,9 +76,6 @@ spec:
        - name: session-secret-key
          secret:
            secretName: session-secret-key
-       - name: gsa-key
-         secret:
-           secretName: query-gsa-key
        - name: ssl-config
          secret:
            optional: false

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -51,8 +51,8 @@ async def healthcheck(request):  # pylint: disable=unused-argument
     return web.Response()
 
 
-def blocking_execute(jbackend, username, session_id, billing_project, code):
-    return jbackend.execute(username, session_id, billing_project, code)
+def blocking_execute(jbackend, username, session_id, billing_project, bucket, code):
+    return jbackend.execute(username, session_id, billing_project, bucket, code)
 
 
 @routes.post('/execute')
@@ -63,10 +63,11 @@ async def execute(request, userdata):
     jbackend = app['jbackend']
     body = await request.json()
     billing_project = body['billing_project']
+    bucket = body['bucket']
     code = body['code']
     log.info(f'execute: {code}')
     await add_user(app, userdata)
-    jresp = await blocking_to_async(thread_pool, blocking_execute, jbackend, userdata['username'], userdata['session_id'], billing_project, code)
+    jresp = await blocking_to_async(thread_pool, blocking_execute, jbackend, userdata['username'], userdata['session_id'], billing_project, bucket, code)
     return java_to_web_response(jresp)
 
 


### PR DESCRIPTION
The problem was query was writing the job configuration to the query bucket, but workers only get the user gsa, so they were unable to read the configuration.  This worked in the tests because the query and user account are both the test service account.

I can remove the query-gsa-key and the hail-query bucket after this goes in.
