### PR TITLE
Fix warning in Table/MatrixTable checkpoint docs

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2453,6 +2453,7 @@ class MatrixTable(ExprContainer):
         -------
         :class:`MatrixTable`
 
+
         .. include:: _templates/write_warning.rst
 
         Notes

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1178,6 +1178,7 @@ class Table(ExprContainer):
         -------
         :class:`Table`
 
+
         .. include:: _templates/write_warning.rst
 
         Notes


### PR DESCRIPTION
Not sure why the extra line is required here... riddles of Sphinx.

https://hail.is/docs/0.2/hail.Table.html#hail.Table.checkpoint
https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.checkpoint

Before
<img width="1029" alt="Screen Shot 2020-06-08 at 9 30 12 PM" src="https://user-images.githubusercontent.com/1156625/84096487-0cb98d00-a9d0-11ea-8623-12288df6eace.png">

After
<img width="1042" alt="Screen Shot 2020-06-08 at 9 35 06 PM" src="https://user-images.githubusercontent.com/1156625/84096490-10e5aa80-a9d0-11ea-9be9-c3dfd8b049a9.png">
