### PR TITLE
Support tuples in hailctl dataproc describe

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/describe.py
+++ b/hail/python/hailtop/hailctl/dataproc/describe.py
@@ -18,7 +18,7 @@ def parse_schema(s):
             if s[i] == end_delimiter:
                 if s[:i]:
                     values.append(s[:i])
-                if element_type in ['Array', 'Set', 'Dict']:
+                if element_type in ['Array', 'Set', 'Dict', 'Tuple']:
                     return {'type': element_type, 'value': values}, s[i + 1:]
                 return {'type': element_type, 'value': OrderedDict(zip(keys, values))}, s[i + 1:]
 


### PR DESCRIPTION
With this table
```
ds = hl.utils.range_table(10)
ds = ds.annotate(t=hl.tuple([1, "Foo", True]))
ds.write("test.ht")
```

`hailctl dataproc describe test.ht` currently outputs the following for "Row fields":
```
----------------------------------------
Row fields:
    'idx': int32
    't': tuple<>
----------------------------------------
```

With this change, it outputs:
```
----------------------------------------
Row fields:
    'idx': int32
    't': tuple<int32, str, bool>
----------------------------------------
```