### PR TITLE
[query] Fix `import_plink` with n_partitions > 1

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -606,7 +606,7 @@ class PLINKTests(unittest.TestCase):
         hl.export_plink(mt, bfile, ind_id=mt.s, cm_position=mt.cm_position)
 
         mt_imported = hl.import_plink(bfile + '.bed', bfile + '.bim', bfile + '.fam',
-                                      a2_reference=True, reference_genome='GRCh37')
+                                      a2_reference=True, reference_genome='GRCh37', n_partitions=8)
         self.assertTrue(mt._same(mt_imported))
         self.assertTrue(mt.aggregate_rows(hl.agg.all(mt.cm_position == 15.0)))
 

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -217,8 +217,8 @@ object MatrixPLINKReader {
       var end = partScan(p + 1)
       if (start < end) {
         while (end + 1 < nVariants
-          && lOrd.equiv(variants(end).asInstanceOf[Row].get(0),
-            variants(end + 1).asInstanceOf[Row].get(0)))
+          && lOrd.equiv(variants(end).locusAlleles.asInstanceOf[Row].get(0),
+            variants(end + 1).locusAlleles.asInstanceOf[Row].get(0)))
           end += 1
         
         cb += Row(params.bed, start, end)


### PR DESCRIPTION
CHANGELOG: Fixed `hl.import_plink` with multiple data partitions.