### PR TITLE
[internal-gateway] add allow global access to the yaml

### DIFF
--- a/internal-gateway/service.yaml
+++ b/internal-gateway/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: internal-gateway
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
+    networking.gke.io/internal-load-balancer-allow-global-access: "true"
 spec:
   ports:
   - name: http


### PR DESCRIPTION
Currently, this is set inside GCP, but if anyone were to apply this service.yaml file,
it would reset the global access to `false`. This change ensures that the service.yaml
for internal-gateway reflects the actual desired state.

This annotation was added in GKE 1.16 which we now have.