### PR TITLE
[ci] fix clone to actually retry

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -140,8 +140,8 @@ def clone_or_fetch_script(repo):
 { RETRY_FUNCTION_SCRIPT }
 
 function clone() {{
-    rm -rf ./{*,.*}
-    git clone {shq(repo)} ./
+    rm -rf ./{{*,.*}}
+    git clone { shq(repo) } ./
 }}
 
 if [ ! -d .git ]; then

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -139,16 +139,10 @@ def clone_or_fetch_script(repo):
     return f"""
 { RETRY_FUNCTION_SCRIPT }
 
-function clone() {{ ( set -e
-    dir=$(mktemp -d)
-    git clone {shq(repo)} $dir
-    echo $?
-    (cd $dir && git status)  # verify the clone actually worked
-    echo $?
-    for x in $(ls -A $dir); do
-        mv -- "$dir/$x" ./
-    done
-) }}
+function clone() {{
+    rm -rf ./{*,.*}
+    git clone {shq(repo)} ./
+}}
 
 if [ ! -d .git ]; then
   time retry clone


### PR DESCRIPTION
I do not understand how `set -e` works in bash functions, but I know what
currently exists does not retry properly. I have verified this works as intended.

It deletes *all* files in the current folder, then tries to clone into this folder.
If the clone fails, becasue it is the last command in the function, the function
will return the same exit code. The retry function will then retry `clone`. Because
`clone` removes all files in the directory before attempting a clone, it is idempotent.

Users of the checkout script all use it by creating an empty directory and cd'ing into it.