### PR TITLE
[docs] remove ?highlight

### DIFF
--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -990,8 +990,8 @@ Released 2018-12-07
 
  - (hail#4845) The [or_error](https://hail.is/docs/0.2/functions/core.html#hail.expr.builders.CaseBuilder.or_error) method in `hl.case` and `hl.switch` statements now takes a string expression rather than a string literal, allowing more informative messages for errors and assertions.
  - (hail#4865) We use this new `or_error` functionality in methods that require biallelic variants to include an offending variant in the error message.
- - (hail#4820) Added [hl.reversed](https://hail.is/docs/0.2/functions/collections.html?highlight=reversed#hail.expr.functions.reversed) for reversing arrays and strings.
- - (hail#4895) Added `include_strand` option to the [hl.liftover](https://hail.is/docs/0.2/functions/genetics.html?highlight=liftover#hail.expr.functions.liftover) function.
+ - (hail#4820) Added [hl.reversed](https://hail.is/docs/0.2/functions/collections.html#hail.expr.functions.reversed) for reversing arrays and strings.
+ - (hail#4895) Added `include_strand` option to the [hl.liftover](https://hail.is/docs/0.2/functions/genetics.html#hail.expr.functions.liftover) function.
 
 
 ### Performance improvements

--- a/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
+++ b/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
@@ -587,7 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Variant QC is a bit more of the same: we can use the [variant_qc](https://hail.is/docs/0.2/methods/genetics.html?highlight=variant%20qc#hail.methods.variant_qc) function to produce a variety of useful statistics, plot them, and filter."
+    "Variant QC is a bit more of the same: we can use the [variant_qc](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.variant_qc) function to produce a variety of useful statistics, plot them, and filter."
    ]
   },
   {

--- a/hail/python/hail/docs/tutorials/06-joins.ipynb
+++ b/hail/python/hail/docs/tutorials/06-joins.ipynb
@@ -162,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we only want the field `x` from `t2`, we can select it with `t2[t1.a].x`. Then we add this field to `t1` with the `anntotate_rows()` method. The new joined table `j` has a field `t2_x` that comes from the rows of `t2`. The tables could be joined, because they shared the same number of keys (1) and the same key type (string). The keys do not need to share the same name. Notice that the rows with keys present in `t2` but not in `t1` do not show up in the final result. This join syntax performs a left join. Tables also have a SQL-style inner/left/right/outer [join()](https://hail.is/docs/0.2/hail.Table.html?highlight=join#hail.Table.join) method.\n",
+    "Since we only want the field `x` from `t2`, we can select it with `t2[t1.a].x`. Then we add this field to `t1` with the `anntotate_rows()` method. The new joined table `j` has a field `t2_x` that comes from the rows of `t2`. The tables could be joined, because they shared the same number of keys (1) and the same key type (string). The keys do not need to share the same name. Notice that the rows with keys present in `t2` but not in `t1` do not show up in the final result. This join syntax performs a left join. Tables also have a SQL-style inner/left/right/outer [join()](https://hail.is/docs/0.2/hail.Table.html#hail.Table.join) method.\n",
     "\n",
     "The magic of keys is that they can be used to create a mapping, like a Python dictionary, between the keys of one table and the row values of another table: `table[expr]` will refer to the row of `table` that has a key value of `expr`. If the row is not unique, one such row is chosen arbitrarily.\n",
     "\n",


### PR DESCRIPTION
Algolia crawls anchor tags, and treats query strings as distinct urls (since apriori there is no way to know that that doesn't represent a unique page, since query strings can be used for routing).

We don't use ?highlight consistently anyway, and it frankly doesn't add anything useful (it highlights what the page already scrolls to).