### PR TITLE
[hail] changes to facilitate changing master to trunk

### DIFF
--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -38,7 +38,7 @@ spec:
              value: /secrets/oauth-token/oauth-token
 {% if deploy %}
            - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-is/hail:master",true]]'
+             value: '[["hail-is/hail:master",true],["hail-is/hail:trunk",true]]'
 {% else %}
            - name: HAIL_WATCHED_BRANCHES
              value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -1013,4 +1013,4 @@ Released 2018-12-07
 
 We didn't start manually curating information about user-facing changes until version 0.2.4.
 
-The full commit history is available [here](https://github.com/hail-is/hail/commits/master).
+The full commit history is available [here](https://github.com/hail-is/hail/commits/trunk).

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -76,7 +76,7 @@ project is a good candidate for merging.
 Keep in mind the following principles when submitting a pull request:
 
 - A PR should focus on a single feature. Multiple features should be split into multiple PRs.
-- Before submitting your PR, you should rebase onto the latest master.
+- Before submitting your PR, you should rebase onto the latest trunk.
 - PRs must pass all tests before being merged. See the section above on `Running the tests`_ locally.
 - PRs require a review before being merged. We will assign someone from our dev team to review your PR.
 - When you make a PR, include a short message that describes the purpose of the

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -66,7 +66,7 @@ git push origin $HAIL_PIP_VERSION
 # make GitHub release
 curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/hail/releases -d '{
   "tag_name": "'$HAIL_PIP_VERSION'",
-  "target_commitish": "master",
+  "target_commitish": "trunk",
   "name": "'$HAIL_PIP_VERSION'",
   "body": "Hail version '$HAIL_PIP_VERSION'",
   "draft": false,

--- a/site/www/references.md
+++ b/site/www/references.md
@@ -13,7 +13,7 @@ Or you could include the following line in your bibliography:
 
 <pre class='sourceCode'><code>Hail Team. Hail 0.2. https://github.com/hail-is/hail</code></pre>
 
-Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/master/hail/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
+Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/trunk/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
 
 *Last updated on March 30th, 2020*
 


### PR DESCRIPTION
We should merge this first to fix CI. It will only break some links while we rename master.

As discussed, let's leave this open until Tuesday lab meeting when we'll all make the switch.