### PR TITLE
[query] various minor fixes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -10,8 +10,6 @@ import is.hail.types.physical.PType
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
-import scala.reflect.{ClassTag, classTag}
-
 case class CodeCacheKey(aggSigs: IndexedSeq[AggStateSig], args: Seq[(String, PType)], body: IR)
 
 case class CodeCacheValue(typ: PType, f: (Int, Region) => Any)

--- a/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericLines.scala
@@ -260,7 +260,7 @@ object GenericLines {
         val partScan = parts.scanLeft(0L)(_ + _)
         Iterator.range(0, fileNParts)
           .map { i =>
-            var start = partScan(i)
+            val start = partScan(i)
             var end = partScan(i + 1)
             if (codec != null)
               end = makeVirtualOffset(end, 0)

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -49,7 +49,6 @@ class PartitionIteratorLongReader(
       SizedStream.unsized(Stream.unfold[Code[Long]](
         (_, k) =>
           Code(
-            Code._fatal[Unit](""),
             hasNext := it.get.hasNext,
             hasNext.orEmpty(next := Code.longValue(it.get.next())),
             k(COption(!hasNext, next))),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -581,7 +581,7 @@ object LowerTableIR {
           if (nPreservedFields == newKey.length || isSorted) {
             val newPartitioner = loweredChild.partitioner
               .coarsen(nPreservedFields)
-              .extendKey(t.typ.keyType)
+              .extendKeySamePartitions(t.typ.keyType)
             loweredChild.changePartitionerNoRepartition(newPartitioner)
           } else {
             val sorted = ctx.backend.lowerDistributedSort(ctx, loweredChild, newKey.map(k => SortField(k, Ascending)))

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -188,7 +188,6 @@ object TextMatrixReader {
   }
 
   def fromJValue(ctx: ExecuteContext, jv: JValue): TextMatrixReader = {
-    val backend = ctx.backend
     val fs = ctx.fs
 
     implicit val formats: Formats = DefaultFormats

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -130,6 +130,14 @@ class RVDPartitioner(
     RVDPartitioner.generate(newKType, rangeBounds)
   }
 
+  def extendKeySamePartitions(newKType: TStruct): RVDPartitioner = {
+    require(kType isPrefixOf newKType)
+    new RVDPartitioner(
+      newKType,
+      rangeBounds,
+      allowedOverlap)
+  }
+
   // Operators (produce new partitioners)
 
   def subdivide(


### PR DESCRIPTION
Summary:
 - remove debug statement (?)  in PartitionIteratorLongReader
 - LowerTableIR needs to truncate the partitioner when truncating the keys.  Otherwise, the partitioner will refer to rows that can be modified elsewhere.
 - Added a missing ToStream in TableExplode lowering

Unfortunately, the local backend tests are now segfaulting.  How's the debugging allocator fix coming @tpoterba @johnc1231?