### PR TITLE
[lir] add code splitter, currently unused

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -483,11 +483,7 @@ class DependentMethodBuilder[C](val mb: MethodBuilder[C]) extends WrappedMethodB
     val L = new lir.Block()
 
     val obj = new lir.Local(null, "new_dep_fun", cb.ti)
-    L.append(lir.store(obj, lir.newInstance(cb.ti)))
-    L.append(lir.methodStmt(INVOKESPECIAL,
-      cb.className, "<init>", "()V", false,
-      UnitInfo,
-      Array(lir.load(obj))))
+    L.append(lir.store(obj, lir.newInstance(cb.ti, cb.lInit, FastIndexedSeq.empty[lir.ValueX])))
 
     var end = L
     setFields.foreach { f =>

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -143,9 +143,7 @@ object Code {
     end.append(lir.store(linst, lir.newInstance(tti,
       Type.getInternalName(tcls), "<init>", Type.getConstructorDescriptor(c), tti, argvs)))
 
-    val newC = new VCode(start, end, lir.load(linst))
-    args.foreach(_.clear())
-    newC
+    new VCode(start, end, lir.load(linst))
   }
 
   def newInstance[C](cb: ClassBuilder[C], ctor: MethodBuilder[C], args: IndexedSeq[Code[_]]): Code[C] = {
@@ -155,9 +153,7 @@ object Code {
 
     end.append(lir.store(linst, lir.newInstance(cb.ti, ctor.lmethod, argvs)))
 
-    val newC = new VCode(start, end, lir.load(linst))
-    args.foreach(_.clear())
-    newC
+    new VCode(start, end, lir.load(linst))
   }
 
   def newInstance[T <: AnyRef]()(implicit tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -128,18 +128,23 @@ object Code {
   def foreach[A](it: Seq[A])(f: A => Code[Unit]): Code[Unit] = Code(it.map(f))
 
   def newInstance[T <: AnyRef](parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T]): Code[T] = {
-    val ti = classInfo[T]
+    val tti = classInfo[T]
 
-    val L = new lir.Block()
+    val tcls = tct.runtimeClass
 
-    val linst = new lir.Local(null, "new_inst", ti)
-    L.append(lir.store(linst, lir.newInstance(ti)))
+    val c = tcls.getDeclaredConstructor(parameterTypes: _*)
+    assert(c != null,
+      s"no such method ${ tcls.getName }(${
+        parameterTypes.map(_.getName).mkString(", ")
+      })")
 
-    val inst = new VCode(L, L, lir.load(linst))
-    val ctor = inst.invokeConstructor(parameterTypes, args)
+    val (start, end, argvs) = Code.sequenceValues(args)
+    val linst = new lir.Local(null, "new_inst", tti)
+    end.append(lir.store(linst, lir.newInstance(tti,
+      Type.getInternalName(tcls), "<init>", Type.getConstructorDescriptor(c), tti, argvs)))
 
-    val newC = new VCode(ctor.start, ctor.end, lir.load(linst))
-    ctor.clear()
+    val newC = new VCode(start, end, lir.load(linst))
+    args.foreach(_.clear())
     newC
   }
 
@@ -147,10 +152,12 @@ object Code {
     val (start, end, argvs) = sequenceValues(args)
 
     val linst = new lir.Local(null, "new_inst", cb.ti)
-    end.append(lir.store(linst, lir.newInstance(cb.ti)))
-    end.append(lir.methodStmt(INVOKESPECIAL, ctor.lmethod, argvs))
 
-    new VCode(start, end, lir.load(linst))
+    end.append(lir.store(linst, lir.newInstance(cb.ti, ctor.lmethod, argvs)))
+
+    val newC = new VCode(start, end, lir.load(linst))
+    args.foreach(_.clear())
+    newC
   }
 
   def newInstance[T <: AnyRef]()(implicit tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
@@ -445,6 +452,8 @@ object Code {
 }
 
 trait Code[+T] {
+  // val stack = Thread.currentThread().getStackTrace
+
   def start: lir.Block
 
   def end: lir.Block
@@ -1052,16 +1061,6 @@ object Invokeable {
 
     Invokeable(cls, m)
   }
-
-  def lookupConstructor[T](cls: Class[T], parameterTypes: Array[Class[_]]): Invokeable[T, Unit] = {
-    val c = cls.getDeclaredConstructor(parameterTypes: _*)
-    assert(c != null,
-      s"no such method ${ cls.getName }(${
-        parameterTypes.map(_.getName).mkString(", ")
-      })")
-
-    Invokeable(cls, c)
-  }
 }
 
 class Invokeable[T, S](tcls: Class[T],
@@ -1086,12 +1085,11 @@ class Invokeable[T, S](tcls: Class[T],
       new VCode(start, end, null)
     } else {
       val t = new lir.Local(null, "invoke", sti)
-      end.append(
-        lir.store(t, lir.methodInsn(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs)))
-      var v = lir.load(t)
+      var r = lir.methodInsn(invokeOp, Type.getInternalName(tcls), name, descriptor, isInterface, sti, argvs)
       if (concreteReturnType != sct.runtimeClass)
-        v = lir.checkcast(Type.getInternalName(sct.runtimeClass), v)
-      new VCode(start, end, v)
+        r = lir.checkcast(Type.getInternalName(sct.runtimeClass), r)
+      end.append(lir.store(t, r))
+      new VCode(start, end, lir.load(t))
     }
   }
 }
@@ -1198,9 +1196,6 @@ class CodeObject[T <: AnyRef : ClassTag](val lhs: Code[T]) {
 
   def put[S](field: String, rhs: Code[S])(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[Unit] =
     FieldRef[T, S](field).put(lhs, rhs)
-
-  def invokeConstructor(parameterTypes: Array[Class[_]], args: Array[Code[_]]): Code[Unit] =
-    Invokeable.lookupConstructor[T](implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], parameterTypes).invoke(lhs, args)
 
   def invoke[S](method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])
     (implicit sct: ClassTag[S]): Code[S] =

--- a/hail/src/main/scala/is/hail/lir/InitializeLocals.scala
+++ b/hail/src/main/scala/is/hail/lir/InitializeLocals.scala
@@ -32,16 +32,22 @@ class InitializeLocals(m: Method) {
       def visit(x: X): Unit = {
         x match {
           case x: StoreX =>
-            val l = localIdx(x.l)
-            geni.clear(l)
-            killi.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.clear(l)
+              killi.set(l)
+            }
           case x: LoadX =>
-            val l = localIdx(x.l)
-            geni.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.set(l)
+            }
           case x: IincX =>
-            val l = localIdx(x.l)
-            geni.set(l)
-            killi.set(l)
+            if (!x.l.isInstanceOf[Parameter]) {
+              val l = localIdx(x.l)
+              geni.set(l)
+              killi.set(l)
+            }
           case _ =>
         }
         x.children.foreach(visit)
@@ -108,11 +114,9 @@ class InitializeLocals(m: Method) {
     var i = entryUsedIn.nextSetBit(0)
     while (i >= 0) {
       val l = locals(i)
-      if (!l.isInstanceOf[Parameter]) {
-        // println(s"  init $l ${l.ti}")
-        m.entry.prepend(
-          store(locals(i), defaultValue(l.ti)))
-      }
+      // println(s"  init $l ${l.ti}")
+      m.entry.prepend(
+        store(locals(i), defaultValue(l.ti)))
 
       i = entryUsedIn.nextSetBit(i + 1)
     }

--- a/hail/src/main/scala/is/hail/lir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/lir/Pretty.scala
@@ -122,7 +122,11 @@ object Pretty {
 
   def header(x: X): String = x match {
     case x: IfX => s"${ asm.util.Printer.OPCODES(x.op) } ${ x.Ltrue } ${ x.Lfalse }"
-    case x: GotoX => x.L.toString
+    case x: GotoX =>
+      if (x.L != null)
+        x.L.toString
+      else
+        "null"
     case x: SwitchX => s"${ x.Ldefault } (${ x.Lcases.mkString(" ") })"
     case x: LdcX => s"${ x.a.toString } ${ x.ti }"
     case x: InsnX => asm.util.Printer.OPCODES(x.op)
@@ -132,7 +136,7 @@ object Pretty {
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.f }"
     case x: GetFieldX =>
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.f }"
-    case x: NewInstanceX => x.ti.iname
+    case x: NewInstanceX => s"${ x.ti.iname } ${ x.ctor }"
     case x: TypeInsnX =>
       s"${ asm.util.Printer.OPCODES(x.op) } ${ x.t }"
     case x: NewArrayX => x.eti.desc

--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -137,10 +137,12 @@ class SimplifyControl(m: Method) {
     }
 
     val rootFinalTarget = mutable.Map[Int, Block]()
-    blocks.zipWithIndex.foreach { case (b, i) =>
+    blocks.indices.foreach { i =>
       val r = u.find(i)
-      val t = finalTarget(blocks(r))
-      rootFinalTarget(r) = t
+      if (r == i) {
+        val t = finalTarget(blocks(r))
+        rootFinalTarget(r) = t
+      }
     }
 
     for (b <- blocks) {

--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -1,0 +1,184 @@
+package is.hail.lir
+
+import is.hail.utils.UnionFind
+
+import scala.collection.mutable
+
+object SimplifyControl {
+  def apply(m: Method): Unit = {
+    new SimplifyControl(m).simplify()
+  }
+}
+
+class SimplifyControl(m: Method) {
+  private val uses = mutable.Map[Block, mutable.Set[(ControlX, Int)]]()
+
+  private val q = mutable.Set[Block]()
+
+  def removeUse(M: Block, c: ControlX, i: Int): Unit = {
+    val r = uses(M).remove((c, i))
+    assert(r)
+  }
+
+  def addUse(M: Block, c: ControlX, i: Int): Unit = {
+    val r = uses(M).add((c, i))
+    assert(r)
+  }
+
+  def finalTarget(b0: Block): Block = {
+    var b = b0
+    while (b.first != null &&
+      b.first.isInstanceOf[GotoX])
+      b = b.first.asInstanceOf[GotoX].L
+    b
+  }
+
+  def simplifyBlock(L: Block): Unit = {
+    val last = L.last.asInstanceOf[ControlX]
+
+    if (uses(L).isEmpty && (L ne m.entry)) {
+      var i = 0
+      while (i < last.targetArity()) {
+        val M = last.target(i)
+        removeUse(M, last, i)
+        last.setTarget(i, null)
+
+        q += M
+        if (uses(M).size == 1) {
+          val (u, _) = uses(M).head
+          q += u.parent
+        }
+
+        i += 1
+      }
+
+      // just popped off q
+      uses -= L
+
+      return
+    }
+
+    var i = 0
+    while (i < last.targetArity()) {
+      val M = last.target(i)
+      val newM = finalTarget(M)
+      if (M ne newM) {
+        removeUse(M, last, i)
+        last.setTarget(i, newM)
+        addUse(newM, last, i)
+
+        q += M
+        if (uses(M).size == 1) {
+          val (u, _) = uses(M).head
+          q += u.parent
+        }
+        q += L
+      }
+      i += 1
+    }
+
+    last match {
+      case x: IfX =>
+        val M = x.Ltrue
+        if (M eq x.Lfalse) {
+          x.remove()
+          removeUse(x.Ltrue, x, 0)
+          x.Ltrue = null
+          removeUse(x.Lfalse, x, 1)
+          x.Lfalse = null
+
+          val g = goto(M)
+          addUse(M, g, 0)
+
+          L.append(g)
+
+          // if there is one parent, it is L
+          q += L
+        }
+
+      case x: GotoX =>
+        val M = x.L
+        if ((M ne L) && uses(M).size == 1 && (m.entry ne M)) {
+          x.remove()
+          removeUse(x.L, x, 0)
+          x.L = null
+
+          while (M.first != null) {
+            val z = M.first
+            z.remove()
+            L.append(z)
+          }
+
+          q -= M
+          uses -= M
+
+          q += L
+        }
+
+      case _ =>
+    }
+  }
+
+  def unify(): Unit = {
+    val (blocks, blockIdx) = m.findAndIndexBlocks()
+
+    val u = new UnionFind(blocks.length)
+    blocks.indices.foreach { i =>
+      u.makeSet(i)
+    }
+
+    for (b <- blocks) {
+      if (b.first != null &&
+        b.first.isInstanceOf[GotoX]) {
+        u.sameSet(
+          blockIdx(b),
+          blockIdx(b.first.asInstanceOf[GotoX].L))
+      }
+    }
+
+    val rootFinalTarget = mutable.Map[Int, Block]()
+    blocks.zipWithIndex.foreach { case (b, i) =>
+      val r = u.find(i)
+      val t = finalTarget(blocks(r))
+      rootFinalTarget(r) = t
+    }
+
+    for (b <- blocks) {
+      val last = b.last.asInstanceOf[ControlX]
+      var i = 0
+      while (i < last.targetArity()) {
+        last.setTarget(i,
+          rootFinalTarget(u.find(blockIdx(last.target(i)))))
+        i += 1
+      }
+    }
+  }
+
+  def simplify(): Unit = {
+    unify()
+
+    val blocks = m.findBlocks()
+
+    blocks.foreach { b =>
+      uses(b) = mutable.Set()
+    }
+
+    for (b <- blocks) {
+      q += b
+
+      val last = b.last.asInstanceOf[ControlX]
+      var i = 0
+      while (i < last.targetArity()) {
+        val t = last.target(i)
+        addUse(t, last, i)
+        i += 1
+      }
+    }
+
+    while (q.nonEmpty) {
+      val b = q.head
+      q -= b
+      simplifyBlock(b)
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -1,0 +1,204 @@
+package is.hail.lir
+
+import is.hail.asm4s.{BooleanInfo, IntInfo, TypeInfo, UnitInfo}
+import is.hail.utils.FastIndexedSeq
+import org.objectweb.asm.Opcodes._
+
+object SplitMethod {
+  val TargetMethodSize: Int = 2000
+
+  def apply(c: Classx[_], m: Method): Unit = {
+    new SplitMethod(c, m).split()
+  }
+}
+
+class SplitMethod(c: Classx[_], m: Method) {
+  private var blocks = m.findBlocks()
+
+  private val paramFields = m.parameterTypeInfo.zipWithIndex.map { case (ti, i) =>
+    c.newField(genName("f", s"arg$i"), ti)
+  }
+
+  def splitLargeStatements(): Unit = {
+    for (b <- blocks) {
+      def splitLargeStatement(c: StmtX): Unit = {
+        def visit(x: ValueX): Int = {
+          // FIXME this doesn't handle many moderate-sized children
+          val size = 1 + x.children.map(visit).sum
+
+          if (size > SplitMethod.TargetMethodSize / 2) {
+            val l = m.newLocal("spill_large_expr", x.ti)
+            x.replace(load(l))
+            c.insertBefore(store(l, x))
+            1
+          } else
+            size
+        }
+
+        c.children.foreach(visit)
+      }
+
+      var x = b.first
+      while (x != null) {
+        splitLargeStatement(x)
+        x = x.next
+      }
+    }
+  }
+
+  def spillLocals(): Unit = {
+    val (locals, localIdx) = m.findAndIndexLocals(blocks)
+
+    val fields = locals.map { l =>
+      if (l.isInstanceOf[Parameter])
+        null
+      else
+        c.newField(genName("f", l.name), l.ti)
+    }
+
+    def localField(l: Local): Field =
+      l match {
+        case p: Parameter =>
+          if (p.i == 0)
+            null
+          else
+            paramFields(p.i - 1)
+        case _ => fields(localIdx(l))
+      }
+
+    def spill(x: X): Unit = {
+      x.children.foreach(spill)
+      x match {
+        case x: LoadX =>
+          val f = localField(x.l)
+          if (f != null)
+            x.replace(getField(f, load(m.getParam(0))))
+        case x: IincX =>
+          val f = localField(x.l)
+          assert(f != null)
+          x.replace(
+            putField(f, load(m.getParam(0)),
+              insn(IADD,
+                getField(f, load(m.getParam(0))),
+                ldcInsn(x.i, IntInfo))))
+        case x: StoreX =>
+          val f = localField(x.l)
+          assert(f != null)
+          val v = x.children(0)
+          v.remove()
+          x.replace(putField(f, load(m.getParam(0)), v))
+        case _ =>
+      }
+    }
+
+    for (b <- blocks) {
+      var x = b.first
+      while (x != null) {
+        val n = x.next
+        spill(x)
+        x = n
+      }
+    }
+  }
+
+  def splitBlock(b: Block): Unit = {
+    val last = b.last
+
+    val returnTI = last match {
+      case _: GotoX => UnitInfo
+      case _: IfX => BooleanInfo
+      case _: SwitchX => IntInfo
+      case _: ReturnX => m.returnTypeInfo
+      case _: ThrowX => UnitInfo
+    }
+
+    var L = new Block()
+    var x = b.first
+    var size = 0
+
+    while (x != last) {
+      if (size > SplitMethod.TargetMethodSize) {
+        val newM = c.newMethod(genName("m", "wrapped"), FastIndexedSeq.empty[TypeInfo[_]], UnitInfo)
+        L.method = newM
+        newM.setEntry(L)
+        L.append(returnx())
+
+        x.insertBefore(methodStmt(INVOKEVIRTUAL, newM, Array(load(m.getParam(0)))))
+
+        L = new Block()
+        size = 0
+      }
+
+      size += x.approxByteCodeSize()
+      val n = x.next
+      x.remove()
+      L.append(x)
+      x = n
+    }
+
+    val newM = c.newMethod(genName("m", "wrapped"), FastIndexedSeq.empty[TypeInfo[_]], returnTI)
+    L.method = newM
+    newM.setEntry(L)
+
+    def invokeNewM(): ValueX =
+      methodInsn(INVOKEVIRTUAL, newM, Array(load(m.getParam(0))))
+
+    def invokeNewMStmt(): StmtX =
+      methodStmt(INVOKEVIRTUAL, newM, Array(load(m.getParam(0))))
+
+    last match {
+      case _: GotoX | _: ThrowX =>
+        L.append(returnx())
+        last.insertBefore(invokeNewMStmt())
+      case x: IfX =>
+        val Ltrue = x.Ltrue
+        val Lfalse = x.Lfalse
+
+        x.remove()
+        L.append(x)
+
+        val newLtrue = new Block()
+        newLtrue.method = newM
+        newLtrue.append(returnx(ldcInsn(0, BooleanInfo)))
+        x.Ltrue = newLtrue
+
+        val newLfalse = new Block()
+        newLfalse.method = newM
+        newLfalse.append(returnx(ldcInsn(0, BooleanInfo)))
+        x.Lfalse = newLfalse
+
+        b.append(
+          ifx(IFNE, invokeNewM(), Ltrue, Lfalse))
+      case x: SwitchX => IntInfo
+        val i = x.children(0)
+        x.setChild(0, invokeNewM())
+        L.append(returnx(i))
+      case _: ReturnX =>
+        if (returnTI eq UnitInfo) {
+          L.append(returnx())
+          last.insertBefore(invokeNewMStmt())
+        } else {
+          val c = x.children(0)
+          x.setChild(0, invokeNewM())
+          L.append(returnx(c))
+        }
+    }
+  }
+
+  def split(): Unit = {
+    splitLargeStatements()
+    spillLocals()
+
+    for (b <- blocks) {
+      splitBlock(b)
+    }
+
+    // this can't get split
+    m.parameterTypeInfo.indices.foreach { i =>
+      m.entry.prepend(putField(
+        paramFields(i),
+        load(m.getParam(0)),
+        load(m.getParam(i + 1))))
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -13,7 +13,7 @@ object SplitMethod {
 }
 
 class SplitMethod(c: Classx[_], m: Method) {
-  private var blocks = m.findBlocks()
+  private val blocks = m.findBlocks()
 
   private val paramFields = m.parameterTypeInfo.zipWithIndex.map { case (ti, i) =>
     c.newField(genName("f", s"arg$i"), ti)

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -3,10 +3,8 @@ package is.hail.lir
 import java.io.PrintWriter
 
 import scala.collection.mutable
-
 import is.hail.asm4s._
 import is.hail.utils._
-
 import org.objectweb.asm.Opcodes._
 
 // FIXME move typeinfo stuff lir
@@ -87,20 +85,34 @@ class Classx[C](val name: String, val superName: String) {
     }
 
     for (m <- methods) {
-      m.simplifyBlocks()
+      SimplifyControl(m)
     }
+
+    /*
+    for (m <- methods) {
+      if (m.approxByteCodeSize() > SplitMethod.TargetMethodSize)
+      if (m.name != "<init>")
+        SplitMethod(this, m)
+    }
+     */
 
     for (m <- methods) {
       InitializeLocals(m)
     }
 
-    // println(Pretty(this))
+    /*
+    {
+      println(name)
+      for (m <- methods) {
+        println(s"  ${ m.name } ${ m.approxByteCodeSize() }")
+      }
+    }
+     */
 
     Emit(this,
       print
       // Some(new PrintWriter(System.out))
     )
-
   }
 }
 
@@ -181,24 +193,26 @@ class Method private[lir] (
     while (s.nonEmpty) {
       val L = s.pop()
       if (!visited.contains(L)) {
-        blocks += L
+        if (L != null) {
+          blocks += L
 
-        var x = L.first
-        while (x != null) {
-          x match {
-            case x: IfX =>
-              s.push(x.Ltrue)
-              s.push(x.Lfalse)
-            case x: GotoX =>
-              s.push(x.L)
-            case x: SwitchX =>
-              s.push(x.Ldefault)
-              x.Lcases.foreach(s.push)
-            case _ =>
+          var x = L.first
+          while (x != null) {
+            x match {
+              case x: IfX =>
+                s.push(x.Ltrue)
+                s.push(x.Lfalse)
+              case x: GotoX =>
+                s.push(x.L)
+              case x: SwitchX =>
+                s.push(x.Ldefault)
+                x.Lcases.foreach(s.push)
+              case _ =>
+            }
+            x = x.next
           }
-          x = x.next
+          visited += L
         }
-        visited += L
       }
     }
 
@@ -216,9 +230,11 @@ class Method private[lir] (
     val visited: mutable.Set[Local] = mutable.Set()
 
     def visitLocal(l: Local): Unit = {
-      if (!visited.contains(l)) {
-        locals += l
-        visited += l
+      if (!l.isInstanceOf[Parameter]) {
+        if (!visited.contains(l)) {
+          locals += l
+          visited += l
+        }
       }
     }
 
@@ -262,53 +278,13 @@ class Method private[lir] (
     }
   }
 
-  def simplifyBlocks(): Unit = {
-    @scala.annotation.tailrec
-    def finalTarget(b: Block): Block = {
-      if (b.first != null &&
-        b.first.isInstanceOf[GotoX]) {
-        finalTarget(b.first.asInstanceOf[GotoX].L)
-      } else
-        b
-    }
-
-    @scala.annotation.tailrec
-    def simplifyBlock(L: Block): Unit = {
-      L.last match {
-        case x: IfX =>
-          x.setLtrue(finalTarget(x.Ltrue))
-          x.setLfalse(finalTarget(x.Lfalse))
-
-          val M = x.Ltrue
-          if (x.Lfalse eq M) {
-            x.remove()
-            x.setLtrue(null)
-            x.setLfalse(null)
-            L.append(goto(M))
-          }
-
-        case x: GotoX =>
-          val M = x.L
-          if ((M ne L) && M.uses.size == 1 && (entry ne M)) {
-            x.remove()
-            x.setL(null)
-            while (M.first != null) {
-              val z = M.first
-              z.remove()
-              L.append(z)
-            }
-            simplifyBlock(L)
-          } else
-            x.setL(finalTarget(x.L))
-
-        case _ =>
-      }
-    }
-
+  def approxByteCodeSize(): Int = {
     val blocks = findBlocks()
-
-    for (ell <- blocks)
-      simplifyBlock(ell)
+    var size = 0
+    for (b <- blocks) {
+      size += b.approxByteCodeSize()
+    }
+    size
   }
 }
 
@@ -332,32 +308,8 @@ class Block {
 
   var method: Method = _
 
-  val uses: mutable.Set[ControlX] = mutable.Set()
-
   var first: StmtX = _
   var last: StmtX = _
-
-  def replace(L: Block): Unit = {
-    if (method != null && (method.entry eq this)) {
-      method.setEntry(L)
-    }
-
-    while (uses.nonEmpty) {
-      val x = uses.head
-      x match {
-        case x: GotoX =>
-          assert(x.L eq this)
-          x.setL(L)
-        case x: IfX =>
-          if (x.Ltrue eq this)
-            x.setLtrue(L)
-          if (x.Lfalse eq this)
-            x.setLfalse(L)
-      }
-    }
-
-    assert(uses.isEmpty)
-  }
 
   def prepend(x: StmtX): Unit = {
     assert(x.parent == null)
@@ -403,6 +355,17 @@ class Block {
   }
 
   override def toString: String = f"L${ System.identityHashCode(this) }%08x"
+
+  def approxByteCodeSize(): Int = {
+    var size = 1 // for the block
+    var x = first
+    while (x != null) {
+      size += x.approxByteCodeSize()
+      x = x.next
+    }
+    size
+  }
+
 }
 
 // X stands for eXpression
@@ -443,6 +406,18 @@ abstract class X {
     }
     children(i) = x
   }
+
+  def remove(): Unit
+
+  def approxByteCodeSize(): Int = {
+    var size = 0
+    def visit(x: X): Unit = {
+      size += 1
+      x.children.foreach(visit)
+    }
+    visit(this)
+    size
+  }
 }
 
 abstract class StmtX extends X {
@@ -466,93 +441,135 @@ abstract class StmtX extends X {
     next = null
     prev = null
   }
+
+  def replace(x: StmtX): Unit = {
+    assert(x.parent == null)
+    assert(parent != null)
+
+    x.next = next
+    x.prev = prev
+    x.parent = parent
+
+    if (parent.first == this)
+      parent.first = x
+    if (parent.last == this)
+      parent.last = x
+    if (next != null)
+      next.prev = x
+    if (prev != null)
+      prev.next = x
+
+    next = null
+    prev = null
+    parent = null
+  }
+
+  def insertBefore(x: StmtX): Unit = {
+    assert(parent != null)
+    assert(x.parent == null)
+
+    x.next = this
+    x.parent = parent
+    if (prev != null) {
+      x.prev = prev
+      prev.next = x
+    } else {
+      parent.first = x
+    }
+    prev = x
+  }
 }
 
-abstract class ControlX extends StmtX
+abstract class ControlX extends StmtX {
+  def targetArity(): Int
+
+  def target(i: Int): Block
+
+  def setTarget(i: Int, b: Block): Unit
+}
 
 abstract class ValueX extends X {
   var parent: X = _
 
   def ti: TypeInfo[_]
+
+  def remove(): Unit = {
+    var i = 0
+    while (parent.children(i) ne this)
+      i += 1
+    parent.setChild(i, null)
+    assert(parent == null)
+  }
+
+  def replace(x: ValueX): Unit = {
+    var i = 0
+    while (parent.children(i) ne this)
+      i += 1
+    parent.setChild(i, x)
+    assert(parent == null)
+  }
 }
 
 class GotoX extends ControlX {
-  var _L: Block = _
+  var L: Block = _
 
-  def L: Block = _L
+  def targetArity(): Int = 1
 
-  def setL(newL: Block): Unit = {
-    if (_L != null)
-      _L.uses -= this
-    if (newL != null)
-      newL.uses += this
-    _L = newL
+  def target(i: Int): Block = {
+    assert(i == 0)
+    L
+  }
+
+  def setTarget(i: Int, b: Block): Unit = {
+    assert(i == 0)
+    L = b
   }
 }
 
 class IfX(val op: Int) extends ControlX {
-  var _Ltrue: Block = _
+  var Ltrue: Block = _
+  var Lfalse: Block = _
 
-  def Ltrue: Block = _Ltrue
+  def targetArity(): Int = 2
 
-  def setLtrue(newLtrue: Block): Unit = {
-    removeUses()
-    _Ltrue = newLtrue
-    addUses()
+  def target(i: Int): Block = {
+    if (i == 0)
+      Ltrue
+    else {
+      assert(i == 1)
+      Lfalse
+    }
   }
 
-  var _Lfalse: Block = _
-
-  def Lfalse: Block = _Lfalse
-
-  def setLfalse(newLfalse: Block): Unit = {
-    removeUses()
-    _Lfalse = newLfalse
-    addUses()
-  }
-
-  private def removeUses(): Unit = {
-    if (_Ltrue != null)
-      _Ltrue.uses -= this
-    if (_Lfalse != null)
-      _Lfalse.uses -= this
-  }
-
-  private def addUses(): Unit = {
-    if (_Ltrue != null)
-      _Ltrue.uses += this
-    if (_Lfalse != null)
-      _Lfalse.uses += this
+  def setTarget(i: Int, b: Block): Unit = {
+    if (i == 0)
+      Ltrue = b
+    else {
+      assert(i == 1)
+      Lfalse = b
+    }
   }
 }
 
 class SwitchX() extends ControlX {
-  private[this] var _Ldefault: Block = _
+  var Ldefault: Block = _
 
-  private[this] var _Lcases: IndexedSeq[Block] = FastIndexedSeq()
+  var Lcases: Array[Block] = Array.empty[Block]
 
-  def Ldefault: Block = _Ldefault
+  def targetArity(): Int = 1 + Lcases.length
 
-  def Lcases: IndexedSeq[Block] = _Lcases
-
-  def setDefault(newDefault: Block): Unit = {
-    if (_Ldefault != null)
-      _Ldefault.uses -= this
-    _Ldefault = newDefault
-    if (_Ldefault != null)
-      _Ldefault.uses += this
+  def target(i: Int): Block = {
+    if (i == 0)
+      Ldefault
+    else
+      Lcases(i - 1)
   }
 
-  def setCases(newCases: IndexedSeq[Block]): Unit = {
-    _Lcases.foreach { c =>
-      if (c != null)
-        c.uses -= this
-    }
-    _Lcases = newCases
-    _Lcases.foreach { c =>
-      if (c != null)
-        c.uses += this
-    }
+  def setTarget(i: Int, b: Block): Unit = {
+    if (i == 0)
+      Ldefault = b
+    else
+      Lcases(i - 1) = b
   }
 }
 
@@ -562,9 +579,21 @@ class PutFieldX(val op: Int, val f: FieldRef) extends StmtX
 
 class IincX(val l: Local, val i: Int) extends StmtX
 
-class ReturnX() extends ControlX
+class ReturnX() extends ControlX {
+  def targetArity(): Int = 0
 
-class ThrowX() extends ControlX
+  def target(i: Int): Block = throw new IndexOutOfBoundsException()
+
+  def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
+}
+
+class ThrowX() extends ControlX {
+  def targetArity(): Int = 0
+
+  def target(i: Int): Block = throw new IndexOutOfBoundsException()
+
+  def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
+}
 
 class StmtOpX(val op: Int) extends StmtX
 
@@ -635,6 +664,9 @@ class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
       case I2D => DoubleInfo
       case L2D => DoubleInfo
       case F2D => DoubleInfo
+      // Boolean
+      case I2B => BooleanInfo
+
     }
   }
 }
@@ -651,7 +683,7 @@ class NewArrayX(val eti: TypeInfo[_]) extends ValueX {
   def ti: TypeInfo[_] = arrayInfo(eti)
 }
 
-class NewInstanceX(val ti: TypeInfo[_]) extends ValueX
+class NewInstanceX(val ti: TypeInfo[_], val ctor: MethodRef) extends ValueX
 
 class LdcX(val a: Any, val ti: TypeInfo[_]) extends ValueX {
   assert(

--- a/hail/src/main/scala/is/hail/lir/package.scala
+++ b/hail/src/main/scala/is/hail/lir/package.scala
@@ -39,16 +39,16 @@ package object lir {
   def ifx(op: Int, c: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c)
-    x.setLtrue(Ltrue)
-    x.setLfalse(Lfalse)
+    x.Ltrue = Ltrue
+    x.Lfalse = Lfalse
     x
   }
 
   def ifx(op: Int, c1: ValueX, c2: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c1, c2)
-    x.setLtrue(Ltrue)
-    x.setLfalse(Lfalse)
+    x.Ltrue = Ltrue
+    x.Lfalse = Lfalse
     x
   }
 
@@ -58,8 +58,8 @@ package object lir {
 
     val x = new SwitchX()
     setChildren(x, c)
-    x.setDefault(Ldefault)
-    x.setCases(cases)
+    x.Ldefault = Ldefault
+    x.Lcases = cases.toArray
     x
   }
 
@@ -67,7 +67,7 @@ package object lir {
     assert(L != null)
     val x = new GotoX
     x.setArity(0)
-    x.setL(L)
+    x.L = L
     x
   }
 
@@ -228,8 +228,20 @@ package object lir {
   }
 
   def newInstance(
-    ti: TypeInfo[_]
-  ): ValueX = new NewInstanceX(ti)
+    ti: TypeInfo[_],
+    owner: String, name: String, desc: String, returnTypeInfo: TypeInfo[_],
+    args: IndexedSeq[ValueX]
+  ): ValueX = {
+    val x = new NewInstanceX(ti, new MethodLit(owner, name, desc, isInterface = false, returnTypeInfo))
+    setChildren(x, args)
+    x
+  }
+
+  def newInstance(ti: TypeInfo[_], method: Method, args: IndexedSeq[ValueX]): ValueX = {
+    val x = new NewInstanceX(ti, method)
+    setChildren(x, args)
+    x
+  }
 
   def checkcast(iname: String): (ValueX) => ValueX = (c) => checkcast(iname, c)
 


### PR DESCRIPTION
Due to bytecode verification rules, an allocated but uninitalized object cannot be stored into a field, so the NEW and INVOKESPECIAL constructor call bytecodes cannot be split across methods.  Therefore, I modified newInstance to fuse those operations together.

I broke out control simplification and made it a stronger.

Added method splitting.  Currently, method splitting splits out basic blocks into their own, straight-line methods and all the control flow remains in the original method.  All locals are spilled to fields which is terrible, but what we're doing now.  I expect two changes in the future: recover the structured control flow (there are standard algorithms for this) so we can split out control flow, and use the dataflow analysis from InitializeLocals to only spill locals split across method boundaries.

I will make a stacked PR on this that removes method wrapping from Emit and enables lir method splitting.
