### PR TITLE
Don't use a 0 pointer in TableWriter

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -180,7 +180,11 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
                   IEmitCode.present(cb, PCode(keyType, keyRVB.offset))
                 },
                   ob.invoke[Long]("indexOffset"),
-                  IEmitCode.present(cb, PCode(+PCanonicalStruct(), 0L)))
+                  {
+                    val pcs = PCanonicalStruct(true)
+                    IEmitCode.present(cb, PCode(pcs, pcs.allocate(region)))
+                  }
+                )
               }
               cb += ob.writeByte(1.asInstanceOf[Byte])
               cb += enc(region, coerce[Long](row.value), ob)


### PR DESCRIPTION
Working on the safe memory allocator that checks if we are accessing invalid memory, it's catching this 0 pointer. 

There are already tests that hit `TableWriter`, and this should result in no functionality change. 