### PR TITLE
[batch] fix another logging error

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -6,6 +6,7 @@ import datetime
 import asyncio
 import logging
 import base64
+import dateutil.parser
 import sortedcontainers
 import aiohttp
 from hailtop.utils import time_msecs, secret_alnum_string
@@ -427,7 +428,7 @@ gsutil -m cp run.log worker.log /var/log/syslog dockerd.log  gs://$WORKER_LOGS_B
             log.warning(f'event has no payload')
             return
 
-        timestamp = event.timestamp.timestamp() * 1000
+        timestamp = dateutil.parser.isoparse(event['timestamp']).timestamp() * 1000
         version = payload['version']
         if version != '1.2':
             log.warning('unknown event verison {version}')

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -31,6 +31,7 @@ pylint==2.3.1
 PyMySQL==0.9.3
 pytest-instafail==0.4.1
 pytest==4.6.3
+python-dateutil==2.8.1
 python-json-logger==0.1.11
 requests==2.22.0
 setuptools>=38.6.0


### PR DESCRIPTION
I'm seeing this in the driver logs:

```
ERROR 2020-06-16 23:37:18,446 in event loop Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/batch/driver/instance_pool.py", line 500, in event_loop
    await self.handle_event(event)
  File "/usr/local/lib/python3.7/dist-packages/batch/driver/instance_pool.py", line 430, in handle_event
    timestamp = event.timestamp.timestamp() * 1000
AttributeError: 'dict' object has no attribute 'timestamp'
```

`event['timestamp']` is in RFC3339 Zulu format with nanosecond precision, for example: 2020-06-08T16:49:53.374657381Z, see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry

There is no native RFC3339 Python parser.  RFC3339 is nearly identicaly to ISO 8601, except maybe some timezone differences which aren't relevant in Zulu format, see: https://en.wikipedia.org/wiki/ISO_8601.   There isn't a native Python ISO 8601 parser.

dateutil.parser.isoparse is a ISO 8601 parser (and is maybe also supports RFC3339?  I can't quite tell.)

Note, Python datetime only has microsecond accuracy, but that's fine because we only store millisecond accuracy.

Time is the worst.