### PR TITLE
[query] Fix aggregation semantics in MT group_rows_by/group_cols_by

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1542,3 +1542,15 @@ class Tests(unittest.TestCase):
         mt = mt.key_cols_by(col_id = hl.str(mt.col_idx))
         mt = mt.add_col_index()
         mt.show()
+
+    def test_filtered_entries_group_rows_by(self):
+        mt = hl.utils.range_matrix_table(1, 1)
+        mt = mt.filter_entries(False)
+        mt = mt.group_rows_by(x=mt.row_idx // 10).aggregate(c=hl.agg.count())
+        assert mt.entries().collect() == [hl.Struct(x=0, col_idx=0, c=0)]
+
+    def test_filtered_entries_group_cols_by(self):
+        mt = hl.utils.range_matrix_table(1, 1)
+        mt = mt.filter_entries(False)
+        mt = mt.group_cols_by(x=mt.col_idx // 10).aggregate(c=hl.agg.count())
+        assert mt.entries().collect() == [hl.Struct(row_idx=0, x=0, c=0)]

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -592,7 +592,7 @@ object LowerMatrixIR {
                 let(sa = 'global (colsField)('__result_idx)) {
                   aggLet(sa = 'global (colsField)('__element_idx),
                     g = 'row (entriesField)('__element_idx)) {
-                    eeSub
+                    aggFilter(!'g.isNA, eeSub)
                   }
                 })))
 
@@ -661,7 +661,7 @@ object LowerMatrixIR {
                   .apply('value)
                   .streamAgg(aggElementIdx ~>
                     aggLet(g = '__entries (aggElementIdx), sa = 'global (colsField)(aggElementIdx)) {
-                      eeSub
+                      aggFilter(!'g.isNA, eeSub)
                     }))
             }))
           .mapGlobals(

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -157,7 +157,7 @@ object Simplify {
 
     case x@If(False(), _, altr) => altr
 
-    case If(c, cnsq, altr) if cnsq == altr =>
+    case If(c, cnsq, altr) if cnsq == altr && cnsq.typ != TVoid =>
       if (isDefinitelyDefined(c))
         cnsq
       else


### PR DESCRIPTION
Fixes #8953

CHANGELOG: Fixed aggregation behavior of `MatrixTable.{group_rows_by, group_cols_by}` to skip filtered entries.