### PR TITLE
[site] fix utf-8 encoding

### DIFF
--- a/site/www/search.xslt
+++ b/site/www/search.xslt
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-15" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:import href="template.xslt" />
     <xsl:template match="h1[@id='hail']"></xsl:template>


### PR DESCRIPTION
Occurred because I moved the  #hits .aa-suggestion-title-separator:before to an inline style, and the xml parser converted the utf-8 character to ISO-8859-15.

current:
<img width="1284" alt="Screenshot 2020-06-17 14 51 34" src="https://user-images.githubusercontent.com/5543229/84937887-70b41380-b0aa-11ea-94f4-6011c27fd4bd.png">

after:
<img width="1070" alt="Screenshot 2020-06-17 14 51 47" src="https://user-images.githubusercontent.com/5543229/84937890-71e54080-b0aa-11ea-88c3-c40365f4025a.png">
