### PR TITLE
[query] Fix partitioner memory error

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.{Annotation, Region}
+import is.hail.annotations.{Annotation, Region, UnsafeRow}
 import is.hail.asm4s.Value
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.EmitStream.SizedStream
@@ -88,6 +88,7 @@ object Literal {
 final case class Literal(_typ: Type, value: Annotation) extends IR {
   require(!CanEmit(_typ))
   require(value != null)
+  // require(SafeRow.isSafe(value))
 }
 
 final case class I32(x: Int) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -88,6 +88,7 @@ object Literal {
 final case class Literal(_typ: Type, value: Annotation) extends IR {
   require(!CanEmit(_typ))
   require(value != null)
+  // expensive, for debugging
   // require(SafeRow.isSafe(value))
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -302,9 +302,9 @@ object LoweredTableReader {
       FastIndexedSeq[TypeInfo[_]](classInfo[Region]), LongInfo,
       summary,
       optimize = true)
-
+    
     val a = f(0, ctx.r)(ctx.r)
-    val s = new UnsafeRow(resultPType.asInstanceOf[PStruct], ctx.r, a)
+    val s = SafeRow(resultPType.asInstanceOf[PStruct], a)
 
     val ksorted = s.getBoolean(0)
     val pksorted = s.getBoolean(1)

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -16,6 +16,8 @@ class RVDPartitioner(
   val rangeBounds: Array[Interval],
   allowedOverlap: Int
 ) {
+  // assert(rangeBounds.forall(SafeRow.isSafe))
+
   override def toString: String =
     s"RVDPartitioner($kType, ${rangeBounds.mkString("[", ",\n", "]")})"
 

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -16,6 +16,7 @@ class RVDPartitioner(
   val rangeBounds: Array[Interval],
   allowedOverlap: Int
 ) {
+  // expensive, for debugging
   // assert(rangeBounds.forall(SafeRow.isSafe))
 
   override def toString: String =


### PR DESCRIPTION
The new generic lines coerce code could produce a partitioner with unsafe values.  Those unsafe values ended up in the Compile cache, which become invalid when owning region was cleared.

This fixes the memory errors I was seeing when running with the local backend.  It is possible it will fix (some?) of the errors you were investigating, @johnc1231.