### PR TITLE
[site] prevent background from encroaching all-hero-content on wide views

### DIFF
--- a/site/www/style.css
+++ b/site/www/style.css
@@ -3,6 +3,7 @@ html {
   font-size: 100%;
   line-height: 1.15;
   -webkit-text-size-adjust: 100%;
+  background: #fff;
 }
 
 * {
@@ -15,6 +16,7 @@ body {
   line-height: 1.6;
   margin: auto;
   border-color: #ddd;
+  background: inherit;
 }
 
 a:hover {
@@ -130,6 +132,7 @@ img {
   align-items: center;
   flex-direction: row;
   padding: 0px 50px;
+  background: inherit;
 }
 
 section.left div {
@@ -256,7 +259,7 @@ a {
   text-decoration: underline;
 }
 
-.about.dark a.button:hover, {
+.about.dark a.button:hover {
   text-decoration: none;
 }
 
@@ -821,6 +824,14 @@ pre code {
   #hero-content {
     padding-right: 0px;
     max-width: 48rem;
+  }
+}
+
+@media only screen and (min-width: 1521px) {
+  #all-hero-content {
+    box-shadow: 0px 0px 100px 100px rgba(255,255,255, 1);
+    background: inherit;
+    z-index:1;
   }
 }
 


### PR DESCRIPTION
Points shouldn't show through central section, too noisy, triggers trichophobia. This fixes a regression (previously there was enough padding to make the space between the title and panel to block point/line visibility), and improves on that previous state (by making the entire central section uniformly opaque, gives more visual consistency and will mean future padding changes don't break opaqueness). 

After:
<img width="2570" alt="Screenshot 2020-06-18 11 45 37" src="https://user-images.githubusercontent.com/5543229/85042714-87fe0a00-b159-11ea-954d-6a50b47f1b15.png">
