### PR TITLE
[site] don't overflow install section

### DIFF
--- a/site/www/index.xslt
+++ b/site/www/index.xslt
@@ -49,7 +49,7 @@ show(p)
                 </div>
             </div>
         </div>
-        <div id="install" class="about dark">
+        <div id="install" class="about dark" style='z-index:1'>
             <div class="header-wrap" style="justify-content: center;">
                 <h1>Install</h1>
             </div>

--- a/site/www/index.xslt
+++ b/site/www/index.xslt
@@ -49,7 +49,7 @@ show(p)
                 </div>
             </div>
         </div>
-        <div id="install" class="about dark" style='z-index:1'>
+        <div id="install" class="about dark" style="z-index:1">
             <div class="header-wrap" style="justify-content: center;">
                 <h1>Install</h1>
             </div>


### PR DESCRIPTION
On views narrower than the height of the graph image + 100px, the slide box will overflow the adjacent install section.

Fixed using inline style to avoid css caching issues until the build process is fixed.