### PR TITLE
[query][qggs] refactor PhysicalAggSig

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -653,15 +653,15 @@ object IRParser {
     val sig = identifier(it) match {
       case "Grouped" =>
         val pt = ptype_expr(env)(it)
-        val nested = base_seq_parser(p_agg_sigs(env))(it)
-        GroupedAggSig(pt, nested.map(_.toFastSeq))
+        val nested = p_agg_sigs(env)(it)
+        GroupedAggSig(pt, nested)
       case "ArrayLen" =>
         val knownLength = boolean_literal(it)
-        val nested = base_seq_parser(p_agg_sigs(env))(it)
-        ArrayLenAggSig(knownLength, nested.map(_.toFastSeq))
+        val nested = p_agg_sigs(env)(it)
+        ArrayLenAggSig(knownLength, nested)
       case "AggElements" =>
-        val nested = base_seq_parser(p_agg_sigs(env))(it)
-        AggElementsAggSig(nested.map(_.toFastSeq))
+        val nested = p_agg_sigs(env)(it)
+        AggElementsAggSig(nested)
       case op =>
         val state = agg_state_signature(env)(it)
         PhysicalAggSig(AggOp.fromString(op), state)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -87,31 +87,22 @@ object Pretty {
           sb += ' '
           sb.append(t.toString)
           sb += '\n'
-          basePrettySeq(nested.map(_.toFastSeq), depth + 2, prettyPhysicalAggSigs)
+          prettyPhysicalAggSigs(nested, depth + 2)
         case ArrayLenAggSig(kl, nested) =>
           sb.append("ArrayLen")
           sb += ' '
           sb.append(prettyBooleanLiteral(kl))
           sb += '\n'
-          basePrettySeq(nested.map(_.toFastSeq), depth + 2, prettyPhysicalAggSigs)
+          prettyPhysicalAggSigs(nested, depth + 2)
         case AggElementsAggSig(nested) =>
           sb.append("AggElements")
           sb += '\n'
-          basePrettySeq(nested.map(_.toFastSeq), depth + 2, prettyPhysicalAggSigs)
+          prettyPhysicalAggSigs(nested, depth + 2)
         case PhysicalAggSig(op, state) =>
           sb.append(prettyClass(op))
           sb += '\n'
           prettyAggStateSignature(state, depth + 2)
       }
-      sb += ')'
-    }
-    def prettyAggSignature(aggSig: AggSignature, depth: Int): Unit = {
-      sb.append(" " * depth)
-      sb += '('
-      sb.append(prettyClass(aggSig.op))
-      sb += ' '
-      sb.append(aggSig.initOpArgs.map(_.parsableString()).mkString(" (", " ", ")"))
-      sb.append(aggSig.seqOpArgs.map(_.parsableString()).mkString(" (", " ", ")"))
       sb += ')'
     }
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -465,7 +465,7 @@ class Aggregators2Suite extends HailSuite {
   }
 
   @Test def testArrayElementsAgg() {
-    val alState = ArrayLenAggSig(knownLength = false, Array(pnnAggSig, countAggSig, sumAggSig).map(FastSeq(_)))
+    val alState = ArrayLenAggSig(knownLength = false, FastSeq(pnnAggSig, countAggSig, sumAggSig))
 
     val value = FastIndexedSeq(
       FastIndexedSeq(Row("a", 0L), Row("b", 0L), Row("c", 0L), Row("f", 0L)),
@@ -502,9 +502,9 @@ class Aggregators2Suite extends HailSuite {
   }
 
   @Test def testNestedArrayElementsAgg() {
-    val alstate1 = ArrayLenAggSig(knownLength = false, Array(FastSeq(sumAggSig)))
-    val aestate1 = AggElementsAggSig(Array(FastSeq(sumAggSig)))
-    val alstate2 = ArrayLenAggSig(knownLength = false, Array(FastSeq[PhysicalAggSig](alstate1, aestate1)))
+    val alstate1 = ArrayLenAggSig(knownLength = false, FastSeq(sumAggSig))
+    val aestate1 = AggElementsAggSig(FastSeq(sumAggSig))
+    val alstate2 = ArrayLenAggSig(knownLength = false, FastSeq[PhysicalAggSig](alstate1))
 
     val init = InitOp(0, FastIndexedSeq(Begin(FastIndexedSeq[IR](
       InitOp(0, FastIndexedSeq(Begin(FastIndexedSeq[IR](
@@ -537,7 +537,7 @@ class Aggregators2Suite extends HailSuite {
       FastIndexedSeq(null, null, null, Row("f", 5L)))
 
     val take = PhysicalAggSig(Take(), TakeStateSig(PType.canonical(t)))
-    val alstate = ArrayLenAggSig(knownLength = false, Array(FastSeq(take)))
+    val alstate = ArrayLenAggSig(knownLength = false, FastSeq(take))
 
     val init = InitOp(0, FastIndexedSeq(Begin(FastIndexedSeq[IR](
       InitOp(0, FastIndexedSeq(I32(3)), take)
@@ -555,7 +555,7 @@ class Aggregators2Suite extends HailSuite {
   }
 
   @Test def testGroup() {
-    val group = GroupedAggSig(PCanonicalString(), Array(pnnAggSig, countAggSig, sumAggSig).map(FastSeq(_)))
+    val group = GroupedAggSig(PCanonicalString(), FastSeq(pnnAggSig, countAggSig, sumAggSig))
 
     val initOpArgs = FastIndexedSeq(Begin(FastIndexedSeq(
       InitOp(0, FastIndexedSeq(), pnnAggSig),
@@ -582,8 +582,8 @@ class Aggregators2Suite extends HailSuite {
 
   @Test def testNestedGroup() {
 
-    val group1 = GroupedAggSig(PCanonicalString(), Array(pnnAggSig, countAggSig, sumAggSig).map(FastSeq(_)))
-    val group2 = GroupedAggSig(PCanonicalString(), FastSeq(FastSeq[PhysicalAggSig](group1)))
+    val group1 = GroupedAggSig(PCanonicalString(), FastSeq(pnnAggSig, countAggSig, sumAggSig))
+    val group2 = GroupedAggSig(PCanonicalString(), FastSeq[PhysicalAggSig](group1))
 
     val initOpArgs = FastIndexedSeq(
       InitOp(0, FastIndexedSeq(

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2889,7 +2889,7 @@ class IRSuite extends HailSuite {
     val countSig = AggSignature(Count(), Seq(), Seq())
     val count = ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq.empty, countSig)
 
-    val groupSignature = GroupedAggSig(PInt32(true), FastSeq(FastSeq(pSumSig)))
+    val groupSignature = GroupedAggSig(PInt32(true), FastSeq(pSumSig))
 
     val table = TableRange(100, 10)
 


### PR DESCRIPTION
From a conversation we had a while ago---

It turns out PhysicalAggSig *does* need to know nested aggOps, since they're used in constructing the correct resultOp for a nested aggregator, but we don't need to carry *all* the operations that are happening on a given agg state, only the AggOps that are going to be used in the CombOp/ResultOp. This lets us get rid of the weird `Seq[Seq[PhysicalAggSig]]` that was confusing by only tracking the "main" aggOp on a given state.

I'm still not entirely happy with how this looks, but I think that not carrying around an array of possible ops is much nicer.

Shouldn't cause conflicts with the aggregator lowering stuff, but I'm assigning you just in case.