### PR TITLE
Fix links to references.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the [documentation](https://hail.is/docs/0.2/) for more info on using Hail.
 
 ### Community
 
-Hail has been widely adopted in academia and industry, including as the analysis platform for the [genome aggregation database](https://gnomad.broadinstitute.org) and [UK Biobank rapid GWAS](https://www.nealelab.is/uk-biobank). Learn more about [Hail-powered science](hail/www/references.md).
+Hail has been widely adopted in academia and industry, including as the analysis platform for the [genome aggregation database](https://gnomad.broadinstitute.org) and [UK Biobank rapid GWAS](https://www.nealelab.is/uk-biobank). Learn more about [Hail-powered science](https://hail.is/references.html).
 
 ### Contribute
 

--- a/site/www/references.md
+++ b/site/www/references.md
@@ -13,7 +13,7 @@ Or you could include the following line in your bibliography:
 
 <pre class='sourceCode'><code>Hail Team. Hail 0.2. https://github.com/hail-is/hail</code></pre>
 
-Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/master/hail/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
+Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/master/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
 
 *Last updated on March 30th, 2020*
 


### PR DESCRIPTION
A few links to references.md were broken when website files were moved in #8923.

This changes the "Hail-powered science" link in README.md to point to the references page on the website instead of the references.md file in GitHub and fixes the "editing this page directly" link on https://hail.is/references.html.