### PR TITLE
[query/lir] add Block.replace

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -11,19 +11,7 @@ object SimplifyControl {
 }
 
 class SimplifyControl(m: Method) {
-  private val uses = mutable.Map[Block, mutable.Set[(ControlX, Int)]]()
-
   private val q = mutable.Set[Block]()
-
-  def removeUse(M: Block, c: ControlX, i: Int): Unit = {
-    val r = uses(M).remove((c, i))
-    assert(r)
-  }
-
-  def addUse(M: Block, c: ControlX, i: Int): Unit = {
-    val r = uses(M).add((c, i))
-    assert(r)
-  }
 
   def finalTarget(b0: Block): Block = {
     var b = b0
@@ -36,24 +24,20 @@ class SimplifyControl(m: Method) {
   def simplifyBlock(L: Block): Unit = {
     val last = L.last.asInstanceOf[ControlX]
 
-    if (uses(L).isEmpty && (L ne m.entry)) {
+    if (L.uses.isEmpty && (L ne m.entry)) {
       var i = 0
       while (i < last.targetArity()) {
         val M = last.target(i)
-        removeUse(M, last, i)
         last.setTarget(i, null)
 
         q += M
-        if (uses(M).size == 1) {
-          val (u, _) = uses(M).head
+        if (M.uses.size == 1) {
+          val (u, _) = M.uses.head
           q += u.parent
         }
 
         i += 1
       }
-
-      // just popped off q
-      uses -= L
 
       return
     }
@@ -63,13 +47,11 @@ class SimplifyControl(m: Method) {
       val M = last.target(i)
       val newM = finalTarget(M)
       if (M ne newM) {
-        removeUse(M, last, i)
         last.setTarget(i, newM)
-        addUse(newM, last, i)
 
         q += M
-        if (uses(M).size == 1) {
-          val (u, _) = uses(M).head
+        if (M.uses.size == 1) {
+          val (u, _) = M.uses.head
           q += u.parent
         }
         q += L
@@ -82,13 +64,10 @@ class SimplifyControl(m: Method) {
         val M = x.Ltrue
         if (M eq x.Lfalse) {
           x.remove()
-          removeUse(x.Ltrue, x, 0)
           x.Ltrue = null
-          removeUse(x.Lfalse, x, 1)
           x.Lfalse = null
 
           val g = goto(M)
-          addUse(M, g, 0)
 
           L.append(g)
 
@@ -98,9 +77,8 @@ class SimplifyControl(m: Method) {
 
       case x: GotoX =>
         val M = x.L
-        if ((M ne L) && uses(M).size == 1 && (m.entry ne M)) {
+        if ((M ne L) && M.uses.size == 1 && (m.entry ne M)) {
           x.remove()
-          removeUse(x.L, x, 0)
           x.L = null
 
           while (M.first != null) {
@@ -110,7 +88,6 @@ class SimplifyControl(m: Method) {
           }
 
           q -= M
-          uses -= M
 
           q += L
         }
@@ -161,21 +138,8 @@ class SimplifyControl(m: Method) {
 
     val blocks = m.findBlocks()
 
-    blocks.foreach { b =>
-      uses(b) = mutable.Set()
-    }
-
-    for (b <- blocks) {
+    for (b <- blocks)
       q += b
-
-      val last = b.last.asInstanceOf[ControlX]
-      var i = 0
-      while (i < last.targetArity()) {
-        val t = last.target(i)
-        addUse(t, last, i)
-        i += 1
-      }
-    }
 
     while (q.nonEmpty) {
       val b = q.head

--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -64,8 +64,8 @@ class SimplifyControl(m: Method) {
         val M = x.Ltrue
         if (M eq x.Lfalse) {
           x.remove()
-          x.Ltrue = null
-          x.Lfalse = null
+          x.setLtrue(null)
+          x.setLfalse(null)
 
           val g = goto(M)
 
@@ -79,7 +79,7 @@ class SimplifyControl(m: Method) {
         val M = x.L
         if ((M ne L) && M.uses.size == 1 && (m.entry ne M)) {
           x.remove()
-          x.L = null
+          x.setL(null)
 
           while (M.first != null) {
             val z = M.first

--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -160,12 +160,12 @@ class SplitMethod(c: Classx[_], m: Method) {
         val newLtrue = new Block()
         newLtrue.method = newM
         newLtrue.append(returnx(ldcInsn(0, BooleanInfo)))
-        x.Ltrue = newLtrue
+        x.setLtrue(newLtrue)
 
         val newLfalse = new Block()
         newLfalse.method = newM
         newLfalse.append(returnx(ldcInsn(0, BooleanInfo)))
-        x.Lfalse = newLfalse
+        x.setLfalse(newLfalse)
 
         b.append(
           ifx(IFNE, invokeNewM(), Ltrue, Lfalse))

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -542,52 +542,64 @@ abstract class ValueX extends X {
 }
 
 class GotoX extends ControlX {
-  var L: Block = _
+  private var _L: Block = _
+
+  def L: Block = _L
+
+  def setL(newL: Block): Unit = setTarget(0, newL)
 
   def targetArity(): Int = 1
 
   def target(i: Int): Block = {
     assert(i == 0)
-    L
+    _L
   }
 
   def setTarget(i: Int, b: Block): Unit = {
     assert(i == 0)
-    if (L != null)
-      L.removeUse(this, 0)
-    L = b
+    if (_L != null)
+      _L.removeUse(this, 0)
+    _L = b
     if (b != null)
       b.addUse(this, 0)
   }
 }
 
 class IfX(val op: Int) extends ControlX {
-  var Ltrue: Block = _
-  var Lfalse: Block = _
+  private var _Ltrue: Block = _
+  private var _Lfalse: Block = _
+
+  def Ltrue: Block = _Ltrue
+
+  def Lfalse: Block = _Lfalse
+
+  def setLtrue(newLtrue: Block): Unit = setTarget(0, newLtrue)
+
+  def setLfalse(newLfalse: Block): Unit = setTarget(1, newLfalse)
 
   def targetArity(): Int = 2
 
   def target(i: Int): Block = {
     if (i == 0)
-      Ltrue
+      _Ltrue
     else {
       assert(i == 1)
-      Lfalse
+      _Lfalse
     }
   }
 
   def setTarget(i: Int, b: Block): Unit = {
     if (i == 0) {
-      if (Ltrue != null)
-        Ltrue.removeUse(this, 0)
-      Ltrue = b
+      if (_Ltrue != null)
+        _Ltrue.removeUse(this, 0)
+      _Ltrue = b
       if (b != null)
         b.addUse(this, 0)
     } else {
       assert(i == 1)
-      if (Lfalse != null)
-        Lfalse.removeUse(this, 1)
-      Lfalse = b
+      if (_Lfalse != null)
+        _Lfalse.removeUse(this, 1)
+      _Lfalse = b
       if (b != null)
         b.addUse(this, 1)
     }
@@ -595,31 +607,56 @@ class IfX(val op: Int) extends ControlX {
 }
 
 class SwitchX() extends ControlX {
-  var Ldefault: Block = _
+  private var _Ldefault: Block = _
 
-  var Lcases: Array[Block] = Array.empty[Block]
+  private var _Lcases: Array[Block] = Array.empty[Block]
 
-  def targetArity(): Int = 1 + Lcases.length
+  def Ldefault: Block = _Ldefault
+
+  def setLdefault(newLdefault: Block): Unit = setTarget(0, newLdefault)
+
+  def Lcases: IndexedSeq[Block] = _Lcases
+
+  def setLcases(newLcases: IndexedSeq[Block]): Unit = {
+    var i = 0
+    while (i < _Lcases.length) {
+      val L = _Lcases(i)
+      if (L != null)
+        L.removeUse(this, i + 1)
+      _Lcases(i) = null
+      i += 1
+    }
+    _Lcases = newLcases.toArray
+    i = 0
+    while (i < _Lcases.length) {
+      val L = _Lcases(i)
+      if (L != null)
+        L.addUse(this, i + 1)
+      i += 1
+    }
+  }
+  
+  def targetArity(): Int = 1 + _Lcases.length
 
   def target(i: Int): Block = {
     if (i == 0)
       Ldefault
     else
-      Lcases(i - 1)
+      _Lcases(i - 1)
   }
 
   def setTarget(i: Int, b: Block): Unit = {
     if (i == 0) {
-      if (Ldefault != null)
-        Ldefault.removeUse(this, 0)
-      Ldefault = b
+      if (_Ldefault != null)
+        _Ldefault.removeUse(this, 0)
+      _Ldefault = b
       if (b != null)
         b.addUse(this, 0)
     } else {
-      val L = Lcases(i - 1)
+      val L = _Lcases(i - 1)
       if (L != null)
         L.removeUse(this, i)
-      Lcases(i - 1) = b
+      _Lcases(i - 1) = b
       if (b != null)
         b.addUse(this, i)
     }

--- a/hail/src/main/scala/is/hail/lir/package.scala
+++ b/hail/src/main/scala/is/hail/lir/package.scala
@@ -39,16 +39,16 @@ package object lir {
   def ifx(op: Int, c: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c)
-    x.Ltrue = Ltrue
-    x.Lfalse = Lfalse
+    x.setLtrue(Ltrue)
+    x.setLfalse(Lfalse)
     x
   }
 
   def ifx(op: Int, c1: ValueX, c2: ValueX, Ltrue: Block, Lfalse: Block): ControlX = {
     val x = new IfX(op)
     setChildren(x, c1, c2)
-    x.Ltrue = Ltrue
-    x.Lfalse = Lfalse
+    x.setLtrue(Ltrue)
+    x.setLfalse(Lfalse)
     x
   }
 
@@ -58,8 +58,8 @@ package object lir {
 
     val x = new SwitchX()
     setChildren(x, c)
-    x.Ldefault = Ldefault
-    x.Lcases = cases.toArray
+    x.setLdefault(Ldefault)
+    x.setLcases(cases)
     x
   }
 
@@ -67,7 +67,7 @@ package object lir {
     assert(L != null)
     val x = new GotoX
     x.setArity(0)
-    x.L = L
+    x.setL(L)
     x
   }
 


### PR DESCRIPTION
I need this for upcoming improvements to SplitMethod.

Summary:
 - add Block.replace
 - have Block track uses
 - makes SimplifyControl simpler
 - Method.findBlocks prunes dead uses
