### PR TITLE
Fix Memory Leak in ExportBgen

### DIFF
--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -324,7 +324,7 @@ object ExportBGEN {
 
     val d = digitsNeeded(mv.rvd.getNumPartitions)
 
-    val (files, droppedPerPart) = mv.rvd.crdd.mapPartitionsWithIndex { case (i: Int, it: Iterator[Long]) =>
+    val (files, droppedPerPart) = mv.rvd.crdd.boundary.mapPartitionsWithIndex { case (i: Int, it: Iterator[Long]) =>
       val context = TaskContext.get
       val pf =
         parallelOutputPath + "/" +


### PR DESCRIPTION
CHANGELOG: Fix memory leak in ExportBgen

If you look a dozen or so lines under the `boundary` I added, you'll see a :

```
        it.foreach { ptr =>
          val (b, d) = bpw.emitVariant(ptr)
          out.write(b)
          dropped += d
        }
```

So that thing is stepping through the iterator without freeing. The `boundary` is to do a `clear` after each read from the `it`. 