### PR TITLE
[query][bugfix] don't prune all streams in zip if none of them are used

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -969,16 +969,21 @@ object PruneDeadFields {
         val valueTypes = names.zip(as).map { case (name, a) =>
           bodyEnv.eval.lookupOption(name).map(ab => unifySeq(coerce[TStream](a.typ).elementType, ab.result()))
         }
-        unifyEnvs(
-          as.zip(valueTypes).map { case (a, vtOption) =>
-            val at = coerce[TStream](a.typ)
-            if (behavior == ArrayZipBehavior.AssumeSameLength) {
-              vtOption.map { vt =>
-                memoizeValueIR(a, TStream(vt), memo)
-              }.getOrElse(BindingEnv.empty)
-            } else
-              memoizeValueIR(a, TStream(vtOption.getOrElse(minimal(at.elementType))), memo)
-          } ++ Array(bodyEnv.deleteEval(names)): _*)
+        if (behavior == ArrayZipBehavior.AssumeSameLength && valueTypes.forall(_.isEmpty)) {
+          unifyEnvs(memoizeValueIR(as.head, TStream(minimal(coerce[TStream](as.head.typ).elementType)), memo) +:
+            Array(bodyEnv.deleteEval(names)): _*)
+        } else {
+          unifyEnvs(
+            as.zip(valueTypes).map { case (a, vtOption) =>
+              val at = coerce[TStream](a.typ)
+              if (behavior == ArrayZipBehavior.AssumeSameLength) {
+                vtOption.map { vt =>
+                  memoizeValueIR(a, TStream(vt), memo)
+                }.getOrElse(BindingEnv.empty)
+              } else
+                memoizeValueIR(a, TStream(vtOption.getOrElse(minimal(at.elementType))), memo)
+            } ++ Array(bodyEnv.deleteEval(names)): _*)
+        }
       case StreamFilter(a, name, cond) =>
         val aType = a.typ.asInstanceOf[TStream]
         val bodyEnv = memoizeValueIR(cond, cond.typ, memo)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3702,4 +3702,19 @@ class IRSuite extends HailSuite {
     assertNumDistinct(flatten(selfZip(stream, 2)), 10)
     assertNumDistinct(bindIR(ToArray(stream))(a => selfZip(ToStream(a), 2)), 5)
   }
+
+  @Test def testZipDoesntPruneLengthInfo(): Unit = {
+    for (behavior <- Array(ArrayZipBehavior.AssumeSameLength,
+      ArrayZipBehavior.AssertSameLength,
+      ArrayZipBehavior.TakeMinLength,
+      ArrayZipBehavior.ExtendNA)) {
+      val zip = StreamZip(
+        FastIndexedSeq(StreamRange(0, 10, 1), StreamRange(0, 10, 1)),
+        FastIndexedSeq("x", "y"),
+        makestruct("x" -> Str("foo"), "y" -> Str("bar")),
+        behavior)
+
+      assertEvalsTo(ToArray(zip), Array.fill(10)(Row("foo", "bar")).toFastIndexedSeq)
+    }
+  }
 }


### PR DESCRIPTION
if we're zipping two streams and neither of them is referenced in the zip body, the pruner removes both streams in the AssumeSameLength case.