### PR TITLE
[query] fix bug in LoweredTableReader

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -12,8 +12,8 @@ object AggSignature {
       AggSignature(Collect(), FastSeq(), FastSeq(requestedType.asInstanceOf[TArray].elementType))
     case AggSignature(Take(), Seq(n), Seq(_)) =>
       AggSignature(Take(), FastSeq(n), FastSeq(requestedType.asInstanceOf[TArray].elementType))
-    case AggSignature(TakeBy(), Seq(n), Seq(_, k)) =>
-      AggSignature(TakeBy(), FastSeq(n), FastSeq(requestedType.asInstanceOf[TArray].elementType, k))
+    case AggSignature(TakeBy(reverse), Seq(n), Seq(_, k)) =>
+      AggSignature(TakeBy(reverse), FastSeq(n), FastSeq(requestedType.asInstanceOf[TArray].elementType, k))
     case AggSignature(PrevNonnull(), Seq(), Seq(_)) =>
       AggSignature(PrevNonnull(), FastSeq(), FastSeq(requestedType))
     case _ => agg
@@ -42,7 +42,7 @@ final case class Min() extends AggOp
 final case class Product() extends AggOp
 final case class Sum() extends AggOp
 final case class Take() extends AggOp
-final case class TakeBy() extends AggOp
+final case class TakeBy(so: SortOrder = Ascending) extends AggOp
 final case class Group() extends AggOp
 final case class AggElements() extends AggOp
 final case class AggElementsLengthCheck() extends AggOp

--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -89,7 +89,7 @@ object ContainsAggIntermediate {
 
 object AggIsCommutative {
   def apply(op: AggOp): Boolean = op match {
-    case Take() | Collect() | PrevNonnull() | TakeBy() => false
+    case Take() | Collect() | PrevNonnull() | TakeBy(_) => false
     case _ => true
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -621,7 +621,7 @@ object IRParser {
       case "TakeByStateSig" =>
         val vt = ptype_expr(env)(it)
         val kt = ptype_expr(env)(it)
-        TakeByStateSig(vt, kt)
+        TakeByStateSig(vt, kt, Ascending)
       case "CollectStateSig" =>
         val pt = ptype_expr(env)(it)
         CollectStateSig(pt)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -153,7 +153,7 @@ object LoweredTableReader {
       FastIndexedSeq(TInt32),
       FastIndexedSeq(keyType, keyType))
 
-    val maxkey = AggSignature(TakeBy(),
+    val maxkey = AggSignature(TakeBy(Descending),
       FastIndexedSeq(TInt32),
       FastIndexedSeq(keyType, keyType))
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -315,7 +315,6 @@ class Aggregators2Suite extends HailSuite {
         perm <- permutations;
         so <- FastIndexedSeq(Ascending, Descending)
     ) {
-      println(s"take $n, reverse=$so")
       test(n, perm, t, identity[IR], identity[Row], TInt32, GetField(_, "b"), so)
     }
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -265,6 +265,8 @@ class Aggregators2Suite extends HailSuite {
       Row(null, null, null, null, null, null, null, null)
     )
 
+    val rowsReversed = rows.take(rows.length - 3).reverse ++ rows.takeRight(3)
+
     val permutations = Array(
       rows, // sorted
       rows.reverse, // reversed
@@ -292,9 +294,9 @@ class Aggregators2Suite extends HailSuite {
       (TStruct("x" -> TInt32, "y" -> TInt64), GetField(_, "a"))
     )
 
-    def test(n: Int, data: IndexedSeq[Row], valueType: Type, valueF: IR => IR, resultF: Row => Any, keyType: Type, keyF: IR => IR): Unit = {
+    def test(n: Int, data: IndexedSeq[Row], valueType: Type, valueF: IR => IR, resultF: Row => Any, keyType: Type, keyF: IR => IR, so: SortOrder = Ascending): Unit = {
 
-      val aggSig = PhysicalAggSig(TakeBy(), TakeByStateSig(PType.canonical(valueType), PType.canonical(keyType)))
+      val aggSig = PhysicalAggSig(TakeBy(), TakeByStateSig(PType.canonical(valueType), PType.canonical(keyType), so))
       val seqOpArgs = Array.tabulate(rows.length) { i =>
         val ref = ArrayRef(Ref("rows", TArray(t)), i)
         FastIndexedSeq[IR](valueF(ref), keyF(ref))
@@ -303,16 +305,18 @@ class Aggregators2Suite extends HailSuite {
       assertAggEquals(aggSig,
         FastIndexedSeq(I32(n)),
         seqOpArgs,
-        expected = rows.take(n).map(resultF),
+        expected = (if (so == Descending) rowsReversed else rows).take(n).map(resultF),
         args = FastIndexedSeq(("rows", (TArray(t), data))))
     }
 
     // test counts and data input orderings
     for (
       n <- FastIndexedSeq(0, 1, 4, 100);
-        perm <- permutations
+        perm <- permutations;
+        so <- FastIndexedSeq(Ascending, Descending)
     ) {
-      test(n, perm, t, identity[IR], identity[Row], TInt32, GetField(_, "b"))
+      println(s"take $n, reverse=$so")
+      test(n, perm, t, identity[IR], identity[Row], TInt32, GetField(_, "b"), so)
     }
 
     // test key and value types
@@ -329,7 +333,7 @@ class Aggregators2Suite extends HailSuite {
     // test GC behavior by passing a large collection
     val rows2 = Array.tabulate(1200)(i => Row(i, i.toString)).toFastIndexedSeq
     val t2 = TStruct("a" -> TInt32, "b" -> TString)
-    val aggSig2 = PhysicalAggSig(TakeBy(), TakeByStateSig(PType.canonical(t2), PType.canonical(TInt32)))
+    val aggSig2 = PhysicalAggSig(TakeBy(), TakeByStateSig(PType.canonical(t2), PType.canonical(TInt32), Ascending))
     val seqOpArgs2 = Array.tabulate(rows2.length)(i => FastIndexedSeq[IR](
       ArrayRef(Ref("rows", TArray(t2)), i), GetField(ArrayRef(Ref("rows", TArray(t2)), i), "a")))
 

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -360,6 +360,15 @@ class TableIRSuite extends HailSuite {
     assertEvalsTo(joined, Row(expected.filter(pred).map(joinProjectF).toFastIndexedSeq, Row()))
   }
 
+  // Catches a bug in the partitioner created by the importer.
+  @Test def testTableJoinOfImport() {
+    val mt = importVCF(ctx, "src/test/resources/sample.vcf")
+    var t: TableIR = MatrixRowsTable(mt)
+    t = TableMapRows(t, SelectFields(Ref("row", t.typ.rowType), Seq("locus", "alleles")))
+    val join: TableIR = TableJoin(t, t, "inner", 2)
+    assertEvalsTo(TableCount(join), 346L)
+  }
+
   @Test def testTableKeyBy() {
     implicit val execStrats = ExecStrategy.interpretOnly
     val data = Array(Array("A", 1), Array("A", 2), Array("B", 1))


### PR DESCRIPTION
`LoweredTableReader.makeCoercer` was using the same aggregator to find both the min and max keys in a partition, hence creating degenerate partitioners. This manifested in incorrect results in joins. This PR fixes it by adding a `SortOrder` option to the `TakeBy` aggregator, and using a descending `TakeBy` to compute the max key.