### PR TITLE
Fix link to Hail 0.1 docs

### DIFF
--- a/hail/python/hail/docs/index.rst
+++ b/hail/python/hail/docs/index.rst
@@ -36,7 +36,7 @@ Indices and tables
 
 * :ref:`genindex`
 
-If you would like to refer to our Hail v0.1 (deprecated) docs, please view `Hail 0.1 docs <docs/0.1/index.html>`_
+If you would like to refer to our Hail v0.1 (deprecated) docs, please view `Hail 0.1 docs </docs/0.1/index.html>`_
 
 
 


### PR DESCRIPTION
Currently, the link to Hail 0.1 docs at the bottom of https://hail.is/docs/0.2/index.html links to https://hail.is/docs/0.2/docs/0.1/index.html. This changes it to https://hail.is/docs/0.1/index.html.