### PR TITLE
[query] Fix bug in linreg aggregator when n == 0

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1019,6 +1019,15 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(r.multiple_p_value, 0.56671386)
         self.assertAlmostEqual(r.n, 5)
 
+    def test_linreg_no_data(self):
+        ht = hl.utils.range_table(1).filter(False)
+        r = ht.aggregate(hl.agg.linreg(ht.idx, 0))
+        for k, v in r.items():
+            if k == 'n':
+                assert v == 0
+            else:
+                assert v is None, k
+
     def test_aggregator_downsample(self):
         xs = [2, 6, 4, 9, 1, 8, 5, 10, 3, 7]
         ys = [2, 6, 4, 9, 1, 8, 5, 10, 3, 7]

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -13,7 +13,8 @@ object LinearRegressionAggregator {
   val vector = PCanonicalArray(scalar, true)
   val stateType: PCanonicalTuple = PCanonicalTuple(true, vector, vector, PInt32(true))
 
-  def resultType: PCanonicalStruct = PCanonicalStruct(required = true, "xty" -> vector, "beta" -> vector, "diag_inv" -> vector, "beta0" -> vector)
+  private val optVector = vector.setRequired(false)
+  def resultType: PCanonicalStruct = PCanonicalStruct(required = true, "xty" -> optVector, "beta" -> optVector, "diag_inv" -> optVector, "beta0" -> optVector)
 
   def computeResult(region: Region, xtyPtr: Long, xtxPtr: Long, k0: Int): Long = {
     val xty = DenseVector(UnsafeRow.readArray(vector, null, xtyPtr)


### PR DESCRIPTION
CHANGELOG: Fix crash when using `hl.agg.linreg` with no aggregated data.