### PR TITLE
[query] Refactor LoweringPipeline so that optimization is a pass

### DIFF
--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -74,7 +74,7 @@ class LocalBackend(
   def stop(): Unit = LocalBackend.stop()
 
   private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir0: IR, print: Option[PrintWriter] = None): (PTuple, Long) = {
-    val ir = LoweringPipeline.darrayLowerer(DArrayLowering.All).apply(ctx, ir0, optimize = true).asInstanceOf[IR]
+    val ir = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, ir0).asInstanceOf[IR]
 
     if (!Compilable(ir))
       throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -279,7 +279,7 @@ class ServiceBackend() extends Backend {
         ctx.backendContext = new ServiceBackendContext(username, sessionID, billingProject, bucket)
 
         var x = IRParser.parse_value_ir(ctx, code)
-        x = LoweringPipeline.darrayLowerer(DArrayLowering.All).apply(ctx, x, optimize = true)
+        x = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, x)
           .asInstanceOf[IR]
         val (pt, f) = Compile[AsmFunction1RegionLong](ctx,
           FastIndexedSeq[(String, PType)](),

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -269,7 +269,7 @@ class SparkBackend(
       case (false, true) => DArrayLowering.BMOnly
       case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
     }
-    val ir = LoweringPipeline.darrayLowerer(typesToLower).apply(ctx, ir0, optimize).asInstanceOf[IR]
+    val ir = LoweringPipeline.darrayLowerer(true)(typesToLower).apply(ctx, ir0).asInstanceOf[IR]
 
     if (!Compilable(ir))
       throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -40,7 +40,7 @@ object Compile {
     ir = Subst(ir, BindingEnv(params
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t), i)) => e.bind(n, In(i, t)) }))
-    ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
+    ir = LoweringPipeline.compileLowerer(optimize).apply(ctx, ir).asInstanceOf[IR].noSharing
 
     TypeCheck(ir, BindingEnv.empty)
     InferPType(ir)
@@ -101,7 +101,7 @@ object CompileWithAggregators2 {
     ir = Subst(ir, BindingEnv(params
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t), i)) => e.bind(n, In(i, t)) }))
-    ir = LoweringPipeline.compileLowerer.apply(ctx, ir, optimize).asInstanceOf[IR].noSharing
+    ir = LoweringPipeline.compileLowerer(optimize).apply(ctx, ir).asInstanceOf[IR].noSharing
 
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](params.map { case (name, t) => name -> t.virtualType })))
 

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -25,7 +25,7 @@ object CompileAndEvaluate {
     ir0: IR,
     optimize: Boolean = true
   ): Either[Unit, (PTuple, Long)] = {
-    val ir = LoweringPipeline.relationalLowerer.apply(ctx, ir0, optimize).asInstanceOf[IR]
+    val ir = LoweringPipeline.relationalLowerer(optimize).apply(ctx, ir0).asInstanceOf[IR]
 
     if (ir.typ == TVoid)
       // void is not really supported by IR utilities

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -19,17 +19,17 @@ object Interpret {
     apply(tir, ctx, optimize = true)
 
   def apply(tir: TableIR, ctx: ExecuteContext, optimize: Boolean): TableValue = {
-    val lowered = LoweringPipeline.legacyRelationalLowerer(ctx, tir, optimize).asInstanceOf[TableIR]
+    val lowered = LoweringPipeline.legacyRelationalLowerer(optimize)(ctx, tir).asInstanceOf[TableIR]
     lowered.execute(ctx)
   }
 
   def apply(mir: MatrixIR, ctx: ExecuteContext, optimize: Boolean): TableValue = {
-    val lowered = LoweringPipeline.legacyRelationalLowerer(ctx, mir, optimize).asInstanceOf[TableIR]
+    val lowered = LoweringPipeline.legacyRelationalLowerer(optimize)(ctx, mir).asInstanceOf[TableIR]
     lowered.execute(ctx)
   }
 
   def apply(bmir: BlockMatrixIR, ctx: ExecuteContext, optimize: Boolean): BlockMatrix = {
-    val lowered = LoweringPipeline.legacyRelationalLowerer(ctx, bmir, optimize).asInstanceOf[BlockMatrixIR]
+    val lowered = LoweringPipeline.legacyRelationalLowerer(optimize)(ctx, bmir).asInstanceOf[BlockMatrixIR]
     lowered.execute(ctx)
   }
 
@@ -43,7 +43,7 @@ object Interpret {
   ): T = {
     val rwIR = env.m.foldLeft[IR](ir0) { case (acc, (k, (value, t))) => Let(k, Literal.coerce(t, value), acc) }
 
-    val lowered = LoweringPipeline.relationalLowerer.apply(ctx, rwIR, optimize).asInstanceOf[IR]
+    val lowered = LoweringPipeline.relationalLowerer(optimize).apply(ctx, rwIR).asInstanceOf[IR]
 
     val result = run(ctx, lowered, Env.empty[Any], args, Memo.empty).asInstanceOf[T]
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -21,6 +21,12 @@ trait LoweringPass {
   protected def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR
 }
 
+case class OptimizePass(context: String) extends LoweringPass {
+  val before: IRState = AnyIR
+  val after: IRState = AnyIR
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ir, true, context, ctx)
+}
+
 case object LowerMatrixToTablePass extends LoweringPass {
   val before: IRState = AnyIR
   val after: IRState = MatrixLoweredToTable

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -535,7 +535,7 @@ class EmitStreamSuite extends HailSuite {
 
   @Test def testEmitAggScan() {
     def assertAggScan(ir: IR, inType: Type, tests: (Any, Any)*): Unit = {
-      val aggregate = compileStream(LoweringPipeline.compileLowerer.apply(ctx, ir, false).asInstanceOf[IR],
+      val aggregate = compileStream(LoweringPipeline.compileLowerer(false).apply(ctx, ir).asInstanceOf[IR],
         PType.canonical(inType))
       for ((inp, expected) <- tests)
         assert(aggregate(inp) == expected, Pretty(ir))

--- a/hail/src/test/scala/is/hail/expr/ir/LoweringPipelineSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LoweringPipelineSuite.scala
@@ -1,0 +1,12 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import is.hail.expr.ir.lowering.{LowerMatrixToTablePass, LoweringPipeline, OptimizePass}
+import org.testng.annotations.Test
+
+class LoweringPipelineSuite extends HailSuite {
+  @Test def testNoOpt(): Unit = {
+    val lp = LoweringPipeline(LowerMatrixToTablePass, OptimizePass("foo"), OptimizePass("bar"))
+    assert(lp.noOptimization() == LoweringPipeline(LowerMatrixToTablePass))
+  }
+}


### PR DESCRIPTION
I need this for TableAggregate work, but think this is a good change regardless.