### PR TITLE
[query] pass ci argument to faf, fixes #8945

### DIFF
--- a/hail/src/main/scala/is/hail/experimental/package.scala
+++ b/hail/src/main/scala/is/hail/experimental/package.scala
@@ -25,7 +25,7 @@ package object experimental {
       val root = uniroot(f, lower, upper, tol)
       val rounder = 1d / (precision / 100d)
       var max_af = math.round(root.getOrElse(0.0) * rounder) / rounder
-      while (findMaxAC(max_af, an) < ac) {
+      while (findMaxAC(max_af, an, ci) < ac) {
         max_af += precision
       }
       max_af - precision


### PR DESCRIPTION
CHANGELOG: fixes bug where ci parameter is not passed through experimental.filtering_allele_frequency

fixes #8945