### PR TITLE
[query] Fix PCanonicalIntervalValue loadStart and loadEnd

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -82,12 +82,12 @@ class PCanonicalIntervalSettable(
   def loadStart(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.startDefined(a)),
-      pt.pointType.load(pt.loadStart(a)))
+      pt.pointType.load(pt.startOffset(a)))
 
   def loadEnd(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.endDefined(a)),
-      pt.pointType.load(pt.loadEnd(a)))
+      pt.pointType.load(pt.endOffset(a)))
 
   def store(pc: PCode): Code[Unit] = {
     Code(


### PR DESCRIPTION
Struct's loadField has been changed to load the address directly in the
case of the field being a collection type. PCanonicalIntervalValue was
using loadStart and loadEnd rather than startOffset and endOffset which
caused addresses to be loaded twice in the case of intervals of
collections, leading to segfaults.

This code is currently unused, but will be used in EmitCodeOrdering #8725 