### PR TITLE
[query] add StreamMultiMerge and StreamZipJoin nodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -98,7 +98,11 @@ object Children {
     case StreamMerge(l, r, _) =>
       Array(l, r)
     case StreamZip(as, names, body, _) =>
-      as ++ Array(body)
+      as :+ body
+    case StreamZipJoin(as, _) =>
+      as
+    case StreamMultiMerge(as, _) =>
+      as
     case StreamFilter(a, name, cond) =>
       Array(a, cond)
     case StreamFlatMap(a, name, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -161,6 +161,12 @@ object Copy {
       case StreamZip(_, names, _, behavior) =>
         assert(newChildren.length == names.length + 1)
         StreamZip(newChildren.init.asInstanceOf[IndexedSeq[IR]], names, newChildren(names.length).asInstanceOf[IR], behavior)
+      case StreamZipJoin(as, key) =>
+        assert(newChildren.length == as.length)
+        StreamZipJoin(newChildren.asInstanceOf[IndexedSeq[IR]], key)
+      case StreamMultiMerge(as, key) =>
+        assert(newChildren.length == as.length)
+        StreamMultiMerge(newChildren.asInstanceOf[IndexedSeq[IR]], key)
       case StreamFilter(_, name, _) =>
         assert(newChildren.length == 2)
         StreamFilter(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -346,6 +346,9 @@ case class EmitCode(setup: Code[Unit], m: Code[Boolean], pv: PCode) {
       cb.goto(eci.Lmissing)
       eci
     }
+
+  def get(): PCode =
+    PCode(pv.pt, Code(setup, m.orEmpty(Code._fatal[Unit]("expected non-missing")), pv.code))
 }
 
 abstract class EmitSettable extends EmitValue {

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -263,6 +263,14 @@ final case class StreamZip(as: IndexedSeq[IR], names: IndexedSeq[String], body: 
   lazy val nameIdx: Map[String, Int] = names.zipWithIndex.toMap
   override def typ: TStream = coerce[TStream](super.typ)
 }
+final case class StreamMultiMerge(as: IndexedSeq[IR], key: IndexedSeq[String]) extends IR {
+  override def typ: TStream = coerce[TStream](super.typ)
+  override def pType: PStream = coerce[PStream](super.pType)
+}
+final case class StreamZipJoin(as: IndexedSeq[IR], key: IndexedSeq[String]) extends IR {
+  override def typ: TStream = coerce[TStream](super.typ)
+  override def pType: PStream = coerce[PStream](super.pType)
+}
 final case class StreamFilter(a: IR, name: String, cond: IR) extends IR {
   override def typ: TStream = coerce[TStream](super.typ)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -170,6 +170,25 @@ object InferPType {
         PCanonicalStream(getCompatiblePType(Seq(leftEltType, rightEltType), r.elementType), r.required)
       case StreamZip(as, names, body, behavior) =>
         PCanonicalStream(body.pType, requiredness(node).required)
+      case StreamZipJoin(as, _) =>
+        val r = requiredness(node).asInstanceOf[RIterable]
+        val rEltType = r.elementType.asInstanceOf[RIterable]
+        val eltTypes = as.map(_.pType.asInstanceOf[PStream].elementType)
+        assert(eltTypes.forall(_.required))
+        assert(rEltType.required)
+        PCanonicalStream(
+          PCanonicalArray(
+            getCompatiblePType(eltTypes, rEltType.elementType).setRequired(rEltType.elementType.required),
+            required = rEltType.required),
+          r.required)
+      case StreamMultiMerge(as, _) =>
+        val r = coerce[RIterable](requiredness(node))
+        val eltTypes = as.map(_.pType.asInstanceOf[PStream].elementType)
+        assert(eltTypes.forall(_.required))
+        assert(r.elementType.required)
+        PCanonicalStream(
+          getCompatiblePType(as.map(_.pType.asInstanceOf[PStream].elementType), r.elementType),
+          r.required)
       case StreamFilter(a, name, cond) => a.pType
       case StreamFlatMap(a, name, body) =>
         PCanonicalStream(coerce[PIterable](body.pType).elementType, requiredness(node).required)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -116,6 +116,10 @@ object InferType {
         l.typ
       case StreamZip(as, _, body, _) =>
         TStream(body.typ)
+      case StreamZipJoin(as, _) =>
+        TStream(TArray(coerce[TStream](as.head.typ).elementType))
+      case StreamMultiMerge(as, _) =>
+        TStream(coerce[TStream](as.head.typ).elementType)
       case StreamFilter(a, name, cond) =>
         a.typ
       case StreamFlatMap(a, name, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -476,6 +476,91 @@ object Interpret {
             interpret(body, e, args)
           }
         }
+      case StreamMultiMerge(as, key) =>
+        val streams = as.map(interpret(_, env, args).asInstanceOf[IndexedSeq[Row]])
+        val k = as.length
+        val tournament = Array.fill[Int](k)(-1)
+        val structType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
+        val (kType, getKey) = structType.select(key)
+        val heads = Array.fill[Int](k)(-1)
+        val ordering = kType.ordering.toOrdering.on[Row](getKey)
+
+        def get(i: Int): Row = streams(i)(heads(i))
+        def lt(li: Int, lv: Row, ri: Int, rv: Row): Boolean = {
+          val c = ordering.compare(lv, rv)
+          c < 0 || (c == 0 && li < ri)
+        }
+
+        def advance(i: Int) {
+          heads(i) += 1
+          var winner = if (heads(i) < streams(i).length) i else k
+          var j = (i + k) / 2
+          while (j != 0 && tournament(j) != -1) {
+            val challenger = tournament(j)
+            if (challenger != k && (winner == k || lt(j, get(challenger), i, get(winner)))) {
+              tournament(j) = winner
+              winner = challenger
+            }
+            j = j / 2
+          }
+          tournament(j) = winner
+        }
+
+        for (i <- 0 until k) { advance(i) }
+
+        val builder = new ArrayBuilder[Row]()
+        while (tournament(0) != k) {
+          val i = tournament(0)
+          val elt = streams(i)(heads(i))
+          advance(i)
+          builder += elt
+        }
+        builder.result().toFastIndexedSeq
+      case StreamZipJoin(as, key) =>
+        val streams = as.map(interpret(_, env, args).asInstanceOf[IndexedSeq[Row]])
+        val k = as.length
+        val tournament = Array.fill[Int](k)(-1)
+        val structType = coerce[TStruct](coerce[TStream](as.head.typ).elementType)
+        val (kType, getKey) = structType.select(key)
+        val heads = Array.fill[Int](k)(-1)
+        val ordering = kType.ordering.toOrdering.on[Row](getKey)
+        val hasKey = TBaseStruct.getJoinOrdering(kType.types).equivNonnull _
+
+        def get(i: Int): Row = streams(i)(heads(i))
+
+        def advance(i: Int) {
+          heads(i) += 1
+          var winner = if (heads(i) < streams(i).length) i else k
+          var j = (i + k) / 2
+          while (j != 0 && tournament(j) != -1) {
+            val challenger = tournament(j)
+            if (challenger != k && (winner == k || ordering.lteq(get(challenger), get(winner)))) {
+              tournament(j) = winner
+              winner = challenger
+            }
+            j = j / 2
+          }
+          tournament(j) = winner
+        }
+
+        for (i <- 0 until k) { advance(i) }
+
+        val builder = new ArrayBuilder[IndexedSeq[Row]]()
+        while (tournament(0) != k) {
+          val i = tournament(0)
+          val elt = Array.fill[Row](k)(null)
+          elt(i) = streams(i)(heads(i))
+          val curKey = getKey(elt(i))
+          advance(i)
+          var j = tournament(0)
+          while (j != k && hasKey(getKey(get(j)), curKey)) {
+            elt(j) = streams(j)(heads(j))
+            advance(j)
+            j = tournament(0)
+          }
+          builder += elt
+        }
+        builder.result().toFastIndexedSeq
       case StreamFilter(a, name, cond) =>
         val aValue = interpret(a, env, args)
         if (aValue == null)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -274,6 +274,8 @@ object Pretty {
               case ArrayZipBehavior.ExtendNA => "ExtendNA"
               case ArrayZipBehavior.AssumeSameLength => "AssumeSameLength"
             }) + " " + prettyIdentifiers(names)
+            case StreamZipJoin(_, key) => prettyIdentifiers(key)
+            case StreamMultiMerge(_, key) => prettyIdentifiers(key)
             case StreamFilter(_, name, _) => prettyIdentifier(name)
             case StreamFlatMap(_, name, _) => prettyIdentifier(name)
             case StreamFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -486,6 +486,14 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case StreamZip(as, names, body, behavior) =>
         requiredness.union(as.forall(lookup(_).required))
         coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
+      case StreamZipJoin(as, _) =>
+        requiredness.union(as.forall(lookup(_).required))
+        val eltType = coerce[RIterable](coerce[RIterable](requiredness).elementType).elementType
+        eltType.unionFrom(as.map(lookup(_).asInstanceOf[RIterable].elementType))
+        eltType.union(false)
+      case StreamMultiMerge(as, _) =>
+        requiredness.union(as.forall(lookup(_).required))
+        coerce[RIterable](requiredness).elementType.unionFrom(as.map(a => coerce[RIterable](lookup(a)).elementType))
       case StreamFilter(a, name, cond) =>
         requiredness.unionFrom(lookup(a))
       case StreamFlatMap(a, name, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -290,6 +290,18 @@ object TypeCheck {
         assert(as.length == names.length)
         assert(x.typ.elementType == body.typ)
         assert(as.forall(_.typ.isInstanceOf[TStream]))
+      case x@StreamZipJoin(as, key) =>
+        val streamType = coerce[TStream](as.head.typ)
+        assert(as.forall(_.typ == streamType))
+        val eltType = coerce[TStruct](streamType.elementType)
+        assert(x.typ.elementType == TArray(eltType))
+        assert(key.forall(eltType.hasField))
+      case x@StreamMultiMerge(as, key) =>
+        val streamType = coerce[TStream](as.head.typ)
+        assert(as.forall(_.typ == streamType))
+        val eltType = coerce[TStruct](streamType.elementType)
+        assert(x.typ.elementType == eltType)
+        assert(key.forall(eltType.hasField))
       case x@StreamFilter(a, name, cond) =>
         assert(a.typ.asInstanceOf[TStream].elementType.isRealizable)
         assert(cond.typ == TBoolean)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -232,12 +232,11 @@ class EmitStreamSuite extends HailSuite {
   }
 
   @Test def testES2MultiZip() {
-    import scala.collection.IndexedSeq
     val f = compile3[Int, Int, Int, Unit] { (mb, n1, n2, n3) =>
       val s1 = checkedRange(0, n1, "s1", mb)
       val s2 = checkedRange(0, n2, "s2", mb)
       val s3 = checkedRange(0, n3, "s3", mb)
-      val z = Stream.multiZip(IndexedSeq(s1.stream, s2.stream, s3.stream)).asInstanceOf[Stream[IndexedSeq[Code[Int]]]]
+      val z = Stream.multiZip(IndexedSeq(s1.stream, s2.stream, s3.stream))
 
       Code(
         s1.init, s2.init, s3.init,
@@ -253,6 +252,37 @@ class EmitStreamSuite extends HailSuite {
     } {
       f(n1, n2, n3)
     }
+  }
+
+  @Test def testES2kWayMerge() {
+    def merge(k: Int) {
+      val f = compile1[Int, Unit] { (mb, _) =>
+        val ranges = Array.tabulate(k)(i => checkedRange(0 + i, 5 + i, s"s$i", mb, print = false))
+
+        val z = Stream.kWayMerge[Int](
+           mb, ranges.map(_.stream),
+           (li, lv, ri, rv) => Code.memoize(lv, "lv", rv, "rv") { (lv, rv) =>
+             lv < rv || (lv.ceq(rv) && li < ri)
+           })
+
+
+        Code(
+          Code(ranges.map(_.init)),
+          z.forEach(mb, { case (i, l) =>
+            log(const("(").concat(i.toS).concat(", ").concat(l.toS).concat(")"), enabled = false)
+          }),
+          Code(ranges.map(_.assertClosed(1))))
+      }
+      f(0)
+    }
+    for {
+      k <- 0 to 5
+    } {
+//      println(s"k = $k")
+      merge(k)
+//      println()
+    }
+
   }
 
   private def compileStream[F: TypeInfo, T](

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2322,6 +2322,113 @@ class IRSuite extends HailSuite {
                      joinType))
   }
 
+  @Test def testStreamZipJoin() {
+    def makeStream(a: Seq[Integer]): IR = {
+      MakeStream(
+        a.zipWithIndex.map { case (n, idx) =>
+          MakeStruct(FastSeq(
+            "k1" -> (if (n == null) NA(TInt32) else I32(n)),
+            "k2" -> Str("x"),
+            "idx" -> I32(idx)))},
+        TStream(TStruct("k1" -> TInt32, "k2" -> TString, "idx" -> TInt32)))
+    }
+
+    def zipJoin(as: IndexedSeq[Seq[Integer]], key: Int): IR = {
+      val streams = as.map(makeStream)
+      ToArray(StreamZipJoin(streams, FastIndexedSeq("k1", "k2").take(key)))
+    }
+
+    assertEvalsTo(
+      zipJoin(FastIndexedSeq(Array[Integer](0, 1, null), Array[Integer](1, 2, null)), 1),
+      FastIndexedSeq(
+        FastIndexedSeq(Row(0, "x", 0), null),
+        FastIndexedSeq(Row(1, "x", 1), Row(1, "x", 0)),
+        FastIndexedSeq(null, Row(2, "x", 1)),
+        FastIndexedSeq(Row(null, "x", 2), null),
+        FastIndexedSeq(null, Row(null, "x", 2))))
+
+    assertEvalsTo(
+      zipJoin(FastIndexedSeq(Array[Integer](0, 1), Array[Integer](1, 2), Array[Integer](0, 2)), 1),
+      FastIndexedSeq(
+        FastIndexedSeq(Row(0, "x", 0), null, Row(0, "x", 0)),
+        FastIndexedSeq(Row(1, "x", 1), Row(1, "x", 0), null),
+        FastIndexedSeq(null, Row(2, "x", 1), Row(2, "x", 1))))
+
+    assertEvalsTo(
+      zipJoin(FastIndexedSeq(Array[Integer](0, 1), Array[Integer](), Array[Integer](0, 2)), 1),
+      FastIndexedSeq(
+        FastIndexedSeq(Row(0, "x", 0), null, Row(0, "x", 0)),
+        FastIndexedSeq(Row(1, "x", 1), null, null),
+        FastIndexedSeq(null, null, Row(2, "x", 1))))
+
+    assertEvalsTo(
+      zipJoin(FastIndexedSeq(Array[Integer](), Array[Integer]()), 1),
+      FastIndexedSeq())
+
+    assertEvalsTo(
+      zipJoin(FastIndexedSeq(Array[Integer](0, 1)), 1),
+      FastIndexedSeq(
+        FastIndexedSeq(Row(0, "x", 0)),
+        FastIndexedSeq(Row(1, "x", 1))))
+  }
+
+  @Test def testStreamMultiMerge() {
+    def makeStream(a: Seq[Integer]): IR = {
+      MakeStream(
+        a.zipWithIndex.map { case (n, idx) =>
+          MakeStruct(FastSeq(
+            "k1" -> (if (n == null) NA(TInt32) else I32(n)),
+            "k2" -> Str("x"),
+            "idx" -> I32(idx)))},
+        TStream(TStruct("k1" -> TInt32, "k2" -> TString, "idx" -> TInt32)))
+    }
+
+    def merge(as: IndexedSeq[Seq[Integer]], key: Int): IR = {
+      val streams = as.map(makeStream)
+      ToArray(StreamMultiMerge(streams, FastIndexedSeq("k1", "k2").take(key)))
+    }
+
+    assertEvalsTo(
+      merge(FastIndexedSeq(Array[Integer](0, 1, null, null), Array[Integer](1, 2, null, null)), 1),
+      FastIndexedSeq(
+        Row(0, "x", 0),
+        Row(1, "x", 1),
+        Row(1, "x", 0),
+        Row(2, "x", 1),
+        Row(null, "x", 2),
+        Row(null, "x", 3),
+        Row(null, "x", 2),
+        Row(null, "x", 3)))
+
+    assertEvalsTo(
+      merge(FastIndexedSeq(Array[Integer](0, 1), Array[Integer](1, 2), Array[Integer](0, 2)), 1),
+      FastIndexedSeq(
+        Row(0, "x", 0),
+        Row(0, "x", 0),
+        Row(1, "x", 1),
+        Row(1, "x", 0),
+        Row(2, "x", 1),
+        Row(2, "x", 1)))
+
+    assertEvalsTo(
+      merge(FastIndexedSeq(Array[Integer](0, 1), Array[Integer](), Array[Integer](0, 2)), 1),
+      FastIndexedSeq(
+        Row(0, "x", 0),
+        Row(0, "x", 0),
+        Row(1, "x", 1),
+        Row(2, "x", 1)))
+
+    assertEvalsTo(
+      merge(FastIndexedSeq(Array[Integer](), Array[Integer]()), 1),
+      FastIndexedSeq())
+
+    assertEvalsTo(
+      merge(FastIndexedSeq(Array[Integer](0, 1)), 1),
+      FastIndexedSeq(
+        Row(0, "x", 0),
+        Row(1, "x", 1)))
+  }
+
   @Test def testJoinRightDistinct() {
     implicit val execStrats = ExecStrategy.javaOnly
 


### PR DESCRIPTION
This PR adds stream nodes `StreamMultiMerge` and `StreamZipJoin`, which will be used to implement `TableUnion` and `TableMultiWayZipJoin`. The two nodes were so similar, both in implementation and in interface, that I thought bundling them into one PR would actually make it *easier* to review, but I can split them up if you disagree.

The implementations of both nodes use tournament trees, a very simple data structure ideal for this problem. Think of it as a priority queue specialized to holding exactly `k` elements, so when you pop the top element, you must immediately replace it with a new value.

A tournament tree is just what it sounds like. It is a complete binary tree with `k` leaves. Conceptually, the leaves hold the current `k` elements (the heads of each of the `k` input streams), while each internal node records the result of the comparison between the "winners" of the two subtrees, where in this case the winner is the least element. Thus we can find the smallest of all `k` elements by looking at the root node.

If we remove the smallest element, and replace it with the next value from that stream, we change the value in the corresponding leaf node, then we just need to replay the comparisons at all internal nodes on the path to the root. Note that to replay a comparison, we only need to know what element *lost* at this node previously. It must have lost to the previous overall winner, the element we just replaced.

Using that observation, we only need to store the `k` current values in the `k` leaves, and in each of the `k-1` internal nodes we store the index of the element which lost the comparison at that node. That just leaves the overall winner, which we can store in a separate variable. Note that each element besides the overall winner loses exactly one "match", so the internal nodes store a permutation of the indices 0 to (k-1), minus the overall winner. This is a so-called "loser tree".

In the implementation, I store the `k` leaves in a `Array[Long]`, where each element is a pointer to the head of the corresponding stream, and I store the `k-1` internal nodes in a `Array[Int]`, in the usual breadth-first order, where each element is the index of the stream which lost the comparison at that node (had the larger value). I use an index of `-1` to represent an imaginary element smaller than all real elements, and similarly an index of `k` is larger than all real elements. The tournament tree begins filled with `-1`, and each stream is advanced once, as their values push out all the `-1`s. When a steam ends, it's leaf is given the value `k`, and once the overall winner is `k`, we know all streams have ended.