### PR TITLE
[query] fix LocalBackend.load_references_from_dataset

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -279,7 +279,7 @@ class LocalBackend(Py4JBackend):
         self._hail_package.variant.ReferenceGenome.fromJSON(json.dumps(config))
 
     def load_references_from_dataset(self, path):
-        return json.loads(self._hail_package.variant.ReferenceGenome.fromHailDataset(self.fs._jfs, path))
+        return json.loads(self._jbackend.pyLoadReferencesFromDataset(path))
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
         self._jbackend.pyFromFASTAFile(

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -204,4 +204,7 @@ class LocalBackend(
     // Use a local sort for the moment to enable larger pipelines to run
     LowerDistributedSort.localSort(ctx, stage, sortFields)
   }
+
+  def pyLoadReferencesFromDataset(path: String): String =
+    ReferenceGenome.fromHailDataset(fs, path)
 }


### PR DESCRIPTION
LocalBackend uses LocalFS. LocalFS doesn't have a Java analog or a _jfs field.