### PR TITLE
[query] Solve recursive LowerToCDA issue

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -3,6 +3,7 @@ package is.hail.backend
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.{ExecuteContext, SortField}
 import is.hail.expr.ir.lowering.TableStage
+import is.hail.types.virtual.Type
 import is.hail.utils._
 
 import scala.reflect.ClassTag
@@ -23,6 +24,6 @@ abstract class Backend {
   def asSpark(op: String): SparkBackend =
     fatal(s"${ getClass.getSimpleName }: $op requires SparkBackend")
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage
+  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Seq[(String, Type)]): TableStage
 }
 

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -11,6 +11,8 @@ import is.hail.expr.ir.lowering._
 import is.hail.expr.ir._
 import is.hail.types.physical.{PTuple, PType, PVoid}
 import is.hail.types.virtual.TVoid
+import is.hail.types.physical.{PTuple, PType}
+import is.hail.types.virtual.{TVoid, Type}
 import is.hail.backend.{Backend, BackendContext, BroadcastValue}
 import is.hail.io.fs.{FS, HadoopFS}
 import is.hail.utils._
@@ -220,9 +222,9 @@ class LocalBackend(
     }
   }
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage = {
+  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Seq[(String, Type)]): TableStage = {
     // Use a local sort for the moment to enable larger pipelines to run
-    LowerDistributedSort.localSort(ctx, stage, sortFields)
+    LowerDistributedSort.localSort(ctx, stage, sortFields, relationalLetsAbove)
   }
 
   def pyLoadReferencesFromDataset(path: String): String =

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -11,6 +11,7 @@ import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, MakeTuple, SortFi
 import is.hail.types.physical.{PBaseStruct, PType}
 import is.hail.io.fs.{FS, GoogleStorageFS}
 import is.hail.services.batch_client.BatchClient
+import is.hail.types.virtual.Type
 import is.hail.utils._
 import org.apache.commons.io.IOUtils
 import org.apache.log4j.LogManager
@@ -297,8 +298,8 @@ class ServiceBackend() extends Backend {
     }
   }
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage = {
+  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Seq[(String, Type)]): TableStage = {
     // Use a local sort for the moment to enable larger pipelines to run
-    LowerDistributedSort.localSort(ctx, stage, sortFields)
+    LowerDistributedSort.localSort(ctx, stage, sortFields, relationalLetsAbove)
   }
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -11,7 +11,7 @@ import is.hail.expr.{JSONAnnotationImpex, SparkAnnotationImpex, Validate}
 import is.hail.expr.ir.lowering._
 import is.hail.expr.ir._
 import is.hail.types.physical.{PStruct, PTuple, PType}
-import is.hail.types.virtual.{TStruct, TVoid}
+import is.hail.types.virtual.{TStruct, TVoid, Type}
 import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
 import is.hail.io.fs.{HadoopFS}
 import is.hail.utils._
@@ -528,9 +528,9 @@ class SparkBackend(
     }
   }
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage = {
+  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Seq[(String, Type)]): TableStage = {
     // Use a local sort for the moment to enable larger pipelines to run
-    LowerDistributedSort.localSort(ctx, stage, sortFields)
+    LowerDistributedSort.localSort(ctx, stage, sortFields, relationalLetsAbove)
   }
 
   def pyImportFam(path: String, isQuantPheno: Boolean, delimiter: String, missingValue: String): String =

--- a/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
@@ -1,0 +1,43 @@
+package is.hail.expr.ir
+
+import is.hail.utils.ArrayBuilder
+
+object LiftRelationalValues {
+
+  def apply(ir0: IR): IR = {
+
+    def rewrite(ir: BaseIR, ab: ArrayBuilder[(String, IR)]): BaseIR = ir match {
+      case LiftMeOut(child) =>
+        val ref = RelationalRef(genUID(), child.typ)
+        val newChild = rewrite(child, ab).asInstanceOf[IR]
+        ab += ((ref.name, newChild))
+        ref
+      case _: TableAggregate
+           | _: TableCount
+           | _: TableToValueApply
+           | _: BlockMatrixToValueApply
+           | _: TableCollect
+           | _: BlockMatrixCollect
+           | _: TableGetGlobals =>
+        val ref = RelationalRef(genUID(), ir.asInstanceOf[IR].typ)
+        val rwChildren = ir.children.map(rewrite(_, ab))
+        val newChild = if ((rwChildren, ir.children).zipped.forall(_ eq _))
+          ir
+        else
+          ir.copy(rwChildren)
+        ab += ((ref.name, newChild.asInstanceOf[IR]))
+        ref
+      case x =>
+        val rwChildren = x.children.map(rewrite(_, ab))
+        if ((rwChildren, ir.children).zipped.forall(_ eq _))
+          ir
+        else
+          ir.copy(rwChildren)
+    }
+
+    val ab = new ArrayBuilder[(String, IR)]
+    val rw = rewrite(ir0, ab).asInstanceOf[IR]
+    ab.result().foldRight[IR](rw) { case ((name, value), acc) => RelationalLet(name, value, acc)
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -4,15 +4,15 @@ import is.hail.annotations.{Annotation, ExtendedOrdering, Region, SafeRow, Unsaf
 import is.hail.asm4s.{AsmFunction1RegionLong, LongInfo, classInfo}
 import is.hail.expr.ir._
 import is.hail.types.physical.{PArray, PStruct, PTuple}
-import is.hail.types.virtual.TStruct
+import is.hail.types.virtual.{TStruct, Type}
 import is.hail.rvd.RVDPartitioner
 import is.hail.utils._
 import org.apache.spark.sql.Row
 
 object LowerDistributedSort {
-  def localSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField]): TableStage = {
+  def localSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Seq[(String, Type)]): TableStage = {
     val numPartitions = stage.partitioner.numPartitions
-    val collected = stage.collectWithGlobals()
+    val collected = stage.collectWithGlobals(relationalLetsAbove)
 
     val (resultPType: PStruct, f) = ctx.timer.time("LowerDistributedSort.localSort.compile")(Compile[AsmFunction1RegionLong](ctx,
       FastIndexedSeq(),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -151,28 +151,29 @@ class TableStage(
       globals = globalsRef)
   }
 
-  def mapCollect(f: IR => IR): IR = {
-    mapCollectWithGlobals(f) { (parts, globals) => parts }
+  def mapCollect(bindings: Seq[(String, Type)])(f: IR => IR): IR = {
+    mapCollectWithGlobals(bindings)(f) { (parts, globals) => parts }
   }
 
-  def mapCollectWithGlobals(mapF: IR => IR)(body: (IR, IR) => IR): IR =
-    mapCollectWithContextsAndGlobals((part, ctx) => mapF(part))(body)
+  def mapCollectWithGlobals(bindings: Seq[(String, Type)])(mapF: IR => IR)(body: (IR, IR) => IR): IR =
+    mapCollectWithContextsAndGlobals(bindings)((part, ctx) => mapF(part))(body)
 
-  def mapCollectWithContextsAndGlobals(mapF: (IR, Ref) => IR)(body: (IR, IR) => IR): IR = {
-    val broadcastRefs = MakeStruct(broadcastVals)
+  def mapCollectWithContextsAndGlobals(bindings: Seq[(String, Type)])(mapF: (IR, Ref) => IR)(body: (IR, IR) => IR): IR = {
+    val allBroadcastVals = broadcastVals ++ bindings.map { case (name, t) => (name, Ref(name, t))}
+    val broadcastRefs = MakeStruct(allBroadcastVals)
     val glob = Ref(genUID(), broadcastRefs.typ)
 
     val cda = CollectDistributedArray(
       contexts, broadcastRefs,
       ctxRefName, glob.name,
-      broadcastVals.foldLeft(mapF(partitionIR, Ref(ctxRefName, ctxType))) { case (accum, (name, _)) =>
+      allBroadcastVals.foldLeft(mapF(partitionIR, Ref(ctxRefName, ctxType))) { case (accum, (name, _)) =>
         Let(name, GetField(glob, name), accum)
       })
 
     wrapInBindings(body(cda, globals))
   }
 
-  def collectWithGlobals(): IR = mapCollectWithGlobals(ToArray) { (parts, globals) =>
+  def collectWithGlobals(bindings: Seq[(String, Type)]): IR = mapCollectWithGlobals(bindings)(ToArray) { (parts, globals) =>
     MakeStruct(FastSeq(
       "rows" -> ToArray(flatMapIR(ToStream(parts))(ToStream)),
       "global" -> globals))
@@ -334,8 +335,8 @@ class TableStage(
 }
 
 object LowerTableIR {
-  def apply(ir: IR, typesToLower: DArrayLowering.Type, ctx: ExecuteContext, r: RequirednessAnalysis): IR = {
-    def lowerIR(ir: IR) = LowerToCDA.lower(ir, typesToLower, ctx, r)
+  def apply(ir: IR, typesToLower: DArrayLowering.Type, ctx: ExecuteContext, r: RequirednessAnalysis, relationalLetsAbove: Seq[(String, Type)]): IR = {
+    def lowerIR(ir: IR) = LowerToCDA.lower(ir, typesToLower, ctx, r, relationalLetsAbove)
 
     def lower(tir: TableIR): TableStage = {
       if (typesToLower == DArrayLowering.BMOnly)
@@ -471,7 +472,7 @@ object LowerTableIR {
           }
 
           val sortFields = newKeyType.fieldNames.map(fieldName => SortField(fieldName, Ascending)).toIndexedSeq
-          val shuffled = ctx.backend.lowerDistributedSort(ctx, withNewKeyFields, sortFields)
+          val shuffled = ctx.backend.lowerDistributedSort(ctx, withNewKeyFields, sortFields, relationalLetsAbove)
           val repartitioned = shuffled.repartitionNoShuffle(shuffled.partitioner.strictify)
 
           repartitioned.mapPartition { partition =>
@@ -524,7 +525,7 @@ object LowerTableIR {
               partitionSizeArrayFunc,
               FastIndexedSeq(howManyPartsToTry.name -> 4),
               bindIR(loweredChild.mapContexts(_ => StreamTake(ToStream(childContexts), howManyPartsToTry)){ ctx: IR => ctx }
-                                 .mapCollect(StreamLen)) { counts =>
+                                 .mapCollect(relationalLetsAbove)(StreamLen)) { counts =>
                 If((Cast(streamSumIR(ToStream(counts)), TInt64) >= targetNumRows) || (ArrayLen(childContexts) <= ArrayLen(counts)),
                   counts,
                   Recur(partitionSizeArrayFunc, FastIndexedSeq(howManyPartsToTry * 4), TArray(TInt32)))
@@ -595,7 +596,7 @@ object LowerTableIR {
               bindIR(
                 loweredChild
                   .mapContexts(_ => StreamDrop(ToStream(childContexts), maxIR(totalNumPartitions - howManyPartsToTry, 0))){ ctx: IR => ctx }
-                  .mapCollect(StreamLen)
+                  .mapCollect(relationalLetsAbove)(StreamLen)
               ) { counts =>
                 If((Cast(streamSumIR(ToStream(counts)), TInt64) >= targetNumRows) || (totalNumPartitions <= ArrayLen(counts)),
                   counts,
@@ -703,7 +704,7 @@ object LowerTableIR {
               .extendKeyPreservesPartitioning(newKey)
           else {
             val sorted = ctx.backend.lowerDistributedSort(
-              ctx, loweredChild, newKey.map(k => SortField(k, Ascending)))
+              ctx, loweredChild, newKey.map(k => SortField(k, Ascending)), relationalLetsAbove)
             assert(sorted.kType.fieldNames.sameElements(newKey))
             sorted
           }
@@ -764,7 +765,7 @@ object LowerTableIR {
           if (TableOrderBy.isAlreadyOrdered(sortFields, loweredChild.partitioner.kType.fieldNames))
             loweredChild.changePartitionerNoRepartition(RVDPartitioner.unkeyed(loweredChild.partitioner.numPartitions))
           else
-            ctx.backend.lowerDistributedSort(ctx, loweredChild, sortFields)
+            ctx.backend.lowerDistributedSort(ctx, loweredChild, sortFields, relationalLetsAbove)
 
         case TableExplode(child, path) =>
           lower(child).mapPartition { rows =>
@@ -818,18 +819,18 @@ object LowerTableIR {
       case TableCount(tableIR) =>
         val stage = lower(tableIR)
         invoke("sum", TInt64,
-          stage.mapCollect(rows => Cast(StreamLen(rows), TInt64)))
+          stage.mapCollect(relationalLetsAbove)(rows => Cast(StreamLen(rows), TInt64)))
 
       case TableToValueApply(child, ForceCountTable()) =>
         val stage = lower(child)
         invoke("sum", TInt64,
-          stage.mapCollect(rows => Cast(StreamLen(mapIR(rows)(row => Consume(row))), TInt64))          )
+          stage.mapCollect(relationalLetsAbove)(rows => Cast(StreamLen(mapIR(rows)(row => Consume(row))), TInt64))          )
 
       case TableGetGlobals(child) =>
         lower(child).getGlobals()
 
       case TableCollect(child) =>
-        lower(child).collectWithGlobals()
+        lower(child).collectWithGlobals(relationalLetsAbove)
 
       case TableAggregate(child, query) =>
         val resultUID = genUID()
@@ -849,7 +850,7 @@ object LowerTableIR {
         val initFromSerializedStates = Begin(aggs.aggs.zipWithIndex.map { case (agg, i) =>
           InitFromSerializedValue(i, GetTupleElement(initStateRef, i), agg.state )})
 
-        lcWithInitBinding.mapCollectWithGlobals({ part: IR =>
+        lcWithInitBinding.mapCollectWithGlobals(relationalLetsAbove)({ part: IR =>
           Let("global", lc.globals,
             RunAgg(
               Begin(FastIndexedSeq(
@@ -884,7 +885,7 @@ object LowerTableIR {
         lower(child).getNumPartitions()
 
       case TableWrite(child, writer) =>
-        writer.lower(ctx, lower(child), child, coerce[RTable](r.lookup(child)))
+        writer.lower(ctx, lower(child), child, coerce[RTable](r.lookup(child)), relationalLetsAbove)
 
       case node if node.children.exists(_.isInstanceOf[TableIR]) =>
         throw new LowererUnsupportedOperation(s"IR nodes with TableIR children must be defined explicitly: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -40,6 +40,16 @@ case object LowerMatrixToTablePass extends LoweringPass {
   }
 }
 
+case object LiftRelationalValuesToRelationalLets extends LoweringPass {
+  val before: IRState = MatrixLoweredToTable
+  val after: IRState = MatrixLoweredToTable
+  val context: String = "LiftRelationalValuesToRelationalLets"
+
+  def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = ir match {
+    case x: IR => LiftRelationalValues(x)
+  }
+}
+
 case object LegacyInterpretNonCompilablePass extends LoweringPass {
   val before: IRState = MatrixLoweredToTable
   val after: IRState = ExecutableTableIR

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -59,6 +59,7 @@ object LoweringPipeline {
       OptimizePass("darrayLowerer, initial IR"),
       LowerMatrixToTablePass,
       OptimizePass("darrayLowerer, after LowerMatrixToTable"),
+      LiftRelationalValuesToRelationalLets,
       LowerToDistributedArrayPass(DArrayLowering.All),
       OptimizePass("darrayLowerer, after LowerToCDA")
     ),
@@ -66,6 +67,7 @@ object LoweringPipeline {
       OptimizePass("darrayLowerer, initial IR"),
       LowerMatrixToTablePass,
       OptimizePass("darrayLowerer, after LowerMatrixToTable"),
+      LiftRelationalValuesToRelationalLets,
       LowerToDistributedArrayPass(DArrayLowering.TableOnly),
       OptimizePass("darrayLowerer, after LowerToCDA")
     ),
@@ -73,6 +75,7 @@ object LoweringPipeline {
       OptimizePass("darrayLowerer, initial IR"),
       LowerMatrixToTablePass,
       OptimizePass("darrayLowerer, after LowerMatrixToTable"),
+      LiftRelationalValuesToRelationalLets,
       LowerToDistributedArrayPass(DArrayLowering.BMOnly),
       OptimizePass("darrayLowerer, after LowerToCDA")
     ))

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -69,6 +69,19 @@ class TableIRSuite extends HailSuite {
     assertEvalsTo(node, Row(Array.tabulate(10)(i => Row(i, i)).toFastIndexedSeq, Row()))
   }
 
+  @Test def testNestedRangeCollect() {
+    implicit val execStrats = ExecStrategy.allRelational
+
+    val r = TableRange(2, 2)
+    val tc = GetField(collect(r), "rows")
+    val m = TableMapRows(r, InsertFields(Ref("row", r.typ.rowType), FastIndexedSeq("collected" -> tc)))
+    assertEvalsTo(collect(m),
+      Row(FastIndexedSeq(
+        Row(0, FastIndexedSeq(Row(0), Row(1))),
+        Row(1, FastIndexedSeq(Row(0), Row(1)))
+    ), Row()))
+  }
+
   @Test def testRangeSum() {
     implicit val execStrats = ExecStrategy.interpretOnly
     val t = TableRange(10, 2)

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -29,7 +29,7 @@ class BlockMatrixStageSuite extends HailSuite {
         def blockBody(ctxRef: Ref): IR = body(ctxRef)
       }
     }
-    stage.collectBlocks(b => b, order.getOrElse(ctxs.map(_._1)))
+    stage.collectBlocks(Seq())(b => b, order.getOrElse(ctxs.map(_._1)))
   }
 
   @Test def testBlockMatrixCollectOrdering(): Unit = {


### PR DESCRIPTION
* Add new LiftRelationalValues pass, run before LowerToCDA.
* RelationalLets are converted to Lets during lowering, and broadcast.
* RelationalRefs are converted to normal Refs.

Stacked on #9041