### PR TITLE
[hail] properly report suppressed exceptions in `using`

### DIFF
--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -605,6 +605,7 @@ package object utils extends Logging
         caught = true
         try {
           r.close()
+          throw original
         } catch {
           case duringClose: Exception =>
             duringClose.addSuppressed(original)

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -608,8 +608,14 @@ package object utils extends Logging
           throw original
         } catch {
           case duringClose: Exception =>
-            duringClose.addSuppressed(original)
-            throw duringClose
+            if (original == duringClose) {
+              log.info(s"""The exact same exception object, ${original}, was thrown by both
+                          |the consumer and the close method. I will throw the original.""".stripMargin)
+              throw original
+            } else {
+              duringClose.addSuppressed(original)
+              throw duringClose
+            }
         }
     } finally {
       if (!caught) {

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -607,7 +607,7 @@ package object utils extends Logging
           r.close()
         } catch {
           case duringClose: Exception =>
-            duringClose.addSupressed(original)
+            duringClose.addSuppressed(original)
             throw duringClose
         }
     } finally {


### PR DESCRIPTION
If an exception occurs in a finally cause, the original exception is completely
lost. For example:

```
Exception in thread "main" java.lang.RuntimeException: second
    at Foo.main(Foo.java:6)
class Foo {
    public static void main(String[] args) {
        try {
            throw new RuntimeException("first");
        } finally {
            throw new RuntimeException("second");
        }
    }
}
```

This seems so unwieldly as to be unreasonable, but this seems to be the correct
answer:

```
Exception in thread "main" java.lang.RuntimeException: Exception during closing!!!
    at Foo.close(Foo.java:3)
    at Foo.main(Foo.java:12)
    Suppressed: java.lang.RuntimeException: first
        at Foo.main(Foo.java:8)
Caused by: java.lang.RuntimeException: cause of exception during close
    ... 2 more
class Foo {
    public static void close() {
        throw new RuntimeException("Exception during closing!!!", new RuntimeException("cause of exception during close"));
    }
    public static void main(String[] args) {
        boolean caught = false;
        try {
            throw new RuntimeException("first");
        } catch (Exception original) {
            caught = true;
            try {
                close();
            } catch (Exception duringClose) {
                duringClose.addSuppressed(original);
                throw duringClose;
            }
        } finally {
            if (!caught)
                close();
        }
    }
}
```

I've implemented that here.