### PR TITLE
[query] Per Pipeline Static Filesystem

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -79,7 +79,8 @@ class ModuleBuilder() {
 
   def newClass[C](name: String)(implicit cti: TypeInfo[C]): ClassBuilder[C] = {
     val c = new ClassBuilder[C](this, name)
-    c.addInterface(cti.iname)
+    if (cti != UnitInfo)
+      c.addInterface(cti.iname)
     classes += c
     c
   }

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1133,6 +1133,14 @@ class ThisFieldRef[T: TypeInfo](cb: ClassBuilder[_], f: Field[T]) extends Settab
   def store(rhs: Code[T]): Code[Unit] = f.put(cb._this, rhs)
 }
 
+class StaticFieldRef[T: TypeInfo](f: StaticField[T]) extends Settable[T] {
+  def name: String = f.name
+
+  def get: Code[T] = f.get()
+
+  def store(rhs: Code[T]): Code[Unit] = f.put(rhs)
+}
+
 class LocalRef[T](val l: lir.Local) extends Settable[T] {
   def get: Code[T] = Code(lir.load(l))
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -124,8 +124,14 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
   def newEmitMethod(name: String, argsInfo: IndexedSeq[MaybeGenericTypeInfo[_]], returnInfo: MaybeGenericTypeInfo[_]): EmitMethodBuilder[C] =
     ecb.newEmitMethod(name, argsInfo, returnInfo)
 
+  def newStaticEmitMethod(name: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] =
+    ecb.newStaticEmitMethod(name, argsInfo, returnInfo)
+
   def genEmitMethod(baseName: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] =
     ecb.genEmitMethod(baseName, argsInfo, returnInfo)
+
+  def genStaticEmitMethod(baseName: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] =
+    ecb.genStaticEmitMethod(baseName, argsInfo, returnInfo)
 
   def getCodeOrdering(
     t1: PType, t2: PType, sortOrder: SortOrder, op: CodeOrdering.Op, ignoreMissingness: Boolean
@@ -557,7 +563,7 @@ class EmitClassBuilder[C](
     }
   }
 
-  def newEmitMethod(name: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] = {
+  private def getCodeArgsInfo(argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): (IndexedSeq[TypeInfo[_]], TypeInfo[_]) = {
     val codeArgsInfo = argsInfo.flatMap {
       case CodeParamType(ti) => FastIndexedSeq(ti)
       case EmitParamType(pt) => EmitCode.codeTupleTypes(pt)
@@ -574,6 +580,12 @@ class EmitClassBuilder[C](
         }
     }
 
+    (codeArgsInfo, codeReturnInfo)
+  }
+
+  def newEmitMethod(name: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] = {
+    val (codeArgsInfo, codeReturnInfo) = getCodeArgsInfo(argsInfo, returnInfo)
+
     new EmitMethodBuilder[C](
       argsInfo, returnInfo,
       this,
@@ -585,6 +597,15 @@ class EmitClassBuilder[C](
       argsInfo.map(ai => CodeParamType(ai.base)), CodeParamType(returnInfo.base),
       this,
       cb.newMethod(name, argsInfo, returnInfo))
+  }
+
+  def newStaticEmitMethod(name: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] = {
+    val (codeArgsInfo, codeReturnInfo) = getCodeArgsInfo(argsInfo, returnInfo)
+
+    new EmitMethodBuilder[C](
+      argsInfo, returnInfo,
+      this,
+      cb.newStaticMethod(name, codeArgsInfo, codeReturnInfo))
   }
 
   def genDependentFunction[F](baseName: String,
@@ -750,6 +771,9 @@ class EmitClassBuilder[C](
   def genEmitMethod[A1: TypeInfo, A2: TypeInfo, A3: TypeInfo, A4: TypeInfo, A5: TypeInfo, R: TypeInfo](baseName: String): EmitMethodBuilder[C] =
     genEmitMethod(baseName, FastIndexedSeq[ParamType](typeInfo[A1], typeInfo[A2], typeInfo[A3], typeInfo[A4], typeInfo[A5]), typeInfo[R])
 
+  def genStaticEmitMethod(baseName: String, argsInfo: IndexedSeq[ParamType], returnInfo: ParamType): EmitMethodBuilder[C] =
+    newStaticEmitMethod(genName("sm", baseName), argsInfo, returnInfo)
+
   def wrapInEmitMethod[R: TypeInfo](
     baseName: String,
     body: (EmitMethodBuilder[_]) => Code[R]): Code[R] = {
@@ -890,7 +914,7 @@ class EmitMethodBuilder[C](
   // EmitMethodBuilder methods
 
   // this, ...
-  private val emitParamCodeIndex = emitParamTypes.scanLeft(1) {
+  private val emitParamCodeIndex = emitParamTypes.scanLeft((!mb.isStatic).toInt) {
     case (i, CodeParamType(_)) =>
       i + 1
     case (i, EmitParamType(pt)) =>
@@ -898,21 +922,23 @@ class EmitMethodBuilder[C](
   }
 
   def getCodeParam[T: TypeInfo](emitIndex: Int): Settable[T] = {
-    if (emitIndex == 0)
+    if (emitIndex == 0 && !mb.isStatic)
       mb.getArg[T](0)
     else {
-      assert(emitParamTypes(emitIndex - 1).isInstanceOf[CodeParamType])
-      mb.getArg[T](emitParamCodeIndex(emitIndex - 1))
+      val static = (!mb.isStatic).toInt
+      assert(emitParamTypes(emitIndex - static).isInstanceOf[CodeParamType])
+      mb.getArg[T](emitParamCodeIndex(emitIndex - static))
     }
   }
 
   def getEmitParam(emitIndex: Int): EmitValue = {
-    assert(emitIndex != 0)
-    val _pt = emitParamTypes(emitIndex - 1).asInstanceOf[EmitParamType].pt
+    assert(mb.isStatic || emitIndex != 0)
+    val static = (!mb.isStatic).toInt
+    val _pt = emitParamTypes(emitIndex - static).asInstanceOf[EmitParamType].pt
     assert(!_pt.isInstanceOf[PStream])
 
     val ts = _pt.codeTupleTypes()
-    val codeIndex = emitParamCodeIndex(emitIndex - 1)
+    val codeIndex = emitParamCodeIndex(emitIndex - static)
 
     new EmitValue {
       val pt: PType = _pt
@@ -1021,6 +1047,9 @@ class EmitMethodBuilder[C](
 
   def newPresentEmitLocal(pt: PType): PresentEmitSettable =
     newPresentEmitSettable(pt, newPLocal(pt))
+
+  def newPresentEmitLocal(name: String, pt: PType): PresentEmitSettable =
+    newPresentEmitSettable(pt, newPLocal(name, pt))
 
   def newPresentEmitField(pt: PType): PresentEmitSettable =
     newPresentEmitSettable(pt, newPField(pt))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -71,6 +71,8 @@ trait WrappedEmitClassBuilder[C] extends WrappedEmitModuleBuilder {
 
   def newField[T: TypeInfo](name: String): Field[T] = ecb.newField[T](name)
 
+  def newStaticField[T: TypeInfo](name: String, init: Code[T]): StaticField[T] = ecb.newStaticField[T](name, init)
+
   def genField[T: TypeInfo](baseName: String): Field[T] = ecb.genField(baseName)
 
   def genFieldThisRef[T: TypeInfo](name: String = null): ThisFieldRef[T] = ecb.genFieldThisRef[T](name)
@@ -226,6 +228,8 @@ class EmitClassBuilder[C](
   def className: String = cb.className
 
   def newField[T: TypeInfo](name: String): Field[T] = cb.newField[T](name)
+
+  def newStaticField[T: TypeInfo](name: String, init: Code[T]): StaticField[T] = cb.newStaticField[T](name, init)
 
   def genField[T: TypeInfo](baseName: String): Field[T] = cb.genField(baseName)
 

--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -43,8 +43,9 @@ object Emit {
 
   def emit(cn: ClassNode, m: Method): Unit = {
     val blocks = m.findBlocks()
+    val static = if (m.isStatic) ACC_STATIC else 0
 
-    val mn = new MethodNode(ACC_PUBLIC, m.name, m.desc, null, null)
+    val mn = new MethodNode(ACC_PUBLIC | static, m.name, m.desc, null, null)
     cn.methods.asInstanceOf[java.util.List[MethodNode]].add(mn)
 
     val labelNodes = blocks.map(L => L -> new LabelNode).toMap
@@ -55,14 +56,14 @@ object Emit {
     val end = new LabelNode
 
     var n = 0
-    val parameterIndex = new Array[Int](m.parameterTypeInfo.length + 1)
+    val parameterIndex = new Array[Int](m.parameterTypeInfo.length + (!m.isStatic).toInt)
     var i = 0
     while (i < parameterIndex.length) {
       parameterIndex(i) = n
-      if (i == 0)
+      if (i == 0 && !m.isStatic)
         n += 1 // this
       else
-        n += m.parameterTypeInfo(i - 1).slots
+        n += m.parameterTypeInfo(i - (!m.isStatic).toInt).slots
       i += 1
     }
 

--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -202,7 +202,10 @@ object Emit {
       cn.interfaces.asInstanceOf[java.util.List[String]].add(intf)
 
     for (f <- c.fields) {
-      val fn = new FieldNode(ACC_PUBLIC, f.name, f.ti.desc, null, null)
+      val fn = f match {
+        case f: Field => new FieldNode(ACC_PUBLIC, f.name, f.ti.desc, null, null)
+        case f: StaticField => new FieldNode(ACC_PUBLIC | ACC_STATIC, f.name, f.ti.desc, null, null)
+      }
       cn.fields.asInstanceOf[java.util.List[FieldNode]].add(fn)
     }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -32,8 +32,9 @@ class Classx[C](val name: String, val superName: String) {
 
   def newMethod(name: String,
     parameterTypeInfo: IndexedSeq[TypeInfo[_]],
-    returnTypeInfo: TypeInfo[_]): Method = {
-    val method = new Method(this, name, parameterTypeInfo, returnTypeInfo)
+    returnTypeInfo: TypeInfo[_],
+    isStatic: Boolean = false): Method = {
+    val method = new Method(this, name, parameterTypeInfo, returnTypeInfo, isStatic)
     methods += method
     method
   }
@@ -162,9 +163,10 @@ class Method private[lir] (
   val classx: Classx[_],
   val name: String,
   val parameterTypeInfo: IndexedSeq[TypeInfo[_]],
-  val returnTypeInfo: TypeInfo[_]) extends MethodRef {
+  val returnTypeInfo: TypeInfo[_],
+  val isStatic: Boolean) extends MethodRef {
 
-  def nParameters: Int = parameterTypeInfo.length + 1
+  def nParameters: Int = parameterTypeInfo.length + (!isStatic).toInt
 
   def owner: String = classx.name
 
@@ -182,10 +184,10 @@ class Method private[lir] (
 
   def getParam(i: Int): Parameter = {
     new Parameter(this, i,
-      if (i == 0)
+      if (i == 0 && !isStatic)
         new ClassInfo(classx.name)
       else
-        parameterTypeInfo(i - 1))
+        parameterTypeInfo(i - (!isStatic).toInt))
   }
 
   def newLocal(name: String, ti: TypeInfo[_]): Local =
@@ -248,10 +250,10 @@ class Method private[lir] (
     var i = 0
     while (i < nParameters) {
       localsb += (
-        if (i == 0)
+        if (i == 0 && !isStatic)
           new Parameter(this, 0, classx.ti)
         else
-          new Parameter(this, i, parameterTypeInfo(i - 1)))
+          new Parameter(this, i, parameterTypeInfo(i - (!isStatic).toInt)))
       i += 1
     }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -14,7 +14,7 @@ class Classx[C](val name: String, val superName: String) {
 
   val methods: mutable.ArrayBuffer[Method] = new mutable.ArrayBuffer()
 
-  val fields: mutable.ArrayBuffer[Field] = new mutable.ArrayBuffer()
+  val fields: mutable.ArrayBuffer[FieldRef] = new mutable.ArrayBuffer()
 
   val interfaces: mutable.ArrayBuffer[String] = new mutable.ArrayBuffer()
 
@@ -29,6 +29,12 @@ class Classx[C](val name: String, val superName: String) {
   }
 
   def genField(baseName: String, ti: TypeInfo[_]): Field = newField(genName("f", baseName), ti)
+
+  def newStaticField(name: String, ti: TypeInfo[_]): StaticField = {
+    val f = new StaticField(this, name, ti)
+    fields += f
+    f
+  }
 
   def newMethod(name: String,
     parameterTypeInfo: IndexedSeq[TypeInfo[_]],
@@ -136,6 +142,10 @@ abstract class FieldRef {
 }
 
 class Field private[lir] (classx: Classx[_], val name: String, val ti: TypeInfo[_]) extends FieldRef {
+  def owner: String = classx.name
+}
+
+class StaticField private[lir] (classx: Classx[_], val name: String, val ti: TypeInfo[_]) extends FieldRef {
   def owner: String = classx.name
 }
 
@@ -649,7 +659,7 @@ class SwitchX() extends ControlX {
       i += 1
     }
   }
-  
+
   def targetArity(): Int = 1 + _Lcases.length
 
   def target(i: Int): Block = {

--- a/hail/src/main/scala/is/hail/lir/package.scala
+++ b/hail/src/main/scala/is/hail/lir/package.scala
@@ -174,6 +174,9 @@ package object lir {
   def getStaticField(owner: String, name: String, ti: TypeInfo[_]): ValueX =
     new GetFieldX(GETSTATIC, new FieldLit(owner, name, ti))
 
+  def getStaticField(lf: StaticField): ValueX =
+    new GetFieldX(GETSTATIC, lf)
+
   def getField(owner: String, name: String, ti: TypeInfo[_], obj: ValueX): ValueX = {
     val x = new GetFieldX(GETFIELD, new FieldLit(owner, name, ti))
     setChildren(x, obj)
@@ -196,6 +199,12 @@ package object lir {
 
   def putStaticField(owner: String, name: String, ti: TypeInfo[_], v: ValueX): StmtX = {
     val x = new PutFieldX(PUTSTATIC, new FieldLit(owner, name, ti))
+    setChildren(x, v)
+    x
+  }
+
+  def putStaticField(lf: StaticField, v: ValueX): StmtX = {
+    val x = new PutFieldX(PUTSTATIC, lf)
     setChildren(x, v)
     x
   }


### PR DESCRIPTION
The interfaces are `newStaticField` and `newStaticMethod` on (Emit)ClassBuilder. The first
usage of this feature is to move the `FS` off of the class itself and onto a container class.