### PR TITLE
[query][bugfix] fix #9016 (wrong subset tuple field names on PTuple)

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PTuple.scala
@@ -14,7 +14,7 @@ trait PTuple extends PBaseStruct {
 
   lazy val virtualType: TTuple = TTuple(_types.map(tf => TupleField(tf.index, tf.typ.virtualType)))
 
-  lazy val fields: IndexedSeq[PField] = types.zipWithIndex.map { case (t, i) => PField(s"$i", t, i) }
+  lazy val fields: IndexedSeq[PField] = _types.zipWithIndex.map { case (PTupleField(tidx, t), i) => PField(s"$tidx", t, i) }
   lazy val nFields: Int = fields.size
 
   protected val tupleFundamentalType: PTuple


### PR DESCRIPTION
Here's the minimal case for replicating #9016:
```
t = hl.array([hl.struct(a=hl.tuple([0, 1]))])

t2 = hl.Table.parallelize(t)
t2 = t2.annotate(b=t2.a[0], c=t2.a[1])
t2.drop('a', 'b').collect()
```

The issue was that the PTuple `fields` argument is carrying the wrong field index, which is what EType.defaultFromPType uses to construct the EType (since it operates on the fundamental type).