### PR TITLE
[query] fix TableIRSuite

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -16,8 +16,11 @@ import org.testng.annotations.{DataProvider, Test}
 class TableIRSuite extends HailSuite {
   def rangeKT: TableIR = TableKeyBy(TableRange(20, 4), FastIndexedSeq())
 
-  def collect(tir: TableIR): TableCollect = TableCollect(TableKeyBy(tir, FastIndexedSeq()))
-  def collectNoKey(tir: TableIR): TableCollect = TableCollect(tir)
+  def collect(tir: TableIR): IR =
+    TableAggregate(tir, MakeStruct(FastSeq(
+      "rows" -> IRAggCollect(Ref("row", tir.typ.rowType)),
+      "global" -> Ref("global", tir.typ.globalType))))
+  def collectNoKey(tir: TableIR): IR = TableCollect(tir)
 
   implicit val execStrats: Set[ExecStrategy] = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
 


### PR DESCRIPTION
TableIRSuite extensively uses the function
```
def collect(tir: TableIR): TableCollect = TableCollect(TableKeyBy(tir, FastIndexedSeq()))
```
to compare the result of a `TableIR` with the expected collection. But `TableCollect` makes no promises what order the results will be in, and in particular the optimizer is allowed to remove that `TableKeyBy`.

This PR redefines that function to use the collect aggregator, which does promise the order rows are collected.

It also fixes a small type error in the `TableJoin` lowering case that was uncovered.