### PR TITLE
[query] Expose _nd as nd

### DIFF
--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -13,20 +13,20 @@ def block_matrix_nested_multiply():
 @benchmark()
 def make_ndarray_bench():
     ht = hl.utils.range_table(200_000)
-    ht = ht.annotate(x=hl._nd.array(hl.range(200_000)))
+    ht = ht.annotate(x=hl.nd.array(hl.range(200_000)))
     ht._force_count()
 
 @benchmark()
 def ndarray_addition_benchmark():
-    arr = hl._nd.ones((1024, 1024))
+    arr = hl.nd.ones((1024, 1024))
     hl.eval(arr + arr)
 
 @benchmark()
 def ndarray_matmul_int64_benchmark():
-    arr = hl._nd.arange(1024 * 1024).map(hl.int64).reshape((1024, 1024))
+    arr = hl.nd.arange(1024 * 1024).map(hl.int64).reshape((1024, 1024))
     hl.eval(arr @ arr)
 
 @benchmark()
 def ndarray_matmul_float64_benchmark():
-    arr = hl._nd.arange(1024 * 1024).map(hl.float64).reshape((1024, 1024))
+    arr = hl.nd.arange(1024 * 1024).map(hl.float64).reshape((1024, 1024))
     hl.eval(arr @ arr)

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -41,7 +41,7 @@ from . import plot
 from . import experimental
 from . import ir
 from . import backend
-from . import nd as _nd
+from . import nd
 from hail.expr import aggregators as agg
 from hail.utils import Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls, \
     hadoop_stat, hadoop_exists, hadoop_is_file, hadoop_is_dir, copy_log
@@ -84,7 +84,7 @@ __all__ = [
     'methods',
     'stats',
     'linalg',
-    '_nd',
+    'nd',
     'plot',
     'experimental',
     'ir',

--- a/hail/python/hail/conftest.py
+++ b/hail/python/hail/conftest.py
@@ -142,7 +142,7 @@ def generate_datasets(doctest_namespace):
     doctest_namespace['tup'] = hl.literal(("a", 1, [1, 2, 3]))
     doctest_namespace['s'] = hl.literal('The quick brown fox')
     doctest_namespace['interval2'] = hl.Interval(3, 6)
-    doctest_namespace['nd'] = hl._nd.array([[1, 2], [3, 4]])
+    doctest_namespace['nd'] = hl.nd.array([[1, 2], [3, 4]])
 
     # Overview
     doctest_namespace['ht'] = hl.import_table("data/kt_example1.tsv", impute=True)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3467,7 +3467,7 @@ class IntervalExpression(Expression):
 class NDArrayExpression(Expression):
     """Expression of type :class:`.tndarray`.
 
-    >>> nd = hl._nd.array([[1, 2], [3, 4]])
+    >>> nd = hl.nd.array([[1, 2], [3, 4]])
     """
 
     @property
@@ -3598,7 +3598,7 @@ class NDArrayExpression(Expression):
         Examples
         --------
 
-        >>> v = hl._nd.array([1, 2, 3, 4]) # doctest: +SKIP
+        >>> v = hl.nd.array([1, 2, 3, 4]) # doctest: +SKIP
         >>> m = v.reshape((2, 2)) # doctest: +SKIP
 
         Returns
@@ -3679,14 +3679,14 @@ class NDArrayNumericExpression(NDArrayExpression):
 
     def _bin_op_numeric(self, name, other, ret_type_f=None):
         if isinstance(other, list) or isinstance(other, np.ndarray):
-            other = hl._nd.array(other)
+            other = hl.nd.array(other)
 
         self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric(name, other_broadcast, ret_type_f)
 
     def _bin_op_numeric_reverse(self, name, other, ret_type_f=None):
         if isinstance(other, list) or isinstance(other, np.ndarray):
-            other = hl._nd.array(other)
+            other = hl.nd.array(other)
 
         self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric_reverse(name, other_broadcast, ret_type_f)
@@ -3791,7 +3791,7 @@ class NDArrayNumericExpression(NDArrayExpression):
 
     def __rmatmul__(self, other):
         if not isinstance(other, NDArrayNumericExpression):
-            other = hl._nd.array(other)
+            other = hl.nd.array(other)
         return other.__matmul__(self)
 
     def __matmul__(self, other):
@@ -3819,7 +3819,7 @@ class NDArrayNumericExpression(NDArrayExpression):
         :class:`.NDArrayNumericExpression` or :class:`.NumericExpression`
         """
         if not isinstance(other, NDArrayNumericExpression):
-            other = hl._nd.array(other)
+            other = hl.nd.array(other)
 
         if self.ndim == 0 or other.ndim == 0:
             raise ValueError('MatMul must be between objects of 1 dimension or more. Try * instead')

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1439,7 +1439,7 @@ def test_join_distinct_preserves_count():
 
 def test_write_table_containing_ndarray():
     t = hl.utils.range_table(5)
-    t = t.annotate(n = hl._nd.arange(t.idx))
+    t = t.annotate(n = hl.nd.arange(t.idx))
     f = new_temp_file(extension='ht')
     t.write(f)
     t2 = hl.read_table(f)


### PR DESCRIPTION
Pycharm thought `hl.nd` didn't exist, and I'm pretty sure we could
have had issues on certain python installations without this change.