### PR TITLE
[query] Add tree_matmul, matrix multiply in case of large inner dimension 

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -8,7 +8,7 @@ from .phase_by_transmission import phase_by_transmission, \
     phase_trio_matrix_by_transmission, explode_trio_matrix
 from .datasets import load_dataset
 from .import_gtf import import_gtf, get_gene_intervals
-from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_block_matrices
+from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_block_matrices, write_block_matrices
 from .export_entries_by_col import export_entries_by_col
 from .vcf_combiner import sparse_split_multi, run_combiner, lgt_to_gt, densify
 from .function import define_function
@@ -40,6 +40,7 @@ __all__ = ['ld_score',
            'write_matrix_tables',
            'block_matrices_tofiles',
            'export_block_matrices',
+           'write_block_matrices',
            'export_entries_by_col',
            'define_function',
            'simulate_phenotypes',

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -43,6 +43,7 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
     writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression, custom_filenames)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
 
+@typecheck(bms=sequenceof(BlockMatrix), prefix=str, overwrite=bool)
 def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False):
-    writer = BlockMatrixNativeMultiWriter
+    writer = BlockMatrixNativeMultiWriter(prefix, overwrite)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -44,7 +44,21 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
 
 
-@typecheck(bms=sequenceof(BlockMatrix), prefix=str, overwrite=bool, force_row_major=bool)
-def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False, force_row_major: bool = False):
-    writer = BlockMatrixNativeMultiWriter(prefix, overwrite, force_row_major)
+@typecheck(bms=sequenceof(BlockMatrix), path_prefix=str, overwrite=bool, force_row_major=bool)
+def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False, force_row_major: bool = False):
+    """Writes a sequence of block matrices to disk in the same format as BlockMatrix.write.
+
+    :param bms: :obj:`list` of :class:`BlockMatrix`
+        Block matrices to write to disk.
+    :param path_prefix: obj:`str`
+        Prefix of path to write the block matrices to.
+    :param overwrite: obj:`bool`
+        If true, overwrite any files with the same name as the block matrices being generated.
+    :param force_row_major: obj:`bool`
+        If ``True``, transform blocks in column-major format
+        to row-major format before writing.
+        If ``False``, write blocks in their current format.
+    :return:
+    """
+    writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -44,7 +44,7 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
 
 
-@typecheck(bms=sequenceof(BlockMatrix), path_prefix=str, overwrite=bool, force_row_major=bool)
+@typecheck(bms=sequenceof(BlockMatrix), path_prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
 def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False, force_row_major: bool = False, stage_locally: bool = False):
     """Writes a sequence of block matrices to disk in the same format as BlockMatrix.write.
 
@@ -62,5 +62,5 @@ def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bo
         If ``True``, major output will be written to temporary local storage
         before being copied to ``output``.
     """
-    writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major)
+    writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major, stage_locally)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -45,7 +45,8 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
 
 
 @typecheck(bms=sequenceof(BlockMatrix), path_prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
-def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False, force_row_major: bool = False, stage_locally: bool = False):
+def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False,
+                         force_row_major: bool = False, stage_locally: bool = False):
     """Writes a sequence of block matrices to disk in the same format as BlockMatrix.write.
 
     :param bms: :obj:`list` of :class:`BlockMatrix`

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -43,7 +43,8 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
     writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression, custom_filenames)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
 
-@typecheck(bms=sequenceof(BlockMatrix), prefix=str, overwrite=bool)
-def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False):
-    writer = BlockMatrixNativeMultiWriter(prefix, overwrite)
+
+@typecheck(bms=sequenceof(BlockMatrix), prefix=str, overwrite=bool, force_row_major=bool)
+def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False, force_row_major: bool = False):
+    writer = BlockMatrixNativeMultiWriter(prefix, overwrite, force_row_major)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -45,7 +45,7 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
 
 
 @typecheck(bms=sequenceof(BlockMatrix), path_prefix=str, overwrite=bool, force_row_major=bool)
-def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False, force_row_major: bool = False):
+def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bool = False, force_row_major: bool = False, stage_locally: bool = False):
     """Writes a sequence of block matrices to disk in the same format as BlockMatrix.write.
 
     :param bms: :obj:`list` of :class:`BlockMatrix`
@@ -58,7 +58,9 @@ def write_block_matrices(bms: List[BlockMatrix], path_prefix: str, overwrite: bo
         If ``True``, transform blocks in column-major format
         to row-major format before writing.
         If ``False``, write blocks in their current format.
-    :return:
+    :param stage_locally: :obj:`bool`
+        If ``True``, major output will be written to temporary local storage
+        before being copied to ``output``.
     """
     writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from hail import MatrixTable
 from hail.linalg import BlockMatrix
-from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter, BlockMatrixMultiWrite, BlockMatrixBinaryMultiWriter, BlockMatrixTextMultiWriter
+from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter, BlockMatrixMultiWrite, BlockMatrixBinaryMultiWriter, BlockMatrixTextMultiWriter, BlockMatrixNativeMultiWriter
 from hail.typecheck import nullable, sequenceof, typecheck, enumeration
 from hail.utils.java import Env
 
@@ -41,4 +41,8 @@ def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool =
         assert len(custom_filenames) == len(bms), "Number of block matrices and number of custom filenames must be equal"
 
     writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index, compression, custom_filenames)
+    Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
+
+def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False):
+    writer = BlockMatrixNativeMultiWriter
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -114,6 +114,7 @@ __all__ = [
     'BlockMatrixBinaryWriter',
     'BlockMatrixRectanglesWriter',
     'BlockMatrixMultiWriter',
+    'BlockMatrixNativeMultiWriter',
     'BlockMatrixBinaryMultiWriter',
     'BlockMatrixTextMultiWriter',
     'BlockMatrixPersistWriter',

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -59,7 +59,7 @@ from .table_writer import TableWriter, TableNativeWriter, TableTextWriter
 from .blockmatrix_writer import BlockMatrixWriter, BlockMatrixNativeWriter, \
     BlockMatrixBinaryWriter, BlockMatrixRectanglesWriter, \
     BlockMatrixMultiWriter, BlockMatrixBinaryMultiWriter, \
-    BlockMatrixTextMultiWriter, BlockMatrixPersistWriter
+    BlockMatrixTextMultiWriter, BlockMatrixPersistWriter, BlockMatrixNativeMultiWriter
 from .renderer import Renderable, RenderableStr, ParensRenderer, \
     RenderableQueue, RQStack, Renderer, PlainRenderer, CSERenderer
 

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -179,7 +179,7 @@ class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
 
     def __eq__(self, other):
         return isinstance(other, BlockMatrixNativeMultiWriter) and \
-               self.prefix == other.prefix and \
-               self.overwrite == other.overwrite and \
-               self.force_row_major == other.force_row_major and \
-               self.stage_locally == other.stage_locally
+            self.prefix == other.prefix and \
+            self.overwrite == other.overwrite and \
+            self.force_row_major == other.force_row_major and \
+            self.stage_locally == other.stage_locally

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -163,20 +163,23 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
 
 class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
     @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool)
-    def __init__(self, prefix, overwrite, force_row_major):
+    def __init__(self, prefix, overwrite, force_row_major, stage_locally):
         self.prefix = prefix
         self.overwrite = overwrite
         self.force_row_major = force_row_major
+        self.stage_locally = stage_locally
 
     def render(self):
         writer = {'name': 'BlockMatrixNativeMultiWriter',
                   'prefix': self.prefix,
                   'overwrite': self.overwrite,
-                  'forceRowMajor': self.force_row_major}
+                  'forceRowMajor': self.force_row_major,
+                  'stageLocally': self.stage_locally}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
         return isinstance(other, BlockMatrixNativeMultiWriter) and \
                self.prefix == other.prefix and \
                self.overwrite == other.overwrite and \
-               self.force_row_major == other.force_row_major
+               self.force_row_major == other.force_row_major and \
+               self.stage_locally == other.stage_locally

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -162,7 +162,7 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
 
 
 class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
-    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool)
+    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
     def __init__(self, prefix, overwrite, force_row_major, stage_locally):
         self.prefix = prefix
         self.overwrite = overwrite

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -159,3 +159,21 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
         return isinstance(other, BlockMatrixPersistWriter) and \
             self.id == other.id and \
             self.storage_level == other.storage_level
+
+
+class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
+    @typecheck_method(prefix=str, overwrite=bool)
+    def __init__(self, prefix, overwrite):
+        self.prefix = prefix
+        self.overwrite = overwrite
+
+    def render(self):
+        writer = {'name': 'BlockMatrixNativeMultiWriter',
+                  'prefix': self.prefix,
+                  'overwrite': self.overwrite}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixNativeMultiWriter) and \
+               self.prefix == other.prefix and \
+               self.overwrite == other.overwrite

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -162,18 +162,21 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
 
 
 class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
-    @typecheck_method(prefix=str, overwrite=bool)
-    def __init__(self, prefix, overwrite):
+    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool)
+    def __init__(self, prefix, overwrite, force_row_major):
         self.prefix = prefix
         self.overwrite = overwrite
+        self.force_row_major = force_row_major
 
     def render(self):
         writer = {'name': 'BlockMatrixNativeMultiWriter',
                   'prefix': self.prefix,
-                  'overwrite': self.overwrite}
+                  'overwrite': self.overwrite,
+                  'forceRowMajor': self.force_row_major}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
         return isinstance(other, BlockMatrixNativeMultiWriter) and \
                self.prefix == other.prefix and \
-               self.overwrite == other.overwrite
+               self.overwrite == other.overwrite and \
+               self.force_row_major == other.force_row_major

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2214,7 +2214,7 @@ class BlockMatrixMultiWrite(IR):
         self.writer = writer
 
     def copy(self, *block_matrices):
-        return BlockMatrixWrite(block_matrices, self.writer)
+        return BlockMatrixMultiWrite(block_matrices, self.writer)
 
     def head_str(self):
         return f'"{self.writer.render()}"'

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -564,11 +564,13 @@ class BlockMatrix(object):
 
     @property
     def _last_col_block_width(self):
-        return self.n_cols % self.block_size
+        remainder = self.n_cols % self.block_size
+        return remainder if remainder != 0 else self.block_size
 
     @property
     def _last_row_block_height(self):
-        return self.n_rows % self.block_size
+        remainder = self.n_rows % self.block_size
+        return remainder if remainder != 0 else self.block_size
 
     @typecheck_method(path=str,
                       overwrite=bool,
@@ -1435,7 +1437,7 @@ class BlockMatrix(object):
         start_col = start_bcol * self.block_size
         stop_col = (stop_bcol - 1) * self.block_size + (self._last_col_block_width if stop_bcol == self._n_block_cols else self.block_size)
 
-        #print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
+        print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
 
         return self[start_row:stop_row, start_col:stop_col]
 
@@ -1463,7 +1465,7 @@ class BlockMatrix(object):
             inner_ranges = list(zip(split_points[:-1], split_points[1:]))
             print(inner_ranges)
             blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),
-                                self._select_blocks((start, stop), (0, self._n_block_cols))) for start, stop in inner_ranges]
+                                b._select_blocks((start, stop), (0, b._n_block_cols))) for start, stop in inner_ranges]
 
             intermediate_multiply_exprs = [b1 @ b2 for b1, b2 in blocks_to_multiply]
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1459,7 +1459,7 @@ class BlockMatrix(object):
 
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
-    @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=nullable(str))
+    @typecheck_method(b=oneof(np.ndarray, block_matrix_type), splits=int, path_prefix=nullable(str))
     def tree_matmul(self, b, *, splits, path_prefix=None):
         """Matrix multiplication in situations with large inner dimension.
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1441,8 +1441,8 @@ class BlockMatrix(object):
 
         return self[start_row:stop_row, start_col:stop_col]
 
-    @typecheck_method(b=oneof(np.ndarray, block_matrix_type), _split_on_inner=int)
-    def __matmul__(self, b, _split_on_inner=1):
+    @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
+    def __matmul__(self, b):
         """Matrix multiplication: a @ b.
 
         Parameters
@@ -1458,20 +1458,40 @@ class BlockMatrix(object):
 
         if self.n_cols != b.n_rows:
             raise ValueError(f'incompatible shapes for matrix multiplication: {self.shape} and {b.shape}')
+        
+        return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
-        if _split_on_inner != 1:
-            inner_brange_size = int(math.ceil(self._n_block_cols / _split_on_inner))
+    @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=str)
+    def tree_matmul(self, b, split_on_inner, path_prefix):
+        """Matrix multiplication in situations with large inner dimension. This function splits a single matrix multiplication into
+        `split_on_inner` smaller matrix multiplications, does the smaller multiplications, checkpoints them with names defined by `file_name_prefix`,
+        and adds them together. This is useful in cases when the multiplication of two large matrices results in a much smaller matrix.
+
+        Parameters
+        ----------
+        b: :class:`numpy.ndarray` or :class:`BlockMatrix`
+        split_on_inner: :obj:`int`
+        path_prefix: :class:`str`
+
+        Returns
+        -------
+        :class:`.BlockMatrix`
+        """
+        if isinstance(b, np.ndarray):
+            b = BlockMatrix(_to_bmir(b, self.block_size))
+
+        if self.n_cols != b.n_rows:
+            raise ValueError(f'incompatible shapes for matrix multiplication: {self.shape} and {b.shape}')
+
+        if split_on_inner != 1:
+            inner_brange_size = int(math.ceil(self._n_block_cols / split_on_inner))
             split_points = list(range(0, self._n_block_cols, inner_brange_size)) + [self._n_block_cols]
             inner_ranges = list(zip(split_points[:-1], split_points[1:]))
-            print(inner_ranges)
             blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),
                                 b._select_blocks((start, stop), (0, b._n_block_cols))) for start, stop in inner_ranges]
 
             intermediate_multiply_exprs = [b1 @ b2 for b1, b2 in blocks_to_multiply]
 
-            path_prefix = new_temp_file(prefix="block_matrix_multipy_intermediates")
-            #new_local_temp_file("block_matrix_multiply_intermediates")
-            print(path_prefix)
             hl.experimental.write_block_matrices(intermediate_multiply_exprs, path_prefix)
             read_intermediates = [BlockMatrix.read(f"{path_prefix}_{i}") for i in range(0, len(intermediate_multiply_exprs))]
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1460,7 +1460,7 @@ class BlockMatrix(object):
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=nullable(str))
-    def tree_matmul(self, b, splits, path_prefix=None):
+    def tree_matmul(self, b, *, splits, path_prefix=None):
         """Matrix multiplication in situations with large inner dimension.
 
         This function splits a single matrix multiplication into `split_on_inner` smaller matrix multiplications,
@@ -1470,9 +1470,9 @@ class BlockMatrix(object):
         Parameters
         ----------
         b: :class:`numpy.ndarray` or :class:`BlockMatrix`
-        splits: :obj:`int`
+        splits: :obj:`int` (keyword only argument)
             The number of smaller multiplications to do.
-        path_prefix: :obj:`str`
+        path_prefix: :obj:`str` (keyword only argument)
             The prefix of the path to write the block matrices to. If unspecified, writes to a tmpdir.
 
         Returns

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2154,8 +2154,6 @@ class BlockMatrix(object):
 
             return [start_row, end_row, start_col, end_col]
 
-        #n_block_rows = (self.n_rows + self.block_size - 1) // self.block_size
-        #n_block_cols = (self.n_cols + self.block_size - 1) // self.block_size
         block_indices = itertools.product(range(self._n_block_rows), range(self._n_block_cols))
         rectangles = [bounds(block_row, block_col) for (block_row, block_col) in block_indices]
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1437,8 +1437,6 @@ class BlockMatrix(object):
         start_col = start_bcol * self.block_size
         stop_col = (stop_bcol - 1) * self.block_size + (self._last_col_block_width if stop_bcol == self._n_block_cols else self.block_size)
 
-        print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
-
         return self[start_row:stop_row, start_col:stop_col]
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1460,7 +1460,7 @@ class BlockMatrix(object):
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=nullable(str))
-    def tree_matmul(self, b, split_on_inner, path_prefix=None):
+    def tree_matmul(self, b, splits, path_prefix=None):
         """Matrix multiplication in situations with large inner dimension.
 
         This function splits a single matrix multiplication into `split_on_inner` smaller matrix multiplications,
@@ -1470,7 +1470,7 @@ class BlockMatrix(object):
         Parameters
         ----------
         b: :class:`numpy.ndarray` or :class:`BlockMatrix`
-        split_on_inner: :obj:`int`
+        splits: :obj:`int`
             The number of smaller multiplications to do.
         path_prefix: :obj:`str`
             The prefix of the path to write the block matrices to. If unspecified, writes to a tmpdir.
@@ -1488,8 +1488,8 @@ class BlockMatrix(object):
         if path_prefix is None:
             path_prefix = new_temp_file("tree_matmul_tmp")
 
-        if split_on_inner != 1:
-            inner_brange_size = int(math.ceil(self._n_block_cols / split_on_inner))
+        if splits != 1:
+            inner_brange_size = int(math.ceil(self._n_block_cols / splits))
             split_points = list(range(0, self._n_block_cols, inner_brange_size)) + [self._n_block_cols]
             inner_ranges = list(zip(split_points[:-1], split_points[1:]))
             blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1430,12 +1430,12 @@ class BlockMatrix(object):
         start_bcol, stop_bcol = block_col_range
 
         start_row = start_brow * self.block_size
-        stop_row = (stop_brow - 1) * self.block_size + (self._last_row_block_height if start_brow == self._n_block_rows - 1 else self.block_size)
+        stop_row = (stop_brow - 1) * self.block_size + (self._last_row_block_height if stop_brow == self._n_block_rows else self.block_size)
 
         start_col = start_bcol * self.block_size
-        stop_col = (stop_bcol - 1) * self.block_size + (self._last_col_block_width if start_bcol == self._n_block_cols - 1 else self.block_size)
+        stop_col = (stop_bcol - 1) * self.block_size + (self._last_col_block_width if stop_bcol == self._n_block_cols else self.block_size)
 
-        print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
+        #print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
 
         return self[start_row:stop_row, start_col:stop_col]
 
@@ -1465,15 +1465,13 @@ class BlockMatrix(object):
             blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),
                                 self._select_blocks((start, stop), (0, self._n_block_cols))) for start, stop in inner_ranges]
 
+            intermediate_multiply_exprs = [b1 @ b2 for b1, b2 in blocks_to_multiply]
 
-            intermediates = []
-            for b1, b2 in blocks_to_multiply:
-                temp_path = hl.utils.new_temp_file()
-                (b1 @ b2).write(temp_path)
+            path_prefix = new_local_temp_file("block_matrix_multiply_intermediates")
+            hl.experimental.write_block_matrices(intermediate_multiply_exprs, path_prefix)
+            read_intermediates = [BlockMatrix.read(f"{path_prefix}_{i}") for i in range(0, len(intermediate_multiply_exprs))]
 
-
-            
-            return sum(intermediates)
+            return sum(read_intermediates)
         
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -22,7 +22,7 @@ from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativ
 from hail.ir import ExportType
 from hail.table import Table
 from hail.typecheck import typecheck, typecheck_method, nullable, oneof, \
-    sliceof, sequenceof, lazy, enumeration, numeric, tupleof, func_spec
+    sliceof, sequenceof, lazy, enumeration, numeric, tupleof, func_spec, sized_tupleof
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1,8 +1,9 @@
 import os
 
 import itertools
-import numpy as np
+import math
 import re
+import numpy as np
 import scipy.linalg as spla
 
 import hail as hl
@@ -1408,7 +1409,7 @@ class BlockMatrix(object):
         return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense", reverse=True)
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
-    def __matmul__(self, b):
+    def __matmul__(self, b, _split_on_inner=1):
         """Matrix multiplication: a @ b.
 
         Parameters
@@ -1424,6 +1425,12 @@ class BlockMatrix(object):
 
         if self.n_cols != b.n_rows:
             raise ValueError(f'incompatible shapes for matrix multiplication: {self.shape} and {b.shape}')
+
+        inner_range_size = int(math.ceil(self.n_cols / _split_on_inner))
+        split_points = range(0, self.n_cols, inner_range_size) + [self.n_cols]
+        inner_ranges = zip(split_points[:-1], split_points[1:])
+        blocks_to_multiply = [(self[:, start:stop], self[start:stop, :]) for start, stop in inner_ranges]
+
 
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1463,15 +1463,18 @@ class BlockMatrix(object):
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=str)
     def tree_matmul(self, b, split_on_inner, path_prefix):
-        """Matrix multiplication in situations with large inner dimension. This function splits a single matrix multiplication into
-        `split_on_inner` smaller matrix multiplications, does the smaller multiplications, checkpoints them with names defined by `file_name_prefix`,
-        and adds them together. This is useful in cases when the multiplication of two large matrices results in a much smaller matrix.
+        """Matrix multiplication in situations with large inner dimension. This function splits a single matrix
+        multiplication into `split_on_inner` smaller matrix multiplications, does the smaller multiplications,
+        checkpoints them with names defined by `file_name_prefix`, and adds them together. This is useful in cases when
+        the multiplication of two large matrices results in a much smaller matrix.
 
         Parameters
         ----------
         b: :class:`numpy.ndarray` or :class:`BlockMatrix`
         split_on_inner: :obj:`int`
-        path_prefix: :class:`str`
+            The number of smaller multiplications to do.
+        path_prefix: :obj:`str`
+            The prefix of the path to write the block matrices to.
 
         Returns
         -------

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -534,6 +534,14 @@ class BlockMatrix(object):
         return self.shape[1]
 
     @property
+    def _n_block_rows(self): 
+        return (self.n_rows + self.block_size - 1) // self.block_size
+
+    @property
+    def _n_block_cols(self):
+        return (self.n_cols + self.block_size - 1) // self.block_size
+
+    @property
     def shape(self):
         """Shape of matrix.
 
@@ -553,6 +561,14 @@ class BlockMatrix(object):
         :obj:`int`
         """
         return self._bmir.typ.block_size
+
+    @property
+    def _last_col_block_width(self):
+        return self.n_cols % self.block_size
+
+    @property
+    def _last_row_block_height(self):
+        return self.n_rows % self.block_size
 
     @typecheck_method(path=str,
                       overwrite=bool,
@@ -1408,7 +1424,22 @@ class BlockMatrix(object):
     def __rtruediv__(self, b):
         return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense", reverse=True)
 
-    @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
+    @typecheck_method(block_row_range=sized_tupleof(int, int), block_col_range=sized_tupleof(int, int))
+    def _select_blocks(self, block_row_range, block_col_range):
+        start_brow, stop_brow = block_row_range
+        start_bcol, stop_bcol = block_col_range
+
+        start_row = start_brow * self.block_size
+        stop_row = (stop_brow - 1) * self.block_size + (self._last_row_block_height if start_brow == self._n_block_rows - 1 else self.block_size)
+
+        start_col = start_bcol * self.block_size
+        stop_col = (stop_bcol - 1) * self.block_size + (self._last_col_block_width if start_bcol == self._n_block_cols - 1 else self.block_size)
+
+        print(f"{block_row_range}, {block_col_range} -> {(start_row, stop_row)}, {(start_col, stop_col)}")
+
+        return self[start_row:stop_row, start_col:stop_col]
+
+    @typecheck_method(b=oneof(np.ndarray, block_matrix_type), _split_on_inner=int)
     def __matmul__(self, b, _split_on_inner=1):
         """Matrix multiplication: a @ b.
 
@@ -1426,12 +1457,24 @@ class BlockMatrix(object):
         if self.n_cols != b.n_rows:
             raise ValueError(f'incompatible shapes for matrix multiplication: {self.shape} and {b.shape}')
 
-        inner_range_size = int(math.ceil(self.n_cols / _split_on_inner))
-        split_points = range(0, self.n_cols, inner_range_size) + [self.n_cols]
-        inner_ranges = zip(split_points[:-1], split_points[1:])
-        blocks_to_multiply = [(self[:, start:stop], self[start:stop, :]) for start, stop in inner_ranges]
+        if _split_on_inner != 1:
+            inner_brange_size = int(math.ceil(self._n_block_cols / _split_on_inner))
+            split_points = list(range(0, self._n_block_cols, inner_brange_size)) + [self._n_block_cols]
+            inner_ranges = list(zip(split_points[:-1], split_points[1:]))
+            print(inner_ranges)
+            blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),
+                                self._select_blocks((start, stop), (0, self._n_block_cols))) for start, stop in inner_ranges]
 
 
+            intermediates = []
+            for b1, b2 in blocks_to_multiply:
+                temp_path = hl.utils.new_temp_file()
+                (b1 @ b2).write(temp_path)
+
+
+            
+            return sum(intermediates)
+        
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
     @typecheck_method(x=numeric)
@@ -2069,12 +2112,12 @@ class BlockMatrix(object):
             If true, export elements as raw bytes in row major order.
         """
         def rows_in_block(block_row):
-            if block_row == n_block_rows - 1:
+            if block_row == self._n_block_rows - 1:
                 return self.n_rows - block_row * self.block_size
             return self.block_size
 
         def cols_in_block(block_col):
-            if block_col == n_block_cols - 1:
+            if block_col == self._n_block_cols - 1:
                 return self.n_cols - block_col * self.block_size
             return self.block_size
 
@@ -2086,9 +2129,9 @@ class BlockMatrix(object):
 
             return [start_row, end_row, start_col, end_col]
 
-        n_block_rows = (self.n_rows + self.block_size - 1) // self.block_size
-        n_block_cols = (self.n_cols + self.block_size - 1) // self.block_size
-        block_indices = itertools.product(range(n_block_rows), range(n_block_cols))
+        #n_block_rows = (self.n_rows + self.block_size - 1) // self.block_size
+        #n_block_cols = (self.n_cols + self.block_size - 1) // self.block_size
+        block_indices = itertools.product(range(self._n_block_rows), range(self._n_block_cols))
         rectangles = [bounds(block_row, block_col) for (block_row, block_col) in block_indices]
 
         self.export_rectangles(path_out, rectangles, delimiter, binary)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1469,7 +1469,9 @@ class BlockMatrix(object):
 
             intermediate_multiply_exprs = [b1 @ b2 for b1, b2 in blocks_to_multiply]
 
-            path_prefix = new_local_temp_file("block_matrix_multiply_intermediates")
+            path_prefix = new_temp_file(prefix="block_matrix_multipy_intermediates")
+            #new_local_temp_file("block_matrix_multiply_intermediates")
+            print(path_prefix)
             hl.experimental.write_block_matrices(intermediate_multiply_exprs, path_prefix)
             read_intermediates = [BlockMatrix.read(f"{path_prefix}_{i}") for i in range(0, len(intermediate_multiply_exprs))]
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -534,7 +534,7 @@ class BlockMatrix(object):
         return self.shape[1]
 
     @property
-    def _n_block_rows(self): 
+    def _n_block_rows(self):
         return (self.n_rows + self.block_size - 1) // self.block_size
 
     @property
@@ -1456,7 +1456,7 @@ class BlockMatrix(object):
 
         if self.n_cols != b.n_rows:
             raise ValueError(f'incompatible shapes for matrix multiplication: {self.shape} and {b.shape}')
-        
+
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type), split_on_inner=int, path_prefix=str)
@@ -1489,7 +1489,7 @@ class BlockMatrix(object):
             split_points = list(range(0, self._n_block_cols, inner_brange_size)) + [self._n_block_cols]
             inner_ranges = list(zip(split_points[:-1], split_points[1:]))
             blocks_to_multiply = [(self._select_blocks((0, self._n_block_rows), (start, stop)),
-                                b._select_blocks((start, stop), (0, b._n_block_cols))) for start, stop in inner_ranges]
+                                   b._select_blocks((start, stop), (0, b._n_block_cols))) for start, stop in inner_ranges]
 
             intermediate_multiply_exprs = [b1 @ b2 for b1, b2 in blocks_to_multiply]
 
@@ -1497,7 +1497,7 @@ class BlockMatrix(object):
             read_intermediates = [BlockMatrix.read(f"{path_prefix}_{i}") for i in range(0, len(intermediate_multiply_exprs))]
 
             return sum(read_intermediates)
-        
+
         return BlockMatrix(BlockMatrixDot(self._bmir, b._bmir))
 
     @typecheck_method(x=numeric)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -475,16 +475,15 @@ class Tests(unittest.TestCase):
 
         # Variety of block sizes and splits
         fifty_by_sixty = np.arange(50 * 60).reshape((50, 60))
+        sixty_by_twenty_five = np.arange(60 * 25).reshape((60, 25))
         block_sizes = [7, 10]
         split_sizes = [2, 9]
         for block_size in block_sizes:
-            print(f"Handling block_size = {block_size}")
-            bm = BlockMatrix.from_numpy(fifty_by_sixty, block_size)
-            bmt = BlockMatrix.from_numpy(fifty_by_sixty.T, block_size)
+            bm_fifty_by_sixty = BlockMatrix.from_numpy(fifty_by_sixty, block_size)
+            bm_sixty_by_twenty_five = BlockMatrix.from_numpy(sixty_by_twenty_five, block_size)
             for split_size in split_sizes:
-                print(f"Handling split_size = {split_size}")
-                self._assert_eq(bm.tree_matmul(bmt, split_size), fifty_by_sixty @ fifty_by_sixty.T)
-                self._assert_eq(bmt.tree_matmul(bm, split_size), fifty_by_sixty.T @ fifty_by_sixty)
+                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_fifty_by_sixty.T, split_size), fifty_by_sixty @ fifty_by_sixty.T)
+                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_sixty_by_twenty_five, split_size), fifty_by_sixty @ sixty_by_twenty_five)
 
 
     def test_fill(self):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -463,15 +463,15 @@ class Tests(unittest.TestCase):
         nrow = np.array([[7.0, 8.0, 9.0]])
         row = BlockMatrix.from_numpy(nrow, block_size=2)
 
-        self._assert_eq(m.tree_matmul(m.T, 2, new_temp_file()), nm @ nm.T)
-        self._assert_eq(m.tree_matmul(nm.T, 2, new_temp_file()), nm @ nm.T)
-        self._assert_eq(row.tree_matmul(row.T, 2, new_temp_file()), nrow @ nrow.T)
-        self._assert_eq(row.tree_matmul(nrow.T, 2, new_temp_file()), nrow @ nrow.T)
+        self._assert_eq(m.tree_matmul(m.T, 2), nm @ nm.T)
+        self._assert_eq(m.tree_matmul(nm.T, 2), nm @ nm.T)
+        self._assert_eq(row.tree_matmul(row.T, 2), nrow @ nrow.T)
+        self._assert_eq(row.tree_matmul(nrow.T, 2), nrow @ nrow.T)
 
-        self._assert_eq(m.T.tree_matmul(m, 2, new_temp_file()), nm.T @ nm)
-        self._assert_eq(m.T.tree_matmul(nm, 2, new_temp_file()), nm.T @ nm)
-        self._assert_eq(row.T.tree_matmul(row, 2, new_temp_file()), nrow.T @ nrow)
-        self._assert_eq(row.T.tree_matmul(nrow, 2, new_temp_file()), nrow.T @ nrow)
+        self._assert_eq(m.T.tree_matmul(m, 2), nm.T @ nm)
+        self._assert_eq(m.T.tree_matmul(nm, 2), nm.T @ nm)
+        self._assert_eq(row.T.tree_matmul(row, 2), nrow.T @ nrow)
+        self._assert_eq(row.T.tree_matmul(nrow, 2), nrow.T @ nrow)
 
         # Variety of block sizes and splits
         fifty_by_sixty = np.arange(50 * 60).reshape((50, 60))
@@ -483,8 +483,8 @@ class Tests(unittest.TestCase):
             bmt = BlockMatrix.from_numpy(fifty_by_sixty.T, block_size)
             for split_size in split_sizes:
                 print(f"Handling split_size = {split_size}")
-                self._assert_eq(bm.tree_matmul(bmt, split_size, new_temp_file()), fifty_by_sixty @ fifty_by_sixty.T)
-                self._assert_eq(bmt.tree_matmul(bm, split_size, new_temp_file()), fifty_by_sixty.T @ fifty_by_sixty)
+                self._assert_eq(bm.tree_matmul(bmt, split_size), fifty_by_sixty @ fifty_by_sixty.T)
+                self._assert_eq(bmt.tree_matmul(bm, split_size), fifty_by_sixty.T @ fifty_by_sixty)
 
 
     def test_fill(self):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -4,6 +4,7 @@ from hail.linalg import BlockMatrix
 from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalError
 from ..helpers import *
 import numpy as np
+import tempfile
 import math
 from hail.expr.expressions import ExpressionException
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -463,15 +463,15 @@ class Tests(unittest.TestCase):
         nrow = np.array([[7.0, 8.0, 9.0]])
         row = BlockMatrix.from_numpy(nrow, block_size=2)
 
-        self._assert_eq(m.tree_matmul(m.T, 2), nm @ nm.T)
-        self._assert_eq(m.tree_matmul(nm.T, 2), nm @ nm.T)
-        self._assert_eq(row.tree_matmul(row.T, 2), nrow @ nrow.T)
-        self._assert_eq(row.tree_matmul(nrow.T, 2), nrow @ nrow.T)
+        self._assert_eq(m.tree_matmul(m.T, splits=2), nm @ nm.T)
+        self._assert_eq(m.tree_matmul(nm.T, splits=2), nm @ nm.T)
+        self._assert_eq(row.tree_matmul(row.T, splits=2), nrow @ nrow.T)
+        self._assert_eq(row.tree_matmul(nrow.T, splits=2), nrow @ nrow.T)
 
-        self._assert_eq(m.T.tree_matmul(m, 2), nm.T @ nm)
-        self._assert_eq(m.T.tree_matmul(nm, 2), nm.T @ nm)
-        self._assert_eq(row.T.tree_matmul(row, 2), nrow.T @ nrow)
-        self._assert_eq(row.T.tree_matmul(nrow, 2), nrow.T @ nrow)
+        self._assert_eq(m.T.tree_matmul(m, splits=2), nm.T @ nm)
+        self._assert_eq(m.T.tree_matmul(nm, splits=2), nm.T @ nm)
+        self._assert_eq(row.T.tree_matmul(row, splits=2), nrow.T @ nrow)
+        self._assert_eq(row.T.tree_matmul(nrow, splits=2), nrow.T @ nrow)
 
         # Variety of block sizes and splits
         fifty_by_sixty = np.arange(50 * 60).reshape((50, 60))
@@ -482,8 +482,8 @@ class Tests(unittest.TestCase):
             bm_fifty_by_sixty = BlockMatrix.from_numpy(fifty_by_sixty, block_size)
             bm_sixty_by_twenty_five = BlockMatrix.from_numpy(sixty_by_twenty_five, block_size)
             for split_size in split_sizes:
-                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_fifty_by_sixty.T, split_size), fifty_by_sixty @ fifty_by_sixty.T)
-                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_sixty_by_twenty_five, split_size), fifty_by_sixty @ sixty_by_twenty_five)
+                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_fifty_by_sixty.T, splits=split_size), fifty_by_sixty @ fifty_by_sixty.T)
+                self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_sixty_by_twenty_five, splits=split_size), fifty_by_sixty @ sixty_by_twenty_five)
 
 
     def test_fill(self):

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -11,7 +11,7 @@ object BlockMatrixWriter {
     override val typeHints = ShortTypeHints(
       List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter],
         classOf[BlockMatrixBinaryMultiWriter], classOf[BlockMatrixTextMultiWriter],
-        classOf[BlockMatrixPersistWriter]))
+        classOf[BlockMatrixPersistWriter], classOf[BlockMatrixNativeMultiWriter]))
     override val typeHintFieldName: String = "name"
   }
 }
@@ -81,4 +81,13 @@ case class BlockMatrixTextMultiWriter(
 
   def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit =
     BlockMatrix.exportBlockMatrices(fs, bms, prefix, overwrite, delimiter, header, addIndex, compression, customFilenames)
+}
+
+case class BlockMatrixNativeMultiWriter(
+  prefix: String,
+  overwrite: Boolean) extends BlockMatrixMultiWriter {
+
+  def apply(bms: IndexedSeq[BlockMatrix]): Unit = {
+    BlockMatrix.writeBlockMatrices(bms, prefix, overwrite)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -85,9 +85,10 @@ case class BlockMatrixTextMultiWriter(
 
 case class BlockMatrixNativeMultiWriter(
   prefix: String,
-  overwrite: Boolean) extends BlockMatrixMultiWriter {
+  overwrite: Boolean,
+  forceRowMajor: Boolean) extends BlockMatrixMultiWriter {
 
   def apply(bms: IndexedSeq[BlockMatrix]): Unit = {
-    BlockMatrix.writeBlockMatrices(bms, prefix, overwrite)
+    BlockMatrix.writeBlockMatrices(bms, prefix, overwrite, forceRowMajor)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -88,7 +88,7 @@ case class BlockMatrixNativeMultiWriter(
   overwrite: Boolean,
   forceRowMajor: Boolean) extends BlockMatrixMultiWriter {
 
-  def apply(bms: IndexedSeq[BlockMatrix]): Unit = {
-    BlockMatrix.writeBlockMatrices(bms, prefix, overwrite, forceRowMajor)
+  def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit = {
+    BlockMatrix.writeBlockMatrices(fs, bms, prefix, overwrite, forceRowMajor)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -59,15 +59,15 @@ case class BlockMatrixRectanglesWriter(
 }
 
 abstract class BlockMatrixMultiWriter {
-  def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit
+  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit
 }
 
 case class BlockMatrixBinaryMultiWriter(
   prefix: String,
   overwrite: Boolean) extends BlockMatrixMultiWriter {
 
-  def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit =
-    BlockMatrix.binaryWriteBlockMatrices(fs, bms, prefix, overwrite)
+  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
+    BlockMatrix.binaryWriteBlockMatrices(ctx.fs, bms, prefix, overwrite)
 }
 
 case class BlockMatrixTextMultiWriter(
@@ -79,8 +79,8 @@ case class BlockMatrixTextMultiWriter(
   compression: Option[String],
   customFilenames: Option[Array[String]]) extends BlockMatrixMultiWriter {
 
-  def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit =
-    BlockMatrix.exportBlockMatrices(fs, bms, prefix, overwrite, delimiter, header, addIndex, compression, customFilenames)
+  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit =
+    BlockMatrix.exportBlockMatrices(ctx.fs, bms, prefix, overwrite, delimiter, header, addIndex, compression, customFilenames)
 }
 
 case class BlockMatrixNativeMultiWriter(
@@ -88,7 +88,7 @@ case class BlockMatrixNativeMultiWriter(
   overwrite: Boolean,
   forceRowMajor: Boolean) extends BlockMatrixMultiWriter {
 
-  def apply(fs: FS, bms: IndexedSeq[BlockMatrix]): Unit = {
-    BlockMatrix.writeBlockMatrices(fs, bms, prefix, overwrite, forceRowMajor)
+  def apply(ctx: ExecuteContext, bms: IndexedSeq[BlockMatrix]): Unit = {
+    BlockMatrix.writeBlockMatrices(ctx, bms, prefix, overwrite, forceRowMajor)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -812,7 +812,7 @@ object Interpret {
       case BlockMatrixWrite(child, writer) =>
         writer(ctx, child.execute(ctx))
       case BlockMatrixMultiWrite(blockMatrices, writer) =>
-        writer(ctx.fs, blockMatrices.map(_.execute(ctx)))
+        writer(ctx, blockMatrices.map(_.execute(ctx)))
       case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id))) =>
         HailContext.sparkBackend("interpret UnpersistBlockMatrix").bmCache.unpersistBlockMatrix(id)
       case _: UnpersistBlockMatrix =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -9,6 +9,7 @@ import is.hail._
 import is.hail.annotations._
 import is.hail.backend.BroadcastValue
 import is.hail.backend.spark.SparkBackend
+import is.hail.utils._
 import is.hail.expr.Parser
 import is.hail.expr.ir.{CompileAndEvaluate, ExecuteContext, IR, TableValue}
 import is.hail.types._
@@ -334,7 +335,7 @@ object BlockMatrix {
   ): Unit = {
 
     val fs = HailContext.sFS
-    def blockMatrixURI(matrixIdx: Int): String = prefix + matrixIdx
+    def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
     def partitionURI(matrixIdx: Int, partitionIdx: Int) = s"{$prefix}{$matrixIdx}/$partitionIdx"
 
     // Deal with overwrite, make the folders
@@ -346,6 +347,8 @@ object BlockMatrix {
         fatal(s"file already exists: $uri")
 
       fs.mkDir(uri)
+      // Need a parts folder inside.
+      fs.mkDir(uri + "/parts")
     }}
 
     def writeBlock(it: Iterator[((Int, Int), BDM[Double])], os: OutputStream): Int = {
@@ -367,31 +370,42 @@ object BlockMatrix {
     val rdds = bms.map(bm => bm.blocks)
     val blockMatrixMetadataFields = bms.map(bm => (bm.blockSize, bm.nRows, bm.nCols, bm.gp.maybeBlocks))
     val first = rdds(0)
+    val nPartitions = rdds.map(_.getNumPartitions).sum
+    val numDigits = digitsNeeded(nPartitions)
 
     val func = (rddIndex: Int, partitionIndex: Int, it: Iterator[((Int, Int), BDM[Double])]) => {
-      // Write each RDD
-      //val (partFiles, partitionCounts) = ???
+      // Write each chunk wherever it belongs
+      val pathToBlockMatrixRDD = blockMatrixURI(rddIndex)
+      val partFileName = partFile(numDigits, partitionIndex, TaskContext.get())
 
-      fs.writeDataFile(blockMatrixURI(rddIndex) + metadataRelativePath) { os =>
-        implicit val formats = defaultJSONFormats
-        val (blockSize, nRows, nCols, maybeBlocks) = blockMatrixMetadataFields(rddIndex)
-        jackson.Serialization.write(
-          BlockMatrixMetadata(blockSize, nRows, nCols, maybeBlocks, Array.empty[String]), os)
-      }
+      
+      println(s"Processing partition $partitionIndex from rdd $rddIndex")
 
-      fs.writeTextFile(blockMatrixURI(rddIndex) + "/_SUCCESS")(out => ())
-      Iterator.single(0)
+      Iterator.single((rddIndex, partFileName))
     }
 
-    val ordd = new OriginUnionRDD[((Int, Int), BDM[Double]), Int](
+    val ordd = new OriginUnionRDD[((Int, Int), BDM[Double]), (Int, String)](
       first.sparkContext,
       rdds,
       func
     )
 
-    val x = ordd.collect()
+    val rddNumberAndPartFiles = ordd.collect()
+    val grouped = rddNumberAndPartFiles.groupBy(_._1)
+    grouped.foreach{ case (rddIndex, numberedPartFiles) =>
+      val partFiles = numberedPartFiles.map{case (_, partFileName) => partFileName}
 
-    println("Round tripped")
+      fs.writeDataFile(blockMatrixURI(rddIndex) + metadataRelativePath) { os =>
+        implicit val formats = defaultJSONFormats
+        val (blockSize, nRows, nCols, maybeBlocks) = blockMatrixMetadataFields(rddIndex)
+        jackson.Serialization.write(
+          BlockMatrixMetadata(blockSize, nRows, nCols, maybeBlocks, partFiles), os)
+      }
+
+      fs.writeTextFile(blockMatrixURI(rddIndex) + "/_SUCCESS")(out => ())
+    }
+
+    log.info("Wrote block matrices to disk")
   }
 }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -326,6 +326,14 @@ object BlockMatrix {
 
     using(fs.create(prefix + "/_SUCCESS"))(out => ())
   }
+
+  def writeBlockMatrices(
+    bms: IndexedSeq[BlockMatrix],
+    prefix: String,
+    overwrite: Boolean
+  ): Unit = {
+    println("Round tripped")
+  }
 }
 
 // must be top-level for Jackson to serialize correctly

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -99,9 +99,7 @@ object BlockMatrix {
         override val partitioner = Some(gp)
 
         protected def getPartitions: Array[Partition] = Array.tabulate(gp.numPartitions)(pi =>
-          new Partition {
-            def index: Int = pi
-          })
+          new Partition { def index: Int = pi } )
 
         def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] =
           Iterator.single(piBlock(gp, split.index))
@@ -194,7 +192,7 @@ object BlockMatrix {
   }
 
   private[linalg] def block(bm: BlockMatrix, parts: Array[Partition], gp: GridPartitioner, context: TaskContext,
-                            i: Int, j: Int): Option[BDM[Double]] = {
+    i: Int, j: Int): Option[BDM[Double]] = {
     val pi = gp.coordinatesPart(i, j)
     if (pi >= 0) {
       val it = bm.blocks.iterator(parts(pi), context)
@@ -215,34 +213,22 @@ object BlockMatrix {
 
     implicit class Shim(l: M) {
       def +(r: M): M = l.add(r)
-
       def -(r: M): M = l.sub(r)
-
       def *(r: M): M = l.mul(r)
-
       def /(r: M): M = l.div(r)
-
       def +(r: Double): M = l.scalarAdd(r)
-
       def -(r: Double): M = l.scalarSub(r)
-
       def *(r: Double): M = l.scalarMul(r)
-
       def /(r: Double): M = l.scalarDiv(r)
-
       def T: M = l.transpose()
     }
 
     implicit class ScalarShim(l: Double) {
       def +(r: M): M = r.scalarAdd(l)
-
       def -(r: M): M = r.reverseScalarSub(l)
-
       def *(r: M): M = r.scalarMul(l)
-
       def /(r: M): M = r.reverseScalarDiv(l)
     }
-
   }
 
   def collectMatrices(bms: IndexedSeq[BlockMatrix]): RDD[BDM[Double]] = new CollectMatricesRDD(bms)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -339,7 +339,6 @@ object BlockMatrix {
     def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
     def partitionURI(matrixIdx: Int, partitionIdx: Int) = s"{$prefix}{$matrixIdx}/$partitionIdx"
 
-    // Deal with overwrite, make the folders
     bms.zipWithIndex.foreach{ case (bm, bIdx) => {
       val uri = blockMatrixURI(bIdx)
       if (overwrite)
@@ -348,7 +347,6 @@ object BlockMatrix {
         fatal(s"file already exists: $uri")
 
       fs.mkDir(uri)
-      // Need a parts folder inside.
       fs.mkDir(uri + "/parts")
     }}
 
@@ -357,7 +355,6 @@ object BlockMatrix {
       val (_, lm) = it.next()
       assert(!it.hasNext)
 
-      // TODO Replace false with forceRowMajor
       lm.write(os, forceRowMajor, bufferSpec)
       os.close()
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -17,10 +17,11 @@ import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PFloat
 import is.hail.types.virtual._
 import is.hail.io._
 import is.hail.rvd.{RVD, RVDContext, RVDPartitioner}
-import is.hail.sparkextras.{ContextRDD, OriginUnionRDD}
+import is.hail.sparkextras.{ContextRDD, OriginUnionPartition, OriginUnionRDD}
 import is.hail.utils._
-import is.hail.utils.richUtils.{RichArray, RichDenseMatrixDouble}
+import is.hail.utils.richUtils.{RichArray, RichContextRDD, RichDenseMatrixDouble}
 import is.hail.io.fs.FS
+import is.hail.io.index.IndexWriter
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.math3.random.MersenneTwister
 import org.apache.spark.executor.InputMetrics
@@ -91,25 +92,27 @@ object BlockMatrix {
     new BlockingBufferSpec(32 * 1024,
       new LZ4FastBlockBufferSpec(32 * 1024,
         new StreamBlockBufferSpec))
-  
+
   def apply(gp: GridPartitioner, piBlock: (GridPartitioner, Int) => ((Int, Int), BDM[Double])): BlockMatrix =
     new BlockMatrix(
       new RDD[((Int, Int), BDM[Double])](SparkBackend.sparkContext("BlockMatrix.apply"), Nil) {
         override val partitioner = Some(gp)
-  
+
         protected def getPartitions: Array[Partition] = Array.tabulate(gp.numPartitions)(pi =>
-          new Partition { def index: Int = pi } )
-  
+          new Partition {
+            def index: Int = pi
+          })
+
         def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] =
           Iterator.single(piBlock(gp, split.index))
       }, gp.blockSize, gp.nRows, gp.nCols)
-  
+
   def fromBreezeMatrix(lm: BDM[Double]): M =
     fromBreezeMatrix(lm, defaultBlockSize)
 
   def fromBreezeMatrix(lm: BDM[Double], blockSize: Int): M = {
     val gp = GridPartitioner(blockSize, lm.rows, lm.cols)
-    
+
     val localBlocksBc = Array.tabulate(gp.numPartitions) { pi =>
       val (i, j) = gp.blockCoordinates(pi)
       val (blockNRows, blockNCols) = gp.blockDims(pi)
@@ -118,7 +121,7 @@ object BlockMatrix {
 
       HailContext.backend.broadcast(lm(iOffset until iOffset + blockNRows, jOffset until jOffset + blockNCols).copy)
     }
-    
+
     BlockMatrix(gp, (gp, pi) => (gp.blockCoordinates(pi), localBlocksBc(pi).value))
   }
 
@@ -133,19 +136,19 @@ object BlockMatrix {
       val (i, j) = gp.blockCoordinates(pi)
       ((i, j), BDM.fill[Double](gp.blockRowNRows(i), gp.blockColNCols(j))(value))
     })
-  
+
   // uniform or Gaussian
   def random(nRows: Long, nCols: Long, blockSize: Int = defaultBlockSize,
-    seed: Long = 0, gaussian: Boolean): M =
+             seed: Long = 0, gaussian: Boolean): M =
     BlockMatrix(GridPartitioner(blockSize, nRows, nCols), (gp, pi) => {
       val (i, j) = gp.blockCoordinates(pi)
       val blockSeed = seed + 15485863 * pi // millionth prime
 
       val randBasis: RandBasis = new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(blockSeed)))
       val rand = if (gaussian) randBasis.gaussian else randBasis.uniform
-      
+
       ((i, j), BDM.rand[Double](gp.blockRowNRows(i), gp.blockColNCols(j), rand))
-    } )
+    })
 
   def map2(f: (Double, Double) => Double)(l: M, r: M): M =
     l.map2(r, f)
@@ -157,9 +160,9 @@ object BlockMatrix {
 
   def checkWriteSuccess(fs: FS, uri: String) {
     if (!fs.exists(uri + "/_SUCCESS"))
-      fatal(s"Error reading block matrix. Earlier write failed: no success indicator found at uri $uri")    
+      fatal(s"Error reading block matrix. Earlier write failed: no success indicator found at uri $uri")
   }
-  
+
   def readMetadata(fs: FS, uri: String): BlockMatrixMetadata = {
     using(fs.open(uri + metadataRelativePath)) { is =>
       implicit val formats = defaultJSONFormats
@@ -191,7 +194,7 @@ object BlockMatrix {
   }
 
   private[linalg] def block(bm: BlockMatrix, parts: Array[Partition], gp: GridPartitioner, context: TaskContext,
-    i: Int, j: Int): Option[BDM[Double]] = {
+                            i: Int, j: Int): Option[BDM[Double]] = {
     val pi = gp.coordinatesPart(i, j)
     if (pi >= 0) {
       val it = bm.blocks.iterator(parts(pi), context)
@@ -212,13 +215,19 @@ object BlockMatrix {
 
     implicit class Shim(l: M) {
       def +(r: M): M = l.add(r)
+
       def -(r: M): M = l.sub(r)
+
       def *(r: M): M = l.mul(r)
+
       def /(r: M): M = l.div(r)
 
       def +(r: Double): M = l.scalarAdd(r)
+
       def -(r: Double): M = l.scalarSub(r)
+
       def *(r: Double): M = l.scalarMul(r)
+
       def /(r: Double): M = l.scalarDiv(r)
 
       def T: M = l.transpose()
@@ -226,10 +235,14 @@ object BlockMatrix {
 
     implicit class ScalarShim(l: Double) {
       def +(r: M): M = r.scalarAdd(l)
+
       def -(r: M): M = r.reverseScalarSub(l)
+
       def *(r: M): M = r.scalarMul(l)
+
       def /(r: M): M = r.reverseScalarDiv(l)
     }
+
   }
 
   def collectMatrices(bms: IndexedSeq[BlockMatrix]): RDD[BDM[Double]] = new CollectMatricesRDD(bms)
@@ -260,15 +273,15 @@ object BlockMatrix {
   }
 
   def exportBlockMatrices(
-    fs: FS,
-    bms: IndexedSeq[BlockMatrix],
-    prefix: String,
-    overwrite: Boolean,
-    delimiter: String,
-    header: Option[String],
-    addIndex: Boolean,
-    compression: Option[String],
-    customFilenames: Option[Array[String]]): Unit = {
+                           fs: FS,
+                           bms: IndexedSeq[BlockMatrix],
+                           prefix: String,
+                           overwrite: Boolean,
+                           delimiter: String,
+                           header: Option[String],
+                           addIndex: Boolean,
+                           compression: Option[String],
+                           customFilenames: Option[Array[String]]): Unit = {
 
     if (overwrite)
       fs.delete(prefix, recursive = true)
@@ -279,7 +292,7 @@ object BlockMatrix {
 
     val d = digitsNeeded(bms.length)
     val fsBc = fs.broadcast
-    
+
     val nameFunction = customFilenames match {
       case None => i: Int => StringUtils.leftPad(i.toString, d, '0') + ".tsv"
       case Some(filenames) => filenames.apply(_)
@@ -328,50 +341,17 @@ object BlockMatrix {
     using(fs.create(prefix + "/_SUCCESS"))(out => ())
   }
 
-  def writeBlockMatrices2(
-    ctx: ExecuteContext,
-    bms: IndexedSeq[BlockMatrix],
-    prefix: String,
-    overwrite: Boolean,
-    forceRowMajor: Boolean,
-    stageLocally: Boolean
-  ): Unit = {
-    val fs = ctx.fs
-
-    // Plan:
-    // 1. Map all the BlockMatrices to RDDs
-    // 2. join all the RDDs. Need a function of the form:
-    // rddIndex, partitionIndex, T => U
-    // Let T = ((Int, Int), BDM[Double])
-    // Let U = ???
-    // Problem: Need an interface that allows me to pick the filenames I'm writing to dynamically.
-
-    val rdds = bms.map(bm => bm.blocks)
-    val first = rdds(0)
-    val nPartitions = rdds.map(_.getNumPartitions).sum
-    val numDigits = digitsNeeded(nPartitions)
-
-    val ordd = new OriginUnionRDD[((Int, Int), BDM[Double]), (Int, String)](
-      first.sparkContext,
-      rdds,
-      ???
-    )
-
-    val joinedRDD: RDD[_] = ???
-    val (partFiles, partitionCounts) = joinedRDD.writePartitions(ctx, ???, ???, ???)
-  }
-
   def writeBlockMatrices(
-    fs: FS,
-    bms: IndexedSeq[BlockMatrix],
-    prefix: String,
-    overwrite: Boolean,
-    forceRowMajor: Boolean
-  ): Unit = {
+     fs: FS,
+     bms: IndexedSeq[BlockMatrix],
+     prefix: String,
+     overwrite: Boolean,
+     forceRowMajor: Boolean
+   ): Unit = {
 
     def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
 
-    bms.zipWithIndex.foreach{ case (bm, bIdx) => {
+    bms.zipWithIndex.foreach { case (bm, bIdx) =>
       val uri = blockMatrixURI(bIdx)
       if (overwrite)
         fs.delete(prefix, recursive = true)
@@ -380,9 +360,9 @@ object BlockMatrix {
 
       fs.mkDir(uri)
       fs.mkDir(uri + "/parts")
-    }}
+    }
 
-    def writeBlock(it: Iterator[((Int, Int), BDM[Double])], os: OutputStream): Int = {
+    def writeBlock(ctx: RVDContext, it: Iterator[((Int, Int), BDM[Double])], os: OutputStream, iw: IndexWriter): Long = {
       assert(it.hasNext)
       val (_, lm) = it.next()
       assert(!it.hasNext)
@@ -390,7 +370,7 @@ object BlockMatrix {
       lm.write(os, forceRowMajor, bufferSpec)
       os.close()
 
-      1
+      1L
     }
 
     if (bms.isEmpty) {
@@ -403,39 +383,39 @@ object BlockMatrix {
     val nPartitions = rdds.map(_.getNumPartitions).sum
     val numDigits = digitsNeeded(nPartitions)
 
-    val func = (rddIndex: Int, partitionIndex: Int, it: Iterator[((Int, Int), BDM[Double])]) => {
-      // Write each chunk wherever it belongs
-      val pathToBlockMatrixRDD = blockMatrixURI(rddIndex)
-      val partFileName = partFile(numDigits, partitionIndex, TaskContext.get())
-      val finalFilename = pathToBlockMatrixRDD + "/parts/" + partFileName
-      val os = fs.create(finalFilename)
-      writeBlock(it, os)
-
-      Iterator.single((rddIndex, partFileName))
-    }
-
-    val ordd = new OriginUnionRDD[((Int, Int), BDM[Double]), (Int, String)](
+    val ordd = new OriginUnionRDD[((Int, Int), BDM[Double]), ((Int, Int), BDM[Double])](
       first.sparkContext,
       rdds,
-      func
+      (_, _, it) => it
     )
 
-    val rddNumberAndPartFiles = ordd.collect()
-    val grouped = rddNumberAndPartFiles.groupBy(_._1)
-    grouped.foreach{ case (rddIndex, numberedPartFiles) =>
-      val partFiles = numberedPartFiles.map{case (_, partFileName) => partFileName}
+    val partMap = ordd.partitions.map(part => part.asInstanceOf[OriginUnionPartition]).
+      map(oup => (oup.index, (oup.originIdx, oup.originPart.index))).toMap
 
-      using(new DataOutputStream(fs.create(blockMatrixURI(rddIndex) + metadataRelativePath))) { os =>
-        implicit val formats = defaultJSONFormats
-        val (blockSize, nRows, nCols, maybeBlocks) = blockMatrixMetadataFields(rddIndex)
-        jackson.Serialization.write(
-          BlockMatrixMetadata(blockSize, nRows, nCols, maybeBlocks, partFiles), os)
-      }
-
-      using(fs.create(blockMatrixURI(rddIndex) + "/_SUCCESS"))(out => ())
+    val writerRDD = ContextRDD.weaken(ordd).cmapPartitionsWithContextAndIndex { (i, ctx, it) =>
+      val (rddIndex, partIndex) = partMap(i)
+      val trueIt = it(ctx)
+      val rootPath = blockMatrixURI(rddIndex)
+      val fileName = partFile(numDigits, partIndex, TaskContext.get)
+      val nameAndCountIt = RichContextRDD.writeParts(ctx, rootPath, fileName, null, (_) => null, false, fs, "/tmp/foo", trueIt, writeBlock)
+      nameAndCountIt.map { case (name, count) => (name, rddIndex) }
     }
 
-    log.info("Wrote block matrices to disk")
+    val rddNumberAndPartFiles = writerRDD.collect()
+    val grouped = rddNumberAndPartFiles.groupBy(_._2)
+    grouped.foreach { case (rddIndex, numberedPartFiles) =>
+      val partFiles = numberedPartFiles.map { case (partFileName, _) => partFileName }
+      val metadataPath = blockMatrixURI(rddIndex.toInt) + metadataRelativePath
+      using(new DataOutputStream(fs.create(metadataPath))) { os =>
+        implicit val formats = defaultJSONFormats
+        val (blockSize, nRows, nCols, maybeBlocks) = blockMatrixMetadataFields(rddIndex.toInt)
+        jackson.Serialization.write(
+          BlockMatrixMetadata(blockSize, nRows, nCols, maybeBlocks, partFiles), os
+        )
+      }
+
+      using(fs.create(blockMatrixURI(rddIndex.toInt) + "/_SUCCESS"))(out => ())
+    }
   }
 }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -273,15 +273,16 @@ object BlockMatrix {
   }
 
   def exportBlockMatrices(
-                           fs: FS,
-                           bms: IndexedSeq[BlockMatrix],
-                           prefix: String,
-                           overwrite: Boolean,
-                           delimiter: String,
-                           header: Option[String],
-                           addIndex: Boolean,
-                           compression: Option[String],
-                           customFilenames: Option[Array[String]]): Unit = {
+    fs: FS,
+    bms: IndexedSeq[BlockMatrix],
+    prefix: String,
+    overwrite: Boolean,
+    delimiter: String,
+    header: Option[String],
+    addIndex: Boolean,
+    compression: Option[String],
+    customFilenames: Option[Array[String]]
+  ): Unit = {
 
     if (overwrite)
       fs.delete(prefix, recursive = true)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -331,7 +331,8 @@ object BlockMatrix {
   def writeBlockMatrices(
     bms: IndexedSeq[BlockMatrix],
     prefix: String,
-    overwrite: Boolean
+    overwrite: Boolean,
+    forceRowMajor: Boolean
   ): Unit = {
 
     val fs = HailContext.sFS
@@ -357,7 +358,7 @@ object BlockMatrix {
       assert(!it.hasNext)
 
       // TODO Replace false with forceRowMajor
-      lm.write(os, false, bufferSpec)
+      lm.write(os, forceRowMajor, bufferSpec)
       os.close()
 
       1
@@ -377,9 +378,9 @@ object BlockMatrix {
       // Write each chunk wherever it belongs
       val pathToBlockMatrixRDD = blockMatrixURI(rddIndex)
       val partFileName = partFile(numDigits, partitionIndex, TaskContext.get())
-
-      
-      println(s"Processing partition $partitionIndex from rdd $rddIndex")
+      val finalFilename = pathToBlockMatrixRDD + "/parts/" + partFileName
+      val os = fs.unsafeWriter(finalFilename)
+      writeBlock(it, os)
 
       Iterator.single((rddIndex, partFileName))
     }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -337,7 +337,6 @@ object BlockMatrix {
 
     val fs = HailContext.sFS
     def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
-    def partitionURI(matrixIdx: Int, partitionIdx: Int) = s"{$prefix}{$matrixIdx}/$partitionIdx"
 
     bms.zipWithIndex.foreach{ case (bm, bIdx) => {
       val uri = blockMatrixURI(bIdx)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -342,7 +342,7 @@ object BlockMatrix {
   }
 
   def writeBlockMatrices(
-     fs: FS,
+     ctx: ExecuteContext,
      bms: IndexedSeq[BlockMatrix],
      prefix: String,
      overwrite: Boolean,
@@ -350,6 +350,8 @@ object BlockMatrix {
    ): Unit = {
 
     def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
+    val fs = ctx.fs
+    val tmpdir = ctx.localTmpdir
 
     bms.zipWithIndex.foreach { case (bm, bIdx) =>
       val uri = blockMatrixURI(bIdx)
@@ -397,7 +399,7 @@ object BlockMatrix {
       val trueIt = it(ctx)
       val rootPath = blockMatrixURI(rddIndex)
       val fileName = partFile(numDigits, partIndex, TaskContext.get)
-      val nameAndCountIt = RichContextRDD.writeParts(ctx, rootPath, fileName, null, (_) => null, false, fs, "/tmp/foo", trueIt, writeBlock)
+      val nameAndCountIt = RichContextRDD.writeParts(ctx, rootPath, fileName, null, (_) => null, false, fs, tmpdir, trueIt, writeBlock)
       nameAndCountIt.map { case (name, count) => (name, rddIndex) }
     }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -425,14 +425,14 @@ object BlockMatrix {
     grouped.foreach{ case (rddIndex, numberedPartFiles) =>
       val partFiles = numberedPartFiles.map{case (_, partFileName) => partFileName}
 
-      fs.writeDataFile(blockMatrixURI(rddIndex) + metadataRelativePath) { os =>
+      using(new DataOutputStream(fs.create(blockMatrixURI(rddIndex) + metadataRelativePath))) { os =>
         implicit val formats = defaultJSONFormats
         val (blockSize, nRows, nCols, maybeBlocks) = blockMatrixMetadataFields(rddIndex)
         jackson.Serialization.write(
           BlockMatrixMetadata(blockSize, nRows, nCols, maybeBlocks, partFiles), os)
       }
 
-      fs.writeTextFile(blockMatrixURI(rddIndex) + "/_SUCCESS")(out => ())
+      using(fs.create(blockMatrixURI(rddIndex) + "/_SUCCESS"))(out => ())
     }
 
     log.info("Wrote block matrices to disk")

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1589,28 +1589,4 @@ object RVD {
 
     partCounts
   }
-
-//  def coscheduleActions[T: ClassTag](
-//    rvds: IndexedSeq[RVD],
-//    actions: IndexedSeq[(Int, Iterator[RegionValue]) => Iterator[T]]
-//  ): Array[Array[T]] =
-//    coscheduleActions(rvds, (i, pi, it) => actions(i)(pi, it))
-//
-//  def coscheduleActions[T: ClassTag](
-//    rvds: IndexedSeq[RVD],
-//    actions: (Int, Int, Iterator[RegionValue]) => Iterator[T]
-//  ): Array[Array[T]] = {
-//    assert(rvds.length == actions.length)
-//    if (rvds.isEmpty)
-//      return Array.empty[Array[T]]
-//    val first = rvds(0)
-//    val crdd = new ContextRDD(
-//      new OriginUnionRDD[RVDContext => Iterator[RegionValue], RVDContext => Iterator[(Int, T)]](
-//        first.crdd.rdd.sparkContext,
-//        rvds.map(_.crdd.rdd),
-//        (i, pi, it) => Iterator.single { (ctx: RVDContext) =>
-//          actions(i)(pi, singletonElement(it)(ctx)).map(x => (i, x)) }),
-//      first.crdd.mkc)
-//    return crdd.collect().groupBy(_._1).values.map(_.map(_._2)).toArray
-//  }
 }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1589,4 +1589,28 @@ object RVD {
 
     partCounts
   }
+
+//  def coscheduleActions[T: ClassTag](
+//    rvds: IndexedSeq[RVD],
+//    actions: IndexedSeq[(Int, Iterator[RegionValue]) => Iterator[T]]
+//  ): Array[Array[T]] =
+//    coscheduleActions(rvds, (i, pi, it) => actions(i)(pi, it))
+//
+//  def coscheduleActions[T: ClassTag](
+//    rvds: IndexedSeq[RVD],
+//    actions: (Int, Int, Iterator[RegionValue]) => Iterator[T]
+//  ): Array[Array[T]] = {
+//    assert(rvds.length == actions.length)
+//    if (rvds.isEmpty)
+//      return Array.empty[Array[T]]
+//    val first = rvds(0)
+//    val crdd = new ContextRDD(
+//      new OriginUnionRDD[RVDContext => Iterator[RegionValue], RVDContext => Iterator[(Int, T)]](
+//        first.crdd.rdd.sparkContext,
+//        rvds.map(_.crdd.rdd),
+//        (i, pi, it) => Iterator.single { (ctx: RVDContext) =>
+//          actions(i)(pi, singletonElement(it)(ctx)).map(x => (i, x)) }),
+//      first.crdd.mkc)
+//    return crdd.collect().groupBy(_._1).values.map(_.map(_._2)).toArray
+//  }
 }

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -553,10 +553,10 @@ package object utils extends Logging
       1 + digitsNeeded(i / 10)
   }
 
-  def partFile(d: Int, i: Int): String = {
+  def partFile(numDigits: Int, i: Int): String = {
     val is = i.toString
-    assert(is.length <= d)
-    "part-" + StringUtils.leftPad(is, d, "0")
+    assert(is.length <= numDigits)
+    "part-" + StringUtils.leftPad(is, numDigits, "0")
   }
 
   def partSuffix(ctx: TaskContext): String = {


### PR DESCRIPTION
This PR introduces `tree_matmul`, a method on `BlockMatrix` that allows for greater parallelism when multiplying two large matrices that result in a small matrix (i.e. the inner dimension is much larger than the outer dimensions). 

In order to do this, this PR takes a `split_on_inner` parameter. This parameter defines how many subdivisions to break the two matrices into. Corresponding subdivisions are multiplied, written to disk, then read back in and summed. 

For example, if you are multiplying a 4k by 500k matrix by its transpose, your answer will be a 4k by 4k block. With normal matrix multiply, you'd get no parallelism at all, since the result is only a single partition. If you instead use `tree_matmul` with `split_on_inner = 5`, hail will do the following:

1. Break up 4k by 500k matrix into five 4k by 100k matrices.
2. Break up 500k by 4k matrix into five 100k by 4k matrices. 
3. Multiply corresponding matrices together, creating five 4k by 4k matrices.
4. Write them all to disk, then read them back in.
5. Sum the 5 read in matrices together to get your result.


This PR also introduces a `write_block_matrices` function that writes out a list of `BlockMatrix` in parallel. This was necessary to write out all of the intermediate matrices in `tree_matmul`. 

@konradjk 
@danking 