### PR TITLE
Run local commands using check_call instead of check_output

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -193,7 +193,7 @@ class LocalBackend(Backend):
             print(script)
         else:
             try:
-                sp.check_output(script, shell=True)
+                sp.check_call(script, shell=True)
             except sp.CalledProcessError as e:
                 print(e)
                 print(e.output)


### PR DESCRIPTION
Run local commands using check_call instead of check_output so that command stdout goes to the terminal.