### PR TITLE
[batch] input file cache

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -3,7 +3,8 @@ FROM python:3.7-slim-stretch
 RUN apt-get update && \
   apt-get -y install \
     curl \
-    gnupg && \
+    gnupg \
+    xfsprogs && \
   rm -rf /var/lib/apt/lists/*
 
 RUN export GCSFUSE_REPO=gcsfuse-bionic && \

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -17,6 +17,11 @@ RUN apt-get update && \
     gcsfuse && \
   rm -rf /var/lib/apt/lists/*
 
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
+    mv /root/google-cloud-sdk /
+ENV PATH $PATH:/google-cloud-sdk/bin
+
 COPY docker/requirements.txt .
 RUN python3 -m pip install --no-cache-dir -U -r requirements.txt
 

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -333,6 +333,7 @@ docker run \
     -e WORKER_CONFIG=$WORKER_CONFIG \
     -e MAX_IDLE_TIME_MSECS=$MAX_IDLE_TIME_MSECS \
     -e LOCAL_SSD_MOUNT=/mnt/disks/$LOCAL_SSD_NAME \
+    -e BATCH_WORKER_IMAGE=$BATCH_WORKER_IMAGE \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/bin/docker:/usr/bin/docker \
     -v /usr/sbin/xfs_quota:/usr/sbin/xfs_quota \

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -29,7 +29,8 @@ from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_
 # import uvloop
 
 from ..utils import parse_cpu_in_mcpu, parse_memory_in_bytes, adjust_cores_for_memory_request, \
-    worker_memory_per_core_gb, cost_from_msec_mcpu, adjust_cores_for_packability, coalesce
+    worker_memory_per_core_gb, cost_from_msec_mcpu, adjust_cores_for_packability, coalesce, \
+    parse_storage_in_bytes, adjust_cores_for_storage_request, total_worker_storage
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
@@ -74,6 +75,7 @@ deploy_config = get_deploy_config()
 
 BATCH_JOB_DEFAULT_CPU = os.environ.get('HAIL_BATCH_JOB_DEFAULT_CPU', '1')
 BATCH_JOB_DEFAULT_MEMORY = os.environ.get('HAIL_BATCH_JOB_DEFAULT_MEMORY', '3.75G')
+BATCH_JOB_DEFAULT_STORAGE = os.environ.get('HAIL_BATCH_JOB_DEFAULT_STORAGE', '5G')
 
 
 @routes.get('/healthcheck')
@@ -589,9 +591,17 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     resources['cpu'] = BATCH_JOB_DEFAULT_CPU
                 if 'memory' not in resources:
                     resources['memory'] = BATCH_JOB_DEFAULT_MEMORY
+                if 'storage' not in resources:
+                    # FIXME: pvc_size is deprecated
+                    pvc_size = spec.get('pvc_size')
+                    if pvc_size:
+                        resources['storage'] = pvc_size
+                    else:
+                        resources['storage'] = BATCH_JOB_DEFAULT_STORAGE
 
                 req_cores_mcpu = parse_cpu_in_mcpu(resources['cpu'])
                 req_memory_bytes = parse_memory_in_bytes(resources['memory'])
+                req_storage_bytes = parse_storage_in_bytes(resources['storage'])
 
                 if req_cores_mcpu == 0:
                     raise web.HTTPBadRequest(
@@ -599,14 +609,16 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         f'cpu cannot be 0')
 
                 cores_mcpu = adjust_cores_for_memory_request(req_cores_mcpu, req_memory_bytes, worker_type)
+                cores_mcpu = adjust_cores_for_storage_request(cores_mcpu, req_storage_bytes, worker_cores)
                 cores_mcpu = adjust_cores_for_packability(cores_mcpu)
 
                 if cores_mcpu > worker_cores * 1000:
                     total_memory_available = worker_memory_per_core_gb(worker_type) * worker_cores
+                    total_storage_available = total_worker_storage()
                     raise web.HTTPBadRequest(
                         reason=f'resource requests for job {id} are unsatisfiable: '
-                        f'requested: cpu={resources["cpu"]}, memory={resources["memory"]} '
-                        f'maximum: cpu={worker_cores}, memory={total_memory_available}G')
+                        f'requested: cpu={resources["cpu"]}, memory={resources["memory"]} storage={resources["storage"]}'
+                        f'maximum: cpu={worker_cores}, memory={total_memory_available}G, storage={total_storage_available}G')
 
                 secrets = spec.get('secrets')
                 if not secrets:

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -17,10 +17,11 @@ import re
 #   'output_files': [{"from": str, "to": str}],
 #   'parent_ids': [int],
 #   'port': int,
-#   'pvc_size': str,
+#   'pvc_size': str
 #   'resoures': {
 #     'memory': str,
-#     'cpu': str
+#     'cpu': str,
+#     'storage': str
 #   },
 #   'secrets': [{
 #     'namespace': str,
@@ -42,7 +43,7 @@ ENV_VAR_KEYS = {'name', 'value'}
 
 SECRET_KEYS = {'namespace', 'name', 'mount_path'}
 
-RESOURCES_KEYS = {'memory', 'cpu'}
+RESOURCES_KEYS = {'memory', 'cpu', 'storage'}
 
 FILE_KEYS = {'from', 'to'}
 
@@ -238,6 +239,7 @@ def validate_job(i, job):
         if not isinstance(port, int):
             raise ValidationError(f'jobs[{i}].port not int')
 
+    # pvc_size is deprecated in favor of resources[storage]
     if 'pvc_size' in job:
         pvc_size = job['pvc_size']
         if not isinstance(pvc_size, str):
@@ -266,6 +268,13 @@ def validate_job(i, job):
                 raise ValidationError(f'jobs[{i}].resources.cpu is not str')
             if not CPU_REGEX.fullmatch(cpu):
                 raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
+
+        if 'storage' in resources:
+            storage = resources['storage']
+            if not isinstance(storage, str):
+                raise ValidationError(f'jobs[{i}].resources.storage is not str')
+            if not MEMORY_REGEX.fullmatch(storage):
+                raise ValidationError(f'jobs[{i}].resources.storage must match regex: {MEMORY_REGEXPAT}')
 
     if 'secrets' in job:
         secrets = job['secrets']

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -89,6 +89,10 @@ def parse_memory_in_bytes(memory_string):
     return None
 
 
+def parse_storage_in_bytes(storage_string):
+    return parse_memory_in_bytes(storage_string)
+
+
 def worker_memory_per_core_gb(worker_type):
     if worker_type == 'standard':
         m = 3.75
@@ -115,6 +119,29 @@ def cores_mcpu_to_memory_bytes(cores_in_mcpu, worker_type):
 
 def adjust_cores_for_memory_request(cores_in_mcpu, memory_in_bytes, worker_type):
     min_cores_mcpu = memory_bytes_to_cores_mcpu(memory_in_bytes, worker_type)
+    return max(cores_in_mcpu, min_cores_mcpu)
+
+
+def total_worker_storage():
+    # local ssd is 375Gi
+    # reserve 25Gi for images
+    return 375 - 25
+
+
+def worker_storage_per_core_bytes(worker_cores):
+    return (total_worker_storage() * 1024**3) // worker_cores
+
+
+def storage_bytes_to_cores_mcpu(storage_in_bytes, worker_cores):
+    return math.ceil((storage_in_bytes / worker_storage_per_core_bytes(worker_cores)) * 1000)
+
+
+def cores_mcpu_to_storage_bytes(cores_in_mcpu, worker_cores):
+    return int((cores_in_mcpu / 1000) * worker_storage_per_core_bytes(worker_cores))
+
+
+def adjust_cores_for_storage_request(cores_in_mcpu, storage_in_bytes, worker_cores):
+    min_cores_mcpu = storage_bytes_to_cores_mcpu(storage_in_bytes, worker_cores)
     return max(cores_in_mcpu, min_cores_mcpu)
 
 

--- a/batch/batch/worker/flock.py
+++ b/batch/batch/worker/flock.py
@@ -1,0 +1,54 @@
+import fcntl
+import os
+import argparse
+import subprocess as sp
+
+
+class Flock:
+    def __init__(self, path, nonblock=False):
+        self.path = os.path.abspath(path)
+        self.flock_flags = fcntl.LOCK_EX
+        self.fds = []
+
+        if nonblock:
+            self.flock_flags |= fcntl.LOCK_NB
+
+        if os.path.isdir(self.path):
+            self.path = self.path.rstrip('/') + '/'
+
+    def __enter__(self):
+        dirname, filename = os.path.split(self.path)
+
+        components = dirname.split('/')
+        for i in range(2, len(components) + 1):
+            path = '/'.join(components[:i])
+            os.makedirs(path, exist_ok=True)
+            fd = os.open(path, os.O_RDONLY)
+            self.fds.append(fd)
+            fcntl.flock(fd, self.flock_flags)
+
+        if filename:
+            fd = os.open(self.path, os.O_CREAT)
+            self.fds.append(fd)
+            fcntl.flock(fd, self.flock_flags)
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        for fd in reversed(self.fds):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('path', type=str)
+    parser.add_argument('-c', dest='command', type=str, required=True)
+    parser.add_argument('-n', dest='nonblock', action='store_true')
+    args = parser.parse_args()
+
+    with Flock(args.path, args.nonblock):
+        try:
+            sp.check_output(args.command, stderr=sp.STDOUT, shell=True)
+        except sp.CalledProcessError as e:
+            print(e.output)
+            raise e

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -19,7 +19,8 @@ import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
 from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT, \
-    sleep_and_backoff, retry_all_errors, check_shell, CalledProcessError, check_shell_output
+    sleep_and_backoff, retry_all_errors, check_shell, CalledProcessError, blocking_to_async, \
+    check_shell_output
 from hailtop.tls import ssl_client_session
 
 # import uvloop
@@ -57,6 +58,7 @@ PROJECT = os.environ['PROJECT']
 WORKER_CONFIG = json.loads(base64.b64decode(os.environ['WORKER_CONFIG']).decode())
 MAX_IDLE_TIME_MSECS = int(os.environ['MAX_IDLE_TIME_MSECS'])
 LOCAL_SSD_MOUNT = os.environ['LOCAL_SSD_MOUNT']
+BATCH_WORKER_IMAGE = os.environ['BATCH_WORKER_IMAGE']
 
 log.info(f'CORES {CORES}')
 log.info(f'NAME {NAME}')
@@ -70,6 +72,7 @@ log.info(f'PROJECT {PROJECT}')
 log.info(f'WORKER_CONFIG {WORKER_CONFIG}')
 log.info(f'MAX_IDLE_TIME_MSECS {MAX_IDLE_TIME_MSECS}')
 log.info(f'LOCAL_SSD_MOUNT {LOCAL_SSD_MOUNT}')
+log.info(f'BATCH_WORKER_IMAGE {BATCH_WORKER_IMAGE}')
 
 worker_config = WorkerConfig(WORKER_CONFIG)
 assert worker_config.cores == CORES
@@ -290,6 +293,10 @@ class Container:
         volume_mounts = self.spec.get('volume_mounts')
         if volume_mounts:
             host_config['Binds'] = volume_mounts
+
+        mounts = self.spec.get('mounts')
+        if mounts:
+            host_config['Mounts'] = mounts
 
         if env:
             config['Env'] = env
@@ -526,7 +533,34 @@ async def add_gcsfuse_bucket(mount_path, bucket, key_file, read_only):
         delay = await sleep_and_backoff(delay)
 
 
-def copy_command(src, dst):
+def input_copy_command(user, src, dst, io_path):
+    if src.startswith('gs://'):
+        cache_src = f'/host/cache/{user}{src[4:]}'
+    else:
+        cache_src = f'/host/cache/{user}{src}'
+
+    if dst.startswith('/io/'):
+        dst = f'/host{io_path}{dst[3:]}'
+
+    escaped_src = re.escape(os.path.basename(src))
+
+    return f'''
+retry python3 -m batch.worker.flock {cache_src} \
+    -c "mkdir -p {shq(os.path.dirname(dst))} && \
+        mkdir -p {shq(os.path.dirname(cache_src))} && \
+        (cp -p -R --reflink {shq(cache_src)} {shq(dst)} || true) && \
+        (gsutil -q stat {shq(src)};
+         if [ \$? = 0 ]; then
+           gsutil -m rsync -x '(?!^{escaped_src}$)' {shq(os.path.dirname(src))} {shq(os.path.dirname(dst))};
+         else
+           gsutil -m rsync -r -d {shq(src)} {shq(dst)} || gsutil -m cp -r {shq(src)} {shq(dst)};
+         fi) && \
+        rm -Rf {shq(cache_src)} && \
+        cp -p -R --reflink {shq(dst)} {shq(cache_src)}"
+'''  # pylint: disable=anomalous-backslash-in-string
+
+
+def output_copy_command(src, dst):
     if not dst.startswith('gs://'):
         mkdirs = f'mkdir -p {shq(os.path.dirname(dst))} && '
     else:
@@ -534,10 +568,14 @@ def copy_command(src, dst):
     return f'{mkdirs}retry gsutil -m cp -R {shq(src)} {shq(dst)}'
 
 
-def copy(files):
+def copy(files, name, user, io_path):
     assert files
 
-    copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
+    if name == 'input':
+        copies = ' && '.join([input_copy_command(user, f['from'], f['to'], io_path) for f in files])
+    else:
+        assert name == 'output'
+        copies = ' && '.join([output_copy_command(f['from'], f['to']) for f in files])
     return f'''
 set -ex
 
@@ -549,15 +587,17 @@ retry gcloud -q auth activate-service-account --key-file=/gsa-key/key.json
 '''
 
 
-def copy_container(job, name, files, volume_mounts, cpu, memory):
-    sh_expression = copy(files)
+def copy_container(job, name, files, volume_mounts, mounts, cpu, memory):
+    sh_expression = copy(files, name, job.user, job.io_host_path())
+    log.info(sh_expression)
     copy_spec = {
-        'image': 'google/cloud-sdk:269.0.0-alpine',
+        'image': BATCH_WORKER_IMAGE,
         'name': name,
-        'command': ['/bin/sh', '-c', sh_expression],
+        'command': ['/bin/bash', '-c', sh_expression],
         'cpu': cpu,
         'memory': memory,
-        'volume_mounts': volume_mounts
+        'volume_mounts': volume_mounts,
+        'mounts': mounts
     }
     return Container(job, name, copy_spec)
 
@@ -599,8 +639,9 @@ class Job:
         input_files = job_spec.get('input_files')
         output_files = job_spec.get('output_files')
 
-        copy_volume_mounts = []
+        input_volume_mounts = []
         main_volume_mounts = []
+        output_volume_mounts = []
 
         if job_spec.get('mount_docker_socket'):
             main_volume_mounts.append('/var/run/docker.sock:/var/run/docker.sock')
@@ -609,7 +650,7 @@ class Job:
         if self.mount_io:
             volume_mount = f'{self.io_host_path()}:/io'
             main_volume_mounts.append(volume_mount)
-            copy_volume_mounts.append(volume_mount)
+            output_volume_mounts.append(volume_mount)
 
         gcsfuse = job_spec.get('gcsfuse')
         self.gcsfuse = gcsfuse
@@ -625,7 +666,8 @@ class Job:
                 main_volume_mounts.append(volume_mount)
                 # this will be the user gsa-key
                 if secret.get('mount_in_copy', False):
-                    copy_volume_mounts.append(volume_mount)
+                    input_volume_mounts.append(volume_mount)
+                    output_volume_mounts.append(volume_mount)
 
         env = []
         for item in job_spec.get('env', []):
@@ -653,8 +695,16 @@ class Job:
         containers = {}
 
         if input_files:
+            input_mounts = [{
+                'Source': LOCAL_SSD_MOUNT,
+                'Target': '/host',
+                'Type': 'bind',
+                'BindOptions': {
+                    'Propogation': 'shared'
+                }
+            }]
             containers['input'] = copy_container(
-                self, 'input', input_files, copy_volume_mounts,
+                self, 'input', input_files, input_volume_mounts, input_mounts,
                 self.cpu_in_mcpu, self.memory_in_bytes)
 
         # main container
@@ -676,8 +726,9 @@ class Job:
         containers['main'] = Container(self, 'main', main_spec)
 
         if output_files:
+            output_mounts = None
             containers['output'] = copy_container(
-                self, 'output', output_files, copy_volume_mounts,
+                self, 'output', output_files, output_volume_mounts, output_mounts,
                 self.cpu_in_mcpu, self.memory_in_bytes)
 
         self.containers = containers
@@ -794,6 +845,9 @@ python3 -m batch.worker.flock /xfsquota/projects -c "echo \"{self.project_id}:{s
 
     async def delete(self):
         log.info(f'deleting {self}')
+        await check_shell(f'xfs_quota -x -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host')
+        await check_shell(f'sed "/{self.project_name}:{self.project_id}/d" -i /etc/projid')
+        await check_shell(f'sed "/{self.project_id}:/d" -i /etc/projects')
         self.deleted = True
         for _, c in self.containers.items():
             await c.delete()
@@ -842,12 +896,57 @@ python3 -m batch.worker.flock /xfsquota/projects -c "echo \"{self.project_id}:{s
         return f'job {self.id}'
 
 
+class FileCache:
+    def __init__(self, path, pool):
+        self.path = path
+        self.cleanup = asyncio.Event()
+        self.pool = pool
+
+    async def async_init(self):
+        asyncio.ensure_future(self.monitor_loop())
+        asyncio.ensure_future(self.cleanup_loop())
+
+    async def used_disk_space(self):
+        usage = await blocking_to_async(self.pool, shutil.disk_usage, self.path)
+        return usage.used / usage.total
+
+    async def remove(self, path):
+        await blocking_to_async(self.pool, os.remove, path)
+
+    async def monitor_loop(self):
+        while True:
+            if await self.used_disk_space() > 0.9:
+                log.info('more than 0 bytes used, cleaning up')
+                self.cleanup.set()
+                await asyncio.sleep(60)
+            else:
+                await asyncio.sleep(5)
+
+    async def cleanup_loop(self):
+        while True:
+            await self.cleanup.wait()
+            for root, _, files in os.walk(self.path + '/cache/'):
+                for file in files:
+                    if await self.used_disk_space() < 0.7:
+                        break
+
+                    file_path = f'{root}/{file}'
+                    try:
+                        with Flock(file_path, nonblock=True):
+                            await self.remove(file_path)
+                            log.info(f'removed file {file_path}')
+                    except Exception:
+                        log.exception(f'could not remove in-use file {file_path}')
+            self.cleanup.clear()
+
+
 class Worker:
     def __init__(self):
         self.cores_mcpu = CORES * 1000
         self.last_updated = time_msecs()
         self.cpu_sem = FIFOWeightedSemaphore(self.cores_mcpu)
         self.pool = concurrent.futures.ThreadPoolExecutor()
+        self.file_cache = FileCache('/host', self.pool)
         self.jobs = {}
 
         # filled in during activation
@@ -966,6 +1065,8 @@ class Worker:
             await app_runner.setup()
             site = web.TCPSite(app_runner, '0.0.0.0', 5000)
             await site.start()
+
+            await self.file_cache.async_init()
 
             try:
                 await asyncio.wait_for(self.activate(), MAX_IDLE_TIME_MSECS / 1000)

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -19,7 +19,7 @@ import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
 from hailtop.utils import time_msecs, request_retry_transient_errors, RETRY_FUNCTION_SCRIPT, \
-    sleep_and_backoff, retry_all_errors, check_shell, CalledProcessError
+    sleep_and_backoff, retry_all_errors, check_shell, CalledProcessError, check_shell_output
 from hailtop.tls import ssl_client_session
 
 # import uvloop
@@ -27,13 +27,14 @@ from hailtop.tls import ssl_client_session
 from hailtop.config import DeployConfig
 from gear import configure_logging
 
-from .utils import parse_cpu_in_mcpu, parse_image_tag, parse_memory_in_bytes, \
-    adjust_cores_for_memory_request, cores_mcpu_to_memory_bytes, adjust_cores_for_packability
-from .semaphore import FIFOWeightedSemaphore
-from .log_store import LogStore
-from .globals import HTTP_CLIENT_MAX_SIZE, STATUS_FORMAT_VERSION
-from .batch_format_version import BatchFormatVersion
-from .worker_config import WorkerConfig
+from ..utils import parse_cpu_in_mcpu, parse_image_tag, parse_memory_in_bytes, \
+    adjust_cores_for_memory_request, cores_mcpu_to_memory_bytes, adjust_cores_for_packability, \
+    adjust_cores_for_storage_request, cores_mcpu_to_storage_bytes
+from ..semaphore import FIFOWeightedSemaphore
+from ..log_store import LogStore
+from ..globals import HTTP_CLIENT_MAX_SIZE, STATUS_FORMAT_VERSION
+from ..batch_format_version import BatchFormatVersion
+from ..worker_config import WorkerConfig
 
 # uvloop.install()
 
@@ -55,6 +56,7 @@ INSTANCE_ID = os.environ['INSTANCE_ID']
 PROJECT = os.environ['PROJECT']
 WORKER_CONFIG = json.loads(base64.b64decode(os.environ['WORKER_CONFIG']).decode())
 MAX_IDLE_TIME_MSECS = int(os.environ['MAX_IDLE_TIME_MSECS'])
+LOCAL_SSD_MOUNT = os.environ['LOCAL_SSD_MOUNT']
 
 log.info(f'CORES {CORES}')
 log.info(f'NAME {NAME}')
@@ -67,6 +69,7 @@ log.info(f'INSTANCE_ID {INSTANCE_ID}')
 log.info(f'PROJECT {PROJECT}')
 log.info(f'WORKER_CONFIG {WORKER_CONFIG}')
 log.info(f'MAX_IDLE_TIME_MSECS {MAX_IDLE_TIME_MSECS}')
+log.info(f'LOCAL_SSD_MOUNT {LOCAL_SSD_MOUNT}')
 
 worker_config = WorkerConfig(WORKER_CONFIG)
 assert worker_config.cores == CORES
@@ -248,6 +251,7 @@ class Container:
         self.timing = {}
         self.container_status = None
         self.log = None
+        self.overlay_path = None
 
     def container_config(self):
         weight = worker_fraction_in_1024ths(self.spec['cpu'])
@@ -361,6 +365,18 @@ class Container:
                 self.container = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
                     create_container, config, name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}')
 
+            c = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(self.container.show)
+
+            merged_overlay_path = c['GraphDriver']['Data']['MergedDir']
+            assert merged_overlay_path.endswith('/merged')
+            self.overlay_path = merged_overlay_path[:-7].replace(LOCAL_SSD_MOUNT, '/host')
+            os.makedirs(f'{self.overlay_path}/', exist_ok=True)
+
+            await check_shell(f'''
+python3 -m batch.worker.flock /xfsquota/projects -c "echo \"{self.job.project_id}:{self.overlay_path}\" >> /xfsquota/projects"
+''')
+            await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.job.project_name}" /host/')
+
             async with self.step('starting'):
                 await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
                     start_container, self.container)
@@ -414,6 +430,12 @@ class Container:
         return self.log
 
     async def delete_container(self):
+        if self.overlay_path:
+            path = self.overlay_path.replace('/', r'\/')
+            await check_shell(f'''
+python3 -m batch.worker.flock /xfsquota/projects -c "sed -i '/:{path}/d' /xfsquota/projects"
+''')
+
         if self.container:
             try:
                 log.info(f'{self}: deleting container')
@@ -541,6 +563,8 @@ def copy_container(job, name, files, volume_mounts, cpu, memory):
 
 
 class Job:
+    quota_project_id = 100
+
     def secret_host_path(self, secret):
         return f'{self.scratch}/secrets/{secret["name"]}'
 
@@ -572,7 +596,6 @@ class Job:
         self.start_time = None
         self.end_time = None
 
-        pvc_size = job_spec.get('pvc_size')
         input_files = job_spec.get('input_files')
         output_files = job_spec.get('output_files')
 
@@ -582,7 +605,7 @@ class Job:
         if job_spec.get('mount_docker_socket'):
             main_volume_mounts.append('/var/run/docker.sock:/var/run/docker.sock')
 
-        self.mount_io = (pvc_size or input_files or output_files)
+        self.mount_io = (input_files or output_files)
         if self.mount_io:
             volume_mount = f'{self.io_host_path()}:/io'
             main_volume_mounts.append(volume_mount)
@@ -610,14 +633,21 @@ class Job:
 
         req_cpu_in_mcpu = parse_cpu_in_mcpu(job_spec['resources']['cpu'])
         req_memory_in_bytes = parse_memory_in_bytes(job_spec['resources']['memory'])
+        req_storage_in_bytes = parse_memory_in_bytes(job_spec['resources']['storage'])
 
         cpu_in_mcpu = adjust_cores_for_memory_request(req_cpu_in_mcpu, req_memory_in_bytes, worker_config.instance_type)
+        cpu_in_mcpu = adjust_cores_for_storage_request(cpu_in_mcpu, req_storage_in_bytes, CORES)
         cpu_in_mcpu = adjust_cores_for_packability(cpu_in_mcpu)
 
         self.cpu_in_mcpu = cpu_in_mcpu
         self.memory_in_bytes = cores_mcpu_to_memory_bytes(self.cpu_in_mcpu, worker_config.instance_type)
+        self.storage_in_bytes = cores_mcpu_to_storage_bytes(self.cpu_in_mcpu, CORES)
 
         self.resources = worker_config.resources(self.cpu_in_mcpu, self.memory_in_bytes)
+
+        self.project_name = f'batch-{self.batch_id}-job-{self.job_id}'
+        self.project_id = Job.quota_project_id
+        Job.quota_project_id += 1
 
         # create containers
         containers = {}
@@ -673,6 +703,16 @@ class Job:
 
                 log.info(f'{self}: initializing')
                 self.state = 'initializing'
+
+                os.makedirs(f'{self.scratch}/')
+                await check_shell(f'''
+python3 -m batch.worker.flock /xfsquota/projid -c "echo \"{self.project_name}:{self.project_id}\" >> /xfsquota/projid"
+''')
+                await check_shell(f'''
+python3 -m batch.worker.flock /xfsquota/projects -c "echo \"{self.project_id}:{self.scratch}\" >> /xfsquota/projects"
+''')
+                await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.project_name}" /host/')
+                await check_shell(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft={self.storage_in_bytes} bhard={self.storage_in_bytes} {self.project_name}" /host/')
 
                 if self.mount_io:
                     os.makedirs(self.io_host_path())
@@ -740,6 +780,11 @@ class Job:
                             mount_path = self.gcsfuse_path(bucket)
                             await check_shell(f'fusermount -u {mount_path}')
                             log.info(f'unmounted gcsfuse bucket {bucket} from {mount_path}')
+
+                    await check_shell(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host')
+                    await check_shell(f'''python3 -m batch.worker.flock /xfsquota/projid -c "sed -i '/{self.project_name}:{self.project_id}/d' /xfsquota/projid"''')
+                    await check_shell(f'''python3 -m batch.worker.flock /xfsquota/projects -c "sed -i '/{self.project_id}:/d' /xfsquota/projects"''')
+
                     shutil.rmtree(self.scratch, ignore_errors=True)
                 except Exception:
                     log.exception('while deleting volumes')

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -184,6 +184,8 @@ spec:
            value: "0.1"
          - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
            value: "375M"
+         - name: HAIL_BATCH_JOB_DEFAULT_STORAGE
+           value: "1G"
 {% endif %}
 {% if deploy %}
          - name: HAIL_BATCH_BUCKET_NAME

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -141,6 +141,17 @@ class Test(unittest.TestCase):
         status = j.wait()
         assert j._get_out_of_memory(status, 'main')
 
+    def test_out_of_storage(self):
+        builder = self.client.create_batch()
+        resources = {'cpu': '0.1', 'memory': '10M', 'storage': '5Gi'}
+        j = builder.create_job('ubuntu:18.04',
+                               ['/bin/sh', '-c', 'fallocate -l 100GiB /foo'],
+                               resources=resources)
+        builder.submit()
+        status = j.wait()
+        assert status['state'] == 'Failed', status
+        assert "fallocate failed: No space left on device" in j.log()['main']
+
     def test_unsubmitted_state(self):
         builder = self.client.create_batch()
         j = builder.create_job('ubuntu:18.04', ['echo', 'test'])

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -196,7 +196,7 @@ def test_input_dependency_directory(client):
                             command=['/bin/sh', '-c', 'mkdir -p /io/test/; echo head1 > /io/test/data1 ; echo head2 > /io/test/data2'],
                             output_files=[('/io/test/', f'gs://{bucket_name}')])
     tail = batch.create_job('ubuntu:18.04',
-                            command=['/bin/sh', '-c', 'cat /io/test/data1 ; cat /io/test/data2'],
+                            command=['/bin/sh', '-c', 'cat /io/test/data1; cat /io/test/data2'],
                             input_files=[(f'gs://{bucket_name}/test', '/io/')],
                             parents=[head])
     batch.submit()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -423,6 +423,8 @@ class ServiceBackend(Backend):
                 resources['cpu'] = job._cpu
             if job._memory:
                 resources['memory'] = job._memory
+            if job._storage:
+                resources['storage'] = job._storage
 
             j = bc_batch.create_job(image=job._image if job._image else default_image,
                                     command=['/bin/bash', '-c', cmd],
@@ -431,7 +433,6 @@ class ServiceBackend(Backend):
                                     resources=resources,
                                     input_files=inputs if len(inputs) > 0 else None,
                                     output_files=outputs if len(outputs) > 0 else None,
-                                    pvc_size=job._storage,
                                     always_run=job._always_run,
                                     timeout=job._timeout,
                                     gcsfuse=job._gcsfuse if len(job._gcsfuse) > 0 else None,

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -119,10 +119,10 @@ scheduled on this machine, then the cost per core hour is **$0.02774**.
 
 .. note::
 
-    The amount of CPU reserved for a job can be rounded up if the equivalent memory request
+    The amount of CPU reserved for a job can be rounded up if the equivalent memory and/or storage request
     requires a larger fraction of the worker. Currently, each 1 core requested
-    gets 3.75 GB of memory. Therefore, if a user requests 1 CPU and 7 GB of memory, the user
-    will get 2 cores for their job and will be billed for 2 cores.
+    gets 3.75 GB of memory and 21.875 GB of storage. Therefore, if a user requests 1 CPU and 7 GB of memory,
+    the user will get 2 cores for their job and will be billed for 2 cores.
 
 .. note::
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -370,7 +370,7 @@ class BatchBuilder:
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
-                   input_files=None, output_files=None, always_run=False, pvc_size=None,
+                   input_files=None, output_files=None, always_run=False,
                    timeout=None, gcsfuse=None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
@@ -433,8 +433,6 @@ class BatchBuilder:
             job_spec['input_files'] = [{"from": src, "to": dst} for (src, dst) in input_files]
         if output_files:
             job_spec['output_files'] = [{"from": src, "to": dst} for (src, dst) in output_files]
-        if pvc_size:
-            job_spec['pvc_size'] = pvc_size
         if gcsfuse:
             job_spec['gcsfuse'] = [{"bucket": bucket, "mount_path": mount_path, "read_only": read_only}
                                    for (bucket, mount_path, read_only) in gcsfuse]

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -144,7 +144,7 @@ class BatchBuilder:
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
-                   input_files=None, output_files=None, always_run=False, pvc_size=None,
+                   input_files=None, output_files=None, always_run=False,
                    timeout=None, gcsfuse=None):
         if parents:
             parents = [parent._async_job for parent in parents]
@@ -155,7 +155,7 @@ class BatchBuilder:
             service_account=service_account,
             attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
-            pvc_size=pvc_size, timeout=timeout, gcsfuse=gcsfuse)
+            timeout=timeout, gcsfuse=gcsfuse)
 
         return Job.from_async_job(async_job)
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -20,7 +20,7 @@ log = logging.getLogger('hailtop.utils')
 RETRY_FUNCTION_SCRIPT = """function retry() {
     "$@" ||
         (sleep 2 && "$@") ||
-        (sleep 5 && "$@")
+        (sleep 5 && "$@");
 }"""
 
 


### PR DESCRIPTION
- I left in pvc_size for backwards compatibility. We can rip it out at some point.
- I'm not happy with how the batch_worker_image seems slower now with the gsutil addition. Not sure if there's a better solution here.

I tested a lot of this by hand on dev deploy. For example, making sure the flocks were right, the project quotas were right, the cache was working, the garbage collector, and the backwards compatibility with pvc_size was working. Let me know if you think there are other things I should test.

If this is too much, I can think about splitting the storage and the cache into two PRs. I just figured since I almost had it all done together to push on that.