### PR TITLE
[hailctl dataproc] Add some tests for hailctl dataproc modify

### DIFF
--- a/hail/python/test/hailtop/hailctl/dataproc/conftest.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/conftest.py
@@ -9,7 +9,8 @@ def gcloud_config(request):
     return {
         "account": "test@hail.is",
         "project": "hailctl-dataproc-tests",
-        "dataproc/region": "us-central1"
+        "dataproc/region": "us-central1",
+        "compute/zone": "use-central1-b",
     }
 
 


### PR DESCRIPTION
Follow on to #9066.

Still todo: tests for `--update-hail-version`. Those will require a mock for deploy metadata.