### PR TITLE
[dnd] add DNDArray.inner_product

### DIFF
--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -1,9 +1,10 @@
 import json
 import numpy as np
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Callable
 
 from hail.utils.java import Env
 from hail.utils import range_table, new_temp_file
+from hail.expr import Expression
 from hail import nd
 from hail.matrixtable import MatrixTable
 from hail.table import Table
@@ -11,8 +12,8 @@ from hail.table import Table
 import hail as hl
 
 
-def array(mt: MatrixTable, entrc_field: str, *, block_size=None) -> 'DNDArray':
-    return DNDArray.from_matrix_table(mt, entrc_field, block_size=block_size)
+def array(mt: MatrixTable, entry_field: str, *, block_size=None) -> 'DNDArray':
+    return DNDArray.from_matrix_table(mt, entry_field, block_size=block_size)
 
 
 def read(fname: str) -> 'DNDArray':
@@ -166,7 +167,11 @@ class DNDArray:
         m = m._key_by_assert_sorted(self.c_field, self.r_field)
         return DNDArray(m)
 
-    def __matmul__(self, right: 'DNDArray') -> 'DNDArray':
+    def _block_inner_product(self,
+                             right: 'DNDArray',
+                             block_product: Callable[[Expression, Expression], Expression],
+                             block_aggregate: Callable[[Expression], Expression]
+                             ) -> 'DNDArray':
         left = self
         assert left.block_size == right.block_size
         assert left.n_cols == right.n_rows
@@ -192,17 +197,8 @@ class DNDArray:
         o = o.annotate(left=left.m[o.r, o.k].block)
         o = o._key_by_assert_sorted('k', 'c', 'r')
         o = o.annotate(right=right.m[o.k, o.c].block)
-        o = o.annotate(product=o.left @ o.right)
 
-        # FIXME: use ndarray sum / fma
-        def ndarray_to_array(ndarray):
-            return hl.rbind(
-                ndarray.shape[0],
-                ndarray.shape[1],
-                lambda n_rows, n_cols: hl.range(hl.int(n_rows * n_cols)).map(
-                    lambda absolute: o.product[absolute % n_rows, absolute // n_rows]))
-        o = o.annotate(shape=o.product.shape,
-                       product=ndarray_to_array(o.product))
+        o = o.annotate(product=block_product(o.left, o.right))
         o = o._key_by_assert_sorted('r', 'c', 'k')
         o = o._key_by_assert_sorted('r', 'c')
 
@@ -212,10 +208,7 @@ class DNDArray:
 
         o = Table(ir.TableAggregateByKey(
             o._tir,
-            hl.struct(
-                shape=hl.agg.take(o.shape, 1)[0],
-                block=hl.agg.array_sum(o.product))._ir))
-        o = o.annotate(block=hl.nd.from_column_major(o.block, o.shape))
+            hl.struct(block=block_aggregate(o.product))._ir))
         o = o.select('block')
         o = o.select_globals(
             r_field='r',
@@ -226,6 +219,59 @@ class DNDArray:
             n_block_cols=n_block_cols,
             block_size=block_size)
         return DNDArray(o)
+
+    def __matmul__(self, right: 'DNDArray') -> 'DNDArray':
+        # FIXME: use ndarray sum / fma
+        def block_product(left, right):
+            product = left @ right
+            return hl.struct(
+                shape=product.shape,
+                block=hl.rbind(
+                    product.shape[0],
+                    product.shape[1],
+                    lambda n_rows, n_cols: hl.range(hl.int(n_rows * n_cols)).map(
+                        lambda absolute: product[absolute % n_rows, absolute // n_rows])))
+
+        def block_aggregate(prod):
+            shape = prod.shape
+            block = prod.block
+            return hl.nd.from_column_major(
+                hl.agg.array_sum(block),
+                hl.agg.take(shape, 1)[0])
+
+        return self._block_inner_product(right, block_product, block_aggregate)
+
+    def inner_product(self,
+                      right: 'DNDArray',
+                      multiply: Callable[[Expression, Expression], Expression],
+                      add: Callable[[Expression, Expression], Expression],
+                      zero: Expression,
+                      add_as_an_aggregator: Callable[[Expression], Expression]
+    ) -> 'DNDArray':
+        def block_product(left, right):
+            n_rows = left.shape[0]
+            n_inner = left.shape[1]
+            n_cols = right.shape[1]
+
+            def compute_element(absolute):
+                row = absolute % n_rows
+                col = absolute // n_rows
+                return hl.range(hl.int(n_inner)).map(
+                    lambda inner: multiply(left[row, inner], right[inner, col])
+                ).fold(add, zero)
+
+            return hl.struct(
+                shape=(left.shape[0], right.shape[1]),
+                block=hl.range(hl.int(n_rows * n_cols)).map(compute_element))
+
+        def block_aggregate(prod):
+            shape = prod.shape
+            block = prod.block
+            return hl.nd.from_column_major(
+                hl.agg.array_agg(add_as_an_aggregator, block),
+                hl.agg.take(shape, 1)[0])
+
+        return self._block_inner_product(right, block_product, block_aggregate)
 
     def write(self, *args, **kwargs) -> 'DNDArray':
         return self.m.write(*args, **kwargs)

--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -245,7 +245,7 @@ class DNDArray:
                       add: Callable[[Expression, Expression], Expression],
                       zero: Expression,
                       add_as_an_aggregator: Callable[[Expression], Expression]
-    ) -> 'DNDArray':
+                      ) -> 'DNDArray':
         def block_product(left, right):
             n_rows, n_inner = left.shape
             _, n_cols = right.shape

--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -224,8 +224,7 @@ class DNDArray:
         # FIXME: use ndarray sum / fma
         def block_product(left, right):
             product = left @ right
-            n_rows = product.shape[0]
-            n_cols = product.shape[1]
+            n_rows, n_cols = product.shape
             return hl.struct(
                 shape=product.shape,
                 block=hl.range(hl.int(n_rows * n_cols)).map(

--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -224,13 +224,12 @@ class DNDArray:
         # FIXME: use ndarray sum / fma
         def block_product(left, right):
             product = left @ right
+            n_rows = product.shape[0]
+            n_cols = product.shape[1]
             return hl.struct(
                 shape=product.shape,
-                block=hl.rbind(
-                    product.shape[0],
-                    product.shape[1],
-                    lambda n_rows, n_cols: hl.range(hl.int(n_rows * n_cols)).map(
-                        lambda absolute: product[absolute % n_rows, absolute // n_rows])))
+                block=hl.range(hl.int(n_rows * n_cols)).map(
+                    lambda absolute: product[absolute % n_rows, absolute // n_rows]))
 
         def block_aggregate(prod):
             shape = prod.shape

--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -247,9 +247,8 @@ class DNDArray:
                       add_as_an_aggregator: Callable[[Expression], Expression]
     ) -> 'DNDArray':
         def block_product(left, right):
-            n_rows = left.shape[0]
-            n_inner = left.shape[1]
-            n_cols = right.shape[1]
+            n_rows, n_inner = left.shape
+            _, n_cols = right.shape
 
             def compute_element(absolute):
                 row = absolute % n_rows

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1763,7 +1763,8 @@ class TupleExpression(Expression, Sequence):
                                      self[i]
                                      for i in range(len(self))[item.start:item.stop:item.step]]))
         if not 0 <= item < len(self):
-            raise IndexError("Out of bounds index. Tuple length is {}.".format(len(self)))
+            raise IndexError("Out of bounds index, {}. Tuple length is {}.".format(
+                item, len(self)))
         return construct_expr(ir.GetTupleElement(self._ir, item), self.dtype.types[item], self._indices)
 
     def __len__(self):

--- a/hail/python/test/hail/experimental/test_dnd_array.py
+++ b/hail/python/test/hail/experimental/test_dnd_array.py
@@ -110,3 +110,50 @@ def test_medium_matmul():
     a_result = a @ a.T
 
     assert np.array_equal(da_result, a_result)
+
+
+def test_matmul_via_inner_product():
+    n_variants = 10
+    n_samples = 10
+    block_size = 3
+    n_blocks = 16
+    mt = hl.utils.range_matrix_table(n_variants, n_samples)
+    mt = mt.select_entries(x=mt.row_idx * mt.col_idx)
+
+    da = hl.experimental.dnd.array(mt, 'x', block_size=block_size)
+    prod = (da @ da.T).checkpoint(new_temp_file())
+    assert prod._force_count_blocks() == n_blocks
+    prod_result = prod.collect().reshape(n_variants, n_variants)
+
+    ip_result = da.inner_product(da.T,
+                                 lambda l, r: l * r,
+                                 lambda l, r: l + r,
+                                 hl.float(0.0),
+                                 lambda prod: hl.agg.sum(prod)
+    ).collect().reshape(n_variants, n_variants)
+
+    assert np.array_equal(prod_result, ip_result)
+
+
+def test_king_homo_estimator():
+    hl.set_global_seed(1)
+    mt = hl.balding_nichols_model(2, 5, 5)
+    mt = mt.select_entries(genotype_score=hl.float(mt.GT.n_alt_alleles()))
+    da = hl.experimental.dnd.array(mt, 'genotype_score', block_size=3)
+
+    def sqr(x):
+        return x * x
+    score_difference = da.T.inner_product(
+        da,
+        lambda l, r: sqr(l - r),
+        lambda l, r: l + r,
+        hl.float(0),
+        hl.agg.sum
+    ).checkpoint(new_temp_file())
+    assert np.array_equal(
+        score_difference.collect(),
+        np.array([[0., 6., 4., 2., 4.],
+                  [6., 0., 6., 4., 6.],
+                  [4., 6., 0., 6., 0.],
+                  [2., 4., 6., 0., 6.],
+                  [4., 6., 0., 6., 0.]]))


### PR DESCRIPTION
Implement an arbitrary inner product operation. This is the critical piece of
infrastructure that underlies all relatedness inference algorithms. The typical
inner product on real number matrices is defined as:

```
L_ij : matrix of shape a by b
M_kl : matrix of shape b by c
N_il : matrix of shape a by c, the inner product of L and M.

N_il = Sum_k (L_ik * M_kl)
```

This PR allows the user to define what `*` means and what `Sum` means. For
example, the KING paper defines an estimator for relatedness of homogeneous
populations called KING-homo. KING-homo's numerator is given by
`score_difference` below.

```python3
mt = hl.balding_nichols_model(2, 5, 5)
mt = mt.select_entries(genotype_score=hl.float(mt.GT.n_alt_alleles()))
da = hl.experimental.dnd.array(mt, 'genotype_score', block_size=3)
score_difference = da.T.inner_product(
        da,
        lambda l, r: sqr(l - r),
        lambda l, r: l + r,
        hl.float(0),
        hl.agg.sum
)
```

The rest of KING-homo is just manipulation of row fields.

Eventually we need to implement `ndarray_inner_product(self, other, product, sum)`
which does a cache-friendly pass over the data but applies arbitrary user
product and sum operations.