### PR TITLE
[hailctl dataproc] Respect project and zone args when adding tags to cluster

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -354,5 +354,14 @@ def main(args, pass_through_args):
         print("Starting cluster '{}'...".format(args.name))
         gcloud.run(cmd[1:])
 
-        if args.master_tags:
-            gcloud.run(['compute', 'instances', 'add-tags', args.name + '-m', '--tags', args.master_tags])
+    if args.master_tags:
+        add_tags_command = ['compute', 'instances', 'add-tags', args.name + '-m', '--tags', args.master_tags]
+
+        if args.project:
+            add_tags_command.append(f"--project={args.project}")
+        if args.zone:
+            add_tags_command.append(f"--zone={args.zone}")
+
+        print('gcloud ' + ' '.join(add_tags_command))
+        if not args.dry_run:
+            gcloud.run(add_tags_command)

--- a/hail/python/test/hailtop/hailctl/dataproc/test_start.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_start.py
@@ -128,3 +128,20 @@ def test_master_tags(gcloud_run):
     assert gcloud_run.call_count == 2
     assert gcloud_run.call_args_list[0][0][0][:4] == ["dataproc", "clusters", "create", "test-cluster"]
     assert gcloud_run.call_args_list[1][0][0] == ["compute", "instances", "add-tags", "test-cluster-m", "--tags", "foo"]
+
+
+def test_master_tags_project(gcloud_run):
+    cli.main(["start", "test-cluster", "--master-tags=foo", "--project=some-project"])
+    assert gcloud_run.call_count == 2
+    assert "--project=some-project" in gcloud_run.call_args_list[1][0][0]
+
+
+def test_master_tags_zone(gcloud_run):
+    cli.main(["start", "test-cluster", "--master-tags=foo", "--zone=us-east1-d"])
+    assert gcloud_run.call_count == 2
+    assert "--zone=us-east1-d" in gcloud_run.call_args_list[1][0][0]
+
+
+def test_master_tags_dry_run(gcloud_run):
+    cli.main(["start", "test-cluster", "--master-tags=foo", "--dry-run"])
+    assert gcloud_run.call_count == 0


### PR DESCRIPTION
Currently, project and zone arguments to `hailctl dataproc start` are not included in the `gcloud compute instances add-tags` command used to add tags to the master node. Thus, adding tags may fail if the cluster is created in a non-default project/zone or if a default project/zone is not set.