### PR TITLE
[hail] fix installation instructions

### DIFF
--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -2,7 +2,7 @@
 Install Hail on Mac OS X
 ========================
 
-- Install `Java 8 <https://www.oracle.com/java/technologies/javase-jre8-downloads.html>`__.
+- Install `Java 8 <https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html>`__.
 - Install Python 3.6 or 3.7. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
 - Open Terminal.app and execute ``pip install hail``.
 - `Run your first Hail query! <try.rst>`__


### PR DESCRIPTION
For reasons completely unclear to me, on Mac OS X, you have to install a JDK to
get the `java` command line tool. https://stackoverflow.com/questions/34074039/java-command-line-requires-jdk-on-mac