### PR TITLE
[query] ndarray inverse using LAPACK

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -9,7 +9,7 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     TailLoop, Recur, ApplyBinaryPrimOp, ApplyUnaryPrimOp, ApplyComparisonOp, \
     MakeArray, ArrayRef, ArrayLen, ArrayZeros, StreamRange, MakeNDArray, \
     NDArrayShape, NDArrayReshape, NDArrayMap, NDArrayRef, NDArraySlice, \
-    NDArrayReindex, NDArrayAgg, NDArrayMatMul, NDArrayQR, NDArrayWrite, \
+    NDArrayReindex, NDArrayAgg, NDArrayMatMul, NDArrayQR, NDArrayInv, NDArrayWrite, \
     ArraySort, ToSet, ToDict, ToArray, CastToArray, ToStream, \
     LowerBoundOnOrderedCollection, GroupByKey, StreamMap, StreamZip, \
     StreamFilter, StreamFlatMap, StreamFold, StreamScan, \
@@ -154,6 +154,7 @@ __all__ = [
     'NDArrayAgg',
     'NDArrayMatMul',
     'NDArrayQR',
+    'NDArrayInv',
     'NDArrayWrite',
     'ArraySort',
     'ToSet',

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -806,7 +806,8 @@ class NDArrayMatMul(IR):
 
         ndim = hail.linalg.utils.misc._ndarray_matmul_ndim(self.left.typ.ndim, self.right.typ.ndim)
         from hail.expr.expressions import unify_types
-        self._type = tndarray(unify_types(self.left.typ.element_type, self.right.typ.element_type), ndim)
+        self._type = tndarray(unify_types(self.left.typ.element_type,
+                                          self.right.typ.element_type), ndim)
 
 
 class NDArrayQR(IR):
@@ -835,6 +836,7 @@ class NDArrayQR(IR):
         else:
             raise ValueError("Cannot compute type for mode: " + self.mode)
 
+
 class NDArrayInv(IR):
     @typecheck_method(nd=IR)
     def __init__(self, nd):
@@ -848,6 +850,7 @@ class NDArrayInv(IR):
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)
         self._type = tndarray(tfloat64, 2)
+
 
 class NDArrayWrite(IR):
     @typecheck_method(nd=IR, path=IR)
@@ -1773,7 +1776,8 @@ class InsertFields(IR):
     def render_children(self, r):
         return [
             self.old,
-            hail.ir.RenderableStr('None' if self.field_order is None else parsable_strings(self.field_order)),
+            hail.ir.RenderableStr(
+                'None' if self.field_order is None else parsable_strings(self.field_order)),
             *(InsertFields.IFRenderField(escape_id(f), x) for f, x in self.fields)
         ]
 
@@ -2515,7 +2519,8 @@ def subst(ir, env, agg_env):
         return AggArrayPerElement(_subst(ir.array, agg_env),
                                   ir.element_name,
                                   ir.index_name,
-                                  _subst(ir.agg_ir, delete(env, ir.index_name), delete(agg_env, ir.element_name)),
+                                  _subst(ir.agg_ir, delete(env, ir.index_name),
+                                         delete(agg_env, ir.element_name)),
                                   ir.is_scan)
     else:
         assert isinstance(ir, IR)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -835,6 +835,19 @@ class NDArrayQR(IR):
         else:
             raise ValueError("Cannot compute type for mode: " + self.mode)
 
+class NDArrayInv(IR):
+    @typecheck_method(nd=IR)
+    def __init__(self, nd):
+        super().__init__(nd)
+        self.nd = nd
+
+    @typecheck_method(nd=IR)
+    def copy(self):
+        return NDArrayInv(self.nd)
+
+    def _compute_type(self, env, agg_env):
+        self.nd._compute_type(env, agg_env)
+        self._type = tndarray(tfloat64, 2)
 
 class NDArrayWrite(IR):
     @typecheck_method(nd=IR, path=IR)

--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,5 +1,5 @@
-from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal
+from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv
 
 __all__ = [
-    'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'diagonal'
+    'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'diagonal', 'inv'
 ]

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -8,7 +8,7 @@ from hail.expr.expressions import (
     expr_int32, expr_int64, expr_tuple, expr_any, expr_array, expr_ndarray,
     Int64Expression, cast_expr, construct_expr)
 from hail.expr.expressions.typed_expressions import NDArrayNumericExpression
-from hail.ir import NDArrayQR
+from hail.ir import NDArrayQR, NDArrayInv
 
 
 def array(input_array):
@@ -255,3 +255,21 @@ def qr(nd, mode="reduced"):
         return construct_expr(ir, tndarray(tfloat64, 2))
     elif mode in ["complete", "reduced"]:
         return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)))
+
+@typecheck(nd=expr_ndarray())
+def inv(nd):
+    """Performs a matrix inversion.
+
+    :param nd: A 2 dimensional ndarray, shape(M, N)
+
+    Returns
+    -------
+    - a: ndarray of float64
+        The inverted matrix
+    """
+
+    assert nd.ndim == 2, "Matrix inversion requires 2 dimensional ndarray"
+
+    float_nd = nd.map(lambda x: hl.float64(x))
+    ir = NDArrayInv(float_nd._ir)
+    return construct_expr(ir, tndarray(tfloat64, 2))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -239,7 +239,8 @@ def qr(nd, mode="reduced"):
     - r: ndarray of float64
         The upper-triangular matrix R.
     - (h, tau): ndarrays of float64
-        The array h contains the Householder reflectors that generate q along with r. The tau array contains scaling factors for the reflectors
+        The array h contains the Householder reflectors that generate q along with r.
+        The tau array contains scaling factors for the reflectors
     """
 
     assert nd.ndim == 2, "QR decomposition requires 2 dimensional ndarray"
@@ -255,6 +256,7 @@ def qr(nd, mode="reduced"):
         return construct_expr(ir, tndarray(tfloat64, 2))
     elif mode in ["complete", "reduced"]:
         return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)))
+
 
 @typecheck(nd=expr_ndarray())
 def inv(nd):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1,5 +1,6 @@
 import pytest
 
+from hail.nd import inv
 from hail.linalg import BlockMatrix
 from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalError
 from ..helpers import *
@@ -999,6 +1000,11 @@ class Tests(unittest.TestCase):
         s = x.svd(compute_uv=False, complexity_bound=0)
         assert np.all(s >= 0)
 
+    def test_inv(self):
+        c = np.random.randn(5, 5)
+        d = np.linalg.inv(c)
+        dhail = hl.eval(hl.nd.inv(c))
+        assert np.allclose(dhail, d)
 
     @skip_unless_spark_backend()
     def test_filtering(self):

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -143,6 +143,8 @@ object Children {
       Array(l, r)
     case NDArrayQR(nd, _) =>
       Array(nd)
+    case NDArrayInv(nd) =>
+      Array(nd)
     case NDArrayWrite(nd, path) =>
       Array(nd, path)
     case AggFilter(cond, aggIR, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -111,6 +111,9 @@ object Copy {
       case NDArrayQR(_, mode) =>
         assert(newChildren.length == 1)
         NDArrayQR(newChildren(0).asInstanceOf[IR], mode)
+      case NDArrayInv(_) =>
+        assert(newChildren.length == 1)
+        NDArrayInv(newChildren(0).asInstanceOf[IR])
       case NDArrayWrite(_, _) =>
         assert(newChildren.length == 2)
         NDArrayWrite(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1987,6 +1987,81 @@ class Emit[C](
         }
         EmitCode(ndt.setup, ndt.m, PCode(pt, result))
 
+      case NDArrayInv(nd) =>
+        // Based on https://github.com/numpy/numpy/blob/v1.19.0/numpy/linalg/linalg.py#L477-L547
+        val ndt = emitNDArrayStandardStrides(nd)
+        val ndAddress = mb.genFieldThisRef[Long]()
+        val ndPType = nd.pType.asInstanceOf[PCanonicalNDArray]
+
+        val shapeAddress: Value[Long] = new Value[Long] {
+          def get: Code[Long] = ndPType.shape.load(ndAddress)
+        }
+        val shapeTuple = new CodePTuple(ndPType.shape.pType, shapeAddress)
+        val shapeArray = (0 until ndPType.shape.pType.nFields).map(shapeTuple[Long](_))
+
+        assert(shapeArray.length == 2)
+
+        val M = shapeArray(0)
+        val N = shapeArray(1)
+        val LDA = M
+
+        val dataAddress = ndPType.data.load(ndAddress)
+
+        val IPIVptype = PCanonicalArray(PInt32Required, true)
+        val IPIVaddr = mb.genFieldThisRef[Long]()
+        val WORKaddr = mb.genFieldThisRef[Long]()
+        val Aaddr = mb.genFieldThisRef[Long]()
+        val An = mb.newLocal[Int]() // same as array order
+
+        val INFOdgetrf = mb.newLocal[Int]()
+        val INFOdgetri = mb.newLocal[Int]()
+        val INFOerror = (fun: String, info: LocalRef[Int]) => (info cne 0)
+          .orEmpty(Code._fatal[Unit](const(s"LAPACK error ${fun}. Error code = ").concat(info.toS)))
+
+        val computeLU = Code(FastIndexedSeq(
+          ndAddress := ndt.value[Long],
+          (N cne M).orEmpty(Code._fatal[Unit](const("Can only invert square matrix"))),
+          An := (M * N).toI,
+
+          Aaddr := ndPType.data.pType.allocate(region, An),
+          ndPType.data.pType.stagedInitialize(Aaddr, An),
+          Region.copyFrom(ndPType.data.pType.firstElementOffset(dataAddress, An),
+            ndPType.data.pType.firstElementOffset(Aaddr, An), An.toL * 8L),
+
+          IPIVaddr := IPIVptype.allocate(region, N.toI),
+          IPIVptype.stagedInitialize(IPIVaddr, N.toI),
+
+          INFOdgetrf := Code.invokeScalaObject5[Int, Int, Long, Int, Long, Int](LAPACK.getClass, "dgetrf",
+            M.toI,
+            N.toI,
+            ndPType.data.pType.firstElementOffset(Aaddr, An.toI),
+            LDA.toI,
+            IPIVptype.firstElementOffset(IPIVaddr, N.toI)
+          ),
+          INFOerror("dgetrf", INFOdgetrf),
+
+          WORKaddr := Code.invokeStatic1[Memory, Long, Long]("malloc", An.toL * 8L),
+
+          INFOdgetri := Code.invokeScalaObject6[Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgetri",
+            N.toI,
+            ndPType.data.pType.firstElementOffset(Aaddr, An.toI),
+            LDA.toI,
+            IPIVptype.firstElementOffset(IPIVaddr, N.toI),
+            WORKaddr,
+            N.toI
+          ),
+          INFOerror("dgetri", INFOdgetri)
+        ))
+
+        val shapeBuilder = ndPType.makeShapeBuilder(shapeArray.map(_.get))
+        val stridesBuilder = ndPType.makeColumnMajorStridesBuilder(shapeArray.map(_.get), mb)
+
+        val res = Code(
+          computeLU,
+          ndPType.construct(shapeBuilder, stridesBuilder, Aaddr, mb)
+        )
+        EmitCode(ndt.setup, ndt.m, PCode(ndPType, res))
+
       case x@CollectDistributedArray(contexts, globals, cname, gname, body) =>
         val ctxType = coerce[PArray](contexts.pType).elementType
         val gType = globals.pType

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2011,7 +2011,7 @@ class Emit[C](
         val IPIVaddr = mb.genFieldThisRef[Long]()
         val WORKaddr = mb.genFieldThisRef[Long]()
         val Aaddr = mb.genFieldThisRef[Long]()
-        val An = mb.newLocal[Int]() // same as array order
+        val An = mb.newLocal[Int]()
 
         val INFOdgetrf = mb.newLocal[Int]()
         val INFOdgetri = mb.newLocal[Int]()

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -394,7 +394,13 @@ object NDArrayQR {
     "complete" -> PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 2)))
 }
 
+object NDArrayInv {
+  val pType = PCanonicalNDArray(PFloat64Required, 2)
+}
+
 final case class NDArrayQR(nd: IR, mode: String) extends IR
+
+final case class NDArrayInv(nd: IR) extends IR
 
 final case class AggFilter(cond: IR, aggIR: IR, isScan: Boolean) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -229,7 +229,8 @@ object InferPType {
         val lTyp = coerce[PNDArray](l.pType)
         val rTyp = coerce[PNDArray](r.pType)
         PCanonicalNDArray(lTyp.elementType, TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims), requiredness(node).required)
-      case NDArrayQR(nd, mode) => NDArrayQR.pTypes(mode)
+      case NDArrayQR(_, mode) => NDArrayQR.pTypes(mode)
+      case NDArrayInv(_) => NDArrayInv.pType
       case MakeStruct(fields) =>
         PCanonicalStruct(requiredness(node).required,
           fields.map { case (name, a) => (name, a.pType) }: _ *)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -183,6 +183,8 @@ object InferType {
         } else {
           throw new NotImplementedError(s"Cannot infer type for mode $mode")
         }
+      case NDArrayInv(_) =>
+        TNDArray(TFloat64, Nat(2))
       case NDArrayWrite(_, _) => TVoid
       case AggFilter(_, aggIR, _) =>
         aggIR.typ

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -891,6 +891,9 @@ object IRParser {
         val mode = string_literal(it)
         val nd = ir_value_expr(env)(it)
         NDArrayQR(nd, mode)
+      case "NDArrayInv" =>
+        val nd = ir_value_expr(env)(it)
+        NDArrayInv(nd)
       case "ToSet" => ToSet(ir_value_expr(env)(it))
       case "ToDict" => ToDict(ir_value_expr(env)(it))
       case "ToArray" => ToArray(ir_value_expr(env)(it))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -578,7 +578,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case NDArrayMatMul(l, r) =>
         requiredness.unionFrom(lookup(l))
         requiredness.union(lookup(r).required)
-      case NDArrayQR(nd, mode) => requiredness.fromPType(NDArrayQR.pTypes(mode))
+      case NDArrayQR(_, mode) => requiredness.fromPType(NDArrayQR.pTypes(mode))
+      case NDArrayInv(_) => requiredness.fromPType(NDArrayInv.pType)
       case MakeStruct(fields) =>
         fields.foreach { case (n, f) =>
           coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -233,6 +233,10 @@ object TypeCheck {
         val ndType = nd.typ.asInstanceOf[TNDArray]
         assert(ndType.elementType == TFloat64)
         assert(ndType.nDims == 2)
+      case x@NDArrayInv(nd) =>
+        val ndType = nd.typ.asInstanceOf[TNDArray]
+        assert(ndType.elementType == TFloat64)
+        assert(ndType.nDims == 2)
       case x@ArraySort(a, l, r, lessThan) =>
         assert(a.typ.isInstanceOf[TStream])
         assert(lessThan.typ == TBoolean)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2244,6 +2244,14 @@ class IRSuite extends HailSuite {
     assertEvalsTo(makeNDArrayRef(matMulCube, IndexedSeq(0, 0, 0)), 30.0)
   }
 
+  @Test def testNDArrayInv() {
+    implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
+    val matrixColMajor = makeNDArray(FastSeq(1.5, 2.0, 4.0, 5.0), FastSeq(2, 2), False())
+    val inv = NDArrayInv(matrixColMajor)
+    val expectedInv = FastSeq(FastSeq(-10.0, 4.0), FastSeq(8.0, -3.0))
+    assertNDEvals(inv, expectedInv)
+  }
+
   @Test def testNDArraySlice() {
     implicit val execStrats: Set[ExecStrategy] = Set()
 


### PR DESCRIPTION
to flesh out our linear algebra, and in service of regenie. eventually, this, qr, and other linalg functions should be moved to hl.linalg I think, to match scipy, numpy, dask, etc

we should also decide whether to break out LU factorization. Numpy, scipy, dask do this, so that's my preference for a followup pr, because people who are looking for a fleshed out linalg experience may want this.

also, we should have less than double precision support, but this matches QR.