### PR TITLE
[batch] Add requester pays option

### DIFF
--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -18,7 +18,7 @@ import re
 #   'parent_ids': [int],
 #   'port': int,
 #   'pvc_size': str,
-#   'requester_pays': str,
+#   'requester_pays_project': str,
 #   'resoures': {
 #     'memory': str,
 #     'cpu': str
@@ -36,7 +36,7 @@ import re
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays', 'resources', 'secrets', 'service_account', 'timeout'
+    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays_project', 'resources', 'secrets', 'service_account', 'timeout'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}
@@ -246,10 +246,10 @@ def validate_job(i, job):
         if not MEMORY_REGEX.fullmatch(pvc_size):
             raise ValidationError(f'jobs[{i}].pvc_size must match regex: {MEMORY_REGEXPAT}')
 
-    if 'requester_pays' in job:
-        requester_pays = job['requester_pays']
-        if not isinstance(requester_pays, str):
-            raise ValidationError(f'jobs[{i}].requester_pays not str')
+    if 'requester_pays_project' in job:
+        requester_pays_project = job['requester_pays_project']
+        if not isinstance(requester_pays_project, str):
+            raise ValidationError(f'jobs[{i}].requester_pays_project not str')
 
     if 'resources' in job:
         resources = job['resources']

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -18,6 +18,7 @@ import re
 #   'parent_ids': [int],
 #   'port': int,
 #   'pvc_size': str,
+#   'requester_pays': str,
 #   'resoures': {
 #     'memory': str,
 #     'cpu': str
@@ -35,7 +36,7 @@ import re
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'resources', 'secrets', 'service_account', 'timeout'
+    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays', 'resources', 'secrets', 'service_account', 'timeout'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}
@@ -244,6 +245,11 @@ def validate_job(i, job):
             raise ValidationError(f'jobs[{i}].pvc_size not str')
         if not MEMORY_REGEX.fullmatch(pvc_size):
             raise ValidationError(f'jobs[{i}].pvc_size must match regex: {MEMORY_REGEXPAT}')
+
+    if 'requester_pays' in job:
+        requester_pays = job['requester_pays']
+        if not isinstance(requester_pays, str):
+            raise ValidationError(f'jobs[{i}].requester_pays not str')
 
     if 'resources' in job:
         resources = job['resources']

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -504,24 +504,24 @@ async def add_gcsfuse_bucket(mount_path, bucket, key_file, read_only):
         delay = await sleep_and_backoff(delay)
 
 
-def copy_command(src, dst, requester_pays=None):
+def copy_command(src, dst, requester_pays_project=None):
     if not dst.startswith('gs://'):
         mkdirs = f'mkdir -p {shq(os.path.dirname(dst))} && '
     else:
         mkdirs = ''
 
-    if requester_pays:
-        requester_pays = f'-u {requester_pays}'
+    if requester_pays_project:
+        requester_pays_project = f'-u {requester_pays_project}'
     else:
-        requester_pays = ''
+        requester_pays_project = ''
 
-    return f'{mkdirs}retry gsutil {requester_pays} -m cp -R {shq(src)} {shq(dst)}'
+    return f'{mkdirs}retry gsutil {requester_pays_project} -m cp -R {shq(src)} {shq(dst)}'
 
 
-def copy(files, requester_pays):
+def copy(files, requester_pays_project):
     assert files
 
-    copies = ' && '.join([copy_command(f['from'], f['to'], requester_pays) for f in files])
+    copies = ' && '.join([copy_command(f['from'], f['to'], requester_pays_project) for f in files])
     return f'''
 set -ex
 
@@ -533,8 +533,8 @@ retry gcloud -q auth activate-service-account --key-file=/gsa-key/key.json
 '''
 
 
-def copy_container(job, name, files, volume_mounts, cpu, memory, requester_pays):
-    sh_expression = copy(files, requester_pays)
+def copy_container(job, name, files, volume_mounts, cpu, memory, requester_pays_project):
+    sh_expression = copy(files, requester_pays_project)
     copy_spec = {
         'image': 'google/cloud-sdk:269.0.0-alpine',
         'name': name,
@@ -585,7 +585,7 @@ class Job:
         copy_volume_mounts = []
         main_volume_mounts = []
 
-        requester_pays = job_spec.get('requester_pays')
+        requester_pays_project = job_spec.get('requester_pays_project')
 
         if job_spec.get('mount_docker_socket'):
             main_volume_mounts.append('/var/run/docker.sock:/var/run/docker.sock')
@@ -633,7 +633,7 @@ class Job:
         if input_files:
             containers['input'] = copy_container(
                 self, 'input', input_files, copy_volume_mounts,
-                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays)
+                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays_project)
 
         # main container
         main_spec = {
@@ -656,7 +656,7 @@ class Job:
         if output_files:
             containers['output'] = copy_container(
                 self, 'output', output_files, copy_volume_mounts,
-                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays)
+                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays_project)
 
         self.containers = containers
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -545,13 +545,3 @@ echo $HAIL_BATCH_WORKER_IP
             assert e.status == 400
         else:
             assert False, f'should receive a 400 Bad Request {batch.id}'
-
-    def test_requester_pays(self):
-        batch = self.client.create_batch()
-        j = batch.create_job('ubuntu:18.04',
-                             command=['/bin/sh', '-c', 'cat /io/hello'],
-                             input_files=[(f'gs://hail-services-requester-pays/hello', '/io/')])
-        batch = batch.submit()
-        batch.wait()
-        assert j._get_exit_code(j.status(), 'main') == 0, j._status
-        assert j.log()['main'] == 'hello\n', j.status()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -551,7 +551,7 @@ echo $HAIL_BATCH_WORKER_IP
         j = batch.create_job('ubuntu:18.04',
                              command=['/bin/sh', '-c', 'cat /io/hello'],
                              input_files=[(f'gs://hail-services-requester-pays/hello', '/io/')])
-        batch.submit()
+        batch = batch.submit()
         batch.wait()
         assert j._get_exit_code(j.status(), 'main') == 0, j._status
         assert j.log()['main'] == 'hello\n', j.status()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -545,3 +545,13 @@ echo $HAIL_BATCH_WORKER_IP
             assert e.status == 400
         else:
             assert False, f'should receive a 400 Bad Request {batch.id}'
+
+    def test_requester_pays(self):
+        batch = self.client.create_batch()
+        j = batch.create_job('ubuntu:18.04',
+                             command=['/bin/sh', '-c', 'cat /io/hello'],
+                             input_files=[(f'gs://hail-services-requester-pays/hello', '/io/')])
+        batch.submit()
+        batch.wait()
+        assert j._get_exit_code(j.status(), 'main') == 0, j._status
+        assert j.log()['main'] == 'hello\n', j.status()

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -101,10 +101,10 @@ class LocalBackend(Backend):
         copied_input_resource_files = set()
         os.makedirs(tmpdir + '/inputs/', exist_ok=True)
 
-        if batch.requester_pays:
-            requester_pays = f'-u {batch.requester_pays}'
+        if batch.requester_pays_project:
+            requester_pays_project = f'-u {batch.requester_pays_project}'
         else:
-            requester_pays = ''
+            requester_pays_project = ''
 
         def copy_input(job, r):
             if isinstance(r, InputResourceFile):
@@ -112,7 +112,7 @@ class LocalBackend(Backend):
                     copied_input_resource_files.add(r)
 
                     if r._input_path.startswith('gs://'):
-                        return [f'gsutil {requester_pays} cp {shq(r._input_path)} {shq(r._get_path(tmpdir))}']
+                        return [f'gsutil {requester_pays_project} cp {shq(r._input_path)} {shq(r._get_path(tmpdir))}']
 
                     absolute_input_path = os.path.realpath(r._input_path)
 
@@ -137,7 +137,7 @@ class LocalBackend(Backend):
                     directory = os.path.dirname(dest)
                     os.makedirs(directory, exist_ok=True)
                     return 'cp'
-                return f'gsutil {requester_pays} cp'
+                return f'gsutil {requester_pays_project} cp'
 
             if isinstance(r, InputResourceFile):
                 return [f'{_cp(dest)} {shq(r._input_path)} {shq(dest)}'
@@ -441,7 +441,7 @@ class ServiceBackend(Backend):
                                     timeout=job._timeout,
                                     gcsfuse=job._gcsfuse if len(job._gcsfuse) > 0 else None,
                                     env=env_vars,
-                                    requester_pays=batch.requester_pays)
+                                    requester_pays_project=batch.requester_pays_project)
 
             n_jobs_submitted += 1
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -101,13 +101,18 @@ class LocalBackend(Backend):
         copied_input_resource_files = set()
         os.makedirs(tmpdir + '/inputs/', exist_ok=True)
 
+        if batch.requester_pays:
+            requester_pays = f'-u {batch.requester_pays}'
+        else:
+            requester_pays = ''
+
         def copy_input(job, r):
             if isinstance(r, InputResourceFile):
                 if r not in copied_input_resource_files:
                     copied_input_resource_files.add(r)
 
                     if r._input_path.startswith('gs://'):
-                        return [f'gsutil cp {shq(r._input_path)} {shq(r._get_path(tmpdir))}']
+                        return [f'gsutil {requester_pays} cp {shq(r._input_path)} {shq(r._get_path(tmpdir))}']
 
                     absolute_input_path = os.path.realpath(r._input_path)
 
@@ -132,7 +137,7 @@ class LocalBackend(Backend):
                     directory = os.path.dirname(dest)
                     os.makedirs(directory, exist_ok=True)
                     return 'cp'
-                return 'gsutil cp'
+                return f'gsutil {requester_pays} cp'
 
             if isinstance(r, InputResourceFile):
                 return [f'{_cp(dest)} {shq(r._input_path)} {shq(dest)}'
@@ -435,7 +440,8 @@ class ServiceBackend(Backend):
                                     always_run=job._always_run,
                                     timeout=job._timeout,
                                     gcsfuse=job._gcsfuse if len(job._gcsfuse) > 0 else None,
-                                    env=env_vars)
+                                    env=env_vars,
+                                    requester_pays=batch.requester_pays)
 
             n_jobs_submitted += 1
 

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -50,7 +50,7 @@ class Batch:
     attributes: :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Key-value pairs of additional attributes. 'name' is not a valid keyword.
         Use the name argument instead.
-    requester_pays: :obj:`str`, optional
+    requester_pays_project: :obj:`str`, optional
         The name of the Google project to be billed when accessing requester pays buckets.
     default_image: :obj:`str`, optional
         Docker image to use by default if not specified by a job.
@@ -85,7 +85,7 @@ class Batch:
                  name: Optional[str] = None,
                  backend: Optional[Backend] = None,
                  attributes: Optional[Dict[str, str]] = None,
-                 requester_pays: Optional[str] = None,
+                 requester_pays_project: Optional[str] = None,
                  default_image: Optional[str] = None,
                  default_memory: Optional[str] = None,
                  default_cpu: Optional[str] = None,
@@ -105,7 +105,7 @@ class Batch:
             raise BatchException("'name' is not a valid attribute. Use the name argument instead.")
         self.attributes = attributes
 
-        self.requester_pays = requester_pays
+        self.requester_pays_project = requester_pays_project
 
         self._default_image = default_image
         self._default_memory = default_memory

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -50,6 +50,8 @@ class Batch:
     attributes: :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Key-value pairs of additional attributes. 'name' is not a valid keyword.
         Use the name argument instead.
+    requester_pays: :obj:`str`, optional
+        The name of the Google project to be billed when accessing requester pays buckets.
     default_image: :obj:`str`, optional
         Docker image to use by default if not specified by a job.
     default_memory: :obj:`str`, optional
@@ -83,6 +85,7 @@ class Batch:
                  name: Optional[str] = None,
                  backend: Optional[Backend] = None,
                  attributes: Optional[Dict[str, str]] = None,
+                 requester_pays: Optional[str] = None,
                  default_image: Optional[str] = None,
                  default_memory: Optional[str] = None,
                  default_cpu: Optional[str] = None,
@@ -101,6 +104,8 @@ class Batch:
         if 'name' in attributes:
             raise BatchException("'name' is not a valid attribute. Use the name argument instead.")
         self.attributes = attributes
+
+        self.requester_pays = requester_pays
 
         self._default_image = default_image
         self._default_memory = default_memory

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -371,7 +371,7 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None,
-                   timeout=None, gcsfuse=None):
+                   timeout=None, gcsfuse=None, requester_pays=None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
 
@@ -438,6 +438,8 @@ class BatchBuilder:
         if gcsfuse:
             job_spec['gcsfuse'] = [{"bucket": bucket, "mount_path": mount_path, "read_only": read_only}
                                    for (bucket, mount_path, read_only) in gcsfuse]
+        if requester_pays:
+            job_spec['requester_pays'] = requester_pays
 
         self._job_specs.append(job_spec)
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -371,7 +371,7 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None,
-                   timeout=None, gcsfuse=None, requester_pays=None):
+                   timeout=None, gcsfuse=None, requester_pays_project=None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
 
@@ -438,8 +438,8 @@ class BatchBuilder:
         if gcsfuse:
             job_spec['gcsfuse'] = [{"bucket": bucket, "mount_path": mount_path, "read_only": read_only}
                                    for (bucket, mount_path, read_only) in gcsfuse]
-        if requester_pays:
-            job_spec['requester_pays'] = requester_pays
+        if requester_pays_project:
+            job_spec['requester_pays_project'] = requester_pays_project
 
         self._job_specs.append(job_spec)
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -145,7 +145,7 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None,
-                   timeout=None, gcsfuse=None, requester_pays=None):
+                   timeout=None, gcsfuse=None, requester_pays_project=None):
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -155,7 +155,8 @@ class BatchBuilder:
             service_account=service_account,
             attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
-            pvc_size=pvc_size, timeout=timeout, gcsfuse=gcsfuse, requester_pays=requester_pays)
+            pvc_size=pvc_size, timeout=timeout, gcsfuse=gcsfuse,
+            requester_pays_project=requester_pays_project)
 
         return Job.from_async_job(async_job)
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -145,7 +145,7 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None,
-                   timeout=None, gcsfuse=None):
+                   timeout=None, gcsfuse=None, requester_pays=None):
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -155,7 +155,7 @@ class BatchBuilder:
             service_account=service_account,
             attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
-            pvc_size=pvc_size, timeout=timeout, gcsfuse=gcsfuse)
+            pvc_size=pvc_size, timeout=timeout, gcsfuse=gcsfuse, requester_pays=requester_pays)
 
         return Job.from_async_job(async_job)
 

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -15,8 +15,9 @@ from hailtop.config import get_user_config
 
 
 class LocalTests(unittest.TestCase):
-    def batch(self):
-        return Batch(backend=LocalBackend())
+    def batch(self, requester_pays=None):
+        return Batch(backend=LocalBackend(),
+                     requester_pays=requester_pays)
 
     def read(self, file):
         with open(file, 'r') as f:
@@ -292,6 +293,13 @@ class LocalTests(unittest.TestCase):
         t2.command(f'echo "hello" >> {j.foo.bed}')
         b.run()
 
+    def test_requester_pays(self):
+        b = self.batch(requester_pays='hail-vdc')
+        input = b.read_input('gs://hail-services-requester-pays/hello')
+        j = b.new_job()
+        j.command(f'cat {input}')
+        assert b.run().status()['state'] == 'success'
+
 
 class BatchTests(unittest.TestCase):
     def setUp(self):
@@ -326,10 +334,11 @@ class BatchTests(unittest.TestCase):
     def tearDown(self):
         self.backend.close()
 
-    def batch(self):
+    def batch(self, requester_pays=None):
         return Batch(backend=self.backend,
                      default_image='google/cloud-sdk:237.0.0-alpine',
-                     attributes={'foo': 'a', 'bar': 'b'})
+                     attributes={'foo': 'a', 'bar': 'b'},
+                     requester_pays=requester_pays)
 
     def test_single_task_no_io(self):
         b = self.batch()
@@ -473,6 +482,13 @@ class BatchTests(unittest.TestCase):
         j.gcsfuse(self.bucket_name, f'/{self.bucket_name}', read_only=True)
 
         assert b.run().status()['state'] == 'failure'
+
+    def test_requester_pays(self):
+        b = self.batch(requester_pays='hail-vdc')
+        input = b.read_input('gs://hail-services-requester-pays/hello')
+        j = b.new_job()
+        j.command(f'cat {input}')
+        assert b.run().status()['state'] == 'success'
 
     def test_benchmark_lookalike_workflow(self):
         b = self.batch()

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -7,7 +7,6 @@ import uuid
 import google.oauth2.service_account
 import google.cloud.storage
 
-from hailtop.config import get_user_config
 from hailtop.batch import Batch, ServiceBackend, LocalBackend
 from hailtop.batch.utils import arg_max
 from hailtop.utils import grouped
@@ -15,9 +14,9 @@ from hailtop.config import get_user_config
 
 
 class LocalTests(unittest.TestCase):
-    def batch(self, requester_pays=None):
+    def batch(self, requester_pays_project=None):
         return Batch(backend=LocalBackend(),
-                     requester_pays=requester_pays)
+                     requester_pays_project=requester_pays_project)
 
     def read(self, file):
         with open(file, 'r') as f:
@@ -327,11 +326,11 @@ class BatchTests(unittest.TestCase):
     def tearDown(self):
         self.backend.close()
 
-    def batch(self, requester_pays=None):
+    def batch(self, requester_pays_project=None):
         return Batch(backend=self.backend,
                      default_image='google/cloud-sdk:237.0.0-alpine',
                      attributes={'foo': 'a', 'bar': 'b'},
-                     requester_pays=requester_pays)
+                     requester_pays_project=requester_pays_project)
 
     def test_single_task_no_io(self):
         b = self.batch()
@@ -477,7 +476,7 @@ class BatchTests(unittest.TestCase):
         assert b.run().status()['state'] == 'failure'
 
     def test_requester_pays(self):
-        b = self.batch(requester_pays='hail-vdc')
+        b = self.batch(requester_pays_project='hail-vdc')
         input = b.read_input('gs://hail-services-requester-pays/hello')
         j = b.new_job()
         j.command(f'cat {input}')

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -293,13 +293,6 @@ class LocalTests(unittest.TestCase):
         t2.command(f'echo "hello" >> {j.foo.bed}')
         b.run()
 
-    def test_requester_pays(self):
-        b = self.batch(requester_pays='hail-vdc')
-        input = b.read_input('gs://hail-services-requester-pays/hello')
-        j = b.new_job()
-        j.command(f'cat {input}')
-        assert b.run().status()['state'] == 'success'
-
 
 class BatchTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I debated whether to have this option on a batch which would require a database migration to add a new field to the batches table or just have it in the job spec for all jobs (same for all jobs). What I did is the easiest thing. It assumes all requester pay accesses are billed to the same project.