### PR TITLE
List Pylint and Flake8 in dev requirements

### DIFF
--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,3 +1,5 @@
+flake8==3.7.8
+pylint==2.3.1
 pytest==4.5
 pytest-html==1.20.0
 pytest-xdist==1.28


### PR DESCRIPTION
Based on [discussion](https://github.com/hail-is/hail/pull/9092#discussion_r456509655) in #9092.

Pylint and Flake8 are necessary to run `check-hail` and `check` tasks in [hail/python/Makefile](https://github.com/hail-is/hail/blob/88aa36ce94ffd3501602784887fd40ece917834a/hail/python/Makefile#L4-L14). However, they are not currently included in [hail/python/dev-requirements.txt](https://github.com/hail-is/hail/blob/88aa36ce94ffd3501602784887fd40ece917834a/hail/python/dev-requirements.txt).