### PR TITLE
[hail] NDArray eye

### DIFF
--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,6 +1,6 @@
-from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv, concatenate
+from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv, concatenate, eye
 
 __all__ = [
     'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'diagonal', 'inv',
-    'concatenate'
+    'concatenate', 'eye'
 ]

--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,6 +1,6 @@
-from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv, concatenate, eye
+from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv, concatenate, eye, identity
 
 __all__ = [
     'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'diagonal', 'inv',
-    'concatenate', 'eye'
+    'concatenate', 'eye', 'identity'
 ]

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -338,7 +338,8 @@ def eye(N, M=None, dtype=hl.tfloat64):
 
     See Also
     --------
-    diag : Gets the diagonal of a 2 dimensional NDArray
+    :func:`.identity`
+    :func:`.diagonal`
 
     Examples
     --------
@@ -362,3 +363,35 @@ def eye(N, M=None, dtype=hl.tfloat64):
                           hl.literal(1, dtype),
                           hl.literal(0, dtype))
     )).reshape((n_row, n_col))
+
+
+@typecheck(N=expr_numeric, dtype=HailType)
+def identity(N, dtype=hl.tfloat64):
+    """
+    Constructs a 2-D :class:`.NDArrayExpression` representing the identity array.
+    The identity array is a square array with ones on
+    the main diagonal.
+    Parameters
+    ----------
+    n : :class:`.NumericExpression` or Python number
+      Number of rows and columns in the output.
+    dtype : numeric :class:`.HailType`, optional
+      Element type of the returned array. Defaults to :py:data:`.tfloat64`
+
+    Returns
+    -------
+    out : :class:`.NDArrayExpression`
+        `n` x `n` ndarray with its main diagonal set to one, and all other elements 0.
+
+    See Also
+    --------
+    :func:`.eye`
+
+    Examples
+    --------
+    >>> hl.eval(hl.nd.identity(3))
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+    """
+    return eye(N, dtype=dtype)

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -329,7 +329,7 @@ def eye(N, M=None, dtype=hl.tfloat64):
     M : :class:`.NumericExpression` or Python number, optional
       Number of columns in the output. If None, defaults to `N`.
     dtype : numeric :class:`.HailType`, optional
-      Element type of the returned array
+      Element type of the returned array. Defaults to :py:data:`.tfloat64`
 
     Returns
     -------
@@ -342,13 +342,13 @@ def eye(N, M=None, dtype=hl.tfloat64):
 
     Examples
     --------
-    >>> np.nd.eye(2, dtype=hl.tint32)
+    >>> hl.eval(hl.nd.eye(2, dtype=hl.tint32))
     array([[1, 0],
-           [0, 1]])
-    >>> hl.nd.eye(3)
-    array([[ 1.,  0.,  0.],
-           [ 0.,  1.,  0.],
-           [ 0.,  0.,  1.]])
+           [0, 1]], dtype=int32)
+    >>> hl.eval(hl.nd.eye(3))
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
     """
 
     n_row = hl.int32(N)
@@ -357,12 +357,8 @@ def eye(N, M=None, dtype=hl.tfloat64):
     else:
         n_col = hl.int32(M)
 
-    shape_product = n_row * n_col
-    n_rows_sq = hl.cond(n_row <= n_col, n_row, n_col)
-    max_el_sq = n_rows_sq * n_rows_sq
-
-    return array(hl.range(hl.int32(shape_product)).map(
-        lambda i: hl.cond((i < max_el_sq) & ((i % n_rows_sq) == (i // n_rows_sq)),
+    return hl.nd.array(hl.range(0, hl.int32(n_row * n_col)).map(
+        lambda i: hl.cond((i // n_col) == (i - (i // n_col) * n_col),
                           hl.literal(1, dtype),
                           hl.literal(0, dtype))
     )).reshape((n_row, n_col))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -357,7 +357,7 @@ def eye(N, M=None, dtype=hl.tfloat64):
     else:
         n_col = hl.int32(M)
 
-    return hl.nd.array(hl.range(0, hl.int32(n_row * n_col)).map(
+    return hl.nd.array(hl.range(0, n_row * n_col).map(
         lambda i: hl.cond((i // n_col) == (i - (i // n_col) * n_col),
                           hl.literal(1, dtype),
                           hl.literal(0, dtype))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -343,13 +343,13 @@ def eye(N, M=None, dtype=hl.tfloat64):
 
     Examples
     --------
-    >>> hl.eval(hl.nd.eye(2, dtype=hl.tint32))
-    array([[1, 0],
-           [0, 1]], dtype=int32)
     >>> hl.eval(hl.nd.eye(3))
     array([[1., 0., 0.],
            [0., 1., 0.],
            [0., 0., 1.]])
+    >>> hl.eval(hl.nd.eye(2, 5, dtype=hl.tint32))
+    array([[1, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0]], dtype=int32)
     """
 
     n_row = hl.int32(N)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1020,9 +1020,9 @@ class Tests(unittest.TestCase):
         assert np.allclose(np_res, res)
 
     def test_eye(self):
-        assert(np.allclose(hl.eval(hl.nd.eye(4,4)), np.eye(4,4)))
-        assert(np.allclose(hl.eval(hl.nd.eye(1,4)), np.eye(1,4)))
-        assert(np.allclose(hl.eval(hl.nd.eye(7,4)), np.eye(7,4)))
+        for i in range(13):
+            for y in range(13):
+                assert(np.allclose(hl.eval(hl.nd.eye(i,y)), np.eye(i,y)))
 
     @skip_unless_spark_backend()
     def test_filtering(self):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1019,6 +1019,11 @@ class Tests(unittest.TestCase):
         res = hl.eval(hl.nd.concatenate([x, y]))
         assert np.allclose(np_res, res)
 
+    def test_eye(self):
+        assert(np.allclose(hl.eval(hl.nd.eye(4,4)), np.eye(4,4)))
+        assert(np.allclose(hl.eval(hl.nd.eye(1,4)), np.eye(1,4)))
+        assert(np.allclose(hl.eval(hl.nd.eye(7,4)), np.eye(7,4)))
+
     @skip_unless_spark_backend()
     def test_filtering(self):
         np_square = np.arange(16, dtype=np.float64).reshape((4, 4))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1024,6 +1024,10 @@ class Tests(unittest.TestCase):
             for y in range(13):
                 assert(np.allclose(hl.eval(hl.nd.eye(i,y)), np.eye(i,y)))
 
+    def test_identity(self):
+        for i in range(13):
+            assert(np.allclose(hl.eval(hl.nd.identity(i)), np.identity(i)))
+
     @skip_unless_spark_backend()
     def test_filtering(self):
         np_square = np.arange(16, dtype=np.float64).reshape((4, 4))


### PR DESCRIPTION
Identity matrix, needed for ridge regression in Hail. This is obviously suboptimal, it should be a special instance of a sparse ndarray that specifies 'k', but this matches the Numpy implementation and represents a good start.