### PR TITLE
[ci] make create_ssl_config_root idempotent and use it in dev deploy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -130,15 +130,19 @@ steps:
      valueFrom: create_certs_image.image
    script: |
      openssl req -new -x509 -subj /CN=hail-root -nodes -newkey rsa:4096 -keyout hail-root-key.pem -out hail-root-cert.pem
-     kubectl create secret generic -n {{ default_ns.name }} ssl-config-hail-root \
-             --from-file=hail-root-key.pem \
-             --from-file=hail-root-cert.pem
+     until kubectl get secret -n {{ default_ns.name }} ssl-config-hail-root
+     do
+         kubectl create secret generic -n {{ default_ns.name }} ssl-config-hail-root \
+                 --from-file=hail-root-key.pem \
+                 --from-file=hail-root-cert.pem
+     done
    serviceAccount:
      name: admin
      namespace:
        valueFrom: default_ns.name
    scopes:
     - test
+    - dev
    dependsOn:
     - default_ns
     - create_certs_image


### PR DESCRIPTION
This needs to be done at least once. The root SSL/TLS key is used to sign all
other keys used in the namespace. We do not recreate it when we deploy into
default or into dev namesapces.