### PR TITLE
[hail] Unify sql-config secret creation

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -9,6 +9,7 @@ import asyncio
 import aiohttp
 import kubernetes_asyncio as kube
 from hailtop.utils import time_msecs
+from hailtop.utils.sql_config import create_secret_data_from_config
 from hailtop import aiogoogle
 from gear import create_session, Database
 
@@ -199,26 +200,19 @@ GRANT ALL ON `{name}`.* TO '{name}'@'%';
 ''')
         self.name = name
 
-    @staticmethod
-    def secret_data_from_config(config):
-        assert config.get('db') is not None
-        return {
-            'sql-config.json': json.dumps(config),
-            'sql-config.cnf': f'''
-[client]
-host={config['host']}
-user={config['user']}
-password="{config['password']}"
-database={config['db']}
-'''
-        }
-
     def secret_data(self):
         with open('/database-server-config/sql-config.json', 'r') as f:
             server_config = json.loads(f.read())
+        with open('/database-server-config/server-ca.pem', 'r') as f:
+            server_ca = f.read()
+        with open('/database-server-config/client-cert.pem', 'r') as f:
+            client_cert = f.read()
+        with open('/database-server-config/client-key.pem', 'r') as f:
+            client_key = f.read()
 
         if is_test_deployment:
-            return self.secret_data_from_config(server_config)
+            return create_secret_data_from_config(
+                server_config, server_ca, client_cert, client_key)
 
         assert self.name is not None
         assert self.password is not None
@@ -232,7 +226,8 @@ database={config['db']}
             'connection_name': server_config['connection_name'],
             'db': self.name
         }
-        return self.secret_data_from_config(config)
+        return create_secret_data_from_config(
+            config, server_ca, client_cert, client_key)
 
     async def _delete(self, name):
         if is_test_deployment:

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -9,7 +9,7 @@ import asyncio
 import aiohttp
 import kubernetes_asyncio as kube
 from hailtop.utils import time_msecs
-from hailtop.utils.sql_config import create_secret_data_from_config
+from hailtop.auth.sql_config import create_secret_data_from_config
 from hailtop import aiogoogle
 from gear import create_session, Database
 

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -8,7 +8,7 @@ import asyncio
 import shutil
 from shlex import quote as shq
 from hailtop.utils import check_shell, check_shell_output
-from hailtop.utils.sql_config import create_secret_data_from_config
+from hailtop.auth.sql_config import create_secret_data_from_config
 from gear import Database
 
 assert len(sys.argv) == 2

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -8,6 +8,7 @@ import asyncio
 import shutil
 from shlex import quote as shq
 from hailtop.utils import check_shell, check_shell_output
+from hailtop.utils.sql_config import create_secret_data_from_config
 from gear import Database
 
 assert len(sys.argv) == 2
@@ -22,39 +23,18 @@ def generate_token(size=12):
 
 
 async def write_user_config(namespace, database_name, user, config):
-    files = []
-
-    files.append('sql-config.json')
-    with open(f'sql-config.json', 'w') as f:
-        f.write(json.dumps(config))
-
-    files.append('sql-config.cnf')
-    with open(f'sql-config.cnf', 'w') as f:
-        f.write(f'''[client]
-host={config["host"]}
-user={config["user"]}
-password="{config["password"]}"
-database={config["db"]}
-''')
-        if config.get('ssl-ca') is not None:
-            f.write(f'ssl-ca={config["ssl-ca"]}\n')
-        if config.get('ssl-cert') is not None:
-            f.write(f'ssl-cert={config["ssl-cert"]}\n')
-        if config.get('ssl-key') is not None:
-            f.write(f'ssl-key={config["ssl-key"]}\n')
-        if config.get('ssl-mode') is not None:
-            f.write(f'ssl-mode={config["ssl-mode"]}\n')
-
-    if os.path.exists('/sql-config/server-ca.pem'):
-        files.append('server-ca.pem')
-        shutil.copy('/sql-config/server-ca.pem', 'server-ca.pem')
-    if os.path.exists('/sql-config/client-key.pem'):
-        files.append('client-key.pem')
-        shutil.copy('/sql-config/client-key.pem', 'client-key.pem')
-    if os.path.exists('/sql-config/client-cert.pem'):
-        files.append('client-cert.pem')
-        shutil.copy('/sql-config/client-cert.pem', 'client-cert.pem')
-
+    with open('/sql-config/server-ca.pem', 'r') as f:
+        server_ca = f.read()
+    with open('/sql-config/client-cert.pem', 'r') as f:
+        client_cert = f.read()
+    with open('/sql-config/client-key.pem', 'r') as f:
+        client_key = f.read()
+    secret = create_secret_data_from_config(
+        config, server_ca, client_cert, client_key)
+    files = secret.keys()
+    for fname, data in secret.items():
+        with open(os.path.basename(fname), 'w') as f:
+            f.write(data)
     secret_name = f'sql-{database_name}-{user}-config'
     print(f'creating secret {secret_name}')
     from_files = ' '.join(f'--from-file={f}' for f in files)

--- a/hail/python/hailtop/auth/__init__.py
+++ b/hail/python/hailtop/auth/__init__.py
@@ -1,3 +1,4 @@
+import sql_config
 from .tokens import get_tokens
 from .auth import (
     async_get_userinfo, get_userinfo, namespace_auth_headers,
@@ -10,5 +11,6 @@ __all__ = [
     'namespace_auth_headers',
     'service_auth_headers',
     'async_copy_paste_login',
-    'copy_paste_login'
+    'copy_paste_login',
+    'sql_config'
 ]

--- a/hail/python/hailtop/auth/__init__.py
+++ b/hail/python/hailtop/auth/__init__.py
@@ -1,4 +1,4 @@
-import sql_config
+from . import sql_config
 from .tokens import get_tokens
 from .auth import (
     async_get_userinfo, get_userinfo, namespace_auth_headers,

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -1,0 +1,23 @@
+import json
+
+
+def create_secret_data_from_config(config, server_ca, client_cert, client_key):
+    assert all(config.get(x) is not None
+               for x in ('host', 'user', 'password', 'db', 'ssl-ca', 'ssl-cert',
+                         'ssl-key', 'ssl-mode')), config.keys()
+    secret_data = dict()
+    secret_data['sql-config.json'] = json.dumps(config)
+    secret_data['sql-config.cnf'] = f'''[client]
+host={config["host"]}
+user={config["user"]}
+password="{config["password"]}"
+database={config["db"]}
+ssl-ca={config["ssl-ca"]}
+ssl-cert={config["ssl-cert"]}
+ssl-key={config["ssl-key"]}
+ssl-mode={config["ssl-mode"]}
+'''
+    secret_data['server-ca.pem'] = server_ca
+    secret_data['client-cert.pem'] = client_cert
+    secret_data['client-key.pem'] = client_key
+    return secret_data


### PR DESCRIPTION
The auth driver currently uses the old secret format. The new secret format
includes SSL information. This change defines the secret format once in hailtop
and uses it everywhere. I also simplified the auth secret format: everyone uses
SSL/TLS to talk to databases now, so assume all necessary files are present.