### PR TITLE
[notebook] fix notebook, improve tls naming, add typing to tls.py

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,7 +8,7 @@ import google.oauth2.id_token
 import google_auth_oauthlib.flow
 from hailtop.config import get_deploy_config
 from hailtop.utils import secret_alnum_string
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import (
     setup_aiohttp_session,
     rest_authenticated_users_only, web_authenticated_developers_only,
@@ -364,4 +364,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -8,7 +8,7 @@ import traceback
 from hailtop.utils import (
     time_msecs, sleep_and_backoff, is_transient_error,
     time_msecs_str, humanize_timedelta_msecs)
-from hailtop.tls import ssl_client_session
+from hailtop.tls import in_cluster_ssl_client_sesion
 
 from .globals import complete_states, tasks, STATUS_FORMAT_VERSION
 from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \
@@ -102,7 +102,7 @@ GROUP BY batches.id;
 
     if record['user'] == 'ci':
         # only jobs from CI may use batch's TLS identity
-        make_client_session = ssl_client_session
+        make_client_session = in_cluster_ssl_client_sesion
     else:
         make_client_session = aiohttp.ClientSession
     try:

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -8,7 +8,7 @@ import traceback
 from hailtop.utils import (
     time_msecs, sleep_and_backoff, is_transient_error,
     time_msecs_str, humanize_timedelta_msecs)
-from hailtop.tls import in_cluster_ssl_client_sesion
+from hailtop.tls import in_cluster_ssl_client_session
 
 from .globals import complete_states, tasks, STATUS_FORMAT_VERSION
 from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \
@@ -102,7 +102,7 @@ GROUP BY batches.id;
 
     if record['user'] == 'ci':
         # only jobs from CI may use batch's TLS identity
-        make_client_session = in_cluster_ssl_client_sesion
+        make_client_session = in_cluster_ssl_client_session
     else:
         make_client_session = aiohttp.ClientSession
     try:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -14,7 +14,7 @@ from gear import Database, setup_aiohttp_session, web_authenticated_developers_o
     check_csrf_token, transaction, AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import time_msecs, RateLimit
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from hailtop import aiogoogle
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
@@ -747,4 +747,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -19,7 +19,7 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
                            retry_long_running, LoggingTimer)
 from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_server_ssl_context, ssl_client_session
+from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_sesion
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only, web_authenticated_users_only,
                   web_authenticated_developers_only, check_csrf_token, transaction,
@@ -929,7 +929,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with ssl_client_session(
+    async with in_cluster_ssl_client_sesion(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
@@ -1394,7 +1394,7 @@ async def index(request, userdata):
 
 
 async def cancel_batch_loop_body(app):
-    async with ssl_client_session(
+    async with in_cluster_ssl_client_sesion(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',
@@ -1406,7 +1406,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with ssl_client_session(
+    async with in_cluster_ssl_client_sesion(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',
@@ -1486,4 +1486,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -19,7 +19,7 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
                            retry_long_running, LoggingTimer)
 from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_sesion
+from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_session
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only, web_authenticated_users_only,
                   web_authenticated_developers_only, check_csrf_token, transaction,
@@ -929,7 +929,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with in_cluster_ssl_client_sesion(
+    async with in_cluster_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
@@ -1394,7 +1394,7 @@ async def index(request, userdata):
 
 
 async def cancel_batch_loop_body(app):
-    async with in_cluster_ssl_client_sesion(
+    async with in_cluster_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',
@@ -1406,7 +1406,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with in_cluster_ssl_client_sesion(
+    async with in_cluster_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -21,7 +21,7 @@ import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError)
-from hailtop.tls import ssl_client_session
+from hailtop.tls import in_cluster_ssl_client_sesion
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 # import uvloop
@@ -936,7 +936,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with ssl_client_session(
+                async with in_cluster_ssl_client_sesion(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
@@ -990,7 +990,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with ssl_client_session(
+                async with in_cluster_ssl_client_sesion(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
@@ -1045,7 +1045,7 @@ class Worker:
             'status': status
         }
 
-        async with ssl_client_session(
+        async with in_cluster_ssl_client_sesion(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             await request_retry_transient_errors(
                 session, 'POST',
@@ -1059,7 +1059,7 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with ssl_client_session(
+        async with in_cluster_ssl_client_sesion(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             resp = await request_retry_transient_errors(
                 session, 'POST',

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -21,7 +21,7 @@ import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError)
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.tls import get_context_specific_ssl_client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 # import uvloop
@@ -936,7 +936,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with in_cluster_ssl_client_session(
+                async with get_context_specific_ssl_client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
@@ -990,7 +990,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with in_cluster_ssl_client_session(
+                async with get_context_specific_ssl_client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
@@ -1045,7 +1045,7 @@ class Worker:
             'status': status
         }
 
-        async with in_cluster_ssl_client_session(
+        async with get_context_specific_ssl_client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             await request_retry_transient_errors(
                 session, 'POST',
@@ -1059,7 +1059,7 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with in_cluster_ssl_client_session(
+        async with get_context_specific_ssl_client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             resp = await request_retry_transient_errors(
                 session, 'POST',

--- a/batch/batch/worker.py
+++ b/batch/batch/worker.py
@@ -21,7 +21,7 @@ import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError)
-from hailtop.tls import in_cluster_ssl_client_sesion
+from hailtop.tls import in_cluster_ssl_client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 # import uvloop
@@ -936,7 +936,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with in_cluster_ssl_client_sesion(
+                async with in_cluster_ssl_client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
@@ -990,7 +990,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with in_cluster_ssl_client_sesion(
+                async with in_cluster_ssl_client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
@@ -1045,7 +1045,7 @@ class Worker:
             'status': status
         }
 
-        async with in_cluster_ssl_client_sesion(
+        async with in_cluster_ssl_client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             await request_retry_transient_errors(
                 session, 'POST',
@@ -1059,7 +1059,7 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with in_cluster_ssl_client_sesion(
+        async with in_cluster_ssl_client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             resp = await request_retry_transient_errors(
                 session, 'POST',

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,14 +1,14 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.tls import in_cluster_ssl_client_sesion
+from hailtop.tls import in_cluster_ssl_client_session
 
 
 class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = in_cluster_ssl_client_sesion(raise_for_status=True,
-                                                         timeout=aiohttp.ClientTimeout(total=60))
+        self.real_session = in_cluster_ssl_client_session(raise_for_status=True,
+                                                          timeout=aiohttp.ClientTimeout(total=60))
 
     def __enter__(self):
         return self

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,14 +1,14 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.tls import ssl_client_session
+from hailtop.tls import in_cluster_ssl_client_sesion
 
 
 class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = ssl_client_session(raise_for_status=True,
-                                               timeout=aiohttp.ClientTimeout(total=60))
+        self.real_session = in_cluster_ssl_client_sesion(raise_for_status=True,
+                                                         timeout=aiohttp.ClientTimeout(total=60))
 
     def __enter__(self):
         return self

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -12,7 +12,7 @@ from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import setup_aiohttp_session, \
     rest_authenticated_developers_only, web_authenticated_developers_only, \
     check_csrf_token, AccessLogger, create_database_pool
@@ -425,4 +425,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_sesion
+from hailtop.tls import in_cluster_ssl_client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,7 +19,7 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with in_cluster_ssl_client_sesion(
+    async with in_cluster_ssl_client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import ssl_client_session
+from hailtop.tls import in_cluster_ssl_client_sesion
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,7 +19,7 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with ssl_client_session(
+    async with in_cluster_ssl_client_sesion(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -6,7 +6,7 @@ from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
 from hailtop.utils import request_retry_transient_errors
-from hailtop.tls import ssl_client_session
+from hailtop.tls import in_cluster_ssl_client_sesion
 
 log = logging.getLogger('gear.auth')
 
@@ -16,7 +16,7 @@ deploy_config = get_deploy_config()
 async def _userdata_from_session_id(session_id):
     headers = {'Authorization': f'Bearer {session_id}'}
     try:
-        async with ssl_client_session(
+        async with in_cluster_ssl_client_sesion(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             resp = await request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -6,7 +6,7 @@ from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
 from hailtop.utils import request_retry_transient_errors
-from hailtop.tls import in_cluster_ssl_client_sesion
+from hailtop.tls import in_cluster_ssl_client_session
 
 log = logging.getLogger('gear.auth')
 
@@ -16,7 +16,7 @@ deploy_config = get_deploy_config()
 async def _userdata_from_session_id(session_id):
     headers = {'Authorization': f'Bearer {session_id}'}
     try:
-        async with in_cluster_ssl_client_sesion(
+        async with in_cluster_ssl_client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             resp = await request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -2,7 +2,7 @@ import os
 import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 from .tokens import get_tokens
 
@@ -13,7 +13,7 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with get_context_specific_client_ssl_context(
+    async with get_context_specific_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         resp = await request_retry_transient_errors(
             session, 'GET', userinfo_url, headers=headers)

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -2,7 +2,7 @@ import os
 import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 from .tokens import get_tokens
 
@@ -13,7 +13,7 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with ssl_client_session(
+    async with get_context_specific_client_ssl_context(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         resp = await request_retry_transient_errors(
             session, 'GET', userinfo_url, headers=headers)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -11,7 +11,7 @@ from asyncinit import asyncinit
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 from .globals import tasks, complete_states
 
@@ -555,7 +555,7 @@ class BatchClient:
         self.url = deploy_config.base_url('batch')
 
         if session is None:
-            session = get_context_specific_client_ssl_context(
+            session = get_context_specific_ssl_client_session(
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60))
         self._session = session

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -11,7 +11,7 @@ from asyncinit import asyncinit
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 from .globals import tasks, complete_states
 
@@ -555,8 +555,9 @@ class BatchClient:
         self.url = deploy_config.base_url('batch')
 
         if session is None:
-            session = ssl_client_session(raise_for_status=True,
-                                         timeout=aiohttp.ClientTimeout(total=60))
+            session = get_context_specific_client_ssl_context(
+                raise_for_status=True,
+                timeout=aiohttp.ClientTimeout(total=60))
         self._session = session
 
         h = {}

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):
@@ -97,7 +97,7 @@ async def async_main(args):
     else:
         auth_ns = deploy_config.service_ns('auth')
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
-    async with get_context_specific_client_ssl_context(
+    async with get_context_specific_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         await auth_flow(deploy_config, auth_ns, session)
 

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 
 def init_parser(parser):
@@ -97,7 +97,7 @@ async def async_main(args):
     else:
         auth_ns = deploy_config.service_ns('auth')
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
-    async with ssl_client_session(
+    async with get_context_specific_client_ssl_context(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         await auth_flow(deploy_config, auth_ns, session)
 

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -3,7 +3,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -20,7 +20,7 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with ssl_client_session(
+    async with get_context_specific_client_ssl_context(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -3,7 +3,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -20,7 +20,7 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with get_context_specific_client_ssl_context(
+    async with get_context_specific_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -27,7 +27,7 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = get_context_specific_client_ssl_context(
+        self._session = get_context_specific_ssl_client_session(
             timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
 

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 
 def init_parser(parser):
@@ -27,7 +27,7 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = ssl_client_session(
+        self._session = get_context_specific_client_ssl_context(
             timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
 

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import aiohttp
 import logging
 import json
@@ -6,7 +7,7 @@ import ssl
 from ssl import Purpose
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.poolmanager import PoolManager
+from urllib3.poolmanager import PoolManager  # type: ignore
 
 log = logging.getLogger('hailtop.ssl')
 server_ssl_context = None
@@ -17,7 +18,7 @@ class NoSSLConfigFound(Exception):
     pass
 
 
-def _get_ssl_config():
+def _get_ssl_config() -> Dict[str, str]:
     config_file = os.environ.get('HAIL_SSL_CONFIG_FILE', '/ssl-config/ssl-config.json')
     if os.path.isfile(config_file):
         log.info(f'ssl config file found at {config_file}')
@@ -28,7 +29,7 @@ def _get_ssl_config():
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')
 
 
-def get_server_ssl_context():
+def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
     global server_ssl_context
     if server_ssl_context is None:
         ssl_config = _get_ssl_config()
@@ -45,34 +46,38 @@ def get_server_ssl_context():
     return server_ssl_context
 
 
-def get_client_ssl_context():
+def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
     global client_ssl_context
     if client_ssl_context is None:
-        try:
-            ssl_config = _get_ssl_config()
-            client_ssl_context = ssl.create_default_context(
-                purpose=Purpose.SERVER_AUTH,
-                cafile=ssl_config['outgoing_trust'])
-            client_ssl_context.load_cert_chain(ssl_config['cert'],
-                                               keyfile=ssl_config['key'],
-                                               password=None)
-            client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-            client_ssl_context.check_hostname = True
-        except NoSSLConfigFound:
-            log.info(f'no ssl config file found, using sensible defaults')
-            client_ssl_context = ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
+        ssl_config = _get_ssl_config()
+        client_ssl_context = ssl.create_default_context(
+            purpose=Purpose.SERVER_AUTH,
+            cafile=ssl_config['outgoing_trust'])
+        client_ssl_context.load_cert_chain(ssl_config['cert'],
+                                           keyfile=ssl_config['key'],
+                                           password=None)
+        client_ssl_context.verify_mode = ssl.CERT_REQUIRED
+        client_ssl_context.check_hostname = True
     return client_ssl_context
 
 
-def ssl_client_session(*args, **kwargs):
+def get_context_specific_client_ssl_context() -> ssl.SSLContext:
+    try:
+        return get_in_cluster_client_ssl_context()
+    except NoSSLConfigFound:
+        log.info('no ssl config file found, using external configuration. This '
+                 'context cannot connect directly to services inside the cluster.')
+        return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
+
+
+def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
     assert 'connector' not in kwargs
-    return aiohttp.ClientSession(
-        *args, **kwargs,
-        connector=aiohttp.TCPConnector(ssl=get_client_ssl_context()))
+    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_client_ssl_context())
+    return aiohttp.ClientSession(*args, **kwargs)
 
 
-def ssl_requests_client_session(*args, **kwargs):
-    session = requests.Session(*args, **kwargs)
+def in_cluster_ssl_requests_client_session() -> requests.Session:
+    session = requests.Session()
     ssl_config = _get_ssl_config()
     session.mount('https://', TLSAdapter(ssl_config['cert'],
                                          ssl_config['key'],
@@ -80,13 +85,13 @@ def ssl_requests_client_session(*args, **kwargs):
     return session
 
 
-def check_ssl_config(ssl_config):
+def check_ssl_config(ssl_config: Dict[str, str]):
     for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
         assert ssl_config.get(key) is not None, key
     for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
         if not os.path.isfile(ssl_config[key]):
             raise ValueError(f'specified {key}, {ssl_config[key]} does not exist')
-    log.info(f'using tls and verifying client and server certificates')
+    log.info('using tls and verifying client and server certificates')
 
 
 class TLSAdapter(HTTPAdapter):

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -76,6 +76,12 @@ def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
     return aiohttp.ClientSession(*args, **kwargs)
 
 
+def get_context_specific_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
+    assert 'connector' not in kwargs
+    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_context_specific_client_ssl_context())
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
 def in_cluster_ssl_requests_client_session() -> requests.Session:
     session = requests.Session()
     ssl_config = _get_ssl_config()

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -12,7 +12,7 @@ from kubernetes_asyncio import client, config
 import kubernetes_asyncio as kube
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_server_ssl_context, ssl_client_session
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import setup_aiohttp_session, create_database_pool, \
     web_authenticated_users_only, web_maybe_authenticated_user, web_authenticated_developers_only, \
     check_csrf_token, AccessLogger
@@ -242,7 +242,7 @@ async def notebook_status_from_notebook(k8s, service, headers, cookies, notebook
                 service,
                 f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}')
             try:
-                async with ssl_client_session(
+                async with aiohttp.ClientSession(
                         timeout=aiohttp.ClientTimeout(total=1),
                         headers=headers,
                         cookies=cookies) as session:
@@ -817,4 +817,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from gear import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_context_specific_client_ssl_context
+from hailtop.tls import get_context_specific_ssl_client_session
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with get_context_specific_client_ssl_context(raise_for_status=True) as session:
+    async with get_context_specific_ssl_client_session(raise_for_status=True) as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from gear import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import ssl_client_session
+from hailtop.tls import get_context_specific_client_ssl_context
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with ssl_client_session(raise_for_status=True) as session:
+    async with get_context_specific_client_ssl_context(raise_for_status=True) as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -8,7 +8,7 @@ import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import setup_aiohttp_session, rest_authenticated_users_only, AccessLogger
 
 uvloop.install()
@@ -199,4 +199,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_server_ssl_context())
+        ssl_context=get_in_cluster_server_ssl_context())

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -6,7 +6,7 @@ import aiohttp_session
 from kubernetes_asyncio import client, config
 import logging
 from hailtop.auth import async_get_userinfo
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import configure_logging, setup_aiohttp_session
 
 uvloop.install()
@@ -109,4 +109,4 @@ app.on_startup.append(on_startup)
 web.run_app(app,
             host='0.0.0.0',
             port=5000,
-            ssl_context=get_server_ssl_context())
+            ssl_context=get_in_cluster_server_ssl_context())

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -9,7 +9,7 @@ import random
 import humanize
 import logging
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_server_ssl_context
+from hailtop.tls import get_in_cluster_server_ssl_context
 from gear import setup_aiohttp_session, web_maybe_authenticated_user, AccessLogger
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
 
@@ -299,4 +299,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_server_ssl_context())
+                ssl_context=get_in_cluster_server_ssl_context())


### PR DESCRIPTION
The fix for Notebook is on line 242. Copying from my Zulip post:

> I made a mistake when I implemented TLS.
>
> In the following code snippet we use ssl_client_session which should probably be
> called in_cluster_ssl_client_session. It's supposed to be used to communicate
> with other services in the cluster. That needs to be changed back to
> aiohttp.ClientSession which loads the normal system certificates (including the
> VeriSign root certs that signed the public certs that gateway uses, different
> from the internal certs that our services use).
>
> In particular, note that the error says "unable to get local issuer
> certificate." That means that the local trust store lacks a certificate that
> trusts the remote server's certificate. In Dania's case, the default python on
> OS X lacks all certificates, so every remote server is untrusted. In notebook's
> case, ssl_client_session creates an SSL/TLS session that only trusts Hail
> internal services (in particular, it does not trust the certificates that
> gateway uses for incoming public traffic). The error also says that the server
> in question is workshop.hail.is which is a public domain (note the hail.is), so
> that traffic is going through the public gateway with its public certificates.
>
> ```
> # don't have dev credentials to connect through internal.hail.is
> ready_url = deploy_config.external_url(
>     service,
>     f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}')
> try:
>     async with ssl_client_session(
>             timeout=aiohttp.ClientTimeout(total=1),
>             headers=headers,
>             cookies=cookies) as session:
>         async with session.get(ready_url) as resp:
> ```

I also changed the names and functionality of the functions in tls. Now
`in_cluster_ssl_context` will error if there is no ssl configuration found
instead of silently (and confusingly) using an SSLContext suited for public
communication (and wrong for in-cluster communication).

I added `get_context_specific_client_ssl_context` which should only be used in
publicly consumable tools (*never* in a service). This function allows the same
tool to be used inside and outside the cluster. It will load the correct certs
for your environment (it will load public certs if you're outside the cluster,
it will load in-cluster-only certs if you're in the cluster).

I also added types to `tls.py` and fixed some type errors.