### PR TITLE
[query] lower native BlockMatrixRead/BlockMatrixWrite

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -32,7 +32,7 @@ abstract class BlockMatrixWriter {
   def pathOpt: Option[String]
   def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit
 
-  def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, eltR: TypeWithRequiredness): IR =
+  def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, bindings: Seq[(String, Type)], eltR: TypeWithRequiredness): IR =
     throw new LowererUnsupportedOperation(s"unimplemented writer: \n${ this.getClass }")
 }
 
@@ -45,7 +45,7 @@ case class BlockMatrixNativeWriter(
 
   def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit = bm.write(ctx, path, overwrite, forceRowMajor, stageLocally)
 
-  override def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, eltR: TypeWithRequiredness): IR = {
+  override def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, bindings: Seq[(String, Type)], eltR: TypeWithRequiredness): IR = {
     if (stageLocally)
       throw new LowererUnsupportedOperation(s"stageLocally not supported in BlockMatrixWrite lowering")
     val etype = EBlockMatrixNDArray(EType.fromTypeAndAnalysis(bm.typ.elementType, eltR), encodeRowMajor = forceRowMajor, required = true)
@@ -55,7 +55,7 @@ case class BlockMatrixNativeWriter(
     val blockMap = blocks.zipWithIndex.toMap
     val paths = s.addContext(TString) { idx =>
       Str(s"$path/parts/part-${ blockMap(idx) }-")
-    }.collectBlocks({ (ctx, block) =>
+    }.collectBlocks(bindings)({ (ctx, block) =>
       WriteValue(block, GetField(ctx, "new") + UUID4(), spec)
     }, blocks.toArray)
     RelationalWriter.scoped(path, overwrite, None)(WriteMetadata(paths, BlockMatrixNativeMetadataWriter(path, stageLocally, bm.typ)))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -1,10 +1,21 @@
 package is.hail.expr.ir
 
+import java.io.DataOutputStream
+
 import is.hail.HailContext
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.Nat
+import is.hail.expr.ir.lowering.{BlockMatrixStage, LowererUnsupportedOperation}
+import is.hail.io.TypedCodecSpec
 import is.hail.io.fs.FS
-import is.hail.linalg.BlockMatrix
+import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata}
+import is.hail.types.{BlockMatrixType, TypeWithRequiredness}
+import is.hail.types.encoded.{EBlockMatrixNDArray, EType}
+import is.hail.types.virtual.{TArray, TNDArray, TString, Type}
+import is.hail.utils._
 import is.hail.utils.richUtils.RichDenseMatrixDouble
-import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
+import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints, jackson}
 
 object BlockMatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {
@@ -20,6 +31,9 @@ object BlockMatrixWriter {
 abstract class BlockMatrixWriter {
   def pathOpt: Option[String]
   def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit
+
+  def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, eltR: TypeWithRequiredness): IR =
+    throw new LowererUnsupportedOperation(s"unimplemented writer: \n${ this.getClass }")
 }
 
 case class BlockMatrixNativeWriter(
@@ -30,7 +44,71 @@ case class BlockMatrixNativeWriter(
   def pathOpt: Option[String] = Some(path)
 
   def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit = bm.write(ctx, path, overwrite, forceRowMajor, stageLocally)
+
+  override def lower(ctx: ExecuteContext, s: BlockMatrixStage, bm: BlockMatrixIR, eltR: TypeWithRequiredness): IR = {
+    if (stageLocally)
+      throw new LowererUnsupportedOperation(s"stageLocally not supported in BlockMatrixWrite lowering")
+    val etype = EBlockMatrixNDArray(EType.fromTypeAndAnalysis(bm.typ.elementType, eltR), encodeRowMajor = forceRowMajor, required = true)
+    val spec = TypedCodecSpec(etype, TNDArray(bm.typ.elementType, Nat(2)), BlockMatrix.bufferSpec)
+
+    val blocks = bm.typ.allBlocks(forceColMajor = true)
+    val blockMap = blocks.zipWithIndex.toMap
+    val paths = s.addContext(TString) { idx =>
+      Str(s"$path/parts/part-${ blockMap(idx) }-")
+    }.collectBlocks({ (ctx, block) =>
+      WriteValue(block, GetField(ctx, "new") + UUID4(), spec)
+    }, blocks.toArray)
+    RelationalWriter.scoped(path, overwrite, None)(WriteMetadata(paths, BlockMatrixNativeMetadataWriter(path, stageLocally, bm.typ)))
+  }
 }
+
+case class BlockMatrixNativeMetadataWriter(path: String, stageLocally: Boolean, typ: BlockMatrixType) extends MetadataWriter {
+
+  case class BMMetadataHelper(path: String, blockSize: Int, nRows: Long, nCols: Long, partIdxToBlockIdx: Option[IndexedSeq[Int]]) {
+    def write(fs: FS, rawPartFiles: Array[String]): Unit = {
+      val partFiles = rawPartFiles.map(_.split('/').last)
+      using(new DataOutputStream(fs.create(s"$path/metadata.json"))) { os =>
+        implicit val formats = defaultJSONFormats
+        jackson.Serialization.write(
+          BlockMatrixMetadata(blockSize, nRows, nCols, partIdxToBlockIdx, partFiles),
+          os)
+      }
+      val nBlocks = partIdxToBlockIdx.map(_.length).getOrElse {
+        BlockMatrixType.numBlocks(nRows, blockSize) * BlockMatrixType.numBlocks(nCols, blockSize)
+      }
+      assert(nBlocks == partFiles.length, s"$nBlocks vs ${ partFiles.mkString(", ") }")
+
+      info(s"wrote matrix with $nRows ${ plural(nRows, "row") } " +
+        s"and $nCols ${ plural(nCols, "column") } " +
+        s"as $nBlocks ${ plural(nBlocks, "block") } " +
+        s"of size $blockSize to $path")
+    }
+  }
+
+  def annotationType: Type = TArray(TString)
+
+  def writeMetadata(
+    writeAnnotations: => IEmitCode,
+    cb: EmitCodeBuilder,
+    region: Value[Region]): Unit = {
+    val metaHelper = BMMetadataHelper(path, typ.blockSize, typ.nRows, typ.nCols, typ.linearizedDefinedBlocks)
+
+    val pc = writeAnnotations.handle(cb, cb._fatal("write annotations can't be missing!")).asIndexable
+    val a = pc.memoize(cb, "filePaths")
+    val partFiles = cb.newLocal[Array[String]]("partFiles")
+    val n = cb.newLocal[Int]("n", a.loadLength())
+    val i = cb.newLocal[Int]("i", 0)
+    cb.assign(partFiles, Code.newArray[String](n))
+    cb.whileLoop(i < n, {
+      val s = a.loadElement(cb, i).handle(cb, cb._fatal("file name can't be missing!")).asString
+      cb += partFiles.update(i, s.loadString())
+      cb.assign(i, i + 1)
+    })
+    cb += cb.emb.getObject(metaHelper).invoke[FS, Array[String], Unit]("write", cb.emb.getFS, partFiles)
+  }
+}
+
+
 
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
   def pathOpt: Option[String] = Some(path)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -218,7 +218,7 @@ object Children {
     case WritePartition(stream, ctx, _) => Array(stream, ctx)
     case WriteMetadata(writeAnnotations, _) => Array(writeAnnotations)
     case ReadValue(path, _, _) => Array(path)
-    case WriteValue(value, pathPrefix, spec) => Array(value, pathPrefix)
+    case WriteValue(value, path, spec) => Array(value, path)
     case LiftMeOut(child) => Array(child)
     case ShuffleWith(keyFields, rowType, rowEType, keyEType, name, writer, readers) =>
       Array(writer, readers)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -355,7 +355,7 @@ object Copy {
       case ReadValue(path, spec, requestedType) =>
         assert(newChildren.length == 1)
         ReadValue(newChildren(0).asInstanceOf[IR], spec, requestedType)
-      case WriteValue(value, pathPrefix, spec) =>
+      case WriteValue(value, path, spec) =>
         assert(newChildren.length == 2)
         WriteValue(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], spec)
       case LiftMeOut(_) =>

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -689,7 +689,7 @@ final case class WritePartition(value: IR, writeCtx: IR, writer: PartitionWriter
 final case class WriteMetadata(writeAnnotations: IR, writer: MetadataWriter) extends IR
 
 final case class ReadValue(path: IR, spec: AbstractTypedCodecSpec, requestedType: Type) extends IR
-final case class WriteValue(value: IR, pathPrefix: IR, spec: AbstractTypedCodecSpec) extends IR
+final case class WriteValue(value: IR, path: IR, spec: AbstractTypedCodecSpec) extends IR
 
 final case class UnpersistBlockMatrix(child: BlockMatrixIR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -246,7 +246,7 @@ object InferType {
       case WritePartition(value, writeCtx, writer) => writer.returnType
       case _: WriteMetadata => TVoid
       case ReadValue(_, _, typ) => typ
-      case WriteValue(value, pathPrefix, spec) => TString
+      case WriteValue(value, path, spec) => TString
       case LiftMeOut(child) => child.typ
       case ShuffleWith(_, _, _, _, _, _, readers) =>
         readers.typ

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -437,7 +437,7 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec) extends Partition
     def emitIR(ir: IR, env: Emit.E = env, region: Value[Region] = region, container: Option[AggContainer] = container): EmitCode =
       emitter.emitWithRegion(ir, mb, region, env, container)
 
-    val (eltType, dec) = spec.buildEmitDecoderF[Long](requestedType, mb.ecb)
+    val (eltType, dec) = spec.buildTypedEmitDecoderF[Long](requestedType, mb.ecb)
 
     COption.fromEmitCode(emitIR(context)).map { path =>
       val pathString = path.asString.loadString()

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -149,7 +149,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
     mb: EmitMethodBuilder[_],
     region: Value[Region],
     stream: SizedStream): EmitCode = {
-    val enc = spec.buildEmitEncoderF(eltType, mb.ecb, typeInfo[Long]) //(Value[Region], Value[T], Value[OutputBuffer]) => Code[Unit]
+    val enc = spec.buildEmitEncoder(eltType, mb.ecb)
 
     val keyType = ifIndexed { index.get._2 }
     val indexWriter = ifIndexed { StagedIndexWriter.withDefaults(keyType, mb.ecb) }
@@ -184,7 +184,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
                   IEmitCode.present(cb, PCode(+PCanonicalStruct(), 0L)))
               }
               cb += ob.writeByte(1.asInstanceOf[Byte])
-              cb += enc(region, coerce[Long](row.value), ob)
+              cb += enc(region, row, ob)
               cb.assign(n, n + 1L)
             })
           }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -465,8 +465,8 @@ object TypeCheck {
       case x@ReadValue(path, spec, requestedType) =>
         assert(path.typ == TString)
         assert(spec.encodedType.decodedPType(requestedType).virtualType == requestedType)
-      case x@WriteValue(value, pathPrefix, spec) =>
-        assert(pathPrefix.typ == TString)
+      case x@WriteValue(value, path, spec) =>
+        assert(path.typ == TString)
       case LiftMeOut(_) =>
       case x@ShuffleWith(_, _, _, _, _, writer, readers) =>
         assert(writer.typ == TArray(TBinary))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -113,12 +113,12 @@ class TypedRegionBackedAggState(val typ: PType, val kb: EmitClassBuilder[_]) ext
     cb += Code(newState(off), StagedRegionValueBuilder.deepCopy(kb, region, storageType, src, off))
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
-    val enc = TypedCodecSpec(storageType, codec).buildEmitEncoderF[Long](storageType, kb)
+    val enc = TypedCodecSpec(storageType, codec).buildTypedEmitEncoderF[Long](storageType, kb)
     (cb, ob: Value[OutputBuffer]) => cb += enc(region, off, ob)
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
-    val (t, dec) = TypedCodecSpec(storageType, codec).buildEmitDecoderF[Long](storageType.virtualType, kb)
+    val (t, dec) = TypedCodecSpec(storageType, codec).buildTypedEmitDecoderF[Long](storageType.virtualType, kb)
     val off2: Settable[Long] = kb.genFieldThisRef[Long]()
     (cb, ib: Value[InputBuffer]) => cb += Code(off2 := dec(region, ib), Region.copyFrom(off2, off, const(storageType.byteSize)))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -68,7 +68,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = { (cb, ob) =>
     cb += TypedCodecSpec(CallStatsState.stateType, codec)
-      .buildEmitEncoderF[Long](CallStatsState.stateType, kb)(region, off, ob)
+      .buildTypedEmitEncoderF[Long](CallStatsState.stateType, kb)(region, off, ob)
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -57,7 +57,7 @@ class StagedArrayBuilder(eltType: PType, cb: EmitClassBuilder[_], region: Value[
 
   def serialize(codec: BufferSpec): Value[OutputBuffer] => Code[Unit] = {
     { ob: Value[OutputBuffer] =>
-      val enc = TypedCodecSpec(eltArray, codec).buildEmitEncoderF[Long](eltArray, cb)
+      val enc = TypedCodecSpec(eltArray, codec).buildTypedEmitEncoderF[Long](eltArray, cb)
 
       Code(
         ob.writeInt(size),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.expr.Nat
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.GetElement
-import is.hail.types.BlockMatrixSparsity
+import is.hail.types.{BlockMatrixSparsity, TypeWithRequiredness}
 import is.hail.types.virtual._
 import is.hail.utils.{FastIndexedSeq, FastSeq}
 
@@ -18,9 +18,10 @@ case class EmptyBlockMatrixStage(eltType: Type) extends BlockMatrixStage(Array()
 
   def blockBody(ctxRef: Ref): IR = NA(TNDArray(eltType, Nat(2)))
 
-  override def collectBlocks(bindings: Seq[(String, Type)])(f: IR => IR, blocksToCollect: Array[(Int, Int)]): IR = {
+
+  override def collectBlocks(bindings: Seq[(String, Type)])(f: (IR, IR) => IR, blocksToCollect: Array[(Int, Int)]): IR = {
     assert(blocksToCollect.isEmpty)
-    MakeArray(FastSeq(), TArray(f(blockBody(Ref("x", ctxType))).typ))
+    MakeArray(FastSeq(), TArray(f(Ref("x", ctxType), blockBody(Ref("x", ctxType))).typ))
   }
 }
 
@@ -29,9 +30,9 @@ abstract class BlockMatrixStage(val globalVals: Array[(String, IR)], val ctxType
 
   def blockBody(ctxRef: Ref): IR
 
-  def collectBlocks(bindings: Seq[(String, Type)])(f: IR => IR, blocksToCollect: Array[(Int, Int)]): IR = {
+  def collectBlocks(bindings: Seq[(String, Type)])(f: (IR, IR) => IR, blocksToCollect: Array[(Int, Int)]): IR = {
     val ctxRef = Ref(genUID(), ctxType)
-    val body = f(blockBody(ctxRef))
+    val body = f(ctxRef, blockBody(ctxRef))
     val ctxs = MakeStream(blocksToCollect.map(idx => blockContext(idx)), TStream(ctxRef.typ))
     val bodyFreeVars = FreeVariables(body, supportsAgg = false, supportsScan = false)
     val bcFields = globalVals.filter { case (f, _) => bodyFreeVars.eval.lookupOption(f).isDefined }
@@ -89,7 +90,7 @@ object LowerBlockMatrixIR {
     }
 
     def lowerNonEmpty(bmir: BlockMatrixIR): BlockMatrixStage = bmir match {
-      case BlockMatrixRead(reader) => unimplemented(bmir)
+      case BlockMatrixRead(reader) => reader.lower(ctx)
       case x: BlockMatrixLiteral => unimplemented(bmir)
       case BlockMatrixMap(child, eltName, f, _) =>
         lower(child).mapBody { (_, body) =>
@@ -168,7 +169,7 @@ object LowerBlockMatrixIR {
         val blocksRowMajor = Array.range(0, child.typ.nRowBlocks).flatMap { i =>
           Array.tabulate(child.typ.nColBlocks)(j => i -> j).filter(child.typ.hasBlock)
         }
-        val cda = bm.collectBlocks(relationalLetsAbove)(b => b, blocksRowMajor)
+        val cda = bm.collectBlocks(relationalLetsAbove)((_, b) => b, blocksRowMajor)
         val blockResults = Ref(genUID(), cda.typ)
 
         val rows = if (child.typ.isSparse) {
@@ -190,8 +191,22 @@ object LowerBlockMatrixIR {
           ToArray(StreamMap(StreamRange(0, child.typ.nRowBlocks, 1), i.name, NDArrayConcat(cols, 1)))
         }
         Let(blockResults.name, cda, NDArrayConcat(rows, 0))
-      case BlockMatrixToValueApply(child, GetElement(index)) => unimplemented(node)
-      case BlockMatrixWrite(child, writer) => unimplemented(node)
+      case BlockMatrixToValueApply(child, GetElement(IndexedSeq(i, j))) =>
+        val rowBlock = child.typ.getBlockIdx(i)
+        val colBlock = child.typ.getBlockIdx(j)
+
+        val iInBlock = i - rowBlock * child.typ.blockSize
+        val jInBlock = j - colBlock * child.typ.blockSize
+
+        val lowered = lower(child)
+
+        val elt = bindIR(lowered.blockContext(rowBlock -> colBlock)) { ctx =>
+          NDArrayRef(lowered.blockBody(ctx), FastIndexedSeq(I64(iInBlock), I64(jInBlock)))
+        }
+
+        lowered.globalVals.foldRight[IR](elt) { case ((f, v), accum) => Let(f, v, accum) }
+      case BlockMatrixWrite(child, writer) =>
+        writer.lower(ctx, lower(child), child, TypeWithRequiredness(child.typ.elementType)) //FIXME: BlockMatrixIR is currently ignored in Requiredness inference since all eltTypes are +TFloat64
       case BlockMatrixMultiWrite(blockMatrices, writer) => unimplemented(node)
       case node if node.children.exists(_.isInstanceOf[BlockMatrixIR]) =>
         throw new LowererUnsupportedOperation(s"IR nodes with BlockMatrixIR children need explicit rules: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -206,7 +206,7 @@ object LowerBlockMatrixIR {
 
         lowered.globalVals.foldRight[IR](elt) { case ((f, v), accum) => Let(f, v, accum) }
       case BlockMatrixWrite(child, writer) =>
-        writer.lower(ctx, lower(child), child, TypeWithRequiredness(child.typ.elementType)) //FIXME: BlockMatrixIR is currently ignored in Requiredness inference since all eltTypes are +TFloat64
+        writer.lower(ctx, lower(child), child, relationalLetsAbove, TypeWithRequiredness(child.typ.elementType)) //FIXME: BlockMatrixIR is currently ignored in Requiredness inference since all eltTypes are +TFloat64
       case BlockMatrixMultiWrite(blockMatrices, writer) => unimplemented(node)
       case node if node.children.exists(_.isInstanceOf[BlockMatrixIR]) =>
         throw new LowererUnsupportedOperation(s"IR nodes with BlockMatrixIR children need explicit rules: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -51,16 +51,16 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
 
   def buildCodeOutputBuffer(os: Code[OutputStream]): Code[OutputBuffer] = _bufferSpec.buildCodeOutputBuffer(os)
 
-  def buildEmitDecoderF[T](requestedType: Type, cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) = {
+  def buildTypedEmitDecoderF[T](requestedType: Type, cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) = {
     val rt = encodedType.decodedPType(requestedType)
     val mb = encodedType.buildDecoderMethod(rt, cb)
     (rt, (region: Value[Region], buf: Value[InputBuffer]) => mb.invokeCode[T](region, buf))
   }
 
   def buildEmitDecoderF[T](cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) =
-    buildEmitDecoderF(_vType, cb)
+    buildTypedEmitDecoderF(_vType, cb)
 
-  def buildEmitEncoderF[T](t: PType, cb: EmitClassBuilder[_]): StagedEncoderF[T] = {
+  def buildTypedEmitEncoderF[T](t: PType, cb: EmitClassBuilder[_]): StagedEncoderF[T] = {
     val mb = encodedType.buildEncoderMethod(t, cb)
     (region: Value[Region], off: Value[T], buf: Value[OutputBuffer]) => mb.invokeCode[Unit](off, buf)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -137,7 +137,20 @@ class BlockMatrixIRSuite extends HailSuite {
     val read = ReadValue(Str(path), spec, typ)
     assertNDEvals(read, expected)
     assertNDEvals(ReadValue(
-      WriteValue(read, Str(ctx.createTmpPath("read-blockmatrix-ir", "hv")), spec),
+      WriteValue(read, Str(ctx.createTmpPath("read-blockmatrix-ir", "hv")) + UUID4(), spec),
       spec, typ), expected)
+  }
+
+  @Test def readWriteBlockMatrix() {
+    val original = "src/test/resources/blockmatrix_example/0"
+    val expected = BlockMatrix.read(ctx.fs, original).toBreezeMatrix()
+
+    val path = ctx.createTmpPath("read-blockmatrix-ir", "bm")
+
+    assertEvalsTo(BlockMatrixWrite(
+      BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, original)),
+      BlockMatrixNativeWriter(path, overwrite = true, forceRowMajor = false, stageLocally = false)), ())
+
+    assertBMEvalsTo(BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, path)), expected)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3811,7 +3811,7 @@ class IRSuite extends HailSuite {
     val node = In(0, pt)
     val spec = TypedCodecSpec(pt, BufferSpec.defaultUncompressed)
     val prefix = ctx.createTmpPath("test-read-write-values")
-    val filename = WriteValue(node, Str(prefix), spec)
+    val filename = WriteValue(node, Str(prefix) + UUID4(), spec)
     for (v <- Array(value, null)) {
       assertEvalsTo(ReadValue(filename, spec, pt.virtualType), FastIndexedSeq(v -> pt.virtualType), v)
     }
@@ -3826,7 +3826,7 @@ class IRSuite extends HailSuite {
     val readArray = Let("files",
       CollectDistributedArray(StreamMap(StreamRange(0, 10, 1), "x", node), MakeStruct(FastSeq()),
         "ctx", "globals",
-        WriteValue(Ref("ctx", node.typ), Str(prefix), spec)),
+        WriteValue(Ref("ctx", node.typ), Str(prefix) + UUID4(), spec)),
       StreamMap(ToStream(Ref("files", TArray(TString))), "filename",
         ReadValue(Ref("filename", TString), spec, pt.virtualType)))
     for (v <- Array(value, null)) {

--- a/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/lowering/BlockMatrixStageSuite.scala
@@ -29,7 +29,7 @@ class BlockMatrixStageSuite extends HailSuite {
         def blockBody(ctxRef: Ref): IR = body(ctxRef)
       }
     }
-    stage.collectBlocks(Seq())(b => b, order.getOrElse(ctxs.map(_._1)))
+    stage.collectBlocks(Seq())((_, b) => b, order.getOrElse(ctxs.map(_._1)))
   }
 
   @Test def testBlockMatrixCollectOrdering(): Unit = {


### PR DESCRIPTION
Also, tidies up some of the emit encoder/decoder function signatures.