### PR TITLE
[docker] make pip fast

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -17,7 +17,9 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 COPY docker/requirements.txt .
-RUN python3 -m pip install --no-cache-dir -U -r requirements.txt
+# re: pip install --upgrade pip: https://github.com/grpc/grpc/issues/22815
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --no-cache-dir -U -r requirements.txt
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -39,7 +39,7 @@ ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 
 COPY docker/requirements.txt .
 # re: pip install --upgrade pip: https://github.com/grpc/grpc/issues/22815
-RUN python3 -m pip install --upgrade pip keyrings.alt && \
+RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade -r requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH:+${PYTHONPATH}:}$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -38,7 +38,9 @@ ENV SPARK_HOME /spark-2.4.0-bin-hadoop2.7
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 
 COPY docker/requirements.txt .
-RUN python3 -m pip install --no-cache-dir -U -r requirements.txt
+# re: pip install --upgrade pip: https://github.com/grpc/grpc/issues/22815
+RUN python3 -m pip install --upgrade pip keyrings.alt && \
+    python3 -m pip install --no-cache-dir --upgrade -r requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH:+${PYTHONPATH}:}$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip"
 ENV PYSPARK_PYTHON python3


### PR DESCRIPTION
Old versions of pip could only download some packages in source form which
requires compiling them. New version of pip can download these packages in
binary form which requires no compilation. This *substantially* improves docker
build times when you have to run `pip` in any layer.