### PR TITLE
[auth] give a reason when wrong auth is used

### DIFF
--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -54,6 +54,9 @@ def rest_authenticated_users_only(fun):
     async def wrapped(request, *args, **kwargs):
         userdata = await userdata_from_rest_request(request)
         if not userdata:
+            web_userdata = await userdata_from_web_request(request)
+            if web_userdata:
+                return web.HTTPUnauthorized(reason="provided web auth to REST endpoint")
             raise web.HTTPUnauthorized()
         return await fun(request, userdata, *args, **kwargs)
     return wrapped
@@ -83,6 +86,9 @@ def web_authenticated_users_only(redirect=True):
         async def wrapped(request, *args, **kwargs):
             userdata = await userdata_from_web_request(request)
             if not userdata:
+                rest_userdata = await userdata_from_rest_request(request)
+                if rest_userdata:
+                    return web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
                 raise _web_unauthorized(request, redirect)
             return await fun(request, userdata, *args, **kwargs)
         return wrapped


### PR DESCRIPTION
Numerous times, I have sent REST credentials to a web endpoint. It is supremely annoying
to run around in circles wondering how your credentials got out of date. I think
this message is safe because the user really is a credentialed user, they just
used the wrong endpoint.