### PR TITLE
Revert 8970 and Prevent Unsafe.copyMemory from being called with length 0

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Memory.java
+++ b/hail/src/main/scala/is/hail/annotations/Memory.java
@@ -58,17 +58,23 @@ public final class Memory {
     }
 
     public static void memcpy(byte[] dst, long dstOff, byte[] src, long srcOff, long n) {
-        unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n);
+        if (n > 0) {
+            unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n);
+        }
     }
 
     // srcOff is in doubles, n is in doubles
     public static void memcpy(byte[] dst, long dstOff, double[] src, long srcOff, long n) {
-        unsafe.copyMemory(src, Unsafe.ARRAY_DOUBLE_BASE_OFFSET + srcOff * 8, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n * 8);
+        if (n > 0) {
+            unsafe.copyMemory(src, Unsafe.ARRAY_DOUBLE_BASE_OFFSET + srcOff * 8, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n * 8);
+        }
     }
 
     // dstOff is in doubles, n is in doubles
     public static void memcpy(double[] dst, long dstOff, byte[] src, long srcOff, long n) {
-        unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, dst, Unsafe.ARRAY_DOUBLE_BASE_OFFSET + dstOff * 8, n * 8);
+        if (n > 0) {
+            unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, dst, Unsafe.ARRAY_DOUBLE_BASE_OFFSET + dstOff * 8, n * 8);
+        }
     }
     
     public static void memcpy(long dst, byte[] src, long srcOff, long n) {
@@ -161,15 +167,21 @@ public final class Memory {
 
 
     public static void memcpy(long dst, long src, long n) {
-        unsafe.copyMemory(src, dst, n);
+        if (n > 0) {
+            unsafe.copyMemory(src, dst, n);
+        }
     }
 
     public static void copyToArray(byte[] dst, long dstOff, long src, long n) {
-        unsafe.copyMemory(null, src, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n);
+        if (n > 0) {
+            unsafe.copyMemory(null, src, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET + dstOff, n);
+        }
     }
 
     public static void copyFromArray(long dst, byte[] src, long srcOff, long n) {
-        unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, null, dst, n);
+        if (n > 0) {
+            unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET + srcOff, null, dst, n);
+        }
     }
 
     static {

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -181,11 +181,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
                   IEmitCode.present(cb, PCode(keyType, keyRVB.offset))
                 },
                   ob.invoke[Long]("indexOffset"),
-                  {
-                    val pcs = PCanonicalStruct(true)
-                    IEmitCode.present(cb, PCode(pcs, pcs.allocate(region)))
-                  }
-                )
+                  IEmitCode.present(cb, PCode(+PCanonicalStruct(), 0L)))
               }
               cb += ob.writeByte(1.asInstanceOf[Byte])
               cb += enc(region, coerce[Long](row.value), ob)


### PR DESCRIPTION
In response to @cseed's comments here: https://github.com/hail-is/hail/pull/8970

Assigning Arcturus since they reviewed 8970. 