### PR TITLE
NDArray Slicing Clamp Bounds

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -109,6 +109,17 @@ def test_ndarray_slice():
     assert "Slice step cannot be zero" in str(exc)
 
 
+def test_ndarray_transposed_slice():
+    a = hl.nd.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    np_a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    aT = a.T
+    np_aT = np_a.T
+    assert_ndarrays_eq(
+        (a, np_a),
+        (aT[0:aT.shape[0], 0:5], np_aT[0:np_aT.shape[0], 0:5])
+    )
+
+
 def test_ndarray_eval():
     data_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     mishapen_data_list1 = [[4], [1, 2, 3]]
@@ -586,6 +597,7 @@ def test_ndarray_mixed():
          hl.nd.ones((5, 10)).map(lambda x: x + 5)).reshape(hl.null(hl.ttuple(hl.tint64, hl.tint64))).T.reshape((10, 5))) is None
     assert hl.eval(hl.or_missing(False, hl.nd.array(np.arange(10)).reshape(
         (5, 2)).map(lambda x: x * 2)).map(lambda y: y * 2)) is None
+
 
 
 def test_ndarray_show():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,8 @@ def test_ndarray_slice():
         (mat[::-1, :], np_mat[::-1, :]),
         (flat[4:1:-2], np_flat[4:1:-2]),
         (flat[0:0:1], np_flat[0:0:1]),
-        (flat[-4:-1:2], np_flat[-4:-1:2])
+        (flat[-4:-1:2], np_flat[-4:-1:2]),
+        #(mat[0:20, 2:17], np_mat[0:20, 2:17])
     )
 
     assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -95,7 +95,9 @@ def test_ndarray_slice():
         (flat[0:0:1], np_flat[0:0:1]),
         (flat[-4:-1:2], np_flat[-4:-1:2]),
         (mat[0:20, 0:17], np_mat[0:20, 0:17]),
-        (mat[0:20, 2:17], np_mat[0:20, 2:17])
+        (mat[0:20, 2:17], np_mat[0:20, 2:17]),
+        (mat[9:2:-1, 1:4], np_mat[9:2:-1, 1:4]),
+        (mat[9:-1:-1, 1:4], np_mat[9:-1:-1, 1:4])
     )
 
     assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -94,7 +94,8 @@ def test_ndarray_slice():
         (flat[4:1:-2], np_flat[4:1:-2]),
         (flat[0:0:1], np_flat[0:0:1]),
         (flat[-4:-1:2], np_flat[-4:-1:2]),
-        #(mat[0:20, 2:17], np_mat[0:20, 2:17])
+        (mat[0:20, 0:17], np_mat[0:20, 0:17]),
+        (mat[0:20, 2:17], np_mat[0:20, 2:17])
     )
 
     assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -824,6 +824,12 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 
   def compare(rhs: Code[Long]): Code[Int] = Code(lhs, rhs, lir.insn2(LCMP))
 
+  def max(rhs: Code[Long]): Code[Long] =
+    Code.invokeStatic2[Math, Long, Long, Long]("max", lhs, rhs)
+
+  def min(rhs: Code[Long]): Code[Long] =
+    Code.invokeStatic2[Math, Long, Long, Long]("min", lhs, rhs)
+
   def <(rhs: Code[Long]): Code[Boolean] = compare(rhs) < 0
 
   def <=(rhs: Code[Long]): Code[Boolean] = compare(rhs) <= 0

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2722,7 +2722,7 @@ class Emit[C](
                 const(1L) + ((stop - start) - 1L) / step,
                 (step < 0L && start >= stop).mux(
                   (((stop - start) + 1L) / step) + 1L,
-                  0L)).min(childShapeCached(i)),
+                  0L)),
             s"nda_slice_shape$i")
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2616,7 +2616,7 @@ class Emit[C](
           n := inputType.loadLength(inputArray),
           (n < 1).orEmpty(Code._fatal[Unit]("NDArrayConcat: can't concatenate 0 NDArrays")))
 
-        val (missingSetup: Code[Unit@unchecked], missing: Code[Boolean@unchecked], setupShape: Code[Unit@unchecked]) = (inputType.required, inputNDType.required) match {
+        val (missingSetup: Code[Unit @unchecked], missing: Code[Boolean @unchecked], setupShape: Code[Unit @unchecked]) = (inputType.required, inputNDType.required) match {
           case (true, true) => (Code._empty, false: Code[Boolean], Code(
             codeNDs.setup,
             codeNDs.m.orEmpty(Code._fatal[Unit]("NDArrayConcat: required NDArray can't be missing")),
@@ -2701,28 +2701,23 @@ class Emit[C](
         val slicesm = mb.genFieldThisRef[Boolean]("ndarr_slicem")
         val slices = new CodePTuple(coerce[PTuple](slicesIR.pType), slicesValueAddress)
 
-        val slicersAndIndices = slices.withTypesAndIndices.collect {
-          case (t: PTuple, slice, i) => (new CodePTuple(t, coerce[Long](slice)), i)
+        val slicers = slices.withTypes.collect {
+          case (t: PTuple, slice) => new CodePTuple(t, coerce[Long](slice))
         }
-
-        val slicers = slicersAndIndices.map(_._1)
 
         val missingSliceElements = slicers.map(_.missingnessPattern.reduce(_ || _)).fold(false: Code[Boolean])(_ || _)
         val anyMissingness = missingSliceElements || slices.missingnessPattern.fold(false: Code[Boolean])(_ || _)
 
-        val codeSlicesAndIndices = slicersAndIndices.map{ case (slice, idx) => (slice.values[Long, Long, Long], idx)}
+        val codeSlices = slicers.map(_.values[Long, Long, Long])
 
-        val (childShapeCachingCode, childShapeCached) = childEmitter.outputShape.cacheEntries(mb, LongInfo)
-
-        val sb = SetupBuilder(mb, Code(childEmitter.setupShape, childShapeCachingCode))
-
-        val outputShape = codeSlicesAndIndices.map { case ((start, stop, step), i) =>
+        val sb = SetupBuilder(mb, childEmitter.setupShape)
+        val outputShape = codeSlices.zipWithIndex.map { case ((start, stop, step), i) =>
           sb.memoizeField(
-              (step >= 0L && start <= stop).mux(
-                const(1L) + ((stop - start) - 1L) / step,
-                (step < 0L && start >= stop).mux(
-                  (((stop - start) + 1L) / step) + 1L,
-                  0L)),
+            (step >= 0L && start <= stop).mux(
+              const(1L) + ((stop - start) - 1L) / step,
+              (step < 0L && start >= stop).mux(
+                (((stop - start) + 1L) / step) + 1L,
+                0L)),
             s"nda_slice_shape$i")
         }
 


### PR DESCRIPTION
When slicing an ndarray, if someone asks for a slice bigger than the array, we need to clamp the edges of that slice. 

I will make a follow up PR that elevates `clamp` to a proper Hail function like `min` and `max`, as I think it's generally useful. 