### PR TITLE
[query] ndarray slice bounds fixed

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3579,7 +3579,7 @@ class NDArrayExpression(Expression):
                              f'Expected {self.ndim} dimensions but got {len(item)}')
 
         n_sliced_dims = len([s for s in item if isinstance(s, slice)])
-        print("n_sliced_dims are", n_sliced_dims)
+
         if n_sliced_dims > 0:
             slices = []
             for i, s in enumerate(item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3596,7 +3596,7 @@ class NDArrayExpression(Expression):
                     min_bound = hl.cond(step > 0, to_expr(0, tint64), to_expr(-1, tint64))
                     if s.start is not None:
                         # python treats start < -dlen as None when step < 0: [0,1][-3:0:-1]
-                        # and 0 otherwise: [0,1][-3::]
+                        # and 0 otherwise: [0,1][-3::1] == [0,1][0::1]
                         start = hl.case() \
                                 .when(s.start >= dlen, max_bound) \
                                 .when(s.start >= 0, s.start) \
@@ -3607,7 +3607,7 @@ class NDArrayExpression(Expression):
 
                     if s.stop is not None:
                         # python treats stop < -dlen as None when step < 0: [0,1][0:-3:-1] == [0,1][0::-1]
-                        # and dlen otherwise: [0,1][:-3:1] == [] while [0,1][::1] == [0, 1]
+                        # and 0 otherwise: [0,1][:-3:1] == [0,1][:0:1]
                         stop = hl.case() \
                                .when(s.stop >= dlen, max_bound) \
                                .when(s.stop >= 0, s.stop) \

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3609,7 +3609,7 @@ class NDArrayExpression(Expression):
                                .when(s.stop >= dlen, max_bound) \
                                .when(s.stop >= 0, s.stop) \
                                .when((s.stop + dlen) >= 0, dlen + s.stop) \
-                               .default(default_start)
+                               .default(default_stop)
                     else:
                         stop = default_stop
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3598,10 +3598,10 @@ class NDArrayExpression(Expression):
                         # python treats start < -dlen as None when step < 0: [0,1][-3:0:-1]
                         # and 0 otherwise: [0,1][-3::1] == [0,1][0::1]
                         start = hl.case() \
-                                .when(s.start >= dlen, max_bound) \
-                                .when(s.start >= 0, s.start) \
-                                .when((s.start + dlen) >= 0, dlen + s.start) \
-                                .default(min_bound)
+                            .when(s.start >= dlen, max_bound) \
+                            .when(s.start >= 0, s.start) \
+                            .when((s.start + dlen) >= 0, dlen + s.start) \
+                            .default(min_bound)
                     else:
                         start = hl.cond(step >= 0, to_expr(0, tint64), dlen - 1)
 
@@ -3609,10 +3609,10 @@ class NDArrayExpression(Expression):
                         # python treats stop < -dlen as None when step < 0: [0,1][0:-3:-1] == [0,1][0::-1]
                         # and 0 otherwise: [0,1][:-3:1] == [0,1][:0:1]
                         stop = hl.case() \
-                               .when(s.stop >= dlen, max_bound) \
-                               .when(s.stop >= 0, s.stop) \
-                               .when((s.stop + dlen) >= 0, dlen + s.stop) \
-                               .default(min_bound)
+                            .when(s.stop >= dlen, max_bound) \
+                            .when(s.stop >= 0, s.stop) \
+                            .when((s.stop + dlen) >= 0, dlen + s.stop) \
+                            .default(min_bound)
                     else:
                         stop = hl.cond(step > 0, dlen, to_expr(-1, tint64))
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3593,7 +3593,7 @@ class NDArrayExpression(Expression):
 
                     if s.start is not None:
                         start = hl.case() \
-                                .when(s.start >= dlen, s.start) \
+                                .when(s.start >= dlen, dlen) \
                                 .when(s.start >= 0, s.start) \
                                 .when((s.start + dlen) >= 0, dlen + s.start) \
                                 .default(0)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3593,25 +3593,23 @@ class NDArrayExpression(Expression):
                         step = to_expr(1, tint64)
 
                     max_bound = hl.if_else(step > 0, dlen, dlen - 1)
-                    default_start = hl.cond(step >= 0, to_expr(0, tint64), dlen - 1)
-                    default_stop = hl.cond(step >= 0, dlen, to_expr(-1, tint64))
                     if s.start is not None:
                         start = hl.case() \
                                 .when(s.start >= dlen, max_bound) \
                                 .when(s.start >= 0, s.start) \
                                 .when((s.start + dlen) >= 0, dlen + s.start) \
-                                .default(default_start)
+                                .default(max_bound)
                     else:
-                        start = default_start
+                        start = hl.cond(step >= 0, to_expr(0, tint64), dlen - 1)
 
                     if s.stop is not None:
                         stop = hl.case() \
                                .when(s.stop >= dlen, max_bound) \
                                .when(s.stop >= 0, s.stop) \
                                .when((s.stop + dlen) >= 0, dlen + s.stop) \
-                               .default(default_stop)
+                               .default(max_bound)
                     else:
-                        stop = default_stop
+                        stop = hl.cond(step >= 0, dlen, to_expr(-1, tint64))
 
                     slices.append(hl.tuple((start, stop, step)))
                 else:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3609,7 +3609,7 @@ class NDArrayExpression(Expression):
                                .when(s.stop >= dlen, max_bound) \
                                .when(s.stop >= 0, s.stop) \
                                .when((s.stop + dlen) >= 0, dlen + s.stop) \
-                               .default(default_stop)
+                               .default(default_start)
                     else:
                         stop = default_stop
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,11 @@ def test_ndarray_slice():
         (mat[::-1, :], np_mat[::-1, :]),
         (flat[4:1:-2], np_flat[4:1:-2]),
         (flat[0:0:1], np_flat[0:0:1]),
-        (flat[-4:-1:2], np_flat[-4:-1:2])
+        (flat[-4:-1:2], np_flat[-4:-1:2]),
+        (mat[0:20, 0:17], np_mat[0:20, 0:17]),
+        (mat[0:20, 2:17], np_mat[0:20, 2:17]),
+        (mat[9:2:-1, 1:4], np_mat[9:2:-1, 1:4]),
+        (mat[9:-1:-1, 1:4], np_mat[9:-1:-1, 1:4])
     )
 
     assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None
@@ -105,6 +109,17 @@ def test_ndarray_slice():
     with pytest.raises(FatalError) as exc:
         hl.eval(flat[::0])
     assert "Slice step cannot be zero" in str(exc)
+
+
+def test_ndarray_transposed_slice():
+    a = hl.nd.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    np_a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    aT = a.T
+    np_aT = np_a.T
+    assert_ndarrays_eq(
+        (a, np_a),
+        (aT[0:aT.shape[0], 0:5], np_aT[0:np_aT.shape[0], 0:5])
+    )
 
 
 def test_ndarray_eval():
@@ -584,6 +599,7 @@ def test_ndarray_mixed():
          hl.nd.ones((5, 10)).map(lambda x: x + 5)).reshape(hl.null(hl.ttuple(hl.tint64, hl.tint64))).T.reshape((10, 5))) is None
     assert hl.eval(hl.or_missing(False, hl.nd.array(np.arange(10)).reshape(
         (5, 2)).map(lambda x: x * 2)).map(lambda y: y * 2)) is None
+
 
 
 def test_ndarray_show():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -16,7 +16,7 @@ def assert_ndarrays(asserter, exprs_and_expecteds):
 
     evaled_and_expected = zip(evaled_exprs, expecteds)
     for (idx, (evaled, expected)) in enumerate(evaled_and_expected):
-        assert asserter(evaled, expected), f"NDArray comparison {idx} failed"
+        assert asserter(evaled, expected), f"NDArray comparison {idx} failed, got: {evaled}, expected: {expected}"
 
 
 def assert_ndarrays_eq(*expr_and_expected):
@@ -69,6 +69,9 @@ def test_ndarray_slice():
     mat = hl.nd.array(np_mat)
     np_flat = np.arange(20)
     flat = hl.nd.array(np_flat)
+    a = [0, 1]
+    an = np.array(a)
+    ah = hl.nd.array(a)
 
     assert_ndarrays_eq(
         (rect_prism[:, :, :], np_rect_prism[:, :, :]),
@@ -81,8 +84,8 @@ def test_ndarray_slice():
          np_rect_prism[0, :, 1:4:2] + np_rect_prism[:, :1, 1:4:2]),
         (rect_prism[0:, :, 1:4:2] + rect_prism[:, :1, 1:4:2],
          np_rect_prism[0:, :, 1:4:2] + np_rect_prism[:, :1, 1:4:2]),
-        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]),
         (rect_prism[0, 0, -3:-1], np_rect_prism[0, 0, -3:-1]),
+
         (flat[15:5:-1], np_flat[15:5:-1]),
         (flat[::-1], np_flat[::-1]),
         (flat[::22], np_flat[::22]),
@@ -90,14 +93,44 @@ def test_ndarray_slice():
         (flat[15:5], np_flat[15:5]),
         (flat[3:12:-1], np_flat[3:12:-1]),
         (flat[12:3:1], np_flat[12:3:1]),
-        (mat[::-1, :], np_mat[::-1, :]),
         (flat[4:1:-2], np_flat[4:1:-2]),
         (flat[0:0:1], np_flat[0:0:1]),
         (flat[-4:-1:2], np_flat[-4:-1:2]),
+
+        (mat[::-1, :], np_mat[::-1, :]),
+        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]),
+        (mat[-1:4:1, 0], np_mat[-1:4:1, 0]),
+        (mat[-1:4:-1, 0], np_mat[-1:4:-1, 0]),
+        # out of bounds on start
+        (mat[9:2:-1, 1:4], np_mat[9:2:-1, 1:4]),
+        (mat[9:-1:-1, 1:4], np_mat[9:-1:-1, 1:4]),
+        (mat[-5::, 0], np_mat[-5::, 0]),
+        (mat[-5::-1, 0], np_mat[-5::-1, 0]),
+        (mat[-5:-1:-1, 0], np_mat[-5:-1:-1, 0]),
+        (mat[-5:-5:-1, 0], np_mat[-5:-5:-1, 0]),
+        (mat[4::, 0], np_mat[4::, 0]),
+        (mat[4:-1:, 0], np_mat[4:-1:, 0]),
+        (mat[4:-1:-1, 0], np_mat[4:-1:-1, 0]),
+        (mat[5::, 0], np_mat[5::, 0]),
+        (mat[5::-1, 0], np_mat[5::-1, 0]),
+        (mat[-5::-1, 0], np_mat[-5::-1, 0]),
+        (mat[-5::1, 0], np_mat[-5::1, 0]),
+        (mat[5:-1:-1, 0], np_mat[5:-1:-1, 0]),
+        (mat[5:-5:-1, 0], np_mat[5:-5:-1, 0]),
+        # out of bounds on stop
         (mat[0:20, 0:17], np_mat[0:20, 0:17]),
         (mat[0:20, 2:17], np_mat[0:20, 2:17]),
-        (mat[9:2:-1, 1:4], np_mat[9:2:-1, 1:4]),
-        (mat[9:-1:-1, 1:4], np_mat[9:-1:-1, 1:4])
+        (mat[:4, 0], np_mat[:4, 0]),
+        (mat[:4:-1, 0], np_mat[:4:-1, 0]),
+        (mat[:-5, 0], np_mat[:-5, 0]),
+        (mat[:-5:-1, 0], np_mat[:-5:-1, 0]),
+        (mat[0:-5, 0], np_mat[0:-5, 0]),
+        (mat[0:-5:-1, 0], np_mat[0:-5:-1, 0]),
+
+        (ah[:-3:1], an[:-3:1]),
+        (ah[:-3:-1], an[:-3:-1]),
+        (ah[-3::-1], an[-3::-1]),
+        (ah[-3::1], an[-3::1])
     )
 
     assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None


### PR DESCRIPTION
This PR supersedes #9146, sets ndarray slicing behavior to follow ndarray/python semantics when out of bounds: upper_bound = len_dim if step > 0 else len_dim - 1, lower_bound = 0 if step > 0 else -1 (since our -1 has the effect of a slice bound that is None)

The other PR doesn't clamp dimensions properly (min and max out of bounds for start and stop are identical), and missed a 2nd issue, which is that python changes clamping behavior when step is negative. I bet this polymorphism is the reason we don't allow non-1 steps for ArrayExpressions.
  - @johnc1231 could you still follow up on the byte code generation issue?

I've verified this works in the boundary cases.