### PR TITLE
Two LocalBackend fixes

### DIFF
--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 import scala.collection.JavaConverters._
 import java.io.PrintWriter
 
-class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T]
+class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serializable
 
 object LocalBackend {
   private var theLocalBackend: LocalBackend = _

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -665,7 +665,7 @@ object ReferenceGenome {
     }
   }
 
-  private def writeReference(fs: is.hail.io.fs.FS, path: String, rg: ReferenceGenome) {
+  def writeReference(fs: is.hail.io.fs.FS, path: String, rg: ReferenceGenome) {
     val rgPath = path + "/" + rg.name + ".json.gz"
     if (!hailReferences.contains(rg.name) && !fs.exists(rgPath))
       rg.asInstanceOf[ReferenceGenome].write(fs, rgPath)


### PR DESCRIPTION
make LocalBroadcastValue serializable.
make writeReference public.

Gets the local tests to 419 passing:

 > ====== 344 failed, 419 passed, 75 skipped, 16 warnings in 362.06 seconds =======
