### PR TITLE
CHANGELOG: Fix bug that prevented concatenating ndarrays that are fields of a table

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -869,8 +869,7 @@ class NDArrayConcat(IR):
             other.axis == self.axis
 
     def _compute_type(self, env, agg_env):
-        for a in self.nds.args:
-            a._compute_type(env, agg_env)
+        self.nds._compute_type(env, agg_env)
 
         self._type = self.nds.typ.element_type
 

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -312,14 +312,15 @@ def concatenate(nds, axis=0):
     - res: ndarray
         The concatenated array
     """
-    head_ndim = nds[0].ndim
+    head_nd = nds[0]
+    head_ndim = head_nd.ndim
     for nd in nds:
         assert(nd.ndim == head_ndim)
 
     makearr = aarray(nds)
     concat_ir = NDArrayConcat(makearr._ir, axis)
 
-    return construct_expr(concat_ir, concat_ir.typ)
+    return construct_expr(concat_ir, tndarray(head_nd._type.element_type, head_ndim))
 
 
 @typecheck(N=expr_numeric, M=nullable(expr_numeric), dtype=HailType)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -901,6 +901,11 @@ def test_hstack():
     b = np.array([[2], [3], [4]])
     assert(np.array_equal(hl.eval(hl.nd.hstack((a, b))), np.hstack((a, b))))
 
+    ht = hl.utils.range_table(10)
+    ht = ht.annotate(x=hl.nd.array([1, 2, 3]), y=hl.nd.array([4, 5, 6]))
+    ht = ht.annotate(stacked = hl.nd.hstack([ht.x, ht.y]))
+    assert np.array_equal(ht.collect()[0].stacked, np.array([1, 2, 3, 4, 5, 6]))
+
 
 def test_eye():
     for i in range(13):


### PR DESCRIPTION
CHANGELOG: Fix bug that prevented concatenating ndarrays that are fields of a table

Two bugs:

1. We can't call `.typ` on `concat_ir`, since that kicks off the type inference process before this IR gets wrapped in a `TableIR` that provides the necessary context to infer the type.
2. We need to `_compute_type` on `self.nds` as a whole, not just each of its `args`. 