### PR TITLE
[query] Better error message when using `in` incorrectly

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -642,6 +642,10 @@ class Expression(object):
     def __len__(self):
         raise TypeError("'Expression' objects have no static length: use 'hl.len' for the length of collections")
 
+    def __contains__(self, item):
+        class_name = type(self).__name__
+        raise TypeError(f"`{class_name} objects don't support the `in` operator.")
+
     def __hash__(self):
         return super(Expression, self).__hash__()
 

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -640,6 +640,7 @@ class Expression(object):
         return self._type
 
     def __len__(self):
+        import pdb; pdb.set_trace()
         raise TypeError("'Expression' objects have no static length: use 'hl.len' for the length of collections")
 
     def __hash__(self):

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -640,7 +640,6 @@ class Expression(object):
         return self._type
 
     def __len__(self):
-        import pdb; pdb.set_trace()
         raise TypeError("'Expression' objects have no static length: use 'hl.len' for the length of collections")
 
     def __hash__(self):

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -644,7 +644,7 @@ class Expression(object):
 
     def __contains__(self, item):
         class_name = type(self).__name__
-        raise TypeError(f"`{class_name} objects don't support the `in` operator.")
+        raise TypeError(f"`{class_name}` objects don't support the `in` operator.")
 
     def __hash__(self):
         return super(Expression, self).__hash__()

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1571,6 +1571,9 @@ class StructExpression(Mapping[str, Expression], Expression):
     def __iter__(self):
         return iter(self._fields)
 
+    def __contains__(self, item):
+        return item in self._fields
+
     def __hash__(self):
         return object.__hash__(self)
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -472,6 +472,12 @@ class ArrayExpression(CollectionExpression):
                 filt_stack.append(candidate)
             return self._method("indexArray", self.dtype.element_type, item, '\n'.join(filt_stack))
 
+
+    @typecheck_method(item=expr_any)
+    def __contains__(self, item):
+        return self.contains(item)
+
+
     @typecheck_method(item=expr_any)
     def contains(self, item):
         """Returns a boolean indicating whether `item` is found in the array.

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -402,7 +402,7 @@ class CollectionExpression(Expression):
     def __contains__(self, element):
         class_name = type(self).__name__
         raise TypeError(f"Cannot use `in` operator on hail `{class_name}`s. Use the `contains` method instead."
-                         "`names.contains('Charlie')` instead of `'Charlie' in names`")
+                        "`names.contains('Charlie')` instead of `'Charlie' in names`")
 
 
 class ArrayExpression(CollectionExpression):
@@ -476,7 +476,6 @@ class ArrayExpression(CollectionExpression):
                     continue
                 filt_stack.append(candidate)
             return self._method("indexArray", self.dtype.element_type, item, '\n'.join(filt_stack))
-
 
     @typecheck_method(item=expr_any)
     def contains(self, item):
@@ -1276,7 +1275,6 @@ class DictExpression(Expression):
                             "    dict key type:  '{}'\n"
                             "    type of 'item': '{}'".format(self.dtype.key_type, item.dtype))
         return self._index(self.dtype.value_type, self._kc.coerce(item))
-
 
     @typecheck_method(item=expr_any)
     def contains(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -399,6 +399,11 @@ class CollectionExpression(Expression):
             hl.agg.mean(length),
             hl.agg.explode(lambda elt: elt._all_summary_aggs(), self)))
 
+    def __contains__(self, element):
+        class_name = type(self).__name__
+        raise TypeError(f"Cannot use `in` operator on hail `{class_name}`s. Use the `contains` method instead."
+                         "`names.contains('Charlie')` instead of `'Charlie' in names`")
+
 
 class ArrayExpression(CollectionExpression):
     """Expression of type :class:`.tarray`.
@@ -471,12 +476,6 @@ class ArrayExpression(CollectionExpression):
                     continue
                 filt_stack.append(candidate)
             return self._method("indexArray", self.dtype.element_type, item, '\n'.join(filt_stack))
-
-
-    @typecheck_method(item=expr_any)
-    def __contains__(self, item):
-        raise TypeError("Cannot use `in` operator on hail `ArrayExpression`s. Use the `contains` method instead."
-                        "`names.contains('Charlie')` instead of `'Charlie' in names`")
 
 
     @typecheck_method(item=expr_any)
@@ -1278,10 +1277,6 @@ class DictExpression(Expression):
                             "    type of 'item': '{}'".format(self.dtype.key_type, item.dtype))
         return self._index(self.dtype.value_type, self._kc.coerce(item))
 
-    @typecheck_method(item=expr_any)
-    def __contains__(self, item):
-        raise TypeError("Cannot use `in` operator on hail `SetExpression`s. Use the `contains` method instead."
-                        "`names.contains('Charlie')` instead of `'Charlie' in names`")
 
     @typecheck_method(item=expr_any)
     def contains(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -475,7 +475,8 @@ class ArrayExpression(CollectionExpression):
 
     @typecheck_method(item=expr_any)
     def __contains__(self, item):
-        return self.contains(item)
+        raise TypeError("Cannot use `in` operator on hail `ArrayExpression`s. Use the `contains` method instead."
+                        "`names.contains('Charlie')` instead of `'Charlie' in names`")
 
 
     @typecheck_method(item=expr_any)
@@ -1276,6 +1277,11 @@ class DictExpression(Expression):
                             "    dict key type:  '{}'\n"
                             "    type of 'item': '{}'".format(self.dtype.key_type, item.dtype))
         return self._index(self.dtype.value_type, self._kc.coerce(item))
+
+    @typecheck_method(item=expr_any)
+    def __contains__(self, item):
+        raise TypeError("Cannot use `in` operator on hail `SetExpression`s. Use the `contains` method instead."
+                        "`names.contains('Charlie')` instead of `'Charlie' in names`")
 
     @typecheck_method(item=expr_any)
     def contains(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -2354,6 +2354,10 @@ class StringExpression(Expression):
                                 "found expression of type '{}'".format(item.dtype))
             return self._index(tstr, item)
 
+    def __contains__(self, item):
+        raise TypeError(f"Cannot use `in` operator on hail `StringExpression`s. Use the `contains` method instead."
+                        "`my_string.contains('cat')` instead of `'cat' in my_string`")
+
     def __add__(self, other):
         """Concatenate strings.
 


### PR DESCRIPTION
Let me know if you think the error message is clear. 