### PR TITLE
[query] make concatenate operations work with array expressions

### DIFF
--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -11,8 +11,7 @@ from hail.expr.expressions import (
 from hail.expr.expressions.typed_expressions import NDArrayNumericExpression
 from hail.ir import NDArrayQR, NDArrayInv, NDArrayConcat
 
-tsequenceof_nd = oneof(sequenceof(expr_ndarray()), tupleof(expr_ndarray()),
-                       expr_array(expr_ndarray()))
+tsequenceof_nd = oneof(sequenceof(expr_ndarray()), expr_array(expr_ndarray()))
 shape_type = oneof(expr_int64, tupleof(expr_int64), expr_tuple())
 
 

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -441,12 +441,10 @@ def vstack(arrs):
            [3],
            [4]], dtype=int32)
     """
-    if isinstance(arrs, list):
-        ndim = arrs[0].dtype.ndim
-    else:
-        ndim = arrs.dtype.element_type.ndim
+    head_nd = arrs[0]
+    head_ndim = head_nd.ndim
 
-    if ndim == 1:
+    if head_ndim == 1:
         return concatenate(hl.map(lambda a: a._broadcast(2), arrs), 0)
 
     return concatenate(arrs, 0)
@@ -491,13 +489,10 @@ def hstack(arrs):
            [2, 3],
            [3, 4]], dtype=int32)
     """
+    head_nd = arrs[0]
+    head_ndim = head_nd.ndim
 
-    if isinstance(arrs, list):
-        ndim = arrs[0].dtype.ndim
-    else:
-        ndim = arrs.dtype.element_type.ndim
-
-    if ndim == 1:
+    if head_ndim == 1:
         axis = 0
     else:
         axis = 1

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -441,8 +441,7 @@ def vstack(arrs):
            [3],
            [4]], dtype=int32)
     """
-    head_nd = arrs[0]
-    head_ndim = head_nd.ndim
+    head_ndim = arrs[0].ndim
 
     if head_ndim == 1:
         return concatenate(hl.map(lambda a: a._broadcast(2), arrs), 0)
@@ -489,8 +488,7 @@ def hstack(arrs):
            [2, 3],
            [3, 4]], dtype=int32)
     """
-    head_nd = arrs[0]
-    head_ndim = head_nd.ndim
+    head_ndim = arrs[0].ndim
 
     if head_ndim == 1:
         axis = 0

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -865,46 +865,76 @@ def test_concatenate():
     res = hl.eval(hl.nd.concatenate([x, y], axis=1))
     assert np.array_equal(np_res, res)
 
+    res = hl.eval(hl.nd.concatenate(hl.array([x, y]), axis=1))
+    assert np.array_equal(np_res, res)
+
     x = np.array([[1], [3]])
     y = np.array([[5], [6]])
 
     seq = [x, y]
+    seq2 = hl.array(seq)
     np_res = np.concatenate(seq)
     res = hl.eval(hl.nd.concatenate(seq))
     assert np.array_equal(np_res, res)
 
+    res = hl.eval(hl.nd.concatenate(seq2))
+    assert np.array_equal(np_res, res)
+
     seq = (x, y)
+    seq2 = hl.array([x, y])
     np_res = np.concatenate(seq)
     res = hl.eval(hl.nd.concatenate(seq))
+    assert np.array_equal(np_res, res)
+
+    res = hl.eval(hl.nd.concatenate(seq2))
     assert np.array_equal(np_res, res)
 
 
 def test_vstack():
+    ht = hl.utils.range_table(10)
+
+    def assert_table(a, b):
+        ht2 = ht.annotate(x=hl.nd.array(a), y=hl.nd.array(b))
+        ht2 = ht2.annotate(stacked=hl.nd.vstack([ht2.x, ht2.y]))
+        assert np.array_equal(ht2.collect()[0].stacked, np.vstack([a, b]))
+
     a = np.array([1, 2, 3])
     b = np.array([2, 3, 4])
 
     seq = (a, b)
+    seq2 = hl.array([a, b])
     assert(np.array_equal(hl.eval(hl.nd.vstack(seq)), np.vstack(seq)))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(seq2)), np.vstack(seq)))
+    assert_table(a, b)
 
     a = np.array([[1], [2], [3]])
     b = np.array([[2], [3], [4]])
     seq = (a, b)
+    seq2 = hl.array([a, b])
     assert(np.array_equal(hl.eval(hl.nd.vstack(seq)), np.vstack(seq)))
+    assert(np.array_equal(hl.eval(hl.nd.vstack(seq2)), np.vstack(seq)))
+    assert_table(a, b)
 
 
 def test_hstack():
+    ht = hl.utils.range_table(10)
+
+    def assert_table(a, b):
+        ht2 = ht.annotate(x=hl.nd.array(a), y=hl.nd.array(b))
+        ht2 = ht2.annotate(stacked=hl.nd.hstack([ht2.x, ht2.y]))
+        assert np.array_equal(ht2.collect()[0].stacked, np.hstack([a, b]))
+
     a = np.array([1, 2, 3])
     b = np.array([2, 3, 4])
     assert(np.array_equal(hl.eval(hl.nd.hstack((a, b))), np.hstack((a, b))))
+    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, b]))), np.hstack((a, b))))
+    assert_table(a, b)
 
     a = np.array([[1], [2], [3]])
     b = np.array([[2], [3], [4]])
     assert(np.array_equal(hl.eval(hl.nd.hstack((a, b))), np.hstack((a, b))))
-
-    ht = hl.utils.range_table(10)
-    ht = ht.annotate(x=hl.nd.array([1, 2, 3]), y=hl.nd.array([4, 5, 6]))
-    ht = ht.annotate(stacked = hl.nd.hstack([ht.x, ht.y]))
-    assert np.array_equal(ht.collect()[0].stacked, np.array([1, 2, 3, 4, 5, 6]))
+    assert(np.array_equal(hl.eval(hl.nd.hstack(hl.array([a, b]))), np.hstack((a, b))))
+    assert_table(a, b)
 
 
 def test_eye():


### PR DESCRIPTION
CHANGELOG: make hl.nd.concatenate, hl.nd.vstack, and hl.nd.hstack accept ArrayExpression of NDArrayExpression, in addition to Python collections of NDArrayExpression