### PR TITLE
[batch] fix resource requests in test

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -65,7 +65,8 @@ class Test(unittest.TestCase):
         builder = self.client.create_batch()
         resources = {
             'cpu': '100m',
-            'memory': '375M'
+            'memory': '375M',
+            'storage': '1Gi'
         }
         # two jobs so the batch msec_mcpu computation is non-trivial
         builder.create_job('ubuntu:18.04', ['echo', 'foo'], resources=resources)


### PR DESCRIPTION
The test deployment sets the default storage to 1GiB instead of the normal 10GiB. As a result, the PR tests passed. The deployment tests fail because the 10GiB default storage request forces a minimum core count of 0.5 CPU. This change explicitly requests less storage, thus preventing the rounding up of core count from 0.25 CPU to 0.5 CPU. The rounding up doubled the mcpu_msec time for the test, thus failing the test.

Fixes this:

```
-------------------------------- live log call ---------------------------------
2020-07-28T15:42:34 INFO batch_client.aioclient aioclient.py:497:submit created batch 70818
2020-07-28T15:42:34 INFO batch_client.aioclient aioclient.py:533:submit closed batch 70818
FAILED
_____________________________ Test.test_msec_mcpu ______________________________

self = <test.test_batch.Test testMethod=test_msec_mcpu>

    def test_msec_mcpu(self):
        builder = self.client.create_batch()
        resources = {
            'cpu': '100m',
            'memory': '375M'
        }
        # two jobs so the batch msec_mcpu computation is non-trivial
        builder.create_job('ubuntu:18.04', ['echo', 'foo'], resources=resources)
        builder.create_job('ubuntu:18.04', ['echo', 'bar'], resources=resources)
        b = builder.submit()
    
        batch = b.wait()
        assert batch['state'] == 'success', batch
    
        batch_msec_mcpu2 = 0
        for job in b.jobs():
            # I'm dying
            job = self.client.get_job(job['batch_id'], job['job_id'])
            job = job.status()
    
            # runs at 250mcpu
            job_msec_mcpu2 = 250 * max(job['status']['end_time'] - job['status']['start_time'], 0)
            # greater than in case there are multiple attempts
            assert job['msec_mcpu'] >= job_msec_mcpu2, batch
    
            batch_msec_mcpu2 += job_msec_mcpu2
    
>       assert batch['msec_mcpu'] == batch_msec_mcpu2, batch
E       AssertionError: {'billing_project': 'test', 'closed': True, 'complete': True, 'cost': '$0.0000', ...}
E       assert 2813000 == 1406500
E         -2813000
E         +1406500
```