### PR TITLE
[batch] Add storage resource to the tests

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -121,20 +121,20 @@ class Test(unittest.TestCase):
 
     def test_invalid_resource_requests(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '1', 'memory': '250Gi'}
+        resources = {'cpu': '1', 'memory': '250Gi', 'storage': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
         with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'resource requests.*unsatisfiable'):
             builder.submit()
 
         builder = self.client.create_batch()
-        resources = {'cpu': '0', 'memory': '1Gi'}
+        resources = {'cpu': '0', 'memory': '1Gi', 'storage': '1Gi'}
         builder.create_job('ubuntu:18.04', ['true'], resources=resources)
         with self.assertRaisesRegex(aiohttp.client.ClientResponseError, 'bad resource request.*cpu cannot be 0'):
             builder.submit()
 
     def test_out_of_memory(self):
         builder = self.client.create_batch()
-        resources = {'cpu': '0.1', 'memory': '10M'}
+        resources = {'cpu': '0.1', 'memory': '10M', 'storage': '1Gi'}
         j = builder.create_job('python:3.6-slim-stretch',
                                ['python', '-c', 'x = "a" * 1000**3'],
                                resources=resources)


### PR DESCRIPTION
Same issue where I didn't specify the storage to be 1Gi, so it got more memory than intended. I changed all the explicit resource requests to be 1Gi.

```
2020-07-28T18:18:12 INFO batch_client.aioclient aioclient.py:497:submit created batch 71161
2020-07-28T18:18:12 INFO batch_client.aioclient aioclient.py:533:submit closed batch 71161
FAILED
___________________________ Test.test_out_of_memory ____________________________

self = <test.test_batch.Test testMethod=test_out_of_memory>

    def test_out_of_memory(self):
        builder = self.client.create_batch()
        resources = {'cpu': '0.1', 'memory': '10M'}
        j = builder.create_job('python:3.6-slim-stretch',
                               ['python', '-c', 'x = "a" * 1000**3'],
                               resources=resources)
        builder.submit()
        status = j.wait()
>       assert j._get_out_of_memory(status, 'main')
E       AssertionError: assert False
E        +  where False = <function Job._get_out_of_memory at 0x7f2781b87050>({'batch_id': 71161, 'cost': '$0.0000', 'duration': 5847, 'exit_code': 0, ...}, 'main')
E        +    where <function Job._get_out_of_memory at 0x7f2781b87050> = <hailtop.batch_client.client.Job object at 0x7f277d7a71d0>._get_out_of_memory

```