### PR TITLE
[query] Fix invalid memory reference in Table.aggregate

### DIFF
--- a/hail/python/cluster-tests/cluster_tree_aggregate.py
+++ b/hail/python/cluster-tests/cluster_tree_aggregate.py
@@ -1,0 +1,6 @@
+import hail as hl
+S = 500
+V = 2000
+mt = hl.balding_nichols_model(1, S, V, 500)
+mt = mt.annotate_cols(n_called = hl.agg.filter(hl.is_defined(mt.GT), hl.agg.count()))
+mt = mt.filter_cols(mt.n_called > 0).count()

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -928,7 +928,7 @@ object Interpret {
             val region = Region(Region.SMALL)
             val initF = initOp(0, region)
             initF.newAggState(region)
-            initF(region, globalsOffset)
+            initF(region, globalsBc.value.readRegionValue(region))
             RegionValue(region, initF.getAggOffset())
           }
 


### PR DESCRIPTION
Fixes #8944

CHANGELOG: Fixed crash (error 134 or SIGSEGV) in `MatrixTable.annotate_cols`, `hl.sample_qc`, and more.