### PR TITLE
[batch] add google-cloud-storage dep

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -18,3 +18,4 @@ requests>=2.21.0,<2.21.1
 scipy>1.2,<1.4
 tabulate==0.8.3
 tqdm==4.42.1
+google-cloud-storage==1.25.*


### PR DESCRIPTION
CHANGELOG: fix missing google-cloud-storage python dependency, required by batch.

This makes the tutorial work: https://hail.is/docs/batch/getting_started.html

Version chosen based on our dataproc dependency declaration in init_notebook.py. Note that 1.25.* will install a new version of google-auth. On that note, it is possible that we can upgrade /auth to use a newer google-auth (@danking), as the issue listed in the /auth docker file (https://github.com/googleapis/google-auth-library-python/issues/443) is obviated by the 1.11.2 release: https://github.com/googleapis/google-auth-library-python/pull/446.