### PR TITLE
[auth] upgrade deps

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,12 +1,8 @@
 FROM {{ service_base_image.image }}
 
-# bug in 0.4.0
-# https://github.com/googleapis/google-auth-library-python-oauthlib/issues/46
-# https://stackoverflow.com/questions/56555687/oauth-throws-missing-code-validator-in-google-oauth2
 RUN pip3 install --upgrade \
-      google-auth-oauthlib==0.3.0 \
-      # https://github.com/googleapis/google-auth-library-python/issues/443
-      google-auth==1.11.0
+      google-auth-oauthlib==0.4.1 \
+      google-auth==1.20.0
 
 COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/


### PR DESCRIPTION
CHANGELOG: auth: upgrade google-auth-oauthlib to 0.4.1 an google-auth to 1.20.0

Note that google-auth-oauthlib 0.4.1 fixes to bug 0.4.0 introduced that prevented us from using that version: https://github.com/googleapis/google-auth-library-python-oauthlib/pull/48/files

1.20.0 is the (latest <2.0-dev) version installed with google-cloud-storage, use by hailctl dataproc, and now hail batch.