### PR TITLE
[query][smm 5] Memory management for StreamFold and StreamFold2

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -899,7 +899,6 @@ class Emit[C](
             // is empty.
             cb.assign(xElt, elt)
             (tmpAccVars, seq).zipped.foreach { (accVar, ir) =>
-              // FIXME: needs to be simultaneous assignment
               cb.assign(accVar,
                 emitI(ir, eltRegion, env = seqEnv)
                   .map(cb)(eltRegion.copyToSibling(mb, _, tmpRegion, accVar.pt)))

--- a/hail/src/main/scala/is/hail/expr/ir/StagedRegion.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StagedRegion.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, Settable, Value}
-import is.hail.types.physical.PCode
+import is.hail.types.physical.{PCode, PType}
 import is.hail.utils._
 
 abstract class StagedRegion {
@@ -12,6 +12,8 @@ abstract class StagedRegion {
 }
 
 trait StagedOwnedRegion extends StagedRegion {
+  val parent: StagedRegion
+
   def allocateRegion(size: Int): Code[Unit]
 
   def free(): Code[Unit]
@@ -25,11 +27,27 @@ trait StagedOwnedRegion extends StagedRegion {
   def copyToParent(mb: EmitMethodBuilder[_], value: PCode): PCode
 
   def addToParentRVB(srvb: StagedRegionValueBuilder, value: PCode): Code[Unit]
+
+  def copyToSibling(mb: EmitMethodBuilder[_], value: PCode, dest: StagedRegion, destType: PType): PCode
+
+  def copyToSibling(mb: EmitMethodBuilder[_], value: PCode, dest: StagedRegion): PCode =
+    copyToSibling(mb, value, dest, value.pt)
 }
 
 object StagedRegion {
   def apply(r: Value[Region], allowSubregions: Boolean = false): StagedRegion =
     if (allowSubregions) new RealStagedRegion(r) else new DummyStagedRegion(r)
+
+  def swap(mb: EmitMethodBuilder[_], x: StagedOwnedRegion, y: StagedOwnedRegion): Code[Unit] = {
+    assert(x.parent == y.parent)
+    (x, y) match {
+      case (x: RealStagedOwnedRegion, y: RealStagedOwnedRegion) =>
+        val temp = mb.newLocal[Region]("sr_swap")
+        Code(temp := x.r, x.r := y.r, y.r := temp)
+      case (x: DummyStagedOwnedRegion, y: DummyStagedOwnedRegion) =>
+        Code._empty
+    }
+  }
 }
 
 class RealStagedRegion(r: Value[Region]) extends StagedRegion {
@@ -37,34 +55,41 @@ class RealStagedRegion(r: Value[Region]) extends StagedRegion {
 
   def createChildRegion(mb: EmitMethodBuilder[_]): StagedOwnedRegion = {
     val newR = mb.newLocal[Region]("staged_region_child")
-    new RealStagedOwnedRegion(newR, r)
+    new RealStagedOwnedRegion(newR, this)
   }
 }
 
-class RealStagedOwnedRegion(r: Settable[Region], parent: Value[Region]) extends RealStagedRegion(r) with StagedOwnedRegion {
+class RealStagedOwnedRegion(val r: Settable[Region], val parent: StagedRegion) extends RealStagedRegion(r) with StagedOwnedRegion {
   def allocateRegion(size: Int): Code[Unit] = r := Region.stagedCreate(size)
 
   def free(): Code[Unit] = Code(r.invalidate(), r := Code._null)
 
   def clear(): Code[Unit] = (r: Value[Region]).clear()
 
-  def giveToParent(): Code[Unit] = parent.invoke("takeOwnershipOf", r)
+  def giveToParent(): Code[Unit] = parent.code.invoke("takeOwnershipOf", r)
 
-  def shareWithParent(): Code[Unit] = parent.invoke("addReferenceTo", r)
+  def shareWithParent(): Code[Unit] = parent.code.invoke("addReferenceTo", r)
 
   def copyToParent(mb: EmitMethodBuilder[_], value: PCode): PCode =
-    value.copyToRegion(mb, parent)
+    value.copyToRegion(mb, parent.code)
 
   def addToParentRVB(srvb: StagedRegionValueBuilder, value: PCode): Code[Unit] =
     srvb.addIRIntermediate(value, deepCopy = true)
+
+  def copyToSibling(mb: EmitMethodBuilder[_], value: PCode, dest: StagedRegion, destType: PType): PCode = {
+    assert(dest.asInstanceOf[RealStagedOwnedRegion].parent == parent)
+    value.copyToRegion(mb, dest.code, destType)
+  }
 }
 
-class DummyStagedRegion(r: Value[Region]) extends StagedOwnedRegion {
+class DummyStagedRegion(r: Value[Region]) extends StagedRegion {
   def code: Value[Region] = r
 
   def createChildRegion(mb: EmitMethodBuilder[_]): StagedOwnedRegion =
-    this
+    new DummyStagedOwnedRegion(r, this)
+}
 
+class DummyStagedOwnedRegion(val r: Value[Region], val parent: StagedRegion) extends DummyStagedRegion(r) with StagedOwnedRegion {
   def allocateRegion(size: Int): Code[Unit] = Code._empty
 
   def free(): Code[Unit] = Code._empty
@@ -79,4 +104,12 @@ class DummyStagedRegion(r: Value[Region]) extends StagedOwnedRegion {
 
   def addToParentRVB(srvb: StagedRegionValueBuilder, value: PCode): Code[Unit] =
     srvb.addIRIntermediate(value, deepCopy = false)
+
+  def copyToSibling(mb: EmitMethodBuilder[_], value: PCode, dest: StagedRegion, destType: PType): PCode = {
+    assert(dest.asInstanceOf[DummyStagedOwnedRegion].parent == parent)
+    if (destType == value.pt)
+      value
+    else
+      value.castTo(mb, dest.code, destType)
+  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -70,8 +70,8 @@ abstract class PCode { self =>
       destType.copyFromTypeAndStackValue(mb, region, pt, code, deepCopy))
   }
 
-  def copyToRegion(mb: EmitMethodBuilder[_], region: Value[Region]): PCode =
-    castTo(mb, region, pt, deepCopy = true)
+  def copyToRegion(mb: EmitMethodBuilder[_], region: Value[Region], destType: PType = pt): PCode =
+    castTo(mb, region, destType, deepCopy = true)
 
   // this is necessary because Scala doesn't infer the return type of
   // PIndexableCode.memoize if PCode.memoize has a default implementation


### PR DESCRIPTION
~~Stacked on #9177~~

These are tricky because of the overlapping lifetimes of the accumulator values. The solution implemented here is to keep two regions. When running the fold body, one region is empty, and the other holds just the previous accumulator. Then we deep copy the new accumulator to the empty region, clear the other one, then swap the two regions before moving to the next iteration.

This required expanding the StagedRegion API a bit. First, it now strictly tracks the parent StagedRegion, even in the non-allocating case where the parent wraps the same run-time region. Second, in addition to copying a value to the parent, we can now copy a value to a sibling. It enforces at compile time that the two regions have the same parent. It follows that either both are actually separate regions, or both are just wrappers around the parent region. In the latter case, copying to a sibling is a no-op.