### PR TITLE
[query][smm 3] force region to be passed to StagedRegionValueBuilder constructor

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -45,18 +45,6 @@ class StagedRegionValueBuilder private (val mb: EmitMethodBuilder[_], val typ: P
     this(mb, typ, parent.region, parent.currentOffset)
   }
 
-  def this(fb: EmitFunctionBuilder[_], rowType: PType) = {
-    this(fb.apply_method, rowType, fb.apply_method.getCodeParam[Region](1), null)
-  }
-
-  def this(fb: EmitFunctionBuilder[_], rowType: PType, pOffset: Value[Long]) = {
-    this(fb.apply_method, rowType, fb.apply_method.getCodeParam[Region](1), pOffset)
-  }
-
-  def this(mb: EmitMethodBuilder[_], rowType: PType) = {
-    this(mb, rowType, mb.getCodeParam[Region](1), null)
-  }
-
   def this(mb: EmitMethodBuilder[_], rowType: PType, r: Value[Region]) = {
     this(mb, rowType, r, null)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1093,7 +1093,7 @@ class Emit[C](
 
       case x@MakeArray(args, _) =>
         val pType = x.pType.asInstanceOf[PArray]
-        val srvb = new StagedRegionValueBuilder(mb, pType)
+        val srvb = new StagedRegionValueBuilder(mb, pType, region.code)
         val addElement = srvb.addIRIntermediate(pType.elementType)
 
         val addElts = args.map { arg =>
@@ -1242,7 +1242,7 @@ class Emit[C](
         def loadValue(n: Code[Int]): Code[_] =
           Region.loadIRIntermediate(vtyp)(etyp.fieldOffset(coerce[Long](eab(n)), 1))
 
-        val srvb = new StagedRegionValueBuilder(mb, ir.pType)
+        val srvb = new StagedRegionValueBuilder(mb, ir.pType, region.code)
 
         type E = Env[(TypeInfo[_], Code[Boolean], Code[_])]
 
@@ -1413,7 +1413,7 @@ class Emit[C](
         COption.toEmitCode(resOpt, mb)
 
       case x@MakeStruct(fields) =>
-        val srvb = new StagedRegionValueBuilder(mb, x.pType)
+        val srvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
         val addFields = fields.map { case (_, x) =>
           val v = emit(x)
           Code(
@@ -1435,7 +1435,7 @@ class Emit[C](
         } else {
           val oldt = coerce[PStruct](oldStruct.pType)
           val oldv = mb.genFieldThisRef[Long]()
-          val srvb = new StagedRegionValueBuilder(mb, x.pType)
+          val srvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
 
           val addFields = fields.map { name =>
             val i = oldt.fieldIdx(name)
@@ -1468,7 +1468,7 @@ class Emit[C](
               val codeOld = emit(old)
               val xo = mb.genFieldThisRef[Long]()
               val updateMap = Map(fields: _*)
-              val srvb = new StagedRegionValueBuilder(mb, x.pType)
+              val srvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
 
               val addFields = { (newMB: EmitMethodBuilder[C], t: PType, v: EmitCode) =>
                 Code(
@@ -1506,7 +1506,7 @@ class Emit[C](
           }
 
       case x@MakeTuple(fields) =>
-        val srvb = new StagedRegionValueBuilder(mb, x.pType)
+        val srvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
         val addFields = fields.map { case (_, x) =>
           val v = emit(x)
           Code(
@@ -2151,7 +2151,7 @@ class Emit[C](
         val encRes = mb.genFieldThisRef[Array[Array[Byte]]]()
 
         def etToTuple(et: EmitCode, t: PType): Code[Long] = {
-          val srvb = new StagedRegionValueBuilder(mb, PCanonicalTuple(false, t))
+          val srvb = new StagedRegionValueBuilder(mb, PCanonicalTuple(false, t), region.code)
           Code(
             srvb.start(),
             et.setup,
@@ -2183,7 +2183,7 @@ class Emit[C](
           buf.invoke[Unit]("flush"))
 
         val decodeResult = {
-          val sab = new StagedRegionValueBuilder(mb, x.pType)
+          val sab = new StagedRegionValueBuilder(mb, x.pType, region.code)
           val bais = Code.newInstance[ByteArrayInputStream, Array[Byte]](encRes(sab.arrayIdx))
           val eltTupled = mb.genFieldThisRef[Long]()
           Code(

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -194,8 +194,8 @@ case class SplitPartitionNativeWriter(
           val pc = codeRow.toI(cb).handle(cb, cb._fatal("row can't be missing"))
           val row = pc.memoize(cb, "row")
           if (hasIndex) {
-            val keyRVB = new StagedRegionValueBuilder(mb, keyType)
-            val aRVB = new StagedRegionValueBuilder(mb, iAnnotationType)
+            val keyRVB = new StagedRegionValueBuilder(mb, keyType, region)
+            val aRVB = new StagedRegionValueBuilder(mb, iAnnotationType, region)
             indexWriter.add(cb, {
               cb += keyRVB.start()
               keyType.fields.foreach { f =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -171,7 +171,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
             { pc =>
               val row = pc.memoize(cb, "row")
               if (hasIndex) {
-                val keyRVB = new StagedRegionValueBuilder(mb, keyType)
+                val keyRVB = new StagedRegionValueBuilder(mb, keyType, region)
                 indexWriter.add(cb, {
                   cb += keyRVB.start()
                   keyType.fields.foreach { f =>

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -426,7 +426,7 @@ class CompiledLineParser(
   @transient private[this] val lineNumber = mb.genFieldThisRef[Long]("lineNumber")
   @transient private[this] val line = mb.genFieldThisRef[String]("line")
   @transient private[this] val pos = mb.genFieldThisRef[Int]("pos")
-  @transient private[this] val srvb = new StagedRegionValueBuilder(mb, rowPType)
+  @transient private[this] val srvb = new StagedRegionValueBuilder(mb, rowPType, region)
 
   fb.cb.emitInit(Code(
     pos := 0,

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -255,11 +255,11 @@ object EType {
       val pt = et.decodedPType(t)
       val f = et.buildDecoder(pt, mb.ecb)
 
-      val region: Code[Region] = mb.getCodeParam[Region](1)
+      val region: Value[Region] = mb.getCodeParam[Region](1)
       val in: Code[InputBuffer] = mb.getCodeParam[InputBuffer](2)
 
       if (pt.isPrimitive) {
-        val srvb = new StagedRegionValueBuilder(mb, pt)
+        val srvb = new StagedRegionValueBuilder(mb, pt, region)
         mb.emit(Code(
           srvb.start(),
           srvb.addIRIntermediate(pt)(f(region, in)),

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -20,7 +20,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalString()
     val input = "hello"
     val fb = EmitFunctionBuilder[Region, String, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb.emb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(
@@ -62,7 +62,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PInt32()
     val input = 3
     val fb = EmitFunctionBuilder[Region, Int, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(
@@ -100,7 +100,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalArray(PInt32())
     val input = 3
     val fb = EmitFunctionBuilder[Region, Int, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(
@@ -140,7 +140,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalStruct("a" -> PCanonicalString(), "b" -> PInt32())
     val input = 3
     val fb = EmitFunctionBuilder[Region, Int, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(
@@ -182,7 +182,7 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalArray(PCanonicalStruct("a" -> PInt32(), "b" -> PCanonicalString()))
     val input = "hello"
     val fb = EmitFunctionBuilder[Region, String, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     val struct = { ssb: StagedRegionValueBuilder =>
       Code(
@@ -325,7 +325,7 @@ class StagedRegionValueSuite extends HailSuite {
     val input = "hello"
     val fb = EmitFunctionBuilder[Region, String, Long](ctx, "fb")
     val codeInput = fb.getCodeParam[String](2)
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     val array = { sab: StagedRegionValueBuilder =>
       Code(
@@ -390,7 +390,7 @@ class StagedRegionValueSuite extends HailSuite {
     val input = 3
     val fb = EmitFunctionBuilder[Region, Int, Long](ctx, "fb")
     val codeInput = fb.getCodeParam[Int](2)
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(
@@ -434,7 +434,7 @@ class StagedRegionValueSuite extends HailSuite {
   def testAddPrimitive() {
     val t = PCanonicalStruct("a" -> PInt32(), "b" -> PBoolean(), "c" -> PFloat64())
     val fb = EmitFunctionBuilder[Region, Int, Boolean, Double, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, t)
+    val srvb = new StagedRegionValueBuilder(fb.emb, t, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(

--- a/hail/src/test/scala/is/hail/types/physical/PSubsetStructSuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PSubsetStructSuite.scala
@@ -15,7 +15,7 @@ class PSubsetStructSuite extends PhysicalTestUtils {
     val intInput = 3
     val longInput = 4L
     val fb = EmitFunctionBuilder[Region, Int, Long, Long](ctx, "fb")
-    val srvb = new StagedRegionValueBuilder(fb, rt)
+    val srvb = new StagedRegionValueBuilder(fb.emb, rt, fb.emb.getCodeParam[Region](1))
 
     fb.emit(
       Code(


### PR DESCRIPTION
Stacked on #9220

The region parameter to emit ostensibly means "construct the value in this region". But in many places `StagedRegionValueBuilder`s are constructed with the default region, which is the argument to the method being emitted into.

This PR fixes all the uses in the emitter to build values in the right region. Most of the remaining users of the constructor with the default region are in tests, so I thought it safest to remove those constructors, and require explicitly passing the region to build into. Otherwise it's too easy to create memory leaks.