### PR TITLE
[query][smm 6] Memory management for other stream consumers

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -665,7 +665,7 @@ abstract class PartitionWriter {
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: Value[Region],
+    region: StagedRegion,
     stream: SizedStream): EmitCode
 
   def ctxType: Type


### PR DESCRIPTION
~~Stacked on #9178~~

This adds memory management to ShuffleWrite, CollectDistributedArray, and WritePartition, all of which are straightforward. With #9178 this finishes all stream consumers, except TableMapPartitions, which will need to pass in the consumer's region.