### PR TITLE
Rename the master branch to main

### DIFF
--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -38,7 +38,7 @@ spec:
              value: /secrets/oauth-token/oauth-token
 {% if deploy %}
            - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-is/hail:master",true],["hail-is/hail:trunk",true]]'
+             value: '[["hail-is/hail:master",true],["hail-is/hail:main",true]]'
 {% else %}
            - name: HAIL_WATCHED_BRANCHES
              value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -38,7 +38,7 @@ spec:
              value: /secrets/oauth-token/oauth-token
 {% if deploy %}
            - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-is/hail:master",true]]'
+             value: '[["hail-is/hail:master",true],["hail-is/hail:trunk",true]]'
 {% else %}
            - name: HAIL_WATCHED_BRANCHES
              value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'

--- a/dev-docs/development_process.md
+++ b/dev-docs/development_process.md
@@ -121,7 +121,7 @@ it sees a new PR, it creates a new batch that will test everything defined in
 the build.yaml file in the root of the repository. This will create a temporary
 namespace in kubernetes for your PR and deploy all the services into it. It will
 also run all the tests such as for query, batch, and ci after merging it with
-the latest version of master. You can view the progress of the build and the
+the latest version of main. You can view the progress of the build and the
 logs for your PR at [ci.hail.is](https://ci.hail.is).
 
 
@@ -154,10 +154,10 @@ review towards the bottom of the Conversation page.
 ## Merge / Deploy
 
 Once a PR has been approved, our continuous integration service (CI) will squash
-merge the commits in the PR into the master branch of the repository. This will
+merge the commits in the PR into the main branch of the repository. This will
 then trigger a deploy batch. The deploy batch will first deploy all of the new
 Docker images, redeploy the running services in the default namespace with the
-latest changes, and rerun all of the tests with the new version of master
+latest changes, and rerun all of the tests with the new version of main
 incorporating your changes.
 
 If this batch fails, a Zulip message will be sent to the entire team linking to

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -175,10 +175,13 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
     app_name : :obj:`str`
         Spark application name.
     master : :obj:`str`, optional
-        Spark master.
+        URL identifying the Spark leader (master) node or `local[N]` for local clusters.
     local : :obj:`str`
-       Local-mode master, used if `master` is not defined here or in the
-       Spark configuration.
+       Local-mode core limit indicator. Must either be `local[N]` where N is a
+       positive integer or `local[*]`. The latter indicates Spark should use all
+       cores available. `local[*]` does not respect most containerization CPU
+       limits. This option is only used if `master` is unset and `spark.master`
+       is not set in the Spark configuration.
     log : :obj:`str`
         Local path for Hail log file. Does not currently support distributed
         file systems like Google Storage, S3, or HDFS.

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -1130,4 +1130,4 @@ Released 2018-12-07
 
 We didn't start manually curating information about user-facing changes until version 0.2.4.
 
-The full commit history is available [here](https://github.com/hail-is/hail/commits/master).
+The full commit history is available [here](https://github.com/hail-is/hail/commits/trunk).

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -1130,4 +1130,4 @@ Released 2018-12-07
 
 We didn't start manually curating information about user-facing changes until version 0.2.4.
 
-The full commit history is available [here](https://github.com/hail-is/hail/commits/trunk).
+The full commit history is available [here](https://github.com/hail-is/hail/commits/main).

--- a/hail/python/hail/docs/cloud/general_advice.rst
+++ b/hail/python/hail/docs/cloud/general_advice.rst
@@ -56,7 +56,7 @@ and 10 preemptible, 8-core workers running for 2 hours is:
 
     2 * (2  * 8 * 0.0575 +  # non-preemptible workers
          10 * 8 * 0.02   +  # preemptible workers
-         1  * 8 * 0.0575)   # master node
+         1  * 8 * 0.0575)   # leader (master) node
 
 2.98 USD.
 

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -76,7 +76,7 @@ project is a good candidate for merging.
 Keep in mind the following principles when submitting a pull request:
 
 - A PR should focus on a single feature. Multiple features should be split into multiple PRs.
-- Before submitting your PR, you should rebase onto the latest trunk.
+- Before submitting your PR, you should rebase onto the latest main.
 - PRs must pass all tests before being merged. See the section above on `Running the tests`_ locally.
 - PRs require a review before being merged. We will assign someone from our dev team to review your PR.
 - When you make a PR, include a short message that describes the purpose of the

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -76,7 +76,7 @@ project is a good candidate for merging.
 Keep in mind the following principles when submitting a pull request:
 
 - A PR should focus on a single feature. Multiple features should be split into multiple PRs.
-- Before submitting your PR, you should rebase onto the latest master.
+- Before submitting your PR, you should rebase onto the latest trunk.
 - PRs must pass all tests before being merged. See the section above on `Running the tests`_ locally.
 - PRs require a review before being merged. We will assign someone from our dev team to review your PR.
 - When you make a PR, include a short message that describes the purpose of the

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2333,16 +2333,16 @@ class BlockMatrix(object):
 
         Warning
         -------
-        The first and third stages invoke distributed matrix
-        multiplication with parallelism bounded by the number of resulting
-        blocks, whereas the second stage is executed on the master node.
-        For matrices of large minimum dimension, it may be preferable to
-        run these stages separately.
+        The first and third stages invoke distributed matrix multiplication with
+        parallelism bounded by the number of resulting blocks, whereas the
+        second stage is executed on the leader (master) node.  For matrices of
+        large minimum dimension, it may be preferable to run these stages
+        separately.
 
-        The performance of the second stage depends critically on the number
-        of master cores and the NumPy / SciPy configuration, viewable
-        with ``np.show_config()``. For Intel machines, we recommend installing
-        the `MKL <https://anaconda.org/anaconda/mkl>`__ package for Anaconda.
+        The performance of the second stage depends critically on the number of
+        leader (master) cores and the NumPy / SciPy configuration, viewable with
+        ``np.show_config()``. For Intel machines, we recommend installing the
+        `MKL <https://anaconda.org/anaconda/mkl>`__ package for Anaconda.
 
         Consequently, the optimal value of `complexity_bound` is highly
         configuration-dependent.

--- a/hail/python/hail/stats/linear_mixed_model.py
+++ b/hail/python/hail/stats/linear_mixed_model.py
@@ -247,7 +247,7 @@ class LinearMixedModel(object):
     likelihood ratio test:
 
     - :meth:`fit_alternatives_numpy` takes one or two ndarrays. It is a pure Python
-      method that evaluates alternatives serially on master.
+      method that evaluates alternatives serially on leader (master).
 
     - :meth:`fit_alternatives` takes one or two paths to block matrices. It
       evaluates alternatives in parallel on the workers.
@@ -752,7 +752,7 @@ class LinearMixedModel(object):
 
         Notes
         -----
-        This Python-only implementation runs serially on master. See
+        This Python-only implementation runs serially on leader (master). See
         the scalable implementation :meth:`fit_alternatives` for documentation
         of the returned table.
 
@@ -895,11 +895,11 @@ class LinearMixedModel(object):
 
         Notes
         -----
-        This method eigendecomposes :math:`K = P^T S P` on the master and
-        returns ``LinearMixedModel(p @ y, p @ x, s)`` and ``p``.
+        This method eigendecomposes :math:`K = P^T S P` on the leader (master)
+        and returns ``LinearMixedModel(p @ y, p @ x, s)`` and ``p``.
 
-        The performance of eigendecomposition depends critically on the
-        number of master cores and the NumPy / SciPy configuration, viewable
+        The performance of eigendecomposition depends critically on the number
+        of leader (master) cores and the NumPy / SciPy configuration, viewable
         with ``np.show_config()``. For Intel machines, we recommend installing
         the `MKL <https://anaconda.org/anaconda/mkl>`__ package for Anaconda.
 

--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -11,7 +11,7 @@ def init_parser(parser):
                         choices=['notebook', 'nb', 'spark-ui', 'ui', 'spark-history', 'hist'],
                         help='Web service to launch.')
     parser.add_argument('--port', '-p', default='10000', type=str,
-                        help='Local port to use for SSH tunnel to master node (default: %(default)s).')
+                        help='Local port to use for SSH tunnel to leader (master) node (default: %(default)s).')
     parser.add_argument('--zone', '-z', type=str, help='Compute zone for Dataproc cluster.')
     parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
@@ -59,7 +59,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     if not args.dry_run:
         print("Connecting to cluster '{}'...".format(args.name))
 
-        # open SSH tunnel to master node
+        # open SSH tunnel to leader (master) node
         sp.check_call(
             cmd,
             stderr=sp.STDOUT

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -16,7 +16,8 @@ DEFAULT_PROPERTIES = {
     'dataproc:dataproc.monitoring.stackdriver.enable': 'false'
 }
 
-# master machine type to memory map, used for setting spark.driver.memory property
+# leadre (master) machine type to memory map, used for setting
+# spark.driver.memory property
 MACHINE_MEM = {
     'n1-standard-1': 3.75,
     'n1-standard-2': 7.5,

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -66,7 +66,7 @@ git push origin $HAIL_PIP_VERSION
 # make GitHub release
 curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/hail/releases -d '{
   "tag_name": "'$HAIL_PIP_VERSION'",
-  "target_commitish": "trunk",
+  "target_commitish": "main",
   "name": "'$HAIL_PIP_VERSION'",
   "body": "Hail version '$HAIL_PIP_VERSION'",
   "draft": false,

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -66,7 +66,7 @@ git push origin $HAIL_PIP_VERSION
 # make GitHub release
 curl -XPOST -H @$GITHUB_OAUTH_HEADER_FILE https://api.github.com/repos/hail-is/hail/releases -d '{
   "tag_name": "'$HAIL_PIP_VERSION'",
-  "target_commitish": "master",
+  "target_commitish": "trunk",
   "name": "'$HAIL_PIP_VERSION'",
   "body": "Hail version '$HAIL_PIP_VERSION'",
   "draft": false,

--- a/site/www/references.md
+++ b/site/www/references.md
@@ -1,7 +1,10 @@
 <div id='references' class='width-960'>
 <div id="hero" class='dark short'>
-<div id="hero-content" class='wide'>
-<h1 id="logo-title">Hail-Powered Science</h1><div class="logo-subtitle">An incomplete list of scientific work enabled by Hail.</div></div></div>
+  <div id="hero-content" class='wide'>
+    <h1 id="logo-title">Hail-Powered Science</h1>
+    <div class="logo-subtitle">An incomplete list of scientific work enabled by Hail.</div>
+  </div>
+</div>
 
 
 <div class='about'>
@@ -16,7 +19,7 @@ Or you could include the following line in your bibliography:
 
 <pre class='sourceCode'><code>Hail Team. Hail 0.2. https://github.com/hail-is/hail</code></pre>
 
-Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/master/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
+Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/trunk/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
 
 *Last updated on March 30th, 2020*
 
@@ -133,5 +136,6 @@ Otherwise, we welcome you to add additional examples by [editing this page direc
 
 *Footnote*
 In addition to software development, the Hail team engages in theoretical, algorithmic, and empirical research inspired by scientific collaboration. Examples include [Loss landscapes of regularized linear autoencoders](https://github.com/danielkunin/Regularized-Linear-Autoencoders), [Secure multi-party linear regression at plaintext speed](https://github.com/jbloom22/DASH), and [A synthetic-diploid benchmark for accurate variant-calling evaluation](https://www.nature.com/articles/s41592-018-0054-7).
+</div>
 </div>
 </div>

--- a/site/www/references.md
+++ b/site/www/references.md
@@ -19,7 +19,7 @@ Or you could include the following line in your bibliography:
 
 <pre class='sourceCode'><code>Hail Team. Hail 0.2. https://github.com/hail-is/hail</code></pre>
 
-Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/trunk/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
+Otherwise, we welcome you to add additional examples by [editing this page directly](https://github.com/hail-is/hail/edit/main/site/www/references.md), after which we will review the pull request to confirm the addition is valid. Please adhere to the existing formatting conventions.
 
 *Last updated on March 30th, 2020*
 


### PR DESCRIPTION
I mixed the required changes with some cosmetic changes to, e.g. docs and comments.

I also added a missing </div> in references.md.

AFAICT, there's no way to change the default branch yet, so I didn't change the PR test CI's test repo's branch yet.

This change will change the references page on the site as soon as its merged, so we should be prepared to switch over when we merge it.