### PR TITLE
[batch] Add fluentd support to worker

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -55,6 +55,6 @@ create-build-worker-image-instance:
 
 .PHONY: create-worker-image
 create-worker-image:
-	-gcloud -q compute --project $(PROJECT) images delete batch-worker-8
-	gcloud -q compute --project $(PROJECT) images create batch-worker-8 --source-disk=build-batch-worker-image --source-disk-zone=$(ZONE)
+	-gcloud -q compute --project $(PROJECT) images delete batch-worker-9
+	gcloud -q compute --project $(PROJECT) images create batch-worker-9 --source-disk=build-batch-worker-image --source-disk-zone=$(ZONE)
 	gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch-worker-image

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -254,7 +254,7 @@ nohup /bin/bash run.sh >run.log 2>&1 &
 '''
                 }, {
                     'key': 'run_script',
-                    'value': '''
+                    'value': r'''
 #!/bin/bash
 set -x
 

--- a/batch/build-batch-worker-image-startup.sh
+++ b/batch/build-batch-worker-image-startup.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+bash add-logging-agent-repo.sh
+
 apt-get update
 
 apt-get install -y \
     apt-transport-https \
     ca-certificates \
     curl \
+    google-fluentd \
+    google-fluentd-catch-all-config-structured \
     jq \
     software-properties-common
 
@@ -34,5 +39,7 @@ docker-credential-gcr configure-docker
 
 docker pull ubuntu:18.04
 docker pull google/cloud-sdk:269.0.0-alpine
+
+service google-fluentd start
 
 shutdown -h now

--- a/batch/build-batch-worker-image-startup.sh
+++ b/batch/build-batch-worker-image-startup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-curl -sSO https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+set -ex
+
+curl --silent --show-error --remote-name --fail https://dl.google.com/cloudagents/add-logging-agent-repo.sh
 bash add-logging-agent-repo.sh
 
 apt-get update


### PR DESCRIPTION
This should wait for #9184 

This PR adds fluentd support for streaming the logs to Logs Viewer.

Things to Note:
-  I didn't have to setup the authorization at all, so I believe it's using the service account on the worker which would be the batch2 service account. I had to give that service account Logs Writer permissions. This is the same service account regardless of the namespace.
- All namespaces have output written.
- I added some labels of the instance id and namespace to help with searching. Let me know if you think we need something else.
- I used a filter to parse the JSON in the worker log to get the right timestamp of the record rather than the publication of the log message in the Logs Viewer

Example Stackdriver Queries:

```
resource.type="gce_instance"
labels.namespace="jigold"
logName="projects/hail-vdc/logs/worker.log"
```

```
resource.type="gce_instance"
labels."compute.googleapis.com/resource_name"="batch-worker-jigold-uyvo5"
logName="projects/hail-vdc/logs/worker.log"
```

I basically just followed this: https://cloud.google.com/logging/docs/agent

Will attempt to get dockerd logs in some other time.