### PR TITLE
[batch] fix Backend missing ABC

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from .job import Job  # pylint: disable=cyclic-import # noqa: F401
 
 
-class Backend:
+class Backend(abc.ABC):
     """
     Abstract class for backends.
     """


### PR DESCRIPTION
Without this abstract* decorators have no effect, class isn't abstract.