### PR TITLE
[address] retry address

### DIFF
--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -5,7 +5,7 @@ import os
 import json
 import logging
 from aiohttp import web
-from ..utils import first_extant_file
+from ..utils import retry_transient_errors, first_extant_file
 from ..tls import get_context_specific_ssl_client_session
 
 log = logging.getLogger('deploy_config')
@@ -118,7 +118,8 @@ class DeployConfig:
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=5),
                 headers=headers) as session:
-            async with await session.get(
+            async with await retry_transient_errors(
+                    session.get,
                     self.url('address', f'/api/{service}')) as resp:
                 dicts = await resp.json()
                 return [(d['address'], d['port']) for d in dicts]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1,3 +1,4 @@
+from typing import Callable, TypeVar, Awaitable
 import os
 import errno
 import random
@@ -333,7 +334,10 @@ def retry_all_errors(msg=None, error_logging_interval=10):
     return _wrapper
 
 
-async def retry_transient_errors(f, *args, **kwargs):
+T = TypeVar('T')
+
+
+async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
     delay = 0.1
     errors = 0
     while True:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -334,7 +334,7 @@ def retry_all_errors(msg=None, error_logging_interval=10):
     return _wrapper
 
 
-T = TypeVar('T')
+T = TypeVar('T')  # pylint: disable=invalid-name
 
 
 async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs) -> T:


### PR DESCRIPTION
This PR changes the `addresses` function on `DeployConfig` to retry all transient errors. In particular, if the address service is temporarily down (maybe its getting redeployed), this change allows the client to repeatedly retry until the address service comes back to life.

I also added some type annotations to `retry_transient_errors`. It takes a function that returns something we can `await` and then applies that function in a loop until it does not raise an error.