### PR TITLE
[query] Fix errors in LowerToCDA.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -266,6 +266,7 @@ object Pretty {
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case TailLoop(name, args, _) => prettyIdentifier(name) + " " + prettyIdentifiers(args.map(_._1).toFastIndexedSeq)
             case Recur(name, _, t) => prettyIdentifier(name) + " " + t.parsableString()
+            // case Ref(name, t) => prettyIdentifier(name) + Option(t).map(x => s" $x").getOrElse("")  // For debug purposes
             case Ref(name, _) => prettyIdentifier(name)
             case RelationalRef(name, t) => prettyIdentifier(name) + " " + t.parsableString()
             case RelationalLet(name, _, _) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -473,6 +473,7 @@ object TypeCheck {
       case x@WriteValue(value, path, spec) =>
         assert(path.typ == TString)
       case LiftMeOut(_) =>
+      case Consume(_) =>
       case x@ShuffleWith(_, _, _, _, _, writer, readers) =>
         assert(writer.typ == TArray(TBinary))
         assert(readers.typ.isRealizable)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -129,7 +129,7 @@ object UtilFunctions extends RegistryFunctions {
       case(_: Type, _: PType, _: PType, _: PType, _: PType) => PBoolean()
     }) {
       case (er, rt, (lT, l), (rT, r), (tolT, tolerance), (absT, absolute)) =>
-        assert(lT.virtualType == rT.virtualType)
+        assert(lT.virtualType == rT.virtualType, s"\n  lt=${lT.virtualType}\n  rt=${rT.virtualType}")
         val lb = boxArg(er, lT)(l)
         val rb = boxArg(er, rT)(r)
         er.mb.getType(lT.virtualType).invoke[Any, Any, Double, Boolean, Boolean]("valuesSimilar", lb, rb, tolerance, absolute)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -21,7 +21,8 @@ trait LoweringPass {
   protected def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR
 }
 
-case class OptimizePass(context: String) extends LoweringPass {
+case class OptimizePass(_context: String) extends LoweringPass {
+  val context = s"optimize: ${_context}"
   val before: IRState = AnyIR
   val after: IRState = AnyIR
   def transform(ctx: ExecuteContext, ir: BaseIR): BaseIR = Optimize(ir, true, context, ctx)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -67,9 +67,7 @@ object LoweringPipeline {
       OptimizePass("darrayLowerer, after LowerMatrixToTable"),
       LiftRelationalValuesToRelationalLets,
       LowerToDistributedArrayPass(DArrayLowering.All),
-      OptimizePass("darrayLowerer, after LowerToCDA"),
-      OptimizePass("darrayLowerer, after LowerToCDA AGAIN"),
-      OptimizePass("darrayLowerer, after LowerToCDA AGAIN")
+      OptimizePass("darrayLowerer, after LowerToCDA")
     ),
     DArrayLowering.TableOnly -> LoweringPipeline(
       OptimizePass("darrayLowerer, initial IR"),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir.{BaseIR, ExecuteContext}
+import is.hail.expr.ir.{BaseIR, ExecuteContext, TypeCheck}
 import is.hail.utils._
 
 case class LoweringPipeline(lowerings: LoweringPass*) {
@@ -16,6 +16,12 @@ case class LoweringPipeline(lowerings: LoweringPass*) {
         case e: Throwable =>
           log.error(s"error while applying lowering '${ l.context }'")
           throw e
+      }
+      try {
+        TypeCheck(x)
+      } catch {
+        case e: Throwable =>
+          fatal(s"error after applying ${ l.context }", e)
       }
     }
 
@@ -61,7 +67,9 @@ object LoweringPipeline {
       OptimizePass("darrayLowerer, after LowerMatrixToTable"),
       LiftRelationalValuesToRelationalLets,
       LowerToDistributedArrayPass(DArrayLowering.All),
-      OptimizePass("darrayLowerer, after LowerToCDA")
+      OptimizePass("darrayLowerer, after LowerToCDA"),
+      OptimizePass("darrayLowerer, after LowerToCDA AGAIN"),
+      OptimizePass("darrayLowerer, after LowerToCDA AGAIN")
     ),
     DArrayLowering.TableOnly -> LoweringPipeline(
       OptimizePass("darrayLowerer, initial IR"),

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.TestUtils._
+import is.hail.expr.ir.TestUtils._
 import is.hail.asm4s.Code
 import is.hail.expr.ir.functions.{IRRandomness, RegistryFunctions}
 import is.hail.types.physical.{PInt32, PInt64}
@@ -135,7 +136,7 @@ class RandomFunctionsSuite extends HailSuite {
           "counter" -> counter)))
 
     val expected = Interpret(tir, ctx).rvd.toRows.collect()
-    val actual = CompileAndEvaluate[IndexedSeq[Row]](ctx, GetField(TableCollect(tir), "rows"), false)
+    val actual = CompileAndEvaluate[IndexedSeq[Row]](ctx, GetField(collect(tir), "rows"), false)
 
     assert(expected.sameElements(actual))
   }

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -14,13 +14,6 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 
 class TableIRSuite extends HailSuite {
-  def rangeKT: TableIR = TableKeyBy(TableRange(20, 4), FastIndexedSeq())
-
-  def collect(tir: TableIR): IR =
-    TableAggregate(tir, MakeStruct(FastSeq(
-      "rows" -> IRAggCollect(Ref("row", tir.typ.rowType)),
-      "global" -> Ref("global", tir.typ.globalType))))
-  def collectNoKey(tir: TableIR): IR = TableCollect(tir)
 
   implicit val execStrats: Set[ExecStrategy] = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
 

--- a/hail/src/test/scala/is/hail/expr/ir/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TestUtils.scala
@@ -6,6 +6,14 @@ import is.hail.utils.{FastIndexedSeq, FastSeq}
 import is.hail.variant.Call
 
 object TestUtils {
+  def rangeKT: TableIR = TableKeyBy(TableRange(20, 4), FastIndexedSeq())
+
+  def collect(tir: TableIR): IR =
+    TableAggregate(tir, MakeStruct(FastSeq(
+      "rows" -> IRAggCollect(Ref("row", tir.typ.rowType)),
+      "global" -> Ref("global", tir.typ.globalType))))
+  def collectNoKey(tir: TableIR): IR = TableCollect(tir)
+
   def toIRInt(i: Integer): IR =
     if (i == null)
       NA(TInt32)


### PR DESCRIPTION
* Fix error in TableKeyByAndAggregate caused by field name clobbering
* Fix error in TableLeftJoinRightDistinct with non-strict left tables
* Fix erroneous key preservation in TableStage.mapPartition
* Add Consume to TypeCheck
* Fix error where globals were not exposed in TableAggregate
* Fix error where globals were not exposed in TableAggregate

New local backend success rate:

```
271 failed, 496 passed, 75 skipped, 15 warnings in 368.17 seconds
```