### PR TITLE
[query] Remove PType.copyFromPValue, replace with PCode.castTo

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -121,11 +121,13 @@ object PCode {
       new PCanonicalNDArrayCode(pt, coerce[Long](code))
     case pt: PCanonicalStream =>
       throw new UnsupportedOperationException(s"Can't PCode.apply unrealizable PType: $pt")
+    case PVoid =>
+      throw new UnsupportedOperationException(s"Can't PCode.apply unrealizable PType: $pt")
     case _ =>
       new PPrimitiveCode(pt, code)
   }
 
-  def _empty: PCode = PCode(PVoid, Code._empty)
+  def _empty: PCode = PVoidCode
 }
 
 object PSettable {

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -461,8 +461,6 @@ abstract class PType extends Serializable with Requiredness {
 
   def defaultValue: PCode = PCode(this, ir.defaultValue(this))
 
-  def copyFromPValue(mb: EmitMethodBuilder[_], region: Value[Region], pv: PCode): PCode =
-    PCode(this, copyFromTypeAndStackValue(mb, region, pv.pt, pv.code))
 
   final def typeCheck(a: Any): Boolean = a == null || _typeCheck(a)
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -24,11 +24,6 @@ trait PUnrealizable extends PType {
   def copyFromTypeAndStackValue(mb: EmitMethodBuilder[_], region: Value[Region], srcPType: PType, stackValue: Code[_], deepCopy: Boolean): Code[_] =
     unsupported
 
-  override def copyFromPValue(mb: EmitMethodBuilder[_], region: Value[Region], pv: PCode): PCode = {
-    assert(pv.pt == this)
-    pv
-  }
-
   protected def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     unsupported
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -63,4 +63,9 @@ trait PUnrealizableCode extends PCode {
     unsupported
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PValue = unsupported
+
+  override def castTo(mb: EmitMethodBuilder[_], region: Value[Region], destPtype: PType): PCode = {
+    assert(destPtype == pt)
+    this
+  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PVoid.scala
@@ -1,7 +1,7 @@
 package is.hail.types.physical
 import is.hail.annotations.{CodeOrdering, Region, UnsafeOrdering}
-import is.hail.asm4s.{Code, MethodBuilder, Value}
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.asm4s.{Code, MethodBuilder, Value, TypeInfo, UnitInfo}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.virtual.{TVoid, Type}
 
 case object PVoid extends PType with PUnrealizable {
@@ -16,4 +16,22 @@ case object PVoid extends PType with PUnrealizable {
   def setRequired(required: Boolean) = PVoid
 
   override def unsafeOrdering(): UnsafeOrdering = throw new NotImplementedError()
+}
+
+case object PVoidCode extends PCode with PUnrealizableCode { self =>
+  override def typeInfo: TypeInfo[_] = UnitInfo
+
+  override def code: Code[_] = Code._empty
+
+  override def tcode[T](implicit ti: TypeInfo[T]): Code[T] = {
+    assert(ti == typeInfo)
+    code.asInstanceOf[Code[T]]
+  }
+
+  def pt: PType = PVoid
+
+  def memoize(cb: EmitCodeBuilder, name: String): PValue = new PValue {
+    val pt = self.pt
+    def get: PCode = self
+  }
 }


### PR DESCRIPTION
This is the first in a series of changes that will push PCode through more of
the PType construction interfaces. The intent is to reduce code duplication,
and have as few interfaces as possible where `Code[_]` or `Code[Long]`
represents a hail type.