### PR TITLE
[query] Fix expression source mismatch exceptions

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -345,12 +345,12 @@ def unify_all(*exprs) -> Tuple[Indices, LinkedList]:
             from .expression_utils import get_refs
             for name, inds in get_refs(e, *[e for a in e._aggregations for e in a.exprs]).items():
                 sources[inds.source].append(str(name))
-                raise ExpressionException(
-                    "Cannot combine expressions from different source objects."
-                    "\n    Found fields from {n} objects:{fields}".format(
-                        n=len(sources),
-                        fields=''.join("\n        {}: {}".format(src, fds) for src, fds in sources.items())
-                    )) from None
+        raise ExpressionException(
+            "Cannot combine expressions from different source objects."
+            "\n    Found fields from {n} objects:{fields}".format(
+                n=len(sources),
+                fields=''.join("\n        {}: {}".format(src, fds) for src, fds in sources.items())
+            )) from None
     first, rest = exprs[0], exprs[1:]
     aggregations = first._aggregations
     for e in rest:

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1574,6 +1574,13 @@ class Tests(unittest.TestCase):
         mt = mt.group_cols_by(x=mt.col_idx // 10).aggregate(c=hl.agg.count())
         assert mt.entries().collect() == [hl.Struct(row_idx=0, x=0, c=0)]
 
+    def test_invalid_field_ref_error(self):
+        mt = hl.balding_nichols_model(2, 5, 5)
+        mt2 = hl.balding_nichols_model(2, 5, 5)
+        with pytest.raises(hl.expr.ExpressionException, match='Found fields from 2 objects:'):
+            mt.annotate_entries(x = mt.GT.n_alt_alleles() * mt2.af)
+
+
 def test_read_write_all_types():
     mt = create_all_values_matrix_table()
     tmp_file = new_temp_file()


### PR DESCRIPTION
Whitespace-only bugfix. Yay Python!

Fixes #9163