### PR TITLE
[query][smm 2] Use stream region management in tests

### DIFF
--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -257,13 +257,27 @@ class SparkBackend(
     case Right((pt, off)) => SafeRow(pt, off).get(0)
   }
 
-  def jvmLowerAndExecute(ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Any, ExecutionTimer) =
-    withExecuteContext() { ctx =>
-      val (l, r) = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
-      (executionResultToAnnotation(ctx, l), r)
-    }
+  def jvmLowerAndExecute(
+    ir0: IR,
+    optimize: Boolean,
+    lowerTable: Boolean,
+    lowerBM: Boolean,
+    print: Option[PrintWriter] = None,
+    allocStrat: EmitAllocationStrategy.T
+  ): (Any, ExecutionTimer) = withExecuteContext() { ctx =>
+    val (l, r) = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print, allocStrat)
+    (executionResultToAnnotation(ctx, l), r)
+  }
 
-  private[this] def _jvmLowerAndExecute(ctx: ExecuteContext, ir0: IR, optimize: Boolean, lowerTable: Boolean, lowerBM: Boolean, print: Option[PrintWriter] = None): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+  private[this] def _jvmLowerAndExecute(
+    ctx: ExecuteContext,
+    ir0: IR,
+    optimize: Boolean,
+    lowerTable: Boolean,
+    lowerBM: Boolean,
+    print: Option[PrintWriter] = None,
+    allocStrat: EmitAllocationStrategy.T
+  ): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
     val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
       case (true, true) => DArrayLowering.All
       case (true, false) => DArrayLowering.TableOnly
@@ -282,7 +296,8 @@ class SparkBackend(
             FastIndexedSeq[(String, PType)](),
             FastIndexedSeq(classInfo[Region]), UnitInfo,
             ir,
-            print = print)
+            print = print,
+            allocStrat = allocStrat)
         }
         ctx.timer.time("Run")(Left(f(0, ctx.r)(ctx.r)))
 
@@ -292,7 +307,8 @@ class SparkBackend(
             FastIndexedSeq[(String, PType)](),
             FastIndexedSeq(classInfo[Region]), LongInfo,
             MakeTuple.ordered(FastSeq(ir)),
-            print = print)
+            print = print,
+            allocStrat = allocStrat)
         }
         ctx.timer.time("Run")(Right((pt, f(0, ctx.r).apply(ctx.r))))
     }
@@ -300,19 +316,19 @@ class SparkBackend(
     (res, ctx.timer)
   }
 
-  def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) =
+  def execute(ir: IR, optimize: Boolean, allocStrat: EmitAllocationStrategy.T = EmitAllocationStrategy.OneRegion): (Any, ExecutionTimer) =
     withExecuteContext() { ctx =>
-      val (l, r) = _execute(ctx, ir, optimize)
+      val (l, r) = _execute(ctx, ir, optimize, allocStrat)
       (executionResultToAnnotation(ctx, l), r)
     }
 
-  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean, allocStrat: EmitAllocationStrategy.T): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
     TypeCheck(ir)
     Validate(ir)
     try {
       val lowerTable = HailContext.getFlag("lower") != null
       val lowerBM = HailContext.getFlag("lower_bm") != null
-      _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM)
+      _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM, allocStrat = allocStrat)
     } catch {
       case _: LowererUnsupportedOperation =>
         (CompileAndEvaluate._apply(ctx, ir, optimize = optimize), ctx.timer)
@@ -329,10 +345,10 @@ class SparkBackend(
     Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
   }
 
-  def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) = {
+  def encodeToBytes(ir: IR, bufferSpecString: String, allocStrat: EmitAllocationStrategy.T = EmitAllocationStrategy.OneRegion): (String, Array[Byte]) = {
     val bs = BufferSpec.parseOrDefault(bufferSpecString)
     withExecuteContext() { ctx =>
-      _execute(ctx, ir, true)._1 match {
+      _execute(ctx, ir, true, allocStrat = allocStrat)._1 match {
         case Left(_) => throw new RuntimeException("expression returned void")
         case Right((t, off)) =>
           assert(t.size == 1)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -345,7 +345,11 @@ class SparkBackend(
     Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
   }
 
-  def encodeToBytes(ir: IR, bufferSpecString: String, allocStrat: EmitAllocationStrategy.T = EmitAllocationStrategy.OneRegion): (String, Array[Byte]) = {
+  // Called from python
+  def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) =
+    encodeToBytes(ir, bufferSpecString, EmitAllocationStrategy.OneRegion)
+
+  def encodeToBytes(ir: IR, bufferSpecString: String, allocStrat: EmitAllocationStrategy.T): (String, Array[Byte]) = {
     val bs = BufferSpec.parseOrDefault(bufferSpecString)
     withExecuteContext() { ctx =>
       _execute(ctx, ir, true, allocStrat = allocStrat)._1 match {

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -24,7 +24,8 @@ object Compile {
     expectedCodeParamTypes: IndexedSeq[TypeInfo[_]], expectedCodeReturnType: TypeInfo[_],
     body: IR,
     optimize: Boolean = true,
-    print: Option[PrintWriter] = None
+    print: Option[PrintWriter] = None,
+    allocStrat: EmitAllocationStrategy.T = EmitAllocationStrategy.OneRegion
   ): (PType, (Int, Region) => F) = {
 
     val normalizeNames = new NormalizeNames(_.toString)
@@ -68,7 +69,7 @@ object Compile {
     assert(fb.mb.parameterTypeInfo == expectedCodeParamTypes, s"expected $expectedCodeParamTypes, got ${ fb.mb.parameterTypeInfo }")
     assert(fb.mb.returnTypeInfo == expectedCodeReturnType, s"expected $expectedCodeReturnType, got ${ fb.mb.returnTypeInfo }")
 
-    Emit(ctx, ir, fb)
+    Emit(ctx, ir, fb, allocStrat = allocStrat)
 
     val f = fb.resultWithIndex(print)
     codeCache += k -> CodeCacheValue(ir.pType, f)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -155,7 +155,8 @@ object TestUtils {
   ): Any = {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
-    HailContext.sparkBackend("TestUtils.loweredExecute").jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter)._1
+    HailContext.sparkBackend("TestUtils.loweredExecute")
+               .jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter, allocStrat = EmitAllocationStrategy.ManyRegions)._1
   }
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)
@@ -219,7 +220,8 @@ object TestUtils {
             FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
             aggIR,
             print = bytecodePrinter,
-            optimize = optimize)
+            optimize = optimize,
+            allocStrat = EmitAllocationStrategy.ManyRegions)
           assert(resultType2.virtualType == resultType)
 
           Region.scoped { region =>
@@ -252,7 +254,8 @@ object TestUtils {
             FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
             MakeTuple.ordered(FastSeq(rewrite(Subst(x, BindingEnv(substEnv))))),
             optimize = optimize,
-            print = bytecodePrinter)
+            print = bytecodePrinter,
+            allocStrat = EmitAllocationStrategy.ManyRegions)
           assert(resultType2.virtualType == resultType)
 
           Region.scoped { region =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3716,7 +3716,7 @@ class IRSuite extends HailSuite {
         |       (MakeStruct (locus  (Apply start Locus(GRCh37) (Ref __uid_3))))
         |       (MakeStruct (locus  (Apply end Locus(GRCh37) (Ref __uid_3)))) (True) (False))))
         |""".stripMargin)
-    val (v, _) = backend.execute(ir, optimize = true)
+    val (v, _) = backend.execute(ir, optimize = true, allocStrat = EmitAllocationStrategy.ManyRegions)
     assert(
       ir.typ.ordering.equiv(
         FastIndexedSeq(


### PR DESCRIPTION
~~Stacked on #9106.~~

Adds an enumeration to control the allocation strategy in emitted code. There are currently three options, `Default`, `OneRegion`, and `ManyRegions`. `OneRegion` replicates the current behavior, and is the default for now. `ManyRegions` always allocates new regions when given the choice. This PR makes Java tests use the `ManyRegions` strategy to catch more lifetime errors. `Default` is somewhere in the middle, and will become the default. It will use one region (at least a constant number of regions) per row of a table. `Default` currently behaves the same as `ManyRegions`. Future work will implement the per-row behavior.