### PR TITLE
[query] NDArray Slice with Indices Needs Bounds Checks

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3617,7 +3617,7 @@ class NDArrayExpression(Expression):
                         stop = hl.cond(step > 0, dlen, to_expr(-1, tint64))
 
                     slices.append(hl.tuple((start, stop, step)))
-                else:  # Not a slice, just an int index
+                else:
                     adjusted_index = hl.if_else(s < 0, s + dlen, s)
                     checked_int = hl.case().when((adjusted_index < dlen) & (adjusted_index >= 0), adjusted_index).or_error(
                         hl.str("Index ") + hl.str(s) + hl.str(f" is out of bounds for axis {i} with size ") + hl.str(dlen)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3583,8 +3583,8 @@ class NDArrayExpression(Expression):
         if n_sliced_dims > 0:
             slices = []
             for i, s in enumerate(item):
+                dlen = self.shape[i]
                 if isinstance(s, slice):
-                    dlen = self.shape[i]
 
                     if s.step is not None:
                         step = hl.case().when(s.step != 0, s.step) \
@@ -3617,8 +3617,12 @@ class NDArrayExpression(Expression):
                         stop = hl.cond(step > 0, dlen, to_expr(-1, tint64))
 
                     slices.append(hl.tuple((start, stop, step)))
-                else:
-                    slices.append(s)
+                else:  # Not a slice, just an int index
+                    adjusted_index = hl.if_else(s < 0, s + dlen, s)
+                    checked_int = hl.case().when((adjusted_index < dlen) & (adjusted_index >= 0), adjusted_index).or_error(
+                        hl.str("Index ") + hl.str(s) + hl.str(f" is out of bounds for axis {i} with size ") + hl.str(dlen)
+                    )
+                    slices.append(checked_int)
             return construct_expr(ir.NDArraySlice(self._ir, hl.tuple(slices)._ir),
                                   tndarray(self._type.element_type, n_sliced_dims),
                                   self._indices,

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -85,6 +85,7 @@ def test_ndarray_slice():
         (rect_prism[0:, :, 1:4:2] + rect_prism[:, :1, 1:4:2],
          np_rect_prism[0:, :, 1:4:2] + np_rect_prism[:, :1, 1:4:2]),
         (rect_prism[0, 0, -3:-1], np_rect_prism[0, 0, -3:-1]),
+        (rect_prism[-1, 0:1, 3:0:-1], np_rect_prism[-1, 0:1, 3:0:-1]),
 
         (flat[15:5:-1], np_flat[15:5:-1]),
         (flat[::-1], np_flat[::-1]),
@@ -139,9 +140,14 @@ def test_ndarray_slice():
     assert hl.eval(rect_prism[:, :, 0:hl.null(hl.tint32):1]) is None
     assert hl.eval(rect_prism[hl.null(hl.tint32), :, :]) is None
 
-    with pytest.raises(FatalError) as exc:
+    with pytest.raises(FatalError, match="Slice step cannot be zero"):
         hl.eval(flat[::0])
-    assert "Slice step cannot be zero" in str(exc)
+
+    with pytest.raises(FatalError, match="Index 3 is out of bounds for axis 0 with size 2"):
+        hl.eval(mat[3, 1:3])
+
+    with pytest.raises(FatalError, match="Index -4 is out of bounds for axis 0 with size 2"):
+        hl.eval(mat[-4, 0:3])
 
 
 def test_ndarray_transposed_slice():


### PR DESCRIPTION
CHANGELOG: Fixed issue where ndarrays being sliced and indexed into in one expression didn't have sufficient bounds checks

Fixes #9144 by checking if indices provided in a slicing expression that mixes slices and single indices are out of bounds. 

Alex, please tell me if you're able to get anymore errors from #9144 with this change. I wasn't able to, but that issue was not super well defined at first so it's unclear to me if this covers all of your problems. I retitled the issue to reflect my understanding of the problems. 


More detail:

In numpy, it is ok for the upper bound of a slice to go past the end of an array, but it is not ok for an indexing operation to do the same. For example:

```
n = np.array([[1,2,3,4], [1,2,3,4]])
n[0:1000, 0:1000]
```

is allowed, the bounds just get clamped. However, this is not allowed:

```
n[1000, 1000]
```

nor is:

```
n[1000, 0:1000]
```

Hail was not handling that last case with a mix of slices and indices correctly. Namely, it was not throwing an out bounds error on the first axis index. 
