### PR TITLE
[query/combiner] Add options to better partition imported GVCFs

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner/__main__.py
+++ b/hail/python/hail/experimental/vcf_combiner/__main__.py
@@ -14,6 +14,15 @@ def main():
     parser.add_argument('out_file', help='Path to final combiner output.')
     parser.add_argument('tmp_path', help='Path to folder for intermediate output '
                                          '(should be an object store path, if running on the cloud).')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--genomes', '-G', dest='is_genomes', action='store_true',
+                       help='Indicates that the combiner is operating on genomes. '
+                            'Affects how the genome is partitioned on input.')
+    group.add_argument('--exomes', '-E', dest='is_genomes', action='store_false',
+                       help='Indicates that the combiner is operating on exomes. '
+                            'Affects how the genome is partitioned on input.')
+    group.add_argument('--import-interval-size', type=int,
+                       help='Interval size for partitioning the reference genome for GVCF import.')
     parser.add_argument('--log', help='Hail log path.')
     parser.add_argument('--header',
                         help='External header, must be readable by all executors. '
@@ -41,6 +50,8 @@ def main():
                  batch_size=args.batch_size,
                  branch_factor=args.branch_factor,
                  target_records=args.target_records,
+                 import_interval_size=args.import_interval_size,
+                 is_genomes=args.is_genomes,
                  overwrite=args.overwrite,
                  reference_genome=args.reference_genome,
                  key_by_locus_and_alleles=args.key_by_locus_and_alleles)

--- a/hail/python/test/hail/experimental/test_vcf_combiner.py
+++ b/hail/python/test/hail/experimental/test_vcf_combiner.py
@@ -52,14 +52,17 @@ def test_1kg_chr22():
         assert n == true_n, sample
         assert n_variant == true_n_variant, sample
 
+def default_exome_intervals(rg):
+    return vc.calculate_even_genome_partitioning(rg, 2 ** 32)  # 4 billion, larger than any contig
+
 def test_gvcf_1k_same_as_import_vcf():
     path = os.path.join(resource('gvcfs'), '1kg_chr22', f'HG00308.hg38.g.vcf.gz')
-    [mt] = hl.import_gvcfs([path], vc.default_exome_intervals('GRCh38'), reference_genome='GRCh38')
+    [mt] = hl.import_gvcfs([path], default_exome_intervals('GRCh38'), reference_genome='GRCh38')
     assert mt._same(hl.import_vcf(path, force_bgz=True, reference_genome='GRCh38').key_rows_by('locus'))
 
 def test_gvcf_subset_same_as_import_vcf():
     path = os.path.join(resource('gvcfs'), 'subset', f'HG00187.hg38.g.vcf.gz')
-    [mt] = hl.import_gvcfs([path], vc.default_exome_intervals('GRCh38'), reference_genome='GRCh38')
+    [mt] = hl.import_gvcfs([path], default_exome_intervals('GRCh38'), reference_genome='GRCh38')
     assert mt._same(hl.import_vcf(path, force_bgz=True, reference_genome='GRCh38').key_rows_by('locus'))
 
 def test_key_by_locus_alleles():


### PR DESCRIPTION
[query/combiner] Add options to better partition imported GVCFs

Teach the VCF combiner three new options:
  * --genomes/-G to indicate that it is operating on genomes
  * --exomes/-E to indicate that it is operating on exomes
  * --import-interval-size to more finely control the partitioning of
    the reference genome on GVCF import.

These are specified as a required mutually exclusive group, exactly one
of them must be present.

This goes along with removing `default_exome_intervals` and adding
`calculate_even_genome_partitioning`. The new function takes a reference
genome and a target interval size and computes a partitioning of the
reference into intervals of length at most the target size. It does so
by looping over the 'regular' contigs of the reference (as such it only
supports GRCh37 and GRCh38 for now) and dividing each contig's length
by the target size and rounding up, obtaining the number of partitions
the contig will be subdivided into. Then dividing the length of the
contig by the number of partitions, getting the true partition size.
Then using the true partition size, generating the intervals. This
hopefully leads to few degenerate cases where some partitions at the end
of contigs are very small.
