### PR TITLE
[query] Makefile: allow folder to be overriden

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -127,6 +127,7 @@ python/README.md: ../README.md
 $(PYTHON_JAR): shadowJar
 	cp -f $(SHADOW_JAR) $@
 
+PYTEST_ARGS = "test/hail"
 .PHONY: pytest
 pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
 pytest: python/README.md $(PYTHON_JAR)
@@ -137,7 +138,6 @@ pytest: python/README.md $(PYTHON_JAR)
      -r A \
      --self-contained-html \
      --html=../build/reports/pytest.html \
-     test/hail \
      $(PYTEST_ARGS)"
 
 .PHONY: doctest

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -127,8 +127,8 @@ python/README.md: ../README.md
 $(PYTHON_JAR): shadowJar
 	cp -f $(SHADOW_JAR) $@
 
-PYTEST_ARGS = test/hail
 .PHONY: pytest
+pytest: PYTEST_TARGET ?= test/hail
 pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
 pytest: python/README.md $(PYTHON_JAR)
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
@@ -138,6 +138,7 @@ pytest: python/README.md $(PYTHON_JAR)
      -r A \
      --self-contained-html \
      --html=../build/reports/pytest.html \
+     $(PYTEST_TARGET) \
      $(PYTEST_ARGS)"
 
 .PHONY: doctest

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -127,7 +127,7 @@ python/README.md: ../README.md
 $(PYTHON_JAR): shadowJar
 	cp -f $(SHADOW_JAR) $@
 
-PYTEST_ARGS = "test/hail"
+PYTEST_ARGS = test/hail
 .PHONY: pytest
 pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
 pytest: python/README.md $(PYTHON_JAR)


### PR DESCRIPTION
A commit from a few months ago removed the ability to specify a single file for testing.