### PR TITLE
[batch] consistently name Docker Hub

### DIFF
--- a/hail/python/hailtop/batch/docs/cookbook/clumping.rst
+++ b/hail/python/hailtop/batch/docs/cookbook/clumping.rst
@@ -88,7 +88,7 @@ The following Docker command builds this image:
     docker build -t 1kg-gwas -f Dockerfile .
 
 Batch can only access images pushed to a Docker repository. You have two repositories available to
-you: the public Dockerhub repository and your project's private Google Container Repository (GCR).
+you: the public Docker Hub repository and your project's private Google Container Repository (GCR).
 It is **not** advisable to put credentials inside any Docker image, even if it is only pushed to a
 private repository.
 
@@ -193,7 +193,7 @@ The return value is the new :class:`.Job` created.
 A couple of things to note about this function:
 
  - We use the image ``hailgenetics/genetics`` which is a publicly available Docker
-   image from Dockerhub maintained by the Hail team that contains many useful bioinformatics
+   image from Docker Hub maintained by the Hail team that contains many useful bioinformatics
    tools including PLINK.
 
  - We explicitly tell PLINK to only use 1Gi of memory because PLINK defaults to using half

--- a/hail/python/hailtop/batch/docs/docker_resources.rst
+++ b/hail/python/hailtop/batch/docs/docker_resources.rst
@@ -9,7 +9,7 @@ What is Docker?
 Docker is a tool for packaging up operating systems, scripts, and environments in order to
 be able to run the same code regardless of what machine the code is executing on. This packaged
 code is called an image. There are three parts to Docker: a mechanism for building images,
-an image repository called DockerHub, and a way to execute code in an image
+an image repository called Docker Hub, and a way to execute code in an image
 called a container. For using Batch effectively, we're only going to focus on building images.
 
 Installation

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -52,7 +52,7 @@ for more information about access control.
     gsutil iam ch serviceAccount:[SERVICE_ACCOUNT_NAME]:objectAdmin gs://[BUCKET_NAME]
 
 The Google Container Repository (GCR) is a Docker repository hosted by Google that is an alternative
-to Dockerhub for storing images. It is recommended to use GCR for images that shouldn't be publically
+to Docker Hub for storing images. It is recommended to use GCR for images that shouldn't be publically
 available. If you have a GCR `associated with your project <https://cloud.google.com/container-registry/docs/>`__,
 then you can enable the service account to view Docker images with the command below where
 `SERVICE_ACCOUNT_NAME` is your full service account name and `PROJECT_ID` is the name of your project


### PR DESCRIPTION
In #9176 Dan and I settled on Docker Hub as the preferred name for that service. This PR makes that consistent across batch docs. I left `docker_resources.rst` alone to avoid conflicting with #9176.