### PR TITLE
[query][smm 10] Memory management for grouped streams

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/StagedRegion.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StagedRegion.scala
@@ -9,6 +9,9 @@ abstract class StagedRegion {
   def code: Value[Region]
 
   def createChildRegion(mb: EmitMethodBuilder[_]): StagedOwnedRegion
+
+  def createDummyChildRegion: StagedOwnedRegion =
+    new DummyStagedOwnedRegion(code, this)
 }
 
 trait StagedOwnedRegion extends StagedRegion {

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -183,53 +183,53 @@ class EmitStreamSuite extends HailSuite {
     f(10, 3)
   }
 
-  @Test def testES2Grouped() {
-    val f = compile1[Int, Unit] { (mb, n) =>
-      val r = checkedRange(0, n, "range", mb)
-      var checkedInner: CheckedStream[Code[Int]] = null
-      val outer = r.stream.grouped(2).map { inner =>
-        checkedInner = new CheckedStream(inner, "inner", mb)
-        checkedInner.stream
-      }
-      val checkedOuter = new CheckedStream(outer, "outer", mb)
-      val run = checkedOuter.stream.forEach(mb, { inner =>
-        inner.forEach(mb, i => log(i.toS))
-      })
-
-      Code(
-        r.init, checkedOuter.init, checkedInner.init,
-        run,
-        r.assertClosed(1),
-        checkedOuter.assertClosed(1),
-        checkedInner.assertClosed((n + 1) / 2))
-    }
-    for (i <- 0 to 5) { f(i) }
-  }
-
-  @Test def testES2GroupedTake() {
-    val f = compile1[Int, Unit] { (mb, n) =>
-      val r = checkedRange(0, n, "range", mb)
-      var checkedInner: CheckedStream[Code[Int]] = null
-      val outer = r.stream.grouped(2).map { inner =>
-        val take = Stream.zip(inner, Stream.range(mb, 0, 1, 1))
-                         .map { case (i, count) => i }
-        checkedInner = new CheckedStream(take, "inner", mb)
-        checkedInner.stream
-      }
-      val checkedOuter = new CheckedStream(outer, "outer", mb)
-      val run = checkedOuter.stream.forEach(mb, { inner =>
-        inner.forEach(mb, i => log(i.toS))
-      })
-
-      Code(
-        r.init, checkedOuter.init, checkedInner.init,
-        run,
-        r.assertClosed(1),
-        checkedOuter.assertClosed(1),
-        checkedInner.assertClosed((n + 1) / 2))
-    }
-    for (i <- 0 to 5) { f(i) }
-  }
+//  @Test def testES2Grouped() {
+//    val f = compile1[Int, Unit] { (mb, n) =>
+//      val r = checkedRange(0, n, "range", mb)
+//      var checkedInner: CheckedStream[Code[Int]] = null
+//      val outer = r.stream.grouped(2).map { inner =>
+//        checkedInner = new CheckedStream(inner, "inner", mb)
+//        checkedInner.stream
+//      }
+//      val checkedOuter = new CheckedStream(outer, "outer", mb)
+//      val run = checkedOuter.stream.forEach(mb, { inner =>
+//        inner.forEach(mb, i => log(i.toS))
+//      })
+//
+//      Code(
+//        r.init, checkedOuter.init, checkedInner.init,
+//        run,
+//        r.assertClosed(1),
+//        checkedOuter.assertClosed(1),
+//        checkedInner.assertClosed((n + 1) / 2))
+//    }
+//    for (i <- 0 to 5) { f(i) }
+//  }
+//
+//  @Test def testES2GroupedTake() {
+//    val f = compile1[Int, Unit] { (mb, n) =>
+//      val r = checkedRange(0, n, "range", mb)
+//      var checkedInner: CheckedStream[Code[Int]] = null
+//      val outer = r.stream.grouped(2).map { inner =>
+//        val take = Stream.zip(inner, Stream.range(mb, 0, 1, 1))
+//                         .map { case (i, count) => i }
+//        checkedInner = new CheckedStream(take, "inner", mb)
+//        checkedInner.stream
+//      }
+//      val checkedOuter = new CheckedStream(outer, "outer", mb)
+//      val run = checkedOuter.stream.forEach(mb, { inner =>
+//        inner.forEach(mb, i => log(i.toS))
+//      })
+//
+//      Code(
+//        r.init, checkedOuter.init, checkedInner.init,
+//        run,
+//        r.assertClosed(1),
+//        checkedOuter.assertClosed(1),
+//        checkedInner.assertClosed((n + 1) / 2))
+//    }
+//    for (i <- 0 to 5) { f(i) }
+//  }
 
   @Test def testES2MultiZip() {
     val f = compile3[Int, Int, Int, Unit] { (mb, n1, n2, n3) =>

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -183,53 +183,55 @@ class EmitStreamSuite extends HailSuite {
     f(10, 3)
   }
 
-//  @Test def testES2Grouped() {
-//    val f = compile1[Int, Unit] { (mb, n) =>
-//      val r = checkedRange(0, n, "range", mb)
-//      var checkedInner: CheckedStream[Code[Int]] = null
-//      val outer = r.stream.grouped(2).map { inner =>
-//        checkedInner = new CheckedStream(inner, "inner", mb)
-//        checkedInner.stream
-//      }
-//      val checkedOuter = new CheckedStream(outer, "outer", mb)
-//      val run = checkedOuter.stream.forEach(mb, { inner =>
-//        inner.forEach(mb, i => log(i.toS))
-//      })
-//
-//      Code(
-//        r.init, checkedOuter.init, checkedInner.init,
-//        run,
-//        r.assertClosed(1),
-//        checkedOuter.assertClosed(1),
-//        checkedInner.assertClosed((n + 1) / 2))
-//    }
-//    for (i <- 0 to 5) { f(i) }
-//  }
-//
-//  @Test def testES2GroupedTake() {
-//    val f = compile1[Int, Unit] { (mb, n) =>
-//      val r = checkedRange(0, n, "range", mb)
-//      var checkedInner: CheckedStream[Code[Int]] = null
-//      val outer = r.stream.grouped(2).map { inner =>
-//        val take = Stream.zip(inner, Stream.range(mb, 0, 1, 1))
-//                         .map { case (i, count) => i }
-//        checkedInner = new CheckedStream(take, "inner", mb)
-//        checkedInner.stream
-//      }
-//      val checkedOuter = new CheckedStream(outer, "outer", mb)
-//      val run = checkedOuter.stream.forEach(mb, { inner =>
-//        inner.forEach(mb, i => log(i.toS))
-//      })
-//
-//      Code(
-//        r.init, checkedOuter.init, checkedInner.init,
-//        run,
-//        r.assertClosed(1),
-//        checkedOuter.assertClosed(1),
-//        checkedInner.assertClosed((n + 1) / 2))
-//    }
-//    for (i <- 0 to 5) { f(i) }
-//  }
+  @Test def testES2Grouped() {
+    val f = compile1[Int, Unit] { (mb, n) =>
+      val r = checkedRange(0, n, "range", mb)
+      var checkedInner: CheckedStream[Code[Int]] = null
+      val dummyRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+      val outer = Stream.grouped(mb, _ => r.stream, 2, dummyRegion).map { inner =>
+        checkedInner = new CheckedStream(inner(dummyRegion), "inner", mb)
+        checkedInner.stream
+      }
+      val checkedOuter = new CheckedStream(outer, "outer", mb)
+      val run = checkedOuter.stream.forEach(mb, { inner =>
+        inner.forEach(mb, i => log(i.toS))
+      })
+
+      Code(
+        r.init, checkedOuter.init, checkedInner.init,
+        run,
+        r.assertClosed(1),
+        checkedOuter.assertClosed(1),
+        checkedInner.assertClosed((n + 1) / 2))
+    }
+    for (i <- 0 to 5) { f(i) }
+  }
+
+  @Test def testES2GroupedTake() {
+    val f = compile1[Int, Unit] { (mb, n) =>
+      val r = checkedRange(0, n, "range", mb)
+      var checkedInner: CheckedStream[Code[Int]] = null
+      val dummyRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+      val outer = Stream.grouped(mb, _ => r.stream, 2, dummyRegion).map { inner =>
+        val take = Stream.zip(inner(dummyRegion), Stream.range(mb, 0, 1, 1))
+                         .map { case (i, count) => i }
+        checkedInner = new CheckedStream(take, "inner", mb)
+        checkedInner.stream
+      }
+      val checkedOuter = new CheckedStream(outer, "outer", mb)
+      val run = checkedOuter.stream.forEach(mb, { inner =>
+        inner.forEach(mb, i => log(i.toS))
+      })
+
+      Code(
+        r.init, checkedOuter.init, checkedInner.init,
+        run,
+        r.assertClosed(1),
+        checkedOuter.assertClosed(1),
+        checkedInner.assertClosed((n + 1) / 2))
+    }
+    for (i <- 0 to 5) { f(i) }
+  }
 
   @Test def testES2MultiZip() {
     val f = compile3[Int, Int, Int, Unit] { (mb, n1, n2, n3) =>


### PR DESCRIPTION
~~Stacked on #9232.~~

This adds memory management to StreamGrouped and StreamGroupByKey. As always, the case where the inner stream is never consumed causes complications. Because the child stream gets its per-element region from the consumer of the inner stream, if the inner stream is unconsumed we have to pass some other region.

The solution implemented here uses the outer stream's eltRegion. If the outer stream's consumer allows creating new regions, the grouping node creates an owned region to construct child stream elements in, and clears it every element (because it is never passed to a consumer). Otherwise, all child elements get created in the outer stream's eltRegion.