### PR TITLE
[query] optimize in CompileAndEvalutate consistently

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -35,7 +35,7 @@ object CompileAndEvaluate {
       FastIndexedSeq(),
       FastIndexedSeq(classInfo[Region]), LongInfo,
       MakeTuple.ordered(FastSeq(ir)),
-      print = None, optimize = false))
+      print = None, optimize = optimize))
 
     val fRunnable = ctx.timer.time("InitializeCompiledFunction")(f(0, ctx.r))
     val resultAddress = ctx.timer.time("RunCompiledFunction")(fRunnable(ctx.r))


### PR DESCRIPTION
Maybe this is an artifact of when we didn't do lowering inside Compile.