### PR TITLE
[query] Benchmark in broad-ctsa

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -57,10 +57,11 @@ pushed_image: image_sha
 BENCHMARK_ITERS ?= 3
 BENCHMARK_REPLICATES ?= 5
 HAIL_WHEEL_DESCRIPTOR ?= $(HAIL_VERSION)-$(SHORT_REVISION)
+BENCHMARK_BUCKET ?= gs://hail-benchmarks-2
 .PHONY: benchmark
 benchmark: pushed_image install
 	@echo Using pushed image `cat pushed_image`
-	$(HAIL_PYTHON3) scripts/benchmark_in_batch.py `cat pushed_image` gs://hail-benchmarks/$(shell whoami) $(HAIL_WHEEL_DESCRIPTOR) $(BENCHMARK_REPLICATES) $(BENCHMARK_ITERS)
+	$(HAIL_PYTHON3) scripts/benchmark_in_batch.py `cat pushed_image` $(BENCHMARK_BUCKET)/$(shell whoami) $(HAIL_WHEEL_DESCRIPTOR) $(BENCHMARK_REPLICATES) $(BENCHMARK_ITERS)
 
 clean:
 	rm -rf python/dist/*


### PR DESCRIPTION
To run benchmarks, you'll need to grant your batch service account permissions:

1. grab service account name from https://auth.hail.is/user

Then:
```
export BATCH_SERVICE_ACCOUNT="..."
gsutil iam ch serviceAccount:${BATCH_SERVICE_ACCOUNT}:objectAdmin gs://hail-benchmarks-2
gsutil iam ch serviceAccount:${BATCH_SERVICE_ACCOUNT}:objectViewer gs://artifacts.broad-ctsa.appspot.com
```