### PR TITLE
[www] remove hero indentation so pandoc can parse the html correctly

### DIFF
--- a/site/www/references.md
+++ b/site/www/references.md
@@ -1,9 +1,9 @@
 <div id='references' class='width-960'>
 <div id="hero" class='dark short'>
-  <div id="hero-content" class='wide'>
-    <h1 id="logo-title">Hail-Powered Science</h1>
-    <div class="logo-subtitle">An incomplete list of scientific work enabled by Hail.</div>
-  </div>
+<div id="hero-content" class='wide'>
+<h1 id="logo-title">Hail-Powered Science</h1>
+<div class="logo-subtitle">An incomplete list of scientific work enabled by Hail.</div>
+</div>
 </div>
 
 


### PR DESCRIPTION
pandoc treats 4-space indentation as a literal text block and wasn't parsing the innermost h1 and div tags.