### PR TITLE
[hailctl dataproc] Replace deprecated gcloud arguments in hailctl dataproc start and modify

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -5,11 +5,15 @@ import argparse
 from . import connect
 from . import describe
 from . import diagnose
+from . import gcloud
 from . import list_clusters
 from . import modify
 from . import start
 from . import stop
 from . import submit
+
+
+MINIMUM_REQUIRED_GCLOUD_VERSION = (285, 0, 0)
 
 
 def parser():
@@ -104,5 +108,15 @@ def main(args):
     args, pass_through_args = p.parse_known_args(args=args)
     if "module" not in args:
         p.error('positional argument required')
+
+    try:
+        gcloud_version = gcloud.get_version()
+        if gcloud_version < MINIMUM_REQUIRED_GCLOUD_VERSION:
+            print(f"hailctl dataproc requires Google Cloud SDK (gcloud) version {'.'.join(map(str, MINIMUM_REQUIRED_GCLOUD_VERSION))} or higher", file=sys.stderr)
+            sys.exit(1)
+    except Exception:
+        # If gcloud's output format changes in the future and the version can't be parsed,
+        # then continue and attempt to run gcloud.
+        print("Warning: unable to determine Google Cloud SDK version", file=sys.stderr)
 
     jmp[args.module].main(args, pass_through_args)

--- a/hail/python/hailtop/hailctl/dataproc/gcloud.py
+++ b/hail/python/hailtop/hailctl/dataproc/gcloud.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 import typing
@@ -15,3 +16,11 @@ def get_config(setting: str) -> typing.Optional[str]:
     except subprocess.CalledProcessError as e:
         print(f"Warning: could not run 'gcloud config get-value {setting}': {e.output.decode}", file=sys.stderr)
         return None
+
+
+def get_version() -> typing.Tuple[int, int, int]:
+    """Get gcloud version as a tuple."""
+    version_output = subprocess.check_output(["gcloud", "version", "--format=json"], stderr=subprocess.DEVNULL).decode().strip()
+    version_info = json.loads(version_output)
+    version = tuple(int(n) for n in version_info["Google Cloud SDK"].split("."))
+    return version

--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -9,8 +9,8 @@ def init_parser(parser):
     parser.add_argument('name', type=str, help='Cluster name.')
     parser.add_argument('--num-workers', '--n-workers', '-w', type=int,
                         help='New number of worker machines (min. 2).')
-    parser.add_argument('--num-preemptible-workers', '--n-pre-workers', '-p', type=int,
-                        help='New number of preemptible worker machines.')
+    parser.add_argument('--num-secondary-workers', '--num-preemptible-workers', '--n-pre-workers', '-p', type=int,
+                        help='New number of secondary (preemptible) worker machines.')
     parser.add_argument('--graceful-decommission-timeout', '--graceful', type=str,
                         help='If set, cluster size downgrade will use graceful decommissioning with the given timeout (e.g. "60m").')
     parser.add_argument('--max-idle', type=str, help='New maximum idle time before shutdown (e.g. "60m").')
@@ -27,8 +27,8 @@ def main(args, pass_through_args):
     if args.num_workers is not None:
         modify_args.append('--num-workers={}'.format(args.num_workers))
 
-    if args.num_preemptible_workers is not None:
-        modify_args.append('--num-preemptible-workers={}'.format(args.num_preemptible_workers))
+    if args.num_secondary_workers is not None:
+        modify_args.append('--num-secondary-workers={}'.format(args.num_secondary_workers))
 
     if args.graceful_decommission_timeout:
         if not modify_args:

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -153,14 +153,14 @@ def init_parser(parser):
                         help='Disk size of master machine, in GB (default: %(default)s).')
     parser.add_argument('--num-master-local-ssds', default=0, type=int,
                         help='Number of local SSDs to attach to the master machine (default: %(default)s).')
-    parser.add_argument('--num-preemptible-workers', '--n-pre-workers', '-p', default=0, type=int,
-                        help='Number of preemptible worker machines (default: %(default)s).')
+    parser.add_argument('--num-secondary-workers', '--num-preemptible-workers', '--n-pre-workers', '-p', default=0, type=int,
+                        help='Number of secondary (preemptible) worker machines (default: %(default)s).')
     parser.add_argument('--num-worker-local-ssds', default=0, type=int,
                         help='Number of local SSDs to attach to each worker machine (default: %(default)s).')
     parser.add_argument('--num-workers', '--n-workers', '-w', default=2, type=int,
                         help='Number of worker machines (default: %(default)s).')
-    parser.add_argument('--preemptible-worker-boot-disk-size', default=40, type=int,
-                        help='Disk size of preemptible machines, in GB (default: %(default)s).')
+    parser.add_argument('--secondary-worker-boot-disk-size', '--preemptible-worker-boot-disk-size', default=40, type=int,
+                        help='Disk size of secondary (preemptible) worker machines, in GB (default: %(default)s).')
     parser.add_argument('--worker-boot-disk-size', default=40, type=int,
                         help='Disk size of worker machines, in GB (default: %(default)s).')
     parser.add_argument('--worker-machine-type', '--worker',
@@ -307,10 +307,10 @@ def main(args, pass_through_args):
     conf.flags['master-machine-type'] = args.master_machine_type
     conf.flags['master-boot-disk-size'] = '{}GB'.format(args.master_boot_disk_size)
     conf.flags['num-master-local-ssds'] = args.num_master_local_ssds
-    conf.flags['num-preemptible-workers'] = args.num_preemptible_workers
+    conf.flags['num-secondary-workers'] = args.num_secondary_workers
     conf.flags['num-worker-local-ssds'] = args.num_worker_local_ssds
     conf.flags['num-workers'] = args.num_workers
-    conf.flags['preemptible-worker-boot-disk-size'] = disk_size(args.preemptible_worker_boot_disk_size)
+    conf.flags['secondary-worker-boot-disk-size'] = disk_size(args.secondary_worker_boot_disk_size)
     conf.flags['worker-boot-disk-size'] = disk_size(args.worker_boot_disk_size)
     conf.flags['worker-machine-type'] = args.worker_machine_type
     if args.region:

--- a/hail/python/test/hailtop/hailctl/dataproc/conftest.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/conftest.py
@@ -2,6 +2,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from hailtop.hailctl.dataproc.cli import MINIMUM_REQUIRED_GCLOUD_VERSION
+
 
 @pytest.fixture
 def gcloud_config():
@@ -23,6 +25,7 @@ def gcloud_run():
 def patch_gcloud(monkeypatch, gcloud_run, gcloud_config):
     """Automatically replace gcloud functions with mocks."""
     monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.run", gcloud_run)
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_version", Mock(return_value=MINIMUM_REQUIRED_GCLOUD_VERSION))
 
     def mock_gcloud_get_config(setting):
         return gcloud_config.get(setting, None)

--- a/hail/python/test/hailtop/hailctl/dataproc/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_cli.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock
+
+import pytest
+
+from hailtop.hailctl.dataproc import cli
+from hailtop.hailctl.dataproc import list_clusters
+
+
+def test_required_gcloud_version_met(monkeypatch):
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_version", Mock(return_value=cli.MINIMUM_REQUIRED_GCLOUD_VERSION))
+
+    mock_list = Mock()
+    monkeypatch.setattr(list_clusters, "main", mock_list)
+    cli.main(["list"])
+
+    assert mock_list.called
+
+
+def test_required_gcloud_version_unmet(monkeypatch, capsys):
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_version", Mock(return_value=(200, 0, 0)))
+
+    mock_list = Mock()
+    monkeypatch.setattr(list_clusters, "main", mock_list)
+    with pytest.raises(SystemExit):
+        cli.main(["list"])
+
+    assert "hailctl dataproc requires Google Cloud SDK (gcloud) version" in capsys.readouterr().err
+
+    assert not mock_list.called
+
+
+def test_unable_to_determine_version(monkeypatch):
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_version", Mock(side_effect=ValueError))
+
+    mock_list = Mock()
+    monkeypatch.setattr(list_clusters, "main", mock_list)
+    cli.main(["list"])
+
+    assert mock_list.called

--- a/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
@@ -47,13 +47,14 @@ def test_modify_workers(gcloud_run, workers_arg):
 
 
 @pytest.mark.parametrize("workers_arg", [
+    "--num-secondary-workers=2",
     "--num-preemptible-workers=2",
     "--n-pre-workers=2",
     "-p=2",
 ])
-def test_modify_preemptible_workers(gcloud_run, workers_arg):
+def test_modify_secondary_workers(gcloud_run, workers_arg):
     cli.main(["modify", "test-cluster", workers_arg])
-    assert "--num-preemptible-workers=2" in gcloud_run.call_args[0][0]
+    assert "--num-secondary-workers=2" in gcloud_run.call_args[0][0]
 
 
 def test_modify_max_idle(gcloud_run):
@@ -63,7 +64,7 @@ def test_modify_max_idle(gcloud_run):
 
 @pytest.mark.parametrize("workers_arg", [
     "--num-workers=2",
-    "--num-preemptible-workers=2",
+    "--num-secondary-workers=2",
 ])
 def test_graceful_decommission_timeout(gcloud_run, workers_arg):
     cli.main(["modify", "test-cluster", workers_arg, "--graceful-decommission-timeout=1h"])

--- a/hail/python/test/hailtop/hailctl/dataproc/test_start.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_start.py
@@ -45,9 +45,13 @@ def test_workers_configuration(gcloud_run):
     assert "--num-workers=4" in gcloud_run.call_args[0][0]
 
 
-def test_secondary_workers_configuration(gcloud_run):
-    cli.main(["start", "--num-preemptible-workers=8", "test-cluster"])
-    assert "--num-preemptible-workers=8" in gcloud_run.call_args[0][0]
+@pytest.mark.parametrize("workers_arg", [
+    "--num-secondary-workers=8",
+    "--num-preemptible-workers=8"
+])
+def test_secondary_workers_configuration(gcloud_run, workers_arg):
+    cli.main(["start", workers_arg, "test-cluster"])
+    assert "--num-secondary-workers=8" in gcloud_run.call_args[0][0]
 
 
 @pytest.mark.parametrize("machine_arg", [
@@ -62,7 +66,7 @@ def test_machine_type_configuration(gcloud_run, machine_arg):
 @pytest.mark.parametrize("machine_arg", [
     "--master-boot-disk-size=250",
     "--worker-boot-disk-size=200",
-    "--preemptible-worker-boot-disk-size=100",
+    "--secondary-worker-boot-disk-size=100"
 ])
 def test_boot_disk_size_configuration(gcloud_run, machine_arg):
     cli.main(["start", machine_arg, "test-cluster"])
@@ -77,7 +81,7 @@ def test_vep_defaults_to_highmem_master_machine(gcloud_run):
 def test_vep_defaults_to_larger_worker_boot_disk(gcloud_run):
     cli.main(["start", "test-cluster", "--vep=GRCh37"])
     assert "--worker-boot-disk-size=200GB" in gcloud_run.call_args[0][0]
-    assert "--preemptible-worker-boot-disk-size=200GB" in gcloud_run.call_args[0][0]
+    assert "--secondary-worker-boot-disk-size=200GB" in gcloud_run.call_args[0][0]
 
 
 @pytest.mark.parametrize("requester_pays_arg", [


### PR DESCRIPTION
[gcloud 284.0.0](https://cloud.google.com/sdk/docs/release-notes#28400_2020-03-10) deprecated the `--num-preemptible-workers` and `--preemptible-worker-boot-disk-size` arguments to `gcloud dataproc clusters create`.

[gcloud 285.0.0](https://cloud.google.com/sdk/docs/release-notes#28500_2020-03-17) deprecated the `--num-preemptible-workers` argument to `gcloud dataproc clusters update`.

This replaces `--num-preemptible-workers` with `--num-secondary-workers` and `--preemptible-worker-boot-disk-size` with `--secondary-worker-boot-disk-size` in calls to `gcloud` from `hailctl dataproc start` and `hailctl dataproc modify`.

Since the new arguments were added in gcloud version 285.0.0 (released in March 2020), this also adds a requirement that gcloud be at least version 285.0.0. Alternatively, the arguments could be switched based on the gcloud version.