### PR TITLE
[query] Add CompareStructs comparison node

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -1,11 +1,10 @@
 package is.hail.annotations
 
 import is.hail.asm4s._
-import is.hail.expr.ir.{Ascending, EmitMethodBuilder, SortOrder}
+import is.hail.expr.ir.{Ascending, Descending, EmitMethodBuilder, SortField, SortOrder}
 import is.hail.types._
 import is.hail.asm4s.coerce
 import is.hail.types.physical._
-import is.hail.expr.ir.{Ascending, Descending}
 import is.hail.utils._
 
 object CodeOrdering {
@@ -16,6 +15,10 @@ object CodeOrdering {
     val missingEqual: Boolean
   }
   final case class Compare(missingEqual: Boolean = true) extends Op {
+    type ReturnType = Int
+    val rtti = typeInfo[Int]
+  }
+  final case class CompareStructs(sf: IndexedSeq[SortField], missingEqual: Boolean = true) extends Op {
     type ReturnType = Int
     val rtti = typeInfo[Int]
   }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -9,7 +9,7 @@ import is.hail.asm4s._
 import is.hail.asm4s.joinpoint.Ctrl
 import is.hail.backend.BackendUtils
 import is.hail.expr.ir.functions.IRRandomness
-import is.hail.types.physical.{PCanonicalTuple, PCode, PSettable, PStream, PType, PValue, typeToTypeInfo}
+import is.hail.types.physical.{PCanonicalTuple, PCode, PSettable, PStream, PStruct, PType, PValue, typeToTypeInfo}
 import is.hail.types.virtual.Type
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.io.fs.FS
@@ -486,10 +486,13 @@ class EmitClassBuilder[C](
 
       val newMB = if (ignoreMissingness) {
         val newMB = genEmitMethod("cord", FastIndexedSeq[ParamType](ti, ti), rt)
-        val ord = t1.codeOrdering(newMB, t2, sortOrder)
+        lazy val ord = t1.codeOrdering(newMB, t2, sortOrder)
         val v1 = newMB.getCodeParam(1)(ti)
         val v2 = newMB.getCodeParam(3)(ti)
         val c: Code[_] = op match {
+          case CodeOrdering.CompareStructs(sf, missingEqual) =>
+            val ord = CodeOrdering.rowOrdering(t1.asInstanceOf[PStruct], t2.asInstanceOf[PStruct], newMB, sf.map(_.sortOrder).toArray, missingEqual)
+            ord.compareNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
           case CodeOrdering.Compare(_) => ord.compareNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
           case CodeOrdering.Equiv(_) => ord.equivNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
           case CodeOrdering.Lt(_) => ord.ltNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
@@ -502,12 +505,15 @@ class EmitClassBuilder[C](
         newMB
       } else {
         val newMB = genEmitMethod("cord", FastIndexedSeq[ParamType](typeInfo[Boolean], ti, typeInfo[Boolean], ti), rt)
-        val ord = t1.codeOrdering(newMB, t2, sortOrder)
+        lazy val ord = t1.codeOrdering(newMB, t2, sortOrder)
         val m1 = newMB.getCodeParam[Boolean](1)
         val v1 = newMB.getCodeParam(2)(ti)
         val m2 = newMB.getCodeParam[Boolean](3)
         val v2 = newMB.getCodeParam(4)(ti)
         val c: Code[_] = op match {
+          case CodeOrdering.CompareStructs(sf, missingEqual) =>
+            val ord = CodeOrdering.rowOrdering(t1.asInstanceOf[PStruct], t2.asInstanceOf[PStruct], newMB, sf.map(_.sortOrder).toArray, missingEqual)
+            ord.compare((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)), missingEqual)
           case CodeOrdering.Compare(missingEqual) => ord.compare((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)), missingEqual)
           case CodeOrdering.Equiv(missingEqual) => ord.equiv((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)), missingEqual)
           case CodeOrdering.Lt(missingEqual) => ord.lt((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)), missingEqual)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -67,7 +67,7 @@ object InferType {
       case ApplyComparisonOp(op, l, r) =>
         assert(l.typ == r.typ)
         op match {
-          case _: Compare => TInt32
+          case _: Compare | _: CompareStructs => TInt32
           case _ => TBoolean
         }
       case a: ApplyIR => a.explicitNode.typ

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -221,6 +221,12 @@ object Interpret {
             case LTEQ(t, _) => t.ordering.lteq(lValue, rValue)
             case GTEQ(t, _) => t.ordering.gteq(lValue, rValue)
             case Compare(t, _) => t.ordering.compare(lValue, rValue)
+            case CompareStructs(t, sf) => ExtendedOrdering.rowOrdering(t.fields.zip(sf).map { case (f, sf) =>
+              sf match {
+                case SortField(_, Ascending) => f.typ.ordering
+                case SortField(_, Descending) => f.typ.ordering.reverse
+              }
+            }.toArray).compare(lValue, rValue)
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -819,10 +819,15 @@ object IRParser {
         ApplyUnaryPrimOp(op, x)
       case "ApplyComparisonOp" =>
         val opName = identifier(it)
+        val op: (Type, Type) => ComparisonOp[_] = opName match {
+          case "CompareStructs" =>
+            val sf = sort_fields(it);
+            { (t1: Type, t2: Type) => assert(t1 == t2); CompareStructs(t1.asInstanceOf[TStruct], sf) }
+          case _ => (t1: Type, t2: Type) => ComparisonOp.fromStringAndTypes((opName, t1, t2))
+        }
         val l = ir_value_expr(env)(it)
         val r = ir_value_expr(env)(it)
-        val op = ComparisonOp.fromStringAndTypes((opName, l.typ, r.typ))
-        ApplyComparisonOp(op, l, r)
+        ApplyComparisonOp(op(l.typ, r.typ), l, r)
       case "MakeArray" =>
         val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TArray]).orNull
         val args = ir_value_children(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -272,7 +272,7 @@ object Pretty {
             case RelationalLet(name, _, _) => prettyIdentifier(name)
             case ApplyBinaryPrimOp(op, _, _) => prettyClass(op)
             case ApplyUnaryPrimOp(op, _) => prettyClass(op)
-            case ApplyComparisonOp(op, _, _) => prettyClass(op)
+            case ApplyComparisonOp(op, _, _) => op.render()
             case GetField(_, name) => prettyIdentifier(name)
             case GetTupleElement(_, idx) => idx.toString
             case MakeTuple(fields) => prettyInts(fields.map(_._1).toFastIndexedSeq)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -437,7 +437,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | True() | False() | _: IsNA | _: Die | _: UUID4 =>
       case _: CombOpValue | _: AggStateValue =>
       case x if x.typ == TVoid =>
-      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) | ApplyComparisonOp(Compare(_, _), _, _) =>
+      case ApplyComparisonOp(EQWithNA(_, _), _, _) | ApplyComparisonOp(NEQWithNA(_, _), _, _) | ApplyComparisonOp(Compare(_, _), _, _) | ApplyComparisonOp(CompareStructs(_, _), _, _) =>
       case ApplyComparisonOp(op, l, r) =>
         fatal(s"non-strict comparison op $op must have explicit case")
       case TableCount(t) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -147,7 +147,7 @@ object TypeCheck {
         assert(op.t1.fundamentalType == l.typ.fundamentalType)
         assert(op.t2.fundamentalType == r.typ.fundamentalType)
         op match {
-          case _: Compare => assert(x.typ == TInt32)
+          case _: Compare | _: CompareStructs => assert(x.typ == TInt32)
           case _ => assert(x.typ == TBoolean)
         }
       case x@MakeArray(args, typ) =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -778,6 +778,33 @@ class IRSuite extends HailSuite {
     assertComparesTo(TFloat64, 1.0, 0.0, expected = true)
   }
 
+  @Test def testApplyComparisonOpCompareStructs() {
+    def assertComparesTo(t: TStruct, sf: IndexedSeq[SortField], x: Any, y: Any, expected: Int) {
+      assertEvalsTo(ApplyComparisonOp(CompareStructs(t, sf), In(0, t), In(1, t)), FastIndexedSeq(x -> t, y -> t), expected)
+    }
+
+    val t1 = TStruct("x" -> TInt32, "y" -> TFloat64)
+    val ascAsc = FastIndexedSeq(SortField("x", Ascending), SortField("y", Ascending))
+    val ascDesc = FastIndexedSeq(SortField("x", Ascending), SortField("y", Descending))
+    val descAsc = FastIndexedSeq(SortField("x", Descending), SortField("y", Ascending))
+    val descDesc = FastIndexedSeq(SortField("x", Descending), SortField("y", Descending))
+
+    assertComparesTo(t1, ascAsc, Row(0, 0d), Row(0, 0d), 0)
+    assertComparesTo(t1, ascDesc, Row(0, 0d), Row(0, 0d), 0)
+    assertComparesTo(t1, descAsc, Row(0, 0d), Row(0, 0d), 0)
+    assertComparesTo(t1, descDesc, Row(0, 0d), Row(0, 0d), 0)
+
+    assertComparesTo(t1, ascAsc, Row(1, 0d), Row(0, 0d), 1)
+    assertComparesTo(t1, ascDesc, Row(1, 0d), Row(0, 0d), 1)
+    assertComparesTo(t1, descAsc, Row(1, 0d), Row(0, 0d), -1)
+    assertComparesTo(t1, descDesc, Row(1, 0d), Row(0, 0d), -1)
+
+    assertComparesTo(t1, ascAsc, Row(0, 1d), Row(0, 0d), 1)
+    assertComparesTo(t1, ascDesc, Row(0, 1d), Row(0, 0d), -1)
+    assertComparesTo(t1, descAsc, Row(0, 1d), Row(0, 0d), 1)
+    assertComparesTo(t1, descDesc, Row(0, 1d), Row(0, 0d), -1)
+  }
+
   @Test def testDieCodeBUilder() {
     assertFatal(Die("msg1", TInt32) + Die("msg2", TInt32), "msg1")
   }
@@ -3062,6 +3089,10 @@ class IRSuite extends HailSuite {
       ApplyBinaryPrimOp(Add(), i, j),
       ApplyUnaryPrimOp(Negate(), i),
       ApplyComparisonOp(EQ(TInt32), i, j),
+      ApplyComparisonOp(CompareStructs(
+        TStruct("x" -> TInt32, "y" -> TFloat64),
+        FastIndexedSeq(SortField("x", Ascending), SortField("y", Descending))),
+        In(0, TStruct("x" -> TInt32, "y" -> TFloat64)), In(1, TStruct("x" -> TInt32, "y" -> TFloat64))),
       MakeArray(FastSeq(i, NA(TInt32), I32(-3)), TArray(TInt32)),
       MakeStream(FastSeq(i, NA(TInt32), I32(-3)), TStream(TInt32)),
       nd,


### PR DESCRIPTION
I need this to write the local keyby/orderby lowering entirely in IR, which is necessary to fix the currently-broken design.