### PR TITLE
[image-fetcher] fix path to curlrc

### DIFF
--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -16,7 +16,7 @@ case $DEFAULT_NAMESPACE in
 	;;
 esac
 
-ln -s /ssl-config/image-fetcher.curlrc $HOME/.curlrc
+ln -s /ssl-config/ssl-config.curlrc $HOME/.curlrc
 
 while true; do
     for image in "gcr.io/$PROJECT/base:latest" google/cloud-sdk:237.0.0-alpine $(curl -sSL https://notebook$NOTEBOOK_BASE_PATH/images); do


### PR DESCRIPTION
The contents of ssl-config are not named after the service in question. See create_certs.py