### PR TITLE
[auth] teach auth to specify SSL for SQL secrets

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import os
-import json
 import pymysql
 import aiomysql
 import logging

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import os
 import json
 import pymysql
@@ -7,6 +8,7 @@ import functools
 import ssl
 
 from hailtop.utils import sleep_and_backoff, LoggingTimer
+from hailtop.auth.sql_config import SQLConfig
 
 
 log = logging.getLogger('gear.database')
@@ -53,38 +55,31 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
     return await acontext_manager.__aexit__(exc_type, exc_val, exc_tb)
 
 
-def get_sql_config(config_file=None):
-    if config_file is None:
+def get_sql_config(maybe_config_file: Optional[str] = None) -> SQLConfig:
+    if maybe_config_file is None:
         config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE',
                                      '/sql-config/sql-config.json')
+    else:
+        config_file = maybe_config_file
     with open(config_file, 'r') as f:
-        sql_config = json.loads(f.read())
-    check_sql_config(sql_config)
-    return sql_config
-
-
-def check_sql_config(sql_config):
-    assert sql_config is not None
-    for key in ('ssl-cert', 'ssl-key', 'ssl-ca', 'ssl-mode'):
-        assert sql_config.get(key) is not None, key
-    for key in ('ssl-cert', 'ssl-key', 'ssl-ca'):
-        if not os.path.isfile(sql_config[key]):
-            raise ValueError(f'specified {key}, {sql_config[key]} does not exist')
+        sql_config = SQLConfig.from_json(f.read())
+    sql_config.check()
     log.info('using tls and verifying server certificates for MySQL')
+    return sql_config
 
 
 database_ssl_context = None
 
 
-def get_database_ssl_context(sql_config=None):
+def get_database_ssl_context(sql_config: Optional[SQLConfig] = None) -> ssl.SSLContext:
     global database_ssl_context
     if database_ssl_context is None:
         if sql_config is None:
             sql_config = get_sql_config()
         database_ssl_context = ssl.create_default_context(
-            cafile=sql_config['ssl-ca'])
-        database_ssl_context.load_cert_chain(sql_config['ssl-cert'],
-                                             keyfile=sql_config['ssl-key'],
+            cafile=sql_config.ssl_ca)
+        database_ssl_context.load_cert_chain(sql_config.ssl_cert,
+                                             keyfile=sql_config.ssl_key,
                                              password=None)
         database_ssl_context.verify_mode = ssl.CERT_REQUIRED
         database_ssl_context.check_hostname = False
@@ -92,15 +87,15 @@ def get_database_ssl_context(sql_config=None):
 
 
 @retry_transient_mysql_errors
-async def create_database_pool(config_file=None, autocommit=True, maxsize=10):
+async def create_database_pool(config_file: str = None, autocommit: bool = True, maxsize: int = 10):
     sql_config = get_sql_config(config_file)
     ssl_context = get_database_ssl_context(sql_config)
     assert ssl_context is not None
     return await aiomysql.create_pool(
         maxsize=maxsize,
         # connection args
-        host=sql_config['host'], user=sql_config['user'], password=sql_config['password'],
-        db=sql_config.get('db'), port=sql_config['port'], charset='utf8',
+        host=sql_config.host, user=sql_config.user, password=sql_config.password,
+        db=sql_config.db, port=sql_config.port, charset='utf8',
         ssl=ssl_context, cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
 
 

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -1,22 +1,94 @@
+from typing import Dict, NamedTuple, Optional, Any
 import json
+import os
 
 
-def create_secret_data_from_config(config, server_ca, client_cert, client_key):
-    assert all(config.get(x) is not None
-               for x in ('host', 'user', 'password', 'db', 'ssl-ca', 'ssl-cert',
-                         'ssl-key', 'ssl-mode')), config.keys()
-    secret_data = dict()
-    secret_data['sql-config.json'] = json.dumps(config)
-    secret_data['sql-config.cnf'] = f'''[client]
-host={config["host"]}
-user={config["user"]}
-password="{config["password"]}"
-database={config["db"]}
-ssl-ca={config["ssl-ca"]}
-ssl-cert={config["ssl-cert"]}
-ssl-key={config["ssl-key"]}
-ssl-mode={config["ssl-mode"]}
+class SQLConfig(NamedTuple):
+    host: str
+    port: int
+    user: str
+    password: str
+    instance: str
+    connection_name: str
+    db: Optional[str]
+    ssl_ca: str
+    ssl_cert: str
+    ssl_key: str
+    ssl_mode: str
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {'host': self.host,
+             'port': self.port,
+             'user': self.user,
+             'password': self.password,
+             'instance': self.instance,
+             'connection_name': self.connection_name,
+             'ssl-ca': self.ssl_ca,
+             'ssl-cert': self.ssl_cert,
+             'ssl-key': self.ssl_key,
+             'ssl-mode': self.ssl_mode}
+        if self.db is not None:
+            d['db'] = self.db
+        return d
+
+    def to_cnf(self) -> str:
+        host_user_password = f'''[client]
+host={self.host}
+user={self.user}
+password="{self.password}"
 '''
+        database_setting = f'database={self.db}\n' if self.db is not None else ''
+        ssl_settings = f'''ssl-ca={self.ssl_ca}
+ssl-cert={self.ssl_cert}
+ssl-key={self.ssl_key}
+ssl-mode={self.ssl_mode}
+'''
+        return host_user_password + database_setting + ssl_settings
+
+    def check(self):
+        assert self.ssl_ca is not None
+        assert self.ssl_cert is not None
+        assert self.ssl_key is not None
+        if not os.path.isfile(self.ssl_cert):
+            raise ValueError(f'specified ssl-cert, {self.ssl_cert}, does not exist')
+        if not os.path.isfile(self.ssl_key):
+            raise ValueError(f'specified ssl-key, {self.ssl_key}, does not exist')
+        if not os.path.isfile(self.ssl_ca):
+            raise ValueError(f'specified ssl-ca, {self.ssl_ca}, does not exist')
+
+    @staticmethod
+    def from_json(s: str) -> 'SQLConfig':
+        return SQLConfig.from_dict(json.loads(s))
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> 'SQLConfig':
+        for k in ('host', 'user', 'password', 'ssl-ca', 'ssl-cert', 'ssl-key', 'ssl-mode'):
+            assert k in d, f'{k} should be in {d}'
+            assert d[k] is not None, f'{k} should not be None in {d}'
+        return SQLConfig(d['host'],
+                         d['port'],
+                         d['user'],
+                         d['password'],
+                         d['instance'],
+                         d['connection_name'],
+                         d.get('db'),
+                         d['ssl-ca'],
+                         d['ssl-cert'],
+                         d['ssl-key'],
+                         d['ssl-mode'])
+
+
+def create_secret_data_from_config(config: SQLConfig,
+                                   server_ca: str,
+                                   client_cert: str,
+                                   client_key: str
+                                   ) -> Dict[str, str]:
+    secret_data = dict()
+    secret_data['sql-config.json'] = config.to_json()
+    secret_data['sql-config.cnf'] = config.to_cnf()
     secret_data['server-ca.pem'] = server_ca
     secret_data['client-cert.pem'] = client_cert
     secret_data['client-key.pem'] = client_key

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -49,6 +49,12 @@ ssl-mode={self.ssl_mode}
         return host_user_password + database_setting + ssl_settings
 
     def check(self):
+        assert self.host is not None
+        assert self.port is not None
+        assert self.user is not None
+        assert self.password is not None
+        assert self.instance is not None
+        assert self.connection is not None
         assert self.ssl_ca is not None
         assert self.ssl_cert is not None
         assert self.ssl_key is not None
@@ -65,20 +71,22 @@ ssl-mode={self.ssl_mode}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> 'SQLConfig':
-        for k in ('host', 'user', 'password', 'ssl-ca', 'ssl-cert', 'ssl-key', 'ssl-mode'):
+        for k in ('host', 'port', 'user', 'password',
+                  'instance', 'connection_name',
+                  'ssl-ca', 'ssl-cert', 'ssl-key', 'ssl-mode'):
             assert k in d, f'{k} should be in {d}'
             assert d[k] is not None, f'{k} should not be None in {d}'
-        return SQLConfig(d['host'],
-                         d['port'],
-                         d['user'],
-                         d['password'],
-                         d['instance'],
-                         d['connection_name'],
-                         d.get('db'),
-                         d['ssl-ca'],
-                         d['ssl-cert'],
-                         d['ssl-key'],
-                         d['ssl-mode'])
+        return SQLConfig(host=d['host'],
+                         port=d['port'],
+                         user=d['user'],
+                         password=d['password'],
+                         instance=d['instance'],
+                         connection_name=d['connection_name'],
+                         db=d.get('db'),
+                         ssl_ca=d['ssl-ca'],
+                         ssl_cert=d['ssl-cert'],
+                         ssl_key=d['ssl-key'],
+                         ssl_mode=d['ssl-mode'])
 
 
 def create_secret_data_from_config(config: SQLConfig,

--- a/hail/python/hailtop/auth/sql_config.py
+++ b/hail/python/hailtop/auth/sql_config.py
@@ -54,7 +54,7 @@ ssl-mode={self.ssl_mode}
         assert self.user is not None
         assert self.password is not None
         assert self.instance is not None
-        assert self.connection is not None
+        assert self.connection_name is not None
         assert self.ssl_ca is not None
         assert self.ssl_cert is not None
         assert self.ssl_key is not None


### PR DESCRIPTION
In https://github.com/hail-is/hail/pull/9113, I forced the auth driver to use
the modern, TLS-required, SQL config format. I incorrectly forgot to specify the
TLS file paths. Luckily, when I tried to create a user account for Patrick
Cummings, instead of creating a broken secret, the auth driver
error'ed. Moreover, the clean up code was broken. As a result, Patrick's account
was stuck in `creating`.

This PR fixes both the clean up code issue (I set `self.namespace` in
`K8sSecretResource`) and specifies the TLS file paths (see driver.py near
line 217).

In addition, this PR attempts to avoid future problems with the sql
configuration by codifying the required components as a NamedTuple, `SQLConfig`. I also
co-located all the parsing and transformation logic between JSON, dicts, and CNF
in the `SQLConfig` class.

I traced back all the users of `create_secret_data_from_config` to ensure they
all now use SQLConfig. I added lots of type annotations, but those won't do
anything right now because we don't have mypy enabled for hailtop.auth.

---

There's a separate issue of us not getting notified that Patrick's account was
not being created due to an error. The relevant logs are linked below. I'm glad
we're starting work on better monitoring. Hopefully error logs like these will
trigger emails to services team.

https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22auth-driver%22;timeRange=2020-08-11T15:44:00.000Z%2F2020-08-11T23:55:00.000Z?project=hail-vdc&query=%0A

Moreover, the infinite retry of his account created tens of google service
accounts that were not cleaned up. I do not yet understand why the google
service account clean up code failed. The clean up code bug that I *do* fix in
this PR addresses the GSA secret and the tokens secret.