### PR TITLE
[hailctl] address pesky deprecation warnings

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -28,7 +28,8 @@ def main(args, pass_through_args):
         modify_args.append('--num-workers={}'.format(args.num_workers))
 
     if args.num_preemptible_workers is not None:
-        modify_args.append('--num-preemptible-workers={}'.format(args.num_preemptible_workers))
+        modify_args.append('--num-secondary-workers={}'.format(args.num_preemptible_workers))
+        modify_args.append('--secondary-worker-type=preemptible')
 
     if args.graceful_decommission_timeout:
         if not modify_args:

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -307,10 +307,11 @@ def main(args, pass_through_args):
     conf.flags['master-machine-type'] = args.master_machine_type
     conf.flags['master-boot-disk-size'] = '{}GB'.format(args.master_boot_disk_size)
     conf.flags['num-master-local-ssds'] = args.num_master_local_ssds
-    conf.flags['num-preemptible-workers'] = args.num_preemptible_workers
+    conf.flags['num-secondary-workers'] = args.num_preemptible_workers
+    conf.flags['secondary-worker-type'] = 'preemptible'
     conf.flags['num-worker-local-ssds'] = args.num_worker_local_ssds
     conf.flags['num-workers'] = args.num_workers
-    conf.flags['preemptible-worker-boot-disk-size'] = disk_size(args.preemptible_worker_boot_disk_size)
+    conf.flags['secondary-worker-boot-disk-size'] = disk_size(args.preemptible_worker_boot_disk_size)
     conf.flags['worker-boot-disk-size'] = disk_size(args.worker_boot_disk_size)
     conf.flags['worker-machine-type'] = args.worker_machine_type
     if args.region:

--- a/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
@@ -53,7 +53,8 @@ def test_modify_workers(gcloud_run, workers_arg):
 ])
 def test_modify_preemptible_workers(gcloud_run, workers_arg):
     cli.main(["modify", "test-cluster", workers_arg])
-    assert "--num-preemptible-workers=2" in gcloud_run.call_args[0][0]
+    assert "--num-secondary-workers=2" in gcloud_run.call_args[0][0]
+    assert "--secondary-worker-type=preemptible" in gcloud_run.call_args[0][0]
 
 
 def test_modify_max_idle(gcloud_run):

--- a/hail/python/test/hailtop/hailctl/dataproc/test_start.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_start.py
@@ -47,7 +47,8 @@ def test_workers_configuration(gcloud_run):
 
 def test_secondary_workers_configuration(gcloud_run):
     cli.main(["start", "--num-preemptible-workers=8", "test-cluster"])
-    assert "--num-preemptible-workers=8" in gcloud_run.call_args[0][0]
+    assert "--num-secondary-workers=8" in gcloud_run.call_args[0][0]
+    assert "--secondary-worker-type=preemptible" in gcloud_run.call_args[0][0]
 
 
 @pytest.mark.parametrize("machine_arg", [


### PR DESCRIPTION
CHANGELOG: Teach `hailctl dataproc` to use new `gcloud` flag names which suppresses the warnings about `--num-secondary-workers`. `hailctl` now requires at least gcloud 284.0.0. Run `gcloud components update` to update.

This has been available since March, it seems high time to fix this and recommend people update gcloud.