### PR TITLE
batch `make deploy` could push stale image

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -46,13 +46,14 @@ push: build
 	docker tag batch-copy $(BATCH_COPY_IMAGE)
 	docker push $(BATCH_COPY_IMAGE)
 
-JINJA_ENVIRONMENT := '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"batch_image":{"image":"$(BATCH_IMAGE)"},"batch_worker_image":{"image":"$(BATCH_WORKER_IMAGE)"},"batch_copy_image":{"image":"$(BATCH_COPY_IMAGE)"},"default_ns":{"name":"default"},"batch_pods_ns":{"name":"batch-pods"},"batch_database":{"user_secret_name":"sql-batch-user-config"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)","k8s_server_url":"$(KUBERNETES_SERVER_URL)"}}'
+JINJA_ENVIRONMENT = '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"batch_image":{"image":"$(BATCH_IMAGE)"},"batch_worker_image":{"image":"$(BATCH_WORKER_IMAGE)"},"batch_copy_image":{"image":"$(BATCH_COPY_IMAGE)"},"default_ns":{"name":"default"},"batch_pods_ns":{"name":"batch-pods"},"batch_database":{"user_secret_name":"sql-batch-user-config"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)","k8s_server_url":"$(KUBERNETES_SERVER_URL)"}}'
 
 .PHONY: deploy
 deploy: push
-	python3 ../ci/jinja2_render.py $(JINJA_ENVIRONMENT) deployment.yaml deployment.yaml.out
-	python3 ../ci/jinja2_render.py $(JINJA_ENVIRONMENT) service-account.yaml service-account.yaml.out
-	python3 ../ci/jinja2_render.py $(JINJA_ENVIRONMENT) service-account-batch-pods.yaml service-account-batch-pods.yaml.out
+	E=$(JINJA_ENVIRONMENT) && \
+	  python3 ../ci/jinja2_render.py $$E deployment.yaml deployment.yaml.out && \
+	  python3 ../ci/jinja2_render.py $$E service-account.yaml service-account.yaml.out && \
+	  python3 ../ci/jinja2_render.py $$E service-account-batch-pods.yaml service-account-batch-pods.yaml.out
 	kubectl -n default apply -f service-account.yaml.out
 	kubectl -n default apply -f service-account-batch-pods.yaml.out
 	kubectl -n default apply -f deployment.yaml.out


### PR DESCRIPTION
Context: `batch/Makefile` is for manually building and deploying batch from your local machine.  This is rare, and is done when we are bootstrapping a new cluster, or something goes wrong and we need to manually intervene.    The service Makefiles have three main targets: `build`, `push` and `deploy`.  `build` builds docker images for the service locally.  `push` pushes them to the Google Container Repository.  `deploy` deploys the new image to Kubernetes.

The `build` target builds a new image, and BATCH_IMAGE uses docker to get the current image.  `:=` means evaluate once.  This means the JINJA_ENVIRONMENT had the image when `make` was invoked.  So if a new image was built, deploy would deploy the wrong image.

@danking @jigold I wonder if this might explain surprising behavior when you were working on the batch issue earlier today.