### PR TITLE
[batch] revert test for wildcards in input paths

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -204,7 +204,7 @@ def test_input_dependency_wildcard(client):
     batch.submit()
     tail.wait()
     assert head._get_exit_code(head.status(), 'input') != 0, head._status
-    assert 'glob wildcards are not allowed in file paths' in tail.log()['input'], tail.log()['input']
+    assert tail.log()['main'] == 'head1\nhead2\n', tail.status()
 
 
 def test_input_dependency_directory(client):


### PR DESCRIPTION
Now that we have the old workers, we allow wildcards in the file paths.