### PR TITLE
[query] Remove PBaseStructValue.apply

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -86,7 +86,7 @@ class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
       cb.emb
     )
 
-    val leftNdShape = PCode.apply(ndTyp.shape.pType, ndTyp.shape.load(leftNdValue.value.asInstanceOf[Value[Long]])).asBaseStruct.memoize(cb, "left_nd_shape")
+    val leftNdShape = leftNdValue.shapes()
 
     val columnMajorLoops = idxVars.zipWithIndex.foldLeft(body) { case (innerLoops, (dimVar, dimIdx)) =>
       Code(

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -192,8 +192,6 @@ abstract class PBaseStruct extends PType {
 }
 
 abstract class PBaseStructValue extends PValue {
-  def apply[T](i: Int): Value[T]
-
   def isFieldMissing(fieldIdx: Int): Code[Boolean]
 
   def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -252,11 +252,6 @@ class PCanonicalBaseStructSettable(
     a := pv.asInstanceOf[PCanonicalBaseStructCode].a
   }
 
-  def apply[T](i: Int): Value[T] =
-    new Value[T] {
-      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
-    }
-
   def isFieldMissing(fieldIdx: Int): Code[Boolean] = {
     this.pt.isFieldMissing(a, fieldIdx)
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -262,6 +262,12 @@ class PCanonicalNDArraySettable(override val pt: PCanonicalNDArray, val a: Setta
     pt.outOfBounds(indices, a, mb)
   }
 
+  override def shapes(): IndexedSeq[Value[Long]] = Array.tabulate(pt.nDims) { i =>
+    new Value[Long] {
+      def get: Code[Long] = pt.loadShape(a, i)
+    }
+  }
+
   override def sameShape(other: PNDArrayValue, mb: EmitMethodBuilder[_]): Code[Boolean] = {
     val comparator = this.pt.shape.pType.codeOrdering(mb, other.pt.shape.pType)
     val thisShape = this.pt.shape.load(this.a).asInstanceOf[Code[comparator.T]]

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -62,6 +62,8 @@ abstract class PNDArray extends PType {
 abstract class PNDArrayValue extends PValue {
   def apply(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Value[_]
 
+  def shapes(): IndexedSeq[Value[Long]]
+
   override def pt: PNDArray = ???
 
   def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Boolean]

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -163,11 +163,6 @@ class PSubsetStructSettable(val pt: PSubsetStruct, a: Settable[Long]) extends PB
       pt.fields(fieldIdx).typ.load(pt.fieldOffset(a, fieldIdx)))
   }
 
-  def apply[T](i: Int): Value[T] =
-    new Value[T] {
-      def get: Code[T] = coerce[T](Region.loadIRIntermediate(pt.types(i))(pt.loadField(a, i)))
-    }
-
   def isFieldMissing(fieldIdx: Int): Code[Boolean] =
     pt.isFieldMissing(a, fieldIdx)
 


### PR DESCRIPTION
It's wildly unsafe. It's better to scope the unsafety in
`IEmitCode.handle` for `loadField`.

Also add `PNDArrayValue.shapes` to handle the previous use case of
`PBaseStructValue.apply`.