### PR TITLE
[query] Use size-based LZ4 compression codec for wireCodec (shuffles)

### DIFF
--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -155,7 +155,7 @@ final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
 
 final case class LZ4SizeBasedBlockBufferSpec(hc: Boolean, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
     extends BlockBufferSpec {
-  val lz4: LZ4 = if (hc) LZ4.hc else LZ4.fast
+  def lz4: LZ4 = if (hc) LZ4.hc else LZ4.fast
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4SizeBasedBlockBufferSpec"
 

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -24,7 +24,7 @@ object BufferSpec {
 
   val wireSpec: BufferSpec = LEB128BufferSpec(
     BlockingBufferSpec(32 * 1024,
-      LZ4SizeBasedBlockBufferSpec(false, 32 * 1024,
+      LZ4SizeBasedBlockBufferSpec("fast", 32 * 1024,
         256,
         new StreamBlockBufferSpec)))
 
@@ -153,9 +153,13 @@ final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
   def typeName = "LZ4FastBlockBufferSpec"
 }
 
-final case class LZ4SizeBasedBlockBufferSpec(hc: Boolean, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
+final case class LZ4SizeBasedBlockBufferSpec(compressorType: String, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
     extends BlockBufferSpec {
-  def lz4: LZ4 = if (hc) LZ4.hc else LZ4.fast
+  def lz4: LZ4 = compressorType match {
+    case "hc" => LZ4.hc
+    case "fast" => LZ4.fast
+  }
+
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4SizeBasedBlockBufferSpec"
 

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -24,7 +24,7 @@ object BufferSpec {
 
   val wireSpec: BufferSpec = LEB128BufferSpec(
     BlockingBufferSpec(32 * 1024,
-      LZ4SizeBasedFastBlockBufferSpec(32 * 1024,
+      LZ4SizeBasedBlockBufferSpec(false, 32 * 1024,
         256,
         new StreamBlockBufferSpec)))
 
@@ -60,7 +60,7 @@ object BufferSpec {
       classOf[LZ4BlockBufferSpec],
       classOf[LZ4HCBlockBufferSpec],
       classOf[LZ4FastBlockBufferSpec],
-      classOf[LZ4SizeBasedFastBlockBufferSpec],
+      classOf[LZ4SizeBasedBlockBufferSpec],
       classOf[StreamBlockBufferSpec],
       classOf[BufferSpec],
       classOf[LEB128BufferSpec],
@@ -153,11 +153,11 @@ final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
   def typeName = "LZ4FastBlockBufferSpec"
 }
 
-final case class LZ4SizeBasedFastBlockBufferSpec(hc: Boolean = false, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
+final case class LZ4SizeBasedBlockBufferSpec(hc: Boolean, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
     extends BlockBufferSpec {
   val lz4: LZ4 = if (hc) LZ4.hc else LZ4.fast
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
-  def typeName = "LZ4SizeBasedFastBlockBufferSpec"
+  def typeName = "LZ4SizeBasedBlockBufferSpec"
 
   def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4SizeBasedCompressingInputBlockBuffer(lz4, blockSize, child.buildInputBuffer(in))
 

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -24,7 +24,8 @@ object BufferSpec {
 
   val wireSpec: BufferSpec = LEB128BufferSpec(
     BlockingBufferSpec(32 * 1024,
-      LZ4FastBlockBufferSpec(32 * 1024,
+      LZ4SizeBasedFastBlockBufferSpec(32 * 1024,
+        256,
         new StreamBlockBufferSpec)))
 
   val memorySpec: BufferSpec = wireSpec
@@ -59,6 +60,7 @@ object BufferSpec {
       classOf[LZ4BlockBufferSpec],
       classOf[LZ4HCBlockBufferSpec],
       classOf[LZ4FastBlockBufferSpec],
+      classOf[LZ4SizeBasedFastBlockBufferSpec],
       classOf[StreamBlockBufferSpec],
       classOf[BufferSpec],
       classOf[LEB128BufferSpec],
@@ -149,6 +151,23 @@ final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
   def lz4 = LZ4.fast
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4FastBlockBufferSpec"
+}
+
+final case class LZ4SizeBasedFastBlockBufferSpec(blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
+    extends BlockBufferSpec {
+  def lz4: LZ4 = LZ4.fast
+  def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
+  def typeName = "LZ4SizeBasedFastBlockBufferSpec"
+
+  def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4SizeBasedCompressingInputBlockBuffer(lz4, blockSize, child.buildInputBuffer(in))
+
+  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new LZ4SizeBasedCompressingOutputBlockBuffer(lz4, blockSize, minCompressionSize, child.buildOutputBuffer(out))
+
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+    Code.newInstance[LZ4SizeBasedCompressingInputBlockBuffer, LZ4, Int, InputBlockBuffer](stagedlz4, blockSize, child.buildCodeInputBuffer(in))
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+    Code.newInstance[LZ4SizeBasedCompressingOutputBlockBuffer, LZ4, Int, Int, OutputBlockBuffer](stagedlz4, blockSize, minCompressionSize, child.buildCodeOutputBuffer(out))
 }
 
 object StreamBlockBufferSpec {

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -153,9 +153,9 @@ final case class LZ4FastBlockBufferSpec(blockSize: Int, child: BlockBufferSpec)
   def typeName = "LZ4FastBlockBufferSpec"
 }
 
-final case class LZ4SizeBasedFastBlockBufferSpec(blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
+final case class LZ4SizeBasedFastBlockBufferSpec(hc: Boolean = false, blockSize: Int, minCompressionSize: Int, child: BlockBufferSpec)
     extends BlockBufferSpec {
-  def lz4: LZ4 = LZ4.fast
+  val lz4: LZ4 = if (hc) LZ4.hc else LZ4.fast
   def stagedlz4: Code[LZ4] = Code.invokeScalaObject0[LZ4](LZ4.getClass, "fast")
   def typeName = "LZ4SizeBasedFastBlockBufferSpec"
 


### PR DESCRIPTION
I'm having a lot of of trouble demonstrating that this is faster using the benchmark system. I can see a marked improvement in shuffle benchmarks using my laptop:
```
$ hb compare /tmp/lz4-before.json /tmp/lz4-after.json
          Benchmark Name      Ratio     Time 1     Time 2
          --------------      -----     ------     ------
shuffle_order_by_10m_int      70.4%     47.193     33.245
```

I also don't see any slowdown for the larger shuffles (which do get slower if we use one of the uncompressed codecs).

Running benchmarks on batch have produced results where the median varies from 1% slower to 6% faster.