### PR TITLE
[query] Add `hl.nd.svd` for doing local Singular Value Decompositions

### DIFF
--- a/hail/python/hail/docs/nd/index.rst
+++ b/hail/python/hail/docs/nd/index.rst
@@ -11,7 +11,8 @@ nd
 
 Notes
 _____
-This is a recently added, experimental module. We would love to hear what use cases you have for this as we expand this functionality
+This is a recently added, experimental module. We would love to hear what use cases you have for this as we expand this functionality.
+As much as possible, we try to mimic the numpy array interface.
 
 .. autosummary::
 
@@ -21,8 +22,10 @@ This is a recently added, experimental module. We would love to hear what use ca
     zeros
     ones
     qr
+    svd
     inv
     concatenate
+    hstack
     vstack
     eye
     identity
@@ -33,8 +36,10 @@ This is a recently added, experimental module. We would love to hear what use ca
 .. autofunction:: zeros
 .. autofunction:: ones
 .. autofunction:: qr
+.. autofunction:: svd
 .. autofunction:: inv
 .. autofunction:: concatenate
+.. autofunction:: hstack
 .. autofunction:: vstack
 .. autofunction:: eye
 .. autofunction:: identity

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -8,7 +8,7 @@ from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
     Void, Cast, NA, IsNA, If, Coalesce, Let, AggLet, Ref, TopLevelReference, \
     TailLoop, Recur, ApplyBinaryPrimOp, ApplyUnaryPrimOp, ApplyComparisonOp, \
     MakeArray, ArrayRef, ArrayLen, ArrayZeros, StreamRange, StreamGrouped, MakeNDArray, \
-    NDArrayShape, NDArrayReshape, NDArrayMap, NDArrayRef, NDArraySlice, \
+    NDArrayShape, NDArrayReshape, NDArrayMap, NDArrayRef, NDArraySlice, NDArraySVD, \
     NDArrayReindex, NDArrayAgg, NDArrayMatMul, NDArrayQR, NDArrayInv, NDArrayConcat, NDArrayWrite, \
     ArraySort, ToSet, ToDict, ToArray, CastToArray, ToStream, \
     LowerBoundOnOrderedCollection, GroupByKey, StreamMap, StreamZip, \

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -155,6 +155,7 @@ __all__ = [
     'NDArrayAgg',
     'NDArrayMatMul',
     'NDArrayQR',
+    'NDArraySVD',
     'NDArrayInv',
     'NDArrayConcat',
     'NDArrayWrite',

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -863,6 +863,9 @@ class NDArraySVD(IR):
     def copy(self):
         return NDArraySVD(self.nd, self.full_matrices, self.compute_uv)
 
+    def head_str(self):
+        return f'{self.full_matrices} {self.compute_uv}'
+
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)
         if self.compute_uv:

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -833,7 +833,6 @@ class NDArrayQR(IR):
         self.nd = nd
         self.mode = mode
 
-    @typecheck_method(nd=IR, mode=str)
     def copy(self):
         return NDArrayQR(self.nd, self.mode)
 
@@ -851,6 +850,22 @@ class NDArrayQR(IR):
             self._type = tndarray(tfloat64, 2)
         else:
             raise ValueError("Cannot compute type for mode: " + self.mode)
+
+
+class NDArraySVD(IR):
+    @typecheck_method(nd=IR, full_matrices=bool, compute_uv=bool)
+    def __init__(self, nd, full_matrices, compute_uv):
+        super().__init__(nd)
+        self.nd = nd
+        self.full_matrices = full_matrices
+        self.compute_uv = compute_uv
+
+    def copy(self):
+        return NDArraySVD(self.nd, self.full_matrices, self.compute_uv)
+
+    def _compute_type(self, env, agg_env):
+        self.nd._compute_type(env, agg_env)
+        return ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2))
 
 
 class NDArrayInv(IR):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -865,7 +865,10 @@ class NDArraySVD(IR):
 
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)
-        return ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2))
+        if self.compute_uv:
+            self._type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2))
+        else:
+            self._type = tndarray(tfloat64, 1)
 
 
 class NDArrayInv(IR):

--- a/hail/python/hail/nd/__init__.py
+++ b/hail/python/hail/nd/__init__.py
@@ -1,6 +1,7 @@
-from .nd import array, from_column_major, arange, full, zeros, ones, qr, diagonal, inv, concatenate, eye, identity, vstack, hstack
+from .nd import array, from_column_major, arange, full, zeros, ones, svd, qr, diagonal, inv, concatenate, \
+    eye, identity, vstack, hstack
 
 __all__ = [
-    'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'diagonal', 'inv',
+    'array', 'from_column_major', 'arange', 'full', 'zeros', 'ones', 'qr', 'svd', 'diagonal', 'inv',
     'concatenate', 'eye', 'identity', 'vstack', 'hstack'
 ]

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -266,7 +266,8 @@ def svd(nd, full_matrices = True, compute_uv = True):
     float_nd = nd.map(lambda x: hl.float64(x))
     ir = NDArraySVD(float_nd._ir, full_matrices, compute_uv)
     #TODO indices, aggregators
-    return construct_expr(ir,ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)))
+    return_type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)) if compute_uv else tndarray(tfloat64, 1)
+    return construct_expr(ir, return_type)
 
 @typecheck(nd=expr_ndarray())
 def inv(nd):

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -262,7 +262,7 @@ def qr(nd, mode="reduced"):
 
 
 @typecheck(nd=expr_ndarray(), full_matrices=bool, compute_uv=bool)
-def svd(nd, full_matrices = True, compute_uv = True):
+def svd(nd, full_matrices=True, compute_uv=True):
     """Performs a singular value decomposition.
 
     :param nd: :class:`.NDArrayExpression`
@@ -287,6 +287,7 @@ def svd(nd, full_matrices = True, compute_uv = True):
 
     return_type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)) if compute_uv else tndarray(tfloat64, 1)
     return construct_expr(ir, return_type)
+
 
 @typecheck(nd=expr_ndarray())
 def inv(nd):

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -263,7 +263,8 @@ def qr(nd, mode="reduced"):
 
 @typecheck(nd=expr_ndarray(), full_matrices=bool, compute_uv=bool)
 def svd(nd, full_matrices = True, compute_uv = True):
-    ir = NDArraySVD(nd._ir, full_matrices, compute_uv)
+    float_nd = nd.map(lambda x: hl.float64(x))
+    ir = NDArraySVD(float_nd._ir, full_matrices, compute_uv)
     #TODO indices, aggregators
     return construct_expr(ir,ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)))
 

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -263,9 +263,28 @@ def qr(nd, mode="reduced"):
 
 @typecheck(nd=expr_ndarray(), full_matrices=bool, compute_uv=bool)
 def svd(nd, full_matrices = True, compute_uv = True):
+    """Performs a singular value decomposition.
+
+    :param nd: :class:`.NDArrayExpression`
+        A 2 dimensional ndarray, shape(M, N).
+    :param full_matrices: `bool`
+        If True (default), u and vt have dimensions (M, M) and (N, N) respectively. Otherwise, they have dimensions
+        (M, K) and (K, N), where K = min(M, N)
+    :param compute_uv: `bool`
+        If True (default), compute the singular vectors u and v. Otherwise, only return a single ndarray, s.
+
+    Returns
+    -------
+    - u: :class:`.NDArrayExpression`
+        The left singular vectors.
+    - s: :class:`.NDArrayExpression`
+        The singular values.
+    - vt: :class:`.NDArrayExpression`
+        The right singular vectors.
+    """
     float_nd = nd.map(lambda x: hl.float64(x))
     ir = NDArraySVD(float_nd._ir, full_matrices, compute_uv)
-    #TODO indices, aggregators
+
     return_type = ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)) if compute_uv else tndarray(tfloat64, 1)
     return construct_expr(ir, return_type)
 

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -9,7 +9,7 @@ from hail.expr.expressions import (
     expr_int32, expr_int64, expr_tuple, expr_any, expr_array, expr_ndarray,
     expr_numeric, Int64Expression, cast_expr, construct_expr)
 from hail.expr.expressions.typed_expressions import NDArrayNumericExpression
-from hail.ir import NDArrayQR, NDArrayInv, NDArrayConcat
+from hail.ir import NDArrayQR, NDArrayInv, NDArrayConcat, NDArraySVD
 
 tsequenceof_nd = oneof(sequenceof(expr_ndarray()), expr_array(expr_ndarray()))
 shape_type = oneof(expr_int64, tupleof(expr_int64), expr_tuple())
@@ -260,6 +260,11 @@ def qr(nd, mode="reduced"):
     elif mode in ["complete", "reduced"]:
         return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)))
 
+
+def svd(nd, full_matrices, compute_uv):
+    ir = NDArraySVD(nd._ir, full_matrices, compute_uv)
+    #TODO indices, aggregators
+    return construct_expr(ir,ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)))
 
 @typecheck(nd=expr_ndarray())
 def inv(nd):

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -261,7 +261,8 @@ def qr(nd, mode="reduced"):
         return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)))
 
 
-def svd(nd, full_matrices, compute_uv):
+@typecheck(nd=expr_ndarray(), full_matrices=bool, compute_uv=bool)
+def svd(nd, full_matrices = True, compute_uv = True):
     ir = NDArraySVD(nd._ir, full_matrices, compute_uv)
     #TODO indices, aggregators
     return construct_expr(ir,ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1), tndarray(tfloat64, 2)))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -771,19 +771,36 @@ def test_svd():
         evaled = hl.eval(hl.nd.svd(nd_expr, full_matrices, compute_uv))
         np_svd = np.linalg.svd(np_array, full_matrices, compute_uv)
 
+        # check shapes
+        for h, n in zip(evaled, np_svd):
+            assert h.shape == n.shape
+
+        k = min(np_array.shape)
+        rank = np.linalg.matrix_rank(np_array)
+
         if compute_uv:
-            np.testing.assert_array_equal(evaled[0], np_svd[0])
-            np.testing.assert_array_equal(evaled[1], np_svd[1])
-            np.testing.assert_array_equal(evaled[2], np_svd[2])
+            np.testing.assert_array_almost_equal(evaled[0][:, :rank], np_svd[0][:, :rank])
+            np.testing.assert_array_almost_equal(evaled[1], np_svd[1])
+            np.testing.assert_array_almost_equal(evaled[2][:rank, :], np_svd[2][:rank, :])
 
         else:
             np.testing.assert_array_equal(evaled, np_svd)
 
     np_small_square = np.arange(4).reshape((2, 2))
     small_square = hl.nd.array(np_small_square)
+    np_rank_2_wide_rectangle = np.arange(12).reshape((4, 3))
+    rank_2_wide_rectangle = hl.nd.array(np_rank_2_wide_rectangle)
+    np_rank_2_tall_rectangle = np_rank_2_wide_rectangle.T
+    rank_2_tall_rectangle = hl.nd.array(np_rank_2_tall_rectangle)
 
     assert_evals_to_same_svd(small_square, np_small_square)
     assert_evals_to_same_svd(small_square, np_small_square, compute_uv=False)
+
+    assert_evals_to_same_svd(rank_2_wide_rectangle, np_rank_2_wide_rectangle)
+    assert_evals_to_same_svd(rank_2_wide_rectangle, np_rank_2_wide_rectangle, full_matrices=False)
+
+    assert_evals_to_same_svd(rank_2_tall_rectangle, np_rank_2_tall_rectangle)
+    assert_evals_to_same_svd(rank_2_tall_rectangle, np_rank_2_tall_rectangle, full_matrices=False)
 
 
 def test_numpy_interop():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -766,6 +766,21 @@ def test_ndarray_qr():
     assert "requires 2 dimensional" in str(exc)
 
 
+def test_svd():
+    def assert_evals_to_same_svd(nd_expr, np_array):
+        evaled = hl.eval(hl.nd.svd(nd_expr))
+        np_svd = np.linalg.svd(np_array)
+
+        np.testing.assert_array_equal(evaled[0], np_svd[0])
+        np.testing.assert_array_equal(evaled[1], np_svd[1])
+        np.testing.assert_array_equal(evaled[2], np_svd[2])
+
+    np_small_square = np.arange(4).reshape((2, 2))
+    small_square = hl.nd.array(np_small_square)
+
+    assert_evals_to_same_svd(small_square, np_small_square)
+
+
 def test_numpy_interop():
     v = [2, 3]
     w = [3, 5]

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -767,18 +767,23 @@ def test_ndarray_qr():
 
 
 def test_svd():
-    def assert_evals_to_same_svd(nd_expr, np_array):
-        evaled = hl.eval(hl.nd.svd(nd_expr))
-        np_svd = np.linalg.svd(np_array)
+    def assert_evals_to_same_svd(nd_expr, np_array, full_matrices=True, compute_uv=True):
+        evaled = hl.eval(hl.nd.svd(nd_expr, full_matrices, compute_uv))
+        np_svd = np.linalg.svd(np_array, full_matrices, compute_uv)
 
-        np.testing.assert_array_equal(evaled[0], np_svd[0])
-        np.testing.assert_array_equal(evaled[1], np_svd[1])
-        np.testing.assert_array_equal(evaled[2], np_svd[2])
+        if compute_uv:
+            np.testing.assert_array_equal(evaled[0], np_svd[0])
+            np.testing.assert_array_equal(evaled[1], np_svd[1])
+            np.testing.assert_array_equal(evaled[2], np_svd[2])
+
+        else:
+            np.testing.assert_array_equal(evaled, np_svd)
 
     np_small_square = np.arange(4).reshape((2, 2))
     small_square = hl.nd.array(np_small_square)
 
     assert_evals_to_same_svd(small_square, np_small_square)
+    assert_evals_to_same_svd(small_square, np_small_square, compute_uv=False)
 
 
 def test_numpy_interop():

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -143,6 +143,8 @@ object Children {
       Array(l, r)
     case NDArrayQR(nd, _) =>
       Array(nd)
+    case NDArraySVD(nd, _, _) =>
+      Array(nd)
     case NDArrayInv(nd) =>
       Array(nd)
     case NDArrayWrite(nd, path) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -111,6 +111,9 @@ object Copy {
       case NDArrayQR(_, mode) =>
         assert(newChildren.length == 1)
         NDArrayQR(newChildren(0).asInstanceOf[IR], mode)
+      case NDArraySVD(_, fullMatrices, computeUV) =>
+        assert(newChildren.length == 1)
+        NDArraySVD(newChildren(0).asInstanceOf[IR], fullMatrices, computeUV)
       case NDArrayInv(_) =>
         assert(newChildren.length == 1)
         NDArrayInv(newChildren(0).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -812,6 +812,16 @@ class Emit[C](
           }
         }
 
+      case NDArraySVD(nd, full_matrices, computeUV) =>
+        emitI(nd).flatMap(cb){ ndPCode =>
+          val ndPVal = ndPCode.asNDArray.memoize(cb, "nd_value_to_svd")
+          val JOBZ = if (computeUV) {
+            "N"
+          } else {
+            if (full_matrices) "S" else "A"
+          }
+          ???
+        }
       case x@RunAgg(body, result, states) =>
         val newContainer = AggContainer.fromBuilder(cb, states.toArray, "run_agg")
         emitVoid(body, container = Some(newContainer))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -820,12 +820,13 @@ class Emit[C](
       case x@NDArraySVD(nd, full_matrices, computeUV) =>
         emitNDArrayStandardStrides(nd).flatMap(cb){ ndPCode =>
           val ndPVal = ndPCode.asNDArray.memoize(cb, "nd_svd_value")
+          val ndPType = ndPCode.asNDArray.pt
 
           val infoDGESDDResult = cb.newLocal[Int]("infoDGESDD")
 
           val LWORKAddress = mb.newLocal[Long]()
 
-          val shapePVal= new PCanonicalBaseStructCode(ndPVal.pt.shape.pType.asInstanceOf[PCanonicalBaseStruct], ndPVal.pt.shape.load(ndPVal.value.asInstanceOf[Long])).memoize(cb, "nd_svd_shape")
+          val shapePVal= new PCanonicalBaseStructCode(ndPVal.pt.shape.pType.asInstanceOf[PCanonicalBaseStruct], ndPVal.pt.shape.load(ndPVal.value.asInstanceOf[Value[Long]])).memoize(cb, "nd_svd_shape")
           val M = shapePVal.loadField(cb, 0).handle(cb, {/* do nothing */}).memoize(cb, "dgesdd_M").value.asInstanceOf[Value[Long]]
           val N = shapePVal.loadField(cb, 1).handle(cb, {/* do nothing */}).memoize(cb, "dgesdd_N").value.asInstanceOf[Value[Long]]
           val K = cb.newLocal[Long]("nd_svd_K")
@@ -836,12 +837,18 @@ class Emit[C](
           val LDU = M
           val VT_data = cb.newField[Long]("dgesdd_VT_address")
           val IWORKAddress = cb.newLocal[Long]("dgesdd_IWORK_address")
+          val A = cb.newLocal[Long]("dgesdd_A_address")
+          val dataAddress = cb.newLocal[Long]("nd_svd_dataArray_address")
 
-          val dataArray = ndPVal.pt.data.load(ndPVal.value.asInstanceOf[Long])
-
+          // FIXME: I can't just hand the data array pointer over like this, needs first element offset and to be copied away.
+          cb.assign(dataAddress, ndPVal.pt.data.load(ndPVal.value.asInstanceOf[Value[Long]]))
           cb.assign(LWORKAddress, Code.invokeStatic1[Memory, Long, Long]("malloc",  8L))
           cb.assign(IWORKAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", K.toL * 8L * 4L)) // 8K 4 byte integers.
+          cb.assign(A, Code.invokeStatic1[Memory, Long, Long]("malloc", M * N * 8L))
           cb.assign(S_data, region.code.allocate(8L, K))
+
+          // Copy data into A:
+          Region.copyFrom(ndPType.data.pType.firstElementOffset(dataAddress, (M * N).toI), A, (M * N) * 8L)
 
           // Determines JOBZ, U for LAPACK, V for LAPACK
           if (computeUV) {
@@ -851,19 +858,19 @@ class Emit[C](
             val vtPType = outputPType.fields(2).typ.asInstanceOf[PNDArray]
 
             val JOBZ = if (full_matrices) "A" else "S"
-            val UCOL: Code[Int] = if (full_matrices) M.toI else K.toI
+            def UCOL: Value[Long] = if (full_matrices) M else K
             val LDVT = if (full_matrices) N else K
 
 
-            cb.assign(U_data, uPType.data.pType.allocate(region.code, UCOL * LDU.toI))
+            cb.assign(U_data, uPType.data.pType.allocate(region.code, UCOL.toI * LDU.toI))
             cb.assign(S_data, sPType.data.pType.allocate(region.code, K.toI))
-            cb.assign(VT_data, vtPType.data.pType.allocate(region.code, ???))
+            cb.assign(VT_data, vtPType.data.pType.allocate(region.code, N.toI * LDVT.toI))
 
             cb.assign(infoDGESDDResult, Code.invokeScalaObject13[String, Int, Int, Long, Int, Long, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dgesdd",
               JOBZ,
               M.toI,
               N.toI,
-              dataArray,
+              A,
               LDA.toI,
               sPType.data.pType.firstElementOffset(S_data),
               uPType.data.pType.firstElementOffset(U_data),
@@ -884,7 +891,7 @@ class Emit[C](
               JOBZ,
               M.toI,
               N.toI,
-              dataArray,
+              A,
               LDA.toI,
               sPType.data.pType.firstElementOffset(S_data),
               uPType.data.pType.firstElementOffset(U_data),
@@ -896,11 +903,11 @@ class Emit[C](
               IWORKAddress
             ))
 
-            val uShapeSeq = IndexedSeq(M.toL, UCOL.toL)
-            val u = uPType.construct(uPType.makeShapeBuilder(uShapeSeq), uPType.makeColumnMajorStridesBuilder(uShapeSeq, mb), U_data, mb, region.code)
+            def uShapeSeq = FastIndexedSeq[Value[Long]](M, UCOL)
+            val u = uPType.construct(uPType.makeShapeBuilder(uShapeSeq.map(_.get)), uPType.makeColumnMajorStridesBuilder(uShapeSeq.map(_.get), mb), U_data, mb, region.code)
 
-            val sShapeSeq = IndexedSeq(K.toL)
-            val s = sPType.construct(sPType.makeShapeBuilder(sShapeSeq), sPType.makeColumnMajorStridesBuilder(sShapeSeq, mb), S_data, mb, region.code)
+            val sShapeSeq = FastIndexedSeq[Value[Long]](K)
+            val s = sPType.construct(sPType.makeShapeBuilder(sShapeSeq.map(_.get)), sPType.makeColumnMajorStridesBuilder(sShapeSeq.map(_.get), mb), S_data, mb, region.code)
             val vt = vtPType.construct(???, ???, VT_data, mb, region.code)
 
             val resultSRVB = new StagedRegionValueBuilder(mb, outputPType, region.code)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -827,7 +827,7 @@ class Emit[C](
 
           val shapePVal= new PCanonicalBaseStructCode(ndPVal.pt.shape.pType.asInstanceOf[PCanonicalBaseStruct], ndPVal.pt.shape.load(ndPVal.value.asInstanceOf[Long])).memoize(cb, "nd_svd_shape")
           val M = shapePVal[Long](0)
-          val N = shapePVal[Long](1).
+          val N = shapePVal[Long](1)
           val K = cb.newLocal[Long]("nd_svd_K")
           cb.assign(K, (M < N).mux(M, N))
           val LDA = M
@@ -861,15 +861,15 @@ class Emit[C](
 
             cb.assign(infoDGESDDResult, Code.invokeScalaObject13[String, Int, Int, Long, Int, Long, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dgesdd",
               JOBZ,
-              M,
-              N,
+              M.toI,
+              N.toI,
               dataArray,
-              LDA,
+              LDA.toI,
               sPType.data.pType.firstElementOffset(S_data),
               uPType.data.pType.firstElementOffset(U_data),
-              LDU,
+              LDU.toI,
               vtPType.data.pType.firstElementOffset(VT_data),
-              LDVT,
+              LDVT.toI,
               LWORKAddress,
               -1,
               IWORKAddress
@@ -882,15 +882,15 @@ class Emit[C](
 
             cb.assign(infoDGESDDResult, Code.invokeScalaObject13[String, Int, Int, Long, Int, Long, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dgesdd",
               JOBZ,
-              M,
-              N,
+              M.toI,
+              N.toI,
               dataArray,
-              LDA,
+              LDA.toI,
               sPType.data.pType.firstElementOffset(S_data),
               uPType.data.pType.firstElementOffset(U_data),
-              LDU,
+              LDU.toI,
               vtPType.data.pType.firstElementOffset(VT_data),
-              LDVT,
+              LDVT.toI,
               WORK,
               LWORK,
               IWORKAddress

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -919,16 +919,16 @@ class Emit[C](
           cb.append(infoDGESDDErrorTest("Failed result computation."))
 
           val sShapeSeq = FastIndexedSeq[Value[Long]](K)
-          val s = sPType.construct(sPType.makeShapeBuilder(sShapeSeq.map(_.get)), sPType.makeColumnMajorStridesBuilder(sShapeSeq.map(_.get), mb), sData, mb, region.code)
+          val s = sPType.construct(sPType.makeShapeBuilder(sShapeSeq), sPType.makeColumnMajorStridesBuilder(sShapeSeq, mb), sData, mb, region.code)
 
           val resultPCode = if (computeUV) {
             val uShapeSeq = FastIndexedSeq[Value[Long]](M, UCOL)
             val uPType = optUPType.get
-            val u = uPType.construct(uPType.makeShapeBuilder(uShapeSeq.map(_.get)), uPType.makeColumnMajorStridesBuilder(uShapeSeq.map(_.get), mb), U_data, mb, region.code)
+            val u = uPType.construct(uPType.makeShapeBuilder(uShapeSeq), uPType.makeColumnMajorStridesBuilder(uShapeSeq, mb), U_data, mb, region.code)
 
             val vtShapeSeq = FastIndexedSeq[Value[Long]](LDVT, N)
             val vtPType = optVTPType.get
-            val vt = vtPType.construct(vtPType.makeShapeBuilder(vtShapeSeq.map(_.get)), vtPType.makeColumnMajorStridesBuilder(vtShapeSeq.map(_.get), mb), vtData, mb, region.code)
+            val vt = vtPType.construct(vtPType.makeShapeBuilder(vtShapeSeq), vtPType.makeColumnMajorStridesBuilder(vtShapeSeq, mb), vtData, mb, region.code)
 
             val resultSRVB = new StagedRegionValueBuilder(mb, x.pType, region.code)
             cb.append(Code(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -826,8 +826,8 @@ class Emit[C](
           val LWORKAddress = mb.newLocal[Long]()
 
           val shapePVal= new PCanonicalBaseStructCode(ndPVal.pt.shape.pType.asInstanceOf[PCanonicalBaseStruct], ndPVal.pt.shape.load(ndPVal.value.asInstanceOf[Long])).memoize(cb, "nd_svd_shape")
-          val M = shapePVal[Long](0)
-          val N = shapePVal[Long](1)
+          val M = shapePVal.loadField(cb, 0).handle(cb, {/* do nothing */}).memoize(cb, "dgesdd_M").value.asInstanceOf[Value[Long]]
+          val N = shapePVal.loadField(cb, 1).handle(cb, {/* do nothing */}).memoize(cb, "dgesdd_N").value.asInstanceOf[Value[Long]]
           val K = cb.newLocal[Long]("nd_svd_K")
           cb.assign(K, (M < N).mux(M, N))
           val LDA = M

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -410,6 +410,8 @@ object NDArrayInv {
 
 final case class NDArrayQR(nd: IR, mode: String) extends IR
 
+final case class NDArraySVD(nd: IR, full_matrices: Boolean, compute_uv: Boolean)
+
 final case class NDArrayInv(nd: IR) extends IR
 
 final case class AggFilter(cond: IR, aggIR: IR, isScan: Boolean) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -404,13 +404,24 @@ object NDArrayQR {
     "complete" -> PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 2)))
 }
 
+object NDArraySVD {
+  def pTypes(computeUV: Boolean): PType = {
+    if (computeUV) {
+      PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 1), PCanonicalNDArray(PFloat64Required, 2))
+    }
+    else {
+      PCanonicalNDArray(PFloat64Required, 1)
+    }
+  }
+}
+
 object NDArrayInv {
   val pType = PCanonicalNDArray(PFloat64Required, 2)
 }
 
 final case class NDArrayQR(nd: IR, mode: String) extends IR
 
-final case class NDArraySVD(nd: IR, full_matrices: Boolean, compute_uv: Boolean) extends IR
+final case class NDArraySVD(nd: IR, fullMatrices: Boolean, computeUV: Boolean) extends IR
 
 final case class NDArrayInv(nd: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -410,7 +410,7 @@ object NDArrayInv {
 
 final case class NDArrayQR(nd: IR, mode: String) extends IR
 
-final case class NDArraySVD(nd: IR, full_matrices: Boolean, compute_uv: Boolean)
+final case class NDArraySVD(nd: IR, full_matrices: Boolean, compute_uv: Boolean) extends IR
 
 final case class NDArrayInv(nd: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -237,6 +237,7 @@ object InferPType {
         val rTyp = coerce[PNDArray](r.pType)
         PCanonicalNDArray(lTyp.elementType, TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims), requiredness(node).required)
       case NDArrayQR(_, mode) => NDArrayQR.pTypes(mode)
+      case NDArraySVD(_, _, computeUV) => NDArraySVD.pTypes(computeUV)
       case NDArrayInv(_) => NDArrayInv.pType
       case MakeStruct(fields) =>
         PCanonicalStruct(requiredness(node).required,

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -183,6 +183,12 @@ object InferType {
         } else {
           throw new NotImplementedError(s"Cannot infer type for mode $mode")
         }
+      case NDArraySVD(nd, _, compute_uv) =>
+        if (compute_uv) {
+          TTuple(TNDArray(TFloat64, Nat(2)), TNDArray(TFloat64, Nat(1)), TNDArray(TFloat64, Nat(2)))
+        } else {
+          TNDArray(TFloat64, Nat(1))
+        }
       case NDArrayInv(_) =>
         TNDArray(TFloat64, Nat(2))
       case NDArrayWrite(_, _) => TVoid

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -922,6 +922,11 @@ object IRParser {
         val mode = string_literal(it)
         val nd = ir_value_expr(env)(it)
         NDArrayQR(nd, mode)
+      case "NDArraySVD" =>
+        val fullMatrices = boolean_literal(it)
+        val computeUV = boolean_literal(it)
+        val nd = ir_value_expr(env)(it)
+        NDArraySVD(nd, fullMatrices, computeUV)
       case "NDArrayInv" =>
         val nd = ir_value_expr(env)(it)
         NDArrayInv(nd)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -610,6 +610,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(lookup(l))
         requiredness.union(lookup(r).required)
       case NDArrayQR(_, mode) => requiredness.fromPType(NDArrayQR.pTypes(mode))
+      case NDArraySVD(_, _, computeUV) => requiredness.fromPType(NDArraySVD.pTypes(computeUV))
       case NDArrayInv(_) => requiredness.fromPType(NDArrayInv.pType)
       case MakeStruct(fields) =>
         fields.foreach { case (n, f) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -190,6 +190,10 @@ object TypeCheck {
         val ndType = nd.typ.asInstanceOf[TNDArray]
         assert(ndType.elementType == TFloat64)
         assert(ndType.nDims == 2)
+      case x@NDArraySVD(nd, _, computeUV) =>
+        val ndType = nd.typ.asInstanceOf[TNDArray]
+        assert(ndType.elementType == TFloat64)
+        assert(ndType.nDims == 2)
       case x@NDArrayInv(nd) =>
         val ndType = nd.typ.asInstanceOf[TNDArray]
         assert(ndType.elementType == TFloat64)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -190,7 +190,7 @@ object TypeCheck {
         val ndType = nd.typ.asInstanceOf[TNDArray]
         assert(ndType.elementType == TFloat64)
         assert(ndType.nDims == 2)
-      case x@NDArraySVD(nd, _, computeUV) =>
+      case x@NDArraySVD(nd, _, _) =>
         val ndType = nd.typ.asInstanceOf[TNDArray]
         assert(ndType.elementType == TFloat64)
         assert(ndType.nDims == 2)

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -79,19 +79,6 @@ object LAPACK {
     INFOref.getValue()
   }
 
-  def dgesvd(JOBU: String, JOBVT: String, M: Int, N: Int, A: Long, LDA: Int, S: Long, U: Long, LDU: Int, VT: Long, LDVT: Int, WORK: Long, LWORK: Int): Int = {
-    val Mref = new IntByReference(M)
-    val Nref= new IntByReference(N)
-    val LDAref = new IntByReference(LDA)
-    val LDUref = new IntByReference(LDU)
-    val LDVTref = new IntByReference(LDVT)
-    val LWORKRef = new IntByReference(LWORK)
-    val INFOref = new IntByReference(1)
-
-    libraryInstance.dgesvd(JOBU, JOBVT, Mref, Nref, A, LDAref, S, U, LDUref, VT, LDVTref, WORK, LWORKRef, INFOref)
-
-    INFOref.getValue()
-  }
 
   def dgesdd(JOBZ: String, M: Int, N: Int, A: Long, LDA: Int, S: Long, U: Long, LDU: Int, VT: Long, LDVT: Int, WORK: Long, LWORK: Int, IWORK: Long): Int = {
     val Mref = new IntByReference(M)
@@ -125,7 +112,6 @@ trait LAPACKLibrary extends Library {
   def dorgqr(M: IntByReference, N: IntByReference, K: IntByReference, A: Long, LDA: IntByReference, TAU: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dgetrf(M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, INFO: IntByReference)
   def dgetri(N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
-  def dgesvd(JOBU: String, JOBVT: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dgesdd(JOBZ: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, IWORK: Long, INFO: IntByReference)
   def ilaver(MAJOR: IntByReference, MINOR: IntByReference, PATCH: IntByReference)
 }

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -93,6 +93,20 @@ object LAPACK {
     INFOref.getValue()
   }
 
+  def dgesdd(JOBZ: String, M: Int, N: Int, A: Long, LDA: Int, S: Long, U: Long, LDU: Int, VT: Long, LDVT: Int, WORK: Long, LWORK: Int, IWORK: Long): Int = {
+    val Mref = new IntByReference(M)
+    val Nref= new IntByReference(N)
+    val LDAref = new IntByReference(LDA)
+    val LDUref = new IntByReference(LDU)
+    val LDVTref = new IntByReference(LDVT)
+    val LWORKRef = new IntByReference(LWORK)
+    val INFOref = new IntByReference(1)
+
+    libraryInstance.dgesdd(JOBZ, Mref, Nref, A, LDAref, S, U, LDUref, VT, LDVTref, WORK, LWORKRef, IWORK, INFOref)
+
+    INFOref.getValue()
+  }
+
 
   private def versionTest(libInstance: LAPACKLibrary): Try[String] = {
     val major = new IntByReference()
@@ -112,5 +126,6 @@ trait LAPACKLibrary extends Library {
   def dgetrf(M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, INFO: IntByReference)
   def dgetri(N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dgesvd(JOBU: String, JOBVT: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
+  def dgesdd(JOBZ: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, IWORK: Long, INFO: IntByReference)
   def ilaver(MAJOR: IntByReference, MINOR: IntByReference, PATCH: IntByReference)
 }

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -79,6 +79,21 @@ object LAPACK {
     INFOref.getValue()
   }
 
+  def dgesvd(JOBU: String, JOBVT: String, M: Int, N: Int, A: Long, LDA: Int, S: Long, U: Long, LDU: Int, VT: Long, LDVT: Int, WORK: Long, LWORK: Int): Int = {
+    val Mref = new IntByReference(M)
+    val Nref= new IntByReference(N)
+    val LDAref = new IntByReference(LDA)
+    val LDUref = new IntByReference(LDU)
+    val LDVTref = new IntByReference(LDVT)
+    val LWORKRef = new IntByReference(LWORK)
+    val INFOref = new IntByReference(1)
+
+    libraryInstance.dgesvd(JOBU, JOBVT, Mref, Nref, A, LDAref, S, U, LDUref, VT, LDVTref, WORK, LWORKRef, INFOref)
+
+    INFOref.getValue()
+  }
+
+
   private def versionTest(libInstance: LAPACKLibrary): Try[String] = {
     val major = new IntByReference()
     val minor = new IntByReference()
@@ -96,5 +111,6 @@ trait LAPACKLibrary extends Library {
   def dorgqr(M: IntByReference, N: IntByReference, K: IntByReference, A: Long, LDA: IntByReference, TAU: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dgetrf(M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, INFO: IntByReference)
   def dgetri(N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
+  def dgesvd(JOBU: String, JOBVT: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def ilaver(MAJOR: IntByReference, MINOR: IntByReference, PATCH: IntByReference)
 }

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -72,5 +72,7 @@ abstract class PNDArrayValue extends PValue {
 }
 
 abstract class PNDArrayCode extends PCode {
+  override def pt: PNDArray
+
   def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue
 }


### PR DESCRIPTION
This adds an `svd` method to `hl.nd`, allowing us to take singular value decomposition of local ndarrays. This is a generally useful operation, but my primary reason for adding it is to avoid the need to call numpy's SVD as a substep of Annamira's new randomized PCA method. The interface is designed to match numpy exactly. 

Note that this method uses the LAPACK method `dgesdd`, which is newer, faster version of `dgesvd`. As far as I can tell, there's never a reason to use `dgesvd`. 