### PR TITLE
Added better example for the common case of hl.zip

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3348,6 +3348,11 @@ def zip(*arrays, fill_missing: bool = False) -> ArrayExpression:
     Examples
     --------
 
+    >>> hl.eval(hl.zip([1, 2, 3], [4, 5, 6]))
+    [(1, 4), (2, 5), (3, 6)]
+
+    If the arrays are different lengths, the behavior is decided by the `fill_missing` parameter.
+
     >>> hl.eval(hl.zip([1], [10, 20], [100, 200, 300]))
     [(1, 10, 100)]
 


### PR DESCRIPTION
I did not like that all of the `hl.zip` examples returned a length one array. We were only showing how the edge case with different array lengths worked. Now I show an example of the common case, where you have two arrays of the same length and you want to combine them into one array of tuples. 