### PR TITLE
[gear] fix db connection leak in transaction due to cancellation

### DIFF
--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import os
+import asyncio
 import pymysql
 import aiomysql
 import logging
@@ -115,36 +116,56 @@ class TransactionAsyncContextManager:
         self.tx = None
 
 
+async def _release_connection(conn_context_manager):
+    if conn_context_manager is not None:
+        try:
+            if conn_context_manager._conn is not None:
+                await aexit(conn_context_manager)
+        except:
+            log.exception(f'while releasing database connection')
+
+
 class Transaction:
     def __init__(self):
         self.conn_context_manager = None
         self.conn = None
 
     async def async_init(self, db_pool, read_only):
-        self.conn_context_manager = db_pool.acquire()
-        self.conn = await aenter(self.conn_context_manager)
-        async with self.conn.cursor() as cursor:
-            if read_only:
-                await cursor.execute('START TRANSACTION READ ONLY;')
-            else:
-                await cursor.execute('START TRANSACTION;')
+        try:
+            self.conn_context_manager = db_pool.acquire()
+            self.conn = await aenter(self.conn_context_manager)
+            async with self.conn.cursor() as cursor:
+                if read_only:
+                    await cursor.execute('START TRANSACTION READ ONLY;')
+                else:
+                    await cursor.execute('START TRANSACTION;')
+        except:
+            self.conn = None
+            conn_context_manager = self.conn_context_manager
+            self.conn_context_manager = None
+            asyncio.ensure_future(_release_connection(conn_context_manager))
+            raise
 
-    async def _aexit(self, exc_type, exc_val, exc_tb):
+    async def _aexit_1(self, exc_type):
         try:
             if self.conn is not None:
-                try:
-                    if exc_type:
-                        await self.conn.rollback()
-                    else:
-                        await self.conn.commit()
-                finally:
-                    self.conn = None
+                if exc_type:
+                    await self.conn.rollback()
+                else:
+                    await self.conn.commit()
+        except:
+            log.info(f'while exiting transaction', exc_info=True)
+            raise
         finally:
-            if self.conn_context_manager is not None:
-                try:
-                    await aexit(self.conn_context_manager, exc_type, exc_val, exc_tb)
-                finally:
-                    self.conn_context_manager = None
+            self.conn = None
+            conn_context_manager = self.conn_context_manager
+            self.conn_context_manager = None
+            asyncio.ensure_future(_release_connection(conn_context_manager))
+
+    async def _aexit(self, exc_type, exc_val, exc_tb):
+        # cancelling cleanup could leak a connection
+        # await shield becuase we want to wait for commit/rollback to finish
+        await asyncio.shield(self._aexit_1(exc_type))
 
     async def commit(self):
         assert self.conn

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -162,7 +162,7 @@ class Transaction:
             self.conn_context_manager = None
             asyncio.ensure_future(_release_connection(conn_context_manager))
 
-    async def _aexit(self, exc_type, exc_val, exc_tb):
+    async def _aexit(self, exc_type, exc_val, exc_tb):  # pylint: disable=unused-argument
         # cancelling cleanup could leak a connection
         # await shield becuase we want to wait for commit/rollback to finish
         await asyncio.shield(self._aexit_1(exc_type))

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -122,7 +122,7 @@ async def _release_connection(conn_context_manager):
             if conn_context_manager._conn is not None:
                 await aexit(conn_context_manager)
         except:
-            log.exception(f'while releasing database connection')
+            log.exception('while releasing database connection')
 
 
 class Transaction:
@@ -154,7 +154,7 @@ class Transaction:
                 else:
                     await self.conn.commit()
         except:
-            log.info(f'while exiting transaction', exc_info=True)
+            log.info('while exiting transaction', exc_info=True)
             raise
         finally:
             self.conn = None

--- a/pylintrc
+++ b/pylintrc
@@ -11,7 +11,7 @@
 # C1801 Do not use len(SEQUENCE) as condition value
 # W0221 Parameters differ from overridden method
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,too-many-public-methods,broad-except,too-many-return-statements
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,too-many-public-methods,broad-except,too-many-return-statements,bare-except
 
 
 [FORMAT]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
 [flake8]
 # E501 line too long
 # W503 line break before binary operator
-ignore=E501,W503
+# E722 do not use bare 'except'
+ignore=E501,W503,E722
 
 # E402 module level import not at top of file
 # E241 multiple spaces after ','


### PR DESCRIPTION
The old code in `Transaction` to exit the transaction and release the connection back to the pool looked like this:

```
    async def _aexit(self, exc_type, exc_val, exc_tb):
        try:
            if self.conn is not None:
                try:
                    if exc_type:
                        await self.conn.rollback()
                    else:
                        await self.conn.commit()
                finally:
                    self.conn = None
        finally:
            if self.conn_context_manager is not None:
                try:
                    await aexit(self.conn_context_manager, exc_type, exc_val, exc_tb)
                finally:
                    self.conn_context_manager = None
```

The problem was if the current coroutine was cancelled in the call to `aexit(self.conn_context_manager, ...)`, which ultimately calls aiomysql `Pool.release`, the release never happens.  This was happening when database calls in `@only_active_instances` were getting cancelled when the client timed out and terminated the request.  Roughly, the solution is to shield exiting the connection, and return the connection asynchronously in a background task (using `ensure_future`).

FYI @danking @jigold This is a subtle bug/pattern for managing resources that we should all be aware of.