### PR TITLE
[query] Add enumerate, deprecate zip_with_index

### DIFF
--- a/hail/python/hail/docs/functions/collections.rst
+++ b/hail/python/hail/docs/functions/collections.rst
@@ -23,6 +23,7 @@ Collection functions
     map
     flatmap
     zip
+    enumerate
     zip_with_index
     flatten
     any
@@ -39,6 +40,7 @@ Collection functions
 .. autofunction:: map
 .. autofunction:: flatmap
 .. autofunction:: zip
+.. autofunction:: enumerate
 .. autofunction:: zip_with_index
 .. autofunction:: flatten
 .. autofunction:: any

--- a/hail/python/hail/docs/functions/index.rst
+++ b/hail/python/hail/docs/functions/index.rst
@@ -73,6 +73,7 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     map
     flatmap
     zip
+    enumerate
     zip_with_index
     flatten
     any

--- a/hail/python/hail/experimental/full_outer_join_mt.py
+++ b/hail/python/hail/experimental/full_outer_join_mt.py
@@ -94,12 +94,12 @@ def full_outer_join_mt(left: hl.MatrixTable, right: hl.MatrixTable) -> hl.Matrix
     ht = ht.annotate_globals(
         left_keys=hl.group_by(
             lambda t: t[0],
-            hl.zip_with_index(
+            hl.enumerate(
                 ht.left_cols.map(lambda x: hl.tuple([x[f] for f in left.col_key])), index_first=False)).map_values(
             lambda elts: elts.map(lambda t: t[1])),
         right_keys=hl.group_by(
             lambda t: t[0],
-            hl.zip_with_index(
+            hl.enumerate(
                 ht.right_cols.map(lambda x: hl.tuple([x[f] for f in right.col_key])), index_first=False)).map_values(
             lambda elts: elts.map(lambda t: t[1])))
     ht = ht.annotate_globals(

--- a/hail/python/hail/experimental/phase_by_transmission.py
+++ b/hail/python/hail/experimental/phase_by_transmission.py
@@ -128,10 +128,10 @@ def phase_by_transmission(
 
         combinations = hl.flatmap(
             lambda f:
-            hl.zip_with_index(mother_v)
+            hl.enumerate(mother_v)
                 .filter(lambda m: m[1] + f[1] == proband_v)
                 .map(lambda m: hl.struct(m=m[0], f=f[0])),
-            hl.zip_with_index(father_v)
+            hl.enumerate(father_v)
         )
 
         return (
@@ -160,7 +160,7 @@ def phase_by_transmission(
         :rtype: ArrayExpression
         """
 
-        transmitted_allele = hl.zip_with_index(hl.array([mother_call[0], mother_call[1]])).find(lambda m: m[1] == proband_call[0])
+        transmitted_allele = hl.enumerate(hl.array([mother_call[0], mother_call[1]])).find(lambda m: m[1] == proband_call[0])
         return hl.or_missing(
             hl.is_defined(transmitted_allele),
             hl.array([
@@ -330,7 +330,7 @@ def explode_trio_matrix(tm: hl.MatrixTable, col_keys: List[str] = ['s'], keep_tr
     tm = tm.select_entries(**select_entries_expr)
 
     tm = tm.key_cols_by()
-    select_cols_expr = {'__trio_members': hl.zip_with_index(hl.array([tm.proband, tm.father, tm.mother]))}
+    select_cols_expr = {'__trio_members': hl.enumerate(hl.array([tm.proband, tm.father, tm.mother]))}
     if keep_trio_cols:
         select_cols_expr['source_trio'] = hl.struct(**tm.col)
     tm = tm.select_cols(**select_cols_expr)

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -35,7 +35,7 @@ from .functions import literal, chi_squared_test, if_else, cond, switch, case, \
     is_transition, is_transversion, is_insertion, is_deletion, is_indel, \
     is_star, is_complex, is_strand_ambiguous, allele_type, hamming, \
     mendel_error_code, triangle, downcode, gq_from_pl, parse_call, \
-    unphased_diploid_gt_index_call, argmax, argmin, zip, zip_with_index, map, \
+    unphased_diploid_gt_index_call, argmax, argmin, zip, enumerate, zip_with_index, map, \
     flatmap, flatten, any, all, filter, sorted, find, group_by, fold, \
     array_scan, len, min, nanmin, max, nanmax, mean, median, product, sum, \
     cumulative_sum, struct, tuple, set, empty_set, array, empty_array, \
@@ -176,6 +176,7 @@ __all__ = ['HailType',
            'argmax',
            'argmin',
            'zip',
+           'enumerate',
            'zip_with_index',
            'map',
            'flatmap',

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3410,7 +3410,7 @@ def enumerate(a, start=0, *, index_first=True):
     ----------
     a : :class:`.ArrayExpression`
     start : :class:`.Int32Expression`
-        The number the first element of the array is labeled with.
+        The index value from which the counter is started, 0 by default.
     index_first: :obj:`bool`
         If ``True``, the index is the first value of the element tuples. If
         ``False``, the index is the second value.

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -513,7 +513,7 @@ def rbind(*exprs, _ctx=None):
 
     *args, f = exprs
     args = [expr_any.check(arg, 'rbind', f'argument {index}')
-            for index, arg in enumerate(args)]
+            for index, arg in builtins.enumerate(args)]
 
     return hl.bind(f, *args, _ctx=_ctx)
 
@@ -1691,7 +1691,7 @@ def coalesce(*args):
         raise ValueError("'coalesce' requires at least one expression argument")
     *exprs, success = unify_exprs(*args)
     if not success:
-        arg_types = ''.join([f"\n    argument {i}: type '{arg.dtype}'" for i, arg in enumerate(exprs)])
+        arg_types = ''.join([f"\n    argument {i}: type '{arg.dtype}'" for i, arg in builtins.enumerate(exprs)])
         raise TypeError(f"'coalesce' requires all arguments to have the same type or compatible types"
                         f"{arg_types}")
     indices, aggregations = unify_all(*exprs)
@@ -2556,7 +2556,7 @@ def corr(x, y) -> Float64Expression:
 _base_regex = "^([ACGTNM])+$"
 _symbolic_regex = r"(^\.)|(\.$)|(^<)|(>$)|(\[)|(\])"
 _allele_types = ["Unknown", "SNP", "MNP", "Insertion", "Deletion", "Complex", "Star", "Symbolic"]
-_allele_enum = {i: v for i, v in enumerate(_allele_types)}
+_allele_enum = {i: v for i, v in builtins.enumerate(_allele_types)}
 _allele_ints = {v: k for k, v in _allele_enum.items()}
 
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3420,7 +3420,7 @@ def enumerate(a, start=0, *, index_first=True):
     :class:`.ArrayExpression`
         Array of (index, element) or (element, index) tuples.
     """
-    return range(0 + start, len(a) + start).map(lambda i: (start, a[i]) if index_first else (a[i], i))
+    return range(0 + start, len(a) + start).map(lambda i: (i, a[i]) if index_first else (a[i], i))
 
 
 @typecheck(a=expr_array(), index_first=bool)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3420,7 +3420,7 @@ def enumerate(a, start=0, *, index_first=True):
     :class:`.ArrayExpression`
         Array of (index, element) or (element, index) tuples.
     """
-    return range(0 + start, len(a) + start).map(lambda i: (i, a[i]) if index_first else (a[i], i))
+    return range(0, len(a)).map(lambda i: (i + start, a[i]) if index_first else (a[i], i + start))
 
 
 @typecheck(a=expr_array(), index_first=bool)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3389,9 +3389,45 @@ def zip(*arrays, fill_missing: bool = False) -> ArrayExpression:
                           aggregations)
 
 
+@typecheck(a=expr_array(), start=expr_int32, index_first=bool)
+def enumerate(a, start=0, *, index_first=True):
+    """Returns an array of (index, element) tuples.
+
+    Examples
+    --------
+
+    >>> hl.eval(hl.enumerate(['A', 'B', 'C']))
+    [(0, 'A'), (1, 'B'), (2, 'C')]
+
+    >>> hl.eval(hl.enumerate(['A', 'B', 'C'], start=3))
+    [(3, 'A'), (4, 'B'), (5, 'C')]
+
+    >>> hl.eval(hl.enumerate(['A', 'B', 'C'], index_first=False))
+    [('A', 0), ('B', 1), ('C', 2)]
+
+
+    Parameters
+    ----------
+    a : :class:`.ArrayExpression`
+    start : :class:`.Int32Expression`
+        The number the first element of the array is labeled with.
+    index_first: :obj:`bool`
+        If ``True``, the index is the first value of the element tuples. If
+        ``False``, the index is the second value.
+
+    Returns
+    -------
+    :class:`.ArrayExpression`
+        Array of (index, element) or (element, index) tuples.
+    """
+    return range(0 + start, len(a) + start).map(lambda i: (start, a[i]) if index_first else (a[i], i))
+
+
 @typecheck(a=expr_array(), index_first=bool)
 def zip_with_index(a, index_first=True):
-    """Returns an array of (index, element) tuples.
+    """Deprecated in favor of :func:`.enumerate`.
+
+    Returns an array of (index, element) tuples.
 
     Examples
     --------
@@ -3415,7 +3451,7 @@ def zip_with_index(a, index_first=True):
     :class:`.ArrayExpression`
         Array of (index, element) or (element, index) tuples.
     """
-    return bind(lambda aa: range(0, len(aa)).map(lambda i: (i, aa[i]) if index_first else (aa[i], i)), a)
+    return enumerate(a, index_first=index_first)
 
 
 @typecheck(f=func_spec(1, expr_any),

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3576,7 +3576,7 @@ class MatrixTable(ExprContainer):
                     ))
             if _check_cols:
                 wrong_keys = hl.eval(hl.rbind(first.col_key.collect(_localize=False), lambda first_keys: (
-                    hl.zip_with_index([mt.col_key.collect(_localize=False) for mt in datasets[1:]])
+                    hl.enumerate([mt.col_key.collect(_localize=False) for mt in datasets[1:]])
                     .find(lambda x: ~(x[1] == first_keys))[0])))
                 if wrong_keys is not None:
                     raise ValueError(f"'MatrixTable.union_rows' expects all datasets to have the same columns. "

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -440,7 +440,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     ht = ht_local.transmute(**{entries_field_name: ht_local[entries_field_name][x_field_name]})
     ht = ht._group_within_partitions("grouped_fields", block_size)
 
-    ys_and_covs_to_keep_with_indices = hl.zip_with_index(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], y_field_names + cov_field_names))
+    ys_and_covs_to_keep_with_indices = hl.enumerate(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], y_field_names + cov_field_names))
     indices_to_keep = ys_and_covs_to_keep_with_indices.map(lambda pair: pair[0])
     ys_and_covs_to_keep = ys_and_covs_to_keep_with_indices.map(lambda pair: pair[1])
 
@@ -2521,11 +2521,11 @@ def filter_alleles(mt: MatrixTable,
     mt = mt.annotate_rows(__allele_inclusion=inclusion,
                           old_locus=mt.locus,
                           old_alleles=mt.alleles)
-    new_to_old = (hl.zip_with_index(mt.__allele_inclusion)
+    new_to_old = (hl.enumerate(mt.__allele_inclusion)
                   .filter(lambda elt: elt[1])
                   .map(lambda elt: elt[0]))
-    old_to_new_dict = (hl.dict(hl.zip_with_index(hl.zip_with_index(mt.alleles)
-                                                 .filter(lambda elt: mt.__allele_inclusion[elt[0]]))
+    old_to_new_dict = (hl.dict(hl.enumerate(hl.enumerate(mt.alleles)
+                                            .filter(lambda elt: mt.__allele_inclusion[elt[0]]))
                                .map(lambda elt: (elt[1][1], elt[0]))))
 
     old_to_new = hl.bind(lambda d: mt.alleles.map(lambda a: d.get(a)), old_to_new_dict)


### PR DESCRIPTION
`zip_with_index` seems based on Scala's `zipWithIndex`. Here I deprecate that in favor of using the more pythonic `enumerate`. To match the signature of the python function, I add a `start` argument and make our custom `index_first` argument keyword only. 