### PR TITLE
[query] Change decompression order for BGZipInputStream

### DIFF
--- a/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
+++ b/hail/src/main/java/is/hail/io/compress/BGzipInputStream.java
@@ -179,7 +179,12 @@ public class BGzipInputStream extends SplitCompressionInputStream {
     }
 
     public long getVirtualOffset() {
-        return BlockCompressedFilePointerUtil.makeFilePointer(inputBufferInPos, outputBufferPos);
+        if (outputBufferPos == outputBufferSize) {
+            int bsize = bgzipHeader != null ? bgzipHeader.bsize : 0;
+            return BlockCompressedFilePointerUtil.makeFilePointer(inputBufferInPos + bsize, 0);
+        } else {
+            return BlockCompressedFilePointerUtil.makeFilePointer(inputBufferInPos, outputBufferPos);
+        }
     }
 
     public int readBlock(byte[] b) throws IOException {


### PR DESCRIPTION
Instead of decompressing a block as soon as we reach the end of the
previous block, or during construction. We now wait, and if it is
necessary for that read, decompress the next block.
