### PR TITLE
[batch] weight zones by quota capacity

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -48,6 +48,8 @@ class InstancePool:
         self.max_instances = None
         self.pool_size = None
 
+        # default until we update zones
+        # /regions is slow, don't make it synchronous on startup
         self.zones = ['us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f']
         self.zone_weights = [1, 1, 1, 1]
 
@@ -97,7 +99,7 @@ class InstancePool:
 
             remaining = quota_remaining['PREEMPTIBLE_CPUS'] // self.worker_cores
             if self.worker_local_ssd_data_disk:
-                remaining = min(remaining, quota_remaining['LOCAL_SSD_TOTAL_GB'] // 350)
+                remaining = min(remaining, quota_remaining['LOCAL_SSD_TOTAL_GB'] // 375)
             else:
                 remaining = min(remaining, quota_remaining['SSD_TOTAL_GB'] // self.worker_pd_ssd_data_disk_size_gb)
 

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -115,7 +115,7 @@ class InstancePool:
     async def update_zones_loop(self):
         while True:
             log.info('update zones loop')
-            self.update_zones()
+            await self.update_zones()
             await asyncio.sleep(60)
 
     async def async_init(self):

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -101,7 +101,7 @@ class InstancePool:
             else:
                 remaining = min(remaining, quota_remaining['SSD_TOTAL_GB'] // self.worker_pd_ssd_data_disk_size_gb)
 
-            weight = max(remaining // len(r['zones'], 1))
+            weight = max(remaining // len(r['zones']), 1)
             for z in r['zones']:
                 zone_name = os.path.basename(urllib.parse.urlparse(z).path)
                 new_zones.append(zone_name)

--- a/hail/python/hailtop/aiogoogle/client/compute_client.py
+++ b/hail/python/hailtop/aiogoogle/client/compute_client.py
@@ -20,7 +20,6 @@ class PagedIterator:
     async def __anext__(self):
         if self._page is None:
             assert 'pageToken' not in self._request_params
-            print('first page')
             self._page = await self._client.get(self._path, params=self._request_params, **self._request_kwargs)
             self._index = 0
 
@@ -33,7 +32,6 @@ class PagedIterator:
             next_page_token = self._page.get('nextPageToken')
             if next_page_token is not None:
                 self._request_params['pageToken'] = next_page_token
-                print('next page')
                 self._page = await self._client.get(self._path, params=self._request_params, **self._request_kwargs)
                 self._index = 0
             else:

--- a/hail/python/hailtop/aiogoogle/client/compute_client.py
+++ b/hail/python/hailtop/aiogoogle/client/compute_client.py
@@ -1,4 +1,43 @@
+from typing import Mapping, Any
 from .base_client import BaseClient
+
+
+class PagedIterator:
+    def __init__(self, client: 'ComputeClient', path: str, request_params: Mapping[str, Any], request_kwargs: Mapping[str, Any]):
+        assert 'params' not in request_kwargs
+        self._client = client
+        self._path = path
+        if request_params is None:
+            request_params = {}
+        self._request_params = request_params
+        self._request_kwargs = request_kwargs
+        self._page = None
+        self._index = None
+
+    def __aiter__(self) -> 'PagedIterator':
+        return self
+
+    async def __anext__(self):
+        if self._page is None:
+            assert 'pageToken' not in self._request_params
+            print('first page')
+            self._page = await self._client.get(self._path, params=self._request_params, **self._request_kwargs)
+            self._index = 0
+
+        while True:
+            if 'items' in self._page and self._index < len(self._page['items']):
+                i = self._index
+                self._index += 1
+                return self._page['items'][i]
+
+            next_page_token = self._page.get('nextPageToken')
+            if next_page_token is not None:
+                self._request_params['pageToken'] = next_page_token
+                print('next page')
+                self._page = await self._client.get(self._path, params=self._request_params, **self._request_kwargs)
+                self._index = 0
+            else:
+                raise StopAsyncIteration
 
 
 class ComputeClient(BaseClient):
@@ -10,3 +49,6 @@ class ComputeClient(BaseClient):
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/get
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/delete
+
+    async def list(self, path: str, *, params: Mapping[str, Any] = None, **kwargs) -> Any:
+        return PagedIterator(self, path, params, kwargs)


### PR DESCRIPTION
Instead of using a fixed weighting, query the GCP /regions endpoint which includes the quota limit and usage.  Use this to weight zones for new instance requests.  Added a ComputeClient.list endpoint that should work with any GCE list endpoint that is paged.

I'm working on improving this logic further by tracking how often instance create requests fail and then weighting zones by `capacity * p(create instance will succeed)`.