### PR TITLE
[query] Framework for making compiler passes stack safe

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.utils._
+import is.hail.utils.StackSafe._
 
 class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = false) {
   var count: Int = 0
@@ -12,20 +13,25 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
 
   def apply(ir: IR, env: Env[String]): IR = apply(ir, BindingEnv(env))
 
-  def apply(ir: IR, env: BindingEnv[String]): IR = normalizeIR(ir, env).asInstanceOf[IR]
+  def apply(ir: IR, env: BindingEnv[String]): IR = normalizeIR(ir, env).run().asInstanceOf[IR]
 
-  def apply(ir: BaseIR): BaseIR = normalizeIR(ir, BindingEnv(agg=Some(Env.empty), scan=Some(Env.empty)))
+  def apply(ir: BaseIR): BaseIR = normalizeIR(ir, BindingEnv(agg=Some(Env.empty), scan=Some(Env.empty))).run()
 
-  private def normalizeIR(ir: BaseIR, env: BindingEnv[String], context: Array[String] = Array()): BaseIR = {
+  private def normalizeIR(ir: BaseIR, env: BindingEnv[String], context: Array[String] = Array()): StackFrame[BaseIR] = {
 
-    def normalizeBaseIR(next: BaseIR, env: BindingEnv[String] = env): BaseIR = normalizeIR(next, env, context :+ ir.getClass().getName())
+    def normalizeBaseIR(next: BaseIR, env: BindingEnv[String] = env): StackFrame[BaseIR] =
+      call(normalizeIR(next, env, context :+ ir.getClass().getName()))
 
-    def normalize(next: IR, env: BindingEnv[String] = env): IR = normalizeIR(next, env, context :+ ir.getClass().getName()).asInstanceOf[IR]
+    def normalize(next: IR, env: BindingEnv[String] = env): StackFrame[IR] =
+      call(normalizeIR(next, env, context :+ ir.getClass().getName()).asInstanceOf[StackFrame[IR]])
 
     ir match {
       case Let(name, value, body) =>
         val newName = gen()
-        Let(newName, normalize(value), normalize(body, env.copy(eval = env.eval.bind(name, newName))))
+        for {
+          newValue <- normalize(value)
+          newBody <- normalize(body, env.copy(eval = env.eval.bind(name, newName)))
+        } yield Let(newName, newValue, newBody)
       case Ref(name, typ) =>
         val newName = env.eval.lookupOption(name) match {
           case Some(n) => n
@@ -35,7 +41,7 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
             else
               name
         }
-        Ref(newName, typ)
+        done(Ref(newName, typ))
       case Recur(name, args, typ) =>
         val newName = env.eval.lookupOption(name) match {
           case Some(n) => n
@@ -45,86 +51,153 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
             else
               name
         }
-        Recur(newName, args.map(v => normalize(v)), typ)
+        for {
+          newArgs <- args.mapRecur(v => normalize(v))
+        } yield Recur(newName, newArgs, typ)
       case AggLet(name, value, body, isScan) =>
         val newName = gen()
         val (valueEnv, bodyEnv) = if (isScan)
           env.promoteScan -> env.bindScan(name, newName)
         else
           env.promoteAgg -> env.bindAgg(name, newName)
-        AggLet(newName, normalize(value, valueEnv), normalize(body, bodyEnv), isScan)
+        for {
+          newValue <- normalize(value, valueEnv)
+          newBody <- normalize(body, bodyEnv)
+        } yield AggLet(newName, newValue, newBody, isScan)
       case TailLoop(name, args, body) =>
         val newFName = gen()
         val newNames = Array.tabulate(args.length)(i => gen())
         val (names, values) = args.unzip
-        TailLoop(newFName, newNames.zip(values.map(v => normalize(v))), normalize(body, env.copy(eval = env.eval.bind(names.zip(newNames) :+ name -> newFName: _*))))
+        for {
+          newValues <- values.mapRecur(v => normalize(v))
+          newBody <- normalize(body, env.copy(eval = env.eval.bind(names.zip(newNames) :+ name -> newFName: _*)))
+        } yield TailLoop(newFName, newNames.zip(newValues), newBody)
       case ArraySort(a, left, right, lessThan) =>
         val newLeft = gen()
         val newRight = gen()
-        ArraySort(normalize(a), newLeft, newRight, normalize(lessThan, env.bindEval(left -> newLeft, right -> newRight)))
+        for {
+          newA <- normalize(a)
+          newLessThan <- normalize(lessThan, env.bindEval(left -> newLeft, right -> newRight))
+        } yield ArraySort(newA, newLeft, newRight, newLessThan)
       case StreamMap(a, name, body) =>
         val newName = gen()
-        StreamMap(normalize(a), newName, normalize(body, env.bindEval(name, newName)))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(name, newName))
+        } yield StreamMap(newA, newName, newBody)
       case StreamZip(as, names, body, behavior) =>
         val newNames = names.map(_ => gen())
-        StreamZip(as.map(normalize(_)), newNames, normalize(body, env.bindEval(names.zip(newNames): _*)), behavior)
+        for {
+          newAs <- as.mapRecur(normalize(_))
+          newBody <- normalize(body, env.bindEval(names.zip(newNames): _*))
+        } yield StreamZip(newAs, newNames, newBody, behavior)
       case StreamZipJoin(as, key, curKey, curVals, joinF) =>
         val newCurKey = gen()
         val newCurVals = gen()
-        StreamZipJoin(as.map(normalize(_)), key, newCurKey, newCurVals, normalize(joinF, env.bindEval(curKey -> newCurKey, curVals -> newCurVals)))
+        for {
+          newAs <- as.mapRecur(normalize(_))
+          newJoinF <- normalize(joinF, env.bindEval(curKey -> newCurKey, curVals -> newCurVals))
+        } yield StreamZipJoin(newAs, key, newCurKey, newCurVals, newJoinF)
       case StreamFilter(a, name, body) =>
         val newName = gen()
-        StreamFilter(normalize(a), newName, normalize(body, env.bindEval(name, newName)))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(name, newName))
+        } yield StreamFilter(newA, newName, newBody)
       case StreamFlatMap(a, name, body) =>
         val newName = gen()
-        StreamFlatMap(normalize(a), newName, normalize(body, env.bindEval(name, newName)))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(name, newName))
+        } yield StreamFlatMap(newA, newName, newBody)
       case StreamFold(a, zero, accumName, valueName, body) =>
         val newAccumName = gen()
         val newValueName = gen()
-        StreamFold(normalize(a), normalize(zero), newAccumName, newValueName, normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName)))
+        for {
+          newA <- normalize(a)
+          newZero <- normalize(zero)
+          newBody <- normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName))
+        } yield StreamFold(newA, newZero, newAccumName, newValueName, newBody)
       case StreamFold2(a, accum, valueName, seq, res) =>
         val newValueName = gen()
-        val (accNames, newAcc) = accum.map { case (old, ir) =>
-          val newName = gen()
-          ((old, newName), (newName, normalize(ir)))
-        }.unzip
-        val resEnv = env.bindEval(accNames: _*)
-        val seqEnv = resEnv.bindEval(valueName, newValueName)
-        StreamFold2(normalize(a), newAcc, newValueName, seq.map(normalize(_, seqEnv)), normalize(res, resEnv))
+        for {
+          newA <- normalize(a)
+          newAccum <- accum.mapRecur { case (old, ir) =>
+            val newName = gen()
+            for {
+              newIr <- normalize(ir)
+            } yield ((old, newName), (newName, newIr))
+          }
+          (accNames, newAcc) = newAccum.unzip
+          resEnv = env.bindEval(accNames: _*)
+          seqEnv = resEnv.bindEval(valueName, newValueName)
+          newSeq <- seq.mapRecur(normalize(_, seqEnv))
+          newRes <- normalize(res, resEnv)
+        } yield StreamFold2(newA, newAcc, newValueName, newSeq, newRes)
       case StreamScan(a, zero, accumName, valueName, body) =>
         val newAccumName = gen()
         val newValueName = gen()
-        StreamScan(normalize(a), normalize(zero), newAccumName, newValueName, normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName)))
+        for {
+          newA <- normalize(a)
+          newZero <- normalize(zero)
+          newBody <- normalize(body, env.bindEval(accumName -> newAccumName, valueName -> newValueName))
+        } yield StreamScan(newA, newZero, newAccumName, newValueName, newBody)
       case StreamFor(a, valueName, body) =>
         val newValueName = gen()
-        StreamFor(normalize(a), newValueName, normalize(body, env.bindEval(valueName, newValueName)))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.bindEval(valueName, newValueName))
+        } yield StreamFor(newA, newValueName, newBody)
       case StreamAgg(a, name, body) =>
         // FIXME: Uncomment when bindings are threaded through test suites
         // assert(env.agg.isEmpty)
         val newName = gen()
-        StreamAgg(normalize(a), newName, normalize(body, env.copy(agg = Some(env.eval.bind(name, newName)))))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.copy(agg = Some(env.eval.bind(name, newName))))
+        } yield
+        StreamAgg(newA, newName, newBody)
       case RunAggScan(a, name, init, seq, result, sig) =>
         val newName = gen()
         val e2 = env.bindEval(name, newName)
-        RunAggScan(normalize(a), newName, normalize(init, env), normalize(seq, e2), normalize(result, e2), sig)
+        for {
+          newA <- normalize(a)
+          newInit <- normalize(init, env)
+          newSeq <- normalize(seq, e2)
+          newResult <- normalize(result, e2)
+        } yield RunAggScan(newA, newName, newInit, newSeq, newResult, sig)
       case StreamAggScan(a, name, body) =>
         // FIXME: Uncomment when bindings are threaded through test suites
         // assert(env.scan.isEmpty)
         val newName = gen()
         val newEnv = env.eval.bind(name, newName)
-        StreamAggScan(normalize(a), newName, normalize(body, env.copy(eval = newEnv, scan = Some(newEnv))))
+        for {
+          newA <- normalize(a)
+          newBody <- normalize(body, env.copy(eval = newEnv, scan = Some(newEnv)))
+        } yield StreamAggScan(newA, newName, newBody)
       case StreamJoinRightDistinct(left, right, lKey, rKey, l, r, joinF, joinType) =>
         val newL = gen()
         val newR = gen()
         val newEnv = env.bindEval(l -> newL, r -> newR)
-        StreamJoinRightDistinct(normalize(left), normalize(right), lKey, rKey, newL, newR, normalize(joinF, newEnv), joinType)
+        for {
+          newLeft <- normalize(left)
+          newRight <- normalize(right)
+          newJoinF <- normalize(joinF, newEnv)
+        } yield StreamJoinRightDistinct(newLeft, newRight, lKey, rKey, newL, newR, newJoinF, joinType)
       case NDArrayMap(nd, name, body) =>
         val newName = gen()
-        NDArrayMap(normalize(nd), newName, normalize(body, env.bindEval(name -> newName)))
+        for {
+          newNd <- normalize(nd)
+          newBody <- normalize(body, env.bindEval(name -> newName))
+        } yield NDArrayMap(newNd, newName, newBody)
       case NDArrayMap2(l, r, lName, rName, body) =>
         val newLName = gen()
         val newRName = gen()
-        NDArrayMap2(normalize(l), normalize(r), newLName, newRName, normalize(body, env.bindEval(lName -> newLName, rName -> newRName)))
+        for {
+          newL <- normalize(l)
+          newR <- normalize(r)
+          newBody <- normalize(body, env.bindEval(lName -> newLName, rName -> newRName))
+        } yield NDArrayMap2(newL, newR, newLName, newRName, newBody)
       case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) =>
         val newElementName = gen()
         val newIndexName = gen()
@@ -132,21 +205,36 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
           env.promoteScan -> env.bindScan(elementName, newElementName)
         else
           env.promoteAgg -> env.bindAgg(elementName, newElementName)
-        AggArrayPerElement(normalize(a, aEnv), newElementName, newIndexName, normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName)), knownLength.map(normalize(_, env)), isScan)
+        for {
+          newA <- normalize(a, aEnv)
+          newAggBody <- normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName))
+          newKnownLength <- knownLength.mapRecur(normalize(_, env))
+        } yield AggArrayPerElement(newA, newElementName, newIndexName, newAggBody, newKnownLength, isScan)
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         val newC = gen()
         val newG = gen()
-        CollectDistributedArray(normalize(ctxs), normalize(globals), newC, newG, normalize(body, BindingEnv.eval(cname -> newC, gname -> newG)))
+        for {
+          newCtxs <- normalize(ctxs)
+          newGlobals <- normalize(globals)
+          newBody <- normalize(body, BindingEnv.eval(cname -> newC, gname -> newG))
+        } yield CollectDistributedArray(newCtxs, newGlobals, newC, newG, newBody)
       case RelationalLet(name, value, body) =>
-        RelationalLet(name, normalize(value, BindingEnv.empty), normalize(body))
+        for {
+          newValue <- normalize(value, BindingEnv.empty)
+          newBody <- normalize(body)
+        } yield RelationalLet(name, newValue, newBody)
       case ShuffleWith(keyFields, rowType, rowEType, keyEType, name, writer, readers) =>
         val newName = gen()
-        ShuffleWith(keyFields, rowType, rowEType, keyEType, newName,
-          normalize(writer, env.copy(eval = env.eval.bind(name, newName))),
-          normalize(readers, env.copy(eval = env.eval.bind(name, newName))))
-      case x => x.copy(x.children.iterator.zipWithIndex.map { case (child, i) =>
-        normalizeBaseIR(child, ChildBindings.transformed(x, i, env, { case (name, _) => name }))
-      }.toFastIndexedSeq)
+        for {
+          newWriter <- normalize(writer, env.copy(eval = env.eval.bind(name, newName)))
+          newReaders <- normalize(readers, env.copy(eval = env.eval.bind(name, newName)))
+        } yield ShuffleWith(keyFields, rowType, rowEType, keyEType, newName, newWriter, newReaders)
+      case x =>
+        for {
+          newChildren <- x.children.iterator.zipWithIndex.map { case (child, i) =>
+            normalizeBaseIR(child, ChildBindings.transformed(x, i, env, { case (name, _) => name }))
+          }.collectRecur
+        } yield x.copy(newChildren)
 
     }
   }

--- a/hail/src/main/scala/is/hail/utils/StackSafe.scala
+++ b/hail/src/main/scala/is/hail/utils/StackSafe.scala
@@ -1,0 +1,176 @@
+package is.hail.utils
+
+import scala.annotation.tailrec
+import scala.collection.generic.{CanBuild, CanBuildFrom}
+
+object StackSafe {
+
+  def done[A](result: A): StackFrame[A] = Done(result)
+
+  def call[A](body: => StackFrame[A]): StackFrame[A] =
+    Thunk(() => body)
+
+  object StackFrame {
+    @tailrec def run[A](frame: StackFrame[A]): A = frame match {
+      case Done(result) => result
+      case Thunk(thunk) => run(thunk())
+      case more: More[x, A] => run(more.advance())
+    }
+  }
+
+  abstract class StackFrame[A] {
+    def flatMap[B](f: A => StackFrame[B]): StackFrame[B] = this match {
+      case Done(result) => f(result)
+      case thunk: Thunk[A] =>
+        val cell = new ContCell[A, B](f)
+        new More[A, B] (thunk, cell, cell)
+      case more: More[x, A] =>
+        val cell = new ContCell[A, B](f)
+        more.append(cell, cell)
+    }
+
+    def map[B](f: A => B): StackFrame[B] = flatMap(a => Done(f(a)))
+
+    final def run(): A = StackFrame.run(this)
+  }
+
+  private class ContCell[A, B](val f: A => StackFrame[B], var next: ContCell[B, _] = null)
+
+  private final case class Done[A](result: A) extends StackFrame[A]
+
+  private final case class Thunk[A](force: () => StackFrame[A]) extends StackFrame[A]
+
+  private final class More[A, B](
+    // private vars don't create getters/setters
+    private var next: StackFrame[A],
+    private var contHead: ContCell[A, _],
+    private var contTail: ContCell[_, B]
+  ) extends StackFrame[B] {
+
+    @inline def advance(): StackFrame[B] = {
+      if (contHead == null) next.asInstanceOf[StackFrame[B]]
+      else next match {
+        case Done(result) =>
+          contHead match {
+            case head: ContCell[A, x] =>
+              val ret = this.asInstanceOf[More[x, B]]
+              ret.next = head.f(result)
+              ret.contHead = head.next
+              ret
+          }
+        case thunk: Thunk[A] =>
+          next = thunk.force()
+          this
+        case more2: More[_, A] =>
+          if (contHead != null)
+            more2.append(contHead, contTail)
+          else
+            more2.asInstanceOf[More[_, B]]
+      }
+    }
+
+    @inline def append[C](head: ContCell[B, _], tail: ContCell[_, C]): More[A, C] = {
+      val resultM = this.asInstanceOf[More[A, C]]
+      if (contHead == null) {
+        // A = B
+        resultM.contHead = head.asInstanceOf[ContCell[A, _]]
+      } else {
+        contTail.next = head
+      }
+      resultM.contTail = tail
+      resultM
+    }
+  }
+
+  implicit class RichIndexedSeq[A](val s: IndexedSeq[A]) extends AnyVal {
+    def mapRecur[B, That](f: A => StackFrame[B])(implicit bf: CanBuildFrom[IndexedSeq[A], B, That]): StackFrame[That] = {
+      val builder = bf(s)
+      builder.sizeHint(s)
+      var i = 0
+      var cont: B => StackFrame[That] = null
+      def loop(): StackFrame[That] = {
+        if (i < s.size) {
+          f(s(i)).flatMap(cont)
+        } else {
+          done(builder.result)
+        }
+      }
+      cont = { b =>
+        builder += b
+        i += 1
+        loop()
+      }
+      loop()
+    }
+  }
+
+  implicit class RichArray[A](val a: Array[A]) extends AnyVal {
+    def mapRecur[B](f: A => StackFrame[B])(implicit bf: CanBuildFrom[Array[A], B, Array[B]]): StackFrame[Array[B]] = {
+      val builder = bf(a)
+      builder.sizeHint(a)
+      var i = 0
+      var cont: B => StackFrame[Array[B]] = null
+      def loop(): StackFrame[Array[B]] = {
+        if (i < a.size) {
+          f(a(i)).flatMap(cont)
+        } else {
+          done(builder.result)
+        }
+      }
+      cont = { b =>
+        builder += b
+        i += 1
+        loop()
+      }
+      loop()
+    }
+  }
+
+  implicit class RichOption[A](val o: Option[A]) extends AnyVal {
+    def mapRecur[B](f: A => StackFrame[B]): StackFrame[Option[B]] = {
+      o match {
+        case None => done(None)
+        case Some(a) => call(f(a)).map(b => Some(b))
+      }
+    }
+  }
+
+  implicit class RichIterator[A](val i: Iterator[StackFrame[A]]) extends AnyVal {
+    def collectRecur(implicit bf: CanBuild[A, Array[A]]): StackFrame[IndexedSeq[A]] = {
+      val builder = bf()
+      var cont: A => StackFrame[IndexedSeq[A]] = null
+      def loop(): StackFrame[IndexedSeq[A]] = {
+        if (i.hasNext) {
+          i.next().flatMap(cont)
+        } else {
+          done(builder.result())
+        }
+      }
+      cont = { a =>
+        builder += a
+        call(loop())
+      }
+      loop()
+    }
+  }
+
+  def fillArray[A](n: Int)(body: => StackFrame[A])(implicit bf: CanBuild[A, Array[A]]): StackFrame[Array[A]] = {
+    val builder = bf()
+    builder.sizeHint(n)
+    var i = 0
+    var cont: A => StackFrame[Array[A]] = null
+    def loop(): StackFrame[Array[A]] = {
+      if (i < n) {
+        body.flatMap(cont)
+      } else {
+        done(builder.result)
+      }
+    }
+    cont = { a =>
+      builder += a
+      i += 1
+      loop()
+    }
+    loop()
+  }
+}


### PR DESCRIPTION
This PR adds `utils/StackSafe.scala`, which contains generic tools for writing stack safe code. To illustrate its use, I've converted `NormalizeNames` and `RewriteBottomUp` to be stack safe.

This approach optimizes for the minimal possible change to existing code to make it stack safe. I originally expected this to have mediocre performance, and designed this to have optimization opportunities--requiring more substantial rewrites--where we found it was necessary.

In a follow up PR, I converted the IR parser to be stack safe. In benchmarking that, I'm not able to see any performance penalty (if anything, the stack safe version looks slightly faster, which is probably just noise). So it's possible this will perform well enough as is, but we can keep an eye on it as we convert more passes.

The basic idea is to rewrite functions that can be called recursively (directly or indirectly through a path of mutually recursive functions) from `f: (...) => A` to `f: (...) => StackFrame[A]`. Where the former evaluates, executing all recursive calls, and then returns the `A` result, the later returns a description of the work to be done before making any recursive calls. The method `StackFrame[A].run(): A` executes that description in a non-recursive loop.

`StackFrame` is a monad, implementing `map` and `flatMap`, which allows the `for` syntactic sugar to be used. When a method makes several recursive calls, this can be significantly more readable.

The public api is small. There are the free functions
```scala
def done[A](result: A): StackFrame[A]
def call[A](body: => StackFrame[A]): StackFrame[A]
```
and the methods
```scala
abstract class StackFrame[A] {
  def flatMap[B](f: A => StackFrame[B]): StackFrame[B]
  def map[B](f: A => B): StackFrame[B] = flatMap(a => Done(f(a)))
  def run(): A
}
```
`done` is basically the return statement. `call` is very important: it wraps a recursive call in a thunk, so that returning a `StackFrame` doesn't require descending all the way to the leaves of the recursion. The basic rule is that any cycle of mutually recursive function calls must have at least one `call` on the cycle. Trying to keep it to just one `call` per cycle minimizes the number of closures that must be allocated.

As an example, `NormalizeNames.normalizeIR` now returns `StackFrame[BaseIR]`, and `def apply(ir: BaseIR): BaseIR` calls `normalizeIR(ir, ...).run()` to actually run the traversal. The case for `Let` in `normalizeIR` is rewritten from
```scala
case Let(name, value, body) =>
  val newName = gen()
  Let(newName, normalize(value), normalize(body, env.copy(eval = env.eval.bind(name, newName))))
```
to
```scala
case Let(name, value, body) =>
  val newName = gen()
  for {
    newValue <- normalize(value)
    newBody <- normalize(body, env.copy(eval = env.eval.bind(name, newName)))
  } yield Let(newName, newValue, newBody)
```
or without the sugar
```scala
case Let(name, value, body) =>
  val newName = gen()
  normalize(value).flatMap { newValue =>
    normalize(body, env.copy(eval = env.eval.bind(name, newName))).map { newBody =>
      Let(newName, newValue, newBody)
    }
  }
```
All recursive calls go through `normalize`, which has been rewritten to `call(normalizeIR(...))`. This guarantees all recursive cycles contain one `call`.