### PR TITLE
[query] Fix local shuffle implementation with no rows

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.{Annotation, ExtendedOrdering, Region, SafeRow, Unsaf
 import is.hail.asm4s.{AsmFunction1RegionLong, LongInfo, classInfo}
 import is.hail.expr.ir._
 import is.hail.types.physical.{PArray, PStruct, PTuple}
-import is.hail.types.virtual.{TStruct, Type}
+import is.hail.types.virtual.{TStream, TStruct, Type}
 import is.hail.rvd.RVDPartitioner
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -44,6 +44,14 @@ object LowerDistributedSort {
     }(ord))
     val nPartitionsAdj = math.max(math.min(sortedRows.length, numPartitions), 1)
     val itemsPerPartition = (sortedRows.length.toDouble / nPartitionsAdj).ceil.toInt
+
+    if (itemsPerPartition == 0)
+      return TableStage(
+        globals = Literal(resultPType.fieldType("global").virtualType, rowsAndGlobal.get(1)),
+        partitioner = RVDPartitioner.empty(kType),
+        MakeStream(FastSeq(), TStream(TStruct())),
+        _ => MakeStream(FastSeq(), TStream(stage.rowType))
+      )
 
     // partitioner needs keys to be ascending
     val partitionerKeyType = TStruct(sortFields.takeWhile(_.sortOrder == Ascending).map(f => (f.field, rowType.virtualType.fieldType(f.field))): _*)


### PR DESCRIPTION
stacked on #9319 