### PR TITLE
[git][docker][hail] pervasively ignore the mypy_cache folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *~
 .*.crc
 *.pyc
+.mypy_cache/
 **/hail-*.log
 hail/.bloop/
 hail/.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ hs_err_pid*.log
 *-checkpoint.ipynb
 *hail/python/hail/docs/tutorials/data*
 *hail/python/hailtop/pipeline/docs/output*
+.mypy_cache/

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -170,6 +170,7 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) 
 	rsync -rv \
 	    --exclude '__pycache__/' \
 	    --exclude 'benchmark_hail/' \
+	    --exclude '.mypy_cache/' \
 	    --exclude 'docs/' \
 	    --exclude 'dist/' \
 	    --exclude 'test/' \


### PR DESCRIPTION
These things get huge! There is one for each folder and most of the hail ones
are bigger than 10MB