### PR TITLE
[hail] Eliminate quadratic behavior in BlockMatrix.to_matrix_table_row_major

### DIFF
--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -54,3 +54,10 @@ def blockmatrix_write_from_entry_expr_range_mt_standardize():
 def sum_table_of_ndarrays():
     ht = hl.utils.range_table(400).annotate(nd=hl.nd.ones((4096, 4096)))
     ht.aggregate(hl.agg.ndarray_sum(ht.nd))
+
+
+@benchmark()
+def to_matrix_table_row_major():
+    mt = hl.utils.range_matrix_table(20_000, 20_000, n_partitions=4)
+    bm = hl.linalg.BlockMatrix.from_entry_expr(mt.row_idx + mt.col_idx)
+    bm.to_matrix_table_row_major()._force_count_rows()

--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -57,7 +57,7 @@ def sum_table_of_ndarrays():
 
 
 @benchmark()
-def to_matrix_table_row_major():
+def block_matrix_to_matrix_table_row_major():
     mt = hl.utils.range_matrix_table(20_000, 20_000, n_partitions=4)
     bm = hl.linalg.BlockMatrix.from_entry_expr(mt.row_idx + mt.col_idx)
     bm.to_matrix_table_row_major()._force_count_rows()


### PR DESCRIPTION
CHANGELOG: Eliminate quadratic behavior in `BlockMatrix.to_matrix_table_row_major`. Users should expect significant reduction in run-time.

There are two significant changes in this PR:
- Teach `LZ4InputBlockBuffer` how to skip bytes without decompressing every block, and
- Teach BlockMatrix to use a small cache of rows when converting from a BlockMatrix to a row-wise RDD.

### Blocked LZ4 Byte Skipping

We compress in blocks of 16 KiB. The blocks begin with an 32-bit integer indicating the decompressed length. When we're skipping large numbers of bytes we can request an `LZ4InputBlockBuffer` to skip decompression if the entire block will be skipped.

### BlockMatrix Blocks to Rows Caching
Currently, for every row in every block, BM opens a file, skips to the appropriate location, reads that one row, writes it into an RVB, and then closes the file. This has terrible cache and I/O performance. Instead, we allocate 32 MiB to cache the rows of each block. We divide the cache evenly across all rows. The new implementation requires the cache can at least fit one row of the block, with 32 MiB we're good up to ~4 million (total) columns. We'll need to reimplement this to also use a tree-aggregate long before we get to 4 million columns.

### Benchmark Results

This branch vs main (3149211fb79b):
```
           Benchmark Name      Ratio     Time 1     Time 2
           --------------      -----     ------     ------
to_matrix_table_row_major     716.3%    251.300   1800.000
----------------------
Harmonic mean: 716.3%
Geometric mean: 716.3%
Arithmetic mean: 716.3%
Median:  716.3%
```