### PR TITLE
[internal-gateway] lower per-instance request rate to 45

### DIFF
--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -8,7 +8,7 @@ map $http_x_forwarded_proto $updated_scheme {
      '' $scheme;
 }
 
-limit_req_zone global zone=limit:1m rate=83r/s;
+limit_req_zone global zone=limit:1m rate=45r/s;
 
 map $maybe_router_scheme $router_scheme {
     default $maybe_router_scheme;


### PR DESCRIPTION
It seems that 83 is potentially too high now.  I saw batch-driver get overwhelmed with the current setting.  However, there was also a bug related leaking database connections which also contributed to the observed behavior.  Batch was able to make forward progress with 45, so at least this is safe and can be adjusted again next time we're running at scale.