### PR TITLE
[benchmark] use latest SHA

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -41,7 +41,7 @@ image_sha: wheel cleanup_image
 	# it's possible that the HAIL_WHEEL installs different dependencies, but this generally creates less work for docker
 	cp ../hail/python/requirements.txt .
 	docker build -t $(BENCHMARK_DOCKER_TAG) . --build-arg HAIL_WHEEL=$(notdir $(HAIL_WHEEL)) --build-arg BENCHMARK_WHEEL=$(notdir $(BENCHMARK_WHEEL))
-	@printf $(shell docker images -q --no-trunc $(BENCHMARK_DOCKER_TAG) | sed -e 's,[^:]*:,,') > image_sha
+	@printf $$(docker images -q --no-trunc $(BENCHMARK_DOCKER_TAG) | sed -e 's,[^:]*:,,') > image_sha
 	@echo Image sha is `cat image_sha`
 	rm $(notdir $(HAIL_WHEEL))
 	rm $(notdir $(BENCHMARK_WHEEL))


### PR DESCRIPTION
Make evaluates the entire recipe before executing it. Consider this:
```
(base) # cat Makefile; rm -rf file; make foo
foo:
	echo hello > file
	echo $(shell cat file)
cat: file: No such file or directory
echo hello > file
echo 

```
The file does not exist because Make runs cat before the recipe is executed.