### PR TITLE
[batch] add tokens to aggregated_batch_resources

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -29,7 +29,6 @@ from ..batch_configuration import REFRESH_INTERVAL_IN_SECONDS, \
     DEFAULT_NAMESPACE, BATCH_BUCKET_NAME, HAIL_SHA, HAIL_SHOULD_PROFILE, \
     WORKER_LOGS_BUCKET_NAME, PROJECT
 from ..globals import HTTP_CLIENT_MAX_SIZE
-from ..utils import cost_from_msec_mcpu
 
 from .instance_pool import InstancePool
 from .scheduler import Scheduler

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -576,8 +576,11 @@ LOCK IN SHARE MODE;
 
         agg_batch_resources = tx.execute_and_fetchall('''
 SELECT batch_id, JSON_OBJECTAGG(resource, `usage`) as resources
-FROM aggregated_batch_resources
-GROUP BY batch_id
+FROM (
+  SELECT batch_id, resource, SUM(`usage`) AS `usage`
+  FROM aggregated_batch_resources
+  GROUP BY batch_id, resource) AS t
+GROUP BY t.batch_id
 LOCK IN SHARE MODE;
 ''')
 

--- a/batch/sql/add-aggregated-batch-resources-tokens.sql
+++ b/batch/sql/add-aggregated-batch-resources-tokens.sql
@@ -1,0 +1,80 @@
+ALTER TABLE aggregated_batch_resources ADD COLUMN token INT NOT NULL DEFAULT 0;
+
+ALTER TABLE aggregated_batch_resources DROP PRIMARY KEY, ADD PRIMARY KEY (batch_id, resource, token);
+
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_after_update $$
+CREATE TRIGGER attempts_after_update AFTER UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  DECLARE job_cores_mcpu INT;
+  DECLARE msec_diff BIGINT;
+  DECLARE msec_mcpu_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  SET msec_diff = (GREATEST(COALESCE(NEW.end_time - NEW.start_time, 0), 0) -
+                   GREATEST(COALESCE(OLD.end_time - OLD.start_time, 0), 0));
+
+  SET msec_mcpu_diff = msec_diff * job_cores_mcpu;
+
+  UPDATE batches
+  SET msec_mcpu = batches.msec_mcpu + msec_mcpu_diff
+  WHERE id = NEW.batch_id;
+
+  UPDATE jobs
+  SET msec_mcpu = jobs.msec_mcpu + msec_mcpu_diff
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  SELECT batch_id, resource, rand_token, msec_diff * quantity
+  FROM attempt_resources
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  SELECT batch_id, job_id, resource, msec_diff * quantity
+  FROM attempt_resources
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
+END $$
+
+DROP TRIGGER IF EXISTS attempt_resources_after_insert $$
+CREATE TRIGGER attempt_resources_after_insert AFTER INSERT ON attempt_resources
+FOR EACH ROW
+BEGIN
+  DECLARE cur_start_time BIGINT;
+  DECLARE cur_end_time BIGINT;
+  DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  SELECT start_time, end_time INTO cur_start_time, cur_end_time
+  FROM attempts
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  LOCK IN SHARE MODE;
+
+  SET msec_diff = GREATEST(COALESCE(cur_end_time - cur_start_time, 0), 0);
+
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  VALUES (NEW.batch_id, NEW.job_id, NEW.resource, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, NEW.resource, rand_token, NEW.quantity * msec_diff)
+  ON DUPLICATE KEY UPDATE
+    `usage` = `usage` + NEW.quantity * msec_diff;
+END $$
+
+DELIMITER ;

--- a/batch/sql/estimated-current.txt
+++ b/batch/sql/estimated-current.txt
@@ -199,8 +199,9 @@ CREATE INDEX batch_attributes_key_value ON `batch_attributes` (`key`, `value`(25
 CREATE TABLE IF NOT EXISTS `aggregated_batch_resources` (
   `batch_id` BIGINT NOT NULL,
   `resource` VARCHAR(100) NOT NULL,
+  `token` INT NOT NULL,
   `usage` BIGINT NOT NULL DEFAULT 0,
-  PRIMARY KEY (`batch_id`, `resource`),
+  PRIMARY KEY (`batch_id`, `resource`, `token`),
   FOREIGN KEY (`batch_id`) REFERENCES batches(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`resource`) REFERENCES resources(`resource`) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -261,6 +262,11 @@ BEGIN
   DECLARE job_cores_mcpu INT;
   DECLARE msec_diff BIGINT;
   DECLARE msec_mcpu_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT cores_mcpu INTO job_cores_mcpu FROM jobs
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
@@ -278,28 +284,17 @@ BEGIN
   SET msec_mcpu = jobs.msec_mcpu + msec_mcpu_diff
   WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id;
 
-  UPDATE aggregated_batch_resources
-  JOIN (SELECT batch_id, resource, quantity
-        FROM attempt_resources
-        WHERE batch_id = NEW.batch_id AND
-        job_id = NEW.job_id AND
-        attempt_id = NEW.attempt_id) AS t
-  ON aggregated_batch_resources.batch_id = t.batch_id AND
-    aggregated_batch_resources.resource = t.resource
-  SET `usage` = `usage` + msec_diff * t.quantity
-  WHERE aggregated_batch_resources.batch_id = NEW.batch_id;
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  SELECT batch_id, resource, rand_token, msec_diff * quantity
+  FROM attempt_resources
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 
-  UPDATE aggregated_job_resources
-  JOIN (SELECT batch_id, job_id, resource, quantity
-        FROM attempt_resources
-        WHERE batch_id = NEW.batch_id AND
-        job_id = NEW.job_id AND
-        attempt_id = NEW.attempt_id) AS t
-  ON aggregated_job_resources.batch_id = t.batch_id AND
-    aggregated_job_resources.job_id = t.job_id AND
-    aggregated_job_resources.resource = t.resource
-  SET `usage` = `usage` + msec_diff * t.quantity
-  WHERE aggregated_job_resources.batch_id = NEW.batch_id AND aggregated_job_resources.job_id = NEW.job_id;
+  INSERT INTO aggregated_job_resources (batch_id, job_id, resource, `usage`)
+  SELECT batch_id, job_id, resource, msec_diff * quantity
+  FROM attempt_resources
+  WHERE batch_id = NEW.batch_id AND job_id = NEW.job_id AND attempt_id = NEW.attempt_id
+  ON DUPLICATE KEY UPDATE `usage` = `usage` + msec_diff * quantity;
 END $$
 
 CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
@@ -437,6 +432,11 @@ BEGIN
   DECLARE cur_start_time BIGINT;
   DECLARE cur_end_time BIGINT;
   DECLARE msec_diff BIGINT;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
 
   SELECT start_time, end_time INTO cur_start_time, cur_end_time
   FROM attempts
@@ -450,8 +450,8 @@ BEGIN
   ON DUPLICATE KEY UPDATE
     `usage` = `usage` + NEW.quantity * msec_diff;
 
-  INSERT INTO aggregated_batch_resources (batch_id, resource, `usage`)
-  VALUES (NEW.batch_id, NEW.resource, NEW.quantity * msec_diff)
+  INSERT INTO aggregated_batch_resources (batch_id, resource, token, `usage`)
+  VALUES (NEW.batch_id, NEW.resource, rand_token, NEW.quantity * msec_diff)
   ON DUPLICATE KEY UPDATE
     `usage` = `usage` + NEW.quantity * msec_diff;
 END $$

--- a/build.yaml
+++ b/build.yaml
@@ -1551,6 +1551,8 @@ steps:
       script: /io/sql/fix-mark-job-complete-on-error.sql
     - name: add-worker-pd-ssd-data-disk
       script: /io/sql/add-worker-pd-ssd-data-disk.sql
+    - name: add-aggregated-batch-resources-tokens
+      script: /io/sql/add-aggregated-batch-resources-tokens.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/


### PR DESCRIPTION
I tested this by adding the check_aggregated_resources loop which didn't throw any errors. I tested the cost by looking at the UI and submitting one job that cost $0.0004 and then two of that same job in a batch and it cost $0.0008. The database looked like this:

mysql> select * FROM aggregated_batch_resources where batch_id > 46;
+----------+--------------------------+-------------+-------+
| batch_id | resource                 | usage       | token |
+----------+--------------------------+-------------+-------+
|       47 | compute/n1-preemptible/1 |    25867000 |    11 |
|       47 | compute/n1-preemptible/1 |           0 |   115 |
|       47 | compute/n1-preemptible/1 |           0 |   132 |
|       47 | disk/local-ssd/1         |  9932928000 |    11 |
|       47 | disk/local-ssd/1         |           0 |    54 |
|       47 | disk/local-ssd/1         |           0 |   132 |
|       47 | disk/pd-ssd/1            |   529756160 |    11 |
|       47 | disk/pd-ssd/1            |           0 |   132 |
|       47 | disk/pd-ssd/1            |           0 |   186 |
|       47 | ip-fee/1024/1            |    26487808 |    11 |
|       47 | ip-fee/1024/1            |           0 |   132 |
|       47 | ip-fee/1024/1            |           0 |   188 |
|       47 | memory/n1-preemptible/1  |    99329280 |    11 |
|       47 | memory/n1-preemptible/1  |           0 |    26 |
|       47 | memory/n1-preemptible/1  |           0 |   132 |
|       47 | service-fee/1            |    25867000 |    11 |
|       47 | service-fee/1            |           0 |   110 |
|       47 | service-fee/1            |           0 |   132 |
|       48 | compute/n1-preemptible/1 |           0 |    31 |
|       48 | compute/n1-preemptible/1 |           0 |    76 |
|       48 | compute/n1-preemptible/1 |    27659000 |    94 |
|       48 | compute/n1-preemptible/1 |    26520000 |   122 |
|       48 | compute/n1-preemptible/1 |           0 |   156 |
|       48 | compute/n1-preemptible/1 |           0 |   168 |
|       48 | disk/local-ssd/1         | 10621056000 |    94 |
|       48 | disk/local-ssd/1         | 10183680000 |   122 |
|       48 | disk/local-ssd/1         |           0 |   125 |
|       48 | disk/local-ssd/1         |           0 |   154 |
|       48 | disk/local-ssd/1         |           0 |   156 |
|       48 | disk/local-ssd/1         |           0 |   168 |
|       48 | disk/pd-ssd/1            |           0 |    69 |
|       48 | disk/pd-ssd/1            |   566456320 |    94 |
|       48 | disk/pd-ssd/1            |           0 |   102 |
|       48 | disk/pd-ssd/1            |   543129600 |   122 |
|       48 | disk/pd-ssd/1            |           0 |   156 |
|       48 | disk/pd-ssd/1            |           0 |   168 |
|       48 | ip-fee/1024/1            |           0 |    57 |
|       48 | ip-fee/1024/1            |    28322816 |    94 |
|       48 | ip-fee/1024/1            |    27156480 |   122 |
|       48 | ip-fee/1024/1            |           0 |   128 |
|       48 | ip-fee/1024/1            |           0 |   156 |
|       48 | ip-fee/1024/1            |           0 |   168 |
|       48 | memory/n1-preemptible/1  |   106210560 |    94 |
|       48 | memory/n1-preemptible/1  |           0 |   119 |
|       48 | memory/n1-preemptible/1  |   101836800 |   122 |
|       48 | memory/n1-preemptible/1  |           0 |   139 |
|       48 | memory/n1-preemptible/1  |           0 |   156 |
|       48 | memory/n1-preemptible/1  |           0 |   168 |
|       48 | service-fee/1            |           0 |    21 |
|       48 | service-fee/1            |           0 |    64 |
|       48 | service-fee/1            |    27659000 |    94 |
|       48 | service-fee/1            |    26520000 |   122 |
|       48 | service-fee/1            |           0 |   156 |
|       48 | service-fee/1            |           0 |   168 |
+----------+--------------------------+-------------+-------+

The reason for 3 entries per resource is `schedule_job` calls attempts_resources_after_insert where as `mark_job_started` and `mark_job_complete` call attempts_resources_after_update.