### PR TITLE
[hail][docs] overhaul docs build Makefile

### DIFF
--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -5,6 +5,7 @@ python/hail.egg-info
 python/hail/backend/hail-all-spark.jar
 python/hail/hail_pip_version
 python/hail/hail_version
+python/hail/docs/change_log.rst
 python/hail/docs/_build/*
 python/hail/docs/_static/hail_version.js
 python/hailtop/hailctl/hail_version

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -168,6 +168,8 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) 
 	mkdir -p build/deploy/src
 	cp ../README.md build/deploy/
 	rsync -rv \
+	    --exclude '.eggs/' \
+	    --exclude '.pytest_cache/' \
 	    --exclude '__pycache__/' \
 	    --exclude 'benchmark_hail/' \
 	    --exclude '.mypy_cache/' \
@@ -271,33 +273,54 @@ benchmark: $(WHEEL)
 install-benchmark:
 	HAIL_WHEEL=DUMMY HAIL_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark install
 
+python/hail/docs/change_log.rst: python/hail/docs/change_log.md
+	sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \
+    < $< \
+    | pandoc -o $@
+
 .PHONY: batch-docs
-batch-docs:
-	rm -rf build/batch/docs
-	mkdir -p build/batch
-	cp -R python/hailtop/batch/docs build/batch/
-	$(MAKE) -C build/batch/docs BUILDDIR=_build clean html
+batch-docs: install-editable
+	$(MAKE) -C python/hailtop/batch/docs \
+          BUILDDIR=../../../build/docs/batch \
+          html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/batch
-	mv build/batch/docs/_build/html build/www/docs/batch
+	cp -R build/docs/batch/html build/www/docs/batch
+	find build/www/docs/batch \
+       -iname *.html \
+       -type f \
+       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built Batch docs: build/www/docs/batch/index.html
 
 HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 .PHONY: hail-docs
-hail-docs: install $(PYTHON_VERSION_INFO)
-	mkdir -p build/docs
-	rm -rf build/docs
-	cp -R python/hail/docs build/
-	cp python/hail/hail_version build/
-	sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \
-    < build/docs/change_log.md \
-    | pandoc -o build/docs/change_log.rst
-	$(MAKE) SPHINXOPTS='-tchecktutorial' -C build/docs BUILDDIR=_build clean html
+hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
+	$(MAKE) -C python/hail/docs \
+          SPHINXOPTS='-tchecktutorial' \
+          BUILDDIR=../../../build/docs/hail \
+          html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
-	mv build/docs/_build/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
-	find ./build/www -iname *.html -type f -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
+	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
+	find build/www/docs/$(HAIL_MAJOR_MINOR_VERSION) \
+       -iname *.html \
+       -type f \
+       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built Hail docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
+
+.PHONY: hail-docs-no-test
+hail-docs-no-test:  $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
+	$(MAKE) -C python/hail/docs \
+          BUILDDIR=../../../build/docs/hail \
+          html
+	mkdir -p build/www/docs
+	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
+	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
+	find build/www/docs/$(HAIL_MAJOR_MINOR_VERSION) \
+       -iname *.html \
+       -type f \
+       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
+	@echo Built docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: upload-docs
 upload-docs: hail-docs batch-docs
@@ -307,25 +330,7 @@ upload-docs: hail-docs batch-docs
 	gsutil -m acl set public-read $(docs_location)
 
 .PHONY: test
-test: pytest jvm-test doctest tutorial-test
-
-.PHONY: tutorial-test
-docs-no-test: install $(PYTHON_VERSION_INFO) install-dev-deps
-	mkdir -p build
-	rm -rf build/www
-	rm -rf build/docs
-	mkdir -p build/docs
-	cp -R python/hail/docs build/
-	cp python/hail/hail_version build/
-	sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \
-    < build/docs/change_log.md \
-    | pandoc -o build/docs/change_log.rst
-	$(MAKE) -C build/docs BUILDDIR=_build clean html
-	mkdir -p build/www/docs
-	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
-	mv build/docs/_build/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
-	find ./build/www -iname *.html -type f -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
-	@echo Built docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
+test: pytest jvm-test doctest
 
 .PHONY: native-lib native-lib-test native-lib-clean native-lib-prebuilt native-lib-reset-prebuilt
 native-lib:
@@ -340,15 +345,18 @@ native-lib-reset-prebuilt:
 	$(MAKE) -C src/main/c reset-prebuilt
 
 clean: clean-env native-lib-clean
+	make -C python/hail/docs clean
+	make -C python/hailtop/batch/docs clean
 	./gradlew clean $(GRADLE_ARGS)
 	rm -rf build/
 	rm -rf $(PYTHON_JAR)
 	rm -rf python/README.md
 	rm -rf $(SCALA_BUILD_INFO)
 	rm -rf $(PYTHON_VERSION_INFO)
+	rm -rf python/hail/docs/change_log.rst
 
 .PHONY: update-hail-repl
 update-hail-repl: NAMESPACE ?= default
 update-hail-repl: wheel
 	kubectl -n $(NAMESPACE) cp $(WHEEL) $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}'):.
-	kubectl -n $(NAMESPACE) exec -it $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}') -- pip3 install -U hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
+	kubectl -n $(NAMESPACE) exec -it $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}') -- pip3 install- U hail-$(HAIL_PIP_VERSION)-py3-none-any.whl

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -359,4 +359,4 @@ clean: clean-env native-lib-clean
 update-hail-repl: NAMESPACE ?= default
 update-hail-repl: wheel
 	kubectl -n $(NAMESPACE) cp $(WHEEL) $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}'):.
-	kubectl -n $(NAMESPACE) exec -it $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}') -- pip3 install- U hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
+	kubectl -n $(NAMESPACE) exec -it $$(kubectl get pods -n $(NAMESPACE) -l app=hail-repl | tail -n +2 | awk '{print $$1}') -- pip3 install -U hail-$(HAIL_PIP_VERSION)-py3-none-any.whl

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -279,7 +279,7 @@ python/hail/docs/change_log.rst: python/hail/docs/change_log.md
 	  | pandoc -o $@
 
 .PHONY: batch-docs
-batch-docs: install-editable
+batch-docs:
 	$(MAKE) -C python/hailtop/batch/docs \
 	      BUILDDIR=$(PWD)/build/docs/batch \
 	      html
@@ -294,7 +294,7 @@ batch-docs: install-editable
 
 HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 .PHONY: hail-docs
-hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
+hail-docs: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs
 	        SPHINXOPTS='-tchecktutorial' \
 	        BUILDDIR=$(PWD)/build/docs/hail \
@@ -309,7 +309,7 @@ hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.r
 	@echo Built Hail docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: hail-docs-no-test
-hail-docs-no-test:  $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
+hail-docs-no-test: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
 	        BUILDDIR=$(PWD)/build/docs/hail \
 	        html

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -281,15 +281,15 @@ python/hail/docs/change_log.rst: python/hail/docs/change_log.md
 .PHONY: batch-docs
 batch-docs: install-editable
 	$(MAKE) -C python/hailtop/batch/docs \
-          BUILDDIR=../../../build/docs/batch \
+          BUILDDIR=$(PWD)/build/docs/batch \
           html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/batch
 	cp -R build/docs/batch/html build/www/docs/batch
 	find build/www/docs/batch \
-       -iname *.html \
-       -type f \
-       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
+	     -iname *.html \
+	     -type f \
+	     -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built Batch docs: build/www/docs/batch/index.html
 
 HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
@@ -297,29 +297,29 @@ HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
           SPHINXOPTS='-tchecktutorial' \
-          BUILDDIR=../../../build/docs/hail \
+          BUILDDIR=$(PWD)/build/docs/hail \
           html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	find build/www/docs/$(HAIL_MAJOR_MINOR_VERSION) \
-       -iname *.html \
-       -type f \
-       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
+	     -iname *.html \
+	     -type f \
+	     -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built Hail docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: hail-docs-no-test
 hail-docs-no-test:  $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
-          BUILDDIR=../../../build/docs/hail \
+          BUILDDIR=$(PWD)/build/docs/hail \
           html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	find build/www/docs/$(HAIL_MAJOR_MINOR_VERSION) \
-       -iname *.html \
-       -type f \
-       -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
+	     -iname *.html \
+	     -type f \
+	     -exec sed -i -e "s/\.css/\.css\?v\=$(HAIL_CACHE_VERSION)/" {} +;
 	@echo Built docs: build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)/index.html
 
 .PHONY: upload-docs

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -275,8 +275,8 @@ install-benchmark:
 
 python/hail/docs/change_log.rst: python/hail/docs/change_log.md
 	sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \
-    < $< \
-    | pandoc -o $@
+	  < $< \
+	  | pandoc -o $@
 
 .PHONY: batch-docs
 batch-docs: install-editable

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -295,7 +295,7 @@ batch-docs:
 HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 .PHONY: hail-docs
 hail-docs: $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
-	$(MAKE) -C python/hail/docs
+	$(MAKE) -C python/hail/docs \
 	        SPHINXOPTS='-tchecktutorial' \
 	        BUILDDIR=$(PWD)/build/docs/hail \
 	        html

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -281,8 +281,8 @@ python/hail/docs/change_log.rst: python/hail/docs/change_log.md
 .PHONY: batch-docs
 batch-docs: install-editable
 	$(MAKE) -C python/hailtop/batch/docs \
-          BUILDDIR=$(PWD)/build/docs/batch \
-          html
+	      BUILDDIR=$(PWD)/build/docs/batch \
+	      html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/batch
 	cp -R build/docs/batch/html build/www/docs/batch
@@ -295,10 +295,10 @@ batch-docs: install-editable
 HAIL_CACHE_VERSION = $(shell cat python/hail/hail_version)
 .PHONY: hail-docs
 hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
-	$(MAKE) -C python/hail/docs \
-          SPHINXOPTS='-tchecktutorial' \
-          BUILDDIR=$(PWD)/build/docs/hail \
-          html
+	$(MAKE) -C python/hail/docs
+	        SPHINXOPTS='-tchecktutorial' \
+	        BUILDDIR=$(PWD)/build/docs/hail \
+	        html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
@@ -311,8 +311,8 @@ hail-docs: install-editable $(PYTHON_VERSION_INFO) python/hail/docs/change_log.r
 .PHONY: hail-docs-no-test
 hail-docs-no-test:  $(PYTHON_VERSION_INFO) python/hail/docs/change_log.rst
 	$(MAKE) -C python/hail/docs \
-          BUILDDIR=$(PWD)/build/docs/hail \
-          html
+	        BUILDDIR=$(PWD)/build/docs/hail \
+	        html
 	mkdir -p build/www/docs
 	rm -rf build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)
 	cp -R build/docs/hail/html build/www/docs/$(HAIL_MAJOR_MINOR_VERSION)

--- a/hail/python/hail/docs/Makefile
+++ b/hail/python/hail/docs/Makefile
@@ -47,20 +47,15 @@ help:
 clean:
 	rm -rf $(BUILDDIR)
 
-.PHONY: check-python
-check-python:
-	@echo "Ensuring that Hail can be imported..."
-	python3 -c "import hail"
-
 .PHONY: tutorials-tar
-tutorials-tar:
-	rm -rf tutorials/data
-	rm -f tutorials/*.log
+tutorials-tar: $(BUILDDIR)/html/tutorials.tar.gz
+
+$(BUILDDIR)/html/tutorials.tar.gz: $(wildcard tutorials/*.ipynb)
 	mkdir -p $(BUILDDIR)/html
-	tar cvf $(BUILDDIR)/html/tutorials.tar.gz tutorials
+	tar cvf $(BUILDDIR)/html/tutorials.tar.gz $^
 
 .PHONY: html
-html: check-python tutorials-tar
+html: tutorials-tar
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/hail/python/hailtop/batch/docs/Makefile
+++ b/hail/python/hailtop/batch/docs/Makefile
@@ -24,13 +24,8 @@ help:
 clean:
 	rm -rf $(BUILDDIR)
 
-.PHONY: check-python
-check-python:
-	@echo "Ensuring that Batch can be imported..."
-	python3 -c "import hailtop.batch"
-
 .PHONY: html
-html: check-python
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
It takes one minute to build the docs *even if nothing has changed since the
last build*. There are a few things that lengthen the feedback cycle:

- We defeat Sphinx's input cache by deleting and re-copying over all the source
  files.
- We defeat Sphinx's output cache by `mv`ing the output to a new location.
- We check that Hail is installed (at a cost of two seconds) *every* time we
  build the docs. This isn't necessary, Sphinx prints a reasonable message
  ("cannot import ...") if Hail is not installed.
- We create a wheel file every time we build the docs at a cost of several
  seconds.
- We recreate the tutorials tar even if it has not changed.

Instead, I propose this PR:

- Do not copy the source files.
- Copy the output to the new location.
- Do not check hail is installed.
- Do not even install Hail.
- Use Make to check if the tutorial tar need be recreated.

Regarding not installing Hail: even install-editable takes two seconds. It is
the developer's responsibility to ensure the right version of Hail is
installed. When you check out a branch just run `make install-editable`
once. Then edit the docs to your heart's desire, never re-install Hail.

With this PR it takes ~3.5 seconds to rebuild the docs if nothing has
changed. We do work proportional to the number of changed files, not
proportional to all files. Sphinx itself takes 2-3 seconds, so we can't do much
better than this.

Dice came up Patrick, but I imagine @tpoterba has thoughts.