### PR TITLE
[query] Don't broadcast the contigRecoding if there are no contigs

### DIFF
--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1465,14 +1465,15 @@ class PartitionedVCFRDD(
   @(transient@param) _partitions: Array[Partition]
 ) extends RDD[String](SparkBackend.sparkContext("PartitionedVCFRDD"), Seq()) {
 
-  val contigRemappingBc = sparkContext.broadcast(reverseContigMapping)
+  val contigRemappingBc = if (reverseContigMapping.size != 0) sparkContext.broadcast(reverseContigMapping) else null
 
   protected def getPartitions: Array[Partition] = _partitions
 
   def compute(split: Partition, context: TaskContext): Iterator[String] = {
     val p = split.asInstanceOf[PartitionedVCFPartition]
 
-    val chromToQuery = contigRemappingBc.value.getOrElse(p.chrom, p.chrom)
+    val chromToQuery = if (contigRemappingBc != null) contigRemappingBc.value.getOrElse(p.chrom, p.chrom) else p.chrom
+
     val reg = {
       val r = new TabixReader(file, fsBc.value)
       val tid = r.chr2tid(chromToQuery)


### PR DESCRIPTION
We end up with tens of thousands of miniscule broadcasts across
thousands of executors, the management of which seems to take signifigant
time.
