### PR TITLE
[batch] block containers from using the metadata server

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -414,8 +414,8 @@ set -x
 
 # only allow udp/53 (dns) to metadata server
 # -I inserts at the head of the chain, so the ACCEPT rule runs first
-iptables -I FORWARD -i docker0 -d 169.254.169.254 -j DROP
-iptables -I FORWARD -i docker0 -d 169.254.169.254 -p udp -m udp --destination-port 53 -j ACCEPT
+iptables -I DOCKER-USER -d 169.254.169.254 -j DROP
+iptables -I DOCKER-USER -d 169.254.169.254 -p udp -m udp --destination-port 53 -j ACCEPT
 
 # add docker daemon debug logging
 jq '.debug = true' /etc/docker/daemon.json > daemon.json.tmp

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -557,3 +557,11 @@ echo $HAIL_BATCH_WORKER_IP
             assert e.status == 400
         else:
             assert False, f'should receive a 400 Bad Request {batch.id}'
+
+    def test_verify_no_access_to_metadata_server(self):
+        builder = self.client.create_batch()
+        j = builder.create_job('google/cloud-sdk', ['gcloud', 'auth', 'login'])
+        builder.submit()
+        status = j.wait()
+        assert status['state'] == 'Failed', status
+        assert "No credentialed accounts." in j.log()['main']

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -564,4 +564,4 @@ echo $HAIL_BATCH_WORKER_IP
         builder.submit()
         status = j.wait()
         assert status['state'] == 'Success', status
-        assert "No credentialed accounts." in j.log()['main']
+        assert "No credentialed accounts." in j.log()['main'], j.log()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -563,5 +563,5 @@ echo $HAIL_BATCH_WORKER_IP
         j = builder.create_job('google/cloud-sdk', ['gcloud', 'auth', 'list'])
         builder.submit()
         status = j.wait()
-        assert status['state'] == 'Failed', status
+        assert status['state'] == 'Success', status
         assert "No credentialed accounts." in j.log()['main']

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -564,4 +564,4 @@ echo $HAIL_BATCH_WORKER_IP
         builder.submit()
         status = j.wait()
         assert status['state'] == 'Success', status
-        assert "No credentialed accounts." in j.log()['main'], j.log()
+        assert "No credentialed accounts." in j.log()['main'], (j.log()['main'], status)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -560,7 +560,7 @@ echo $HAIL_BATCH_WORKER_IP
 
     def test_verify_no_access_to_metadata_server(self):
         builder = self.client.create_batch()
-        j = builder.create_job('google/cloud-sdk', ['gcloud', 'auth', 'login'])
+        j = builder.create_job('google/cloud-sdk', ['gcloud', 'auth', 'list'])
         builder.submit()
         status = j.wait()
         assert status['state'] == 'Failed', status


### PR DESCRIPTION
We're supposed to use DOCKER-USER https://docs.docker.com/network/iptables/.

I also added a test.