### PR TITLE
[hail] implement sort_columns for dndarray

### DIFF
--- a/hail/python/hail/experimental/dnd/array.py
+++ b/hail/python/hail/experimental/dnd/array.py
@@ -106,12 +106,12 @@ class DNDArray:
         else:
             col_keys = mt.col_key.collect(_localize=False)
             out_of_order = hl.range(hl.len(col_keys) - 1).map(
-                lambda i: col_keys[i] > col_keys[i+1])
+                lambda i: col_keys[i] > col_keys[i + 1])
             out_of_order = out_of_order.collect()[0]
             if any(out_of_order):
                 raise ValueError(
-                    f'from_matrix_table: columns are not in sorted order. You may request a '
-                    f'sort with sort_columns=True.')
+                    'from_matrix_table: columns are not in sorted order. You may request a '
+                    'sort with sort_columns=True.')
 
         mt = (mt
               .select_globals()

--- a/hail/python/test/hail/experimental/test_dnd_array.py
+++ b/hail/python/test/hail/experimental/test_dnd_array.py
@@ -310,3 +310,42 @@ def test_dndarray_rsub_scalar():
     a_result = 10 - a1
 
     assert np.array_equal(da_result, a_result)
+
+
+def test_dndarray_errors_on_unsorted_columns():
+    n_variants = 10
+    n_samples = 10
+    block_size = 3
+    mt = hl.utils.range_matrix_table(n_variants, n_samples)
+    mt = mt.key_cols_by(sampleid=hl.str('zyxwvutsrq')[mt.col_idx])
+    mt = mt.select_entries(x=mt.row_idx * mt.col_idx)
+    try:
+        hl.experimental.dnd.array(mt, 'x', block_size=block_size)
+    except ValueError as err:
+        assert 'columns are not in sorted order', err.args[0]
+    else:
+        assert False
+
+
+def test_dndarray_sort_columns():
+    n_variants = 10
+    n_samples = 10
+    block_size = 3
+    disorder = [0, 9, 8, 7, 1, 2, 3, 4, 6, 5]
+    order = [x[0]
+             for x in sorted(enumerate(disorder),
+                             key=lambda x: x[1])]
+    mt = hl.utils.range_matrix_table(n_variants, n_samples)
+    mt = mt.key_cols_by(sampleid=hl.literal(disorder)[mt.col_idx])
+    mt = mt.select_entries(x=mt.row_idx * mt.col_idx)
+    da = hl.experimental.dnd.array(mt, 'x', block_size=block_size, sort_columns=True)
+
+    a = np.array(
+        [r * order[c] for r in range(n_variants) for c in range(n_samples)]
+    ).reshape((n_variants, n_samples))
+
+    assert np.array_equal(da.collect(), a)
+
+    result = (da.T @ da).collect()
+    expected = a.T @ a
+    assert np.array_equal(result, expected)


### PR DESCRIPTION
In `main`, dnd array is just very broken if the columns are not ordered by their
column key.

I also added the missing `n_partitions` kwarg to `array`.