### PR TITLE
[query] Switch _buildEncoder methods to use CodeBuilder infrastructure

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -469,7 +469,7 @@ class MethodBuilder[C](
   // very long method names, repeated hundreds of thousands of times can cause memory issues.
   // If necessary to find the name of a method precisely, this can be set to around the constant
   // limit of 65535 characters, but usually, this can be much smaller.
-  val methodName: String = _mname.substring(0, scala.math.min(_mname.length, 8192 /* 65535 */))
+  val methodName: String = _mname.substring(0, scala.math.min(_mname.length, 2000 /* 65535 */))
 
   if (methodName != "<init>" && !isJavaIdentifier(methodName))
     throw new IllegalArgumentException(s"Illegal method name, not Java identifier: $methodName")

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -466,7 +466,10 @@ class MethodBuilder[C](
   val returnTypeInfo: TypeInfo[_],
   val isStatic: Boolean = false
 ) extends WrappedClassBuilder[C] {
-  val methodName: String = _mname.substring(0, scala.math.min(_mname.length, 65535))
+  // very long method names, repeated hundreds of thousands of times can cause memory issues.
+  // If necessary to find the name of a method precisely, this can be set to around the constant
+  // limit of 65535 characters, but usually, this can be much smaller.
+  val methodName: String = _mname.substring(0, scala.math.min(_mname.length, 8192 /* 65535 */))
 
   if (methodName != "<init>" && !isJavaIdentifier(methodName))
     throw new IllegalArgumentException(s"Illegal method name, not Java identifier: $methodName")

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -209,11 +209,11 @@ class StagedBlockLinkedList(val elemType: PType, val cb: EmitClassBuilder[_]) {
       val i = serF.newLocal[Int]()
       val b = serF.newLocal[Long]()
       Code(
-        foreachNode(serF, n) { Code(
-          ob.writeBoolean(true),
-          b := buffer(n),
-          bufferEType.buildPrefixEncoder(bufferType.encodableType, serF, b, ob, count(n)))
-        },
+        foreachNode(serF, n) { EmitCodeBuilder.scopedVoid(serF) { cb =>
+          cb += ob.writeBoolean(true)
+          cb.assign(b, buffer(n))
+          bufferEType.buildPrefixEncoder(cb, bufferType.encodableType, b, ob, count(n))
+        }},
         ob.writeBoolean(false))
     }
     serF.invokeCode(region, outputBuffer)

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitMethodBuilder, ParamType}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, ParamType}
 import is.hail.types.{BaseStruct, BaseType}
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -92,90 +92,58 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       PCanonicalNDArray(elementType, t.nDims, required)
   }
 
-  override def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    val ft = pt.asInstanceOf[PBaseStruct]
-    val vs = coerce[Long](v)
-    val writeMissingBytes = if (ft.size == size) {
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    val pv = PCode(pt, v).asBaseStruct.memoize(cb, "base_struct")
+    val ft = pv.pt
+    // write missing bytes
+    if (ft.size == size) {
       val missingBytes = UnsafeUtils.packBitsToBytes(ft.nMissing)
-      var c = Code._empty
       ft match {
         case ps: PCanonicalBaseStruct if ps.fieldRequired.sameElements(fields.map(_.typ.required)) =>
           if (nMissingBytes > 1)
-            c = Code(c, out.writeBytes(coerce[Long](v), missingBytes - 1))
+            cb += out.writeBytes(pv.tcode[Long], missingBytes - 1)
           if (nMissingBytes > 0)
-            c = Code(c, out.writeByte((Region.loadByte(vs + (missingBytes.toLong - 1)).toI & const(EType.lowBitMask(ft.nMissing & 0x7))).toB))
+            cb += out.writeByte((Region.loadByte(pv.tcode[Long] + (missingBytes.toLong - 1)).toI & const(EType.lowBitMask(ft.nMissing & 0x7))).toB)
         case _ =>
           fields.filter(f => !f.typ.required)
             .grouped(8)
             .foreach { group =>
-              c = Code(c, out.writeByte(group.zipWithIndex.map { case (f, i) =>
-                ft.isFieldMissing(vs, f.index).toI << i
-              }.reduce(_ | _).toB))
+              val byte = group.zipWithIndex.map { case (f, i) =>
+                pv.isFieldMissing(f.index).toI << i
+              }.reduce(_ | _).toB
+              cb += out.writeByte(byte)
             }
       }
-      c
     } else {
-      val groupSize = 64
-      var methodIdx = 0
-      var currentMB = mb.genEmitMethod(s"missingbits_group_$methodIdx", FastIndexedSeq[ParamType](LongInfo, classInfo[OutputBuffer]), UnitInfo)
-      var wrappedC: Code[Unit] = Code._empty
-      var methodC: Code[Unit] = Code._empty
-
       var j = 0
       var n = 0
       while (j < size) {
-        if (n % groupSize == 0) {
-          currentMB.emit(methodC)
-          methodC = Code._empty
-          wrappedC = Code(wrappedC, currentMB.invokeCode[Unit](v, out))
-          methodIdx += 1
-          currentMB = mb.genEmitMethod(s"missingbits_group_$methodIdx", FastIndexedSeq[ParamType](LongInfo, classInfo[OutputBuffer]), UnitInfo)
-        }
         var b: Code[Int] = 0
         var k = 0
         while (k < 8 && j < size) {
           val f = fields(j)
           if (!f.typ.required) {
-            val i = ft.fieldIdx(f.name)
-            b = b | (ft.isFieldMissing(currentMB.getCodeParam[Long](1), i).toI << k)
+            b = b | (pv.isFieldMissing(f.name).toI << k)
             k += 1
           }
           j += 1
         }
         if (k > 0) {
-          methodC = Code(methodC, currentMB.getCodeParam[OutputBuffer](2).writeByte(b.toB))
+          cb += out.writeByte(b.toB)
           n += 1
         }
       }
-      currentMB.emit(methodC)
-      wrappedC = Code(wrappedC, currentMB.invokeCode[Unit](v, out))
 
       assert(n == nMissingBytes)
-      wrappedC
     }
 
-    val writeFields = Code(fields.grouped(64).zipWithIndex.map { case (fieldGroup, groupIdx) =>
-      val groupMB = mb.genEmitMethod(s"write_fields_group_$groupIdx", FastIndexedSeq[ParamType](LongInfo, classInfo[OutputBuffer]), UnitInfo)
-
-      val addr = groupMB.getCodeParam[Long](1)
-      val out2 = groupMB.getCodeParam[OutputBuffer](2)
-      groupMB.emit(Code(
-        fieldGroup.map { ef =>
-          val i = ft.fieldIdx(ef.name)
-          val pf = ft.fields(i)
-          val encodeField = ef.typ.buildEncoder(pf.typ, groupMB.ecb)
-          val v = Region.loadIRIntermediate(pf.typ)(ft.fieldOffset(addr, i))
-          ft.isFieldDefined(addr, i).mux(
-            encodeField(v, out2),
-            Code._empty
-          )
-        }
-      ))
-
-      groupMB.invokeCode[Unit](v, out)
-    }.toArray)
-
-    Code(writeMissingBytes, writeFields, Code._empty)
+    // Write fields
+    fields.foreach { ef =>
+      pv.loadField(cb, ef.name).consume(cb, { /* do nothing */ }, { pc =>
+        val encodeField = ef.typ.buildEncoder(pc.pt, cb.emb.ecb)
+        cb += encodeField(pc.code, out)
+      })
+    }
   }
 
   override def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,14 +13,12 @@ case object EBinaryOptional extends EBinary(false)
 case object EBinaryRequired extends EBinary(true)
 
 class EBinary(override val required: Boolean) extends EFundamentalType {
-  def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
     val addr = coerce[Long](v)
-    val len = mb.newLocal[Int]("len")
     val bT = pt.asInstanceOf[PBinary]
-    Code(
-      len := bT.loadLength(addr),
-      out.writeInt(len),
-      out.writeBytes(bT.bytesAddress(addr), len))
+    val len = cb.newLocal[Int]("len", bT.loadLength(addr))
+    cb += out.writeInt(len)
+    cb += out.writeBytes(bT.bytesAddress(addr), len)
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,8 +13,8 @@ case object EBooleanOptional extends EBoolean(false)
 case object EBooleanRequired extends EBoolean(true)
 
 class EBoolean(override val required: Boolean) extends EFundamentalType {
-  def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    out.writeBoolean(coerce[Boolean](v))
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    cb += out.writeBoolean(coerce[Boolean](v))
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,8 +13,8 @@ case object EFloat32Optional extends EFloat32(false)
 case object EFloat32Required extends EFloat32(true)
 
 class EFloat32(override val required: Boolean) extends EFundamentalType {
-  def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    out.writeFloat(coerce[Float](v))
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    cb += out.writeFloat(coerce[Float](v))
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,8 +13,8 @@ case object EFloat64Optional extends EFloat64(false)
 case object EFloat64Required extends EFloat64(true)
 
 class EFloat64(override val required: Boolean) extends EFundamentalType {
-  override def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    out.writeDouble(coerce[Double](v))
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    cb += out.writeDouble(coerce[Double](v))
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,8 +13,8 @@ case object EInt32Optional extends EInt32(false)
 case object EInt32Required extends EInt32(true)
 
 class EInt32(override val required: Boolean) extends EFundamentalType {
-  def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    out.writeInt(coerce[Int](v))
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    cb += out.writeInt(coerce[Int](v))
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -13,8 +13,8 @@ case object EInt64Optional extends EInt64(false)
 case object EInt64Required extends EInt64(true)
 
 class EInt64(override val required: Boolean) extends EFundamentalType {
-  def _buildFundamentalEncoder(pt: PType, mb: EmitMethodBuilder[_], v: Value[_], out: Value[OutputBuffer]): Code[Unit] = {
-    out.writeLong(coerce[Long](v))
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    cb += out.writeLong(coerce[Long](v))
   }
 
   def _buildFundamentalDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -42,15 +42,15 @@ abstract class EType extends BaseType with Serializable with Requiredness {
     pType -> makeDec
   }
 
-  final def buildEncoder(pt: PType, cb: EmitClassBuilder[_]): StagedEncoder = {
-    buildEncoderMethod(pt, cb).invokeCode(_, _)
+  final def buildEncoder(pt: PType, kb: EmitClassBuilder[_]): StagedEncoder = {
+    buildEncoderMethod(pt, kb).invokeCode(_, _)
   }
 
-  final def buildEncoderMethod(pt: PType, cb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
+  final def buildEncoderMethod(pt: PType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
     if (!encodeCompatible(pt))
       throw new RuntimeException(s"encode incompatible:\n  PT: $pt\n  ET: ${ parsableString() }")
     val ptti = typeToTypeInfo(pt)
-    cb.getOrGenEmitMethod(s"ENCODE_${ pt.asIdent }_TO_${ asIdent }",
+    kb.getOrGenEmitMethod(s"ENCODE_${ pt.asIdent }_TO_${ asIdent }",
       (pt, this, "ENCODE"),
       FastIndexedSeq[ParamType](ptti, classInfo[OutputBuffer]),
       UnitInfo) { mb =>
@@ -61,14 +61,14 @@ abstract class EType extends BaseType with Serializable with Requiredness {
     }
   }
 
-  final def buildDecoder[T](pt: PType, cb: EmitClassBuilder[_]): StagedDecoder[T] = {
-    buildDecoderMethod(pt, cb).invokeCode(_, _)
+  final def buildDecoder[T](pt: PType, kb: EmitClassBuilder[_]): StagedDecoder[T] = {
+    buildDecoderMethod(pt, kb).invokeCode(_, _)
   }
 
-  final def buildDecoderMethod[T](pt: PType, cb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
+  final def buildDecoderMethod[T](pt: PType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
     if (!decodeCompatible(pt))
       throw new RuntimeException(s"decode incompatible:\n  PT: $pt }\n  ET: ${ parsableString() }")
-    cb.getOrGenEmitMethod(s"DECODE_${ asIdent }_TO_${ pt.asIdent }",
+    kb.getOrGenEmitMethod(s"DECODE_${ asIdent }_TO_${ pt.asIdent }",
       (pt, this, "DECODE"),
       FastIndexedSeq[ParamType](typeInfo[Region], classInfo[InputBuffer]),
       typeToTypeInfo(pt)) { mb =>
@@ -80,14 +80,14 @@ abstract class EType extends BaseType with Serializable with Requiredness {
     }
   }
 
-  final def buildInplaceDecoder(pt: PType, cb: EmitClassBuilder[_]): StagedInplaceDecoder = {
-    buildInplaceDecoderMethod(pt, cb).invokeCode(_, _, _)
+  final def buildInplaceDecoder(pt: PType, kb: EmitClassBuilder[_]): StagedInplaceDecoder = {
+    buildInplaceDecoderMethod(pt, kb).invokeCode(_, _, _)
   }
 
-  final def buildInplaceDecoderMethod(pt: PType, cb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
+  final def buildInplaceDecoderMethod(pt: PType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
     if (!decodeCompatible(pt))
       throw new RuntimeException(s"decode incompatible:\n  PT: $pt\n  ET: ${ parsableString() }")
-    cb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }",
+    kb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }",
       (pt, this, "INPLACE_DECODE"),
       FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[Long], classInfo[InputBuffer]),
       UnitInfo)({ mb =>

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -192,11 +192,15 @@ abstract class PBaseStruct extends PType {
 }
 
 abstract class PBaseStructValue extends PValue {
+  def pt: PBaseStruct
+
   def isFieldMissing(fieldIdx: Int): Code[Boolean]
+
+  def isFieldMissing(fieldName: String): Code[Boolean] = isFieldMissing(pt.fieldIdx(fieldName))
 
   def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode
 
-  def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.asInstanceOf[PBaseStruct].fieldIdx(fieldName))
+  def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.fieldIdx(fieldName))
 }
 
 abstract class PBaseStructCode extends PCode {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -556,9 +556,11 @@ class PCanonicalIndexableSettable(
   def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode = {
     val iv = cb.newLocal("pcindval_i", i)
     IEmitCode(cb,
-      pt.isElementMissing(a, iv),
+      isElementMissing(iv),
       pt.elementType.load(elementsAddress + iv.toL * pt.elementByteSize))
   }
+
+  def isElementMissing(i: Code[Int]): Code[Boolean] = pt.isElementMissing(a, i)
 
   def store(pc: PCode): Code[Unit] = {
     Code(

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -97,6 +97,10 @@ abstract class PContainer extends PIterable {
 abstract class PIndexableValue extends PValue {
   def loadLength(): Value[Int]
 
+  def isElementMissing(i: Code[Int]): Code[Boolean]
+
+  def isElementDefined(i: Code[Int]): Code[Boolean] = !isElementMissing(i)
+
   def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode
 }
 


### PR DESCRIPTION
This streamlines the logic significantly. No attempt has been made to have the encoder methods take
PCode/EmitCode directly, but that is the future direction here.