### PR TITLE
Run hail Java tests with checked memory allocator

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -556,7 +556,12 @@ steps:
      {{ code.checkout_script }}
      cd hail
      time retry ./gradlew --version
-     time retry make jars python-version-info wheel HAIL_DEBUG_MODE=1
+     time retry make jars HAIL_DEBUG_MODE=1
+     time retry make jars
+     mkdir build/debug_libs
+     mv io/repo/hail/build/hail-all-spark.jar build/debug_libs/
+     mv io/repo/hail/build/hail-all-spark-test.jar build/debug_libs/
+     time retry make jars python-version-info wheel
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test
      time tar czf resources.tar.gz -C src/test resources

--- a/build.yaml
+++ b/build.yaml
@@ -575,7 +575,7 @@ steps:
        to: /hail.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
-     - from: build/debug_libs/hail-all-spark-test.jar
+     - from: /io/repo/hail/build/debug_libs/hail-all-spark-test.jar
        to: /hail-debug-test.jar
      - from: /io/repo/hail/testng-build.xml
        to: /testng-build.xml

--- a/build.yaml
+++ b/build.yaml
@@ -556,7 +556,7 @@ steps:
      {{ code.checkout_script }}
      cd hail
      time retry ./gradlew --version
-     time retry make jars python-version-info wheel
+     time retry make jars python-version-info wheel HAIL_DEBUG_MODE=1
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test
      time tar czf resources.tar.gz -C src/test resources

--- a/build.yaml
+++ b/build.yaml
@@ -576,6 +576,8 @@ steps:
        to: /hail.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
+     - from: build/debug_libs/hail-all-spar-test.jar
+     - to: /hail-debug-test.jar
      - from: /io/repo/hail/testng-build.xml
        to: /testng-build.xml
      - from: /io/repo/hail/testng-services.xml
@@ -715,7 +717,7 @@ steps:
    inputs:
     - from: /resources.tar.gz
       to: /io/resources.tar.gz
-    - from: /hail-test.jar
+    - from: /hail-debug-test.jar
       to: /io/hail-test.jar
     - from: /splits.tar.gz
       to: /io/splits.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -753,7 +753,7 @@ steps:
    inputs:
     - from: /resources.tar.gz
       to: /io/resources.tar.gz
-    - from: /hail-test.jar
+    - from: /hail-debug-test.jar
       to: /io/hail-test.jar
     - from: /splits.tar.gz
       to: /io/splits.tar.gz
@@ -790,7 +790,7 @@ steps:
    inputs:
     - from: /resources.tar.gz
       to: /io/resources.tar.gz
-    - from: /hail-test.jar
+    - from: /hail-debug-test.jar
       to: /io/hail-test.jar
     - from: /splits.tar.gz
       to: /io/splits.tar.gz
@@ -827,7 +827,7 @@ steps:
    inputs:
     - from: /resources.tar.gz
       to: /io/resources.tar.gz
-    - from: /hail-test.jar
+    - from: /hail-debug-test.jar
       to: /io/hail-test.jar
     - from: /splits.tar.gz
       to: /io/splits.tar.gz
@@ -864,7 +864,7 @@ steps:
    inputs:
     - from: /resources.tar.gz
       to: /io/resources.tar.gz
-    - from: /hail-test.jar
+    - from: /hail-debug-test.jar
       to: /io/hail-test.jar
     - from: /splits.tar.gz
       to: /io/splits.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -576,7 +576,7 @@ steps:
        to: /hail.jar
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
-     - from: build/debug_libs/hail-all-spar-test.jar
+     - from: build/debug_libs/hail-all-spark-test.jar
        to: /hail-debug-test.jar
      - from: /io/repo/hail/testng-build.xml
        to: /testng-build.xml

--- a/build.yaml
+++ b/build.yaml
@@ -557,10 +557,10 @@ steps:
      cd hail
      time retry ./gradlew --version
      time retry make jars HAIL_DEBUG_MODE=1
-     time retry make jars
      mkdir build/debug_libs
-     mv /io/repo/hail/build/hail-all-spark.jar build/debug_libs/
-     mv /io/repo/hail/build/hail-all-spark-test.jar build/debug_libs/
+     pwd
+     mv build/hail-all-spark.jar build/debug_libs/
+     mv build/hail-all-spark-test.jar build/debug_libs/
      time retry make jars python-version-info wheel
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test

--- a/build.yaml
+++ b/build.yaml
@@ -559,8 +559,8 @@ steps:
      time retry make jars HAIL_DEBUG_MODE=1
      time retry make jars
      mkdir build/debug_libs
-     mv io/repo/hail/build/hail-all-spark.jar build/debug_libs/
-     mv io/repo/hail/build/hail-all-spark-test.jar build/debug_libs/
+     mv /io/repo/hail/build/hail-all-spark.jar build/debug_libs/
+     mv /io/repo/hail/build/hail-all-spark-test.jar build/debug_libs/
      time retry make jars python-version-info wheel
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test

--- a/build.yaml
+++ b/build.yaml
@@ -558,9 +558,8 @@ steps:
      time retry ./gradlew --version
      time retry make jars HAIL_DEBUG_MODE=1
      mkdir build/debug_libs
-     pwd
-     mv build/hail-all-spark.jar build/debug_libs/
-     mv build/hail-all-spark-test.jar build/debug_libs/
+     mv build/libs/hail-all-spark.jar build/debug_libs/
+     mv build/libs/hail-all-spark-test.jar build/debug_libs/
      time retry make jars python-version-info wheel
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test

--- a/build.yaml
+++ b/build.yaml
@@ -577,7 +577,7 @@ steps:
      - from: /io/repo/hail/build/libs/hail-all-spark-test.jar
        to: /hail-test.jar
      - from: build/debug_libs/hail-all-spar-test.jar
-     - to: /hail-debug-test.jar
+       to: /hail-debug-test.jar
      - from: /io/repo/hail/testng-build.xml
        to: /testng-build.xml
      - from: /io/repo/hail/testng-services.xml


### PR DESCRIPTION
We want to eventually run all of our tests with the checked memory allocator, plus a few representative tests with the regular allocator. This PR switches the Java tests to the checked memory allocator, while the python tests remain on the normal allocator. I'll follow up to deal with the Python tests, but wanted to get a start in here to at least make sure some CI tests are exercising each allocator.