### PR TITLE
[shuffler] retry socket connect

### DIFF
--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -1,7 +1,7 @@
 package is.hail.services
 
 import java.io.{File, FileInputStream}
-import java.net.Socket
+import java.net.{Socket, ConnectException}
 
 import is.hail.utils._
 import is.hail.services.tls._
@@ -132,7 +132,20 @@ class DeployConfig(
           s"Cannot open a socket from an external client to a service.")
     }
     log.info(s"attempting to connect ${service} at ${host}:${port}")
-    val s = getSSLContext.getSocketFactory().createSocket(host, port)
+    var s = null
+    var attempts = 0
+    while (s == null) {
+      try {
+        s = getSSLContext.getSocketFactory().createSocket(host, port)
+      } catch {
+        case e: ConnectException =>
+          if (attempts % 10 == 0) {
+            log.warn(s"retrying socket connect to ${host}:${port} after receiving ${e}")
+          }
+          attempts += 1
+      }
+    }
+    assert(s != null)
     log.info(s"connected to ${service} at ${host}:${port}")
     s
   }

--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -132,7 +132,7 @@ class DeployConfig(
           s"Cannot open a socket from an external client to a service.")
     }
     log.info(s"attempting to connect ${service} at ${host}:${port}")
-    var s = null
+    var s: Socket = null
     var attempts = 0
     while (s == null) {
       try {


### PR DESCRIPTION
It is possible for socket connect to fail if the shuffle service is down (e.g. https://ci.hail.is/batches/91027/jobs/105).
This change ensure we retry forever, periodically logging that we are retrying