### PR TITLE
[batch] add rest api for billing_projects

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1265,7 +1265,7 @@ async def _query_billing_projects(db, user=None, billing_project=None):
     where_conditions = []
 
     if user:
-        where_conditions.append("JSON_CONTAINS(users, %s)")
+        where_conditions.append("JSON_CONTAINS(users, JSON_QUOTE(%s))")
         args.append(user)
 
     if billing_project:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1265,7 +1265,7 @@ async def _query_billing_projects(db, user=None, billing_project=None):
     where_conditions = []
 
     if user:
-        where_conditions.append("JSON_CONTAINS(users, '%s')")
+        where_conditions.append("JSON_CONTAINS(users, %s)")
         args.append(user)
 
     if billing_project:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1299,6 +1299,8 @@ GROUP BY billing_projects.name, users, msec_mcpu, `limit`;
         cost_resources = record['cost']
         record['accrued_cost'] = coalesce(cost_msec_mcpu, 0) + coalesce(cost_resources, 0)
         del record['msec_mcpu']
+        del record['cost']
+
         if record['users'] is None:
             record['users'] = []
         else:

--- a/batch/batch/front_end/templates/billing_projects.html
+++ b/batch/batch/front_end/templates/billing_projects.html
@@ -14,11 +14,11 @@
     <tbody>
       {% for billing_project in billing_projects %}
       <tr>
-        <td>{{ billing_project }}</td>
+        <td>{{ billing_project['billing_project'] }}</td>
         <td></td>
         <td></td>
       </tr>
-      {% for user in billing_projects[billing_project] %}
+      {% for user in billing_project['users'] %}
       <tr>
         <td></td>
         <td>{{ user }}</td>

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -40,6 +40,16 @@ class Test(unittest.TestCase):
     def tearDown(self):
         self.client.close()
 
+    def test_get_billing_project(self):
+        r = self.client.get_billing_project('test')
+        assert r['billing_project'] == 'test', r
+        assert r['users'] == ['test'], r
+
+    def test_list_billing_projects(self):
+        r = self.client.list_billing_projects()
+        assert len(r) == 1
+        assert r[0]['billing_project'] == 'test', r
+
     def test_job(self):
         builder = self.client.create_batch()
         j = builder.create_job('ubuntu:18.04', ['echo', 'test'])
@@ -406,6 +416,8 @@ class Test(unittest.TestCase):
 
     def test_authorized_users_only(self):
         endpoints = [
+            (requests.get, '/api/v1alpha/billing_projects', 401),
+            (requests.get, '/api/v1alpha/billing_projects/foo', 401),
             (requests.get, '/api/v1alpha/batches/0/jobs/0', 401),
             (requests.get, '/api/v1alpha/batches/0/jobs/0/log', 401),
             (requests.get, '/api/v1alpha/batches', 401),

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -632,6 +632,14 @@ class BatchClient:
     def create_batch(self, attributes=None, callback=None):
         return BatchBuilder(self, attributes, callback)
 
+    async def get_billing_project(self, billing_project):
+        bp_resp = await self._get(f'/api/v1alpha/billing_projects/{billing_project}')
+        return await bp_resp.json()
+
+    async def list_billing_projects(self):
+        bp_resp = await self._get(f'/api/v1alpha/billing_projects')
+        return await bp_resp.json()
+
     async def close(self):
         await self._session.close()
         self._session = None

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -637,7 +637,7 @@ class BatchClient:
         return await bp_resp.json()
 
     async def list_billing_projects(self):
-        bp_resp = await self._get(f'/api/v1alpha/billing_projects')
+        bp_resp = await self._get('/api/v1alpha/billing_projects')
         return await bp_resp.json()
 
     async def close(self):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -203,5 +203,11 @@ class BatchClient:
         builder = self._async_client.create_batch(attributes=attributes, callback=callback)
         return BatchBuilder.from_async_builder(builder)
 
+    def get_billing_project(self, billing_project):
+        return async_to_blocking(self._async_client.get_billing_project(billing_project))
+
+    def list_billing_projects(self):
+        return async_to_blocking(self._async_client.list_billing_projects())
+
     def close(self):
         async_to_blocking(self._async_client.close())

--- a/hail/python/hailtop/hailctl/batch/billing/__init__.py
+++ b/hail/python/hailtop/hailctl/batch/billing/__init__.py
@@ -1,0 +1,3 @@
+from . import cli
+
+__all__ = ['cli']

--- a/hail/python/hailtop/hailctl/batch/billing/cli.py
+++ b/hail/python/hailtop/hailctl/batch/billing/cli.py
@@ -1,0 +1,54 @@
+import sys
+import argparse
+
+from . import list_billing_projects
+from . import get
+
+
+def init_parser():
+    main_parser = argparse.ArgumentParser(
+        prog='hailctl batch billing',
+        description='Manage billing on the service managed by the Hail team.')
+    subparsers = main_parser.add_subparsers()
+
+    list_parser = subparsers.add_parser(
+        'list',
+        help="List billing projects",
+        description="List billing projects")
+    get_parser = subparsers.add_parser(
+        'get',
+        help='Get a particular billing project\'s info',
+        description='Get a particular billing project\'s info')
+
+    list_parser.set_defaults(module='list')
+    list_billing_projects.init_parser(list_parser)
+
+    get_parser.set_defaults(module='get')
+    get.init_parser(get_parser)
+
+    return main_parser
+
+
+def main(args, pass_through_args, client):
+    if not args:
+        init_parser().print_help()
+        sys.exit(0)
+    jmp = {
+        'list': list_billing_projects,
+        'get': get
+    }
+
+    args, pass_through_args = init_parser().parse_known_args(args=pass_through_args)
+
+    try:
+        if not args or 'module' not in args:
+            init_parser().print_help()
+            sys.exit(0)
+        try:
+            jmp[args.module].main(args, pass_through_args, client)
+        except:
+            sys.stderr.write(f"ERROR: no such module: {args.module!r}")
+            init_parser().print_help()
+            sys.exit(1)
+    finally:
+        client.close()

--- a/hail/python/hailtop/hailctl/batch/billing/cli.py
+++ b/hail/python/hailtop/hailctl/batch/billing/cli.py
@@ -40,15 +40,13 @@ def main(args, pass_through_args, client):
 
     args, pass_through_args = init_parser().parse_known_args(args=pass_through_args)
 
-    try:
-        if not args or 'module' not in args:
-            init_parser().print_help()
-            sys.exit(0)
-        try:
-            jmp[args.module].main(args, pass_through_args, client)
-        except:
-            sys.stderr.write(f"ERROR: no such module: {args.module!r}")
-            init_parser().print_help()
-            sys.exit(1)
-    finally:
-        client.close()
+    if not args or 'module' not in args:
+        init_parser().print_help()
+        sys.exit(0)
+
+    if args.module not in jmp:
+        sys.stderr.write(f"ERROR: no such module: {args.module!r}")
+        init_parser().print_help()
+        sys.exit(1)
+
+    jmp[args.module].main(args, pass_through_args, client)

--- a/hail/python/hailtop/hailctl/batch/billing/get.py
+++ b/hail/python/hailtop/hailctl/batch/billing/get.py
@@ -1,0 +1,20 @@
+import aiohttp
+
+from ..batch_cli_utils import make_formatter
+
+
+def init_parser(parser):
+    parser.add_argument('billing_project', type=str, help="Name of the desired billing project")
+    parser.add_argument('-o', type=str, default='yaml', help="Specify output format",
+                        choices=["yaml", "json"])
+
+
+def main(args, pass_through_args, client):  # pylint: disable=unused-argument
+    try:
+        billing_project = client.get_billing_project(args.billing_project)
+    except aiohttp.client_exceptions.ClientResponseError as cle:
+        if cle.code == 403:
+            billing_project = None
+        raise cle
+
+    print(make_formatter(args.o)(billing_project))

--- a/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
+++ b/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
@@ -1,0 +1,11 @@
+from ..batch_cli_utils import make_formatter
+
+
+def init_parser(parser):
+    parser.add_argument('-o', type=str, default='yaml', help="Specify output format",
+                        choices=["yaml", "json"])
+
+
+def main(args, pass_through_args, client):  # pylint: disable=unused-argument
+    billing_projects = client.list_billing_projects()
+    print(make_formatter(args.o)(billing_projects))

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -9,6 +9,7 @@ from . import cancel
 from . import wait
 from . import log
 from . import job
+from . import billing
 
 
 def parser():
@@ -17,6 +18,10 @@ def parser():
         description='Manage batches running on the batch service managed by the Hail team.')
     subparsers = main_parser.add_subparsers()
 
+    billing_parser = subparsers.add_parser(
+        'billing',
+        help='List billing',
+        description='List billing')
     list_parser = subparsers.add_parser(
         'list',
         help="List batches",
@@ -50,6 +55,8 @@ def parser():
         description='Wait for a batch to complete, then print JSON status.'
     )
 
+    billing_parser.set_defaults(module='billing')
+
     list_parser.set_defaults(module='list')
     list_batches.init_parser(list_parser)
 
@@ -79,6 +86,7 @@ def main(args):
         parser().print_help()
         sys.exit(0)
     jmp = {
+        'billing': billing,
         'list': list_batches,
         'delete': delete,
         'get': get,
@@ -92,6 +100,11 @@ def main(args):
 
     # hailctl batch doesn't create batches
     client = BatchClient(None)
+
+    if args.module == 'billing':
+        from .billing import cli  # pylint: disable=import-outside-toplevel
+        cli.main(args, pass_through_args, client)
+        return
 
     try:
         jmp[args.module].main(args, pass_through_args, client)

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -101,12 +101,12 @@ def main(args):
     # hailctl batch doesn't create batches
     client = BatchClient(None)
 
-    if args.module == 'billing':
-        from .billing import cli  # pylint: disable=import-outside-toplevel
-        cli.main(args, pass_through_args, client)
-        return
-
     try:
+        if args.module == 'billing':
+            from .billing import cli  # pylint: disable=import-outside-toplevel
+            cli.main(args, pass_through_args, client)
+            return
+
         jmp[args.module].main(args, pass_through_args, client)
     finally:
         client.close()


### PR DESCRIPTION
- I use a right join in the query so that if there are no users, the record['users'] ends up being None rather than [None].
- I decided that an arbitrary user should be able to see all the other users for billing projects they are on.
- I decided that a developer can see all billing projects.

This is infrastructure that I figured was nice to have but also will make #9354 better so I can add proper tests.