### PR TITLE
[query] encode allocation behavior in stream PTypes

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -602,16 +602,20 @@ class ArrayZeros(IR):
 
 
 class StreamRange(IR):
-    @typecheck_method(start=IR, stop=IR, step=IR)
-    def __init__(self, start, stop, step):
+    @typecheck_method(start=IR, stop=IR, step=IR, separate_regions=bool)
+    def __init__(self, start, stop, step, separate_regions=False):
         super().__init__(start, stop, step)
         self.start = start
         self.stop = stop
         self.step = step
+        self.separate_regions = separate_regions
 
     @typecheck_method(start=IR, stop=IR, step=IR)
     def copy(self, start, stop, step):
         return StreamRange(start, stop, step)
+
+    def head_str(self):
+        return self.separate_regions
 
     def _compute_type(self, env, agg_env):
         self.start._compute_type(env, agg_env)
@@ -1031,14 +1035,18 @@ class CastToArray(IR):
 
 
 class ToStream(IR):
-    @typecheck_method(a=IR)
-    def __init__(self, a):
+    @typecheck_method(a=IR, separate_regions=bool)
+    def __init__(self, a, separate_regions=False):
         super().__init__(a)
         self.a = a
+        self.separate_regions = separate_regions
 
     @typecheck_method(a=IR)
     def copy(self, a):
         return ToStream(a)
+
+    def head_str(self):
+        return self.separate_regions
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -49,13 +49,13 @@ object Children {
       Array(l, r)
     case MakeArray(args, typ) =>
       args.toFastIndexedSeq
-    case MakeStream(args, typ) =>
+    case MakeStream(args, _, _) =>
       args.toFastIndexedSeq
     case ArrayRef(a, i, s) =>
       Array(a, i, s)
     case ArrayLen(a) =>
       Array(a)
-    case StreamRange(start, stop, step) =>
+    case StreamRange(start, stop, step, _) =>
       Array(start, stop, step)
     case ArrayZeros(length) =>
       Array(length)
@@ -77,7 +77,7 @@ object Children {
       Array(a)
     case CastToArray(a) =>
       Array(a)
-    case ToStream(a) =>
+    case ToStream(a, _) =>
       Array(a)
     case LowerBoundOnOrderedCollection(orderedCollection, elem, _) =>
       Array(orderedCollection, elem)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -59,18 +59,18 @@ object Copy {
       case MakeArray(args, typ) =>
         assert(args.length == newChildren.length)
         MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
-      case MakeStream(args, typ) =>
+      case MakeStream(args, typ, separateRegions) =>
         assert(args.length == newChildren.length)
-        MakeStream(newChildren.map(_.asInstanceOf[IR]), typ)
+        MakeStream(newChildren.map(_.asInstanceOf[IR]), typ, separateRegions)
       case ArrayRef(_, _, _) =>
         assert(newChildren.length == 3)
         ArrayRef(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case ArrayLen(_) =>
         assert(newChildren.length == 1)
         ArrayLen(newChildren(0).asInstanceOf[IR])
-      case StreamRange(_, _, _) =>
+      case StreamRange(_, _, _, separateRegions) =>
         assert(newChildren.length == 3)
-        StreamRange(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
+        StreamRange(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR], separateRegions)
       case ArrayZeros(_) =>
         assert(newChildren.length == 1)
         ArrayZeros(newChildren(0).asInstanceOf[IR])
@@ -135,9 +135,9 @@ object Copy {
       case CastToArray(_) =>
         assert(newChildren.length == 1)
         CastToArray(newChildren(0).asInstanceOf[IR])
-      case ToStream(_) =>
+      case ToStream(_, separateRegions) =>
         assert(newChildren.length == 1)
-        ToStream(newChildren(0).asInstanceOf[IR])
+        ToStream(newChildren(0).asInstanceOf[IR], separateRegions)
       case LowerBoundOnOrderedCollection(_, _, asKey) =>
         assert(newChildren.length == 2)
         LowerBoundOnOrderedCollection(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], asKey)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -991,7 +991,8 @@ class Emit[C](
         presentC(sc.states(i).serializeToRegion(cb, coerce[PBinary](pt), region.code))
 
       case x@StreamFold(a, zero, accumName, valueName, body) =>
-        val eltType = coerce[PStream](a.pType).elementType
+        val streamType = coerce[PStream](a.pType)
+        val eltType = streamType.elementType
         val accType = x.accPType
         val eltRegion = region.createChildRegion(mb)
         val tmpRegion = region.createChildRegion(mb)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1280,7 +1280,7 @@ object EmitStream {
             throw new RuntimeException(s"PValue type did not match inferred ptype:\n name: $name\n  pv: ${ ev.pt }\n  ir: $typ")
           COption.fromEmitCode(ev.get).map(_.asStream.stream)
 
-        case x@StreamRange(startIR, stopIR, stepIR) =>
+        case x@StreamRange(startIR, stopIR, stepIR, _) =>
           val eltType = coerce[PStream](x.pType).elementType
           val step = mb.genFieldThisRef[Int]("sr_step")
           val start = mb.genFieldThisRef[Int]("sr_start")
@@ -1318,7 +1318,7 @@ object EmitStream {
             }
           }
 
-        case ToStream(containerIR) =>
+        case ToStream(containerIR, _) =>
           COption.fromEmitCode(emitIR(containerIR)).mapCPS { (containerAddr, k) =>
             val (asetup, a) = EmitCodeBuilder.scoped(mb) { cb =>
               containerAddr.asIndexable.memoize(cb, "ts_a")
@@ -1348,7 +1348,7 @@ object EmitStream {
               k(SizedStream(Code._empty, eltRegion => newStream, Some(len))))
           }
 
-        case x@MakeStream(elements, _) =>
+        case x@MakeStream(elements, _, _) =>
           val eltType = coerce[PStream](x.pType).elementType
           val stream = (eltRegion: StagedRegion) =>
             sequence(mb, eltType, elements.toFastIndexedSeq.map { ir =>
@@ -1361,7 +1361,7 @@ object EmitStream {
         case x@ReadPartition(context, rowType, reader) =>
           reader.emitStream(context, rowType, emitter, mb, outerRegion, env, container)
 
-        case In(n, PCanonicalStream(eltType, _)) =>
+        case In(n, PCanonicalStream(eltType, _, _)) =>
           val xIter = mb.genFieldThisRef[Iterator[java.lang.Long]]("streamInIterator")
           val hasNext = mb.genFieldThisRef[Boolean]("streamInHasNext")
           val next = mb.genFieldThisRef[Long]("streamInNext")

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -155,7 +155,7 @@ object ExtractIntervalFilters {
           case (None, None) =>
             None
         }
-      case StreamFold(ToStream(lit: Literal), False(), acc, value, body) =>
+      case StreamFold(ToStream(lit: Literal, _), False(), acc, value, body) =>
         body match {
           case ApplySpecial("lor", _, Seq(Ref(`acc`, _), ApplySpecial("contains", _, Seq(Ref(`value`, _), k), _)), _) if es.isFirstKey(k) =>
             assert(lit.typ.asInstanceOf[TContainer].elementType.isInstanceOf[TInterval])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -176,22 +176,22 @@ object MakeArray {
 final case class MakeArray(args: Seq[IR], _typ: TArray) extends IR
 
 object MakeStream {
-  def unify(args: Seq[IR], requestedType: TStream = null): MakeStream = {
+  def unify(args: Seq[IR], separateRegions: Boolean = false, requestedType: TStream = null): MakeStream = {
     assert(requestedType != null || args.nonEmpty)
 
     if (args.nonEmpty)
       if (args.forall(_.typ == args.head.typ))
-        return MakeStream(args, TStream(args.head.typ))
+        return MakeStream(args, TStream(args.head.typ), separateRegions)
 
     MakeStream(args.map { arg =>
       val upcast = PruneDeadFields.upcast(arg, requestedType.elementType)
       assert(upcast.typ == requestedType.elementType)
       upcast
-    }, requestedType)
+    }, requestedType, separateRegions)
   }
 }
 
-final case class MakeStream(args: Seq[IR], _typ: TStream) extends IR
+final case class MakeStream(args: Seq[IR], _typ: TStream, separateRegions: Boolean = false) extends IR
 
 object ArrayRef {
   def apply(a: IR, i: IR): ArrayRef = ArrayRef(a, i, Str(""))
@@ -200,7 +200,7 @@ object ArrayRef {
 final case class ArrayRef(a: IR, i: IR, msg: IR) extends IR
 final case class ArrayLen(a: IR) extends IR
 final case class ArrayZeros(length: IR) extends IR
-final case class StreamRange(start: IR, stop: IR, step: IR) extends IR
+final case class StreamRange(start: IR, stop: IR, step: IR, separateRegions: Boolean = false) extends IR
 
 object ArraySort {
   def apply(a: IR, ascending: IR = True(), onKey: Boolean = false): ArraySort = {
@@ -230,7 +230,7 @@ final case class ToSet(a: IR) extends IR
 final case class ToDict(a: IR) extends IR
 final case class ToArray(a: IR) extends IR
 final case class CastToArray(a: IR) extends IR
-final case class ToStream(a: IR) extends IR
+final case class ToStream(a: IR, separateRegions: Boolean = false) extends IR
 
 final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, onKey: Boolean) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -134,10 +134,10 @@ object InferPType {
       case MakeNDArray(data, shape, rowMajor) =>
         val nElem = shape.pType.asInstanceOf[PTuple].size
         PCanonicalNDArray(coerce[PArray](data.pType).elementType.setRequired(true), nElem, requiredness(node).required)
-      case StreamRange(start: IR, stop: IR, step: IR) =>
+      case StreamRange(start: IR, stop: IR, step: IR, separateRegions) =>
         assert(start.pType isOfType stop.pType)
         assert(start.pType isOfType step.pType)
-        PCanonicalStream(start.pType.setRequired(true), requiredness(node).required)
+        PCanonicalStream(start.pType.setRequired(true), separateRegions, required = requiredness(node).required)
       case Let(_, _, body) => body.pType
       case TailLoop(_, _, body) => body.pType
       case a: AbstractApplyNode[_] => a.implementation.returnPType(a.returnType, a.args.map(_.pType))
@@ -158,9 +158,9 @@ object InferPType {
       case CastToArray(a) =>
         val elt = coerce[PIterable](a.pType).elementType
         PCanonicalArray(elt, requiredness(node).required)
-      case ToStream(a) =>
+      case ToStream(a, separateRegions) =>
         val elt = coerce[PIterable](a.pType).elementType
-        PCanonicalStream(elt, requiredness(node).required)
+        PCanonicalStream(elt, separateRegions, required = requiredness(node).required)
       case GroupByKey(collection) =>
         val r = coerce[RDict](requiredness(node))
         val elt = coerce[PBaseStruct](coerce[PStream](collection.pType).elementType)
@@ -172,42 +172,65 @@ object InferPType {
       case StreamGrouped(a, size) =>
         val r = coerce[RIterable](requiredness(node))
         assert(size.pType isOfType PInt32())
-        assert(a.pType.isInstanceOf[PStream])
-        PCanonicalStream(a.pType.setRequired(r.elementType.required), r.required)
+        val innerPType = coerce[PStream](a.pType)
+        PCanonicalStream(innerPType.setRequired(r.elementType.required), innerPType.separateRegions, r.required)
       case StreamGroupByKey(a, key) =>
         val r = coerce[RIterable](requiredness(node))
-        PCanonicalStream(a.pType.setRequired(r.elementType.required), r.required)
+        val innerPType = coerce[PStream](a.pType)
+        PCanonicalStream(innerPType.setRequired(r.elementType.required), innerPType.separateRegions, r.required)
       case StreamMap(a, name, body) =>
-        PCanonicalStream(body.pType, requiredness(node).required)
+        PCanonicalStream(body.pType, coerce[PStream](a.pType).separateRegions, requiredness(node).required)
       case StreamMerge(left, right, key) =>
         val r = coerce[RIterable](requiredness(node))
-        val leftEltType = coerce[PStream](left.pType).elementType
-        val rightEltType = coerce[PStream](right.pType).elementType
-        PCanonicalStream(getCompatiblePType(Seq(leftEltType, rightEltType), r.elementType), r.required)
+        val leftStreamType = coerce[PStream](left.pType)
+        val leftEltType = leftStreamType.elementType
+        val rightStreamType = coerce[PStream](right.pType)
+        val rightEltType = rightStreamType.elementType
+        PCanonicalStream(
+          getCompatiblePType(Seq(leftEltType, rightEltType), r.elementType),
+          leftStreamType.separateRegions || rightStreamType.separateRegions,
+          r.required)
       case StreamZip(as, names, body, behavior) =>
-        PCanonicalStream(body.pType, requiredness(node).required)
+        PCanonicalStream(
+          body.pType,
+          as.exists(a => coerce[PStream](a.pType).separateRegions),
+          requiredness(node).required)
       case StreamZipJoin(as, _, curKey, curVals, joinF) =>
         val r = requiredness(node).asInstanceOf[RIterable]
         val rEltType = joinF.pType
-        PCanonicalStream(rEltType, r.required)
+        PCanonicalStream(
+          rEltType,
+          as.exists(a => coerce[PStream](a.pType).separateRegions),
+          r.required)
       case StreamMultiMerge(as, _) =>
         val r = coerce[RIterable](requiredness(node))
         assert(r.elementType.required)
         PCanonicalStream(
           getCompatiblePType(as.map(_.pType.asInstanceOf[PStream].elementType), r.elementType),
+          as.exists(a => coerce[PStream](a.pType).separateRegions),
           r.required)
       case StreamFilter(a, name, cond) => a.pType
       case StreamFlatMap(a, name, body) =>
-        PCanonicalStream(coerce[PIterable](body.pType).elementType, requiredness(node).required)
+        val innerStreamType = coerce[PStream](body.pType)
+        PCanonicalStream(
+          innerStreamType.elementType,
+          innerStreamType.separateRegions || coerce[PStream](a.pType).separateRegions,
+          requiredness(node).required)
       case x: StreamFold =>
         x.accPType.setRequired(requiredness(node).required)
       case x: StreamFold2 =>
         x.result.pType.setRequired(requiredness(node).required)
-      case x: StreamScan =>
+      case x@StreamScan(a, _, _, _, _) =>
         val r = coerce[RIterable](requiredness(node))
-        PCanonicalStream(x.accPType.setRequired(r.elementType.required), r.required)
-      case StreamJoinRightDistinct(_, _, _, _, _, _, join, _) =>
-        PCanonicalStream(join.pType, requiredness(node).required)
+        PCanonicalStream(
+          x.accPType.setRequired(r.elementType.required),
+          coerce[PStream](a.pType).separateRegions,
+          r.required)
+      case StreamJoinRightDistinct(left, right, _, _, _, _, join, _) =>
+        PCanonicalStream(
+          join.pType,
+          coerce[PStream](left.pType).separateRegions || coerce[PStream](right.pType).separateRegions,
+          requiredness(node).required)
       case NDArrayShape(nd) =>
         val r = nd.pType.asInstanceOf[PNDArray].shape.pType
         r.setRequired(requiredness(node).required)
@@ -284,20 +307,23 @@ object InferPType {
         PCanonicalArray(x.decodedBodyPType, requiredness(node).required)
       case ReadPartition(context, rowType, reader) =>
         val child = reader.rowPType(rowType)
-        PCanonicalStream(child, requiredness(node).required)
+        PCanonicalStream(child, separateRegions = true, required = requiredness(node).required)
       case WritePartition(value, writeCtx, writer) =>
         writer.returnPType(writeCtx.pType, coerce[PStream](value.pType))
       case ReadValue(path, spec, requestedType) =>
         spec.decodedPType(requestedType).setRequired(requiredness(node).required)
-      case MakeStream(irs, t) =>
+      case MakeStream(irs, t, separateRegions) =>
         val r = coerce[RIterable](requiredness(node))
         if (irs.isEmpty) r.canonicalPType(t) else
-          PCanonicalStream(getCompatiblePType(irs.map(_.pType), r.elementType), r.required)
+          PCanonicalStream(getCompatiblePType(irs.map(_.pType), r.elementType), separateRegions, r.required)
       case x@ResultOp(resultIdx, sigs) =>
         PCanonicalTuple(true, sigs.map(_.pResultType): _*)
       case x@RunAgg(body, result, signature) => result.pType
       case x@RunAggScan(array, name, init, seq, result, signature) =>
-        PCanonicalStream(result.pType, array.pType.required)
+        PCanonicalStream(
+          result.pType,
+          coerce[PStream](array.pType).separateRegions,
+          array.pType.required)
       case ShuffleWith(keyFields, rowType, rowEType, keyEType, name, writer, readers) =>
         val r = requiredness(node)
         assert(r.required == readers.pType.required)
@@ -311,13 +337,15 @@ object InferPType {
         assert(r.required)
         PCanonicalStream(
           coerce[TShuffle](id.typ).keyDecodedPType,
-          true)
+          separateRegions = false,
+          required = true)
       case ShuffleRead(id, keyRange) =>
         val r = requiredness(node)
         assert(r.required)
         PCanonicalStream(
           coerce[TShuffle](id.typ).rowDecodedPType,
-          true)
+          separateRegions = true,
+          required = true)
     }
     if (node.pType.virtualType != node.typ)
       throw new RuntimeException(s"pType.virtualType: ${node.pType.virtualType}, vType = ${node.typ}\n  ir=$node")

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -28,7 +28,7 @@ object InferType {
       case RelationalLet(_, _, body) => body.typ
       case In(_, t) => t.virtualType
       case MakeArray(_, t) => t
-      case MakeStream(_, t) => t
+      case MakeStream(_, t, _) => t
       case MakeNDArray(data, shape, _) =>
         TNDArray(coerce[TArray](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case _: ArrayLen => TInt32
@@ -95,7 +95,7 @@ object InferType {
       case CastToArray(a) =>
         val elt = coerce[TContainer](a.typ).elementType
         TArray(elt)
-      case ToStream(a) =>
+      case ToStream(a, _) =>
         val elt = coerce[TIterable](a.typ).elementType
         TStream(elt)
       case StreamLen(a) => TInt32

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -230,7 +230,7 @@ object Interpret {
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
-      case MakeStream(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
+      case MakeStream(elements, _, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
       case x@ArrayRef(a, i, s) =>
         val aValue = interpret(a, env, args)
         val iValue = interpret(i, env, args)
@@ -264,7 +264,7 @@ object Interpret {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Any]].length
-      case StreamRange(start, stop, step) =>
+      case StreamRange(start, stop, step, _) =>
         val startValue = interpret(start, env, args)
         val stopValue = interpret(stop, env, args)
         val stepValue = interpret(step, env, args)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -834,8 +834,9 @@ object IRParser {
         MakeArray.unify(args, typ)
       case "MakeStream" =>
         val typ = opt(it, type_expr(env.typEnv)).map(_.asInstanceOf[TStream]).orNull
+        val separateRegions = boolean_literal(it)
         val args = ir_value_children(env)(it)
-        MakeStream(args, typ)
+        MakeStream(args, typ, separateRegions)
       case "ArrayRef" =>
         val a = ir_value_expr(env)(it)
         val i = ir_value_expr(env)(it)
@@ -844,10 +845,11 @@ object IRParser {
       case "ArrayLen" => ArrayLen(ir_value_expr(env)(it))
       case "StreamLen" => StreamLen(ir_value_expr(env)(it))
       case "StreamRange" =>
+        val separateRegions = boolean_literal(it)
         val start = ir_value_expr(env)(it)
         val stop = ir_value_expr(env)(it)
         val step = ir_value_expr(env)(it)
-        StreamRange(start, stop, step)
+        StreamRange(start, stop, step, separateRegions)
       case "StreamGrouped" =>
         val s = ir_value_expr(env)(it)
         val groupSize = ir_value_expr(env)(it)
@@ -934,7 +936,10 @@ object IRParser {
       case "ToDict" => ToDict(ir_value_expr(env)(it))
       case "ToArray" => ToArray(ir_value_expr(env)(it))
       case "CastToArray" => CastToArray(ir_value_expr(env)(it))
-      case "ToStream" => ToStream(ir_value_expr(env)(it))
+      case "ToStream" =>
+        val separateRegions = boolean_literal(it)
+        val a = ir_value_expr(env)(it)
+        ToStream(a, separateRegions)
       case "LowerBoundOnOrderedCollection" =>
         val onKey = boolean_literal(it)
         val col = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -284,7 +284,10 @@ object Pretty {
             case GetTupleElement(_, idx) => idx.toString
             case MakeTuple(fields) => prettyInts(fields.map(_._1).toFastIndexedSeq)
             case MakeArray(_, typ) => typ.parsableString()
-            case MakeStream(_, typ) => typ.parsableString()
+            case MakeStream(_, typ, separateRegions) =>
+              s"${ typ.parsableString() } ${prettyBooleanLiteral(separateRegions) }"
+            case StreamRange(_, _, _, separateRegions) => prettyBooleanLiteral(separateRegions)
+            case ToStream(_, separateRegions) => prettyBooleanLiteral(separateRegions)
             case StreamMap(_, name, _) => prettyIdentifier(name)
             case StreamMerge(_, _, key) => prettyIdentifiers(key)
             case StreamZip(_, names, _, behavior) => prettyIdentifier(behavior match {

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -930,7 +930,7 @@ object PruneDeadFields {
       case MakeArray(args, _) =>
         val eltType = requestedType.asInstanceOf[TArray].elementType
         unifyEnvsSeq(args.map(a => memoizeValueIR(a, eltType, memo)))
-      case MakeStream(args, _) =>
+      case MakeStream(args, _, _) =>
         val eltType = requestedType.asInstanceOf[TStream].elementType
         unifyEnvsSeq(args.map(a => memoizeValueIR(a, eltType, memo)))
       case ArrayRef(a, i, s) =>
@@ -1715,10 +1715,10 @@ object PruneDeadFields {
         val dep = requestedType.asInstanceOf[TArray]
         val args2 = args.map(a => rebuildIR(a, env, memo))
         MakeArray.unify(args2, TArray(dep.elementType))
-      case MakeStream(args, _) =>
+      case MakeStream(args, _, separateRegions) =>
         val dep = requestedType.asInstanceOf[TStream]
         val args2 = args.map(a => rebuildIR(a, env, memo))
-        MakeStream.unify(args2, TStream(dep.elementType))
+        MakeStream.unify(args2, separateRegions, requestedType = TStream(dep.elementType))
       case StreamMap(a, name, body) =>
         val a2 = rebuildIR(a, env, memo)
         StreamMap(a2, name, rebuildIR(body, env.bindEval(name, a2.typ.asInstanceOf[TStream].elementType), memo))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -467,7 +467,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.unionFrom(defs(node).map(coerce[TypeWithRequiredness]))
       case MakeArray(args, _) =>
         coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
-      case MakeStream(args, _) =>
+      case MakeStream(args, _, _) =>
         coerce[RIterable](requiredness).elementType.unionFrom(args.map(lookup))
       case ArrayRef(a, i, _) =>
         val aReq = lookupAs[RIterable](a)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -202,8 +202,8 @@ object Simplify {
 
     case ArrayLen(ArraySort(a, _, _, _)) => ArrayLen(ToArray(a))
 
-    case ArrayLen(ToArray(MakeStream(args, _))) => I32(args.length)
-    case StreamLen(MakeStream(args, _)) => I32(args.length)
+    case ArrayLen(ToArray(MakeStream(args, _, _))) => I32(args.length)
+    case StreamLen(MakeStream(args, _, _)) => I32(args.length)
 
     case ArrayRef(MakeArray(args, _), I32(i), _) if i >= 0 && i < args.length => args(i)
 
@@ -224,16 +224,18 @@ object Simplify {
 
     case StreamFilter(ArraySort(a, left, right, lessThan), name, cond) => ArraySort(StreamFilter(a, name, cond), left, right, lessThan)
 
-    case StreamFilter(ToStream(ArraySort(a, left, right, lessThan)), name, cond) => ToStream(ArraySort(StreamFilter(a, name, cond), left, right, lessThan))
+    case StreamFilter(ToStream(ArraySort(a, left, right, lessThan), separateRegions), name, cond) =>
+      ToStream(ArraySort(StreamFilter(a, name, cond), left, right, lessThan), separateRegions)
 
     case CastToArray(x) if x.typ.isInstanceOf[TArray] => x
-    case ToArray(ToStream(a)) if a.typ.isInstanceOf[TArray] => a
-    case ToArray(ToStream(a)) if a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict] =>
+    case ToArray(ToStream(a, _)) if a.typ.isInstanceOf[TArray] => a
+    case ToArray(ToStream(a, _)) if a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict] =>
       CastToArray(a)
 
-    case ToStream(ToArray(s)) if s.typ.isInstanceOf[TStream] => s
+    case ToStream(ToArray(s), _) if s.typ.isInstanceOf[TStream] => s
 
-    case ToStream(Let(name, value, ToArray(x))) if x.typ.isInstanceOf[TStream] => Let(name, value, x)
+    case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
+      Let(name, value, x)
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1451,7 +1451,7 @@ case class TableMapPartitions(child: TableIR,
     val rowPType = tv.rvd.rowPType
     val globalPType = tv.globals.t
 
-    val partitionPType = PCanonicalStream(rowPType, true)
+    val partitionPType = PCanonicalStream(rowPType, separateRegions = true, required = true)
     val (newRowPType: PStruct, makeIterator) = CompileIterator.forTableMapPartitions(
       ctx,
       globalPType, partitionPType,

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -107,7 +107,7 @@ object TypeCheck {
         args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x == typ.elementType,
           s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
-      case x@MakeStream(args, typ) =>
+      case x@MakeStream(args, typ, _) =>
         assert(typ != null)
         assert(typ.elementType.isRealizable)
 
@@ -120,7 +120,7 @@ object TypeCheck {
         assert(x.typ == coerce[TArray](a.typ).elementType)
       case ArrayLen(a) =>
         assert(a.typ.isInstanceOf[TArray])
-      case x@StreamRange(a, b, c) =>
+      case x@StreamRange(a, b, c, _) =>
         assert(a.typ == TInt32)
         assert(b.typ == TInt32)
         assert(c.typ == TInt32)
@@ -210,7 +210,7 @@ object TypeCheck {
         assert(a.typ.isInstanceOf[TStream])
       case x@CastToArray(a) =>
         assert(a.typ.isInstanceOf[TContainer])
-      case x@ToStream(a) =>
+      case x@ToStream(a, _) =>
         assert(a.typ.isInstanceOf[TContainer])
       case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
         val elt = coerce[TIterable](orderedCollection.typ).elementType

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -193,11 +193,12 @@ class TableStage(
     LowerToCDA.substLets(wrapInBindings(body(cda, globals)), relationalBindings)
   }
 
-  def collectWithGlobals(relationalBindings: Map[String, IR]): IR = mapCollectWithGlobals(relationalBindings)(ToArray) { (parts, globals) =>
-    MakeStruct(FastSeq(
-      "rows" -> ToArray(flatMapIR(ToStream(parts))(ToStream)),
-      "global" -> globals))
-  }
+  def collectWithGlobals(relationalBindings: Map[String, IR]): IR =
+    mapCollectWithGlobals(relationalBindings)(ToArray) { (parts, globals) =>
+      MakeStruct(FastSeq(
+        "rows" -> ToArray(flatMapIR(ToStream(parts))(ToStream(_))),
+        "global" -> globals))
+    }
 
   def getGlobals(): IR = wrapInBindings(globals)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir.EmitStream.SizedStream
 import is.hail.types.virtual.{TStream, Type}
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, Stream}
 
-final case class PCanonicalStream(elementType: PType, required: Boolean = false) extends PStream {
+final case class PCanonicalStream(elementType: PType, separateRegions: Boolean = false, required: Boolean = false) extends PStream {
   override val fundamentalType: PStream = {
     if (elementType == elementType.fundamentalType)
       this
@@ -28,7 +28,7 @@ final case class PCanonicalStream(elementType: PType, required: Boolean = false)
   override def deepRename(t: Type) = deepRenameStream(t.asInstanceOf[TStream])
 
   private def deepRenameStream(t: TStream): PStream =
-    PCanonicalStream(this.elementType.deepRename(t.elementType), this.required)
+    copy(elementType = elementType.deepRename(t.elementType))
 
   def setRequired(required: Boolean): PCanonicalStream = if(required == this.required) this else this.copy(required = required)
 }

--- a/hail/src/main/scala/is/hail/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStream.scala
@@ -5,6 +5,8 @@ import is.hail.types.virtual.TStream
 abstract class PStream extends PIterable with PUnrealizable {
   lazy val virtualType: TStream = TStream(elementType.virtualType)
 
+  def separateRegions: Boolean
+
   def _asIdent = s"stream_of_${elementType.asIdent}"
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -122,7 +122,7 @@ object PType {
       case TCall => PCanonicalCall(required)
       case t: TLocus => PCanonicalLocus(t.rg, required)
       case t: TInterval => PCanonicalInterval(canonical(t.pointType), required)
-      case t: TStream => PCanonicalStream(canonical(t.elementType), required)
+      case t: TStream => PCanonicalStream(canonical(t.elementType), required = required)
       case t: TArray => PCanonicalArray(canonical(t.elementType), required)
       case t: TSet => PCanonicalSet(canonical(t.elementType), required)
       case t: TDict => PCanonicalDict(canonical(t.keyType), canonical(t.valueType), required)
@@ -148,7 +148,7 @@ object PType {
       case t: PCall => PCanonicalCall(t.required)
       case t: PLocus => PCanonicalLocus(t.rg, t.required)
       case t: PInterval => PCanonicalInterval(canonical(t.pointType), t.required)
-      case t: PStream => PCanonicalStream(canonical(t.elementType), t.required)
+      case t: PStream => PCanonicalStream(canonical(t.elementType), required = t.required)
       case t: PArray => PCanonicalArray(canonical(t.elementType), t.required)
       case t: PSet => PCanonicalSet(canonical(t.elementType), t.required)
       case t: PTuple => PCanonicalTuple(t._types.map(pf => PTupleField(pf.index, canonical(pf.typ))), t.required)
@@ -431,7 +431,7 @@ abstract class PType extends Serializable with Requiredness {
       case t: PInterval =>
         PCanonicalInterval(t.pointType.deepInnerRequired(true), required)
       case t: PStream =>
-        PCanonicalStream(t.elementType.deepInnerRequired(true), required)
+        PCanonicalStream(t.elementType.deepInnerRequired(true), required = required)
       case t =>
         t.setRequired(required)
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1066,70 +1066,70 @@ class IRSuite extends HailSuite {
   }
 
   @Test def testGetNestedPStream() {
-    var types = Seq(PCanonicalStream(PInt32(true), true))
+    var types = Seq(PCanonicalStream(PInt32(true), required = true))
     var res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(true), true))
+    assert(res == PCanonicalStream(PInt32(true), required = true))
 
-    types = Seq(PCanonicalStream(PInt32(true), false))
+    types = Seq(PCanonicalStream(PInt32(true), required = false))
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(true), false))
+    assert(res == PCanonicalStream(PInt32(true), required = false))
 
-    types = Seq(PCanonicalStream(PInt32(false), true))
+    types = Seq(PCanonicalStream(PInt32(false), required = true))
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(false), true))
+    assert(res == PCanonicalStream(PInt32(false), required = true))
 
-    types = Seq(PCanonicalStream(PInt32(false), false))
+    types = Seq(PCanonicalStream(PInt32(false), required = false))
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(false), false))
-
-    types = Seq(
-      PCanonicalStream(PInt32(true), true),
-      PCanonicalStream(PInt32(true), true)
-    )
-    res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(true), true))
+    assert(res == PCanonicalStream(PInt32(false), required = false))
 
     types = Seq(
-      PCanonicalStream(PInt32(false), true),
-      PCanonicalStream(PInt32(true), true)
+      PCanonicalStream(PInt32(true), required = true),
+      PCanonicalStream(PInt32(true), required = true)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(false), true))
+    assert(res == PCanonicalStream(PInt32(true), required = true))
 
     types = Seq(
-      PCanonicalStream(PInt32(false), true),
-      PCanonicalStream(PInt32(true), false)
+      PCanonicalStream(PInt32(false), required = true),
+      PCanonicalStream(PInt32(true), required = true)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PInt32(false), false))
+    assert(res == PCanonicalStream(PInt32(false), required = true))
 
     types = Seq(
-      PCanonicalStream(PCanonicalStream(PInt32(true), true), true),
-      PCanonicalStream(PCanonicalStream(PInt32(true), true), true)
+      PCanonicalStream(PInt32(false), required = true),
+      PCanonicalStream(PInt32(true), required = false)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PCanonicalStream(PInt32(true), true), true))
+    assert(res == PCanonicalStream(PInt32(false), required = false))
 
     types = Seq(
-      PCanonicalStream(PCanonicalStream(PInt32(true), true), true),
-      PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
+      PCanonicalStream(PCanonicalStream(PInt32(true), required = true), required = true),
+      PCanonicalStream(PCanonicalStream(PInt32(true), required = true), required = true)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), true), true))
+    assert(res == PCanonicalStream(PCanonicalStream(PInt32(true), required = true), required = true))
 
     types = Seq(
-      PCanonicalStream(PCanonicalStream(PInt32(true), false), true),
-      PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
+      PCanonicalStream(PCanonicalStream(PInt32(true), required = true), required = true),
+      PCanonicalStream(PCanonicalStream(PInt32(false), required = true), required = true)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), false), true))
+    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), required = true), required = true))
 
     types = Seq(
-      PCanonicalStream(PCanonicalStream(PInt32(true), false), false),
-      PCanonicalStream(PCanonicalStream(PInt32(false), true), true)
+      PCanonicalStream(PCanonicalStream(PInt32(true), required = false), required = true),
+      PCanonicalStream(PCanonicalStream(PInt32(false), required = true), required = true)
     )
     res  = InferPType.getCompatiblePType(types)
-    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), false), false))
+    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), required = false), required = true))
+
+    types = Seq(
+      PCanonicalStream(PCanonicalStream(PInt32(true), required = false), required = false),
+      PCanonicalStream(PCanonicalStream(PInt32(false), required = true), required = true)
+    )
+    res  = InferPType.getCompatiblePType(types)
+    assert(res == PCanonicalStream(PCanonicalStream(PInt32(false), required = false), required = false))
   }
 
   @Test def testGetNestedElementPCanonicalDict() {

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -68,7 +68,7 @@ class RequirednessSuite extends HailSuite {
 
   def pint(r: Boolean): PInt32 = PInt32(r)
 
-  def pstream(r: Boolean, elt: Boolean): PStream = PCanonicalStream(pint(elt), r)
+  def pstream(r: Boolean, elt: Boolean): PStream = PCanonicalStream(pint(elt), required = r)
 
   def parray(r: Boolean, elt: Boolean): PArray = PCanonicalArray(pint(elt), r)
 
@@ -82,7 +82,7 @@ class RequirednessSuite extends HailSuite {
   def pnestednd(r: Boolean, aelt: Boolean): PNDArray =
     PCanonicalNDArray(parray(required, aelt), 2, r)
   def pnestedstream(r: Boolean, a: Boolean, aelt: Boolean): PStream =
-    PCanonicalStream(parray(a, aelt), r)
+    PCanonicalStream(parray(a, aelt), required = r)
   def pnestedarray(r: Boolean, a: Boolean, aelt: Boolean): PArray =
     PCanonicalArray(parray(a, aelt), r)
 
@@ -165,7 +165,7 @@ class RequirednessSuite extends HailSuite {
       PCanonicalArray(PInt32(optional), optional))
     // filter
     nodes += Array(StreamFilter(stream(optional, optional), "x", Ref("x", TInt32).ceq(0)),
-      PCanonicalStream(PInt32(optional), optional))
+      PCanonicalStream(PInt32(optional), required = optional))
     // StreamFold
     nodes += Array(StreamFold(
       nestedstream(optional, optional, optional),
@@ -184,7 +184,7 @@ class RequirednessSuite extends HailSuite {
         nestedstream(optional, optional, optional),
         I32(0), "a", "b",
         ArrayRef(Ref("b", tarray), Ref("a", TInt32))
-      ), PCanonicalStream(PInt32(optional), optional))
+      ), PCanonicalStream(PInt32(optional), required = optional))
     // TailLoop
     val param1 = Ref(genUID(), tarray)
     val param2 = Ref(genUID(), TInt32)


### PR DESCRIPTION
This PR makes the following changes:
* Add a `separateRegions` flag to `PStream`.
* Add a `separateRegions` flag to the stream producer nodes `MakeStream`, `StreamRange`, and `ToStream`.
* Propogate `separateRegions` through all stream nodes in `InferPType`.

The intended semantics is that if a stream's type has the `separateRegions` flag set, its consumer must pass it a region which gets cleared every element. If the flag is not set, there is no requirement; depending on context, the consumer may put every element in the same region, but is also allowed to use separate regions for each element. For example, in a zip, the elements of the zipped stream are put in separate regions iff at least one child stream requires separate regions; in that case, all children will get emitted with separate regions, whether they requested it or not.

In this PR, the `separateRegions` flags are left unused. Eventually, stream consumers will inspect the flag on their child streams' types, and use that information to construct the appropriate `StagedRegion` to pass to `emitStream`. In implementing that, I did some refactoring of the `StagedRegion` design, which I separated out into a follow-up PR.