### PR TITLE
[monitoring] fix test to allow no data returned by big query

### DIFF
--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -32,4 +32,4 @@ async def test_billing_monitoring():
             return data
 
         data = await asyncio.wait_for(wait_forever(), timeout=30 * 60)
-        assert data['cost_by_service'], str(data)
+        assert data['cost_by_service'] is not None, data


### PR DESCRIPTION
Fixes:

```

    async def test_billing_monitoring():
        deploy_config = get_deploy_config()
        monitoring_deploy_config_url = deploy_config.url('monitoring', '/api/v1alpha/billing')
        headers = service_auth_headers(deploy_config, 'monitoring')
        async with in_cluster_ssl_client_session(
                raise_for_status=True,
                timeout=aiohttp.ClientTimeout(total=60)) as session:
    
            async def wait_forever():
                data = None
                while data is None:
                    resp = await utils.request_retry_transient_errors(
                        session, 'GET', f'{monitoring_deploy_config_url}', headers=headers)
                    data = await resp.json()
                    await asyncio.sleep(5)
                return data
    
            data = await asyncio.wait_for(wait_forever(), timeout=30 * 60)
>           assert data['cost_by_service'], str(data)
E           AssertionError: {'cost_by_service': [], 'compute_cost_breakdown': [], 'cost_by_sku_label': [], 'time_period_query': '09/2020'}
E           assert []
```