### PR TITLE
[batch] avoid use of metadata server in regenie tests

### DIFF
--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -8,7 +8,7 @@ from argparse import Namespace, ArgumentParser, SUPPRESS
 from os.path import exists
 from google.cloud import storage  # type: ignore
 from google.cloud.storage.blob import Blob  # type: ignore
-from google.oauth2.credentials import Credentials  # type: ignore
+from google.oauth2.service_account.credentials import Credentials  # type: ignore
 
 
 input_file_args = ["bgen", "bed", "pgen", "sample", "keep", "extract", "exclude", "remove",
@@ -34,8 +34,8 @@ def _read(spath: str):
 
     credentials = None
     key_file = os.environ.get('HAIL_GSA_KEY_FILE')
-    if key_file is not None and key_file != '':
-        credentials = Credentials.from_authorized_user_file(key_file)
+    if key_file:
+        credentials = Credentials.from_service_account_file(key_file)
     client = storage.Client(credentials=credentials)
     blob = Blob.from_string(spath, client)
     return blob.download_as_string().decode("utf-8")

--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -32,7 +32,10 @@ def _read(spath: str):
         with open(spath, "r") as f:
             return f.read()
 
-    credentials = Credentials.from_authorized_user_file(os.environ['HAIL_GSA_KEY_FILE'])
+    credentials = None
+    key_file = os.environ.get('HAIL_GSA_KEY_FILE')
+    if key_file is not None and key_file != '':
+        credentials = Credentials.from_authorized_user_file(key_file)
     client = storage.Client(credentials=credentials)
     blob = Blob.from_string(spath, client)
     return blob.download_as_string().decode("utf-8")

--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -6,9 +6,9 @@ import sys
 import shlex
 from argparse import Namespace, ArgumentParser, SUPPRESS
 from os.path import exists
+import google.oauth2.service_account  # type: ignore
 from google.cloud import storage  # type: ignore
 from google.cloud.storage.blob import Blob  # type: ignore
-from google.oauth2.service_account.credentials import Credentials  # type: ignore
 
 
 input_file_args = ["bgen", "bed", "pgen", "sample", "keep", "extract", "exclude", "remove",
@@ -35,7 +35,7 @@ def _read(spath: str):
     credentials = None
     key_file = os.environ.get('HAIL_GSA_KEY_FILE')
     if key_file:
-        credentials = Credentials.from_service_account_file(key_file)
+        credentials = google.oauth2.service_account.Credentials.from_service_account_file(key_file)
     client = storage.Client(credentials=credentials)
     blob = Blob.from_string(spath, client)
     return blob.download_as_string().decode("utf-8")

--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -1,12 +1,14 @@
 from typing import Set, Dict, Any
 from ... import Batch, LocalBackend, ServiceBackend, Backend
 from ...resource import Resource
+import os
 import sys
 import shlex
 from argparse import Namespace, ArgumentParser, SUPPRESS
 from os.path import exists
 from google.cloud import storage  # type: ignore
 from google.cloud.storage.blob import Blob  # type: ignore
+from google.oauth2.credentials import Credentials  # type: ignore
 
 
 input_file_args = ["bgen", "bed", "pgen", "sample", "keep", "extract", "exclude", "remove",
@@ -30,7 +32,8 @@ def _read(spath: str):
         with open(spath, "r") as f:
             return f.read()
 
-    client = storage.Client()
+    credentials = Credentials.from_authorized_user_file(os.environ['HAIL_GSA_KEY_FILE'])
+    client = storage.Client(credentials=credentials)
     blob = Blob.from_string(spath, client)
     return blob.download_as_string().decode("utf-8")
 


### PR DESCRIPTION
I do not understand how this passed the PR tests, but this fix makes regenie not
use the metadata server to authenticate itself.