### PR TITLE
[internal-gateway] permit TLS connections to internal gateway

### DIFF
--- a/internal-gateway/Dockerfile
+++ b/internal-gateway/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rm -f /etc/nginx/sites-enabled/default
+ADD nginx.conf /etc/nginx/
 ADD internal-gateway.nginx.conf /etc/nginx/conf.d/internal-gateway.conf
 ADD gzip.conf /etc/nginx/conf.d/gzip.conf
 

--- a/internal-gateway/internal-gateway.nginx.conf
+++ b/internal-gateway/internal-gateway.nginx.conf
@@ -79,3 +79,68 @@ server {
         include /ssl-config/ssl-config-proxy.conf;
     }
 }
+
+server {
+    server_name internal.hail;
+    client_max_body_size 50m;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    location = /router_scheme {
+        internal;
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass https://router-resolver.default.svc.cluster.local/router-scheme/$namespace;
+        include /ssl-config/ssl-config-proxy.conf;
+    }
+
+    location ~ ^/([^/]+)/([^/]+) {
+        limit_req zone=limit burst=20 nodelay;
+
+        set $namespace $1;
+        set $service $2;
+
+        auth_request /router_scheme;
+        auth_request_set $maybe_router_scheme $upstream_http_x_router_scheme;
+
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass $router_scheme://router.$namespace.svc.cluster.local;
+
+        proxy_set_header Host $service.internal;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # we do not verify namepsaced routers
+        # include /ssl-config/ssl-config-proxy.conf;
+    }
+}
+
+server {
+    server_name hail;
+    client_max_body_size 50m;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+
+    location / {
+        limit_req zone=limit burst=20 nodelay;
+
+        proxy_pass https://router/;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        include /ssl-config/ssl-config-proxy.conf;
+    }
+}

--- a/internal-gateway/nginx.conf
+++ b/internal-gateway/nginx.conf
@@ -1,0 +1,50 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 768;
+}
+
+http {
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  server_names_hash_bucket_size 128;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+
+  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
+                              '$scheme "$request" $status $body_bytes_sent '
+                              '"$http_referer" "$http_user_agent"';
+  access_log /var/log/nginx/access.log combined_real_ip;
+  error_log /var/log/nginx/error.log;
+
+  include /ssl-config/ssl-config-http.conf;
+
+  gzip on;
+
+  map $http_x_forwarded_proto $updated_scheme {
+       default $http_x_forwarded_proto;
+       '' $scheme;
+  }
+  map $http_x_forwarded_host $updated_host {
+       default $http_x_forwarded_host;
+       '' $http_host;
+  }
+  map $http_upgrade $connection_upgrade {
+      default upgrade;
+      ''      close;
+  }
+
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
+}

--- a/internal-gateway/service.yaml
+++ b/internal-gateway/service.yaml
@@ -13,6 +13,10 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
   selector:
     app: internal-gateway
   loadBalancerIP: "{{ global.internal_ip }}"


### PR DESCRIPTION
The plan for TLS workers is:
- internal-gateway supports HTTP and HTTPS
- workers speak server-auth-only TLS
- internal-gateway supports only HTTPS
- workers proffer client auth
- internal-gateway requires client auth

This is step 1.