### PR TITLE
Better Python Errors

### DIFF
--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -36,10 +36,11 @@ def handle_java_exception(f):
                 raise
 
             tpl = Env.jutils().handleForPython(e.java_exception)
-            deepest, full = tpl._1(), tpl._2()
+            deepest, full, error_id = tpl._1(), tpl._2(), tpl._3()
+
             raise FatalError('%s\n\nJava stack trace:\n%s\n'
                              'Hail version: %s\n'
-                             'Error summary: %s' % (deepest, full, hail.__version__, deepest)) from None
+                             'Error summary: %s' % (deepest, full, hail.__version__, deepest), error_id) from None
         except pyspark.sql.utils.CapturedException as e:
             raise FatalError('%s\n\nJava stack trace:\n%s\n'
                              'Hail version: %s\n'

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -9,7 +9,7 @@ import py4j
 import pyspark
 
 import hail
-from hail.utils.java import FatalError, Env, scala_package_object, scala_object
+from hail.utils.java import FatalError, HailUserError, Env, scala_package_object, scala_object
 from hail.expr.types import dtype
 from hail.expr.table_type import ttable
 from hail.expr.matrix_type import tmatrix
@@ -309,6 +309,12 @@ class SparkBackend(Py4JBackend):
                 return hail_ir._error_id is not None and hail_ir._error_id == error_id
 
             error_sources = ir.search(criteria)
+            better_stack_trace = None
+            if error_sources:
+                better_stack_trace = error_sources[0]._stack_trace
+
+            if better_stack_trace:
+                raise HailUserError(better_stack_trace)
 
             raise e
 

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -307,7 +307,6 @@ class SparkBackend(Py4JBackend):
         except FatalError as e:
             error_id = e._error_id
 
-            # Now need to check if the error code is present on any IR!
             def criteria(hail_ir):
                 return hail_ir._error_id is not None and hail_ir._error_id == error_id
 
@@ -315,7 +314,7 @@ class SparkBackend(Py4JBackend):
             better_stack_trace = None
             if error_sources:
                 better_stack_trace = error_sources[0]._stack_trace
-            import pdb; pdb.set_trace()
+
             if better_stack_trace:
                 error_message = str(e)
                 message_and_trace = (f'{error_message}\n'

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -311,11 +311,11 @@ class SparkBackend(Py4JBackend):
             def criteria(hail_ir):
                 return hail_ir._error_id is not None and hail_ir._error_id == error_id
 
-            error_sources = ir.search(criteria)
+            error_sources = ir.base_search(criteria)
             better_stack_trace = None
             if error_sources:
                 better_stack_trace = error_sources[0]._stack_trace
-
+            import pdb; pdb.set_trace()
             if better_stack_trace:
                 error_message = str(e)
                 message_and_trace = (f'{error_message}\n'

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -319,7 +319,7 @@ class SparkBackend(Py4JBackend):
                 error_message = str(e)
                 message_and_trace = (f'{error_message}\n'
                                      '------------\n'
-                                     'Python stack trace:\n'
+                                     'Hail stack trace:\n'
                                      f'{better_stack_trace}')
                 raise HailUserError(message_and_trace) from None
 

--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -307,5 +307,7 @@ class CaseBuilder(ConditionalBuilder):
         """
         if len(self._cases) == 0:
             raise ExpressionException("'or_error' cannot be called without at least one 'when' call")
-        error_expr = construct_expr(ir.Die(message._ir, self._ret_type), self._ret_type)
+        die_ir = ir.Die(message._ir, self._ret_type)
+        die_ir.save_error_info()
+        error_expr = construct_expr(die_ir, self._ret_type)
         return self._finish(error_expr)

--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -307,7 +307,5 @@ class CaseBuilder(ConditionalBuilder):
         """
         if len(self._cases) == 0:
             raise ExpressionException("'or_error' cannot be called without at least one 'when' call")
-        die_ir = ir.Die(message._ir, self._ret_type)
-        die_ir.save_error_info()
-        error_expr = construct_expr(die_ir, self._ret_type)
+        error_expr = construct_expr(ir.Die(message._ir, self._ret_type), self._ret_type)
         return self._finish(error_expr)

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -1,4 +1,5 @@
 import abc
+import uuid
 
 from hail.utils.java import Env
 from .renderer import Renderer, PlainRenderer, Renderable
@@ -186,6 +187,8 @@ class IR(BaseIR):
         self._free_vars = None
         self._free_agg_vars = None
         self._free_scan_vars = None
+        self._error_id = None
+        self._stack_trace = None
 
     @property
     def aggregations(self):
@@ -278,6 +281,11 @@ class IR(BaseIR):
                 var for i in range(len(self.children))
                 for var in vars_from_child(i)}
         return self._free_scan_vars
+
+    def save_error_info(self):
+        self._error_id = uuid.uuid4().int
+        self._stack_trace = None
+
 
 
 class TableIR(BaseIR):

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -284,8 +284,7 @@ class IR(BaseIR):
 
     def save_error_info(self):
         self._error_id = uuid.uuid4().int
-        self._stack_trace = None
-
+        self._stack_trace = "Stack trace placeholder"
 
 
 class TableIR(BaseIR):

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -206,22 +206,20 @@ class BaseIR(Renderable):
             if 'IPython' in candidate:
                 break
             i -= 1
-        filt_stack = []
 
         forbidden_phrases = [
             '_ir_lambda_method',
             'decorator.py',
+            'decorator-gen',
             'typecheck/check',
             'interactiveshell.py',
             'expressions.construct_variable',
             'traceback.format_stack()'
         ]
-        while i < len(stack):
-            candidate = stack[i]
-            i += 1
-            if any(phrase in candidate for phrase in forbidden_phrases):
-                continue
-            filt_stack.append(candidate)
+        filt_stack = [
+            candidate for candidate in stack[i:]
+            if not any(phrase in candidate for phrase in forbidden_phrases)
+        ]
 
         self._stack_trace = '\n'.join(filt_stack)
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1934,12 +1934,11 @@ class GetTupleElement(IR):
 
 
 class Die(IR):
-    @typecheck_method(message=IR, typ=hail_type, error_id=nullable(int))
+    @typecheck_method(message=IR, typ=hail_type)
     def __init__(self, message, typ, error_id=None):
         super().__init__(message)
         self.message = message
         self._typ = typ
-        self._error_id = error_id if error_id else uuid.uuid4().int
 
     @property
     def typ(self):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1933,19 +1933,23 @@ class GetTupleElement(IR):
 
 
 class Die(IR):
-    @typecheck_method(message=IR, typ=hail_type)
-    def __init__(self, message, typ):
+    @typecheck_method(message=IR, typ=hail_type, error_id=nullable(int), stack_trace=nullable(str))
+    def __init__(self, message, typ, error_id=None, stack_trace=None):
         super().__init__(message)
         self.message = message
         self._typ = typ
-        self.save_error_info()
+        self._error_id = error_id
+        self._stack_trace = stack_trace
+
+        if error_id is None or stack_trace is None:
+            self.save_error_info()
 
     @property
     def typ(self):
         return self._typ
 
     def copy(self, message):
-        return Die(message, self._typ)
+        return Die(message, self._typ, self._error_id, self._stack_trace)
 
     def head_str(self):
         return f'{self._typ._parsable_string()} {self._error_id}'

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1935,7 +1935,7 @@ class GetTupleElement(IR):
 
 class Die(IR):
     @typecheck_method(message=IR, typ=hail_type)
-    def __init__(self, message, typ, error_id=None):
+    def __init__(self, message, typ):
         super().__init__(message)
         self.message = message
         self._typ = typ

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2,7 +2,6 @@ import copy
 from collections import defaultdict
 
 import decorator
-import uuid
 
 import hail
 from hail.expr.types import dtype, HailType, hail_type, tint32, tint64, \

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1939,6 +1939,7 @@ class Die(IR):
         super().__init__(message)
         self.message = message
         self._typ = typ
+        self.save_error_info()
 
     @property
     def typ(self):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1948,7 +1948,7 @@ class Die(IR):
         return Die(message, self._typ)
 
     def head_str(self):
-        return self._typ._parsable_string()
+        return f'{self._typ._parsable_string()} {self._error_id}'
 
     def _eq(self, other):
         return other._typ == self._typ

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2,6 +2,7 @@ import copy
 from collections import defaultdict
 
 import decorator
+import uuid
 
 import hail
 from hail.expr.types import dtype, HailType, hail_type, tint32, tint64, \
@@ -1933,11 +1934,12 @@ class GetTupleElement(IR):
 
 
 class Die(IR):
-    @typecheck_method(message=IR, typ=hail_type)
-    def __init__(self, message, typ):
+    @typecheck_method(message=IR, typ=hail_type, error_id=nullable(int))
+    def __init__(self, message, typ, error_id=None):
         super().__init__(message)
         self.message = message
         self._typ = typ
+        self._error_id = error_id if error_id else uuid.uuid4().int
 
     @property
     def typ(self):

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -3,7 +3,7 @@ from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir
 from .struct import Struct
 from .linkedlist import LinkedList
 from .interval import Interval
-from .java import error, warning, info, FatalError
+from .java import error, warning, info, FatalError, HailUserError
 from .tutorial import get_1kg, get_movie_lens
 from .deduplicate import deduplicate
 
@@ -30,6 +30,7 @@ __all__ = ['hadoop_open',
            'warning',
            'info',
            'FatalError',
+           'HailUserError',
            'range_table',
            'range_matrix_table',
            'HailSeedGenerator',

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -8,6 +8,12 @@ import hail
 class FatalError(Exception):
     """:class:`.FatalError` is an error thrown by Hail method failures"""
 
+    def __init__(self, msg, error_id=-1):
+        super().__init__(msg)
+        self._error_id = error_id
+
+class HailUserError(Exception):
+    """:class:`.HailUserError` is an error thrown by Hail when the user makes an error."""
 
 class Env:
     _jutils = None

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -12,8 +12,10 @@ class FatalError(Exception):
         super().__init__(msg)
         self._error_id = error_id
 
+
 class HailUserError(Exception):
     """:class:`.HailUserError` is an error thrown by Hail when the user makes an error."""
+
 
 class Env:
     _jutils = None

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3246,22 +3246,22 @@ class Tests(unittest.TestCase):
         assert hl.eval(hl.bit_rshift(hl.int64(-11), 64, logical=True)) == 0
 
     def test_bit_shift_errors(self):
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
                 hl.eval(hl.bit_lshift(1, -1))
 
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_rshift(1, -1))
 
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_rshift(1, -1, logical=True))
 
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_lshift(hl.int64(1), -1))
 
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_rshift(hl.int64(1), -1))
 
-        with pytest.raises(hl.utils.FatalError):
+        with pytest.raises(hl.utils.HailUserError):
             hl.eval(hl.bit_rshift(hl.int64(1), -1, logical=True))
 
     def test_prev_non_null(self):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1192,7 +1192,9 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.case(missing_false=True).when(hl.null(hl.tbool), 1).default(2)), 2)
 
         error_case = hl.case().when(False, 1).or_error("foo")
-        self.assertRaises(hl.utils.java.FatalError, lambda: hl.eval(error_case))
+        with pytest.raises(hl.utils.java.HailUserError) as exc:
+            hl.eval(error_case)
+        assert '.or_error("foo")' in str(exc.value)
 
     def test_struct_ops(self):
         s = hl.struct(f1=1, f2=2, f3=3)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2943,11 +2943,11 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: x - 1, 0, 3, tolerance=tol)), 1)
         self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: hl.log(x) - 1, 0, 3, tolerance=tol)), 2.718281828459045, delta=tol)
 
-        with self.assertRaisesRegex(hl.utils.FatalError, "value of f\(x\) is missing"):
+        with self.assertRaisesRegex(hl.utils.HailUserError, "value of f\(x\) is missing"):
             hl.eval(hl.uniroot(lambda x: hl.null('float'), 0, 1))
-        with self.assertRaisesRegex(hl.utils.FatalError, 'opposite signs'):
+        with self.assertRaisesRegex(hl.utils.HailUserError, 'opposite signs'):
             hl.eval(hl.uniroot(lambda x: x ** 2 - 0.5, -1, 1))
-        with self.assertRaisesRegex(hl.utils.FatalError, 'min must be less than max'):
+        with self.assertRaisesRegex(hl.utils.HailUserError, 'min must be less than max'):
             hl.eval(hl.uniroot(lambda x: x, 1, -1))
 
         def multiple_roots(x):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2943,7 +2943,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: x - 1, 0, 3, tolerance=tol)), 1)
         self.assertAlmostEqual(hl.eval(hl.uniroot(lambda x: hl.log(x) - 1, 0, 3, tolerance=tol)), 2.718281828459045, delta=tol)
 
-        with self.assertRaisesRegex(hl.utils.HailUserError, "value of f\(x\) is missing"):
+        with self.assertRaisesRegex(hl.utils.FatalError, "value of f\(x\) is missing"):
             hl.eval(hl.uniroot(lambda x: hl.null('float'), 0, 1))
         with self.assertRaisesRegex(hl.utils.HailUserError, 'opposite signs'):
             hl.eval(hl.uniroot(lambda x: x ** 2 - 0.5, -1, 1))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1,11 +1,9 @@
-import hail as hl
-from hail.utils.java import FatalError
 import numpy as np
 from ..helpers import *
 import tempfile
 import pytest
 
-from hail.utils.java import FatalError
+from hail.utils.java import FatalError, HailUserError
 
 
 def assert_ndarrays(asserter, exprs_and_expecteds):
@@ -140,13 +138,13 @@ def test_ndarray_slice():
     assert hl.eval(rect_prism[:, :, 0:hl.null(hl.tint32):1]) is None
     assert hl.eval(rect_prism[hl.null(hl.tint32), :, :]) is None
 
-    with pytest.raises(FatalError, match="Slice step cannot be zero"):
+    with pytest.raises(HailUserError, match="Slice step cannot be zero"):
         hl.eval(flat[::0])
 
-    with pytest.raises(FatalError, match="Index 3 is out of bounds for axis 0 with size 2"):
+    with pytest.raises(HailUserError, match="Index 3 is out of bounds for axis 0 with size 2"):
         hl.eval(mat[3, 1:3])
 
-    with pytest.raises(FatalError, match="Index -4 is out of bounds for axis 0 with size 2"):
+    with pytest.raises(HailUserError, match="Index -4 is out of bounds for axis 0 with size 2"):
         hl.eval(mat[-4, 0:3])
 
 
@@ -203,11 +201,11 @@ def test_ndarray_eval():
         hl.nd.array(mishapen_data_list1)
     assert "inner dimensions do not match" in str(exc.value)
 
-    with pytest.raises(FatalError) as exc:
+    with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array(hl.array(mishapen_data_list1)))
     assert "inner dimensions do not match" in str(exc.value)
 
-    with pytest.raises(FatalError) as exc:
+    with pytest.raises(HailUserError) as exc:
         hl.eval(hl.nd.array(hl.array(mishapen_data_list2)))
     assert "inner dimensions do not match" in str(exc.value)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -947,7 +947,7 @@ class Tests(unittest.TestCase):
 
         ht = hl.Table.parallelize([{'locus': hl.Locus('1', 1), 'cm': hl.null(hl.tfloat64)}],
                                   hl.tstruct(locus=hl.tlocus('GRCh37'), cm=hl.tfloat64), key=['locus'])
-        with self.assertRaises(HailUserError) as cm:
+        with self.assertRaises(FatalError) as cm:
             hl.linalg.utils.locus_windows(ht.locus, 1.0, coord_expr=ht.cm)
         self.assertTrue("missing value for 'coord_expr'" in str(cm.exception))
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hail.linalg import BlockMatrix
-from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalError
+from hail.utils import new_temp_file, new_local_temp_dir, local_path_uri, FatalError, HailUserError
 from ..helpers import *
 import numpy as np
 import tempfile
@@ -912,7 +912,7 @@ class Tests(unittest.TestCase):
         assert_eq(starts, [0, 1, 1, 3, 3, 5])
         assert_eq(stops, [1, 3, 3, 5, 5, 6])
 
-        with self.assertRaises(FatalError) as cm:
+        with self.assertRaises(HailUserError) as cm:
             hl.linalg.utils.locus_windows(ht.order_by(ht.cm).locus, 1.0)
         self.assertTrue('ascending order' in str(cm.exception))
 
@@ -938,16 +938,16 @@ class Tests(unittest.TestCase):
 
         ht = hl.Table.parallelize([{'locus': hl.null(hl.tlocus()), 'cm': 1.0}],
                                   hl.tstruct(locus=hl.tlocus('GRCh37'), cm=hl.tfloat64), key=['locus'])
-        with self.assertRaises(FatalError) as cm:
+        with self.assertRaises(HailUserError) as cm:
             hl.linalg.utils.locus_windows(ht.locus, 1.0)
         self.assertTrue("missing value for 'locus_expr'" in str(cm.exception))
-        with self.assertRaises(FatalError) as cm:
+        with self.assertRaises(HailUserError) as cm:
             hl.linalg.utils.locus_windows(ht.locus, 1.0, coord_expr=ht.cm)
         self.assertTrue("missing value for 'locus_expr'" in str(cm.exception))
 
         ht = hl.Table.parallelize([{'locus': hl.Locus('1', 1), 'cm': hl.null(hl.tfloat64)}],
                                   hl.tstruct(locus=hl.tlocus('GRCh37'), cm=hl.tfloat64), key=['locus'])
-        with self.assertRaises(FatalError) as cm:
+        with self.assertRaises(HailUserError) as cm:
             hl.linalg.utils.locus_windows(ht.locus, 1.0, coord_expr=ht.cm)
         self.assertTrue("missing value for 'coord_expr'" in str(cm.exception))
 

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -198,7 +198,7 @@ class Tests(unittest.TestCase):
 
     def test_verify_biallelic(self):
         mt = hl.import_vcf(resource('sample2.vcf'))  # has multiallelics
-        with self.assertRaises(hl.utils.FatalError):
+        with self.assertRaises(hl.utils.HailUserError):
             hl.methods.misc.require_biallelic(mt, '')._force_count_rows()
 
     def test_lambda_gc(self):

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -185,7 +185,7 @@ object Children {
       Array(o)
     case In(i, typ) =>
       none
-    case Die(message, typ) =>
+    case Die(message, typ, errorId) =>
       Array(message)
     case ApplyIR(_, _, args) =>
       args.toFastIndexedSeq

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -279,9 +279,9 @@ object Copy {
         assert(newChildren.length == 1)
         GetTupleElement(newChildren(0).asInstanceOf[IR], idx)
       case In(i, t) => In(i, t)
-      case Die(_, typ) =>
+      case Die(_, typ, errorId) =>
         assert(newChildren.length == 1)
-        Die(newChildren(0).asInstanceOf[IR], typ)
+        Die(newChildren(0).asInstanceOf[IR], typ, errorId)
       case x@ApplyIR(fn, typeArgs, args) =>
         val r = ApplyIR(fn, typeArgs, newChildren.map(_.asInstanceOf[IR]))
         r.conversion = x.conversion

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1686,11 +1686,7 @@ class Emit[C](
         val ev = mb.getEmitParam(2 + i)
         assert(ev.pt == expectedPType)
         ev
-      case x@Die(m, typ, errorId) =>
-        log.info("errorId of Die was " + errorId + s" IR was ${x}")
-        if (errorId == -1) {
-          log.info(x.stackTrace)
-        }
+      case @Die(m, typ, errorId) =>
         val cm = emit(m)
         EmitCode(
           Code(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -559,11 +559,11 @@ class Emit[C](
 
         cb.assign(ib, Code._null)
 
-      case Die(m, typ) =>
+      case Die(m, typ, errorId) =>
         val cm = emitI(m)
         val msg = cb.newLocal[String]("exmsg", "<exception message missing>")
         cm.consume(cb, {}, s => cb.assign(msg, s.asString.loadString()))
-        cb._throw(Code.newInstance[HailException, String](msg))
+        cb._throw(Code.newInstance[HailException, String, Int](msg, errorId))
 
       case x@WriteMetadata(annotations, writer) =>
         writer.writeMetadata(emitI(annotations), cb, region.code)
@@ -1686,15 +1686,15 @@ class Emit[C](
         val ev = mb.getEmitParam(2 + i)
         assert(ev.pt == expectedPType)
         ev
-      case Die(m, typ) =>
+      case Die(m, typ, errorId) =>
         val cm = emit(m)
         EmitCode(
           Code(
             cm.setup,
-            Code._throw[HailException, Unit](Code.newInstance[HailException, String](
+            Code._throw[HailException, Unit](Code.newInstance[HailException, String, Int](
               cm.m.mux[String](
                 "<exception message missing>",
-                coerce[String](StringFunctions.wrapArg(EmitRegion(mb, region.code), m.pType)(cm.v)))))),
+                coerce[String](StringFunctions.wrapArg(EmitRegion(mb, region.code), m.pType)(cm.v))), errorId))),
           true,
           pt.defaultValue)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1686,7 +1686,11 @@ class Emit[C](
         val ev = mb.getEmitParam(2 + i)
         assert(ev.pt == expectedPType)
         ev
-      case Die(m, typ, errorId) =>
+      case x@Die(m, typ, errorId) =>
+        log.info("errorId of Die was " + errorId + s" IR was ${x}")
+        if (errorId == -1) {
+          log.info(x.stackTrace)
+        }
         val cm = emit(m)
         EmitCode(
           Code(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1686,7 +1686,7 @@ class Emit[C](
         val ev = mb.getEmitParam(2 + i)
         assert(ev.pt == expectedPType)
         ev
-      case @Die(m, typ, errorId) =>
+      case Die(m, typ, errorId) =>
         val cm = emit(m)
         EmitCode(
           Code(

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -517,15 +517,11 @@ final case class In(i: Int, _typ: PType) extends IR
 
 // FIXME: should be type any
 object Die {
+  def apply(message: String, typ: Type): Die = Die(Str(message), typ, -1)
   def apply(message: String, typ: Type, errorId: Int): Die = Die(Str(message), typ, errorId)
 }
 
-final case class Die(message: IR, _typ: Type, errorId: Int) extends IR {
-  val stackTrace = Thread.currentThread().getStackTrace().mkString("\n")
-  if (errorId == -1 && message.asInstanceOf[Str].x.contains("axis")) {
-    throw new IllegalArgumentException("Mistake")
-  }
-}
+final case class Die(message: IR, _typ: Type, errorId: Int) extends IR
 
 final case class ApplyIR(function: String, typeArgs: Seq[Type], args: Seq[IR]) extends IR {
   var conversion: (Seq[Type], Seq[IR]) => IR = _

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -516,10 +516,10 @@ final case class In(i: Int, _typ: PType) extends IR
 
 // FIXME: should be type any
 object Die {
-  def apply(message: String, typ: Type): Die = Die(Str(message), typ)
+  def apply(message: String, typ: Type, errorId: Int): Die = Die(Str(message), typ, errorId)
 }
 
-final case class Die(message: IR, _typ: Type) extends IR
+final case class Die(message: IR, _typ: Type, errorId: Int) extends IR
 
 final case class ApplyIR(function: String, typeArgs: Seq[Type], args: Seq[IR]) extends IR {
   var conversion: (Seq[Type], Seq[IR]) => IR = _

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import com.google.api.gax.rpc.InvalidArgumentException
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.Value
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
@@ -519,7 +520,12 @@ object Die {
   def apply(message: String, typ: Type, errorId: Int): Die = Die(Str(message), typ, errorId)
 }
 
-final case class Die(message: IR, _typ: Type, errorId: Int) extends IR
+final case class Die(message: IR, _typ: Type, errorId: Int) extends IR {
+  val stackTrace = Thread.currentThread().getStackTrace().mkString("\n")
+  if (errorId == -1 && message.asInstanceOf[Str].x.contains("axis")) {
+    throw new IllegalArgumentException("Mistake")
+  }
+}
 
 final case class ApplyIR(function: String, typeArgs: Seq[Type], args: Seq[IR]) extends IR {
   var conversion: (Seq[Type], Seq[IR]) => IR = _

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import com.google.api.gax.rpc.InvalidArgumentException
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.Value
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -45,7 +45,7 @@ object IRBuilder {
     If(cond(env), cnsq(env), altr(env))
 
   def irDie(message: IRProxy, typ: Type): IRProxy = (env: E) =>
-    Die(message(env), typ)
+    Die(message(env), typ, -1)
 
   def makeArray(first: IRProxy, rest: IRProxy*): IRProxy = arrayToProxy(first +: rest)
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -47,7 +47,7 @@ object InferType {
       case _: SerializeAggs => TVoid
       case _: DeserializeAggs => TVoid
       case _: Begin => TVoid
-      case Die(_, t) => t
+      case Die(_, t, _) => t
       case If(cond, cnsq, altr) =>
         assert(cond.typ == TBoolean)
         assert(cnsq.typ == altr.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -745,9 +745,9 @@ object Interpret {
       case In(i, _) =>
         val (a, _) = args(i)
         a
-      case Die(message, typ) =>
+      case Die(message, typ, errorId) =>
         val message_ = interpret(message).asInstanceOf[String]
-        fatal(if (message_ != null) message_ else "<exception message missing>")
+        fatal(if (message_ != null) message_ else "<exception message missing>",  errorId)
       case ir@ApplyIR(function, _, functionArgs) =>
         interpret(ir.explicitNode, env, args)
       case ApplySpecial("lor", _, Seq(left_, right_), _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1172,8 +1172,9 @@ object IRParser {
         In(idx, typ)
       case "Die" =>
         val typ = type_expr(env.typEnv)(it)
+        val errorId = int32_literal(it)
         val msg = ir_value_expr(env)(it)
-        Die(msg, typ)
+        Die(msg, typ, errorId)
       case "ApplySeeded" =>
         val function = identifier(it)
         val seed = int64_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -327,7 +327,7 @@ object Pretty {
             case SelectFields(_, fields) => fields.map(prettyIdentifier).mkString("(", " ", ")")
             case LowerBoundOnOrderedCollection(_, _, onKey) => prettyBooleanLiteral(onKey)
             case In(i, typ) => s"$typ $i"
-            case Die(message, typ, _) => typ.parsableString()
+            case Die(message, typ, errorId) => s"${typ.parsableString()} $errorId"
             case CollectDistributedArray(_, _, cname, gname, _) =>
               s"${ prettyIdentifier(cname) } ${ prettyIdentifier(gname) }"
             case MatrixRead(typ, dropCols, dropRows, reader) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -327,7 +327,7 @@ object Pretty {
             case SelectFields(_, fields) => fields.map(prettyIdentifier).mkString("(", " ", ")")
             case LowerBoundOnOrderedCollection(_, _, onKey) => prettyBooleanLiteral(onKey)
             case In(i, typ) => s"$typ $i"
-            case Die(message, typ) => typ.parsableString()
+            case Die(message, typ, _) => typ.parsableString()
             case CollectDistributedArray(_, _, cname, gname, _) =>
               s"${ prettyIdentifier(cname) } ${ prettyIdentifier(gname) }"
             case MatrixRead(typ, dropCols, dropRows, reader) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1508,7 +1508,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
         Coalesce(FastIndexedSeq(
           extracted.postAggIR,
-            Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ))))
+            Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ, -1))))
 
       val rowIterationNeedsGlobals = Mentions(extracted.postAggIR, "global")
       val globalsBc =
@@ -1580,7 +1580,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       Let(scanRef, extracted.results,
         Coalesce(FastIndexedSeq(
           extracted.postAggIR,
-          Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ)))))
+          Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ, -1)))))
     assert(rTyp.virtualType == newRow.typ)
 
     // 1. init op on all aggs and write out to initPath
@@ -1807,7 +1807,7 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
       FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
       Coalesce(FastIndexedSeq(
         newGlobals,
-        Die("Internal error: TableMapGlobals: globals missing", newGlobals.typ))))
+        Die("Internal error: TableMapGlobals: globals missing", newGlobals.typ, -1))))
 
     val resultOff = f(0, ctx.r)(ctx.r, tv.globals.value.offset)
     tv.copy(typ = typ,
@@ -2018,7 +2018,7 @@ case class TableKeyByAndAggregate(
       FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
       Coalesce(FastIndexedSeq(
         newKey,
-        Die("Internal error: TableKeyByAndAggregate: newKey missing", newKey.typ))))
+        Die("Internal error: TableKeyByAndAggregate: newKey missing", newKey.typ, -1))))
 
     val globalsBc = prev.globals.broadcast
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1508,7 +1508,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
         Coalesce(FastIndexedSeq(
           extracted.postAggIR,
-            Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ, -1))))
+            Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ))))
 
       val rowIterationNeedsGlobals = Mentions(extracted.postAggIR, "global")
       val globalsBc =
@@ -1580,7 +1580,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       Let(scanRef, extracted.results,
         Coalesce(FastIndexedSeq(
           extracted.postAggIR,
-          Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ, -1)))))
+          Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ)))))
     assert(rTyp.virtualType == newRow.typ)
 
     // 1. init op on all aggs and write out to initPath
@@ -1807,7 +1807,7 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
       FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
       Coalesce(FastIndexedSeq(
         newGlobals,
-        Die("Internal error: TableMapGlobals: globals missing", newGlobals.typ, -1))))
+        Die("Internal error: TableMapGlobals: globals missing", newGlobals.typ))))
 
     val resultOff = f(0, ctx.r)(ctx.r, tv.globals.value.offset)
     tv.copy(typ = typ,
@@ -2018,7 +2018,7 @@ case class TableKeyByAndAggregate(
       FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
       Coalesce(FastIndexedSeq(
         newKey,
-        Die("Internal error: TableKeyByAndAggregate: newKey missing", newKey.typ, -1))))
+        Die("Internal error: TableKeyByAndAggregate: newKey missing", newKey.typ))))
 
     val globalsBc = prev.globals.broadcast
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -384,7 +384,7 @@ object TypeCheck {
           case pstream: PStream => assert(pstream.elementType.isRealizable)
           case _ =>
         }
-      case Die(msg, typ) =>
+      case Die(msg, typ, _) =>
         assert(msg.typ == TString)
       case x@ApplyIR(fn, typeArgs, args) =>
       case x: AbstractApplyNode[_] =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -58,7 +58,7 @@ object DictFunctions extends RegistryFunctions {
           invoke("concat", TString,
             Str("'    not found in dictionary. Keys: "),
             invoke("str", TString, invoke("keys", TArray(k.typ), d)))))
-      get(d, k, Die(errormsg, vtype))
+      get(d, k, Die(errormsg, vtype, -1))
     }
 
     registerIR1("dictToArray", tdict, TArray(TStruct("key" -> tv("key"), "value" -> tv("value")))) { (_, d) =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -129,7 +129,7 @@ object StringFunctions extends RegistryFunctions {
               Str("string index out of bounds: "),
               invoke("concat", TString,
                 invoke("str", TString, i),
-                invoke("concat", TString, Str(" / "), invoke("str", TString, len)))), TInt32),
+                invoke("concat", TString, Str(" / "), invoke("str", TString, len)))), TInt32, -1),
             If(i < 0, i + len, i)),
         invoke("substring", TString, s, idx, idx + 1)))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -966,7 +966,7 @@ object LowerTableIR {
             MakeStruct(
               (lKeyFields, rKeyFields).zipped.map { (lKey, rKey) =>
                 if (joinType == "outer" && lReq.field(lKey).required && rReq.field(rKey).required)
-                  lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey), Die("TableJoin expected non-missing key", left.typ.rowType.fieldType(lKey))))
+                  lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey), Die("TableJoin expected non-missing key", left.typ.rowType.fieldType(lKey), -1)))
                 else
                   lKey -> Coalesce(FastSeq(GetField(lEltRef, lKey), GetField(rEltRef, rKey)))
               }

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -1,14 +1,16 @@
 package is.hail.utils
 
-class HailException(val msg: String, val logMsg: Option[String], cause: Throwable, val error_id: Int) extends RuntimeException(msg, cause) {
+class HailException(val msg: String, val logMsg: Option[String], cause: Throwable, val errorId: Int) extends RuntimeException(msg, cause) {
   def this(msg: String) = this(msg, None, null, -1)
   def this(msg: String, logMsg: Option[String]) = this(msg, logMsg, null, -1)
   def this(msg: String, logMsg: Option[String], cause: Throwable) = this(msg, logMsg, null, -1)
-  def this(msg: String, error_id: Int) = this(msg, None, null, error_id)
+  def this(msg: String, errorId: Int) = this(msg, None, null, errorId)
 }
 
 trait ErrorHandling {
   def fatal(msg: String): Nothing = throw new HailException(msg)
+
+  def fatal(msg: String, errorId: Int) = throw new HailException(msg, errorId)
 
   def fatal(msg: String, cause: Throwable): Nothing = throw new HailException(msg, None, cause)
 
@@ -53,7 +55,7 @@ trait ErrorHandling {
 
     log.error(s"$short\nFrom $logExpanded")
 
-    val error_id = if (e.isInstanceOf[HailException]) e.asInstanceOf[HailException].error_id else -1
+    val error_id = if (e.isInstanceOf[HailException]) e.asInstanceOf[HailException].errorId else -1
 
     (short, expanded, error_id)
   }

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -55,7 +55,19 @@ trait ErrorHandling {
 
     log.error(s"$short\nFrom $logExpanded")
 
-    val error_id = if (e.isInstanceOf[HailException]) e.asInstanceOf[HailException].errorId else -1
+    def searchForErrorCode(exception: Throwable): Int = {
+      if (exception.isInstanceOf[HailException]) {
+        exception.asInstanceOf[HailException].errorId
+      }
+      else if (exception.getCause == null) {
+        -1
+      }
+      else {
+        searchForErrorCode(exception.getCause)
+      }
+    }
+
+    val error_id = searchForErrorCode(e)
 
     (short, expanded, error_id)
   }

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -3,7 +3,7 @@ package is.hail.utils
 class HailException(val msg: String, val logMsg: Option[String], cause: Throwable, val errorId: Int) extends RuntimeException(msg, cause) {
   def this(msg: String) = this(msg, None, null, -1)
   def this(msg: String, logMsg: Option[String]) = this(msg, logMsg, null, -1)
-  def this(msg: String, logMsg: Option[String], cause: Throwable) = this(msg, logMsg, null, -1)
+  def this(msg: String, logMsg: Option[String], cause: Throwable) = this(msg, logMsg, cause, -1)
   def this(msg: String, errorId: Int) = this(msg, None, null, errorId)
 }
 

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -1,8 +1,10 @@
 package is.hail.utils
 
-class HailException(val msg: String, val logMsg: Option[String], cause: Throwable) extends RuntimeException(msg, cause) {
-  def this(msg: String) = this(msg, None, null)
-  def this(msg: String, logMsg: Option[String]) = this(msg, logMsg, null)
+class HailException(val msg: String, val logMsg: Option[String], cause: Throwable, val error_id: Int) extends RuntimeException(msg, cause) {
+  def this(msg: String) = this(msg, None, null, -1)
+  def this(msg: String, logMsg: Option[String]) = this(msg, logMsg, null, -1)
+  def this(msg: String, logMsg: Option[String], cause: Throwable) = this(msg, logMsg, null, -1)
+  def this(msg: String, error_id: Int) = this(msg, None, null, error_id)
 }
 
 trait ErrorHandling {
@@ -44,13 +46,15 @@ trait ErrorHandling {
     }\n"
   }
 
-  def handleForPython(e: Throwable): (String, String) = {
+  def handleForPython(e: Throwable): (String, String, Int) = {
     val short = deepestMessage(e)
     val expanded = expandException(e, false)
     val logExpanded = expandException(e, true)
 
     log.error(s"$short\nFrom $logExpanded")
 
-    (short, expanded)
+    val error_id = if (e.isInstanceOf[HailException]) e.asInstanceOf[HailException].error_id else -1
+
+    (short, expanded, error_id)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2711,7 +2711,7 @@ class IRSuite extends HailSuite {
 
   @Test def testDie() {
     assertFatal(Die("mumblefoo", TFloat64), "mble")
-    assertFatal(Die(NA(TString), TFloat64), "message missing")
+    assertFatal(Die(NA(TString), TFloat64, -1), "message missing")
   }
 
   @Test def testDieInferPType() {


### PR DESCRIPTION
This PR is based on discussion here: https://dev.hail.is/t/better-python-error-messages-idea/201/9 The intention is to create a system to give better error messages from python in a generic way. Tim's work in #7792 does a good job introducing behavior like this this specifically for `ArrayRef` nodes, but I want to add three things on top of that:

1. I don't want to have to do as much custom per IR node work
2. I don't want to send the entire python stack trace over py4j to scala for every node
3. I don't want the user to see a Java stack trace in this scenarios.

This first PR is a proof of concept that adds this behavior for the `Die` node, which will catch any errors generated by uses of `CaseBuilder.or_error`. Follow up PRs should change `ArrayRef` to work this way, as well as catch things like looking up a key in a dictionary but not finding it. In an ideal future, we'd bolt on some extra mechanism to give types to these errors, and we could throw a proper `IndexError` in the `ArrayRef` case or `KeyError` in the dictionary case. 

It feels a little bit messy right now, open to suggestions. I don't love using `-1` as the "no error" situation, but I thought it was probably easier than dealing with optionals between python and scala. 

To give an example of what it looks like, the error message for this script:

```
import hail as hl

ht = hl.utils.range_table(10)
ht = ht.annotate(foo = hl.nd.array([[1], [2], [3]]))
ht = ht.annotate(bar = ht.foo[0:4, 12])
ht.collect()
```

is

```
Traceback (most recent call last):
  File "better_error_test.py", line 6, in <module>
    ht.collect()
  File "<decorator-gen-1103>", line 2, in collect
  File "/Users/johnc/Code/hail/hail/python/hail/typecheck/check.py", line 614, in wrapper
    return __original_func(*args_, **kwargs_)
  File "/Users/johnc/Code/hail/hail/python/hail/table.py", line 1903, in collect
    return Env.backend().execute(e._ir)
  File "/Users/johnc/Code/hail/hail/python/hail/backend/spark_backend.py", line 325, in execute
    raise HailUserError(message_and_trace) from None
hail.utils.java.HailUserError: Error summary: HailException: Index 12 is out of bounds for axis 1 with size 1
------------
Hail stack trace:
  File "better_error_test.py", line 5, in <module>
    ht = ht.annotate(bar = ht.foo[0:4, 12])

  File "<decorator-gen-707>", line 2, in __getitem__

  File "/Users/johnc/Code/hail/hail/python/hail/expr/expressions/typed_expressions.py", line 3709, in __getitem__
    hl.str("Index ") + hl.str(s) + hl.str(f" is out of bounds for axis {i} with size ") + hl.str(dlen)

  File "<decorator-gen-1299>", line 2, in or_error

  File "/Users/johnc/Code/hail/hail/python/hail/expr/builders.py", line 311, in or_error
    die_ir.save_error_info()
```

(Note that ndarray bounds checking internally uses a case builder, which is why this example works). 