### PR TITLE
[query] enable memory managenment in lowered IR

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -189,8 +189,8 @@ object CompileIterator {
     val stepF = fb.apply_method
     val stepFECB = stepF.ecb
 
-    val eltRegion = StagedRegion(eltRegionField, allowSubregions = false)
     val outerRegion = StagedRegion(outerRegionField, allowSubregions = false)
+    val eltRegion = outerRegion.createChildRegion(stepF)
     val emitter = new Emit(ctx, stepFECB)
 
     val ir = LoweringPipeline.compileLowerer(true)(ctx, body).asInstanceOf[IR].noSharing

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -25,8 +25,7 @@ object Compile {
     expectedCodeParamTypes: IndexedSeq[TypeInfo[_]], expectedCodeReturnType: TypeInfo[_],
     body: IR,
     optimize: Boolean = true,
-    print: Option[PrintWriter] = None,
-    allocStrat: EmitAllocationStrategy.T = EmitAllocationStrategy.OneRegion
+    print: Option[PrintWriter] = None
   ): (PType, (Int, Region) => F) = {
 
     val normalizeNames = new NormalizeNames(_.toString)
@@ -70,7 +69,7 @@ object Compile {
     assert(fb.mb.parameterTypeInfo == expectedCodeParamTypes, s"expected $expectedCodeParamTypes, got ${ fb.mb.parameterTypeInfo }")
     assert(fb.mb.returnTypeInfo == expectedCodeReturnType, s"expected $expectedCodeReturnType, got ${ fb.mb.returnTypeInfo }")
 
-    Emit(ctx, ir, fb, allocStrat = allocStrat)
+    Emit(ctx, ir, fb)
 
     val f = fb.resultWithIndex(print)
     codeCache += k -> CodeCacheValue(ir.pType, f)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -87,9 +87,9 @@ object Emit {
     val emitter = new Emit[C](ctx, fb.ecb)
     val regionArg = mb.getCodeParam[Region](1)
     val stagedRegion = allocStrat match {
-      case EmitAllocationStrategy.Default => new RealStagedRegion(regionArg)
-      case EmitAllocationStrategy.ManyRegions => new RealStagedRegion(regionArg)
-      case EmitAllocationStrategy.OneRegion => new DummyStagedRegion(regionArg)
+      case EmitAllocationStrategy.Default => StagedRegion(regionArg, allowSubregions = true)
+      case EmitAllocationStrategy.ManyRegions => StagedRegion(regionArg, allowSubregions = true)
+      case EmitAllocationStrategy.OneRegion => StagedRegion(regionArg, allowSubregions = false)
     }
     if (ir.typ == TVoid) {
       fb.emitWithBuilder { cb =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1639,7 +1639,6 @@ class Emit[C](
 
       case x@StreamLen(a) =>
         val outerRegion = region.asParent(coerce[PStream](a.pType).separateRegions, "StreamLen")
-        println(s"in StreamLen\n${outerRegion.description}")
         emitStream(a, outerRegion).map { ss =>
           val count = mb.newLocal[Int]("stream_length")
           val SizedStream(setup, stream, length) = ss.asStream.stream

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1092,7 +1092,7 @@ class Emit[C](
             // empty.
             cb.assign(xElt, elt)
             cb.assign(xAcc, emitI(body, eltRegion, env.bind(accumName -> xAcc, valueName -> xElt))
-              .map(cb)(eltRegion.copyToSibling(mb, _, tmpRegion, accType)))
+              .map(cb)(eltRegion.copyTo(mb, _, tmpRegion, accType)))
             cb += eltRegion.clear()
             cb += StagedRegion.swap(mb, eltRegion, tmpRegion)
           })
@@ -1137,7 +1137,7 @@ class Emit[C](
             (tmpAccVars, seq).zipped.foreach { (accVar, ir) =>
               cb.assign(accVar,
                 emitI(ir, eltRegion, env = seqEnv)
-                  .map(cb)(eltRegion.copyToSibling(mb, _, tmpRegion, accVar.pt)))
+                  .map(cb)(eltRegion.copyTo(mb, _, tmpRegion, accVar.pt)))
             }
             (accVars, tmpAccVars).zipped.foreach { (v, tmp) => cb.assign(v, tmp) }
             cb += eltRegion.clear()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1075,7 +1075,7 @@ object EmitStream {
 
       Code(LstartNewKey,
         Code.forLoop(i := 0, i < k, i := i + 1, result(i) = 0L),
-        curKey := eltRegions(winner).copyToSibling(mb, winnerPc, destRegion, keyType),
+        curKey := eltRegions(winner).copyTo(mb, winnerPc, destRegion, keyType),
         LaddToResult.goto)
 
       Code(LaddToResult,
@@ -1907,8 +1907,8 @@ object EmitStream {
                 val accRegion = eltRegion.createSiblingRegion(mb)
 
                 Code(Lpush,
-                     xAccInAccR := xAccInEltR.map(StagedRegion.copy(mb, _, eltRegion, accRegion)),
-                     push(xAccInEltR))
+                  xAccInAccR := xAccInEltR.map(eltRegion.copyTo(mb, _, accRegion)),
+                  push(xAccInEltR))
 
                 val bodyEnv = env.bind(accName -> xAccInAccR, eltName -> xElt)
                 val body = emitIR(bodyIR, env = bodyEnv, region = eltRegion)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -315,7 +315,7 @@ object Stream {
       // Need to be able to free the memory used by a child stream element
       // when the outer stream advances before all inner stream elements
       // are consumed.
-      var childEltRegion: StagedOwnedRegion = null
+      var childEltRegion: OwnedStagedRegion = null
 
       var childSource: Source[A] = null
       val inner = (innerEltRegion: ChildStagedRegion) => new Stream[A] {
@@ -1166,8 +1166,8 @@ object EmitStream {
       val xEOS = ctx.mb.genFieldThisRef[Boolean]("st_grpby_eos")
       val xNextGrpReady = ctx.mb.genFieldThisRef[Boolean]("st_grpby_ngr")
 
-      var holdingRegion: StagedOwnedRegion = null
-      var keyRegion: StagedOwnedRegion = null
+      var holdingRegion: OwnedStagedRegion = null
+      var keyRegion: OwnedStagedRegion = null
 
       val LchildPull = CodeLabel()
       val LouterPush = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -2038,8 +2038,8 @@ object EmitStream {
               }
 
               sized(leftSetup,
-                          newStream,
-                          if (joinType == "left") leftLen else None)
+                    newStream,
+                    if (joinType == "left") leftLen else None)
             }
           }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -679,7 +679,7 @@ abstract class PartitionWriter {
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: StagedRegion,
+    region: RootStagedRegion,
     stream: SizedStream): EmitCode
 
   def ctxType: Type

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -679,7 +679,7 @@ abstract class PartitionWriter {
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: RootStagedRegion,
+    region: ParentStagedRegion,
     stream: SizedStream): EmitCode
 
   def ctxType: Type

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -170,7 +170,7 @@ case class SplitPartitionNativeWriter(
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: RootStagedRegion,
+    region: ParentStagedRegion,
     stream: SizedStream): EmitCode = {
     val enc1 = spec1.buildEmitEncoder(eltType, mb.ecb)
     val enc2 = spec2.buildEmitEncoder(eltType, mb.ecb)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -170,7 +170,7 @@ case class SplitPartitionNativeWriter(
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: StagedRegion,
+    region: RootStagedRegion,
     stream: SizedStream): EmitCode = {
     val enc1 = spec1.buildEmitEncoder(eltType, mb.ecb)
     val enc2 = spec2.buildEmitEncoder(eltType, mb.ecb)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -147,7 +147,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: RootStagedRegion,
+    region: ParentStagedRegion,
     stream: SizedStream): EmitCode = {
     val enc = spec.buildEmitEncoder(eltType, mb.ecb)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -147,7 +147,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
     context: EmitCode,
     eltType: PStruct,
     mb: EmitMethodBuilder[_],
-    region: StagedRegion,
+    region: RootStagedRegion,
     stream: SizedStream): EmitCode = {
     val enc = spec.buildEmitEncoder(eltType, mb.ecb)
 

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -156,7 +156,7 @@ object TestUtils {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
     HailContext.sparkBackend("TestUtils.loweredExecute")
-               .jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter, allocStrat = EmitAllocationStrategy.ManyRegions)._1
+               .jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter)._1
   }
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)
@@ -220,8 +220,7 @@ object TestUtils {
             FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
             aggIR,
             print = bytecodePrinter,
-            optimize = optimize,
-            allocStrat = EmitAllocationStrategy.ManyRegions)
+            optimize = optimize)
           assert(resultType2.virtualType == resultType)
 
           Region.scoped { region =>
@@ -254,8 +253,7 @@ object TestUtils {
             FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
             MakeTuple.ordered(FastSeq(rewrite(Subst(x, BindingEnv(substEnv))))),
             optimize = optimize,
-            print = bytecodePrinter,
-            allocStrat = EmitAllocationStrategy.ManyRegions)
+            print = bytecodePrinter)
           assert(resultType2.virtualType == resultType)
 
           Region.scoped { region =>

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -189,7 +189,8 @@ class EmitStreamSuite extends HailSuite {
       var checkedInner: CheckedStream[Code[Int]] = null
       val rootRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
       val eltRegion = rootRegion.createChildRegion(mb)
-      val outer = Stream.grouped(mb, _ => r.stream, 2, rootRegion).map { inner =>
+      val innerStreamType = PCanonicalStream(PInt32())
+      val outer = Stream.grouped(mb, _ => r.stream, innerStreamType, 2, eltRegion).map { inner =>
         checkedInner = new CheckedStream(inner(eltRegion), "inner", mb)
         checkedInner.stream
       }
@@ -214,7 +215,8 @@ class EmitStreamSuite extends HailSuite {
       var checkedInner: CheckedStream[Code[Int]] = null
       val rootRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
       val eltRegion = rootRegion.createChildRegion(mb)
-      val outer = Stream.grouped(mb, _ => r.stream, 2, rootRegion).map { inner =>
+      val innerStreamType = PCanonicalStream(PInt32())
+      val outer = Stream.grouped(mb, _ => r.stream, innerStreamType, 2, eltRegion).map { inner =>
         val take = Stream.zip(inner(eltRegion), Stream.range(mb, 0, 1, 1))
                          .map { case (i, count) => i }
         checkedInner = new CheckedStream(take, "inner", mb)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -307,7 +307,7 @@ class EmitStreamSuite extends HailSuite {
       EmitStream.emit(new Emit(ctx, fb.ecb), s, mb, region, Env.empty, None)
     }
     mb.emit {
-      val arrayt = stream.map(s => EmitStream.toArray(mb, PCanonicalArray(eltType), s.asStream, region))
+      val arrayt = stream.map(s => EmitStream.toArray(mb, PCanonicalArray(eltType), s.asStream, region, allowAllocations = false))
       Code(arrayt.setup, arrayt.m.mux(0L, arrayt.v))
     }
     val f = fb.resultWithIndex()

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -187,9 +187,10 @@ class EmitStreamSuite extends HailSuite {
     val f = compile1[Int, Unit] { (mb, n) =>
       val r = checkedRange(0, n, "range", mb)
       var checkedInner: CheckedStream[Code[Int]] = null
-      val dummyRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
-      val outer = Stream.grouped(mb, _ => r.stream, 2, dummyRegion).map { inner =>
-        checkedInner = new CheckedStream(inner(dummyRegion), "inner", mb)
+      val rootRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+      val eltRegion = rootRegion.createChildRegion(mb)
+      val outer = Stream.grouped(mb, _ => r.stream, 2, rootRegion).map { inner =>
+        checkedInner = new CheckedStream(inner(eltRegion), "inner", mb)
         checkedInner.stream
       }
       val checkedOuter = new CheckedStream(outer, "outer", mb)
@@ -211,9 +212,10 @@ class EmitStreamSuite extends HailSuite {
     val f = compile1[Int, Unit] { (mb, n) =>
       val r = checkedRange(0, n, "range", mb)
       var checkedInner: CheckedStream[Code[Int]] = null
-      val dummyRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
-      val outer = Stream.grouped(mb, _ => r.stream, 2, dummyRegion).map { inner =>
-        val take = Stream.zip(inner(dummyRegion), Stream.range(mb, 0, 1, 1))
+      val rootRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+      val eltRegion = rootRegion.createChildRegion(mb)
+      val outer = Stream.grouped(mb, _ => r.stream, 2, rootRegion).map { inner =>
+        val take = Stream.zip(inner(eltRegion), Stream.range(mb, 0, 1, 1))
                          .map { case (i, count) => i }
         checkedInner = new CheckedStream(take, "inner", mb)
         checkedInner.stream
@@ -259,11 +261,12 @@ class EmitStreamSuite extends HailSuite {
   @Test def testES2kWayMerge() {
     def merge(k: Int) {
       val f = compile1[Int, Unit] { (mb, _) =>
-        val dummyRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+        val rootRegion = StagedRegion(new Value[Region] { def get: Code[Region] = Code._null[Region] }, allowSubregions = false)
+        val eltRegion = rootRegion.createChildRegion(mb)
         val ranges = Array.tabulate(k)(i => checkedRange(0 + i, 5 + i, s"s$i", mb, print = false))
 
         val z = Stream.kWayMerge[Int](
-           mb, ranges.map(cs => (_: StagedRegion) => cs.stream), dummyRegion,
+           mb, ranges.map(cs => (_: StagedRegion) => cs.stream), eltRegion,
            (li, lv, ri, rv) => Code.memoize(lv, "lv", rv, "rv") { (lv, rv) =>
              lv < rv || (lv.ceq(rv) && li < ri)
            })
@@ -307,7 +310,7 @@ class EmitStreamSuite extends HailSuite {
       EmitStream.emit(new Emit(ctx, fb.ecb), s, mb, region, Env.empty, None)
     }
     mb.emit {
-      val arrayt = stream.map(s => EmitStream.toArray(mb, PCanonicalArray(eltType), s.asStream, region, allowAllocations = false))
+      val arrayt = stream.map(s => EmitStream.toArray(mb, PCanonicalArray(eltType), s.asStream, region))
       Code(arrayt.setup, arrayt.m.mux(0L, arrayt.v))
     }
     val f = fb.resultWithIndex()

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3759,7 +3759,7 @@ class IRSuite extends HailSuite {
         |       (MakeStruct (locus  (Apply start Locus(GRCh37) (Ref __uid_3))))
         |       (MakeStruct (locus  (Apply end Locus(GRCh37) (Ref __uid_3)))) (True) (False))))
         |""".stripMargin)
-    val (v, _) = backend.execute(ir, optimize = true, allocStrat = EmitAllocationStrategy.ManyRegions)
+    val (v, _) = backend.execute(ir, optimize = true)
     assert(
       ir.typ.ordering.equiv(
         FastIndexedSeq(


### PR DESCRIPTION
Stacked on #9400 

This PR modifies stream consumers' emit cases to look up `separateRegions` on the child stream's type, using that to construct the appropriate `StagedRegion`, then passing that region into `emitStream`. It also removes `EmitAllocationStrategy`, as this is now encoded in the IR. We may at some point want something similar to choose what allocation behavior to generate during lowering, but that is left for future work.

Getting this to work well required some changes to the `StagedRegion` design.

First, when a stream node needs to create a fresh region which it owns, the new region is now created as a child of the `outerRegion`, not the consumer's `eltRegion` as was done before. This simplifies the semantics of the parent/child relationship: now the lifetime of a child region is always nested inside that of its parent.

The second change also has to do with the tree structure of `StagedRegion`s. Before, any `StagedRegion` could have children, which meant we could have arbitrarily deep trees of `StagedRegion`s, and also that every `StagedRegion` had to know whether children would be genuine sub-regions or just aliases of the parent.

Now, the `StagedRegion` hierarchy is split into `ParentStagedRegion` and `ChildStagedRegion`. A `ParentStagedRegion` can have children, while a `ChildStagedRegion` cannot. The main effect of this is that the `allowAllocations` bit is no longer hereditary. A `ChildStagedRegion` can be converted into a `ParentStagedRegion`, and hence another generation of children can be created, but now doing so requires explicitly specifying `allowAllocations` for the new generation. In emit, this happens at stream consumers, where the allocation strategy will be read off the PType of the stream.

The full hierarchy is now:
* `StagedRegion` - The root class is the type for passing around unowned regions. Besides writing into the region, the method `asRoot` allows converting to a `RootStagedRegion` by specifying `allowAllocations`
  * `ParentStagedRegion` - for passing around un-owned regions which allow creating child regions. Has a `allowSubregions` flag which encodes whether child regions are actually separate run-time regions.
  * `ChildStagedRegion` - un-owned regions which know their parent, allowing methods like `copyToParent` and `createSiblingRegion`
    * `OwnedStagedRegion` - owned regions are always children; adds methods like `free`, `clear`, `giveToParent`
      * The concrete classes `RealOwnedStagedRegion` and `DummyOwnedStagedRegion`. These encode whether the parent region is real or dummy. They are intended to be private to the `StagedRegion` implementation.

### Update

At first, I restricted methods like `copyTo` and `giveTo` to copy/move to either a parent or sibling region. That is easy to verify correctness, but turned out to be too restrictive. I had been assuming an invariant that the `elementRegion` of a stream is always a direct child of the `outerRegion`. But this invariant is violated by some nested stream nodes like `StreamFlatMap` and `StreamGroupBy`.

Take `StreamFlatMap`: the `outerRegion` of the inner stream should be the `eltRegion` of the outer stream, which is created and owned by the FlatMap code. But the `eltRegion` of the final flatMapped stream is passed in from the consumer, so is not a child of the inner stream's `outerRegion`.

It is also possible for the `eltRegion` to be a descendant, but not child, of the `outerRegion`.

To fix this, I had to relax the assertion on `copyTo`, `giveTo`, etc. Now the precondition is that the destination region is a subregion of the parent of the source, captured by the `<=` method: `dest <= this.parent`. Dynamically, `r1 <= r2` should mean that the lifetime of `r1` is nested inside that of `r2`. If `copyTo` actually copies, it is always correct, so consider the case where the source is a `DummyOwnedStagedRegion`, i.e. an alias of its parent. Then `copyTo` generates no code, and the "copied" data actually just points to the original data. For this to be valid for the lifetime of the destination region, we need exactly `dest <= this.parent`.

Finally, to handle the `StreamFlatMap` case, we need a way to register a subregion relationship between two regions after both have been constructed. This is implemented by the `asSubregionOf` method, which adds to a list of `otherAncestors`, which are regions other than the parent which we assume have lifetimes containing that of `this` region.

I also added an assertion to verify that for every stream emitted, `eltRegion <= outerRegion`.