### PR TITLE
Reduce serialization in writeBlockMatrices

### DIFF
--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -218,7 +218,7 @@ class ContextRDD[T: ClassTag](
   def cmapPartitionsWithContextAndIndex[U: ClassTag](f: (Int, RVDContext, (RVDContext) => Iterator[T]) => Iterator[U]): ContextRDD[U] = {
     new ContextRDD(rdd.mapPartitionsWithIndex(
       (i, part) => part.flatMap {
-        x => inCtx(consumerCtx => f(i, consumerCtx, x))
+        x => Iterator.single[RVDContext => Iterator[U]](consumerCtx => f(i, consumerCtx, x))
       }))
   }
 


### PR DESCRIPTION
Using `inCtx` in `cmapPartitionsWithContextAndIndex` was serializing the whole RDD. I'm just inlining it by specifying `Iterator.single`. 