### PR TITLE
[auth] missing ssl_mode

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -228,7 +228,8 @@ GRANT ALL ON `{name}`.* TO '{name}'@'%';
             db=self.name,
             ssl_ca='/sql-config/server-ca.pem',
             ssl_cert='/sql-config/client-cert.pem',
-            ssl_key='/sql-config/client-key.pem')
+            ssl_key='/sql-config/client-key.pem',
+            ssl_mode='VERIFY_CA')
         return create_secret_data_from_config(
             config, server_ca, client_cert, client_key)
 


### PR DESCRIPTION
SQLConfig requires an `ssl_mode`, this prevents auth from creating Developer accounts.

I already deployed this.