### PR TITLE
[annotationdb] Specify region when creating annotation database instance

### DIFF
--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -3,52 +3,52 @@
   "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4341060/",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/DANN.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/DANN.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/DANN.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/DANN.GRCh38.ht",
      "version": "GRCh38"}]},
  "CADD":
  {"description": "CADD: an algorithm designed to annotate both coding and non-coding variants.",
   "url": "http://europepmc.org/abstract/med/11384848",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/CADD.v1.4.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/CADD.v1.4.GRCh37.ht",
      "version": "1.4-GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/CADD.v1.4.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/CADD.v1.4.GRCh38.ht",
      "version": "1.4-GRCh38"}]},
  "Ensembl_homo_sapiens_reference_genome":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
      "version": "95-GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
      "version": "95-GRCh38"}]},
  "Ensembl_homo_sapiens_low_complexity_regions":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
      "version": "95-GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
      "version": "95-GRCh38"}]},
  "gencode":
  {"description": "GENCODE: aims to identify all gene features in the human genome using a combination of computational analysis, manual annotation, and experimental validation.",
   "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431492/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/gencode.v19.annotation.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/gencode.v19.annotation.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/gencode.v31.annotation.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/gencode.v31.annotation.GRCh38.ht",
      "version": "GRCh38"}]},
  "gnomad_lof_metrics":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
   "url": "https://gnomad.broadinstitute.org/",
   "key_properties": ["gene"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/gnomad_v2.1.1_lof_metrics_by_gene.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/gnomad_v2.1.1_lof_metrics_by_gene.ht",
      "version": "2.1.1"}]},
  "gnomad_exome_sites":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
@@ -73,49 +73,49 @@
   "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
   "key_properties": ["gene", "unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/gene_specific_summary_2019-07.txt.gz.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/gene_specific_summary_2019-07.txt.gz.ht",
      "version": "2019-07"}]},
  "clinvar_variant_summary":
  {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
   "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
      "version": "2019-07-GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
      "version": "2019-07-GRCh38"}]},
  "dbNSFP_variants":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp4.0a.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/dbnsfp4.0a.GRCh37.ht",
      "version": "4.0-GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp4.0a.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/dbnsfp4.0a.GRCh38.ht",
      "version": "4.0-GRCh38"}]},
  "dbNSFP_genes":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
   "key_properties": ["gene", "unique"],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
      "version": "4.0"}]},
  "gerp_scores":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
   "key_properties": ["unique"],
   "versions": [
-    {"url": "gs://hail-datasets-us/datasets/1/GERP_scores.GERP++.GRCh37.ht",
+    {"url": "gs://hail-datasets-{region}/datasets/1/GERP_scores.GERP++.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/GERP_scores.GERP++.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/GERP_scores.GERP++.GRCh38.ht",
      "version": "GRCh38"}]},
  "gerp_elements":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
   "key_properties": [],
   "versions": [
-    {"url":"gs://hail-datasets-us/datasets/1/GERP_elements.GERP++.GRCh37.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/GERP_elements.GERP++.GRCh37.ht",
      "version": "GRCh37"},
-    {"url":"gs://hail-datasets-us/datasets/1/GERP_elements.GERP++.GRCh38.ht",
+    {"url":"gs://hail-datasets-{region}/datasets/1/GERP_elements.GERP++.GRCh38.ht",
      "version": "GRCh38"}]}
 }

--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -55,18 +55,18 @@
   "url": "https://gnomad.broadinstitute.org/",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://gnomad-public/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht",
+    {"url":"gs://gnomad-public-requester-pays/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht",
      "version": "2.1.1-GRCh37"},
-    {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht",
+    {"url":"gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht",
      "version": "2.1.1-GRCh38"}]},
  "gnomad_genome_sites":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
   "url": "https://gnomad.broadinstitute.org/",
   "key_properties": ["unique"],
   "versions": [
-    {"url":"gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht",
+    {"url":"gs://gnomad-public-requester-pays/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht",
      "version": "2.1.1-GRCh37"},
-    {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht",
+    {"url":"gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht",
      "version": "2.1.1-GRCh38"}]},
  "clinvar_gene_summary":
  {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -11,9 +11,9 @@ def load_dataset(name,
     Example
     -------
 
-    >>> # Load 1000 Genomes MatrixTable with GRCh38 coordinates
-    >>> mt_1kg = hl.experimental.load_dataset(name='1000_genomes',   # doctest: +SKIP
-    ...                                       version='phase3',
+    >>> # Load 1000 Genomes autosomes MatrixTable with GRCh38 coordinates
+    >>> mt_1kg = hl.experimental.load_dataset(name='1000_Genomes_autosomes',   # doctest: +SKIP
+    ...                                       version='phase_3',
     ...                                       reference_genome='GRCh38')
 
     Parameters

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -87,13 +87,14 @@ class DB:
     This class facilitates the annotation of genetic datasets with variant
     annotations. It accepts either an HTTP(S) URL to an Annotation DB
     configuration or a python :obj:`dict` describing an Annotation DB
-    configuration.
+    configuration. User must specify the region ('us' or 'eu') in which the cluster is
+    running if connecting to the default Hail Annotation DB.
 
     Examples
     --------
     Create an annotation database connecting to the default Hail Annotation DB:
 
-    >>> db = hl.experimental.DB()
+    >>> db = hl.experimental.DB(region='us')
     >>> mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics') # doctest: +SKIP
     """
 


### PR DESCRIPTION
Updated db.py to allow user to specify region as shown below.

`db = hl.experimental.DB(region='us')`
`mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics')`

Data will be accessed from the requester pays bucket in the region specified by the user, available regions are `'us'` and `'eu'`.

Modified the following to include region parameter:
  - `DB` class 
  - `Dataset.from_name_and_json()`

Added method `DatasetVersion.insert_region()` to replace `'{region}'` in `DatasetVersion.url` instance variable with the specified region.