### PR TITLE
[hail/build.gradle] remove Hortonworks repo from build.gradle.

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -22,7 +22,6 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
-    maven { url "https://repo.hortonworks.com/content/repositories/releases/" }
     maven { url "https://repo.spring.io/plugins-release/" }
 }
 


### PR DESCRIPTION
I don't think it is used anymore.  Builds are failing because it is returning 500.

 > Unable to load Maven meta-data from https://repo.hortonworks.com/content/repositories/releases/org/scalanlp/breeze-natives_2.11/maven-metadata.xml.
    > Could not get resource 'https://repo.hortonworks.com/content/repositories/releases/org/scalanlp/breeze-natives_2.11/maven-metadata.xml'.
       > Could not GET 'https://repo.hortonworks.com/content/repositories/releases/org/scalanlp/breeze-natives_2.11/maven-metadata.xml'. Received status code 500 from server: Server Error