### PR TITLE
[query] refactor block matrix persistence to take backend context

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -92,6 +92,9 @@ class Backend(abc.ABC):
     def unpersist_matrix_table(self, mt):
         return mt
 
+    def unpersist_block_matrix(self, id):
+        pass
+
     @abc.abstractmethod
     def register_ir_function(self, name, type_parameters, argument_names, argument_types, return_type, body):
         pass

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -324,6 +324,9 @@ class SparkBackend(Py4JBackend):
     def unpersist_matrix_table(self, mt):
         return MatrixTable._from_java(self._to_java_matrix_ir(mt._mir).pyUnpersist())
 
+    def unpersist_block_matrix(self, id):
+        self._jhc.backend().unpersist(id)
+
     def blockmatrix_type(self, bmir):
         jir = self._to_java_blockmatrix_ir(bmir)
         return tblockmatrix._from_java(jir.typ())

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -2,7 +2,7 @@ from .export_type import ExportType
 from .base_ir import BaseIR, IR, TableIR, MatrixIR, BlockMatrixIR, \
     JIRVectorReference
 from .ir import MatrixWrite, MatrixMultiWrite, BlockMatrixWrite, \
-    BlockMatrixMultiWrite, UnpersistBlockMatrix, TableToValueApply, \
+    BlockMatrixMultiWrite, TableToValueApply, \
     MatrixToValueApply, BlockMatrixToValueApply, \
     Literal, LiftMeOut, Join, JavaIR, I32, I64, F32, F64, Str, FalseIR, TrueIR, \
     Void, Cast, NA, IsNA, If, Coalesce, Let, AggLet, Ref, TopLevelReference, \
@@ -207,7 +207,6 @@ __all__ = [
     'MatrixMultiWrite',
     'BlockMatrixWrite',
     'BlockMatrixMultiWrite',
-    'UnpersistBlockMatrix',
     'TableToValueApply',
     'MatrixToValueApply',
     'BlockMatrixToValueApply',

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -344,9 +344,6 @@ class BlockMatrixIR(BaseIR):
     def renderable_new_block(self, i: int) -> bool:
         return True
 
-    def unpersisted(self):
-        return self
-
 
 class JIRVectorReference(object):
     def __init__(self, jid, length, item_type):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -24,9 +24,6 @@ class BlockMatrixRead(BlockMatrixIR):
     def _compute_type(self):
         self._type = Env.backend().blockmatrix_type(self)
 
-    def unpersisted(self):
-        return self.reader.unpersisted(self)
-
 
 class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, name=str, f=IR, needs_dense=bool)

--- a/hail/python/hail/ir/blockmatrix_reader.py
+++ b/hail/python/hail/ir/blockmatrix_reader.py
@@ -14,9 +14,6 @@ class BlockMatrixReader(object):
     def __eq__(self, other):
         pass
 
-    def unpersisted(self, ir):
-        return ir
-
 
 class BlockMatrixNativeReader(BlockMatrixReader):
     @typecheck_method(path=str)
@@ -68,5 +65,5 @@ class BlockMatrixPersistReader(BlockMatrixReader):
         return isinstance(other, BlockMatrixPersistReader) and \
             self.id == other.id
 
-    def unpersisted(self, ir):
+    def unpersisted(self):
         return self.original

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2316,24 +2316,6 @@ class BlockMatrixMultiWrite(IR):
         return True
 
 
-class UnpersistBlockMatrix(IR):
-    @typecheck_method(child=BlockMatrixIR)
-    def __init__(self, child):
-        super().__init__(child)
-        self.child = child
-
-    def copy(self, child):
-        return UnpersistBlockMatrix(child)
-
-    def _compute_type(self, env, agg_env):
-        self.child._compute_type()
-        self._type = tvoid
-
-    @staticmethod
-    def is_effectful() -> bool:
-        return True
-
-
 class TableToValueApply(IR):
     def __init__(self, child, config):
         super().__init__(child)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -16,7 +16,7 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64, \
     ApplyUnaryPrimOp, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter, TableFromBlockMatrixNativeReader, TableRead, \
     BlockMatrixSlice, BlockMatrixSparsify, BlockMatrixDensify, RectangleSparsifier, \
-    RowIntervalSparsifier, BandSparsifier, PerBlockSparsifier, UnpersistBlockMatrix
+    RowIntervalSparsifier, BandSparsifier, PerBlockSparsifier
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader, BlockMatrixPersistReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter, BlockMatrixPersistWriter
 from hail.ir import ExportType
@@ -1303,8 +1303,10 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
             Unpersisted block matrix.
         """
-        Env.backend().execute(UnpersistBlockMatrix(self._bmir))
-        return BlockMatrix(self._bmir.unpersisted())
+        if isinstance(self._bmir, BlockMatrixRead) and isinstance(self._bmir.reader, BlockMatrixPersistReader):
+            Env.backend().unpersist_block_matrix(self._bmir.reader.id)
+            return self._bmir.reader.unpersisted()
+        return self
 
     def __pos__(self):
         return self

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -351,7 +351,7 @@ class BlockMatrixIRTests(unittest.TestCase):
     def test_parses(self):
         backend = Env.spark_backend('BlockMatrixIRTests.test_parses')
 
-        bmir = hl.BlockMatrix.fill(1, 1, 0.0)._bmir
+        bmir = hl.linalg.BlockMatrix.fill(1, 1, 0.0)._bmir
         backend.execute(ir.BlockMatrixWrite(bmir, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')))
         persist = ir.BlockMatrixRead(ir.BlockMatrixPersistReader('x', bmir))
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -349,8 +349,16 @@ class BlockMatrixIRTests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_parses(self):
-        for x in self.blockmatrix_irs():
-            Env.spark_backend('BlockMatrixIRTests.test_parses')._parse_blockmatrix_ir(str(x))
+        backend = Env.spark_backend('BlockMatrixIRTests.test_parses')
+
+        bmir = hl.BlockMatrix.fill(1, 1, 0.0)._bmir
+        backend.execute(ir.BlockMatrixWrite(bmir, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')))
+        persist = ir.BlockMatrixRead(ir.BlockMatrixPersistReader('x', bmir))
+
+        for x in (self.blockmatrix_irs() + [persist]):
+            backend._parse_blockmatrix_ir(str(x))
+
+        backend.execute(ir.UnpersistBlockMatrix(persist))
 
 
 class ValueTests(unittest.TestCase):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -114,7 +114,6 @@ class ValueIRTests(unittest.TestCase):
             ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake.bm', False, False, False)),
             ir.LiftMeOut(ir.I32(1)),
             ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')),
-            ir.UnpersistBlockMatrix(block_matrix_read),
         ]
 
         return value_irs
@@ -300,7 +299,6 @@ class BlockMatrixIRTests(unittest.TestCase):
         add_two_bms = ir.BlockMatrixMap2(read, read, 'l', 'r', ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')), "Union")
         negate_bm = ir.BlockMatrixMap(read, 'element', ir.ApplyUnaryPrimOp('-', ir.Ref('element')), False)
         sqrt_bm = ir.BlockMatrixMap(read, 'element', hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir, False)
-        persisted = ir.BlockMatrixRead(ir.BlockMatrixPersistReader('x', read))
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
@@ -327,7 +325,6 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         return [
             read,
-            persisted,
             add_two_bms,
             negate_bm,
             sqrt_bm,
@@ -358,7 +355,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         for x in (self.blockmatrix_irs() + [persist]):
             backend._parse_blockmatrix_ir(str(x))
 
-        backend.execute(ir.UnpersistBlockMatrix(persist))
+        backend.unpersist_block_matrix('x')
 
 
 class ValueTests(unittest.TestCase):

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -3,6 +3,8 @@ package is.hail.backend
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.{ExecuteContext, IR, SortField}
 import is.hail.expr.ir.lowering.TableStage
+import is.hail.linalg.BlockMatrix
+import is.hail.types.BlockMatrixType
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
@@ -26,6 +28,14 @@ abstract class Backend {
 
   def broadcast[T: ClassTag](value: T): BroadcastValue[T]
 
+  def persist(backendContext: BackendContext, id: String, value: BlockMatrix, storageLevel: String): Unit
+
+  def unpersist(backendContext: BackendContext, id: String): Unit
+
+  def getPersistedBlockMatrix(backendContext: BackendContext, id: String): BlockMatrix
+
+  def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType
+
   def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]])(f: (Array[Byte], Int) => Array[Byte]): Array[Array[Byte]]
 
   def stop(): Unit
@@ -35,4 +45,3 @@ abstract class Backend {
 
   def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Map[String, IR]): TableStage
 }
-

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -27,6 +27,9 @@ import scala.reflect.ClassTag
 import scala.collection.JavaConverters._
 import java.io.PrintWriter
 
+import is.hail.linalg.BlockMatrix
+import is.hail.types.BlockMatrixType
+
 class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serializable
 
 object LocalBackend {
@@ -245,4 +248,12 @@ class LocalBackend(
 
   def pyImportFam(path: String, isQuantPheno: Boolean, delimiter: String, missingValue: String): String =
     LoadPlink.importFamJSON(fs, path, isQuantPheno, delimiter, missingValue)
+
+  def persist(backendContext: BackendContext, id: String, value: BlockMatrix, storageLevel: String): Unit = ???
+
+  def unpersist(backendContext: BackendContext, id: String): Unit = ???
+
+  def getPersistedBlockMatrix(backendContext: BackendContext, id: String): BlockMatrix = ???
+
+  def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType = ???
 }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -10,7 +10,9 @@ import is.hail.expr.ir.lowering.{DArrayLowering, LowerDistributedSort, LowererUn
 import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, MakeTuple, SortField}
 import is.hail.types.physical.{PBaseStruct, PType}
 import is.hail.io.fs.{FS, GoogleStorageFS}
+import is.hail.linalg.BlockMatrix
 import is.hail.services.batch_client.BatchClient
+import is.hail.types.BlockMatrixType
 import is.hail.types.virtual.Type
 import is.hail.utils._
 import org.apache.commons.io.IOUtils
@@ -302,4 +304,12 @@ class ServiceBackend() extends Backend {
     // Use a local sort for the moment to enable larger pipelines to run
     LowerDistributedSort.localSort(ctx, stage, sortFields, relationalLetsAbove)
   }
+
+  def persist(backendContext: BackendContext, id: String, value: BlockMatrix, storageLevel: String): Unit = ???
+
+  def unpersist(backendContext: BackendContext, id: String): Unit = ???
+
+  def getPersistedBlockMatrix(backendContext: BackendContext, id: String): BlockMatrix = ???
+
+  def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType = ???
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -229,11 +229,13 @@ class SparkBackend(
 
   def persist(backendContext: BackendContext, id: String, value: BlockMatrix, storageLevel: String): Unit = bmCache.persistBlockMatrix(id, value, storageLevel)
 
-  def unpersist(backendContext: BackendContext, id: String): Unit = bmCache.unpersistBlockMatrix(id)
+  def unpersist(backendContext: BackendContext, id: String): Unit = unpersist(id)
 
   def getPersistedBlockMatrix(backendContext: BackendContext, id: String): BlockMatrix = bmCache.getPersistedBlockMatrix(id)
 
   def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType = bmCache.getPersistedBlockMatrixType(id)
+
+  def unpersist(id: String): Unit = bmCache.unpersistBlockMatrix(id)
 
   def withExecuteContext[T]()(f: ExecuteContext => T): T = {
     ExecuteContext.scoped(tmpdir, localTmpdir, this, fs)(f)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
@@ -1,17 +1,26 @@
 package is.hail.backend.spark
 
+import is.hail.backend.BlockMatrixCache
 import is.hail.linalg.BlockMatrix
+import is.hail.types.BlockMatrixType
+import is.hail.utils._
 
 import scala.collection.mutable
 
-case class SparkBlockMatrixCache() {
+case class SparkBlockMatrixCache() extends BlockMatrixCache {
   private[this] val blockmatrices: mutable.Map[String, BlockMatrix] = new mutable.HashMap()
 
   def persistBlockMatrix(id: String, value: BlockMatrix, storageLevel: String): Unit =
     blockmatrices.update(id, value.persist(storageLevel))
 
-  def getPersistedBlockMatrix(id: String): BlockMatrix = blockmatrices(id)
+  def getPersistedBlockMatrix(id: String): BlockMatrix =
+    blockmatrices.getOrElse(id,
+      fatal(s"Persisted BlockMatrix with id ${ id } does not exist."))
 
-  def unpersistBlockMatrix(id: String): Unit =
+  def getPersistedBlockMatrixType(id: String): BlockMatrixType = BlockMatrixType.fromBlockMatrix(blockmatrices(id))
+
+  def unpersistBlockMatrix(id: String): Unit = {
     blockmatrices(id).unpersist()
+    blockmatrices.remove(id)
+  }
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBlockMatrixCache.scala
@@ -1,13 +1,12 @@
 package is.hail.backend.spark
 
-import is.hail.backend.BlockMatrixCache
 import is.hail.linalg.BlockMatrix
 import is.hail.types.BlockMatrixType
 import is.hail.utils._
 
 import scala.collection.mutable
 
-case class SparkBlockMatrixCache() extends BlockMatrixCache {
+case class SparkBlockMatrixCache() {
   private[this] val blockmatrices: mutable.Map[String, BlockMatrix] = new mutable.HashMap()
 
   def persistBlockMatrix(id: String, value: BlockMatrix, storageLevel: String): Unit =
@@ -17,10 +16,11 @@ case class SparkBlockMatrixCache() extends BlockMatrixCache {
     blockmatrices.getOrElse(id,
       fatal(s"Persisted BlockMatrix with id ${ id } does not exist."))
 
-  def getPersistedBlockMatrixType(id: String): BlockMatrixType = BlockMatrixType.fromBlockMatrix(blockmatrices(id))
+  def getPersistedBlockMatrixType(id: String): BlockMatrixType =
+    BlockMatrixType.fromBlockMatrix(getPersistedBlockMatrix(id))
 
   def unpersistBlockMatrix(id: String): Unit = {
-    blockmatrices(id).unpersist()
+    getPersistedBlockMatrix(id).unpersist()
     blockmatrices.remove(id)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -200,7 +200,7 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
 case class BlockMatrixNativePersistParameters(id: String)
 
 object BlockMatrixPersistReader {
-  def fromJValue(ctx: BackendContext, jv: JValue): BlockMatrixNativeReader = {
+  def fromJValue(ctx: BackendContext, jv: JValue): BlockMatrixPersistReader = {
     implicit val formats: Formats = BlockMatrixReader.formats
     val params = jv.extract[BlockMatrixNativePersistParameters]
     BlockMatrixPersistReader(params.id, HailContext.backend.getPersistedBlockMatrixType(ctx, params.id))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -120,7 +120,7 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
 case class BlockMatrixPersistWriter(id: String, storageLevel: String) extends BlockMatrixWriter {
   def pathOpt: Option[String] = None
   def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
-    HailContext.sparkBackend("BlockMatrixPersistWriter").bmCache.persistBlockMatrix(id, bm, storageLevel)
+    HailContext.backend.persist(ctx.backendContext, id, bm, storageLevel)
 }
 
 case class BlockMatrixRectanglesWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -213,7 +213,6 @@ object Children {
     case BlockMatrixToValueApply(child, _) => Array(child)
     case BlockMatrixCollect(child) => Array(child)
     case BlockMatrixWrite(child, _) => Array(child)
-    case UnpersistBlockMatrix(child) => Array(child)
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
     case ReadPartition(path, _, _) => Array(path)

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -13,7 +13,6 @@ object InterpretableButNotCompilable {
     case _: MatrixMultiWrite => true
     case _: TableMultiWrite => true
     case _: BlockMatrixWrite => true
-    case _: UnpersistBlockMatrix => true
     case _: BlockMatrixMultiWrite => true
     case _: TableToValueApply => true
     case _: MatrixToValueApply => true
@@ -38,7 +37,6 @@ object Compilable {
       case _: TableMultiWrite => false
       case _: BlockMatrixCollect => false
       case _: BlockMatrixWrite => false
-      case _: UnpersistBlockMatrix => false
       case _: BlockMatrixMultiWrite => false
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -340,9 +340,6 @@ object Copy {
         BlockMatrixWrite(newChildren(0).asInstanceOf[BlockMatrixIR], writer)
       case BlockMatrixMultiWrite(_, writer) =>
         BlockMatrixMultiWrite(newChildren.map(_.asInstanceOf[BlockMatrixIR]), writer)
-      case UnpersistBlockMatrix(child) =>
-        assert(newChildren.length == 1)
-        UnpersistBlockMatrix(newChildren(0).asInstanceOf[BlockMatrixIR])
       case CollectDistributedArray(_, _, cname, gname, _) =>
         assert(newChildren.length == 3)
         CollectDistributedArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], cname, gname, newChildren(2).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -705,8 +705,6 @@ final case class WriteMetadata(writeAnnotations: IR, writer: MetadataWriter) ext
 final case class ReadValue(path: IR, spec: AbstractTypedCodecSpec, requestedType: Type) extends IR
 final case class WriteValue(value: IR, path: IR, spec: AbstractTypedCodecSpec) extends IR
 
-final case class UnpersistBlockMatrix(child: BlockMatrixIR) extends IR
-
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = {
     assert(self.typ == other.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -241,7 +241,6 @@ object InferType {
       case _: BlockMatrixCollect => TNDArray(TFloat64, Nat(2))
       case _: BlockMatrixWrite => TVoid
       case _: BlockMatrixMultiWrite => TVoid
-      case _: UnpersistBlockMatrix => TVoid
       case TableGetGlobals(child) => child.typ.globalType
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
       case TableToValueApply(child, function) => function.typ(child.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -827,8 +827,8 @@ object Interpret {
         writer(ctx, child.execute(ctx))
       case BlockMatrixMultiWrite(blockMatrices, writer) =>
         writer(ctx, blockMatrices.map(_.execute(ctx)))
-      case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id))) =>
-        HailContext.sparkBackend("interpret UnpersistBlockMatrix").bmCache.unpersistBlockMatrix(id)
+      case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, _))) =>
+        HailContext.backend.unpersist(ctx.backendContext, id)
       case _: UnpersistBlockMatrix =>
       case TableToValueApply(child, function) =>
         function.execute(ctx, child.execute(ctx))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -827,9 +827,6 @@ object Interpret {
         writer(ctx, child.execute(ctx))
       case BlockMatrixMultiWrite(blockMatrices, writer) =>
         writer(ctx, blockMatrices.map(_.execute(ctx)))
-      case UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(id, _))) =>
-        HailContext.backend.unpersist(ctx.backendContext, id)
-      case _: UnpersistBlockMatrix =>
       case TableToValueApply(child, function) =>
         function.execute(ctx, child.execute(ctx))
       case BlockMatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1255,8 +1255,6 @@ object IRParser {
         val writer = deserialize[BlockMatrixMultiWriter](writerStr)
         val blockMatrices = repUntil(it, blockmatrix_ir(env), PunctuationToken(")"))
         BlockMatrixMultiWrite(blockMatrices.toFastIndexedSeq, writer)
-      case "UnpersistBlockMatrix" =>
-        UnpersistBlockMatrix(blockmatrix_ir(env)(it))
       case "CollectDistributedArray" =>
         val cname = identifier(it)
         val gname = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -559,8 +559,8 @@ object Simplify {
       if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
 
     case LiftMeOut(child) if IsConstant(child) => child
-    case x@UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(_, _))) => x
-    case _: UnpersistBlockMatrix => Begin(FastIndexedSeq())
+    case UnpersistBlockMatrix(x) if !x.isInstanceOf[BlockMatrixRead] => Begin(FastIndexedSeq())
+    case UnpersistBlockMatrix(BlockMatrixRead(x)) if !x.isInstanceOf[BlockMatrixPersistReader] => Begin(FastIndexedSeq())
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -559,7 +559,7 @@ object Simplify {
       if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
 
     case LiftMeOut(child) if IsConstant(child) => child
-    case x@UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(_))) => x
+    case x@UnpersistBlockMatrix(BlockMatrixRead(BlockMatrixPersistReader(_, _))) => x
     case _: UnpersistBlockMatrix => Begin(FastIndexedSeq())
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -559,8 +559,6 @@ object Simplify {
       if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
 
     case LiftMeOut(child) if IsConstant(child) => child
-    case UnpersistBlockMatrix(x) if !x.isInstanceOf[BlockMatrixRead] => Begin(FastIndexedSeq())
-    case UnpersistBlockMatrix(BlockMatrixRead(x)) if !x.isInstanceOf[BlockMatrixPersistReader] => Begin(FastIndexedSeq())
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -409,7 +409,6 @@ object TypeCheck {
       case BlockMatrixCollect(_) =>
       case BlockMatrixWrite(_, _) =>
       case BlockMatrixMultiWrite(_, _) =>
-      case UnpersistBlockMatrix(_) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         assert(ctxs.typ.isInstanceOf[TStream])
       case x@ReadPartition(context, rowType, reader) =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -8,7 +8,7 @@ import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions._
-import is.hail.types.TableType
+import is.hail.types.{BlockMatrixType, TableType}
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.types.encoded._
@@ -3425,7 +3425,7 @@ class IRSuite extends HailSuite {
       densify,
       RelationalLetBlockMatrix("x", I32(0), read),
       slice,
-      BlockMatrixRead(BlockMatrixPersistReader("x"))
+      BlockMatrixRead(BlockMatrixPersistReader("x", BlockMatrixType.dense(TFloat64, 1, 1, 5)))
     )
 
     blockMatrixIRs.map(ir => Array(ir))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3198,7 +3198,6 @@ class IRSuite extends HailSuite {
       BlockMatrixWrite(blockMatrix, blockMatrixWriter),
       BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       BlockMatrixWrite(blockMatrix, BlockMatrixPersistWriter("x", "MEMORY_ONLY")),
-      UnpersistBlockMatrix(blockMatrix),
       CollectDistributedArray(StreamRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32)),
       ReadPartition(Str("foo"),
         TStruct("foo" -> TInt32),
@@ -3492,6 +3491,7 @@ class IRSuite extends HailSuite {
     val s = Pretty(persist, elideLiterals = false)
     val x2 = IRParser.parse_blockmatrix_ir(ctx, s)
     assert(x2 == persist)
+    backend.unpersist(ctx.backendContext, "x")
   }
 
   @Test def testCachedIR() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -24,7 +24,7 @@ import is.hail.variant.{Call2, Locus}
 import is.hail.{ExecStrategy, HailContext, HailSuite}
 import org.apache.spark.sql.Row
 import org.json4s.jackson.{JsonMethods, Serialization}
-import org.testng.annotations.{BeforeClass, DataProvider, Test}
+import org.testng.annotations.{DataProvider, Test}
 
 import scala.language.{dynamics, implicitConversions}
 


### PR DESCRIPTION
I need to use the backend context while persisting in order to support this with user separation on the service. I also moved the methods onto the general backend in preparation for implementing this on the service backend.