### PR TITLE
Don't create multiple copies of same RDD during `BlockMatrixRead`. 

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -145,7 +145,18 @@ class BlockMatrixNativeReader(
     BlockMatrixType(TFloat64, tensorShape, isRowVector, metadata.blockSize, sparsity)
   }
 
-  def apply(ctx: ExecuteContext): BlockMatrix = BlockMatrix.read(ctx.fs, params.path)
+  def apply(ctx: ExecuteContext): BlockMatrix = {
+    val key = ("BlockMatrixNativeReader.apply", params.path)
+    if (ctx.memo.contains(key)) {
+      ctx.memo(key).asInstanceOf[BlockMatrix]
+    }
+    else {
+      val bm = BlockMatrix.read(ctx.fs, params.path)
+      ctx.memo.update(key, bm)
+      bm
+    }
+
+  }
 
   override def lower(ctx: ExecuteContext): BlockMatrixStage = {
     val blockFiles = fullType.sparsity.definedBlocksColMajor.map { blocks =>

--- a/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
@@ -56,6 +56,8 @@ class ExecuteContext(
 
   private val tmpPaths = mutable.ArrayBuffer[String]()
 
+  val memo: mutable.Map[Any, Any] = new mutable.HashMap[Any, Any]()
+
   def createTmpPath(prefix: String, extension: String = null): String = {
     val path = ExecuteContext.createTmpPathNoCleanup(tmpdir, prefix, extension)
     tmpPaths += path


### PR DESCRIPTION
CHANGELOG: Drastically reduce memory usage by `tree_matmul`

`tree_matmul` reads from the same RDD many times. The RDDs created by `BlockMatrixRead` can actually be big when reading in a very large matrix, since they contain all the BlockMatrix metadata, which means a very long list of string file names. I don't want to create many different copies of this RDD when it would be better to share one copy. 