### PR TITLE
[ci] raise resources for java services tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2836,8 +2836,8 @@ steps:
    image:
      valueFrom: hail_run_image.image
    resources:
-     memory: "3.75G"
-     cpu: "1"
+     memory: "7.5G"
+     cpu: "2"
    script: |
      set -ex
      cd /io


### PR DESCRIPTION
Increase memory and cpu for test_hail_services_java to match java query tests. This contains tests of the shuffler IR, which runs the hail compiler, so it seems it should have the same resource limits as the other java query tests. #9401 is getting an out of memory error in `testShuffleIR`.