### PR TITLE
Fix `writeBlockMatrices` file already exists check

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -345,8 +345,8 @@ object BlockMatrix {
     bms.zipWithIndex.foreach { case (bm, bIdx) =>
       val uri = blockMatrixURI(bIdx)
       if (overwrite)
-        fs.delete(prefix, recursive = true)
-      else if (fs.exists(prefix))
+        fs.delete(uri, recursive = true)
+      else if (fs.exists(uri))
         fatal(s"file already exists: $uri")
 
       fs.mkDir(uri)


### PR DESCRIPTION
It should complain if `uri` already exists, not `prefix`. 