### PR TITLE
[hailtop/aiogoogle] added StorageClient

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -970,6 +970,7 @@ steps:
         valueFrom: batch_pods_ns.name
       mountPath: /gsa-key
    dependsOn:
+     - batch_pods_ns
      - hail_run_image
      - build_hail
  - kind: runImage
@@ -1010,6 +1011,7 @@ steps:
         valueFrom: batch_pods_ns.name
       mountPath: /gsa-key
    dependsOn:
+     - batch_pods_ns
      - hail_run_image
      - build_hail
  - kind: runImage
@@ -1050,6 +1052,7 @@ steps:
         valueFrom: batch_pods_ns.name
       mountPath: /gsa-key
    dependsOn:
+     - batch_pods_ns
      - hail_run_image
      - build_hail
  - kind: runImage
@@ -1090,6 +1093,7 @@ steps:
         valueFrom: batch_pods_ns.name
       mountPath: /gsa-key
    dependsOn:
+     - batch_pods_ns
      - hail_run_image
      - build_hail
  - kind: runImage
@@ -1130,6 +1134,7 @@ steps:
         valueFrom: batch_pods_ns.name
       mountPath: /gsa-key
    dependsOn:
+     - batch_pods_ns
      - hail_run_image
      - build_hail
  - kind: runImage

--- a/build.yaml
+++ b/build.yaml
@@ -950,7 +950,7 @@ steps:
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export HAIL_TEST_BUCKET=hail-test-dmk9z
-     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=0
@@ -968,7 +968,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /gsa-key
+      mountPath: /test-gsa-key
    dependsOn:
      - batch_pods_ns
      - hail_run_image
@@ -991,7 +991,7 @@ steps:
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export HAIL_TEST_BUCKET=hail-test-dmk9z
-     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=1
@@ -1009,7 +1009,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /gsa-key
+      mountPath: /test-gsa-key
    dependsOn:
      - batch_pods_ns
      - hail_run_image
@@ -1032,7 +1032,7 @@ steps:
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export HAIL_TEST_BUCKET=hail-test-dmk9z
-     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=2
@@ -1050,7 +1050,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /gsa-key
+      mountPath: /test-gsa-key
    dependsOn:
      - batch_pods_ns
      - hail_run_image
@@ -1073,7 +1073,7 @@ steps:
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export HAIL_TEST_BUCKET=hail-test-dmk9z
-     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=3
@@ -1091,7 +1091,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /gsa-key
+      mountPath: /test-gsa-key
    dependsOn:
      - batch_pods_ns
      - hail_run_image
@@ -1114,7 +1114,7 @@ steps:
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
      export HAIL_TEST_BUCKET=hail-test-dmk9z
-     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=4
@@ -1132,7 +1132,7 @@ steps:
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name
-      mountPath: /gsa-key
+      mountPath: /test-gsa-key
    dependsOn:
      - batch_pods_ns
      - hail_run_image

--- a/build.yaml
+++ b/build.yaml
@@ -949,6 +949,8 @@ steps:
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=0
@@ -962,6 +964,11 @@ steps:
        to: /io/resources.tar.gz
      - from: /data.tar.gz
        to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /gsa-key
    dependsOn:
      - hail_run_image
      - build_hail
@@ -982,6 +989,8 @@ steps:
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=1
@@ -995,6 +1004,11 @@ steps:
        to: /io/resources.tar.gz
      - from: /data.tar.gz
        to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /gsa-key
    dependsOn:
      - hail_run_image
      - build_hail
@@ -1015,6 +1029,8 @@ steps:
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=2
@@ -1028,6 +1044,11 @@ steps:
        to: /io/resources.tar.gz
      - from: /data.tar.gz
        to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /gsa-key
    dependsOn:
      - hail_run_image
      - build_hail
@@ -1048,6 +1069,8 @@ steps:
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=3
@@ -1061,6 +1084,11 @@ steps:
        to: /io/resources.tar.gz
      - from: /data.tar.gz
        to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /gsa-key
    dependsOn:
      - hail_run_image
      - build_hail
@@ -1081,6 +1109,8 @@ steps:
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
      export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
      export PYTEST_SPLITS=5
      export PYTEST_SPLIT_INDEX=4
@@ -1094,6 +1124,11 @@ steps:
        to: /io/resources.tar.gz
      - from: /data.tar.gz
        to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /gsa-key
    dependsOn:
      - hail_run_image
      - build_hail

--- a/hail/python/Makefile
+++ b/hail/python/Makefile
@@ -2,6 +2,7 @@ PYTHON := python3
 
 .PHONY: fleep
 fleep:
+	$(PYTHON) -m mypy --ignore-missing-imports hailtop/aiotools hailtop/aiogoogle
 	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiotools
 	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiogoogle
 	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop.aiotools --score=n

--- a/hail/python/Makefile
+++ b/hail/python/Makefile
@@ -1,13 +1,5 @@
 PYTHON := python3
 
-.PHONY: fleep
-fleep:
-	$(PYTHON) -m mypy --ignore-missing-imports hailtop/aiotools hailtop/aiogoogle
-	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiotools
-	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiogoogle
-	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop.aiotools --score=n
-	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop.aiogoogle --score=n
-
 .PHONY: check-hail
 check-hail:
 	$(PYTHON) -m flake8 --config ../../setup.cfg hail

--- a/hail/python/Makefile
+++ b/hail/python/Makefile
@@ -1,5 +1,12 @@
 PYTHON := python3
 
+.PHONY: fleep
+fleep:
+	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiotools
+	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop/aiogoogle
+	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop.aiotools --score=n
+	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop.aiogoogle --score=n
+
 .PHONY: check-hail
 check-hail:
 	$(PYTHON) -m flake8 --config ../../setup.cfg hail

--- a/hail/python/hailtop/aiogoogle/__init__.py
+++ b/hail/python/hailtop/aiogoogle/__init__.py
@@ -1,6 +1,6 @@
 from .auth import Credentials, ApplicationDefaultCredentials, \
     ServiceAccountCredentials, AccessToken, Session
-from .client import BigQueryClient, ContainerClient, ComputeClient, IAmClient, LoggingClient
+from .client import BigQueryClient, ContainerClient, ComputeClient, IAmClient, LoggingClient, StorageClient
 
 __all__ = [
     'Credentials',
@@ -12,5 +12,6 @@ __all__ = [
     'ContainerClient',
     'ComputeClient',
     'IAmClient',
-    'LoggingClient'
+    'LoggingClient',
+    'StorageClient'
 ]

--- a/hail/python/hailtop/aiogoogle/__init__.py
+++ b/hail/python/hailtop/aiogoogle/__init__.py
@@ -1,6 +1,7 @@
 from .auth import Credentials, ApplicationDefaultCredentials, \
     ServiceAccountCredentials, AccessToken, Session
-from .client import BigQueryClient, ContainerClient, ComputeClient, IAmClient, LoggingClient, StorageClient
+from .client import BigQueryClient, ContainerClient, ComputeClient, IAmClient, LoggingClient, \
+    InsertObjectStream, GetObjectStream, StorageClient, GoogleStorageAsyncFS
 
 __all__ = [
     'Credentials',
@@ -13,5 +14,8 @@ __all__ = [
     'ComputeClient',
     'IAmClient',
     'LoggingClient',
-    'StorageClient'
+    'InsertObjectStream',
+    'GetObjectStream',
+    'StorageClient',
+    'GoogleStorageAsyncFS'
 ]

--- a/hail/python/hailtop/aiogoogle/auth/__init__.py
+++ b/hail/python/hailtop/aiogoogle/auth/__init__.py
@@ -1,12 +1,13 @@
 from .credentials import Credentials, ApplicationDefaultCredentials, ServiceAccountCredentials
 from .access_token import AccessToken
-from .session import Session, RateLimitedSession
+from .session import BaseSession, Session, RateLimitedSession
 
 __all__ = [
     'Credentials',
     'ApplicationDefaultCredentials',
     'ServiceAccountCredentials',
     'AccessToken',
+    'BaseSession',
     'Session',
     'RateLimitedSession'
 ]

--- a/hail/python/hailtop/aiogoogle/auth/session.py
+++ b/hail/python/hailtop/aiogoogle/auth/session.py
@@ -43,6 +43,8 @@ class BaseSession(abc.ABC):
 
 
 class RateLimitedSession(BaseSession):
+    _session: Optional[BaseSession]
+
     def __init__(self, *, session: BaseSession, rate_limit: RateLimit):
         self._session = session
         self._rate_limiter = RateLimiter(rate_limit)
@@ -58,6 +60,9 @@ class RateLimitedSession(BaseSession):
 
 
 class Session(BaseSession):
+    _session: Optional[aiohttp.ClientSession]
+    _access_token: Optional[AccessToken]
+
     def __init__(self, *, credentials: Credentials = None, **kwargs):
         if credentials is None:
             credentials = Credentials.default_credentials()

--- a/hail/python/hailtop/aiogoogle/client/__init__.py
+++ b/hail/python/hailtop/aiogoogle/client/__init__.py
@@ -10,6 +10,6 @@ __all__ = [
     'ContainerClient',
     'ComputeClient',
     'IAmClient',
-    'LoggingClient'
+    'LoggingClient',
     'StorageClient'
 ]

--- a/hail/python/hailtop/aiogoogle/client/__init__.py
+++ b/hail/python/hailtop/aiogoogle/client/__init__.py
@@ -3,6 +3,7 @@ from .container_client import ContainerClient
 from .compute_client import ComputeClient
 from .iam_client import IAmClient
 from .logging_client import LoggingClient
+from .storage_client import StorageClient
 
 __all__ = [
     'BigQueryClient',
@@ -10,4 +11,5 @@ __all__ = [
     'ComputeClient',
     'IAmClient',
     'LoggingClient'
+    'StorageClient'
 ]

--- a/hail/python/hailtop/aiogoogle/client/__init__.py
+++ b/hail/python/hailtop/aiogoogle/client/__init__.py
@@ -3,7 +3,7 @@ from .container_client import ContainerClient
 from .compute_client import ComputeClient
 from .iam_client import IAmClient
 from .logging_client import LoggingClient
-from .storage_client import StorageClient
+from .storage_client import InsertObjectStream, GetObjectStream, StorageClient, GoogleStorageAsyncFS
 
 __all__ = [
     'BigQueryClient',

--- a/hail/python/hailtop/aiogoogle/client/__init__.py
+++ b/hail/python/hailtop/aiogoogle/client/__init__.py
@@ -11,5 +11,8 @@ __all__ = [
     'ComputeClient',
     'IAmClient',
     'LoggingClient',
-    'StorageClient'
+    'InsertObjectStream',
+    'GetObjectStream',
+    'StorageClient',
+    'GoogleStorageAsyncFS'
 ]

--- a/hail/python/hailtop/aiogoogle/client/base_client.py
+++ b/hail/python/hailtop/aiogoogle/client/base_client.py
@@ -1,13 +1,15 @@
 from types import TracebackType
 from typing import Any, Optional, Type, TypeVar
 from hailtop.utils import RateLimit
-from hailtop.aiogoogle.auth import Session, RateLimitedSession
+from hailtop.aiogoogle.auth import BaseSession, Session, RateLimitedSession
 
 ClientType = TypeVar('ClientType', bound='BaseClient')
 
 
 class BaseClient:
-    def __init__(self, base_url: str, *, session: Session = None,
+    _session: Optional[BaseSession]
+
+    def __init__(self, base_url: str, *, session: Optional[BaseSession] = None,
                  rate_limit: RateLimit = None, **kwargs):
         self._base_url = base_url
         if session is None:

--- a/hail/python/hailtop/aiogoogle/client/compute_client.py
+++ b/hail/python/hailtop/aiogoogle/client/compute_client.py
@@ -1,9 +1,9 @@
-from typing import Mapping, Any
+from typing import Mapping, Any, Optional
 from .base_client import BaseClient
 
 
 class PagedIterator:
-    def __init__(self, client: 'ComputeClient', path: str, request_params: Mapping[str, Any], request_kwargs: Mapping[str, Any]):
+    def __init__(self, client: 'ComputeClient', path: str, request_params: Optional[Mapping[str, Any]], request_kwargs: Mapping[str, Any]):
         assert 'params' not in request_kwargs
         self._client = client
         self._path = path

--- a/hail/python/hailtop/aiogoogle/client/compute_client.py
+++ b/hail/python/hailtop/aiogoogle/client/compute_client.py
@@ -48,5 +48,5 @@ class ComputeClient(BaseClient):
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/get
     # https://cloud.google.com/compute/docs/reference/rest/v1/instances/delete
 
-    async def list(self, path: str, *, params: Mapping[str, Any] = None, **kwargs) -> Any:
+    async def list(self, path: str, *, params: Mapping[str, Any] = None, **kwargs) -> PagedIterator:
         return PagedIterator(self, path, params, kwargs)

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -1,0 +1,134 @@
+import abc
+import asyncio
+import aiohttp
+from hailtop.aiotools import AsyncStream
+from .base_client import BaseClient
+
+
+class InsertObjectStream(AsyncStream):
+    def __init__(self, it, request_task):
+        super().__init__()
+        self._it = it
+        self._request_task = request_task
+        self._value = None
+
+    def writable(self):
+        return True
+
+    async def write(self, b):
+        assert not self.closed
+        await self._it.feed(b)
+
+    async def _wait_closed(self):
+        await self._it.stop()
+        async with await self._request_task as resp:
+            self._value = await resp.json()
+
+
+class GetObjectStream(AsyncStream):
+    def __init__(self, resp):
+        super().__init__()
+        self._resp = resp
+        self._content = resp.content
+
+    def readable(self) -> bool:
+        return True
+
+    async def read(self, n: int =-1) -> bytes:
+        assert not self._closed
+        return await self._content.read(n)
+
+    async def _wait_closed(self) -> None:
+        self._content = None
+        self._resp.release()
+        self._resp = None
+
+
+class StorageClient(BaseClient):
+    def __init__(self, **kwargs):
+        super().__init__('https://storage.googleapis.com/storage/v1', **kwargs)
+
+    # docs:
+    # https://cloud.google.com/storage/docs/json_api/v1
+
+    async def insert_object(self, bucket: str, name: str, **kwargs) -> InsertObjectStream:
+        if 'params' in kwargs:
+            params = kwargs['params']
+        else:
+            params = {}
+            kwargs['params'] = params
+        assert 'name' not in params
+        params['name'] = name
+        assert 'uploadType' not in params
+        params['uploadType'] = 'media'
+
+        assert 'data' not in kwargs
+        it = FeedableAsyncIterable()
+        kwargs['data'] = aiohttp.AsyncIterablePayload(it)
+        request_task = asyncio.create_task(self._session.post(
+            f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
+            **kwargs))
+        return InsertObjectStream(it, request_task)
+
+    async def get_object(self, bucket: str, name: str, **kwargs) -> GetObjectStream:
+        if 'params' in kwargs:
+            params = kwargs['params']
+        else:
+            params = {}
+            kwargs['params'] = params
+        assert 'alt' not in params
+        params['alt'] = 'media'
+
+        resp = await self._session.get(f'https://storage.googleapis.com/storage/v1/b/{bucket}/o/{name}', **kwargs)
+        return GetObjectStream(resp)
+
+    async def get_object_metadata(self, bucket: str, name: str, **kwargs):
+        params = kwargs.get('params')
+        assert not params or 'alt' not in params
+        return await self.get('/b/{bucket}/o/{name}', **kwargs)
+
+
+class GoogleStorageAsyncFS(AsyncFS):
+    def __init__(self, storage_client: StorageClient = None):
+        if not storage_client:
+            storage_client = StorageClient()
+        self._storage_client = storage_client
+
+    def schemes(self) -> List[str]:
+        return ['gs']
+
+    async def open(self, url: str, mode: str = 'r') -> AsyncStream:
+        if not all(c in 'rwxabt+' for c in mode):
+            raise ValueError(f"invalid mode: {mode}")
+        if 't' in mode and 'b' in mode:
+            raise ValueError(f"can't have text and binary mode at once: {mode}")
+        if 'b' not in mode:
+            raise ValueError(f"text mode not supported: {mode}")
+        if 'x' in mode:
+            raise ValueError(f"exclusive creation not supported: {mode}")
+        if 'a' in mode:
+            raise ValueError(f"append mode not supported: {mode}")
+        if '+' in mode:
+            raise ValueError(f"updating not supported: {mode}")
+        if ('r' in mode) + ('w' in mode) != 1:
+            raise ValueError(f"must have exactly one of read/write mode: {mode}")
+
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != 'gs':
+            raise ValueError(f"invalid scheme, expected gs: {scheme}")
+        bucket = parsed.netloc
+
+        name = parsed.path
+        if name:
+            assert name[0] == '/'
+            name = name[1:]
+
+        if 'r' in mode:
+            return self._storage_client.get_object(bucket, name)
+        else:
+            assert 'w' in mode
+            return self._storage_client.insert_object(bucket, name)
+
+    async def close(self):
+        await self._storage_client.close()
+        self._storage_client = None

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -154,7 +154,6 @@ class GoogleStorageAsyncFS(AsyncFS):
     async def isfile(self, url: str) -> bool:
         try:
             bucket, name = self._get_bucket_name(url)
-            assert not name.endswith('/')
             await self._storage_client.get_object_metadata(bucket, name)
             return True
         except aiohttp.ClientResponseError as e:

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -149,9 +149,12 @@ class GoogleStorageAsyncFS(AsyncFS):
             'prefix': name
         }
         data = await self._storage_client._list_objects(bucket, params=params)
-        assert 'prefixes' not in data or data['prefixes'] is None
+        prefixes = data.get('prefixes')
+        n_prefixes = len(prefixes) if prefixes is not None else 0
         items = data.get('items')
-        return items is not None and len(items) > 0
+        n_items = len(items) if items is not None else 0
+        n = n_prefixes + n_items
+        return n > 0
 
     async def remove(self, url: str) -> None:
         bucket, name = self._get_bucket_name(url)

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -3,7 +3,7 @@ import asyncio
 import urllib.parse
 import aiohttp
 from hailtop.aiotools import AsyncStream, AsyncFS, FeedableAsyncIterable
-from multidict import CIMultiDictProxy
+from multidict import CIMultiDictProxy  # pylint: disable=unused-import
 from .base_client import BaseClient
 
 

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -68,7 +68,7 @@ class StorageClient(BaseClient):
         assert 'data' not in kwargs
         it: FeedableAsyncIterable[bytes] = FeedableAsyncIterable()
         kwargs['data'] = aiohttp.AsyncIterablePayload(it)
-        request_task = asyncio.create_task(self._session.post(
+        request_task = asyncio.ensure_future(self._session.post(
             f'https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o',
             **kwargs))
         return InsertObjectStream(it, request_task)

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -3,6 +3,7 @@ import asyncio
 import urllib.parse
 import aiohttp
 from hailtop.aiotools import AsyncStream, AsyncFS, FeedableAsyncIterable
+from multidict import CIMultiDictProxy
 from .base_client import BaseClient
 
 
@@ -40,6 +41,9 @@ class GetObjectStream(AsyncStream):
     async def read(self, n: int = -1) -> bytes:
         assert not self._closed
         return await self._content.read(n)
+
+    def headers(self) -> 'CIMultiDictProxy[str]':
+        return self._resp.headers
 
     async def _wait_closed(self) -> None:
         self._content = None
@@ -82,7 +86,6 @@ class StorageClient(BaseClient):
         assert 'alt' not in params
         params['alt'] = 'media'
 
-        print(f'making request for {name}')
         resp = await self._session.get(
             f'https://storage.googleapis.com/storage/v1/b/{bucket}/o/{urllib.parse.quote(name, safe="")}', **kwargs)
         return GetObjectStream(resp)

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -1,10 +1,12 @@
-from .stream import AsyncStream, blocking_stream_to_async
+from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 from .fs import AsyncFS, LocalAsyncFS, RouterAsyncFS
 from .utils import FeedableAsyncIterable
 
 __all__ = [
-    'AsyncStream',
-    'blocking_stream_to_async',
+    'ReadableStream',
+    'WritableStream',
+    'blocking_readable_stream_to_async',
+    'blocking_writable_stream_to_async',
     'AsyncFS',
     'LocalAsyncFS',
     'RouterAsyncFS',

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -1,0 +1,10 @@
+from .stream import AsyncStream
+from .fs import AsyncFS, LocalAsyncFS, AsyncRouterFS
+from .utils import FeedableAsyncIterable, blocking_stream_to_async
+
+__all__ = [
+    'AsyncStream',
+    'AsyncFS',
+    'FeedableAsyncIterable',
+    'blocking_stream_to_async'
+]

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -1,10 +1,12 @@
-from .stream import AsyncStream
-from .fs import AsyncFS, LocalAsyncFS, AsyncRouterFS
-from .utils import FeedableAsyncIterable, blocking_stream_to_async
+from .stream import AsyncStream, blocking_stream_to_async
+from .fs import AsyncFS, LocalAsyncFS, RouterAsyncFS
+from .utils import FeedableAsyncIterable
 
 __all__ = [
     'AsyncStream',
+    'blocking_stream_to_async',
     'AsyncFS',
-    'FeedableAsyncIterable',
-    'blocking_stream_to_async'
+    'LocalAsyncFS',
+    'RouterAsyncFS',
+    'FeedableAsyncIterable'
 ]

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -10,7 +10,7 @@ AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')
 
 class AsyncFS(abc.ABC):
     @abc.abstractmethod
-    async def schemes(self) -> List[str]:
+    def schemes(self) -> List[str]:
         pass
 
     @abc.abstractmethod
@@ -36,7 +36,7 @@ class LocalAsyncFS(AsyncFS):
             thread_pool = ThreadPoolExecutor(max_workers=max_workers)
         self._thread_pool = thread_pool
 
-    async def schemes(self) -> List[str]:
+    def schemes(self) -> List[str]:
         return ['file']
 
     async def open(self, url: str, mode: str = 'r') -> AsyncStream:
@@ -58,7 +58,7 @@ class RouterAsyncFS(AsyncFS):
         }
         self._schemes = list(self._filesystems)
 
-    async def schemes(self):
+    def schemes(self):
         return self._schemes
 
     async def open(self, url: str, mode: str = 'r') -> AsyncStream:

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -1,0 +1,68 @@
+import abc
+from .stream import AsyncStream
+
+AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')
+
+
+class AsyncFS(abc.ABC):
+    @abc.abstractmethod
+    @property
+    async def schemes(self) -> List[str]:
+        pass
+
+    @abc.abstractmethod
+    async def open(self, url: str, mode: str = 'r') -> AsyncStream:
+        pass
+
+    async def close(self):
+        pass
+
+    async def __aenter__(self: AsyncFSType) -> AsyncFSType:
+        return self
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> None:
+        await self.close()
+
+class LocalAsyncFS(AsyncFS):
+    def __init__(self, thread_pool):
+        self._thread_pool = _thread_pool
+
+    @property
+    async def schemes(self) -> List[str]:
+        return ['file']
+
+    async def open(self, url: str, mode: str = 'r') -> AsyncStream:
+        if 'b' not in mode:
+            raise ValueError(f"can't open: text mode not supported: {mode}")
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme and parsed.scheme != 'file':
+            raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")
+        blocking_stream_to_async(open(parsed.path, mode))
+
+
+class AsyncRootFS(AsyncFS):
+    def __init__(self, default_scheme : Optional[str], filesystems: List[AsyncFS]):
+        self._default_scheme = default_scheme
+        self._filesystems = {
+            scheme: fs
+            for fs in filesystems
+            for scheme in fs.schemes
+        }
+
+    async def open(url: str, mode: str = 'r') -> AsyncStream:
+        parsed = urllib.parse.urlparse(url)
+        if not url.scheme:
+            if self._default_scheme:
+                parsed = parsed._replace(scheme = default_scheme)
+                url = urllib.parse.urlunparse(parsed)
+            else:
+                raise ValueError(f"can't open: no default scheme and URL has no scheme: {url}")
+
+        fs = self._filesystems.get(parsed.scheme)
+        if fs is None:
+            raise ValueError(f"can't open: unknown scheme: {parsed.scheme}")
+
+        return await fs.open(url, mode)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -1,8 +1,12 @@
-from typing import TypeVar, Optional, List, Type, BinaryIO, cast
+from typing import TypeVar, Optional, List, Type, BinaryIO, cast, Set
 from types import TracebackType
 import abc
+import os
+import os.path
+import shutil
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
+from hailtop.utils import blocking_to_async
 from .stream import AsyncStream, blocking_stream_to_async
 
 AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')
@@ -10,14 +14,38 @@ AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')
 
 class AsyncFS(abc.ABC):
     @abc.abstractmethod
-    def schemes(self) -> List[str]:
+    def schemes(self) -> Set[str]:
         pass
 
     @abc.abstractmethod
     async def open(self, url: str, mode: str = 'r') -> AsyncStream:
         pass
 
-    async def close(self):
+    @abc.abstractmethod
+    async def mkdir(self, url: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def isfile(self, url: str) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def isdir(self, url: str) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def remove(self, url: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def rmtree(self, url: str) -> None:
+        pass
+
+    async def touch(self, url: str) -> None:
+        async with await self.open(url, 'wb') as f:
+            pass
+
+    async def close(self) -> None:
         pass
 
     async def __aenter__(self: AsyncFSType) -> AsyncFSType:
@@ -37,41 +65,99 @@ class LocalAsyncFS(AsyncFS):
         self._thread_pool = thread_pool
 
     def schemes(self) -> List[str]:
-        return ['file']
+        return {'file'}
+
+    def _get_path(self, url):
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme and parsed.scheme != 'file':
+            raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")
+        return parsed.path
 
     async def open(self, url: str, mode: str = 'r') -> AsyncStream:
         if 'b' not in mode:
             raise ValueError(f"can't open: text mode not supported: {mode}")
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme and parsed.scheme != 'file':
-            raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")
-        return blocking_stream_to_async(self._thread_pool, cast(BinaryIO, open(parsed.path, mode)))
+        return blocking_stream_to_async(self._thread_pool, cast(BinaryIO, open(self._get_path(url), mode)))
+
+    async def mkdir(self, url: str) -> None:
+        path = self._get_path(url)
+        os.mkdir(path)
+
+    async def isfile(self, url: str) -> bool:
+        path = self._get_path(url)
+        return await blocking_to_async(self._thread_pool, os.path.isfile, path)
+
+    async def isdir(self, url: str) -> bool:
+        path = self._get_path(url)
+        return await blocking_to_async(self._thread_pool, os.path.isdir, path)
+
+    async def remove(self, url: str) -> None:
+        path = self._get_path(url)
+        return os.remove(path)
+
+    async def rmtree(self, url: str) -> None:
+        path = self._get_path(url)
+        await blocking_to_async(self._thread_pool, shutil.rmtree, path)
 
 
 class RouterAsyncFS(AsyncFS):
     def __init__(self, default_scheme: Optional[str], filesystems: List[AsyncFS]):
-        self._default_scheme = default_scheme
-        self._filesystems = {
-            scheme: fs
-            for fs in filesystems
-            for scheme in fs.schemes()
-        }
-        self._schemes = list(self._filesystems)
+        scheme_fs = {}
+        schemes = set()
+        for fs in filesystems:
+            for scheme in fs.schemes():
+                scheme_fs[scheme] = fs
+                schemes.add(scheme)
 
-    def schemes(self):
+        if default_scheme not in schemes:
+            raise ValueError(f'default scheme {default_scheme} not in set of schemes: {", ".join(schemes)}')
+
+        self._default_scheme = default_scheme
+        self._filesystems = filesystems
+        self._schemes = schemes
+        self._scheme_fs = scheme_fs
+
+    def schemes(self) -> Set[str]:
         return self._schemes
 
-    async def open(self, url: str, mode: str = 'r') -> AsyncStream:
+    def _get_fs(self, url):
         parsed = urllib.parse.urlparse(url)
         if not parsed.scheme:
             if self._default_scheme:
                 parsed = parsed._replace(scheme=self._default_scheme)
                 url = urllib.parse.urlunparse(parsed)
             else:
-                raise ValueError(f"can't open: no default scheme and URL has no scheme: {url}")
+                raise ValueError(f"no default scheme and URL has no scheme: {url}")
 
-        fs = self._filesystems.get(parsed.scheme)
+        fs = self._scheme_fs.get(parsed.scheme)
         if fs is None:
-            raise ValueError(f"can't open: unknown scheme: {parsed.scheme}")
+            raise ValueError(f"unknown scheme: {parsed.scheme}")
 
+        return fs
+
+    async def open(self, url: str, mode: str = 'r') -> AsyncStream:
+        fs = self._get_fs(url)
         return await fs.open(url, mode)
+
+    async def mkdir(self, url: str) -> None:
+        fs = self._get_fs(url)
+        return await fs.mkdir(url)
+
+    async def isfile(self, url: str) -> bool:
+        fs = self._get_fs(url)
+        return await fs.isfile(url)
+
+    async def isdir(self, url: str) -> bool:
+        fs = self._get_fs(url)
+        return await fs.isdir(url)
+
+    async def remove(self, url: str) -> None:
+        fs = self._get_fs(url)
+        return await fs.remove(url)
+
+    async def rmtree(self, url: str) -> None:
+        fs = self._get_fs(url)
+        return await fs.rmtree(url)
+
+    async def close(self) -> None:
+        for fs in self._filesystems:
+            await fs.close()

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -42,7 +42,7 @@ class AsyncFS(abc.ABC):
         pass
 
     async def touch(self, url: str) -> None:
-        async with await self.open(url, 'wb') as f:
+        async with await self.open(url, 'wb'):
             pass
 
     async def close(self) -> None:
@@ -64,10 +64,11 @@ class LocalAsyncFS(AsyncFS):
             thread_pool = ThreadPoolExecutor(max_workers=max_workers)
         self._thread_pool = thread_pool
 
-    def schemes(self) -> List[str]:
+    def schemes(self) -> Set[str]:
         return {'file'}
 
-    def _get_path(self, url):
+    @staticmethod
+    def _get_path(url):
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme and parsed.scheme != 'file':
             raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Optional, List, Type
+from typing import TypeVar, Optional, List, Type, BinaryIO, cast
 from types import TracebackType
 import abc
 from concurrent.futures import ThreadPoolExecutor
@@ -45,7 +45,7 @@ class LocalAsyncFS(AsyncFS):
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme and parsed.scheme != 'file':
             raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")
-        blocking_stream_to_async(self._thread_pool, open(parsed.path, mode))
+        return blocking_stream_to_async(self._thread_pool, cast(BinaryIO, open(parsed.path, mode)))
 
 
 class RouterAsyncFS(AsyncFS):
@@ -63,7 +63,7 @@ class RouterAsyncFS(AsyncFS):
 
     async def open(self, url: str, mode: str = 'r') -> AsyncStream:
         parsed = urllib.parse.urlparse(url)
-        if not url.scheme:
+        if not parsed.scheme:
             if self._default_scheme:
                 parsed = parsed._replace(scheme=self._default_scheme)
                 url = urllib.parse.urlunparse(parsed)

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -1,0 +1,47 @@
+import abc
+
+
+class AsyncStream(abc.ABC):
+    def __init__(self):
+        self._closed = False
+        self._waited_closed = False
+
+    def readable(self) -> bool:
+        return False
+
+    async def read(self, n: int = -1) -> bytes:
+        raise NotImplementedError
+
+    def writable(self) -> bool:
+        return False
+
+    async def write(self, b: bytes) -> None:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        self._closed = True
+
+    @abc.abstractmethod
+    async def _wait_closed(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        self._closed = True
+        if not self._waited_closed:
+            try:
+                await self._wait_closed()
+            finally:
+                self._waited_closed = True
+
+    @property
+    def closed(self) -> None:
+        return self._closed
+
+    async def __aenter__(self) -> 'AsyncStream[_T]':
+        return self
+
+    async def __aexit__(
+            self, exc_type: Optional[Type[BaseException]] = None,
+            exc_value: Optional[BaseException] = None,
+            exc_traceback: Optional[TracebackType] = None) -> None:
+        await self.wait_closed()

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -1,14 +1,12 @@
-from typing import Optional, Type, Generic, TypeVar, BinaryIO
+from typing import Optional, Type, BinaryIO
 from types import TracebackType
 import abc
 import io
 from concurrent.futures import ThreadPoolExecutor
 from hailtop.utils import blocking_to_async
 
-T = TypeVar('T')
 
-
-class AsyncStream(abc.ABC, Generic[T]):
+class AsyncStream(abc.ABC):
     def __init__(self):
         self._closed = False
         self._waited_closed = False
@@ -44,7 +42,7 @@ class AsyncStream(abc.ABC, Generic[T]):
     def closed(self) -> None:
         return self._closed
 
-    async def __aenter__(self) -> 'AsyncStream[T]':
+    async def __aenter__(self) -> 'AsyncStream':
         return self
 
     async def __aexit__(

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -1,7 +1,6 @@
 from typing import Optional, Type, BinaryIO
 from types import TracebackType
 import abc
-import io
 from concurrent.futures import ThreadPoolExecutor
 from hailtop.utils import blocking_to_async
 
@@ -55,7 +54,7 @@ class AsyncStream(abc.ABC):
 class _AsyncStreamFromBlocking(AsyncStream):
     _thread_pool: ThreadPoolExecutor
     _f: Optional[BinaryIO]
-    
+
     def __init__(self, thread_pool: ThreadPoolExecutor, f: BinaryIO):
         super().__init__()
         self._thread_pool = thread_pool

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -1,4 +1,9 @@
+from typing import Optional, Type
+from types import TracebackType
 import abc
+import io
+from concurrent.futures import ThreadPoolExecutor
+from hailtop.utils import blocking_to_async
 
 
 class AsyncStream(abc.ABC):
@@ -6,13 +11,13 @@ class AsyncStream(abc.ABC):
         self._closed = False
         self._waited_closed = False
 
-    def readable(self) -> bool:
+    def readable(self) -> bool:  # pylint: disable=no-self-use
         return False
 
     async def read(self, n: int = -1) -> bytes:
         raise NotImplementedError
 
-    def writable(self) -> bool:
+    def writable(self) -> bool:  # pylint: disable=no-self-use
         return False
 
     async def write(self, b: bytes) -> None:
@@ -37,7 +42,7 @@ class AsyncStream(abc.ABC):
     def closed(self) -> None:
         return self._closed
 
-    async def __aenter__(self) -> 'AsyncStream[_T]':
+    async def __aenter__(self) -> 'AsyncStream[bytes]':
         return self
 
     async def __aexit__(
@@ -45,3 +50,37 @@ class AsyncStream(abc.ABC):
             exc_value: Optional[BaseException] = None,
             exc_traceback: Optional[TracebackType] = None) -> None:
         await self.wait_closed()
+
+
+class _AsyncStreamFromBlocking(AsyncStream):
+    def __init__(self, thread_pool: ThreadPoolExecutor, f: io.RawIOBase):
+        super().__init__()
+        self._thread_pool = thread_pool
+        self._f = f
+
+    @property
+    def readable(self) -> bool:
+        return self._f.readable()
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self.readable():
+            raise NotImplementedError
+        assert not self.closed
+        return await blocking_to_async(self._thread_pool, self._f.read, n)
+
+    def writable(self) -> bool:
+        return self._f.writable()
+
+    async def write(self, b: bytes) -> int:
+        if not self.writable():
+            raise NotImplementedError
+        assert not self.closed
+        return await blocking_to_async(self._thread_pool, self._f.write, b)
+
+    async def _wait_closed(self) -> None:
+        await blocking_to_async(self._thread_pool, self._f.close)
+        self._f = None
+
+
+def blocking_stream_to_async(thread_pool: ThreadPoolExecutor, f: io.RawIOBase) -> _AsyncStreamFromBlocking:
+    return _AsyncStreamFromBlocking(thread_pool, f)

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -58,7 +58,6 @@ class _AsyncStreamFromBlocking(AsyncStream):
         self._thread_pool = thread_pool
         self._f = f
 
-    @property
     def readable(self) -> bool:
         return self._f.readable()
 

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -5,16 +5,47 @@ from concurrent.futures import ThreadPoolExecutor
 from hailtop.utils import blocking_to_async
 
 
-class AsyncStream(abc.ABC):
+class ReadableStream(abc.ABC):
     def __init__(self):
         self._closed = False
         self._waited_closed = False
 
-    def readable(self) -> bool:  # pylint: disable=no-self-use
-        return False
-
     async def read(self, n: int = -1) -> bytes:
         raise NotImplementedError
+
+    def close(self) -> None:
+        self._closed = True
+
+    @abc.abstractmethod
+    async def _wait_closed(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        self._closed = True
+        if not self._waited_closed:
+            try:
+                await self._wait_closed()
+            finally:
+                self._waited_closed = True
+
+    @property
+    def closed(self) -> None:
+        return self._closed
+
+    async def __aenter__(self) -> 'ReadableStream':
+        return self
+
+    async def __aexit__(
+            self, exc_type: Optional[Type[BaseException]] = None,
+            exc_value: Optional[BaseException] = None,
+            exc_traceback: Optional[TracebackType] = None) -> None:
+        await self.wait_closed()
+
+
+class WritableStream(abc.ABC):
+    def __init__(self):
+        self._closed = False
+        self._waited_closed = False
 
     def writable(self) -> bool:  # pylint: disable=no-self-use
         return False
@@ -41,7 +72,7 @@ class AsyncStream(abc.ABC):
     def closed(self) -> None:
         return self._closed
 
-    async def __aenter__(self) -> 'AsyncStream':
+    async def __aenter__(self) -> 'WritableStream':
         return self
 
     async def __aexit__(
@@ -51,7 +82,7 @@ class AsyncStream(abc.ABC):
         await self.wait_closed()
 
 
-class _AsyncStreamFromBlocking(AsyncStream):
+class _ReadableStreamFromBlocking(ReadableStream):
     _thread_pool: ThreadPoolExecutor
     _f: Optional[BinaryIO]
 
@@ -60,20 +91,27 @@ class _AsyncStreamFromBlocking(AsyncStream):
         self._thread_pool = thread_pool
         self._f = f
 
-    def readable(self) -> bool:
-        return self._f.readable()
-
     async def read(self, n: int = -1) -> bytes:
-        if not self.readable():
-            raise NotImplementedError
         return await blocking_to_async(self._thread_pool, self._f.read, n)
+
+    async def _wait_closed(self) -> None:
+        await blocking_to_async(self._thread_pool, self._f.close)
+        self._f = None
+
+
+class _WritableStreamFromBlocking(WritableStream):
+    _thread_pool: ThreadPoolExecutor
+    _f: Optional[BinaryIO]
+
+    def __init__(self, thread_pool: ThreadPoolExecutor, f: BinaryIO):
+        super().__init__()
+        self._thread_pool = thread_pool
+        self._f = f
 
     def writable(self) -> bool:
         return self._f.writable()
 
     async def write(self, b: bytes) -> int:
-        if not self.writable():
-            raise NotImplementedError
         return await blocking_to_async(self._thread_pool, self._f.write, b)
 
     async def _wait_closed(self) -> None:
@@ -81,5 +119,9 @@ class _AsyncStreamFromBlocking(AsyncStream):
         self._f = None
 
 
-def blocking_stream_to_async(thread_pool: ThreadPoolExecutor, f: BinaryIO) -> _AsyncStreamFromBlocking:
-    return _AsyncStreamFromBlocking(thread_pool, f)
+def blocking_readable_stream_to_async(thread_pool: ThreadPoolExecutor, f: BinaryIO) -> _ReadableStreamFromBlocking:
+    return _ReadableStreamFromBlocking(thread_pool, f)
+
+
+def blocking_writable_stream_to_async(thread_pool: ThreadPoolExecutor, f: BinaryIO) -> _WritableStreamFromBlocking:
+    return _WritableStreamFromBlocking(thread_pool, f)

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -1,0 +1,65 @@
+from typing import TypeVar, AsyncIterator
+import io
+import asyncio
+
+
+_T = TypeVar('_T')
+
+
+class _StopFeedableAsyncIterator:
+    pass
+
+
+class FeedableAsyncIterable(AsyncIterator[_T]):
+    def __init__(self, maxsize: int = 1):
+        self._queue = asyncio.Queue(maxsize=maxsize)
+        self._stopped = False
+
+    def __aiter__(self) -> 'FeedableAsyncIterable[_T]':
+        return self
+
+    async def __anext__(self) -> _T:
+        next = await self._queue.get()
+        if isinstance(next, _StopFeedableAsyncIterator):
+            raise StopAsyncIteration
+        return next
+
+    async def feed(self, next: _T) -> None:
+        assert not self._stopped
+        await self._queue.put(next)
+
+    async def stop(self) -> None:
+        await self._queue.put(_StopFeedableAsyncIterator())
+        self._stopped = True
+
+
+class _AsyncStreamFromBlocking(AsyncStream):
+    def __init__(self, f: io.RawIOBase):
+        self._f = f
+
+    @property
+    def readable(self) -> bool:
+        return self._f.readable()
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self.readable():
+            raise NotImplementedError
+        assert not self.closed
+        return self._f.read(n)
+
+    def writable(self) -> bool:
+        return self._f.writable()
+
+    async def write(self, b: bytes) -> None:
+        if not self.writable():
+            raise NotImplementedError
+        assert not self.closed
+        return self._f.write(b)
+
+    async def _wait_closed(self) -> None:
+        self._f.close()
+        self._f = None
+
+
+def blocking_stream_to_async(f: io.RawIOBase) -> _AsyncStreamFromBlocking:
+    return _AsyncStreamFromBlocking(f)

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, AsyncIterator, Union
+from typing import TypeVar, AsyncIterator
 import asyncio
 
 _T = TypeVar('_T')
@@ -10,7 +10,7 @@ class _StopFeedableAsyncIterator:
 
 class FeedableAsyncIterable(AsyncIterator[_T]):
     def __init__(self, maxsize: int = 1):
-        self._queue: asyncio.Queue[Union[_StopFeedableAsyncIterator, _T]] = asyncio.Queue(maxsize=maxsize)
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
         self._stopped = False
 
     def __aiter__(self) -> 'FeedableAsyncIterable[_T]':

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -1,7 +1,5 @@
 from typing import TypeVar, AsyncIterator
-import io
 import asyncio
-
 
 _T = TypeVar('_T')
 
@@ -31,35 +29,3 @@ class FeedableAsyncIterable(AsyncIterator[_T]):
     async def stop(self) -> None:
         await self._queue.put(_StopFeedableAsyncIterator())
         self._stopped = True
-
-
-class _AsyncStreamFromBlocking(AsyncStream):
-    def __init__(self, f: io.RawIOBase):
-        self._f = f
-
-    @property
-    def readable(self) -> bool:
-        return self._f.readable()
-
-    async def read(self, n: int = -1) -> bytes:
-        if not self.readable():
-            raise NotImplementedError
-        assert not self.closed
-        return self._f.read(n)
-
-    def writable(self) -> bool:
-        return self._f.writable()
-
-    async def write(self, b: bytes) -> None:
-        if not self.writable():
-            raise NotImplementedError
-        assert not self.closed
-        return self._f.write(b)
-
-    async def _wait_closed(self) -> None:
-        self._f.close()
-        self._f = None
-
-
-def blocking_stream_to_async(f: io.RawIOBase) -> _AsyncStreamFromBlocking:
-    return _AsyncStreamFromBlocking(f)

--- a/hail/python/hailtop/aiotools/utils.py
+++ b/hail/python/hailtop/aiotools/utils.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, AsyncIterator
+from typing import TypeVar, AsyncIterator, Union
 import asyncio
 
 _T = TypeVar('_T')
@@ -10,7 +10,7 @@ class _StopFeedableAsyncIterator:
 
 class FeedableAsyncIterable(AsyncIterator[_T]):
     def __init__(self, maxsize: int = 1):
-        self._queue = asyncio.Queue(maxsize=maxsize)
+        self._queue: asyncio.Queue[Union[_StopFeedableAsyncIterator, _T]] = asyncio.Queue(maxsize=maxsize)
         self._stopped = False
 
     def __aiter__(self) -> 'FeedableAsyncIterable[_T]':

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -507,16 +507,16 @@ class BatchPoolFuture:
             await asyncio.wait_for(self.fetch_lock.acquire(), timeout=timeout)
             if timeout:
                 timeout -= time.time() - before
-        except asyncio.TimeoutError:
-            raise concurrent.futures.TimeoutError()
+        except asyncio.TimeoutError as e:
+            raise concurrent.futures.TimeoutError() from e
         try:
             if self.value != NO_VALUE:
                 return
             try:
                 await asyncio.wait_for(self.batch._async_batch.wait(disable_progress_bar=True),
                                        timeout=timeout)
-            except asyncio.TimeoutError:
-                raise concurrent.futures.TimeoutError()
+            except asyncio.TimeoutError as e:
+                raise concurrent.futures.TimeoutError() from e
             try:
                 value, traceback = dill.loads(
                     await self.executor.gcs.read_binary_gs_file(self.output_gcs))

--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -6,7 +6,6 @@ from os.path import exists
 import sys
 import shlex
 from argparse import Namespace, ArgumentParser, SUPPRESS
-from os.path import exists
 import google.oauth2.service_account
 from google.cloud import storage
 from google.cloud.storage.blob import Blob

--- a/hail/python/hailtop/batch/genetics/regenie/regenie.py
+++ b/hail/python/hailtop/batch/genetics/regenie/regenie.py
@@ -2,6 +2,7 @@ from typing import Set, Dict, Any
 from ... import Batch, LocalBackend, ServiceBackend, Backend
 from ...resource import Resource
 import os
+from os.path import exists
 import sys
 import shlex
 from argparse import Namespace, ArgumentParser, SUPPRESS

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -48,7 +48,7 @@ class ResourceFile(Resource, str):
         return r
 
     def __init__(self, value: Optional[str]):
-        super(ResourceFile, self).__init__()
+        super().__init__()
         assert value is None or isinstance(value, str)
         self._value = value
         self._source: Optional[job.Job] = None

--- a/hail/python/hailtop/batch/utils.py
+++ b/hail/python/hailtop/batch/utils.py
@@ -13,4 +13,4 @@ def arg_max():
 class BatchException(Exception):
     def __init__(self, msg=''):
         self.msg = msg
-        super(BatchException, self).__init__(msg)
+        super().__init__(msg)

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -7,7 +7,7 @@ import time
 
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
-        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        super().add_fields(log_record, record, message_dict)
         log_record['funcNameAndLine'] = "{}:{}".format(record.funcName, record.lineno)
         log_record['hail_log'] = 1
 

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -125,7 +125,7 @@ def check_ssl_config(ssl_config: Dict[str, str]):
 
 class TLSAdapter(HTTPAdapter):
     def __init__(self, ssl_cert, ssl_key, ssl_ca):
-        super(TLSAdapter, self).__init__()
+        super().__init__()
         self.ssl_cert = ssl_cert
         self.ssl_key = ssl_key
         self.ssl_ca = ssl_ca

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -51,12 +51,12 @@ async def test_write_read(filesystem, file_data):
     token = secrets.token_hex(16)
     file = f'{base}/{token}'
 
-    async with await fs.open(file, 'wb') as f:
+    async with await fs.create(file) as f:
         for b in file_data:
             await f.write(b)
 
     expected = b''.join(file_data)
-    async with await fs.open(file, 'rb') as f:
+    async with await fs.open(file) as f:
         actual = await f.read()
 
     assert expected == actual

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -1,0 +1,126 @@
+import os
+import secrets
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+import pytest
+from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS
+from hailtop.aiogoogle import GoogleStorageAsyncFS
+
+
+@pytest.fixture(params=['file', 'gs', 'router/file', 'router/gs'])
+async def filesystem(request):
+    token = secrets.token_hex(16)
+
+    with ThreadPoolExecutor() as thread_pool:
+        if request.param.startswith('router/'):
+            fs = RouterAsyncFS(
+                'file', [LocalAsyncFS(thread_pool), GoogleStorageAsyncFS()])
+        elif request.param == 'file':
+            fs = LocalAsyncFS(thread_pool)
+        else:
+            fs = GoogleStorageAsyncFS()
+        async with fs:
+            if request.param.endswith('file'):
+                base = f'/tmp/{token}'
+            else:
+                assert request.param.endswith('gs')
+                # FIXME
+                bucket = 'hail-cseed'
+                base = f'gs://{bucket}/{token}'
+
+            await fs.mkdir(base)
+            yield (fs, base)
+            await fs.rmtree(base)
+            assert not await fs.isdir(base)
+
+
+@pytest.fixture(params=['small', 'multipart', 'large'])
+async def file_data(request):
+    if request.param == 'small':
+        return [b'foo']
+    elif request.param == 'multipart':
+        return [b'foo', b'bar', b'baz']
+    else:
+        assert request.param == 'large'
+        return [secrets.token_bytes(1_000_000)]
+
+
+@pytest.mark.asyncio
+async def test_write_read(filesystem, file_data):
+    fs, base = filesystem
+
+    token = secrets.token_hex(16)
+    file = f'{base}/{token}'
+
+    async with await fs.open(file, 'wb') as f:
+        for b in file_data:
+            await f.write(b)
+
+    expected = b''.join(file_data)
+    async with await fs.open(file, 'rb') as f:
+        actual = await f.read()
+
+    assert expected == actual
+
+
+@pytest.mark.asyncio
+async def test_isfile(filesystem):
+    fs, base = filesystem
+
+    token = secrets.token_hex(16)
+    file = f'{base}/{token}'
+
+    # doesn't exist yet
+    assert not await fs.isfile(file)
+
+    await fs.touch(file)
+
+    assert await fs.isfile(file)
+
+
+@pytest.mark.asyncio
+async def test_isdir(filesystem):
+    fs, base = filesystem
+
+    token = secrets.token_hex(16)
+    dir = f'{base}/{token}'
+    await fs.mkdir(dir)
+
+    file = f'{dir}/foo'
+    await fs.touch(file)
+
+    # can't test this until after creating foo
+    assert await fs.isdir(dir)
+
+
+@pytest.mark.asyncio
+async def test_remove(filesystem):
+    fs, base = filesystem
+
+    token = secrets.token_hex(16)
+    file = f'{base}/{token}'
+
+    await fs.touch(file)
+    assert await fs.isfile(file)
+
+    await fs.remove(file)
+
+    assert not await fs.isfile(file)
+
+
+@pytest.mark.asyncio
+async def test_rmtree(filesystem):
+    fs, base = filesystem
+
+    token = secrets.token_hex(16)
+    dir = f'{base}/{token}'
+
+    await fs.mkdir(dir)
+    await fs.touch(f'{dir}/a')
+    await fs.touch(f'{dir}/b')
+
+    assert await fs.isdir(dir)
+
+    await fs.rmtree(dir)
+
+    assert not await fs.isdir(dir)

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -24,8 +24,7 @@ async def filesystem(request):
                 base = f'/tmp/{token}'
             else:
                 assert request.param.endswith('gs')
-                # FIXME
-                bucket = 'hail-cseed'
+                bucket = os.environ['HAIL_TEST_BUCKET']
                 base = f'gs://{bucket}/{token}'
 
             await fs.mkdir(base)

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -144,6 +144,21 @@ async def test_rmtree(filesystem):
 
 
 @pytest.mark.asyncio
+async def test_get_object_metadata():
+    bucket = os.environ['HAIL_TEST_BUCKET']
+    file = secrets.token_hex(16)
+
+    async with StorageClient() as client:
+        async with await client.insert_object(bucket, file) as f:
+            await f.write(b'foo')
+        metadata = await client.get_object_metadata(bucket, file)
+        assert 'etag' in metadata
+        assert metadata['md5Hash'] == 'rL0Y20zC+Fzt72VPzMSk2A=='
+        assert metadata['crc32c'] == 'z8SuHQ=='
+        assert int(metadata['size']) == 3
+
+
+@pytest.mark.asyncio
 async def test_get_object_headers():
     bucket = os.environ['HAIL_TEST_BUCKET']
     file = secrets.token_hex(16)

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -85,11 +85,29 @@ async def test_isdir(filesystem):
     dir = f'{base}/{token}'
     await fs.mkdir(dir)
 
-    file = f'{dir}/foo'
-    await fs.touch(file)
+    await fs.touch(f'{dir}/foo')
 
     # can't test this until after creating foo
     assert await fs.isdir(dir)
+
+
+@pytest.mark.asyncio
+async def test_isdir_subdir_only(filesystem):
+    fs, base = filesystem
+
+    token1 = secrets.token_hex(16)
+    dir = f'{base}/{token1}'
+    await fs.mkdir(dir)
+
+    token2 = secrets.token_hex(16)
+    subdir = f'{dir}/{token2}'
+    await fs.mkdir(subdir)
+
+    await fs.touch(f'{subdir}/foo')
+
+    # can't test this until after creating foo
+    assert await fs.isdir(dir)
+    assert await fs.isdir(subdir)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary of changes:
 - Added a (low level) aiogoogle.StorageClient for Google Storage.
 - Added an abstract AsyncFS interface.  There are currently 3 implementations: GoogleStorageAsyncFS, LocalAsyncFS, and RouterAsyncFS, which can route (based on the scheme) to other file systems.  I tried to copy the standard Python os file system interface (open, remove, mkdir, isfile, etc.)  I'm skeptical about pushing hard on this perspective, and I think we're better off finding a natural interface that that unifies local, gs, (hadoop) and s3.  Maybe a read-only HttpFS.  I think I want to split open() into open (for reading) and create (for writing).  LocalFS operations are run in a thread pool which controls the level of IO parallelism.
 - AsyncFS.open returns an AsyncStream.  This is an async abstraction for Python File-like objects.  It still amazes me Python doesn't have something built in for this.

Next step is a high-level interface for listing objects.  Eventually this and JVM FS should mirror each other.
