### PR TITLE
[query] Fix data race in FASTA reader

### DIFF
--- a/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
+++ b/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
@@ -73,7 +73,7 @@ class FASTAReader(val tmpdir: String, val fsBc: BroadcastValue[FS], val rg: Refe
     reader.value.getSubsequenceAt(contig, start, if (end > maxEnd) maxEnd else end).getBaseString
   }
 
-  private def fillBlock(blockIdx: Int) {
+  private def fillBlock(blockIdx: Int): String = {
     val seq = new StringBuilder
     val start = blockIdx.toLong * blockSize
     var pos = start
@@ -85,13 +85,17 @@ class FASTAReader(val tmpdir: String, val fsBc: BroadcastValue[FS], val rg: Refe
       pos += query.length
     }
 
-    cache.put(blockIdx, seq.result())
+    val res = seq.result()
+    cache.put(blockIdx, res)
+    res
   }
 
   private def readBlock(blockIdx: Int): String = {
-    if (!cache.containsKey(blockIdx))
+    val x = cache.get(blockIdx)
+    if (x != null)
+      x
+    else
       fillBlock(blockIdx)
-    cache.get(blockIdx)
   }
 
   private def readBlock(blockIdx: Int, offset: Int): String = {


### PR DESCRIPTION
In readBlock, membership was checked in a LinkedHashMap, then if it was
found, the value was retrieved from the cache. This lead to a data race
where a value could be evicted between the check and retrival. The
solution is to grab the block value out of the map, and if it is not
null, return it, otherwise, grab the block string, put it in the map,
and return it.

Co-authored-by: Tim Poterba <tpoterba@broadinstitute.org>