### PR TITLE
Avoid calling a tail -> collect in blanczos pca

### DIFF
--- a/hail/python/hail/methods/pca.py
+++ b/hail/python/hail/methods/pca.py
@@ -320,7 +320,7 @@ def _blanczos_pca(entry_expr, k=10, compute_loadings=False, q_iterations=2, over
         num_intervals = len(interval_bounds)
         for i in range(num_intervals - 2):
             intervals.append(hl.utils.Interval(start=interval_bounds[i], end=interval_bounds[i + 1], includes_start=True, includes_end=False))
-        last_interval = hl.utils.Interval(start=interval_bounds[num_intervals - 2], end=interval_bounds[num_intervals-1], includes_start=True, includes_end=True)
+        last_interval = hl.utils.Interval(start=interval_bounds[num_intervals - 2], end=interval_bounds[num_intervals - 1], includes_start=True, includes_end=True)
         intervals.append(last_interval)
 
         return intervals


### PR DESCRIPTION
Tried this locally on a `hl.balding_nichols_model(20, 6000, 50000)` dataset, overall time for 10 pcs with 2 iterations went from ~50 seconds to ~40 seconds. Surprised it made that much of a difference. 