### PR TITLE
emitI: NDArrayShape and NDArrayReindex 

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -993,6 +993,12 @@ class Emit[C](
           IEmitCode(cb, false, resultPCode)
 
         }
+      case x: NDArrayMap  =>  emitDeforestedNDArray(x)
+      case x: NDArrayMap2 =>  emitDeforestedNDArray(x)
+      case x: NDArrayReshape => emitDeforestedNDArray(x)
+      case x: NDArrayConcat => emitDeforestedNDArray(x)
+      case x: NDArraySlice => emitDeforestedNDArray(x)
+      case x: NDArrayFilter => emitDeforestedNDArray(x)
       case x@RunAgg(body, result, states) =>
         val newContainer = AggContainer.fromBuilder(cb, states.toArray, "run_agg")
         emitVoid(body, container = Some(newContainer))
@@ -1777,12 +1783,6 @@ class Emit[C](
         val unified = impl.unify(typeArgs, args.map(_.typ), rt)
         assert(unified)
         impl.apply(EmitRegion(mb, region.code), pt, typeArgs, codeArgs: _*)
-      case x: NDArrayMap  =>  emitDeforestedNDArray(x)
-      case x: NDArrayMap2 =>  emitDeforestedNDArray(x)
-      case x: NDArrayReshape => emitDeforestedNDArray(x)
-      case x: NDArrayConcat => emitDeforestedNDArray(x)
-      case x: NDArraySlice => emitDeforestedNDArray(x)
-      case x: NDArrayFilter => emitDeforestedNDArray(x)
 
       case NDArrayMatMul(lChild, rChild) =>
         val lT = emitNDArrayColumnMajorStrides(lChild)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1290,9 +1290,6 @@ class Emit[C](
     def emitStream(ir: IR): EmitCode =
       EmitStream.emit(this, ir, mb, region, env, container)
 
-    def emitDeforestedNDArray(ir: IR): EmitCode =
-      deforestNDArray(ir, mb, region, env)
-
     def emitNDArrayColumnMajorStrides(ir: IR): EmitCode = {
       EmitCode.fromI(mb) { cb =>
         emit(ir).toI(cb).map(cb) { case pNDCode: PNDArrayCode =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -809,6 +809,9 @@ class Emit[C](
             }
           }
         }
+      case NDArrayShape(ndIR) =>
+        emitI(ndIR).map(cb){ case pc: PNDArrayCode => pc.shape}
+
       case NDArrayRef(nd, idxs) =>
         val ndt = emitI(nd)
         val ndPType = coerce[PNDArray](nd.pType)
@@ -1749,11 +1752,6 @@ class Emit[C](
         assert(unified)
         impl.apply(EmitRegion(mb, region.code), pt, typeArgs, codeArgs: _*)
 
-      case NDArrayShape(ndIR) =>
-        val ndt = emit(ndIR)
-        val ndP = ndIR.pType.asInstanceOf[PNDArray]
-
-        EmitCode(ndt.setup, ndt.m, PCode(pt, ndP.shape.load(ndt.value[Long])))
       case x@NDArrayReindex(child, indexMap) =>
         val childt = emit(child)
         val childPType = coerce[PNDArray](child.pType)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -295,4 +295,6 @@ class PCanonicalNDArrayCode(val pt: PCanonicalNDArray, val a: Code[Long]) extend
   override def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue = memoize(cb, name, cb.localBuilder)
 
   override def memoizeField(cb: EmitCodeBuilder, name: String): PValue = memoize(cb, name, cb.fieldBuilder)
+
+  override def shape: PBaseStructCode = PCode(this.pt.shape.pType, this.pt.shape.load(a)).asBaseStruct
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -270,6 +270,12 @@ class PCanonicalNDArraySettable(override val pt: PCanonicalNDArray, val a: Setta
     }
   }
 
+  override def strides(): IndexedSeq[Value[Long]] = Array.tabulate(pt.nDims) { i =>
+    new Value[Long] {
+      def get: Code[Long] = pt.loadStride(a, i)
+    }
+  }
+
   override def sameShape(other: PNDArrayValue, mb: EmitMethodBuilder[_]): Code[Boolean] = {
     val comparator = this.pt.shape.pType.codeOrdering(mb, other.pt.shape.pType)
     val thisShape = this.pt.shape.load(this.a).asInstanceOf[Code[comparator.T]]

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -64,6 +64,8 @@ abstract class PNDArrayValue extends PValue {
 
   def shapes(): IndexedSeq[Value[Long]]
 
+  def strides(): IndexedSeq[Value[Long]]
+
   override def pt: PNDArray = ???
 
   def outOfBounds(indices: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Boolean]

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -74,5 +74,7 @@ abstract class PNDArrayValue extends PValue {
 abstract class PNDArrayCode extends PCode {
   override def pt: PNDArray
 
+  def shape: PBaseStructCode
+
   def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue
 }


### PR DESCRIPTION
Moving two IR nodes to `emitI`, plus cleaning them up to be a bit more idiomatic.