### PR TITLE
Remove extra checkpoint from blanczos_pca

### DIFF
--- a/hail/python/hail/methods/pca.py
+++ b/hail/python/hail/methods/pca.py
@@ -332,8 +332,6 @@ def _blanczos_pca(entry_expr, k=10, compute_loadings=False, q_iterations=2, over
     num_rows = ht.count()
     new_partitioning = get_even_partitioning(ht, block_size, num_rows)
     ht = hl.read_table(temp_file_name, _intervals=new_partitioning)
-    temp_file_name_2 = hl.utils.new_temp_file("pca", "ht2")
-    ht = ht.checkpoint(temp_file_name_2)
 
     grouped = ht._group_within_partitions("groups", block_size * 2)
     A = grouped.select(ndarray=hl.nd.array(grouped.groups.map(lambda group: group.xs)))


### PR DESCRIPTION
#9425 fixes the bug that caused us to need to checkpoint twice. This PR removes the second checkpoint.

For the `hl.balding_nichols_model(20, 6000, 50000)`, 2 iterations test I've been doing, this gets us down to more like 35 seconds, as opposed to ~40. Current hail PCA takes more like 16 seconds, so we are getting closer (though again, it's not clear that 2 is going to be the right number of iterations in the end).