### PR TITLE
[batch] add option for mounting user token inside batch job

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -644,6 +644,13 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     'mount_path': '/gsa-key',
                     'mount_in_copy': True
                 })
+                if spec.get('mount_tokens', False):
+                    secrets.append({
+                        'namespace': BATCH_PODS_NAMESPACE,
+                        'name': userdata['tokens_secret_name'],
+                        'mount_path': '/user-tokens',
+                        'mount_in_copy': True
+                    })
 
                 sa = spec.get('service_account')
                 check_service_account_permissions(user, sa)

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -651,6 +651,12 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         'mount_path': '/user-tokens',
                         'mount_in_copy': True
                     })
+                    secrets.append({
+                        'namespace': DEFAULT_NAMESPACE,
+                        'name': 'gce-deploy-config',
+                        'mount_path': '/deploy-config',
+                        'mount_in_copy': True
+                    })
 
                 sa = spec.get('service_account')
                 check_service_account_permissions(user, sa)

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -40,7 +40,7 @@ from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays_project', 'resources', 'secrets', 'service_account', 'timeout'
+    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays_project', 'resources', 'secrets', 'service_account', 'timeout', 'mount_tokens'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -40,7 +40,7 @@ from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays_project', 'resources', 'secrets', 'service_account', 'timeout', 'mount_tokens'
+    'always_run', 'attributes', 'command', 'env', 'gcsfuse', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'mount_tokens', 'output_files', 'parent_ids', 'pvc_size', 'port', 'requester_pays_project', 'resources', 'secrets', 'service_account', 'timeout'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}
@@ -197,6 +197,11 @@ def validate_job(i, job):
     mount_docker_socket = job['mount_docker_socket']
     if not isinstance(mount_docker_socket, bool):
         raise ValidationError(f'jobs[{i}].mount_docker_socket not bool')
+
+    if 'mount_tokens' in job:
+        mount_tokens = job['mount_tokens']
+        if not isinstance(mount_tokens, bool):
+            raise ValidationError(f'jobs[{i}].mount_tokens is not bool')
 
     if 'output_files' in job:
         output_files = job['output_files']

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -578,11 +578,12 @@ echo $HAIL_BATCH_WORKER_IP
         assert with_token_status['state'] == 'Success', with_token_status
 
         username = get_userinfo()['username']
-        auth_pattern = r'{' + ','.join(r'\s*"' + k + r'":\s*"(?P<' + k + '>[-@._\w\d]+)"' for k in ["username", "email", "gsa_email"]) + r'\s*}'
 
-        import re
-        m = re.search(auth_pattern, with_token.log()['main'])
-        assert m is not None and m.group("username") == username, (username, with_token.log()['main'])
+        try: 
+            job_userinfo = json.loads(with_token.log()['main'].strip())
+        except: 
+            job_userinfo = None
+        assert job_userinfo is not None and job_userinfo["username"] == username, (username, with_token.log()['main'])
 
         no_token_status = no_token.wait()
         assert no_token_status['state'] == 'Failed', no_token_status

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -569,8 +569,7 @@ echo $HAIL_BATCH_WORKER_IP
 
     def test_user_authentication_within_job(self):
         batch = self.client.create_batch()
-        default_ns = os.environ['HAIL_DEFAULT_NAMESPACE']
-        cmd = ['bash', '-c', f'mkdir -p ~/.hail; hailctl dev config -l gce {default_ns}; hailctl batch list']
+        cmd = ['bash', '-c', f'hailctl batch list']
         with_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=True)
         no_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
         b = batch.submit()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -8,6 +8,7 @@ import time
 import unittest
 import aiohttp
 import requests
+import json
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers, get_userinfo

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -577,11 +577,8 @@ echo $HAIL_BATCH_WORKER_IP
         with_token_status = with_token.wait()
         assert with_token_status['state'] == 'Success', with_token_status
 
-        username = get_userinfo()
-        auth_pattern = r'{' \
-        + ''.join(r'\s."' + k + r'":\s."(?P<' + k + '>[-._\w\d]+)",'
-                       for k in ["username", "email", "gsa_email"]) \
-        + r'\s.}'
+        username = get_userinfo().username
+        auth_pattern = r'{' + ','.join(r'\s*"' + k + r'":\s*"(?P<' + k + '>[-@._\w\d]+)"' for k in ["username", "email", "gsa_email"]) + r'\s*}'
 
         import re
         m = re.search(auth_pattern, with_token.log()['main'])

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -577,7 +577,7 @@ echo $HAIL_BATCH_WORKER_IP
         with_token_status = with_token.wait()
         assert with_token_status['state'] == 'Success', with_token_status
 
-        username = get_userinfo().username
+        username = get_userinfo()['username']
         auth_pattern = r'{' + ','.join(r'\s*"' + k + r'":\s*"(?P<' + k + '>[-@._\w\d]+)"' for k in ["username", "email", "gsa_email"]) + r'\s*}'
 
         import re

--- a/build.yaml
+++ b/build.yaml
@@ -1797,6 +1797,7 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1853,6 +1854,7 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1909,6 +1911,7 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1965,6 +1968,7 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -2021,6 +2025,7 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \

--- a/build.yaml
+++ b/build.yaml
@@ -1797,7 +1797,6 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
-     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1854,7 +1853,6 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
-     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1911,7 +1909,6 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
-     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -1968,7 +1965,6 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
-     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
@@ -2025,7 +2021,6 @@ steps:
      export HAIL_BASE_IMAGE={{ base_image.image }}
      export CI_UTILS_IMAGE={{ ci_utils_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
-     export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -371,7 +371,8 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False,
-                   timeout=None, gcsfuse=None, requester_pays_project=None):
+                   timeout=None, gcsfuse=None, requester_pays_project=None,
+                   mount_tokens=False):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
 
@@ -438,6 +439,8 @@ class BatchBuilder:
                                    for (bucket, mount_path, read_only) in gcsfuse]
         if requester_pays_project:
             job_spec['requester_pays_project'] = requester_pays_project
+        if mount_tokens:
+            job_spec['mount_tokens'] = mount_tokens
 
         self._job_specs.append(job_spec)
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -145,7 +145,8 @@ class BatchBuilder:
                    port=None, resources=None, secrets=None,
                    service_account=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False,
-                   timeout=None, gcsfuse=None, requester_pays_project=None):
+                   timeout=None, gcsfuse=None, requester_pays_project=None,
+                   mount_tokens=False):
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -156,7 +157,7 @@ class BatchBuilder:
             attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
             timeout=timeout, gcsfuse=gcsfuse,
-            requester_pays_project=requester_pays_project)
+            requester_pays_project=requester_pays_project, mount_tokens=mount_tokens)
 
         return Job.from_async_job(async_job)
 


### PR DESCRIPTION
I'd like to give the user the ability to authenticate to our services from within a batch job. The specific use case I need it for is for the query service to be able to cache things with the memory service, but it seems like it could be more broadly applicable. I'm unsure whether this is the correct way to do it.

This is currently not exposed in the python user interface (only in BatchClient), but I can pipe the option through in this PR if we want to.