### PR TITLE
[batch] convert activity logs to audit logs

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -697,9 +697,9 @@ gsutil -m cp dockerd.log gs://$WORKER_LOGS_BUCKET_NAME/batch/logs/$INSTANCE_ID/w
         if event_subtype == 'v1.compute.instances.insert':
             if event_type == 'COMPLETED':
                 severity = event['severity']
-                operation_type = 'insert'
+                operation_id = event['operation']['id']
                 success = (severity != 'ERROR')
-                self.zone_success_rate.push(resource['labels']['zone'], operation_type, success)
+                self.zone_success_rate.push(resource['labels']['zone'], operation_id, success)
         else:
             instance = self.name_instance.get(name)
             if not instance:


### PR DESCRIPTION
I got an email saying the activity logs are no longer supported after September 30th. Here's the [migration instructions](https://cloud.google.com/compute/docs/logging/migrating-from-activity-logs-to-audit-logs#log_entry_field_mappings).

I figured out how to map the fields mostly by trial and error looking at the JSON for an event. The only thing that didn't map at all was the operationType. I hardcoded that as 'insert'.

There are different event_subtype names such as 'v1.compute.instances.insert' or 'beta.compute.instances.insert'. So I did what they suggested and looked for a partial match such as 'compute.instances.insert'.

I can send you the full JSON for the events if you want to double check anything.

I also double checked that the activity logs aren't used anywhere else in the repo, but it might be good for you to confirm that since you wrote a lot of this.