### PR TITLE
emitI NDArrayQR

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1100,6 +1100,8 @@ class Emit[C](
             infoDGEQRFErrorTest("Failed to compute H and Tau.")
           ))
 
+          cb.append(computeHAndTau)
+
           val result = if (mode == "raw") {
             val rawPType = x.pType.asInstanceOf[PTuple]
             val rawOutputSrvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
@@ -1125,10 +1127,8 @@ class Emit[C](
               rawOutputSrvb.end()
             )
 
-            Code(
-              computeHAndTau,
-              constructHAndTauTuple
-            )
+            constructHAndTauTuple
+
           } else {
             val currRow = mb.genFieldThisRef[Int]()
             val currCol = mb.genFieldThisRef[Int]()
@@ -1170,10 +1170,7 @@ class Emit[C](
             )
 
             if (mode == "r") {
-              Code(
-                computeHAndTau,
-                computeR
-              )
+              computeR
             }
             else {
               val crPType = x.pType.asInstanceOf[PTuple]
@@ -1253,7 +1250,6 @@ class Emit[C](
               )
 
               Code(
-                computeHAndTau,
                 rNDArrayAddress := computeR,
                 computeCompleteOrReduced
               )

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1023,6 +1023,247 @@ class Emit[C](
           IEmitCode(cb, false, resultPCode)
 
         }
+      case x@NDArrayQR(nd, mode) =>
+        // See here to understand different modes: https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.qr.html
+        emitNDArrayColumnMajorStrides(nd).map(cb) { case pndCode: PNDArrayCode =>
+          val pndValue = pndCode.memoize(cb, "ndarray_qr_nd")
+          val ndAddress = mb.genFieldThisRef[Long]()
+          val ndPType = nd.pType.asInstanceOf[PNDArray]
+          // This does a lot of byte level copying currently, so only trust
+          // the PCanonicalNDArray representation.
+          assert(ndPType.isInstanceOf[PCanonicalNDArray])
+
+          val shapeArray = pndValue.shapes()
+
+          val LWORKAddress = mb.newLocal[Long]()
+
+          val M = shapeArray(0)
+          val N = shapeArray(1)
+          val K = new Value[Long] {
+            def get: Code[Long] = (M < N).mux(M, N)
+          }
+          val LDA = new Value[Long] {
+            override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
+          }
+
+          def LWORK = Region.loadDouble(LWORKAddress).toI
+
+          val dataAddress = ndPType.data.load(ndAddress)
+
+          val tauPType = PCanonicalArray(PFloat64Required, true)
+          val tauAddress = mb.genFieldThisRef[Long]()
+          val workAddress = mb.genFieldThisRef[Long]()
+          val aAddressDGEQRF = mb.genFieldThisRef[Long]() // Should be column major
+          val rDataAddress = mb.genFieldThisRef[Long]()
+          val aNumElements = mb.genFieldThisRef[Long]()
+
+          val infoDGEQRFResult = mb.newLocal[Int]()
+          val infoDGEQRFErrorTest = (extraErrorMsg: String) => (infoDGEQRFResult cne 0)
+            .orEmpty(Code._fatal[Unit](const(s"LAPACK error DGEQRF. $extraErrorMsg Error code = ").concat(infoDGEQRFResult.toS)))
+
+          val computeHAndTau = Code(FastIndexedSeq(
+            ndAddress := pndValue.value.asInstanceOf[Value[Long]],
+            aNumElements := ndPType.numElements(shapeArray, mb),
+
+            // Make some space for A, which will be overriden during DGEQRF
+            aAddressDGEQRF := ndPType.data.pType.allocate(region.code, aNumElements.toI),
+            ndPType.data.pType.stagedInitialize(aAddressDGEQRF, aNumElements.toI),
+            Region.copyFrom(ndPType.data.pType.firstElementOffset(dataAddress, (M * N).toI),
+              ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI), (M * N) * 8L),
+
+            tauAddress := tauPType.allocate(region.code, K.toI),
+            tauPType.stagedInitialize(tauAddress, K.toI),
+
+            LWORKAddress := region.code.allocate(8L, 8L),
+
+            infoDGEQRFResult := Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
+              M.toI,
+              N.toI,
+              ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
+              LDA.toI,
+              tauPType.firstElementOffset(tauAddress, K.toI),
+              LWORKAddress,
+              -1
+            ),
+            infoDGEQRFErrorTest("Failed size query."),
+
+            workAddress := Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L),
+
+            infoDGEQRFResult := Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
+              M.toI,
+              N.toI,
+              ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
+              LDA.toI,
+              tauPType.firstElementOffset(tauAddress, K.toI),
+              workAddress,
+              LWORK
+            ),
+
+            Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()),
+            infoDGEQRFErrorTest("Failed to compute H and Tau.")
+          ))
+
+          val result = if (mode == "raw") {
+            val rawPType = x.pType.asInstanceOf[PTuple]
+            val rawOutputSrvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
+            val hPType = rawPType.types(0).asInstanceOf[PNDArray]
+            val tauPType = rawPType.types(1).asInstanceOf[PNDArray]
+
+            val hShapeArray = FastIndexedSeq[Value[Long]](N, M)
+            val hShapeBuilder = hPType.makeShapeBuilder(hShapeArray)
+            val hStridesBuilder = hPType.makeRowMajorStridesBuilder(hShapeArray, mb)
+
+            val tauShapeBuilder = tauPType.makeShapeBuilder(FastIndexedSeq(K))
+            val tauStridesBuilder = tauPType.makeRowMajorStridesBuilder(FastIndexedSeq(K), mb)
+
+            val h = hPType.construct(hShapeBuilder, hStridesBuilder, aAddressDGEQRF, mb, region.code)
+            val tau = tauPType.construct(tauShapeBuilder, tauStridesBuilder, tauAddress, mb, region.code)
+
+            val constructHAndTauTuple = Code(
+              rawOutputSrvb.start(),
+              rawOutputSrvb.addIRIntermediate(hPType)(h),
+              rawOutputSrvb.advance(),
+              rawOutputSrvb.addIRIntermediate(tauPType)(tau),
+              rawOutputSrvb.advance(),
+              rawOutputSrvb.end()
+            )
+
+            Code(
+              computeHAndTau,
+              constructHAndTauTuple
+            )
+          } else {
+            val currRow = mb.genFieldThisRef[Int]()
+            val currCol = mb.genFieldThisRef[Int]()
+
+            val (rPType, rRows, rCols) = if (mode == "r") {
+              (x.pType.asInstanceOf[PNDArray], K, N)
+            } else if (mode == "complete") {
+              (x.pType.asInstanceOf[PTuple].types(1).asInstanceOf[PNDArray], M, N)
+            } else if (mode == "reduced") {
+              (x.pType.asInstanceOf[PTuple].types(1).asInstanceOf[PNDArray], K, N)
+            } else {
+              throw new AssertionError(s"Unsupported QR mode $mode")
+            }
+
+            val rShapeArray = FastIndexedSeq[Value[Long]](rRows, rCols)
+
+            val rShapeBuilder = rPType.makeShapeBuilder(rShapeArray)
+            val rStridesBuilder = rPType.makeColumnMajorStridesBuilder(rShapeArray, mb)
+
+            // This block assumes that `rDataAddress` and `aAddressDGEQRF` point to column major arrays.
+            // TODO: Abstract this into ndarray ptype/pcode interface methods.
+            val copyOutUpperTriangle =
+            Code.forLoop(currCol := 0, currCol < rCols.toI, currCol := currCol + 1,
+              Code.forLoop(currRow := 0, currRow < rRows.toI, currRow := currRow + 1,
+                Region.storeDouble(
+                  ndPType.data.pType.elementOffset(rDataAddress, aNumElements.toI, currCol * rRows.toI + currRow),
+                  (currCol >= currRow).mux(
+                    Region.loadDouble(ndPType.data.pType.elementOffset(aAddressDGEQRF, aNumElements.toI, currCol * M.toI + currRow)),
+                    0.0
+                  )
+                )
+              )
+            )
+            val computeR = Code(
+              rDataAddress := rPType.data.pType.allocate(region.code, aNumElements.toI),
+              rPType.data.pType.stagedInitialize(rDataAddress, (rRows * rCols).toI),
+              copyOutUpperTriangle,
+              rPType.construct(rShapeBuilder, rStridesBuilder, rDataAddress, mb, region.code)
+            )
+
+            if (mode == "r") {
+              Code(
+                computeHAndTau,
+                computeR
+              )
+            }
+            else {
+              val crPType = x.pType.asInstanceOf[PTuple]
+              val crOutputSrvb = new StagedRegionValueBuilder(mb, crPType, region.code)
+
+              val qPType = crPType.types(0).asInstanceOf[PNDArray]
+              val qShapeArray = if (mode == "complete") Array(M, M) else Array(M, K)
+              val qShapeBuilder = qPType.makeShapeBuilder(qShapeArray)
+              val qStridesBuilder = qPType.makeColumnMajorStridesBuilder(qShapeArray, mb)
+
+              val rNDArrayAddress = mb.genFieldThisRef[Long]()
+              val qDataAddress = mb.genFieldThisRef[Long]()
+
+              val infoDORGQRResult = mb.genFieldThisRef[Int]()
+              val infoDORQRErrorTest = (extraErrorMsg: String) => (infoDORGQRResult cne 0)
+                .orEmpty(Code._fatal[Unit](const(s"LAPACK error DORGQR. $extraErrorMsg Error code = ").concat(infoDORGQRResult.toS)))
+
+              val qCondition = mb.genFieldThisRef[Boolean]()
+              val numColsToUse = mb.genFieldThisRef[Long]()
+              val aAddressDORGQR = mb.genFieldThisRef[Long]()
+
+              val qNumElements = mb.genFieldThisRef[Long]()
+
+              val computeCompleteOrReduced = Code(Code(FastIndexedSeq(
+                qCondition := const(mode == "complete") && (M > N),
+                numColsToUse := qCondition.mux(M, K),
+                qNumElements := M * numColsToUse,
+                qCondition.mux(
+                  Code(
+                    aAddressDORGQR := ndPType.data.pType.allocate(region.code, qNumElements.toI),
+                    qPType.data.pType.stagedInitialize(aAddressDORGQR, qNumElements.toI),
+                    Region.copyFrom(ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
+                      qPType.data.pType.firstElementOffset(aAddressDORGQR, qNumElements.toI), aNumElements * 8L)
+                  ),
+                  aAddressDORGQR := aAddressDGEQRF
+                ),
+
+                // Query optimal size for work array
+                infoDORGQRResult := Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dorgqr",
+                  M.toI,
+                  numColsToUse.toI,
+                  K.toI,
+                  ndPType.data.pType.firstElementOffset(aAddressDORGQR, aNumElements.toI),
+                  LDA.toI,
+                  tauPType.firstElementOffset(tauAddress, K.toI),
+                  LWORKAddress,
+                  -1
+                ),
+                infoDORQRErrorTest("Failed size query."),
+
+                workAddress := Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L),
+
+                infoDORGQRResult := Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dorgqr",
+                  M.toI,
+                  numColsToUse.toI,
+                  K.toI,
+                  ndPType.data.pType.elementOffset(aAddressDORGQR, (M * numColsToUse).toI, 0),
+                  LDA.toI,
+                  tauPType.elementOffset(tauAddress, K.toI, 0),
+                  workAddress,
+                  LWORK
+                ),
+                Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()),
+                infoDORQRErrorTest("Failed to compute Q."),
+
+                qDataAddress := qPType.data.pType.allocate(region.code, qNumElements.toI),
+                qPType.data.pType.stagedInitialize(qDataAddress, qNumElements.toI),
+                Region.copyFrom(ndPType.data.pType.firstElementOffset(aAddressDORGQR),
+                  qPType.data.pType.firstElementOffset(qDataAddress), (M * numColsToUse) * 8L),
+
+                crOutputSrvb.start(),
+                crOutputSrvb.addIRIntermediate(qPType)(qPType.construct(qShapeBuilder, qStridesBuilder, qDataAddress, mb, region.code)),
+                crOutputSrvb.advance(),
+                crOutputSrvb.addIRIntermediate(rPType)(rNDArrayAddress),
+                crOutputSrvb.advance())),
+                crOutputSrvb.end()
+              )
+
+              Code(
+                computeHAndTau,
+                rNDArrayAddress := computeR,
+                computeCompleteOrReduced
+              )
+            }
+          }
+          PCode(pt, result)
+        }
       case x: NDArrayMap  =>  emitDeforestedNDArray(x)
       case x: NDArrayMap2 =>  emitDeforestedNDArray(x)
       case x: NDArrayReshape => emitDeforestedNDArray(x)
@@ -1953,250 +2194,6 @@ class Emit[C](
           }
           emitter.emit(mb, outputPType, region.code)
         }
-
-      case x@NDArrayQR(nd, mode) =>
-        // See here to understand different modes: https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.qr.html
-        val ndt = emitNDArrayColumnMajorStrides(nd)
-        val ndAddress = mb.genFieldThisRef[Long]()
-        val ndPType = nd.pType.asInstanceOf[PNDArray]
-        // This does a lot of byte level copying currently, so only trust
-        // the PCanonicalNDArray representation.
-        assert(ndPType.isInstanceOf[PCanonicalNDArray])
-
-        val shapeAddress: Value[Long] = new Value[Long] {
-          def get: Code[Long] = ndPType.shape.load(ndAddress)
-        }
-        val shapeTuple = new CodePTuple(ndPType.shape.pType, shapeAddress)
-        val shapeArray = (0 until ndPType.shape.pType.nFields).map(shapeTuple[Long](_))
-
-        val LWORKAddress = mb.newLocal[Long]()
-
-        val M = shapeArray(0)
-        val N = shapeArray(1)
-        val K = new Value[Long] {
-          def get: Code[Long] = (M < N).mux(M, N)
-        }
-        val LDA = new Value[Long] {
-          override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
-        }
-
-        def LWORK = Region.loadDouble(LWORKAddress).toI
-
-        val dataAddress = ndPType.data.load(ndAddress)
-
-        val tauPType = PCanonicalArray(PFloat64Required, true)
-        val tauAddress = mb.genFieldThisRef[Long]()
-        val workAddress = mb.genFieldThisRef[Long]()
-        val aAddressDGEQRF = mb.genFieldThisRef[Long]() // Should be column major
-        val rDataAddress = mb.genFieldThisRef[Long]()
-        val aNumElements = mb.genFieldThisRef[Long]()
-
-        val infoDGEQRFResult = mb.newLocal[Int]()
-        val infoDGEQRFErrorTest = (extraErrorMsg: String) => (infoDGEQRFResult cne  0)
-          .orEmpty(Code._fatal[Unit](const(s"LAPACK error DGEQRF. $extraErrorMsg Error code = ").concat(infoDGEQRFResult.toS)))
-
-        val computeHAndTau = Code(FastIndexedSeq(
-          ndAddress := ndt.value[Long],
-          aNumElements := ndPType.numElements(shapeArray, mb),
-
-          // Make some space for A, which will be overriden during DGEQRF
-          aAddressDGEQRF := ndPType.data.pType.allocate(region.code, aNumElements.toI),
-          ndPType.data.pType.stagedInitialize(aAddressDGEQRF, aNumElements.toI),
-          Region.copyFrom(ndPType.data.pType.firstElementOffset(dataAddress, (M * N).toI),
-            ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI), (M * N) * 8L),
-
-          tauAddress := tauPType.allocate(region.code, K.toI),
-          tauPType.stagedInitialize(tauAddress, K.toI),
-
-          LWORKAddress := region.code.allocate(8L, 8L),
-
-          infoDGEQRFResult := Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
-            M.toI,
-            N.toI,
-            ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
-            LDA.toI,
-            tauPType.firstElementOffset(tauAddress, K.toI),
-            LWORKAddress,
-            -1
-          ),
-          infoDGEQRFErrorTest("Failed size query."),
-
-          workAddress := Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L),
-
-          infoDGEQRFResult := Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
-            M.toI,
-            N.toI,
-            ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
-            LDA.toI,
-            tauPType.firstElementOffset(tauAddress, K.toI),
-            workAddress,
-            LWORK
-          ),
-
-          Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()),
-          infoDGEQRFErrorTest("Failed to compute H and Tau.")
-        ))
-
-        val result = if (mode == "raw") {
-          val rawPType = x.pType.asInstanceOf[PTuple]
-          val rawOutputSrvb = new StagedRegionValueBuilder(mb, x.pType, region.code)
-          val hPType = rawPType.types(0).asInstanceOf[PNDArray]
-          val tauPType = rawPType.types(1).asInstanceOf[PNDArray]
-
-          val hShapeArray = FastIndexedSeq[Value[Long]](N, M)
-          val hShapeBuilder = hPType.makeShapeBuilder(hShapeArray)
-          val hStridesBuilder = hPType.makeRowMajorStridesBuilder(hShapeArray, mb)
-
-          val tauShapeBuilder = tauPType.makeShapeBuilder(FastIndexedSeq(K))
-          val tauStridesBuilder = tauPType.makeRowMajorStridesBuilder(FastIndexedSeq(K), mb)
-
-          val h = hPType.construct(hShapeBuilder, hStridesBuilder, aAddressDGEQRF, mb, region.code)
-          val tau = tauPType.construct(tauShapeBuilder, tauStridesBuilder, tauAddress, mb, region.code)
-
-          val constructHAndTauTuple = Code(
-            rawOutputSrvb.start(),
-            rawOutputSrvb.addIRIntermediate(hPType)(h),
-            rawOutputSrvb.advance(),
-            rawOutputSrvb.addIRIntermediate(tauPType)(tau),
-            rawOutputSrvb.advance(),
-            rawOutputSrvb.end()
-          )
-
-          Code(
-            computeHAndTau,
-            constructHAndTauTuple
-          )
-        } else {
-          val currRow = mb.genFieldThisRef[Int]()
-          val currCol = mb.genFieldThisRef[Int]()
-
-          val (rPType, rRows, rCols) = if (mode == "r") {
-            (x.pType.asInstanceOf[PNDArray], K, N)
-          } else if (mode == "complete") {
-            (x.pType.asInstanceOf[PTuple].types(1).asInstanceOf[PNDArray], M, N)
-          } else if (mode == "reduced") {
-            (x.pType.asInstanceOf[PTuple].types(1).asInstanceOf[PNDArray], K, N)
-          } else {
-            throw new AssertionError(s"Unsupported QR mode $mode")
-          }
-
-          val rShapeArray = FastIndexedSeq[Value[Long]](rRows, rCols)
-
-          val rShapeBuilder = rPType.makeShapeBuilder(rShapeArray)
-          val rStridesBuilder = rPType.makeColumnMajorStridesBuilder(rShapeArray, mb)
-
-          // This block assumes that `rDataAddress` and `aAddressDGEQRF` point to column major arrays.
-          // TODO: Abstract this into ndarray ptype/pcode interface methods.
-          val copyOutUpperTriangle =
-            Code.forLoop(currCol := 0, currCol < rCols.toI, currCol := currCol + 1,
-              Code.forLoop(currRow := 0, currRow < rRows.toI, currRow := currRow + 1,
-                Region.storeDouble(
-                  ndPType.data.pType.elementOffset(rDataAddress, aNumElements.toI, currCol * rRows.toI + currRow),
-                  (currCol >= currRow).mux(
-                    Region.loadDouble(ndPType.data.pType.elementOffset(aAddressDGEQRF, aNumElements.toI, currCol * M.toI + currRow)),
-                    0.0
-                  )
-                )
-              )
-            )
-          val computeR = Code(
-            rDataAddress := rPType.data.pType.allocate(region.code, aNumElements.toI),
-            rPType.data.pType.stagedInitialize(rDataAddress, (rRows * rCols).toI),
-            copyOutUpperTriangle,
-            rPType.construct(rShapeBuilder, rStridesBuilder, rDataAddress, mb, region.code)
-          )
-
-          if (mode == "r") {
-            Code(
-              computeHAndTau,
-              computeR
-            )
-          }
-          else {
-            val crPType = x.pType.asInstanceOf[PTuple]
-            val crOutputSrvb = new StagedRegionValueBuilder(mb, crPType, region.code)
-
-            val qPType = crPType.types(0).asInstanceOf[PNDArray]
-            val qShapeArray = if (mode == "complete") Array(M, M) else Array(M, K)
-            val qShapeBuilder = qPType.makeShapeBuilder(qShapeArray)
-            val qStridesBuilder = qPType.makeColumnMajorStridesBuilder(qShapeArray, mb)
-
-            val rNDArrayAddress = mb.genFieldThisRef[Long]()
-            val qDataAddress = mb.genFieldThisRef[Long]()
-
-            val infoDORGQRResult = mb.genFieldThisRef[Int]()
-            val infoDORQRErrorTest = (extraErrorMsg: String) => (infoDORGQRResult cne 0)
-              .orEmpty(Code._fatal[Unit](const(s"LAPACK error DORGQR. $extraErrorMsg Error code = ").concat(infoDORGQRResult.toS)))
-
-            val qCondition = mb.genFieldThisRef[Boolean]()
-            val numColsToUse = mb.genFieldThisRef[Long]()
-            val aAddressDORGQR = mb.genFieldThisRef[Long]()
-
-            val qNumElements = mb.genFieldThisRef[Long]()
-
-            val computeCompleteOrReduced = Code(Code(FastIndexedSeq(
-              qCondition := const(mode == "complete") && (M > N),
-              numColsToUse := qCondition.mux(M, K),
-              qNumElements := M * numColsToUse,
-              qCondition.mux(
-                Code(
-                  aAddressDORGQR := ndPType.data.pType.allocate(region.code, qNumElements.toI),
-                  qPType.data.pType.stagedInitialize(aAddressDORGQR, qNumElements.toI),
-                  Region.copyFrom(ndPType.data.pType.firstElementOffset(aAddressDGEQRF, aNumElements.toI),
-                    qPType.data.pType.firstElementOffset(aAddressDORGQR, qNumElements.toI), aNumElements * 8L)
-                ),
-                aAddressDORGQR := aAddressDGEQRF
-              ),
-
-              // Query optimal size for work array
-              infoDORGQRResult := Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dorgqr",
-                M.toI,
-                numColsToUse.toI,
-                K.toI,
-                ndPType.data.pType.firstElementOffset(aAddressDORGQR, aNumElements.toI),
-                LDA.toI,
-                tauPType.firstElementOffset(tauAddress, K.toI),
-                LWORKAddress,
-                -1
-              ),
-              infoDORQRErrorTest("Failed size query."),
-
-              workAddress := Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L),
-
-              infoDORGQRResult := Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dorgqr",
-                M.toI,
-                numColsToUse.toI,
-                K.toI,
-                ndPType.data.pType.elementOffset(aAddressDORGQR, (M * numColsToUse).toI, 0),
-                LDA.toI,
-                tauPType.elementOffset(tauAddress, K.toI, 0),
-                workAddress,
-                LWORK
-              ),
-              Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()),
-              infoDORQRErrorTest("Failed to compute Q."),
-
-              qDataAddress := qPType.data.pType.allocate(region.code, qNumElements.toI),
-              qPType.data.pType.stagedInitialize(qDataAddress, qNumElements.toI),
-              Region.copyFrom(ndPType.data.pType.firstElementOffset(aAddressDORGQR),
-                qPType.data.pType.firstElementOffset(qDataAddress), (M * numColsToUse) * 8L),
-
-              crOutputSrvb.start(),
-              crOutputSrvb.addIRIntermediate(qPType)(qPType.construct(qShapeBuilder, qStridesBuilder, qDataAddress, mb, region.code)),
-              crOutputSrvb.advance(),
-              crOutputSrvb.addIRIntermediate(rPType)(rNDArrayAddress),
-              crOutputSrvb.advance())),
-              crOutputSrvb.end()
-            )
-
-            Code(
-              computeHAndTau,
-              rNDArrayAddress := computeR,
-              computeCompleteOrReduced
-            )
-          }
-        }
-        EmitCode(ndt.setup, ndt.m, PCode(pt, result))
 
       case NDArrayInv(nd) =>
         // Based on https://github.com/numpy/numpy/blob/v1.19.0/numpy/linalg/linalg.py#L477-L547


### PR DESCRIPTION
After this and #9450 go in, all NDArray IR nodes will be moved to `emitI`, making it easier for me to update `NDArrayEmitter` to use `EmitCodeBuilder` and `PCode`. I cleaned up `NDArrayQR` a little bit in this PR, but all the low level LAPACK stuff means it's still kind of a mess. 