### PR TITLE
[batch] Change number test worker pool size

### DIFF
--- a/batch/sql/change_test_worker_pool_size.py
+++ b/batch/sql/change_test_worker_pool_size.py
@@ -1,0 +1,26 @@
+import os
+import asyncio
+from gear import Database
+
+
+async def main():
+    scope = os.environ['HAIL_SCOPE']
+
+    if scope == 'deploy':
+        return
+    else:
+        max_instances = 4
+        pool_size = 3
+
+    db = Database()
+    await db.async_init()
+
+    await db.execute_update(
+        '''
+UPDATE globals SET max_instances = %s, pool_size = %s;
+''',
+        (max_instances, pool_size))
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/build.yaml
+++ b/build.yaml
@@ -1631,6 +1631,8 @@ steps:
       script: /io/sql/add-worker-pd-ssd-data-disk.sql
     - name: add-aggregated-batch-resources-tokens
       script: /io/sql/add-aggregated-batch-resources-tokens.sql
+    - name: change-test-worker-pool-size
+      script: /io/sql/change_test_worker_pool_size.py
    inputs:
     - from: /repo/batch/sql
       to: /io/


### PR DESCRIPTION
The tests relying on Batch are getting slower because it takes a long time to download and build Docker images and we're putting more load on Batch. This will increase parallelism and reduce test failures due to timeouts.