### PR TITLE
[query] Make IEmitCode generic

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -16,6 +16,8 @@ import java.util.UUID
 package object ir {
   type TokenIterator = BufferedIterator[Token]
 
+  type IEmitCode = IEmitCodeGen[PCode]
+
   var uidCounter: Long = 0
 
   def genUID(): String = {


### PR DESCRIPTION
Nothing in `IEmitCode` depends on the value being a `PCode`. This PR makes `IEmitCode` a type alias, `IEmitCode = IEmitCodeGen[PCode]`, where `IEmitCodeGen` is a generic version. This supports any pattern where we generate missing and present branches, and the value can be anything to be used while generating the present branch, e.g. `Code`, `PCode`, `Array[PCode]`, `Stream`, or even another optional value (an `EmitCode` or `CodeBuilder => IEmitCode`.