### PR TITLE
[query] fix IEmitCode.consume

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -93,14 +93,14 @@ case class BlockMatrixNativeMetadataWriter(path: String, stageLocally: Boolean, 
     region: Value[Region]): Unit = {
     val metaHelper = BMMetadataHelper(path, typ.blockSize, typ.nRows, typ.nCols, typ.linearizedDefinedBlocks)
 
-    val pc = writeAnnotations.handle(cb, cb._fatal("write annotations can't be missing!")).asIndexable
+    val pc = writeAnnotations.get(cb, "write annotations can't be missing!").asIndexable
     val a = pc.memoize(cb, "filePaths")
     val partFiles = cb.newLocal[Array[String]]("partFiles")
     val n = cb.newLocal[Int]("n", a.loadLength())
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partFiles, Code.newArray[String](n))
     cb.whileLoop(i < n, {
-      val s = a.loadElement(cb, i).handle(cb, cb._fatal("file name can't be missing!")).asString
+      val s = a.loadElement(cb, i).get(cb, "file name can't be missing!").asString
       cb += partFiles.update(i, s.loadString())
       cb.assign(i, i + 1)
     })

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -215,7 +215,7 @@ object CompileIterator {
       eosLabel.goto,
       { element =>
         EmitCodeBuilder.scopedVoid(stepF) { cb =>
-          val pc = element.toI(cb).handle(cb, cb._fatal("missing element!"))
+          val pc = element.toI(cb).get(cb)
           assert(pc.pt.isInstanceOf[PStruct])
           cb.assign(elementAddress, pc.tcode[Long])
           cb += Code._return[Boolean](true)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -983,15 +983,15 @@ class EmitMethodBuilder[C](
         Code(ec.setup, ec.m.mux(ms := true, Code(ms := false, vs := ec.pv)))
 
     def store(cb: EmitCodeBuilder, iec: IEmitCode): Unit =
-      iec.consume(cb, {
-        if (_pt.required)
-          cb._fatal(s"Required EmitSettable cannot be missing ${ _pt }")
-        else
+      if (_pt.required)
+        cb.assign(vs, iec.get(cb, s"Required EmitSettable cannot be missing ${ _pt }"))
+      else
+        iec.consume(cb, {
           cb.assign(ms, true)
-      }, { value =>
-        cb.assign(ms, false)
-        cb.assign(vs, value)
-      })
+        }, { value =>
+          cb.assign(ms, false)
+          cb.assign(vs, value)
+        })
   }
 
   def newEmitLocal(pt: PType): EmitSettable =

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -57,17 +57,23 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     s.store(this, v)
   }
 
-  def memoize[T](pc: PCode, name: String): PValue = pc.memoize(this, name)
+  def memoize(pc: PCode, name: String): PValue = pc.memoize(this, name)
 
-  def memoizeField[T](pc: PCode, name: String): PValue = {
+  def memoizeField(pc: PCode, name: String): PValue = {
     val f = emb.newPField(name, pc.pt)
-    append(f := pc)
+    assign(f, pc)
     f
   }
 
-  def memoize[T](ec: EmitCode, name: String): EmitValue = {
-    val l = emb.newEmitLocal(name, ec.pt)
-    append(l := ec)
+  def memoize(v: EmitCode, name: String): EmitValue = {
+    val l = emb.newEmitLocal(name, v.pt)
+    assign(l, v)
+    l
+  }
+
+  def memoize(v: IEmitCode, name: String): EmitValue = {
+    val l = emb.newEmitLocal(name, v.pt)
+    assign(l, v)
     l
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -192,7 +192,7 @@ case class SplitPartitionNativeWriter(
       def writeFile(codeRow: EmitCode): Code[Unit] = {
         val rowType = coerce[PStruct](codeRow.pt)
         EmitCodeBuilder.scopedVoid(mb) { cb =>
-          val pc = codeRow.toI(cb).handle(cb, cb._fatal("row can't be missing"))
+          val pc = codeRow.toI(cb).get(cb, "row can't be missing")
           val row = pc.memoize(cb, "row")
           if (hasIndex) {
             val keyRVB = new StagedRegionValueBuilder(mb, keyType, eltRegion.code)
@@ -286,24 +286,21 @@ case class MatrixSpecWriter(path: String, typ: MatrixType, rowRelPath: String, g
     cb: EmitCodeBuilder,
     region: Value[Region]): Unit = {
     cb += cb.emb.getFS.invoke[String, Unit]("mkDir", path)
-    writeAnnotations.consume(cb, {
-      cb._fatal("write annotations can't be missing!")
-    }, { case pc: PBaseStructCode =>
-      val partCounts = cb.newLocal[Array[Long]]("partCounts")
-      val c = pc.memoize(cb, "matrixPartCounts")
-      val a = c.loadField(cb, "rows").handle(cb, {}).memoize(cb, "rowCounts").asInstanceOf[PIndexableValue]
+    val pc = writeAnnotations.get(cb, "write annotations can't be missing!").asInstanceOf[PBaseStructCode]
+    val partCounts = cb.newLocal[Array[Long]]("partCounts")
+    val c = pc.memoize(cb, "matrixPartCounts")
+    val a = c.loadField(cb, "rows").get(cb).memoize(cb, "rowCounts").asInstanceOf[PIndexableValue]
 
-      val n = cb.newLocal[Int]("n", a.loadLength())
-      val i = cb.newLocal[Int]("i", 0)
-      cb.assign(partCounts, Code.newArray[Long](n))
-      cb.whileLoop(i < n, {
-        val count = a.loadElement(cb, i).handle(cb, cb._fatal("part count can't be missing!"))
-        cb += partCounts.update(i, count.tcode[Long])
-        cb.assign(i, i + 1)
-      })
-      cb += cb.emb.getObject(new MatrixSpecHelper(path, rowRelPath, globalRelPath, colRelPath, entryRelPath, refRelPath, typ, log))
-        .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").handle(cb, {}).tcode[Long], partCounts)
+    val n = cb.newLocal[Int]("n", a.loadLength())
+    val i = cb.newLocal[Int]("i", 0)
+    cb.assign(partCounts, Code.newArray[Long](n))
+    cb.whileLoop(i < n, {
+      val count = a.loadElement(cb, i).get(cb, "part count can't be missing!")
+      cb += partCounts.update(i, count.tcode[Long])
+      cb.assign(i, i + 1)
     })
+    cb += cb.emb.getObject(new MatrixSpecHelper(path, rowRelPath, globalRelPath, colRelPath, entryRelPath, refRelPath, typ, log))
+      .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").get(cb).tcode[Long], partCounts)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -36,7 +36,7 @@ class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
       val statePV = new PCanonicalBaseStructSettable(stateType, state.off)
       nextNDInput.toI(cb).consume(cb, {}, {case nextNDArrayPCode: PNDArrayCode =>
         val nextNDPV = nextNDArrayPCode.memoize(cb, "ndarray_sum_seqop_next")
-        statePV.loadField(cb, ndarrayFieldNumber).consume[Unit](cb,
+        statePV.loadField(cb, ndarrayFieldNumber).consume(cb,
           {
             cb.append(state.region.getNewRegion(Region.TINY))
             cb.append(stateType.setFieldPresent(state.off, ndarrayFieldNumber))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -19,8 +19,7 @@ object GenotypeFunctions extends RegistryFunctions {
         val i = cb.newLocal[Int]("i", 0)
 
         cb.whileLoop(i < pl.loadLength(), {
-          val value = pl.loadElement(cb, i)
-            .handle(cb, cb += Code._fatal[Unit]("PL cannot have missing elements."))
+          val value = pl.loadElement(cb, i).get(cb, "PL cannot have missing elements.")
           val pli = cb.newLocal[Int]("pli", value.tcode[Int])
           cb.ifx(pli < m, {
             cb.assign(m2, m)

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -48,7 +48,7 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
   def loadFrom(cb: EmitCodeBuilder, ib: StagedIndexWriterUtils, idx: Value[Int]): Unit = {
     cb.assign(region, ib.getRegion(idx))
     cb.assign(node.a, ib.getArrayOffset(idx))
-    val aoff = node.loadField(cb, 0).handle(cb, ()).tcode[Long]
+    val aoff = node.loadField(cb, 0).get(cb).tcode[Long]
     ab.loadFrom(cb, aoff, ib.getLength(idx))
   }
 


### PR DESCRIPTION
`IEmitCode.consume`, with signature `consume[T](cb: EmitCodeBuilder, ifMissing: => Unit, ifPresent: (A) => T): T`, is wrong: it exports a value that is only defined in the present branch to be used after the two branches have joined.

The only use of this manually guarded the exported value by a bit remembering which branch was taken, but this is better handled by memoizing the `IEmitCode` in an `EmitValue`. Almost every other use of `consume` could be more simply expressed using `handle`, and moreover almost every use of `handle` could be more simply expressed using a method `get` which simply throws an exception if the missing branch is taken.

For those few cases where one really does want to consume an `IEmitCode` to a `Code` or `PCode`, with definitions given for each branch, I added `consumeCode` and `consumePCode`.