### PR TITLE
[query/sparse_mt] preserve phasing in lgt_to_gt

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner/sparse_mt_utils.py
+++ b/hail/python/hail/experimental/vcf_combiner/sparse_mt_utils.py
@@ -22,4 +22,4 @@ def lgt_to_gt(lgt, la):
     -----
     This function assumes diploid genotypes.
     """
-    return hl.call(la[lgt[0]], la[lgt[1]])
+    return hl.call(la[lgt[0]], la[lgt[1]], phased=lgt.phased)


### PR DESCRIPTION
Closes #9446