### PR TITLE
Add join method to StringExpression

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -2835,7 +2835,7 @@ class StringExpression(Expression):
         if collection.dtype.element_type != tstr:
             raise TypeError(f"Expected str collection, {collection.dtype.element_type} found")
 
-        return collection._method("mkString", tstr, self)
+        return hl.delimit(collection, self)
 
     def _extra_summary_fields(self, agg_result):
         return {

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -311,6 +311,13 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.eval(string.first_match_in("([^:]*)[:\\t](\\d+)[\\-\\t](\\d+)")) == ['1', '25', '100'])
         self.assertIsNone(hl.eval(string.first_match_in(r"hello (\w+)!")))
 
+    def test_string_join(self):
+        self.assertEqual(hl.eval(hl.str(":").join(["foo", "bar", "baz"])), "foo:bar:baz")
+        self.assertEqual(hl.eval(hl.str(",").join(hl.empty_array(hl.tstr))), "")
+
+        with pytest.raises(TypeError, match="Expected str collection, int32 found"):
+            hl.eval(hl.str(",").join([1, 2, 3]))
+
     def test_cond(self):
         self.assertEqual(hl.eval('A' + hl.cond(True, 'A', 'B')), 'AA')
 


### PR DESCRIPTION
Requested in #9188.

This is similar to [hl.delimit](https://github.com/hail-is/hail/blob/6b5d7a5cde246c5caf53b97c5b17d7e7c6440fec/hail/python/hail/expr/functions.py#L4293-L4326). However, unlike hl.delimit, this throws a TypeError if a collection with a non-string element type is provided. This matches the behavior of Python's [str.join](https://docs.python.org/3/library/stdtypes.html#str.join).