### PR TITLE
[batch] reduce test flakiness

### DIFF
--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -360,7 +360,7 @@ LIMIT %s;
             histogram = collections.defaultdict(int)
             for instance in self.inst_pool.healthy_instances_by_free_cores:
                 histogram[instance.free_cores_mcpu] += 1
-            log.info(f'no viable instances for {cores_mcpu}: {histogram}')
+            log.info(f'schedule: no viable instances for {cores_mcpu}: {histogram}')
             return None
 
         should_wait = True
@@ -371,6 +371,8 @@ LIMIT %s;
 
             scheduled_cores_mcpu = 0
             share = user_share[user]
+
+            log.info(f'schedule: user-share: {user}: {allocated_cores_mcpu} {share}')
 
             remaining = Box(share)
             async for record in user_runnable_jobs(user, remaining):

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -1,6 +1,7 @@
 import logging
 import asyncio
 import sortedcontainers
+import collections
 
 from hailtop.utils import (
     AsyncWorkerPool, WaitableSharedPool, retry_long_running, run_if_changed,
@@ -356,6 +357,10 @@ LIMIT %s;
                 if user != 'ci' or (user == 'ci' and instance.zone.startswith('us-central1')):
                     return instance
                 i += 1
+            histogram = collections.defaultdict(int)
+            for instance in self.inst_pool.healthy_instances_by_free_cores:
+                histogram[instance.free_cores_mcpu] += 1
+            log.info(f'no viable instances for {cores_mcpu}: {histogram}')
             return None
 
         should_wait = True

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -332,7 +332,7 @@ retry docker pull $FROM_IMAGE
 {pull_published_latest}
 CPU_PERIOD=100000
 CPU_QUOTA=$(( $(grep -c ^processor /proc/cpuinfo) * $(cat /sys/fs/cgroup/cpu/cpu.shares) * $CPU_PERIOD / 1024 ))
-MEMORY=$(cat cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+MEMORY=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 docker build --memory="$MEMORY" --cpu-period="$CPU_PERIOD" --cpu-quota="$CPU_QUOTA" -t {shq(self.image)} \
   -f {rendered_dockerfile} \
   --cache-from $FROM_IMAGE {cache_from_published_latest} \


### PR DESCRIPTION
Add a few helpful log statements and use default CPU/mem rather than explicitly specifying it in CI. This reduces cpu from 1 to 0.1. I have to parse the cgroup requirements to ensure that the host docker daemon does not exceed the limits of the build job.