### PR TITLE
[batch] Fix deadlock with exceeded shares

### DIFF
--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import random
 import sortedcontainers
 
 from hailtop.utils import (
@@ -7,6 +8,7 @@ from hailtop.utils import (
     time_msecs, secret_alnum_string)
 
 from ..batch import schedule_job, unschedule_job, mark_job_complete
+from ..utils import WindowFractionCounter
 
 log = logging.getLogger('driver')
 
@@ -14,6 +16,20 @@ log = logging.getLogger('driver')
 class Box:
     def __init__(self, value):
         self.value = value
+
+
+class ExceededSharesCounter:
+    def __init__(self):
+        self._global_counter = WindowFractionCounter(10)
+
+    def push(self, success: bool):
+        self._global_counter.push('exceeded_shares', success)
+
+    def rate(self) -> float:
+        return self._global_counter.fraction()
+
+    def __repr__(self):
+        return f'global {self._global_counter}'
 
 
 class Scheduler:
@@ -25,6 +41,7 @@ class Scheduler:
         self.db = app['db']
         self.inst_pool = app['inst_pool']
         self.async_worker_pool = AsyncWorkerPool(parallelism=100, queue_size=100)
+        self.exceeded_shares_counter = ExceededSharesCounter()
 
     async def async_init(self):
         asyncio.ensure_future(retry_long_running(
@@ -376,7 +393,10 @@ LIMIT %s;
                 record['attempt_id'] = attempt_id
 
                 if scheduled_cores_mcpu + record['cores_mcpu'] > allocated_cores_mcpu:
-                    break
+                    if random.random() > self.exceeded_shares_counter.rate():
+                        self.exceeded_shares_counter.push(True)
+                        break
+                    self.exceeded_shares_counter.push(False)
 
                 instance = get_instance(user, record['cores_mcpu'])
                 if instance:


### PR DESCRIPTION
I noticed that jobs in test deployments were deadlocking because we weren't spinning up extra instances (compared to the production version of Batch). Although each job could fit on an open instance, its allocated share is still less than the core request for that job. This PR aims to increase the probability in which we ignore an exceed shares error the more we have these errors such that at a certain point the rate will be 100% and we'll be able to continue scheduling.