### PR TITLE
linear_regression_rows_nd using TableMapPartitions

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -468,10 +468,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         t = b / se
         p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.d, True, False))
 
-        # Recall, want to generate one row per row in block.
-        key_fields = [key_field for key_field in ht.key]
-        key_dict = {key_field: block[key_field] for key_field in key_fields}
-
         key_fields = [key_field for key_field in ht.key]
         key_dict = {key_field: block[key_field] for key_field in key_fields}
         linreg_fields_dict = {"sum_x": sum_x, "y_transpose_x": ytx.T._data_array(), "beta": b.T._data_array(),

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -419,7 +419,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     # NEW STUFF
     entries_field_name = 'ent'
     sample_field_name = "by_sample"
-    X_field_name = entries_field_name + "_nd"
 
     def all_defined(struct_root, field_names):
         defined_array = hl.array([hl.is_defined(struct_root[field_name]) for field_name in field_names])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2564,7 +2564,7 @@ class Emit[C](
 
               val bodyEnv = env.bind(lName, lElemRef)
                 .bind(rName, rElemRef)
-              val bodyt = dEmit(body, bodyEnv)//emitSelf.emit(body, elemMB, bodyEnv, None)
+              val bodyt = dEmit(body, bodyEnv)
 
               val lIdxVars2 = NDArrayEmitter.zeroBroadcastedDims2(elemMB, idxVars, nDims, leftChildEmitter.outputShape)
               val rIdxVars2 = NDArrayEmitter.zeroBroadcastedDims2(elemMB, idxVars, nDims, rightChildEmitter.outputShape)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1341,7 +1341,7 @@ object EmitStream {
         case ToStream(containerIR, _) =>
           COption.fromEmitCode(emitIR(containerIR)).mapCPS { (containerAddr, k) =>
             val (asetup, a) = EmitCodeBuilder.scoped(mb) { cb =>
-              containerAddr.asIndexable.memoize(cb, "ts_a")
+              containerAddr.asIndexable.memoizeField(cb, "ts_a")
             }
 
             val len = mb.genFieldThisRef[Int]("ts_len")


### PR DESCRIPTION
In this PR, I rewrite `linear_regression_rows_nd` to use `_map_partitions` instead of `_group_within_partitions`. By doing this, I've eliminated the need to do a `key_by` at the end of `linear_regression_rows_nd`. I also think this makes the code clearer. 

This PR also makes a few seemingly random changes that are actually bug fixes:

1. When emitting `Apply` nodes, we were grabbing the `Code[Region]` from the first argument to the `MethodBuilder`. However, the assumption that the first argument will always be a `Region` seems to no longer be true. As such, we just construct a `CodeParam` from the `StagedRegion` we have available. 

2. In the NDArrayEmitter, I want to make sure I call the local `emit` method that passes off to `emitWithRegion`, for the same reason as 1: (Can't trust first argument to be a `Region`)

3. In `EmitStream`, I need to use `memoizeField` instead of `memoize`, because regular `memoize` saves to a `LocalRef`, and that will get reset to 0 when `next` is called on a stream. Lesson: don't trust locals for things that must live between elements of a stream.

I feel like you have a better idea of how the Stream stuff gets emitted than I do Patrick. I'm curious if what I wrote in `process_block` could be written in a way that would lead to better code getting emitted, as I still need to figure out how to squeeze more performance out of this.