### PR TITLE
Use NDArray Version of linear_regression_rows when not on SparkBackend

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -308,7 +308,7 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=()) -> 
     -------
     :class:`.Table`
     """
-    if isinstance(Env.backend(), SparkBackend):
+    if not isinstance(Env.backend(), SparkBackend):
         return _linear_regression_rows_nd(y, x, covariates, block_size, pass_through)
 
     mt = matrix_table_source('linear_regression_rows/x', x)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -307,6 +307,9 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=()) -> 
     -------
     :class:`.Table`
     """
+    if type(Env.backend()).__name__ != "SparkBackend":
+        _linear_regression_rows_nd(y, x, covariates, block_size, pass_through)
+
     mt = matrix_table_source('linear_regression_rows/x', x)
     check_entry_indexed('linear_regression_rows/x', x)
 

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -25,6 +25,7 @@ from hail.utils.java import Env, info, warning
 
 from . import relatedness
 from . import pca
+from ..backend.spark_backend import SparkBackend
 
 pc_relate = relatedness.pc_relate
 identity_by_descent = relatedness.identity_by_descent
@@ -307,7 +308,7 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=()) -> 
     -------
     :class:`.Table`
     """
-    if type(Env.backend()).__name__ != "SparkBackend":
+    if isinstance(Env.backend(), SparkBackend):
         _linear_regression_rows_nd(y, x, covariates, block_size, pass_through)
 
     mt = matrix_table_source('linear_regression_rows/x', x)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -309,7 +309,7 @@ def linear_regression_rows(y, x, covariates, block_size=16, pass_through=()) -> 
     :class:`.Table`
     """
     if isinstance(Env.backend(), SparkBackend):
-        _linear_regression_rows_nd(y, x, covariates, block_size, pass_through)
+        return _linear_regression_rows_nd(y, x, covariates, block_size, pass_through)
 
     mt = matrix_table_source('linear_regression_rows/x', x)
     check_entry_indexed('linear_regression_rows/x', x)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -6,9 +6,7 @@ import numpy as np
 import hail as hl
 import hail.expr.aggregators as agg
 import hail.utils as utils
-from hail.backend.spark_backend import SparkBackend
 from hail.linalg import BlockMatrix
-from hail.utils.java import Env
 from ..helpers import (startTestHailContext, stopTestHailContext, resource,
                        skip_unless_spark_backend, fails_local_backend)
 
@@ -54,8 +52,8 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(hl.impute_sex(ds.GT)._same(hl.impute_sex(ds.GT, aaf='aaf')))
 
-    using_spark = isinstance(Env.backend(), SparkBackend)
-    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if using_spark else [hl._linear_regression_rows_nd]
+        backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
+        linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
     @fails_local_backend()
     def test_linreg_basic(self):

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -6,7 +6,9 @@ import numpy as np
 import hail as hl
 import hail.expr.aggregators as agg
 import hail.utils as utils
+from hail.backend.spark_backend import SparkBackend
 from hail.linalg import BlockMatrix
+from hail.utils.java import Env
 from ..helpers import (startTestHailContext, stopTestHailContext, resource,
                        skip_unless_spark_backend, fails_local_backend)
 
@@ -52,7 +54,8 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(hl.impute_sex(ds.GT)._same(hl.impute_sex(ds.GT, aaf='aaf')))
 
-    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd]
+    using_spark = isinstance(Env.backend(), SparkBackend)
+    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if using_spark else [hl._linear_regression_rows_nd]
 
     @fails_local_backend()
     def test_linreg_basic(self):

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -52,8 +52,8 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(hl.impute_sex(ds.GT)._same(hl.impute_sex(ds.GT, aaf='aaf')))
 
-        backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
-        linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
+    backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
+    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
     @fails_local_backend()
     def test_linreg_basic(self):

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -55,7 +55,6 @@ class Tests(unittest.TestCase):
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
     linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
-    @fails_local_backend()
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -208,7 +207,6 @@ class Tests(unittest.TestCase):
         assert t4._same(t5)
 
 
-    @fails_local_backend()
     def test_linear_regression_without_intercept(self):
         for linreg_function in self.linreg_functions:
             pheno = hl.import_table(resource('regressionLinear.pheno'),
@@ -233,7 +231,6 @@ class Tests(unittest.TestCase):
     # df = data.frame(y, x, c1, c2)
     # fit <- lm(y ~ x + c1 + c2, data=df)
     # summary(fit)["coefficients"]
-    @fails_local_backend()
     def test_linear_regression_with_cov(self):
 
         covariates = hl.import_table(resource('regressionLinear.cov'),
@@ -277,7 +274,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(np.isnan(results[9].standard_error))
             self.assertTrue(np.isnan(results[10].standard_error))
 
-    @fails_local_backend()
     def test_linear_regression_pl(self):
 
         covariates = hl.import_table(resource('regressionLinear.cov'),
@@ -313,7 +309,6 @@ class Tests(unittest.TestCase):
             self.assertAlmostEqual(results[3].t_stat, 1.5872510, places=6)
             self.assertAlmostEqual(results[3].p_value, 0.2533675, places=6)
 
-    @fails_local_backend()
     def test_linear_regression_with_dosage(self):
 
         covariates = hl.import_table(resource('regressionLinear.cov'),
@@ -348,7 +343,6 @@ class Tests(unittest.TestCase):
             self.assertAlmostEqual(results[3].p_value, 0.2533675, places=6)
             self.assertTrue(np.isnan(results[6].standard_error))
 
-    @fails_local_backend()
     def test_linear_regression_equivalence_between_ds_and_gt(self):
         """Test that linear regressions on data converted from dosage to genotype returns the same results"""
         ds_mt = hl.import_vcf(resource('small-ds.vcf'))
@@ -365,7 +359,6 @@ class Tests(unittest.TestCase):
             results_t = ds_results_t.annotate(**gt_results_t[ds_results_t.locus, ds_results_t.alleles])
             self.assertTrue(all(hl.approx_equal(results_t.ds_p_value, results_t.gt_p_value, nan_same=True).collect()))
 
-    @fails_local_backend()
     def test_linear_regression_with_import_fam_boolean(self):
         covariates = hl.import_table(resource('regressionLinear.cov'),
                                      key='Sample',
@@ -396,7 +389,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(np.isnan(results[9].standard_error))
             self.assertTrue(np.isnan(results[10].standard_error))
 
-    @fails_local_backend()
     def test_linear_regression_with_import_fam_quant(self):
         covariates = hl.import_table(resource('regressionLinear.cov'),
                                      key='Sample',
@@ -429,7 +421,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(np.isnan(results[9].standard_error))
             self.assertTrue(np.isnan(results[10].standard_error))
 
-    @fails_local_backend()
     def test_linear_regression_multi_pheno_same(self):
         covariates = hl.import_table(resource('regressionLinear.cov'),
                                      key='Sample',

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -309,6 +309,7 @@ class Tests(unittest.TestCase):
             self.assertAlmostEqual(results[3].t_stat, 1.5872510, places=6)
             self.assertAlmostEqual(results[3].p_value, 0.2533675, places=6)
 
+    @fails_local_backend() # Because of import_gen
     def test_linear_regression_with_dosage(self):
 
         covariates = hl.import_table(resource('regressionLinear.cov'),


### PR DESCRIPTION
SparkBackend is the only one that can actually use the Scala/Breeze version of `linear_regression_rows`, right? Otherwise, we need to use the new ndarray version. 