### PR TITLE
[batch] use a slim image for BPE

### DIFF
--- a/docker/python-dill/Dockerfile
+++ b/docker/python-dill/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:@PYTHON_VERSION@
+RUN pip install -U --no-cache-dir dill numpy scipy sklearn && \
+    apt-get update && \
+    apt-get install -y \
+      libopenblas-base \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/python-dill/Makefile
+++ b/docker/python-dill/Makefile
@@ -1,0 +1,2 @@
+push:
+	bash push.sh

--- a/docker/python-dill/README.md
+++ b/docker/python-dill/README.md
@@ -1,0 +1,1 @@
+These are used by the BatchPoolExecutor.

--- a/docker/python-dill/push.sh
+++ b/docker/python-dill/push.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for version in 3.6 3.6-slim 3.7 3.7-slim 3.8 3.8-slim
+do
+    sed "s/@PYTHON_VERSION@/$version/g" Dockerfile > Dockerfile.out
+    docker build --tag hailgenetics/python-dill:$version - <Dockerfile.out
+    docker push hailgenetics/python-dill:$version
+done

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -142,7 +142,7 @@ class BatchPoolExecutor:
         if image is None:
             if version.major != 3 or version.minor not in (6, 7, 8):
                 raise ValueError(
-                    'You must specify an image if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})')
+                    f'You must specify an image if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})')
             self.image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
         else:
             self.image = image

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -139,7 +139,7 @@ class BatchPoolExecutor:
         self.finished_future_count = 0
         self._shutdown = False
         version = sys.version_info
-        self.image = image or f'hailgenetics/python-dill:{version.major}.{version.minor}'
+        self.image = image or f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
         self.cpus_per_job = cpus_per_job
         self.cleanup_bucket = cleanup_bucket
         self.wait_on_exit = wait_on_exit

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -139,7 +139,13 @@ class BatchPoolExecutor:
         self.finished_future_count = 0
         self._shutdown = False
         version = sys.version_info
-        self.image = image or f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
+        if image is None:
+            if version.major != 3 or version.minor not in (6, 7, 8):
+                raise ValueError(
+                    f'You must specify an image if you are using a Python version other than 3.6, 3.7, or 3.8')
+            self.image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
+        else:
+            self.image = image
         self.cpus_per_job = cpus_per_job
         self.cleanup_bucket = cleanup_bucket
         self.wait_on_exit = wait_on_exit

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -142,7 +142,7 @@ class BatchPoolExecutor:
         if image is None:
             if version.major != 3 or version.minor not in (6, 7, 8):
                 raise ValueError(
-                    f'You must specify an image if you are using a Python version other than 3.6, 3.7, or 3.8')
+                    'You must specify an image if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})')
             self.image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
         else:
             self.image = image
@@ -295,6 +295,7 @@ class BatchPoolExecutor:
         >>> with BatchPoolExecutor() as bpe:  # doctest: +SKIP
         ...     future = bpe.submit(lambda x, y, z: x + y + z,
         ...                         "poly", "ethyl", z="ene")
+        ...     future.result()
         "polyethylene"
 
         Generate a product of two random matrices, on the cloud:


### PR DESCRIPTION
The old BPE images (which still exist) are based on the full python image. The
slim image reduces the size by about 750MB. This should substantially improve
image pull on the n1-standards. I have seen image pull for this image take 136
seconds before in a test job.