### PR TITLE
Add first and last methods to ArrayExpression

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -546,7 +546,7 @@ class ArrayExpression(CollectionExpression):
         >>> hl.eval(names.filter(lambda x: x.startswith('D')).first())
         None
         """
-        return hl.or_missing(hl.len(self) > 0, self[0])
+        return hl.rbind(self, lambda x: hl.or_missing(hl.len(x) > 0, x[0]))
 
     def last(self):
         """Returns the last element of the array, or missing if empty.
@@ -565,7 +565,7 @@ class ArrayExpression(CollectionExpression):
         >>> hl.eval(names.filter(lambda x: x.startswith('D')).last())
         None
         """
-        return hl.rbind(hl.len(self), lambda n: hl.or_missing(n > 0, self[n - 1]))
+        return hl.rbind(self, hl.len(self), lambda x, n: hl.or_missing(n > 0, x[n - 1]))
 
     @typecheck_method(x=oneof(func_spec(1, expr_any), expr_any))
     def index(self, x):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -546,6 +546,7 @@ class ArrayExpression(CollectionExpression):
         >>> hl.eval(names.filter(lambda x: x.startswith('D')).first())
         None
         """
+        # FIXME: this should generate short-circuiting IR when that is possible
         return hl.rbind(self, lambda x: hl.or_missing(hl.len(x) > 0, x[0]))
 
     def last(self):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -529,7 +529,26 @@ class ArrayExpression(CollectionExpression):
         # FIXME: this should generate short-circuiting IR when that is possible
         return hl.rbind(self, lambda x: hl.case().when(x.length() > 0, x[0]).or_missing())
 
-    def tail(self):
+    def first(self):
+        """Returns the first element of the array, or missing if empty.
+
+        Returns
+        -------
+        :class:`.Expression`
+            Element.
+
+        Examples
+        --------
+        >>> hl.eval(names.first())
+        'Alice'
+
+        If the array has no elements, then the result is missing:
+        >>> hl.eval(names.filter(lambda x: x.startswith('D')).first())
+        None
+        """
+        return hl.or_missing(hl.len(self) > 0, self[0])
+
+    def last(self):
         """Returns the last element of the array, or missing if empty.
 
         Returns
@@ -539,14 +558,14 @@ class ArrayExpression(CollectionExpression):
 
         Examples
         --------
-        >>> hl.eval(names.tail())
+        >>> hl.eval(names.last())
         'Charlie'
 
         If the array has no elements, then the result is missing:
-        >>> hl.eval(names.filter(lambda x: x.startswith('D')).tail())
+        >>> hl.eval(names.filter(lambda x: x.startswith('D')).last())
         None
         """
-        return hl.rbind(self, hl.len(self), lambda x, n: hl.or_missing(n > 0, x[n - 1]))
+        return hl.rbind(hl.len(self), lambda n: hl.or_missing(n > 0, self[n - 1]))
 
     @typecheck_method(x=oneof(func_spec(1, expr_any), expr_any))
     def index(self, x):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -539,7 +539,7 @@ class ArrayExpression(CollectionExpression):
 
         Examples
         --------
-        >>> hl.eval(names.head())
+        >>> hl.eval(names.tail())
         'Charlie'
 
         If the array has no elements, then the result is missing:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -526,8 +526,7 @@ class ArrayExpression(CollectionExpression):
         >>> hl.eval(names.filter(lambda x: x.startswith('D')).head())
         None
         """
-        # FIXME: this should generate short-circuiting IR when that is possible
-        return hl.rbind(self, lambda x: hl.case().when(x.length() > 0, x[0]).or_missing())
+        return self.first()
 
     def first(self):
         """Returns the first element of the array, or missing if empty.

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -529,6 +529,25 @@ class ArrayExpression(CollectionExpression):
         # FIXME: this should generate short-circuiting IR when that is possible
         return hl.rbind(self, lambda x: hl.case().when(x.length() > 0, x[0]).or_missing())
 
+    def tail(self):
+        """Returns the last element of the array, or missing if empty.
+
+        Returns
+        -------
+        :class:`.Expression`
+            Element.
+
+        Examples
+        --------
+        >>> hl.eval(names.head())
+        'Charlie'
+
+        If the array has no elements, then the result is missing:
+        >>> hl.eval(names.filter(lambda x: x.startswith('D')).tail())
+        None
+        """
+        return hl.rbind(self, hl.len(self), lambda x, n: hl.or_missing(n > 0, x[n - 1]))
+
     @typecheck_method(x=oneof(func_spec(1, expr_any), expr_any))
     def index(self, x):
         """Returns the first index of `x`, or missing.

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2372,6 +2372,11 @@ class Tests(unittest.TestCase):
         assert hl.eval(a.head()) == 1
         assert hl.eval(a.filter(lambda x: x > 5).head()) is None
 
+    def test_array_tail(self):
+        a = hl.array([1, 2, 3])
+        assert hl.eval(a.tail()) == 3
+        assert hl.eval(a.filter(lambda x: x > 5).tail()) is None
+
     def test_array_index(self):
         a = hl.array([1,2,3])
         assert hl.eval(a.index(2) == 1)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2372,10 +2372,15 @@ class Tests(unittest.TestCase):
         assert hl.eval(a.head()) == 1
         assert hl.eval(a.filter(lambda x: x > 5).head()) is None
 
-    def test_array_tail(self):
+    def test_array_first(self):
+        a = hl.array([1,2,3])
+        assert hl.eval(a.first()) == 1
+        assert hl.eval(a.filter(lambda x: x > 5).first()) is None
+
+    def test_array_last(self):
         a = hl.array([1, 2, 3])
-        assert hl.eval(a.tail()) == 3
-        assert hl.eval(a.filter(lambda x: x > 5).tail()) is None
+        assert hl.eval(a.last()) == 3
+        assert hl.eval(a.filter(lambda x: x > 5).last()) is None
 
     def test_array_index(self):
         a = hl.array([1,2,3])


### PR DESCRIPTION
Add `first` method to ArrayExpression to replace `head`. Add `last` method as the counterpart to `first`.