### PR TITLE
[query] fix performance bug in lir.SimplifyControl

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -107,7 +107,7 @@ class SimplifyControl(m: Method) {
     for (b <- blocks) {
       if (b.first != null &&
         b.first.isInstanceOf[GotoX]) {
-        u.sameSet(
+        u.union(
           blocks.index(b),
           blocks.index(b.first.asInstanceOf[GotoX].L))
       }
@@ -115,10 +115,8 @@ class SimplifyControl(m: Method) {
 
     val rootFinalTarget = mutable.Map[Int, Block]()
     blocks.indices.foreach { i =>
-      val r = u.find(i)
-      if (r == i) {
-        val t = finalTarget(blocks(r))
-        rootFinalTarget(r) = t
+      if (!blocks(i).first.isInstanceOf[GotoX]) {
+        rootFinalTarget(u.find(i)) = blocks(i)
       }
     }
 


### PR DESCRIPTION
This was a good one :)

I haven’t measured the performance difference, but clearly the bug defeated the purpose of using a union-find data structure in the first place, which was to reduce the complexity of `unify` from quadratic to linear.

While I was here, I made a separate simplification. Now that the sets are being unioned as intended, each set contains exactly one block that doesn’t start with a `GotoX`, and that block is the final target of all blocks in the set. That observation allows a simplification when computing the `rootFinalTarget` map.