### PR TITLE
[query] add timeouts and more logging

### DIFF
--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -5,7 +5,8 @@ import requests
 from werkzeug.serving import make_server
 from flask import Response
 
-from hailtop.utils import retry_response_returning_functions
+from hailtop.utils import (retry_response_returning_functions,
+                           external_requests_client_session)
 
 
 class ServerThread(threading.Thread):
@@ -30,10 +31,11 @@ class ServerThread(threading.Thread):
         ping_url = 'http://{}:{}/ping'.format(self.host, self.port)
 
         up = False
+        session = external_requests_client_session()
         while not up:
             try:
                 retry_response_returning_functions(
-                    requests.get, ping_url)
+                    session.get, ping_url)
                 up = True
             except requests.exceptions.ConnectionError:
                 time.sleep(0.01)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -1,5 +1,4 @@
 import os
-import requests
 
 from hail.utils import FatalError
 from hail.expr.types import dtype

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -9,7 +9,8 @@ from hail.expr.blockmatrix_type import tblockmatrix
 
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.auth import service_auth_headers
-from hailtop.utils import retry_response_returning_functions
+from hailtop.utils import (retry_response_returning_functions,
+                           external_requests_client_session)
 from hail.ir.renderer import CSERenderer
 
 from .backend import Backend
@@ -43,9 +44,10 @@ class ServiceBackend(Backend):
         if not deploy_config:
             deploy_config = get_deploy_config()
         self.url = deploy_config.base_url('query')
-        self.headers = service_auth_headers(deploy_config, 'query')
         self._fs = None
         self._logger = PythonOnlyLogger(skip_logging_configuration)
+        self.requests_session = external_requests_client_session(
+            headers=service_auth_headers(deploy_config, 'query'))
 
     @property
     def logger(self):
@@ -74,8 +76,8 @@ class ServiceBackend(Backend):
             'bucket': self._bucket
         }
         resp = retry_response_returning_functions(
-            requests.post,
-            f'{self.url}/execute', json=body, headers=self.headers)
+            self.requests_session.post,
+            f'{self.url}/execute', json=body)
         if resp.status_code == 400 or resp.status_code == 500:
             raise FatalError(resp.text)
         resp.raise_for_status()
@@ -89,8 +91,8 @@ class ServiceBackend(Backend):
     def _request_type(self, ir, kind):
         code = self._render(ir)
         resp = retry_response_returning_functions(
-            requests.post,
-            f'{self.url}/type/{kind}', json=code, headers=self.headers)
+            self.requests_session.post,
+            f'{self.url}/type/{kind}', json=code)
         if resp.status_code == 400 or resp.status_code == 500:
             raise FatalError(resp.text)
         resp.raise_for_status()
@@ -115,8 +117,8 @@ class ServiceBackend(Backend):
 
     def add_reference(self, config):
         resp = retry_response_returning_functions(
-            requests.post,
-            f'{self.url}/references/create', json=config, headers=self.headers)
+            self.requests_session.post,
+            f'{self.url}/references/create', json=config)
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -124,7 +126,7 @@ class ServiceBackend(Backend):
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session.post,
             f'{self.url}/references/create/fasta',
             json={
                 'name': name,
@@ -134,7 +136,7 @@ class ServiceBackend(Backend):
                 'y_contigs': y_contigs,
                 'mt_contigs': mt_contigs,
                 'par': par
-            }, headers=self.headers)
+            })
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -142,10 +144,9 @@ class ServiceBackend(Backend):
 
     def remove_reference(self, name):
         resp = retry_response_returning_functions(
-            requests.delete,
+            self.requests_session.delete,
             f'{self.url}/references/delete',
-            json={'name': name},
-            headers=self.headers)
+            json={'name': name})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -153,10 +154,9 @@ class ServiceBackend(Backend):
 
     def get_reference(self, name):
         resp = retry_response_returning_functions(
-            requests.get,
+            self.requests_session.get,
             f'{self.url}/references/get',
-            json={'name': name},
-            headers=self.headers)
+            json={'name': name})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -169,10 +169,9 @@ class ServiceBackend(Backend):
 
     def add_sequence(self, name, fasta_file, index_file):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session,
             f'{self.url}/references/sequence/set',
-            json={'name': name, 'fasta_file': fasta_file, 'index_file': index_file},
-            headers=self.headers)
+            json={'name': name, 'fasta_file': fasta_file, 'index_file': index_file})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -180,10 +179,9 @@ class ServiceBackend(Backend):
 
     def remove_sequence(self, name):
         resp = retry_response_returning_functions(
-            requests.delete,
+            self.requests_session.delete,
             f'{self.url}/references/sequence/delete',
-            json={'name': name},
-            headers=self.headers)
+            json={'name': name})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -191,11 +189,10 @@ class ServiceBackend(Backend):
 
     def add_liftover(self, name, chain_file, dest_reference_genome):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session.post,
             f'{self.url}/references/liftover/add',
             json={'name': name, 'chain_file': chain_file,
-                  'dest_reference_genome': dest_reference_genome},
-            headers=self.headers)
+                  'dest_reference_genome': dest_reference_genome})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -203,10 +200,9 @@ class ServiceBackend(Backend):
 
     def remove_liftover(self, name, dest_reference_genome):
         resp = retry_response_returning_functions(
-            requests.delete,
+            self.requests_session.delete,
             f'{self.url}/references/liftover/remove',
-            json={'name': name, 'dest_reference_genome': dest_reference_genome},
-            headers=self.headers)
+            json={'name': name, 'dest_reference_genome': dest_reference_genome})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -214,10 +210,9 @@ class ServiceBackend(Backend):
 
     def parse_vcf_metadata(self, path):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session.post,
             f'{self.url}/parse-vcf-metadata',
-            json={'path': path},
-            headers=self.headers)
+            json={'path': path})
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -226,7 +221,7 @@ class ServiceBackend(Backend):
 
     def index_bgen(self, files, index_file_map, rg, contig_recoding, skip_invalid_loci):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session.post,
             f'{self.url}/index-bgen',
             json={
                 'files': files,
@@ -234,8 +229,7 @@ class ServiceBackend(Backend):
                 'rg': rg,
                 'contig_recoding': contig_recoding,
                 'skip_invalid_loci': skip_invalid_loci
-            },
-            headers=self.headers)
+            })
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])
@@ -244,15 +238,14 @@ class ServiceBackend(Backend):
 
     def import_fam(self, path: str, quant_pheno: bool, delimiter: str, missing: str):
         resp = retry_response_returning_functions(
-            requests.post,
+            self.requests_session.post,
             f'{self.url}/import-fam',
             json={
                 'path': path,
                 'quant_pheno': quant_pheno,
                 'delimiter': delimiter,
                 'missing': missing
-            },
-            headers=self.headers)
+            })
         if resp.status_code == 400 or resp.status_code == 500:
             resp_json = resp.json()
             raise FatalError(resp_json['message'])

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -4,7 +4,8 @@ import pkg_resources
 import requests
 import hail as hl
 
-from hailtop.utils import retry_response_returning_functions
+from hailtop.utils import (retry_response_returning_functions,
+                           external_requests_client_session)
 
 from ..utils.java import Env
 from ..typecheck import typecheck_method, oneof
@@ -104,8 +105,9 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
+                session = external_requests_client_session()
                 response = retry_response_returning_functions(
-                    requests.get, url)
+                    session.get, url)
                 config = response.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pkg_resources
-import requests
 import hail as hl
 
 from hailtop.utils import (retry_response_returning_functions,

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -44,6 +44,7 @@ class Env:
     def hc() -> 'hail.context.HailContext':
         if not Env._hc:
             sys.stderr.write("Initializing Hail with default parameters...\n")
+            sys.stderr.flush()
 
             backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
             if backend_name == 'service':

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -111,7 +111,7 @@ def in_cluster_ssl_requests_client_session() -> requests.Session:
     session.mount('https://', TLSAdapter(ssl_config['cert'],
                                          ssl_config['key'],
                                          ssl_config['outgoing_trust'],
-                                         retries=1,
+                                         max_retries=1,
                                          timeout=5))
     return session
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -7,7 +7,7 @@ from .utils import (
     retry_long_running, run_if_changed, run_if_changed_idempotent, LoggingTimer,
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
-    flatten, partition, cost_str)
+    flatten, partition, cost_str, external_requests_client_session)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -60,5 +60,6 @@ __all__ = [
     'RateLimit',
     'RateLimiter',
     'partition',
-    'cost_str'
+    'cost_str',
+    'external_requests_client_session'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -12,6 +12,8 @@ import socket
 import requests
 import google.auth.exceptions
 import time
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
 
 from .time import time_msecs
 
@@ -403,6 +405,31 @@ def retry_response_returning_functions(fun, *args, **kwargs):
             fun, *args, **kwargs)
         delay = sync_sleep_and_backoff(delay)
     return response
+
+
+def external_requests_client_session(headers=None) -> requests.Session:
+    session = requests.Session()
+    adapter = TimeoutHTTPAdapter(max_retries=1, timeout=5)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    if headers:
+        session.headers = headers
+    return session
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, max_retries, timeout):
+        super().__init__(max_retries=max_retries)
+        self.max_retries = max_retries
+        self.timeout = timeout
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            retries=self.max_retries,
+            timeout=self.timeout)
 
 
 async def collect_agen(agen):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -419,9 +419,9 @@ def external_requests_client_session(headers=None) -> requests.Session:
 
 class TimeoutHTTPAdapter(HTTPAdapter):
     def __init__(self, max_retries, timeout):
-        super().__init__(max_retries=max_retries)
         self.max_retries = max_retries
         self.timeout = timeout
+        super().__init__(max_retries=max_retries)
 
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(


### PR DESCRIPTION
- Add a flush after writing the first log statement. This log statement is
  displayed before any network requests, the flush ensures we always see it.
- Set the retries for in-cluster synchronous requests to 1.
- Change all external (ones that go through the gateway) HTTP(S) requests to use
  a centrally defined session. This session improves the situation in two ways:
  1. It prevents urllib from retrying requests, which ensures Hail's retry
     infrastructure is the only retry infrastructure.
  2. It sets a timeout, ensuring that all requests will timeout. Previously,
     requests could hang forever.
  3. It permits setting headers that are used for all requests.