### PR TITLE
[query] Deprecation Decorator

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2,6 +2,8 @@ import builtins
 import functools
 from typing import Union, Optional, Any, Callable, Iterable, TypeVar
 
+from deprecated import deprecated
+
 import hail
 import hail as hl
 from hail.expr.expressions import Expression, ArrayExpression, SetExpression, \
@@ -3423,6 +3425,7 @@ def enumerate(a, start=0, *, index_first=True):
     return range(0, len(a)).map(lambda i: (i + start, a[i]) if index_first else (a[i], i + start))
 
 
+@deprecated(version='0.2.56', reason="Replaced by hl.enumerate")
 @typecheck(a=expr_array(), index_first=bool)
 def zip_with_index(a, index_first=True):
     """Deprecated in favor of :func:`.enumerate`.

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -3,6 +3,7 @@ aiohttp_session>=2.7,<2.8
 asyncinit>=0.2.4,<0.3
 bokeh>1.1,<1.3
 decorator<5
+Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4
 gcsfs==0.2.2
 humanize==1.0.0


### PR DESCRIPTION
Now we can add a decorator to give a warning when a user uses a deprecated thing. It will print a message out when it is used. 

There's a way to get this to automatically print in Sphinx as well, but I'll set that up later. For now, I have manually mentioned in the docstring when a method is deprecated, and now this decorator will give a warning when it's used. 