### PR TITLE
[query] Quick and dirty tabix creation/writing for export_vcf

### DIFF
--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -55,19 +55,22 @@ class MatrixVCFWriter(MatrixWriter):
     @typecheck_method(path=str,
                       append=nullable(str),
                       export_type=ExportType.checker,
-                      metadata=nullable(dictof(str, dictof(str, dictof(str, str)))))
-    def __init__(self, path, append, export_type, metadata):
+                      metadata=nullable(dictof(str, dictof(str, dictof(str, str)))),
+                      tabix=bool)
+    def __init__(self, path, append, export_type, metadata, tabix):
         self.path = path
         self.append = append
         self.export_type = export_type
         self.metadata = metadata
+        self.tabix = tabix
 
     def render(self):
         writer = {'name': 'MatrixVCFWriter',
                   'path': self.path,
                   'append': self.append,
                   'exportType': self.export_type,
-                  'metadata': self.metadata}
+                  'metadata': self.metadata,
+                  'tabix': self.tabix}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
@@ -75,7 +78,8 @@ class MatrixVCFWriter(MatrixWriter):
             other.path == self.path and \
             other.append == self.append and \
             other.export_type == self.export_type and \
-            other.metadata == self.metadata
+            other.metadata == self.metadata and \
+            other.tabix == self.tabix
 
 
 class MatrixGENWriter(MatrixWriter):

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -387,7 +387,7 @@ def export_plink(dataset, output, call=None, fam_id=None, ind_id=None, pat_id=No
            parallel=nullable(ir.ExportType.checker),
            metadata=nullable(dictof(str, dictof(str, dictof(str, str)))),
            tabix=bool)
-def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=None, tabix=False):
+def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=None, *, tabix=False):
     """Export a :class:`.MatrixTable` or :class:`.Table` as a VCF file.
 
     .. include:: ../_templates/req_tvariant.rst
@@ -495,15 +495,12 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
         dictionary should be structured.
     tabix : :obj:`bool`, optional
         If true, writes a tabix index for the output VCF.
-        **Note**: This is currently only supported for
-        the ``parallel=None``.
+        **Note**: This feature is experimental, and the interface and defaults
+        may change in future versions.
     """
     if isinstance(dataset, Table):
         mt = MatrixTable.from_rows_table(dataset)
         dataset = mt.key_cols_by(sample="")
-
-    if tabix and parallel and parallel != ir.ExportType.CONCATENATED:
-        raise ValueError('tabix on parallel export is currently unsupported')
 
     require_col_key_str(dataset, 'export_vcf')
     require_row_key_variant(dataset, 'export_vcf')

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -385,8 +385,9 @@ def export_plink(dataset, output, call=None, fam_id=None, ind_id=None, pat_id=No
            output=str,
            append_to_header=nullable(str),
            parallel=nullable(ir.ExportType.checker),
-           metadata=nullable(dictof(str, dictof(str, dictof(str, str)))))
-def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=None):
+           metadata=nullable(dictof(str, dictof(str, dictof(str, str)))),
+           tabix=bool)
+def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=None, tabix=False):
     """Export a :class:`.MatrixTable` or :class:`.Table` as a VCF file.
 
     .. include:: ../_templates/req_tvariant.rst
@@ -492,11 +493,17 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
         Dictionary with information to fill in the VCF header. See
         :func:`get_vcf_metadata` for how this
         dictionary should be structured.
-
+    tabix : :obj:`bool`, optional
+        If true, writes a tabix index for the output VCF.
+        **Note**: This is currently only supported for
+        the ``parallel=None``.
     """
     if isinstance(dataset, Table):
         mt = MatrixTable.from_rows_table(dataset)
         dataset = mt.key_cols_by(sample="")
+
+    if tabix and parallel and parallel != ir.ExportType.CONCATENATED:
+        raise ValueError('tabix on parallel export is currently unsupported')
 
     require_col_key_str(dataset, 'export_vcf')
     require_row_key_variant(dataset, 'export_vcf')
@@ -521,7 +528,8 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
     writer = ir.MatrixVCFWriter(output,
                                 append_to_header,
                                 parallel,
-                                metadata)
+                                metadata,
+                                tabix)
     Env.backend().execute(ir.MatrixWrite(dataset._mir, writer))
 
 

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -289,9 +289,7 @@ class VCFTests(unittest.TestCase):
         hl.export_vcf(mt.rows(), tmp)
         assert hl.import_vcf(tmp)._same(mt)
 
-    @skip_unless_spark_backend()
-    def test_import_gvcfs(self):
-        path = resource('sample.vcf.bgz')
+    def import_gvcfs_sample_vcf(self, path):
         parts = [
             hl.Interval(start=hl.Struct(locus=hl.Locus('20', 1)),
                         end=hl.Struct(locus=hl.Locus('20', 13509135)),
@@ -321,6 +319,18 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(hl.filter_intervals(vcf2, interval_a).n_partitions(), 2)
         self.assertEqual(hl.filter_intervals(vcf2, interval_b).n_partitions(), 2)
         self.assertEqual(hl.filter_intervals(vcf2, interval_c).n_partitions(), 3)
+
+    @skip_unless_spark_backend()
+    def test_tabix_export(self):
+        mt = hl.import_vcf(resource('sample.vcf.bgz'))
+        tmp = new_temp_file(extension="bgz")
+        hl.export_vcf(mt, tmp, tabix=True)
+        self.import_gvcfs_sample_vcf(tmp)
+
+    @skip_unless_spark_backend()
+    def test_import_gvcfs(self):
+        path = resource('sample.vcf.bgz')
+        self.import_gvcfs_sample_vcf(path)
 
     @skip_unless_spark_backend()
     def test_import_gvcfs_subset(self):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -107,7 +107,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "",
                                                               '[{"start":{"row_idx":0},"end":{"row_idx": 10},"includeStart":true,"includeEnd":false}]',
                                                               hl.dtype('array<interval<struct{row_idx:int32}>>'))),
-            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, ir.ExportType.CONCATENATED, None)),
+            ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, ir.ExportType.CONCATENATED, None, False)),
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -308,9 +308,10 @@ case class MatrixVCFWriter(
   path: String,
   append: Option[String] = None,
   exportType: String = ExportType.CONCATENATED,
-  metadata: Option[VCFMetadata] = None
+  metadata: Option[VCFMetadata] = None,
+  tabix: Boolean = false
 ) extends MatrixWriter {
-  def apply(ctx: ExecuteContext, mv: MatrixValue): Unit = ExportVCF(ctx, mv, path, append, exportType, metadata)
+  def apply(ctx: ExecuteContext, mv: MatrixValue): Unit = ExportVCF(ctx, mv, path, append, exportType, metadata, tabix)
 }
 
 case class MatrixGENWriter(

--- a/hail/src/main/scala/is/hail/io/compress/BGZipLineReader.scala
+++ b/hail/src/main/scala/is/hail/io/compress/BGZipLineReader.scala
@@ -1,0 +1,129 @@
+package is.hail.io.compress
+
+import java.nio.charset.StandardCharsets
+
+import is.hail.backend.BroadcastValue
+import is.hail.io.fs.FS
+import is.hail.utils._
+
+final class BGZipLineReader(
+  private val fsBc: BroadcastValue[FS],
+  private val filePath: String
+)
+  extends java.lang.AutoCloseable
+{
+  private var is = new BGzipInputStream(fsBc.value.openNoCompression(filePath))
+
+  // The line iterator buffer and associated state, we use this to avoid making
+  // endless calls to read() (the no arg version returning int) on the input
+  // stream, we start with 64k to make to make sure that we can always read
+  // a block, and then grow it as neccessary if a line is too large.
+  //
+  // The key invariant here is that bufferCursor should, except possibly in
+  // readLine itself, be less than bufferLen. Should bufferCursor be greater
+  // than or equal to bufferLen, we call refreshBuffer, which also saves the
+  // current input stream virtual offset. If we uphold this invariant, then the
+  // bufferCursor to bufferLen range within the buffer will always contain data
+  // from the current block we are reading, meaning getVirtualOffset will
+  // always return the same value as if we were calling is.read() to read the
+  // lines and is.getVirtualOffset to update the current file pointer for every
+  // call to next
+  private var buffer = new Array[Byte](1 << 16)
+  private var bufferCursor: Int = 0
+  private var bufferLen: Int = 0
+  private var bufferEOF: Boolean = false
+  private var bufferPositionAtLastRead = 0L
+
+  private var virtualFileOffsetAtLastRead = 0L
+
+  def getVirtualOffset: Long = {
+    virtualFileOffsetAtLastRead + (bufferCursor - bufferPositionAtLastRead)
+  }
+
+  def virtualSeek(l: Long): Unit = {
+    is.virtualSeek(l)
+    refreshBuffer(0)
+    bufferCursor = 0
+  }
+
+  private def refreshBuffer(start: Int): Unit = {
+    assert(start < buffer.length)
+    bufferLen = start
+    virtualFileOffsetAtLastRead = is.getVirtualOffset
+    bufferPositionAtLastRead = start
+    val bytesRead = is.read(buffer, start, buffer.length - start)
+    if (bytesRead < 0)
+      bufferEOF = true
+    else {
+      bufferLen = start + bytesRead
+      bufferEOF = false
+    }
+    bufferCursor = start
+  }
+
+  private def decodeString(start: Int, end: Int): String = {
+    var stop = end
+    if (stop > start && buffer(stop) == '\r')
+      stop -= 1
+    val len = end - start
+    new String(buffer, start, len, StandardCharsets.UTF_8)
+  }
+
+  def readLine(): String = {
+    assert(bufferCursor <= bufferLen)
+
+    var start = bufferCursor
+
+    while (true) {
+      var str: String = null;
+      while (bufferCursor < bufferLen && buffer(bufferCursor) != '\n') {
+        bufferCursor += 1
+      }
+
+      if (bufferCursor == bufferLen) { // no newline before end of buffer
+        if (bufferEOF) {
+          // `is` indicates end of file
+          str = decodeString(start, bufferCursor)
+        } else if (bufferLen == buffer.length) {
+          // line overflows buffer, need to increase buffer size
+          val tmp = new Array[Byte](buffer.length * 2)
+          System.arraycopy(buffer, 0, tmp, 0, buffer.length)
+          buffer = tmp
+          refreshBuffer(bufferLen)
+        } else if (start > 0) {
+          // line does not overflow buffer, but spans buffer.
+          // Copy line left to the beginning of buffer and continue
+          val nToCopy = bufferLen - start
+          System.arraycopy(buffer, start, buffer, 0, nToCopy)
+          start = 0
+          refreshBuffer(nToCopy)
+        } else {
+          // line does not span buffer, but does not fill buffer either, read more
+          refreshBuffer(bufferCursor)
+        }
+      } else { // found a newline
+        str = decodeString(start, bufferCursor)
+      }
+
+      if (str != null) {
+        bufferCursor += 1
+        // we refresh here to make sure that the cursor is never pointing to
+        // one past the end of a block, making it so getVirtualOffset will
+        // never return the pointer pointing past the end of a block (the one
+        // that overlaps with the start of the next block).
+        if (bufferCursor >= bufferLen) {
+          refreshBuffer(0)
+        }
+        return str
+      }
+    }
+    throw new AssertionError()
+  }
+
+  override def close() {
+    if (is != null) {
+      is.close()
+      is = null
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/io/compress/BGzipLineReader.scala
+++ b/hail/src/main/scala/is/hail/io/compress/BGzipLineReader.scala
@@ -6,7 +6,7 @@ import is.hail.backend.BroadcastValue
 import is.hail.io.fs.FS
 import is.hail.utils._
 
-final class BGZipLineReader(
+final class BGzipLineReader(
   private val fsBc: BroadcastValue[FS],
   private val filePath: String
 )
@@ -65,7 +65,7 @@ final class BGZipLineReader(
     var stop = end
     if (stop > start && buffer(stop) == '\r')
       stop -= 1
-    val len = end - start
+    val len = stop - start
     new String(buffer, start, len, StandardCharsets.UTF_8)
   }
 
@@ -103,6 +103,10 @@ final class BGZipLineReader(
         }
       } else { // found a newline
         str = decodeString(start, bufferCursor)
+      }
+
+      if (bufferEOF && str.isEmpty) {
+        return null
       }
 
       if (str != null) {

--- a/hail/src/main/scala/is/hail/io/compress/BGzipLineReader.scala
+++ b/hail/src/main/scala/is/hail/io/compress/BGzipLineReader.scala
@@ -83,6 +83,9 @@ final class BGzipLineReader(
       if (bufferCursor == bufferLen) { // no newline before end of buffer
         if (bufferEOF) {
           // `is` indicates end of file
+          if (start == bufferCursor) {
+            return null
+          }
           str = decodeString(start, bufferCursor)
         } else if (bufferLen == buffer.length) {
           // line overflows buffer, need to increase buffer size
@@ -103,10 +106,6 @@ final class BGzipLineReader(
         }
       } else { // found a newline
         str = decodeString(start, bufferCursor)
-      }
-
-      if (bufferEOF && str.isEmpty) {
-        return null
       }
 
       if (str != null) {

--- a/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
+++ b/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 
 import htsjdk.samtools.util.FileExtensions
 import htsjdk.tribble.util.ParsingUtils
-import is.hail.io.compress.BGZipLineReader
+import is.hail.io.compress.BGzipLineReader
 import is.hail.io.fs.FS
 import is.hail.utils._
 import is.hail.backend.BroadcastValue
@@ -301,7 +301,7 @@ final class TabixLineIterator(
 {
   private var i: Int = -1
   private var isEof = false
-  private var lines = new BGZipLineReader(fsBc, filePath)
+  private var lines = new BGzipLineReader(fsBc, filePath)
 
   def next(): String = {
     var s: String = null

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -469,15 +469,13 @@ object ExportVCF {
         case ExportType.PARALLEL_SEPARATE_HEADER | ExportType.PARALLEL_HEADER_IN_SHARD =>
           val localFsBc = ctx.fsBc
           val files = fs.glob(path + "/part-*").map(_.getPath.getBytes)
-          info(s"Writing tabix index for $path")
+          info(s"Writing tabix index for ${ files.length } in $path")
           ctx.backend.parallelizeAndComputeWithIndex(ctx.backendContext, files) { (pathBytes, _) =>
             TabixVCF(localFsBc, new String(pathBytes))
-            null
+            Array.empty
           }
         case ExportType.PARALLEL_COMPOSABLE =>
           warn("Writing tabix index for `parallel=composable` is not supported. No index will be written.")
-        case _ =>
-          fatal(s"Unknown export type: $exportType")
       }
     }
   }

--- a/hail/src/test/scala/is/hail/io/TabixSuite.scala
+++ b/hail/src/test/scala/is/hail/io/TabixSuite.scala
@@ -3,6 +3,7 @@ package is.hail.io
 import htsjdk.tribble.readers.{TabixReader => HtsjdkTabixReader}
 import is.hail.HailSuite
 import is.hail.io.tabix._
+import is.hail.io.vcf.TabixVCF
 import org.testng.annotations.{BeforeTest, Test}
 import org.testng.asserts.SoftAssert
 
@@ -87,8 +88,7 @@ class TabixSuite extends HailSuite {
     }
   }
 
-  @Test def testLineIterator2() {
-    val vcfFile = "src/test/resources/sample.vcf.bgz"
+  def _testLineIterator2(vcfFile: String) {
     val chr = "20"
     val htsjdkrdr = new HtsjdkTabixReader(vcfFile)
     val hailrdr = new TabixReader(vcfFile, fs)
@@ -122,5 +122,17 @@ class TabixSuite extends HailSuite {
         }
       }
     }
+  }
+
+  @Test def testLineIterator2() {
+    _testLineIterator2("src/test/resources/sample.vcf.bgz")
+  }
+
+  @Test def testWriter() {
+    val vcfFile = "src/test/resources/sample.vcf.bgz"
+    val path = ctx.createTmpPath("test-tabix-write", "bgz")
+    fs.copy(vcfFile, path)
+    TabixVCF(fsBc, vcfFile)
+    _testLineIterator2(vcfFile)
   }
 }


### PR DESCRIPTION
Adds the long requested feature for tabix creation support to export_vcf.

This represents an 80% solution due to the requirement that the file already exist in order to write the index. Leans entirely on htsjdk for index creation.

There is a limitation where index writing is only supported for the export type of `CONCATENATED`, but this should be easy to add to.

CHANGELOG : Teach tabix writing to `export_vcf`, experimental.