### PR TITLE
[query] Add EncodedLiteral node to avoid java serialization

### DIFF
--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -346,15 +346,6 @@ class SparkBackend(
     }
   }
 
-//  def executeLiteral(ir: IR): IR = {
-//    val t = ir.typ
-//    assert(t.isRealizable)
-//    val (value, timings) = execute(ir, optimize = true)
-//    timings.finish()
-//    timings.logInfo()
-//    Literal.coerce(t, value)
-//  }
-
   def executeLiteral(ir: IR): IR = {
     val t = ir.typ
     assert(t.isRealizable)
@@ -363,7 +354,7 @@ class SparkBackend(
       log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
       val (retVal, timer) = _execute(ctx, ir, true)
       val literalIR = retVal match {
-        case Left(x) => Literal(TVoid, x)
+        case Left(x) => throw new HailException("Can't create literal")
         case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.hailValueToByteArray(pt, addr, ctx), 0)
       }
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -346,13 +346,33 @@ class SparkBackend(
     }
   }
 
+//  def executeLiteral(ir: IR): IR = {
+//    val t = ir.typ
+//    assert(t.isRealizable)
+//    val (value, timings) = execute(ir, optimize = true)
+//    timings.finish()
+//    timings.logInfo()
+//    Literal.coerce(t, value)
+//  }
+
   def executeLiteral(ir: IR): IR = {
     val t = ir.typ
     assert(t.isRealizable)
-    val (value, timings) = execute(ir, optimize = true)
-    timings.finish()
-    timings.logInfo()
-    Literal.coerce(t, value)
+    val (literalIR, timer) = withExecuteContext() { ctx =>
+      val queryID = Backend.nextID()
+      log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
+      val (retVal, timer) = _execute(ctx, ir, true)
+      val literalIR = retVal match {
+        case Left(x) => Literal(TVoid, x)
+        case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.hailValueToByteArray(pt, addr, ctx), 0)
+      }
+
+      log.info(s"finished execution of query $queryID")
+      (literalIR, timer)
+    }
+    timer.finish()
+    timer.logInfo()
+    literalIR
   }
 
   def executeJSON(ir: IR): String = {

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -15,6 +15,7 @@ object Children {
     case True() => none
     case False() => none
     case Literal(_, _) => none
+    case EncodedLiteral(_, _) => none
     case Void() => none
     case Cast(v, typ) =>
       Array(v)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -12,6 +12,7 @@ object Copy {
       case True() => True()
       case False() => False()
       case Literal(typ, value) => Literal(typ, value)
+      case EncodedLiteral(codec, value) => EncodedLiteral(codec, value)
       case Void() => Void()
       case Cast(_, typ) =>
         assert(newChildren.length == 1)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -695,11 +695,6 @@ class Emit[C](
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
       case x@EncodedLiteral(codec, value) =>
-//        val storedBytes = mb.addLiteral(value.ba, PCanonicalBinaryRequired).asInstanceOf[PBinaryValue]
-//        val stagedIs = Code.newInstance[ByteArrayInputStream, Array[Byte]](storedBytes.loadBytes())
-//        val ib = cb.newLocal[InputBuffer]("encoded_literal_ib")
-//        cb.assign(ib, codec.buildCodeInputBuffer(stagedIs))
-//        val pc = codec.buildEmitDecoder(x.typ, cb.emb.ecb)(region.code, ib)
         presentPC(mb.addEncodedLiteral(x))
       case True() =>
         presentC(const(true))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -695,6 +695,7 @@ class Emit[C](
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
       case x@EncodedLiteral(codec, value) =>
+        assert(x.pType == codec.decodedPType())
         presentPC(mb.addEncodedLiteral(x))
       case True() =>
         presentC(const(true))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -694,6 +694,13 @@ class Emit[C](
             Class.forName("is.hail.expr.ir.package$"), "uuid4"))))
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
+      case x@EncodedLiteral(codec, value) =>
+        val is = new ByteArrayInputStream(value)
+        val cis = _const(is, new ClassInfo[InputStream]("InputStream"))
+        val ib = cb.newLocal[InputBuffer]("encoded_literal_ib")
+        cb.assign(ib, codec.buildCodeInputBuffer(cis))
+        val pc = codec.buildEmitDecoder(x.typ, cb.emb.ecb)(region.code, ib)
+        presentPC(pc)
       case True() =>
         presentC(const(true))
       case False() =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -695,10 +695,10 @@ class Emit[C](
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
       case x@EncodedLiteral(codec, value) =>
-        val is = new ByteArrayInputStream(value)
-        val cis = _const(is, new ClassInfo[InputStream]("InputStream"))
+        val storedBytes = mb.addLiteral(value, PCanonicalBinaryRequired).asInstanceOf[PBinaryValue]
+        val stagedIs = Code.newInstance[ByteArrayInputStream, Array[Byte]](storedBytes.loadBytes())
         val ib = cb.newLocal[InputBuffer]("encoded_literal_ib")
-        cb.assign(ib, codec.buildCodeInputBuffer(cis))
+        cb.assign(ib, codec.buildCodeInputBuffer(stagedIs))
         val pc = codec.buildEmitDecoder(x.typ, cb.emb.ecb)(region.code, ib)
         presentPC(pc)
       case True() =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -695,12 +695,12 @@ class Emit[C](
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, x.pType))
       case x@EncodedLiteral(codec, value) =>
-        val storedBytes = mb.addLiteral(value, PCanonicalBinaryRequired).asInstanceOf[PBinaryValue]
-        val stagedIs = Code.newInstance[ByteArrayInputStream, Array[Byte]](storedBytes.loadBytes())
-        val ib = cb.newLocal[InputBuffer]("encoded_literal_ib")
-        cb.assign(ib, codec.buildCodeInputBuffer(stagedIs))
-        val pc = codec.buildEmitDecoder(x.typ, cb.emb.ecb)(region.code, ib)
-        presentPC(pc)
+//        val storedBytes = mb.addLiteral(value.ba, PCanonicalBinaryRequired).asInstanceOf[PBinaryValue]
+//        val stagedIs = Code.newInstance[ByteArrayInputStream, Array[Byte]](storedBytes.loadBytes())
+//        val ib = cb.newLocal[InputBuffer]("encoded_literal_ib")
+//        cb.assign(ib, codec.buildCodeInputBuffer(stagedIs))
+//        val pc = codec.buildEmitDecoder(x.typ, cb.emb.ecb)(region.code, ib)
+        presentPC(mb.addEncodedLiteral(x))
       case True() =>
         presentC(const(true))
       case False() =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -290,6 +290,8 @@ class EmitClassBuilder[C](
 
   private[this] val literalsMap: mutable.Map[(PType, Any), PSettable] =
     mutable.Map[(PType, Any), PSettable]()
+  private[this] val encodedLiteralsMap: mutable.Map[EncodedLiteral, PSettable] =
+    mutable.Map[EncodedLiteral, PSettable]()
   private[this] lazy val encLitField: Settable[Array[Byte]] = genFieldThisRef[Array[Byte]]("encodedLiterals")
 
   lazy val partitionRegion: Settable[Region] = genFieldThisRef[Region]("partitionRegion")

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -91,6 +91,21 @@ final case class Literal(_typ: Type, value: Annotation) extends IR {
   // require(SafeRow.isSafe(value))
 }
 
+object EncodedLiteral {
+
+  def hailValueToByteArray(pt: PType, addr: Long, ctx: ExecuteContext): IR = {
+    val etype = EType.defaultFromPType(pt)
+    val codec = TypedCodecSpec(etype, pt.virtualType, BufferSpec.defaultUncompressed)
+    val bytes = codec.encode(ctx, pt, addr)
+    EncodedLiteral(codec, bytes)
+  }
+}
+
+final case class EncodedLiteral(codec: TypedCodecSpec, value: Array[Byte]) extends IR {
+//  !CanEmit(codec.encodedVirtualType)
+//  require(value != null)
+}
+
 final case class I32(x: Int) extends IR
 final case class I64(x: Long) extends IR
 final case class F32(x: Float) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -92,6 +92,9 @@ final case class Literal(_typ: Type, value: Annotation) extends IR {
 }
 
 object EncodedLiteral {
+  def apply(codec: TypedCodecSpec, value: Array[Byte]): EncodedLiteral = {
+    EncodedLiteral(codec, new WrappedByteArray(value))
+  }
 
   def hailValueToByteArray(pt: PType, addr: Long, ctx: ExecuteContext): IR = {
     val etype = EType.defaultFromPType(pt)
@@ -101,9 +104,23 @@ object EncodedLiteral {
   }
 }
 
-final case class EncodedLiteral(codec: TypedCodecSpec, value: Array[Byte]) extends IR {
-  !CanEmit(codec.encodedVirtualType)
+final case class EncodedLiteral(codec: TypedCodecSpec, value: WrappedByteArray) extends IR {
+  require(!CanEmit(codec.encodedVirtualType))
   require(value != null)
+}
+
+class WrappedByteArray(val ba: Array[Byte]) {
+  override def hashCode(): Int = java.util.Arrays.hashCode(ba)
+
+  override def equals(obj: Any): Boolean = {
+    if (!obj.isInstanceOf[WrappedByteArray]) {
+      false
+    }
+    else {
+      val other = obj.asInstanceOf[WrappedByteArray]
+      java.util.Arrays.equals(ba, other.ba)
+    }
+  }
 }
 
 final case class I32(x: Int) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -102,8 +102,8 @@ object EncodedLiteral {
 }
 
 final case class EncodedLiteral(codec: TypedCodecSpec, value: Array[Byte]) extends IR {
-//  !CanEmit(codec.encodedVirtualType)
-//  require(value != null)
+  !CanEmit(codec.encodedVirtualType)
+  require(value != null)
 }
 
 final case class I32(x: Int) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -120,7 +120,7 @@ object InferPType {
     }
     node._pType = node match {
       case x if x.typ == TVoid => PVoid
-      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: UUID4 | _: Literal | _: EncodedLiteral | _: True | _: False
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: UUID4 | _: Literal | _: True | _: False
            | _: Cast | _: NA | _: Die | _: IsNA | _: ArrayZeros | _: ArrayLen | _: StreamLen
            | _: LowerBoundOnOrderedCollection | _: ApplyBinaryPrimOp
            | _: ApplyUnaryPrimOp | _: ApplyComparisonOp | _: WriteValue

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -120,7 +120,7 @@ object InferPType {
     }
     node._pType = node match {
       case x if x.typ == TVoid => PVoid
-      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: UUID4 | _: Literal | _: True | _: False
+      case _: I32 | _: I64 | _: F32 | _: F64 | _: Str | _: UUID4 | _: Literal | _: EncodedLiteral | _: True | _: False
            | _: Cast | _: NA | _: Die | _: IsNA | _: ArrayZeros | _: ArrayLen | _: StreamLen
            | _: LowerBoundOnOrderedCollection | _: ApplyBinaryPrimOp
            | _: ApplyUnaryPrimOp | _: ApplyComparisonOp | _: WriteValue

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -126,6 +126,8 @@ object InferPType {
            | _: ApplyUnaryPrimOp | _: ApplyComparisonOp | _: WriteValue
            | _: NDArrayAgg | _: ShuffleWrite | _: AggStateValue | _: CombOpValue | _: InitFromSerializedValue =>
         requiredness(node).canonicalPType(node.typ)
+      case EncodedLiteral(codec, _) =>
+        codec.decodedPType()
       case CastRename(v, typ) => v.pType.deepRename(typ)
       case x: BaseRef if usesAndDefs.free.contains(RefEquality(x)) =>
         env.lookup(x.name)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -15,6 +15,7 @@ object InferType {
       case Str(_) => TString
       case UUID4(_) => TString
       case Literal(t, _) => t
+      case EncodedLiteral(codec, _) => codec.encodedVirtualType
       case True() | False() => TBoolean
       case Void() => TVoid
       case Cast(_, t) => t

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -7,6 +7,7 @@ object Interpretable {
     !ir.typ.isInstanceOf[TNDArray] &&
     (ir match {
       case
+        _: EncodedLiteral |
         _: StreamMerge |
         _: RunAgg |
         _: InitOp |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -775,6 +775,8 @@ object IRParser {
       case "Literal" =>
         val (t, v) = ir_value(env.typEnv)(it)
         done(Literal.coerce(t, v))
+      case "EncodedLiteral" =>
+        throw new UnsupportedOperationException("Not currently parsable")
       case "Void" => done(Void())
       case "Cast" =>
         val typ = type_expr(env.typEnv)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -269,6 +269,8 @@ object Pretty {
                   else
                     "<literal value>"
                 )
+            case EncodedLiteral(codec, _) =>
+              s"EncodedLiteral[${codec.encodedVirtualType.parsableString()}]"
             case Let(name, _, _) => prettyIdentifier(name)
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case TailLoop(name, args, _) => prettyIdentifier(name) + " " + prettyIdentifiers(args.map(_._1).toFastIndexedSeq)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -269,8 +269,7 @@ object Pretty {
                   else
                     "<literal value>"
                 )
-            case EncodedLiteral(codec, _) =>
-              s"EncodedLiteral[${codec.encodedVirtualType.parsableString()}]"
+            case EncodedLiteral(codec, _) => codec.encodedVirtualType.parsableString()
             case Let(name, _, _) => prettyIdentifier(name)
             case AggLet(name, _, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case TailLoop(name, args, _) => prettyIdentifier(name) + " " + prettyIdentifiers(args.map(_._1).toFastIndexedSeq)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -445,6 +445,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
       case _: NA => requiredness.union(false)
       case Literal(t, a) => requiredness.unionLiteral(a)
+        //TODO: Ask if I did this one right, not sure.
+      case EncodedLiteral(codec, value) => requiredness.fromPType(codec.decodedPType())
 
       case Coalesce(values) =>
         val reqs = values.map(lookup)

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -445,7 +445,6 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
       case _: NA => requiredness.union(false)
       case Literal(t, a) => requiredness.unionLiteral(a)
-        //TODO: Ask if I did this one right, not sure.
       case EncodedLiteral(codec, value) => requiredness.fromPType(codec.decodedPType())
 
       case Coalesce(values) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -37,6 +37,7 @@ object TypeCheck {
       case Str(x) =>
       case UUID4(_) =>
       case Literal(_, _) =>
+      case EncodedLiteral(_, _) =>
       case Void() =>
       case Cast(v, typ) => if (!Casts.valid(v.typ, typ))
         throw new RuntimeException(s"invalid cast:\n  " +

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -139,6 +139,8 @@ object PSettable {
   def apply(sb: SettableBuilder, _pt: PType, name: String): PSettable = _pt match {
     case pt: PCanonicalArray =>
       PCanonicalIndexableSettable(sb, pt, name)
+    case pt: PCanonicalBinary =>
+      PCanonicalBinarySettable(sb,pt, name)
     case pt: PCanonicalSet =>
       PCanonicalIndexableSettable(sb, pt, name)
     case pt: PCanonicalDict =>

--- a/hail/src/test/scala/is/hail/expr/ir/EncodedLiteralSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EncodedLiteralSuite.scala
@@ -1,0 +1,21 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import org.testng.annotations.Test
+
+class EncodedLiteralSuite extends HailSuite {
+
+  @Test
+  def testWrappedByteArrayEquality(): Unit = {
+    val byteArray1 = Array[Byte](1, 2, 1, 1)
+    val byteArray2 = Array[Byte](1, 2, 1, 1)
+    val byteArray3 = Array[Byte](0, 0, 1, 0)
+    val wba1 = new WrappedByteArray(byteArray1)
+    val wba2 = new WrappedByteArray(byteArray2)
+    val wba3 = new WrappedByteArray(byteArray3)
+
+    assert(wba1 == wba1)
+    assert(wba1 == wba2)
+    assert(wba1 != wba3)
+  }
+}


### PR DESCRIPTION
Introduces `EncodedLiteral`, a literal that is stored as an `EType` encoded array of bytes. 

I did this with the intention of making PCA faster, but so far this seems to take roughly the same amount of time. Currently this is only used by `_blanczos_pca`, since that's the only code using `IR._persist`