### PR TITLE
[query/lir] findBlocks asserts well-formed blocks

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -15,8 +15,7 @@ class SimplifyControl(m: Method) {
 
   def finalTarget(b0: Block): Block = {
     var b = b0
-    while (b.first != null &&
-      b.first.isInstanceOf[GotoX])
+    while (b.first.isInstanceOf[GotoX])
       b = b.first.asInstanceOf[GotoX].L
     b
   }


### PR DESCRIPTION
This PR asserts a stronger precondition for `Method.findBlocks`: all reachable blocks must be non-empty, must be terminated by a control expression, and all targets of the control expression must be non-null.