### PR TITLE
[query/lir] remove dead code on the fly

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
+++ b/hail/src/main/scala/is/hail/lir/SimplifyControl.scala
@@ -15,8 +15,7 @@ class SimplifyControl(m: Method) {
 
   def finalTarget(b0: Block): Block = {
     var b = b0
-    while (b.first != null &&
-      b.first.isInstanceOf[GotoX])
+    while (b.first.isInstanceOf[GotoX])
       b = b.first.asInstanceOf[GotoX].L
     b
   }


### PR DESCRIPTION
Stacked on #9489 

This PR enforces a stronger invariant on `lir.Block`: a block can never contain dead code, i.e. code that follows a control statement. Prior to this, dead code could be added to a block, only to be removed later. But it's just as easy to have `Block.append` check if a statement to be added would be dead, and just not add it in the first place. And having the stronger invariant always hold allows for some simplifications in the code, in addition to a simpler mental model.