### PR TITLE
[hailctl] Fix config file name

### DIFF
--- a/hail/python/hailtop/config/user_config.py
+++ b/hail/python/hailtop/config/user_config.py
@@ -1,12 +1,14 @@
 import os
 import configparser
 
+from pathlib import Path
+
 user_config = None
 
 
 def get_user_config_path():
     xdg_config_home = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
-    return xdg_config_home + '/hail/config.yaml'
+    return Path(xdg_config_home, 'hail', 'config.ini')
 
 
 def get_user_config():
@@ -14,7 +16,14 @@ def get_user_config():
     if user_config is None:
         user_config = configparser.ConfigParser()
         config_file = get_user_config_path()
-        os.makedirs(os.path.dirname(config_file), exist_ok=True)
-        open(config_file, 'a').close()
+        os.makedirs(config_file.parent, exist_ok=True)
+        # in older versions, the config file was accidentally named
+        # config.yaml, if the new config does not exist, and the old
+        # one does, silently rename it
+        old_path = config_file.with_name('config.yaml')
+        if old_path.exists() and not config_file.exists():
+            old_path.rename(config_file)
+        else:
+            config_file.touch(exist_ok=True)
         user_config.read(config_file)
     return user_config


### PR DESCRIPTION
It was previously called config.yaml, when it was actually a python
configparser config file, which is a subset of [ini syntax].

[ini syntax]: https://docs.python.org/3/library/configparser.html

Check to see if the .yaml file exists and the .ini file does not exist.
If so, silently rename the config file to the new name.