### PR TITLE
[query] Throw better error in VCFLine.nextField if separator is not a tab

### DIFF
--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -295,7 +295,9 @@ final class VCFLine(val line: String, arrayElementsRequired: Boolean,
   def nextField(): Unit = {
     if (pos == line.length)
       parseError("unexpected end of line")
-    assert(line(pos) == '\t')
+    if (line(pos) != '\t') {
+      parseError("expected tab character between fields")
+    }
     pos += 1 // tab
   }
 


### PR DESCRIPTION
I have yet to successfully create a VCF that doesn't hit another error before hitting this one. But user hit this here: https://discuss.hail.is/t/assertionerror-exception/1700