### PR TITLE
[query] bytecode debug info for exceptions

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -92,8 +92,8 @@ trait WrappedModuleBuilder {
 class ModuleBuilder() {
   val classes = new mutable.ArrayBuffer[ClassBuilder[_]]()
 
-  def newClass[C](name: String)(implicit cti: TypeInfo[C]): ClassBuilder[C] = {
-    val c = new ClassBuilder[C](this, name)
+  def newClass[C](name: String, sourceFile: Option[String] = None)(implicit cti: TypeInfo[C]): ClassBuilder[C] = {
+    val c = new ClassBuilder[C](this, name, sourceFile)
     if (cti != UnitInfo)
       c.addInterface(cti.iname)
     classes += c
@@ -208,11 +208,13 @@ trait WrappedClassBuilder[C] extends WrappedModuleBuilder {
 
 class ClassBuilder[C](
   val modb: ModuleBuilder,
-  val className: String) extends WrappedModuleBuilder {
+  val className: String,
+  val sourceFile: Option[String]
+) extends WrappedModuleBuilder {
 
   val ti: TypeInfo[C] = new ClassInfo[C](className)
 
-  val lclass = new lir.Classx[C](className, "java/lang/Object")
+  val lclass = new lir.Classx[C](className, "java/lang/Object", sourceFile)
 
   val methods: mutable.ArrayBuffer[MethodBuilder[C]] = new mutable.ArrayBuffer[MethodBuilder[C]](16)
   val fields: mutable.ArrayBuffer[FieldNode] = new mutable.ArrayBuffer[FieldNode](16)

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -127,7 +127,10 @@ object Code {
 
   def foreach[A](it: Seq[A])(f: A => Code[Unit]): Code[Unit] = Code(it.map(f))
 
-  def newInstance[T <: AnyRef](parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T]): Code[T] = {
+  def newInstance[T <: AnyRef](parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T]): Code[T] =
+    newInstance(parameterTypes, args, 0)
+
+  def newInstance[T <: AnyRef](parameterTypes: Array[Class[_]], args: Array[Code[_]], lineNumber: Int)(implicit tct: ClassTag[T]): Code[T] = {
     val tti = classInfo[T]
 
     val tcls = tct.runtimeClass
@@ -140,8 +143,10 @@ object Code {
 
     val (start, end, argvs) = Code.sequenceValues(args)
     val linst = new lir.Local(null, "new_inst", tti)
-    end.append(lir.store(linst, lir.newInstance(tti,
-      Type.getInternalName(tcls), "<init>", Type.getConstructorDescriptor(c), tti, argvs)))
+    val newInstX = lir.newInstance(
+      tti, Type.getInternalName(tcls), "<init>",
+      Type.getConstructorDescriptor(c), tti, argvs, lineNumber)
+    end.append(lir.store(linst, newInstX, lineNumber))
 
     new VCode(start, end, lir.load(linst))
   }
@@ -169,7 +174,11 @@ object Code {
 
   def newInstance[T <: AnyRef, A1, A2, A3](a1: Code[A1], a2: Code[A2], a3: Code[A3])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2],
     a3ct: ClassTag[A3], tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
-    newInstance[T](Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass), Array[Code[_]](a1, a2, a3))
+    newInstance(a1, a2, a3, 0)
+
+  def newInstance[T <: AnyRef, A1, A2, A3](a1: Code[A1], a2: Code[A2], a3: Code[A3], lineNumber: Int)(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2],
+    a3ct: ClassTag[A3], tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
+    newInstance[T](Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass), Array[Code[_]](a1, a2, a3), lineNumber)
 
   def newInstance[T <: AnyRef, A1, A2, A3, A4](a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4]
   )(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
@@ -295,7 +304,7 @@ object Code {
   def invokeStatic5[T, A1, A2, A3, A4, A5, S](method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5])(implicit tct: ClassTag[T], sct: ClassTag[S], a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5]): Code[S] =
     invokeStatic[S](tct.runtimeClass, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4, a5))(sct)
 
-  def _null[T >: Null](implicit tti: TypeInfo[T]): Code[T] = Code(lir.insn(ACONST_NULL, tti))
+  def _null[T >: Null](implicit tti: TypeInfo[T]): Code[T] = Code(lir.insn0(ACONST_NULL, tti))
 
   def _empty: Code[Unit] = Code[Unit](null: lir.ValueX)
 
@@ -311,23 +320,38 @@ object Code {
     }
   }
 
-  def _throw[T <: java.lang.Throwable, U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] = {
+  private def getEmitLineNum: Int = {
+    val st = Thread.currentThread().getStackTrace
+    val i = st.indexWhere(ste => ste.getFileName == "Emit.scala")
+    if (i == -1) 0 else st(i).getLineNumber
+  }
+
+  def _throw[T <: java.lang.Throwable, U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] =
+    _throw[T, U](cerr, getEmitLineNum)
+
+  def _throw[T <: java.lang.Throwable, U](cerr: Code[T], lineNumber: Int)(implicit uti: TypeInfo[U]): Code[U] = {
     if (uti eq UnitInfo) {
-      cerr.end.append(lir.throwx(cerr.v))
+      cerr.end.append(lir.throwx(cerr.v, lineNumber))
       val newC = new VCode(cerr.start, cerr.end, null)
       cerr.clear()
       newC
     } else
-      Code(cerr, lir.insn1(ATHROW, uti))
+      Code(cerr, lir.insn1(ATHROW, uti, lineNumber))
   }
 
   def _fatal[U](msg: Code[String])(implicit uti: TypeInfo[U]): Code[U] =
-    Code._throw[is.hail.utils.HailException, U](Code.newInstance[is.hail.utils.HailException, String, Option[String], Throwable](
+    _fatal[U](msg, getEmitLineNum)
+
+  def _fatal[U](msg: Code[String], lineNumber: Int)(implicit uti: TypeInfo[U]): Code[U] = {
+    val cerr = Code.newInstance[is.hail.utils.HailException, String, Option[String], Throwable](
       msg,
       Code.invokeStatic0[scala.Option[String], scala.Option[String]]("empty"),
-      Code._null[Throwable]))
+      Code._null[Throwable],
+      lineNumber)
+    Code._throw[is.hail.utils.HailException, U](cerr, lineNumber)
+  }
 
-  def _fatal[U](msg: Code[String], errorId: Int)(implicit uti: TypeInfo[U]): Code[U] =
+  def _fatalWithID[U](msg: Code[String], errorId: Int)(implicit uti: TypeInfo[U]): Code[U] =
     Code._throw[is.hail.utils.HailException, U](Code.newInstance[is.hail.utils.HailException, String, Int](
       msg,
       errorId))

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -51,7 +51,7 @@ object Compile {
     val fb = EmitFunctionBuilder[F](ctx, "Compiled",
       CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
         EmitParamType(pt)
-      }, returnType)
+      }, returnType, Some("Emit.scala"))
 
     /*
     {
@@ -113,7 +113,7 @@ object CompileWithAggregators {
     val fb = EmitFunctionBuilder[F](ctx, "CompiledWithAggs",
       CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
         EmitParamType(pt)
-      }, returnType)
+      }, returnType, Some("Emit.scala"))
 
     /*
     {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -42,11 +42,11 @@ case class EmitParam(ec: EmitCode) extends Param
 case class CodeParam(c: Code[_]) extends Param
 
 class EmitModuleBuilder(val ctx: ExecuteContext, val modb: ModuleBuilder) {
-  def newEmitClass[C](name: String)(implicit cti: TypeInfo[C]): EmitClassBuilder[C] =
-    new EmitClassBuilder(this, modb.newClass(name))
+  def newEmitClass[C](name: String, sourceFile: Option[String] = None)(implicit cti: TypeInfo[C]): EmitClassBuilder[C] =
+    new EmitClassBuilder(this, modb.newClass(name, sourceFile))
 
-  def genEmitClass[C](baseName: String)(implicit cti: TypeInfo[C]): EmitClassBuilder[C] =
-    newEmitClass[C](genName("C", baseName))
+  def genEmitClass[C](baseName: String, sourceFile: Option[String] = None)(implicit cti: TypeInfo[C]): EmitClassBuilder[C] =
+    newEmitClass[C](genName("C", baseName), sourceFile)
 
   private[this] var _staticFS: Settable[FS] = _
 
@@ -772,10 +772,10 @@ class EmitClassBuilder[C](
 
 object EmitFunctionBuilder {
   def apply[F](
-    ctx: ExecuteContext, baseName: String, paramTypes: IndexedSeq[ParamType], returnType: ParamType
+    ctx: ExecuteContext, baseName: String, paramTypes: IndexedSeq[ParamType], returnType: ParamType, sourceFile: Option[String] = None
   )(implicit fti: TypeInfo[F]): EmitFunctionBuilder[F] = {
     val modb = new EmitModuleBuilder(ctx, new ModuleBuilder())
-    val cb = modb.genEmitClass[F](baseName)
+    val cb = modb.genEmitClass[F](baseName, sourceFile)
     val apply = cb.newEmitMethod("apply", paramTypes, returnType)
     new EmitFunctionBuilder(apply)
   }

--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -58,7 +58,7 @@ class SplitMethod(
     }
   }
 
-  private val spillsClass = new Classx(genName("C", s"${ m.name }Spills"), "java/lang/Object")
+  private val spillsClass = new Classx(genName("C", s"${ m.name }Spills"), "java/lang/Object", None)
   private val spillsCtor = {
     val ctor = spillsClass.newMethod("<init>", FastIndexedSeq(), UnitInfo)
     val L = new Block()
@@ -171,7 +171,7 @@ class SplitMethod(
           if (f != null) {
             x.replace(
               putField(f, getSpills(),
-                insn(IADD,
+                insn2(IADD)(
                   getField(f, getSpills()),
                   ldcInsn(x.i, IntInfo))))
           }

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes._
 
 // FIXME move typeinfo stuff lir
 
-class Classx[C](val name: String, val superName: String) {
+class Classx[C](val name: String, val superName: String, val sourceFile: Option[String]) {
   val ti: TypeInfo[C] = new ClassInfo[C](name)
 
   val methods: mutable.ArrayBuffer[Method] = new mutable.ArrayBuffer()
@@ -448,6 +448,8 @@ abstract class X {
 
   var children: Array[ValueX] = new Array(0)
 
+  val lineNumber: Int
+
   def setArity(n: Int): Unit = {
     var i = n
     while (i < children.length) {
@@ -618,7 +620,7 @@ abstract class ValueX extends X {
   }
 }
 
-class GotoX extends ControlX {
+class GotoX(val lineNumber: Int = 0) extends ControlX {
   private var _L: Block = _
 
   def L: Block = _L
@@ -642,7 +644,7 @@ class GotoX extends ControlX {
   }
 }
 
-class IfX(val op: Int) extends ControlX {
+class IfX(val op: Int, val lineNumber: Int = 0) extends ControlX {
   private var _Ltrue: Block = _
   private var _Lfalse: Block = _
 
@@ -683,7 +685,7 @@ class IfX(val op: Int) extends ControlX {
   }
 }
 
-class SwitchX() extends ControlX {
+class SwitchX(val lineNumber: Int = 0) extends ControlX {
   private var _Ldefault: Block = _
 
   private var _Lcases: Array[Block] = Array.empty[Block]
@@ -748,13 +750,13 @@ class SwitchX() extends ControlX {
   }
 }
 
-class StoreX(var l: Local) extends StmtX
+class StoreX(var l: Local, val lineNumber: Int = 0) extends StmtX
 
-class PutFieldX(val op: Int, val f: FieldRef) extends StmtX
+class PutFieldX(val op: Int, val f: FieldRef, val lineNumber: Int = 0) extends StmtX
 
-class IincX(var l: Local, val i: Int) extends StmtX
+class IincX(var l: Local, val i: Int, val lineNumber: Int = 0) extends StmtX
 
-class ReturnX() extends ControlX {
+class ReturnX(val lineNumber: Int = 0) extends ControlX {
   def targetArity(): Int = 0
 
   def target(i: Int): Block = throw new IndexOutOfBoundsException()
@@ -762,7 +764,7 @@ class ReturnX() extends ControlX {
   def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
 }
 
-class ThrowX() extends ControlX {
+class ThrowX(val lineNumber: Int = 0) extends ControlX {
   def targetArity(): Int = 0
 
   def target(i: Int): Block = throw new IndexOutOfBoundsException()
@@ -770,11 +772,11 @@ class ThrowX() extends ControlX {
   def setTarget(i: Int, b: Block): Unit = throw new IndexOutOfBoundsException()
 }
 
-class StmtOpX(val op: Int) extends StmtX
+class StmtOpX(val op: Int, val lineNumber: Int = 0) extends StmtX
 
-class MethodStmtX(val op: Int, val method: MethodRef) extends StmtX
+class MethodStmtX(val op: Int, val method: MethodRef, val lineNumber: Int = 0) extends StmtX
 
-class TypeInsnX(val op: Int, val t: String) extends ValueX {
+class TypeInsnX(val op: Int, val t: String, val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = {
     assert(op == CHECKCAST)
     // FIXME, ClassInfo should take the internal name
@@ -782,7 +784,7 @@ class TypeInsnX(val op: Int, val t: String) extends ValueX {
   }
 }
 
-class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
+class InsnX(val op: Int, _ti: TypeInfo[_], val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = {
     if (_ti != null)
       return _ti
@@ -856,26 +858,26 @@ class InsnX(val op: Int, _ti: TypeInfo[_]) extends ValueX {
   }
 }
 
-class LoadX(var l: Local) extends ValueX {
+class LoadX(var l: Local, val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = l.ti
 }
 
-class GetFieldX(val op: Int, val f: FieldRef) extends ValueX {
+class GetFieldX(val op: Int, val f: FieldRef, val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = f.ti
 }
 
-class NewArrayX(val eti: TypeInfo[_]) extends ValueX {
+class NewArrayX(val eti: TypeInfo[_], val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = arrayInfo(eti)
 }
 
-class NewInstanceX(val ti: TypeInfo[_], val ctor: MethodRef) extends ValueX
+class NewInstanceX(val ti: TypeInfo[_], val ctor: MethodRef, val lineNumber: Int = 0) extends ValueX
 
-class LdcX(val a: Any, val ti: TypeInfo[_]) extends ValueX {
+class LdcX(val a: Any, val ti: TypeInfo[_], val lineNumber: Int = 0) extends ValueX {
   assert(
     a.isInstanceOf[String] || a.isInstanceOf[Double] || a.isInstanceOf[Float] || a.isInstanceOf[Int] || a.isInstanceOf[Long],
     s"not a string, double, float, int, or long: $a")
 }
 
-class MethodX(val op: Int, val method: MethodRef) extends ValueX {
+class MethodX(val op: Int, val method: MethodRef, val lineNumber: Int = 0) extends ValueX {
   def ti: TypeInfo[_] = method.returnTypeInfo
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -264,7 +264,7 @@ class PCanonicalNDArraySettable(override val pt: PCanonicalNDArray, val a: Setta
       val eMsg = const("Index ").concat(indices(dimIndex).toS)
         .concat(s" is out of bounds for axis $dimIndex with size ")
         .concat(shape(dimIndex).toS)
-      (indices(dimIndex) >= shape(dimIndex)).orEmpty(Code._fatal[Unit](eMsg, errorId))
+      (indices(dimIndex) >= shape(dimIndex)).orEmpty(Code._fatalWithID[Unit](eMsg, errorId))
     }
   }
 


### PR DESCRIPTION
This PR is a first step towards full debug information in generated bytecode. It lays the foundation in lir, and uses it to add line numbers to generated exceptions, which then show up in the stack trace. The line numbers are computed by taking the stack trace in `Code._fatal`, and finding the most recent line in `Emit.scala`, if any. Sometimes this will be less useful, e.g. exceptions thrown in aggregators, but it's a step.

The design of the source location tracking in lir is very simple: every instruction has an associated line number, and `lir.Emit` watches for when the line numbers of the current and previous instruction are different, and emits the start of a new line number interval. This design might be slightly wasteful of memory, if we expect groups of several consecutive instructions to come from the same source line, but it's probably fine, and makes preserving the source location information through lir transformations trivial. In any case, I expect it to be easy to change in the future if necessary.