### PR TITLE
[hail] Fix memory leak in BM and make cache size configurable

### DIFF
--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -94,18 +94,21 @@ class TextTableReader(TableReader):
 
 
 class TableFromBlockMatrixNativeReader(TableReader):
-    @typecheck_method(path=str, n_partitions=nullable(int))
-    def __init__(self, path, n_partitions):
+    @typecheck_method(path=str, n_partitions=nullable(int), maximum_cache_memory_in_bytes=nullable(int))
+    def __init__(self, path, n_partitions, maximum_cache_memory_in_bytes):
         self.path = path
         self.n_partitions = n_partitions
+        self.maximum_cache_memory_in_bytes = maximum_cache_memory_in_bytes
 
     def render(self):
         reader = {'name': 'TableFromBlockMatrixNativeReader',
                   'path': self.path,
-                  'nPartitions': self.n_partitions}
+                  'nPartitions': self.n_partitions,
+                  'maximumCacheMemoryInBytes': maximum_cache_memory_in_bytes}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):
         return isinstance(other, TableFromBlockMatrixNativeReader) and \
             other.path == self.path and \
-            other.n_partitions == self.n_partitions
+            other.n_partitions == self.n_partitions and \
+            other.maximum_cache_memory_in_bytes == self.maximum_cache_memory_in_bytes

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -104,7 +104,7 @@ class TableFromBlockMatrixNativeReader(TableReader):
         reader = {'name': 'TableFromBlockMatrixNativeReader',
                   'path': self.path,
                   'nPartitions': self.n_partitions,
-                  'maximumCacheMemoryInBytes': maximum_cache_memory_in_bytes}
+                  'maximumCacheMemoryInBytes': self.maximum_cache_memory_in_bytes}
         return escape_str(json.dumps(reader))
 
     def __eq__(self, other):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1705,8 +1705,8 @@ class BlockMatrix(object):
             one row of th matrix in memory. If this value is exactly the size of
             one row, then a partition makes a network request for every row of
             every block. Larger values reduce the number of network requests. If
-            memory permits, setting this value to the size of one row permits
-            one network request per block per partition.
+            memory permits, setting this value to the size of one output
+            partition permits one network request per block per partition.
 
         Notes
         -----
@@ -1741,8 +1741,8 @@ class BlockMatrix(object):
             one row of th matrix in memory. If this value is exactly the size of
             one row, then a partition makes a network request for every row of
             every block. Larger values reduce the number of network requests. If
-            memory permits, setting this value to the size of one row permits
-            one network request per block per partition.
+            memory permits, setting this value to the size of one output
+            partition permits one network request per block per partition.
 
         Notes
         -----

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1718,6 +1718,9 @@ class BlockMatrix(object):
             Table where each row corresponds to a row in the block matrix.
         """
         path = new_temp_file()
+        if maximum_cache_memory_in_bytes > (1 << 31) - 1:
+            raise ValueError(
+                f'maximum_cache_memory_in_bytes must be less than 2^31 -1, was: {maximum_cache_memory_in_bytes}')
 
         self.write(path, overwrite=True, force_row_major=True)
         reader = TableFromBlockMatrixNativeReader(path, n_partitions, maximum_cache_memory_in_bytes)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1718,7 +1718,7 @@ class BlockMatrix(object):
             Table where each row corresponds to a row in the block matrix.
         """
         path = new_temp_file()
-        if maximum_cache_memory_in_bytes > (1 << 31) - 1:
+        if maximum_cache_memory_in_bytes and maximum_cache_memory_in_bytes > (1 << 31) - 1:
             raise ValueError(
                 f'maximum_cache_memory_in_bytes must be less than 2^31 -1, was: {maximum_cache_memory_in_bytes}')
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1702,7 +1702,7 @@ class BlockMatrix(object):
         maximum_cache_memory_in_bytes : int or None
             The amount of memory to reserve, per partition, to cache rows of the
             matrix in memory. This value must be at least large enough to hold
-            one row of th matrix in memory. If this value is exactly the size of
+            one row of the matrix in memory. If this value is exactly the size of
             one row, then a partition makes a network request for every row of
             every block. Larger values reduce the number of network requests. If
             memory permits, setting this value to the size of one output
@@ -1738,7 +1738,7 @@ class BlockMatrix(object):
         maximum_cache_memory_in_bytes : int or None
             The amount of memory to reserve, per partition, to cache rows of the
             matrix in memory. This value must be at least large enough to hold
-            one row of th matrix in memory. If this value is exactly the size of
+            one row of the matrix in memory. If this value is exactly the size of
             one row, then a partition makes a network request for every row of
             every block. Larger values reduce the number of network requests. If
             memory permits, setting this value to the size of one output

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -210,6 +210,19 @@ class Tests(unittest.TestCase):
                 self.assertTrue(expected._same(actual))
 
     @fails_local_backend()
+    def test_to_table_maximum_cache_memory_in_bytes_limits(self):
+        bm = BlockMatrix._create(5, 2, [float(i) for i in range(10)], 2)
+        try:
+            bm.to_table_row_major(2, maximum_cache_memory_in_bytes=15)._force_count()
+        except Exception as exc:
+            assert 'BlockMatrixCachedPartFile must be able to hold at least one row of every block in memory' in exc.message
+        else:
+            assert False
+
+        bm = BlockMatrix._create(5, 2, [float(i) for i in range(10)], 2)
+        bm.to_table_row_major(2, maximum_cache_memory_in_bytes=16)._force_count()
+
+    @fails_local_backend()
     def test_to_matrix_table(self):
         n_partitions = 2
         rows, cols = 2, 5

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -215,7 +215,7 @@ class Tests(unittest.TestCase):
         try:
             bm.to_table_row_major(2, maximum_cache_memory_in_bytes=15)._force_count()
         except Exception as exc:
-            assert 'BlockMatrixCachedPartFile must be able to hold at least one row of every block in memory' in exc.message
+            assert 'BlockMatrixCachedPartFile must be able to hold at least one row of every block in memory' in exc.args[0]
         else:
             assert False
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -674,8 +674,8 @@ object TableFromBlockMatrixNativeReader {
 
   }
 
-  def apply(fs: FS, path: String, nPartitions: Option[Int] = None): TableFromBlockMatrixNativeReader =
-    TableFromBlockMatrixNativeReader(fs, TableFromBlockMatrixNativeReaderParameters(path, nPartitions))
+  def apply(fs: FS, path: String, nPartitions: Option[Int] = None, maximumCacheMemoryInBytes: Option[Int] = None): TableFromBlockMatrixNativeReader =
+    TableFromBlockMatrixNativeReader(fs, TableFromBlockMatrixNativeReaderParameters(path, nPartitions, maximumCacheMemoryInBytes))
 
   def fromJValue(fs: FS, jv: JValue): TableFromBlockMatrixNativeReader = {
     implicit val formats: Formats = TableReader.formats

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -684,7 +684,7 @@ object TableFromBlockMatrixNativeReader {
   }
 }
 
-case class TableFromBlockMatrixNativeReaderParameters(path: String, nPartitions: Option[Int])
+case class TableFromBlockMatrixNativeReaderParameters(path: String, nPartitions: Option[Int], maximumCacheMemoryInBytes: Option[Int])
 
 case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeReaderParameters, metadata: BlockMatrixMetadata) extends TableReader {
   def pathsUsed: Seq[String] = FastSeq(params.path)
@@ -712,7 +712,8 @@ case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeRe
   }
 
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
-    val rowsRDD = new BlockMatrixReadRowBlockedRDD(ctx.fsBc, params.path, partitionRanges, metadata)
+    val rowsRDD = new BlockMatrixReadRowBlockedRDD(ctx.fsBc, params.path, partitionRanges, metadata,
+      maybeMaximumCacheMemoryInBytes = params.maximumCacheMemoryInBytes)
 
     val partitionBounds = partitionRanges.map { r => Interval(Row(r.start), Row(r.end), true, false) }
     val partitioner = new RVDPartitioner(fullType.keyType, partitionBounds)


### PR DESCRIPTION
CHANGELOG: Remove memory leak in `BlockMatrix.to_matrix_table_row_major` and `BlockMatrix.to_table_row_major`. Also, make the cache size used in both methods configurable.

The `ref` variable was holding entire blocks in memory for no reason. It was a
vestiage of debugging. Moreover, the configurable cache permits users to fine tune
memory usage.