### PR TITLE
[query] Fix NDArrays of Non-numerics: Part 1

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -655,6 +655,7 @@ class tndarray(HailType):
 
     def _convert_from_json(self, x):
         if is_numeric(self._element_type):
+            np_type = self.element_type.to_numpy()
             return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
         else:
             raise TypeError("Hail cannot currently return ndarrays of non-numeric or boolean type.")

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -654,8 +654,10 @@ class tndarray(HailType):
         return f'NDArray[{self._element_type._parsable_string()},{self.ndim}]'
 
     def _convert_from_json(self, x):
-        np_type = self.element_type.to_numpy()
-        return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
+        if is_numeric(self._element_type):
+            return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
+        else:
+            raise TypeError("Hail cannot currently return ndarrays of non-numeric or boolean type.")
 
     def _convert_to_json(self, x):
         data = x.flatten("F").tolist()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -333,6 +333,9 @@ def test_ndarray_map():
     s_lens = s.map(lambda e: hl.len(e))
     assert np.array_equal(hl.eval(s_lens), np.array([4, 2, 5]))
 
+    structs = hl.nd.array([hl.struct(x=5, y=True), hl.struct(x=9, y=False)])
+    assert np.array_equal(hl.eval(structs.map(lambda e: e.y)), np.array([True, False]))
+
 
 def test_ndarray_map2():
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -329,6 +329,10 @@ def test_ndarray_map():
 
     assert hl.eval(hl.null(hl.tndarray(hl.tfloat, 1)).map(lambda x: x * 2)) is None
 
+    s = hl.nd.array(["hail", "is", "great"])
+    s_lens = s.map(lambda e: hl.len(e))
+    assert np.array_equal(hl.eval(s_lens), np.array([4, 2, 5]))
+
 
 def test_ndarray_map2():
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -799,7 +799,7 @@ class Emit[C](
               val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
               val dataValue = dataCode.memoize(cb, "make_ndarray_data")
               val dataPtr = dataValue.get.tcode[Long]
-              val requiredData = dataPType.checkedConvertFrom(mb, region.code, dataPtr, coerce[PArray](dataContainer), "NDArray cannot have missing data")
+              val requiredData = dataPType.copyFromType(mb, region.code, dataContainer, dataPtr, false)
 
               (0 until nDims).foreach { index =>
                 cb.ifx(shapeTupleValue.isFieldMissing(index),

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -125,9 +125,6 @@ trait PArrayBackedContainer extends PContainer {
   def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean] =
     arrayRep.hasMissingValues(sourceOffset)
 
-  def checkedConvertFrom(mb: EmitMethodBuilder[_], r: Value[Region], sourceOffset: Code[Long], sourceType: PContainer, msg: String): Code[Long] =
-    arrayRep.checkedConvertFrom(mb, r, sourceOffset, sourceType, msg)
-
   def copyFrom(region: Region, srcOff: Long): Long =
     arrayRep.copyFrom(region, srcOff)
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -87,8 +87,6 @@ abstract class PContainer extends PIterable {
 
   def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean]
 
-  def checkedConvertFrom(mb: EmitMethodBuilder[_], r: Value[Region], sourceOffset: Code[Long], sourceType: PContainer, msg: String): Code[Long]
-
   def nextElementAddress(currentOffset: Long): Long
 
   def nextElementAddress(currentOffset: Code[Long]): Code[Long]

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -118,47 +118,7 @@ class PContainerTest extends PhysicalTestUtils {
         missing <- 1 to num
     } assert(testHasMissingValues(sourceType, nullInByte(num, missing)) == true)
   }
-
-  @Test def checkedConvertFromTest() {
-    val sourceType = PCanonicalArray(PInt64(false))
-    val destType = PCanonicalArray(PInt64(true))
-
-    testConvert(sourceType, destType, nullInByte(0, 0), false)
-
-    // 1 byte
-    testConvert(sourceType, destType, nullInByte(1, 0), false)
-    testConvert(sourceType, destType, nullInByte(1, 1), true)
-    testConvert(sourceType, destType, nullInByte(5, 5), true)
-
-    // 1 full byte
-    testConvert(sourceType, destType, nullInByte(8, 0), false)
-    testConvert(sourceType, destType, nullInByte(8, 1), true)
-    testConvert(sourceType, destType, nullInByte(8, 5), true)
-    testConvert(sourceType, destType, nullInByte(8, 8), true)
-
-    // 1 byte + remainder
-    testConvert(sourceType, destType, nullInByte(11, 0), false)
-    testConvert(sourceType, destType, nullInByte(13, 13), true)
-    testConvert(sourceType, destType, nullInByte(13, 9), true)
-    testConvert(sourceType, destType, nullInByte(13, 8), true)
-
-    // 1 Long
-    testConvert(sourceType, destType, nullInByte(64, 0), false)
-    testConvert(sourceType, destType, nullInByte(64, 1), true)
-    testConvert(sourceType, destType, nullInByte(64, 64), true)
-
-    // 1 Long + remainder
-    testConvert(sourceType, destType, nullInByte(67, 0), false)
-    testConvert(sourceType, destType, nullInByte(67, 67), true)
-    testConvert(sourceType, destType, nullInByte(67, 65), true)
-    testConvert(sourceType, destType, nullInByte(67, 64), true)
-
-    // 1 Long + 1 byte + remainder
-    testConvert(sourceType, destType, nullInByte(79, 0), false)
-    testConvert(sourceType, destType, nullInByte(79, 72), true)
-    testConvert(sourceType, destType, nullInByte(79, 8), true)
-  }
-
+  
   @Test def arrayCopyTest() {
     // Note: can't test where data is null due to ArrayStack.top semantics (ScalaToRegionValue: assert(size_ > 0))
     def runTests(deepCopy: Boolean, interpret: Boolean) {

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -17,27 +17,6 @@ class PContainerTest extends PhysicalTestUtils {
     })
   }
 
-  def testConvert(sourceType: PArray, destType: PArray, data: IndexedSeq[Any], expectFalse: Boolean) {
-    val srcRegion = Region()
-    val src = ScalaToRegionValue(srcRegion, sourceType, data)
-
-    log.info(s"Testing $data")
-
-    val fb = EmitFunctionBuilder[Region, Long, Long](ctx, "not_empty")
-    val codeRegion = fb.getCodeParam[Region](1)
-    val value = fb.getCodeParam[Long](2)
-
-    fb.emit(destType.checkedConvertFrom(fb.apply_method, codeRegion, value, sourceType, "ShouldHaveNoNull"))
-
-    val f = fb.result()()
-    val destRegion = Region()
-    if (expectFalse) {
-      val thrown = intercept[Exception](f(destRegion,src))
-      assert(thrown.getMessage == "ShouldHaveNoNull")
-    } else
-      f(destRegion,src)
-  }
-
   def testContainsNonZeroBits(sourceType: PArray, data: IndexedSeq[Any]) = {
     val srcRegion = Region()
     val src = ScalaToRegionValue(srcRegion, sourceType, data)


### PR DESCRIPTION
CHANGELOG: Fixed bug where making NDArrays of non-numeric types would fail. Non-numeric ndarrays still cannot be collected to python though. 

NDArrays of non numeric types are broken, have been for a while. No one seems to use them for that currently, so it hasn't been an issue, but I suspect with `dndarray` or BlockedMatrixTable experiments it's going to be desirable. 

This PR starts to address that problem by doing the following:

1. `checkedConvertFrom`, which only supported primitive arrays, is replaced with the more flexible `copyFromType`. As this was the only use of `checkedConvertFrom`, I removed it altogether. 

2. Add tests that show that it's now possible to make an ndarray of non-numeric types, so long as the only things that get returned in python are numbers.

The remaining problems all involve conversions to numpy. If you never convert to numpy, things should be fine:

1. I need to get strides out of the Java ndarray representation. Strides make no sense for non-numeric objects after converting from Java to Python. We say the size of a required tuple of 3 int32's is 12 bytes, but that's not going to be the size of the python object

2. Strings are tricky too, since the numpy string dtype comes with a max length, so we'll have to do a pass over the strings to figure out how large the largest one is before converting. 