### PR TITLE
[hailctl] use execvp for hailctl curl

### DIFF
--- a/hail/python/hailtop/hailctl/curl.py
+++ b/hail/python/hailtop/hailctl/curl.py
@@ -1,5 +1,5 @@
 import sys
-import subprocess
+import os
 
 from hailtop.auth import namespace_auth_headers
 from hailtop.config import get_deploy_config
@@ -18,4 +18,4 @@ def main(args):
                for k, v in headers.items()
                for x in ['-H', f'{k}: {v}']]
     path = deploy_config.with_service(svc, ns).url(svc, path)
-    subprocess.check_call(['curl', *headers, *args[3:], path])
+    os.execvp('curl', ['curl', *headers, *args[3:], path])


### PR DESCRIPTION
Subprocess machinery is unnecessary here, we exit right after returning, so use `exec` instead.