### PR TITLE
[batch] fix flaky batch invariants test

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -568,7 +568,7 @@ async def check_resource_aggregation(app, db):
     async def check(tx):
         attempt_resources = tx.execute_and_fetchall('''
 SELECT attempt_resources.batch_id, attempt_resources.job_id, attempt_resources.attempt_id,
-  JSON_OBJECTAGG(resource, quantity * COALESCE(end_time - start_time, 0)) as resources
+  JSON_OBJECTAGG(resource, quantity * GREATEST(COALESCE(end_time - start_time, 0), 0)) as resources
 FROM attempt_resources
 INNER JOIN attempts
 ON attempts.batch_id = attempt_resources.batch_id AND


### PR DESCRIPTION
I have added an item to services design meeting to further discuss the meaning of
`start_time` and `end_time` of an attempt. For the time being, this eliminates the
flakiness that is preventing PRs from merging.