### PR TITLE
 [hailctl batch client] Add ability to cache batch status.

### DIFF
--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -114,6 +114,9 @@ class Batch:
     def status(self):
         return async_to_blocking(self._async_batch.status())
 
+    def last_known_status(self):
+        return async_to_blocking(self._async_batch.last_known_status())
+
     def jobs(self, q=None):
         return agen_to_blocking(self._async_batch.jobs(q=q))
 


### PR DESCRIPTION
This will avoid extra requests especially since most batches statuses
will not change (most batches are finished).

The new function last_known_status() will make an HTTP request if and
only if the saved status is None.