### PR TITLE
[query/lir] Don’t use asm.tree in lir.Emit

### DIFF
--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -213,6 +213,9 @@ object Emit {
       emitClass(c, cw, logMethodSizes = true)
 
       val b = cw.toByteArray
+      // For efficiency, the ClassWriter does no checking, and may generate invalid
+      // bytecode. This will verify the generated class file, printing errors
+      // to System.out.
       // This next line should always be commented out!
 //      CheckClassAdapter.verify(new ClassReader(b), false, new PrintWriter(System.err))
       b

--- a/hail/src/main/scala/is/hail/lir/Emit.scala
+++ b/hail/src/main/scala/is/hail/lir/Emit.scala
@@ -213,8 +213,8 @@ object Emit {
       emitClass(c, cw, logMethodSizes = true)
 
       val b = cw.toByteArray
-      //       This next line should always be commented out!
-//            CheckClassAdapter.verify(new ClassReader(b), false, new PrintWriter(System.err))
+      // This next line should always be commented out!
+//      CheckClassAdapter.verify(new ClassReader(b), false, new PrintWriter(System.err))
       b
     } catch {
       case e: Exception =>


### PR DESCRIPTION
This is a simple refactoring of `lir.Emit` to directly use the core visitor based interface of ASM, rather than the higher level `tree` interface. This should have a small performance benefit, as we aren't building the in-memory tree representation only to immediately walk it with a visitor. But I also find this version of `Emit` slightly cleaner.

For reference, you can find the documentation for ASM 5.1 [here](https://javadoc.io/doc/org.ow2.asm/asm/5.1/index.html).