### PR TITLE
[batch] require YARL <1.6.0 which avoids bug

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -51,4 +51,6 @@ urllib3==1.24.3
 uvloop==0.14.0
 Werkzeug==0.15.4
 wheel>=0.31.0
+# yarl 1.6.0 broke query string parsing in aiohttp 3.6.[012] https://github.com/aio-libs/aiohttp/issues/4972#issuecomment-700290809
+yarl<1.6.0
 zulip==0.6.3


### PR DESCRIPTION
Related issues in upstream projects:

- YARL issue: aio-libs/yarl#509
- aiohttp issue: aio-libs/aiohttp#4972
