### PR TITLE
[hailctl dataproc] Add support for requester pays buckets to hailctl dataproc describe

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/describe.py
+++ b/hail/python/hailtop/hailctl/dataproc/describe.py
@@ -101,10 +101,15 @@ def get_partitions_info_str(j):
 def init_parser(parser):
     # arguments with default parameters
     parser.add_argument('file', type=str, help='Path to hail file (either MatrixTable or Table).')
+    parser.add_argument('--requester-pays-project-id', help='Project to be billed for GCS requests.')
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument
-    command = ['gsutil'] if args.file.startswith('gs://') else []
+    command = []
+    if args.file.startswith('gs://'):
+        command = ['gsutil']
+        if args.requester_pays_project_id:
+            command.extend(['-u', args.requester_pays_project_id])
 
     j = json.loads(
         decompress(

--- a/hail/python/hailtop/hailctl/dataproc/describe.py
+++ b/hail/python/hailtop/hailctl/dataproc/describe.py
@@ -101,7 +101,7 @@ def get_partitions_info_str(j):
 def init_parser(parser):
     # arguments with default parameters
     parser.add_argument('file', type=str, help='Path to hail file (either MatrixTable or Table).')
-    parser.add_argument('--requester-pays-project-id', help='Project to be billed for GCS requests.')
+    parser.add_argument('--requester-pays-project-id', '-u', help='Project to be billed for GCS requests.')
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument


### PR DESCRIPTION
Currently, there is no way to use `hailctl dataproc describe` on a table in a [requester pays](https://cloud.google.com/storage/docs/requester-pays) bucket. Accessing files in requester pays buckets requires adding a `-u` flag to `gsutil` with the project to bill for operation, network, and data retrieval charges.

https://cloud.google.com/storage/docs/using-requester-pays#using