### PR TITLE
[git][services, mostly] add *.out files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ hs_err_pid*.log
 *hail/python/hail/docs/tutorials/data*
 *hail/python/hailtop/pipeline/docs/output*
 .mypy_cache/
+*.out


### PR DESCRIPTION
We generate these a lot as intermediates when we manually build service images. I think it should be pretty safe to ignore all of these, since I don't know of anything we need to check in with that extension.