### PR TITLE
[ci] Pretty print create_database.py json config

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -929,7 +929,10 @@ LC_ALL=C tr -dc '[:alnum:]' </dev/urandom | head -c 16 > {self.user_password_fil
         create_database_script = f'''
 set -ex
 
-python3 create_database.py {shq(json.dumps(create_database_config))}
+create_database_config={shq(json.dumps(create_database_config, indent=2))}
+python3 create_database.py <<EOF
+$create_database_config
+EOF
 '''
 
         input_files = []

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -11,8 +11,8 @@ from hailtop.utils import check_shell, check_shell_output
 from hailtop.auth.sql_config import create_secret_data_from_config, SQLConfig
 from gear import Database
 
-assert len(sys.argv) == 2
-create_database_config = json.loads(sys.argv[1])
+assert len(sys.argv) == 1
+create_database_config = json.load(sys.stdin)
 
 
 def generate_token(size=12):
@@ -148,7 +148,7 @@ async def shutdown():
             await check_shell(f'''
 kubectl -n {s["namespace"]} delete --ignore-not-found=true deployment {s["name"]}
 ''')
-    
+
     did_shutdown = True
 
 


### PR DESCRIPTION
Save it to a variable and pass it to standard input using a heredoc
instead of a gnarly command line argument.  This still outputs the
config to the logs/job output since the variable assignment expression
will be printed with `set -x`.