### PR TITLE
[query] Port etype decoders to CodeBuilder

### DIFF
--- a/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBoolean.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -18,8 +18,8 @@ class EBoolean(override val required: Boolean) extends EFundamentalType {
   }
 
   def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
     pt: PType,
-    mb: EmitMethodBuilder[_],
     region: Value[Region],
     in: Value[InputBuffer]
   ): Code[Boolean] = in.readBoolean()

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat32.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -18,8 +18,8 @@ class EFloat32(override val required: Boolean) extends EFundamentalType {
   }
 
   def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
     pt: PType,
-    mb: EmitMethodBuilder[_],
     region: Value[Region],
     in: Value[InputBuffer]
   ): Code[Float] = in.readFloat()

--- a/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EFloat64.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -16,8 +16,10 @@ class EFloat64(override val required: Boolean) extends EFundamentalType {
   def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
     cb += out.writeDouble(coerce[Double](v))
   }
-def _buildFundamentalDecoder( pt: PType,
-    mb: EmitMethodBuilder[_],
+
+  def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
+    pt: PType,
     region: Value[Region],
     in: Value[InputBuffer]
   ): Code[Double] = in.readDouble()

--- a/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -18,8 +18,8 @@ class EInt32(override val required: Boolean) extends EFundamentalType {
   }
 
   def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
     pt: PType,
-    mb: EmitMethodBuilder[_],
     region: Value[Region],
     in: Value[InputBuffer]
   ): Code[Int] = in.readInt()

--- a/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt64.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.types.BaseType
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -18,8 +18,8 @@ class EInt64(override val required: Boolean) extends EFundamentalType {
   }
 
   def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
     pt: PType,
-    mb: EmitMethodBuilder[_],
     region: Value[Region],
     in: Value[InputBuffer]
   ): Code[Long] = in.readLong()

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.annotations.{Region}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCodeBuilder}
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical.{PCanonicalNDArray, PCode, PType}
 import is.hail.types.virtual.{TNDArray, Type}
@@ -42,29 +42,32 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     }
   }
 
-  override def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = {
+  def _buildDecoder(
+    cb: EmitCodeBuilder,
+    pt: PType,
+    region: Value[Region],
+    in: Value[InputBuffer]
+  ): Code[_] = {
     val pnd = pt.asInstanceOf[PCanonicalNDArray]
-    val shapeVars = (0 until nDims).map(i => mb.newLocal[Long](s"ndarray_decoder_shape_$i"))
-    val totalNumElements = mb.newLocal[Long]("ndarray_decoder_total_num_elements")
+    val readElemF = elementType.buildInplaceDecoder(pnd.elementType, cb.emb.ecb)
 
-    val readElemF = elementType.buildInplaceDecoder(pnd.elementType, mb.ecb)
-    val dataAddress = mb.newLocal[Long]("ndarray_decoder_data_addr")
+    val shapeVars = (0 until nDims).map(i => cb.newLocal[Long](s"ndarray_decoder_shape_$i", in.readLong()))
+    val totalNumElements = cb.newLocal[Long]("ndarray_decoder_total_num_elements", 1L)
+    shapeVars.foreach { s =>
+      cb.assign(totalNumElements, totalNumElements * s)
+    }
 
-    val dataIdx = mb.newLocal[Int]("ndarray_decoder_data_idx")
+    val dataAddress = cb.newLocal[Long]("ndarray_decoder_data_addr",
+      pnd.data.pType.allocate(region, totalNumElements.toI))
+    cb += pnd.data.pType.stagedInitialize(dataAddress, totalNumElements.toI)
 
-    Code(
-      totalNumElements := 1L,
-      Code(shapeVars.map(shapeVar => Code(
-        shapeVar := in.readLong(),
-        totalNumElements := totalNumElements * shapeVar
-      ))),
-      dataAddress := pnd.data.pType.allocate(region, totalNumElements.toI),
-      pnd.data.pType.stagedInitialize(dataAddress, totalNumElements.toI),
-      Code.forLoop(dataIdx := 0, dataIdx < totalNumElements.toI, dataIdx := dataIdx + 1,
-        readElemF(region, pnd.data.pType.elementOffset(dataAddress, totalNumElements.toI, dataIdx), in)
-      ),
-      pnd.construct(pnd.makeShapeBuilder(shapeVars), pnd.makeColumnMajorStridesBuilder(shapeVars, mb), dataAddress, mb, region)
-    )
+    val dataIdx = cb.newLocal[Int]("ndarray_decoder_data_idx")
+    cb.forLoop(cb.assign(dataIdx, 0), dataIdx < totalNumElements.toI, cb.assign(dataIdx, dataIdx + 1),
+      cb += readElemF(region, pnd.data.pType.elementOffset(dataAddress, totalNumElements.toI, dataIdx), in))
+
+    pnd.construct(pnd.makeShapeBuilder(shapeVars),
+      pnd.makeColumnMajorStridesBuilder(shapeVars, cb.emb),
+      dataAddress, cb.emb, region)
   }
 
   def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {

--- a/hail/src/main/scala/is/hail/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ETransposedArrayOfStructs.scala
@@ -49,7 +49,8 @@ final case class ETransposedArrayOfStructs(
     case _ => false
   }
 
-  def _buildDecoder(pt: PType, mb: EmitMethodBuilder[_], region: Value[Region], in: Value[InputBuffer]): Code[_] = {
+  def _buildDecoder(cb: EmitCodeBuilder, pt: PType, region: Value[Region], in: Value[InputBuffer]): Code[_] = {
+    val mb = cb.emb
     val arrayPType = pt.asInstanceOf[PArray]
     val elementPStruct = arrayPType.elementType.asInstanceOf[PBaseStruct]
 


### PR DESCRIPTION
One exception is ETransposedArrayOfStructs, where I take the copout of `val mb = cb.ecb` at the top of the function.