### PR TITLE
[query] Expand Python version compatibility with spark 3

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -8,7 +8,7 @@ MAKEFLAGS += --no-builtin-rules
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-SCALA_VERSION = 2.11.12
+SCALA_VERSION := 2.11.12
 SPARK_VERSION := 2.4.5
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 57

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,9 +1,13 @@
 import pkg_resources
 import sys
+import pyspark
 
-if not (3, 6) < sys.version_info < (3, 8):
-    raise EnvironmentError('Hail requires Python 3.6 or 3.7, found {}.{}'.format(
+if sys.version_info < (3, 6):
+    raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+if pyspark.__version__ < '3' and sys.version_info > (3, 8):
+    raise EnvironmentError('Hail with spark {} requires Python 3.6 or 3.7, found {}.{}'.format(
+        pyspark.__version__, sys.version_info.major, sys.version_info.minor))
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources
@@ -16,10 +20,10 @@ __doc__ = r"""
  /_/ /_/\_,_/_/_/
 ===================
 
-For API documentation, visit the website: www.hail.is
+For API documentation, visit the website: https://www.hail.is
 
 For help, visit either:
- - the forum (discuss.hail.is)
+ - the forum: https://discuss.hail.is
  - or our Zulip chatroom: https://hail.zulipchat.com
 
 To report a bug, please open an issue: https://github.com/hail-is/hail/issues

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,13 +1,9 @@
 import pkg_resources
 import sys
-import pyspark
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
-if pyspark.__version__ < '3' and sys.version_info > (3, 8):
-    raise EnvironmentError('Hail with spark {} requires Python 3.6 or 3.7, found {}.{}'.format(
-        pyspark.__version__, sys.version_info.major, sys.version_info.minor))
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -23,6 +23,11 @@ from .py4j_backend import Py4JBackend
 from ..hail_logging import Logger
 
 
+if pyspark.__version__ < '3' and sys.version_info > (3, 8):
+    raise EnvironmentError('Hail with spark {} requires Python 3.6 or 3.7, found {}.{}'.format(
+        pyspark.__version__, sys.version_info.major, sys.version_info.minor))
+
+
 def handle_java_exception(f):
     def deco(*args, **kwargs):
         import pyspark


### PR DESCRIPTION
Spark 3 resolved the issues with library changes python 3.8, so we can
now use python 3.8 as long as pyspark is version 3 or greater.

I also took this opertunity to make every link in or welcome doc message
a canonical https link that will be recognized as such by many parsers
such as sufficiently advanced terminal emulators.