### PR TITLE
[query] port firstMatchIn to IEmitCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -587,6 +587,12 @@ abstract class RegistryFunctions {
       impl(cb, r, rt, a1)
     }
 
+  def registerIEmitCode2(name: String, mt1: Type, mt2: Type, rt: Type, pt: (Type, PType, PType) => PType)
+    (impl: (EmitCodeBuilder, Value[Region], PType, IEmitCode, IEmitCode) => IEmitCode): Unit =
+    registerIEmitCode(name, Array(mt1, mt2), rt, unwrappedApply(pt)) { case (cb, r, rt, Array(a1, a2)) =>
+      impl(cb, r, rt, a1, a2)
+    }
+
   def registerEmitCode0(name: String, rt: Type, pt: PType)(impl: EmitRegion => EmitCode): Unit =
     registerEmitCode(name, Array[Type](), rt, (_: Type, _: Seq[PType]) => pt) { case (r, rt, Array()) => impl(r) }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -37,7 +37,7 @@ object GenotypeFunctions extends RegistryFunctions {
 
     registerIEmitCode1("dosage", TArray(tv("N", "float64")), TFloat64,  (_: Type, _: PType) => PFloat64()
     ) { case (cb, r, rt, gp) =>
-      gp.flatMap(cb) { case (gpc: PIndexableCode) =>
+      gp().flatMap(cb) { case (gpc: PIndexableCode) =>
         val gpv = gpc.memoize(cb, "dosage_gp")
 
         cb.ifx(gpv.loadLength().cne(3),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -214,15 +214,13 @@ object StringFunctions extends RegistryFunctions {
 
     registerIEmitCode2("firstMatchIn", TString, TString, TArray(TString), {
       case(_: Type, _: PType, _: PType) => PCanonicalArray(PCanonicalString(true))
-    }) { case (cb: EmitCodeBuilder, region: Value[Region], rt: PArray, s: IEmitCode, r: IEmitCode) =>
-
-      s.flatMap(cb) { case sc: PStringCode =>
-        r.flatMap(cb) { case rc: PStringCode =>
-          val s = cb.newLocal("s", sc.loadString())
-          val r = cb.newLocal("r", rc.loadString())
+    }) { case (cb: EmitCodeBuilder, region: Value[Region], rt: PArray,
+               s: (() => IEmitCode), r: (() => IEmitCode)) =>
+      s().flatMap(cb) { case sc: PStringCode =>
+        r().flatMap(cb) { case rc: PStringCode =>
           val out = cb.newLocal[IndexedSeq[String]]("out",
             Code.invokeScalaObject2[String, String, IndexedSeq[String]](
-              thisClass, "firstMatchIn", s, r))
+              thisClass, "firstMatchIn", sc.loadString(), rc.loadString()))
           IEmitCode(cb, out.isNull, {
             val len = cb.newLocal[Int]("len", out.invoke[Int]("size"))
             val srvb: StagedRegionValueBuilder = new StagedRegionValueBuilder(cb.emb, rt, region)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -212,38 +212,34 @@ object StringFunctions extends RegistryFunctions {
       case (_: Type, _: PType, _: PType) => PCanonicalString()
     })(thisClass, "arrayMkString")
 
-    registerEmitCode2("firstMatchIn", TString, TString, TArray(TString), {
+    registerIEmitCode2("firstMatchIn", TString, TString, TArray(TString), {
       case(_: Type, _: PType, _: PType) => PCanonicalArray(PCanonicalString(true))
-    }) {
-      case (er: EmitRegion, rt: PArray, s: EmitCode, r: EmitCode) =>
-      val out: LocalRef[IndexedSeq[String]] = er.mb.newLocal[IndexedSeq[String]]()
+    }) { case (cb: EmitCodeBuilder, region: Value[Region], rt: PArray, s: IEmitCode, r: IEmitCode) =>
 
-      val srvb: StagedRegionValueBuilder = new StagedRegionValueBuilder(er, rt)
-      val len: LocalRef[Int] = er.mb.newLocal[Int]()
-      val elt: LocalRef[String] = er.mb.newLocal[String]()
-
-      val setup = Code(s.setup, r.setup)
-      val missing = s.m || r.m || Code(
-        out := Code.invokeScalaObject2[String, String, IndexedSeq[String]](
-          thisClass, "firstMatchIn",
-          asm4s.coerce[String](wrapArg(er, s.pt)(s.value[Long])),
-          asm4s.coerce[String](wrapArg(er, r.pt)(r.value[Long]))),
-        out.isNull)
-      val value =
-        out.ifNull(
-          defaultValue(rt),
-          Code(
-            len := out.invoke[Int]("size"),
-            srvb.start(len),
-            Code.whileLoop(srvb.arrayIdx < len,
-              elt := out.invoke[Int, String]("apply", srvb.arrayIdx),
-              elt.ifNull(
-                srvb.setMissing(),
-                srvb.addString(elt)),
-              srvb.advance()),
-            srvb.end()))
-
-      EmitCode(setup, missing, PCode(rt, value))
+      s.flatMap(cb) { case sc: PStringCode =>
+        r.flatMap(cb) { case rc: PStringCode =>
+          val s = cb.newLocal("s", sc.loadString())
+          val r = cb.newLocal("r", rc.loadString())
+          val out = cb.newLocal[IndexedSeq[String]]("out",
+            Code.invokeScalaObject2[String, String, IndexedSeq[String]](
+              thisClass, "firstMatchIn", s, r))
+          IEmitCode(cb, out.isNull, {
+            val len = cb.newLocal[Int]("len", out.invoke[Int]("size"))
+            val srvb: StagedRegionValueBuilder = new StagedRegionValueBuilder(cb.emb, rt, region)
+            val elt = cb.newLocal[String]("elt")
+            val value = Code(
+                srvb.start(len),
+                Code.whileLoop(srvb.arrayIdx < len,
+                  elt := out.invoke[Int, String]("apply", srvb.arrayIdx),
+                  elt.ifNull(
+                    srvb.setMissing(),
+                    srvb.addString(elt)),
+                  srvb.advance()),
+                srvb.end())
+            PCode(rt, value)
+          })
+        }
+      }
     }
 
     registerEmitCode2("hamming", TString, TString, TInt32, {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -161,7 +161,7 @@ object UtilFunctions extends RegistryFunctions {
       }
       registerIEmitCode1(s"to${name}OrMissing", TString, t, (_: Type, xPT: PType) => rpt.setRequired(xPT.required)) {
         case (cb, r, rt, x) =>
-          x.flatMap(cb) { case (sc: PStringCode) =>
+          x().flatMap(cb) { case (sc: PStringCode) =>
             val sv = cb.newLocal[String]("s", sc.loadString())
             IEmitCode(cb,
               !Code.invokeScalaObject1[String, Boolean](thisClass, s"isValid$name", sv),


### PR DESCRIPTION
This function used `defaultValue`, which is going away as it requires `typeToTypeInfo` (which is also going away)