### PR TITLE
[batch][auth][ci][monitoring][notebook] check for sql mutation

### DIFF
--- a/auth/Makefile
+++ b/auth/Makefile
@@ -10,6 +10,7 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 check:
 	$(PYTHON) -m flake8 auth
 	$(PYTHON) -m pylint --rcfile ../pylintrc auth --score=n
+	../check-sql.sh
 
 .PHONY: build
 build:

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -13,6 +13,7 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 check:
 	$(PYTHON) -m flake8  --config ../setup.cfg batch
 	$(PYTHON) -m pylint --rcfile ../pylintrc batch --score=n
+	../check-sql.sh
 
 .PHONY: build
 build:

--- a/build.yaml
+++ b/build.yaml
@@ -104,6 +104,9 @@ steps:
      mkdir repo
      cd repo
      {{ code.checkout_script }}
+     {% if 'target_sha' in code %}
+     export HAIL_TARGET_SHA={{ code.target_sha }}
+     {% endif %}
      make -k check-services
    dependsOn:
      - service_base_image

--- a/check-sql.sh
+++ b/check-sql.sh
@@ -9,7 +9,7 @@ target_treeish=${HAIL_TARGET_SHA:-$(git merge-base main HEAD)}
 modified_sql_file_list=$(mktemp)
 
 git diff --name-status $target_treeish sql \
-    | grep -Ev '^A|^M\t[^/]+/sql/estimated-current.txt' \
+    | grep -Ev '^A|^M\t[^/]+/sql/(estimated-current.sql|delete-[^ ]+-tables.sql)' \
            > $modified_sql_file_list
 
 if [ "$(cat $modified_sql_file_list | wc -l)" -ne 0 ]

--- a/check-sql.sh
+++ b/check-sql.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Verify the the working tree modifices no sql files relative to the main
+# branch. This will always pass on a deploy because the working tree is an
+# unmodified copy of the main branch.
+
+target_treeish=${HAIL_TARGET_SHA:-$(git merge-base main HEAD)}
+
+modified_sql_file_list=$(mktemp)
+
+git diff --name-status $target_treeish sql \
+    | grep -Ev '^A|^M\t[^/]+/sql/estimated-current.txt' \
+           > $modified_sql_file_list
+
+if [ "$(cat $modified_sql_file_list | wc -l)" -ne 0 ]
+then
+    cat $modified_sql_file_list
+    echo 'At least one migration file was modified. See above.'
+    exit 1
+fi

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -13,6 +13,7 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 check:
 	$(PYTHON) -m flake8 ci
 	$(PYTHON) -m pylint --rcfile ../pylintrc ci --score=n
+	../check-sql.sh
 
 .PHONY: build-ci-utils
 build-ci-utils:

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -11,6 +11,7 @@ PYTHON := PYTHONPATH=$(PYTHONPATH)../hail/python:../gear:../web_common python3
 check:
 	$(PYTHON) -m flake8 monitoring
 	$(PYTHON) -m pylint --rcfile ../pylintrc monitoring --score=n
+	../check-sql.sh
 
 .PHONY: build
 build:

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -5,3 +5,4 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 check:
 	$(PYTHON) -m flake8 notebook
 	$(PYTHON) -m pylint --rcfile ../pylintrc notebook --score=n
+	../check-sql.sh


### PR DESCRIPTION
SQL migrations are not permitted to be modified. Unfortunately, our tests
previously did not verify this at all. Indeed, a PR merged which modified a SQL
file. This PR caused main to fail a deploy.

This change verifies that no SQL migration is mutated in the source SHA relative
to the target SHA. One can also use it locally by running `make
check-services` from the root. Unfortunately, it does not work properly when run
on the main branch because there is no obvious point of comparison.

I considered comparing against the previous commit, but that might cause
failures if we have to manually fix something in batch. As such, I prefer a
non-deploy only test.