### PR TITLE
[annotationdb] update annotation db docs page for deploy

### DIFF
--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.js
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.js
@@ -1,67 +1,80 @@
-$("#checkAll").click(function(){
+$("#checkAll").click(function () {
     $('input:checkbox').not(this).prop('checked', this.checked);
 });
 
-$.ajax({type: 'GET',
-        url: ('https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
-              hail_version +
-              '%2fannotation_db.json?alt=media'),
-        dataType: 'json',
-        success: function (data) {
-          for (name in data) {
-            dataset = data[name]
-            versions_string = dataset.versions.map(function (i) {
-              return i["version"]
-            }).reduce(function (i, j) {
-              return i + "; " + j
-            })
-            tr = $('<tr/>');
-            tr.append("<td><input type='checkbox' class='checkboxadd' value='"+name+"' onClick='updateTextArea()'/>&nbsp;</td>")
-            tr.append("<td>" + name + "</td>");
-            tr.append("<td>" + dataset.description + "\n<a href='"+ dataset.url + "'>link</a></td>");
-            tr.append("<td>" + versions_string + "</td>");
-            $('.table1').append(tr);
-          }
+$.ajax({
+    type: 'GET',
+    url: ('https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
+        hail_version +
+        '%2fdatasets.json?alt=media'),
+    dataType: 'json',
+    success: function (data) {
+        for (var name in data) {
+            let dataset = data[name]
+            if ('annotation_db' in dataset) {
+                let versions_string = dataset.versions.map(function (i) {
+                    let version = i["version"]
+                    if (!version) version = "None"
+                    return version
+                }).reduce(function (i, j) {
+                    return i + "<br>" + j
+                })
+                let ref_genome_string = dataset.versions.map(function (i) {
+                    let rg = i["reference_genome"]
+                    if (!rg) rg = "None"
+                    return rg
+                }).reduce(function (i, j) {
+                    return i + "<br>" + j
+                })
+                let tr = $('<tr/>');
+                tr.append("<td><input type='checkbox' class='checkboxadd' value='" + name + "' onClick='updateTextArea()'/>&nbsp;</td>")
+                tr.append("<td>" + name + "</td>");
+                tr.append("<td>" + dataset.description + "\n<a href='" + dataset.url + "'>link</a></td>");
+                tr.append("<td>" + versions_string + "</td>");
+                tr.append("<td>" + ref_genome_string + "</td>");
+                $('.table1').append(tr);
+            }
         }
-       });
+    }
+});
 
 
 function filterTable() {
-  let input = document.getElementById("searchInput")
-  let filter = input.value.toUpperCase()
-  let table = document.getElementById("table1")
-  let tr = table.getElementsByTagName("tr")
-  var found = false
-  for (var i = 0; i < tr.length; i++) {
-    let td = tr[i].getElementsByTagName("td")
-    for (var j = 0; j < td.length; j++) {
-      if (td[j].innerHTML.toUpperCase().indexOf(filter) > -1) {
-        found = true
-      }
+    let input = document.getElementById("searchInput")
+    let filter = input.value.toUpperCase()
+    let table = document.getElementById("table1")
+    let tr = table.getElementsByTagName("tr")
+    var found = false
+    for (var i = 0; i < tr.length; i++) {
+        let td = tr[i].getElementsByTagName("td")
+        for (var j = 0; j < td.length; j++) {
+            if (td[j].innerHTML.toUpperCase().indexOf(filter) > -1) {
+                found = true
+            }
+        }
+        if (found) {
+            tr[i].style.display = ""
+            found = false
+        } else if (!tr[i].id.match('^tableHeader')) {
+            tr[i].style.display = "none"
+        }
     }
-    if (found) {
-      tr[i].style.display = ""
-      found = false
-    } else if (!tr[i].id.match('^tableHeader'))  {
-      tr[i].style.display = "none"
-    }
-  }
 }
 
 function copy() {
-  let textarea = document.getElementById("result");
-  textarea.select();
-  document.execCommand("copy");
+    let textarea = document.getElementById("result");
+    textarea.select();
+    document.execCommand("copy");
 }
 
 
 function updateTextArea() {
     var text = "db = hl.experimental.DB()\nmt = db.annotate_rows_db(mt";
-    $('input[type=checkbox]:checked').filter(".checkboxadd").each( function() {
+    $('input[type=checkbox]:checked').filter(".checkboxadd").each(function () {
         text += ', "' + $(this).val() + '"';
         $('#result').val(text + ')');
     });
-     $('input[type="checkbox"]:not(:checked)').filter(".checkboxadd").each( function(){
+    $('input[type="checkbox"]:not(:checked)').filter(".checkboxadd").each(function () {
         $('#result').val(text + ')');
     });
 }

--- a/hail/python/hail/docs/annotation_database_ui.rst
+++ b/hail/python/hail/docs/annotation_database_ui.rst
@@ -75,6 +75,7 @@ own Hail script.
     <th>name</th>
     <th>description</th>
     <th>version</th>
+    <th>reference genome</th>
     </tr>
     </table>
     </div>

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -1,7 +1,6 @@
 {
   "1000_Genomes_autosomes": {
     "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
-    "key_properties": [],
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -24,7 +23,6 @@
   },
   "1000_Genomes_chrMT": {
     "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
-    "key_properties": [],
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -39,7 +37,6 @@
   },
   "1000_Genomes_chrX": {
     "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
-    "key_properties": [],
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -62,7 +59,6 @@
   },
   "1000_Genomes_chrY": {
     "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
-    "key_properties": [],
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -84,10 +80,12 @@
     ]
   },
   "CADD": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "Combined Annotation Dependent Depletion (CADD): an algorithm designed to annotate both coding and non-coding variants.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://cadd.gs.washington.edu/",
     "versions": [
       {
@@ -109,10 +107,12 @@
     ]
   },
   "DANN": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "DANN: a deep learning approach for annotating the pathogenicity of genetic variants.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4341060/",
     "versions": [
       {
@@ -134,10 +134,12 @@
     ]
   },
   "Ensembl_homo_sapiens_low_complexity_regions": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://useast.ensembl.org/index.html",
     "versions": [
       {
@@ -159,10 +161,12 @@
     ]
   },
   "Ensembl_homo_sapiens_reference_genome": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://useast.ensembl.org/index.html",
     "versions": [
       {
@@ -185,7 +189,6 @@
   },
   "GTEx_RNA_seq_gene_TPMs": {
     "description": "Genotype-Tissue Expression (GTEx): an ongoing effort to build a comprehensive public resource to study tissue-specific gene expression and regulation.",
-    "key_properties": [],
     "url": "https://gtexportal.org/home/",
     "versions": [
       {
@@ -200,7 +203,6 @@
   },
   "GTEx_RNA_seq_gene_read_counts": {
     "description": "Genotype-Tissue Expression (GTEx): an ongoing effort to build a comprehensive public resource to study tissue-specific gene expression and regulation.",
-    "key_properties": [],
     "url": "https://gtexportal.org/home/",
     "versions": [
       {
@@ -215,7 +217,6 @@
   },
   "GTEx_RNA_seq_junction_read_counts": {
     "description": "Genotype-Tissue Expression (GTEx): an ongoing effort to build a comprehensive public resource to study tissue-specific gene expression and regulation.",
-    "key_properties": [],
     "url": "https://gtexportal.org/home/",
     "versions": [
       {
@@ -230,7 +231,6 @@
   },
   "UK_Biobank_Rapid_GWAS_both_sexes": {
     "description": "UK Biobank GWAS: GWAS analysis of 7,221 phenotypes across 6 continental ancestry groups in the UK Biobank.",
-    "key_properties": [],
     "url": "http://www.nealelab.is/uk-biobank",
     "versions": [
       {
@@ -245,7 +245,6 @@
   },
   "UK_Biobank_Rapid_GWAS_female": {
     "description": "UK Biobank GWAS: GWAS analysis of 7,221 phenotypes across 6 continental ancestry groups in the UK Biobank.",
-    "key_properties": [],
     "url": "http://www.nealelab.is/uk-biobank",
     "versions": [
       {
@@ -260,7 +259,6 @@
   },
   "UK_Biobank_Rapid_GWAS_male": {
     "description": "UK Biobank GWAS: GWAS analysis of 7,221 phenotypes across 6 continental ancestry groups in the UK Biobank.",
-    "key_properties": [],
     "url": "http://www.nealelab.is/uk-biobank",
     "versions": [
       {
@@ -274,11 +272,13 @@
     ]
   },
   "clinvar_gene_summary": {
+    "annotation_db": {
+      "key_properties": [
+        "gene",
+        "unique"
+      ]
+    },
     "description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
-    "key_properties": [
-      "gene",
-      "unique"
-    ],
     "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
     "versions": [
       {
@@ -292,8 +292,10 @@
     ]
   },
   "clinvar_variant_summary": {
+    "annotation_db": {
+      "key_properties": []
+    },
     "description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
-    "key_properties": [],
     "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
     "versions": [
       {
@@ -315,11 +317,13 @@
     ]
   },
   "dbNSFP_genes": {
+    "annotation_db": {
+      "key_properties": [
+        "gene",
+        "unique"
+      ]
+    },
     "description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
-    "key_properties": [
-      "gene",
-      "unique"
-    ],
     "url": "https://sites.google.com/site/jpopgen/dbNSFP",
     "versions": [
       {
@@ -333,8 +337,10 @@
     ]
   },
   "dbNSFP_variants": {
+    "annotation_db": {
+      "key_properties": []
+    },
     "description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
-    "key_properties": [],
     "url": "https://sites.google.com/site/jpopgen/dbNSFP",
     "versions": [
       {
@@ -356,8 +362,10 @@
     ]
   },
   "gencode": {
+    "annotation_db": {
+      "key_properties": []
+    },
     "description": "GENCODE: aims to identify all gene features in the human genome using a combination of computational analysis, manual annotation, and experimental validation.",
-    "key_properties": [],
     "url": "https://www.gencodegenes.org/",
     "versions": [
       {
@@ -379,10 +387,12 @@
     ]
   },
   "gerp_elements": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
     "versions": [
       {
@@ -404,10 +414,12 @@
     ]
   },
   "gerp_scores": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
     "versions": [
       {
@@ -429,10 +441,12 @@
     ]
   },
   "gnomad_exome_sites": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -452,10 +466,12 @@
     ]
   },
   "gnomad_genome_sites": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -475,10 +491,12 @@
     ]
   },
   "gnomad_lof_metrics": {
+    "annotation_db": {
+      "key_properties": [
+        "gene"
+      ]
+    },
     "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
-    "key_properties": [
-      "gene"
-    ],
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -492,10 +510,12 @@
     ]
   },
   "ldsc_baselineLD_annotations": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "LDSC Baseline-LD Model: contains 75 annotations (additional annotations included in later versions) including functional regions, histone marks, GERP scores, LD-related annotations of population genetics forces, MAF bins, and more.",
-    "key_properties": [
-      "unique"
-    ],
     "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6133304/",
     "versions": [
       {
@@ -510,7 +530,6 @@
   },
   "ldsc_baselineLD_ldscores": {
     "description": "LDSC Baseline-LD Model: contains 75 annotations (additional annotations included in later versions) including functional regions, histone marks, GERP scores, LD-related annotations of population genetics forces, MAF bins, and more.",
-    "key_properties": [],
     "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6133304/",
     "versions": [
       {
@@ -525,7 +544,6 @@
   },
   "ldsc_baseline_ldscores": {
     "description": "LDSC Baseline Model: contains 53 annotations including functional regions, histone marks, GERP scores, LD-related annotations of population genetics forces, and MAF bins.",
-    "key_properties": [],
     "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4626285/",
     "versions": [
       {

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -144,7 +144,13 @@ class Dataset:
         """
         assert 'description' in doc, doc
         assert 'url' in doc, doc
-        assert 'key_properties' in doc, doc
+        if 'annotation_db' in doc:
+            assert 'key_properties' in doc['annotation_db']
+            key_props = set(doc['annotation_db']['key_properties'])
+        else:
+            assert 'key_properties' in doc
+            key_props = set(doc['key_properties'])
+        assert 'annotation_db' in doc, doc
         assert 'versions' in doc, doc
         versions = [DatasetVersion.from_json(x) for x in doc['versions']]
         if not custom_config:
@@ -153,7 +159,7 @@ class Dataset:
             return Dataset(name,
                            doc['description'],
                            doc['url'],
-                           set(doc['key_properties']),
+                           key_props,
                            versions)
 
     def __init__(self,
@@ -273,7 +279,7 @@ class DB:
             raise ValueError(
                 'annotation database can only annotate Hail MatrixTable or Table')
 
-    def dataset_by_name(self, name: str) -> Dataset:
+    def dataset_by_name(self, name: str) -> 'Dataset':
         """Retrieve :class:`Dataset` object by name.
 
         Parameters

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -33,8 +33,8 @@ class DatasetVersion:
         -------
         :class:`.DatasetVersion`
         """
-        assert 'url' in doc, doc
-        assert 'version' in doc, doc
+        assert 'url' in doc
+        assert 'version' in doc
         return DatasetVersion(doc['url'],
                               doc['version'])
 
@@ -142,16 +142,14 @@ class Dataset:
         :class:`Dataset`
             If versions exist for region returns a :class:`.Dataset` object, else None.
         """
-        assert 'description' in doc, doc
-        assert 'url' in doc, doc
+        assert 'description' in doc
+        assert 'url' in doc
         if 'annotation_db' in doc:
             assert 'key_properties' in doc['annotation_db']
-            key_props = set(doc['annotation_db']['key_properties'])
+            key_properties = set(doc['annotation_db']['key_properties'])
         else:
-            assert 'key_properties' in doc
-            key_props = set(doc['key_properties'])
-        assert 'annotation_db' in doc, doc
-        assert 'versions' in doc, doc
+            key_properties = set()
+        assert 'versions' in doc
         versions = [DatasetVersion.from_json(x) for x in doc['versions']]
         if not custom_config:
             versions = DatasetVersion.get_region(name, versions, region)
@@ -159,7 +157,7 @@ class Dataset:
             return Dataset(name,
                            doc['description'],
                            doc['url'],
-                           key_props,
+                           key_properties,
                            versions)
 
     def __init__(self,

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -33,8 +33,8 @@ class DatasetVersion:
         -------
         :class:`.DatasetVersion`
         """
-        assert 'url' in doc
-        assert 'version' in doc
+        assert 'url' in doc, doc
+        assert 'version' in doc, doc
         return DatasetVersion(doc['url'],
                               doc['version'])
 
@@ -142,14 +142,14 @@ class Dataset:
         :class:`Dataset`
             If versions exist for region returns a :class:`.Dataset` object, else None.
         """
-        assert 'description' in doc
-        assert 'url' in doc
+        assert 'description' in doc, doc
+        assert 'url' in doc, doc
         if 'annotation_db' in doc:
-            assert 'key_properties' in doc['annotation_db']
+            assert 'key_properties' in doc['annotation_db'], doc['annotation_db']
             key_properties = set(doc['annotation_db']['key_properties'])
         else:
             key_properties = set()
-        assert 'versions' in doc
+        assert 'versions' in doc, doc
         versions = [DatasetVersion.from_json(x) for x in doc['versions']]
         if not custom_config:
             versions = DatasetVersion.get_region(name, versions, region)

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -19,11 +19,11 @@ class AnnotationDBTests(unittest.TestCase):
         cls.db_json = {
             'unique_dataset': {'description': 'now with unique rows!',
                                'url': 'https://example.com',
-                               'key_properties': ['unique'],
+                               'annotation_db': {'key_properties': ['unique']},
                                'versions': [{'url': fname, 'version': 'v1-GRCh37'}]},
             'nonunique_dataset': {'description': 'non-unique rows :(',
                                   'url': 'https://example.net',
-                                  'key_properties': [],
+                                  'annotation_db': {'key_properties': []},
                                   'versions': [{'url': fname, 'version': 'v1-GRCh37'}]}}
 
     @classmethod

--- a/hail/scripts/deploy.sh
+++ b/hail/scripts/deploy.sh
@@ -81,7 +81,7 @@ cloud_sha_location=gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.
 printf "$GIT_VERSION" | gsutil cp  - $cloud_sha_location
 gsutil acl set public-read $cloud_sha_location
 
-# deploy annotation db json
-annotation_db_json_url=gs://hail-common/annotationdb/$HAIL_VERSION/annotation_db.json
-gsutil cp python/hail/experimental/annotation_db.json $annotation_db_json_url
-gsutil -m retention temp set $annotation_db_json_url
+# deploy datasets (annotation db) json
+datasets_json_url=gs://hail-common/annotationdb/$HAIL_VERSION/datasets.json
+gsutil cp python/hail/experimental/datasets.json $datasets_json_url
+gsutil -m retention temp set $datasets_json_url


### PR DESCRIPTION
Changes to make sure that only the annotation datasets are visible on the docs page, now that the `datasets.json` config file contains all available datasets.

Overview:

- In `datasets.json`, moved "key_properties" inside an "annotation_db" field, like `"annotation_db":  {"key_properties":  []}`, so that only the datasets with the "annotation_db" key are shown in the annotation DB docs page. Removed "key_properties" from non-annotation datasets.

- Minor reformatting changes to docs page, added a reference genome column to the HTML table.

- Updated deploy script to reflect the filename change from `annotation_db.json` to `datasets.json`.

- Modified checks for keys in dicts from `assert key in doc, doc` to `assert key in doc` in `DatasetVersion.from_json()` and `Dataset.from_name_and_json()`. Since the `doc` that is passed to these methods from the checked in JSON file is just a dict like `doc = {"annotation_db": {"key_properties": [...]}, "description": ..., "url":  ..., "versions": [...]}` this seems to work fine. Let me know if `key in doc, doc` form was used for other reasons I've overlooked.


