### PR TITLE
[batch] add api for managing billing projects

### DIFF
--- a/batch/batch/exceptions.py
+++ b/batch/batch/exceptions.py
@@ -7,7 +7,7 @@ class BatchUserError(Exception):
         self.message = message
         self.ui_error_type = severity
 
-    def api_response(self):
+    def http_response(self):
         return web.HTTPForbidden(reason=self.message)
 
 
@@ -15,7 +15,15 @@ class NonExistentBillingProjectError(BatchUserError):
     def __init__(self, billing_project):
         super().__init__(f'Billing project {billing_project} does not exist.', 'error')
 
-    def api_response(self):
+    def http_response(self):
+        return web.HTTPNotFound(reason=self.message)
+
+
+class NonExistentUserError(BatchUserError):
+    def __init__(self, user, billing_project):
+        super().__init__(f'User {user} is not in billing project {billing_project} does not exist.', 'error')
+
+    def http_response(self):
         return web.HTTPNotFound(reason=self.message)
 
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -107,6 +107,7 @@ async def _handle_ui_error(session, f, *args, **kwargs):
     else:
         return False
 
+
 async def _handle_api_error(f, *args, **kwargs):
     try:
         await f(*args, **kwargs)
@@ -1690,7 +1691,7 @@ async def _delete_billing_project(db, billing_project):
     async def delete_project(tx):
         row = await tx.execute_and_fetchone(
             'SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;',
-                (billing_project,))
+            (billing_project,))
         if not row:
             raise NonExistentBillingProjectError(billing_project)
         assert row['name'] == billing_project

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1505,7 +1505,7 @@ INSERT INTO billing_project_users(billing_project, user)
 VALUES (%s, %s);
         ''',
             (billing_project, user))
-        await insert()  # pylint: disable=no-value-for-parameter
+    await insert()  # pylint: disable=no-value-for-parameter
 
 
 @routes.post('/billing_projects/{billing_project}/users/add')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1599,8 +1599,8 @@ SELECT name, `status`, batches.id as batch_id
 FROM billing_projects
 LEFT JOIN batches
 ON billing_projects.name = batches.billing_project
-WHERE name = %s and `status` != 'deleted' AND batches.time_completed IS NULL
-LIMIT 1 FOR UPDATE;
+AND billing_projects.`status` != 'deleted' AND batches.time_completed IS NULL
+WHERE name = %s LIMIT 1 FOR UPDATE;
     ''',
             (billing_project,))
         if not row:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1600,7 +1600,7 @@ FROM billing_projects
 LEFT JOIN batches
 ON billing_projects.name = batches.billing_project
 WHERE name = %s and `status` != 'deleted' AND batches.time_completed IS NULL
-FOR UPDATE LIMIT 1;
+LIMIT 1 FOR UPDATE;
     ''',
             (billing_project,))
         if not row:

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1608,7 +1608,7 @@ LIMIT 1 FOR UPDATE;
         assert row['name'] == billing_project
         if row['status'] == 'closed':
             raise BatchUserError(f'Billing project {billing_project} is already closed or deleted.', 'info')
-        if row['batch'] is not None:
+        if row['batch_id'] is not None:
             raise BatchUserError(f'Billing project {billing_project} has open or running batches.', 'error')
 
         await tx.execute_update(

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -23,7 +23,7 @@ from hailtop.config import get_deploy_config
 from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_session
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
-from gear import (Database, setup_aiohttp_session,
+from gear import (Database, setup_aiohttp_session, rest_authenticated_developers_only,
                   rest_authenticated_users_only, web_authenticated_users_only,
                   web_authenticated_developers_only, check_csrf_token, transaction)
 from web_common import (setup_aiohttp_jinja2, setup_common_static_routes,
@@ -36,7 +36,7 @@ from ..utils import (adjust_cores_for_memory_request, worker_memory_per_core_gb,
                      adjust_cores_for_storage_request, total_worker_storage_gib)
 from ..batch import batch_record_to_dict, job_record_to_dict
 from ..exceptions import (BatchUserError, NonExistentBillingProjectError,
-                          ClosedBillingProjectError)
+                          NonExistentUserError, ClosedBillingProjectError)
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
 from ..batch_configuration import (BATCH_PODS_NAMESPACE, BATCH_BUCKET_NAME,
@@ -73,10 +73,16 @@ REQUEST_TIME_GET_BILLING_PROJECT = REQUEST_TIME.labels(endpoint='/api/v1alpha/bi
 REQUEST_TIME_GET_BILLING_UI = REQUEST_TIME.labels(endpoint='/billing', verb="GET")
 REQUEST_TIME_GET_BILLING_PROJECTS_UI = REQUEST_TIME.labels(endpoint='/billing_projects', verb="GET")
 REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_UI = REQUEST_TIME.labels(endpoint='/billing_projects/billing_project/users/user/remove', verb="POST")
+REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/billing_project/users/{user}/remove', verb="POST")
 REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_UI = REQUEST_TIME.labels(endpoint='/billing_projects/billing_project/users/add', verb="POST")
+REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/users/{user}/add', verb="POST")
 REQUEST_TIME_POST_CREATE_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/create', verb="POST")
+REQUEST_TIME_POST_CREATE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/create', verb="POST")
 REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/{billing_project}/close', verb="POST")
+REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/close', verb="POST")
 REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/{billing_project}/reopen', verb="POST")
+REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/reopen', verb="POST")
+REQUEST_TIME_POST_DELETE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/reopen', verb="POST")
 
 routes = web.RouteTableDef()
 
@@ -100,6 +106,12 @@ async def _handle_ui_error(session, f, *args, **kwargs):
         return True
     else:
         return False
+
+async def _handle_api_error(f, *args, **kwargs):
+    try:
+        await f(*args, **kwargs)
+    except BatchUserError as e:
+        raise e.http_response()
 
 
 async def _query_batch_jobs(request, batch_id):
@@ -1403,17 +1415,7 @@ async def get_billing_project(request, userdata):
     return web.json_response(data=billing_projects[0])
 
 
-@routes.post('/billing_projects/{billing_project}/users/{user}/remove')
-@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_UI)
-@check_csrf_token
-@web_authenticated_developers_only(redirect=False)
-async def post_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
-    db = request.app['db']
-    billing_project = request.match_info['billing_project']
-    user = request.match_info['user']
-
-    session = await aiohttp_session.get_session(request)
-
+async def _remove_user_from_billing_project(db, billing_project, user):
     @transaction(db)
     async def delete(tx):
         row = await tx.execute_and_fetchone(
@@ -1428,17 +1430,14 @@ WHERE billing_projects.name = %s;
 ''',
             (billing_project, user, billing_project))
         if not row:
-            set_message(session, f'No such billing project {billing_project}.', 'error')
-            raise web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+            raise NonExistentBillingProjectError(billing_project)
         assert row['billing_project'] == billing_project
 
         if row['status'] in {'closed', 'deleted'}:
-            set_message(session, f'Billing project {billing_project} has been closed or deleted and cannot be modified.', 'error')
-            raise web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+            raise BatchUserError(f'Billing project {billing_project} has been closed or deleted and cannot be modified.', 'error')
 
         if row['user'] is None:
-            set_message(session, f'User {user} is not member of billing project {billing_project}.', 'info')
-            raise web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+            raise NonExistentUserError(user, billing_project)
 
         await tx.just_execute(
             '''
@@ -1447,8 +1446,33 @@ WHERE billing_project = %s AND user = %s;
 ''',
             (billing_project, user))
     await delete()  # pylint: disable=no-value-for-parameter
-    set_message(session, f'Removed user {user} from billing project {billing_project}.', 'info')
+
+
+@routes.post('/billing_projects/{billing_project}/users/{user}/remove')
+@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_UI)
+@check_csrf_token
+@web_authenticated_developers_only(redirect=False)
+async def post_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+    user = request.match_info['user']
+
+    session = await aiohttp_session.get_session(request)
+    errored = await _handle_ui_error(session, _remove_user_from_billing_project, db, billing_project, user)
+    if not errored:
+        set_message(session, f'Removed user {user} from billing project {billing_project}.', 'info')
     return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+
+
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/remove')
+@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_API)
+@rest_authenticated_developers_only
+async def api_get_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+    user = request.match_info['user']
+    await _handle_api_error(_remove_user_from_billing_project, db, billing_project, user)
+    return web.json_response({'billing_project': billing_project, 'user': user})
 
 
 async def _add_user_to_billing_project(db, billing_project, user):
@@ -1474,7 +1498,6 @@ WHERE billing_projects.name = %s AND billing_projects.`status` != 'deleted' LOCK
 
         if row['user'] is not None:
             raise BatchUserError(f'User {user} is already member of billing project {billing_project}.', 'info')
-
         await tx.execute_insertone(
             '''
 INSERT INTO billing_project_users(billing_project, user)
@@ -1502,17 +1525,19 @@ async def post_billing_projects_add_user(request, userdata):  # pylint: disable=
     return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
 
 
-@routes.post('/billing_projects/create')
-@prom_async_time(REQUEST_TIME_POST_CREATE_BILLING_PROJECT_UI)
-@check_csrf_token
-@web_authenticated_developers_only(redirect=False)
-async def post_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/add')
+@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_API)
+@rest_authenticated_developers_only
+async def api_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
-    post = await request.post()
-    billing_project = post['billing_project']
+    user = request.match_info['user']
+    billing_project = request.match_info['billing_project']
 
-    session = await aiohttp_session.get_session(request)
+    await _handle_api_error(_add_user_to_billing_project, db, billing_project, user)
+    return web.json_response({'billing_project': billing_project, 'user': user})
 
+
+async def _create_billing_project(db, billing_project):
     @transaction(db)
     async def insert(tx):
         row = await tx.execute_and_fetchone(
@@ -1523,8 +1548,7 @@ FOR UPDATE;
 ''',
             (billing_project))
         if row is not None:
-            set_message(session, f"Billing project {billing_project} (status: {row['status']}) already exists.", 'error')
-            raise web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+            raise BatchUserError(f'Billing project {billing_project} already exists.', 'error')
 
         await tx.execute_insertone(
             '''
@@ -1533,8 +1557,36 @@ VALUES (%s);
 ''',
             (billing_project,))
     await insert()  # pylint: disable=no-value-for-parameter
-    set_message(session, f'Added billing project {billing_project}.', 'info')
+
+
+@routes.post('/billing_projects/create')
+@prom_async_time(REQUEST_TIME_POST_CREATE_BILLING_PROJECT_UI)
+@check_csrf_token
+@web_authenticated_developers_only(redirect=False)
+async def post_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    post = await request.post()
+    billing_project = post['billing_project']
+
+    session = await aiohttp_session.get_session(request)
+    try:
+        await _create_billing_project(db, billing_project)
+    except KeyError as e:
+        set_message(session, str(e), 'error')
+    else:
+        set_message(session, f'Added billing project {billing_project}.', 'info')
+
     return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+
+
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/create')
+@prom_async_time(REQUEST_TIME_POST_CREATE_BILLING_PROJECT_API)
+@rest_authenticated_developers_only
+async def api_get_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+    await _handle_api_error(_create_billing_project, db, billing_project)
+    return web.json_response(billing_project)
 
 
 async def _close_billing_project(db, billing_project):
@@ -1579,6 +1631,17 @@ async def post_close_billing_projects(request, userdata):  # pylint: disable=unu
     return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
 
 
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/close')
+@prom_async_time(REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_API)
+@rest_authenticated_developers_only
+async def api_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+
+    await _handle_api_error(_close_billing_project, db, billing_project)
+    return web.json_response(billing_project)
+
+
 async def _reopen_billing_project(db, billing_project):
     @transaction(db)
     async def open_project(tx):
@@ -1610,6 +1673,47 @@ async def post_reopen_billing_projects(request, userdata):  # pylint: disable=un
     if not errored:
         set_message(session, f'Re-opened billing project {billing_project}.', 'info')
     return web.HTTPFound(deploy_config.external_url('batch', '/billing_projects'))
+
+
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/reopen')
+@prom_async_time(REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_API)
+@rest_authenticated_developers_only
+async def api_reopen_billing_projects(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+    await _handle_api_error(_reopen_billing_project, db, billing_project)
+    return web.json_response(billing_project)
+
+
+async def _delete_billing_project(db, billing_project):
+    @transaction(db)
+    async def delete_project(tx):
+        row = await tx.execute_and_fetchone(
+            'SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;',
+                (billing_project,))
+        if not row:
+            raise NonExistentBillingProjectError(billing_project)
+        assert row['name'] == billing_project
+        if row['status'] == 'deleted':
+            raise BatchUserError(f'Billing project {billing_project} is already deleted.', 'info')
+        if row['status'] == 'open':
+            raise BatchUserError(f'Billing project {billing_project} is open and cannot be deleted.', 'error')
+
+        await tx.execute_update(
+            "UPDATE billing_projects SET `status` = 'closed' WHERE name = %s;",
+            (billing_project, ))
+    await delete_project()  # pylint: disable=no-value-for-parameter
+
+
+@routes.post('/api/v1alpha/billing_projects/{billing_project}/delete')
+@prom_async_time(REQUEST_TIME_POST_DELETE_BILLING_PROJECT_API)
+@rest_authenticated_developers_only
+async def api_delete_billing_projects(request, userdata):  # pylint: disable=unused-argument
+    db = request.app['db']
+    billing_project = request.match_info['billing_project']
+
+    await _handle_api_error(_delete_billing_project, db, billing_project)
+    return web.json_response(billing_project)
 
 
 @routes.get('')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1701,7 +1701,7 @@ async def _delete_billing_project(db, billing_project):
             raise BatchUserError(f'Billing project {billing_project} is open and cannot be deleted.', 'error')
 
         await tx.execute_update(
-            "UPDATE billing_projects SET `status` = 'closed' WHERE name = %s;",
+            "UPDATE billing_projects SET `status` = 'deleted' WHERE name = %s;",
             (billing_project, ))
     await delete_project()  # pylint: disable=no-value-for-parameter
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -31,10 +31,11 @@ async def dev_client():
 @pytest.fixture(scope='module')
 def get_billing_project_name():
     prefix = f'__testproject_{secrets.token_urlsafe(15)}'
-    count = 0
+    projects = []
     def get_name():
-        count += 1
-        return f'{prefix}_{count}'
+        name = f'{prefix}_{len(projects)}'
+        projects.append(name)
+        return name
     return get_name
 
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -73,7 +73,7 @@ async def test_bad_token():
 
 async def test_get_billing_project(make_client):
     c = await make_client()
-    r = c.list_billing_projects()
+    r = await c.list_billing_projects()
     assert r['billing_project'] == 'test', r
     assert set(r['users']) == {'test', 'test-dev'}, r
     assert r['closed'] == False, r
@@ -81,7 +81,7 @@ async def test_get_billing_project(make_client):
 
 async def test_list_billing_projects(make_client):
     c = await make_client()
-    r = c.list_billing_projects()
+    r = await c.list_billing_projects()
     test_bps = [p for p in r if p['billing_project'] == 'test']
     assert len(test_bps) == 1, r
     bp = test_bps[0]

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -134,7 +134,7 @@ async def test_close_reopen_billing_project(dev_client, new_billing_project):
     project = new_billing_project
     await dev_client.close_billing_project(project)
     r = await dev_client.list_billing_projects()
-    assert [bp for bp in r if bp['billing_project'] == project and not bp['closed']] == [], r
+    assert [bp for bp in r if bp['billing_project'] == project and bp['status'] == 'open'] == [], r
 
     try:
         await dev_client.close_billing_project(project)
@@ -143,7 +143,7 @@ async def test_close_reopen_billing_project(dev_client, new_billing_project):
 
     await dev_client.reopen_billing_project(project)
     r = await dev_client.list_billing_projects()
-    assert [bp['billing_project'] for bp in r if bp['billing_project'] == project and not bp['closed']] == [project], r
+    assert [bp['billing_project'] for bp in r if bp['billing_project'] == project and bp['status'] == 'open'] == [project], r
 
     try:
         await dev_client.reopen_billing_project(project)
@@ -155,7 +155,7 @@ async def test_close_billing_project_with_open_batch_errors(dev_client, make_cli
     project = new_billing_project
     await dev_client.add_user("test", project)
     client = await make_client(project)
-    b = client.create_batch()._create()
+    b = await client.create_batch()._create()
 
     try:
         await dev_client.close_billing_project(project)
@@ -194,10 +194,6 @@ async def test_delete_billing_project_only_when_closed(dev_client, new_billing_p
 
     await dev_client.close_billing_project(project)
     await dev_client.delete_billing_project(project)
-
-    r = await dev_client.list_billing_projects()
-    bps = {p['billing project'] for p in r}
-    assert project not in bps
 
     try:
         await dev_client.get_billing_project(project)

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -213,7 +213,7 @@ async def test_add_and_delete_user(dev_client, new_billing_project):
     assert r['billing_project']  == project
 
     bp = await dev_client.get_billing_project(project)
-    assert r['user'] in bp['users']
+    assert r['user'] in bp['users'], bp
 
     try:
         await dev_client.add_user('test', project)

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -49,8 +49,6 @@ async def new_billing_project(dev_client, get_billing_project_name):
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
     else:
-        for user in r['users']:
-            await dev_client.remove_user(user, project)
         if r['status'] == 'open':
             await dev_client.close_billing_project(project)
         if r['status'] != 'deleted':
@@ -97,26 +95,36 @@ async def test_unauthorized_billing_project_modification(make_client, new_billin
         await client.create_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 401, e
+    else:
+        assert False, 'expected error'
 
     try:
         await client.add_user('test', project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 401, e
+    else:
+        assert False, 'expected error'
 
     try:
         await client.remove_user('test', project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 401, e
+    else:
+        assert False, 'expected error'
 
     try:
         await client.close_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 401, e
+    else:
+        assert False, 'expected error'
 
     try:
         await client.reopen_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 401, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_create_billing_project(dev_client, new_billing_project):
@@ -128,6 +136,8 @@ async def test_create_billing_project(dev_client, new_billing_project):
         await dev_client.create_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_close_reopen_billing_project(dev_client, new_billing_project):
@@ -149,6 +159,8 @@ async def test_close_reopen_billing_project(dev_client, new_billing_project):
         await dev_client.reopen_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_close_billing_project_with_open_batch_errors(dev_client, make_client, new_billing_project):
@@ -161,6 +173,8 @@ async def test_close_billing_project_with_open_batch_errors(dev_client, make_cli
         await dev_client.close_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
     await client._patch(f'/api/v1alpha/batches/{b.id}/close')
 
 
@@ -169,6 +183,8 @@ async def test_close_nonexistent_billing_project(dev_client):
         await dev_client.close_billing_project("nonexistent_project")
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_add_user_with_nonexistent_billing_project(dev_client):
@@ -176,6 +192,8 @@ async def test_add_user_with_nonexistent_billing_project(dev_client):
         await dev_client.add_user("test", "nonexistent_project")
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_remove_user_with_nonexistent_billing_project(dev_client):
@@ -183,6 +201,8 @@ async def test_remove_user_with_nonexistent_billing_project(dev_client):
         await dev_client.remove_user("test", "nonexistent_project")
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_delete_billing_project_only_when_closed(dev_client, new_billing_project):
@@ -191,6 +211,8 @@ async def test_delete_billing_project_only_when_closed(dev_client, new_billing_p
         await dev_client.delete_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
 
     await dev_client.close_billing_project(project)
     await dev_client.delete_billing_project(project)
@@ -199,11 +221,15 @@ async def test_delete_billing_project_only_when_closed(dev_client, new_billing_p
         await dev_client.get_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
+    else:
+        assert False, 'expected error'
 
     try:
         await dev_client.reopen_billing_project(project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
 
 
 async def test_add_and_delete_user(dev_client, new_billing_project):
@@ -219,6 +245,8 @@ async def test_add_and_delete_user(dev_client, new_billing_project):
         await dev_client.add_user('test', project)
     except aiohttp.ClientResponseError as e:
         assert e.status == 403, e
+    else:
+        assert False, 'expected error'
 
     r = await dev_client.remove_user('test', project)
     assert r['user']  == 'test'
@@ -230,4 +258,6 @@ async def test_add_and_delete_user(dev_client, new_billing_project):
     try:
         await dev_client.remove_user('test', project)
     except aiohttp.ClientResponseError as e:
-        assert e.status == 403, e
+        assert e.status == 404, e
+    else:
+        assert False, 'expected error'

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -76,7 +76,7 @@ async def test_get_billing_project(make_client):
     r = await c.get_billing_project('test')
     assert r['billing_project'] == 'test', r
     assert set(r['users']) == {'test', 'test-dev'}, r
-    assert r['closed'] == False, r
+    assert r['status'] == 'open', r
 
 
 async def test_list_billing_projects(make_client):

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -1,0 +1,234 @@
+import aiohttp
+import base64
+import os
+import pytest
+import secrets
+from hailtop.batch_client.aioclient import BatchClient
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def make_client():
+    _bcs = []
+    def factory(project=None):
+        bc = await BatchClient(project, _token_file=os.environ['HAIL_TEST_TOKEN_FILE'])
+        _bcs.append(bc)
+        return bc
+
+    yield factory
+    for bc in _bcs:
+        await bc.close()
+
+
+@pytest.fixture
+async def dev_client():
+    bc = await BatchClient(None, _token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
+    yield bc
+    await bc.close()
+
+
+@pytest.fixture(scope='module')
+def get_billing_project_name():
+    prefix = f'__testproject_{secrets.token_urlsafe(15)}'
+    count = 0
+    def get_name():
+        count += 1
+        return f'{prefix}_{count}'
+    return get_name
+
+
+@pytest.fixture
+async def new_billing_project(dev_client, get_billing_project_name):
+    project = get_billing_project_name()
+    yield await dev_client.create_billing_project(project)
+
+    try:
+        r = await dev_client.get_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+    else:
+        for user in r['users']:
+            await dev_client.remove_user(user, project)
+        if r['status'] == 'open':
+            await dev_client.close_billing_project(project)
+        if r['status'] != 'deleted':
+            await dev_client.delete_billing_project(project)
+
+
+async def test_bad_token():
+    token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode('ascii')
+    bc = await BatchClient('test', _token=token)
+    try:
+        b = bc.create_batch()
+        j = b.create_job('ubuntu:18.04', ['false'])
+        await b.submit()
+        assert False, j
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+    finally:
+        await bc.close()
+
+
+async def test_get_billing_project(make_client):
+    r = await make_client().get_billing_project('test')
+    assert r['billing_project'] == 'test', r
+    assert set(r['users']) == {'test', 'test-dev'}, r
+    assert r['closed'] == False, r
+
+
+async def test_list_billing_projects(make_client):
+    r = await make_client().list_billing_projects()
+    test_bps = [p for p in r if p['billing_project'] == 'test']
+    assert len(test_bps) == 1, r
+    bp = test_bps[0]
+    assert bp['billing_project'] == 'test', bp
+    assert set(bp['users']) == {'test', 'test-dev'}, bp
+    assert bp['status'] == 'open', bp
+
+
+async def test_unauthorized_billing_project_modification(make_client, new_billing_project):
+    project = new_billing_project
+    client = make_client()
+    try:
+        await client.create_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+
+    try:
+        await client.add_user('test', project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+
+    try:
+        await client.remove_user('test', project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+
+    try:
+        await client.close_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+
+    try:
+        await client.reopen_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 401, e
+
+
+async def test_create_billing_project(dev_client, new_billing_project):
+    project = new_billing_project
+    r = await dev_client.list_billing_projects()
+    assert project in {bp['billing_project'] for bp in r}
+
+    try:
+        await dev_client.create_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+
+
+async def test_close_reopen_billing_project(dev_client, new_billing_project):
+    project = new_billing_project
+    await dev_client.close_billing_project(project)
+    r = await dev_client.list_billing_projects()
+    assert [bp for bp in r if bp['billing_project'] == project and not bp['closed']] == [], r
+
+    try:
+        await dev_client.close_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+
+    await dev_client.reopen_billing_project(project)
+    r = await dev_client.list_billing_projects()
+    assert [bp['billing_project'] for bp in r if bp['billing_project'] == project and not bp['closed']] == [project], r
+
+    try:
+        await dev_client.reopen_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+
+
+async def test_close_billing_project_with_open_batch_errors(dev_client, make_client, new_billing_project):
+    project = new_billing_project
+    await dev_client.add_user("test", project)
+    client = make_client(project)
+    b = client.create_batch()._create()
+
+    try:
+        await dev_client.close_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+    await client._patch(f'/api/v1alpha/batches/{b.id}/close')
+
+
+async def test_close_nonexistent_billing_project(dev_client):
+    try:
+        await dev_client.close_billing_project("nonexistent_project")
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+
+
+async def test_add_user_with_nonexistent_billing_project(dev_client):
+    try:
+        await dev_client.add_user("test", "nonexistent_project")
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+
+
+async def test_remove_user_with_nonexistent_billing_project(dev_client):
+    try:
+        await dev_client.remove_user("test", "nonexistent_project")
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+
+
+async def test_delete_billing_project_only_when_closed(dev_client, new_billing_project):
+    project = new_billing_project
+    try:
+        await dev_client.delete_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+
+    await dev_client.close_billing_project(project)
+    await dev_client.delete_billing_project(project)
+
+    r = await dev_client.list_billing_projects()
+    bps = {p['billing project'] for p in r}
+    assert project not in bps
+
+    try:
+        await dev_client.get_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 404, e
+
+    try:
+        await dev_client.reopen_billing_project(project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 403, e
+
+
+async def test_add_and_delete_user(dev_client, new_billing_project):
+    project = new_billing_project
+    r = await dev_client.add_user('test', project)
+    assert r['user']  == 'test'
+    assert r['billing_project']  == project
+
+    bp = await dev_client.get_billing_project(project)
+    assert r['user'] in bp['users']
+
+    try:
+        await dev_client.add_user('test', project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 409, e
+
+    r = await dev_client.remove_user('test', project)
+    assert r['user']  == 'test'
+    assert r['billing_project']  == project
+
+    bp = await dev_client.get_billing_project(project)
+    assert r['user'] not in bp['users']
+
+    try:
+        await dev_client.remove_user('test', project)
+    except aiohttp.ClientResponseError as e:
+        assert e.status == 400, e

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def make_client():
     _bcs = []
-    def factory(project=None):
+    async def factory(project=None):
         bc = await BatchClient(project, _token_file=os.environ['HAIL_TEST_TOKEN_FILE'])
         _bcs.append(bc)
         return bc
@@ -89,7 +89,7 @@ async def test_list_billing_projects(make_client):
 
 async def test_unauthorized_billing_project_modification(make_client, new_billing_project):
     project = new_billing_project
-    client = make_client()
+    client = await make_client()
     try:
         await client.create_billing_project(project)
     except aiohttp.ClientResponseError as e:
@@ -151,7 +151,7 @@ async def test_close_reopen_billing_project(dev_client, new_billing_project):
 async def test_close_billing_project_with_open_batch_errors(dev_client, make_client, new_billing_project):
     project = new_billing_project
     await dev_client.add_user("test", project)
-    client = make_client(project)
+    client = await make_client(project)
     b = client.create_batch()._create()
 
     try:

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -73,7 +73,7 @@ async def test_bad_token():
 
 async def test_get_billing_project(make_client):
     c = await make_client()
-    r = await c.list_billing_projects()
+    r = await c.get_billing_project('test')
     assert r['billing_project'] == 'test', r
     assert set(r['users']) == {'test', 'test-dev'}, r
     assert r['closed'] == False, r

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -218,7 +218,7 @@ async def test_add_and_delete_user(dev_client, new_billing_project):
     try:
         await dev_client.add_user('test', project)
     except aiohttp.ClientResponseError as e:
-        assert e.status == 409, e
+        assert e.status == 403, e
 
     r = await dev_client.remove_user('test', project)
     assert r['user']  == 'test'
@@ -230,4 +230,4 @@ async def test_add_and_delete_user(dev_client, new_billing_project):
     try:
         await dev_client.remove_user('test', project)
     except aiohttp.ClientResponseError as e:
-        assert e.status == 400, e
+        assert e.status == 403, e

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -72,14 +72,16 @@ async def test_bad_token():
 
 
 async def test_get_billing_project(make_client):
-    r = await make_client().get_billing_project('test')
+    c = await make_client()
+    r = c.list_billing_projects()
     assert r['billing_project'] == 'test', r
     assert set(r['users']) == {'test', 'test-dev'}, r
     assert r['closed'] == False, r
 
 
 async def test_list_billing_projects(make_client):
-    r = await make_client().list_billing_projects()
+    c = await make_client()
+    r = c.list_billing_projects()
     test_bps = [p for p in r if p['billing_project'] == 'test']
     assert len(test_bps) == 1, r
     bp = test_bps[0]

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -221,7 +221,7 @@ async def test_delete_billing_project_only_when_closed(dev_client, new_billing_p
     try:
         await dev_client.get_billing_project(project)
     except aiohttp.ClientResponseError as e:
-        assert e.status == 404, e
+        assert e.status == 403, e
     else:
         assert False, 'expected error'
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -47,7 +47,7 @@ async def new_billing_project(dev_client, get_billing_project_name):
     try:
         r = await dev_client.get_billing_project(project)
     except aiohttp.ClientResponseError as e:
-        assert e.status == 404, e
+        assert e.status == 403, e
     else:
         assert r['status'] != 'deleted', r
         if r['status'] == 'open':

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.asyncio
 async def make_client():
     _bcs = []
     async def factory(project=None):
-        bc = await BatchClient(project, _token_file=os.environ['HAIL_TEST_TOKEN_FILE'])
+        bc = await BatchClient(project, token_file=os.environ['HAIL_TEST_TOKEN_FILE'])
         _bcs.append(bc)
         return bc
 
@@ -23,7 +23,7 @@ async def make_client():
 
 @pytest.fixture
 async def dev_client():
-    bc = await BatchClient(None, _token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
+    bc = await BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
     yield bc
     await bc.close()
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -49,6 +49,7 @@ async def new_billing_project(dev_client, get_billing_project_name):
     except aiohttp.ClientResponseError as e:
         assert e.status == 404, e
     else:
+        assert r['status'] != 'deleted', r
         if r['status'] == 'open':
             await dev_client.close_billing_project(project)
         if r['status'] != 'deleted':

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -41,18 +41,6 @@ def client():
     client.close()
 
 
-def test_get_billing_project(client):
-    r = client.get_billing_project('test')
-    assert r['billing_project'] == 'test', r
-    assert set(r['users']) == {'test', 'test-dev'}, r
-
-
-def test_list_billing_projects(client):
-    r = client.list_billing_projects()
-    assert len(r) == 1
-    assert r[0]['billing_project'] == 'test', r
-
-
 def test_job(client):
     builder = client.create_batch()
     j = builder.create_job('ubuntu:18.04', ['echo', 'test'])
@@ -462,20 +450,6 @@ def test_authorized_users_only():
         r = retry_response_returning_functions(
             method, full_url, allow_redirects=False)
         assert r.status_code == expected, (full_url, r, expected)
-
-
-def test_bad_token():
-    token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode('ascii')
-    bc = BatchClient('test', _token=token)
-    try:
-        b = bc.create_batch()
-        j = b.create_job('ubuntu:18.04', ['false'])
-        b.submit()
-        assert False, j
-    except aiohttp.ClientResponseError as e:
-        assert e.status == 401, e
-    finally:
-        bc.close()
 
 
 def test_gcr_image(client):

--- a/build.yaml
+++ b/build.yaml
@@ -2171,6 +2171,8 @@ steps:
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2196,6 +2198,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /dev-tokens
     - name: ssl-config-batch-tests
       namespace:
         valueFrom: default_ns.name
@@ -2231,6 +2237,8 @@ steps:
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2256,6 +2264,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /dev-tokens
     - name: ssl-config-batch-tests
       namespace:
         valueFrom: default_ns.name
@@ -2291,6 +2303,8 @@ steps:
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2316,6 +2330,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /dev-tokens
     - name: ssl-config-batch-tests
       namespace:
         valueFrom: default_ns.name
@@ -2351,6 +2369,8 @@ steps:
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2376,6 +2396,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /dev-tokens
     - name: ssl-config-batch-tests
       namespace:
         valueFrom: default_ns.name
@@ -2411,6 +2435,8 @@ steps:
      export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
      export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2436,6 +2462,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /dev-tokens
     - name: ssl-config-batch-tests
       namespace:
         valueFrom: default_ns.name

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -87,5 +87,5 @@ def get_tokens(file=None):
             default_tokens = Tokens.default_tokens()
         return default_tokens
     if file not in tokens:
-        tokens[file] = Tokens(file)
+        tokens[file] = Tokens.from_file(file)
     return tokens[file]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -658,6 +658,30 @@ class BatchClient:
         bp_resp = await self._get('/api/v1alpha/billing_projects')
         return await bp_resp.json()
 
+    async def create_billing_project(self, project):
+        bp_resp = await self._post(f'/api/v1alpha/billing_projects/{project}/create')
+        return await bp_resp.json()
+
+    async def add_user(self, user, project):
+        resp = await self._post(f'/api/v1alpha/billing_projects/{project}/users/{user}/add')
+        return await resp.json()
+
+    async def remove_user(self, user, project):
+        resp = await self._post(f'/api/v1alpha/billing_projects/{project}/users/{user}/remove')
+        return await resp.json()
+
+    async def close_billing_project(self, project):
+        bp_resp = await self._post(f'/api/v1alpha/billing_projects/{project}/close')
+        return await bp_resp.json()
+
+    async def reopen_billing_project(self, project):
+        bp_resp = await self._post(f'/api/v1alpha/billing_projects/{project}/reopen')
+        return await bp_resp.json()
+
+    async def delete_billing_project(self, project):
+        bp_resp = await self._post(f'/api/v1alpha/billing_projects/{project}/delete')
+        return await bp_resp.json()
+
     async def close(self):
         await self._session.close()
         self._session = None


### PR DESCRIPTION
add endpoints for creating/deleting billing projects and adding/removing users from billing projects to let us add batch users with billing projects for tests without having to trigger a migration. This will make testing user isolation easier.

I create a new file to test account-related things; all the deletions from test_batch were moved over to that test file.

Stacked on #9579, #9585.