### PR TITLE
[tls] Simplify TLS use and enable TLS for address

### DIFF
--- a/address/address/address.py
+++ b/address/address/address.py
@@ -9,7 +9,7 @@ import kubernetes_asyncio as kube
 from gear import (setup_aiohttp_session, web_authenticated_developers_only,
                   rest_authenticated_users_only)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
 import uvloop
@@ -153,4 +153,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -13,7 +13,8 @@ deploy_config = get_deploy_config()
 async def test_connect_to_address_on_pod_ip():
     async with httpx.client_session(
             raise_for_status=True,
-            headers=service_auth_headers(deploy_config, 'address')) as session:
+            headers=service_auth_headers(deploy_config, 'address'),
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session,
             'GET',

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -18,4 +18,4 @@ async def test_connect_to_address_on_pod_ip():
         await request_retry_transient_errors(
             session,
             'GET',
-            f'https://address/{deploy_config.base_path("address")}/api/address')
+            deploy_config.url('address', '/api/address'))

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -2,7 +2,7 @@ import pytest
 import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -11,7 +11,7 @@ deploy_config = get_deploy_config()
 
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
-    async with client_session(
+    async with httpx.client_session(
             raise_for_status=True,
             headers=service_auth_headers(deploy_config, 'address')) as session:
         await request_retry_transient_errors(

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -14,5 +14,4 @@ async def test_connect_to_address_on_pod_ip():
             raise_for_status=True,
             headers=service_auth_headers(deploy_config, 'address'),
             timeout=aiohttp.ClientTimeout(total=60)) as session:
-        await session.get(
-            deploy_config.url('address', '/api/address')
+        await session.get(deploy_config.url('address', '/api/address'))

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -3,7 +3,6 @@ import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop import httpx
-from hailtop.utils import request_retry_transient_errors
 
 
 deploy_config = get_deploy_config()
@@ -15,7 +14,5 @@ async def test_connect_to_address_on_pod_ip():
             raise_for_status=True,
             headers=service_auth_headers(deploy_config, 'address'),
             timeout=aiohttp.ClientTimeout(total=60)) as session:
-        await request_retry_transient_errors(
-            session,
-            'GET',
-            deploy_config.url('address', '/api/address'))
+        await session.get(
+            deploy_config.url('address', '/api/address')

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -2,7 +2,7 @@ import pytest
 import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import in_cluster_no_hostname_checks_ssl_client_connection
+from hailtop.httpx import in_cluster_ssl_client_session
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -11,7 +11,7 @@ deploy_config = get_deploy_config()
 
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
-    async with in_cluster_no_hostname_checks_ssl_client_connection(
+    async with in_cluster_ssl_client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60),
             headers=service_auth_headers(deploy_config, 'address')) as session:

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -11,7 +11,6 @@ deploy_config = get_deploy_config()
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
     async with httpx.client_session(
-            raise_for_status=True,
             headers=service_auth_headers(deploy_config, 'address'),
             timeout=aiohttp.ClientTimeout(total=60)) as session:
         await session.get(deploy_config.url('address', '/api/address'))

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -2,7 +2,7 @@ import pytest
 import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -11,9 +11,8 @@ deploy_config = get_deploy_config()
 
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60),
             headers=service_auth_headers(deploy_config, 'address')) as session:
         await request_retry_transient_errors(
             session,

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -13,4 +13,4 @@ async def test_connect_to_address_on_pod_ip():
     async with httpx.client_session(
             headers=service_auth_headers(deploy_config, 'address'),
             timeout=aiohttp.ClientTimeout(total=60)) as session:
-        await session.get(deploy_config.url('address', '/api/address'))
+        await session.get(deploy_config.url('address', '/api/address', use_address=True))

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -15,8 +15,7 @@ async def test_connect_to_address_on_pod_ip():
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60),
             headers=service_auth_headers(deploy_config, 'address')) as session:
-        address, port = await deploy_config.address('address')
         await request_retry_transient_errors(
             session,
             'GET',
-            f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
+            f'https://address/{deploy_config.base_path("address")}/api/address')

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -365,4 +365,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,7 +8,7 @@ import google.oauth2.id_token
 import google_auth_oauthlib.flow
 from hailtop.config import get_deploy_config
 from hailtop.utils import secret_alnum_string
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (
     setup_aiohttp_session,

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,7 +8,7 @@ import google.oauth2.id_token
 import google_auth_oauthlib.flow
 from hailtop.config import get_deploy_config
 from hailtop.utils import secret_alnum_string
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (
     setup_aiohttp_session,
@@ -365,4 +365,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -101,12 +101,12 @@ GROUP BY batches.id;
 
     if record['user'] == 'ci':
         # only jobs from CI may use batch's TLS identity
-        make_client_session = httpx.client_session
+        client_session = httpx.client_session(retry_transient=False)
     else:
-        make_client_session = aiohttp.ClientSession
+        client_session = aiohttp.ClientSession(
+            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)
     try:
-        async with make_client_session(
-                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+        async with client_session as session:
             await session.post(callback, json=batch_record_to_dict(record))
             log.info(f'callback for batch {batch_id} successful')
     except Exception:

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -282,8 +282,9 @@ async def unschedule_job(app, record):
         if instance.state in ('inactive', 'deleted'):
             break
         try:
-            async with aiohttp.ClientSession(
-                    raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+            async with httpx.client_session(
+                    retry_transient=False,
+                    timeout=aiohttp.ClientTimeout(total=60)) as session:
                 await session.delete(url)
                 await instance.mark_healthy()
                 break
@@ -454,8 +455,9 @@ async def schedule_job(app, record, instance):
         log.info(f'schedule job {id} on {instance}: made job config')
 
         try:
-            async with aiohttp.ClientSession(
-                    raise_for_status=True, timeout=aiohttp.ClientTimeout(total=2)) as session:
+            async with httpx.client_session(
+                    retry_transient=False,
+                    timeout=aiohttp.ClientTimeout(total=2)) as session:
                 url = (f'http://{instance.ip_address}:5000'
                        f'/api/v1alpha/batches/jobs/create')
                 await session.post(url, json=body)

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -8,7 +8,7 @@ import traceback
 from hailtop.utils import (
     time_msecs, sleep_and_backoff, is_transient_error,
     time_msecs_str, humanize_timedelta_msecs, cost_str)
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 
 from .globals import complete_states, tasks, STATUS_FORMAT_VERSION
 from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -104,7 +104,7 @@ GROUP BY batches.id;
         client_session = httpx.client_session(retry_transient=False)
     else:
         client_session = aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)
+            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5))
     try:
         async with client_session as session:
             await session.post(callback, json=batch_record_to_dict(record))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -8,7 +8,7 @@ import traceback
 from hailtop.utils import (
     time_msecs, sleep_and_backoff, is_transient_error,
     time_msecs_str, humanize_timedelta_msecs, cost_str)
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop import httpx
 
 from .globals import complete_states, tasks, STATUS_FORMAT_VERSION
 from .batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS, \
@@ -101,7 +101,7 @@ GROUP BY batches.id;
 
     if record['user'] == 'ci':
         # only jobs from CI may use batch's TLS identity
-        make_client_session = in_cluster_ssl_client_session
+        make_client_session = httpx.client_session
     else:
         make_client_session = aiohttp.ClientSession
     try:

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -4,6 +4,7 @@ import logging
 import secrets
 import humanize
 from hailtop.utils import time_msecs, time_msecs_str
+from hailtop import httpx
 
 from ..database import check_call_procedure
 from ..globals import INSTANCE_VERSION
@@ -135,8 +136,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
     async def check_is_active_and_healthy(self):
         if self._state == 'active' and self.ip_address:
             try:
-                async with aiohttp.ClientSession(
-                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     async with session.get(f'http://{self.ip_address}:5000/healthcheck') as resp:
                         actual_name = (await resp.json()).get('name')
                         if actual_name and actual_name != self.name:

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -1,4 +1,3 @@
-import aiohttp
 import datetime
 import logging
 import secrets

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -18,7 +18,7 @@ from gear import (Database, setup_aiohttp_session,
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import time_msecs, RateLimit, serialization
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop import aiogoogle
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
@@ -741,4 +741,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -18,7 +18,7 @@ from gear import (Database, setup_aiohttp_session,
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import time_msecs, RateLimit, serialization
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop import aiogoogle
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
@@ -741,4 +741,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -21,7 +21,7 @@ from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.hail_logging import AccessLogger
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only, web_authenticated_users_only,
@@ -965,7 +965,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with client_session(raise_for_status=True) as session:
+    async with httpx.client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
@@ -1505,7 +1505,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 
 
 async def cancel_batch_loop_body(app):
-    async with client_session(raise_for_status=True) as session:
+    async with httpx.client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
@@ -1516,7 +1516,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with client_session(raise_for_status=True) as session:
+    async with httpx.client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -968,8 +968,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
     async with httpx.client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
-        await request_retry_transient_errors(
-            session, 'PATCH',
+        await session.patch(
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
             headers=app['driver_headers'])
 
@@ -1508,8 +1507,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 
 async def cancel_batch_loop_body(app):
     async with httpx.client_session(raise_for_status=True) as session:
-        await request_retry_transient_errors(
-            session, 'POST',
+        await session.post(
             deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
             headers=app['driver_headers'])
 
@@ -1519,8 +1517,7 @@ async def cancel_batch_loop_body(app):
 
 async def delete_batch_loop_body(app):
     async with httpx.client_session(raise_for_status=True) as session:
-        await request_retry_transient_errors(
-            session, 'POST',
+        await session.post(
             deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
             headers=app['driver_headers'])
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -20,8 +20,8 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.tls import server_ssl_context
+from hailtop.httpx import client_session
 from hailtop.hail_logging import AccessLogger
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only, web_authenticated_users_only,
@@ -965,8 +965,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with in_cluster_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+    async with client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
@@ -1506,8 +1505,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 
 
 async def cancel_batch_loop_body(app):
-    async with in_cluster_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+    async with client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
@@ -1518,8 +1516,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with in_cluster_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+    async with client_session(raise_for_status=True) as session:
         await request_retry_transient_errors(
             session, 'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
@@ -1601,4 +1598,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -20,7 +20,7 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.httpx import client_session
 from hailtop.hail_logging import AccessLogger
 from gear import (Database, setup_aiohttp_session,
@@ -1598,4 +1598,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -20,7 +20,8 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_session
+from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.httpx import in_cluster_ssl_client_session
 from hailtop.hail_logging import AccessLogger
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only, web_authenticated_users_only,

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -15,8 +15,8 @@ from prometheus_async.aio.web import server_stats
 import google.oauth2.service_account
 import google.api_core.exceptions
 from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
-                           request_retry_transient_errors, run_if_changed,
-                           retry_long_running, LoggingTimer, cost_str)
+                           run_if_changed, retry_long_running, LoggingTimer,
+                           cost_str)
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
@@ -222,13 +222,12 @@ async def _get_job_log_from_record(app, batch_id, job_id, record):
     state = record['state']
     ip_address = record['ip_address']
     if state == 'Running':
-        async with aiohttp.ClientSession(
-                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+        async with httpx.client_session() as session:
             try:
                 url = (f'http://{ip_address}:5000'
                        f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-                resp = await request_retry_transient_errors(session, 'GET', url)
-                return await resp.json()
+                async with session.get(url) as resp:
+                    return await resp.json()
             except aiohttp.ClientResponseError as e:
                 if e.status == 404:
                     return None
@@ -355,13 +354,12 @@ async def _get_full_job_status(app, record):
     assert record['status'] is None
 
     ip_address = record['ip_address']
-    async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+    async with httpx.client_session() as session:
         try:
             url = (f'http://{ip_address}:5000'
                    f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/status')
-            resp = await request_retry_transient_errors(session, 'GET', url)
-            return await resp.json()
+            async with session.get(url) as resp:
+                return await resp.json()
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
                 return None
@@ -966,7 +964,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
         raise
 
     async with httpx.client_session(
-            raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
         await session.patch(
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
@@ -1506,7 +1503,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 
 
 async def cancel_batch_loop_body(app):
-    async with httpx.client_session(raise_for_status=True) as session:
+    async with httpx.client_session() as session:
         await session.post(
             deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
             headers=app['driver_headers'])
@@ -1516,7 +1513,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with httpx.client_session(raise_for_status=True) as session:
+    async with httpx.client_session() as session:
         await session.post(
             deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
             headers=app['driver_headers'])

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -965,7 +965,9 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with httpx.client_session(raise_for_status=True) as session:
+    async with httpx.client_session(
+            raise_for_status=True,
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1066,9 +1066,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with httpx.client_session(
-                        retry_transient=False,
-                        raise_for_status=True) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
                     # gone (e.g. testing a PR), this would go into an
@@ -1121,11 +1119,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                # TO REVIEWER: should this retry transient issues (like 504s)?
-                # It previously did not, but seems reasonable to retry?
-                async with httpx.client_session(
-                        retry_transient=False,
-                        raise_for_status=True) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
                         json=body, headers=self.headers)
@@ -1179,7 +1173,7 @@ class Worker:
             'status': status
         }
 
-        async with httpx.client_session(raise_for_status=True) as session:
+        async with httpx.client_session() as session:
             await session.post(
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/job_started'),
                 json=body, headers=self.headers)
@@ -1192,7 +1186,6 @@ class Worker:
 
     async def activate(self):
         async with httpx.client_session(
-                raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60)) as session:
             async with session.post(
                     deploy_config.url('batch-driver', '/api/v1alpha/instances/activate'),

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -22,7 +22,7 @@ from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError, blocking_to_async, check_shell_output,
                            retry_long_running, run_if_changed)
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 # import uvloop

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -23,7 +23,7 @@ from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            CalledProcessError, blocking_to_async, check_shell_output,
                            retry_long_running, run_if_changed)
 
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 # import uvloop
@@ -1066,7 +1066,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with client_session(
+                async with httpx.client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
@@ -1120,7 +1120,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with client_session(raise_for_status=True) as session:
+                async with httpx.client_session(raise_for_status=True) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
                         json=body, headers=self.headers)
@@ -1174,7 +1174,7 @@ class Worker:
             'status': status
         }
 
-        async with client_session(raise_for_status=True) as session:
+        async with httpx.client_session(raise_for_status=True) as session:
             await request_retry_transient_errors(
                 session, 'POST',
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/job_started'),
@@ -1187,7 +1187,7 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with client_session(
+        async with httpx.client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             resp = await request_retry_transient_errors(
                 session, 'POST',

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -18,9 +18,9 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import (time_msecs, request_retry_transient_errors,
-                           RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
-                           CalledProcessError, blocking_to_async, check_shell_output,
+from hailtop.utils import (time_msecs, RETRY_FUNCTION_SCRIPT, sleep_and_backoff,
+                           retry_all_errors, check_shell, CalledProcessError,
+                           blocking_to_async, check_shell_output,
                            retry_long_running, run_if_changed)
 
 from hailtop import httpx

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -27,6 +27,10 @@ class FailureInjectingClientSession:
                     real_url=path),
                 history=())
 
+    async def _request(self, method, path, *args, **kwargs):
+        self.maybe_fail(method, path, kwargs.get('headers', {}))
+        return await self.real_session.request(method, path, *args, **kwargs)
+
     async def request(self, method, path, *args, **kwargs):
         self.maybe_fail(method, path, kwargs.get('headers', {}))
         return await self.real_session.request(method, path, *args, **kwargs)

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,14 +1,14 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 
 
 class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = in_cluster_ssl_client_session(raise_for_status=True,
-                                                          timeout=aiohttp.ClientTimeout(total=60))
+        self.real_session = client_session(raise_for_status=True,
+                                           timeout=aiohttp.ClientTimeout(total=60))
 
     def __enter__(self):
         return self

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,7 +1,7 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 
 
 class FailureInjectingClientSession:

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -31,3 +31,6 @@ class FailureInjectingClientSession:
     async def request(self, method, path, *args, **kwargs):
         self.maybe_fail(method, path, kwargs.get('headers', {}))
         return await self.real_session.request(method, path, *args, **kwargs)
+
+    async def post(self, path, *args, **kwargs):
+        return await self.request(self, 'POST', path, *args, **kwargs)

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,14 +1,13 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.httpx import client_session
+from hailtop import httpx
 
 
 class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = client_session(raise_for_status=True,
-                                           timeout=aiohttp.ClientTimeout(total=60))
+        self.real_session = httpx.client_session()
 
     def __enter__(self):
         return self

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -32,4 +32,4 @@ class FailureInjectingClientSession:
         return await self.real_session.request(method, path, *args, **kwargs)
 
     async def post(self, path, *args, **kwargs):
-        return await self.request(self, 'POST', path, *args, **kwargs)
+        return await self.request('POST', path, *args, **kwargs)

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -5,7 +5,7 @@ import requests
 from werkzeug.serving import make_server
 from flask import Response
 
-from hailtop.httpx import blocking_client_session
+from hailtop import httpx
 
 
 class ServerThread(threading.Thread):
@@ -30,7 +30,7 @@ class ServerThread(threading.Thread):
         ping_url = 'http://{}:{}/ping'.format(self.host, self.port)
 
         up = False
-        with blocking_client_session() as session:
+        with httpx.blocking_client_session() as session:
             while not up:
                 try:
                     with session.get(ping_url) as resp:

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -6,7 +6,6 @@ from werkzeug.serving import make_server
 from flask import Response
 
 from hailtop.httpx import blocking_client_session
-from hailtop.utils import sync_retry_transient_errors
 
 
 class ServerThread(threading.Thread):

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -34,8 +34,8 @@ class ServerThread(threading.Thread):
         with blocking_client_session() as session:
             while not up:
                 try:
-                    sync_retry_transient_errors(
-                        session.get, ping_url)
+                    with session.get(ping_url) as resp:
+                        resp.text()
                     up = True
                 except requests.exceptions.ConnectionError:
                     time.sleep(0.01)

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -5,8 +5,8 @@ import requests
 from werkzeug.serving import make_server
 from flask import Response
 
-from hailtop.utils import (retry_response_returning_functions,
-                           external_requests_client_session)
+from hailtop.httpx import blocking_client_session
+from hailtop.utils import sync_retry_transient_errors
 
 
 class ServerThread(threading.Thread):
@@ -31,14 +31,14 @@ class ServerThread(threading.Thread):
         ping_url = 'http://{}:{}/ping'.format(self.host, self.port)
 
         up = False
-        session = external_requests_client_session()
-        while not up:
-            try:
-                retry_response_returning_functions(
-                    session.get, ping_url)
-                up = True
-            except requests.exceptions.ConnectionError:
-                time.sleep(0.01)
+        with blocking_client_session() as session:
+            while not up:
+                try:
+                    sync_retry_transient_errors(
+                        session.get, ping_url)
+                    up = True
+                except requests.exceptions.ConnectionError:
+                    time.sleep(0.01)
 
     def start(self):
         super().start()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -12,7 +12,6 @@ import json
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers, get_userinfo
 from hailtop.httpx import blocking_client_session
-from hailtop.utils import sync_retry_transient_errors
 from hailtop.batch_client.client import BatchClient, Job
 
 from .utils import legacy_batch_status
@@ -440,7 +439,7 @@ def test_log_after_failing_job(client):
 
 
 def test_authorized_users_only():
-    with blocking_client_session() as session:
+    with blocking_client_session(raise_for_status=False) as session:
         endpoints = [
             (session.get, '/api/v1alpha/billing_projects', 401),
             (session.get, '/api/v1alpha/billing_projects/foo', 401),
@@ -582,12 +581,9 @@ def test_batch_create_validation():
     ]
     url = deploy_config.url('batch', '/api/v1alpha/batches/create')
     headers = service_auth_headers(deploy_config, 'batch')
-    with blocking_client_session() as session:
+    with blocking_client_session(raise_for_status=False) as session:
         for config in bad_configs:
-            with session.post(url,
-                              json=config,
-                              allow_redirects=True,
-                              headers=headers) as resp:
+            with session.post(url, json=config, headers=headers) as resp:
                 assert resp.status == 400, (config, resp.text())
 
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -588,7 +588,7 @@ def test_batch_create_validation():
                               json=config,
                               allow_redirects=True,
                               headers=headers) as resp:
-                assert resp.status == 400, (config, resp)
+                assert resp.status == 400, (config, resp.text())
 
 
 def test_duplicate_parents(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -11,7 +11,7 @@ import json
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers, get_userinfo
-from hailtop.httpx import blocking_client_session
+from hailtopd import httpx
 from hailtop.batch_client.client import BatchClient, Job
 
 from .utils import legacy_batch_status
@@ -439,7 +439,7 @@ def test_log_after_failing_job(client):
 
 
 def test_authorized_users_only():
-    with blocking_client_session(raise_for_status=False) as session:
+    with httpx.blocking_client_session(raise_for_status=False) as session:
         endpoints = [
             (session.get, '/api/v1alpha/billing_projects', 401),
             (session.get, '/api/v1alpha/billing_projects/foo', 401),
@@ -582,7 +582,7 @@ def test_batch_create_validation():
     ]
     url = deploy_config.url('batch', '/api/v1alpha/batches/create')
     headers = service_auth_headers(deploy_config, 'batch')
-    with blocking_client_session(raise_for_status=False) as session:
+    with httpx.blocking_client_session(raise_for_status=False) as session:
         for config in bad_configs:
             with session.post(url, json=config, headers=headers) as resp:
                 assert resp.status == 400, (config, resp.text())

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -621,7 +621,7 @@ def test_user_authentication_within_job(client):
     batch.submit()
 
     with_token_status = with_token.wait()
-    assert with_token_status['state'] == 'Success', with_token_status
+    assert with_token_status['state'] == 'Success', (with_token_status, with_token.log())
 
     username = get_userinfo()['username']
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -11,7 +11,7 @@ import json
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers, get_userinfo
-from hailtopd import httpx
+from hailtop import httpx
 from hailtop.batch_client.client import BatchClient, Job
 
 from .utils import legacy_batch_status

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -539,7 +539,8 @@ def test_restartable_insert(client):
         return False
 
     with FailureInjectingClientSession(every_third_time) as session:
-        client = BatchClient('test', session=session)
+        client = BatchClient('test')
+        client._async_client._session.session = session
         builder = client.create_batch()
 
         for _ in range(9):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -458,7 +458,7 @@ def test_authorized_users_only():
             (session.get, '/batches/0/jobs/0', 302)]
         for method, url, expected in endpoints:
             full_url = deploy_config.url('batch', url)
-            with session.request(method, full_url, allow_redirects=False) as resp:
+            with method(full_url, allow_redirects=False) as resp:
                 assert resp.status == expected, (full_url, resp.text(), expected)
 
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -459,9 +459,8 @@ def test_authorized_users_only():
             (session.get, '/batches/0/jobs/0', 302)]
         for method, url, expected in endpoints:
             full_url = deploy_config.url('batch', url)
-            with sync_retry_transient_errors(
-                    session.request, method, full_url, allow_redirects=False) as resp:
-                assert resp.status == expected, (full_url, r, expected)
+            with session.request(method, full_url, allow_redirects=False) as resp:
+                assert resp.status == expected, (full_url, resp.text(), expected)
 
 
 def test_bad_token():
@@ -585,13 +584,11 @@ def test_batch_create_validation():
     headers = service_auth_headers(deploy_config, 'batch')
     with blocking_client_session() as session:
         for config in bad_configs:
-            with sync_retry_transient_errors(
-                    session.post,
-                    url,
-                    json=config,
-                    allow_redirects=True,
-                    headers=headers) as resp:
-                assert resp.status == 400, (config, r)
+            with session.post(url,
+                              json=config,
+                              allow_redirects=True,
+                              headers=headers) as resp:
+                assert resp.status == 400, (config, resp)
 
 
 def test_duplicate_parents(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -459,9 +459,9 @@ def test_authorized_users_only():
             (session.get, '/batches/0/jobs/0', 302)]
         for method, url, expected in endpoints:
             full_url = deploy_config.url('batch', url)
-            r = sync_retry_transient_errors(
-                session.request, method, full_url, allow_redirects=False)
-            assert r.status_code == expected, (full_url, r, expected)
+            with sync_retry_transient_errors(
+                    session.request, method, full_url, allow_redirects=False) as resp:
+                assert resp.status == expected, (full_url, r, expected)
 
 
 def test_bad_token():
@@ -585,13 +585,13 @@ def test_batch_create_validation():
     headers = service_auth_headers(deploy_config, 'batch')
     with blocking_client_session() as session:
         for config in bad_configs:
-            r = sync_retry_transient_errors(
-                session.post,
-                url,
-                json=config,
-                allow_redirects=True,
-                headers=headers)
-            assert r.status_code == 400, (config, r)
+            with sync_retry_transient_errors(
+                    session.post,
+                    url,
+                    json=config,
+                    allow_redirects=True,
+                    headers=headers) as resp:
+                assert resp.status == 400, (config, r)
 
 
 def test_duplicate_parents(client):

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
+from hailtop import httpx
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,8 +18,7 @@ async def test_invariants():
     deploy_config = get_deploy_config()
     url = deploy_config.url('batch-driver', '/check_invariants')
     headers = service_auth_headers(deploy_config, 'batch-driver')
-    async with client_session(
-            raise_for_status=True,
+    async with httpx.client_session(
             timeout=aiohttp.ClientTimeout(total=60)) as session:
         async with session.get(url, headers=headers) as resp:
             data = await resp.json()

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -21,10 +21,8 @@ async def test_invariants():
     async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
-
-        resp = await utils.request_retry_transient_errors(
-            session, 'GET', url, headers=headers)
-        data = await resp.json()
+        async with session.get(url, headers=headers) as resp:
+            data = await resp.json()
 
         assert data['check_incremental_error'] is None, data
         assert data['check_resource_aggregation_error'] is None, data

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,7 +18,7 @@ async def test_invariants():
     deploy_config = get_deploy_config()
     url = deploy_config.url('batch-driver', '/check_invariants')
     headers = service_auth_headers(deploy_config, 'batch-driver')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -5,7 +5,7 @@ from aiohttp import web
 import logging
 from gear import setup_aiohttp_session, web_authenticated_developers_only
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger, configure_logging
 from hailtop.utils import retry_long_running
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -260,4 +260,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -5,7 +5,7 @@ from aiohttp import web
 import logging
 from gear import setup_aiohttp_session, web_authenticated_developers_only
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger, configure_logging
 from hailtop.utils import retry_long_running
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -260,4 +260,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/build.yaml
+++ b/build.yaml
@@ -2836,6 +2836,10 @@ steps:
       namespace:
         valueFrom: batch_pods_ns.name
       mountPath: /user-tokens
+    - name: ssl-config-batch-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
     - name: test-gsa-key
       namespace:
         valueFrom: batch_pods_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -1802,6 +1802,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /deploy-config
+    - name: ssl-config-auth-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
    dependsOn:
     - default_ns
     - create_accounts
@@ -1850,6 +1854,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /deploy-config
+    - name: ssl-config-auth-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
    dependsOn:
     - default_ns
     - create_accounts

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -12,7 +12,7 @@ from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, rest_authenticated_developers_only,
                   web_authenticated_developers_only, check_csrf_token,
@@ -433,4 +433,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -12,7 +12,7 @@ from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, rest_authenticated_developers_only,
                   web_authenticated_developers_only, check_csrf_token,
@@ -433,4 +433,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -27,9 +27,8 @@ async def test_deploy():
             deploy_state = None
             failure_information = None
             while deploy_state is None:
-                resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{ci_deploy_status_url}', headers=headers)
-                deploy_statuses = await resp.json()
+                with session.get(f'{ci_deploy_status_url}', headers=headers) as resp:
+                    deploy_statuses = await resp.json()
                 log.info(f'deploy_statuses:\n{json.dumps(deploy_statuses, indent=2)}')
                 assert len(deploy_statuses) == 1, deploy_statuses
                 deploy_status = deploy_statuses[0]

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,7 +19,7 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -20,7 +20,6 @@ async def test_deploy():
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
     async with client_session(
-            raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 
         async def wait_forever():

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
+from hailtop import httpx
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,7 +19,7 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with client_session(
+    async with httpx.client_session(
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 
         async def wait_forever():

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -27,7 +27,7 @@ async def test_deploy():
             deploy_state = None
             failure_information = None
             while deploy_state is None:
-                with session.get(f'{ci_deploy_status_url}', headers=headers) as resp:
+                async with session.get(f'{ci_deploy_status_url}', headers=headers) as resp:
                     deploy_statuses = await resp.json()
                 log.info(f'deploy_statuses:\n{json.dumps(deploy_statuses, indent=2)}')
                 assert len(deploy_statuses) == 1, deploy_statuses

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio

--- a/dev-docs/hail-overview.md
+++ b/dev-docs/hail-overview.md
@@ -116,6 +116,7 @@ Libraries for services:
 * $HAIL/hail/python/hailtop/auth: user authorization library
 * $HAIL/hail/python/hailtop/config: user and deployment configuration library
 * $HAIL/hail/python/hailtop/tls.py: TLS utilities for services
+* $HAIL/hail/python/hailtop/httpx.py: HTTP(S) client utilities for services
 * $HAIL/hail/python/hailtop/utils: various
 * $HAIL/tls: for TLS configuration and deployment
 * $HAIL/web_common: service HTML templates

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -6,7 +6,7 @@ from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
 from hailtop.utils import request_retry_transient_errors
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 
 log = logging.getLogger('gear.auth')
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -15,7 +15,7 @@ deploy_config = get_deploy_config()
 async def _userdata_from_session_id(session_id):
     headers = {'Authorization': f'Bearer {session_id}'}
     try:
-        async with httpx.client_session(raise_for_status=True) as session:
+        async with httpx.client_session() as session:
             async with session.get(
                     deploy_config.url('auth', '/api/v1alpha/userinfo'),
                     headers=headers) as resp:

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -5,8 +5,8 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
+from hailtop.httpx import client_session
 from hailtop.utils import request_retry_transient_errors
-from hailtop.httpx import in_cluster_ssl_client_session
 
 log = logging.getLogger('gear.auth')
 
@@ -16,8 +16,7 @@ deploy_config = get_deploy_config()
 async def _userdata_from_session_id(session_id):
     headers = {'Authorization': f'Bearer {session_id}'}
     try:
-        async with in_cluster_ssl_client_session(
-                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+        async with client_session(raise_for_status=True) as session:
             resp = await request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),
                 headers=headers)

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -5,7 +5,7 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.utils import request_retry_transient_errors
 
 log = logging.getLogger('gear.auth')
@@ -16,7 +16,7 @@ deploy_config = get_deploy_config()
 async def _userdata_from_session_id(session_id):
     headers = {'Authorization': f'Bearer {session_id}'}
     try:
-        async with client_session(raise_for_status=True) as session:
+        async with httpx.client_session(raise_for_status=True) as session:
             resp = await request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),
                 headers=headers)

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -76,9 +76,7 @@ class ServiceBackend(Backend):
             'billing_project': self._billing_project,
             'bucket': self._bucket
         }
-        with sync_retry_transient_errors(
-                self.session.post,
-                f'{self.url}/execute', json=body) as resp:
+        with self.session.post(f'{self.url}/execute', json=body) as resp:
             if resp.status == 400 or resp.status == 500:
                 raise FatalError(resp.text)
             resp.raise_for_status()
@@ -91,9 +89,7 @@ class ServiceBackend(Backend):
 
     def _request_type(self, ir, kind):
         code = self._render(ir)
-        with sync_retry_transient_errors(
-                self.session.post,
-                f'{self.url}/type/{kind}', json=code) as resp:
+        with self.session.post(f'{self.url}/type/{kind}', json=code) as resp:
             if resp.status == 400 or resp.status == 500:
                 raise FatalError(resp.text)
             resp.raise_for_status()
@@ -117,17 +113,14 @@ class ServiceBackend(Backend):
         return tblockmatrix._from_json(resp)
 
     def add_reference(self, config):
-        with sync_retry_transient_errors(
-                self.session.post,
-                f'{self.url}/references/create', json=config) as resp:
+        with self.session.post(f'{self.url}/references/create', json=config) as resp:
             if resp.status == 400 or resp.status == 500:
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
             resp.raise_for_status()
 
     def from_fasta_file(self, name, fasta_file, index_file, x_contigs, y_contigs, mt_contigs, par):
-        with sync_retry_transient_errors(
-                self.session.post,
+        with self.session.post(
                 f'{self.url}/references/create/fasta',
                 json={
                     'name': name,
@@ -144,20 +137,14 @@ class ServiceBackend(Backend):
             resp.raise_for_status()
 
     def remove_reference(self, name):
-        with sync_retry_transient_errors(
-                self.session.delete,
-                f'{self.url}/references/delete',
-                json={'name': name}) as resp:
+        with self.session.delete(f'{self.url}/references/delete', json={'name': name}) as resp:
             if resp.status == 400 or resp.status == 500:
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
             resp.raise_for_status()
 
     def get_reference(self, name):
-        with sync_retry_transient_errors(
-                self.session.get,
-                f'{self.url}/references/get',
-                json={'name': name}) as resp:
+        with self.session.get(f'{self.url}/references/get', json={'name': name}) as resp:
             if resp.status == 400 or resp.status == 500:
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
@@ -179,8 +166,7 @@ class ServiceBackend(Backend):
             resp.raise_for_status()
 
     def remove_sequence(self, name):
-        with sync_retry_transient_errors(
-                self.session.delete,
+        with self.session.delete(
                 f'{self.url}/references/sequence/delete',
                 json={'name': name}) as resp:
             if resp.status == 400 or resp.status == 500:
@@ -189,8 +175,7 @@ class ServiceBackend(Backend):
             resp.raise_for_status()
 
     def add_liftover(self, name, chain_file, dest_reference_genome):
-        with sync_retry_transient_errors(
-                self.session.post,
+        with self.session.post(
                 f'{self.url}/references/liftover/add',
                 json={'name': name, 'chain_file': chain_file,
                       'dest_reference_genome': dest_reference_genome}) as resp:
@@ -200,8 +185,7 @@ class ServiceBackend(Backend):
             resp.raise_for_status()
 
     def remove_liftover(self, name, dest_reference_genome):
-        with sync_retry_transient_errors(
-                self.session.delete,
+        with self.session.delete(
                 f'{self.url}/references/liftover/remove',
                 json={'name': name, 'dest_reference_genome': dest_reference_genome}) as resp:
             if resp.status == 400 or resp.status == 500:
@@ -210,8 +194,7 @@ class ServiceBackend(Backend):
             resp.raise_for_status()
 
     def parse_vcf_metadata(self, path):
-        with sync_retry_transient_errors(
-                self.session.post,
+        with self.session.post(
                 f'{self.url}/parse-vcf-metadata',
                 json={'path': path}) as resp:
             if resp.status == 400 or resp.status == 500:
@@ -221,8 +204,7 @@ class ServiceBackend(Backend):
             return resp.json()
 
     def index_bgen(self, files, index_file_map, rg, contig_recoding, skip_invalid_loci):
-        with sync_retry_transient_errors(
-                self.session.post,
+        with self.session.post(
                 f'{self.url}/index-bgen',
                 json={
                     'files': files,
@@ -238,8 +220,7 @@ class ServiceBackend(Backend):
             return resp.json()
 
     def import_fam(self, path: str, quant_pheno: bool, delimiter: str, missing: str):
-        with sync_retry_transient_errors(
-                self.session.post,
+        with self.session.post(
                 f'{self.url}/import-fam',
                 json={
                     'path': path,

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -149,8 +149,7 @@ class ServiceBackend(Backend):
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
             resp.raise_for_status()
-            ref = resp.json()
-            assert ref is not None, (resp, name)
+            return resp.json()
 
     def load_references_from_dataset(self, path):
         # FIXME

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -9,7 +9,7 @@ from hail.expr.blockmatrix_type import tblockmatrix
 
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import blocking_client_session
+from hailtop import httpx
 from hail.ir.renderer import CSERenderer
 
 from .backend import Backend
@@ -45,7 +45,7 @@ class ServiceBackend(Backend):
         self.url = deploy_config.base_url('query')
         self._fs = None
         self._logger = PythonOnlyLogger(skip_logging_configuration)
-        self.session = blocking_client_session(
+        self.session = httpx.blocking_client_session(
             raise_for_status=False,
             headers=service_auth_headers(deploy_config, 'query'),
             timeout=aiohttp.ClientTimeout(total=600))

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -149,7 +149,8 @@ class ServiceBackend(Backend):
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
             resp.raise_for_status()
-            return resp.json()
+            ref = resp.json()
+            assert ref is not None, (resp, name)
 
     def load_references_from_dataset(self, path):
         # FIXME

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -1,3 +1,4 @@
+import aiohttp
 import os
 
 from hail.utils import FatalError
@@ -47,7 +48,7 @@ class ServiceBackend(Backend):
         self._logger = PythonOnlyLogger(skip_logging_configuration)
         self.session = blocking_client_session(
             headers=service_auth_headers(deploy_config, 'query'),
-            timeout=600)
+            timeout=aiohttp.ClientTimeout(total=600))
 
     @property
     def logger(self):

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -91,8 +91,8 @@ class ServiceBackend(Backend):
     def _request_type(self, ir, kind):
         code = self._render(ir)
         with sync_retry_transient_errors(
-            self.session.post,
-            f'{self.url}/type/{kind}', json=code) as resp:
+                self.session.post,
+                f'{self.url}/type/{kind}', json=code) as resp:
             if resp.status == 400 or resp.status == 500:
                 raise FatalError(resp.text)
             resp.raise_for_status()

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -145,7 +145,7 @@ class ServiceBackend(Backend):
 
     def get_reference(self, name):
         with self.session.get(f'{self.url}/references/get', json={'name': name}) as resp:
-            if resp.status == 400 or resp.status == 500:
+            if resp.status >= 400:
                 resp_json = resp.json()
                 raise FatalError(resp_json['message'])
             resp.raise_for_status()

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -253,7 +253,7 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                with blocking_client_session() as session, sync_retry_transient_errors(session.get, url, raise_for_status=True) as resp:
+                with blocking_client_session() as session, session.get(url, raise_for_status=True) as resp:
                     config = resp.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -6,7 +6,7 @@ from typing import List, Set, Iterable, Optional, Union, Tuple
 import hail as hl
 import pkg_resources
 
-from hailtop.httpx import blocking_client_session
+from hailtop import httpx
 
 from .lens import MatrixRows, TableRows
 from ..expr import StructExpression
@@ -252,7 +252,7 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                with blocking_client_session() as session, session.get(url) as resp:
+                with httpx.blocking_client_session() as session, session.get(url) as resp:
                     config = resp.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -7,7 +7,6 @@ import hail as hl
 import pkg_resources
 
 from hailtop.httpx import blocking_client_session
-from hailtop.utils import sync_retry_transient_errors
 
 from .lens import MatrixRows, TableRows
 from ..expr import StructExpression

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -252,7 +252,7 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                with blocking_client_session() as session, session.get(url, raise_for_status=True) as resp:
+                with blocking_client_session() as session, session.get(url) as resp:
                     config = resp.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -253,8 +253,7 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                with blocking_client_session() as session, \
-                     sync_retry_transient_errors(session.get, url, raise_for_status=True) as resp:
+                with blocking_client_session() as session, sync_retry_transient_errors(session.get, url, raise_for_status=True) as resp:
                     config = resp.json()
             assert isinstance(config, dict)
         else:

--- a/hail/python/hailtop/aiogoogle/auth/access_token.py
+++ b/hail/python/hailtop/aiogoogle/auth/access_token.py
@@ -1,5 +1,7 @@
 import time
 
+from ... import httpx
+
 
 class AccessToken:
     def __init__(self, credentials):
@@ -7,7 +9,7 @@ class AccessToken:
         self._access_token = None
         self._expires_at = None
 
-    async def auth_headers(self, session):
+    async def auth_headers(self, session: httpx.ClientSession):
         now = time.time()
         if self._access_token is None or now > self._expires_at:
             self._access_token = await self.credentials.get_access_token(session)

--- a/hail/python/hailtop/aiogoogle/auth/session.py
+++ b/hail/python/hailtop/aiogoogle/auth/session.py
@@ -79,7 +79,7 @@ class Session(BaseSession):
             kwargs['headers'].update(auth_headers)
         else:
             kwargs['headers'] = auth_headers
-        return self._session.request(method, url, **kwargs)
+        return await self._session.request(method, url, **kwargs)
 
     async def close(self) -> None:
         if self._session is not None:

--- a/hail/python/hailtop/aiogoogle/auth/session.py
+++ b/hail/python/hailtop/aiogoogle/auth/session.py
@@ -1,7 +1,6 @@
 from types import TracebackType
 from typing import Optional, Type, TypeVar
 import abc
-import aiohttp
 from hailtop.utils import RateLimit, RateLimiter
 from .credentials import Credentials
 from .access_token import AccessToken

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -13,9 +13,8 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with httpx.client_session(raise_for_status=True) as session:
-        resp = await request_retry_transient_errors(
-            session, 'GET', userinfo_url, headers=headers)
+    async with httpx.client_session() as session \
+               session.get(userinfo_url, headers=headers) as resp:
         return await resp.json()
 
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -13,9 +13,9 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with httpx.client_session() as session, \
-               session.get(userinfo_url, headers=headers) as resp:
-        return await resp.json()
+    async with httpx.client_session() as session:
+        async with session.get(userinfo_url, headers=headers) as resp:
+            return await resp.json()
 
 
 def get_userinfo(deploy_config=None):

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -1,5 +1,4 @@
 import os
-import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking
 from hailtop import httpx

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -2,7 +2,7 @@ import os
 import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 from .tokens import get_tokens
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -2,7 +2,7 @@ import os
 import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 from .tokens import get_tokens
 
@@ -13,8 +13,7 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+    async with httpx.client_session(raise_for_status=True) as session:
         resp = await request_retry_transient_errors(
             session, 'GET', userinfo_url, headers=headers)
         return await resp.json()

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -13,7 +13,7 @@ async def async_get_userinfo(deploy_config=None, headers=None):
     if headers is None:
         headers = service_auth_headers(deploy_config, 'auth')
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
-    async with httpx.client_session() as session \
+    async with httpx.client_session() as session, \
                session.get(userinfo_url, headers=headers) as resp:
         return await resp.json()
 

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -8,7 +8,7 @@ import functools
 import sys
 import time
 
-from hailtop.utils import secret_alnum_string, partition
+from hailtop.utils import (secret_alnum_string, partition, async_to_blocking)
 import hailtop.batch_client.aioclient as low_level_batch_client
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 
@@ -36,10 +36,6 @@ def chunk(fn):
     def chunkedfn(*args):
         return [fn(*arglist) for arglist in zip(*args)]
     return chunkedfn
-
-
-def async_to_blocking(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 class BatchPoolExecutor:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -12,7 +12,7 @@ from asyncinit import asyncinit
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 from .globals import tasks, complete_states
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -11,7 +11,7 @@ from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
+from hailtop.utils import bounded_gather, tqdm, TQDM_DEFAULT_DISABLE
 from hailtop import httpx
 
 from .globals import tasks, complete_states

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -558,8 +558,8 @@ class BatchBuilder:
 
 @asyncinit
 class BatchClient:
-    async def __init__(self, billing_project, deploy_config=None, session=None,
-                       headers=None, _token=None, token_file=None):
+    async def __init__(self, billing_project, deploy_config=None, headers=None,
+                       _token=None, token_file=None):
         self.billing_project = billing_project
 
         if not deploy_config:
@@ -567,9 +567,7 @@ class BatchClient:
 
         self.url = deploy_config.base_url('batch')
 
-        if session is None:
-            session = httpx.client_session()
-        self._session = session
+        self._session = httpx.client_session()
 
         h = {}
         if headers:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -568,9 +568,7 @@ class BatchClient:
         self.url = deploy_config.base_url('batch')
 
         if session is None:
-            session = httpx.client_session(
-                raise_for_status=True,
-                timeout=aiohttp.ClientTimeout(total=60))
+            session = httpx.client_session()
         self._session = session
 
         h = {}
@@ -583,23 +581,19 @@ class BatchClient:
         self._headers = h
 
     async def _get(self, path, params=None):
-        return await request_retry_transient_errors(
-            self._session, 'GET',
+        return await self._session.get(
             self.url + path, params=params, headers=self._headers)
 
     async def _post(self, path, data=None, json=None):
-        return await request_retry_transient_errors(
-            self._session, 'POST',
+        return await self._session.post(
             self.url + path, data=data, json=json, headers=self._headers)
 
     async def _patch(self, path):
-        return await request_retry_transient_errors(
-            self._session, 'PATCH',
+        return await self._session.patch(
             self.url + path, headers=self._headers)
 
     async def _delete(self, path):
-        return await request_retry_transient_errors(
-            self._session, 'DELETE',
+        return await self._session.delete(
             self.url + path, headers=self._headers)
 
     async def list_batches(self, q=None, last_batch_id=None, limit=2**64):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -12,7 +12,7 @@ from asyncinit import asyncinit
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 from .globals import tasks, complete_states
 
@@ -568,7 +568,7 @@ class BatchClient:
         self.url = deploy_config.base_url('batch')
 
         if session is None:
-            session = get_context_specific_ssl_client_session(
+            session = httpx.client_session(
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60))
         self._session = session

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -1,5 +1,4 @@
 from typing import Optional
-import asyncio
 
 from . import aioclient
 from hailtop.utils import async_to_blocking

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -2,10 +2,7 @@ from typing import Optional
 import asyncio
 
 from . import aioclient
-
-
-def async_to_blocking(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from hailtop.utils import async_to_blocking
 
 
 def sync_anext(ait):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -172,10 +172,10 @@ class BatchBuilder:
 
 
 class BatchClient:
-    def __init__(self, billing_project, deploy_config=None, session=None,
-                 headers=None, _token=None):
+    def __init__(self, billing_project, deploy_config=None, headers=None,
+                 _token=None):
         self._async_client = async_to_blocking(
-            aioclient.BatchClient(billing_project, deploy_config, session, headers=headers, _token=_token))
+            aioclient.BatchClient(billing_project, deploy_config, headers=headers, _token=_token))
 
     @property
     def bucket(self):

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -80,7 +80,7 @@ class DeployConfig:
             return ''
         return f'/{ns}/{service}'
 
-    def base_url(s elf, service: str, *, base_scheme: str = 'http', use_address: bool = False) -> str:
+    def base_url(self, service: str, *, base_scheme: str = 'http', use_address: bool = False) -> str:
         scheme = self.scheme(service, base_scheme=base_scheme, use_address=use_address)
         domain = self.domain(service, use_address=use_address)
         return f'{scheme}://{domain}{self.base_path(service)}'

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -52,10 +52,12 @@ class DeployConfig:
     def service_ns(self, service: str) -> str:
         return self._service_namespace.get(service, self._default_namespace)
 
-    def scheme(self, service: str, base_scheme: str = 'http') -> str:
-        if self._location == 'gce' and service not in DeployConfig.ADDRESS_SERVICES:
-            return base_scheme
-        return base_scheme + 's'
+    def scheme(self, service: str, base_scheme: str = 'http', use_address: bool = False) -> str:
+        if use_address and service in DeployConfig.ADDRESS_SERVICES:
+            return base_scheme + 's'
+        if self._location != 'gce':
+            return base_scheme + 's'
+        return base_scheme
 
     def domain(self, service: str, use_address: bool = False) -> str:
         ns = self.service_ns(service)
@@ -78,8 +80,10 @@ class DeployConfig:
             return ''
         return f'/{ns}/{service}'
 
-    def base_url(self, service: str, *, base_scheme: str = 'http', use_address: bool = False) -> str:
-        return f'{self.scheme(service, base_scheme)}://{self.domain(service, use_address=use_address)}{self.base_path(service)}'
+    def base_url(s elf, service: str, *, base_scheme: str = 'http', use_address: bool = False) -> str:
+        scheme = self.scheme(service, base_scheme=base_scheme, use_address=use_address)
+        domain = self.domain(service, use_address=use_address)
+        return f'{scheme}://{domain}{self.base_path(service)}'
 
     def url(self, service: str, path: str, *, base_scheme: str = 'http', use_address: bool = False) -> str:
         return f'{self.base_url(service, base_scheme=base_scheme, use_address=use_address)}{path}'

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -144,7 +144,7 @@ class DeployConfig:
                 headers=headers) as session:
             async with await retry_transient_errors(
                     session.get,
-                    self.url('address', f'/api/{service}'), use_address=False) as resp:
+                    self.url('address', f'/api/{service}', use_address=False)) as resp:
                 dicts = await resp.json()
                 return [(d['address'], d['port']) for d in dicts]
 

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -69,7 +69,7 @@ class DeployConfig:
             return f'{service}.hail.is'
         return 'internal.hail.is'
 
-    def base_path(self, service: str) -> strr:
+    def base_path(self, service: str) -> str:
         ns = self.service_ns(service)
         if ns == 'default':
             return ''

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -13,11 +13,11 @@ log = logging.getLogger('deploy_config')
 
 class DeployConfig:
     @staticmethod
-    def from_config(config):
+    def from_config(config) -> 'DeployConfig':
         return DeployConfig(config['location'], config['default_namespace'], config['service_namespace'])
 
     @staticmethod
-    def from_config_file(config_file=None):
+    def from_config_file(config_file=None) -> 'DeployConfig':
         config_file = first_extant_file(
             config_file,
             os.environ.get('HAIL_DEPLOY_CONFIG_FILE'),
@@ -37,26 +37,26 @@ class DeployConfig:
             }
         return DeployConfig.from_config(config)
 
-    def __init__(self, location, default_namespace, service_namespace):
+    def __init__(self, location: str, default_namespace: str, service_namespace: str):
         assert location in ('external', 'k8s', 'gce')
         self._location = location
         self._default_namespace = default_namespace
         self._service_namespace = service_namespace
 
-    def with_service(self, service, ns):
+    def with_service(self, service, ns) -> 'DeployConfig':
         return DeployConfig(self._location, self._default_namespace, {**self._service_namespace, service: ns})
 
-    def location(self):
+    def location(self) -> str:
         return self._location
 
-    def service_ns(self, service):
+    def service_ns(self, service: str) -> str:
         return self._service_namespace.get(service, self._default_namespace)
 
-    def scheme(self, base_scheme='http'):
+    def scheme(self, base_scheme: str = 'http') -> str:
         # FIXME: should depend on ssl context
         return (base_scheme + 's') if self._location in ('external', 'k8s') else base_scheme
 
-    def domain(self, service):
+    def domain(self, service: str) -> str:
         ns = self.service_ns(service)
         if self._location == 'k8s':
             return f'{service}.{ns}'
@@ -69,31 +69,31 @@ class DeployConfig:
             return f'{service}.hail.is'
         return 'internal.hail.is'
 
-    def base_path(self, service):
+    def base_path(self, service: str) -> strr:
         ns = self.service_ns(service)
         if ns == 'default':
             return ''
         return f'/{ns}/{service}'
 
-    def base_url(self, service, base_scheme='http'):
+    def base_url(self, service: str, base_scheme: str = 'http') -> str:
         return f'{self.scheme(base_scheme)}://{self.domain(service)}{self.base_path(service)}'
 
-    def url(self, service, path, base_scheme='http'):
+    def url(self, service: str, path: str, base_scheme: str = 'http') -> str:
         return f'{self.base_url(service, base_scheme=base_scheme)}{path}'
 
-    def auth_session_cookie_name(self):
+    def auth_session_cookie_name(self) -> str:
         auth_ns = self.service_ns('auth')
         if auth_ns == 'default':
             return 'session'
         return 'sesh'
 
-    def external_url(self, service, path, base_scheme='http'):
+    def external_url(self, service: str, path: str, base_scheme: str = 'http') -> str:
         ns = self.service_ns(service)
         if ns == 'default':
             return f'{base_scheme}s://{service}.hail.is{path}'
         return f'{base_scheme}s://internal.hail.is/{ns}/{service}{path}'
 
-    def prefix_application(self, app, service, **kwargs):
+    def prefix_application(self, app, service: str, **kwargs):
         base_path = self.base_path(service)
         if not base_path:
             return app
@@ -144,10 +144,10 @@ class DeployConfig:
         return address
 
 
-deploy_config = None
+deploy_config: Optional[DeployConfig] = None
 
 
-def get_deploy_config():
+def get_deploy_config() -> DeployConfig:
     global deploy_config
 
     if not deploy_config:

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -2,6 +2,7 @@ import os
 import socket
 import asyncio
 import webbrowser
+import aiohttp
 from aiohttp import web
 
 from hailtop.config import get_deploy_config
@@ -97,7 +98,9 @@ async def async_main(args):
         auth_ns = deploy_config.service_ns('auth')
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
     async with httpx.client_session(
-            raise_for_status=True, headers=headers) as session:
+            raise_for_status=True,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         await auth_flow(deploy_config, auth_ns, session)
 
 

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -2,12 +2,11 @@ import os
 import socket
 import asyncio
 import webbrowser
-import aiohttp
 from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -97,8 +96,8 @@ async def async_main(args):
     else:
         auth_ns = deploy_config.service_ns('auth')
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+    async with httpx.client_session(
+            raise_for_status=True, headers=headers) as session:
         await auth_flow(deploy_config, auth_ns, session)
 
 

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -98,7 +98,6 @@ async def async_main(args):
         auth_ns = deploy_config.service_ns('auth')
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
     async with httpx.client_session(
-            raise_for_status=True,
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
         await auth_flow(deploy_config, auth_ns, session)

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -21,7 +21,6 @@ async def async_main():
 
     headers = service_auth_headers(deploy_config, 'auth')
     async with httpx.client_session(
-            raise_for_status=True,
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -3,7 +3,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -1,9 +1,8 @@
 import asyncio
-import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -20,8 +19,7 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+    async with httpx.client_session(raise_for_status=True, headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass
     auth_ns = deploy_config.service_ns('auth')

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -1,3 +1,4 @@
+import aiohttp
 import asyncio
 
 from hailtop.config import get_deploy_config
@@ -19,7 +20,10 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with httpx.client_session(raise_for_status=True, headers=headers) as session:
+    async with httpx.client_session(
+            raise_for_status=True,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass
     auth_ns = deploy_config.service_ns('auth')

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -28,6 +28,7 @@ class CIClient:
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
         self._session = httpx.client_session(
+            raise_for_status=False,
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=60))
         return self

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -1,11 +1,10 @@
 import asyncio
 import webbrowser
-import aiohttp
 import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -27,8 +26,7 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = get_context_specific_ssl_client_session(
-            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+        self._session = httpx.client_session(headers=headers)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -1,3 +1,4 @@
+import aiohttp
 import asyncio
 import webbrowser
 import sys
@@ -26,7 +27,9 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = httpx.client_session(headers=headers)
+        self._session = httpx.client_session(
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60))
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -1,10 +1,9 @@
 import asyncio
-import aiohttp
 import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -52,8 +51,7 @@ class QueryClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'query')
-        self._session = get_context_specific_ssl_client_session(
-            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+        self._session = httpx.client_session(headers=headers)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -1,3 +1,4 @@
+import aiohttp
 import asyncio
 import sys
 
@@ -51,7 +52,9 @@ class QueryClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'query')
-        self._session = httpx.client_session(headers=headers)
+        self._session = httpx.client_session(
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60))
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -31,7 +31,7 @@ class HailResolver(aiohttp.abc.AbstractResolver):
         self.deploy_config = get_deploy_config()
 
     async def resolve(self, host: str, port: int, family: int) -> List[Dict[str, Any]]:
-        if family in (socket.AF_INET, socket.AF_INET6):
+        if family in (0, socket.AF_INET, socket.AF_INET6):
             maybe_address_and_port = await self.deploy_config.maybe_address(host)
             if maybe_address_and_port is not None:
                 address, resolved_port = maybe_address_and_port
@@ -87,13 +87,13 @@ class BlockingContextManager:
         self.context_manager = context_manager
 
     async def __enter__(self) -> BlockingClientResponse:
-        return async_to_blocking(self.context_manager.__aenter__)
+        return async_to_blocking(self.context_manager.__aenter__())
 
     async def __exit__(self,
                        exc_type: Optional[Type[BaseException]],
                        exc: Optional[BaseException],
                        tb: Optional[TracebackType]) -> None:
-        async_to_blocking(self.context_manager.__aexit__)
+        async_to_blocking(self.context_manager.__aexit__())
 
 
 class BlockingClientSession:
@@ -176,7 +176,7 @@ class BlockingClientSession:
         return self.session.version
 
     def __enter__(self) -> 'BlockingClientSession':
-        self.session = async_to_blocking(self.session.__aenter__)
+        self.session = async_to_blocking(self.session.__aenter__())
         return self
 
     def __exit__(self,

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -9,11 +9,12 @@ from .utils import async_to_blocking, retry_transient_errors
 
 log = logging.getLogger('hailtop.httpx')
 
+HailAsyncClientSession = Union[aiohttp.ClientSession, 'RetryingClientSession']
 
 def client_session(*args,
                    retry_transient=True,
                    raise_for_status=True,
-                   **kwargs) -> Union[aiohttp.ClientSession, 'RetryingClientSession']:
+                   **kwargs) -> HailAsyncClientSession:
     assert 'connector' not in kwargs
     if get_deploy_config().location() == 'external':
         kwargs['connector'] = aiohttp.TCPConnector(
@@ -208,7 +209,7 @@ class BlockingContextManager:
 
 
 class BlockingClientSession:
-    def __init__(self, session: aiohttp.ClientSession):
+    def __init__(self, session: HailAsyncClientSession):
         self.session = session
 
     def request(self,

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -20,7 +20,7 @@ def client_session(*args, **kwargs) -> aiohttp.ClientSession:
             ssl=internal_client_ssl_context(),
             resolver=HailResolver())
     if 'timeout' not in kwargs:
-        kwargs['timeout'] = aiohttp.ClientTimeout(total=15)
+        kwargs['timeout'] = aiohttp.ClientTimeout(total=5)
     return aiohttp.ClientSession(*args, **kwargs)
 
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -32,7 +32,7 @@ class HailResolver(aiohttp.abc.AbstractResolver):
 
     async def resolve(self, host: str, port: int, family: int) -> List[Dict[str, Any]]:
         if family in (socket.AF_INET, socket.AF_INET6):
-            maybe_address_and_port = self.deploy_config.maybe_address(host)
+            maybe_address_and_port = await self.deploy_config.maybe_address(host)
             if maybe_address_and_port is not None:
                 address, resolved_port = maybe_address_and_port
                 return [{'hostname': host,

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -1,4 +1,5 @@
-from typing import (Dict, Any, List, Tuple, Optional, Type, Union, Awaitable)
+from typing import (Dict, Any, List, Tuple, Optional, Type, Union, Awaitable,
+                    Generator)
 from types import TracebackType
 import aiohttp
 import socket
@@ -42,9 +43,9 @@ class ResponseManager:
         self.response = await self.response_coroutine
         return self.response
 
-    async def __await__(self) -> aiohttp.ClientResponse:
+    def __await__(self) -> Generator[Any, None, aiohttp.ClientResponse]:
         assert self.response is None
-        return await self.response_coroutine
+        return self.response_coroutine.__await__()
 
     async def __aexit__(self,
                         exc_type: Optional[Type[BaseException]],

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -1,4 +1,4 @@
-from typing import (Dict, Any, List, Tuple, Optional, Type, Union, Awaitable,
+from typing import (Dict, Any, List, Tuple, Optional, Type, Awaitable,
                     Generator)
 from types import TracebackType
 import aiohttp
@@ -9,6 +9,7 @@ from .tls import internal_client_ssl_context, external_client_ssl_context
 from .utils import async_to_blocking, retry_transient_errors
 
 log = logging.getLogger('hailtop.httpx')
+
 
 def client_session(*args,
                    retry_transient: bool = True,
@@ -28,6 +29,10 @@ def client_session(*args,
     return ClientSession(
         aiohttp.ClientSession(*args, **kwargs),
         retry_transient=retry_transient)
+
+
+def blocking_client_session(*args, **kwargs) -> 'BlockingClientSession':
+    return BlockingClientSession(client_session(*args, **kwargs))
 
 
 class ResponseManager:
@@ -220,7 +225,7 @@ class BlockingContextManager:
 
 
 class BlockingClientSession:
-    def __init__(self, session: HailAsyncClientSession):
+    def __init__(self, session: ClientSession):
         self.session = session
 
     def request(self,
@@ -307,7 +312,3 @@ class BlockingClientSession:
                  exc_val: Optional[BaseException],
                  exc_tb: Optional[TracebackType]) -> None:
         self.close()
-
-
-def blocking_client_session(*args, **kwargs) -> BlockingClientSession:
-    return BlockingClientSession(client_session(*args, **kwargs))

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -176,7 +176,8 @@ class HailResolver(aiohttp.abc.AbstractResolver):
         return await self.dns.resolve(host, port, family)
 
     async def close(self) -> None:
-        await self.dns.close()
+        if self.dns is not None:
+            await self.dns.close()
 
 
 class BlockingClientResponse:

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -41,10 +41,10 @@ class HailResolver(aiohttp.abc.AbstractResolver):
                          'family': family,
                          'proto': 0,
                          'flags': 0}]
-        return self.dns.resolve(host, port, family)
+        return await self.dns.resolve(host, port, family)
 
     async def close(self) -> None:
-        self.dns.close()
+        await self.dns.close()
 
 
 class BlockingClientResponse:

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -11,6 +11,7 @@ log = logging.getLogger('hailtop.httpx')
 
 HailAsyncClientSession = Union[aiohttp.ClientSession, 'RetryingClientSession']
 
+
 def client_session(*args,
                    retry_transient=True,
                    raise_for_status=True,

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -241,13 +241,13 @@ class BlockingContextManager:
     def __init__(self, context_manager):
         self.context_manager = context_manager
 
-    async def __enter__(self) -> BlockingClientResponse:
-        return async_to_blocking(self.context_manager.__aenter__())
+    def __enter__(self) -> BlockingClientResponse:
+        return BlockingClientResponse(async_to_blocking(self.context_manager.__aenter__()))
 
-    async def __exit__(self,
-                       exc_type: Optional[Type[BaseException]],
-                       exc: Optional[BaseException],
-                       tb: Optional[TracebackType]) -> None:
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc: Optional[BaseException],
+                 tb: Optional[TracebackType]) -> None:
         async_to_blocking(self.context_manager.__aexit__())
 
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -1,0 +1,188 @@
+from typing import Dict, Any, List, Union, Tuple, Optional, Type, TracebackType
+import aiohttp
+import socket
+import logging
+from urllib3.poolmanager import PoolManager
+from hailtop.config import get_deploy_config
+from .tls import (get_in_cluster_client_ssl_context,
+                  get_context_specific_client_ssl_context,
+                  _get_ssl_config)
+from .utils import async_to_blocking
+
+log = logging.getLogger('hailtop.httpx')
+
+
+def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
+    assert 'connector' not in kwargs
+    kwargs['connector'] = aiohttp.TCPConnector(
+        ssl=get_in_cluster_client_ssl_context(),
+        resolver=HailResolver())
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+def get_context_specific_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
+    assert 'connector' not in kwargs
+    kwargs['connector'] = aiohttp.TCPConnector(
+        ssl=get_context_specific_client_ssl_context(),
+        resolver=HailResolver())
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class HailResolver(aiohttp.abc.AbstractResolver):
+    """Use Hail in-cluster DNS with fallback."""
+    def __init__(self):
+        self.dns = aiohttp.AsyncResolver()
+        self.deploy_config = get_deploy_config()
+
+    async def resolve(self, host: str, port: int, family: int) -> List[Dict[str, Any]]:
+        if family in (socket.AF_INET, socket.AF_INET6):
+            maybe_address_and_port = self.deploy_config.maybe_address(host)
+            if maybe_address_and_port is not None:
+                address, resolved_port = maybe_address_and_port
+                return [{'hostname': host,
+                         'host': address,
+                         'port': resolved_port,
+                         'family': family,
+                         'proto': 0,
+                         'flags': 0}]
+        return self.dns.resolve(host, port, family)
+
+    async def close(self) -> None:
+        self.dns.close()
+
+
+class BlockingClientResponse:
+    def __init__(self, client_response):
+        self.client_response = client_response
+
+    def read(self) -> bytes:
+        return async_to_blocking(self.client_response.read())
+
+    def text(self, encoding: Optional[str] = None, errors: str = 'strict') -> str:
+        return async_to_blocking(self.client_response.text())
+
+    def json(self, *,
+             encoding: str = None,
+             loads: aiohttp.typedefs.JSONDecoder = aiohttp.typedefs.DEFAULT_JSON_DECODER,
+             content_type: Optional[str] = 'application/json') -> Any:
+        return async_to_blocking(self.client_response.json())
+
+    def __del__(self) -> str:
+        self.client_response.__del__()
+
+    def history(self) -> Tuple[aiohttp.ClientResponse, ...]:
+        return self.client_response.history()
+
+    def __repr__(self) -> str:
+        return f'BlcokingClientRepsonse({repr(self.client_response)})'
+
+    def raise_for_status(self) -> None:
+        self.client_response.raise_for_status()
+
+
+class BlockingContextManager:
+    def __init__(self, context_manager):
+        self.context_manager = context_manager
+
+    async def __enter__(self) -> BlockingClientResponse:
+        return async_to_blocking(self.context_manager.__aenter__)
+
+    async def __exit__(self,
+                       exc_type: Optional[Type[BaseException]],
+                       exc: Optional[BaseException],
+                       tb: Optional[TracebackType]) -> None:
+        async_to_blocking(self.context_manager.__aexit__)
+
+
+class BlockingClientSession:
+    def __init__(self, session: aiohttp.ClientSession):
+        self.session = session
+
+    def request(self,
+                method: str,
+                url: aiohttp.typedefs.StrOrURL,
+                **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.request(
+            self, method, url, **kwargs))
+
+    def get(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            allow_redirects: bool = True,
+            **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.get(
+            self, url, allow_redirects=allow_redirects, **kwargs))
+
+    def options(self,
+                url: aiohttp.typedefs.StrOrURL,
+                *,
+                allow_redirects: bool = True,
+                **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.options(
+            self, url, allow_redirects=allow_redirects, **kwargs))
+
+    def head(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             allow_redirects: bool = False,
+             **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.head(
+            self, url, allow_redirects=allow_redirects, **kwargs))
+
+    def post(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             data: Any = None, **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.post(
+            self, url, **kwargs))
+
+    def put(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            data: Any = None,
+            **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.put(
+            self, url, data=data, **kwargs))
+
+    def patch(self,
+              url: aiohttp.typedefs.StrOrURL,
+              *,
+              data: Any = None,
+              **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.patch(
+            self, url, data=data, **kwargs))
+
+    def delete(self,
+               url: aiohttp.typedefs.StrOrURL,
+               **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.delete(self, url, **kwargs))
+
+    def close(self) -> None:
+        async_to_blocking(self.session.close())
+
+    @property
+    def closed(self) -> bool:
+        return self.session.closed()
+
+    @property
+    def cookie_jar(self) -> aiohttp.AbstractCookieJar:
+        return self.session.cookie_jar
+
+    @property
+    def version(self) -> Tuple[int, int]:
+        return self.session.version
+
+    def __enter__(self) -> 'BlockingClientSession':
+        self.session = async_to_blocking(self.session.__aenter__)
+        return self
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> None:
+        self.close()
+
+
+def blocking_in_cluster_ssl_client_session(*args, **kwargs) -> BlockingClientSession:
+    async_session = in_cluster_ssl_client_session(*args, **kwargs)
+    return BlockingClientSession(async_session)

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -248,7 +248,7 @@ class BlockingContextManager:
                  exc_type: Optional[Type[BaseException]],
                  exc: Optional[BaseException],
                  tb: Optional[TracebackType]) -> None:
-        async_to_blocking(self.context_manager.__aexit__())
+        async_to_blocking(self.context_manager.__aexit__(exc_type, exc, tb))
 
 
 class BlockingClientSession:

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -67,8 +67,8 @@ class ClientSession:
                                             method: str,
                                             url: aiohttp.typedefs.StrOrURL,
                                             **kwargs: Any) -> aiohttp.ClientResponse:
+        raise_for_status = kwargs.pop('raise_for_status', self.raise_for_status)
         response = await self.session._request(method, url, **kwargs)
-        raise_for_status = kwargs.get('raise_for_status', self.raise_for_status)
         if raise_for_status and response.status >= 400:
             message = response.reason or ''
             try:
@@ -87,7 +87,7 @@ class ClientSession:
                 method: str,
                 url: aiohttp.typedefs.StrOrURL,
                 **kwargs: Any) -> ResponseManager:
-        retry_transient = kwargs.get('retry_transient', self.retry_transient)
+        retry_transient = kwargs.pop('retry_transient', self.retry_transient)
         if retry_transient:
             coroutine = retry_transient_errors(
                 self._request_and_raise_for_status, method, url, **kwargs)

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -162,7 +162,7 @@ class HailResolver(aiohttp.abc.AbstractResolver):
         if self.dns is None:
             # the AsyncResolver must be created from an async function:
             # https://github.com/aio-libs/aiohttp/issues/3573#issuecomment-456742539
-            self.dns = aiohttp.AsyncResolver()
+            self.dns = aiohttp.DefaultResolver()
         if family in (0, socket.AF_INET, socket.AF_INET6):
             maybe_address_and_port = await self.deploy_config.maybe_address(host)
             if maybe_address_and_port is not None:

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -6,9 +6,8 @@ import ssl
 from ssl import Purpose
 
 log = logging.getLogger('hailtop.tls')
-server_ssl_context = None
-client_ssl_context = None
-no_hostname_checks_client_ssl_context = None
+_server_ssl_context = None
+_client_ssl_context = None
 
 
 class NoSSLConfigFound(Exception):
@@ -36,35 +35,35 @@ def check_ssl_config(ssl_config: Dict[str, str]):
 
 
 def internal_server_ssl_context() -> ssl.SSLContext:
-    global server_ssl_context
-    if server_ssl_context is None:
+    global _server_ssl_context
+    if _server_ssl_context is None:
         ssl_config = _get_ssl_config()
-        server_ssl_context = ssl.create_default_context(
+        _server_ssl_context = ssl.create_default_context(
             purpose=Purpose.CLIENT_AUTH,
             cafile=ssl_config['incoming_trust'])
-        server_ssl_context.load_cert_chain(ssl_config['cert'],
+        _server_ssl_context.load_cert_chain(ssl_config['cert'],
                                            keyfile=ssl_config['key'],
                                            password=None)
-        server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
+        _server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
         # FIXME: mTLS
-        # server_ssl_context.verify_mode = ssl.CERT_REQURIED
-        server_ssl_context.check_hostname = False  # clients have no hostnames
-    return server_ssl_context
+        # _server_ssl_context.verify_mode = ssl.CERT_REQURIED
+        _server_ssl_context.check_hostname = False  # clients have no hostnames
+    return _server_ssl_context
 
 
 def internal_client_ssl_context() -> ssl.SSLContext:
-    global client_ssl_context
-    if client_ssl_context is None:
+    global _client_ssl_context
+    if _client_ssl_context is None:
         ssl_config = _get_ssl_config()
-        client_ssl_context = ssl.create_default_context(
+        _client_ssl_context = ssl.create_default_context(
             purpose=Purpose.SERVER_AUTH,
             cafile=ssl_config['outgoing_trust'])
-        client_ssl_context.load_cert_chain(ssl_config['cert'],
+        _client_ssl_context.load_cert_chain(ssl_config['cert'],
                                            keyfile=ssl_config['key'],
                                            password=None)
-        client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        client_ssl_context.check_hostname = True
-    return client_ssl_context
+        _client_ssl_context.verify_mode = ssl.CERT_REQUIRED
+        _client_ssl_context.check_hostname = True
+    return _client_ssl_context
 
 
 def external_client_ssl_context() -> ssl.SSLContext:

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -42,8 +42,8 @@ def internal_server_ssl_context() -> ssl.SSLContext:
             purpose=Purpose.CLIENT_AUTH,
             cafile=ssl_config['incoming_trust'])
         _server_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
+                                            keyfile=ssl_config['key'],
+                                            password=None)
         _server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
         # FIXME: mTLS
         # _server_ssl_context.verify_mode = ssl.CERT_REQURIED
@@ -59,8 +59,8 @@ def internal_client_ssl_context() -> ssl.SSLContext:
             purpose=Purpose.SERVER_AUTH,
             cafile=ssl_config['outgoing_trust'])
         _client_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
+                                            keyfile=ssl_config['key'],
+                                            password=None)
         _client_ssl_context.verify_mode = ssl.CERT_REQUIRED
         _client_ssl_context.check_hostname = True
     return _client_ssl_context

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -58,6 +58,10 @@ def internal_client_ssl_context() -> ssl.SSLContext:
         _client_ssl_context = ssl.create_default_context(
             purpose=Purpose.SERVER_AUTH,
             cafile=ssl_config['outgoing_trust'])
+        # setting cafile in `create_default_context` ignores the system default
+        # certificates. We must explicitly request them again with
+        # load_default_certs.
+        _client_ssl_context.load_default_certs()
         _client_ssl_context.load_cert_chain(ssl_config['cert'],
                                             keyfile=ssl_config['key'],
                                             password=None)

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -35,7 +35,7 @@ def check_ssl_config(ssl_config: Dict[str, str]):
     log.info('using tls and verifying client and server certificates')
 
 
-def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
+def internal_server_ssl_context() -> ssl.SSLContext:
     global server_ssl_context
     if server_ssl_context is None:
         ssl_config = _get_ssl_config()
@@ -52,7 +52,7 @@ def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
     return server_ssl_context
 
 
-def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
+def internal_client_ssl_context() -> ssl.SSLContext:
     global client_ssl_context
     if client_ssl_context is None:
         ssl_config = _get_ssl_config()
@@ -67,10 +67,5 @@ def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
     return client_ssl_context
 
 
-def get_context_specific_client_ssl_context() -> ssl.SSLContext:
-    try:
-        return get_in_cluster_client_ssl_context()
-    except NoSSLConfigFound:
-        log.info('no ssl config file found, using external configuration. This '
-                 'context cannot connect directly to services inside the cluster.')
-        return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
+def external_client_ssl_context() -> ssl.SSLContext:
+    return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -1,19 +1,11 @@
-from typing import Dict, Any, List, Union
-import aiohttp
+from typing import Dict
 import logging
 import json
 import os
 import ssl
-import socket
 from ssl import Purpose
-import requests
-from requests.adapters import HTTPAdapter
-import urllib3
-from urllib3.poolmanager import PoolManager
-from requests.compat import urlparse, urlunparse
-from hailtop.config import get_deploy_config
 
-log = logging.getLogger('hailtop.ssl')
+log = logging.getLogger('hailtop.tls')
 server_ssl_context = None
 client_ssl_context = None
 no_hostname_checks_client_ssl_context = None
@@ -32,6 +24,15 @@ def _get_ssl_config() -> Dict[str, str]:
         check_ssl_config(ssl_config)
         return ssl_config
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')
+
+
+def check_ssl_config(ssl_config: Dict[str, str]):
+    for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
+        assert ssl_config.get(key) is not None, key
+    for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
+        if not os.path.isfile(ssl_config[key]):
+            raise ValueError(f'specified {key}, {ssl_config[key]} does not exist')
+    log.info('using tls and verifying client and server certificates')
 
 
 def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
@@ -73,84 +74,3 @@ def get_context_specific_client_ssl_context() -> ssl.SSLContext:
         log.info('no ssl config file found, using external configuration. This '
                  'context cannot connect directly to services inside the cluster.')
         return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
-
-
-def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(
-        ssl=get_in_cluster_client_ssl_context(),
-        resolver=HailResolver())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def get_context_specific_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(
-        ssl=get_context_specific_client_ssl_context(),
-        resolver=HailResolver())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-class HailResolver(aiohttp.abc.AbstractResolver):
-    """Use Hail in-cluster DNS with fallback."""
-    def __init__(self):
-        self.dns = aiohttp.AsyncResolver()
-        self.deploy_config = get_deploy_config()
-
-    async def resolve(self, host: str, port: int, family: int) -> List[Dict[str, Any]]:
-        if family == socket.AF_INET or family == socket.AF_INET6:
-            maybe_address_and_port = self.deploy_config.maybe_address(host)
-            if maybe_address_and_port is not None:
-                address, resolved_port = maybe_address_and_port
-                return [{'hostname': host,
-                         'host': address,
-                         'port': resolved_port,
-                         'family': family,
-                         'proto': 0,
-                         'flags': 0}]
-        return self.dns.resolve(host, port, family)
-
-    async def close(self) -> None:
-        self.dns.close()
-
-
-def in_cluster_ssl_requests_client_session() -> requests.Session:
-    session = requests.Session()
-    ssl_config = _get_ssl_config()
-    session.mount('https://', TLSAdapter(ssl_config['cert'],
-                                         ssl_config['key'],
-                                         ssl_config['outgoing_trust'],
-                                         max_retries=1,
-                                         timeout=5))
-    return session
-
-
-def check_ssl_config(ssl_config: Dict[str, str]):
-    for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
-        assert ssl_config.get(key) is not None, key
-    for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
-        if not os.path.isfile(ssl_config[key]):
-            raise ValueError(f'specified {key}, {ssl_config[key]} does not exist')
-    log.info('using tls and verifying client and server certificates')
-
-
-class TLSAdapter(HTTPAdapter):
-    def __init__(self, ssl_cert: str, ssl_key: str, ssl_ca: str, max_retries: int, timeout: Union[int, float]):
-        super().__init__()
-        self.ssl_cert = ssl_cert
-        self.ssl_key = ssl_key
-        self.ssl_ca = ssl_ca
-        self.max_retries = max_retries
-        self.timeout = timeout
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            key_file=self.ssl_key,
-            cert_file=self.ssl_cert,
-            ca_certs=self.ssl_ca,
-            assert_hostname=True,
-            retries=self.max_retries,
-            timeout=self.timeout)

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -62,22 +62,6 @@ def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
     return client_ssl_context
 
 
-def get_in_cluster_no_hostname_checks_client_ssl_context() -> ssl.SSLContext:
-    global no_hostname_checks_client_ssl_context
-    if no_hostname_checks_client_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        no_hostname_checks_client_ssl_context = ssl.create_default_context(
-            purpose=Purpose.SERVER_AUTH,
-            cafile=ssl_config['outgoing_trust'])
-        no_hostname_checks_client_ssl_context.load_cert_chain(
-            ssl_config['cert'],
-            keyfile=ssl_config['key'],
-            password=None)
-        no_hostname_checks_client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        no_hostname_checks_client_ssl_context.check_hostname = False
-    return no_hostname_checks_client_ssl_context
-
-
 def get_context_specific_client_ssl_context() -> ssl.SSLContext:
     try:
         return get_in_cluster_client_ssl_context()
@@ -90,12 +74,6 @@ def get_context_specific_client_ssl_context() -> ssl.SSLContext:
 def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
     assert 'connector' not in kwargs
     kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def in_cluster_no_hostname_checks_ssl_client_connection(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_no_hostname_checks_client_ssl_context())
     return aiohttp.ClientSession(*args, **kwargs)
 
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -7,7 +7,7 @@ from .utils import (
     retry_long_running, run_if_changed, run_if_changed_idempotent, LoggingTimer,
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
-    flatten, partition, cost_str, external_requests_client_session)
+    flatten, partition, cost_str)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -62,6 +62,5 @@ __all__ = [
     'RateLimiter',
     'partition',
     'cost_str',
-    'external_requests_client_session',
     'serialization'
 ]

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,13 +1,12 @@
 from .time import time_msecs, time_msecs_str, humanize_timedelta_msecs
-from .utils import (
-    unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
-    bounded_gather, grouped, sleep_and_backoff, is_transient_error,
-    request_retry_transient_errors, collect_agen, retry_all_errors,
-    retry_transient_errors, retry_long_running, run_if_changed,
-    run_if_changed_idempotent, LoggingTimer, WaitableSharedPool,
-    RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
-    retry_response_returning_functions, first_extant_file, secret_alnum_string,
-    flatten, partition, cost_str)
+from .utils import (unzip, async_to_blocking, blocking_to_async,
+                    AsyncWorkerPool, bounded_gather, grouped, sleep_and_backoff,
+                    is_transient_error, collect_agen, retry_all_errors,
+                    retry_transient_errors, retry_long_running, run_if_changed,
+                    run_if_changed_idempotent, LoggingTimer, WaitableSharedPool,
+                    RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
+                    first_extant_file, secret_alnum_string, flatten, partition,
+                    cost_str)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -44,13 +43,11 @@ __all__ = [
     'run_if_changed_idempotent',
     'LoggingTimer',
     'WaitableSharedPool',
-    'request_retry_transient_errors',
     'collect_agen',
     'tqdm',
     'TQDM_DEFAULT_DISABLE',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
-    'retry_response_returning_functions',
     'first_extant_file',
     'secret_alnum_string',
     'rate_gib_hour_to_mib_msec',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -2,10 +2,10 @@ from .time import time_msecs, time_msecs_str, humanize_timedelta_msecs
 from .utils import (
     unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
     bounded_gather, grouped, sleep_and_backoff, is_transient_error,
-    request_retry_transient_errors, request_raise_transient_errors,
-    collect_agen, retry_all_errors, retry_transient_errors,
-    retry_long_running, run_if_changed, run_if_changed_idempotent, LoggingTimer,
-    WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
+    request_retry_transient_errors, collect_agen, retry_all_errors,
+    retry_transient_errors, retry_long_running, run_if_changed,
+    run_if_changed_idempotent, LoggingTimer, WaitableSharedPool,
+    RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str)
 from .process import (
@@ -45,7 +45,6 @@ __all__ = [
     'LoggingTimer',
     'WaitableSharedPool',
     'request_retry_transient_errors',
-    'request_raise_transient_errors',
     'collect_agen',
     'tqdm',
     'TQDM_DEFAULT_DISABLE',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -5,15 +5,12 @@ import random
 import logging
 import asyncio
 import aiohttp
-from aiohttp import web
 import urllib3
 import secrets
 import socket
 import requests
 import google.auth.exceptions
 import time
-from requests.adapters import HTTPAdapter
-from urllib3.poolmanager import PoolManager
 
 from .time import time_msecs
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -384,26 +384,6 @@ def sync_retry_transient_errors(f: Callable[..., T], *args, **kwargs) -> T:
         delay = sync_sleep_and_backoff(delay)
 
 
-async def request_retry_transient_errors(session, method, url, **kwargs):
-    return await retry_transient_errors(session.request, method, url, **kwargs)
-
-
-def retry_response_returning_functions(fun, *args, **kwargs):
-    delay = 0.1
-    errors = 0
-    response = sync_retry_transient_errors(
-        fun, *args, **kwargs)
-    while response.status_code in RETRYABLE_HTTP_STATUS_CODES:
-        errors += 1
-        if errors % 10 == 0:
-            log.warning(f'encountered {errors} bad status codes, most recent '
-                        f'one was {response.status_code}')
-        response = sync_retry_transient_errors(
-            fun, *args, **kwargs)
-        delay = sync_sleep_and_backoff(delay)
-    return response
-
-
 async def collect_agen(agen):
     return [x async for x in agen]
 

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -8,7 +8,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
         self.assertEqual(deploy_config.domain('quam'), 'quam.hail.is')
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
         self.assertEqual(deploy_config.domain('quam'), 'quam.default')

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -31,9 +31,7 @@ class MemoryClient:
 
     async def async_init(self):
         if self._session is None:
-            self._session = get_context_specific_ssl_client_session(
-                raise_for_status=True,
-                timeout=aiohttp.ClientTimeout(total=60))
+            self._session = client_session(raise_for_status=True)
         if 'Authorization' not in self._headers:
             self._headers.update(service_auth_headers(self._deploy_config, 'memory'))
 

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -31,7 +31,6 @@ class MemoryClient:
     async def async_init(self):
         if self._session is None:
             self._session = httpx.client_session(
-                raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60))
         if 'Authorization' not in self._headers:
             self._headers.update(service_auth_headers(self._deploy_config, 'memory'))

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -45,10 +45,9 @@ class MemoryClient:
         params = {'q': filename, 'etag': etag}
         try:
             url = f'{self.url}/api/v1alpha/objects'
-            async with await request_retry_transient_errors(self._session,
-                                                            'get', url,
-                                                            params=params,
-                                                            headers=self._headers) as response:
+            async with await self._session.get(url,
+                                               params=params,
+                                               headers=self._headers) as response:
                 return await response.read()
         except aiohttp.ClientResponseError as e:
             if e.status == 404:

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -31,7 +31,9 @@ class MemoryClient:
 
     async def async_init(self):
         if self._session is None:
-            self._session = httpx.client_session(raise_for_status=True)
+            self._session = httpx.client_session(
+                raise_for_status=True,
+                timeout=aiohttp.ClientTimeout(total=60))
         if 'Authorization' not in self._headers:
             self._headers.update(service_auth_headers(self._deploy_config, 'memory'))
 

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -7,7 +7,6 @@ from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
 from hailtop import httpx
-from hailtop.utils import request_retry_transient_errors
 
 
 class MemoryClient:

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 from hailtop.utils import request_retry_transient_errors
 
 

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
-from hailtop.httpx import client_session
+from hailtop import httpx
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -31,7 +31,7 @@ class MemoryClient:
 
     async def async_init(self):
         if self._session is None:
-            self._session = client_session(raise_for_status=True)
+            self._session = httpx.client_session(raise_for_status=True)
         if 'Authorization' not in self._headers:
             self._headers.update(service_auth_headers(self._deploy_config, 'memory'))
 

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -12,7 +12,7 @@ import kubernetes_asyncio as kube
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors
 from gear import setup_aiohttp_session, rest_authenticated_users_only
 
@@ -120,4 +120,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=server_ssl_context())

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -12,7 +12,7 @@ import kubernetes_asyncio as kube
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors
 from gear import setup_aiohttp_session, rest_authenticated_users_only
 
@@ -120,4 +120,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -10,7 +10,7 @@ from hailtop import aiogoogle
 from hailtop.aiogoogle import BigQueryClient
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import run_if_changed_idempotent, retry_long_running, time_msecs, cost_str
 from gear import (Database, setup_aiohttp_session,
                   web_authenticated_developers_only, rest_authenticated_developers_only,
@@ -242,4 +242,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import in_cluster_ssl_client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -25,9 +25,8 @@ async def test_billing_monitoring():
         async def wait_forever():
             data = None
             while data is None:
-                resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{monitoring_deploy_config_url}', headers=headers)
-                data = await resp.json()
+                async with session.get(f'{monitoring_deploy_config_url}', headers=headers) as resp:
+                    data = await resp.json()
                 await asyncio.sleep(5)
             return data
 

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,7 +18,7 @@ async def test_billing_monitoring():
     deploy_config = get_deploy_config()
     monitoring_deploy_config_url = deploy_config.url('monitoring', '/api/v1alpha/billing')
     headers = service_auth_headers(deploy_config, 'monitoring')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
+from hailtop import httpx
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,8 +18,7 @@ async def test_billing_monitoring():
     deploy_config = get_deploy_config()
     monitoring_deploy_config_url = deploy_config.url('monitoring', '/api/v1alpha/billing')
     headers = service_auth_headers(deploy_config, 'monitoring')
-    async with client_session(
-            raise_for_status=True,
+    async with httpx.client_session(
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 
         async def wait_forever():

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -12,7 +12,7 @@ from kubernetes_asyncio import client, config
 import kubernetes_asyncio as kube
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, create_database_pool,
                   web_authenticated_users_only, web_maybe_authenticated_user,
@@ -814,4 +814,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -12,7 +12,7 @@ from kubernetes_asyncio import client, config
 import kubernetes_asyncio as kube
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, create_database_pool,
                   web_authenticated_users_only, web_maybe_authenticated_user,
@@ -814,4 +814,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from hailtop.hail_logging import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import get_context_specific_ssl_client_session
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from hailtop.hail_logging import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.httpx import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with get_context_specific_ssl_client_session(raise_for_status=True) as session:
+    async with client_session() as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from hailtop.hail_logging import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.httpx import client_session
+from hailtop import httpx
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with client_session() as session:
+    async with httpx.client_session() as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -8,7 +8,7 @@ import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, rest_authenticated_users_only, rest_authenticated_developers_only
 
@@ -230,4 +230,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -8,7 +8,7 @@ import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, rest_authenticated_users_only, rest_authenticated_developers_only
 
@@ -230,4 +230,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=server_ssl_context())

--- a/query/test/test_query.py
+++ b/query/test/test_query.py
@@ -2,6 +2,7 @@ import pytest
 import hail as hl
 from hailtop.hailctl.dev.query import cli
 
+
 def test_simple_table():
     t = hl.utils.range_table(50, 3)
     t = t.filter((t.idx % 3 == 0) | ((t.idx / 7) % 3 == 0))

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -6,7 +6,7 @@ import aiohttp_session
 from kubernetes_asyncio import client, config
 import logging
 from hailtop.auth import async_get_userinfo
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import configure_logging
 from gear import setup_aiohttp_session
 
@@ -110,4 +110,4 @@ app.on_startup.append(on_startup)
 web.run_app(app,
             host='0.0.0.0',
             port=5000,
-            ssl_context=get_in_cluster_server_ssl_context())
+            ssl_context=server_ssl_context())

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -6,7 +6,7 @@ import aiohttp_session
 from kubernetes_asyncio import client, config
 import logging
 from hailtop.auth import async_get_userinfo
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import configure_logging
 from gear import setup_aiohttp_session
 
@@ -110,4 +110,4 @@ app.on_startup.append(on_startup)
 web.run_app(app,
             host='0.0.0.0',
             port=5000,
-            ssl_context=server_ssl_context())
+            ssl_context=internal_server_ssl_context())

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -3,7 +3,7 @@ import datetime
 import os
 import asyncio
 import aiohttp
-from aiohttp import web, ClientSession
+from aiohttp import web
 import gidgethub.aiohttp
 import random
 import humanize
@@ -13,6 +13,7 @@ from collections import defaultdict
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
+from hailtop import httpx
 from gear import setup_aiohttp_session, web_maybe_authenticated_user
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
 
@@ -59,7 +60,7 @@ timestamp = None
 
 
 class AsanaClient:
-    _session: Optional[ClientSession]
+    _session: Optional[httpx.ClientSession]
 
     def __init__(self, *, token: Optional[str] = None):
         self._base_url = 'https://app.asana.com/api/1.0'
@@ -69,19 +70,22 @@ class AsanaClient:
             with open(asana_token_file, 'r') as f:
                 token = f.read().strip()
 
-        self._session = ClientSession(headers={'Authorization': f'Bearer {token}'})
+        self._session = httpx.client_session(headers={'Authorization': f'Bearer {token}'})
 
     async def get(self, path: str, **kwargs) -> Any:
+        assert self._session is not None
         async with await self._session.get(
                 f'{self._base_url}{path}', **kwargs) as resp:
             return await resp.json()
 
     async def post(self, path: str, **kwargs) -> Any:
+        assert self._session is not None
         async with await self._session.post(
                 f'{self._base_url}{path}', **kwargs) as resp:
             return await resp.json()
 
     async def delete(self, path: str, **kwargs) -> None:
+        assert self._session is not None
         async with await self._session.delete(
                 f'{self._base_url}{path}', **kwargs) as resp:
             return await resp.json()
@@ -401,9 +405,7 @@ async def on_startup(app):
                                 '/secrets/scorecard-github-access-token.txt')
     with open(token_file, 'r') as f:
         token = f.read().strip()
-    session = aiohttp.ClientSession(
-        raise_for_status=True,
-        timeout=aiohttp.ClientTimeout(total=60))
+    session = httpx.client_session(timeout=aiohttp.ClientTimeout(total=60))
     gh_client = gidgethub.aiohttp.GitHubAPI(session, 'scorecard', oauth_token=token)
     app['gh_client'] = gh_client
 

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -11,7 +11,7 @@ import logging
 from collections import defaultdict
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, web_maybe_authenticated_user
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -434,4 +434,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=server_ssl_context())

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -11,7 +11,7 @@ import logging
 from collections import defaultdict
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, web_maybe_authenticated_user
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -434,4 +434,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # E501 line too long
 # W503 line break before binary operator
-extend-ignore=E501,W503
+ignore=E501,W503
 
 # E402 module level import not at top of file
 # E241 multiple spaces after ','

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # E501 line too long
 # W503 line break before binary operator
-ignore=E501,W503
+extend-ignore=E501,W503
 
 # E402 module level import not at top of file
 # E241 multiple spaces after ','

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -86,3 +86,6 @@ principals:
 - name: monitoring-tests
   domain: monitoring-tests
   kind: json
+- name: auth-tests
+  domain: auth-tests
+  kind: json


### PR DESCRIPTION
This PR attempts to simplify the use of TLS and HTTP(S) in Hail. The big changes
are in `hail/python/hailtop`. In particular I removed several functions with
confusingly overlapping functionality in `tls.py`. Instead, we now have three
functions:

- `internal_server_ssl_context`
- `internal_client_ssl_context`
- `external_client_ssl_context`

The client context is configured to seek certificates from its peers. Both
internal contexts load the Hail certificate chain specified in the Hail SSL
Config. The external client context does not load the hail certificate chain.

I intend all Hail's HTTP(S) requests to use `httpx.py` (so named to not conflict
with modules named `http`). Again, I have simplified the landscape. We now have
two functions:

- `httpx.client_session`: The constructor for all asynchronous, HTTPS client
  sessions.
- `httpx.blocking_client_session`: The constructor for all synchronous, HTTPS
   client sessions.


Both sessions have the exact same configuration parameters. The API is exactly
the same except the blocking client session replaces asynchronous methods with
synchronous ones.

Both sessions accept the `aiohttp.ClientSession` constructor parameters. They
support one new parameter and modify the behavior of one old parameter.
- `retry_transient`: when set to `True` this parameter will retry all transient
  errors in all requests made by this session. This defaults to `True`.
- `raise_for_status`: this parameter now defaults to `True` and includes the
  response body text in the error message. Both
Both parameters may be overridden on a per-request basis.

- `httpx.ResponseManager` and `httpx.ClientSession` work together to enable
  `retry_transient` and `raise_for_status`. Aiohttp has this unusual structure where
  all the request methods are synchronous but they return an object that is both
  awaitable and an async context manager. I mirror their structure exactly. The
  `httpx.ResponseManager` is both awaitable and an async context manager. Its
  `response_coroutine` field is a coroutine that includes the retry and
  raise-for-status logic.

- The `HailResolver` overrides domain name resolution to first consult the Hail
  `address` service. `address` is effectively a domain name server. It watches
  kubernetes services and publishes the pod IPs. It supports two name styles:
  `service` and `service.namespace`. The former uses the deploy config to
  determine in which namespace to find the given service. Currently, the
  client-side library only looks up IPs for `shuffler` and `address`.

- `BlockingClientSession` and `BlockingContextManager` wrap the
  aforementioned `httpx` classes. `BlockingClientResponse` wraps an
  `aiohttp.ClientResponse`

---

Examples of correct usage:

A blocking HTTPS request:

```python3
with httpx.blocking_client_session() as session:
    with session.post(url, json=config, headers=headers) as resp:
        assert resp.status == 200
        print(resp.text())
```

An asynchronous HTTPS request to auth:
```python3
async with httpx.client_session() as session:
    async with session.get(
            deploy_config.url('auth', '/api/v1alpha/userinfo'),
            headers=headers) as resp:
        assert resp.status == 200
        print(await resp.json())
```

A blocking HTTPS session with a large default timeout:

```python3
httpx.blocking_client_session(
    headers=service_auth_headers(deploy_config, 'query'),
    timeout=aiohttp.ClientTimeout(total=600))
```

cc: @catoverdrive @Dania-Abuhijleh 