### PR TITLE
Use ?= in make variables for spark and scala versions

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -627,7 +627,7 @@ steps:
      {{ code.checkout_script }}
      cd hail
      time retry ./gradlew --version
-     export SPARK_VERSION="3.0.0"
+     export SPARK_VERSION="3.0.1" SCALA_VERSION="2.12.12"
      time retry make jars python-version-info wheel
    dependsOn:
      - hail_build_image

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -8,8 +8,8 @@ MAKEFLAGS += --no-builtin-rules
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-SCALA_VERSION := 2.11.12
-SPARK_VERSION := 2.4.5
+SCALA_VERSION ?= 2.11.12
+SPARK_VERSION ?= 2.4.5
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 57
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)


### PR DESCRIPTION
The semantics of setting a variable in make are kinda weird, example:

```make
FOO := foo
BAR ?= bar
.PHONY: echo
echo:
	echo $(FOO) $(BAR)
```

```sh
$ FOO=baz make
echo foo bar
foo bar
$ make FOO=baz
echo baz bar
baz bar
$ BAR=baz make
echo foo baz
foo baz
```

This will fix an issue where ci wasn't actually building with spark 3.