### PR TITLE
[hail] maybe fix nbsphinx/nbconvert issues

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2036,7 +2036,7 @@ steps:
      - from: /wheel-container.tar
        to: /io/wheel-container.tar
      - from: /repo/query/test
-       to: /io/test
+       to: /io/
    dependsOn:
     - default_ns
     - batch_pods_ns

--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -7,7 +7,7 @@ pytest-xdist==1.28
 pytest-instafail==0.4.1
 sphinx==3.1.2
 sphinx-autodoc-typehints==1.11.0
-nbsphinx==0.4
+nbsphinx==0.7.1
 sphinx_rtd_theme==0.4.2
 jupyter==1.0.0
 tornado<6


### PR DESCRIPTION
See discussion in Zulip: https://hail.zulipchat.com/#narrow/stream/127527-team/topic/ci/near/212305447

The nbconvert package changed how template extensions work. It is possible
this broke nbsphinx.