### PR TITLE
NDArraySum should TreeAggregate

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -116,6 +116,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
       case AggElements() => true
       case AggElementsLengthCheck() => true
       case Downsample() => true
+      case NDArraySum() => true
       case _ => false
     }
     aggs.exists(containsBigAggregator)


### PR DESCRIPTION
Summing ndarrays should use tree aggregation strategy, as they can be big. They will be big in things like blanczos PCA.