### PR TITLE
[benchmark] fix missed HAIL_VERSION rename in makefile

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -267,11 +267,11 @@ install-deps: install-dev-deps
 
 .PHONY: benchmark
 benchmark: $(WHEEL)
-	HAIL_WHEEL=../hail/$(WHEEL) HAIL_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark benchmark
+	HAIL_WHEEL=../hail/$(WHEEL) HAIL_PIP_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark benchmark
 
 .PHONY: install-benchmark
 install-benchmark:
-	HAIL_WHEEL=DUMMY HAIL_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark install
+	HAIL_WHEEL=DUMMY HAIL_PIP_VERSION=$(HAIL_PIP_VERSION) $(MAKE) -C ../benchmark install
 
 python/hail/docs/change_log.rst: python/hail/docs/change_log.md
 	sed -E "s/\(hail\#([0-9]+)\)/(\[#\1](https:\/\/github.com\/hail-is\/hail\/pull\/\1))/g" \


### PR DESCRIPTION
#9500 didn't update the `hail/hail` makefile