### PR TITLE
[query] Hail Python Tests Should Use Checked Memory Allocator

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -569,7 +569,7 @@ steps:
      {{ code.checkout_script }}
      cd hail
      time retry ./gradlew --version
-     time retry make jars HAIL_DEBUG_MODE=1
+     time retry make jars wheel HAIL_DEBUG_MODE=1
      mkdir build/debug_libs
      mv build/libs/hail-all-spark.jar build/debug_libs/
      mv build/libs/hail-all-spark-test.jar build/debug_libs/

--- a/build.yaml
+++ b/build.yaml
@@ -1204,6 +1204,45 @@ steps:
      - hail_run_image
      - build_hail
  - kind: runImage
+   name: test_hail_python_unchecked_allocator
+   image:
+     valueFrom: hail_run_image.image
+   resources:
+     memory: "7.5G"
+     cpu: "2"
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xzf resources.tar.gz
+     tar xzf data.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export HAIL_TEST_RESOURCES_DIR=./resources
+     export HAIL_DOCTEST_DATA_DIR=./data
+     export HAIL_TEST_BUCKET=hail-test-dmk9z
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
+     python3 -m pytest -m unchecked_allocator --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+     - from: /resources.tar.gz
+       to: /io/resources.tar.gz
+     - from: /data.tar.gz
+       to: /io/data.tar.gz
+   secrets:
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /test-gsa-key
+   dependsOn:
+     - batch_pods_ns
+     - hail_run_image
+     - build_hail
+ - kind: runImage
    name: test_hail_python_local_backend_0
    image:
      valueFrom: hail_run_image.image

--- a/build.yaml
+++ b/build.yaml
@@ -1057,7 +1057,7 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
-     tar xvf wheel-container.tar
+     tar xvf debug-wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
@@ -1068,8 +1068,8 @@ steps:
      export PYTEST_SPLIT_INDEX=1
      python3 -m pytest --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     - from: /debug-wheel-container.tar
+       to: /io/debug-wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -1098,7 +1098,7 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
-     tar xvf wheel-container.tar
+     tar xvf debug-wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
@@ -1109,8 +1109,8 @@ steps:
      export PYTEST_SPLIT_INDEX=2
      python3 -m pytest --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     - from: /debug-wheel-container.tar
+       to: /io/debug-wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -1139,7 +1139,7 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
-     tar xvf wheel-container.tar
+     tar xvf debug-wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
@@ -1150,8 +1150,8 @@ steps:
      export PYTEST_SPLIT_INDEX=3
      python3 -m pytest --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     - from: /debug-wheel-container.tar
+       to: /io/debug-wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz
@@ -1180,7 +1180,7 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
-     tar xvf wheel-container.tar
+     tar xvf debug-wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
@@ -1191,8 +1191,8 @@ steps:
      export PYTEST_SPLIT_INDEX=4
      python3 -m pytest --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     - from: /debug-wheel-container.tar
+       to: /io/debug-wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -574,6 +574,7 @@ steps:
      mkdir build/debug_libs
      mv build/libs/hail-all-spark.jar build/debug_libs/
      mv build/libs/hail-all-spark-test.jar build/debug_libs/
+     mv build/deploy/dist/debug-wheel-container.tar build/debug_libs
      time retry make jars python-version-info wheel
      time (cd python && zip -r hail.zip hail hailtop)
      time tar czf test.tar.gz -C python test
@@ -599,7 +600,7 @@ steps:
        to: /hail.zip
      - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
        to: /wheel-container.tar
-     - from: /io/repo/hail/build/deploy/dist/debug-wheel-container.tar
+     - from: /io/repo/hail/build/debug_libs/debug-wheel-container.tar
        to: /debug-wheel-container.tar
      - from: /io/repo/hail/test.tar.gz
        to: /test.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -570,6 +570,7 @@ steps:
      cd hail
      time retry ./gradlew --version
      time retry make jars wheel HAIL_DEBUG_MODE=1
+     time tar -cvf build/deploy/dist/debug-wheel-container.tar build/deploy/dist/hail-*-py3-none-any.whl
      mkdir build/debug_libs
      mv build/libs/hail-all-spark.jar build/debug_libs/
      mv build/libs/hail-all-spark-test.jar build/debug_libs/
@@ -598,6 +599,8 @@ steps:
        to: /hail.zip
      - from: /io/repo/hail/build/deploy/dist/wheel-container.tar
        to: /wheel-container.tar
+     - from: /io/repo/hail/build/deploy/dist/debug-wheel-container.tar
+       to: /debug-wheel-container.tar
      - from: /io/repo/hail/test.tar.gz
        to: /test.tar.gz
      - from: /io/repo/hail/resources.tar.gz
@@ -1011,7 +1014,7 @@ steps:
      tar xzf test.tar.gz
      tar xzf resources.tar.gz
      tar xzf data.tar.gz
-     tar xvf wheel-container.tar
+     tar xvf debug-wheel-container.tar
      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
      export HAIL_TEST_RESOURCES_DIR=./resources
      export HAIL_DOCTEST_DATA_DIR=./data
@@ -1022,8 +1025,8 @@ steps:
      export PYTEST_SPLIT_INDEX=0
      python3 -m pytest --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
    inputs:
-     - from: /wheel-container.tar
-       to: /io/wheel-container.tar
+     - from: /debug-wheel-container.tar
+       to: /io/debug-wheel-container.tar
      - from: /test.tar.gz
        to: /io/test.tar.gz
      - from: /resources.tar.gz

--- a/build.yaml
+++ b/build.yaml
@@ -570,7 +570,8 @@ steps:
      cd hail
      time retry ./gradlew --version
      time retry make jars wheel HAIL_DEBUG_MODE=1
-     time tar -cvf build/deploy/dist/debug-wheel-container.tar build/deploy/dist/hail-*-py3-none-any.whl
+     (cd build/deploy/dist/ && tar -cvf debug-wheel-container.tar hail-*-py3-none-any.whl)
+     cd /io/repo/hail
      mkdir build/debug_libs
      mv build/libs/hail-all-spark.jar build/debug_libs/
      mv build/libs/hail-all-spark-test.jar build/debug_libs/

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -92,6 +92,7 @@ class Tests(unittest.TestCase):
         ht = x.annotate(fp=hl.cond(~x.tp, hl.rand_bool(0.2), False))
         _, aucs = hl.experimental.plot_roc_curve(ht, ['score1', 'score2', 'score3'])
 
+    @pytest.mark.unchecked_allocator
     @fails_local_backend()
     def test_ld_score_regression(self):
 

--- a/hail/python/test/hail/methods/test_king.py
+++ b/hail/python/test/hail/methods/test_king.py
@@ -1,3 +1,5 @@
+import pytest
+
 import hail as hl
 from ..helpers import resource, startTestHailContext, stopTestHailContext, fails_local_backend
 
@@ -39,7 +41,7 @@ def test_king_small():
         resource('balding-nichols-1024-variants-4-samples-3-populations.kin0'),
         kinship)
 
-
+@pytest.mark.unchecked_allocator
 @fails_local_backend()
 def test_king_large():
     plink_path = resource('fastlmmTest')

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -231,6 +231,7 @@ class Tests(unittest.TestCase):
     # df = data.frame(y, x, c1, c2)
     # fit <- lm(y ~ x + c1 + c2, data=df)
     # summary(fit)["coefficients"]
+    @pytest.mark.unchecked_allocator
     def test_linear_regression_with_cov(self):
 
         covariates = hl.import_table(resource('regressionLinear.cov'),


### PR DESCRIPTION
This PR:

- Switches all python tests to run in debug mode on the checked allocator.
- Adds a pytest mark, `unchecked_allocator`. Anything with this mark will be rerun with the unchecked allocator as a way of testing the unchecked allocator