### PR TITLE
LocalBackend Better Errors

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -15,7 +15,7 @@ from hail.expr.table_type import ttable
 from hail.expr.types import dtype
 from hail.ir import JavaIR
 from hail.ir.renderer import CSERenderer
-from hail.utils.java import FatalError, HailUserError, scala_package_object, scala_object
+from hail.utils.java import scala_package_object, scala_object
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
@@ -217,37 +217,6 @@ class LocalBackend(Py4JBackend):
 
     def _to_java_blockmatrix_ir(self, ir):
         return self._to_java_ir(ir, self._parse_blockmatrix_ir)
-
-    def execute(self, ir, timed=False):
-        jir = self._to_java_value_ir(ir)
-        # print(self._hail_package.expr.ir.Pretty.apply(jir, True, -1))
-        try:
-            result = json.loads(self._jhc.backend().executeJSON(jir))
-            value = ir.typ._from_json(result['value'])
-            timings = result['timings']
-
-            return (value, timings) if timed else value
-        except FatalError as e:
-            error_id = e._error_id
-
-            def criteria(hail_ir):
-                return hail_ir._error_id is not None and hail_ir._error_id == error_id
-
-            error_sources = ir.base_search(criteria)
-            better_stack_trace = None
-            if error_sources:
-                better_stack_trace = error_sources[0]._stack_trace
-
-            if better_stack_trace:
-                error_message = str(e)
-                message_and_trace = (f'{error_message}\n'
-                                     '------------\n'
-                                     'Hail stack trace:\n'
-                                     f'{better_stack_trace}')
-                raise HailUserError(message_and_trace) from None
-
-            raise e
-
 
     def value_type(self, ir):
         jir = self._to_java_value_ir(ir)

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -9,14 +9,13 @@ import pkg_resources
 import py4j
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 
-import hail
 from hail.expr.blockmatrix_type import tblockmatrix
 from hail.expr.matrix_type import tmatrix
 from hail.expr.table_type import ttable
 from hail.expr.types import dtype
 from hail.ir import JavaIR
 from hail.ir.renderer import CSERenderer
-from hail.utils.java import FatalError, Env, scala_package_object, scala_object
+from hail.utils.java import FatalError, HailUserError, scala_package_object, scala_object
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
@@ -222,11 +221,33 @@ class LocalBackend(Py4JBackend):
     def execute(self, ir, timed=False):
         jir = self._to_java_value_ir(ir)
         # print(self._hail_package.expr.ir.Pretty.apply(jir, True, -1))
-        result = json.loads(self._jhc.backend().executeJSON(jir))
-        value = ir.typ._from_json(result['value'])
-        timings = result['timings']
+        try:
+            result = json.loads(self._jhc.backend().executeJSON(jir))
+            value = ir.typ._from_json(result['value'])
+            timings = result['timings']
 
-        return (value, timings) if timed else value
+            return (value, timings) if timed else value
+        except FatalError as e:
+            error_id = e._error_id
+
+            def criteria(hail_ir):
+                return hail_ir._error_id is not None and hail_ir._error_id == error_id
+
+            error_sources = ir.base_search(criteria)
+            better_stack_trace = None
+            if error_sources:
+                better_stack_trace = error_sources[0]._stack_trace
+
+            if better_stack_trace:
+                error_message = str(e)
+                message_and_trace = (f'{error_message}\n'
+                                     '------------\n'
+                                     'Hail stack trace:\n'
+                                     f'{better_stack_trace}')
+                raise HailUserError(message_and_trace) from None
+
+            raise e
+
 
     def value_type(self, ir):
         jir = self._to_java_value_ir(ir)

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -17,30 +17,9 @@ from hail.expr.types import dtype
 from hail.ir import JavaIR
 from hail.ir.renderer import CSERenderer
 from hail.utils.java import FatalError, Env, scala_package_object, scala_object
-from .py4j_backend import Py4JBackend
+from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
-
-
-def handle_java_exception(f):
-    def deco(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except py4j.protocol.Py4JJavaError as e:
-            s = e.java_exception.toString()
-
-            # py4j catches NoSuchElementExceptions to stop array iteration
-            if s.startswith('java.util.NoSuchElementException'):
-                raise
-
-            tpl = Env.jutils().handleForPython(e.java_exception)
-            deepest, full = tpl._1(), tpl._2()
-            raise FatalError('%s\n\nJava stack trace:\n%s\n'
-                             'Hail version: %s\n'
-                             'Error summary: %s' % (deepest, full, hail.__version__, deepest)) from None
-
-    return deco
-
 
 _installed = False
 _original = None

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,8 +1,40 @@
 import abc
 
+import py4j
+
+import hail
 from hail.ir.renderer import CSERenderer
-from hail.utils.java import Env
+from hail.utils.java import FatalError, Env
 from .backend import Backend
+
+
+def handle_java_exception(f):
+    def deco(*args, **kwargs):
+        import pyspark
+        try:
+            return f(*args, **kwargs)
+        except py4j.protocol.Py4JJavaError as e:
+            s = e.java_exception.toString()
+
+            # py4j catches NoSuchElementExceptions to stop array iteration
+            if s.startswith('java.util.NoSuchElementException'):
+                raise
+
+            tpl = Env.jutils().handleForPython(e.java_exception)
+            deepest, full, error_id = tpl._1(), tpl._2(), tpl._3()
+
+            if error_id != -1:
+                raise FatalError('Error summary: %s' % (deepest,), error_id) from None
+            else:
+                raise FatalError('%s\n\nJava stack trace:\n%s\n'
+                                 'Hail version: %s\n'
+                                 'Error summary: %s' % (deepest, full, hail.__version__, deepest), error_id) from None
+        except pyspark.sql.utils.CapturedException as e:
+            raise FatalError('%s\n\nJava stack trace:\n%s\n'
+                             'Hail version: %s\n'
+                             'Error summary: %s' % (e.desc, e.stackTrace, hail.__version__, e.desc)) from None
+
+    return deco
 
 
 class Py4JBackend(Backend):

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -96,4 +96,3 @@ class Py4JBackend(Backend):
                 raise HailUserError(message_and_trace) from None
 
             raise e
-

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -8,7 +8,7 @@ from threading import Thread
 import py4j
 import pyspark
 
-from hail.utils.java import FatalError, HailUserError, Env, scala_package_object, scala_object
+from hail.utils.java import Env, scala_package_object, scala_object
 from hail.expr.types import dtype
 from hail.expr.table_type import ttable
 from hail.expr.matrix_type import tmatrix

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1182,7 +1182,6 @@ class Tests(unittest.TestCase):
             .default(4))
         self.assertEqual(hl.eval(expr5), -1)
 
-    @fails_local_backend()
     def test_case(self):
         def make_case(x):
             x = hl.literal(x)
@@ -2958,7 +2957,6 @@ class Tests(unittest.TestCase):
         self.assert_evals_to(hl.mean(s), 3)
         self.assert_evals_to(hl.median(s), 3)
 
-    @fails_local_backend()
     def test_uniroot(self):
         tol = 1.220703e-4
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3267,7 +3267,6 @@ class Tests(unittest.TestCase):
         assert hl.eval(hl.bit_rshift(hl.int64(-1), 64)) == -1
         assert hl.eval(hl.bit_rshift(hl.int64(-11), 64, logical=True)) == 0
 
-    @fails_local_backend()
     def test_bit_shift_errors(self):
         with pytest.raises(hl.utils.HailUserError):
                 hl.eval(hl.bit_lshift(1, -1))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -25,7 +25,6 @@ def assert_ndarrays_almost_eq(*expr_and_expected):
     assert_ndarrays(np.allclose, expr_and_expected)
 
 
-@fails_local_backend()
 def test_ndarray_ref():
 
     scalar = 5.0
@@ -61,7 +60,6 @@ def test_ndarray_ref():
     assert "Index 4 is out of bounds for axis 0 with size 3" in str(exc)
 
 
-@fails_local_backend()
 def test_ndarray_slice():
     np_rect_prism = np.arange(24).reshape((2, 3, 4))
     rect_prism = hl.nd.array(np_rect_prism)
@@ -161,7 +159,6 @@ def test_ndarray_transposed_slice():
     )
 
 
-@fails_local_backend()
 def test_ndarray_eval():
     data_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     mishapen_data_list1 = [[4], [1, 2, 3]]
@@ -625,7 +622,6 @@ def test_ndarray_full():
     assert hl.eval(hl.nd.full((5, 6, 7), hl.int32(3), dtype=hl.tfloat64)).dtype, np.float64
 
 
-@skip_unless_spark_backend()
 def test_ndarray_arange():
     assert_ndarrays_eq(
         (hl.nd.arange(40), np.arange(40)),
@@ -646,7 +642,6 @@ def test_ndarray_mixed():
          hl.nd.ones((5, 10)).map(lambda x: x + 5)).reshape(hl.null(hl.ttuple(hl.tint64, hl.tint64))).T.reshape((10, 5))) is None
     assert hl.eval(hl.or_missing(False, hl.nd.array(np.arange(10)).reshape(
         (5, 2)).map(lambda x: x * 2)).map(lambda y: y * 2)) is None
-
 
 
 def test_ndarray_show():

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -905,7 +905,6 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: hl.linalg.utils.array_windows(np.array([]), -1))
         self.assertRaises(ValueError, lambda: hl.linalg.utils.array_windows(np.array(['str']), 1))
 
-    @fails_local_backend()
     def test_locus_windows(self):
         def assert_eq(a, b):
             self.assertTrue(np.array_equal(a, np.array(b)))


### PR DESCRIPTION
This PR updates the LocalBackend to match the behavior of the SparkBackend w.r.t. error handling. 

- `handle_java_exception` and `execute` are lifted into the parent file, `Py4JBackend`. 
- Tests in `test_ndarrays` that were marked as failing local tests are now passing, since the only failure was inconsistent handling of errors. 

The error handling changes in question here were introduced in #9398 
