### PR TITLE
[query] group_by aggregator needs to check axes in grouping expression

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -158,7 +158,7 @@ class AggFunc(object):
 
         return construct_expr(ir.AggGroupBy(group._ir, aggregation._ir, self._as_scan),
                               tdict(group.dtype, aggregation.dtype),
-                              Indices(indices.source, aggregation._indices.axes),
+                              Indices(indices.source, indices.axes),
                               aggregations)
 
     def array_agg(self, array, f):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -754,6 +754,11 @@ class Tests(unittest.TestCase):
         for aggregation, expected in tests:
             self.assertEqual(t.aggregate(aggregation), expected)
 
+    def test_aggregator_scope_mt(self):
+        mt = hl.utils.range_matrix_table(10, 10).annotate_entries(ent_field = 1)
+        with pytest.raises(hl.expr.ExpressionException, match="unexpected indices"):
+            mt.aggregate_cols(hl.agg.group_by(mt.ent_field, hl.agg.sum(mt.col_idx)))
+
     def test_aggregator_bindings(self):
         t = hl.utils.range_table(5)
         with self.assertRaises(hl.expr.ExpressionException):


### PR DESCRIPTION
Previously, when we did `hl.agg.group_by(group_expr, aggregation_expr)`, we were only tracking the indices picked up from the `aggregation_expr`. This led to us throwing bad error messages. 