### PR TITLE
[batch] Get rid of double copying in io

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -552,7 +552,7 @@ def copy_command(src, dst, requester_pays_project=None):
 
     cp = f'retry gsutil {requester_pays_project} -m cp -R {shq(src)} {shq(dst)}'
 
-    return f'{mkdirs_file}{cp} || {mkdirs_dir}{cp}'
+    return f'({mkdirs_file}{cp}) || ({mkdirs_dir}{cp})'
 
 
 def copy(files, name, requester_pays_project):


### PR DESCRIPTION
This PR fixes the double copying of input and output files. This was due to missing parentheses in the shell command for copying.