### PR TITLE
[query] use a 10 minute timeout

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -46,7 +46,8 @@ class ServiceBackend(Backend):
         self._fs = None
         self._logger = PythonOnlyLogger(skip_logging_configuration)
         self.requests_session = external_requests_client_session(
-            headers=service_auth_headers(deploy_config, 'query'))
+            headers=service_auth_headers(deploy_config, 'query'),
+            timeout=600)
 
     @property
     def logger(self):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -410,16 +410,16 @@ def retry_response_returning_functions(fun, *args, **kwargs):
         errors += 1
         if errors % 10 == 0:
             log.warning(f'encountered {errors} bad status codes, most recent '
-                        f'one was {response.status_code}', exc_info=True)
+                        f'one was {response.status_code}')
         response = sync_retry_transient_errors(
             fun, *args, **kwargs)
         delay = sync_sleep_and_backoff(delay)
     return response
 
 
-def external_requests_client_session(headers=None) -> requests.Session:
+def external_requests_client_session(headers=None, timeout=5) -> requests.Session:
     session = requests.Session()
-    adapter = TimeoutHTTPAdapter(max_retries=1, timeout=5)
+    adapter = TimeoutHTTPAdapter(max_retries=1, timeout=timeout)
     session.mount('http://', adapter)
     session.mount('https://', adapter)
     if headers:

--- a/query/test/test_query.py
+++ b/query/test/test_query.py
@@ -8,27 +8,27 @@ def test_simple_table():
     n = t.count()
     print(f'n {n}')
     assert n == 17
-    
+
 @pytest.mark.asyncio
 async def test_flags():
     async with cli.QueryClient() as client:
         all_flags, invalid = await client.get_flag([])
         assert len(invalid) == 0
-        
+
         for test_flag, test_value in all_flags.items():
             old = await client.set_flag(test_flag, "new_value")
             assert old == test_value
-            
+
             flags, _ = await client.get_flag([test_flag])
             assert flags == {test_flag: "new_value"}
-        
+
             old = await client.set_flag(test_flag, None)
             assert old == "new_value"
-            
+
             if test_value is not None:
                 old = await client.set_flag(test_flag, test_value)
                 assert old is None
-        
+
         flags, invalid = await client.get_flag(["invalid"])
         assert invalid == ["'invalid'"]
         assert flags == {}


### PR DESCRIPTION
If query has to pull its image fresh each job takes ~2 minutes. I also fixed some
whitespace issues in the tests and a little bug in `retry_response_returning_functions`.