### PR TITLE
[benchmark] add profiler options to hail-bench

### DIFF
--- a/benchmark/python/benchmark_hail/run/cli.py
+++ b/benchmark/python/benchmark_hail/run/cli.py
@@ -48,6 +48,14 @@ def main(args_):
     parser.add_argument('--dry-run',
                         action='store_true',
                         help='Print benchmarks to execute, but do not run.')
+    parser.add_argument('--profile', '-p',
+                        choices=['cpu', 'alloc'],
+                        nargs='?', const='cpu',
+                        help='Run with async-profiler.')
+    parser.add_argument('--prof-fmt', '-f',
+                        choices=['html', 'flame', 'jfr'],
+                        default='html',
+                        help='Choose profiler output.')
 
     args = parser.parse_args(args_)
 
@@ -59,8 +67,10 @@ def main(args_):
         records.append(stats)
 
     data_dir = args.data_dir or os.environ.get('HAIL_BENCHMARK_DIR') or '/tmp/hail_benchmark_data'
+    profiler_path = os.environ.get('ASYNC_PROFILER_HOME')
     config = RunConfig(args.n_iter, handler, noisy=not args.quiet, timeout=args.timeout, dry_run=args.dry_run,
-                       data_dir=data_dir, cores=args.cores, verbose=args.verbose, log=args.log)
+                       data_dir=data_dir, cores=args.cores, verbose=args.verbose, log=args.log,
+                       profiler_path=profiler_path, profile=args.profile, prof_fmt=args.prof_fmt)
     if args.tests:
         run_list(args.tests.split(','), config)
     if args.pattern:


### PR DESCRIPTION
Add async-profiler support to hail-bench.

Add options:
* `--profile` (`-p`). Can be `-p cpu` or `-p alloc`; `-p` alone defaults to `cpu`.
* `--prof-fmt` (`-f`). Can be `-f html`, `-f flame`, or `-f jfr`. If not specified, defaults to `html`. `html` writes a collapsible tree as you would see in a profiler gui. `flame` writes an svg format flame graph. `jfr` writes a Java Flight Recorder format file which can be read by Java Mission Control or the integrated IntelliJ profiler.

Uses [async-profiler](https://github.com/jvm-profiling-tools/async-profiler), which must be installed at the path `$ASYNC_PROFILER_HOME`. It attaches to the spark JVM using the JVMTI argument interface. The JVMTI async-profiler arguments are described [here](https://github.com/jvm-profiling-tools/async-profiler/blob/v1.8.1/src/arguments.cpp#L49).