### PR TITLE
[batch] Add infrastructure for not running batch tests in production

### DIFF
--- a/batch/test/conftest.py
+++ b/batch/test/conftest.py
@@ -28,3 +28,8 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if not digest(item.name) % n_splits == split_index:
             item.add_marker(skip_this)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if exitstatus == 5:  # no matching tests
+        session.exitstatus = 0

--- a/build.yaml
+++ b/build.yaml
@@ -2121,6 +2121,7 @@ steps:
              --log-cli-level=INFO \
              -s \
              -vv \
+             -m "not test_scope_only" \
              --instafail \
              -k "not test_scale and not test_invariants" \
              --durations=0 \
@@ -2181,6 +2182,7 @@ steps:
              --log-cli-level=INFO \
              -s \
              -vv \
+             -m "not test_scope_only" \
              --instafail \
              -k "not test_scale and not test_invariants" \
              --durations=0 \
@@ -2241,6 +2243,7 @@ steps:
              --log-cli-level=INFO \
              -s \
              -vv \
+             -m "not test_scope_only" \
              --instafail \
              -k "not test_scale and not test_invariants" \
              --durations=0 \
@@ -2301,6 +2304,7 @@ steps:
              --log-cli-level=INFO \
              -s \
              -vv \
+             -m "not test_scope_only" \
              --instafail \
              -k "not test_scale and not test_invariants" \
              --durations=0 \
@@ -2361,6 +2365,7 @@ steps:
              --log-cli-level=INFO \
              -s \
              -vv \
+             -m "not test_scope_only" \
              --instafail \
              -k "not test_scale and not test_invariants" \
              --durations=0 \
@@ -2370,6 +2375,70 @@ steps:
       to: /io/
    port: 5000
    timeout: 1200
+   secrets:
+    - name: gce-deploy-config
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /deploy-config
+    - name: test-tokens
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /user-tokens
+    - name: ssl-config-batch-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
+    - name: test-gsa-key
+      namespace:
+        valueFrom: batch_pods_ns.name
+      mountPath: /test-gsa-key
+   dependsOn:
+    - create_deploy_config
+    - create_accounts
+    - default_ns
+    - batch_pods_ns
+    - copy_files
+    - base_image
+    - batch_image
+    - ci_utils_image
+    - deploy_batch
+    - netcat_ubuntu_image
+    - curl_image
+ - kind: runImage
+   name: test_batch_test_only
+   image:
+     valueFrom: batch_image.image
+   script: |
+     set -ex
+     export PYTEST_SPLITS=5
+     export PYTEST_SPLIT_INDEX=4
+     export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+     export HAIL_BASE_IMAGE={{ base_image.image }}
+     export CI_UTILS_IMAGE={{ ci_utils_image.image }}
+     export HAIL_CURL_IMAGE={{ curl_image.image }}
+     export HAIL_BATCH_PODS_NAMESPACE={{ batch_pods_ns.name }}
+     export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_CURL_IMAGE={{ curl_image.image }}
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest \
+             --log-date-format="%Y-%m-%dT%H:%M:%S" \
+             --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
+             --log-cli-level=INFO \
+             -s \
+             -vv \
+             -m "test_scope_only" \
+             --instafail \
+             -k "not test_scale and not test_invariants" \
+             --durations=0 \
+             /io/test/
+   inputs:
+    - from: /repo/batch/test
+      to: /io/
+   port: 5000
+   timeout: 1200
+   scopes:
+    - dev
+    - test
    secrets:
     - name: gce-deploy-config
       namespace:
@@ -3252,6 +3321,7 @@ steps:
     - test_batch_2
     - test_batch_3
     - test_batch_4
+    - test_batch_test_only
     - test_ci
     - test_hailtop_batch_0
     - test_hailtop_batch_1


### PR DESCRIPTION
This is for @catoverdrive and I to be able to manipulate billing projects and their limits in tests. But we don't want to litter the default namespace with a bunch of bogus projects. We also need to reset the accrued costs to 0 in order for the billing limit tests to work.

@danking -- FYI