### PR TITLE
[hailtop-auth] allow tokens to be loaded from user-specified file

### DIFF
--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -24,7 +24,7 @@ def get_userinfo(deploy_config=None):
     return async_to_blocking(async_get_userinfo(deploy_config))
 
 
-def namespace_auth_headers(deploy_config, ns, authorize_target=True, _token_file=None):
+def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, _token_file=None):
     tokens = get_tokens(_token_file)
     headers = {}
     if authorize_target:
@@ -34,9 +34,9 @@ def namespace_auth_headers(deploy_config, ns, authorize_target=True, _token_file
     return headers
 
 
-def service_auth_headers(deploy_config, service, authorize_target=True, _token_file=None):
+def service_auth_headers(deploy_config, service, authorize_target=True, *, _token_file=None):
     ns = deploy_config.service_ns(service)
-    return namespace_auth_headers(deploy_config, ns, authorize_target, _token_file)
+    return namespace_auth_headers(deploy_config, ns, authorize_target, _token_file=_token_file)
 
 
 def copy_paste_login(copy_paste_token, namespace=None):

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -24,8 +24,8 @@ def get_userinfo(deploy_config=None):
     return async_to_blocking(async_get_userinfo(deploy_config))
 
 
-def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, _token_file=None):
-    tokens = get_tokens(_token_file)
+def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, token_file=None):
+    tokens = get_tokens(token_file)
     headers = {}
     if authorize_target:
         headers['Authorization'] = f'Bearer {tokens.namespace_token_or_error(ns)}'
@@ -34,9 +34,9 @@ def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, _token_f
     return headers
 
 
-def service_auth_headers(deploy_config, service, authorize_target=True, *, _token_file=None):
+def service_auth_headers(deploy_config, service, authorize_target=True, *, token_file=None):
     ns = deploy_config.service_ns(service)
-    return namespace_auth_headers(deploy_config, ns, authorize_target, _token_file=_token_file)
+    return namespace_auth_headers(deploy_config, ns, authorize_target, token_file=token_file)
 
 
 def copy_paste_login(copy_paste_token, namespace=None):

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -24,8 +24,8 @@ def get_userinfo(deploy_config=None):
     return async_to_blocking(async_get_userinfo(deploy_config))
 
 
-def namespace_auth_headers(deploy_config, ns, authorize_target=True):
-    tokens = get_tokens()
+def namespace_auth_headers(deploy_config, ns, authorize_target=True, _token_file=None):
+    tokens = get_tokens(_token_file)
     headers = {}
     if authorize_target:
         headers['Authorization'] = f'Bearer {tokens.namespace_token_or_error(ns)}'
@@ -34,9 +34,9 @@ def namespace_auth_headers(deploy_config, ns, authorize_target=True):
     return headers
 
 
-def service_auth_headers(deploy_config, service, authorize_target=True):
+def service_auth_headers(deploy_config, service, authorize_target=True, _token_file=None):
     ns = deploy_config.service_ns(service)
-    return namespace_auth_headers(deploy_config, ns, authorize_target)
+    return namespace_auth_headers(deploy_config, ns, authorize_target, _token_file)
 
 
 def copy_paste_login(copy_paste_token, namespace=None):

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -81,7 +81,7 @@ default_tokens = None
 def get_tokens(file=None):
     global tokens
     global default_tokens
-    
+
     if file is None:
         if default_tokens is None:
             default_tokens = Tokens.default_tokens()

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -17,8 +17,7 @@ class Tokens(collections.abc.MutableMapping):
             return os.path.expanduser('~/.hail/tokens.json')
         return '/user-tokens/tokens.json'
 
-    def __init__(self):
-        tokens_file = self.get_tokens_file()
+    def __init__(self, tokens_file):
         if os.path.isfile(tokens_file):
             with open(tokens_file, 'r') as f:
                 self._tokens = json.load(f)
@@ -64,12 +63,15 @@ to obtain new credentials.
             json.dump(self._tokens, f)
 
 
-tokens = None
+tokens = {}
 
 
-def get_tokens():
+def get_tokens(file=None):
     global tokens
 
-    if not tokens:
-        tokens = Tokens()
-    return tokens
+    if file is None:
+        file = Tokens.get_tokens_file()
+
+    if file not in tokens:
+        tokens[file] = Tokens(file)
+    return tokens[file]

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -17,14 +17,25 @@ class Tokens(collections.abc.MutableMapping):
             return os.path.expanduser('~/.hail/tokens.json')
         return '/user-tokens/tokens.json'
 
-    def __init__(self, tokens_file):
+    @staticmethod
+    def default_tokens():
+        tokens_file = Tokens.get_tokens_file()
         if os.path.isfile(tokens_file):
             with open(tokens_file, 'r') as f:
-                self._tokens = json.load(f)
-            log.info(f'tokens loaded from {tokens_file}')
+                log.info(f'tokens loaded from {tokens_file}')
+                return Tokens(json.load(f))
         else:
             log.info(f'tokens file not found: {tokens_file}')
-            self._tokens = {}
+            return Tokens({})
+
+    @staticmethod
+    def from_file(tokens_file):
+        with open(tokens_file, 'r') as f:
+            log.info(f'tokens loaded from {tokens_file}')
+            return Tokens(json.load(f))
+
+    def __init__(self, tokens):
+        self._tokens = tokens
 
     def __setitem__(self, key, value):
         self._tokens[key] = value

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -75,14 +75,17 @@ to obtain new credentials.
 
 
 tokens = {}
+default_tokens = None
 
 
 def get_tokens(file=None):
     global tokens
-
+    global default_tokens
+    
     if file is None:
-        file = Tokens.get_tokens_file()
-
+        if default_tokens is None:
+            default_tokens = Tokens.default_tokens()
+        return default_tokens
     if file not in tokens:
         tokens[file] = Tokens(file)
     return tokens[file]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -552,7 +552,7 @@ class BatchBuilder:
 @asyncinit
 class BatchClient:
     async def __init__(self, billing_project, deploy_config=None, session=None,
-                       headers=None, _token=None):
+                       headers=None, _token=None, _token_file=None):
         self.billing_project = billing_project
 
         if not deploy_config:
@@ -572,7 +572,7 @@ class BatchClient:
         if _token:
             h['Authorization'] = f'Bearer {_token}'
         else:
-            h.update(service_auth_headers(deploy_config, 'batch'))
+            h.update(service_auth_headers(deploy_config, 'batch', _token_file=_token_file))
         self._headers = h
 
     async def _get(self, path, params=None):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -552,7 +552,7 @@ class BatchBuilder:
 @asyncinit
 class BatchClient:
     async def __init__(self, billing_project, deploy_config=None, session=None,
-                       headers=None, _token=None, _token_file=None):
+                       headers=None, _token=None, token_file=None):
         self.billing_project = billing_project
 
         if not deploy_config:
@@ -572,7 +572,7 @@ class BatchClient:
         if _token:
             h['Authorization'] = f'Bearer {_token}'
         else:
-            h.update(service_auth_headers(deploy_config, 'batch', _token_file=_token_file))
+            h.update(service_auth_headers(deploy_config, 'batch', token_file=token_file))
         self._headers = h
 
     async def _get(self, path, params=None):


### PR DESCRIPTION
I need to be able to load tokens for multiple users for #9553 and would like to pipe it through the auth utilities in a reasonable way so I can use them. Let me know if this looks ok or if there's a better way to do it?