### PR TITLE
[query] Add lowered execution path for `hl.read_matrix_table`

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -73,7 +73,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(f(hl.eval(mt.annotate_globals(foo=hl.literal(x, t)).foo), x), f"{x}, {t}")
             self.assertTrue(f(hl.eval(ht.annotate_globals(foo=hl.literal(x, t)).foo), x), f"{x}, {t}")
 
-    @fails_local_backend()
     def test_head(self):
         # no empty partitions
         mt1 = hl.utils.range_matrix_table(10, 10)
@@ -100,7 +99,6 @@ class Tests(unittest.TestCase):
         assert mt1.head(1, None).count() == (1, 10)
         assert mt1.head(None, 1).count() == (10, 1)
 
-    @fails_local_backend()
     def test_tail(self):
         # no empty partitions
         mt1 = hl.utils.range_matrix_table(10, 10)
@@ -878,7 +876,6 @@ class Tests(unittest.TestCase):
         q = (vcf.locus >= l3) & (vcf.locus < l4)
         self.assertTrue(vcf.filter_rows(p | q)._same(mt))
 
-    @fails_local_backend()
     def test_codecs_matrix(self):
         from hail.utils.java import scala_object
         supported_codecs = scala_object(Env.hail().io, 'BufferSpec').specs()
@@ -899,7 +896,6 @@ class Tests(unittest.TestCase):
             rt2 = hl.read_table(temp)
             self.assertTrue(rt._same(rt2))
 
-    @fails_local_backend()
     def test_fix3307_read_mt_wrong(self):
         mt = hl.import_vcf(resource('sample2.vcf'))
         mt = hl.split_multi_hts(mt)
@@ -1491,7 +1487,6 @@ class Tests(unittest.TestCase):
         mt.show(handler=assert_res)
 
 
-    @fails_local_backend()
     def test_partitioned_write(self):
         mt = hl.utils.range_matrix_table(40, 3, 5)
 
@@ -1531,7 +1526,6 @@ class Tests(unittest.TestCase):
         ],
                    mt.filter_rows((mt.row_idx >= 5) & (mt.row_idx < 35)))
 
-    @fails_local_backend()
     def test_partitioned_write_coerce(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         parts = [
@@ -1558,12 +1552,10 @@ class Tests(unittest.TestCase):
         with pytest.raises(hl.utils.FatalError, match='metadata does not contain file version'):
             hl.read_matrix_table(resource('0.1-1fd5cc7.vds'))
 
-    @fails_local_backend()
     def test_legacy_files_with_required_globals(self):
         hl.read_table(resource('required_globals.ht'))._force_count()
         hl.read_matrix_table(resource('required_globals.mt'))._force_count_rows()
 
-    @fails_local_backend()
     def test_matrix_native_write_range(self):
         mt = hl.utils.range_matrix_table(11, 3, n_partitions=3)
         f = new_temp_file()

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -369,15 +369,12 @@ class VCFTests(unittest.TestCase):
             ref_str = ref.read().decode('utf-8')
             self.assertEqual(ref_str, data)
 
-    @fails_local_backend()
     def test_vcf_parser_golden_master__ex_GRCh37(self):
         self._test_vcf_parser_golden_master(resource('ex.vcf'), 'GRCh37')
 
-    @fails_local_backend()
     def test_vcf_parser_golden_master__sample_GRCh37(self):
         self._test_vcf_parser_golden_master(resource('sample.vcf'), 'GRCh37')
 
-    @fails_local_backend()
     def test_vcf_parser_golden_master__gvcf_GRCh37(self):
         self._test_vcf_parser_golden_master(resource('gvcfs/HG00096.g.vcf.gz'), 'GRCh38')
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -247,103 +247,10 @@ object HailContext {
     bounds: Option[Interval],
     partIdx: Int,
     metrics: InputMetrics = null
-  ): Iterator[Long] = new Iterator[Long] {
-    private val region = ctx.region
-    private val idx = idxr.map(_.queryByInterval(bounds.get).buffered)
-
-    private val trackedRowsIn = new ByteTrackingInputStream(isRows)
-    private val trackedEntriesIn = new ByteTrackingInputStream(isEntries)
-
-    private val rowsIdxField = rowsOffsetField.map { f => idxr.get.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
-    private val entriesIdxField = entriesOffsetField.map { f => idxr.get.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
-
-    private val inserter = mkInserter(partIdx, ctx.freshRegion())
-    private val rows = try {
-      if (idx.map(_.hasNext).getOrElse(true)) {
-        val dec = mkRowsDec(trackedRowsIn)
-        idx.foreach { idx =>
-          val i = idx.head
-          val off = rowsIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
-          dec.seek(off)
-        }
-        dec
-      } else {
-        isRows.close()
-        isEntries.close()
-        null
-      }
-    } catch {
-      case e: Exception =>
-        idxr.foreach(_.close())
-        isRows.close()
-        isEntries.close()
-        throw e
-    }
-    private val entries = try {
-      if (rows == null) {
-        null
-      } else {
-        val dec = mkEntriesDec(trackedEntriesIn)
-        idx.foreach { idx =>
-          val i = idx.head
-          val off = entriesIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
-          dec.seek(off)
-        }
-        dec
-      }
-    } catch {
-      case e: Exception =>
-        idxr.foreach(_.close())
-        isRows.close()
-        isEntries.close()
-        throw e
-    }
-
-    require(!((rows == null) ^ (entries == null)))
-    private def nextCont(): Byte = {
-      val br = rows.readByte()
-      val be = entries.readByte()
-      assert(br == be)
-      br
-    }
-
-    private var cont: Byte = if (rows != null) nextCont() else 0
-
-    def hasNext: Boolean = cont != 0 && idx.map(_.hasNext).getOrElse(true)
-
-    def next(): Long = {
-      if (!hasNext)
-        throw new NoSuchElementException("next on empty iterator")
-
-      try {
-        idx.map(_.next())
-        val rowOff = rows.readRegionValue(region)
-        val entOff = entries.readRegionValue(region)
-        val off = inserter(region, rowOff, entOff)
-        cont = nextCont()
-
-        if (cont == 0) {
-          rows.close()
-          entries.close()
-          idxr.foreach(_.close())
-        }
-
-        off
-      } catch {
-        case e: Exception =>
-          rows.close()
-          entries.close()
-          idxr.foreach(_.close())
-          throw e
-      }
-    }
-
-    override def finalize(): Unit = {
-      idxr.foreach(_.close())
-      if (rows != null) rows.close()
-      if (entries != null) entries.close()
-    }
-  }
+  ): Iterator[Long] = new MaybeIndexedReadZippedIterator(mkRowsDec, mkEntriesDec, mkInserter(partIdx, ctx.partitionRegion),
+    ctx.r,
+    isRows, isEntries,
+    idxr.orNull, rowsOffsetField.orNull, entriesOffsetField.orNull, bounds.orNull, metrics)
 
   def pyRemoveIrVector(id: Int) {
     get.irVectors.remove(id)

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -192,6 +192,13 @@ object Code {
   )(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], a7ct: ClassTag[A7], tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
     newInstance[T](Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass, a7ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4, a5, a6, a7))
 
+  def newInstance11[T <: AnyRef, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4],
+    a5: Code[A5], a6: Code[A6], a7: Code[A7], a8: Code[A8], a9: Code[A9], a10: Code[A10], a11: Code[A11]
+  )(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], a7ct: ClassTag[A7],
+    a8ct: ClassTag[A8], a9ct: ClassTag[A9], a10ct: ClassTag[A10], a11ct: ClassTag[A11], tct: ClassTag[T], tti: TypeInfo[T]): Code[T] =
+    newInstance[T](Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass, a7ct.runtimeClass,
+      a8ct.runtimeClass, a9ct.runtimeClass, a10ct.runtimeClass, a11ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+
   def newArray[T](size: Code[Int])(implicit tti: TypeInfo[T]): Code[Array[T]] =
     Code(size, lir.newArray(tti))
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -89,6 +89,7 @@ final case class Literal(_typ: Type, value: Annotation) extends IR {
   require(value != null)
   // expensive, for debugging
   // require(SafeRow.isSafe(value))
+  // assert(_typ.typeCheck(value), s"literal invalid:\n  ${_typ}\n  $value")
 }
 
 object EncodedLiteral {
@@ -644,6 +645,7 @@ object PartitionReader {
     override val typeHints = ShortTypeHints(List(
       classOf[PartitionNativeReader],
       classOf[PartitionNativeReaderIndexed],
+      classOf[PartitionZippedNativeReader],
       classOf[AbstractTypedCodecSpec],
       classOf[TypedCodecSpec])
     ) + BufferSpec.shortTypeHints

--- a/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
+++ b/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
@@ -1,0 +1,131 @@
+package is.hail.io.index
+
+import java.io.InputStream
+
+import is.hail.annotations.Region
+import is.hail.asm4s.AsmFunction3RegionLongLongLong
+import is.hail.io.Decoder
+import is.hail.types.virtual.TStruct
+import is.hail.utils.{ByteTrackingInputStream, Interval}
+import org.apache.spark.executor.InputMetrics
+import org.apache.spark.sql.Row
+
+class MaybeIndexedReadZippedIterator(
+  mkRowsDec: (InputStream) => Decoder,
+  mkEntriesDec: (InputStream) => Decoder,
+  inserter: AsmFunction3RegionLongLongLong,
+  region: Region,
+  isRows: InputStream,
+  isEntries: InputStream,
+  idxr: IndexReader,
+  rowsOffsetField: String,
+  entriesOffsetField: String,
+  bounds: Interval,
+  metrics: InputMetrics = null
+) extends Iterator[Long] {
+
+  private[this] var closed: Boolean = false
+
+  private[this] val idx = Option(idxr).map(_.queryByInterval(bounds).buffered)
+
+  private[this] val trackedRowsIn = new ByteTrackingInputStream(isRows)
+  private[this] val trackedEntriesIn = new ByteTrackingInputStream(isEntries)
+
+  private[this] val rowsIdxField = Option(rowsOffsetField).map { f => idxr.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
+  private[this] val entriesIdxField = Option(entriesOffsetField).map { f => idxr.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
+
+  private[this] val rows = try {
+    if (idx.forall(_.hasNext)) {
+      val dec = mkRowsDec(trackedRowsIn)
+      idx.foreach { idx =>
+        val i = idx.head
+        val off = rowsIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
+        dec.seek(off)
+      }
+      dec
+    } else {
+      isRows.close()
+      isEntries.close()
+      null
+    }
+  } catch {
+    case e: Exception =>
+      if (idxr != null)
+        idxr.close()
+      isRows.close()
+      isEntries.close()
+      throw e
+  }
+  private[this] val entries = try {
+    if (rows == null) {
+      null
+    } else {
+      val dec = mkEntriesDec(trackedEntriesIn)
+      idx.foreach { idx =>
+        val i = idx.head
+        val off = entriesIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
+        dec.seek(off)
+      }
+      dec
+    }
+  } catch {
+    case e: Exception =>
+      if (idxr != null)
+        idxr.close()
+      isRows.close()
+      isEntries.close()
+      throw e
+  }
+
+  require(!((rows == null) ^ (entries == null)))
+
+  private def nextCont(): Byte = {
+    val br = rows.readByte()
+    val be = entries.readByte()
+    assert(br == be)
+    br
+  }
+
+  private var cont: Byte = if (rows != null) nextCont() else 0
+
+  def hasNext: Boolean = cont != 0 && idx.forall(_.hasNext)
+
+  def next(): Long = _next()
+
+  def _next(): Long = {
+    if (!hasNext)
+      throw new NoSuchElementException("next on empty iterator")
+
+    try {
+      idx.map(_.next())
+      val rowOff = rows.readRegionValue(region)
+      val entOff = entries.readRegionValue(region)
+      val off = inserter(region, rowOff, entOff)
+      cont = nextCont()
+
+      if (cont == 0) {
+        close()
+      }
+
+      off
+    } catch {
+      case e: Exception =>
+        close()
+        throw e
+    }
+  }
+
+  def close(): Unit = {
+    if (!closed) {
+      if (idxr != null)
+        idxr.close()
+      if (rows != null) rows.close()
+      if (entries != null) entries.close()
+      closed = true
+    }
+  }
+
+  override def finalize(): Unit = {
+    close()
+  }
+}


### PR DESCRIPTION
11 new tests passing.

Can briefly walk you through the change in 1:1.