### PR TITLE
[query] RVD to table stage infrastructure

### DIFF
--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -152,3 +152,19 @@ def assert_evals_to(e, v):
 def assert_all_eval_to(*expr_and_expected):
     exprs, expecteds = zip(*expr_and_expected)
     assert_evals_to(hl.tuple(exprs), expecteds)
+
+
+def lower_only():
+    @decorator
+    def wrapper(func, *args, **kwargs):
+        flags = hl._get_flags()
+        prev_lower = flags.get('lower')
+        prev_lower_only = flags.get('lower_only')
+
+        hl._set_flags(lower='1', lower_only='1')
+
+        try:
+            return func(*args, **kwargs)
+        finally:
+            hl._set_flags(lower=prev_lower, lower_only=prev_lower_only)
+    return wrapper

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1536,3 +1536,10 @@ def test_map_partitions_indexed():
     ht = hl.read_table(tmp_file, _intervals=[hl.Interval(start=hl.Struct(idx=11), end=hl.Struct(idx=55))])
     ht = ht.key_by()._map_partitions(lambda partition: [hl.struct(foo=partition)])
     assert [inner.idx for outer in ht.foo.collect() for inner in outer] == list(range(11, 55))
+
+
+@lower_only()
+def test_lowered_persist():
+    ht = hl.utils.range_table(100, 10).persist()
+    assert ht.count() == 100
+    assert ht.filter(ht.idx == 55).count() == 1

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -469,6 +469,7 @@ class HailContext private(
 object HailFeatureFlags {
   val defaults: Map[String, (String, String)] = Map[String, (String, String)](
     ("lower", ("HAIL_DEV_LOWER" -> null)),
+    ("lower_only", ("HAIL_DEV_LOWER_ONLY" -> null)),
     ("lower_bm", ("HAIL_DEV_LOWER_BM" -> null)),
     ("max_leader_scans", ("HAIL_DEV_MAX_LEADER_SCANS" -> "1000")),
     ("distributed_scan_comb_op", ("HAIL_DEV_DISTRIBUTED_SCAN_COMB_OP" -> null)),

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -340,6 +340,7 @@ class SparkBackend(
       val lowerBM = HailContext.getFlag("lower_bm") != null
       _jvmLowerAndExecute(ctx, ir, optimize, lowerTable, lowerBM)
     } catch {
+      case e: LowererUnsupportedOperation if HailContext.getFlag("lower_only") != null => throw e
       case _: LowererUnsupportedOperation =>
         (CompileAndEvaluate._apply(ctx, ir, optimize = optimize), ctx.timer)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -93,7 +93,7 @@ final case class Literal(_typ: Type, value: Annotation) extends IR {
 }
 
 object EncodedLiteral {
-  def apply(codec: TypedCodecSpec, value: Array[Byte]): EncodedLiteral = {
+  def apply(codec: AbstractTypedCodecSpec, value: Array[Byte]): EncodedLiteral = {
     EncodedLiteral(codec, new WrappedByteArray(value))
   }
 
@@ -105,7 +105,7 @@ object EncodedLiteral {
   }
 }
 
-final case class EncodedLiteral(codec: TypedCodecSpec, value: WrappedByteArray) extends IR {
+final case class EncodedLiteral(codec: AbstractTypedCodecSpec, value: WrappedByteArray) extends IR {
   require(!CanEmit(codec.encodedVirtualType))
   require(value != null)
 }
@@ -643,6 +643,7 @@ final case class CollectDistributedArray(contexts: IR, globals: IR, cname: Strin
 object PartitionReader {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
+      classOf[PartitionRVDReader],
       classOf[PartitionNativeReader],
       classOf[PartitionNativeReaderIndexed],
       classOf[PartitionZippedNativeReader],

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -481,7 +481,7 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
 
       val upcastF = mb.genFieldThisRef[AsmFunction2RegionLongLong]("rvdreader_upcast")
 
-      val broadcastRVD = mb.getObject[BroadcastRVD](BroadcastRVD(ctx.backend.asSpark("RVDReader"), rvd))
+      val broadcastRVD = mb.getObject[BroadcastRVD](new BroadcastRVD(ctx.backend.asSpark("RVDReader"), rvd))
       SizedStream.unsized { eltRegion =>
         Stream.unfold[Code[Long]](
           (_, k) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1064,6 +1064,9 @@ object LowerTableIR {
             Let(globalName, loweredChild.globals, Let(partitionStreamName, part, body))
           }
 
+        case TableLiteral(typ, rvd, enc, encodedGlobals) =>
+          RVDToTableStage(rvd, EncodedLiteral(enc, encodedGlobals))
+
         case node =>
           throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")
       }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/RVDToTableStage.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/RVDToTableStage.scala
@@ -1,0 +1,15 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.expr.ir.{IR, PartitionRVDReader, ReadPartition, StreamRange}
+import is.hail.rvd.RVD
+
+object RVDToTableStage {
+  def apply(rvd: RVD, globals: IR): TableStage = {
+    TableStage(
+      globals = globals,
+      partitioner = rvd.partitioner,
+      contexts = StreamRange(0, rvd.getNumPartitions, 1),
+      body = ReadPartition(_, rvd.rowType, PartitionRVDReader(rvd))
+    )
+  }
+}

--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -33,10 +33,6 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
     encodedType.decodedPType(requestedType)
   }
 
-  def decodedPType(): PType = {
-    encodedType.decodedPType(_vType)
-  }
-
   def buildDecoder(ctx: ExecuteContext, requestedType: Type): (PType, (InputStream) => Decoder) = {
     val (rt, bufferToDecoder) = encodedType.buildDecoder(ctx, requestedType)
     (rt, (in: InputStream) => bufferToDecoder(_bufferSpec.buildInputBuffer(in)))
@@ -50,18 +46,4 @@ final case class TypedCodecSpec(_eType: EType, _vType: Type, _bufferSpec: Buffer
   def buildCodeInputBuffer(is: Code[InputStream]): Code[InputBuffer] = _bufferSpec.buildCodeInputBuffer(is)
 
   def buildCodeOutputBuffer(os: Code[OutputStream]): Code[OutputBuffer] = _bufferSpec.buildCodeOutputBuffer(os)
-
-  def buildTypedEmitDecoderF[T](requestedType: Type, cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) = {
-    val rt = encodedType.decodedPType(requestedType)
-    val mb = encodedType.buildDecoderMethod(rt, cb)
-    (rt, (region: Value[Region], buf: Value[InputBuffer]) => mb.invokeCode[T](region, buf))
-  }
-
-  def buildEmitDecoderF[T](cb: EmitClassBuilder[_]): (PType, StagedDecoderF[T]) =
-    buildTypedEmitDecoderF(_vType, cb)
-
-  def buildTypedEmitEncoderF[T](t: PType, cb: EmitClassBuilder[_]): StagedEncoderF[T] = {
-    val mb = encodedType.buildEncoderMethod(t, cb)
-    (region: Value[Region], off: Value[T], buf: Value[OutputBuffer]) => mb.invokeCode[Unit](off, buf)
-  }
 }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1534,3 +1534,13 @@ object RVD {
     fileData
   }
 }
+
+case class BroadcastRVD(@transient val backend: SparkBackend, @transient val rvd: RVD) extends Serializable {
+  private[this] val crdd = rvd.crdd
+  private[this] val bcPartitions = backend.broadcast(rvd.crdd.partitions)
+
+  def computePartition(idx: Int, region: Region, partitionRegion: Region): Iterator[Long] = {
+    val ctx = new RVDContext(partitionRegion, region)
+    crdd.iterator(bcPartitions.value(idx), TaskContext.get()).flatMap(_.apply(ctx))
+  }
+}

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1535,7 +1535,7 @@ object RVD {
   }
 }
 
-case class BroadcastRVD(@transient val backend: SparkBackend, @transient val rvd: RVD) extends Serializable {
+class BroadcastRVD(backend: SparkBackend, rvd: RVD) extends Serializable {
   private[this] val crdd = rvd.crdd
   private[this] val bcPartitions = backend.broadcast(rvd.crdd.partitions)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -49,6 +49,8 @@ abstract class PCode { self =>
     (Code(dst := r.allocate(pt.byteSize, pt.alignment), store(mb, r, dst)), dst)
   }
 
+  def asPrimitive: PPrimitiveCode = asInstanceOf[PPrimitiveCode]
+
   def asIndexable: PIndexableCode = asInstanceOf[PIndexableCode]
 
   def asBaseStruct: PBaseStructCode = asInstanceOf[PBaseStructCode]

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -83,5 +83,9 @@ class PPrimitiveCode(val pt: PType, val code: Code[_]) extends PCode {
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PValue = defaultMemoizeFieldImpl(cb, name)
 
-  def primCode[T]: Code[T] = coerce[T](code)
+  def primCode[T](implicit ti: TypeInfo[T]): Code[T] = {
+    val IndexedSeq(typeInfo) = pt.codeTupleTypes()
+    assert(ti == typeInfo)
+    code.asInstanceOf[Code[T]]
+  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -82,4 +82,6 @@ class PPrimitiveCode(val pt: PType, val code: Code[_]) extends PCode {
   def memoize(cb: EmitCodeBuilder, name: String): PValue = defaultMemoizeImpl(cb, name)
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PValue = defaultMemoizeFieldImpl(cb, name)
+
+  def primCode[T]: Code[T] = coerce[T](code)
 }


### PR DESCRIPTION
Currently tested with TableLiteral on the Spark backend.