### PR TITLE
[docker] Introduce Hail Ubuntu Image and hail-pip-install

### DIFF
--- a/address/Dockerfile
+++ b/address/Dockerfile
@@ -2,7 +2,6 @@ FROM {{ service_base_image.image }}
 
 COPY address/setup.py address/MANIFEST.in /address/
 COPY address/address /address/address/
-RUN pip3 install --no-cache-dir /address && \
-  rm -rf /address
+RUN hail-pip-install /address && rm -rf /address
 
 EXPOSE 5000

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,12 +1,11 @@
 FROM {{ service_base_image.image }}
 
-RUN pip3 install --upgrade \
+RUN hail-pip-install \
       google-auth-oauthlib==0.4.1 \
-      google-auth==1.20.0
+      google-auth==1.21.1
 
 COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/
-RUN pip3 install --no-cache-dir /auth && \
-  rm -rf /auth
+RUN hail-pip-install /auth && rm -rf /auth
 
 EXPOSE 5000

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -2,7 +2,6 @@ FROM {{ service_base_image.image }}
 
 COPY batch/setup.py batch/MANIFEST.in /batch/
 COPY batch/batch /batch/batch/
-RUN pip3 install --no-cache-dir /batch && \
-  rm -rf /batch
+RUN hail-pip-install /batch && rm -rf /batch
 
 EXPOSE 5000

--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -17,22 +17,21 @@ RUN apt-get update && \
     gcsfuse && \
   rm -rf /var/lib/apt/lists/*
 
+COPY docker/hail-ubuntu/pip.conf /root/.config/pip/pip.conf
+COPY docker/hail-ubuntu/hail-pip-install /bin/hail-pip-install
+RUN python3 -m pip install --upgrade --no-cache-dir pip
+
 COPY docker/requirements.txt .
-# re: pip install --upgrade pip: https://github.com/grpc/grpc/issues/22815
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --no-cache-dir -U -r requirements.txt
+RUN hail-pip-install -r requirements.txt
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
-RUN python3 -m pip install --no-deps --no-cache-dir /hailtop \
-  && rm -rf /hailtop
+RUN hail-pip-install --no-deps /hailtop && rm -rf /hailtop
 
 COPY gear/setup.py /gear/setup.py
 COPY gear/gear /gear/gear/
-RUN python3 -m pip install --no-deps --no-cache-dir /gear \
-  && rm -rf /gear
+RUN hail-pip-install --no-deps /gear && rm -rf /gear
 
 COPY batch/setup.py batch/MANIFEST.in /batch/
 COPY batch/batch /batch/batch/
-RUN pip3 install --no-cache-dir /batch && \
-  rm -rf /batch
+RUN hail-pip-install --no-deps /batch && rm -rf /batch

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -24,7 +24,7 @@ build:
 	-docker pull gcr.io/$(PROJECT)/python:3.7-slim-stretch
 	-docker pull $(BATCH_WORKER_LATEST)
 	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile.worker Dockerfile.worker.out
-	docker build -t batch-worker -f Dockerfile.worker --cache-from batch-worker,$(BATCH_WORKER_LATEST),gcr.io/$(PROJECT)/python:3.7-slim-stretch ..
+	docker build -t batch-worker -f Dockerfile.worker.out --cache-from batch-worker,$(BATCH_WORKER_LATEST),gcr.io/$(PROJECT)/python:3.7-slim-stretch ..
 
 .PHONY: push
 push: build

--- a/benchmark-service/Dockerfile
+++ b/benchmark-service/Dockerfile
@@ -4,16 +4,8 @@ COPY benchmark-service/benchmark /benchmark-service/benchmark/
 
 COPY benchmark-service/setup.py benchmark-service/MANIFEST.in  /benchmark-service/
 
-RUN pip3 install --no-cache-dir /benchmark-service && \
-    rm -rf /benchmark-service
-
-RUN pip3 install plotly
-
-RUN pip3 install pandas
-
-RUN pip3 install scipy
-
-RUN pip3 install numpy
+RUN hail-pip-install /benchmark-service && rm -rf /benchmark-service && \
+    hail-pip-install plotly pandas scipy numpy
 
 EXPOSE 5000
 

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -23,15 +23,17 @@ RUN apt-get update && \
 
 
 COPY requirements.txt .
-RUN pip3 -q install -r requirements.txt
-
-RUN pip3 -q install aiomysql
-
+RUN python3 -m pip install --upgrade --no-cache-dir --upgrade pip && \
+  python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir -r requirements.txt && \
+  python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir aiomysql && \
+  python3 -m pip check
 
 ARG HAIL_WHEEL
 COPY $HAIL_WHEEL .
-RUN pip3 -q install $HAIL_WHEEL
+RUN python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir --quiet $HAIL_WHEEL && \
+  python3 -m pip check
 
 ARG BENCHMARK_WHEEL
 COPY $BENCHMARK_WHEEL .
-RUN pip3 -q install $BENCHMARK_WHEEL
+RUN python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir --quiet $BENCHMARK_WHEEL && \
+  python3 -m pip check

--- a/blog/Dockerfile.nginx
+++ b/blog/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 RUN apt-get update -y && \
     apt-get install -y nginx && \

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,9 @@
 steps:
+ - kind: buildImage
+   name: hail_ubuntu_image
+   dockerFile: docker/hail-ubuntu/Dockerfile
+   contextPath: docker/hail-ubuntu
+   publishAs: hail-ubuntu
  - kind: createNamespace
    name: default_ns
    namespaceName: default
@@ -19,6 +24,8 @@ steps:
    dockerFile: echo/Dockerfile
    contextPath: echo
    publishAs: echo
+   dependsOn:
+     - hail_ubuntu_image
  - kind: deploy
    name: deploy_echo
    namespace:
@@ -89,6 +96,8 @@ steps:
    dockerFile: docker/Dockerfile.base
    contextPath: .
    publishAs: base
+   dependsOn:
+    - hail_ubuntu_image
  - kind: buildImage
    name: service_base_image
    dockerFile: docker/Dockerfile.service-base
@@ -534,7 +543,7 @@ steps:
    contextPath: router
    publishAs: router
    dependsOn:
-     - base_image
+     - hail_ubuntu_image
  - kind: buildImage
    name: batch_image
    dockerFile: batch/Dockerfile
@@ -968,6 +977,7 @@ steps:
    publishAs: hail-base
    dependsOn:
     - build_hail
+    - hail_ubuntu_image
    inputs:
     - from: /wheel-container.tar
       to: /wheel-container.tar
@@ -978,6 +988,7 @@ steps:
    publishAs: hail-base
    dependsOn:
     - build_hail
+    - hail_ubuntu_image
    inputs:
     - from: /wheel-container.tar
       to: /wheel-container.tar
@@ -2193,14 +2204,18 @@ steps:
    name: netcat_ubuntu_image
    dockerFile:
      inline: |
-       FROM gcr.io/{{ global.project }}/ubuntu:18.04
+       FROM {{ hail_ubuntu_image.image }}
        RUN apt-get update && apt-get install netcat -y
+   dependsOn:
+    - hail_ubuntu_image
  - kind: buildImage
    name: curl_image
    dockerFile:
      inline: |
-       FROM gcr.io/{{ global.project }}/ubuntu:18.04
+       FROM {{ hail_ubuntu_image.image }}
        RUN apt-get update && apt-get install curl -y
+   dependsOn:
+    - hail_ubuntu_image
  - kind: runImage
    name: test_memory
    image:
@@ -2681,7 +2696,7 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /ssl-config
-   timeout: 2400
+   timeout: 5400
    scopes:
     - test
     - dev
@@ -3111,6 +3126,8 @@ steps:
    dockerFile: blog/Dockerfile.nginx
    contextPath: blog
    publishAs: blog_nginx
+   dependsOn:
+    - hail_ubuntu_image
  - kind: deploy
    name: deploy_blog
    namespace:
@@ -3242,6 +3259,7 @@ steps:
    publishAs: hail-public
    dependsOn:
     - copy_files
+    - hail_ubuntu_image
    inputs:
      - from: /hail_pip_version
        to: /hail_pip_version

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,8 +2,7 @@ FROM {{ service_base_image.image }}
 
 COPY ci/setup.py ci/MANIFEST.in /ci/
 COPY ci/ci /ci/ci/
-RUN pip3 install --no-cache-dir /ci && \
-  rm -rf /ci
+RUN hail-pip-install /ci && rm -rf /ci
 
 EXPOSE 5000
 

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -4,7 +4,7 @@ RUN apt-get update && \
   apt-get -y install docker.io && \
   rm -rf /var/lib/apt/lists/*
 
-RUN pip3 --no-cache-dir install twine
+RUN hail-pip-install twine
 
 COPY jinja2_render.py .
 COPY wait-for.py .

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -2,10 +2,6 @@ FROM {{ base_image.image }}
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
-RUN python3 -m pip install --no-cache-dir /hailtop \
-  && rm -rf /hailtop
-
+RUN hail-pip-install /hailtop && rm -rf /hailtop
 COPY ci/test/ /test/
-RUN python3 -m pip install --no-cache-dir \
-  pytest-instafail==0.4.1 \
-  pytest-asyncio==0.10.0
+RUN hail-pip-install pytest-instafail==0.4.1 pytest-asyncio==0.10.0

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -38,10 +38,17 @@ steps:
    dependsOn:
     - inline_image
  - kind: buildImage
+   name: hail_ubuntu_image
+   dockerFile: docker/hail-ubuntu/Dockerfile
+   contextPath: docker/hail-ubuntu
+   publishAs: hail-ubuntu
+ - kind: buildImage
    name: base_image
    dockerFile: docker/Dockerfile.base
    contextPath: .
    publishAs: base
+   dependsOn:
+    - hail_ubuntu_image
  - kind: buildImage
    name: service_base_image
    dockerFile: docker/Dockerfile.service-base

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -39,5 +39,5 @@ async def test_deploy():
             log.info(f'returning {deploy_status} {failure_information}')
             return deploy_state, failure_information
 
-        deploy_state, failure_information = await asyncio.wait_for(wait_forever(), timeout=30 * 60)
+        deploy_state, failure_information = await wait_forever()
         assert deploy_state == 'success', str(failure_information)

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
 
@@ -14,10 +14,7 @@ RUN apt-get update && \
     xsltproc pandoc \
     jq \
     openjdk-8-jdk-headless \
-    python \
-    python3.7 python3-pip python3.7-dev \
     liblapack3 \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 \
   && rm -rf /var/lib/apt/lists/*
 
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
@@ -26,23 +23,15 @@ RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
     /google-cloud-sdk/bin/gcloud -q components install beta kubectl
 ENV PATH $PATH:/google-cloud-sdk/bin
 
-RUN wget -nv -O spark-2.4.0-bin-hadoop2.7.tgz https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && \
-  tar xzf spark-2.4.0-bin-hadoop2.7.tgz && \
-  rm spark-2.4.0-bin-hadoop2.7.tgz
+COPY docker/requirements.txt .
+RUN hail-pip-install -r requirements.txt pyspark==2.4.0
+
+ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
+ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
+ENV PYSPARK_PYTHON python3
 
 # Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
-RUN wget -nv -O /spark-2.4.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
-COPY docker/core-site.xml /spark-2.4.0-bin-hadoop2.7/conf/core-site.xml
-
-ENV SPARK_HOME /spark-2.4.0-bin-hadoop2.7
-ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
-
-COPY docker/requirements.txt .
-# re: pip install --upgrade pip: https://github.com/grpc/grpc/issues/22815
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install --no-cache-dir --upgrade -r requirements.txt
-
-ENV PYTHONPATH "${PYTHONPATH:+${PYTHONPATH}:}$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip"
-ENV PYSPARK_PYTHON python3
+RUN wget -nv -O ${SPARK_HOME}/jars/gcs-connector-hadoop2-2.0.1.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar
+COPY docker/core-site.xml ${SPARK_HOME}/conf/core-site.xml
 
 COPY pylintrc setup.cfg /

--- a/docker/Dockerfile.service-base
+++ b/docker/Dockerfile.service-base
@@ -3,22 +3,20 @@ FROM {{ base_image.image }}
 RUN apt-get update && \
   apt-get -y install \
     build-essential \
+    python3-dev \
   && rm -rf /var/lib/apt/lists/*
 
 COPY docker/service-base-requirements.txt .
-RUN python3 -m pip install --no-cache-dir -U -r service-base-requirements.txt
+RUN hail-pip-install -r service-base-requirements.txt
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
-RUN python3 -m pip install --no-deps --no-cache-dir /hailtop \
-  && rm -rf /hailtop
+RUN hail-pip-install /hailtop && rm -rf /hailtop
 
 COPY gear/setup.py /gear/setup.py
 COPY gear/gear /gear/gear/
-RUN python3 -m pip install --no-deps --no-cache-dir /gear \
-  && rm -rf /gear
+RUN hail-pip-install /gear && rm -rf /gear
 
 COPY web_common/setup.py web_common/MANIFEST.in /web_common/
 COPY web_common/web_common /web_common/web_common/
-RUN pip3 install --no-cache-dir /web_common && \
-  rm -rf /web_common
+RUN hail-pip-install /web_common && rm -rf /web_common

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,10 @@
 include ../config.mk
 
 .PHONY: build
-build: base-stmp service-base
+build: base-stmp service-base hail-ubuntu
+
+BASE_LATEST = gcr.io/$(PROJECT)/hail-ubuntu:latest
+BASE_IMAGE = gcr.io/$(PROJECT)/hail-ubuntu:$(shell docker images -q --no-trunc hail-ubuntu:latest | sed -e 's,[^:]*:,,')
 
 BASE_LATEST = gcr.io/$(PROJECT)/base:latest
 BASE_IMAGE = gcr.io/$(PROJECT)/base:$(shell docker images -q --no-trunc base:latest | sed -e 's,[^:]*:,,')
@@ -15,29 +18,37 @@ HAIL_PUBLIC_IMAGE = gcr.io/$(PROJECT)/hail-public:$(shell docker images -q --no-
 GENETICS_PUBLIC_LATEST = gcr.io/$(PROJECT)/genetics-public:latest
 GENETICS_PUBLIC_IMAGE = gcr.io/$(PROJECT)/genetics-public:$(shell docker images -q --no-trunc genetics-public:latest | sed -e 's,[^:]*:,,')
 
+.PHONY: hail-ubuntu
+hail-ubuntu: hail-ubuntu-stmp
+
+hail-ubuntu-stmp: hail-ubuntu/Dockerfile hail-ubuntu/hail_pip_install hail-ubuntu/pip.conf
+	-docker pull gcr.io/$(PROJECT)/ubuntu:bionic-20200921
+	-docker pull $(HAIL_UBUNTU_LATEST)
+	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' hail-ubuntu/Dockerfile hail-ubuntu/Dockerfile.out
+	docker build -t hail-ubuntu -f hail-ubuntu/Dockerfile.out --cache-from hail-ubuntu,$(HAIL_UBUNTU_LATEST),ubuntu:bionic-20200921 hail-ubuntu
+	touch hail-ubuntu-stmp
+
 .PHONY: base
 base: base-stmp
 
-base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
-	-docker pull gcr.io/$(PROJECT)/ubuntu:18.04
+base-stmp: hail-ubuntu-stmp Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull $(BASE_LATEST)
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile.base Dockerfile.base.out
 	[ "$(shell bash stat-permissions.sh Dockerfile.base)" = "644" ]
 	[ "$(shell bash stat-permissions.sh core-site.xml)" = "644" ]
 	[ "$(shell bash stat-permissions.sh requirements.txt)" = "644" ]
 	[ "$(shell bash stat-permissions.sh ../pylintrc)" = "644" ]
 	[ "$(shell bash stat-permissions.sh ../setup.cfg)" = "644" ]
-	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile.base Dockerfile.base.out
-	docker build -t base -f Dockerfile.base.out --cache-from base,$(BASE_LATEST),gcr.io/$(PROJECT)/ubuntu:18.04 ..
+	docker build -t base -f Dockerfile.base.out --cache-from base,$(BASE_LATEST),hail-ubuntu ..
 	touch base-stmp
 
 .PHONY: service-base
 service-base: base-stmp
-	-docker pull gcr.io/$(PROJECT)/ubuntu:18.04
 	-docker pull $(SERVICE_BASE_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
 	[ "$(shell bash stat-permissions.sh Dockerfile.service-base.out)" = "644" ]
 	[ "$(shell bash stat-permissions.sh service-base-requirements.txt)" = "644" ]
-	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base,gcr.io/$(PROJECT)/ubuntu:18.04 ..
+	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base,hail-ubuntu ..
 
 .PHONY: hail-public-image
 hail-public-image:
@@ -45,9 +56,9 @@ hail-public-image:
 	cp ../hail/build/deploy/dist/hail-*-py3-none-any.whl hail/
 	cd hail && tar -cvf wheel-container.tar hail-*-py3-none-any.whl
 	-docker pull $(HAIL_PUBLIC_LATEST)
-	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' hail/Dockerfile hail/Dockerfile.out
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile.base Dockerfile.base.out
 	docker build hail -f hail/Dockerfile.out -t hail-public \
-     --cache-from hail-public,$(HAIL_PUBLIC_LATEST),ubuntu:18.04 \
+     --cache-from hail-public,$(HAIL_PUBLIC_LATEST)hail-ubuntu \
      hail
 
 .PHONY: genetics-public-image

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/{{ global.project }}/ubuntu:bionic-20200921
+ENV LANG C.UTF-8
+RUN apt-get update && apt-get install -y python3.7 python3.7-dev python3-pip && rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
+    python3 -m pip install --upgrade --no-cache-dir pip
+COPY pip.conf /root/.config/pip/pip.conf
+COPY hail-pip-install /bin/hail-pip-install

--- a/docker/hail-ubuntu/hail-pip-install
+++ b/docker/hail-ubuntu/hail-pip-install
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+python3 -m pip install "$@"
+exec python3 -m pip check

--- a/docker/hail-ubuntu/pip.conf
+++ b/docker/hail-ubuntu/pip.conf
@@ -1,0 +1,6 @@
+[global]
+timeout = 5
+use-feature = 2020-resolver
+upgrade = true
+no-cache-dir = true
+retries = 5

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -1,6 +1,5 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
-ENV LANG C.UTF-8
 ENV MAKEFLAGS -j2
 
 RUN apt-get update && \
@@ -15,7 +14,7 @@ RUN apt-get update && \
     vim \
   && rm -rf /var/lib/apt/lists/*
 COPY hail_pip_version /
-RUN pip3 --no-cache-dir install \
+RUN hail-pip-install \
       hail==$(cat /hail_pip_version) \
       ipython \
       matplotlib \

--- a/docker/python-dill/Dockerfile
+++ b/docker/python-dill/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:@PYTHON_VERSION@
-RUN pip install -U --no-cache-dir dill numpy scipy sklearn && \
+RUN pip install --use-feature=2020-resolver --upgrade --no-cache-dir dill numpy scipy sklearn && \
+    python3 -m pip check && \
     apt-get update && \
     apt-get install -y \
       libopenblas-base \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -34,7 +34,7 @@ prometheus_async==19.2.0
 prometheus_client==0.7.1
 pyjwt==1.7.1
 pylint==2.6.0
-PyMySQL==0.9.3
+PyMySQL==0.9.2
 pytest==4.6.3
 pytest-asyncio==0.10.0
 pytest-html==1.20.0
@@ -55,4 +55,3 @@ wheel>=0.31.0
 # yarl 1.6.0 broke query string parsing in aiohttp 3.6.[012] https://github.com/aio-libs/aiohttp/issues/4972#issuecomment-700290809
 yarl<1.6.0
 zulip==0.6.3
-six>1.14.0

--- a/docker/third-party/images.txt
+++ b/docker/third-party/images.txt
@@ -13,5 +13,6 @@ python:3.8
 python:3.8-slim
 redis:6.0.6-alpine
 ubuntu:18.04
+ubuntu:bionic-20200921
 ubuntu:19.04
 ubuntu:20.04

--- a/echo/Dockerfile
+++ b/echo/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 RUN apt-get update && apt-get install -y socat
 CMD ["socat", "TCP4-LISTEN:5000,fork", "EXEC:cat"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 RUN apt-get update -y && \
     apt-get install -y nginx && \

--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -6,9 +6,10 @@ GATEWAY_LATEST = gcr.io/$(PROJECT)/gateway:latest
 GATEWAY_IMAGE = gcr.io/$(PROJECT)/gateway:$(shell docker images -q --no-trunc gateway | sed -e 's,[^:]*:,,')
 
 build:
-	docker pull ubuntu:18.04
+	$(MAKE) -C ../docker hail-ubuntu
 	-docker pull $(GATEWAY_LATEST)
-	docker build -t gateway --cache-from gateway,$(GATEWAY_LATEST),ubuntu:18.04 .
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile Dockerfile.out
+	docker build -t gateway -f Dockerfile.out --cache-from gateway,$(GATEWAY_LATEST),hail-ubuntu .
 
 push: build
 	docker tag gateway $(GATEWAY_LATEST)

--- a/hail/Dockerfile.hail-pip-installed-python36
+++ b/hail/Dockerfile.hail-pip-installed-python36
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
 
@@ -11,10 +11,10 @@ RUN apt-get update && \
 
 COPY hail/python/requirements.txt requirements.txt
 COPY hail/python/dev-requirements.txt dev-requirements.txt
-RUN python3 -m pip install -U -r requirements.txt -r dev-requirements.txt
+RUN hail-pip-install -r requirements.txt -r dev-requirements.txt
 
 COPY wheel-container.tar wheel-container.tar
 RUN tar -xf wheel-container.tar && \
-    python3 -m pip install hail-*-py3-none-any.whl
+    hail-pip-install hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /

--- a/hail/Dockerfile.hail-pip-installed-python37
+++ b/hail/Dockerfile.hail-pip-installed-python37
@@ -1,20 +1,18 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
   apt-get -y install \
     openjdk-8-jdk-headless \
-    python3.7 python3-pip \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY hail/python/requirements.txt requirements.txt
 COPY hail/python/dev-requirements.txt dev-requirements.txt
-RUN python3 -m pip install -U -r requirements.txt -r dev-requirements.txt
+RUN hail-pip-install -r requirements.txt -r dev-requirements.txt
 
 COPY wheel-container.tar wheel-container.tar
 RUN tar -xf wheel-container.tar && \
-    python3 -m pip install hail-*-py3-none-any.whl
+    hail-pip-install hail-*-py3-none-any.whl
 
 COPY pylintrc setup.cfg /

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -2,7 +2,7 @@ FROM {{ service_base_image.image }}
 
 COPY python/requirements.txt .
 COPY python/dev-requirements.txt .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt -r dev-requirements.txt
+RUN hail-pip-install -r requirements.txt -r dev-requirements.txt
 
 RUN apt-get update && \
   apt-get -y install \

--- a/hail/Dockerfile.hailtop
+++ b/hail/Dockerfile.hailtop
@@ -2,5 +2,4 @@ FROM {{ base_image.image }}
 
 COPY python/setup-hailtop.py /hailtop/setup.py
 COPY python/hailtop /hailtop/hailtop/
-RUN python3 -m pip install --no-cache-dir /hailtop \
-  && rm -rf /hailtop
+RUN hail-pip-install /hailtop && rm -rf /hailtop

--- a/internal-gateway/Dockerfile
+++ b/internal-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 RUN apt-get update -y && \
     apt-get install -y nginx && \

--- a/internal-gateway/Makefile
+++ b/internal-gateway/Makefile
@@ -6,10 +6,10 @@ INTERNAL_GATEWAY_LATEST = gcr.io/$(PROJECT)/internal-gateway:latest
 INTERNAL_GATEWAY_IMAGE = gcr.io/$(PROJECT)/internal-gateway:$(shell docker images -q --no-trunc internal-gateway | sed -e 's,[^:]*:,,')
 
 build:
-	docker pull gcr.io/$(PROJECT)/ubuntu:18.04
+	$(MAKE) -C ../docker hail-ubuntu
 	-docker pull $(INTERNAL_GATEWAY_LATEST)
-	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile Dockerfile.out
-	docker build -f Dockerfile.out -t internal-gateway --cache-from internal-gateway,$(INTERNAL_GATEWAY_LATEST),gcr.io/$(PROJECT)/ubuntu:18.04 .
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile Dockerfile.out
+	docker build -t internal-gateway -f Dockerfile.out --cache-from internal-gateway,$(INTERNAL_GATEWAY_LATEST),hail-ubuntu .
 
 push: build
 	docker tag internal-gateway $(INTERNAL_GATEWAY_LATEST)

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 RUN apt-get update -y
 

--- a/letsencrypt/Makefile
+++ b/letsencrypt/Makefile
@@ -1,5 +1,8 @@
 include ../config.mk
 
+LETSENCRYPT_LATEST = gcr.io/$(PROJECT)/letsencrypt:latest
+LETSENCRYPT_IMAGE = gcr.io/$(PROJECT)/letsencrypt:$(shell docker images -q --no-trunc letsencrypt | sed -e 's,[^:]*:,,')
+
 STATIC_CONFIG = letsencrypt-pod.yaml letsencrypt.sh
 
 .PHONY: $(STATIC_CONFIG) build push start-service run clean
@@ -12,17 +15,21 @@ $(STATIC_CONFIG): %: %.in
 	  < $< > $@
 
 build: letsencrypt.sh
-	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile Dockerfile.out
-	docker build -f Dockerfile.out -t letsencrypt .
+	$(MAKE) -C ../docker hail-ubuntu
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile Dockerfile.out
+	docker build -f Dockerfile.out -t letsencrypt --cache-from letsencrypt,$(LETSENCRYPT_LATEST),hail-ubuntu .
 
 push: build
-	docker tag letsencrypt gcr.io/$(PROJECT)/letsencrypt
-	docker push gcr.io/$(PROJECT)/letsencrypt
+	docker tag letsencrypt $(LETSENCRYPT_LATEST)
+	docker push $(LETSENCRYPT_LATEST)
+	docker tag letsencrypt $(LETSENCRYPT_IMAGE)
+	docker push $(LETSENCRYPT_IMAGE)
 
 start-service: service.yaml
 	kubectl -n default apply -f service.yaml
 
 run: letsencrypt-pod.yaml service.yaml push
+	python3 ../ci/jinja2_render.py '{"letsencrypt_image":{"image":"$(LETSENCRYPT_IMAGE)"}}' letsencrypt-pod.yaml letsencrypt-pod.yaml.out
 	/bin/bash run-letsencrypt.sh
 
 clean:

--- a/letsencrypt/run-letsencrypt.sh
+++ b/letsencrypt/run-letsencrypt.sh
@@ -14,7 +14,7 @@ while [[ $N != 0 ]]; do
 done
 
 # run letsencrypt pod
-kubectl -n default create -f letsencrypt-pod.yaml
+kubectl -n default create -f letsencrypt-pod.yaml.out
 echo "Waiting for letsencrypt to complete..."
 EC=""
 while [[ $EC = "" ]]; do

--- a/memory/Dockerfile
+++ b/memory/Dockerfile
@@ -2,7 +2,6 @@ FROM {{ service_base_image.image }}
 
 COPY memory/setup.py /memory/
 COPY memory/memory /memory/memory/
-RUN pip3 install --no-cache-dir /memory && \
-  rm -rf /memory
+RUN hail-pip-install /memory && rm -rf /memory
 
 EXPOSE 5000

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -4,7 +4,6 @@ COPY monitoring/monitoring /monitoring/monitoring/
 
 COPY monitoring/setup.py monitoring/MANIFEST.in  /monitoring/
 
-RUN pip3 install --no-cache-dir /monitoring && \
-    rm -rf /monitoring
+RUN hail-pip-install /monitoring && rm -rf /monitoring
 
 EXPOSE 5000

--- a/monitoring/Dockerfile.test
+++ b/monitoring/Dockerfile.test
@@ -1,6 +1,4 @@
 FROM {{ service_base_image.image }}
 
 COPY monitoring/test/ /test/
-RUN python3 -m pip install --no-cache-dir \
-  pytest-instafail==0.4.1 \
-  pytest-asyncio==0.10.0
+RUN hail-pip-install pytest-instafail==0.4.1 pytest-asyncio==0.10.0

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -2,8 +2,9 @@ FROM {{ service_base_image.image }}
 
 COPY notebook/setup.py notebook/MANIFEST.in /notebook/
 COPY notebook/notebook /notebook/notebook/
-RUN pip3 install --no-cache-dir /notebook && \
-  rm -rf /notebook
+RUN pip3 install --use-feature=2020-resolver --upgrade --no-cache-dir /notebook && \
+  rm -rf /notebook && \
+  python3 -m pip check
 
 EXPOSE 5000
 

--- a/notebook/images/hail/Dockerfile
+++ b/notebook/images/hail/Dockerfile
@@ -7,13 +7,14 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-RUN pip install --no-cache-dir \
+RUN pip install --use-feature=2020-resolver --upgrade --no-cache-dir \
   jupyter \
   jupyter-spark \
   "tornado<6" \
   hail==0.2.54 \
   jupyter_contrib_nbextensions \
   && \
+  pip check && \
   jupyter serverextension enable --user --py jupyter_spark && \
   jupyter nbextension install --user --py jupyter_spark && \
   jupyter contrib nbextension install --user && \

--- a/notebook/worker/Dockerfile
+++ b/notebook/worker/Dockerfile
@@ -7,11 +7,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 USER jovyan
 
-RUN pip install --no-cache-dir \
+RUN pip install --use-feature=2020-resolver --upgrade --no-cache-dir \
   'jupyter-spark<0.5' \
   hail==0.2.4 \
   jupyter_contrib_nbextensions \
   && \
+  pip check && \
   jupyter serverextension enable --user --py jupyter_spark && \
   jupyter nbextension install --user --py jupyter_spark && \
   jupyter contrib nbextension install --user && \

--- a/query/Dockerfile
+++ b/query/Dockerfile
@@ -2,8 +2,7 @@ FROM {{ service_base_image.image }}
 
 COPY query/setup.py /query/
 COPY query/query /query/query/
-RUN pip3 install --no-cache-dir /query && \
-  rm -rf /query
+RUN hail-pip-install /query && rm -rf /query
 
 COPY query/hail.jar /
 

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/{{ global.project }}/ubuntu:18.04
+FROM {{ hail_ubuntu_image.image }}
 
 RUN apt-get update -y && \
     apt-get install -y nginx && \

--- a/router/Makefile
+++ b/router/Makefile
@@ -5,10 +5,10 @@ ROUTER_IMAGE = gcr.io/$(PROJECT)/router:$(shell docker images -q --no-trunc rout
 
 .PHONY: build
 build:
-	docker pull gcr.io/$(PROJECT)/ubuntu:18.04
+	$(MAKE) -C ../docker hail-ubuntu
 	-docker pull $(ROUTER_LATEST)
-	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile Dockerfile.out
-	docker build -f Dockerfile.out -t router --cache-from router,$(ROUTER_LATEST),gcr.io/$(PROJECT)/ubuntu:18.04 .
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"hail-ubuntu"}}' Dockerfile Dockerfile.out
+	docker build -f Dockerfile.out -t router --cache-from router,$(ROUTER_LATEST),hail-ubuntu .
 
 .PHONY: push
 push: build

--- a/scorecard/Dockerfile
+++ b/scorecard/Dockerfile
@@ -2,8 +2,7 @@ FROM {{ service_base_image.image }}
 
 COPY scorecard/setup.py scorecard/MANIFEST.in /scorecard/
 COPY scorecard/scorecard /scorecard/scorecard/
-RUN pip3 install --no-cache-dir /scorecard && \
-  rm -rf /scorecard
+RUN hail-pip-install /scorecard && rm -rf /scorecard
 
 EXPOSE 5000
 

--- a/shuffler/Dockerfile
+++ b/shuffler/Dockerfile
@@ -1,7 +1,3 @@
 FROM {{ service_base_image.image }}
 
 COPY hail.jar /
-
-EXPOSE 443
-ENTRYPOINT ["java"]
-CMD ["-cp", "/spark-2.4.0-bin-hadoop2.7/jars/*:/hail.jar", "is.hail.services.shuffler.server.ShuffleServer"]

--- a/shuffler/deployment.yaml
+++ b/shuffler/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - name: shuffler
           image: "{{ shuffler_image.image }}"
+          command:
+            - "/bin/bash"
+            - "-c"
+            - "exec java -cp ${SPARK_HOME}/jars/*:/hail.jar is.hail.services.shuffler.server.ShuffleServer"
           env:
            - name: HAIL_DOMAIN
              value: "{{ global.domain }}"

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/{{ global.project }}/debian:9.5
 
-RUN apt-get update -y && \
+RUN apt-get update && \
     apt-get install -y nginx curl python-minimal && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We've had a number of pip issues recently, particularly incompatibilities with the `six` package. The central issue is that pip will install incompatible package versions with only a warning message. This primarily happens when a set of packages is installed (say in a parent image) and then a new set of packages are installed later. Pip attempts to satisfy all requirements of the packages in an installed set, but it does not consider the versions of packages already installed.

In this PR, I pervasively change every use of `pip` to be followed by the use of `pip check`. Pip check errors if there are incompatible package versions installed. Rather than change every place that we use `pip install`, I created an ubuntu image with a script, `hail-pip-install`, and pip configuration which makes it easy to do the right thing. Now, we should always install python packages like this:

```
hail-pip-install package1 package2 package3
```

The script will ensure that all packages are compatible with existing packages. Moreover, it will retry downloads five times.

I did not make every Dockerfile depend on the new hail-ubuntu-image because they are legacy Dockerfile that I didn't want to edit. These include the benchmark Dockerfile and some notebook workers.

PySpark presented a challenge because we did not install it via pip. As a result, packages, such as Hail, which depend on PySpark failed the `pip check`. I modified all uses of PySpark to instead use the standard pip-installed version of PySpark. In particular, take a look at how query and shuffler changed.

cc: @Dania-Abuhijleh @catoverdrive 