### PR TITLE
[docker] Teach Hail Ubuntu Image how to resiliently install apt packages

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -1,21 +1,12 @@
 FROM gcr.io/{{ global.project }}/python:3.7-slim-stretch
 
-RUN apt-get update && \
-  apt-get -y install \
-    curl \
-    gnupg \
-    xfsprogs && \
-  rm -rf /var/lib/apt/lists/*
-
-RUN export GCSFUSE_REPO=gcsfuse-bionic && \
-  echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
-RUN apt-get update && \
-  apt-get -y install \
-    fuse \
-    gcsfuse && \
-  rm -rf /var/lib/apt/lists/*
+COPY docker/hail-ubuntu/hail-apt-get-install /bin/hail-apt-get-install
+RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
+    hail-apt-get-install curl gnupg xfsprogs && \
+    export GCSFUSE_REPO=gcsfuse-bionic && \
+    echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    hail-apt-get-install fuse gcsfuse
 
 COPY docker/hail-ubuntu/pip.conf /root/.config/pip/pip.conf
 COPY docker/hail-ubuntu/hail-pip-install /bin/hail-pip-install

--- a/blog/Dockerfile.nginx
+++ b/blog/Dockerfile.nginx
@@ -1,8 +1,6 @@
 FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update -y && \
-    apt-get install -y nginx && \
-    rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install nginx
 
 RUN rm -f /etc/nginx/sites-enabled/default && \
     rm -f /etc/nginx/nginx.conf

--- a/build.yaml
+++ b/build.yaml
@@ -1599,6 +1599,7 @@ steps:
    dependsOn:
      - base_image
      - build_site_www
+     - hail_ubuntu_image
  - kind: deploy
    name: deploy_site
    namespace:
@@ -2205,7 +2206,7 @@ steps:
    dockerFile:
      inline: |
        FROM {{ hail_ubuntu_image.image }}
-       RUN apt-get update && apt-get install netcat -y
+       RUN hail-apt-get-install netcat
    dependsOn:
     - hail_ubuntu_image
  - kind: buildImage
@@ -2213,7 +2214,7 @@ steps:
    dockerFile:
      inline: |
        FROM {{ hail_ubuntu_image.image }}
-       RUN apt-get update && apt-get install curl -y
+       RUN hail-apt-get-install curl
    dependsOn:
     - hail_ubuntu_image
  - kind: runImage

--- a/ci/Dockerfile.ci-utils
+++ b/ci/Dockerfile.ci-utils
@@ -1,11 +1,7 @@
 FROM {{ service_base_image.image }}
 
-RUN apt-get update && \
-  apt-get -y install docker.io && \
-  rm -rf /var/lib/apt/lists/*
-
+RUN hail-apt-get-install docker.io
 RUN hail-pip-install twine
-
 COPY jinja2_render.py .
 COPY wait-for.py .
 COPY create_database.py .

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,9 +1,6 @@
 FROM {{ hail_ubuntu_image.image }}
 
-ENV LANG C.UTF-8
-
-RUN apt-get update && \
-  apt-get -y install \
+RUN hail-apt-get-install \
     git \
     htop \
     unzip bzip2 zip tar \
@@ -14,8 +11,7 @@ RUN apt-get update && \
     xsltproc pandoc \
     jq \
     openjdk-8-jdk-headless \
-    liblapack3 \
-  && rm -rf /var/lib/apt/lists/*
+    liblapack3
 
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \

--- a/docker/Dockerfile.service-base
+++ b/docker/Dockerfile.service-base
@@ -1,10 +1,6 @@
 FROM {{ base_image.image }}
 
-RUN apt-get update && \
-  apt-get -y install \
-    build-essential \
-    python3-dev \
-  && rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install build-essential python3-dev
 
 COPY docker/service-base-requirements.txt .
 RUN hail-pip-install -r service-base-requirements.txt

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,7 +21,7 @@ GENETICS_PUBLIC_IMAGE = gcr.io/$(PROJECT)/genetics-public:$(shell docker images 
 .PHONY: hail-ubuntu
 hail-ubuntu: hail-ubuntu-stmp
 
-hail-ubuntu-stmp: hail-ubuntu/Dockerfile hail-ubuntu/hail_pip_install hail-ubuntu/pip.conf
+hail-ubuntu-stmp: hail-ubuntu/Dockerfile hail-ubuntu/hail_pip_install hail-ubuntu/pip.conf hail-ubuntu/hail-apt-get-install
 	-docker pull gcr.io/$(PROJECT)/ubuntu:bionic-20200921
 	-docker pull $(HAIL_UBUNTU_LATEST)
 	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' hail-ubuntu/Dockerfile hail-ubuntu/Dockerfile.out

--- a/docker/genetics/Dockerfile
+++ b/docker/genetics/Dockerfile
@@ -1,13 +1,11 @@
 FROM {{ hail_public_image.image }}
 
-RUN apt-get update && \
-  apt-get -y install \
+RUN hail-apt-get-install \
     cmake \
     libbz2-dev \
     libcurl4-openssl-dev \
     liblzma-dev \
-    zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
+    zlib1g-dev
 
 RUN mkdir samtools && \
     (cd samtools && \
@@ -38,12 +36,10 @@ RUN mkdir gcta && \
      unzip gcta_1.93.1beta.zip && \
      rm -rf gcta_1.93.1beta.zip)
 
-RUN apt-get update && \
-  apt-get -y install \
+RUN hail-apt-get-install \
     libgsl-dev \
     liblapacke-dev \
-    libopenblas-dev \
-  && rm -rf /var/lib/apt/lists/*
+    libopenblas-dev
 
 RUN mkdir eigenstrat && \
     (cd eigenstrat && \

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,6 +1,8 @@
 FROM gcr.io/{{ global.project }}/ubuntu:bionic-20200921
 ENV LANG C.UTF-8
-RUN apt-get update && apt-get install -y python3.7 python3.7-dev python3-pip && rm -rf /var/lib/apt/lists/* && \
+COPY hail-apt-get-install /bin/hail-apt-get-install
+RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
+    hail-apt-get-install python3.7 python3.7-dev python3-pip && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
     python3 -m pip install --upgrade --no-cache-dir pip
 COPY pip.conf /root/.config/pip/pip.conf

--- a/docker/hail-ubuntu/hail-apt-get-install
+++ b/docker/hail-ubuntu/hail-apt-get-install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+apt-get update
+apt-get -y install "$@"
+exec rm -rf /var/lib/apt/lists/*

--- a/docker/hail/Dockerfile
+++ b/docker/hail/Dockerfile
@@ -2,8 +2,7 @@ FROM {{ hail_ubuntu_image.image }}
 
 ENV MAKEFLAGS -j2
 
-RUN apt-get update && \
-  apt-get -y install \
+RUN hail-apt-get-install \
     curl \
     git \
     liblapack3 \
@@ -11,8 +10,7 @@ RUN apt-get update && \
     python3 python3-pip \
     rsync \
     unzip bzip2 zip tar \
-    vim \
-  && rm -rf /var/lib/apt/lists/*
+    vim
 COPY hail_pip_version /
 RUN hail-pip-install \
       hail==$(cat /hail_pip_version) \

--- a/echo/Dockerfile
+++ b/echo/Dockerfile
@@ -1,3 +1,3 @@
 FROM {{ hail_ubuntu_image.image }}
-RUN apt-get update && apt-get install -y socat
+RUN hail-apt-get-install socat
 CMD ["socat", "TCP4-LISTEN:5000,fork", "EXEC:cat"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,8 +1,6 @@
 FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update -y && \
-    apt-get install -y nginx && \
-    rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install nginx
 
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD gateway.nginx.conf /etc/nginx/conf.d/gateway.conf

--- a/hail/Dockerfile.hail-build
+++ b/hail/Dockerfile.hail-build
@@ -1,6 +1,3 @@
 FROM {{ base_image.image }}
 
-RUN apt-get update && \
-  apt-get -y install \
-    liblz4-dev \
-    maven
+RUN hail-apt-get-install liblz4-dev maven

--- a/hail/Dockerfile.hail-pip-installed-python36
+++ b/hail/Dockerfile.hail-pip-installed-python36
@@ -1,13 +1,10 @@
 FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
-
-RUN apt-get update && \
-  apt-get -y install \
+RUN hail-apt-get-install \
     openjdk-8-jdk-headless \
     python3.6 python3-pip \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
-  && rm -rf /var/lib/apt/lists/*
+  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 
 COPY hail/python/requirements.txt requirements.txt
 COPY hail/python/dev-requirements.txt dev-requirements.txt

--- a/hail/Dockerfile.hail-pip-installed-python37
+++ b/hail/Dockerfile.hail-pip-installed-python37
@@ -2,10 +2,7 @@ FROM {{ hail_ubuntu_image.image }}
 
 ENV LANG C.UTF-8
 
-RUN apt-get update && \
-  apt-get -y install \
-    openjdk-8-jdk-headless \
-  && rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install openjdk-8-jdk-headless
 
 COPY hail/python/requirements.txt requirements.txt
 COPY hail/python/dev-requirements.txt dev-requirements.txt

--- a/hail/Dockerfile.hail-repl
+++ b/hail/Dockerfile.hail-repl
@@ -1,8 +1,6 @@
 FROM {{ base_image.image }}
 ENV PYTHONPATH ""
-RUN apt-get update && \
-  apt-get -y install \
-    liblz4-dev
+RUN hail-apt-get-install liblz4-dev
 COPY wheel-container.tar ./
 RUN tar -xf wheel-container.tar && \
     pip3 install -U hail-*-py3-none-any.whl && \

--- a/hail/Dockerfile.hail-run
+++ b/hail/Dockerfile.hail-run
@@ -4,9 +4,7 @@ COPY python/requirements.txt .
 COPY python/dev-requirements.txt .
 RUN hail-pip-install -r requirements.txt -r dev-requirements.txt
 
-RUN apt-get update && \
-  apt-get -y install \
-    liblz4-dev
+RUN hail-apt-get-install liblz4-dev
 
 # FIXME belongs in hail-test image
 RUN mkdir -p plink && \

--- a/internal-gateway/Dockerfile
+++ b/internal-gateway/Dockerfile
@@ -1,9 +1,6 @@
 FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update -y && \
-    apt-get install -y nginx && \
-    rm -rf /var/lib/apt/lists/*
-
+RUN hail-apt-get-install nginx
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD nginx.conf /etc/nginx/
 ADD internal-gateway.nginx.conf /etc/nginx/conf.d/internal-gateway.conf

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,15 +1,10 @@
 FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update -y
-
 # get add-apt-repository
-RUN apt-get update -y && \
-    apt-get install -y nginx software-properties-common && \
+RUN hail-apt-get-install nginx software-properties-common && \
     bash -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata' && \
     add-apt-repository -y ppa:certbot/certbot && \
-    apt-get update -y && \
-    apt-get install -y python-certbot-nginx wget && \
-    rm -rf /var/lib/apt/lists/*
+    hail-apt-get-install python-certbot-nginx wget
 
 RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
     chmod +x /usr/local/bin/kubectl

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,8 +1,6 @@
 FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update -y && \
-    apt-get install -y nginx && \
-    rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install nginx
 
 RUN rm -f /etc/nginx/sites-enabled/default && \
     rm -f /etc/nginx/nginx.conf

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,8 +1,10 @@
-FROM gcr.io/{{ global.project }}/debian:9.5
+FROM {{ hail_ubuntu_image.image }}
 
-RUN apt-get update && \
-    apt-get install -y nginx curl python-minimal && \
-    rm -rf /var/lib/apt/lists/*
+RUN hail-apt-get-install \
+  nginx \
+  curl \
+  python-minimal \
+  libnginx-mod-http-subs-filter
 
 RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
     mv /root/google-cloud-sdk /

--- a/site/Makefile
+++ b/site/Makefile
@@ -47,8 +47,9 @@ push: build
 	docker push $(IMAGE)
 
 deploy: push
+	$(MAKE) -C ../docker hail-ubuntu
 	test $(NAMESPACE)
-	python3 ../ci/jinja2_render.py '{"global": {"domain":"hail.is"},"default_ns":{"name":"$(NAMESPACE)"},"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"site_image":{"image":"$(IMAGE)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"global": {"domain":"hail.is"},"default_ns":{"name":"$(NAMESPACE)"},"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"site_image":{"image":"$(IMAGE)"},"hail_ubuntu_image":{"image":"hail-ubuntu"}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out
 
 clean:

--- a/tls/Dockerfile
+++ b/tls/Dockerfile
@@ -1,11 +1,8 @@
 FROM {{ service_base_image.image }}
 
 # re: RANDFILE, https://github.com/openssl/openssl/issues/7754#issuecomment-444063355
-RUN apt-get update && \
-  apt-get -y install \
-    openssl \
-  && rm -rf /var/lib/apt/lists/* && \
-  sed -i 's/^RANDFILE/#RANDFILE/' /etc/ssl/openssl.cnf
+RUN hail-apt-get-install openssl && \
+    sed -i 's/^RANDFILE/#RANDFILE/' /etc/ssl/openssl.cnf
 
 COPY config.yaml .
 COPY create_certs.py .


### PR DESCRIPTION
This PR is stacked on #9593. The key files to look at are in `docker/hail-ubuntu`. I introduced `hail-apt-get-install` which packages up the `apt-get update` and the removal of temporary files. I also set the number of package-download retries to 5.