### PR TITLE
[query] Add PCodeParam and PCodeParamType

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -50,8 +50,8 @@ object Compile {
 
     val fb = EmitFunctionBuilder[F](ctx, "Compiled",
       CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
-        EmitParamType(pt)
-      }, returnType, Some("Emit.scala"))
+        pt.asEmitParam
+      }, returnType.asEmitParam, Some("Emit.scala"))
 
     /*
     {
@@ -112,8 +112,8 @@ object CompileWithAggregators {
     val returnType = ir.pType
     val fb = EmitFunctionBuilder[F](ctx, "CompiledWithAggs",
       CodeParamType(typeInfo[Region]) +: params.map { case (_, pt) =>
-        EmitParamType(pt)
-      }, returnType, Some("Emit.scala"))
+        pt.asEmitParam
+      }, returnType.asEmitParam, Some("Emit.scala"))
 
     /*
     {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1842,7 +1842,8 @@ class Emit[C](
           case ArraySort(a, l, r, lessThan) => (a, lessThan, Code._empty, Array(l, r))
           case ToSet(a) =>
             val discardNext = mb.genEmitMethod("discardNext",
-              FastIndexedSeq[ParamType](typeInfo[Region], eltType, eltType), typeInfo[Boolean])
+              FastIndexedSeq[ParamType](typeInfo[Region], eltType.asEmitParam, eltType.asEmitParam),
+              typeInfo[Boolean])
             val cmp2 = ApplyComparisonOp(EQWithNA(eltVType), In(0, eltType), In(1, eltType))
             InferPType(cmp2)
             val EmitCode(s, m, pv) = emitInMethod(cmp2, discardNext)
@@ -1862,7 +1863,8 @@ class Emit[C](
               case t: PTuple => (GetTupleElement(In(0, eltType), 0), GetTupleElement(In(1, eltType), 0), t.types(0))
             }
             val discardNext = mb.genEmitMethod("discardNext",
-              FastIndexedSeq[ParamType](typeInfo[Region], eltType, eltType), typeInfo[Boolean])
+              FastIndexedSeq[ParamType](typeInfo[Region], eltType.asEmitParam, eltType.asEmitParam),
+              typeInfo[Boolean])
 
             val cmp2 = ApplyComparisonOp(EQWithNA(keyType.virtualType), k0, k1).deepCopy()
             InferPType(cmp2)
@@ -1980,7 +1982,7 @@ class Emit[C](
         val compare2 = ApplyComparisonOp(EQWithNA(ktyp.virtualType), lastKey, currKey)
         InferPType(compare2)
         val isSame = mb.genEmitMethod("isSame",
-          FastIndexedSeq(typeInfo[Region], etyp, etyp),
+          FastIndexedSeq(typeInfo[Region], etyp.asEmitParam, etyp.asEmitParam),
           BooleanInfo)
         isSame.emitWithBuilder { cb =>
           val isSameCode = emitInMethod(compare2, isSame)
@@ -2227,7 +2229,7 @@ class Emit[C](
         val functionID: String = {
           val bodyFB = EmitFunctionBuilder[Region, Array[Byte], Array[Byte], Array[Byte]](ctx, "collect_distributed_array")
           val bodyMB = bodyFB.genEmitMethod("cdaBody",
-            Array[ParamType](typeInfo[Region], ctxType, gType),
+            Array[ParamType](typeInfo[Region], ctxType.asEmitParam, gType.asEmitParam),
             typeInfo[Long])
 
           val (cRetPtype, cDec) = x.contextSpec.buildEmitDecoderF[Long](bodyFB.ecb)
@@ -2448,7 +2450,7 @@ class Emit[C](
     var newEnv = getEnv(env, f)
 
     val sort = f.genEmitMethod("sort",
-      FastIndexedSeq(typeInfo[Region], elemPType, elemPType),
+      FastIndexedSeq(typeInfo[Region], elemPType.asEmitParam, elemPType.asEmitParam),
       BooleanInfo)
 
     if (leftRightComparatorNames.nonEmpty) {
@@ -3108,4 +3110,3 @@ abstract class NDArrayEmitter2(val outputShape: IEmitCodeGen[IndexedSeq[Value[Lo
     cb.append(columnMajorLoops)
   }
 }
-

--- a/hail/src/main/scala/is/hail/expr/ir/Param.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Param.scala
@@ -1,0 +1,32 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s.{Code, TypeInfo}
+import is.hail.types.physical.{PCode, PType}
+
+sealed trait ParamType  {
+  def nCodes: Int
+}
+
+case class CodeParamType(ti: TypeInfo[_]) extends ParamType {
+  def nCodes: Int = 1
+
+  override def toString: String = s"CodeParam($ti)"
+}
+
+case class PCodeParamType(pt: PType) extends ParamType {
+  def nCodes: Int = pt.nCodes
+
+  override def toString: String = s"PCodeParam($pt, $nCodes)"
+}
+
+case class EmitParamType(pt: PType) extends ParamType {
+  def nCodes: Int = pt.nCodes
+
+  override def toString: String = s"EmitParam($pt, $nCodes)"
+}
+
+sealed trait Param
+
+case class CodeParam(c: Code[_]) extends Param
+case class EmitParam(ec: EmitCode) extends Param
+case class PCodeParam(pc: PCode) extends Param

--- a/hail/src/main/scala/is/hail/expr/ir/Param.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Param.scala
@@ -3,6 +3,8 @@ package is.hail.expr.ir
 import is.hail.asm4s.{Code, TypeInfo}
 import is.hail.types.physical.{PCode, PType}
 
+import scala.language.existentials
+
 sealed trait ParamType  {
   def nCodes: Int
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -383,7 +383,7 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
 
   val seqOp: (EmitCodeBuilder, EmitCode, EmitCode) => Unit = {
     val mb = kb.genEmitMethod("take_by_seqop",
-      FastIndexedSeq[ParamType](valueType, keyType),
+      FastIndexedSeq[ParamType](valueType.asEmitParam, keyType.asEmitParam),
       UnitInfo)
 
     val value = mb.getEmitParam(1)

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -176,11 +176,13 @@ package object ir {
 
   implicit def toCodeParamType(ti: TypeInfo[_]): CodeParamType = CodeParamType(ti)
 
-  implicit def toEmitParamType(pt: PType): EmitParamType = EmitParamType(pt)
-
   implicit def toCodeParam(c: Code[_]): CodeParam = CodeParam(c)
 
   implicit def valueToCodeParam(v: Value[_]): CodeParam = CodeParam(v)
+
+  implicit def toPCodeParam(pc: PCode): PCodeParam = PCodeParam(pc)
+
+  implicit def pValueToPCodeParam(pv: PValue): PCodeParam = PCodeParam(pv)
 
   implicit def toEmitParam(ec: EmitCode): EmitParam = EmitParam(ec)
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -470,6 +470,10 @@ abstract class PType extends Serializable with Requiredness {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(ti)
 
+  def asParam: PCodeParamType = PCodeParamType(this)
+
+  def asEmitParam: EmitParamType = EmitParamType(this)
+
   def nCodes: Int = 1
 
   def codeReturnType(): TypeInfo[_] = ???


### PR DESCRIPTION
Remove implicit conversion from ptype to EmitParamType, adding asParam
and asEmitParam to PType for explicit conversion.

Currently PCodeParams are implemented pretty poorly as we should really
be creating the proper PValue from the parameters. This will require
either expanding nCodes for PCode or automatically memoizing the value
when getPCodeParam is called.

This is left for a future PR.