### PR TITLE
[hail] minor fixes

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -48,7 +48,7 @@ from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  
                         hadoop_stat, hadoop_exists, hadoop_is_file,
                         hadoop_is_dir, copy_log)
 
-from .context import (init, stop, spark_context, default_reference,  # noqa: E402
+from .context import (init, init_local, stop, spark_context, default_reference,  # noqa: E402
                       get_reference, set_global_seed, _set_flags, _get_flags, current_backend,
                       debug_info, citation, cite_hail, cite_hail_bibtex, version)
 
@@ -56,6 +56,7 @@ scan = agg.aggregators.ScanFunctions({name: getattr(agg, name) for name in agg._
 
 __all__ = [
     'init',
+    'init_local',
     'stop',
     'spark_context',
     'default_reference',

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -122,7 +122,7 @@ class LocalBackend(
   def execute(ir: IR): (Any, ExecutionTimer) =
     withExecuteContext() { ctx =>
       val queryID = Backend.nextID()
-      log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
+      log.info(s"starting execution of query $queryID of initial size ${ IRSize(ir) }")
       val (pt, a) = _execute(ctx, ir)
       log.info(s"finished execution of query $queryID")
       val result = pt match {

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -325,7 +325,7 @@ class SparkBackend(
   def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) =
     withExecuteContext() { ctx =>
       val queryID = Backend.nextID()
-      log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
+      log.info(s"starting execution of query $queryID of initial size ${ IRSize(ir) }")
       val (l, r) = _execute(ctx, ir, optimize)
       val javaObjResult = ctx.timer.time("convertRegionValueToAnnotation")(executionResultToAnnotation(ctx, l))
       log.info(s"finished execution of query $queryID")

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -90,7 +90,7 @@ case class MatrixNativeWriter(
     val rowWriter = SplitPartitionNativeWriter(
       rowSpec, s"$path/rows/rows/parts/",
       entrySpec, s"$path/entries/rows/parts/",
-      Some(s"$path/index/parts/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
+      Some(s"$path/index/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
 
     lowered.mapContexts { oldCtx =>
       val d = digitsNeeded(lowered.numPartitions)

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -50,7 +50,7 @@ case class TableNativeWriter(
     // write out partitioner key, which may be stricter than table key
     val partitioner = ts.partitioner
     val pKey: PStruct = coerce[PStruct](rowSpec.decodedPType(partitioner.kType))
-    val rowWriter = PartitionNativeWriter(rowSpec, s"$path/rows/parts/", Some(s"$path/index/parts/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
+    val rowWriter = PartitionNativeWriter(rowSpec, s"$path/rows/parts/", Some(s"$path/index/" -> pKey), if (stageLocally) Some(ctx.localTmpdir) else None)
     val globalWriter = PartitionNativeWriter(globalSpec, s"$path/globals/parts/", None, None)
 
     ts.mapContexts { oldCtx =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -215,7 +215,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
         cb.assign(filename, pContextType.loadString(pctx))
         if (hasIndex) {
           val indexFile = cb.newLocal[String]("indexFile")
-          cb.assign(indexFile, const(index.get._1).concat(filename))
+          cb.assign(indexFile, const(index.get._1).concat(filename).concat(".idx"))
           indexWriter.init(cb, indexFile)
         }
         cb.assign(filename, const(partPrefix).concat(filename))

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -151,7 +151,7 @@ object AbstractRVDSpec {
       Row(
         s"${ absPathLeft }/parts/${ partPath }",
         s"${ absPathRight }/parts/${ partPath }",
-        indexSpecLeft.map(indexSpec => s"${ absPathLeft }/${ indexSpec.relPath }/parts/${ partPath }").orNull,
+        indexSpecLeft.map(indexSpec => s"${ absPathLeft }/${ indexSpec.relPath }/${ partPath }.idx").orNull,
         RVDPartitioner.intervalToIRRepresentation(interval, kSize))
     }
 
@@ -512,7 +512,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
       val contextsValues: IndexedSeq[Row] = tmpPartitioner.rangeBounds.zip(partPaths).map { case (interval, partPath) =>
         Row(
           s"${ absPath }/parts/${ partPath }",
-          s"${ absPath }/${ indexSpec.relPath }/parts/${ partPath }",
+          s"${ absPath }/${ indexSpec.relPath }/${ partPath }.idx",
           RVDPartitioner.intervalToIRRepresentation(interval, kSize))
       }
 


### PR DESCRIPTION
 - Expose init_local.
 - Fix formatting of some error messages (stray }).
 - Fix index paths, they don't have a "parts" component, have ".idx" suffix.  This showed up as an issue interopreating between Spark and local modes.

FYI @tpoterba rather than just testing them independently, it might be worthwhile to have write/read interop tests between the various backends.  Spark to local is partially tested by the pre-existing (matrix)tables tests, but not the other way.