### PR TITLE
Fix isSupertype for Tuples

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -57,9 +57,16 @@ object PruneDeadFields {
               false
           }
         case (t1: TTuple, t2: TTuple) =>
-            t1.size == t2.size &&
-            t1.types.zip(t2.types)
-              .forall { case (elt1, elt2) => isSupertype(elt1, elt2) }
+          var idx = -1
+          t1.fields.forall { f =>
+            val t2field = t2.fields(t2.fieldIndex(f.index))
+            if (t2field.index > idx) {
+              idx = t2field.index
+              isSupertype(f.typ, t2field.typ)
+            } else {
+              false
+            }
+          }
         case (t1: Type, t2: Type) => t1 == t2
         case _ => fatal(s"invalid comparison: $superType / $subType")
       }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -36,6 +36,17 @@ class PruneSuite extends HailSuite {
       TStruct("c" -> TArray(TStruct.empty))) == TStruct("a" -> TStruct("ab" -> TStruct.empty), "c" -> TArray(TStruct.empty)))
   }
 
+  @Test def testIsSupertype(): Unit = {
+    val emptyTuple = TTuple.empty
+    val tuple1Int = TTuple(TInt32)
+    val tuple2Ints = TTuple(TInt32, TInt32)
+    val tuple2IntsFirstRemoved = TTuple(IndexedSeq(TupleField(1, TInt32)))
+
+    assert(PruneDeadFields.isSupertype(emptyTuple, tuple2Ints))
+    assert(PruneDeadFields.isSupertype(tuple1Int, tuple2Ints))
+    assert(PruneDeadFields.isSupertype(tuple2IntsFirstRemoved, tuple2Ints))
+  }
+
   def checkMemo(ir: BaseIR, requestedType: BaseType, expected: Array[BaseType]) {
     val irCopy = ir.deepCopy()
     assert(PruneDeadFields.isSupertype(requestedType, irCopy.typ),


### PR DESCRIPTION
`isSupertype` on a `TTuple` and a `TStruct` should behave identically. 