### PR TITLE
[query] Fix memory management for partition readers

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -704,7 +704,7 @@ abstract class PartitionReader {
     requestedType: Type,
     emitter: Emit[C],
     mb: EmitMethodBuilder[C],
-    region: StagedRegion,
+    partitionRegion: StagedRegion,
     env0: Emit.E,
     container: Option[AggContainer]): COption[SizedStream]
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -431,9 +431,10 @@ object TableNativeReader {
     val filterIntervals = params.options.map(_.filterIntervals).getOrElse(false)
 
     if (filterIntervals && !spec.indexed)
-      fatal("""`intervals` specified on an unindexed table.
-              |This table was written using an older version of hail
-              |rewrite the table in order to create an index to proceed""".stripMargin)
+      fatal(
+        """`intervals` specified on an unindexed table.
+          |This table was written using an older version of hail
+          |rewrite the table in order to create an index to proceed""".stripMargin)
 
     new TableNativeReader(params, spec)
   }
@@ -504,7 +505,9 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
 
 trait AbstractNativeReader extends PartitionReader {
   def spec: AbstractTypedCodecSpec
+
   def rowPType(requestedType: Type): PType = spec.decodedPType(requestedType)
+
   def fullRowType: Type = spec.encodedVirtualType
 }
 
@@ -516,11 +519,11 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec) extends AbstractN
     requestedType: Type,
     emitter: Emit[C],
     mb: EmitMethodBuilder[C],
-    region: StagedRegion,
+    partitionRegion: StagedRegion,
     env: Emit.E,
     container: Option[AggContainer]): COption[SizedStream] = {
 
-    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = region, container: Option[AggContainer] = container): EmitCode =
+    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = partitionRegion, container: Option[AggContainer] = container): EmitCode =
       emitter.emitWithRegion(ir, mb, region, env, container)
 
     val (eltType, dec) = spec.buildTypedEmitDecoderF[Long](requestedType, mb.ecb)
@@ -531,19 +534,18 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec) extends AbstractN
       val decRes = mb.newEmitLocal(PInt64Optional)
       val hasNext = mb.newLocal[Boolean]("pnr_hasNext")
       val next = mb.newLocal[Long]("pnr_next")
-      val stream = Stream.unfold[Code[Long]](
+
+      SizedStream.unsized(eltRegion => Stream.unfold[Code[Long]](
         (_, k) =>
           Code(
             hasNext := xRowBuf.readByte().toZ,
-            hasNext.orEmpty(next := dec(region.code,xRowBuf)),
+            hasNext.orEmpty(next := dec(eltRegion.code, xRowBuf)),
             k(COption(!hasNext, next))))
         .map(
           pc => EmitCode.present(eltType, pc),
           setup0 = None,
           setup = Some(xRowBuf := spec
-            .buildCodeInputBuffer(mb.open(pathString, true))))
-
-      SizedStream.unsized(eltRegion => stream)
+            .buildCodeInputBuffer(mb.open(pathString, true)))))
     }
   }
 
@@ -561,11 +563,11 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
     requestedType: Type,
     emitter: Emit[C],
     mb: EmitMethodBuilder[C],
-    region: StagedRegion,
+    partitionRegion: StagedRegion,
     env: Emit.E,
     container: Option[AggContainer]): COption[SizedStream] = {
 
-    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = region, container: Option[AggContainer] = container): EmitCode =
+    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = partitionRegion, container: Option[AggContainer] = container): EmitCode =
       emitter.emitWithRegion(ir, mb, region, env, container)
 
     val (eltType, makeDec) = spec.buildDecoder(ctx, requestedType)
@@ -579,15 +581,16 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
     val makeDecCode = mb.getObject[(InputStream => Decoder)](makeDec)
     COption.fromEmitCode(emitIR(context)).map { ctxStruct =>
       val getIndexReader: Code[String] => Code[IndexReader] = { (indexPath: Code[String]) =>
-          Code.checkcast[IndexReader](
-            makeIndexCode.invoke[AnyRef, AnyRef, AnyRef, AnyRef]("apply", mb.getFS, indexPath, Code.boxInt(8)))
+        Code.checkcast[IndexReader](
+          makeIndexCode.invoke[AnyRef, AnyRef, AnyRef, AnyRef]("apply", mb.getFS, indexPath, Code.boxInt(8)))
       }
 
       val hasNext = mb.newLocal[Boolean]("pnr_hasNext")
       val next = mb.newLocal[Long]("pnr_next")
       val idxr = mb.genFieldThisRef[IndexReader]("pnri_idx_reader")
       val it = mb.genFieldThisRef[IndexReadIterator]("pnri_idx_iterator")
-      val stream = Stream.unfold[Code[Long]](
+
+      SizedStream.unsized(eltRegion => Stream.unfold[Code[Long]](
         (_, k) =>
           Code(
             hasNext := it.invoke[Boolean]("hasNext"),
@@ -613,7 +616,7 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
                   String,
                   Interval,
                   InputMetrics](makeDecCode,
-                  region.code,
+                  eltRegion.code,
                   mb.open(ctxMemo.loadField(cb, "partitionPath")
                     .get(cb)
                     .asString
@@ -635,9 +638,7 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
                   Code._null[InputMetrics]
                 ))
             }),
-          close = Some(it.invoke[Unit]("close")))
-
-      SizedStream.unsized(eltRegion => stream)
+          close = Some(it.invoke[Unit]("close"))))
     }
   }
 
@@ -678,11 +679,11 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
     requestedType: Type,
     emitter: Emit[C],
     mb: EmitMethodBuilder[C],
-    region: StagedRegion,
+    partitionRegion: StagedRegion,
     env: Emit.E,
     container: Option[AggContainer]): COption[SizedStream] = {
 
-    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = region, container: Option[AggContainer] = container): EmitCode =
+    def emitIR(ir: IR, env: Emit.E = env, region: StagedRegion = partitionRegion, container: Option[AggContainer] = container): EmitCode =
       emitter.emitWithRegion(ir, mb, region, env, container)
 
     val (leftRType, rightRType) = splitRequestedTypes(requestedType)
@@ -699,7 +700,7 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
         InsertFields(Ref("left", pLeft.virtualType),
           pRight.fieldNames.map(f =>
             f -> GetField(Ref("right", pRight.virtualType), f))))
-      (t, { (pidx: java.lang.Integer, r) => mk(pidx, r)})
+      (t, { (pidx: java.lang.Integer, r) => mk(pidx, r) })
     }
 
     val (eltType: PStruct, makeInserter) = fieldInserter(ctx, leftPType, rightPType)
@@ -758,7 +759,8 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
       val hasNext = mb.newLocal[Boolean]("pnr_hasNext")
       val next = mb.newLocal[Long]("pnr_next")
       val it = mb.genFieldThisRef[MaybeIndexedReadZippedIterator]("pnri_idx_iterator")
-      val stream = Stream.unfold[Code[Long]](
+
+      SizedStream.unsized(eltRegion => Stream.unfold[Code[Long]](
         (_, k) =>
           Code(
             hasNext := it.invoke[Boolean]("hasNext"),
@@ -785,8 +787,8 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
                   InputMetrics](
                   makeLeftDecCode,
                   makeRightDecCode,
-                  Code.checkcast[AsmFunction3RegionLongLongLong](makeInserterCode.invoke[AnyRef, AnyRef, AnyRef]("apply", Code.boxInt(0), region.code)),
-                  region.code,
+                  Code.checkcast[AsmFunction3RegionLongLongLong](makeInserterCode.invoke[AnyRef, AnyRef, AnyRef]("apply", Code.boxInt(0), eltRegion.code)),
+                  eltRegion.code,
                   mb.open(ctxMemo.loadField(cb, "leftPartitionPath")
                     .handle(cb, cb._fatal(""))
                     .asString
@@ -803,8 +805,7 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
                 ))
             }),
           close = Some(it.invoke[Unit]("close")))
-
-      SizedStream.unsized(eltRegion => stream)
+      )
     }
   }
 
@@ -866,7 +867,7 @@ class TableNativeReader(
     case _ => false
   }
 
-  override def toString(): String = s"TableNativeReader(${params})"
+  override def toString(): String = s"TableNativeReader(${ params })"
 
   override def lowerGlobals(ctx: ExecuteContext, requestedGlobalsType: TStruct): IR = {
     val globalsSpec = spec.globalsSpec
@@ -895,7 +896,9 @@ case class TableNativeZippedReader(
   specRight: AbstractTableSpec
 ) extends TableReader {
   def pathsUsed: Seq[String] = FastSeq(pathLeft, pathRight)
+
   private lazy val filterIntervals = options.map(_.filterIntervals).getOrElse(false)
+
   private def intervals = options.map(_.intervals)
 
   require((specLeft.table_type.rowType.fieldNames ++ specRight.table_type.rowType.fieldNames).areDistinct())
@@ -998,6 +1001,7 @@ case class TableNativeZippedReader(
       val rightStruct = reqStruct.filterSet(specRight.table_type.rowType.fieldNames.toSet)._1
       (leftStruct, rightStruct)
     }
+
     val (reqLeft, reqRight) = splitRequestedTypes(requestedType.rowType)
 
     AbstractRVDSpec.readZippedLowered(ctx,
@@ -1030,6 +1034,7 @@ case class TableFromBlockMatrixNativeReaderParameters(path: String, nPartitions:
 
 case class TableFromBlockMatrixNativeReader(params: TableFromBlockMatrixNativeReaderParameters, metadata: BlockMatrixMetadata) extends TableReader {
   def pathsUsed: Seq[String] = FastSeq(params.path)
+
   val getNumPartitions: Int = params.nPartitions.getOrElse(HailContext.backend.defaultParallelism)
 
   val partitionRanges = (0 until getNumPartitions).map { i =>
@@ -1163,7 +1168,7 @@ case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) 
           Iterator.range(0, nRowPartition)
             .map { _ =>
               bais.readValue(ctx.region)
-           }
+            }
         }
       }
     TableValue(ctx, typ, globals, RVD.unkeyed(resultRowType, rvd))
@@ -1467,7 +1472,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
       pfs.map(pf => (pf.name, pf.typ))
 
     def unionFieldPTypes(ps: PStruct, ps2: PStruct): IndexedSeq[(String, PType)] =
-      ps.fields.zip(ps2.fields).map { case(pf1, pf2) =>
+      ps.fields.zip(ps2.fields).map { case (pf1, pf2) =>
         (pf1.name, InferPType.getCompatiblePType(Seq(pf1.typ, pf2.typ)))
       }
 
@@ -1483,7 +1488,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
         (noIndex(leftRVDType.kType.fields), noIndex(leftRVDType.valueType.fields), rValueTypeFields)
       case "right" =>
         val keyTypeFields = leftRVDType.kType.fields.zip(rightRVDType.kType.fields).map({
-          case(pf1, pf2) => {
+          case (pf1, pf2) => {
             assert(pf1.typ isOfType pf2.typ)
             (pf1.name, pf2.typ)
           }
@@ -1497,7 +1502,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
         (keyTypeFields, lValueTypeFields, rValueTypeFields)
     }
 
-    val newRowPType = PCanonicalStruct(true, lkT ++ lvT ++ rvT :_*)
+    val newRowPType = PCanonicalStruct(true, lkT ++ lvT ++ rvT: _*)
 
     assert(newRowPType.virtualType == newRowType)
 
@@ -1705,7 +1710,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         rvb.startStruct()
         rvb.addFields(rowType, rv, keyIdx) // Add the key
         rvb.startMissingArray(localDataLength) // add the values
-      var i = 0
+        var i = 0
         while (i < rvs.length) {
           val (rv, j) = rvs(i)
           rvb.setArrayIndex(j)
@@ -1850,7 +1855,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         FastIndexedSeq(classInfo[Region], LongInfo, LongInfo), LongInfo,
         Coalesce(FastIndexedSeq(
           extracted.postAggIR,
-            Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ))))
+          Die("Internal error: TableMapRows: row expression missing", extracted.postAggIR.typ))))
 
       val rowIterationNeedsGlobals = Mentions(extracted.postAggIR, "global")
       val globalsBc =
@@ -1974,12 +1979,14 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             val path = tmpBase + "/" + partFile(d, i, TaskContext.get)
             val file1 = filesToMerge(i * 2)
             val file2 = filesToMerge(i * 2 + 1)
+
             def readToBytes(is: DataInputStream): Array[Byte] = {
               val len = is.readInt()
               val b = new Array[Byte](len)
               is.readFully(b)
               b
             }
+
             val b1 = using(new DataInputStream(fsBc.value.open(file1)))(readToBytes)
             val b2 = using(new DataInputStream(fsBc.value.open(file2)))(readToBytes)
             using(new DataOutputStream(fsBc.value.create(path))) { os =>
@@ -2123,7 +2130,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     tv.copy(
       typ = typ,
       rvd = tv.rvd.mapPartitionsWithIndexAndValue(RVDType(rTyp.asInstanceOf[PStruct], typ.key), partitionIndices)(itF))
-   }
+  }
 }
 
 case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {


### PR DESCRIPTION
Use eltRegion instead of partitionRegion.