### PR TITLE
[datasets][annotationdb] specify cloud storage platform (gcp or aws)

### DIFF
--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.js
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.js
@@ -69,7 +69,7 @@ function copy() {
 
 
 function updateTextArea() {
-    var text = "db = hl.experimental.DB()\nmt = db.annotate_rows_db(mt";
+    var text = "db = hl.experimental.DB(region='us', cloud='gcp')\nmt = db.annotate_rows_db(mt";
     $('input[type=checkbox]:checked').filter(".checkboxadd").each(function () {
         text += ', "' + $(this).val() + '"';
         $('#result').val(text + ')');

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -6,16 +6,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh37.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_autosomes.phase_3.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh37.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh37.mt"
+          }
         },
         "version": "phase_3"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh38.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh38.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_autosomes.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh38.mt"
+          }
         },
         "version": "phase_3"
       }
@@ -28,8 +38,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_chrMT.phase_3.GRCh37.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_chrMT.phase_3.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrMT.phase_3.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrMT.phase_3.GRCh37.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrMT.phase_3.GRCh37.mt"
+          }
         },
         "version": "phase_3"
       }
@@ -42,16 +57,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh37.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrX.phase_3.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh37.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh37.mt"
+          }
         },
         "version": "phase_3"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh38.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh38.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrX.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh38.mt"
+          }
         },
         "version": "phase_3"
       }
@@ -64,16 +89,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh37.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrY.phase_3.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh37.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh37.mt"
+          }
         },
         "version": "phase_3"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh38.mt",
-          "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh38.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrY.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh38.mt"
+          }
         },
         "version": "phase_3"
       }
@@ -91,16 +126,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/CADD.v1.4.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/CADD.v1.4.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/CADD.v1.4.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/CADD.v1.4.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/CADD.v1.4.GRCh37.ht"
+          }
         },
         "version": "1.4"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/CADD.v1.4.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/CADD.v1.4.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/CADD.v1.4.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/CADD.v1.4.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/CADD.v1.4.GRCh38.ht"
+          }
         },
         "version": "1.4"
       }
@@ -118,16 +163,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/DANN.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/DANN.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/DANN.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/DANN.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/DANN.GRCh37.ht"
+          }
         },
         "version": null
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/DANN.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/DANN.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/DANN.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/DANN.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/DANN.GRCh38.ht"
+          }
         },
         "version": null
       }
@@ -145,16 +200,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht"
+          }
         },
         "version": "release_95"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht"
+          }
         },
         "version": "release_95"
       }
@@ -172,16 +237,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht"
+          }
         },
         "version": "release_95"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht"
+          }
         },
         "version": "release_95"
       }
@@ -194,8 +269,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_gene_TPMs.v7.GRCh37.mt",
-          "us": "gs://hail-datasets-us/GTEx_RNA_seq_gene_TPMs.v7.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_RNA_seq_gene_TPMs.v7.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_gene_TPMs.v7.GRCh37.mt",
+            "us": "gs://hail-datasets-us/GTEx_RNA_seq_gene_TPMs.v7.GRCh37.mt"
+          }
         },
         "version": "v7"
       }
@@ -208,8 +288,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_gene_read_counts.v7.GRCh37.mt",
-          "us": "gs://hail-datasets-us/GTEx_RNA_seq_gene_read_counts.v7.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_RNA_seq_gene_read_counts.v7.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_gene_read_counts.v7.GRCh37.mt",
+            "us": "gs://hail-datasets-us/GTEx_RNA_seq_gene_read_counts.v7.GRCh37.mt"
+          }
         },
         "version": "v7"
       }
@@ -222,8 +307,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_junction_read_counts.v7.GRCh37.mt",
-          "us": "gs://hail-datasets-us/GTEx_RNA_seq_junction_read_counts.v7.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_RNA_seq_junction_read_counts.v7.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_RNA_seq_junction_read_counts.v7.GRCh37.mt",
+            "us": "gs://hail-datasets-us/GTEx_RNA_seq_junction_read_counts.v7.GRCh37.mt"
+          }
         },
         "version": "v7"
       }
@@ -236,8 +326,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_both_sexes.v2.GRCh37.mt",
-          "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_both_sexes.v2.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/UK_Biobank_Rapid_GWAS_both_sexes.v2.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_both_sexes.v2.GRCh37.mt",
+            "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_both_sexes.v2.GRCh37.mt"
+          }
         },
         "version": "v2"
       }
@@ -250,8 +345,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_female.v2.GRCh37.mt",
-          "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_female.v2.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/UK_Biobank_Rapid_GWAS_female.v2.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_female.v2.GRCh37.mt",
+            "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_female.v2.GRCh37.mt"
+          }
         },
         "version": "v2"
       }
@@ -264,8 +364,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_male.v2.GRCh37.mt",
-          "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_male.v2.GRCh37.mt"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/UK_Biobank_Rapid_GWAS_male.v2.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/UK_Biobank_Rapid_GWAS_male.v2.GRCh37.mt",
+            "us": "gs://hail-datasets-us/UK_Biobank_Rapid_GWAS_male.v2.GRCh37.mt"
+          }
         },
         "version": "v2"
       }
@@ -284,8 +389,13 @@
       {
         "reference_genome": null,
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/gene_specific_summary_2019-07.txt.gz.ht",
-          "us": "gs://hail-datasets-us/annotations/gene_specific_summary_2019-07.txt.gz.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/gene_specific_summary_2019-07.txt.gz.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/gene_specific_summary_2019-07.txt.gz.ht",
+            "us": "gs://hail-datasets-us/annotations/gene_specific_summary_2019-07.txt.gz.ht"
+          }
         },
         "version": "2019-07"
       }
@@ -301,16 +411,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/variant_summary_2019-07.GRCh37.txt.gz.ht",
-          "us": "gs://hail-datasets-us/annotations/variant_summary_2019-07.GRCh37.txt.gz.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/variant_summary_2019-07.GRCh37.txt.gz.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/variant_summary_2019-07.GRCh37.txt.gz.ht",
+            "us": "gs://hail-datasets-us/annotations/variant_summary_2019-07.GRCh37.txt.gz.ht"
+          }
         },
         "version": "2019-07"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/variant_summary_2019-07.GRCh38.txt.gz.ht",
-          "us": "gs://hail-datasets-us/annotations/variant_summary_2019-07.GRCh38.txt.gz.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/variant_summary_2019-07.GRCh38.txt.gz.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/variant_summary_2019-07.GRCh38.txt.gz.ht",
+            "us": "gs://hail-datasets-us/annotations/variant_summary_2019-07.GRCh38.txt.gz.ht"
+          }
         },
         "version": "2019-07"
       }
@@ -329,8 +449,13 @@
       {
         "reference_genome": null,
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
-          "us": "gs://hail-datasets-us/annotations/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
+            "us": "gs://hail-datasets-us/annotations/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht"
+          }
         },
         "version": "4.0"
       }
@@ -346,16 +471,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/dbnsfp4.0a.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/dbnsfp4.0a.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/dbnsfp4.0a.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/dbnsfp4.0a.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/dbnsfp4.0a.GRCh37.ht"
+          }
         },
         "version": "4.0"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/dbnsfp4.0a.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/dbnsfp4.0a.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/dbnsfp4.0a.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/dbnsfp4.0a.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/dbnsfp4.0a.GRCh38.ht"
+          }
         },
         "version": "4.0"
       }
@@ -371,16 +506,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/gencode.v19.annotation.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/gencode.v19.annotation.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/gencode.v19.annotation.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/gencode.v19.annotation.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/gencode.v19.annotation.GRCh37.ht"
+          }
         },
         "version": "v19"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/gencode.v31.annotation.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/gencode.v31.annotation.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/gencode.v31.annotation.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/gencode.v31.annotation.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/gencode.v31.annotation.GRCh38.ht"
+          }
         },
         "version": "v31"
       }
@@ -398,16 +543,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/GERP_elements.GERP++.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/GERP_elements.GERP++.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/GERP_elements.GERP++.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/GERP_elements.GERP++.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/GERP_elements.GERP++.GRCh37.ht"
+          }
         },
         "version": "hg19"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/GERP_elements.GERP++.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/GERP_elements.GERP++.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/GERP_elements.GERP++.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/GERP_elements.GERP++.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/GERP_elements.GERP++.GRCh38.ht"
+          }
         },
         "version": "hg19"
       }
@@ -425,16 +580,26 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/GERP_scores.GERP++.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/GERP_scores.GERP++.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/GERP_scores.GERP++.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/GERP_scores.GERP++.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/GERP_scores.GERP++.GRCh37.ht"
+          }
         },
         "version": "hg19"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/GERP_scores.GERP++.GRCh38.ht",
-          "us": "gs://hail-datasets-us/annotations/GERP_scores.GERP++.GRCh38.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/GERP_scores.GERP++.GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/GERP_scores.GERP++.GRCh38.ht",
+            "us": "gs://hail-datasets-us/annotations/GERP_scores.GERP++.GRCh38.ht"
+          }
         },
         "version": "hg19"
       }
@@ -452,14 +617,24 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "us": "gs://gnomad-public-requester-pays/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht"
+          }
         },
         "version": "2.1.1"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "us": "gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht"
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht"
+          }
         },
         "version": "2.1.1"
       }
@@ -477,14 +652,24 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "us": "gs://gnomad-public-requester-pays/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht"
+          }
         },
         "version": "2.1.1"
       },
       {
         "reference_genome": "GRCh38",
         "url": {
-          "us": "gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht"
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht"
+          }
         },
         "version": "2.1.1"
       }
@@ -502,8 +687,13 @@
       {
         "reference_genome": null,
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht",
-          "us": "gs://hail-datasets-us/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht",
+            "us": "gs://hail-datasets-us/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht"
+          }
         },
         "version": "2.1.1"
       }
@@ -521,8 +711,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-eu/annotations/LDSC_baselineLD_v2.2_ld_scores.GRCh37.ht",
-          "us": "gs://hail-datasets-us/annotations/LDSC_baselineLD_v2.2_ld_scores.GRCh37.ht"
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/annotations/LDSC_baselineLD_v2.2_ld_scores.GRCh37.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/annotations/LDSC_baselineLD_v2.2_ld_scores.GRCh37.ht",
+            "us": "gs://hail-datasets-us/annotations/LDSC_baselineLD_v2.2_ld_scores.GRCh37.ht"
+          }
         },
         "version": "2.2"
       }
@@ -535,8 +730,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-us/LDSC_baselineLD_v2.2_ld_scores.GRCh37.mt",
-          "us": "gs://hail-datasets-eu/LDSC_baselineLD_v2.2_ld_scores.GRCh37.mt"
+          "aws": {
+            "us": "gs://hail-datasets-eu/LDSC_baselineLD_v2.2_ld_scores.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-us/LDSC_baselineLD_v2.2_ld_scores.GRCh37.mt",
+            "us": "gs://hail-datasets-eu/LDSC_baselineLD_v2.2_ld_scores.GRCh37.mt"
+          }
         },
         "version": "2.2"
       }
@@ -549,8 +749,13 @@
       {
         "reference_genome": "GRCh37",
         "url": {
-          "eu": "gs://hail-datasets-us/LDSC_baseline_v1.1_ld_scores.GRCh37.mt",
-          "us": "gs://hail-datasets-eu/LDSC_baseline_v1.1_ld_scores.GRCh37.mt"
+          "aws": {
+            "us": "gs://hail-datasets-eu/LDSC_baseline_v1.1_ld_scores.GRCh37.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-us/LDSC_baseline_v1.1_ld_scores.GRCh37.mt",
+            "us": "gs://hail-datasets-eu/LDSC_baseline_v1.1_ld_scores.GRCh37.mt"
+          }
         },
         "version": "1.1"
       }

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -9,8 +9,8 @@ import pkg_resources
 def load_dataset(name: str,
                  version: str,
                  reference_genome: str,
-                 region: str,
-                 cloud: str) -> Union[hl.Table, hl.MatrixTable]:
+                 region: str = 'us',
+                 cloud: str = 'gcp') -> Union[hl.Table, hl.MatrixTable]:
     """Load a genetic dataset from Hail's repository.
 
     Example
@@ -28,14 +28,17 @@ def load_dataset(name: str,
     name : :class:`str`
         Name of the dataset to load.
     version : :class:`str`
-        Version of the named dataset to load
+        Version of the named dataset to load.
         (see available versions in documentation).
     reference_genome : :class:`str`
         Reference genome build, 'GRCh37' or 'GRCh38'.
     region : :class:`str`
         Specify region for bucket, 'us' or 'eu'.
+        Default is 'us'.
+        Note: 'eu' region is currently only available when cloud set to 'gcp'.
     cloud : :class:`str`
         Specify if using Google Cloud Platform or Amazon Web Services, 'gcp' or 'aws'.
+        Default is 'gcp'.
 
     Returns
     -------

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -49,7 +49,7 @@ def load_dataset(name: str,
     valid_clouds = {'gcp', 'aws'}
     if cloud not in valid_clouds:
         raise ValueError(f'Specify valid cloud parameter, received: cloud={repr(cloud)}. '
-                         f'Valid cloud values are {valid_clouds}.')
+                         f'Valid cloud platforms are {valid_clouds}.')
 
     config_path = pkg_resources.resource_filename(__name__, 'datasets.json')
     assert os.path.exists(config_path), f'{config_path} does not exist'

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -1,13 +1,16 @@
-import os
-import pkg_resources
 import json
+import os
+from typing import Union
+
 import hail as hl
+import pkg_resources
 
 
-def load_dataset(name,
-                 version,
-                 reference_genome,
-                 region):
+def load_dataset(name: str,
+                 version: str,
+                 reference_genome: str,
+                 region: str,
+                 cloud: str) -> Union[hl.Table, hl.MatrixTable]:
     """Load a genetic dataset from Hail's repository.
 
     Example
@@ -17,7 +20,8 @@ def load_dataset(name,
     >>> mt_1kg = hl.experimental.load_dataset(name='1000_Genomes_autosomes',   # doctest: +SKIP
     ...                                       version='phase_3',
     ...                                       reference_genome='GRCh38',
-    ...                                       region='us')
+    ...                                       region='us',
+    ...                                       cloud='gcp')
 
     Parameters
     ----------
@@ -26,10 +30,12 @@ def load_dataset(name,
     version : :class:`str`
         Version of the named dataset to load
         (see available versions in documentation).
-    reference_genome : `GRCh37` or `GRCh38`
-        Reference genome build.
-    region : `us` or `eu`
-        Specify region for GCP bucket.
+    reference_genome : :class:`str`
+        Reference genome build, 'GRCh37' or 'GRCh38'.
+    region : :class:`str`
+        Specify region for bucket, 'us' or 'eu'.
+    cloud : :class:`str`
+        Specify if using Google Cloud Platform or Amazon Web Services, 'gcp' or 'aws'.
 
     Returns
     -------
@@ -37,8 +43,13 @@ def load_dataset(name,
 
     valid_regions = {'us', 'eu'}
     if region not in valid_regions:
-        raise ValueError(f'Specify valid region parameter, received: region={region}. '
-                         f'Valid regions are {valid_regions}.')
+        raise ValueError(f'Specify valid region parameter, received: region={repr(region)}. '
+                         f'Valid region values are {valid_regions}.')
+
+    valid_clouds = {'gcp', 'aws'}
+    if cloud not in valid_clouds:
+        raise ValueError(f'Specify valid cloud parameter, received: cloud={repr(cloud)}. '
+                         f'Valid cloud values are {valid_clouds}.')
 
     config_path = pkg_resources.resource_filename(__name__, 'datasets.json')
     assert os.path.exists(config_path), f'{config_path} does not exist'
@@ -52,25 +63,33 @@ def load_dataset(name,
     versions = set(dataset['version'] for dataset in datasets[name]['versions'])
     if version not in versions:
         raise ValueError("""Version {0} not available for dataset {1}.
-                            Available versions: {{{2}}}.""".format(repr(version),
-                                                                   repr(name),
-                                                                   repr('","'.join(versions))))
+                            Available versions: {2}.""".format(repr(version),
+                                                               repr(name),
+                                                               repr(versions)))
 
     reference_genomes = set(dataset['reference_genome'] for dataset in datasets[name]['versions'])
     if reference_genome not in reference_genomes:
         raise ValueError("""Reference genome build {0} not available for dataset {1}.
-                            Available reference genome builds: {{'{2}'}}.""".format(repr(reference_genome),
-                                                                                    repr(name),
-                                                                                    '\',\''.join(reference_genomes)))
+                            Available reference genome builds: {2}.""".format(repr(reference_genome),
+                                                                              repr(name),
+                                                                              repr(reference_genomes)))
 
-    regions = set(k for dataset in datasets[name]['versions'] for k in dataset['url'].keys())
+    clouds = set(k for dataset in datasets[name]['versions'] for k in dataset['url'].keys())
+    if cloud not in clouds:
+        raise ValueError("""Cloud platform {0} not available for dataset {1}.
+                            Available cloud platforms: {2}.""".format(repr(cloud),
+                                                                      repr(name),
+                                                                      repr(clouds)))
+
+    regions = set(k for dataset in datasets[name]['versions'] for k in dataset['url'][cloud].keys())
     if region not in regions:
-        raise ValueError("""Region {0} not available for dataset {1}.
-                            Available regions: {{{2}}}.""".format(repr(region),
-                                                                  repr(name),
-                                                                  repr('","'.join(regions))))
+        raise ValueError("""Region {0} not available for dataset {1} on cloud platform {2}.
+                            Available regions: {3}.""".format(repr(region),
+                                                              repr(name),
+                                                              repr(cloud),
+                                                              repr(regions)))
 
-    path = [dataset['url'][region]
+    path = [dataset['url'][cloud][region]
             for dataset in datasets[name]['versions']
             if all([dataset['version'] == version,
                     dataset['reference_genome'] == reference_genome])]

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -20,11 +20,11 @@ class AnnotationDBTests(unittest.TestCase):
             'unique_dataset': {'description': 'now with unique rows!',
                                'url': 'https://example.com',
                                'annotation_db': {'key_properties': ['unique']},
-                               'versions': [{'url': fname, 'version': 'v1-GRCh37'}]},
+                               'versions': [{'url': fname, 'version': 'v1', 'reference_genome': 'GRCh37'}]},
             'nonunique_dataset': {'description': 'non-unique rows :(',
                                   'url': 'https://example.net',
                                   'annotation_db': {'key_properties': []},
-                                  'versions': [{'url': fname, 'version': 'v1-GRCh37'}]}}
+                                  'versions': [{'url': fname, 'version': 'v1', 'reference_genome': 'GRCh37'}]}}
 
     @classmethod
     def tearDownAnnotationDBTests(cls):

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -17,14 +17,29 @@ class AnnotationDBTests(unittest.TestCase):
         t.write(fname)
         cls.temp_dir = d
         cls.db_json = {
-            'unique_dataset': {'description': 'now with unique rows!',
-                               'url': 'https://example.com',
-                               'annotation_db': {'key_properties': ['unique']},
-                               'versions': [{'url': fname, 'version': 'v1', 'reference_genome': 'GRCh37'}]},
-            'nonunique_dataset': {'description': 'non-unique rows :(',
-                                  'url': 'https://example.net',
-                                  'annotation_db': {'key_properties': []},
-                                  'versions': [{'url': fname, 'version': 'v1', 'reference_genome': 'GRCh37'}]}}
+            'unique_dataset': {
+                'description': 'now with unique rows!',
+                'url': 'https://example.com',
+                'annotation_db': {'key_properties': ['unique']},
+                'versions': [{
+                    'url': {"aws": {"eu": fname, "us": fname},
+                            "gcp": {"eu": fname, "us": fname}},
+                    'version': 'v1',
+                    'reference_genome': 'GRCh37'
+                }]
+            },
+            'nonunique_dataset': {
+                'description': 'non-unique rows :(',
+                'url': 'https://example.net',
+                'annotation_db': {'key_properties': []},
+                'versions': [{
+                    'url': {"aws": {"eu": fname, "us": fname},
+                            "gcp": {"eu": fname, "us": fname}},
+                    'version': 'v1',
+                    'reference_genome': 'GRCh37'
+                }]
+            }
+        }
 
     @classmethod
     def tearDownAnnotationDBTests(cls):
@@ -35,7 +50,7 @@ class AnnotationDBTests(unittest.TestCase):
     tearDownClass = tearDownAnnotationDBTests
 
     def test_uniqueness(self):
-        db = hl.experimental.DB(region='us', config=AnnotationDBTests.db_json)
+        db = hl.experimental.DB(region='us', cloud='gcp', config=AnnotationDBTests.db_json)
         t = hl.utils.range_table(10)
         t = t.annotate(locus=hl.locus('1', t.idx + 1))
         t = db.annotate_rows_db(t, 'unique_dataset', 'nonunique_dataset')


### PR DESCRIPTION
This allows the user to specify the cloud platform ('gcp' or 'aws') they are using when accessing datasets via the datasets API and annotation DB. A user running hail on AWS would read from the s3 bucket, and a user running on GCP would read from the gs bucket (can also still read locally from gs bucket with cloud storage connector installed). Not intended for cross-platform use like running a dataproc cluster and trying to access the s3 bucket, or trying to access the gs bucket on an EMR cluster. Will assume user on AWS has their configuration set with their credentials. 

Did not have permissions to set up a cluster or EC2 instance on AWS to test, but was able to access all the datasets without issue on a dataproc cluster when using s3a:// prefixes and providing my AWS credentials in the spark config. So these changes should (hopefully) work fine on an EMR cluster with the s3:// client. Everything worked as expected on GCP.

Overview of changes:
- Added missing type hints to `load_dataset()` function and methods in `db.py`.
- In `datasets.json`:
  - Added AWS urls so now for each version of a dataset in dataset["versions"], the url entry looks like:
```
"url": {
  "aws": {
    "us": "s3://hail-datasets-us-east-1/..."
  },
  "gcp": {
    "eu": "gs://hail-datasets-eu/...",
    "us": "gs://hail-datasets-us/...
  }
```
- In `load_dataset()` function:
  - Added `cloud` parameter, set default values to `region='us'` and `cloud='gcp`.
- In `DB` class:
  - Added `cloud` parameter to constructor, set default values to `region='us'` and `cloud='gcp`.
  - All datasets in `datasets.json` currently end up in the `_DB__by_name` dictionary, even if not annotation datasets. Added line 279 in `db.py` to fix this and filter out datasets that are not annotation datasets (datasets missing "annotation_db" key).
- In `Dataset` class:
  - Added `cloud` and `custom_config` parameters to `Dataset.from_name_and_json()` to pass to `DatasetVersion.from_json()` to grab correct urls for platform.
  - Refactored `Dataset.from_name_and_json()`. Will require users passing a custom config to be of same format as what is in `datasets.json` for now. So each key: value pair in a user provided config should be as below:
```
"dataset_name": {
"annotation_db": {"key_properties": ["..."]},
"description": "...",
"url": "...",
"versions": [
  {
    "reference_genome": "...",
    "url": {"aws": {"eu": "...", "us": "..."},
            "gcp": {"eu": "...", "us": "..."}},
    "version": "..."
  }]}
```
- In `DatasetVersion` class:
  - Added `reference_genome` attribute, now that the version and reference genome are two separate fields in `datasets.json`.
  - Modified `DatasetVersion.from_json()` to handle cloud parameter to grab correct version url when using checked-in config file.