### PR TITLE
[hailctl dataproc] Print all gcloud args in hailctl dataproc modify

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -76,7 +76,7 @@ def main(args, pass_through_args):
         cmd.extend(pass_through_args)
 
         # print underlying gcloud command
-        print('gcloud ' + ' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join(cmd[5:]))
+        print('gcloud ' + ' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join(cmd[4:]))
 
         # Update cluster
         if not args.dry_run:


### PR DESCRIPTION
Currently, the `hailctl dataproc modify` does not print the first (after the cluster name) argument to `gcloud dataproc clusters update`. This bug was introduced in [#9078](https://github.com/hail-is/hail/pull/9078/files#diff-498f7c9ef8feab597e2213c7cbf2ca3d7f11c2f2427eea44850156ffc4c44fb0L54-R51).

For example:
```
$ hailctl dataproc modify some-cluster --num-workers 2 --dry-run
gcloud dataproc clusters update some-cluster \

```

With this change, the `--num-workers` argument is printed.
```
$ hailctl dataproc modify some-cluster --num-workers 2 --dry-run
gcloud dataproc clusters update some-cluster \
    --num-workers=2
```