### PR TITLE
[hailctl dataproc] Support interval fields in hailctl dataproc describe

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/describe.py
+++ b/hail/python/hailtop/hailctl/dataproc/describe.py
@@ -18,7 +18,7 @@ def parse_schema(s):
             if s[i] == end_delimiter:
                 if s[:i]:
                     values.append(s[:i])
-                if element_type in ['Array', 'Set', 'Dict', 'Tuple']:
+                if element_type in ['Array', 'Set', 'Dict', 'Tuple', 'Interval']:
                     return {'type': element_type, 'value': values}, s[i + 1:]
                 return {'type': element_type, 'value': OrderedDict(zip(keys, values))}, s[i + 1:]
 


### PR DESCRIPTION
`hailctl dataproc describe` does not currently display point types for interval fields.

For example, with this table:
```
ds = hl.utils.range_table(10)
ds = ds.annotate(interval=hl.parse_locus_interval(hl.str(ds.idx + 1) + ":1-100"))
ds.write("test.ht")
```

```
$ hailctl dataproc describe test.ht
...
----------------------------------------
Row fields:
    'idx': int32
    'interval': interval<>
----------------------------------------
...
```

With this change,
```
$ hailctl dataproc describe test.ht
...
----------------------------------------
Row fields:
    'idx': int32
    'interval': interval<locus<grch37>>
----------------------------------------
...
```