### PR TITLE
[hail] update execution timer

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -105,9 +105,9 @@ class ServiceBackend() extends Backend {
     users -= username
   }
 
-  def userContext[T](username: String)(f: (ExecuteContext) => T): T = {
+  def userContext[T](username: String, timer: ExecutionTimer)(f: (ExecuteContext) => T): T = {
     val user = users(username)
-    ExecuteContext.scoped(user.tmpdir, "file:///tmp", this, user.fs)(f)
+    ExecuteContext.scoped(user.tmpdir, "file:///tmp", this, user.fs, timer)(f)
   }
 
   def defaultParallelism: Int = 10
@@ -227,76 +227,86 @@ class ServiceBackend() extends Backend {
 
   def valueType(username: String, s: String): Response = {
     statusForException {
-      userContext(username) { ctx =>
-        val x = IRParser.parse_value_ir(ctx, s)
-        x.typ.toString
+      ExecutionTimer.logTime("ServiceBackend.valueType") { timer =>
+        userContext(username, timer) { ctx =>
+          val x = IRParser.parse_value_ir(ctx, s)
+          x.typ.toString
+        }
       }
     }
   }
 
   def tableType(username: String, s: String): Response = {
     statusForException {
-      userContext(username) { ctx =>
-        val x = IRParser.parse_table_ir(ctx, s)
-        val t = x.typ
-        val jv = JObject("global" -> JString(t.globalType.toString),
-          "row" -> JString(t.rowType.toString),
-          "row_key" -> JArray(t.key.map(f => JString(f)).toList))
-        JsonMethods.compact(jv)
+      ExecutionTimer.logTime("ServiceBackend.tableType") { timer =>
+        userContext(username, timer) { ctx =>
+          val x = IRParser.parse_table_ir(ctx, s)
+          val t = x.typ
+          val jv = JObject("global" -> JString(t.globalType.toString),
+            "row" -> JString(t.rowType.toString),
+            "row_key" -> JArray(t.key.map(f => JString(f)).toList))
+          JsonMethods.compact(jv)
+        }
       }
     }
   }
 
   def matrixTableType(username: String, s: String): Response = {
     statusForException {
-      userContext(username) { ctx =>
-        val x = IRParser.parse_matrix_ir(ctx, s)
-        val t = x.typ
-        val jv = JObject("global" -> JString(t.globalType.toString),
-          "col" -> JString(t.colType.toString),
-          "col_key" -> JArray(t.colKey.map(f => JString(f)).toList),
-          "row" -> JString(t.rowType.toString),
-          "row_key" -> JArray(t.rowKey.map(f => JString(f)).toList),
-          "entry" -> JString(t.entryType.toString))
-        JsonMethods.compact(jv)
+      ExecutionTimer.logTime("ServiceBackend.matrixTableType") { timer =>
+        userContext(username, timer) { ctx =>
+          val x = IRParser.parse_matrix_ir(ctx, s)
+          val t = x.typ
+          val jv = JObject("global" -> JString(t.globalType.toString),
+            "col" -> JString(t.colType.toString),
+            "col_key" -> JArray(t.colKey.map(f => JString(f)).toList),
+            "row" -> JString(t.rowType.toString),
+            "row_key" -> JArray(t.rowKey.map(f => JString(f)).toList),
+            "entry" -> JString(t.entryType.toString))
+          JsonMethods.compact(jv)
+        }
       }
     }
   }
 
   def blockMatrixType(username: String, s: String): Response = {
     statusForException {
-      userContext(username) { ctx =>
-        val x = IRParser.parse_blockmatrix_ir(ctx, s)
-        val t = x.typ
-        val jv = JObject("element_type" -> JString(t.elementType.toString),
-          "shape" -> JArray(t.shape.map(s => JInt(s)).toList),
-          "is_row_vector" -> JBool(t.isRowVector),
-          "block_size" -> JInt(t.blockSize))
-        JsonMethods.compact(jv)
+      ExecutionTimer.logTime("ServiceBackend.blockMatrixType") { timer =>
+        userContext(username, timer) { ctx =>
+          val x = IRParser.parse_blockmatrix_ir(ctx, s)
+          val t = x.typ
+          val jv = JObject("element_type" -> JString(t.elementType.toString),
+            "shape" -> JArray(t.shape.map(s => JInt(s)).toList),
+            "is_row_vector" -> JBool(t.isRowVector),
+            "block_size" -> JInt(t.blockSize))
+          JsonMethods.compact(jv)
+        }
       }
     }
   }
 
   def execute(username: String, sessionID: String, billingProject: String, bucket: String, code: String): Response = {
     statusForException {
-      userContext(username) { ctx =>
-        ctx.backendContext = new ServiceBackendContext(username, sessionID, billingProject, bucket)
+      ExecutionTimer.logTime("ServiceBackend.execute") { timer =>
+        userContext(username, timer) { ctx =>
+          ctx.backendContext = new ServiceBackendContext(username, sessionID, billingProject, bucket)
 
-        var x = IRParser.parse_value_ir(ctx, code)
-        x = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, x)
-          .asInstanceOf[IR]
-        val (pt, f) = Compile[AsmFunction1RegionLong](ctx,
-          FastIndexedSeq[(String, PType)](),
-          FastIndexedSeq[TypeInfo[_]](classInfo[Region]), LongInfo,
-          MakeTuple.ordered(FastIndexedSeq(x)),
-          optimize = true)
+          var x = IRParser.parse_value_ir(ctx, code)
+          x = LoweringPipeline.darrayLowerer(true)(DArrayLowering.All).apply(ctx, x)
+            .asInstanceOf[IR]
+          val (pt, f) = Compile[AsmFunction1RegionLong](ctx,
+            FastIndexedSeq[(String, PType)](),
+            FastIndexedSeq[TypeInfo[_]](classInfo[Region]), LongInfo,
+            MakeTuple.ordered(FastIndexedSeq(x)),
+            optimize = true)
 
-        val a = f(0, ctx.r)(ctx.r)
-        val v = new UnsafeRow(pt.asInstanceOf[PBaseStruct], ctx.r, a)
+          val a = f(0, ctx.r)(ctx.r)
+          val v = new UnsafeRow(pt.asInstanceOf[PBaseStruct], ctx.r, a)
 
-        JsonMethods.compact(
-          JObject(List("value" -> JSONAnnotationImpex.exportAnnotation(v.get(0), x.typ),
-            "type" -> JString(x.typ.toString))))
+          JsonMethods.compact(
+            JObject(List("value" -> JSONAnnotationImpex.exportAnnotation(v.get(0), x.typ),
+              "type" -> JString(x.typ.toString))))
+        }
       }
     }
   }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -243,8 +243,8 @@ class SparkBackend(
 
   def unpersist(id: String): Unit = bmCache.unpersistBlockMatrix(id)
 
-  def withExecuteContext[T]()(f: ExecuteContext => T): T = {
-    ExecuteContext.scoped(tmpdir, localTmpdir, this, fs)(f)
+  def withExecuteContext[T](timer: ExecutionTimer)(f: ExecuteContext => T): T = {
+    ExecuteContext.scoped(tmpdir, localTmpdir, this, fs, timer)(f)
   }
 
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new SparkBroadcastValue[T](sc.broadcast(value))
@@ -274,14 +274,17 @@ class SparkBackend(
   }
 
   def jvmLowerAndExecute(
+    timer: ExecutionTimer,
     ir0: IR,
     optimize: Boolean,
     lowerTable: Boolean,
     lowerBM: Boolean,
     print: Option[PrintWriter] = None
-  ): (Any, ExecutionTimer) = withExecuteContext() { ctx =>
-    val (l, r) = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
-    (executionResultToAnnotation(ctx, l), r)
+  ): Any = {
+    withExecuteContext(timer) { ctx =>
+      val l = _jvmLowerAndExecute(ctx, ir0, optimize, lowerTable, lowerBM, print)
+      executionResultToAnnotation(ctx, l)
+    }
   }
 
   private[this] def _jvmLowerAndExecute(
@@ -291,14 +294,14 @@ class SparkBackend(
     lowerTable: Boolean,
     lowerBM: Boolean,
     print: Option[PrintWriter] = None
-  ): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+  ): Either[Unit, (PTuple, Long)] = {
     val typesToLower: DArrayLowering.Type = (lowerTable, lowerBM) match {
       case (true, true) => DArrayLowering.All
       case (true, false) => DArrayLowering.TableOnly
       case (false, true) => DArrayLowering.BMOnly
       case (false, false) => throw new LowererUnsupportedOperation("no lowering enabled")
     }
-    val ir = LoweringPipeline.darrayLowerer(true)(typesToLower).apply(ctx, ir0).asInstanceOf[IR]
+    val ir = LoweringPipeline.darrayLowerer(optimize)(typesToLower).apply(ctx, ir0).asInstanceOf[IR]
 
     if (!Compilable(ir))
       throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${ Pretty(ir) }")
@@ -325,20 +328,20 @@ class SparkBackend(
         ctx.timer.time("Run")(Right((pt, f(0, ctx.r).apply(ctx.r))))
     }
 
-    (res, ctx.timer)
+    res
   }
 
-  def execute(ir: IR, optimize: Boolean): (Any, ExecutionTimer) =
-    withExecuteContext() { ctx =>
+  def execute(timer: ExecutionTimer, ir: IR, optimize: Boolean): Any =
+    withExecuteContext(timer) { ctx =>
       val queryID = Backend.nextID()
       log.info(s"starting execution of query $queryID of initial size ${ IRSize(ir) }")
-      val (l, r) = _execute(ctx, ir, optimize)
+      val l = _execute(ctx, ir, optimize)
       val javaObjResult = ctx.timer.time("convertRegionValueToAnnotation")(executionResultToAnnotation(ctx, l))
       log.info(s"finished execution of query $queryID")
-      (javaObjResult, r)
+      javaObjResult
     }
 
-  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean): (Either[Unit, (PTuple, Long)], ExecutionTimer) = {
+  private[this] def _execute(ctx: ExecuteContext, ir: IR, optimize: Boolean): Either[Unit, (PTuple, Long)] = {
     TypeCheck(ir)
     Validate(ir)
     try {
@@ -348,66 +351,67 @@ class SparkBackend(
     } catch {
       case e: LowererUnsupportedOperation if HailContext.getFlag("lower_only") != null => throw e
       case _: LowererUnsupportedOperation =>
-        (CompileAndEvaluate._apply(ctx, ir, optimize = optimize), ctx.timer)
+        CompileAndEvaluate._apply(ctx, ir, optimize = optimize)
     }
   }
 
   def executeLiteral(ir: IR): IR = {
     val t = ir.typ
     assert(t.isRealizable)
-    val (literalIR, timer) = withExecuteContext() { ctx =>
-      val queryID = Backend.nextID()
-      log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
-      val (retVal, timer) = _execute(ctx, ir, true)
-      val literalIR = retVal match {
-        case Left(x) => throw new HailException("Can't create literal")
-        case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.hailValueToByteArray(pt, addr, ctx), 0)
+    ExecutionTimer.logTime("SparkBackend.executeLiteral") { timer =>
+      withExecuteContext(timer) { ctx =>
+        val queryID = Backend.nextID()
+        log.info(s"starting execution of query $queryID} of initial size ${ IRSize(ir) }")
+        val retVal = _execute(ctx, ir, true)
+        val literalIR = retVal match {
+          case Left(x) => throw new HailException("Can't create literal")
+          case Right((pt, addr)) => GetFieldByIdx(EncodedLiteral.hailValueToByteArray(pt, addr, ctx), 0)
+        }
+        log.info(s"finished execution of query $queryID")
+        literalIR
       }
-
-      log.info(s"finished execution of query $queryID")
-      (literalIR, timer)
     }
-    timer.finish()
-    timer.logInfo()
-    literalIR
   }
 
   def executeJSON(ir: IR): String = {
-    val t = ir.typ
-    val (value, timings) = execute(ir, optimize = true)
-    val jsonValue = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
-    timings.finish()
-    timings.logInfo()
-
-    Serialization.write(Map("value" -> jsonValue, "timings" -> timings.asMap()))(new DefaultFormats {})
+    val (jsonValue, timer) = ExecutionTimer.time("SparkBackend.executeJSON") { timer =>
+      val t = ir.typ
+      val value = execute(timer, ir, optimize = true)
+      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value, t))
+    }
+    Serialization.write(Map("value" -> jsonValue, "timings" -> timer.toMap))(new DefaultFormats {})
   }
 
   // Called from python
   def encodeToBytes(ir: IR, bufferSpecString: String): (String, Array[Byte]) = {
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    withExecuteContext() { ctx =>
-      _execute(ctx, ir, true)._1 match {
-        case Left(_) => throw new RuntimeException("expression returned void")
-        case Right((t, off)) =>
-          assert(t.size == 1)
-          val elementType = t.fields(0).typ
-          val codec = TypedCodecSpec(
-            EType.defaultFromPType(elementType), elementType.virtualType, bs)
-          assert(t.isFieldDefined(off, 0))
-          (elementType.toString, codec.encode(ctx, elementType, t.loadField(off, 0)))
+    ExecutionTimer.logTime("SparkBackend.encodeToBytes") { timer =>
+      val bs = BufferSpec.parseOrDefault(bufferSpecString)
+      withExecuteContext(timer) { ctx =>
+        _execute(ctx, ir, true) match {
+          case Left(_) => throw new RuntimeException("expression returned void")
+          case Right((t, off)) =>
+            assert(t.size == 1)
+            val elementType = t.fields(0).typ
+            val codec = TypedCodecSpec(
+              EType.defaultFromPType(elementType), elementType.virtualType, bs)
+            assert(t.isFieldDefined(off, 0))
+            (elementType.toString, codec.encode(ctx, elementType, t.loadField(off, 0)))
+        }
       }
     }
   }
 
   def decodeToJSON(ptypeString: String, b: Array[Byte], bufferSpecString: String): String = {
-    val t = IRParser.parsePType(ptypeString)
-    val bs = BufferSpec.parseOrDefault(bufferSpecString)
-    val codec = TypedCodecSpec(EType.defaultFromPType(t), t.virtualType, bs)
-    withExecuteContext() { ctx =>
-      val (pt, off) = codec.decode(ctx, t.virtualType, b, ctx.r)
-      assert(pt.virtualType == t.virtualType)
-      JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
-        UnsafeRow.read(pt, ctx.r, off), pt.virtualType))
+    ExecutionTimer.logTime("SparkBackend.decodeToJSON") { timer =>
+      val t = IRParser.parsePType(ptypeString)
+      val bs = BufferSpec.parseOrDefault(bufferSpecString)
+      val codec = TypedCodecSpec(EType.defaultFromPType(t), t.virtualType, bs)
+      withExecuteContext(timer) { ctx =>
+        val (pt, off) = codec.decode(ctx, t.virtualType, b, ctx.r)
+        assert(pt.virtualType == t.virtualType)
+        JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
+          UnsafeRow.read(pt, ctx.r, off), pt.virtualType))
+      }
     }
   }
 
@@ -417,51 +421,61 @@ class SparkBackend(
     rg: String,
     contigRecoding: java.util.Map[String, String],
     skipInvalidLoci: Boolean) {
-    withExecuteContext() { ctx =>
-      IndexBgen(ctx, files.asScala.toArray, indexFileMap.asScala.toMap, Option(rg), contigRecoding.asScala.toMap, skipInvalidLoci)
+    ExecutionTimer.logTime("SparkBackend.pyIndexBgen") { timer =>
+      withExecuteContext(timer) { ctx =>
+        IndexBgen(ctx, files.asScala.toArray, indexFileMap.asScala.toMap, Option(rg), contigRecoding.asScala.toMap, skipInvalidLoci)
+      }
+      info(s"Number of BGEN files indexed: ${ files.size() }")
     }
-    info(s"Number of BGEN files indexed: ${ files.size() }")
   }
 
   def pyFromDF(df: DataFrame, jKey: java.util.List[String]): TableIR = {
-    val key = jKey.asScala.toArray.toFastIndexedSeq
-    val signature = SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
-    withExecuteContext() { ctx =>
-      TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)))
+    ExecutionTimer.logTime("SparkBackend.pyFromDF") { timer =>
+      val key = jKey.asScala.toArray.toFastIndexedSeq
+      val signature = SparkAnnotationImpex.importType(df.schema).setRequired(true).asInstanceOf[PStruct]
+      withExecuteContext(timer) { ctx =>
+        TableLiteral(TableValue(ctx, signature.virtualType.asInstanceOf[TStruct], key, df.rdd, Some(signature)))
+      }
     }
   }
 
   def pyPersistMatrix(storageLevel: String, mir: MatrixIR): MatrixIR = {
-    val level = try {
-      StorageLevel.fromString(storageLevel)
-    } catch {
-      case e: IllegalArgumentException =>
-        fatal(s"unknown StorageLevel: $storageLevel")
-    }
+    ExecutionTimer.logTime("SparkBackend.pyPersistMatrix") { timer =>
+      val level = try {
+        StorageLevel.fromString(storageLevel)
+      } catch {
+        case e: IllegalArgumentException =>
+          fatal(s"unknown StorageLevel: $storageLevel")
+      }
 
-    withExecuteContext() { ctx =>
-      val tv = Interpret(mir, ctx, optimize = true)
-      MatrixLiteral(mir.typ, TableLiteral(tv.persist(ctx, level)))
+      withExecuteContext(timer) { ctx =>
+        val tv = Interpret(mir, ctx, optimize = true)
+        MatrixLiteral(mir.typ, TableLiteral(tv.persist(ctx, level)))
+      }
     }
   }
 
   def pyPersistTable(storageLevel: String, tir: TableIR): TableIR = {
-    val level = try {
-      StorageLevel.fromString(storageLevel)
-    } catch {
-      case e: IllegalArgumentException =>
-        fatal(s"unknown StorageLevel: $storageLevel")
-    }
+    ExecutionTimer.logTime("SparkBackend.pyPersistTable") { timer =>
+      val level = try {
+        StorageLevel.fromString(storageLevel)
+      } catch {
+        case e: IllegalArgumentException =>
+          fatal(s"unknown StorageLevel: $storageLevel")
+      }
 
-    withExecuteContext() { ctx =>
-      val tv = Interpret(tir, ctx, optimize = true)
-      TableLiteral(tv.persist(ctx, level))
+      withExecuteContext(timer) { ctx =>
+        val tv = Interpret(tir, ctx, optimize = true)
+        TableLiteral(tv.persist(ctx, level))
+      }
     }
   }
 
   def pyToDF(tir: TableIR): DataFrame = {
-    withExecuteContext() { ctx =>
-      Interpret(tir, ctx).toDF()
+    ExecutionTimer.logTime("SparkBackend.pyToDF") { timer =>
+      withExecuteContext(timer) { ctx =>
+        Interpret(tir, ctx).toDF()
+      }
     }
   }
 
@@ -483,107 +497,126 @@ class SparkBackend(
     externalSampleIds: java.util.List[java.util.List[String]],
     externalHeader: String
   ): String = {
-    withExecuteContext() { ctx =>
-      val reader = new VCFsReader(ctx,
-        files.asScala.toArray,
-        callFields.asScala.toSet,
-        entryFloatTypeName,
-        Option(rg),
-        Option(contigRecoding).map(_.asScala.toMap).getOrElse(Map.empty[String, String]),
-        arrayElementsRequired,
-        skipInvalidLoci,
-        gzAsBGZ,
-        forceGZ,
-        TextInputFilterAndReplace(Option(find), Option(filter), Option(replace)),
-        partitionsJSON, partitionsTypeStr,
-        Option(externalSampleIds).map(_.asScala.map(_.asScala.toArray).toArray),
-        Option(externalHeader))
+    ExecutionTimer.logTime("SparkBackend.pyImportVCFs") { timer =>
+      withExecuteContext(timer) { ctx =>
+        val reader = new VCFsReader(ctx,
+          files.asScala.toArray,
+          callFields.asScala.toSet,
+          entryFloatTypeName,
+          Option(rg),
+          Option(contigRecoding).map(_.asScala.toMap).getOrElse(Map.empty[String, String]),
+          arrayElementsRequired,
+          skipInvalidLoci,
+          gzAsBGZ,
+          forceGZ,
+          TextInputFilterAndReplace(Option(find), Option(filter), Option(replace)),
+          partitionsJSON, partitionsTypeStr,
+          Option(externalSampleIds).map(_.asScala.map(_.asScala.toArray).toArray),
+          Option(externalHeader))
 
-      val irs = reader.read(ctx)
-      val id = HailContext.get.addIrVector(irs)
-      val out = JObject(
-        "vector_ir_id" -> JInt(id),
-        "length" -> JInt(irs.length),
-        "type" -> reader.typ.pyJson)
-      JsonMethods.compact(out)
+        val irs = reader.read(ctx)
+        val id = HailContext.get.addIrVector(irs)
+        val out = JObject(
+          "vector_ir_id" -> JInt(id),
+          "length" -> JInt(irs.length),
+          "type" -> reader.typ.pyJson)
+        JsonMethods.compact(out)
+      }
     }
   }
 
   def pyReferenceAddLiftover(name: String, chainFile: String, destRGName: String): Unit = {
-    withExecuteContext() { ctx =>
-      ReferenceGenome.referenceAddLiftover(ctx, name, chainFile, destRGName)
+    ExecutionTimer.logTime("SparkBackend.pyReferenceAddLiftover") { timer =>
+      withExecuteContext(timer) { ctx =>
+        ReferenceGenome.referenceAddLiftover(ctx, name, chainFile, destRGName)
+      }
     }
   }
 
   def pyFromFASTAFile(name: String, fastaFile: String, indexFile: String,
     xContigs: java.util.List[String], yContigs: java.util.List[String], mtContigs: java.util.List[String],
     parInput: java.util.List[String]): ReferenceGenome = {
-    withExecuteContext() { ctx =>
-      ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
-        xContigs.asScala.toArray, yContigs.asScala.toArray, mtContigs.asScala.toArray, parInput.asScala.toArray)
+    ExecutionTimer.logTime("SparkBackend.pyFromFASTAFile") { timer =>
+      withExecuteContext(timer) { ctx =>
+        ReferenceGenome.fromFASTAFile(ctx, name, fastaFile, indexFile,
+          xContigs.asScala.toArray, yContigs.asScala.toArray, mtContigs.asScala.toArray, parInput.asScala.toArray)
+      }
     }
   }
 
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit = {
-    withExecuteContext() { ctx =>
-      ReferenceGenome.addSequence(ctx, name, fastaFile, indexFile)
+    ExecutionTimer.logTime("SparkBackend.pyAddSequence") { timer =>
+      withExecuteContext(timer) { ctx =>
+        ReferenceGenome.addSequence(ctx, name, fastaFile, indexFile)
+      }
     }
   }
 
   def pyExportBlockMatrix(
     pathIn: String, pathOut: String, delimiter: String, header: String, addIndex: Boolean, exportType: String,
     partitionSize: java.lang.Integer, entries: String): Unit = {
-    withExecuteContext() { ctx =>
-      val rm = RowMatrix.readBlockMatrix(fs, pathIn, partitionSize)
-      entries match {
-        case "full" =>
-          rm.export(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-        case "lower" =>
-          rm.exportLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-        case "strict_lower" =>
-          rm.exportStrictLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-        case "upper" =>
-          rm.exportUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
-        case "strict_upper" =>
-          rm.exportStrictUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+    ExecutionTimer.logTime("SparkBackend.pyExportBlockMatrix") { timer =>
+      withExecuteContext(timer) { ctx =>
+        val rm = RowMatrix.readBlockMatrix(fs, pathIn, partitionSize)
+        entries match {
+          case "full" =>
+            rm.export(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+          case "lower" =>
+            rm.exportLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+          case "strict_lower" =>
+            rm.exportStrictLowerTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+          case "upper" =>
+            rm.exportUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+          case "strict_upper" =>
+            rm.exportStrictUpperTriangle(ctx, pathOut, delimiter, Option(header), addIndex, exportType)
+        }
       }
     }
   }
 
   def pyFitLinearMixedModel(lmm: LinearMixedModel, pa_t: RowMatrix, a_t: RowMatrix): TableIR = {
-    withExecuteContext() { ctx =>
-      lmm.fit(ctx, pa_t, Option(a_t))
+    ExecutionTimer.logTime("SparkBackend.pyAddSequence") { timer =>
+      withExecuteContext(timer) { ctx =>
+        lmm.fit(ctx, pa_t, Option(a_t))
+      }
     }
   }
 
   def parse_value_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): IR = {
-    withExecuteContext() { ctx =>
-      IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    ExecutionTimer.logTime("SparkBackend.parse_value_ir") { timer =>
+      withExecuteContext(timer) { ctx =>
+        IRParser.parse_value_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+      }
     }
   }
 
   def parse_table_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): TableIR = {
-    withExecuteContext() { ctx =>
-      IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    ExecutionTimer.logTime("SparkBackend.parse_table_ir") { timer =>
+      withExecuteContext(timer) { ctx =>
+        IRParser.parse_table_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+      }
     }
   }
 
   def parse_matrix_ir(s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]): MatrixIR = {
-    withExecuteContext() { ctx =>
-      IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    ExecutionTimer.logTime("SparkBackend.parse_matrix_ir") { timer =>
+      withExecuteContext(timer) { ctx =>
+        IRParser.parse_matrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+      }
     }
   }
 
   def parse_blockmatrix_ir(
     s: String, refMap: java.util.Map[String, String], irMap: java.util.Map[String, BaseIR]
   ): BlockMatrixIR = {
-    withExecuteContext() { ctx =>
-      IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+    ExecutionTimer.logTime("SparkBackend.parse_blockmatrix_ir") { timer =>
+      withExecuteContext(timer) { ctx =>
+        IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(ctx, refMap.asScala.toMap.mapValues(IRParser.parseType), irMap.asScala.toMap))
+      }
     }
   }
 
   def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Map[String, IR]): TableStage = {
-
     val (globals, rvd) = TableStageToRVD(ctx, stage, relationalLetsAbove)
 
     if (sortFields.forall(_.sortOrder == Ascending)) {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -155,8 +155,11 @@ object TestUtils {
   ): Any = {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
-    HailContext.sparkBackend("TestUtils.loweredExecute")
-               .jvmLowerAndExecute(x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter)._1
+
+    ExecutionTimer.logTime("TestUtils.loweredExecute") { timer =>
+      HailContext.sparkBackend("TestUtils.loweredExecute")
+        .jvmLowerAndExecute(timer, x, optimize = false, lowerTable = true, lowerBM = true, print = bytecodePrinter)
+    }
   }
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3758,7 +3758,9 @@ class IRSuite extends HailSuite {
         |       (MakeStruct (locus  (Apply start Locus(GRCh37) (Ref __uid_3))))
         |       (MakeStruct (locus  (Apply end Locus(GRCh37) (Ref __uid_3)))) (True) (False))))
         |""".stripMargin)
-    val (v, _) = backend.execute(ir, optimize = true)
+    val v = ExecutionTimer.logTime("IRSuite.regressionTestUnifyBug") { timer =>
+      backend.execute(timer, ir, optimize = true)
+    }
     assert(
       ir.typ.ordering.equiv(
         FastIndexedSeq(


### PR DESCRIPTION
FYI @tpoterba 

Rework `ExecutionTimer` with two goals in mind:

Report total time, children time, self time (total - children) and % in children for each timed section.  I think this improves clarity of reporting vs the old format.  The timing log lines now look like:

```
2020-10-20 12:10:38 root: INFO: timing SparkBackend.executeJSON total 43.597ms self 0.941ms children 42.655ms %children 97.84%
```

Decouple the timer from the execution context so we can time more than just the execution.  In particular, I want timings starting from entering the JVM from Python (and in fact, I plan to write an ExecutionTimer in Python so we can time e.g. a call to Backend.execute and include timings from the JVM, but also printing the IR, unserializing the response, etc.)
