### PR TITLE
[docker] ignore mypy_cache everywhere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 *~
 .*.crc
 *.pyc
-.mypy_cache/
+**/.mypy_cache/
 **/hail-*.log
 hail/.bloop/
 hail/.gradle/


### PR DESCRIPTION
Without the ** it seems to not ignore any mypy_cache. This results in extraordinarily slow local builds.