### PR TITLE
[services] pervasively gracefully shutdown

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -191,8 +191,8 @@ FROM globals;
         self.task_manager.ensure_future(self.control_loop())
         self.task_manager.ensure_future(self.instance_monitoring_loop())
         self.task_manager.ensure_future(retry_long_running(
-                'update_zones_loop',
-                self.update_zones_loop))
+            'update_zones_loop',
+            self.update_zones_loop))
 
     def shutdown(self):
         self.task_manager.shutdown()

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -11,6 +11,7 @@ import base64
 import dateutil.parser
 import sortedcontainers
 import aiohttp
+from hailtop import aiotools
 from hailtop.utils import (
     retry_long_running, time_msecs, secret_alnum_string)
 
@@ -112,6 +113,8 @@ class InstancePool:
 
         self.name_instance = {}
 
+        self.task_manager = aiotools.BackgroundTaskManager()
+
     async def update_zones(self):
         northamerica_regions = {
             # 'northamerica-northeast1',
@@ -184,13 +187,15 @@ FROM globals;
             instance = Instance.from_record(self.app, record)
             self.add_instance(instance)
 
-        asyncio.ensure_future(self.event_loop())
-        asyncio.ensure_future(self.control_loop())
-        asyncio.ensure_future(self.instance_monitoring_loop())
+        self.task_manager.ensure_future(self.event_loop())
+        self.task_manager.ensure_future(self.control_loop())
+        self.task_manager.ensure_future(self.instance_monitoring_loop())
+        self.task_manager.ensure_future(retry_long_running(
+                'update_zones_loop',
+                self.update_zones_loop))
 
-        asyncio.ensure_future(retry_long_running(
-            'update_zones_loop',
-            self.update_zones_loop))
+    def shutdown(self):
+        self.task_manager.shutdown()
 
     def config(self):
         return {

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -55,10 +55,10 @@ class Scheduler:
             run_if_changed, self.cancel_ready_state_changed, self.cancel_cancelled_ready_jobs_loop_body))
         self.task_manager.ensure_future(retry_long_running(
             'cancel_cancelled_running_jobs_loop',
-            run_if_changed, self.cancel_running_state_changed, self.cancel_cancelled_running_jobs_loop_body)),
+            run_if_changed, self.cancel_running_state_changed, self.cancel_cancelled_running_jobs_loop_body))
         self.task_manager.ensure_future(retry_long_running(
             'bump_loop',
-            self.bump_loop))])
+            self.bump_loop))
 
     def shutdown(self):
         try:

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -1,6 +1,7 @@
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 from .fs import FileStatus, FileListEntry, AsyncFS, LocalAsyncFS, RouterAsyncFS
 from .utils import FeedableAsyncIterable
+from .tasks import BackgroundTaskManager
 
 __all__ = [
     'ReadableStream',
@@ -12,5 +13,6 @@ __all__ = [
     'AsyncFS',
     'LocalAsyncFS',
     'RouterAsyncFS',
-    'FeedableAsyncIterable'
+    'FeedableAsyncIterable',
+    'BackgroundTaskManager'
 ]

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -8,11 +8,10 @@ log = logging.getLogger('aiotools.tasks')
 
 class BackgroundTaskManager:
     def __init__(self):
-        self.tasks: weakref.WeakSet[asyncio.Task] = weakref.WeakSet
+        self.tasks: weakref.WeakSet = weakref.WeakSet()
 
     def ensure_future(self, coroutine):
-        self.tasks.add(
-            asyncio.ensure_future(coroutine))
+        self.tasks.add(asyncio.ensure_future(coroutine))
 
     def shutdown(self):
         for task in self.tasks:

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -16,7 +16,6 @@ class BackgroundTaskManager:
     def shutdown(self):
         for task in self.tasks:
             try:
-                if task:
-                    task.cancel()
+                task.cancel()
             except Exception:
                 log.warning(f'encountered an exception while cancelling background task: {task}', exc_info=True)

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -1,0 +1,23 @@
+import asyncio
+import logging
+import weakref
+
+
+log = logging.getLogger('aiotools.tasks')
+
+
+class BackgroundTaskManager:
+    def __init__(self):
+        self.tasks: weakref.WeakSet[asyncio.Task] = weakref.WeakSet
+
+    def ensure_future(self, coroutine):
+        self.tasks.add(
+            asyncio.ensure_future(coroutine))
+
+    def shutdown(self):
+        for task in self.tasks:
+            try:
+                if task:
+                    task.cancel()
+            except Exception:
+                log.warning(f'encountered an exception while cancelling background task: {task}', exc_info=True)

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -207,11 +207,10 @@ class AsyncWorkerPool:
 
     def shutdown(self):
         for worker in self.workers:
-            if worker:
-                try:
-                    worker.cancel()
-                except Exception:
-                    pass
+            try:
+                worker.cancel()
+            except Exception:
+                pass
 
 
 class WaitableSharedPool:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -145,7 +145,7 @@ class AsyncThrottledGather:
         for worker in self._workers:
             try:
                 worker.cancel()
-            except:
+            except Exception:
                 pass
 
     async def _worker(self):
@@ -210,7 +210,7 @@ class AsyncWorkerPool:
             if worker:
                 try:
                     worker.cancel()
-                except:
+                except Exception:
                     pass
 
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -12,6 +12,7 @@ import socket
 import requests
 import google.auth.exceptions
 import time
+import weakref
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 
@@ -142,7 +143,10 @@ class AsyncThrottledGather:
 
     def _cancel_workers(self):
         for worker in self._workers:
-            worker.cancel()
+            try:
+                worker.cancel()
+            except:
+                pass
 
     async def _worker(self):
         while True:
@@ -166,10 +170,11 @@ class AsyncThrottledGather:
                 self._done.set()
 
     async def wait(self):
-        if self.count > 0:
-            await self._done.wait()
-
-        self._cancel_workers()
+        try:
+            if self.count > 0:
+                await self._done.wait()
+        finally:
+            self._cancel_workers()
 
         if self._errors:
             raise self._errors[0]
@@ -180,9 +185,9 @@ class AsyncThrottledGather:
 class AsyncWorkerPool:
     def __init__(self, parallelism, queue_size=1000):
         self._queue = asyncio.Queue(maxsize=queue_size)
-
-        for _ in range(parallelism):
+        self.workers = weakref.WeakSet([
             asyncio.ensure_future(self._worker())
+            for _ in range(parallelism)])
 
     async def _worker(self):
         while True:
@@ -199,6 +204,14 @@ class AsyncWorkerPool:
 
     def call_nowait(self, f, *args, **kwargs):
         self._queue.put_nowait((f, args, kwargs))
+
+    def shutdown(self):
+        for worker in self.workers:
+            if worker:
+                try:
+                    worker.cancel()
+                except:
+                    pass
 
 
 class WaitableSharedPool:

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -107,12 +107,23 @@ async def on_startup(app):
     app['redis_pool'] = await aioredis.create_pool(socket)
 
 
+async def on_cleanup(app):
+    try:
+        app['thread_pool'].shutdown()
+    finally:
+        try:
+            app['worker_pool'].shutdown()
+        finally:
+            app['redis_pool'].close()
+
+
 def run():
     app = web.Application()
 
     setup_aiohttp_session(app)
     app.add_routes(routes)
     app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
 
     deploy_config = get_deploy_config()
     web.run_app(

--- a/web_common/Makefile
+++ b/web_common/Makefile
@@ -1,4 +1,4 @@
-PYTHONPATH := ../hail/python:../gear
+EXTRA_PYTHONPATH := ../hail/python:../gear
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 
 .PHONY: check


### PR DESCRIPTION
`asyncio.ensure_future` creates background tasks. When a service is shutdown by
kubernetes, these background tasks keep the service up for the full 30 second
grace-period. This impedes development and deployment velocity.

This change eliminates all uses of `asyncio.ensure_future` which ignore the
returned future. Instead, all these futures are managed by a
`aiotools.BackgroundTaskManager`. This is a new class which holds a (weak)
reference to all of its created tasks and provides `shutdown` to cancel all the
tasks. Canceling the tasks ensures a speedy shutdown.

The use of a weak reference is critical to enable the garbage collector to clean
up tasks that have completed successfully. In particular, the batch worker
creates short-lived, background tasks.

cc: @catoverdrive @Dania-Abuhijleh 