### PR TITLE
[query] TableAggregateByKey Memoization Fix

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -443,8 +443,9 @@ object PruneDeadFields {
       case TableMapGlobals(child, newGlobals) =>
         val globalDep = memoizeAndGetDep(newGlobals, requestedType.globalType, child.typ, memo)
         memoizeTableIR(child, unify(child.typ, requestedType.copy(globalType = globalDep.globalType), globalDep), memo)
-      case TableAggregateByKey(child, newRow) =>
-        val aggDep = memoizeAndGetDep(newRow, requestedType.rowType, child.typ, memo)
+      case TableAggregateByKey(child, expr) =>
+        val exprRequestedType = requestedType.rowType.filter(f => expr.typ.asInstanceOf[TStruct].hasField(f.name))._1
+        val aggDep = memoizeAndGetDep(expr, exprRequestedType, child.typ, memo)
         memoizeTableIR(child, TableType(key = child.typ.key,
           rowType = unify(child.typ.rowType, aggDep.rowType, selectKey(child.typ.rowType, child.typ.key)),
           globalType = unify(child.typ.globalType, aggDep.globalType, requestedType.globalType)), memo)

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -76,17 +76,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
   def hasField(name: String): Boolean = fieldIdx.contains(name)
 
-  def field(name: String): Field = {
-    try {
-      fields(fieldIdx(name))
-    } catch {
-      case e: Throwable => {
-        println(s"FIELDS WERE ${fields}")
-        throw e
-      }
-    }
-
-  }
+  def field(name: String): Field = fields(fieldIdx(name))
 
   def fieldType(name: String): Type = types(fieldIdx(name))
 

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -76,7 +76,17 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
   def hasField(name: String): Boolean = fieldIdx.contains(name)
 
-  def field(name: String): Field = fields(fieldIdx(name))
+  def field(name: String): Field = {
+    try {
+      fields(fieldIdx(name))
+    } catch {
+      case e: Throwable => {
+        println(s"FIELDS WERE ${fields}")
+        throw e
+      }
+    }
+
+  }
 
   def fieldType(name: String): Type = types(fieldIdx(name))
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -386,6 +386,17 @@ class PruneSuite extends HailSuite {
     checkMemo(tka, subsetTable(tka.typ), Array(subsetTable(tab.typ, "row.3", "NO_KEY"), null, null))
   }
 
+  @Test def testTableAggregateByKeyMemo(): Unit = {
+    val emptyStruct = MakeStruct(Seq.empty[(String, IR)])
+
+    val tabk = TableAggregateByKey(
+      tab,
+      SelectFields(Ref("row", tab.typ.rowType), Seq("2"))
+    )
+    checkMemo(tabk, requestedType = subsetTable(tabk.typ, "row.3", "row.2"),
+      Array(subsetTable(tabk.typ, "row.3", "row.2"), null, null))
+  }
+
   @Test def testTableUnionMemo() {
     checkMemo(
       TableUnion(FastIndexedSeq(tab, tab)),

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -59,7 +59,7 @@ class PruneSuite extends HailSuite {
     }
     irCopy.children.zipWithIndex.foreach { case (child, i) =>
       if (expected(i) != null && expected(i) != ms.requestedType.lookup(child)) {
-        fatal(s"For base IR $ir\n  Child $i\n  Expected: ${ expected(i) }\n  Actual:   ${ ms.requestedType.lookup(child) }")
+        fatal(s"For base IR $ir\n  Child $i with IR ${irCopy.children(i)}\n  Expected: ${ expected(i) }\n  Actual:   ${ ms.requestedType.lookup(child) }")
       }
     }
   }
@@ -387,14 +387,12 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testTableAggregateByKeyMemo(): Unit = {
-    val emptyStruct = MakeStruct(Seq.empty[(String, IR)])
-
     val tabk = TableAggregateByKey(
       tab,
-      SelectFields(Ref("row", tab.typ.rowType), Seq("2"))
+      SelectFields(Ref("row", tab.typ.rowType), Seq("5"))
     )
-    checkMemo(tabk, requestedType = subsetTable(tabk.typ, "row.3", "row.2"),
-      Array(subsetTable(tabk.typ, "row.3", "row.2"), null, null))
+    checkMemo(tabk, requestedType = subsetTable(tabk.typ, "row.3", "row.5"),
+      Array(subsetTable(tabk.typ, "row.3", "row.5"), TStruct(("5", TString))))
   }
 
   @Test def testTableUnionMemo() {


### PR DESCRIPTION
When you have `TableAggregateByKey(child, expr)`, you cannot assume that the keys of the result are present in `expr`, so the memoization rule has to be changed to request only the subset of fields in the requested type that are present in `expr`. 

One of the bugs found during #9578 