### PR TITLE
[query] SelectFields Memoization Fix

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1313,7 +1313,10 @@ object PruneDeadFields {
         )
       case SelectFields(old, fields) =>
         val sType = requestedType.asInstanceOf[TStruct]
-        memoizeValueIR(old, TStruct(fields.flatMap(f => sType.fieldOption(f).map(f -> _.typ)): _*), memo)
+        val oldReqType = TStruct(old.typ.asInstanceOf[TStruct]
+          .fieldNames
+          .flatMap(fn => sType.fieldOption(fn).map(fd => (fd.name, fd.typ))): _*)
+        memoizeValueIR(old, oldReqType, memo)
       case GetField(o, name) =>
         memoizeValueIR(o, TStruct(name -> requestedType), memo)
       case MakeTuple(fields) =>

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -548,6 +548,7 @@ class PruneSuite extends HailSuite {
   val justA = TStruct("a" -> TInt32)
   val justB = TStruct("b" -> TInt32)
   val aAndB = TStruct("a" -> TInt32, "b" -> TInt32)
+  val bAndA = TStruct("b" -> TInt32, "a" -> TInt32)
   val justARequired = TStruct("a" -> TInt32)
   val justBRequired = TStruct("b" -> TInt32)
 
@@ -732,6 +733,7 @@ class PruneSuite extends HailSuite {
 
   @Test def testSelectFieldsMemo() {
     checkMemo(SelectFields(ref, Seq("a", "b")), justA, Array(justA))
+    checkMemo(SelectFields(ref, Seq("b", "a")), bAndA, Array(aAndB))
   }
 
   @Test def testGetFieldMemo() {


### PR DESCRIPTION
`SelectFields(child, fields)` needs to make sure that even if `fields` doesn't match the order present in `child.typ`, it still requests the fields in the order from `child.typ`. Otherwise, we break the invariant that `requestedType` is always a super type of the full IR type. 