### PR TITLE
[query] MatrixUnionCols Rebuild Rule and TypeCheck

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -454,6 +454,11 @@ object TypeCheck {
         val newRowType = body.typ.asInstanceOf[TStream].elementType.asInstanceOf[TStruct]
         child.typ.key.foreach { k => if (!newRowType.hasField(k)) throw new RuntimeException(s"prev key: ${child.typ.key}, new row: ${newRowType}")}
 
+      case MatrixUnionCols(left, right, joinType) =>
+        assert(left.typ.rowKeyStruct == right.typ.rowKeyStruct, s"${left.typ.rowKeyStruct} != ${right.typ.rowKeyStruct}")
+        assert(left.typ.colType == right.typ.colType, s"${left.typ.colType} != ${right.typ.colType}")
+        assert(left.typ.entryType == right.typ.entryType, s"${left.typ.entryType} != ${right.typ.entryType}")
+
       case _: TableIR =>
       case _: MatrixIR =>
       case _: BlockMatrixIR =>

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1069,7 +1069,6 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testMatrixUnionColsRebuild(): Unit = {
-    println(mat.typ)
     def getColField(name: String) = {
       GetField(Ref("sa", mat.typ.colType), name)
     }
@@ -1091,8 +1090,11 @@ class PruneSuite extends HailSuite {
         childrenMatch(rebuilt)
     )
 
-    val renamedMat = MatrixMapCols(mat,
-      MakeStruct(Seq(("ck", getColField("ck")), ("c2", getColField("c2")), ("c3", getColField("c3")))), Some(FastIndexedSeq("ck"))
+    // Since `mat` is a MatrixLiteral, it won't be rebuilt, will keep all fields. But wrappedMat is a MatrixMapCols, so it will drop
+    // unrequested fields. This test would fail without upcasting in the MatrixUnionCols rebuild rule.
+    val muc2 = MatrixUnionCols(mat, wrappedMat, "inner")
+    checkRebuild[MatrixUnionCols](muc2, muc2.typ.copy(colType = TStruct(("ck", TString))), (old, rebuilt) =>
+      childrenMatch(rebuilt)
     )
 
   }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -67,7 +67,7 @@ class PruneSuite extends HailSuite {
   def checkRebuild[T <: BaseIR](
     ir: T,
     requestedType: BaseType,
-    f: (T, T) => Boolean = (left: TableIR, right: TableIR) => left == right) {
+    f: (T, T) => Boolean = (left: T, right: T) => left == right) {
     val irCopy = ir.deepCopy()
     val ms = PruneDeadFields.ComputeMutableState(Memo.empty[BaseType], mutable.HashMap.empty)
     val rebuilt = (irCopy match {
@@ -1066,6 +1066,35 @@ class PruneSuite extends HailSuite {
           _.typ.colKey.isEmpty
         }
       })
+  }
+
+  @Test def testMatrixUnionColsRebuild(): Unit = {
+    println(mat.typ)
+    def getColField(name: String) = {
+      GetField(Ref("sa", mat.typ.colType), name)
+    }
+    def childrenMatch(matrixUnionCols: MatrixUnionCols): Boolean = {
+      matrixUnionCols.left.typ.colType == matrixUnionCols.right.typ.colType &&
+        matrixUnionCols.left.typ.entryType == matrixUnionCols.right.typ.entryType
+    }
+
+    val wrappedMat = MatrixMapCols(mat,
+      MakeStruct(Seq(("ck", getColField("ck")), ("c2", getColField("c2")), ("c3", getColField("c3")))), Some(FastIndexedSeq("ck"))
+    )
+
+    val mucBothSame = MatrixUnionCols(wrappedMat, wrappedMat, "inner")
+    checkRebuild(mucBothSame, mucBothSame.typ)
+    checkRebuild[MatrixUnionCols](mucBothSame, mucBothSame.typ.copy(colType = TStruct(("ck", TString), ("c2", TInt32))), (old, rebuilt) =>
+      (old.typ.rowType == rebuilt.typ.rowType) &&
+        (old.typ.globalType == rebuilt.typ.globalType) &&
+        (rebuilt.typ.colType.fieldNames.toIndexedSeq == IndexedSeq("ck", "c2")) &&
+        childrenMatch(rebuilt)
+    )
+
+    val renamedMat = MatrixMapCols(mat,
+      MakeStruct(Seq(("ck", getColField("ck")), ("c2", getColField("c2")), ("c3", getColField("c3")))), Some(FastIndexedSeq("ck"))
+    )
+
   }
 
   @Test def testMatrixAnnotateRowsTableRebuild() {


### PR DESCRIPTION
`MatrixUnionCols` didn't have a rebuild rule, which was wrong because we need it to ensure that the left and right column and entry types continue to match. It also didn't have a `TypeCheck` rule, so I made one based on the rules outlined in the hail docs for `union_cols`. 