### PR TITLE
[query] allow unrealizable ref in extract

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -324,9 +324,6 @@ object Extract {
     def extract(node: IR): IR = this.extract(node, ab, seqBuilder, letBuilder, result, r, isScan)
 
     ir match {
-      case Ref(name, typ) =>
-        assert(typ.isRealizable)
-        ir
       case x@AggLet(name, value, body, _) =>
         letBuilder += x
         extract(body)

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -853,6 +853,16 @@ class TableIRSuite extends HailSuite {
     }
   }
 
+  @Test def testNestedStreamInTable(): Unit = {
+    var tir: TableIR = TableRange(1, 1)
+    var ir: IR = rangeIR(5)
+    ir = StreamGrouped(ir, 2)
+    ir = ToArray(mapIR(ir)(ToArray))
+    ir = InsertFields(Ref("row", tir.typ.rowType), Seq("foo" -> ir))
+    tir = TableMapRows(tir, ir)
+    assertEvalsTo(collect(tir), Row(FastIndexedSeq(Row(0, FastIndexedSeq(FastIndexedSeq(0, 1), FastIndexedSeq(2, 3), FastIndexedSeq(4)))), Row()))
+  }
+
   val parTable1Length = 7
   val parTable1Type = TStruct("rows" -> TArray(TStruct("a1" -> TString, "b1" -> TInt32, "c1" -> TString)), "global" -> TStruct("x" -> TString))
   val value1 = Row(FastIndexedSeq(0 until parTable1Length: _*).map(i => Row("row" + i, i * i, s"t1_${i}")), Row("global"))


### PR DESCRIPTION
This assertion was getting triggered by the ref `inner` in a perfectly correct IR of the form `StreamMap(inner, StreamGrouped(...), ...)`. There's no way to avoid the unrealizable ref when mapping over a nested stream, and I don't see why `extract` depends on this assertion.