### PR TITLE
[check-sql] fix check-sql

### DIFF
--- a/check-sql.sh
+++ b/check-sql.sh
@@ -9,7 +9,7 @@ target_treeish=${HAIL_TARGET_SHA:-$(git merge-base main HEAD)}
 modified_sql_file_list=$(mktemp)
 
 git diff --name-status $target_treeish sql \
-    | grep -Ev '^A|^M\t[^/]+/sql/(estimated-current.sql|delete-[^ ]+-tables.sql)' \
+    | grep -Ev $'^A|^M\t[^/]+/sql/(estimated-current.sql|delete-[^ ]+-tables.sql)' \
            > $modified_sql_file_list
 
 if [ "$(cat $modified_sql_file_list | wc -l)" -ne 0 ]


### PR DESCRIPTION
This sends a literal tab character to grep, taking advantage of Bash ANSI-C style quoting (see https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_03_03.html)