### PR TITLE
[query] Fix InsertFields rebuild rule when overwriting field with same name but different type

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1878,7 +1878,7 @@ object PruneDeadFields {
               log.info(s"Prune: InsertFields: eliminating field '$f'")
               None
             }
-          }, fieldOrder.map(fds => fds.filter(f => depFields.contains(f) || preservedChildFields.contains(f))))
+          }, fieldOrder.map(fds => fds.filter(f => depFields.contains(f) || wrappedChild.typ.asInstanceOf[TStruct].hasField(f))))
       case SelectFields(old, fields) =>
         val depStruct = requestedType.asInstanceOf[TStruct]
         val old2 = rebuildIR(old, env, memo)

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1230,6 +1230,14 @@ class PruneSuite extends HailSuite {
           "b" -> NA(TInt64)
         )
       })
+
+    // Example needs to have field insertion that overwrites an unrequested field with a different type.
+    val insertF = InsertFields(Ref("foo", TStruct(("a", TInt32), ("b", TInt32))),
+      IndexedSeq(("a", I64(8)))
+    )
+    checkRebuild[InsertFields](insertF, TStruct(("b", TInt32)), (old, rebuilt) => {
+      PruneDeadFields.isSupertype(rebuilt.typ, old.typ)
+    })
   }
 
   @Test def testMakeTupleRebuild() {


### PR DESCRIPTION
I added a test to demonstrate the problem. The `InsertFields` is overwriting the type of a field that is not part of the requested type. Previously we would just not insert anything and leave the rebuilt child alone. But when the child is a `Ref` or a `Literal` or something that doesn't actually get rebuilt differently, the old way would lead to a situation where the rebuilt IR is not a supertype of the original IR. By inserting a `SelectFields` to subset away the fields that would have been overwritten, we avoid this problem. 

Happy to further elaborate if the above isn't clear. 