### PR TITLE
Python Chained Linear Regression, Attempt 2

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -384,9 +384,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         raise ValueError("'linear_regression_rows_nd': found no values for 'y'")
     is_chained = y_is_list and isinstance(y[0], list)
 
-    if is_chained:
-        raise ValueError("linear_regression_rows_nd does not currently support chained linear regression.")
-
     if is_chained and any(len(lst) == 0 for lst in y):
         raise ValueError("'linear_regression_rows': found empty inner list for 'y'")
 
@@ -411,18 +408,22 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
     cov_field_names = list(f'__cov{i}' for i in range(len(covariates)))
 
-    row_fields = _get_regression_row_fields(mt, pass_through, 'linear_regression_rows_nd')
+    row_field_names = _get_regression_row_fields(mt, pass_through, 'linear_regression_rows_nd')
 
     # FIXME: selecting an existing entry field should be emitted as a SelectFields
     mt = mt._select_all(col_exprs=dict(**y_dict,
                                        **dict(zip(cov_field_names, covariates))),
-                        row_exprs=row_fields,
+                        row_exprs=row_field_names,
                         col_key=[],
                         entry_exprs={x_field_name: x})
 
-    # NEW STUFF
     entries_field_name = 'ent'
     sample_field_name = "by_sample"
+
+    if not is_chained:
+        y_field_names = [y_field_names]
+
+    num_y_lists = len(y_field_names)
 
     def all_defined(struct_root, field_names):
         defined_array = hl.array([hl.is_defined(struct_root[field_name]) for field_name in field_names])
@@ -440,49 +441,86 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     def dot_rows_with_themselves(matrix):
         return (matrix * matrix) @ hl.nd.ones(matrix.shape[1])
 
+    def array_from_struct(struct, field_names):
+        return hl.array([struct[field_name] for field_name in field_names])
+
     ht_local = mt._localize_entries(entries_field_name, sample_field_name)
 
     ht = ht_local.transmute(**{entries_field_name: ht_local[entries_field_name][x_field_name]})
 
-    ys_and_covs_to_keep_with_indices = hl.enumerate(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], y_field_names + cov_field_names))
-    indices_to_keep = ys_and_covs_to_keep_with_indices.map(lambda pair: pair[0])
-    ys_and_covs_to_keep = ys_and_covs_to_keep_with_indices.map(lambda pair: pair[1])
+    list_of_ys_and_covs_to_keep_with_indices = \
+        [hl.enumerate(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], one_y_field_name_set + cov_field_names)) for one_y_field_name_set in y_field_names]
 
-    cov_nd = hl.nd.array(ys_and_covs_to_keep.map(lambda struct: hl.array([struct[cov_name] for cov_name in cov_field_names]))) if cov_field_names else hl.nd.zeros((hl.len(indices_to_keep), 0))
-    ht = ht.annotate_globals(kept_samples=indices_to_keep,
-                             __y_nd=hl.nd.array(ys_and_covs_to_keep.map(lambda struct: hl.array([struct[y_name] for y_name in y_field_names]))),
-                             __cov_nd=cov_nd)
+    def make_one_cov_matrix(ys_and_covs_to_keep):
+        return hl.nd.array(ys_and_covs_to_keep.map(lambda struct: array_from_struct(struct, cov_field_names))) \
+            if cov_field_names else hl.nd.zeros((hl.len(ys_and_covs_to_keep), 0))
+
+    def make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set):
+        return hl.nd.array(ys_and_covs_to_keep.map(lambda struct: array_from_struct(struct, one_y_field_name_set)))
+
+    list_of_ys_and_covs_to_keep = [inner_list.map(lambda pair: pair[1]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
+    list_of_indices_to_keep = [inner_list.map(lambda pair: pair[0]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
+
+    cov_nds = [make_one_cov_matrix(ys_and_covs_to_keep) for ys_and_covs_to_keep in list_of_ys_and_covs_to_keep]
+
+    y_nds = [make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set)
+             for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)]
+
+    ht = ht.annotate_globals(kept_samples=list_of_indices_to_keep,
+                             __y_nds=y_nds,
+                             __cov_nds=cov_nds)
     k = builtins.len(covariates)
-    n = hl.len(ht.kept_samples)
-    ht = ht.annotate_globals(d=n - k - 1)
-    cov_Qt = hl.if_else(k > 0, hl.nd.qr(ht.__cov_nd)[0].T, hl.nd.zeros((0, n)))
-    ht = ht.annotate_globals(__Qty=cov_Qt @ ht.__y_nd)
-    ht = ht.annotate_globals(__yyp=dot_rows_with_themselves(ht.__y_nd.T) - dot_rows_with_themselves(ht.__Qty.T))
+    ns = ht.index_globals().kept_samples.map(lambda one_sample_set: hl.len(one_sample_set))
+    ht = ht.annotate_globals(ds=ns.map(lambda n: n - k - 1))
+    cov_Qts = hl.if_else(k > 0,
+                         ht.__cov_nds.map(lambda one_cov_nd: hl.nd.qr(one_cov_nd)[0].T),
+                         ns.map(lambda n: hl.nd.zeros((0, n))))
+    ht = ht.annotate_globals(__cov_Qts=cov_Qts)
+    ht = ht.annotate_globals(__Qtys=hl.range(num_y_lists).map(lambda i: ht.__cov_Qts[i] @ ht.__y_nds[i]))
+    ht = ht.annotate_globals(__yyps=hl.range(num_y_lists).map(lambda i: dot_rows_with_themselves(ht.__y_nds[i].T) - dot_rows_with_themselves(ht.__Qtys[i].T)))
 
     def process_block(block):
-        X = hl.nd.array(block[entries_field_name].map(lambda row: mean_impute(select_array_indices(row, ht.kept_samples)))).T
-        sum_x = (X.T @ hl.nd.ones((n,)))._data_array()
-        Qtx = cov_Qt @ X
-        ytx = ht.__y_nd.T @ X
-        xyp = ytx - (ht.__Qty.T @ Qtx)
-        xxpRec = (dot_rows_with_themselves(X.T) - dot_rows_with_themselves(Qtx.T)).map(lambda entry: 1 / entry)
-        b = xyp * xxpRec
-        se = ((1.0 / ht.d) * (ht.__yyp.reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
-        t = b / se
-        p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.d, True, False))
+        rows_in_block = hl.len(block)
 
-        key_fields = [key_field for key_field in ht.key]
-        key_dict = {key_field: block[key_field] for key_field in key_fields}
-        linreg_fields_dict = {"sum_x": sum_x, "y_transpose_x": ytx.T._data_array(), "beta": b.T._data_array(),
-                              "standard_error": se.T._data_array(), "t_stat": t.T._data_array(), "p_value": p.T._data_array()}
-        combined_dict = {**key_dict, **linreg_fields_dict}
+        # Processes one block group based on given idx. Returns a single struct.
+        def process_y_group(idx):
+            X = hl.nd.array(block[entries_field_name].map(lambda row: mean_impute(select_array_indices(row, ht.kept_samples[idx])))).T
+            n = ns[idx]
+            sum_x = (X.T @ hl.nd.ones((n,)))
+            Qtx = ht.__cov_Qts[idx] @ X
+            ytx = ht.__y_nds[idx].T @ X
+            xyp = ytx - (ht.__Qtys[idx].T @ Qtx)
+            xxpRec = (dot_rows_with_themselves(X.T) - dot_rows_with_themselves(Qtx.T)).map(lambda entry: 1 / entry)
+            b = xyp * xxpRec
+            se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
+            t = b / se
+            p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
+            return hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(), y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
+                             standard_error=se.T._data_array(), t_stat=t.T._data_array(), p_value=p.T._data_array())
 
-        # Need to pull off "struct of arrays to array of structs". How?
-        # Turn it into a giant zipped list, so that it can be iterated over all at once
-        combined_field_names = [key for key, value in combined_dict.items()]
-        combined_field_data = [value for key, value in combined_dict.items()]
-        linreg_structs = hl.zip(*combined_field_data).map(lambda tup: hl.struct(**{combined_field_names[i]: tup[i] for i in range(len(combined_field_names))}))
-        return linreg_structs
+        per_y_list = hl.range(num_y_lists).map(lambda i: process_y_group(i))
+
+        key_field_names = [key_field for key_field in ht.key]
+
+        def build_row(row_idx):
+            # For every field we care about, map across all y's, getting the row_idxth one from each.
+            idxth_keys = {field_name: block[field_name][row_idx] for field_name in key_field_names}
+            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
+            computed_row_fields = {
+                field_name: per_y_list.map(lambda one_y: one_y[field_name][row_idx]) for field_name in computed_row_field_names
+            }
+            pass_through_rows = {
+                field_name: block[field_name][row_idx] for field_name in row_field_names
+            }
+
+            if not is_chained:
+                computed_row_fields = {key: value[0] for key, value in computed_row_fields.items()}
+
+            return hl.struct(**{**idxth_keys, **computed_row_fields, **pass_through_rows})
+
+        new_rows = hl.range(rows_in_block).map(build_row)
+
+        return new_rows
 
     def process_partition(part):
         grouped = part.grouped(block_size)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -464,7 +464,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     cov_nds = hl.array([make_one_cov_matrix(ys_and_covs_to_keep) for ys_and_covs_to_keep in list_of_ys_and_covs_to_keep])
 
     y_nds = hl.array([make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set)
-             for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)])
+                      for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)])
 
     ht = ht.annotate_globals(kept_samples=list_of_indices_to_keep)
     k = builtins.len(covariates)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -90,7 +90,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(t1._same(t4a))
             self.assertTrue(t1._same(t4b))
 
-    @fails_local_backend()
     def test_linreg_pass_through(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -101,39 +100,39 @@ class Tests(unittest.TestCase):
 
         mt = hl.import_vcf(resource('regressionLinear.vcf')).annotate_rows(foo = hl.struct(bar=hl.rand_norm(0, 1)))
 
-        # single group
-        lr_result = hl.linear_regression_rows(phenos[mt.s].Pheno, mt.GT.n_alt_alleles(), [1.0],
-                                              pass_through=['filters', mt.foo.bar, mt.qual])
+        for linreg_function in self.linreg_functions:
 
-        assert mt.aggregate_rows(hl.agg.all(mt.foo.bar == lr_result[mt.row_key].bar))
+            # single group
+            lr_result = linreg_function(phenos[mt.s].Pheno, mt.GT.n_alt_alleles(), [1.0],
+                                        pass_through=['filters', mt.foo.bar, mt.qual])
 
-        # chained
-        lr_result = hl.linear_regression_rows([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
-                                              pass_through=['filters', mt.foo.bar, mt.qual])
+            assert mt.aggregate_rows(hl.agg.all(mt.foo.bar == lr_result[mt.row_key].bar))
 
-        assert mt.aggregate_rows(hl.agg.all(mt.foo.bar == lr_result[mt.row_key].bar))
+            # chained
+            lr_result = linreg_function([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
+                                        pass_through=['filters', mt.foo.bar, mt.qual])
 
-        # check types
-        assert 'filters' in lr_result.row
-        assert lr_result.filters.dtype == mt.filters.dtype
+            assert mt.aggregate_rows(hl.agg.all(mt.foo.bar == lr_result[mt.row_key].bar))
 
-        assert 'bar' in lr_result.row
-        assert lr_result.bar.dtype == mt.foo.bar.dtype
+            # check types
+            assert 'filters' in lr_result.row
+            assert lr_result.filters.dtype == mt.filters.dtype
 
-        assert 'qual' in lr_result.row
-        assert lr_result.qual.dtype == mt.qual.dtype
+            assert 'bar' in lr_result.row
+            assert lr_result.bar.dtype == mt.foo.bar.dtype
 
-        # should run successfully with key fields
-        hl.linear_regression_rows([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
-                                  pass_through=['locus', 'alleles'])
+            assert 'qual' in lr_result.row
+            assert lr_result.qual.dtype == mt.qual.dtype
 
-        # complex expression
-        with pytest.raises(ValueError):
-            hl.linear_regression_rows([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
-                                      pass_through=[mt.filters.length()])
+            # should run successfully with key fields
+            linreg_function([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
+                            pass_through=['locus', 'alleles'])
 
+            # complex expression
+            with pytest.raises(ValueError):
+                linreg_function([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
+                                pass_through=[mt.filters.length()])
 
-    @fails_local_backend()
     def test_linreg_chained(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -146,65 +145,68 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_cols(pheno=phenos[mt.s].Pheno, cov=covs[mt.s])
         mt = mt.annotate_entries(x=mt.GT.n_alt_alleles()).cache()
 
-        t1 = hl.linear_regression_rows(y=[[mt.pheno], [mt.pheno]], x=mt.x, covariates=[1, mt.cov.Cov1, mt.cov.Cov2])
-        def all_eq(*args):
-            pred = True
-            for a in args:
-                if isinstance(a, hl.expr.Expression) \
-                        and isinstance(a.dtype, hl.tarray) \
-                        and isinstance(a.dtype.element_type, hl.tarray):
-                    pred = pred & (hl.all(lambda x: x,
-                        hl.map(lambda elt: ((hl.is_nan(elt[0]) & hl.is_nan(elt[1])) | (elt[0] == elt[1])),
-                               hl.zip(a[0], a[1]))))
-                else:
-                    pred = pred & ((hl.is_nan(a[0]) & hl.is_nan(a[1])) | (a[0] == a[1]))
-            return pred
+        for linreg_function in self.linreg_functions:
 
-        assert t1.aggregate(hl.agg.all(
-            all_eq(t1.n,
-                   t1.sum_x,
-                   t1.y_transpose_x,
-                   t1.beta,
-                   t1.standard_error,
-                   t1.t_stat,
-                   t1.p_value)))
+            t1 = linreg_function(y=[[mt.pheno], [mt.pheno]], x=mt.x, covariates=[1, mt.cov.Cov1, mt.cov.Cov2])
 
-        mt2 = mt.filter_cols(mt.cov.Cov2 >= 0)
-        mt3 = mt.filter_cols(mt.cov.Cov2 <= 0)
+            def all_eq(*args):
+                pred = True
+                for a in args:
+                    if isinstance(a, hl.expr.Expression) \
+                            and isinstance(a.dtype, hl.tarray) \
+                            and isinstance(a.dtype.element_type, hl.tarray):
+                        pred = pred & (hl.all(lambda x: x,
+                                              hl.map(lambda elt: ((hl.is_nan(elt[0]) & hl.is_nan(elt[1])) | (elt[0] == elt[1])),
+                                                     hl.zip(a[0], a[1]))))
+                    else:
+                        pred = pred & ((hl.is_nan(a[0]) & hl.is_nan(a[1])) | (a[0] == a[1]))
+                return pred
 
-        # test that chained linear regression can replicate separate calls with different missingness
-        t2 = hl.linear_regression_rows(y=mt2.pheno, x=mt2.x, covariates=[1, mt2.cov.Cov1])
-        t3 = hl.linear_regression_rows(y=mt3.pheno, x=mt3.x, covariates=[1, mt3.cov.Cov1])
+            assert t1.aggregate(hl.agg.all(
+                all_eq(t1.n,
+                       t1.sum_x,
+                       t1.y_transpose_x,
+                       t1.beta,
+                       t1.standard_error,
+                       t1.t_stat,
+                       t1.p_value)))
 
-        chained = hl.linear_regression_rows(y=[[hl.case().when(mt.cov.Cov2 >= 0, mt.pheno).or_missing()],
-                                               [hl.case().when(mt.cov.Cov2 <= 0, mt.pheno).or_missing()]],
-                                            x=mt.x,
-                                            covariates=[1, mt.cov.Cov1])
-        chained = chained.annotate(r0=t2[chained.key], r1=t3[chained.key])
-        assert chained.aggregate(hl.agg.all(
-            all_eq([chained.n[0], chained.r0.n],
-                   [chained.n[1], chained.r1.n],
-                   [chained.sum_x[0], chained.r0.sum_x],
-                   [chained.sum_x[1], chained.r1.sum_x],
-                   [chained.y_transpose_x[0][0], chained.r0.y_transpose_x],
-                   [chained.y_transpose_x[1][0], chained.r1.y_transpose_x],
-                   [chained.beta[0][0], chained.r0.beta],
-                   [chained.beta[1][0], chained.r1.beta],
-                   [chained.standard_error[0][0], chained.r0.standard_error],
-                   [chained.standard_error[1][0], chained.r1.standard_error],
-                   [chained.t_stat[0][0], chained.r0.t_stat],
-                   [chained.t_stat[1][0], chained.r1.t_stat],
-                   [chained.p_value[0][0], chained.r0.p_value],
-                   [chained.p_value[1][0], chained.r1.p_value])))
+            mt2 = mt.filter_cols(mt.cov.Cov2 >= 0)
+            mt3 = mt.filter_cols(mt.cov.Cov2 <= 0)
 
-        # test differential missingness against each other
-        phenos = [hl.case().when(mt.cov.Cov2 >= -1, mt.pheno).or_missing(),
-                  hl.case().when(mt.cov.Cov2 <= 1, mt.pheno).or_missing()]
-        t4 = hl.linear_regression_rows(phenos, mt.x, covariates=[1])
-        t5 = hl.linear_regression_rows([phenos], mt.x, covariates=[1])
+            # test that chained linear regression can replicate separate calls with different missingness
+            t2 = hl.linear_regression_rows(y=mt2.pheno, x=mt2.x, covariates=[1, mt2.cov.Cov1])
+            t3 = hl.linear_regression_rows(y=mt3.pheno, x=mt3.x, covariates=[1, mt3.cov.Cov1])
 
-        t5 = t5.annotate(**{x: t5[x][0] for x in ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']})
-        assert t4._same(t5)
+            chained = hl.linear_regression_rows(y=[[hl.case().when(mt.cov.Cov2 >= 0, mt.pheno).or_missing()],
+                                                   [hl.case().when(mt.cov.Cov2 <= 0, mt.pheno).or_missing()]],
+                                                x=mt.x,
+                                                covariates=[1, mt.cov.Cov1])
+            chained = chained.annotate(r0=t2[chained.key], r1=t3[chained.key])
+            assert chained.aggregate(hl.agg.all(
+                all_eq([chained.n[0], chained.r0.n],
+                       [chained.n[1], chained.r1.n],
+                       [chained.sum_x[0], chained.r0.sum_x],
+                       [chained.sum_x[1], chained.r1.sum_x],
+                       [chained.y_transpose_x[0][0], chained.r0.y_transpose_x],
+                       [chained.y_transpose_x[1][0], chained.r1.y_transpose_x],
+                       [chained.beta[0][0], chained.r0.beta],
+                       [chained.beta[1][0], chained.r1.beta],
+                       [chained.standard_error[0][0], chained.r0.standard_error],
+                       [chained.standard_error[1][0], chained.r1.standard_error],
+                       [chained.t_stat[0][0], chained.r0.t_stat],
+                       [chained.t_stat[1][0], chained.r1.t_stat],
+                       [chained.p_value[0][0], chained.r0.p_value],
+                       [chained.p_value[1][0], chained.r1.p_value])))
+
+            # test differential missingness against each other
+            phenos = [hl.case().when(mt.cov.Cov2 >= -1, mt.pheno).or_missing(),
+                      hl.case().when(mt.cov.Cov2 <= 1, mt.pheno).or_missing()]
+            t4 = hl.linear_regression_rows(phenos, mt.x, covariates=[1])
+            t5 = hl.linear_regression_rows([phenos], mt.x, covariates=[1])
+
+            t5 = t5.annotate(**{x: t5[x][0] for x in ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']})
+            assert t4._same(t5)
 
 
     def test_linear_regression_without_intercept(self):


### PR DESCRIPTION
Replacing #9578 

_linear_regression_rows_nd now supports chained linear regression correctly. Also added support for pass through arguments. This should now support everything that regular linear regression supports, but all written in Python. This allows a few more tests to run on local backend.

I'd be particularly interested in whether you think there's a way to write this that would generate more efficient IR. It seems hacky to have to map over the range of rows and index into it, but I didn't see a better way.