### PR TITLE
[auth] Add ability to easily create new service accounts

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -198,12 +198,16 @@ async def post_create_user(request, userdata):  # pylint: disable=unused-argumen
     db = request.app['db']
     post = await request.post()
     username = post['username']
-    email = post['email']
+    email = post.get('email')
     is_developer = post.get('is_developer') == '1'
     is_service_account = post.get('is_service_account') == '1'
 
     if is_developer and is_service_account:
         set_message(session, 'User cannot be both a developer and a service account.', 'error')
+        return web.HTTPFound(deploy_config.external_url('auth', '/users'))
+
+    if not is_service_account and email is None:
+        set_message(session, 'Email is required for users that are not service accounts.', 'error')
         return web.HTTPFound(deploy_config.external_url('auth', '/users'))
 
     user_id = await db.execute_insertone(

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -200,13 +200,18 @@ async def post_create_user(request, userdata):  # pylint: disable=unused-argumen
     username = post['username']
     email = post['email']
     is_developer = post.get('is_developer') == '1'
+    is_service_account = post.get('is_service_account') == '1'
+
+    if is_developer and is_service_account:
+        set_message(session, 'User cannot be both a developer and a service account.', 'error')
+        return web.HTTPFound(deploy_config.external_url('auth', '/users'))
 
     user_id = await db.execute_insertone(
         '''
-INSERT INTO users (state, username, email, is_developer)
+INSERT INTO users (state, username, email, is_developer, is_service_account)
 VALUES (%s, %s, %s, %s);
 ''',
-        ('creating', username, email, is_developer))
+        ('creating', username, email, is_developer, is_service_account))
 
     set_message(session, f'Created user {user_id} {username}.', 'info')
 

--- a/auth/auth/templates/users.html
+++ b/auth/auth/templates/users.html
@@ -6,6 +6,7 @@
     <div>Username: <input name="username" /></div>
     <div>Email: <input name="email" /></div>
     <div><input type="checkbox" name="is_developer" value="1" /> Developer</div>
+    <div><input type="checkbox" name="is_service_account" value="1" /> Service Account</div>
     <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>  
     <button>
       Create

--- a/auth/auth/templates/users.html
+++ b/auth/auth/templates/users.html
@@ -3,7 +3,7 @@
 {% block content %}
   <h1>Create User</h1>
   <form action="{{ base_path }}/users" method="POST">
-    <div>Username: <input name="username" /></div>
+    <div>Username: <input required name="username" /></div>
     <div>Email: <input name="email" /></div>
     <div><input type="checkbox" name="is_developer" value="1" /> Developer</div>
     <div><input type="checkbox" name="is_service_account" value="1" /> Service Account</div>

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -58,6 +58,8 @@ def secret_alnum_string(n=22, *, case=None):
         alphabet = numbers + upper
     elif case == 'lower':
         alphabet = numbers + lower
+    elif case == 'numbers':
+        alphabet = numbers
     else:
         raise ValueError(f'invalid argument for case {case}')
     return ''.join([secrets.choice(alphabet) for _ in range(n)])


### PR DESCRIPTION
I can generate the new auth-driver service account by hand, but this will be much better. Am I missing anything or is it this easy?