### PR TITLE
[batch] Add pod disruption budget for batch-driver

### DIFF
--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -124,6 +124,16 @@ spec:
            optional: false
            secretName: ssl-config-batch-driver
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: batch-driver
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: batch
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Not sure if this will help make GKE move the pod if the node needs to be repaired rather than waiting for the node to repair.