### PR TITLE
PType shouldn't have default bytesize

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -352,7 +352,7 @@ abstract class PType extends Serializable with Requiredness {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering
 
-  def byteSize: Long = 1
+  def byteSize: Long
 
   def alignment: Long = byteSize
 


### PR DESCRIPTION
No one was using it, it just adds a potential footgun when making new ptypes

Assigning Tim on the off chance it conflicts with his STypes PR, it's a tiny change though so hopefully fine.