### PR TITLE
[batch] Add warnings for non-gcr images

### DIFF
--- a/hail/python/hailtop/batch/__init__.py
+++ b/hail/python/hailtop/batch/__init__.py
@@ -1,4 +1,5 @@
 import nest_asyncio
+import warnings
 
 from .batch import Batch
 from .batch_pool_executor import BatchPoolExecutor
@@ -22,3 +23,6 @@ __all__ = ['Batch',
            ]
 
 nest_asyncio.apply()
+
+warnings.filterwarnings('once', append=True)
+del warnings

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -474,8 +474,7 @@ class ServiceBackend(Backend):
             image = job._image if job._image else default_image
             if not image.startswith('gcr.io/'):
                 warnings.warn(f'Using an image {image} not in GCR. '
-                              f'Jobs may fail due to Docker Hub rate limits.',
-                              UserWarning)
+                              f'Jobs may fail due to Docker Hub rate limits.')
 
             j = bc_batch.create_job(image=image,
                                     command=[job._shell if job._shell else self._DEFAULT_SHELL, '-c', cmd],


### PR DESCRIPTION
I'm not sure why we had the default be ubuntu:latest but I think 18.04 is better.