### PR TITLE
Linear Regression ND Performance Fix

### DIFF
--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -179,8 +179,8 @@ def linear_regression_rows(mt_path):
 @benchmark(args=random_doubles.handle('mt'))
 def linear_regression_rows_nd(mt_path):
     mt = hl.read_matrix_table(mt_path)
-    num_phenos = 100
-    num_covs = 20
+    num_phenos = 20
+    num_covs = 10
     pheno_dict = {f"pheno_{i}": hl.rand_unif(0, 1) for i in range(num_phenos)}
     cov_dict = {f"cov_{i}": hl.rand_unif(0, 1) for i in range(num_covs)}
     mt = mt.annotate_cols(**pheno_dict)

--- a/benchmark/python/benchmark_hail/run/methods_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/methods_benchmarks.py
@@ -179,8 +179,8 @@ def linear_regression_rows(mt_path):
 @benchmark(args=random_doubles.handle('mt'))
 def linear_regression_rows_nd(mt_path):
     mt = hl.read_matrix_table(mt_path)
-    num_phenos = 20
-    num_covs = 10
+    num_phenos = 100
+    num_covs = 20
     pheno_dict = {f"pheno_{i}": hl.rand_unif(0, 1) for i in range(num_phenos)}
     cov_dict = {f"cov_{i}": hl.rand_unif(0, 1) for i in range(num_covs)}
     mt = mt.annotate_cols(**pheno_dict)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4242,7 +4242,9 @@ def _ndarray(collection, row_major=None, dtype=None):
     data_expr = data_expr.map(lambda value: cast_expr(value, dtype))
     ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
 
-    return construct_expr(ndir, tndarray(data_expr.dtype.element_type, ndim))
+    new_indices, new_aggregations = unify_all(data_expr, shape_expr)
+
+    return construct_expr(ndir, tndarray(data_expr.dtype.element_type, ndim), new_indices, new_aggregations)
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -498,10 +498,10 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             xxpRec = (dot_rows_with_themselves(X.T) - dot_rows_with_themselves(Qtx.T)).map(lambda entry: 1 / entry)
             b = xyp * xxpRec
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
-            t = b / se
-            p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
+            # t = b / se
+            # p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
             return hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(), y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
-                             standard_error=se.T._data_array(), t_stat=t.T._data_array(), p_value=p.T._data_array())
+                             standard_error=se.T._data_array()) # t_stat=t.T._data_array(), p_value=p.T._data_array())
 
             # return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta': b.T._data_array(),
             #         'standard_error': se.T._data_array(), 't_stat': t.T._data_array(), 'p_value': p.T._data_array()}
@@ -514,7 +514,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         def build_row(per_y_list, row_idx):
             # For every field we care about, map across all y's, getting the row_idxth one from each.
             idxth_keys = {field_name: block[field_name][row_idx] for field_name in key_field_names}
-            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
+            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error'] #, 't_stat', 'p_value']
             computed_row_fields = {
                 #field_name: [one_y[field_name][row_idx] for one_y in per_y_list] for field_name in computed_row_field_names
                 field_name: per_y_list.map(lambda one_y: one_y[field_name][row_idx]) for field_name in computed_row_field_names
@@ -539,7 +539,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     res = ht._map_partitions(process_partition)
 
     if not y_is_list:
-        fields = ['y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
+        fields = ['y_transpose_x', 'beta' 'standard_error']#, 't_stat', 'p_value']
         res = res.annotate(**{f: res[f][0] for f in fields})
 
     res = res.select_globals()

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -500,11 +500,12 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
             t = b / se
             return hl.rbind(t, lambda t:
-                hl.rbind(ht.ds[idx], lambda d:
-                    hl.rbind(t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), d, True, False)), lambda p:
-                        hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(),
-                                  y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
-                                  standard_error=se.T._data_array(), t_stat=t.T._data_array(), p_value=p.T._data_array()))))
+                            hl.rbind(ht.ds[idx], lambda d:
+                                     hl.rbind(t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), d, True, False)), lambda p:
+                                              hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(),
+                                                        y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
+                                                        standard_error=se.T._data_array(), t_stat=t.T._data_array(),
+                                                        p_value=p.T._data_array()))))
 
         per_y_list = hl.range(num_y_lists).map(lambda i: process_y_group(i))
 
@@ -537,7 +538,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     res = ht._map_partitions(process_partition)
 
     if not y_is_list:
-        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat','p_value']
+        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat', 'p_value']
         res = res.annotate(**{f: res[f][0] for f in fields})
 
     res = res.select_globals()

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -499,24 +499,22 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             b = xyp * xxpRec
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
             t = b / se
-            # p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
-            return hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(), y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
-                             standard_error=se.T._data_array(), t_stat=t.T._data_array(),)# p_value=p.T._data_array())
+            return hl.rbind(t, lambda t:
+                hl.rbind(ht.ds[idx], lambda d:
+                    hl.rbind(t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), d, True, False)), lambda p:
+                        hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(),
+                                  y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
+                                  standard_error=se.T._data_array(), t_stat=t.T._data_array(), p_value=p.T._data_array()))))
 
-            # return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta': b.T._data_array(),
-            #         'standard_error': se.T._data_array(), 't_stat': t.T._data_array(), 'p_value': p.T._data_array()}
-
-        #per_y_list = [process_y_group(i) for i in range(num_y_lists)]
         per_y_list = hl.range(num_y_lists).map(lambda i: process_y_group(i))
 
         key_field_names = [key_field for key_field in ht.key]
 
-        def build_row(per_y_list, row_idx):
+        def build_row(row_idx):
             # For every field we care about, map across all y's, getting the row_idxth one from each.
             idxth_keys = {field_name: block[field_name][row_idx] for field_name in key_field_names}
-            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat',] # 'p_value']
+            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
             computed_row_fields = {
-                #field_name: [one_y[field_name][row_idx] for one_y in per_y_list] for field_name in computed_row_field_names
                 field_name: per_y_list.map(lambda one_y: one_y[field_name][row_idx]) for field_name in computed_row_field_names
             }
             pass_through_rows = {
@@ -528,7 +526,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
             return hl.struct(**{**idxth_keys, **computed_row_fields, **pass_through_rows})
 
-        new_rows = hl.rbind(per_y_list, lambda l_per_y_list: hl.range(rows_in_block).map(lambda inner_i: build_row(l_per_y_list, inner_i)))
+        new_rows = hl.range(rows_in_block).map(lambda inner_i: build_row(inner_i))
 
         return new_rows
 
@@ -539,7 +537,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     res = ht._map_partitions(process_partition)
 
     if not y_is_list:
-        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat',] # 'p_value']
+        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat','p_value']
         res = res.annotate(**{f: res[f][0] for f in fields})
 
     res = res.select_globals()

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -500,7 +500,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
             t = b / se
             p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
-            return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta':b.T._data_array(),
+            return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta': b.T._data_array(),
                     'standard_error': se.T._data_array(), 't_stat': t.T._data_array(), 'p_value': p.T._data_array()}
 
         per_y_list = [process_y_group(i) for i in range(num_y_lists)]

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -498,10 +498,10 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             xxpRec = (dot_rows_with_themselves(X.T) - dot_rows_with_themselves(Qtx.T)).map(lambda entry: 1 / entry)
             b = xyp * xxpRec
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
-            # t = b / se
+            t = b / se
             # p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
             return hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(), y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
-                             standard_error=se.T._data_array()) # t_stat=t.T._data_array(), p_value=p.T._data_array())
+                             standard_error=se.T._data_array(), t_stat=t.T._data_array(),)# p_value=p.T._data_array())
 
             # return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta': b.T._data_array(),
             #         'standard_error': se.T._data_array(), 't_stat': t.T._data_array(), 'p_value': p.T._data_array()}
@@ -514,7 +514,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         def build_row(per_y_list, row_idx):
             # For every field we care about, map across all y's, getting the row_idxth one from each.
             idxth_keys = {field_name: block[field_name][row_idx] for field_name in key_field_names}
-            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error'] #, 't_stat', 'p_value']
+            computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat',] # 'p_value']
             computed_row_fields = {
                 #field_name: [one_y[field_name][row_idx] for one_y in per_y_list] for field_name in computed_row_field_names
                 field_name: per_y_list.map(lambda one_y: one_y[field_name][row_idx]) for field_name in computed_row_field_names
@@ -539,7 +539,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     res = ht._map_partitions(process_partition)
 
     if not y_is_list:
-        fields = ['y_transpose_x', 'beta' 'standard_error']#, 't_stat', 'p_value']
+        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat',] # 'p_value']
         res = res.annotate(**{f: res[f][0] for f in fields})
 
     res = res.select_globals()

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -538,7 +538,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     res = ht._map_partitions(process_partition)
 
     if not y_is_list:
-        fields = ['y_transpose_x', 'beta' 'standard_error', 't_stat', 'p_value']
+        fields = ['y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
         res = res.annotate(**{f: res[f][0] for f in fields})
 
     res = res.select_globals()

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -476,7 +476,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         return ht.annotate_globals(
             kept_samples=kept_samples,
             __y_nds=y_nds,
-            cov_nds=cov_nds,
             ns=ns,
             ds=ns.map(lambda n: n - k - 1),
             __cov_Qts=cov_Qts,

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -466,19 +466,22 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     y_nds = hl.array([make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set)
                       for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)])
 
-    ht = ht.annotate_globals(kept_samples=list_of_indices_to_keep)
+    ht = ht.annotate_globals(
+        kept_samples=list_of_indices_to_keep,
+        __y_nds=y_nds,
+        cov_nds=cov_nds
+    )
     k = builtins.len(covariates)
     ns = ht.index_globals().kept_samples.map(lambda one_sample_set: hl.len(one_sample_set))
     cov_Qts = hl.if_else(k > 0,
-                         cov_nds.map(lambda one_cov_nd: hl.nd.qr(one_cov_nd)[0].T),
+                         ht.cov_nds.map(lambda one_cov_nd: hl.nd.qr(one_cov_nd)[0].T),
                          ns.map(lambda n: hl.nd.zeros((0, n))))
     Qtys = hl.range(num_y_lists).map(lambda i: cov_Qts[i] @ hl.array(y_nds)[i])
     ht = ht.annotate_globals(
-        __y_nds=y_nds,
         ds=ns.map(lambda n: n - k - 1),
         __cov_Qts=cov_Qts,
         __Qtys=Qtys,
-        __yyps=hl.range(num_y_lists).map(lambda i: dot_rows_with_themselves(y_nds[i].T) - dot_rows_with_themselves(Qtys[i].T)))
+        __yyps=hl.range(num_y_lists).map(lambda i: dot_rows_with_themselves(ht.__y_nds[i].T) - dot_rows_with_themselves(Qtys[i].T)))
 
     def process_block(block):
         rows_in_block = hl.len(block)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -448,9 +448,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
     ht = ht_local.transmute(**{entries_field_name: ht_local[entries_field_name][x_field_name]})
 
-    list_of_ys_and_covs_to_keep_with_indices = \
-        [hl.enumerate(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], one_y_field_name_set + cov_field_names)) for one_y_field_name_set in y_field_names]
-
     def make_one_cov_matrix(ys_and_covs_to_keep):
         return hl.nd.array(ys_and_covs_to_keep.map(lambda struct: array_from_struct(struct, cov_field_names))) \
             if cov_field_names else hl.nd.zeros((hl.len(ys_and_covs_to_keep), 0))
@@ -458,30 +455,35 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
     def make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set):
         return hl.nd.array(ys_and_covs_to_keep.map(lambda struct: array_from_struct(struct, one_y_field_name_set)))
 
-    list_of_ys_and_covs_to_keep = [inner_list.map(lambda pair: pair[1]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
-    list_of_indices_to_keep = [inner_list.map(lambda pair: pair[0]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
+    def setup_globals(ht):
+        list_of_ys_and_covs_to_keep_with_indices = \
+            [hl.enumerate(ht[sample_field_name]).filter(lambda struct_with_index: all_defined(struct_with_index[1], one_y_field_name_set + cov_field_names)) for one_y_field_name_set in y_field_names]
 
-    cov_nds = hl.array([make_one_cov_matrix(ys_and_covs_to_keep) for ys_and_covs_to_keep in list_of_ys_and_covs_to_keep])
+        list_of_ys_and_covs_to_keep = [inner_list.map(lambda pair: pair[1]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
+        kept_samples = [inner_list.map(lambda pair: pair[0]) for inner_list in list_of_ys_and_covs_to_keep_with_indices]
 
-    y_nds = hl.array([make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set)
-                      for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)])
+        cov_nds = hl.array([make_one_cov_matrix(ys_and_covs_to_keep) for ys_and_covs_to_keep in list_of_ys_and_covs_to_keep])
 
-    ht = ht.annotate_globals(
-        kept_samples=list_of_indices_to_keep,
-        __y_nds=y_nds,
-        cov_nds=cov_nds
-    )
-    k = builtins.len(covariates)
-    ns = ht.index_globals().kept_samples.map(lambda one_sample_set: hl.len(one_sample_set))
-    cov_Qts = hl.if_else(k > 0,
-                         ht.cov_nds.map(lambda one_cov_nd: hl.nd.qr(one_cov_nd)[0].T),
-                         ns.map(lambda n: hl.nd.zeros((0, n))))
-    Qtys = hl.range(num_y_lists).map(lambda i: cov_Qts[i] @ hl.array(y_nds)[i])
-    ht = ht.annotate_globals(
-        ds=ns.map(lambda n: n - k - 1),
-        __cov_Qts=cov_Qts,
-        __Qtys=Qtys,
-        __yyps=hl.range(num_y_lists).map(lambda i: dot_rows_with_themselves(ht.__y_nds[i].T) - dot_rows_with_themselves(Qtys[i].T)))
+        y_nds = hl.array([make_one_y_matrix(ys_and_covs_to_keep, one_y_field_name_set)
+                          for ys_and_covs_to_keep, one_y_field_name_set in zip(list_of_ys_and_covs_to_keep, y_field_names)])
+
+        k = builtins.len(covariates)
+        ns = hl.array(kept_samples).map(lambda one_sample_set: hl.len(one_sample_set))
+        cov_Qts = hl.if_else(k > 0,
+                             cov_nds.map(lambda one_cov_nd: hl.nd.qr(one_cov_nd)[0].T),
+                             ns.map(lambda n: hl.nd.zeros((0, n))))
+        Qtys = hl.range(num_y_lists).map(lambda i: cov_Qts[i] @ hl.array(y_nds)[i])
+        return ht.annotate_globals(
+            kept_samples=kept_samples,
+            __y_nds=y_nds,
+            cov_nds=cov_nds,
+            ns=ns,
+            ds=ns.map(lambda n: n - k - 1),
+            __cov_Qts=cov_Qts,
+            __Qtys=Qtys,
+            __yyps=hl.range(num_y_lists).map(lambda i: dot_rows_with_themselves(y_nds[i].T) - dot_rows_with_themselves(Qtys[i].T)))
+
+    ht = setup_globals(ht)
 
     def process_block(block):
         rows_in_block = hl.len(block)
@@ -489,7 +491,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         # Processes one block group based on given idx. Returns a single struct.
         def process_y_group(idx):
             X = hl.nd.array(block[entries_field_name].map(lambda row: mean_impute(select_array_indices(row, ht.kept_samples[idx])))).T
-            n = ns[idx]
+            n = ht.ns[idx]
             sum_x = (X.T @ hl.nd.ones((n,)))
             Qtx = ht.__cov_Qts[idx] @ X
             ytx = ht.__y_nds[idx].T @ X
@@ -499,10 +501,10 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             se = ((1.0 / ht.ds[idx]) * (ht.__yyps[idx].reshape((-1, 1)) @ xxpRec.reshape((1, -1)) - (b * b))).map(lambda entry: hl.sqrt(entry))
             t = b / se
             p = t.map(lambda entry: 2 * hl.expr.functions.pT(-hl.abs(entry), ht.ds[idx], True, False))
-            return hl.struct(n=hl.range(rows_in_block).map(lambda i: n), sum_x=sum_x._data_array(), y_transpose_x=ytx.T._data_array(), beta=b.T._data_array(),
-                             standard_error=se.T._data_array(), t_stat=t.T._data_array(), p_value=p.T._data_array())
+            return {'n': hl.range(rows_in_block).map(lambda i: n), 'sum_x': sum_x._data_array(), 'y_transpose_x': ytx.T._data_array(), 'beta':b.T._data_array(),
+                    'standard_error': se.T._data_array(), 't_stat': t.T._data_array(), 'p_value': p.T._data_array()}
 
-        per_y_list = hl.range(num_y_lists).map(lambda i: process_y_group(i))
+        per_y_list = [process_y_group(i) for i in range(num_y_lists)]
 
         key_field_names = [key_field for key_field in ht.key]
 
@@ -511,7 +513,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             idxth_keys = {field_name: block[field_name][row_idx] for field_name in key_field_names}
             computed_row_field_names = ['n', 'sum_x', 'y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
             computed_row_fields = {
-                field_name: per_y_list.map(lambda one_y: one_y[field_name][row_idx]) for field_name in computed_row_field_names
+                field_name: [one_y[field_name][row_idx] for one_y in per_y_list] for field_name in computed_row_field_names
             }
             pass_through_rows = {
                 field_name: block[field_name][row_idx] for field_name in row_field_names

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -526,7 +526,7 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
             return hl.struct(**{**idxth_keys, **computed_row_fields, **pass_through_rows})
 
-        new_rows = hl.range(rows_in_block).map(lambda inner_i: build_row(inner_i))
+        new_rows = hl.range(rows_in_block).map(build_row)
 
         return new_rows
 

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -253,12 +253,14 @@ def qr(nd, mode="reduced"):
 
     float_nd = nd.map(lambda x: hl.float64(x))
     ir = NDArrayQR(float_nd._ir, mode)
+    indices = nd._indices
+    aggs = nd._aggregations
     if mode == "raw":
-        return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1)))
+        return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 1)), indices, aggs)
     elif mode == "r":
-        return construct_expr(ir, tndarray(tfloat64, 2))
+        return construct_expr(ir, tndarray(tfloat64, 2), indices, aggs)
     elif mode in ["complete", "reduced"]:
-        return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)))
+        return construct_expr(ir, ttuple(tndarray(tfloat64, 2), tndarray(tfloat64, 2)), indices, aggs)
 
 
 @typecheck(nd=expr_ndarray(), full_matrices=bool, compute_uv=bool)


### PR DESCRIPTION
#9634 Introduced a large performance regression in the `linear_regression_rows_nd` benchmark (making it about 4x slower). This PR fixes that by doing two things:

1. Move all the global into one single `annotate_globals` expression, so that CSE can work properly. This required fixing a bug in some ndarray expressions that were not correctly tracking their source tables. To make sure I was only referencing the global versions of this computed things, rather accidentally recomputing, I wrapped the global setup in a function to scope the variables. This improvement was minor, didn't hit the real root of the problem.

2. Much more significantly, and not 100% clear why: `process_y_group` is now a function that returns a python dictionary, instead of a hail struct. I can guess that the allocation required by making a struct was wasteful, but it seems crazy that it was "make the benchmark 4x slower" amounts of wasteful. 

While this is not user facing yet, would be good to get this in before an eventual 0.2.60 release if we want to avoid benchmarks regressing between versions.