### PR TITLE
Region Pool Per Task instead of Per Thread

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.Backend
+import is.hail.backend.{Backend, HailTaskContext}
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.IRFunctionRegistry
@@ -340,7 +340,7 @@ object HailContext {
       val fs = fsBc.value
       val idxname = s"$path/$idxPath/${ p.file }.idx"
       val filename = s"$path/parts/${ p.file }"
-      val idxr = mkIndexReader(fs, idxname, 8) // default cache capacity
+      val idxr = mkIndexReader(fs, idxname, 8, HailTaskContext.get().getRegionPool()) // default cache capacity
       val in = fs.open(filename)
       (in, idxr, p.bounds, context.taskMetrics().inputMetrics)
     })
@@ -379,7 +379,7 @@ object HailContext {
       val fs = fsBc.value
       val idxr = mkIndexReader.map { mk =>
         val idxname = s"$pathRows/${ indexSpecRows.get.relPath }/${ p.file }.idx"
-        mk(fs, idxname, 8) // default cache capacity
+        mk(fs, idxname, 8, HailTaskContext.get().getRegionPool()) // default cache capacity
       }
       val inRows = fs.open(s"$pathRows/parts/${ p.file }")
       val inEntries = fs.open(s"$pathEntries/parts/${ p.file }")

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -265,9 +265,6 @@ object Region {
     case t: PBaseStruct => (addr, v) => Region.copyFrom(coerce[Long](v), addr, t.byteSize)
   }
 
-  def stagedCreate(blockSize: Size): Code[Region] =
-    Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), Code._null)
-
   def stagedCreate(blockSize: Size, pool: Code[RegionPool]): Code[Region] =
     Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), pool)
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -268,7 +268,7 @@ object Region {
   def stagedCreate(blockSize: Size, pool: Code[RegionPool]): Code[Region] =
     Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), pool)
 
-  def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
+  def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool): Region = {
     (if (pool == null) {
       val htc = HailTaskContext.get()
       if (htc == null) {

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -268,6 +268,9 @@ object Region {
   def stagedCreate(blockSize: Size): Code[Region] =
     Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), Code._null)
 
+  def stagedCreate(blockSize: Size, pool: Code[RegionPool]): Code[Region] =
+    Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), pool)
+
   def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
     (if (pool == null) RegionPool.get else pool)
       .getRegion(blockSize)
@@ -448,6 +451,10 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 
   def prettyBits(): String = {
     "FIXME: implement prettyBits on Region"
+  }
+
+  def getPool(): RegionPool = {
+    pool
   }
 }
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -15,8 +15,6 @@ object Region {
   val SIZES: Array[Long] = Array(64 * 1024, 8 * 1024, 1024, 256)
   val BLOCK_THRESHOLD: Long = 4 * 1024
 
-  def scoped[T](f: Region => T): T = using(Region())(f)
-
   def loadInt(addr: Long): Int = Memory.loadInt(addr)
 
   def loadLong(addr: Long): Long = Memory.loadLong(addr)

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -269,14 +269,7 @@ object Region {
     Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), pool)
 
   def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool): Region = {
-    (if (pool == null) {
-      val htc = HailTaskContext.get()
-      if (htc == null) {
-        throw new IllegalStateException(s"RegionPool requested but HailTaskContext was null. On worker = ${TaskContext.get() != null}")
-      }
-      htc.getRegionPool()
-    } else pool)
-      .getRegion(blockSize)
+    pool.getRegion(blockSize)
   }
 
   def pretty(off: Long, n: Int, header: String): String = {

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -2,8 +2,10 @@ package is.hail.annotations
 
 import is.hail.asm4s
 import is.hail.asm4s.{Code, coerce}
+import is.hail.backend.HailTaskContext
 import is.hail.types.physical._
 import is.hail.utils._
+import org.apache.spark.TaskContext
 
 object Region {
   type Size = Int
@@ -267,12 +269,13 @@ object Region {
     Code.invokeScalaObject2[Int, RegionPool, Region](Region.getClass, "apply", asm4s.const(blockSize), pool)
 
   def apply(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
-    (if (pool == null) RegionPool.get else pool)
-      .getRegion(blockSize)
-  }
-
-  def makeNamed(blockSize: Region.Size = Region.REGULAR, pool: RegionPool = null): Region = {
-    (if (pool == null) RegionPool.get else pool)
+    (if (pool == null) {
+      val htc = HailTaskContext.get()
+      if (htc == null) {
+        throw new IllegalStateException(s"RegionPool requested but HailTaskContext was null. On worker = ${TaskContext.get() != null}")
+      }
+      htc.getRegionPool()
+    } else pool)
       .getRegion(blockSize)
   }
 

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -17,10 +17,6 @@ object Region {
 
   def scoped[T](f: Region => T): T = using(Region())(f)
 
-  def smallScoped[T](f: Region => T): T = using(Region(SMALL))(f)
-
-  def tinyScoped[T](f: Region => T): T = using(Region(TINY))(f)
-
   def loadInt(addr: Long): Int = Memory.loadInt(addr)
 
   def loadLong(addr: Long): Long = Memory.loadLong(addr)

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -7,15 +7,6 @@ import is.hail.utils._
 import org.apache.spark.TaskContext
 
 object RegionPool {
-  def get: RegionPool = {
-    val htc = HailTaskContext.get()
-
-    if (htc == null) {
-      throw new IllegalStateException(s"RegionPool requested but HailTaskContext was null. On worker = ${TaskContext.get() != null}")
-    }
-
-    htc.getRegionPool()
-  }
 
   def apply(strictMemoryCheck: Boolean = false): RegionPool = {
     val thread = Thread.currentThread()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -10,6 +10,8 @@ object RegionPool {
     val thread = Thread.currentThread()
     new RegionPool(strictMemoryCheck, thread.getName, thread.getId)
   }
+
+  def scoped[T](f: RegionPool => T): T = using(RegionPool(false))(f)
 }
 
 final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, threadID: Long) extends AutoCloseable {
@@ -131,6 +133,8 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
 
 
   }
+
+  def scopedRegion[T](f: Region => T): T = using(Region(pool = this))(f)
 
   override def finalize(): Unit = close()
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -4,13 +4,14 @@ import is.hail.asm4s
 import is.hail.asm4s.Code
 import is.hail.backend.HailTaskContext
 import is.hail.utils._
+import org.apache.spark.TaskContext
 
 object RegionPool {
   def get: RegionPool = {
     val htc = HailTaskContext.get()
 
     if (htc == null) {
-      throw new IllegalStateException("RegionPool requested but HailTaskContext was null")
+      throw new IllegalStateException(s"RegionPool requested but HailTaskContext was null. On worker = ${TaskContext.get() != null}")
     }
 
     htc.getRegionPool()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -134,6 +134,8 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
   }
 
   def scopedRegion[T](f: Region => T): T = using(Region(pool = this))(f)
+  def scopedSmallRegion[T](f: Region => T): T = using(Region(Region.SMALL, pool=this))(f)
+  def scopedTinyRegion[T](f: Region => T): T = using(Region(Region.TINY, pool=this))(f)
 
   override def finalize(): Unit = close()
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -1,5 +1,7 @@
 package is.hail.annotations
 
+import is.hail.asm4s
+import is.hail.asm4s.Code
 import is.hail.backend.HailTaskContext
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -4,7 +4,15 @@ import is.hail.backend.HailTaskContext
 import is.hail.utils._
 
 object RegionPool {
-  def get: RegionPool = HailTaskContext.get().getRegionPool()
+  def get: RegionPool = {
+    val htc = HailTaskContext.get()
+
+    if (htc == null) {
+      throw new IllegalStateException("RegionPool requested but HailTaskContext was null")
+    }
+
+    htc.getRegionPool()
+  }
 
   def apply(strictMemoryCheck: Boolean = false): RegionPool = {
     val thread = Thread.currentThread()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -1,13 +1,10 @@
 package is.hail.annotations
 
+import is.hail.backend.HailTaskContext
 import is.hail.utils._
 
 object RegionPool {
-  private lazy val thePool: ThreadLocal[RegionPool] = new ThreadLocal[RegionPool]() {
-    override def initialValue(): RegionPool = RegionPool()
-  }
-
-  def get: RegionPool = thePool.get()
+  def get: RegionPool = HailTaskContext.get().getRegionPool()
 
   def apply(strictMemoryCheck: Boolean = false): RegionPool = {
     val thread = Thread.currentThread()

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -100,10 +100,9 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
   def numFreeBlocks(): Int = freeBlocks.map(_.size).sum
 
   def logStats(context: String): Unit = {
-    val pool = RegionPool.get
-    val nFree = pool.numFreeRegions()
-    val nRegions = pool.numRegions()
-    val nBlocks = pool.numFreeBlocks()
+    val nFree = this.numFreeRegions()
+    val nRegions = this.numRegions()
+    val nBlocks = this.numFreeBlocks()
 
     val freeBlockCounts = freeBlocks.map(_.size)
     val usedBlockCounts = blocks.zip(freeBlockCounts).map { case (tot, free) => tot - free }

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -1,10 +1,6 @@
 package is.hail.annotations
 
-import is.hail.asm4s
-import is.hail.asm4s.Code
-import is.hail.backend.HailTaskContext
 import is.hail.utils._
-import org.apache.spark.TaskContext
 
 object RegionPool {
 

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -36,10 +36,7 @@ abstract class Backend {
 
   def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType
 
-  def parallelizeAndComputeWithIndex(
-    backendContext: BackendContext,
-    collection: Array[Array[Byte]],
-    dependency: Option[TableStageDependency] = None)(f: (Array[Byte], Int) => Array[Byte]): Array[Array[Byte]]
+  def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]], dependency: Option[TableStageDependency] = None)(f: (Array[Byte], HailTaskContext) => Array[Byte]): Array[Array[Byte]]
 
   def stop(): Unit
 

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -1,7 +1,7 @@
 package is.hail.backend
 
 import is.hail.HailContext
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s._
 import is.hail.expr.ir.lowering.TableStageDependency
 
@@ -25,7 +25,7 @@ class BackendUtils(mods: Array[(String, (Int, Region) => BackendUtils.F)]) {
 
     backend.parallelizeAndComputeWithIndex(backendContext, contexts, tsd) { (ctx, i) =>
       val gs = globalsBC.value
-      Region.scoped { region =>
+      RegionPool.get.scopedRegion { region =>
         val res = f(i, region)(region, ctx, gs)
         res
       }

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -25,7 +25,7 @@ class BackendUtils(mods: Array[(String, (Int, Region) => BackendUtils.F)]) {
 
     backend.parallelizeAndComputeWithIndex(backendContext, contexts, tsd) { (ctx, i) =>
       val gs = globalsBC.value
-      RegionPool.get.scopedRegion { region =>
+      HailTaskContext.get.getRegionPool().scopedRegion { region =>
         val res = f(i, region)(region, ctx, gs)
         res
       }

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -23,12 +23,12 @@ class BackendUtils(mods: Array[(String, (Int, Region) => BackendUtils.F)]) {
     val globalsBC = backend.broadcast(globals)
     val f = getModule(modID)
 
-    backend.parallelizeAndComputeWithIndex(backendContext, contexts, tsd) { (ctx, i) =>
-      val gs = globalsBC.value
-      HailTaskContext.get.getRegionPool().scopedRegion { region =>
-        val res = f(i, region)(region, ctx, gs)
-        res
-      }
-    }
+    backend.parallelizeAndComputeWithIndex(backendContext, contexts, tsd)({ (ctx, htc) =>
+          val gs = globalsBC.value
+          HailTaskContext.get.getRegionPool().scopedRegion { region =>
+            val res = f(htc.partitionId(), region)(region, ctx, gs)
+            res
+          }
+        })
   }
 }

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -1,5 +1,7 @@
 package is.hail.backend
 
+import is.hail.annotations.RegionPool
+
 object HailTaskContext {
   def get(): HailTaskContext = taskContext.get
 
@@ -13,6 +15,10 @@ abstract class HailTaskContext {
   def stageId(): Int
   def partitionId(): Int
   def attemptNumber(): Int
+
+  private lazy val thePool = RegionPool()
+
+  def getRegionPool(): RegionPool = thePool
 
   def partSuffix(): String = {
     val rng = new java.security.SecureRandom()

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -1,11 +1,28 @@
 package is.hail.backend
 
+import is.hail.HailContext
 import is.hail.annotations.RegionPool
+import is.hail.backend.local.{LocalBackend, LocalTaskContext}
+import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
+import org.apache.spark.TaskContext
 
 object HailTaskContext {
   def get(): HailTaskContext = taskContext.get
 
-  private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]
+  private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]() {
+    override def initialValue(): HailTaskContext = {
+      val backend = HailContext.get.backend
+      if (backend.isInstanceOf[SparkBackend]) {
+        val sparkTC = TaskContext.get()
+        assert(sparkTC != null, "Spark Task Context was null, maybe this ran on the driver?")
+        new SparkTaskContext(sparkTC)
+      } else if (backend.isInstanceOf[LocalBackend]) {
+        throw new IllegalStateException("Internal Hail Error. Must manually set HailTaskContext for local backend.")
+      } else {
+        throw new IllegalStateException("Unsupported backend type.")
+      }
+    }
+  }
   def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
   def unset(): Unit = {
     taskContext.get().getRegionPool().close()

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -6,8 +6,8 @@ object HailTaskContext {
   def get(): HailTaskContext = taskContext.get
 
   private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]
-  protected[backend] def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
-  protected[backend] def unset(): Unit = taskContext.remove()
+  def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
+  def unset(): Unit = taskContext.remove()
 }
 
 abstract class HailTaskContext {

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -11,16 +11,9 @@ object HailTaskContext {
 
   private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]() {
     override def initialValue(): HailTaskContext = {
-      val backend = HailContext.get.backend
-      if (backend.isInstanceOf[SparkBackend]) {
         val sparkTC = TaskContext.get()
         assert(sparkTC != null, "Spark Task Context was null, maybe this ran on the driver?")
         new SparkTaskContext(sparkTC)
-      } else if (backend.isInstanceOf[LocalBackend]) {
-        throw new IllegalStateException("Internal Hail Error. Must manually set HailTaskContext for local backend.")
-      } else {
-        throw new IllegalStateException("Unsupported backend type.")
-      }
     }
   }
   def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -17,7 +17,7 @@ object HailTaskContext {
     }
   }
   def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
-  def unset(): Unit = {
+  def finish(): Unit = {
     taskContext.get().getRegionPool().close()
     taskContext.remove()
   }

--- a/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
+++ b/hail/src/main/scala/is/hail/backend/HailTaskContext.scala
@@ -7,7 +7,10 @@ object HailTaskContext {
 
   private[this] val taskContext: ThreadLocal[HailTaskContext] = new ThreadLocal[HailTaskContext]
   def setTaskContext(tc: HailTaskContext): Unit = taskContext.set(tc)
-  def unset(): Unit = taskContext.remove()
+  def unset(): Unit = {
+    taskContext.get().getRegionPool().close()
+    taskContext.remove()
+  }
 }
 
 abstract class HailTaskContext {

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -76,7 +76,7 @@ class LocalBackend(
   def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]],
     dependency: Option[TableStageDependency] = None)(f: (Array[Byte], Int) => Array[Byte]): Array[Array[Byte]] = {
     collection.zipWithIndex.map { case (c, i) =>
-      HailTaskContext.setTaskContext(new LocalTaskContext())
+      HailTaskContext.setTaskContext(new LocalTaskContext(i))
       val bytes = f(c, i)
       HailTaskContext.unset()
       bytes

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -31,9 +31,9 @@ class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serial
 class LocalTaskContext(val partitionId: Int) extends HailTaskContext {
   override type BackendType = LocalBackend
 
-  override def stageId(): Int = ???
+  override def stageId(): Int = 0
 
-  override def attemptNumber(): Int = ???
+  override def attemptNumber(): Int = 0
 }
 
 object LocalBackend {

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -73,11 +73,10 @@ class LocalBackend(
 
   def broadcast[T : ClassTag](value: T): BroadcastValue[T] = new LocalBroadcastValue[T](value)
 
-  def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]],
-    dependency: Option[TableStageDependency] = None)(f: (Array[Byte], Int) => Array[Byte]): Array[Array[Byte]] = {
+  def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]], dependency: Option[TableStageDependency] = None)(f: (Array[Byte], HailTaskContext) => Array[Byte]): Array[Array[Byte]] = {
     collection.zipWithIndex.map { case (c, i) =>
       HailTaskContext.setTaskContext(new LocalTaskContext(i))
-      val bytes = f(c, i)
+      val bytes = f(c, HailTaskContext.get())
       HailTaskContext.finish()
       bytes
     }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -28,12 +28,10 @@ import scala.reflect.ClassTag
 
 class LocalBroadcastValue[T](val value: T) extends BroadcastValue[T] with Serializable
 
-class LocalTaskContext extends HailTaskContext {
+class LocalTaskContext(val partitionId: Int) extends HailTaskContext {
   override type BackendType = LocalBackend
 
   override def stageId(): Int = ???
-
-  override def partitionId(): Int = ???
 
   override def attemptNumber(): Int = ???
 }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -78,7 +78,7 @@ class LocalBackend(
     collection.zipWithIndex.map { case (c, i) =>
       HailTaskContext.setTaskContext(new LocalTaskContext(i))
       val bytes = f(c, i)
-      HailTaskContext.unset()
+      HailTaskContext.finish()
       bytes
     }
   }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -70,7 +70,7 @@ object Worker {
     val htc = new ServiceTaskContext(i)
     HailTaskContext.setTaskContext(htc)
     val result = f(context, i)
-    HailTaskContext.unset()
+    HailTaskContext.finish()
 
     using(fs.createNoCompression(s"$root/result.$i")) { os =>
       os.write(result)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -46,7 +46,7 @@ object Worker {
     }
 
     val f = using(new ObjectInputStream(fs.openNoCompression(s"$root/f"))) { is =>
-      is.readObject().asInstanceOf[(Array[Byte], Int) => Array[Byte]]
+      is.readObject().asInstanceOf[(Array[Byte], HailTaskContext) => Array[Byte]]
     }
 
     var offset = 0L
@@ -69,7 +69,7 @@ object Worker {
 
     val htc = new ServiceTaskContext(i)
     HailTaskContext.setTaskContext(htc)
-    val result = f(context, i)
+    val result = f(context, htc)
     HailTaskContext.finish()
 
     using(fs.createNoCompression(s"$root/result.$i")) { os =>

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -128,8 +128,7 @@ class ServiceBackend() extends Backend {
     def value: T = _value
   }
 
-  def parallelizeAndComputeWithIndex(_backendContext: BackendContext, collection: Array[Array[Byte]],
-    dependency: Option[TableStageDependency] = None)(f: (Array[Byte], Int) => Array[Byte]): Array[Array[Byte]] = {
+  def parallelizeAndComputeWithIndex(_backendContext: BackendContext, collection: Array[Array[Byte]], dependency: Option[TableStageDependency] = None)(f: (Array[Byte], HailTaskContext) => Array[Byte]): Array[Array[Byte]] = {
     val backendContext = _backendContext.asInstanceOf[ServiceBackendContext]
 
     val user = users(backendContext.username)

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -667,7 +667,6 @@ class SparkBackendComputeRDD(
 
   override def compute(partition: Partition, context: TaskContext): Iterator[Array[Byte]] = {
     val sp = partition.asInstanceOf[SparkBackendComputeRDDPartition]
-    HailTaskContext.setTaskContext(new SparkTaskContext(TaskContext.get))
     Iterator.single(f(sp.data, sp.index))
   }
 }

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -47,6 +47,10 @@ class SparkTaskContext(ctx: TaskContext) extends HailTaskContext {
   override def stageId(): Int = ctx.stageId()
   override def partitionId(): Int = ctx.partitionId()
   override def attemptNumber(): Int = ctx.attemptNumber()
+
+  ctx.addTaskCompletionListener(tc =>
+    this.getRegionPool().close()
+  )
 }
 
 object SparkBackend {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -100,12 +100,12 @@ object Emit {
 
 object AggContainer {
   // FIXME remove this when EmitStream also has a codebuilder
-  def fromVars(aggs: Array[AggStateSig], mb: EmitMethodBuilder[_], pool: Code[RegionPool], region: Settable[Region], off: Settable[Long]): (AggContainer, Code[Unit], Code[Unit]) = {
+  def fromVars(aggs: Array[AggStateSig], mb: EmitMethodBuilder[_], region: Settable[Region], off: Settable[Long]): (AggContainer, Code[Unit], Code[Unit]) = {
 
     val (setup, aggState) = EmitCodeBuilder.scoped(mb) { cb =>
       val states = agg.StateTuple(aggs.map(a => agg.AggStateSig.getState(a, cb.emb.ecb)))
       val aggState = new agg.TupleAggregatorState(mb.ecb, states, region, off)
-      cb += (region := Region.stagedCreate(Region.REGULAR, pool))
+      cb += (region := Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
       cb += region.load().setNumParents(aggs.length)
       cb += (off := region.load().allocate(aggState.storageType.alignment, aggState.storageType.byteSize))
       states.createStates(cb)
@@ -121,12 +121,12 @@ object AggContainer {
     (AggContainer(aggs, aggState, () => ()), setup, cleanup)
   }
 
-  def fromMethodBuilder[C](aggs: Array[AggStateSig], mb: EmitMethodBuilder[C], pool: Code[RegionPool], varPrefix: String): (AggContainer, Code[Unit], Code[Unit]) =
-    fromVars(aggs, mb, pool, mb.genFieldThisRef[Region](s"${varPrefix}_top_region"), mb.genFieldThisRef[Long](s"${varPrefix}_off"))
+  def fromMethodBuilder[C](aggs: Array[AggStateSig], mb: EmitMethodBuilder[C], varPrefix: String): (AggContainer, Code[Unit], Code[Unit]) =
+    fromVars(aggs, mb, mb.genFieldThisRef[Region](s"${varPrefix}_top_region"), mb.genFieldThisRef[Long](s"${varPrefix}_off"))
 
-  def fromBuilder[C](cb: EmitCodeBuilder, pool: Code[RegionPool], aggs: Array[AggStateSig], varPrefix: String): AggContainer = {
+  def fromBuilder[C](cb: EmitCodeBuilder, aggs: Array[AggStateSig], varPrefix: String): AggContainer = {
     val off = cb.newField[Long](s"${varPrefix}_off")
-    val region = cb.newField[Region](s"${varPrefix}_top_region", Region.stagedCreate(Region.REGULAR, pool))
+    val region = cb.newField[Region](s"${varPrefix}_top_region", Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
     val states = agg.StateTuple(aggs.map(a => agg.AggStateSig.getState(a, cb.emb.ecb)))
     val aggState = new agg.TupleAggregatorState(cb.emb.ecb, states, region, off)
     cb += region.load().setNumParents(aggs.length)
@@ -1444,7 +1444,7 @@ class Emit[C](
       case x: NDArraySlice => emitDeforestedNDArray(x)
       case x: NDArrayFilter => emitDeforestedNDArray(x)
       case x@RunAgg(body, result, states) =>
-        val newContainer = AggContainer.fromBuilder(cb, region.code.getPool(), states.toArray, "run_agg")
+        val newContainer = AggContainer.fromBuilder(cb, states.toArray, "run_agg")
         emitVoid(body, container = Some(newContainer))
         val codeRes = emitI(result, container = Some(newContainer))
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -802,6 +802,7 @@ class EmitClassBuilder[C](
           f.asInstanceOf[FunctionWithAggRegion].setNumSerialized(nSerializedAggs)
         f.asInstanceOf[FunctionWithSeededRandomness].setPartitionIndex(idx)
         if (f.isInstanceOf[FunctionWithPool]) {
+          assert(region != null, s"On worker = ${TaskContext.get() != null}")
           f.asInstanceOf[FunctionWithPool].setPool(region.pool)
         }
         f

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -801,7 +801,9 @@ class EmitClassBuilder[C](
         if (nSerializedAggs != 0)
           f.asInstanceOf[FunctionWithAggRegion].setNumSerialized(nSerializedAggs)
         f.asInstanceOf[FunctionWithSeededRandomness].setPartitionIndex(idx)
-        f.asInstanceOf[FunctionWithPool].setPool(region.pool)
+        if (f.isInstanceOf[FunctionWithPool]) {
+          f.asInstanceOf[FunctionWithPool].setPool(region.pool)
+        }
         f
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -415,7 +415,7 @@ class EmitClassBuilder[C](
 
     val baos = new ByteArrayOutputStream()
     val enc = spec.buildEncoder(ctx, litType)(baos)
-    Region.scoped { region =>
+    this.emodb.ctx.r.pool.scopedRegion { region =>
       val rvb = new RegionValueBuilder(region)
       rvb.start(litType)
       rvb.startTuple()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -384,8 +384,8 @@ object Stream {
       Code(LchildPull, childSource.pull)
 
       Source[StagedRegion => Stream[A]](
-        setup0 = Code(childSource.setup0, childEltRegion.allocateRegion(Region.REGULAR)),
-        close0 = Code(childEltRegion.allocateRegion(Region.REGULAR), childSource.close0),
+        setup0 = Code(childSource.setup0, childEltRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
+        close0 = Code(childEltRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()), childSource.close0),
         setup = Code(
           childSource.setup,
           xSize := size,
@@ -570,7 +570,7 @@ object Stream {
         })
 
       Source[(EmitCode, EmitCode)](
-        setup0 = Code(leftSource.setup0, rightSource.setup0, rightRegion.allocateRegion(Region.REGULAR)),
+        setup0 = Code(leftSource.setup0, rightSource.setup0, rightRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
         close0 = Code(rightRegion.free(), leftSource.close0, rightSource.close0),
         setup = Code(pulledRight := false, rightEOS := false, leftSource.setup, rightSource.setup),
         close = Code(leftSource.close, rightSource.close),
@@ -674,8 +674,8 @@ object Stream {
       Source[EmitCode](
         setup0 = Code(leftSource.setup0,
           rightSource.setup0,
-          leftRegion.allocateRegion(Region.REGULAR),
-          rightRegion.allocateRegion(Region.REGULAR)),
+          leftRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()),
+          rightRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
         close0 = Code(leftRegion.free(),
           rightRegion.free(),
           leftSource.close0,
@@ -798,8 +798,8 @@ object Stream {
 
       Source[(EmitCode, EmitCode)](
         setup0 = Code(leftSource.setup0, rightSource.setup0,
-                      leftRegion.allocateRegion(Region.REGULAR),
-                      rightRegion.allocateRegion(Region.REGULAR)),
+                      leftRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()),
+                      rightRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
         close0 = Code(leftRegion.free(), rightRegion.free(),
                       leftSource.close0, rightSource.close0),
         setup = Code(pulledRight := false, c := 0,
@@ -935,7 +935,7 @@ object EmitStream {
     val SizedStream(ssSetup, stream, optLen) = sstream
     val eltRegion = destRegion.createChildRegion(mb)
     Code(FastSeq(
-      eltRegion.allocateRegion(Region.REGULAR),
+      eltRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()),
       ssSetup,
       ab.clear,
       ab.ensureCapacity(optLen.getOrElse(16)),
@@ -980,7 +980,7 @@ object EmitStream {
       case Some(len) =>
         val eltRegion = destRegion.createChildRegion(mb)
         val ptr = Code.sequence1(FastIndexedSeq(
-            eltRegion.allocateRegion(Region.REGULAR),
+            eltRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()),
             ss.setup,
             srvb.start(len),
             ss.stream(eltRegion).forEach(ctx, mb, { et =>
@@ -1292,7 +1292,7 @@ object EmitStream {
       Code(LouterEos, outerEos)
 
       Source[ChildStagedRegion => Stream[PCode]](
-        setup0 = Code(childSource.setup0, holdingRegion.allocateRegion(Region.REGULAR), keyRegion.allocateRegion(Region.TINIER)),
+        setup0 = Code(childSource.setup0, holdingRegion.allocateRegion(Region.REGULAR, mb.ecb.pool()), keyRegion.allocateRegion(Region.TINIER, mb.ecb.pool())),
         close0 = Code(holdingRegion.free(), keyRegion.free(), childSource.close0),
         setup = Code(
           childSource.setup,
@@ -1622,7 +1622,7 @@ object EmitStream {
                       }
                     }
                   },
-                  setup0 = Some(tmpRegion.allocateRegion(Region.REGULAR)),
+                  setup0 = Some(tmpRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
                   close0 = Some(tmpRegion.free()))
                 .flatten
             }
@@ -1904,7 +1904,7 @@ object EmitStream {
                 }
                 .flatten.flatten
                 .map(x => x,
-                     setup0 = Some(outerEltRegion.allocateRegion(Region.REGULAR)),
+                     setup0 = Some(outerEltRegion.allocateRegion(Region.REGULAR, mb.ecb.pool())),
                      close0 = Some(outerEltRegion.free()))
             }
 
@@ -1994,7 +1994,7 @@ object EmitStream {
                   })
 
                 Source[EmitCode](
-                  setup0 = Code(source.setup0, accRegion.allocateRegion(Region.TINIER)),
+                  setup0 = Code(source.setup0, accRegion.allocateRegion(Region.TINIER, mb.ecb.pool())),
                   setup = Code(hasPulled := false, source.setup),
                   close = source.close,
                   close0 = Code(accRegion.free(), source.close0),
@@ -2043,7 +2043,7 @@ object EmitStream {
                 },
                 setup0 = Some(aggSetup),
                 close0 = Some(aggCleanup),
-                setup = Some(Code(tmpRegion.allocateRegion(Region.SMALL), cInit, tmpRegion.free())))
+                setup = Some(Code(tmpRegion.allocateRegion(Region.SMALL, mb.ecb.pool()), cInit, tmpRegion.free())))
             }
 
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -2014,8 +2014,7 @@ object EmitStream {
           }
 
         case x@RunAggScan(array, name, init, seqs, result, states) =>
-          val pool = outerRegion.code.getPool()
-          val (newContainer, aggSetup, aggCleanup) = AggContainer.fromMethodBuilder(states.toArray, mb, pool,"array_agg_scan")
+          val (newContainer, aggSetup, aggCleanup) = AggContainer.fromMethodBuilder(states.toArray, mb,"array_agg_scan")
 
           val eltType = coerce[PStream](array.pType).elementType
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -2014,7 +2014,8 @@ object EmitStream {
           }
 
         case x@RunAggScan(array, name, init, seqs, result, states) =>
-          val (newContainer, aggSetup, aggCleanup) = AggContainer.fromMethodBuilder(states.toArray, mb, "array_agg_scan")
+          val pool = outerRegion.code.getPool()
+          val (newContainer, aggSetup, aggCleanup) = AggContainer.fromMethodBuilder(states.toArray, mb, pool,"array_agg_scan")
 
           val eltType = coerce[PStream](array.pType).elementType
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -822,7 +822,6 @@ object Interpret {
         val tvs = children.map(_.execute(ctx))
         writer(ctx, tvs)
       case TableWrite(child, writer) =>
-        log.info(s"I am using a ${writer}")
         writer(ctx, child.execute(ctx))
       case BlockMatrixWrite(child, writer) =>
         writer(ctx, child.execute(ctx))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -883,13 +883,15 @@ object Interpret {
           }
 
           // creates a region, giving ownership to the caller
-          val read: WrappedByteArray => RegionValue = {
+          val read: RegionPool => (WrappedByteArray => RegionValue) = {
             val deserialize = extracted.deserialize(ctx, spec)
-            (a: WrappedByteArray) => {
-              val r = Region(Region.SMALL)
-              val res = deserialize(r, a.bytes)
-              a.clear()
-              RegionValue(r, res)
+            (pool: RegionPool) => {
+              (a: WrappedByteArray) => {
+                val r = Region(Region.SMALL, pool)
+                val res = deserialize(r, a.bytes)
+                a.clear()
+                RegionValue(r, res)
+              }
             }
           }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -776,7 +776,7 @@ object Interpret {
         }
       case ir: AbstractApplyNode[_] =>
         val argTuple = PType.canonical(TTuple(ir.args.map(_.typ): _*)).setRequired(true).asInstanceOf[PTuple]
-        Region.scoped { region =>
+        ctx.r.pool.scopedRegion { region =>
           val (rt, f) = functionMemo.getOrElseUpdate(ir, {
             val wrappedArgs: IndexedSeq[BaseIR] = ir.args.zipWithIndex.map { case (x, i) =>
               GetTupleElement(Ref("in", argTuple.virtualType), i)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -847,7 +847,7 @@ object Interpret {
             FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
             MakeTuple.ordered(FastSeq(extracted.postAggIR)))
 
-          Region.scoped { region =>
+          ctx.r.pool.scopedRegion { region =>
             SafeRow(rt, f(0, region)(region, globalsOffset))
           }
         } else {
@@ -946,7 +946,7 @@ object Interpret {
             Let(res, extracted.results, MakeTuple.ordered(FastSeq(extracted.postAggIR))))
           assert(rTyp.types(0).virtualType == query.typ)
 
-          Region.scoped { r =>
+          ctx.r.pool.scopedRegion { r =>
             val resF = f(0, r)
             resF.setAggState(rv.region, rv.offset)
             val res = SafeRow(rTyp, resF(r, globalsOffset))
@@ -963,7 +963,7 @@ object Interpret {
           FastIndexedSeq(classInfo[Region]), LongInfo,
           MakeTuple.ordered(FastSeq(child)),
           optimize = false)
-        Region.scoped { r =>
+        ctx.r.pool.scopedRegion { r =>
           SafeRow.read(rt, makeFunction(0, r)(r)).asInstanceOf[Row](0)
         }
       case UUID4(_) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -884,7 +884,7 @@ object Interpret {
           val read: WrappedByteArray => RegionValue = {
             val deserialize = extracted.deserialize(ctx, spec)
             (a: WrappedByteArray) => {
-              val r = Region(Region.SMALL)
+              val r = Region(Region.SMALL, pool=ctx.r.pool)
               val res = deserialize(r, a.bytes)
               a.clear()
               RegionValue(r, res)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -928,7 +928,7 @@ object Interpret {
           // creates a new region holding the zero value, giving ownership to
           // the caller
           val mkZero = () => {
-            val region = Region(Region.SMALL)
+            val region = Region(Region.SMALL, pool=ctx.r.pool)
             val initF = initOp(0, region)
             initF.newAggState(region)
             initF(region, globalsBc.value.readRegionValue(region))

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -239,7 +239,7 @@ case class SplitPartitionNativeWriter(
         cb.assign(ob1, spec1.buildCodeOutputBuffer(Code.checkcast[OutputStream](os1)))
         cb.assign(ob2, spec2.buildCodeOutputBuffer(Code.checkcast[OutputStream](os2)))
         cb.assign(n, 0L)
-        cb += eltRegion.allocateRegion(Region.REGULAR)
+        cb += eltRegion.allocateRegion(Region.REGULAR, cb.emb.ecb.pool())
         cb += stream.getStream(eltRegion).forEach(ctx, mb, writeFile)
         cb += eltRegion.free()
         cb += ob1.writeByte(0.asInstanceOf[Byte])

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2400,7 +2400,7 @@ case class TableKeyByAndAggregate(
 
     val serialize = extracted.serialize(ctx, spec)
     val deserialize = extracted.deserialize(ctx, spec)
-    val combOp = extracted.combOpFSerialized(ctx, spec)
+    val combOp = extracted.combOpFSerializedWorkersOnly(ctx, spec)
 
     val initF = makeInit(0, ctx.r)
     val globalsOffset = prev.globals.value.offset

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -2063,7 +2063,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       val globalRegion = ctx.partitionRegion
       val globals = if (scanSeqNeedsGlobals) globalsBc.value.readRegionValue(globalRegion) else 0
 
-      RegionPool.get.scopedSmallRegion { aggRegion =>
+      HailTaskContext.get.getRegionPool().scopedSmallRegion { aggRegion =>
         val seq = eltSeqF(i, globalRegion)
 
         seq.setAggState(aggRegion, read(aggRegion, initAgg))

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1931,8 +1931,8 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     assert(rTyp.virtualType == newRow.typ)
 
     // 1. init op on all aggs and write out to initPath
-    val initAgg = Region.scoped { aggRegion =>
-      Region.scoped { fRegion =>
+    val initAgg = ctx.r.pool.scopedRegion { aggRegion =>
+      ctx.r.pool.scopedRegion { fRegion =>
         val init = initF(0, fRegion)
         init.newAggState(aggRegion)
         init(fRegion, tv.globals.value.offset)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1992,7 +1992,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             val b1 = using(new DataInputStream(fsBc.value.open(file1)))(readToBytes)
             val b2 = using(new DataInputStream(fsBc.value.open(file2)))(readToBytes)
             using(new DataOutputStream(fsBc.value.create(path))) { os =>
-              val bytes = combOpFNeedsPool(ctx.r.pool)(b1, b2)
+              val bytes = combOpFNeedsPool(() => ctx.r.pool)(b1, b2)
               os.writeInt(bytes.length)
               os.write(bytes)
             }
@@ -2031,7 +2031,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
               b
             }
 
-            b = combOpFNeedsPool(ctx.r.pool)(b, using(new DataInputStream(fsBc.value.open(path)))(readToBytes))
+            b = combOpFNeedsPool(() => ctx.r.pool)(b, using(new DataInputStream(fsBc.value.open(path)))(readToBytes))
           }
           b
         }
@@ -2076,7 +2076,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     }, HailContext.getFlag("max_leader_scans").toInt)
 
     // 3. load in partition aggregations, comb op as necessary, write back out.
-    val partAggs = scanPartitionAggs.scanLeft(initAgg)(combOpFNeedsPool(ctx.r.pool))
+    val partAggs = scanPartitionAggs.scanLeft(initAgg)(combOpFNeedsPool(() => ctx.r.pool))
     val scanAggCount = tv.rvd.getNumPartitions
     val partitionIndices = new Array[Long](scanAggCount)
     val scanAggsPerPartitionFile = ctx.createTmpPath("table-map-rows-scan-aggs-part")

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -226,7 +226,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
         cb.assign(os, Code.newInstance[ByteTrackingOutputStream, OutputStream](mb.create(filename)))
         cb.assign(ob, spec.buildCodeOutputBuffer(Code.checkcast[OutputStream](os)))
         cb.assign(n, 0L)
-        cb += eltRegion.allocateRegion(Region.REGULAR)
+        cb += eltRegion.allocateRegion(Region.REGULAR, cb.emb.ecb.pool())
         cb += stream.getStream(eltRegion).forEach(ctx, mb, writeFile)
         cb += eltRegion.free()
         cb += ob.writeByte(0.asInstanceOf[Byte])

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -57,8 +57,9 @@ trait RegionBackedAggState extends AggregatorState {
 
   def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(const(regionSize))
 
-  def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize)))
+  def createState(cb: EmitCodeBuilder): Unit = {
+    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
+  }
 
   def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] = regionLoader(r)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -49,7 +49,7 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize)))
+    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
   override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
     Code.memoize(src, "acdfa_load_src") { src =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -17,7 +17,7 @@ class CollectAggState(val elemType: PType, val kb: EmitClassBuilder[_]) extends 
 
   def createState(cb: EmitCodeBuilder): Unit =
     cb.ifx(region.isNull, {
-      cb.assign(r, Region.stagedCreate(regionSize))
+      cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
       cb += region.invalidate()
     })
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -351,7 +351,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
         top := max(top, bufferTop),
         oldRegion := region,
         oldRoot := root,
-        r := Region.stagedCreate(regionSize),
+        r := Region.stagedCreate(regionSize, region.getPool()),
         treeSize := 0,
         tree.init,
         copyFromTree(oldRootBTree),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -52,7 +52,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
   def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize)))
+    cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
   val binType = PCanonicalStruct(required = true, "x" -> PInt32Required, "y" -> PInt32Required)
   val pointType = PCanonicalStruct(required = true, "x" -> PFloat64Required, "y" -> PFloat64Required, "label" -> labelType)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, RegionValue}
+import is.hail.annotations.{Region, RegionPool, RegionValue}
 import is.hail.asm4s._
 import is.hail.expr.ir
 import is.hail.expr.ir._
@@ -169,7 +169,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
       )))
 
     { (bytes1: Array[Byte], bytes2: Array[Byte]) =>
-      Region.smallScoped { r =>
+      RegionPool.get.scopedSmallRegion { r =>
         val f2 = f(0, r)
         f2.newAggState(r)
         f2.setSerializedAgg(0, bytes1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -158,30 +158,10 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
   }
 
   def combOpFSerializedWorkersOnly(ctx: ExecuteContext, spec: BufferSpec): (Array[Byte], Array[Byte]) => Array[Byte] = {
-    val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](ctx,
-      states ++ states,
-      FastIndexedSeq(),
-      FastIndexedSeq(classInfo[Region]), UnitInfo,
-      Begin(FastSeq(
-        ir.DeserializeAggs(0, 0, spec, states),
-        ir.DeserializeAggs(nAggs, 1, spec, states),
-        Begin(aggs.zipWithIndex.map { case (sig, i) => CombOp(i, i + nAggs, sig) }),
-        SerializeAggs(0, 0, spec, states)
-      )))
-
-    (bytes1: Array[Byte], bytes2: Array[Byte]) =>
-    HailTaskContext.get.getRegionPool().scopedSmallRegion { r =>
-      val f2 = f(0, r)
-      f2.newAggState(r)
-      f2.setSerializedAgg(0, bytes1)
-      f2.setSerializedAgg(1, bytes2)
-      f2(r)
-      f2.storeAggsToRegion()
-      f2.getSerializedAgg(0)
-    }
+    combOpFSerializedFromRegionPool(ctx, spec)(() => HailTaskContext.get().getRegionPool())
   }
 
-  def combOpFSerializedFromRegionPool(ctx: ExecuteContext, spec: BufferSpec): RegionPool => ((Array[Byte], Array[Byte]) => Array[Byte]) = {
+  def combOpFSerializedFromRegionPool(ctx: ExecuteContext, spec: BufferSpec): (() => RegionPool) => ((Array[Byte], Array[Byte]) => Array[Byte]) = {
     val (_, f) = ir.CompileWithAggregators[AsmFunction1RegionUnit](ctx,
       states ++ states,
       FastIndexedSeq(),
@@ -193,8 +173,8 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
         SerializeAggs(0, 0, spec, states)
       )))
 
-    pool: RegionPool => { (bytes1: Array[Byte], bytes2: Array[Byte]) =>
-      pool.scopedSmallRegion { r =>
+    poolGetter: (() => RegionPool) => { (bytes1: Array[Byte], bytes2: Array[Byte]) =>
+      poolGetter().scopedSmallRegion { r =>
         val f2 = f(0, r)
         f2.newAggState(r)
         f2.setSerializedAgg(0, bytes1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, RegionPool, RegionValue}
 import is.hail.asm4s._
+import is.hail.backend.HailTaskContext
 import is.hail.expr.ir
 import is.hail.expr.ir._
 import is.hail.io.BufferSpec
@@ -169,7 +170,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
       )))
 
     (bytes1: Array[Byte], bytes2: Array[Byte]) =>
-    RegionPool.get.scopedSmallRegion { r =>
+    HailTaskContext.get.getRegionPool().scopedSmallRegion { r =>
       val f2 = f(0, r)
       f2.newAggState(r)
       f2.setSerializedAgg(0, bytes1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -20,7 +20,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val kb: EmitClassBuil
   def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, { cb.assign(r, Region.stagedCreate(regionSize)) })
+    cb.ifx(region.isNull, { cb.assign(r, Region.stagedCreate(regionSize, kb.pool())) })
 
   override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
     Code.memoize(src, "take_rvas_src") { src =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -79,7 +79,7 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
 
   def createState(cb: EmitCodeBuilder): Unit =
     cb.ifx(region.isNull, {
-      cb.assign(r, Region.stagedCreate(regionSize))
+      cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
       cb += region.invalidate()
     })
 
@@ -312,7 +312,7 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
           garbage := garbage + 1,
           (garbage >= maxGarbage).orEmpty(Code(
             oldRegion := region,
-            r := Region.stagedCreate(regionSize),
+            r := Region.stagedCreate(regionSize, kb.pool()),
             ab.reallocateData(),
             initStaging(),
             garbage := 0,

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -77,7 +77,7 @@ object RichContextRDDRegionValue {
     ctx: RVDContext,
     partDigits: Int,
     stageLocally: Boolean,
-    makeIndexWriter: (String) => IndexWriter,
+    makeIndexWriter: (String, RegionPool) => IndexWriter,
     makeRowsEnc: (OutputStream) => Encoder,
     makeEntriesEnc: (OutputStream) => Encoder
   ): FileWriteMetadata = {
@@ -110,7 +110,7 @@ object RichContextRDDRegionValue {
         using(fs.create(entriesPartPath)) { entriesOS =>
           val trackedEntriesOS = new ByteTrackingOutputStream(entriesOS)
           using(makeEntriesEnc(trackedEntriesOS)) { entriesEN =>
-            using(makeIndexWriter(idxPath)) { iw =>
+            using(makeIndexWriter(idxPath, ctx.r.pool)) { iw =>
               var rowCount = 0L
 
               it.foreach { ptr =>

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -133,7 +133,8 @@ object BgenRDDPartitions extends Logging {
       var fileIndex = 0
       while (fileIndex < nonEmptyFilesAfterFilter.length) {
         val file = nonEmptyFilesAfterFilter(fileIndex)
-        using(indexReaderBuilder(fs, file.indexPath, 8)) { index =>
+        // TODO Not sure I should be using ctx's pool here.
+        using(indexReaderBuilder(fs, file.indexPath, 8, ctx.r.pool)) { index =>
           val nPartitions = math.min(fileNPartitions(fileIndex), file.nVariants.toInt)
           val partNVariants = partition(file.nVariants.toInt, nPartitions)
           val partFirstVariantIndex = partNVariants.scan(0)(_ + _).init

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -1,7 +1,7 @@
 package is.hail.io.bgen
 
 import is.hail.HailContext
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, HailTaskContext}
 import is.hail.expr.ir.ExecuteContext
 import is.hail.types.TableType
 import is.hail.types.physical.{PCanonicalStruct, PStruct}
@@ -117,11 +117,14 @@ object IndexBgen {
       .foreachPartition { it =>
         val partIdx = TaskContext.get.partitionId()
         val idxPath = indexFilePaths(partIdx)
+        val htc = HailTaskContext.get()
 
-        using(makeIW(idxPath)) { iw =>
-          it.foreach { r =>
-            assert(r.getInt(fileIdxIdx) == partIdx)
-            iw.appendRow(Row(r(locusIdx), r(allelesIdx)), r.getLong(offsetIdx), Row())
+        htc.getRegionPool().scopedRegion { r =>
+          using(makeIW(idxPath, r.pool)) { iw =>
+            it.foreach { r =>
+              assert(r.getInt(fileIdxIdx) == partIdx)
+              iw.appendRow(Row(r(locusIdx), r(allelesIdx)), r.getLong(offsetIdx), Row())
+            }
           }
         }
         info(s"Finished writing index file for ${ bgenFilePaths(partIdx) }")

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -194,7 +194,7 @@ object LoadBgen {
         val (intPType: PStruct, intDec) = internalNodeCodec.buildDecoder(ctx, internalNodeCodec.encodedVirtualType)
         IndexReaderBuilder.withDecoders(leafDec, intDec, BgenSettings.indexKeyType(rg), BgenSettings.indexAnnotationType, leafPType, intPType)
       }
-      using(indexReaderBuilder(fs, indexFile, 8)) { index =>
+      using(indexReaderBuilder(fs, indexFile, 8, ctx.r.pool)) { index =>
         val attributes = index.attributes
         val rg = Option(attributes("reference_genome")).map(name => ReferenceGenome.getReference(name.asInstanceOf[String]))
         val skipInvalidLoci = attributes("skip_invalid_loci").asInstanceOf[Boolean]

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -67,7 +67,7 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
   }
 
   def create(cb: EmitCodeBuilder): Unit = {
-    cb.assign(region, Region.stagedCreate(Region.REGULAR))
+    cb.assign(region, Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
     allocate(cb)
   }
 

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -53,7 +53,7 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
   }
 
   def create(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
-    cb.assign(region, Region.stagedCreate(Region.REGULAR))
+    cb.assign(region, Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
     node.store(cb, pType.loadCheapPCode(cb, pType.allocate(region)))
     idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), PCode(idxType, firstIdx))
     ab.create(cb, pType.fieldOffset(node.a, "keys"))

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -470,10 +470,10 @@ object ExportVCF {
           val localFsBc = ctx.fsBc
           val files = fs.glob(path + "/part-*").map(_.getPath.getBytes)
           info(s"Writing tabix index for ${ files.length } in $path")
-          ctx.backend.parallelizeAndComputeWithIndex(ctx.backendContext, files) { (pathBytes, _) =>
-            TabixVCF(localFsBc, new String(pathBytes))
-            Array.empty
-          }
+          ctx.backend.parallelizeAndComputeWithIndex(ctx.backendContext, files)({ (pathBytes, _) =>
+                      TabixVCF(localFsBc, new String(pathBytes))
+                      Array.empty
+                    })
         case ExportType.PARALLEL_COMPOSABLE =>
           warn("Writing tabix index for `parallel=composable` is not supported. No index will be written.")
       }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -390,7 +390,7 @@ object BlockMatrix {
       val trueIt = it(ctx)
       val rootPath = blockMatrixURI(rddIndex)
       val fileName = partFile(numDigits, partIndex, TaskContext.get)
-      val fileDataIterator = RichContextRDD.writeParts(ctx, rootPath, fileName, null, (_) => null, false, fs, tmpdir, trueIt, writeBlock)
+      val fileDataIterator = RichContextRDD.writeParts(ctx, rootPath, fileName, null, (_, _) => null, false, fs, tmpdir, trueIt, writeBlock)
       fileDataIterator.map { fd => (fd, rddIndex) }
     }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -2042,7 +2042,7 @@ class WriteBlocksRDD(
     val writeBlocksPart = split.asInstanceOf[WriteBlocksRDDPartition]
     val start = writeBlocksPart.start
     writeBlocksPart.range.zip(writeBlocksPart.parentPartitions).foreach { case (pi, pPart) =>
-      using(RVDContext.defaultFromPool(HailTaskContext.get().getRegionPool())) { ctx =>
+      using(RVDContext.default(HailTaskContext.get().getRegionPool())) { ctx =>
         val it = crdd.iterator(pPart, context, ctx)
 
         if (pi == start) {

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -315,7 +315,7 @@ case class LocalLDPrune(
     val standardizedRDD = mv.rvd
       .mapPartitions(mv.rvd.typ.copy(rowType = bpvType)){ (ctx, it) =>
         val hcView = new HardCallView(fullRowPType, callField)
-        val region = Region()
+        val region = Region(pool=ctx.r.pool)
         val rvb = new RegionValueBuilder(region)
 
         it.flatMap { ptr =>
@@ -346,7 +346,7 @@ case class LocalLDPrune(
     val sitesOnly = rvdLP.mapPartitions(
       tableType.canonicalRVDType
     )({ (ctx, it) =>
-      val region = Region()
+      val region = Region(pool=ctx.r.pool)
       val rvb = new RegionValueBuilder(region)
 
       it.map { ptr =>

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -91,7 +91,7 @@ object AbstractRVDSpec {
 
     val (part0Count, bytesWritten) =
       using(fs.create(partsPath + "/" + filePath)) { os =>
-        using(RVDContext.defaultFromPool(execCtx.r.pool)) { ctx =>
+        using(RVDContext.default(execCtx.r.pool)) { ctx =>
           val rvb = ctx.rvb
           RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(execCtx, rowType))(ctx,
             rows.iterator.map { a =>

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -91,7 +91,7 @@ object AbstractRVDSpec {
 
     val (part0Count, bytesWritten) =
       using(fs.create(partsPath + "/" + filePath)) { os =>
-        using(RVDContext.default) { ctx =>
+        using(RVDContext.defaultFromPool(execCtx.r.pool)) { ctx =>
           val rvb = ctx.rvb
           RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(execCtx, rowType))(ctx,
             rows.iterator.map { a =>

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -749,7 +749,7 @@ class RVD(
     val enc = TypedCodecSpec(rowPType, BufferSpec.wireSpec)
     val encodedData = collectAsBytes(execCtx, enc)
     val (pType: PStruct, dec) = enc.buildDecoder(execCtx, rowType)
-    Region.scoped { region =>
+    execCtx.r.pool.scopedRegion { region =>
       RegionValue.fromBytes(dec, region, encodedData.iterator)
         .map { ptr =>
           val row = SafeRow(pType, ptr)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -45,9 +45,7 @@ class RVD(
   require(crdd.getNumPartitions == partitioner.numPartitions)
 
   require(typ.kType.virtualType isIsomorphicTo partitioner.kType)
-
-  val myOrigin = Thread.currentThread().getStackTrace.mkString("\n")
-
+  
   // Basic accessors
 
   def sparkContext: SparkContext = crdd.sparkContext

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -45,7 +45,7 @@ class RVD(
   require(crdd.getNumPartitions == partitioner.numPartitions)
 
   require(typ.kType.virtualType isIsomorphicTo partitioner.kType)
-  
+
   // Basic accessors
 
   def sparkContext: SparkContext = crdd.sparkContext

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -689,7 +689,6 @@ class RVD(
      commutative: Boolean,
      tree: Boolean
   ): T = {
-    log.info(s"Combining, origin = \n ${myOrigin}")
     var reduced = crdd.cmapPartitionsWithIndex[U] { (i, ctx, it) => Iterator.single(serialize(itF(i, ctx, it))) }
 
     if (tree) {

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -1,6 +1,6 @@
 package is.hail.rvd
 
-import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.annotations.{Region, RegionPool, RegionValueBuilder}
 import is.hail.utils._
 
 import scala.collection.mutable
@@ -24,13 +24,13 @@ class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseab
   own(r)
 
   def freshContext(): RVDContext = {
-    val ctx = new RVDContext(partitionRegion, Region())
+    val ctx = new RVDContext(partitionRegion, Region(pool=r.pool))
     own(ctx)
     ctx
   }
 
   def freshRegion(blockSize: Region.Size = Region.REGULAR): Region = {
-    val r2 = Region(blockSize)
+    val r2 = Region(blockSize, pool = r.pool)
     own(r2)
     r2
   }

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -6,14 +6,8 @@ import is.hail.utils._
 import scala.collection.mutable
 
 object RVDContext {
-  def default: RVDContext = {
-    val partRegion = Region()
-    val ctx = new RVDContext(partRegion, Region())
-    ctx.own(partRegion)
-    ctx
-  }
 
-  def defaultFromPool(pool: RegionPool) = {
+  def default(pool: RegionPool) = {
     val partRegion = Region(pool=pool)
     val ctx = new RVDContext(partRegion, Region(pool=pool))
     ctx.own(partRegion)

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -12,6 +12,13 @@ object RVDContext {
     ctx.own(partRegion)
     ctx
   }
+
+  def defaultFromPool(pool: RegionPool) = {
+    val partRegion = Region(pool=pool)
+    val ctx = new RVDContext(partRegion, Region(pool=pool))
+    ctx.own(partRegion)
+    ctx
+  }
 }
 
 class RVDContext(val partitionRegion: Region, val r: Region) extends AutoCloseable {

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
@@ -35,7 +35,7 @@ object RVDPartitionInfo {
     seed: Int,
     producerContext: RVDContext
   ): RVDPartitionInfo = {
-    using(RVDContext.default) { localctx =>
+    using(RVDContext.default(producerContext.r.pool)) { localctx =>
       val kPType = typ.kType
       val pkOrd = typ.copy(key = typ.key.take(partitionKey)).kOrd
       val minF = WritableRegionValue(kPType, localctx.freshRegion())

--- a/hail/src/main/scala/is/hail/services/shuffler/LSM.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/LSM.scala
@@ -95,14 +95,15 @@ object LSM {
 
 class LSM (
   path: String,
-  codecs: ShuffleCodecSpec
+  codecs: ShuffleCodecSpec,
+  pool: RegionPool
 ) extends AutoCloseable {
-  private[this] val rootRegion: Region = Region()
+  private[this] val rootRegion: Region = Region(pool=pool)
   private[this] val log = Logger.getLogger(getClass.getName)
   val keyOrd: UnsafeOrdering = codecs.keyDecodedPType.unsafeOrdering
   private[this] val region = ThreadLocal.withInitial(new Supplier[Region]() {
     def get(): Region = {
-      val region = Region()
+      val region = Region(pool=pool)
       rootRegion.synchronized {
         rootRegion.addReferenceTo(region)
       }

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleClient.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleClient.scala
@@ -140,9 +140,11 @@ class ShuffleClient (
 
   val codecs = {
     ExecutionTimer.logTime("ShuffleClient.codecs") { timer =>
-      using(new ExecuteContext("/tmp", "file:///tmp", null, null, Region(), timer)) { ctx =>
-        new ShuffleCodecSpec(ctx, shuffleType, rowEncodingPType, keyEncodingPType)
-      }
+      RegionPool.scoped(rp =>
+        using(new ExecuteContext("/tmp", "file:///tmp", null, null, Region(pool=rp), timer)) { ctx =>
+          new ShuffleCodecSpec(ctx, shuffleType, rowEncodingPType, keyEncodingPType)
+        }
+      )
     }
   }
 

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -162,7 +162,7 @@ class ContextRDD[T: ClassTag](
   private[this] def sparkManagedContext[U](func: RVDContext => U): U = {
     val tc = TaskContext.get()
     HailTaskContext.setTaskContext(new SparkTaskContext(tc))
-    val c = RVDContext.default
+    val c = RVDContext.default(HailTaskContext.get().getRegionPool())
     TaskContext.get().addTaskCompletionListener[Unit] { (_: TaskContext) =>
       c.close()
     }
@@ -245,7 +245,7 @@ class ContextRDD[T: ClassTag](
       { (taskContext, it: Iterator[RVDContext => Iterator[T]]) =>
         val tc = new SparkTaskContext(taskContext)
         HailTaskContext.setTaskContext(tc)
-        val c = RVDContext.default
+        val c = RVDContext.default(tc.getRegionPool())
         val ans = f(taskContext.partitionId(), c, it.flatMap(_(c)))
         ans
       })

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -139,7 +139,7 @@ class LinearMixedModel(lmmData: LMMData) {
       val r0 = 0 to 0
       val r1 = 1 until f
       
-      val region = Region()
+      val region = Region(pool=HailTaskContext.get().getRegionPool())
       val rv = RegionValue(region)
       val rvb = new RegionValueBuilder(region)
 

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -3,6 +3,7 @@ package is.hail.stats
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV}
 import is.hail.HailContext
 import is.hail.annotations.{BroadcastRow, Region, RegionValue, RegionValueBuilder}
+import is.hail.backend.HailTaskContext
 import is.hail.expr.ir.{ExecuteContext, TableIR, TableLiteral, TableValue}
 import is.hail.types.TableType
 import is.hail.types.physical.{PCanonicalStruct, PFloat64, PInt64, PStruct}
@@ -70,7 +71,7 @@ class LinearMixedModel(lmmData: LMMData) {
       val r0 = 0 to 0
       val r1 = 1 until f
 
-      val region = Region()
+      val region = Region(pool = HailTaskContext.get().getRegionPool())
       val rv = RegionValue(region)
       val rvb = new RegionValueBuilder(region)
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
@@ -1,6 +1,6 @@
 package is.hail.utils.richUtils
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s._
 
 class RichCodeRegion(val region: Code[Region]) extends AnyVal {
@@ -36,4 +36,6 @@ class RichCodeRegion(val region: Code[Region]) extends AnyVal {
   def storeJavaObject(obj: Code[AnyRef]): Code[Int] = region.invoke[AnyRef, Int]("storeJavaObject", obj)
 
   def lookupJavaObject(idx: Code[Int]): Code[AnyRef] = region.invoke[Int, AnyRef]("lookupJavaObject", idx)
+
+  def getPool(): Code[RegionPool] = region.invoke[RegionPool]("getPool")
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -105,7 +105,6 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
     val d = digitsNeeded(nPartitions)
 
     val fileData = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
-      assert(false)
       HailTaskContext.setTaskContext(new SparkTaskContext(TaskContext.get()))
       val f = partFile(d, i, TaskContext.get)
       RichContextRDD.writeParts(ctx, path, f, idxRelPath, mkIdxWriter, stageLocally, fs, localTmpdir, it, write)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -106,7 +106,6 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
     val d = digitsNeeded(nPartitions)
 
     val fileData = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
-      HailTaskContext.setTaskContext(new SparkTaskContext(TaskContext.get()))
       val f = partFile(d, i, TaskContext.get)
       RichContextRDD.writeParts(ctx, path, f, idxRelPath, mkIdxWriter, stageLocally, fs, localTmpdir, it, write)
     }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -3,6 +3,7 @@ package is.hail.utils.richUtils
 import java.io._
 
 import is.hail.HailContext
+import is.hail.annotations.{Region, RegionPool}
 import is.hail.backend.HailTaskContext
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir.ExecuteContext
@@ -19,7 +20,7 @@ import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
 
 object RichContextRDD {
-  def writeParts[T](ctx: RVDContext, rootPath: String, f:String, idxRelPath: String, mkIdxWriter: (String) => IndexWriter,
+  def writeParts[T](ctx: RVDContext, rootPath: String, f:String, idxRelPath: String, mkIdxWriter: (String, RegionPool) => IndexWriter,
                     stageLocally: Boolean, fs: FS, localTmpdir: String, it: Iterator[T],
                     write: (RVDContext, Iterator[T], OutputStream, IndexWriter) => (Long, Long)): Iterator[FileWriteMetadata] = {
     val finalFilename = rootPath + "/parts/" + f
@@ -37,7 +38,7 @@ object RichContextRDD {
       } else
         finalFilename -> finalIdxFilename
     val os = fs.create(filename)
-    val iw = mkIdxWriter(idxFilename)
+    val iw = mkIdxWriter(idxFilename, ctx.r.pool)
 
     // write must close `os` and `iw`
     val (rowCount, bytesWritten) = write(ctx, it, os, iw)
@@ -89,7 +90,7 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
     path: String,
     idxRelPath: String,
     stageLocally: Boolean,
-    mkIdxWriter: (String) => IndexWriter,
+    mkIdxWriter: (String, RegionPool) => IndexWriter,
     write: (RVDContext, Iterator[T], OutputStream, IndexWriter) => (Long, Long)
   ): Array[FileWriteMetadata] = {
     val localTmpdir = ctx.localTmpdir

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -3,6 +3,8 @@ package is.hail.utils.richUtils
 import java.io._
 
 import is.hail.HailContext
+import is.hail.backend.HailTaskContext
+import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir.ExecuteContext
 import is.hail.io.FileWriteMetadata
 import is.hail.io.fs.FS
@@ -103,6 +105,8 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[T]) {
     val d = digitsNeeded(nPartitions)
 
     val fileData = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
+      assert(false)
+      HailTaskContext.setTaskContext(new SparkTaskContext(TaskContext.get()))
       val f = partFile(d, i, TaskContext.get)
       RichContextRDD.writeParts(ctx, path, f, idxRelPath, mkIdxWriter, stageLocally, fs, localTmpdir, it, write)
     }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -205,6 +205,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       path,
       null,
       stageLocally,
-      (_) => null,
+      (_, _) => null,
       (_, it, os, _) => write(it, os))
 }

--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -1,10 +1,10 @@
 package is.hail
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RegionPool}
 import is.hail.backend.BroadcastValue
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.ExecuteContext
-import is.hail.utils.ExecutionTimer
+import is.hail.utils.{ExecutionTimer, using}
 import is.hail.io.fs.FS
 import org.apache.spark.SparkContext
 import org.scalatest.testng.TestNGSuite
@@ -51,12 +51,15 @@ class HailSuite extends TestNGSuite {
 
   var ctx: ExecuteContext = _
 
+  var pool: RegionPool = _
+
   @BeforeMethod
   def setupContext(context: ITestContext): Unit = {
     assert(timer == null)
     timer = new ExecutionTimer("HailSuite")
     assert(ctx == null)
-    ctx = new ExecuteContext(backend.tmpdir, backend.localTmpdir, backend, fs, Region(), timer)
+    pool = RegionPool()
+    ctx = new ExecuteContext(backend.tmpdir, backend.localTmpdir, backend, fs, Region(pool=pool), timer)
   }
 
   @AfterMethod
@@ -65,6 +68,7 @@ class HailSuite extends TestNGSuite {
     ctx = null
     timer.finish()
     timer = null
+    pool.close()
   }
 
   def withExecuteContext[T]()(f: ExecuteContext => T): T = {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -259,7 +259,7 @@ object TestUtils {
             print = bytecodePrinter)
           assert(resultType2.virtualType == resultType)
 
-          Region.scoped { region =>
+          ctx.r.pool.scopedRegion { region =>
             val rvb = new RegionValueBuilder(region)
             rvb.start(argsPType)
             rvb.startTuple()

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -226,7 +226,7 @@ object TestUtils {
             optimize = optimize)
           assert(resultType2.virtualType == resultType)
 
-          Region.scoped { region =>
+          ctx.r.pool.scopedRegion { region =>
             val rvb = new RegionValueBuilder(region)
             rvb.start(argsPType)
             rvb.startTuple()

--- a/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
@@ -119,7 +119,7 @@ class RegionSuite extends TestNGSuite {
     RegionPool.scoped { pool =>
       def offset(region: Region) = region.allocate(0)
 
-      def numUsed(): Int = RegionPool.get.numRegions() - RegionPool.get.numFreeRegions()
+      def numUsed(): Int = pool.numRegions() - pool.numFreeRegions()
 
       def assertUsesRegions[T](n: Int)(f: => T): T = {
         val usedRegionCount = numUsed()

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -30,7 +30,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -39,7 +39,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     val bytes = input.getBytes()
     val bt = PCanonicalBinary()
@@ -72,7 +72,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -81,7 +81,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     rv2.setOffset(region2.allocate(4, 4))
     Region.storeInt(rv2.offset, input)
@@ -111,7 +111,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -120,7 +120,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     rv2.setOffset(ScalaToRegionValue(region2, rt, FastIndexedSeq(input)))
 
@@ -152,7 +152,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -161,7 +161,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     rv2.setOffset(ScalaToRegionValue(region2, rt, Annotation("hello", input)))
 
@@ -207,7 +207,7 @@ class StagedRegionValueSuite extends HailSuite {
     )
 
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -216,7 +216,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     val rvb = new RegionValueBuilder(region2)
     rvb.start(rt)
@@ -245,8 +245,8 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalArray(PCanonicalStruct("a" -> PInt32(), "b" -> PCanonicalString()))
     val intVal = 20
     val strVal = "a string with a partner of 20"
-    val region = Region()
-    val region2 = Region()
+    val region = Region(pool=pool)
+    val region2 = Region(pool=pool)
     val rvb = new RegionValueBuilder(region)
     val rvb2 = new RegionValueBuilder(region2)
     val rv = RegionValue(region)
@@ -286,8 +286,8 @@ class StagedRegionValueSuite extends HailSuite {
     val rt = PCanonicalStruct("a" -> PInt32(), "b" -> PCanonicalString(), "c" -> PFloat64())
     val intVal = 30
     val floatVal = 39.273d
-    val r = Region()
-    val r2 = Region()
+    val r = Region(pool=pool)
+    val r2 = Region(pool=pool)
     val rv = RegionValue(r)
     val rv2 = RegionValue(r2)
     val rvb = new RegionValueBuilder(r)
@@ -349,7 +349,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -358,7 +358,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     val rvb = new RegionValueBuilder(region2)
 
@@ -403,7 +403,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, input))
 
@@ -412,7 +412,7 @@ class StagedRegionValueSuite extends HailSuite {
       println(rv.pretty(rt))
     }
 
-    val region2 = Region()
+    val region2 = Region(pool=pool)
     val rv2 = RegionValue(region2)
     rv2.setOffset(ScalaToRegionValue(region2, rt, FastIndexedSeq(input, null)))
 
@@ -449,7 +449,7 @@ class StagedRegionValueSuite extends HailSuite {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val f = fb.result()()
     def run(i: Int, b: Boolean, d: Double): (Int, Boolean, Double) = {
       val off = f(region, i, b, d)

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -470,8 +470,8 @@ class StagedRegionValueSuite extends HailSuite {
 
     val p = Prop.forAll(g) { case (t, a) =>
       assert(t.virtualType.typeCheck(a))
-      val copy = Region.scoped { region =>
-        val copyOff = Region.scoped { srcRegion =>
+      val copy = pool.scopedRegion { region =>
+        val copyOff = pool.scopedRegion { srcRegion =>
           val src = ScalaToRegionValue(srcRegion, t, a)
 
           val fb = EmitFunctionBuilder[Region, Long, Long](ctx, "deep_copy")
@@ -511,7 +511,7 @@ class StagedRegionValueSuite extends HailSuite {
       Row(1, IndexedSeq(), IndexedSeq(-1), Set(Row("aa")))
     )
 
-    Region.scoped { r =>
+    pool.scopedRegion { r =>
       val rvb = new RegionValueBuilder(r)
       rvb.start(t2)
       rvb.addAnnotation(t2.virtualType, value)
@@ -542,7 +542,7 @@ class StagedRegionValueSuite extends HailSuite {
     )
 
     val valueT2 = t2.types(0)
-    Region.scoped { r =>
+    pool.scopedRegion { r =>
       val rvb = new RegionValueBuilder(r)
       rvb.start(valueT2)
       rvb.addAnnotation(valueT2.virtualType, value)

--- a/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -61,10 +61,10 @@ class UnsafeSuite extends HailSuite {
   }
 
   @Test def testCodec() {
-    val region = Region()
-    val region2 = Region()
-    val region3 = Region()
-    val region4 = Region()
+    val region = Region(pool=pool)
+    val region2 = Region(pool=pool)
+    val region3 = Region(pool=pool)
+    val region4 = Region(pool=pool)
     val rvb = new RegionValueBuilder(region)
 
     val path = ctx.createTmpPath("test-codec", "ser")
@@ -147,7 +147,7 @@ class UnsafeSuite extends HailSuite {
       FastIndexedSeq[Int](1, 2, 3) -> PCanonicalArray(PInt32()))
 
     valuesAndTypes.foreach { case (v, t) =>
-      Region.scoped { region =>
+      pool.scopedRegion { region =>
         val off = ScalaToRegionValue(region, t, v)
         BufferSpec.specs.foreach { spec =>
           val cs2 = TypedCodecSpec(t, spec)
@@ -186,8 +186,8 @@ class UnsafeSuite extends HailSuite {
   }
 
   @Test def testRegionValue() {
-    val region = Region()
-    val region2 = Region()
+    val region = Region(pool=pool)
+    val region2 = Region(pool=pool)
     val rvb = new RegionValueBuilder(region)
     val rvb2 = new RegionValueBuilder(region2)
 
@@ -326,8 +326,8 @@ class UnsafeSuite extends HailSuite {
   }
 
   @Test def testUnsafeOrdering() {
-    val region = Region()
-    val region2 = Region()
+    val region = Region(pool=pool)
+    val region2 = Region(pool=pool)
     val rvb = new RegionValueBuilder(region)
     val rvb2 = new RegionValueBuilder(region2)
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -55,7 +55,7 @@ class Aggregators2Suite extends HailSuite {
     if (transformResult.isEmpty)
       assert(resultType.virtualType.typeCheck(expected), s"expected type ${ resultType.virtualType.parsableString() }, got ${expected}")
 
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val argOff = ScalaToRegionValue(region, argT, argVs)
 
       def withArgs(foo: IR) = {
@@ -87,7 +87,7 @@ class Aggregators2Suite extends HailSuite {
         val init = initF(0, region)
         val res = resOneF(0, region)
 
-        Region.smallScoped { aggRegion =>
+        pool.scopedSmallRegion { aggRegion =>
           init.newAggState(aggRegion)
           init(region, argOff)
           res.setAggState(aggRegion, init.getAggOffset())
@@ -100,7 +100,7 @@ class Aggregators2Suite extends HailSuite {
         val init = initF(0, region)
         val seq = withArgs(Begin(seqs))(0, region)
         val write = writeF(0, region)
-        Region.smallScoped { aggRegion =>
+        pool.scopedSmallRegion { aggRegion =>
           init.newAggState(aggRegion)
           init(region, argOff)
           val ioff = init.getAggOffset()
@@ -113,7 +113,7 @@ class Aggregators2Suite extends HailSuite {
         }
       }.toArray
 
-      Region.smallScoped { aggRegion =>
+      pool.scopedSmallRegion { aggRegion =>
         val combOp = combAndDuplicate(0, region)
         combOp.newAggState(aggRegion)
         serializedParts.zipWithIndex.foreach { case (s, i) =>

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -316,7 +316,7 @@ class EmitStreamSuite extends HailSuite {
       Code(arrayt.setup, arrayt.m.mux(0L, arrayt.v))
     }
     val f = fb.resultWithIndex()
-    (arg: T) => Region.scoped { r =>
+    (arg: T) => pool.scopedRegion { r =>
       val off = call(f(0, r), r, arg)
       if (off == 0L)
         null
@@ -379,7 +379,7 @@ class EmitStreamSuite extends HailSuite {
         }),
       len))
     val f = fb.resultWithIndex()
-    Region.scoped { r =>
+    pool.scopedRegion { r =>
       val len = f(0, r)(r)
       if (len < 0) None else Some(len)
     }

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -700,7 +700,7 @@ class EmitStreamSuite extends HailSuite {
       FastIndexedSeq(classInfo[Region], LongInfo), LongInfo,
       ir)
 
-    Region.smallScoped { r =>
+    pool.scopedSmallRegion { r =>
       val rvb = new RegionValueBuilder(r)
       rvb.start(t)
       rvb.addAnnotation(t.virtualType, Row(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)))

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -41,7 +41,6 @@ object TestRegisterFunctions extends RegistryFunctions {
 class FunctionSuite extends HailSuite {
 
   implicit val execStrats = ExecStrategy.javaOnly
-  val region = Region(pool=pool)
 
   TestRegisterFunctions.registerAll()
 
@@ -107,7 +106,7 @@ class FunctionSuite extends HailSuite {
       mb.emit(i := i - 100)
     }
     fb.emit(Code(i := 0, mb1.invokeCode(), mb2.invokeCode(), i))
-    Region.scoped { r =>
+    pool.scopedRegion { r =>
 
       assert(fb.resultWithIndex().apply(0, r)() == 2)
     }

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -41,7 +41,7 @@ object TestRegisterFunctions extends RegistryFunctions {
 class FunctionSuite extends HailSuite {
 
   implicit val execStrats = ExecStrategy.javaOnly
-  val region = Region()
+  val region = Region(pool=pool)
 
   TestRegisterFunctions.registerAll()
 

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -216,7 +216,7 @@ class OrderingSuite extends HailSuite {
       a2 <- t.genNonmissingValue
     } yield (t, a1, a2)
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
-      Region.scoped { region =>
+      pool.scopedRegion { region =>
         val pType = PType.canonical(t)
         val rvb = new RegionValueBuilder(region)
 
@@ -272,7 +272,7 @@ class OrderingSuite extends HailSuite {
       a2 <- t.genNonmissingValue
     } yield (t, a1, a2)
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
-      Region.scoped { region =>
+      pool.scopedRegion { region =>
         val pType = PType.canonical(t)
         val rvb = new RegionValueBuilder(region)
 
@@ -446,7 +446,7 @@ class OrderingSuite extends HailSuite {
       val pTuple = PCanonicalTuple(false, pt)
       val pArray = PCanonicalArray(pt)
 
-      Region.scoped { region =>
+      pool.scopedRegion { region =>
         val rvb = new RegionValueBuilder(region)
 
         rvb.start(pset)

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -63,7 +63,7 @@ class OrderingSuite extends HailSuite {
       t <- Type.genStruct
       a <- t.genNonmissingValue
     } yield (t, a)
-    val p = Prop.forAll(compareGen) { case (t, a) => Region.scoped { region =>
+    val p = Prop.forAll(compareGen) { case (t, a) => pool.scopedRegion { region =>
       val pType = PType.canonical(t).asInstanceOf[PStruct]
       val rvb = new RegionValueBuilder(region)
 
@@ -485,7 +485,7 @@ class OrderingSuite extends HailSuite {
       val dict = a.asInstanceOf[Map[Any, Any]]
       val pDict = PType.canonical(tDict).asInstanceOf[PDict]
 
-      Region.scoped { region =>
+      pool.scopedRegion { region =>
         val rvb = new RegionValueBuilder(region)
 
         rvb.start(pDict)

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -218,7 +218,7 @@ class TestSet {
 class StagedBTreeSuite extends HailSuite {
 
   @Test def testBTree(): Unit = {
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val refSet = new TestSet()
       val nodeSizeParams = Array(
         2 -> Gen.choose(-10, 10),

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -15,7 +15,7 @@ class TakeByAggregatorSuite extends HailSuite {
       val cb = fb.ecb
       val stringPT = PCanonicalString(true)
       val tba = new TakeByRVAS(PCanonicalString(true), PInt64Optional, PCanonicalArray(stringPT, required = true), cb)
-      Region.scoped { r =>
+      pool.scopedRegion { r =>
         val argR = fb.getCodeParam[Region](1)
         val i = fb.genFieldThisRef[Long]()
         val off = fb.genFieldThisRef[Long]()
@@ -50,7 +50,7 @@ class TakeByAggregatorSuite extends HailSuite {
     val fb = EmitFunctionBuilder[Region, Long](ctx, "take_by_test_missing")
     val cb = fb.ecb
     val tba = new TakeByRVAS(PInt32Optional, PInt32Optional, PCanonicalArray(PInt32Optional, required = true), cb)
-    Region.scoped { r =>
+    pool.scopedRegion { r =>
       val argR = fb.getCodeParam[Region](1)
       val rt = tba.resultType
 
@@ -81,7 +81,7 @@ class TakeByAggregatorSuite extends HailSuite {
       val fb = EmitFunctionBuilder[Region, Long](ctx, "take_by_test_random")
       val kb = fb.ecb
 
-      Region.scoped { r =>
+      pool.scopedRegion { r =>
         val argR = fb.getCodeParam[Region](1)
         val i = fb.genFieldThisRef[Int]()
         val random = fb.genFieldThisRef[Int]()

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -42,7 +42,7 @@ class DownsampleSuite extends HailSuite {
       Code._empty
     }
 
-    Region.smallScoped { r =>
+    pool.scopedSmallRegion { r =>
       fb.resultWithIndex().apply(0, r).apply()
     }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir.agg
 
 import is.hail.HailSuite
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitFunctionBuilder
 import is.hail.types.physical.{PCanonicalArray, PCanonicalString}
@@ -12,11 +12,13 @@ class DownsampleSuite extends HailSuite {
 
   @Test def testLargeRandom(): Unit = {
     val lt = PCanonicalArray(PCanonicalString())
-    val fb = EmitFunctionBuilder[Unit](ctx, "foo")
+    val fb = EmitFunctionBuilder[RegionPool, Unit](ctx, "foo")
     val cb = fb.ecb
     val ds1 = new DownsampleState(cb, lt, maxBufferSize = 4)
     val ds2 = new DownsampleState(cb, lt, maxBufferSize = 4)
     val ds3 = new DownsampleState(cb, lt, maxBufferSize = 4)
+
+    val stagedPool = fb.newLocal[RegionPool]("pool")
 
     val rng = fb.newRNG(0)
     val i = fb.newLocal[Int]()
@@ -24,9 +26,10 @@ class DownsampleSuite extends HailSuite {
     val x = fb.newLocal[Double]()
     val y = fb.newLocal[Double]()
     fb.emitWithBuilder { cb =>
-      cb.assign(ds1.r, Region.stagedCreate(Region.SMALL))
-      cb.assign(ds2.r, Region.stagedCreate(Region.SMALL))
-      cb.assign(ds3.r, Region.stagedCreate(Region.SMALL))
+      cb.assign(stagedPool, fb.getCodeParam[RegionPool](1))
+      cb.assign(ds1.r, Region.stagedCreate(Region.SMALL, stagedPool))
+      cb.assign(ds2.r, Region.stagedCreate(Region.SMALL, stagedPool))
+      cb.assign(ds3.r, Region.stagedCreate(Region.SMALL, stagedPool))
       cb.assign(i, 0)
       cb += ds1.init(100)
       cb += ds2.init(100)
@@ -43,7 +46,7 @@ class DownsampleSuite extends HailSuite {
     }
 
     pool.scopedSmallRegion { r =>
-      fb.resultWithIndex().apply(0, r).apply()
+      fb.resultWithIndex().apply(0, r).apply(pool)
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -135,7 +135,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
   }
 
   @Test def testPushIntsRequired() {
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val b = new BlockLinkedList[Int](region, PInt32Required)
       for (i <- 1 to 100) b += i
       assertEquals(b.toIndexedSeq, IndexedSeq.tabulate(100)(_ + 1))
@@ -143,7 +143,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
   }
 
   @Test def testPushStrsMissing() {
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val a = new ArrayBuilder[String]()
       val b = new BlockLinkedList[String](region, PCanonicalString())
       for (i <- 1 to 100) {
@@ -156,7 +156,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
   }
 
   @Test def testAppendAnother() {
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val b1 = new BlockLinkedList[String](region, PCanonicalString())
       val b2 = new BlockLinkedList[String](region, PCanonicalString())
       b1 += "{"
@@ -169,7 +169,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
   }
 
   @Test def testDeepCopy() {
-    Region.scoped { region =>
+    pool.scopedRegion { region =>
       val b1 = new BlockLinkedList[Double](region, PFloat64())
       b1 ++= Seq(1.0, 2.0, 3.0)
       val b2 = b1.copy()

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -42,7 +42,7 @@ class IndexSuite extends HailSuite {
     attributes: Map[String, Any]) {
     val bufferSpec = BufferSpec.default
 
-    val iw = IndexWriter.builder(ctx, keyType, annotationType, branchingFactor, attributes)(file)
+    val iw = IndexWriter.builder(ctx, keyType, annotationType, branchingFactor, attributes)(file, pool)
     data.zip(annotations).zipWithIndex.foreach { case ((s, a), offset) =>
       iw.appendRow(s, offset, a)
     }

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -65,7 +65,7 @@ class IndexSuite extends HailSuite {
     assert(irt == intPType)
     IndexReaderBuilder.withDecoders(leafDec, intDec,
       keyPType.virtualType, annotationPType.virtualType,
-      leafPType, intPType).apply(fs, file, 8)
+      leafPType, intPType).apply(fs, file, 8, pool)
   }
 
   def writeIndex(file: String,

--- a/hail/src/test/scala/is/hail/services/shuffler/LSMSuite.scala
+++ b/hail/src/test/scala/is/hail/services/shuffler/LSMSuite.scala
@@ -33,7 +33,7 @@ class LSMSuite extends HailSuite {
       val keyPType = PType.canonical(keyType)
       val keyEType = EType.defaultFromPType(keyPType).asInstanceOf[EBaseStruct]
       val codecs = new ShuffleCodecSpec(ctx, TShuffle(key, rowType, rowEType, keyEType))
-      using(new LSM(ctx.createTmpPath("lsm"), codecs)) { lsm =>
+      using(new LSM(ctx.createTmpPath("lsm"), codecs, pool=this.pool)) { lsm =>
         val shuffled = Array(4, 3, 1, 2, 0)
 
         lsm.put(struct(4), struct(4, "4"))
@@ -71,7 +71,7 @@ class LSMSuite extends HailSuite {
       val keyPType = PType.canonical(keyType)
       val keyEType = EType.defaultFromPType(keyPType).asInstanceOf[EBaseStruct]
       val codecs = new ShuffleCodecSpec(ctx, TShuffle(key, rowType, rowEType, keyEType))
-      using(new LSM(ctx.createTmpPath("lsm"), codecs)) { lsm =>
+      using(new LSM(ctx.createTmpPath("lsm"), codecs, pool=this.pool)) { lsm =>
         val shuffled = Array(4, 3, 1, 2, 0)
 
         lsm.put(struct(4), struct(4, "4"))
@@ -146,7 +146,7 @@ class LSMSuite extends HailSuite {
       val keyPType = PType.canonical(keyType)
       val keyEType = EType.defaultFromPType(keyPType).asInstanceOf[EBaseStruct]
       val codecs = new ShuffleCodecSpec(ctx, TShuffle(key, rowType, rowEType, keyEType))
-      using(new LSM(ctx.createTmpPath("lsm"), codecs)) { lsm =>
+      using(new LSM(ctx.createTmpPath("lsm"), codecs, pool=this.pool)) { lsm =>
         val shuffled = Random.shuffle((0 until nElements).toIndexedSeq).toArray
 
         var i = 0

--- a/hail/src/test/scala/is/hail/services/shuffler/ShuffleSuite.scala
+++ b/hail/src/test/scala/is/hail/services/shuffler/ShuffleSuite.scala
@@ -41,7 +41,7 @@ class ShuffleSuite extends HailSuite {
         val rowDecodedPType = c.codecs.rowDecodedPType
 
         val values = new ArrayBuilder[Long]()
-        Region.scoped { region =>
+        pool.scopedRegion { region =>
           val rvb = new RegionValueBuilder(region)
           val nElements = 1000000
           val nPartitions = 100

--- a/hail/src/test/scala/is/hail/services/shuffler/ShufflerTestUtils.scala
+++ b/hail/src/test/scala/is/hail/services/shuffler/ShufflerTestUtils.scala
@@ -5,7 +5,8 @@ import is.hail.types.virtual._
 import is.hail.types.physical._
 
 object ShufflerTestUtils {
-  private[this] lazy val region = Region()
+  private[this] lazy val pool = RegionPool()
+  private[this] lazy val region = Region(pool=pool)
   private[this] lazy val rvb = new RegionValueBuilder(region)
 
   def arrayOfUnsafeRow(elementPType: PStruct, array: Array[Long]): Array[UnsafeRow] =

--- a/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PContainerTest.scala
@@ -18,7 +18,7 @@ class PContainerTest extends PhysicalTestUtils {
   }
 
   def testContainsNonZeroBits(sourceType: PArray, data: IndexedSeq[Any]) = {
-    val srcRegion = Region()
+    val srcRegion = Region(pool=pool)
     val src = ScalaToRegionValue(srcRegion, sourceType, data)
 
     log.info(s"Testing $data")
@@ -28,7 +28,7 @@ class PContainerTest extends PhysicalTestUtils {
   }
 
   def testContainsNonZeroBitsStaged(sourceType: PArray, data: IndexedSeq[Any]) = {
-    val srcRegion = Region()
+    val srcRegion = Region(pool=pool)
     val src = ScalaToRegionValue(srcRegion, sourceType, data)
 
     log.info(s"Testing $data")
@@ -43,7 +43,7 @@ class PContainerTest extends PhysicalTestUtils {
   }
 
   def testHasMissingValues(sourceType: PArray, data: IndexedSeq[Any]) = {
-    val srcRegion = Region()
+    val srcRegion = Region(pool=pool)
     val src = ScalaToRegionValue(srcRegion, sourceType, data)
 
     log.info(s"\nTesting $data")

--- a/hail/src/test/scala/is/hail/types/physical/PSubsetStructSuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PSubsetStructSuite.scala
@@ -29,7 +29,7 @@ class PSubsetStructSuite extends PhysicalTestUtils {
       )
     )
 
-    val region = Region()
+    val region = Region(pool=pool)
     val rv = RegionValue(region)
     rv.setOffset(fb.result()()(region, intInput, longInput))
 

--- a/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
@@ -10,8 +10,8 @@ abstract class PhysicalTestUtils extends HailSuite {
     expectCompileError: Boolean = false, expectRuntimeError: Boolean = false,
     deepCopy: Boolean = false, interpret: Boolean = false, expectedValue: Any = null) {
 
-    val srcRegion = Region()
-    val region = Region()
+    val srcRegion = Region(pool=pool)
+    val region = Region(pool=pool)
 
     val srcAddress = sourceType match {
       case x: PSubsetStruct => ScalaToRegionValue(srcRegion, x.ps, sourceValue)


### PR DESCRIPTION
This PR moves us from having thread local `RegionPool`s, to "task local" `RegionPool`s, based on Spark tasks. This should make it easier for us to track peak memory usage across a pipeline.