### PR TITLE
[hail] fix bugs in InputBuffers and RichInputStream

### DIFF
--- a/hail/src/main/scala/is/hail/io/InputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/InputBuffers.scala
@@ -93,36 +93,31 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   def seek(offset: Long) = in.asInstanceOf[ByteTrackingInputStream].seek(offset)
 
   def readByte(): Byte = {
-    val bytesRead = in.read(buff, 0, 1)
-    assert(bytesRead == 1)
+    in.readFully(buff, 0, 1)
     Memory.loadByte(buff, 0)
   }
 
   override def read(buf: Array[Byte], toOff: Int, n: Int): Unit = {
-    in.read(buf, toOff, n)
+    in.readFully(buf, toOff, n)
   }
 
   def readInt(): Int = {
-    val bytesRead = in.read(buff, 0, 4)
-    assert(bytesRead == 4)
+    in.readFully(buff, 0, 4)
     Memory.loadInt(buff, 0)
   }
 
   def readLong(): Long = {
-    val bytesRead = in.read(buff)
-    assert(bytesRead == 8)
+    in.readFully(buff)
     Memory.loadLong(buff, 0)
   }
 
   def readFloat(): Float = {
-    val bytesRead = in.read(buff, 0, 4)
-    assert(bytesRead == 4)
+    in.readFully(buff, 0, 4)
     Memory.loadFloat(buff, 0)
   }
 
   def readDouble(): Double = {
-    val bytesRead = in.read(buff)
-    assert(bytesRead == 8)
+    in.readFully(buff)
     Memory.loadDouble(buff, 0)
   }
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichInputStream.scala
@@ -4,6 +4,10 @@ import java.io.InputStream
 import is.hail.utils._
 
 class RichInputStream(val in: InputStream) extends AnyVal {
+  def readFully(to: Array[Byte]): Unit = {
+    readFully(to, 0, to.length)
+  }
+
   def readFully(to: Array[Byte], toOff: Int, n: Int): Unit = {
     val nRead = readRepeatedly(to, toOff, n)
     if (nRead < n) fatal(s"Premature end of file: expected $n bytes, found $nRead")
@@ -15,7 +19,7 @@ class RichInputStream(val in: InputStream) extends AnyVal {
     var endOfStream = false
     while (read < n && !endOfStream) {
       val r = in.read(to, toOff + read, n - read)
-      if (r <= 0)
+      if (r < 0)
         endOfStream = true
       else
         read += r


### PR DESCRIPTION
The documentation for [`InputStream.read(byte[], int, int)`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read-byte:A-int-int-) explicitly notes:
> Reads up to len bytes of data from the input stream into an array of
> bytes. An attempt is made to read as many as len bytes, but a smaller
> number may be read.

Therefore, our `InputBuffer` methods must not assume `read` returns the requested number of bytes. Moreover, `readFully` should not assume that a read of zero bytes indicates end of stream. End of stream is only indicated by a `-1`.