### PR TITLE
[atgu] add initial version of ATGU intranet service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ check-hail:
 
 .PHONY: check-services
 check-services: check-auth check-batch check-ci check-gear check-memory \
-  check-notebook check-query check-router-resolver check-scorecard check-web-common
+  check-notebook check-query check-router-resolver check-scorecard check-web-common \
+  check-atgu
 
 .PHONY: check-auth
 check-auth:
@@ -59,3 +60,7 @@ check-scorecard:
 .PHONY: check-web-common
 check-web-common:
 	$(MAKE) -C web_common check
+
+.PHONY: check-atgu
+check-atgu:
+	$(MAKE) -C atgu check

--- a/atgu/Dockerfile
+++ b/atgu/Dockerfile
@@ -2,7 +2,6 @@ FROM {{ service_base_image.image }}
 
 COPY atgu/setup.py atgu/MANIFEST.in /atgu/
 COPY atgu/atgu /atgu/atgu/
-RUN pip3 install --no-cache-dir /atgu && \
-  rm -rf /atgu
+RUN hail-pip-install /atgu && rm -rf /atgu
 
 EXPOSE 5000

--- a/atgu/Dockerfile
+++ b/atgu/Dockerfile
@@ -1,0 +1,8 @@
+FROM {{ service_base_image.image }}
+
+COPY atgu/setup.py atgu/MANIFEST.in /atgu/
+COPY atgu/atgu /atgu/atgu/
+RUN pip3 install --no-cache-dir /atgu && \
+  rm -rf /atgu
+
+EXPOSE 5000

--- a/atgu/MANIFEST.in
+++ b/atgu/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include atgu/templates *

--- a/atgu/Makefile
+++ b/atgu/Makefile
@@ -1,0 +1,8 @@
+EXTRA_PYTHONPATH := ../hail/python:../gear
+PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
+
+.PHONY: check
+check:
+	$(PYTHON) -m flake8  --config ../setup.cfg atgu
+	$(PYTHON) -m pylint --rcfile ../pylintrc atgu --score=n
+	../check-sql.sh

--- a/atgu/atgu/__main__.py
+++ b/atgu/atgu/__main__.py
@@ -1,0 +1,7 @@
+from hailtop.hail_logging import configure_logging
+# configure logging before importing anything else
+configure_logging()
+
+from .atgu import run  # noqa: E402 pylint: disable=wrong-import-position
+
+run()

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -32,6 +32,7 @@ def render_template(file):
 
             context = await f(request, *args, **kwargs)
             context['csrf_token'] = csrf_token
+            context['base_path'] = deploy_config.base_path('atgu')
 
             response = aiohttp_jinja2.render_template(file, request, context)
             response.set_cookie('_csrf', csrf_token, domain=os.environ['HAIL_DOMAIN'], secure=True, httponly=True)

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -18,9 +18,6 @@ from gear import (Database, setup_aiohttp_session,
                   check_csrf_token, new_csrf_token)
 
 
-# file upload to cloud
-
-# ATGU styling
 # styling of embedded editor
 
 BUCKET = os.environ['HAIL_ATGU_BUCKET']

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -106,7 +106,7 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
             if not filename:
                 continue
             attachment_id = secrets.token_hex(16)
-            async with await storage_client.get_object(BUCKET, f'atgu/attachments/{attachment_id}') as f:
+            async with await storage_client.insert_object(BUCKET, f'atgu/attachments/{attachment_id}') as f:
                 while True:
                     chunk = await part.read_chunk()
                     if not chunk:
@@ -199,7 +199,7 @@ WHERE id = %s;
             if not filename:
                 continue
             attachment_id = secrets.token_hex(16)
-            async with storage_client.insert_object(BUCKET, f'atgu/attachments/{attachment_id}') as f:
+            async with await storage_client.insert_object(BUCKET, f'atgu/attachments/{attachment_id}') as f:
                 while True:
                     chunk = await part.read_chunk()
                     if not chunk:

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -88,7 +88,7 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
             attachments[id] = filename
         else:
             post[part.name] = await part.text()
-    
+
     # check csrf token
     token1 = request.cookies.get('_csrf')
     token2 = post.get('_csrf')
@@ -100,7 +100,7 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
         '''
 INSERT INTO `atgu_resources` (`title`, `description`, `contents`, `tags`, `attachments`)
 VALUES (%s, %s, %s, %s, %s);
-''', (post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments), id))
+''', (post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments)))
 
     return web.HTTPFound(f'/resources/{id}')
 

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -21,11 +21,12 @@ deploy_config = get_deploy_config()
 routes = web.RouteTableDef()
 
 
+@routes.get('')
 @routes.get('/')
 @routes.get('/resources')
 @web_authenticated_developers_only()
 @aiohttp_jinja2.template('resources.html')
-async def get_resources(request):
+async def get_resources(request, userdata):
     db = request.app['db']
     resources = [resource
                  async for resource
@@ -36,7 +37,7 @@ async def get_resources(request):
 @routes.get('/resources/{id}')
 @web_authenticated_developers_only()
 @aiohttp_jinja2.template('resource.html')
-async def get_resource(request):
+async def get_resource(request, userdata):
     db = request.app['db']
     id = int(request.match_info['batch_id'])
     resource = await db.select_and_fetchone(
@@ -51,7 +52,7 @@ WHERE id = %s;
 
 @web_authenticated_developers_only()
 @aiohttp_jinja2.template('edit_resource.html')
-async def get_edit_resource(request):
+async def get_edit_resource(request, userdata):
     db = request.app['db']
     id = int(request.match_info['id'])
     resource = await db.select_and_fetchone(
@@ -67,7 +68,7 @@ WHERE id = %s;
 @routes.post('/resources/{id}/edit')
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
-async def post_edit_resource(request):
+async def post_edit_resource(request, userdata):
     db = request.app['db']
     id = int(request.match_info['id'])
     old_resource = await db.select_and_fetchone(
@@ -123,14 +124,14 @@ WHERE id = %s
 @routes.get('/resources/create')
 @web_authenticated_developers_only()
 @aiohttp_jinja2.template('create_resource.html')
-async def get_create_resource(request):  # pylint: disable=unused-argument
+async def get_create_resource(request, userdata):  # pylint: disable=unused-argument
     return {}
 
 
 @routes.post('/resources/create')
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
-async def post_create_resource(request):
+async def post_create_resource(request, userdata):
     db = request.app['db']
     attachments = {}
     post = {}
@@ -164,7 +165,7 @@ VALUES (%s, %s, %s, %s, %s);
 
 
 @routes.get('/resources/{resource_id}/attachments/{attachment_id}')
-async def get_attachment(request):
+async def get_attachment(request, userdata):
     db = request.app['db']
     resource_id = int(request.match_info['resource_id'])
     resource = await db.select_and_fetchone(

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -124,7 +124,7 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
     id = await db.execute_insertone(
         '''
 INSERT INTO `atgu_resources` (`time_created`, `title`, `description`, `contents`, `tags`, `attachments`, `time_updated`)
-VALUES (%s, %s, %s, %s, %s);
+VALUES (%s, %s, %s, %s, %s, %s, %s);
 ''', (now, post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments), now))
 
     return web.HTTPFound(deploy_config.external_url('atgu', f'/resources/{id}'))

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -74,6 +74,7 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
         part = await reader.next()
         if not part:
             break
+        log.info(f'part {part.name}')
         if part.name == 'file':
             filename = part.filename
             if not filename:
@@ -95,6 +96,8 @@ async def post_create_resource(request, userdata):  # pylint: disable=unused-arg
         if token1 is None or token2 is None or token1 != token2:
             log.info('request made with invalid csrf tokens')
             raise web.HTTPUnauthorized()
+
+        log.info(f'post {post}')
 
         id = await db.execute_insertone(
             '''

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -17,7 +17,7 @@ from gear import (Database, setup_aiohttp_session,
                   check_csrf_token, new_csrf_token)
 
 
-# file upload to cloud, ...
+# file upload to cloud
 
 # ATGU styling
 # styling of embedded editor
@@ -241,6 +241,7 @@ WHERE id = %s;
 
 
 @routes.get('/resources/{resource_id}/attachments/{attachment_id}')
+@web_authenticated_developers_only()
 async def get_attachment(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
     resource_id = int(request.match_info['resource_id'])

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -15,6 +15,16 @@ from gear import (Database, setup_aiohttp_session,
                   web_authenticated_developers_only,
                   check_csrf_token, new_csrf_token)
 
+
+# delete resource
+# cancel button where appropriate (create, edit)
+# file upload to cloud, ...
+
+# role for admin/editor
+
+# styling of embedded editor
+
+
 log = logging.getLogger(__name__)
 
 deploy_config = get_deploy_config()
@@ -205,7 +215,7 @@ title = %s,
 description = %s,
 contents = %s,
 tags = %s,
-attachments = %s,
+attachments = %s
 WHERE id = %s
 ''', (post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments), id))
 

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -282,8 +282,11 @@ WHERE id = %s;
     await resp.prepare(request)
 
     async with await storage_client.get_object(BUCKET, f'atgu/attachments/{attachment_id}') as f:
-        b = await f.read(8 * 1024)
-        await resp.write(b)
+        while True:
+            b = await f.read(8 * 1024)
+            if not b:
+                break
+            await resp.write(b)
     await resp.write_eof()
 
     return resp

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -1,0 +1,227 @@
+import logging
+import json
+import secrets
+import mimetypes
+import jinja2
+import aiohttp
+from aiohttp import web
+import aiohttp_jinja2
+
+from hailtop.hail_logging import AccessLogger
+from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.config import get_deploy_config
+from gear import (Database, setup_aiohttp_session,
+                  web_authenticated_developers_only,
+                  check_csrf_token)
+
+log = logging.getLogger(__name__)
+
+deploy_config = get_deploy_config()
+
+routes = web.RouteTableDef()
+
+
+@routes.get('/')
+@routes.get('/resources')
+@web_authenticated_developers_only()
+@aiohttp_jinja2.template('resources.html')
+async def get_resources(request):
+    db = request.app['db']
+    resources = [resource
+                 async for resource
+                 in db.select_and_fetchall('SELECT * FROM atgu_resources')]
+    return {'resources': resources}
+
+
+@routes.get('/resources/{id}')
+@web_authenticated_developers_only()
+@aiohttp_jinja2.template('resource.html')
+async def get_resource(request):
+    db = request.app['db']
+    id = int(request.match_info['batch_id'])
+    resource = await db.select_and_fetchone(
+        '''
+SELECT * FROM atgu_resources
+WHERE id = %s;
+''', (id))
+    if not resource:
+        raise web.HTTPNotFound()
+    return {'resource': resource}
+
+
+@web_authenticated_developers_only()
+@aiohttp_jinja2.template('edit_resource.html')
+async def get_edit_resource(request):
+    db = request.app['db']
+    id = int(request.match_info['id'])
+    resource = await db.select_and_fetchone(
+        '''
+SELECT * FROM atgu_resources
+WHERE id = %s;
+''', (id))
+    if not resource:
+        raise web.HTTPNotFound()
+    return {'resource': resource}
+
+
+@routes.post('/resources/{id}/edit')
+@check_csrf_token
+@web_authenticated_developers_only(redirect=False)
+async def post_edit_resource(request):
+    db = request.app['db']
+    id = int(request.match_info['id'])
+    old_resource = await db.select_and_fetchone(
+        '''
+SELECT attachments FROM atgu_resources
+WHERE id = %s;
+''', (id))
+    if not old_resource:
+        raise web.HTTPNotFound()
+
+    old_attachments = json.loads(old_resource['attachments'])
+
+    attachments = {}
+    post = {}
+    reader = aiohttp.MultipartReader(request.headers, request.content)
+    while True:
+        part = await reader.next()
+        if not part:
+            break
+        if part.name == 'attachment':
+            attachment_id = await part.text()
+            assert attachment_id in old_attachments
+            attachments[attachment_id] = old_attachments[attachment_id]
+        elif part.name == 'file':
+            filename = part.filename
+            if not filename:
+                continue
+            attachment_id = secrets.token_hex(16)
+            with open(attachment_id, 'wb') as f:
+                while True:
+                    chunk = await part.read_chunk()
+                    if not chunk:
+                        break
+                    f.write(chunk)
+            attachments[attachment_id] = filename
+        else:
+            post[part.name] = await part.text()
+
+    await db.execute_update(
+        '''
+UPDATE atgu_resources SET
+title = %s,
+description = %s,
+contents = %s,
+tags = %s,
+attachments = %s,
+WHERE id = %s
+''', (post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments), id))
+
+    return web.HTTPFound(f'/resources/{id}')
+
+
+@routes.get('/resources/create')
+@web_authenticated_developers_only()
+@aiohttp_jinja2.template('create_resource.html')
+async def get_create_resource(request):  # pylint: disable=unused-argument
+    return {}
+
+
+@routes.post('/resources/create')
+@check_csrf_token
+@web_authenticated_developers_only(redirect=False)
+async def post_create_resource(request):
+    db = request.app['db']
+    attachments = {}
+    post = {}
+    reader = aiohttp.MultipartReader(request.headers, request.content)
+    while True:
+        part = await reader.next()
+        if not part:
+            break
+        if part.name == 'file':
+            filename = part.filename
+            if not filename:
+                continue
+            id = secrets.token_hex(16)
+            with open(id, 'wb') as f:
+                while True:
+                    chunk = await part.read_chunk()
+                    if not chunk:
+                        break
+                    f.write(chunk)
+            attachments[id] = filename
+        else:
+            post[part.name] = await part.text()
+
+        id = await db.execute_insertone(
+            '''
+INSERT INTO `atgu_resources` (`title`, `description`, `contents`, `tags`, `attachments`)
+VALUES (%s, %s, %s, %s, %s);
+''', (post['title'], post['description'], post['contents'], post['tags'], json.dumps(attachments), id))
+
+    return web.HTTPFound(f'/resources/{id}')
+
+
+@routes.get('/resources/{resource_id}/attachments/{attachment_id}')
+async def get_attachment(request):
+    db = request.app['db']
+    resource_id = int(request.match_info['resource_id'])
+    resource = await db.select_and_fetchone(
+        '''
+SELECT attachments FROM atgu_resources
+WHERE id = %s;
+''', (resource_id))
+    if not resource:
+        raise web.HTTPNotFound()
+
+    attachments = resource['attachments']
+    attachment_id = request.match_info['attachment_id']
+    if attachment_id not in attachments:
+        raise web.HTTPNotFound()
+
+    filename = attachments[attachment_id]
+
+    ct, encoding = mimetypes.guess_type(filename)
+    if not ct:
+        ct = 'application/octet-stream'
+
+    headers = {
+        'Content-Disposition': f'attachment; filename="{filename}"',
+        # 'Content-Disposition': 'inline',
+        'Content-Type': ct
+    }
+    if encoding:
+        headers['Content-Encoding'] = encoding
+
+    return web.FileResponse(
+        f'{attachment_id}',
+        headers=headers)
+
+
+async def on_startup(app):
+    db = Database()
+    await db.async_init()
+    app['db'] = db
+
+
+def run():
+    app = web.Application()
+
+    setup_aiohttp_session(app)
+
+    aiohttp_jinja2.setup(
+        app, loader=jinja2.ChoiceLoader([
+            jinja2.PackageLoader('atgu')
+        ]))
+
+    app.add_routes(routes)
+
+    app.on_startup.append(on_startup)
+
+    web.run_app(
+        deploy_config.prefix_application(app, 'atgu'),
+        host='0.0.0.0',
+        port=5000,
+        access_log_class=AccessLogger,
+        ssl_context=get_in_cluster_server_ssl_context())

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -242,6 +242,7 @@ async def post_delete_resource(request, userdata):  # pylint: disable=unused-arg
 DELETE FROM `atgu_resources`
 WHERE id = %s;
 ''', (id,))
+    return web.HTTPFound(deploy_config.external_url('atgu', '/resources'))
 
 
 @routes.get('/resources/{resource_id}/attachments/{attachment_id}')

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -59,7 +59,7 @@ async def get_resources(request, userdata):  # pylint: disable=unused-argument
 @render_template('resource.html')
 async def get_resource(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
-    id = int(request.match_info['batch_id'])
+    id = int(request.match_info['id'])
     resource = await db.select_and_fetchone(
         '''
 SELECT * FROM atgu_resources

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -1,137 +1,119 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Editor</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  </head>
-  <body>
-    <div class="p-3 mb-3 bg-white border-bottom">
-      <h5 class="my-0 font-weight-normal">ATGU</h5>
-    </div>
+{% extends "layout.html" %}
+{% block title %}Create Resource{% endblock %}
+{% block head %}
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+{% endblock %}
+{% block breadcrumb_items %}
+  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item active" aria-current="page">Create</li>
+{% endblock %}
+{% block container_contents %}
+  <form id="resource-form" action="{{ base_path }}/resources/create" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="_csrf" value="{{ csrf_token }}">
 
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-	<li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
-	<li class="breadcrumb-item active" aria-current="page">Create</li>
-      </ol>
-    </nav>
-    
-    <form id="resource-form" action="{{ base_path }}/resources/create" method="post" enctype="multipart/form-data">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-      
-      <div class="container">
-
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Title:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <input name="title" type="text" style="width:50%;" />
-	  </div>
-	</div>
-
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Description:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <textarea name="description" style="width:100%;" rows="3"></textarea>
-	  </div>
-	</div>
-
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Contents:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <div>
-	      <div id="editor"></div>
-	    </div>
-	  </div>
-	</div>
-
-	<input id="contents-input" name="contents" type="hidden" />
-
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    <div>Tags:</div>
-	    <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <input name="tags" type="text" style="width:40%" />
-	  </div>
-	</div>
-
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    <div>Attachments:</div>
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <div id="files-div">
-	      <div class="my-1">
-		<input name="file" type="file" />
-	      </div>
-	      <div class="my-1">
-		<input name="file" type="file" />
-	      </div>
-	      <div class="my-1">
-		<input name="file" type="file" />
-	      </div>
-	    </div>
-	    <div>
-	      <span id="add-file" class="py-1">
-		<span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
-	      </span>
-	    </div>
-	  </div>
-	</div>
-
-	<div class="m-3">
-	  <button type="submit" class="btn btn-primary mr-3">Create</button>
-	  <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources">Cancel</a>
-	</div>
+      <div class="row my-2">
+        <div class="col-sm-12 col-md-2">
+          Title:
+        </div>
+        <div class="col-sm-12 col-md-10">
+          <input name="title" type="text" style="width:50%;" />
+        </div>
       </div>
-      
-    </form>
 
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
-    
-    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
-    <script>
-      const editorOptions = {
-	  theme: 'snow'
-      };
-      
-      const editor = new Quill('#editor', editorOptions);
-      
-      const resourceForm = document.getElementById("resource-form");
-      const contentsInput = document.getElementById("contents-input");
-      resourceForm.onsubmit = function(event) {
-	  contentsInput.value = JSON.stringify(editor.getContents())
-      }
+      <div class="row my-2">
+        <div class="col-sm-12 col-md-2">
+          Description:
+        </div>
+        <div class="col-sm-12 col-md-10">
+          <textarea name="description" style="width:100%;" rows="3"></textarea>
+        </div>
+      </div>
 
-      function parseHTML(text) {
-	  let dummy = document.createElement('div');
-	  dummy.innerHTML = text.trim()
-	  return dummy.firstChild
-      }
+      <div class="row my-2">
+        <div class="col-sm-12 col-md-2">
+          Contents:
+        </div>
+        <div class="col-sm-12 col-md-10">
+          <div>
+            <div id="editor"></div>
+          </div>
+        </div>
+      </div>
 
-      const addFile = document.getElementById("add-file");
-      const filesDiv = document.getElementById("files-div");
-      addFile.onclick = function(event) {
-	  const newFileDiv = 
-          filesDiv.appendChild(
-	      parseHTML(`
+      <input id="contents-input" name="contents" type="hidden" />
+
+      <div class="row my-2">
+        <div class="col-sm-12 col-md-2">
+          <div>Tags:</div>
+          <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
+        </div>
+        <div class="col-sm-12 col-md-10">
+          <input name="tags" type="text" style="width:40%" />
+        </div>
+      </div>
+
+      <div class="row my-2">
+        <div class="col-sm-12 col-md-2">
+          <div>Attachments:</div>
+        </div>
+        <div class="col-sm-12 col-md-10">
+          <div id="files-div">
+            <div class="my-1">
+              <input name="file" type="file" />
+            </div>
+            <div class="my-1">
+              <input name="file" type="file" />
+            </div>
+            <div class="my-1">
+              <input name="file" type="file" />
+            </div>
+          </div>
+          <div>
+            <span id="add-file" class="py-1">
+              <span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="m-3">
+        <button type="submit" class="btn btn-primary mr-3">Create</button>
+        <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources">Cancel</a>
+      </div>
+
+  </form>
+{% endblock %}
+{% block before_body_end %}
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+  <script>
+    const editorOptions = {
+        theme: 'snow'
+    };
+
+    const editor = new Quill('#editor', editorOptions);
+
+    const resourceForm = document.getElementById("resource-form");
+    const contentsInput = document.getElementById("contents-input");
+    resourceForm.onsubmit = function(event) {
+        contentsInput.value = JSON.stringify(editor.getContents())
+    }
+
+    function parseHTML(text) {
+        let dummy = document.createElement('div');
+        dummy.innerHTML = text.trim()
+        return dummy.firstChild
+    }
+
+    const addFile = document.getElementById("add-file");
+    const filesDiv = document.getElementById("files-div");
+    addFile.onclick = function(event) {
+        const newFileDiv = 
+        filesDiv.appendChild(
+            parseHTML(`
 <div class="my-1">
-  <input name="file" type="file" />
+<input name="file" type="file" />
 </div>`));
-      }
-    </script>
-  </body>
-</html>
+    }
+  </script>
+{% endblock %}

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  </head>
+  <body>
+    <div class="p-3 mb-3 bg-white border-bottom">
+      <h5 class="my-0 font-weight-normal">ATGU</h5>
+    </div>
+
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb bg-transparent">
+	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
+	<li class="breadcrumb-item"><a href="/">Resources</a></li>
+	<li class="breadcrumb-item active" aria-current="page">Create</li>
+      </ol>
+    </nav>
+    
+    <form id="resource-form" action="/resources/create" method="post" enctype="multipart/form-data">
+
+      <div class="container">
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Title:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <input name="title" type="text" style="width:50%;" />
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Description:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <textarea name="description" style="width:100%;" rows="3"></textarea>
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Contents:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <div>
+	      <div id="editor"></div>
+	    </div>
+	  </div>
+	</div>
+
+	<input id="contents-input" name="contents" type="hidden" />
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    <div>Tags:</div>
+	    <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <input name="tags" type="text" style="width:40%" />
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    <div>Attachments:</div>
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <div id="files-div">
+	      <div class="my-1">
+		<input name="file" type="file" />
+	      </div>
+	      <div class="my-1">
+		<input name="file" type="file" />
+	      </div>
+	      <div class="my-1">
+		<input name="file" type="file" />
+	      </div>
+	    </div>
+	    <div>
+	      <span id="add-file" class="py-1">
+		<span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
+	      </span>
+	    </div>
+	  </div>
+	</div>
+
+	<div class="m-3">
+	  <button type="submit" class="btn btn-primary">Create</button>
+	</div>
+      </div>
+      
+    </form>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+    <script>
+      const editorOptions = {
+	  theme: 'snow'
+      };
+      
+      const editor = new Quill('#editor', editorOptions);
+      
+      const resourceForm = document.getElementById("resource-form");
+      const contentsInput = document.getElementById("contents-input");
+      resourceForm.onsubmit = function(event) {
+	  contentsInput.value = JSON.stringify(editor.getContents())
+      }
+
+      function parseHTML(text) {
+	  let dummy = document.createElement('div');
+	  dummy.innerHTML = text.trim()
+	  return dummy.firstChild
+      }
+
+      const addFile = document.getElementById("add-file");
+      const filesDiv = document.getElementById("files-div");
+      addFile.onclick = function(event) {
+	  const newFileDiv = 
+          filesDiv.appendChild(
+	      parseHTML(`
+<div class="my-1">
+  <input name="file" type="file" />
+</div>`));
+      }
+    </script>
+  </body>
+</html>

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -91,7 +91,7 @@
 	</div>
 
 	<div class="m-3">
-	  <button type="submit" class="btn btn-primary">Create</button>
+	  <button type="submit" class="btn btn-primary mr-3">Create</button>
 	  <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources">Cancel</a>
 	</div>
       </div>

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -92,6 +92,7 @@
 
 	<div class="m-3">
 	  <button type="submit" class="btn btn-primary">Create</button>
+	  <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources">Cancel</a>
 	</div>
       </div>
       

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -21,7 +21,8 @@
     </nav>
     
     <form id="resource-form" action="{{ base_path }}/resources/create" method="post" enctype="multipart/form-data">
-
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+      
       <div class="container">
 
 	<div class="row my-2">

--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -14,13 +14,13 @@
 
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
-	<li class="breadcrumb-item"><a href="/">Resources</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
 	<li class="breadcrumb-item active" aria-current="page">Create</li>
       </ol>
     </nav>
     
-    <form id="resource-form" action="/resources/create" method="post" enctype="multipart/form-data">
+    <form id="resource-form" action="{{ base_path }}/resources/create" method="post" enctype="multipart/form-data">
 
       <div class="container">
 

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -97,6 +97,7 @@
       
       <div class="m-3">
 	<button type="submit" class="btn btn-primary">Update</button>
+	<a role="button" class="btn btn-secondary" href="{{ base_path }}/resources/{{ resource['id'] }}">Cancel</a>
       </div>
 
     </form>

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -14,14 +14,14 @@
 
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
-	<li class="breadcrumb-item"><a href="/">Resources</a></li>
-	<li class="breadcrumb-item"><a href="/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
 	<li class="breadcrumb-item active" aria-current="page">Edit</li>
       </ol>
     </nav>
 
-    <form id="resource-form" action="/resources/{{ resource['id'] }}/edit" method="post" enctype="multipart/form-data">
+    <form id="resource-form" action="{{ base_path }}/resources/{{ resource['id'] }}/edit" method="post" enctype="multipart/form-data">
       
       <div class="container">
 
@@ -75,7 +75,7 @@
 	      {% for attachment_id, filename in resource['attachments'].items() %}
 	      <div class="my-1">
 		<input name="attachment" value="{{ attachment_id }}" type="checkbox" class="form-check-input" checked />
-		<a href="/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+		<a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
 		  {{ filename }}
 		</a>
 	      </div>

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  </head>
+  <body>
+    <div class="p-3 mb-3 bg-white border-bottom">
+      <h5 class="my-0 font-weight-normal">ATGU</h5>
+    </div>
+
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb bg-transparent">
+	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
+	<li class="breadcrumb-item"><a href="/">Resources</a></li>
+	<li class="breadcrumb-item"><a href="/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
+	<li class="breadcrumb-item active" aria-current="page">Edit</li>
+      </ol>
+    </nav>
+
+    <form id="resource-form" action="/resources/{{ resource['id'] }}/edit" method="post" enctype="multipart/form-data">
+      
+      <div class="container">
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Title:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <input name="title" type="text" value="{{ resource['title'] }}" style="width:50%;" />
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Description:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <textarea name="description" value="{{ resource['description']}}" style="width:100%;" rows="3"></textarea>
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    Contents:
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <div>
+	      <div id="editor"></div>
+	    </div>
+	  </div>
+	</div>
+
+	<input id="contents-input" name="contents" type="hidden" />
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    <div>Tags:</div>
+	    <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <input name="tags" type="text" value="{{ resource['tags'] }}" style="width:40%" />
+	  </div>
+	</div>
+
+	<div class="row my-2">
+	  <div class="col-sm-12 col-md-2">
+	    <div>Attachments:</div>
+	  </div>
+	  <div class="col-sm-12 col-md-10">
+	    <div id="files-div">
+	      {% for attachment_id, filename in resource['attachments'].items() %}
+	      <div class="my-1">
+		<input name="attachment" value="{{ attachment_id }}" type="checkbox" class="form-check-input" checked />
+		<a href="/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+		  {{ filename }}
+		</a>
+	      </div>
+	      {% endfor %}
+	      <div class="my-1">
+		<input name="file" type="file" />
+	      </div>
+	    </div>
+	    <div>
+	      <span id="add-file" class="py-1">
+		<span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
+	      </span>
+	    </div>
+	  </div>
+	</div>
+
+      </div>
+      
+      <div class="m-3">
+	<button type="submit" class="btn btn-primary">Update</button>
+      </div>
+
+    </form>
+    
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+    <script>
+      const editorOptions = {
+	  theme: 'snow'
+      };
+      
+      const editor = new Quill('#editor', editorOptions);
+      
+      editor.setContents({{ resource['contents']|tojson }});
+      
+      const resourceForm = document.getElementById("resource-form");
+      const contentsInput = document.getElementById("contents-input");
+      resourceForm.onsubmit = function(event) {
+	  contentsInput.value = JSON.stringify(editor.getContents())
+      }
+
+      function parseHTML(text) {
+	  let dummy = document.createElement('div');
+	  dummy.innerHTML = text.trim()
+	  return dummy.firstChild
+      }
+
+      const addFile = document.getElementById("add-file");
+      const filesDiv = document.getElementById("files-div");
+      addFile.onclick = function(event) {
+	  const newFileDiv = 
+          filesDiv.appendChild(
+	      parseHTML(`
+<div class="my-1">
+  <input name="file" type="file" />
+</div>`));
+      }
+    </script>
+  </body>
+</html>

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -1,143 +1,124 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Editor</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  </head>
-  <body>
-    <div class="p-3 mb-3 bg-white border-bottom">
-      <h5 class="my-0 font-weight-normal">ATGU</h5>
-    </div>
-
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-	<li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
-	<li class="breadcrumb-item"><a href="{{ base_path }}/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
-	<li class="breadcrumb-item active" aria-current="page">Edit</li>
-      </ol>
-    </nav>
-
+{% extends "layout.html" %}
+{% block title %}Edit {{ resource['title'] }}{% endblock %}
+{% block head %}
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+{% endblock %}
+{% block breadcrumb_items %}
+  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
+  <li class="breadcrumb-item active" aria-current="page">Edit</li>
+{% endblock %}
+{% block container_contents %}
     <form id="resource-form" action="{{ base_path }}/resources/{{ resource['id'] }}/edit" method="post" enctype="multipart/form-data">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       
-      <div class="container">
+        <div class="row my-2">
+          <div class="col-sm-12 col-md-2">
+            Title:
+          </div>
+          <div class="col-sm-12 col-md-10">
+            <input name="title" type="text" value="{{ resource['title'] }}" style="width:50%;" />
+          </div>
+        </div>
 
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Title:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <input name="title" type="text" value="{{ resource['title'] }}" style="width:50%;" />
-	  </div>
-	</div>
+        <div class="row my-2">
+          <div class="col-sm-12 col-md-2">
+            Description:
+          </div>
+          <div class="col-sm-12 col-md-10">
+            <textarea name="description" value="{{ resource['description']}}" style="width:100%;" rows="3"></textarea>
+          </div>
+        </div>
 
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Description:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <textarea name="description" value="{{ resource['description']}}" style="width:100%;" rows="3"></textarea>
-	  </div>
-	</div>
+        <div class="row my-2">
+          <div class="col-sm-12 col-md-2">
+            Contents:
+          </div>
+          <div class="col-sm-12 col-md-10">
+            <div>
+              <div id="editor"></div>
+            </div>
+          </div>
+        </div>
 
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    Contents:
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <div>
-	      <div id="editor"></div>
-	    </div>
-	  </div>
-	</div>
+        <input id="contents-input" name="contents" type="hidden" />
 
-	<input id="contents-input" name="contents" type="hidden" />
+        <div class="row my-2">
+          <div class="col-sm-12 col-md-2">
+            <div>Tags:</div>
+            <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
+          </div>
+          <div class="col-sm-12 col-md-10">
+            <input name="tags" type="text" value="{{ resource['tags'] }}" style="width:40%" />
+          </div>
+        </div>
 
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    <div>Tags:</div>
-	    <div style="line-height:1.2;"><small class="text-secondary">comma separated</small></div>
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <input name="tags" type="text" value="{{ resource['tags'] }}" style="width:40%" />
-	  </div>
-	</div>
+        <div class="row my-2">
+          <div class="col-sm-12 col-md-2">
+            <div>Attachments:</div>
+          </div>
+          <div class="col-sm-12 col-md-10">
+            <div id="files-div">
+              {% for attachment_id, filename in resource['attachments'].items() %}
+              <div class="my-1">
+                <input name="attachment" value="{{ attachment_id }}" type="checkbox" class="form-check-input" checked />
+                <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+                  {{ filename }}
+                </a>
+              </div>
+              {% endfor %}
+              <div class="my-1">
+                <input name="file" type="file" />
+              </div>
+            </div>
+            <div>
+              <span id="add-file" class="py-1">
+                <span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
+              </span>
+            </div>
+          </div>
+        </div>
 
-	<div class="row my-2">
-	  <div class="col-sm-12 col-md-2">
-	    <div>Attachments:</div>
-	  </div>
-	  <div class="col-sm-12 col-md-10">
-	    <div id="files-div">
-	      {% for attachment_id, filename in resource['attachments'].items() %}
-	      <div class="my-1">
-		<input name="attachment" value="{{ attachment_id }}" type="checkbox" class="form-check-input" checked />
-		<a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
-		  {{ filename }}
-		</a>
-	      </div>
-	      {% endfor %}
-	      <div class="my-1">
-		<input name="file" type="file" />
-	      </div>
-	    </div>
-	    <div>
-	      <span id="add-file" class="py-1">
-		<span class="material-icons" style="vertical-align:middle;">add_box</span> Another File
-	      </span>
-	    </div>
-	  </div>
-	</div>
-
-	<div class="ml-3">
-	  <button type="submit" class="btn btn-primary mr-3">Update</button>
-	  <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources/{{ resource['id'] }}">Cancel</a>
-	</div>
-
-      </div>
+        <div class="ml-3">
+          <button type="submit" class="btn btn-primary mr-3">Update</button>
+          <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources/{{ resource['id'] }}">Cancel</a>
+        </div>
 
     </form>
-    
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
-    
-    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
-    <script>
-      const editorOptions = {
-	  theme: 'snow'
-      };
-      
-      const editor = new Quill('#editor', editorOptions);
-      
-      editor.setContents({{ resource['contents']|tojson }});
-      
-      const resourceForm = document.getElementById("resource-form");
-      const contentsInput = document.getElementById("contents-input");
-      resourceForm.onsubmit = function(event) {
-	  contentsInput.value = JSON.stringify(editor.getContents())
-      }
+{% endblock %}
+{% block before_body_end %}
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+  <script>
+    const editorOptions = {
+        theme: 'snow'
+    };
 
-      function parseHTML(text) {
-	  let dummy = document.createElement('div');
-	  dummy.innerHTML = text.trim()
-	  return dummy.firstChild
-      }
+    const editor = new Quill('#editor', editorOptions);
 
-      const addFile = document.getElementById("add-file");
-      const filesDiv = document.getElementById("files-div");
-      addFile.onclick = function(event) {
-	  const newFileDiv = 
-          filesDiv.appendChild(
-	      parseHTML(`
+    editor.setContents({{ resource['contents']|tojson }});
+
+    const resourceForm = document.getElementById("resource-form");
+    const contentsInput = document.getElementById("contents-input");
+    resourceForm.onsubmit = function(event) {
+        contentsInput.value = JSON.stringify(editor.getContents())
+    }
+
+    function parseHTML(text) {
+        let dummy = document.createElement('div');
+        dummy.innerHTML = text.trim()
+        return dummy.firstChild
+    }
+
+    const addFile = document.getElementById("add-file");
+    const filesDiv = document.getElementById("files-div");
+    addFile.onclick = function(event) {
+        const newFileDiv = 
+        filesDiv.appendChild(
+            parseHTML(`
 <div class="my-1">
-  <input name="file" type="file" />
+<input name="file" type="file" />
 </div>`));
-      }
-    </script>
-  </body>
-</html>
+    }
+  </script>
+{% endblock %}

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -22,6 +22,7 @@
     </nav>
 
     <form id="resource-form" action="{{ base_path }}/resources/{{ resource['id'] }}/edit" method="post" enctype="multipart/form-data">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       
       <div class="container">
 

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -93,11 +93,11 @@
 	  </div>
 	</div>
 
-      </div>
-      
-      <div class="m-3">
-	<button type="submit" class="btn btn-primary">Update</button>
-	<a role="button" class="btn btn-secondary" href="{{ base_path }}/resources/{{ resource['id'] }}">Cancel</a>
+	<div class="ml-3">
+	  <button type="submit" class="btn btn-primary mr-3">Update</button>
+	  <a role="button" class="btn btn-secondary" href="{{ base_path }}/resources/{{ resource['id'] }}">Cancel</a>
+	</div>
+
       </div>
 
     </form>

--- a/atgu/atgu/templates/layout.html
+++ b/atgu/atgu/templates/layout.html
@@ -3,6 +3,7 @@
   <head>
     <title>{% block title %}{% endblock %}</title>    
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous" />
     {% block head %}{% endblock %}
   </head>

--- a/atgu/atgu/templates/layout.html
+++ b/atgu/atgu/templates/layout.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div class="border-bottom">
-      <div class="p-3 h5">ATGU</div>
+      <div class="p-3 m-0 h5">ATGU</div>
     </div>
 
     <nav aria-label="breadcrumb">

--- a/atgu/atgu/templates/layout.html
+++ b/atgu/atgu/templates/layout.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{% block title %}{% endblock %}</title>    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous" />
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    <div class="border-bottom">
+      <div class="p-3 h5">ATGU</div>
+    </div>
+
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb bg-transparent">
+	{% block breadcrumb_items %}{% endblock %}
+      </ol>
+    </nav>
+
+    <div class="container">
+      {% block container_contents %}{% endblock %}
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
+
+    {% block before_body_end %}{% endblock %}
+  </body>
+</html>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="p-3 mb-3 bg-white border-bottom">
+      <h5 class="my-0 font-weight-normal">ATGU</h5>
+    </div>
+
+      <nav aria-label="breadcrumb">
+	<ol class="breadcrumb bg-transparent">
+	  <li class="breadcrumb-item"><a href="/">ATGU</a></li>
+	  <li class="breadcrumb-item"><a href="/">Resources</a></li>
+	  <li class="breadcrumb-item active" aria-current="page">{{ resource['title'] }}</li>
+	</ol>
+      </nav>
+
+      <div class="container">
+	<div class="row">
+	  <div class="col">
+	    <div style="float:right;">
+	      <form action="/resources/{{ resource['id'] }}/edit">
+		<button type="submit" class="btn btn-primary">Edit</button>
+	      </form>
+	    </div>
+	  </div>
+	</div>
+	
+	<h2 class="my-0">{{ resource['title'] }}</h2>
+	
+	<p><small class="text-secondary" style="line-height:1.2;">{{ resource['tags'] }}</small></p>
+	
+	<div class="mb-3">
+	  <div id="contents"></div>
+	</div>
+	
+	{% if resource['attachments'] is not none and resource['attachments']|length > 0 %}
+	<h5>Attachments</h5>
+	<div id="files-div" class="pl-3">
+	  {% for attachment_id, filename in resource['attachments'].items() %}
+	  <div class="my-1">
+	    <a href="/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+	      {{ filename }}
+	    </a>
+	  </div>
+	  {% endfor %}
+	</div>
+	{% endif %}
+    </div>
+    
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+    <script>
+      const contentsOptions = {
+	  readOnly: true,
+	  modules: {
+	      toolbar: false
+	  },
+	  theme: 'snow'
+      };
+      
+      const contents = new Quill('#contents', contentsOptions);
+      contents.setContents({{ resource['contents']|tojson }});
+    </script>
+  </body>
+</html>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -13,8 +13,8 @@
 
       <nav aria-label="breadcrumb">
 	<ol class="breadcrumb bg-transparent">
-	  <li class="breadcrumb-item"><a href="/">ATGU</a></li>
-	  <li class="breadcrumb-item"><a href="/">Resources</a></li>
+	  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+	  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
 	  <li class="breadcrumb-item active" aria-current="page">{{ resource['title'] }}</li>
 	</ol>
       </nav>
@@ -23,7 +23,7 @@
 	<div class="row">
 	  <div class="col">
 	    <div style="float:right;">
-	      <form action="/resources/{{ resource['id'] }}/edit">
+	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit">
 		<button type="submit" class="btn btn-primary">Edit</button>
 	      </form>
 	    </div>
@@ -43,7 +43,7 @@
 	<div id="files-div" class="pl-3">
 	  {% for attachment_id, filename in resource['attachments'].items() %}
 	  <div class="my-1">
-	    <a href="/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+	    <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
 	      {{ filename }}
 	    </a>
 	  </div>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -28,6 +28,8 @@
 
   <p><small class="text-secondary" style="line-height:1.2;">{{ resource['tags'] }}</small></p>
 
+  <p>{{ resource['description'] }}</p>
+
   <div class="mb-3">
     <div id="contents"></div>
   </div>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -26,6 +26,10 @@
 	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit">
 		<button type="submit" class="btn btn-primary">Edit</button>
 	      </form>
+
+	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post">
+		<button type="submit" class="btn btn-danger">Delete</button>
+	      </form>
 	    </div>
 	  </div>
 	</div>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -7,8 +7,8 @@
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
   </head>
   <body>
-    <div class="p-3 mb-3 bg-white border-bottom">
-      <h5 class="my-0 font-weight-normal">ATGU</h5>
+    <div class="p-3 mb-3 bg-white border-bottom h5">
+      ATGU
     </div>
 
       <nav aria-label="breadcrumb">

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -28,6 +28,7 @@
 	      </form>
 
 	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
+		<input type="hidden" name="_csrf" value="{{ csrf_token }}">
 		<button type="submit" class="btn btn-danger">Delete</button>
 	      </form>
 	    </div>

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -1,78 +1,62 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Editor</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
-  </head>
-  <body>
-    <div class="p-3 mb-3 bg-white border-bottom h5">
-      ATGU
+{% extends "layout.html" %}
+{% block title %}{{ resource['title'] }}{% endblock %}
+{% block head %}
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+{% endblock %}
+{% block breadcrumb_items %}
+  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item active" aria-current="page">{{ resource['title'] }}</li>
+{% endblock %}
+{% block container_contents %}
+  <div class="row">
+    <div class="col">
+      <div style="float:right;">
+	<form action="{{ base_path }}/resources/{{ resource['id'] }}/edit" class="pr-3" style="display:inline;">
+	  <button type="submit" class="btn btn-primary">Edit</button>
+	</form>
+
+	<form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
+	  <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+	  <button type="submit" class="btn btn-danger">Delete</button>
+	</form>
+      </div>
     </div>
+  </div>
 
-      <nav aria-label="breadcrumb">
-	<ol class="breadcrumb bg-transparent">
-	  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-	  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
-	  <li class="breadcrumb-item active" aria-current="page">{{ resource['title'] }}</li>
-	</ol>
-      </nav>
+  <h2 class="my-0">{{ resource['title'] }}</h2>
 
-      <div class="container">
-	<div class="row">
-	  <div class="col">
-	    <div style="float:right;">
-	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit" class="pr-3" style="display:inline;">
-		<button type="submit" class="btn btn-primary">Edit</button>
-	      </form>
+  <p><small class="text-secondary" style="line-height:1.2;">{{ resource['tags'] }}</small></p>
 
-	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
-		<input type="hidden" name="_csrf" value="{{ csrf_token }}">
-		<button type="submit" class="btn btn-danger">Delete</button>
-	      </form>
-	    </div>
-	  </div>
+  <div class="mb-3">
+    <div id="contents"></div>
+  </div>
+
+  {% if resource['attachments'] is not none and resource['attachments']|length > 0 %}
+    <h5>Attachments</h5>
+    <div id="files-div" class="pl-3">
+      {% for attachment_id, filename in resource['attachments'].items() %}
+	<div class="my-1">
+	  <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+	    {{ filename }}
+	  </a>
 	</div>
-	
-	<h2 class="my-0">{{ resource['title'] }}</h2>
-	
-	<p><small class="text-secondary" style="line-height:1.2;">{{ resource['tags'] }}</small></p>
-	
-	<div class="mb-3">
-	  <div id="contents"></div>
-	</div>
-	
-	{% if resource['attachments'] is not none and resource['attachments']|length > 0 %}
-	<h5>Attachments</h5>
-	<div id="files-div" class="pl-3">
-	  {% for attachment_id, filename in resource['attachments'].items() %}
-	  <div class="my-1">
-	    <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
-	      {{ filename }}
-	    </a>
-	  </div>
-	  {% endfor %}
-	</div>
-	{% endif %}
+      {% endfor %}
     </div>
-    
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
-    
-    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
-    <script>
-      const contentsOptions = {
-	  readOnly: true,
-	  modules: {
-	      toolbar: false
-	  },
-	  theme: 'snow'
-      };
-      
-      const contents = new Quill('#contents', contentsOptions);
-      contents.setContents({{ resource['contents']|tojson }});
-    </script>
-  </body>
-</html>
+  {% endif %}
+{% endblock %}
+{% block before_body_end %}
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+  <script>
+    const contentsOptions = {
+	readOnly: true,
+	modules: {
+	    toolbar: false
+	},
+	theme: 'snow'
+    };
+
+    const contents = new Quill('#contents', contentsOptions);
+    contents.setContents({{ resource['contents']|tojson }});
+  </script>
+{% endblock %}

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -12,14 +12,14 @@
   <div class="row">
     <div class="col">
       <div style="float:right;">
-	<form action="{{ base_path }}/resources/{{ resource['id'] }}/edit" class="pr-3" style="display:inline;">
-	  <button type="submit" class="btn btn-primary">Edit</button>
-	</form>
+        <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit" class="pr-3" style="display:inline;">
+          <button type="submit" class="btn btn-primary">Edit</button>
+        </form>
 
-	<form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
-	  <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-	  <button type="submit" class="btn btn-danger">Delete</button>
-	</form>
+        <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}">
+          <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
       </div>
     </div>
   </div>
@@ -36,11 +36,11 @@
     <h5>Attachments</h5>
     <div id="files-div" class="pl-3">
       {% for attachment_id, filename in resource['attachments'].items() %}
-	<div class="my-1">
-	  <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
-	    {{ filename }}
-	  </a>
-	</div>
+        <div class="my-1">
+          <a href="{{ base_path }}/resources/{{ resource['id'] }}/attachments/{{ attachment_id }}">
+            {{ filename }}
+          </a>
+        </div>
       {% endfor %}
     </div>
   {% endif %}
@@ -49,11 +49,11 @@
   <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
   <script>
     const contentsOptions = {
-	readOnly: true,
-	modules: {
-	    toolbar: false
-	},
-	theme: 'snow'
+        readOnly: true,
+        modules: {
+            toolbar: false
+        },
+        theme: 'snow'
     };
 
     const contents = new Quill('#contents', contentsOptions);

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -23,11 +23,11 @@
 	<div class="row">
 	  <div class="col">
 	    <div style="float:right;">
-	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit">
+	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/edit" class="pr-3" style="display:inline;">
 		<button type="submit" class="btn btn-primary">Edit</button>
 	      </form>
 
-	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post">
+	      <form action="{{ base_path }}/resources/{{ resource['id'] }}/delete" method="post" style="display:inline;">
 		<button type="submit" class="btn btn-danger">Delete</button>
 	      </form>
 	    </div>

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -14,9 +14,9 @@
   <div class="row">
     <div class="col">
       <div style="float:right;">
-	<form action="{{ base_path }}/resources/create">
-	  <button type="submit" class="btn btn-primary">New</button>
-	</form>
+        <form action="{{ base_path }}/resources/create">
+          <button type="submit" class="btn btn-primary">New</button>
+        </form>
       </div>
     </div>
   </div>
@@ -46,34 +46,34 @@
     const resourcesDiv = document.getElementById('resources');
 
     function oninput() {
-	const query = searchbox.value;
-	let results;
-	if (query.length == 0) {
-	    results = [];
-	    for (let i = 0; i < resources.length; ++i) {
-		results.push({"item": resources[i]});
-	    }
-	} else
-	    results = fuse.search(query);
+        const query = searchbox.value;
+        let results;
+        if (query.length == 0) {
+            results = [];
+            for (let i = 0; i < resources.length; ++i) {
+                results.push({"item": resources[i]});
+            }
+        } else
+            results = fuse.search(query);
 
-	html = '';
-	for (let i = 0; i < results.length; ++i) {
-	    let result = results[i];
-	    let resource = result['item'];
-	    html += `
+        html = '';
+        for (let i = 0; i < results.length; ++i) {
+            let result = results[i];
+            let resource = result['item'];
+            html += `
       <div class="mb-3">
-	<h4 class="my-0">
-	  <a href="{{ base_path }}/resources/${ resource['id'] }">${ resource['title'] }</a>
-	</h4>
-	<div class="ml-3">
-	  <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>
-	  <p class="my-0">${ resource['description'] }</p>
-	</div>
+        <h4 class="my-0">
+          <a href="{{ base_path }}/resources/${ resource['id'] }">${ resource['title'] }</a>
+        </h4>
+        <div class="ml-3">
+          <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>
+          <p class="my-0">${ resource['description'] }</p>
+        </div>
       </div>
 `;
-	}
+        }
 
-	resourcesDiv.innerHTML = html
+        resourcesDiv.innerHTML = html
     }
 
     oninput();

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -1,50 +1,33 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>Editor</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+{% extends "layout.html" %}
+{% block title %}Resources{% endblock %}
+{% block head %}
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
-  </head>
-  <body>
-    <div class="p-3 mb-3 bg-white border-bottom">
-      <h5 class="my-0 font-weight-normal">ATGU</h5>
+{% endblock %}
+{% block breadcrumb_items %}
+    <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Resources</li>
+{% endblock %}
+{% block container_contents %}
+    <div class="row my-3">
+      <div class="col">
+	<div style="float:right;">Search: <input id="searchbox" type="text" /></div>
+      </div>
     </div>
 
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-	<li class="breadcrumb-item active" aria-current="page">Resources</li>
-      </ol>
-    </nav>
-    
-    <div class="container">
-
-      <div class="row my-3">
-	<div class="col">
-	  <div style="float:right;">Search: <input id="searchbox" type="text" /></div>
+    <div class="row">
+      <div class="col">
+	<div style="float:right;">
+	  <form action="{{ base_path }}/resources/create">
+	    <button type="submit" class="btn btn-primary">New</button>
+	  </form>
 	</div>
       </div>
-      
-      <div class="row">
-	<div class="col">
-	  <div style="float:right;">
-	    <form action="{{ base_path }}/resources/create">
-	      <button type="submit" class="btn btn-primary">New</button>
-	    </form>
-	  </div>
-	</div>
-      </div>
-
-      <div id="resources">
-      </div>
-      
     </div>
-    
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
-    
+
+    <div id="resources">
+    </div>
+{% endblock %}
+{% block before_body_end %}
     <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
     
     <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.2"></script>
@@ -101,5 +84,4 @@
       oninput();
       searchbox.oninput = oninput;
     </script>
-  </body>
-</html>
+{% endblock %}

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -1,87 +1,82 @@
 {% extends "layout.html" %}
 {% block title %}Resources{% endblock %}
-{% block head %}
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
-{% endblock %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-    <li class="breadcrumb-item active" aria-current="page">Resources</li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+  <li class="breadcrumb-item active" aria-current="page">Resources</li>
 {% endblock %}
 {% block container_contents %}
-    <div class="row my-3">
-      <div class="col">
-	<div style="float:right;">Search: <input id="searchbox" type="text" /></div>
+  <div class="row my-3">
+    <div class="col">
+      <div style="float:right;">Search: <input id="searchbox" type="text" /></div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <div style="float:right;">
+	<form action="{{ base_path }}/resources/create">
+	  <button type="submit" class="btn btn-primary">New</button>
+	</form>
       </div>
     </div>
+  </div>
 
-    <div class="row">
-      <div class="col">
-	<div style="float:right;">
-	  <form action="{{ base_path }}/resources/create">
-	    <button type="submit" class="btn btn-primary">New</button>
-	  </form>
-	</div>
-      </div>
-    </div>
-
-    <div id="resources">
-    </div>
+  <div id="resources">
+  </div>
 {% endblock %}
 {% block before_body_end %}
-    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
-    
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.2"></script>
-    
-    <script>
-      const resources = {{ resources|tojson }};
-      
-      const options = {
-        shouldSort: true,
-        threshold: 0.3,
-        location: 0,
-        distance: 100,
-        maxPatternLength: 32,
-        minMatchCharLength: 1,
-        keys: ["title", "description", "tags"]
-      };
-      const fuse = new Fuse(resources, options);
-      
-      const searchbox = document.getElementById('searchbox');
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.2"></script>
 
-      const resourcesDiv = document.getElementById('resources');
-      
-      function oninput() {
-          const query = searchbox.value;
-	  let results;
-	  if (query.length == 0) {
-	      results = [];
-	      for (let i = 0; i < resources.length; ++i) {
-		  results.push({"item": resources[i]});
-	      }
-	  } else
-              results = fuse.search(query);
-	  
-	  html = '';
-	  for (let i = 0; i < results.length; ++i) {
-              let result = results[i];
-	      let resource = result['item'];
-	      html += `
-	<div class="mb-3">
-	  <h4 class="my-0">
-	    <a href="{{ base_path }}/resources/${ resource['id'] }">${ resource['title'] }</a>
-	  </h4>
-	  <div class="ml-3">
-	    <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>
-	    <p class="my-0">${ resource['description'] }</p>
-	  </div>
+  <script>
+    const resources = {{ resources|tojson }};
+
+    const options = {
+      shouldSort: true,
+      threshold: 0.3,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+      minMatchCharLength: 1,
+      keys: ["title", "description", "tags"]
+    };
+    const fuse = new Fuse(resources, options);
+
+    const searchbox = document.getElementById('searchbox');
+
+    const resourcesDiv = document.getElementById('resources');
+
+    function oninput() {
+	const query = searchbox.value;
+	let results;
+	if (query.length == 0) {
+	    results = [];
+	    for (let i = 0; i < resources.length; ++i) {
+		results.push({"item": resources[i]});
+	    }
+	} else
+	    results = fuse.search(query);
+
+	html = '';
+	for (let i = 0; i < results.length; ++i) {
+	    let result = results[i];
+	    let resource = result['item'];
+	    html += `
+      <div class="mb-3">
+	<h4 class="my-0">
+	  <a href="{{ base_path }}/resources/${ resource['id'] }">${ resource['title'] }</a>
+	</h4>
+	<div class="ml-3">
+	  <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>
+	  <p class="my-0">${ resource['description'] }</p>
 	</div>
+      </div>
 `;
-	  }
-	  
-	  resourcesDiv.innerHTML = html
-      }
-      
-      oninput();
-      searchbox.oninput = oninput;
-    </script>
+	}
+
+	resourcesDiv.innerHTML = html
+    }
+
+    oninput();
+    searchbox.oninput = oninput;
+  </script>
 {% endblock %}

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -13,7 +13,7 @@
 
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb bg-transparent">
-	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
+	<li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
 	<li class="breadcrumb-item active" aria-current="page">Resources</li>
       </ol>
     </nav>
@@ -29,7 +29,7 @@
       <div class="row">
 	<div class="col">
 	  <div style="float:right;">
-	    <form action="/resources/create">
+	    <form action="{{ base_path }}/resources/create">
 	      <button type="submit" class="btn btn-primary">New</button>
 	    </form>
 	  </div>
@@ -85,7 +85,7 @@
 	      html += `
 	<div class="mb-3">
 	  <h4 class="my-0">
-	    <a href="/resources/${ resource['id'] }">${ resource['title'] }</a>
+	    <a href="{{ base_path }}/resources/${ resource['id'] }">${ resource['title'] }</a>
 	  </h4>
 	  <div class="ml-3">
 	    <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="p-3 mb-3 bg-white border-bottom">
+      <h5 class="my-0 font-weight-normal">ATGU</h5>
+    </div>
+
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb bg-transparent">
+	<li class="breadcrumb-item"><a href="/">ATGU</a></li>
+	<li class="breadcrumb-item active" aria-current="page">Resources</li>
+      </ol>
+    </nav>
+    
+    <div class="container">
+
+      <div class="row my-3">
+	<div class="col">
+	  <div style="float:right;">Search: <input id="searchbox" type="text" /></div>
+	</div>
+      </div>
+      
+      <div class="row">
+	<div class="col">
+	  <div style="float:right;">
+	    <form action="/resources/create">
+	      <button type="submit" class="btn btn-primary">New</button>
+	    </form>
+	  </div>
+	</div>
+      </div>
+
+      <div id="resources">
+      </div>
+      
+    </div>
+    
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js" crossorigin="anonymous"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.4.2"></script>
+    
+    <script>
+      const resources = {{ resources|tojson }};
+      
+      const options = {
+        shouldSort: true,
+        threshold: 0.3,
+        location: 0,
+        distance: 100,
+        maxPatternLength: 32,
+        minMatchCharLength: 1,
+        keys: ["title", "description", "tags"]
+      };
+      const fuse = new Fuse(resources, options);
+      
+      const searchbox = document.getElementById('searchbox');
+
+      const resourcesDiv = document.getElementById('resources');
+      
+      function oninput() {
+          const query = searchbox.value;
+	  let results;
+	  if (query.length == 0) {
+	      results = [];
+	      for (let i = 0; i < resources.length; ++i) {
+		  results.push({"item": resources[i]});
+	      }
+	  } else
+              results = fuse.search(query);
+	  
+	  html = '';
+	  for (let i = 0; i < results.length; ++i) {
+              let result = results[i];
+	      let resource = result['item'];
+	      html += `
+	<div class="mb-3">
+	  <h4 class="my-0">
+	    <a href="/resources/${ resource['id'] }">${ resource['title'] }</a>
+	  </h4>
+	  <div class="ml-3">
+	    <p class="my-0"><small class="text-secondary" style="line-height:1.2;">${ resource['tags'] }</small></p>
+	    <p class="my-0">${ resource['description'] }</p>
+	  </div>
+	</div>
+`;
+	  }
+	  
+	  resourcesDiv.innerHTML = html
+      }
+      
+      oninput();
+      searchbox.oninput = oninput;
+    </script>
+  </body>
+</html>

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           limits:
             memory: "1G"
             cpu: "1"
+        env:
+         - name: HAIL_DOMAIN
+           value: "{{ global.domain }}"
         volumeMounts:
          - name: deploy-config
            mountPath: /deploy-config

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -54,6 +54,14 @@ spec:
         env:
          - name: HAIL_DOMAIN
            value: "{{ global.domain }}"
+	 - name: GOOGLE_APPLICATION_CREDENTIALS
+	   value: /gsa-key/key.json
+         - name: HAIL_ATGU_BUCKET
+{% if deploy %}
+           value: hail-test-dmk9z
+{% else %}
+           value: hail-atgu-data
+{% endif %}
         volumeMounts:
          - name: deploy-config
            mountPath: /deploy-config
@@ -66,6 +74,9 @@ spec:
            readOnly: true
          - name: ssl-config-atgu
            mountPath: /ssl-config
+           readOnly: true
+         - name: gsa-key
+           mountPath: /gsa-key
            readOnly: true
         readinessProbe:
           tcpSocket:
@@ -86,6 +97,9 @@ spec:
          secret:
            optional: false
            secretName: ssl-config-atgu
+       - name: gsa-key
+         secret:
+           secretName: batch-gsa-key
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -99,7 +99,7 @@ spec:
            secretName: ssl-config-atgu
        - name: gsa-key
          secret:
-           secretName: batch-gsa-key
+           secretName: atgu-gsa-key
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atgu
+  labels:
+    app: atgu
+    hail.is/sha: "{{ code.sha }}"
+spec:
+  selector:
+    matchLabels:
+      app: atgu
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: atgu
+        hail.is/sha: "{{ code.sha }}"
+        grafanak8sapp: "true"
+    spec:
+{% if deploy %}
+      priorityClassName: production
+{% endif %}
+      nodeSelector:
+        preemptible: "true"
+      tolerations:
+       - key: preemptible
+         value: "true"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - atgu
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: atgu
+        image: {{ atgu_image.image }}
+        command:
+         - python3
+         - -m
+         - atgu
+        ports:
+         - containerPort: 5000
+        resources:
+          requests:
+            memory: "250M"
+            cpu: "100m"
+          limits:
+            memory: "1G"
+            cpu: "1"
+        volumeMounts:
+         - name: deploy-config
+           mountPath: /deploy-config
+           readOnly: true
+         - name: session-secret-key
+           mountPath: /session-secret-key
+           readOnly: true
+         - name: sql-config
+           mountPath: /sql-config
+           readOnly: true
+         - name: ssl-config-atgu
+           mountPath: /ssl-config
+           readOnly: true
+        readinessProbe:
+          tcpSocket:
+            port: 5000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+       - name: deploy-config
+         secret:
+           secretName: deploy-config
+       - name: session-secret-key
+         secret:
+           secretName: session-secret-key
+       - name: sql-config
+         secret:
+           secretName: "{{ atgu_database.user_secret_name }}"
+       - name: ssl-config-atgu
+         secret:
+           optional: false
+           secretName: ssl-config-atgu
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: atgu
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: atgu
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+   - type: Resource
+     resource:
+       name: cpu
+       targetAverageUtilization: 80
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: atgu
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: atgu

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -54,8 +54,8 @@ spec:
         env:
          - name: HAIL_DOMAIN
            value: "{{ global.domain }}"
-	 - name: GOOGLE_APPLICATION_CREDENTIALS
-	   value: /gsa-key/key.json
+         - name: GOOGLE_APPLICATION_CREDENTIALS
+           value: /gsa-key/key.json
          - name: HAIL_ATGU_BUCKET
 {% if deploy %}
            value: hail-test-dmk9z

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -58,9 +58,9 @@ spec:
            value: /gsa-key/key.json
          - name: HAIL_ATGU_BUCKET
 {% if deploy %}
-           value: hail-test-dmk9z
-{% else %}
            value: hail-atgu-data
+{% else %}
+           value: hail-test-dmk9z
 {% endif %}
         volumeMounts:
          - name: deploy-config

--- a/atgu/setup.py
+++ b/atgu/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name = 'atgu',
+    version = '0.0.1',
+    url = 'https://github.com/hail-is/hail.git',
+    author = 'Hail Team',
+    author_email = 'hail@broadinstitute.org',
+    description = 'ATGU intranet',
+    packages = find_packages(),
+    include_package_data=True
+)

--- a/atgu/sql/delete-atgu-tables.sql
+++ b/atgu/sql/delete-atgu-tables.sql
@@ -1,1 +1,4 @@
+DROP TABLE IF EXISTS `atgu_migration_version`;
+DROP TABLE IF EXISTS `atgu_migrations`;
+
 DROP TABLE IF EXISTS `atgu_resources`;

--- a/atgu/sql/delete-atgu-tables.sql
+++ b/atgu/sql/delete-atgu-tables.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `atgu_resources`;

--- a/atgu/sql/estimated-current.sql
+++ b/atgu/sql/estimated-current.sql
@@ -3,8 +3,8 @@ CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `time_created` BIGINT NOT NULL,
   `title` TEXT NOT NULL,
   `description` TEXT NOT NULL,
-  /* Quill.js documents are stored in the he Delta format.  `contents`
-     is a JSON-encoded Delta.
+  /* Quill.js documents are stored in the Delta format.  `contents` is
+     a JSON-encoded Delta.
      https://quilljs.com/docs/delta/ */
   `contents` LONGTEXT NOT NULL,
   -- comma-separated string of tags

--- a/atgu/sql/estimated-current.sql
+++ b/atgu/sql/estimated-current.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `atgu_resources` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `time_created` BIGINT NOT NULL,
+  `title` TEXT NOT NULL,
+  `description` TEXT NOT NULL,
+  /* Quill.js documents are stored in the he Delta format.  `contents`
+     is a JSON-encoded Delta.
+     https://quilljs.com/docs/delta/ */
+  `contents` LONGTEXT NOT NULL,
+  -- comma-separated string of tags
+  `tags` TEXT NOT NULL,
+  /* `attachments` is a JSON-encoded Dict[str, str] mapping attachment
+      IDs to filenames. */
+  `attachments` TEXT NOT NULL,
+  `time_updated` BIGINT NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE = InnoDB;

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -3,8 +3,8 @@ CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `time_created` BIGINT NOT NULL,
   `title` TEXT NOT NULL,
   `description` TEXT NOT NULL,
-  /* Quill.js documents are stored in the he Delta format.  `contents`
-     is a JSON-encoded Delta.
+  /* Quill.js documents are stored in the Delta format.  `contents` is
+     a JSON-encoded Delta.
      https://quilljs.com/docs/delta/ */
   `contents` LONGTEXT NOT NULL,
   -- comma-separated string of tags

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
   `title` TEXT NOT NULL,
-  `description` TEXT NOT NULL
+  `description` TEXT NOT NULL,
   `contents` LONGTEXT NOT NULL,
   `tags` TEXT NOT NULL,
   `attachments` TEXT NOT NULL

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -4,5 +4,6 @@ CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `description` TEXT NOT NULL,
   `contents` LONGTEXT NOT NULL,
   `tags` TEXT NOT NULL,
-  `attachments` TEXT NOT NULL
+  `attachments` TEXT NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -3,8 +3,14 @@ CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `time_created` BIGINT NOT NULL,
   `title` TEXT NOT NULL,
   `description` TEXT NOT NULL,
+  /* Quill.js documents are stored in the he Delta format.  `contents`
+     is a JSON-encoded Delta.
+     https://quilljs.com/docs/delta/ */
   `contents` LONGTEXT NOT NULL,
+  -- comma-separated string of tags
   `tags` TEXT NOT NULL,
+  /* `attachments` is a JSON-encoded Dict[str, str] mapping attachment
+      IDs to filenames. */
   `attachments` TEXT NOT NULL,
   `time_updated` BIGINT NOT NULL,
   PRIMARY KEY (`id`)

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -1,9 +1,11 @@
 CREATE TABLE IF NOT EXISTS `atgu_resources` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `time_created` BIGINT NOT NULL,
   `title` TEXT NOT NULL,
   `description` TEXT NOT NULL,
   `contents` LONGTEXT NOT NULL,
   `tags` TEXT NOT NULL,
   `attachments` TEXT NOT NULL,
+  `time_updated` BIGINT NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;

--- a/atgu/sql/initial.sql
+++ b/atgu/sql/initial.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `atgu_resources` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `title` TEXT NOT NULL,
+  `description` TEXT NOT NULL
+  `contents` LONGTEXT NOT NULL,
+  `tags` TEXT NOT NULL,
+  `attachments` TEXT NOT NULL
+) ENGINE = InnoDB;

--- a/build.yaml
+++ b/build.yaml
@@ -3542,7 +3542,7 @@ steps:
     - name: initial
       script: /io/sql/initial.sql
    inputs:
-    - from: /repo/agu/sql
+    - from: /repo/atgu/sql
       to: /io/
    namespace:
      valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -3504,3 +3504,56 @@ steps:
     - test_hailtop_batch_3
     - test_hailtop_batch_4
     - test_query
+ - kind: runImage
+   name: delete_atgu_tables
+   image:
+     valueFrom: service_base_image.image
+   script: |
+     set -ex
+     mysql --defaults-extra-file=/sql-config/sql-config.cnf < /io/sql/delete-atgu-tables.sql
+   inputs:
+    - from: /repo/atgu/sql
+      to: /io/
+   secrets:
+    - name: database-server-config
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /sql-config
+   runIfRequested: true
+   scopes:
+    - dev
+   dependsOn:
+    - default_ns
+    - service_base_image
+    - copy_files
+ - kind: buildImage
+   name: atgu_image
+   dockerFile: atgu/Dockerfile
+   contextPath: .
+   publishAs: atgu
+   dependsOn:
+     - service_base_image
+ - kind: createDatabase
+   name: atgu_database
+   databaseName: atgu
+   migrations:
+    - name: initial
+      script: /io/sql/initial.sql
+   inputs:
+    - from: /repo/agu/sql
+      to: /io/
+   namespace:
+     valueFrom: default_ns.name
+   shutdowns:
+    - kind: Deployment
+      namespace:
+        valueFrom: default_ns.name
+      name: atgu
+    - kind: Deployment
+      namespace:
+        valueFrom: default_ns.name
+      name: atgu-driver
+   dependsOn:
+    - default_ns
+    - copy_files
+    - delete_atgu_tables

--- a/build.yaml
+++ b/build.yaml
@@ -3571,8 +3571,9 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - create_certs
     - create_accounts
     - deploy_router
+    - deploy_auth
     - atgu_image
     - atgu_database
-    - create_certs

--- a/build.yaml
+++ b/build.yaml
@@ -3571,6 +3571,7 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - create_accounts
     - deploy_router
     - atgu_image
     - atgu_database

--- a/build.yaml
+++ b/build.yaml
@@ -413,6 +413,7 @@ steps:
      # batch, benchmark, auth gsa keys
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "auth-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "batch-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
+     kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "atgu-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "benchmark-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      # create auth
      N=$(kubectl -n {{ default_ns.name }} get secret --ignore-not-found=true --no-headers auth-tokens | wc -l | tr -d '[:space:]')

--- a/build.yaml
+++ b/build.yaml
@@ -161,6 +161,8 @@ steps:
        to: /repo/notebook/
      - from: /io/repo/monitoring/sql
        to: /repo/monitoring/
+     - from: /io/repo/atgu/sql
+       to: /repo/atgu/
      - from: /io/repo/hail/python/hailtop
        to: /repo/hailtop/
      - from: /io/repo/hail/python/test

--- a/build.yaml
+++ b/build.yaml
@@ -3557,7 +3557,7 @@ steps:
     - default_ns
     - copy_files
     - delete_atgu_tables
-- kind: deploy
+ - kind: deploy
    name: deploy_atgu
    namespace:
      valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -3557,3 +3557,18 @@ steps:
     - default_ns
     - copy_files
     - delete_atgu_tables
+- kind: deploy
+   name: deploy_atgu
+   namespace:
+     valueFrom: default_ns.name
+   config: atgu/deployment.yaml
+   wait:
+    - kind: Service
+      name: atgu
+      for: alive
+   dependsOn:
+    - default_ns
+    - deploy_router
+    - atgu_image
+    - atgu_database
+    - create_certs

--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -13,3 +13,4 @@ auth.@domain@
 ukbb-rg.@domain@
 query.@domain@
 workshop.@domain@
+atgu.@domain@

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -243,6 +243,20 @@ spec:
   selector:
     app: shuffler
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atgu
+  labels:
+    app: atgu
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: atgu
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -316,3 +316,16 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 }
+
+server {
+    server_name atgu.*;
+    client_max_body_size 8m;
+
+    location / {
+        proxy_pass https://atgu/;
+        include /etc/nginx/proxy.conf;
+    }
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+}

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -89,3 +89,6 @@ principals:
 - name: monitoring-tests
   domain: monitoring-tests
   kind: json
+- name: atgu
+  domain: atgu
+  kind: json


### PR DESCRIPTION
This is the initial version of the ATGU intranet service. Currently, it has a curated list of resources which can be created, viewed, edited and deleted.  Resources can have attachments, which I store on Google storage.  I used the async Google Storage client and it worked very nicely with aiohttp.

Right now this developers only.  I may give access to the admins to start curating resources.  I'll follow up with roles and add roles for atgu-viewer and atgu-editor that I'll use in the service.

I think the code is mostly straightforward, but a few remarks:

This is built on Bootstrap.  It doesn't share the the styling with web common (which I probably want to convert).

On the resources page, for client side search I use fuse.js: https://fusejs.io/ (so fast)

For a rich text box (the resource content), I use quill.js: https://quilljs.com/.  Quill doesn't allow you to post its contents in a form, so I use a JS event handler to populate a hidden input with the contents on submission.

I tested it with dev deploy.  I suggest you do the same before reviewing to get a sense of what's here.  Feedback on the UI welcome.