### PR TITLE
Replace conds with if_else

### DIFF
--- a/hail/python/hail/docs/guides/genetics.rst
+++ b/hail/python/hail/docs/guides/genetics.rst
@@ -441,8 +441,8 @@ Polygenic Score Calculation
     >>> mt = mt.annotate_cols(
     ...     prs=hl.agg.sum(
     ...         mt.score * hl.coalesce(
-    ...             hl.cond(mt.flip, 2 - mt.GT.n_alt_alleles(),
-    ...                     mt.GT.n_alt_alleles()), mt.prior)))
+    ...             hl.if_else(mt.flip, 2 - mt.GT.n_alt_alleles(),
+    ...                        mt.GT.n_alt_alleles()), mt.prior)))
 
 :**dependencies**:
 

--- a/hail/python/hail/docs/guides/genetics.rst
+++ b/hail/python/hail/docs/guides/genetics.rst
@@ -437,7 +437,7 @@ Polygenic Score Calculation
     ...     mt.allele == mt.alleles[1], False).or_missing()
     >>> mt = mt.annotate_rows(flip=flip)
     >>> mt = mt.annotate_rows(
-    ...     prior=2 * hl.cond(mt.flip, mt.variant_qc.AF[0], mt.variant_qc.AF[1]))
+    ...     prior=2 * hl.if_else(mt.flip, mt.variant_qc.AF[0], mt.variant_qc.AF[1]))
     >>> mt = mt.annotate_cols(
     ...     prs=hl.agg.sum(
     ...         mt.score * hl.coalesce(

--- a/hail/python/hail/docs/overview/expressions.rst
+++ b/hail/python/hail/docs/overview/expressions.rst
@@ -172,7 +172,7 @@ If/Else Statements
 ~~~~~~~~~~~~~~~~~~
 
 Python ``if`` / ``else`` statements do not work with Hail expressions. Instead,
-you must use the :func:`.cond`, :func:`.case`, and :func:`.switch` functions.
+you must use the :func:`.if_else`, :func:`.case`, and :func:`.switch` functions.
 
 A conditional expression has three components: the condition to evaluate, the
 consequent value to return if the condition is ``True``, and the alternate to
@@ -188,16 +188,16 @@ return if the condition is ``False``. For example:
 In the above conditional, the condition is ``x > 0``, the consequent is ``1``,
 and the alternate is ``0``.
 
-Here is the Hail expression equivalent with :func:`.cond`:
+Here is the Hail expression equivalent with :func:`.if_else`:
 
-    >>> hl.cond(x > 0, 1, 0)
+    >>> hl.if_else(x > 0, 1, 0)
      <Int32Expression of type int32>
 
 This example returns an :class:`.Int32Expression` which can be used in more
 computations. We can add the conditional expression to our array ``a`` from
 earlier:
 
-    >>> a + hl.cond(x > 0, 1, 0)
+    >>> a + hl.if_else(x > 0, 1, 0)
     <ArrayNumericExpression of type array<int32>>
 
 Case Statements
@@ -274,7 +274,7 @@ An example of generating a :class:`.Float64Expression` that is missing is:
 These can be used with conditional statements to set values to missing if they
 don't satisfy a condition:
 
-    >>> hl.cond(x > 2.0, x, hl.null(hl.tfloat))
+    >>> hl.if_else(x > 2.0, x, hl.null(hl.tfloat))
     <Float64Expression of type float64>
 
 The Python representation of a missing value is ``None``. For example, if

--- a/hail/python/hail/docs/overview/matrix_table.rst
+++ b/hail/python/hail/docs/overview/matrix_table.rst
@@ -323,9 +323,9 @@ matrix table.
 First let's add a random phenotype as a new column field `case_status` and then
 compute statistics about the entry field `GQ` for each grouping of `case_status`.
 
-    >>> mt_ann = mt.annotate_cols(case_status = hl.cond(hl.rand_bool(0.5),
-    ...                                                 "CASE",
-    ...                                                 "CONTROL"))
+    >>> mt_ann = mt.annotate_cols(case_status = hl.if_else(hl.rand_bool(0.5),
+    ...                                                    "CASE",
+    ...                                                    "CONTROL"))
 
 Next we group the columns by `case_status` and aggregate:
 

--- a/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
+++ b/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
@@ -888,8 +888,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "entries = entries.annotate(maf_bin = hl.cond(entries.info.AF[0]<0.01, \"< 1%\", \n",
-    "                             hl.cond(entries.info.AF[0]<0.05, \"1%-5%\", \">5%\")))\n",
+    "entries = entries.annotate(maf_bin = hl.if_else(entries.info.AF[0]<0.01, \"< 1%\", \n",
+    "                             hl.if_else(entries.info.AF[0]<0.05, \"1%-5%\", \">5%\")))\n",
     "\n",
     "results2 = (entries.group_by(af_bin = entries.maf_bin, purple_hair = entries.pheno.PurpleHair)\n",
     "      .aggregate(mean_gq = hl.agg.stats(entries.GQ).mean, \n",

--- a/hail/python/hail/docs/tutorials/05-filter-annotate.ipynb
+++ b/hail/python/hail/docs/tutorials/05-filter-annotate.ipynb
@@ -75,9 +75,9 @@
     "missing_occupations = hl.set(['other', 'none'])\n",
     "\n",
     "t = users.annotate(\n",
-    "    cleaned_occupation = hl.cond(missing_occupations.contains(users.occupation),\n",
-    "                                 hl.null('str'),\n",
-    "                                 users.occupation))\n",
+    "    cleaned_occupation = hl.if_else(missing_occupations.contains(users.occupation),\n",
+    "                                    hl.null('str'),\n",
+    "                                    users.occupation))\n",
     "t.show()"
    ]
   },
@@ -170,9 +170,9 @@
     "missing_occupations = hl.set(['other', 'none'])\n",
     "\n",
     "t = users.select(\n",
-    "    cleaned_occupation = hl.cond(missing_occupations.contains(users.occupation),\n",
-    "                                 hl.null('str'),\n",
-    "                                 users.occupation))\n",
+    "    cleaned_occupation = hl.if_else(missing_occupations.contains(users.occupation),\n",
+    "                                    hl.null('str'),\n",
+    "                                    users.occupation))\n",
     "t.show()"
    ]
   },
@@ -185,9 +185,9 @@
     "missing_occupations = hl.set(['other', 'none'])\n",
     "\n",
     "t = users.transmute(\n",
-    "    cleaned_occupation = hl.cond(missing_occupations.contains(users.occupation),\n",
-    "                                 hl.null('str'),\n",
-    "                                 users.occupation))\n",
+    "    cleaned_occupation = hl.if_else(missing_occupations.contains(users.occupation),\n",
+    "                                    hl.null('str'),\n",
+    "                                    users.occupation))\n",
     "t.show()"
    ]
   },

--- a/hail/python/hail/experimental/ld_score_regression.py
+++ b/hail/python/hail/experimental/ld_score_regression.py
@@ -356,9 +356,9 @@ def ld_score_regression(weight_expr,
                                 step1_separators)) - 1,
                         lambda is_separator, step1_block: entry.annotate(
                             __step1_block=step1_block,
-                            __step2_block=hl.cond(~entry.__in_step1 & is_separator,
-                                                  step1_block - 1,
-                                                  step1_block))))),
+                            __step2_block=hl.if_else(~entry.__in_step1 & is_separator,
+                                                     step1_block - 1,
+                                                     step1_block))))),
             hl.range(0, hl.len(ht.__entries)))))
 
     mt = ht._unlocalize_entries('__entries', '__cols', col_keys)
@@ -375,7 +375,7 @@ def ld_score_regression(weight_expr,
 
     # step 1 iteratively reweighted least squares
     for i in range(3):
-        mt = mt.annotate_entries(__w=hl.cond(
+        mt = mt.annotate_entries(__w=hl.if_else(
             mt.__in_step1,
             1.0 / (mt.__w_initial_floor * 2.0 * (mt.__step1_betas[0]
                                                  + mt.__step1_betas[1]
@@ -423,7 +423,7 @@ def ld_score_regression(weight_expr,
 
     # step 2 iteratively reweighted least squares
     for i in range(3):
-        mt = mt.annotate_entries(__w=hl.cond(
+        mt = mt.annotate_entries(__w=hl.if_else(
             mt.__in_step2,
             1.0 / (mt.__w_initial_floor
                    * 2.0 * (mt.__step2_betas[0] +

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -23,7 +23,7 @@ def loop(f: Callable, typ, *args):
         \end{cases}`
 
     we would write:
-    >>> f = lambda recur, x, y: hl.cond(x == 0, y, recur(x - 1, y + x))
+    >>> f = lambda recur, x, y: hl.if_else(x == 0, y, recur(x - 1, y + x))
 
     Full recursion is not supported, and any non-tail-recursive methods will
     throw an error when called.
@@ -54,7 +54,7 @@ def loop(f: Callable, typ, *args):
     Example
     -------
     To find the sum of all the numbers from n=1...10:
-    >>> triangle_f = lambda f, x, total: hl.cond(x == 0, total, f(x - 1, total + x))
+    >>> triangle_f = lambda f, x, total: hl.if_else(x == 0, total, f(x - 1, total + x))
     >>> x = hl.experimental.loop(triangle_f, hl.tint32, 10, 0)
     >>> hl.eval(x)
     55
@@ -78,7 +78,7 @@ def loop(f: Callable, typ, *args):
     ...     converged = hl.is_defined(error) & (error < threshold)
     ...     new_guess = guess - (polynomial(guess) / derivative(guess))
     ...     new_error = hl.abs(new_guess - guess)
-    ...     return hl.cond(converged, guess, f(new_guess, new_error))
+    ...     return hl.if_else(converged, guess, f(new_guess, new_error))
     >>> x = hl.experimental.loop(find_root, hl.tfloat, 0.0, hl.null(hl.tfloat))
     >>> hl.eval(x)
     0.8052291984599675

--- a/hail/python/hail/experimental/phase_by_transmission.py
+++ b/hail/python/hail/experimental/phase_by_transmission.py
@@ -73,7 +73,7 @@ def phase_by_transmission(
         :return: Array of one-hot-encoded alleles
         :rtype: ArrayExpression
         """
-        return hl.cond(
+        return hl.if_else(
             call.is_het(),
             hl.array([
                 hl.call(call[0]).one_hot_alleles(alleles),
@@ -118,7 +118,7 @@ def phase_by_transmission(
         """
 
         proband_v = proband_call.one_hot_alleles(alleles)
-        father_v = hl.cond(
+        father_v = hl.if_else(
             locus.in_x_nonpar() | locus.in_y_nonpar(),
             hl.or_missing(father_call.is_haploid(), hl.array([father_call.one_hot_alleles(alleles)])),
             call_to_one_hot_alleles_array(father_call, alleles)
@@ -138,7 +138,7 @@ def phase_by_transmission(
                 hl.is_defined(combinations) & (hl.len(combinations) == 1),
                 hl.array([
                     hl.call(father_call[combinations[0].f], mother_call[combinations[0].m], phased=True),
-                    hl.cond(father_call.is_haploid(), hl.call(father_call[0], phased=True), phase_parent_call(father_call, combinations[0].f)),
+                    hl.if_else(father_call.is_haploid(), hl.call(father_call[0], phased=True), phase_parent_call(father_call, combinations[0].f)),
                     phase_parent_call(mother_call, combinations[0].m)
                 ])
             )

--- a/hail/python/hail/experimental/tidyr.py
+++ b/hail/python/hail/experimental/tidyr.py
@@ -95,9 +95,9 @@ def spread(ht, field, value, key=None) -> Table:
                        **{fv: hl.agg.filter(ht[field] == fv,
                                             hl.rbind(
                                                 hl.agg.take(ht[value], 1),
-                                                lambda take: hl.cond(hl.len(take) > 0,
-                                                                     take[0],
-                                                                     'NA'))) for fv in field_vals}))
+                                                lambda take: hl.if_else(hl.len(take) > 0,
+                                                                        take[0],
+                                                                        'NA'))) for fv in field_vals}))
 
     ht_tmp = new_temp_file()
     ht.write(ht_tmp)

--- a/hail/python/hail/experimental/vcf_combiner/densify.py
+++ b/hail/python/hail/experimental/vcf_combiner/densify.py
@@ -43,7 +43,7 @@ def densify(sparse_mt):
                 hl.rbind(
                     prev_entries[i], t.__entries[i],
                     lambda prev_entry, entry:
-                    hl.cond(
+                    hl.if_else(
                         (~hl.is_defined(entry)
                          & (prev_entry.END >= t.locus.position)
                          & (prev_entry.__contig == t.__contig_idx)),

--- a/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner/vcf_combiner.py
@@ -152,12 +152,12 @@ def transform_gvcf(mt, info_to_keep=[]) -> Table:
                 handled_fields['LPGT'] = e.PGT
             if 'PL' in e:
                 handled_fields['LPL'] = hl.if_else(has_non_ref,
-                                                hl.if_else(alleles_len > 2,
-                                                        e.PL[:-alleles_len],
-                                                        hl.null(e.PL.dtype)),
-                                                hl.if_else(alleles_len > 1,
-                                                        e.PL,
-                                                        hl.null(e.PL.dtype)))
+                                                   hl.if_else(alleles_len > 2,
+                                                              e.PL[:-alleles_len],
+                                                              hl.null(e.PL.dtype)),
+                                                   hl.if_else(alleles_len > 1,
+                                                              e.PL,
+                                                              hl.null(e.PL.dtype)))
                 handled_fields['RGQ'] = hl.if_else(
                     has_non_ref,
                     e.PL[hl.call(0, alleles_len - 1).unphased_diploid_gt_index()],
@@ -245,13 +245,13 @@ def combine(ts):
                         hl.range(0, hl.len(row.data)).flatmap(
                             lambda i:
                             hl.if_else(hl.is_missing(row.data[i].__entries),
-                                    hl.range(0, hl.len(gbl.g[i].__cols))
-                                    .map(lambda _: hl.null(row.data[i].__entries.dtype.element_type)),
-                                    hl.bind(
-                                        lambda old_to_new: row.data[i].__entries.map(
-                                            lambda e: renumber_entry(e, old_to_new)),
-                                        hl.range(0, hl.len(alleles.local[i])).map(
-                                            lambda j: combined_allele_index[alleles.local[i][j]])))),
+                                       hl.range(0, hl.len(gbl.g[i].__cols))
+                                       .map(lambda _: hl.null(row.data[i].__entries.dtype.element_type)),
+                                       hl.bind(
+                                           lambda old_to_new: row.data[i].__entries.map(
+                                               lambda e: renumber_entry(e, old_to_new)),
+                                           hl.range(0, hl.len(alleles.local[i])).map(
+                                               lambda j: combined_allele_index[alleles.local[i][j]])))),
                         hl.dict(hl.range(0, hl.len(alleles.globl)).map(
                             lambda j: hl.tuple([alleles.globl[j], j])))))),
             ts.row.dtype, ts.globals.dtype)

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -936,8 +936,8 @@ def fraction(predicate) -> Float64Expression:
     :class:`.Expression` of type :py:data:`.tfloat64`
         Fraction of records where `predicate` is ``True``.
     """
-    return hl.bind(lambda n: hl.cond(n == 0, hl.null(hl.tfloat64),
-                                     hl.float64(filter(predicate, count())) / n),
+    return hl.bind(lambda n: hl.if_else(n == 0, hl.null(hl.tfloat64),
+                                        hl.float64(filter(predicate, count())) / n),
                    count())
 
 
@@ -1445,7 +1445,7 @@ def info_score(gp) -> StructExpression:
                         hl.agg.count(),
                         lambda sum_variance, expected_ac, total_dosage, n:
                         hl.rbind(
-                            hl.cond(total_dosage != 0, expected_ac / total_dosage, hl.null(hl.tfloat64)),
+                            hl.if_else(total_dosage != 0, expected_ac / total_dosage, hl.null(hl.tfloat64)),
                             lambda theta: hl.struct(score=hl.case().when(n == 0, hl.null(hl.tfloat64))
                                                     .when((theta == 0.0) | (theta == 1.0), 1.0)
                                                     .default(1.0 - ((sum_variance / n) / (2 * theta * (1 - theta)))),

--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -72,10 +72,10 @@ class SwitchBuilder(ConditionalBuilder):
             else:
                 expr = default
             for value, then in self._cases[::-1]:
-                expr = hl.cond(base == value, then, expr)
+                expr = hl.if_else(base == value, then, expr)
             # needs to be on the outside, because upstream missingness would propagate
             if self._when_missing_case is not None:
-                expr = hl.cond(hl.is_missing(base), self._when_missing_case, expr)
+                expr = hl.if_else(hl.is_missing(base), self._when_missing_case, expr)
             return expr
 
         return hl.bind(f, self._base)

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -474,7 +474,7 @@ class Expression(object):
     def __nonzero__(self):
         raise ExpressionException(
             "The truth value of an expression is undefined\n"
-            "    Hint: instead of 'if x', use 'hl.cond(x, ...)'\n"
+            "    Hint: instead of 'if x', use 'hl.if_else(x, ...)'\n"
             "    Hint: instead of 'x and y' or 'x or y', use 'x & y' or 'x | y'\n"
             "    Hint: instead of 'not x', use '~x'")
 
@@ -961,7 +961,7 @@ class Expression(object):
             entry_array = t[entries]
             if self_name:
                 entry_array = hl.map(lambda x: x[self_name], entry_array)
-            entry_array = hl.map(lambda x: hl.cond(hl.is_missing(x), missing, hl.str(x)),
+            entry_array = hl.map(lambda x: hl.if_else(hl.is_missing(x), missing, hl.str(x)),
                                  entry_array)
             file_contents = t.select(
                 **{k: hl.str(t[k]) for k in ds.row_key},

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -175,7 +175,7 @@ def eval(expression):
     Evaluate a conditional:
 
     >>> x = 6
-    >>> hl.eval(hl.cond(x % 2 == 0, 'Even', 'Odd'))
+    >>> hl.eval(hl.if_else(x % 2 == 0, 'Even', 'Odd'))
     'Even'
 
     Parameters
@@ -205,7 +205,7 @@ def eval_typed(expression):
     Evaluate a conditional:
 
     >>> x = 6
-    >>> hl.eval_typed(hl.cond(x % 2 == 0, 'Even', 'Odd'))
+    >>> hl.eval_typed(hl.if_else(x % 2 == 0, 'Even', 'Odd'))
     ('Even', dtype('str'))
 
     Parameters

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3789,8 +3789,8 @@ class NDArrayExpression(Expression):
                     else:
                         step = to_expr(1, tint64)
 
-                    max_bound = hl.cond(step > 0, dlen, dlen - 1)
-                    min_bound = hl.cond(step > 0, to_expr(0, tint64), to_expr(-1, tint64))
+                    max_bound = hl.if_else(step > 0, dlen, dlen - 1)
+                    min_bound = hl.if_else(step > 0, to_expr(0, tint64), to_expr(-1, tint64))
                     if s.start is not None:
                         # python treats start < -dlen as None when step < 0: [0,1][-3:0:-1]
                         # and 0 otherwise: [0,1][-3::1] == [0,1][0::1]
@@ -3800,7 +3800,7 @@ class NDArrayExpression(Expression):
                             .when((s.start + dlen) >= 0, dlen + s.start) \
                             .default(min_bound)
                     else:
-                        start = hl.cond(step >= 0, to_expr(0, tint64), dlen - 1)
+                        start = hl.if_else(step >= 0, to_expr(0, tint64), dlen - 1)
 
                     if s.stop is not None:
                         # python treats stop < -dlen as None when step < 0: [0,1][0:-3:-1] == [0,1][0::-1]
@@ -3811,7 +3811,7 @@ class NDArrayExpression(Expression):
                             .when((s.stop + dlen) >= 0, dlen + s.stop) \
                             .default(min_bound)
                     else:
-                        stop = hl.cond(step > 0, dlen, to_expr(-1, tint64))
+                        stop = hl.if_else(step > 0, dlen, to_expr(-1, tint64))
 
                     slices.append(hl.tuple((start, stop, step)))
                 else:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -145,7 +145,7 @@ class CollectionExpression(Expression):
 
         # FIXME this should short-circuit
         return self.fold(lambda accum, x:
-                         hl.cond(hl.is_missing(accum) & f(x), x, accum),
+                         hl.if_else(hl.is_missing(accum) & f(x), x, accum),
                          hl.null(self._type.element_type))
 
     @typecheck_method(f=func_spec(1, expr_any))

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -242,6 +242,7 @@ def literal(x: Any, dtype: Optional[Union[HailType, str]] = None):
         return construct_expr(ir.Literal(dtype, x), dtype)
 
 
+@deprecated(version="0.2.59", reason="Replaced by hl.if_else")
 @typecheck(condition=expr_bool, consequent=expr_any, alternate=expr_any, missing_false=bool)
 def cond(condition,
          consequent,
@@ -2495,8 +2496,8 @@ def rand_dirichlet(a, seed=None) -> ArrayExpression:
     return hl.bind(lambda x: x / hl.sum(x),
                    a.map(lambda p:
                          hl.if_else(p == 0.0,
-                                 0.0,
-                                 hl.rand_gamma(p, 1, seed=seed))))
+                                    0.0,
+                                    hl.rand_gamma(p, 1, seed=seed))))
 
 
 @typecheck(x=expr_float64)
@@ -2567,23 +2568,23 @@ _allele_ints = {v: k for k, v in _allele_enum.items()}
 def _num_allele_type(ref, alt) -> Int32Expression:
     return hl.bind(lambda r, a:
                    hl.if_else(r.matches(_base_regex),
-                           hl.case()
-                           .when(a.matches(_base_regex), hl.case()
-                                 .when(r.length() == a.length(),
-                                       hl.if_else(r.length() == 1,
-                                               hl.if_else(r != a, _allele_ints['SNP'], _allele_ints['Unknown']),
-                                               hl.if_else(hamming(r, a) == 1,
-                                                       _allele_ints['SNP'],
-                                                       _allele_ints['MNP'])))
-                                 .when((r.length() < a.length()) & (r[0] == a[0]) & a.endswith(r[1:]),
-                                       _allele_ints["Insertion"])
-                                 .when((r[0] == a[0]) & r.endswith(a[1:]),
-                                       _allele_ints["Deletion"])
-                                 .default(_allele_ints['Complex']))
-                           .when(a == '*', _allele_ints['Star'])
-                           .when(a.matches(_symbolic_regex), _allele_ints['Symbolic'])
-                           .default(_allele_ints['Unknown']),
-                           _allele_ints['Unknown']),
+                              hl.case()
+                              .when(a.matches(_base_regex), hl.case()
+                                    .when(r.length() == a.length(),
+                                          hl.if_else(r.length() == 1,
+                                                     hl.if_else(r != a, _allele_ints['SNP'], _allele_ints['Unknown']),
+                                                     hl.if_else(hamming(r, a) == 1,
+                                                                _allele_ints['SNP'],
+                                                                _allele_ints['MNP'])))
+                                    .when((r.length() < a.length()) & (r[0] == a[0]) & a.endswith(r[1:]),
+                                          _allele_ints["Insertion"])
+                                    .when((r[0] == a[0]) & r.endswith(a[1:]),
+                                          _allele_ints["Deletion"])
+                                    .default(_allele_ints['Complex']))
+                              .when(a == '*', _allele_ints['Star'])
+                              .when(a.matches(_symbolic_regex), _allele_ints['Symbolic'])
+                              .default(_allele_ints['Unknown']),
+                              _allele_ints['Unknown']),
                    ref, alt)
 
 

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1746,7 +1746,7 @@ class MatrixTable(ExprContainer):
         --------
         :meth:`filter_entries`, :meth:`compute_entry_filter_stats`
         """
-        entry_ir = hl.cond(
+        entry_ir = hl.if_else(
             hl.is_defined(self.entry),
             self.entry,
             hl.literal(hl.Struct(**{k: hl.null(v.dtype) for k, v in self.entry.items()})))._ir

--- a/hail/python/hail/methods/family_methods.py
+++ b/hail/python/hail/methods/family_methods.py
@@ -495,7 +495,7 @@ def transmission_disequilibrium_test(dataset, pedigree) -> Table:
     parent_is_valid_het = ((father_is_het & tri.auto_or_x_par)
                            | (tri.mother_entry.GT.is_het() & ~father_is_het))
 
-    copy_state = hl.cond(tri.auto_or_x_par | tri.is_female, 2, 1)
+    copy_state = hl.if_else(tri.auto_or_x_par | tri.is_female, 2, 1)
 
     config = (tri.proband_entry.GT.n_alt_alleles(),
               tri.father_entry.GT.n_alt_alleles(),

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -342,9 +342,9 @@ def export_plink(dataset, output, call=None, fam_id=None, ind_id=None, pat_id=No
                  'pat_id': expr_or_else(pat_id, '0'),
                  'mat_id': expr_or_else(mat_id, '0'),
                  'is_female': expr_or_else(is_female, '0',
-                                           lambda x: hl.cond(x, '2', '1')),
+                                           lambda x: hl.if_else(x, '2', '1')),
                  'pheno': expr_or_else(pheno, 'NA',
-                                       lambda x: hl.cond(x, '2', '1') if x.dtype == tbool else hl.str(x))}
+                                       lambda x: hl.if_else(x, '2', '1') if x.dtype == tbool else hl.str(x))}
 
     locus = dataset.locus
     a = dataset.alleles
@@ -645,7 +645,7 @@ def import_locus_intervals(path,
 
             expr = (
                 hl.bind(t['f0'].first_match_in(interval_regex),
-                        lambda match: hl.cond(hl.bool(skip_invalid_intervals),
+                        lambda match: hl.if_else(hl.bool(skip_invalid_intervals),
                                               checked_match_interval_expr(match),
                                               locus_interval_expr(recode_contig(match[0]),
                                                                   hl.int32(match[1]),

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -646,14 +646,14 @@ def import_locus_intervals(path,
             expr = (
                 hl.bind(t['f0'].first_match_in(interval_regex),
                         lambda match: hl.if_else(hl.bool(skip_invalid_intervals),
-                                              checked_match_interval_expr(match),
-                                              locus_interval_expr(recode_contig(match[0]),
-                                                                  hl.int32(match[1]),
-                                                                  hl.int32(match[2]),
-                                                                  True,
-                                                                  True,
-                                                                  reference_genome,
-                                                                  skip_invalid_intervals))))
+                                                 checked_match_interval_expr(match),
+                                                 locus_interval_expr(recode_contig(match[0]),
+                                                                     hl.int32(match[1]),
+                                                                     hl.int32(match[2]),
+                                                                     True,
+                                                                     True,
+                                                                     reference_genome,
+                                                                     skip_invalid_intervals))))
 
             t = t.select(interval=expr)
 

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -46,8 +46,8 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None, keyed=True) -> Ta
     ...     i=hl.struct(id=pairs.i, is_case=samples[pairs.i].is_case),
     ...     j=hl.struct(id=pairs.j, is_case=samples[pairs.j].is_case))
     >>> def tie_breaker(l, r):
-    ...     return hl.cond(l.is_case & ~r.is_case, -1,
-    ...                    hl.cond(~l.is_case & r.is_case, 1, 0))
+    ...     return hl.if_else(l.is_case & ~r.is_case, -1,
+    ...                       hl.if_else(~l.is_case & r.is_case, 1, 0))
     >>> related_samples_to_remove = hl.maximal_independent_set(
     ...    pairs_with_case.i, pairs_with_case.j, False, tie_breaker)
     >>> result = dataset.filter_cols(hl.is_defined(

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -91,11 +91,11 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     allele_ints = {v: k for k, v in allele_enum.items()}
 
     def allele_type(ref, alt):
-        return hl.bind(lambda at: hl.cond(at == allele_ints['SNP'],
-                                          hl.cond(hl.is_transition(ref, alt),
-                                                  allele_ints['Transition'],
-                                                  allele_ints['Transversion']),
-                                          at),
+        return hl.bind(lambda at: hl.if_else(at == allele_ints['SNP'],
+                                             hl.if_else(hl.is_transition(ref, alt),
+                                                        allele_ints['Transition'],
+                                                        allele_ints['Transversion']),
+                                             at),
                        _num_allele_type(ref, alt))
 
     variant_ac = Env.get_uid()
@@ -129,7 +129,7 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, mt['GT'].ploidy).map(lambda i: mt[variant_ac][mt['GT'][i]] == 1)))
 
     def get_allele_type(allele_idx):
-        return hl.cond(allele_idx > 0, mt[variant_atypes][allele_idx - 1], hl.null(hl.tint32))
+        return hl.if_else(allele_idx > 0, mt[variant_atypes][allele_idx - 1], hl.null(hl.tint32))
 
     bound_exprs['allele_type_counts'] = hl.agg.explode(
         lambda elt: hl.agg.counter(elt),
@@ -438,7 +438,7 @@ def concordance(left, right, *, _localize_global_statistics=True) -> Tuple[List[
     joined = hl.experimental.full_outer_join_mt(left, right)
 
     def get_idx(struct):
-        return hl.cond(
+        return hl.if_else(
             hl.is_missing(struct),
             0,
             hl.coalesce(2 + struct.GT.n_alt_alleles(), 1))

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -156,11 +156,11 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
     mt = mt.filter_rows((mt[aaf] > aaf_threshold) & (mt[aaf] < (1 - aaf_threshold)))
     mt = mt.annotate_cols(ib=agg.inbreeding(mt.call, mt[aaf]))
     kt = mt.select_cols(
-        is_female=hl.cond(mt.ib.f_stat < female_threshold,
-                          True,
-                          hl.cond(mt.ib.f_stat > male_threshold,
-                                  False,
-                                  hl.null(tbool))),
+        is_female=hl.if_else(mt.ib.f_stat < female_threshold,
+                             True,
+                             hl.if_else(mt.ib.f_stat > male_threshold,
+                                        False,
+                                        hl.null(tbool))),
         **mt.ib).cols()
 
     return kt
@@ -2776,7 +2776,7 @@ def filter_alleles_hts(mt: MatrixTable,
     mt = filter_alleles(mt, f)
 
     if subset:
-        newPL = hl.cond(
+        newPL = hl.if_else(
             hl.is_defined(mt.PL),
             hl.bind(
                 lambda unnorm: unnorm - hl.min(unnorm),
@@ -2788,7 +2788,7 @@ def filter_alleles_hts(mt: MatrixTable,
             hl.null(tarray(tint32)))
         return mt.annotate_entries(
             GT=hl.unphased_diploid_gt_index_call(hl.argmin(newPL, unique=True)),
-            AD=hl.cond(
+            AD=hl.if_else(
                 hl.is_defined(mt.AD),
                 hl.range(0, mt.alleles.length()).map(
                     lambda newi: mt.AD[mt.new_to_old[newi]]),
@@ -2799,7 +2799,7 @@ def filter_alleles_hts(mt: MatrixTable,
     # otherwise downcode
     else:
         mt = mt.annotate_rows(__old_to_new_no_na=mt.old_to_new.map(lambda x: hl.or_else(x, 0)))
-        newPL = hl.cond(
+        newPL = hl.if_else(
             hl.is_defined(mt.PL),
             (hl.range(0, hl.triangle(hl.len(mt.alleles)))
              .map(lambda newi: hl.min(hl.range(0, hl.triangle(hl.len(mt.old_alleles)))
@@ -2812,7 +2812,7 @@ def filter_alleles_hts(mt: MatrixTable,
         return mt.annotate_entries(
             GT=hl.call(mt.__old_to_new_no_na[mt.GT[0]],
                        mt.__old_to_new_no_na[mt.GT[1]]),
-            AD=hl.cond(
+            AD=hl.if_else(
                 hl.is_defined(mt.AD),
                 (hl.range(0, hl.len(mt.alleles))
                  .map(lambda newi: hl.sum(hl.range(0, hl.len(mt.old_alleles))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -392,9 +392,9 @@ def eye(N, M=None, dtype=hl.tfloat64):
         n_col = hl.int32(M)
 
     return hl.nd.array(hl.range(0, n_row * n_col).map(
-        lambda i: hl.cond((i // n_col) == (i % n_col),
-                          hl.literal(1, dtype),
-                          hl.literal(0, dtype))
+        lambda i: hl.if_else((i // n_col) == (i % n_col),
+                             hl.literal(1, dtype),
+                             hl.literal(0, dtype))
     )).reshape((n_row, n_col))
 
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -301,9 +301,9 @@ class Table(ExprContainer):
     >>> height_sd_f = 2.5
     >>>
     >>> def get_z(height, sex):
-    ...    return hl.cond(sex == 'M',
-    ...                  (height - height_mean_m) / height_sd_m,
-    ...                  (height - height_mean_f) / height_sd_f)
+    ...    return hl.if_else(sex == 'M',
+    ...                     (height - height_mean_m) / height_sd_m,
+    ...                     (height - height_mean_f) / height_sd_f)
     >>>
     >>> table1 = table1.annotate(height_z = get_z(table1.HT, table1.SEX))
     >>> table1 = table1.annotate_globals(global_field_1 = [1, 2, 3])

--- a/hail/python/hail/utils/tutorial.py
+++ b/hail/python/hail/utils/tutorial.py
@@ -157,7 +157,7 @@ def get_movie_lens(output_dir, overwrite: bool = False):
 
         # utility functions for importing movies
         def field_to_array(ds, field):
-            return hl.cond(ds[field] != 0, hl.array([field]), hl.empty_array(hl.tstr))
+            return hl.if_else(ds[field] != 0, hl.array([field]), hl.empty_array(hl.tstr))
 
         def fields_to_array(ds, fields):
             return hl.flatten(hl.array([field_to_array(ds, f) for f in fields]))

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -88,8 +88,8 @@ class Tests(unittest.TestCase):
     @skip_unless_spark_backend()
     def test_plot_roc_curve(self):
         x = hl.utils.range_table(100).annotate(score1=hl.rand_norm(), score2=hl.rand_norm())
-        x = x.annotate(tp=hl.cond(x.score1 > 0, hl.rand_bool(0.7), False), score3=x.score1 + hl.rand_norm())
-        ht = x.annotate(fp=hl.cond(~x.tp, hl.rand_bool(0.2), False))
+        x = x.annotate(tp=hl.if_else(x.score1 > 0, hl.rand_bool(0.7), False), score3=x.score1 + hl.rand_norm())
+        ht = x.annotate(fp=hl.if_else(~x.tp, hl.rand_bool(0.2), False))
         _, aucs = hl.experimental.plot_roc_curve(ht, ['score1', 'score2', 'score3'])
 
     @pytest.mark.unchecked_allocator
@@ -370,12 +370,12 @@ class Tests(unittest.TestCase):
     def test_loop(self):
         def triangle_with_ints(n):
             return hl.experimental.loop(
-                lambda f, x, c: hl.cond(x > 0, f(x - 1, c + x), c),
+                lambda f, x, c: hl.if_else(x > 0, f(x - 1, c + x), c),
                 hl.tint32, n, 0)
 
         def triangle_with_tuple(n):
             return hl.experimental.loop(
-                lambda f, xc: hl.cond(xc[0] > 0, f((xc[0] - 1, xc[1] + xc[0])), xc[1]),
+                lambda f, xc: hl.if_else(xc[0] > 0, f((xc[0] - 1, xc[1] + xc[0])), xc[1]),
                 hl.tint32, (n, 0))
 
         for triangle in [triangle_with_ints, triangle_with_tuple]:
@@ -394,13 +394,13 @@ class Tests(unittest.TestCase):
         fails_typecheck("bound value",
                         lambda f, x: hl.bind(lambda x: x, f(x)))
         fails_typecheck("branch condition",
-                        lambda f, x: hl.cond(f(x) == 0, x, 1))
+                        lambda f, x: hl.if_else(f(x) == 0, x, 1))
         fails_typecheck("Type error",
-                        lambda f, x: hl.cond(x == 0, f("foo"), 1))
+                        lambda f, x: hl.if_else(x == 0, f("foo"), 1))
 
     def test_nested_loops(self):
         def triangle_loop(n, add_f):
-            recur = lambda f, x, c: hl.cond(x <= n, f(x + 1, add_f(x, c)), c)
+            recur = lambda f, x, c: hl.if_else(x <= n, f(x + 1, add_f(x, c)), c)
             return hl.experimental.loop(recur, hl.tint32, 0, 0)
 
         assert_evals_to(triangle_loop(5, lambda x, c: c + x), 15)
@@ -409,10 +409,10 @@ class Tests(unittest.TestCase):
         n1 = 5
         calls_recur_from_nested_loop = hl.experimental.loop(
             lambda f, x1, c1:
-            hl.cond(x1 <= n1,
+            hl.if_else(x1 <= n1,
                     hl.experimental.loop(
                         lambda f2, x2, c2:
-                        hl.cond(x2 <= x1,
+                        hl.if_else(x2 <= x1,
                                 f2(x2 + 1, c2 + x2),
                                 f(x1 + 1, c1 + c2)),
                         'int32', 0, 0),

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -320,11 +320,11 @@ class Tests(unittest.TestCase):
             hl.eval(hl.str(",").join([1, 2, 3]))
 
     def test_cond(self):
-        self.assertEqual(hl.eval('A' + hl.cond(True, 'A', 'B')), 'AA')
+        self.assertEqual(hl.eval('A' + hl.if_else(True, 'A', 'B')), 'AA')
 
-        self.assertEqual(hl.eval(hl.cond(True, hl.struct(), hl.null(hl.tstruct()))), hl.utils.Struct())
-        self.assertEqual(hl.eval(hl.cond(hl.null(hl.tbool), 1, 2)), None)
-        self.assertEqual(hl.eval(hl.cond(hl.null(hl.tbool), 1, 2, missing_false=True)), 2)
+        self.assertEqual(hl.eval(hl.if_else(True, hl.struct(), hl.null(hl.tstruct()))), hl.utils.Struct())
+        self.assertEqual(hl.eval(hl.if_else(hl.null(hl.tbool), 1, 2)), None)
+        self.assertEqual(hl.eval(hl.if_else(hl.null(hl.tbool), 1, 2, missing_false=True)), 2)
 
     def test_if_else(self):
         self.assertEqual(hl.eval('A' + hl.if_else(True, 'A', 'B')), 'AA')
@@ -341,7 +341,7 @@ class Tests(unittest.TestCase):
                                       arr_sum=hl.agg.array_sum([1, 2, hl.null(tint32)]),
                                       bind_agg=hl.agg.count_where(hl.bind(lambda x: x % 2 == 0, table.idx)),
                                       mean=hl.agg.mean(table.idx),
-                                      mean2=hl.agg.mean(hl.cond(table.idx == 9, table.idx, hl.null(tint32))),
+                                      mean2=hl.agg.mean(hl.if_else(table.idx == 9, table.idx, hl.null(tint32))),
                                       foo=hl.min(3, hl.agg.sum(table.idx))))
 
         self.assertEqual(r.x, 10)
@@ -599,36 +599,36 @@ class Tests(unittest.TestCase):
         t = hl.utils.range_table(10)
 
         tests = [(hl.agg.explode(lambda elt: hl.agg.collect(elt + 1).append(0),
-                              hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                              hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   [9, 10, 10, 11, 0]),
                  (hl.agg.explode(lambda elt: hl.agg.explode(lambda elt2: hl.agg.collect(elt2 + 1).append(0),
                                                       [elt, elt + 1]),
-                              hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                              hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   [9, 10, 10, 11, 10, 11, 11, 12, 0]),
                  (hl.agg.explode(lambda elt: hl.agg.filter(elt > 8,
                                                      hl.agg.collect(elt + 1).append(0)),
-                              hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                              hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   [10, 10, 11, 0]),
                  (hl.agg.explode(lambda elt: hl.agg.group_by(elt % 3,
                                                        hl.agg.collect(elt + 1).append(0)),
-                                           hl.cond(t.idx > 7,
+                                           hl.if_else(t.idx > 7,
                                                    [t.idx, t.idx + 1],
                                                    hl.empty_array(hl.tint32))),
                   {0: [10, 10, 0], 1: [11, 0], 2:[9, 0]}),
                  (hl.agg.explode(lambda elt: hl.agg.count(),
-                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                                 hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   4),
                  (hl.agg.explode(lambda elt: hl.agg.explode(lambda elt2: hl.agg.count(),
                                                             [elt, elt + 1]),
-                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                                 hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   8),
                  (hl.agg.explode(lambda elt: hl.agg.filter(elt > 8,
                                                            hl.agg.count()),
-                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                                 hl.if_else(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
                   3),
                  (hl.agg.explode(lambda elt: hl.agg.group_by(elt % 3,
                                                              hl.agg.count()),
-                                 hl.cond(t.idx > 7,
+                                 hl.if_else(t.idx > 7,
                                          [t.idx, t.idx + 1],
                                          hl.empty_array(hl.tint32))),
                   {0: 2, 1: 1, 2: 1})
@@ -647,7 +647,7 @@ class Tests(unittest.TestCase):
                   {0: [10, 0], 1: [0], 2: [9, 0]}),
                  (hl.agg.group_by(t.idx % 3,
                                hl.agg.explode(lambda elt: hl.agg.collect(elt + 1).append(0),
-                                           hl.cond(t.idx > 7,
+                                           hl.if_else(t.idx > 7,
                                                    [t.idx, t.idx + 1],
                                                    hl.empty_array(hl.tint32)))),
                   {0: [10, 11, 0], 1: [0], 2:[9, 10, 0]}),
@@ -657,7 +657,7 @@ class Tests(unittest.TestCase):
                   {0: 1, 1: 0, 2: 1}),
                  (hl.agg.group_by(t.idx % 3,
                                   hl.agg.explode(lambda elt: hl.agg.count(),
-                                                 hl.cond(t.idx > 7,
+                                                 hl.if_else(t.idx > 7,
                                                          [t.idx, t.idx + 1],
                                                          hl.empty_array(hl.tint32)))),
                   {0: 2, 1: 0, 2: 2}),
@@ -935,7 +935,7 @@ class Tests(unittest.TestCase):
 
     def test_aggregators_hist_neg0(self):
         table = hl.utils.range_table(32)
-        table = table.annotate(d=hl.cond(table.idx == 11, -0.0, table.idx / 3))
+        table = table.annotate(d=hl.if_else(table.idx == 11, -0.0, table.idx / 3))
         r = table.aggregate(hl.agg.hist(table.d, 0, 10, 5))
         self.assertEqual(r.bin_edges, [0, 2, 4, 6, 8, 10])
         self.assertEqual(r.bin_freq, [7, 5, 6, 6, 7])
@@ -1127,8 +1127,8 @@ class Tests(unittest.TestCase):
         ht = hl.utils.range_table(10)
         ht = ht.annotate(tests=hl.range(0, 10).map(
             lambda i: hl.struct(
-                x=hl.cond(hl.rand_bool(0.1), hl.null(hl.tfloat64), hl.rand_unif(-10, 10)),
-                y=hl.cond(hl.rand_bool(0.1), hl.null(hl.tfloat64), hl.rand_unif(-10, 10)))))
+                x=hl.if_else(hl.rand_bool(0.1), hl.null(hl.tfloat64), hl.rand_unif(-10, 10)),
+                y=hl.if_else(hl.rand_bool(0.1), hl.null(hl.tfloat64), hl.rand_unif(-10, 10)))))
 
         results = ht.aggregate(hl.agg.array_agg(lambda test: (hl.agg.corr(test.x, test.y), hl.agg.collect((test.x, test.y))), ht.tests))
 
@@ -1308,10 +1308,10 @@ class Tests(unittest.TestCase):
         df = hl.utils.range_table(10)
         df = df.annotate(all_true=True,
                          all_false=False,
-                         true_or_missing=hl.cond(df.idx % 2 == 0, True, hl.null(tbool)),
-                         false_or_missing=hl.cond(df.idx % 2 == 0, False, hl.null(tbool)),
+                         true_or_missing=hl.if_else(df.idx % 2 == 0, True, hl.null(tbool)),
+                         false_or_missing=hl.if_else(df.idx % 2 == 0, False, hl.null(tbool)),
                          all_missing=hl.null(tbool),
-                         mixed_true_false=hl.cond(df.idx % 2 == 0, True, False),
+                         mixed_true_false=hl.if_else(df.idx % 2 == 0, True, False),
                          mixed_all=hl.switch(df.idx % 3)
                          .when(0, True)
                          .when(1, False)
@@ -2745,7 +2745,7 @@ class Tests(unittest.TestCase):
         group_agg = t2.group_by(t2['group']).aggregate(call_stats=hl.agg.call_stats(t2.GT, t2.alleles))
 
         self.assertTrue(group_agg.all(
-            hl.cond(group_agg.group,
+            hl.if_else(group_agg.group,
                     hl.is_defined(group_agg.call_stats)
                     & (group_agg.call_stats == hl.struct(AC=[3, 3], AF=[0.5, 0.5], AN=6, homozygote_count=[0, 0])),
                     hl.is_defined(group_agg.call_stats)
@@ -2757,7 +2757,7 @@ class Tests(unittest.TestCase):
                           .aggregate(call_stats=hl.agg.call_stats(mt2.GT, mt2.alleles2)).entries())
 
         self.assertTrue(group_cols_agg.all(
-            hl.cond(group_cols_agg.group,
+            hl.if_else(group_cols_agg.group,
                     hl.is_defined(group_cols_agg.call_stats)
                     & (group_cols_agg.call_stats == hl.struct(AC=[3, 3], AF=[0.5, 0.5], AN=6, homozygote_count=[0, 0])),
                     hl.is_defined(group_cols_agg.call_stats)
@@ -2771,7 +2771,7 @@ class Tests(unittest.TestCase):
                           ).entries()
 
         self.assertTrue(group_cols_agg.all(
-            hl.cond(group_cols_agg.group,
+            hl.if_else(group_cols_agg.group,
                     hl.is_defined(group_cols_agg.call_stats)
                     & (group_cols_agg.call_stats == hl.struct(AC=[3, 3], AF=[0.5, 0.5], AN=6, homozygote_count=[0, 0])),
                     hl.is_defined(group_cols_agg.call_stats)
@@ -2783,7 +2783,7 @@ class Tests(unittest.TestCase):
                           .aggregate(call_stats=hl.agg.call_stats(mt2.GT, mt2.alleles2)).entries())
 
         self.assertTrue(group_rows_agg.all(
-            hl.cond(group_rows_agg.group,
+            hl.if_else(group_rows_agg.group,
                     hl.is_defined(group_rows_agg.call_stats)
                     & (group_rows_agg.call_stats == hl.struct(AC=[3, 3], AF=[0.5, 0.5], AN=6, homozygote_count=[0, 0])),
                     hl.is_defined(group_rows_agg.call_stats)
@@ -2797,7 +2797,7 @@ class Tests(unittest.TestCase):
                           ).entries()
 
         self.assertTrue(group_rows_agg.all(
-            hl.cond(group_rows_agg.group,
+            hl.if_else(group_rows_agg.group,
                     hl.is_defined(group_rows_agg.call_stats)
                     & (group_rows_agg.call_stats == hl.struct(AC=[3, 3], AF=[0.5, 0.5], AN=6, homozygote_count=[0, 0])),
                     hl.is_defined(group_rows_agg.call_stats)
@@ -3165,11 +3165,11 @@ class Tests(unittest.TestCase):
 
     def test_issue3729(self):
         t = hl.utils.range_table(10, 3)
-        fold_expr = hl.cond(t.idx == 3,
+        fold_expr = hl.if_else(t.idx == 3,
                             [1, 2, 3],
                             [4, 5, 6]).fold(lambda accum, i: accum & (i == t.idx),
                                             True)
-        t.annotate(foo=hl.cond(fold_expr, 1, 3))._force_count()
+        t.annotate(foo=hl.if_else(fold_expr, 1, 3))._force_count()
 
     def assertValueEqual(self, expr, value, t):
         self.assertEqual(expr.dtype, t)

--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -100,9 +100,9 @@ class Tests(unittest.TestCase):
         ]
         schema = hl.tstruct(l37=hl.tlocus(grch37), l38=hl.tlocus(grch38))
         t = hl.Table.parallelize(rows, schema)
-        self.assertTrue(t.all(hl.cond(hl.is_defined(t.l38),
-                                      hl.liftover(t.l37, 'GRCh38') == t.l38,
-                                      hl.is_missing(hl.liftover(t.l37, 'GRCh38')))))
+        self.assertTrue(t.all(hl.if_else(hl.is_defined(t.l38),
+                                         hl.liftover(t.l37, 'GRCh38') == t.l38,
+                                         hl.is_missing(hl.liftover(t.l37, 'GRCh38')))))
 
         t = t.filter(hl.is_defined(t.l38))
         self.assertTrue(t.count() == 6)

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1375,7 +1375,7 @@ class BGENTests(unittest.TestCase):
         hl.export_bgen(mt, tmp,
                        gp=hl.or_missing(
                            hl.is_defined(mt.GT),
-                           hl.map(lambda i: hl.cond(mt.GT.unphased_diploid_gt_index() == i, 1.0, 0.0),
+                           hl.map(lambda i: hl.if_else(mt.GT.unphased_diploid_gt_index() == i, 1.0, 0.0),
                                   hl.range(0, hl.triangle(hl.len(mt.alleles))))))
         hl.index_bgen(tmp + '.bgen')
         bgen2 = hl.import_bgen(tmp + '.bgen',
@@ -1707,13 +1707,13 @@ class ImportMatrixTableTests(unittest.TestCase):
         col_key = mt.col_key
         mt = mt.key_rows_by()
         mt = mt.annotate_entries(
-            x = hl.cond(hl.str(mt.x) == missing,
-                        hl.null(entry_type),
-                        mt.x))
+            x = hl.if_else(hl.str(mt.x) == missing,
+                           hl.null(entry_type),
+                           mt.x))
         mt = mt.annotate_rows(**{
-            f: hl.cond(hl.str(mt[f]) == missing,
-                       hl.null(mt[f].dtype),
-                       mt[f])
+            f: hl.if_else(hl.str(mt[f]) == missing,
+                          hl.null(mt[f].dtype),
+                          mt[f])
             for f in mt.row})
         mt = mt.key_rows_by(*row_key)
         assert mt._same(actual)

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -34,9 +34,9 @@ def test_pca_against_numpy():
     n_rows = mt.count_rows()
 
     def make_expr(mean):
-        return hl.cond(hl.is_defined(mt.GT),
-                       (mt.GT.n_alt_alleles() - mean) / hl.sqrt(mean * (2 - mean) * n_rows / 2),
-                       0)
+        return hl.if_else(hl.is_defined(mt.GT),
+                          (mt.GT.n_alt_alleles() - mean) / hl.sqrt(mean * (2 - mean) * n_rows / 2),
+                          0)
 
     eigen, scores, loadings = hl.pca(hl.bind(make_expr, mt.AC / mt.n_called), k=3, compute_loadings=True)
     hail_scores = scores.explode('scores').scores.collect()
@@ -84,9 +84,9 @@ def test_blanczos_against_numpy():
     n_rows = mt.count_rows()
 
     def make_expr(mean):
-        return hl.cond(hl.is_defined(mt.GT),
-                       (mt.GT.n_alt_alleles() - mean) / hl.sqrt(mean * (2 - mean) * n_rows / 2),
-                       0)
+        return hl.if_else(hl.is_defined(mt.GT),
+                          (mt.GT.n_alt_alleles() - mean) / hl.sqrt(mean * (2 - mean) * n_rows / 2),
+                          0)
 
     k = 3
 

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -37,9 +37,9 @@ class Tests(unittest.TestCase):
         plink_sex = plink_sex.select('IID', 'SNPSEX', 'F')
         plink_sex = plink_sex.select(
             s=plink_sex.IID,
-            is_female=hl.cond(plink_sex.SNPSEX == 2,
+            is_female=hl.if_else(plink_sex.SNPSEX == 2,
                               True,
-                              hl.cond(plink_sex.SNPSEX == 1,
+                              hl.if_else(plink_sex.SNPSEX == 1,
                                       False,
                                       hl.null(hl.tbool))),
             f_stat=plink_sex.F).key_by('s')
@@ -1190,7 +1190,7 @@ class Tests(unittest.TestCase):
 
         n_samples = filtered_ds.count_cols()
         normalized_mean_imputed_genotype_expr = (
-            hl.cond(hl.is_defined(filtered_ds['GT']),
+            hl.if_else(hl.is_defined(filtered_ds['GT']),
                     (filtered_ds['GT'].n_alt_alleles() - filtered_ds['mean'])
                     * filtered_ds['sd_reciprocal'] * (1 / hl.sqrt(n_samples)), 0))
 
@@ -1238,7 +1238,7 @@ class Tests(unittest.TestCase):
         ds = hl.balding_nichols_model(n_populations=1, n_samples=50, n_variants=10, n_partitions=10).cache()
 
         ht = ds.select_rows(p=hl.agg.sum(ds.GT.n_alt_alleles()) / (2 * 50)).rows()
-        ht = ht.select(maf=hl.cond(ht.p <= 0.5, ht.p, 1.0 - ht.p)).cache()
+        ht = ht.select(maf=hl.if_else(ht.p <= 0.5, ht.p, 1.0 - ht.p)).cache()
 
         pruned_table = hl.ld_prune(ds.GT, 0.0)
         positions = pruned_table.locus.position.collect()
@@ -1379,11 +1379,11 @@ class Tests(unittest.TestCase):
                               weight=weights[ds.locus].weight)
         ds = ds.annotate_cols(pheno=phenotypes[ds.s].Pheno,
                               cov=covariates[ds.s])
-        ds = ds.annotate_cols(pheno=hl.cond(ds.pheno == 1.0,
-                                            False,
-                                            hl.cond(ds.pheno == 2.0,
-                                                    True,
-                                                    hl.null(hl.tbool))))
+        ds = ds.annotate_cols(pheno=hl.if_else(ds.pheno == 1.0,
+                                               False,
+                                               hl.if_else(ds.pheno == 2.0,
+                                                          True,
+                                                          hl.null(hl.tbool))))
 
         hl.skat(key_expr=ds.gene,
                 weight_expr=ds.weight,

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -54,7 +54,7 @@ class Tests(unittest.TestCase):
             x11=kt.f[1:2],
             x12=kt.f.map(lambda x: [x, x + 1]),
             x13=kt.f.map(lambda x: [[x, x + 1], [x + 2]]).flatmap(lambda x: x),
-            x14=hl.cond(kt.a < kt.b, kt.c, hl.null(hl.tint32)),
+            x14=hl.if_else(kt.a < kt.b, kt.c, hl.null(hl.tint32)),
             x15={1, 2, 3}
         ).take(1)[0])
 
@@ -939,12 +939,12 @@ class Tests(unittest.TestCase):
 
     def test_null_joins(self):
         tr = hl.utils.range_table(7, 1)
-        table1 = tr.key_by(new_key=hl.cond((tr.idx == 3) | (tr.idx == 5),
-                                           hl.null(hl.tint32), tr.idx),
+        table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),
+                                              hl.null(hl.tint32), tr.idx),
                            key2=1)
         table1 = table1.select(idx1=table1.idx)
-        table2 = tr.key_by(new_key=hl.cond((tr.idx == 4) | (tr.idx == 6),
-                                           hl.null(hl.tint32), tr.idx),
+        table2 = tr.key_by(new_key=hl.if_else((tr.idx == 4) | (tr.idx == 6),
+                                              hl.null(hl.tint32), tr.idx),
                            key2=1)
         table2 = table2.select(idx2=table2.idx)
 
@@ -979,12 +979,12 @@ class Tests(unittest.TestCase):
 
     def test_null_joins_2(self):
         tr = hl.utils.range_table(7, 1)
-        table1 = tr.key_by(new_key=hl.cond((tr.idx == 3) | (tr.idx == 5),
-                                           hl.null(hl.tint32), tr.idx),
+        table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),
+                                              hl.null(hl.tint32), tr.idx),
                            key2=tr.idx)
         table1 = table1.select(idx1=table1.idx)
-        table2 = tr.key_by(new_key=hl.cond((tr.idx == 4) | (tr.idx == 6),
-                                           hl.null(hl.tint32), tr.idx),
+        table2 = tr.key_by(new_key=hl.if_else((tr.idx == 4) | (tr.idx == 6),
+                                              hl.null(hl.tint32), tr.idx),
                            key2=tr.idx)
         table2 = table2.select(idx2=table2.idx)
 
@@ -1021,7 +1021,7 @@ class Tests(unittest.TestCase):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=tr.idx)
         table1 = table1.select(idx1=table1.idx)
-        table2 = tr.key_by(new_key=hl.cond((tr.idx == 4) | (tr.idx == 6), hl.null(hl.tint32), tr.idx))
+        table2 = tr.key_by(new_key=hl.if_else((tr.idx == 4) | (tr.idx == 6), hl.null(hl.tint32), tr.idx))
         table2 = table2.select(idx2=table2.idx)
 
         left_join = table1.join(table2, 'left')
@@ -1120,8 +1120,8 @@ class Tests(unittest.TestCase):
         ht = hl.utils.range_table(10).annotate(foo=5)
         ht.annotate(a_join=ht[ht.key],
                     a_literal=hl.literal(['a']),
-                    the_row_failure=hl.cond(True, ht.row, hl.null(ht.row.dtype)),
-                    the_global_failure=hl.cond(True, ht.globals, hl.null(ht.globals.dtype))).count()
+                    the_row_failure=hl.if_else(True, ht.row, hl.null(ht.row.dtype)),
+                    the_global_failure=hl.if_else(True, ht.globals, hl.null(ht.globals.dtype))).count()
 
     def test_aggregate_localize_false(self):
         ht = hl.utils.range_table(10)


### PR DESCRIPTION
We deprecated `hl.cond` in favor of `hl.if_else`, but we never added the `@Deprecated` decorator to it since we use `cond` internally everywhere. This PR replaces every instance I could find of `hl.cond` with `hl.if_else`. 