### PR TITLE
Support GRCh37 MT contig in import_gtf

### DIFF
--- a/hail/python/hail/experimental/import_gtf.py
+++ b/hail/python/hail/experimental/import_gtf.py
@@ -163,7 +163,10 @@ def import_gtf(path, reference_genome=None, skip_invalid_contigs=False, min_part
 
     if reference_genome:
         if reference_genome.name == 'GRCh37':
-            ht = ht.annotate(seqname=ht['seqname'].replace('^chr', ''))
+            ht = ht.annotate(seqname=hl.case()
+                             .when((ht['seqname'] == 'M') | (ht['seqname'] == 'chrM'), 'MT')
+                             .when(ht['seqname'].startswith('chr'), ht['seqname'].replace('^chr', ''))
+                             .default(ht['seqname']))
         else:
             ht = ht.annotate(seqname=hl.case()
                                        .when(ht['seqname'].startswith('HLA'), ht['seqname'])


### PR DESCRIPTION
GENCODE GTF files have contigs "chr1", "chr2", ... , "chrX", "chrY", "chrM". Currently, when `reference_genome` is set to GRCh37, `import_gtf` removes the "chr" prefix. This works for chromosomes 1-22, X, and Y.

However, for the mitochondrial contig, Hail expects "MT" instead of "M" and attempting to do anything with the imported table results in an error: `HailException: Invalid interval '[...]' found. Contig 'M' is not in the reference genome 'GRCh37'.`

With this change, `import_gtf` recodes "M" and "chrM" as "MT" so that the intervals are valid for GRCh37.