### PR TITLE
[atgu] fix breadcrumb href targets

### DIFF
--- a/atgu/atgu/templates/create_resource.html
+++ b/atgu/atgu/templates/create_resource.html
@@ -4,8 +4,8 @@
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
 {% endblock %}
 {% block breadcrumb_items %}
-  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/resources">Resources</a></li>
   <li class="breadcrumb-item active" aria-current="page">Create</li>
 {% endblock %}
 {% block container_contents %}

--- a/atgu/atgu/templates/edit_resource.html
+++ b/atgu/atgu/templates/edit_resource.html
@@ -4,8 +4,8 @@
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
 {% endblock %}
 {% block breadcrumb_items %}
-  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/resources">Resources</a></li>
   <li class="breadcrumb-item"><a href="{{ base_path }}/resources/{{ resource['id'] }}">{{ resource['title'] }}</a></li>
   <li class="breadcrumb-item active" aria-current="page">Edit</li>
 {% endblock %}

--- a/atgu/atgu/templates/resource.html
+++ b/atgu/atgu/templates/resource.html
@@ -4,8 +4,8 @@
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" crossorigin="anonymous">
 {% endblock %}
 {% block breadcrumb_items %}
-  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
-  <li class="breadcrumb-item"><a href="{{ base_path }}">Resources</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/resources">Resources</a></li>
   <li class="breadcrumb-item active" aria-current="page">{{ resource['title'] }}</li>
 {% endblock %}
 {% block container_contents %}

--- a/atgu/atgu/templates/resources.html
+++ b/atgu/atgu/templates/resources.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% block title %}Resources{% endblock %}
 {% block breadcrumb_items %}
-  <li class="breadcrumb-item"><a href="{{ base_path }}">ATGU</a></li>
+  <li class="breadcrumb-item"><a href="{{ base_path }}/">ATGU</a></li>
   <li class="breadcrumb-item active" aria-current="page">Resources</li>
 {% endblock %}
 {% block container_contents %}


### PR DESCRIPTION
base_path is empty in production.  href="" refers to the current page,
not the root page.  So always include a trailing slash when using
base_path in the HTML templates.

Also, note, / and /resources are currently the same, but won't be once there are other components besides resources.