### PR TITLE
[gateway] codify gateway nginx.conf

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -3,6 +3,7 @@ FROM {{ hail_ubuntu_image.image }}
 RUN hail-apt-get-install nginx
 
 RUN rm -f /etc/nginx/sites-enabled/default
+ADD nginx.conf /etc/nginx/
 ADD gateway.nginx.conf /etc/nginx/conf.d/gateway.conf
 ADD gzip.conf /etc/nginx/conf.d/gzip.conf
 

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -1,10 +1,3 @@
-include /ssl-config/ssl-config-http.conf;
-
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    ''      close;
-}
-
 server {
     listen 80 default_server;
     listen [::]:80 default_server;

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,50 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 768;
+}
+
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  server_names_hash_bucket_size 128;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+
+  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
+                              '$scheme "$request" $status $body_bytes_sent '
+                              '"$http_referer" "$http_user_agent"';
+  access_log /var/log/nginx/access.log combined_real_ip;
+  error_log /var/log/nginx/error.log;
+
+  include /ssl-config/ssl-config-http.conf;
+
+  gzip on;
+
+  map $http_x_forwarded_proto $updated_scheme {
+       default $http_x_forwarded_proto;
+       '' $scheme;
+  }
+  map $http_x_forwarded_host $updated_host {
+       default $http_x_forwarded_host;
+       '' $http_host;
+  }
+  map $http_upgrade $connection_upgrade {
+      default upgrade;
+      ''      close;
+  }
+
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
Previously, we used the default nginx.conf included by Ubuntu. This
changes us to use the same explicit settings that are used by the
internal-gateway vis-a-vis TLS.

This change also allows me to add (in a future PR) a TCP forwarding
block needed by the forthcoming Hail TCP Proxy.