### PR TITLE
[auth] Simplify and unify use of userinfo

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -606,7 +606,7 @@ def test_user_authentication_within_job(client):
     batch.submit()
 
     with_token_status = with_token.wait()
-    assert with_token_status['state'] == 'Success', with_token_status
+    assert with_token_status['state'] == 'Success', f'{(with_token.log(), with_token_status)}'
 
     username = get_userinfo()['username']
 
@@ -617,7 +617,7 @@ def test_user_authentication_within_job(client):
     assert job_userinfo is not None and job_userinfo["username"] == username, (username, with_token.log()['main'])
 
     no_token_status = no_token.wait()
-    assert no_token_status['state'] == 'Failed', no_token_status
+    assert no_token_status['state'] == 'Failed', f'{(no_token.log(), no_token_status)}'
 
 
 def test_verify_access_to_public_internet(client):

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -5,8 +5,6 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
-from hailtop.utils import request_retry_transient_errors
-from hailtop.tls import in_cluster_ssl_client_session
 from hailtop.auth import async_get_userinfo
 
 log = logging.getLogger('gear.auth')

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -7,15 +7,12 @@ from hailtop.tls import get_context_specific_ssl_client_session
 from .tokens import get_tokens
 
 
-_default_client_session = get_context_specific_ssl_client_session(
-    raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5))
-
-
 async def async_get_userinfo(*, deploy_config=None, session_id=None, client_session=None):
     if deploy_config is None:
         deploy_config = get_deploy_config()
     if client_session is None:
-        client_session = _default_client_session
+        client_session = get_context_specific_ssl_client_session(
+            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5))
 
     if session_id is None:
         headers = service_auth_headers(deploy_config, 'auth')

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -32,7 +32,7 @@ async def async_get_userinfo(*, deploy_config=None, session_id=None, client_sess
 
 
 def get_userinfo(deploy_config=None):
-    return async_to_blocking(async_get_userinfo(deploy_config))
+    return async_to_blocking(async_get_userinfo(deploy_config=deploy_config))
 
 
 def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, token_file=None):

--- a/hail/python/hailtop/hailctl/auth/user.py
+++ b/hail/python/hailtop/hailctl/auth/user.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 from hailtop.auth import get_userinfo
 
@@ -9,6 +10,9 @@ def init_parser(parser):  # pylint: disable=unused-argument
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument
     userinfo = get_userinfo()
+    if userinfo is None:
+        print('not logged in')
+        sys.exit(1)
     result = {
         'username': userinfo['username'],
         'email': userinfo['email'],

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -1,6 +1,5 @@
 import os
 import uvloop
-import aiohttp
 from aiohttp import web
 import aiohttp_session
 from kubernetes_asyncio import client, config

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -27,25 +27,18 @@ async def auth(request):
     k8s_client = app['k8s_client']
     namespace = request.match_info['namespace']
 
-    headers = {}
     if 'X-Hail-Internal-Authorization' in request.headers:
-        headers['Authorization'] = request.headers['X-Hail-Internal-Authorization']
+        session_id = request.headers['X-Hail-Internal-Authorization']
     elif 'Authorization' in request.headers:
-        headers['Authorization'] = request.headers['Authorization']
+        session_id = request.headers['Authorization']
     else:
         session = await aiohttp_session.get_session(request)
         session_id = session.get('session_id')
         if not session_id:
             raise web.HTTPUnauthorized()
-        headers['Authorization'] = f'Bearer {session_id}'
 
-    is_developer = False
-    try:
-        userdata = await async_get_userinfo(headers=headers)
-        is_developer = userdata['is_developer'] == 1
-    except aiohttp.client_exceptions.ClientResponseError as err:
-        assert err.status == 401, err
-
+    userdata = await async_get_userinfo(session_id=session_id)
+    is_developer = userdata is not None and userdata['is_developer'] == 1
     if not is_developer:
         raise web.HTTPUnauthorized()
 


### PR DESCRIPTION
I updated every call site to match the new parameters. This refactoring removes some code duplication, changes a stack trace in `hailctl auth user` to a nice print message, and adds a parameter (`client_session`) which I will use in my forthcoming TCP Proxy PR.