### PR TITLE
[hail-ubuntu] retry apt-get update

### DIFF
--- a/docker/hail-ubuntu/hail-apt-get-install
+++ b/docker/hail-ubuntu/hail-apt-get-install
@@ -2,6 +2,10 @@
 
 set -ex
 
-apt-get update
+apt-get update \
+    || (sleep 2 && apt-get update) \
+    || (sleep 4 && apt-get update) \
+    || (sleep 8 && apt-get update) \
+    || (sleep 16 && apt-get update)
 apt-get -y install "$@"
 exec rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Apt-get update does not use the retries parameter used by
apt-get install. In fact, I could not find any retry configuration
for apt-get update. This is a cheap hack that retries 5 times with
exponential back-off.