### PR TITLE
[ci] delete open batches rather than cancelling them

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -741,10 +741,11 @@ url: {url}
         for pr in self.prs.values():
             await pr._heal(batch_client, dbpool, pr == merge_candidate, gh)
 
+        seen_batch_ids = set(pr.batch.id for pr in self.prs.values() if pr.batch and hasattr(pr.batch, 'id'))
+
         # cancel orphan builds
         running_batches = batch_client.list_batches(
-            f'!complete test=1 target_branch={self.branch.short_str()}')
-        seen_batch_ids = set(pr.batch.id for pr in self.prs.values() if pr.batch and hasattr(pr.batch, 'id'))
+            f'!complete !open test=1 target_branch={self.branch.short_str()}')
         async for batch in running_batches:
             if batch.id not in seen_batch_ids:
                 attrs = batch.attributes
@@ -794,8 +795,8 @@ mkdir -p {shq(repo_dir)}
             self.deploy_state = 'checkout_failure'
         finally:
             if deploy_batch and not self.deploy_batch:
-                log.info(f'cancelling partial deploy batch {deploy_batch.id}')
-                await deploy_batch.cancel()
+                log.info(f'deleting partially deployed batch {deploy_batch.id}')
+                await deploy_batch.delete()
 
     def checkout_script(self):
         return f'''
@@ -859,8 +860,8 @@ mkdir -p {shq(repo_dir)}
             return deploy_batch.id
         finally:
             if deploy_batch and not self.deploy_batch and isinstance(deploy_batch, Batch):
-                log.info(f'cancelling partial deploy batch {deploy_batch.id}')
-                await deploy_batch.cancel()
+                log.info(f'deleting partially created deploy batch {deploy_batch.id}')
+                await deploy_batch.delete()
 
     def checkout_script(self):
         return f'''

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -741,11 +741,10 @@ url: {url}
         for pr in self.prs.values():
             await pr._heal(batch_client, dbpool, pr == merge_candidate, gh)
 
-        seen_batch_ids = set(pr.batch.id for pr in self.prs.values() if pr.batch and hasattr(pr.batch, 'id'))
-
         # cancel orphan builds
         running_batches = batch_client.list_batches(
             f'!complete !open test=1 target_branch={self.branch.short_str()}')
+        seen_batch_ids = set(pr.batch.id for pr in self.prs.values() if pr.batch and hasattr(pr.batch, 'id'))
         async for batch in running_batches:
             if batch.id not in seen_batch_ids:
                 attrs = batch.attributes


### PR DESCRIPTION
We cancel in two cases:
1. A (dev|) deploy failed.
2. A batch was found open but unknown to us.

In the former case, we should delete the batch. The batch contains no extra information
everything we need to know is in the failure message.

In the latter case, an open batch does not cost us anything and
cannot be cancelled anyway, so we choose to ignore them. Such a batch
should only come into existence when CI dies in the middle of submission
which should be quite rare.