### PR TITLE
[ci] fix two longstanding bugs

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -612,14 +612,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: router
+  namespace: {self._name}
   labels:
     app: router
 spec:
   ports:
   - name: http
-    port: 80
+    port: 443
     protocol: TCP
-    targetPort: 80
+    targetPort: 443
   selector:
     app: router
 '''

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -606,7 +606,7 @@ roleRef:
 '''
 
         if self.public:
-            config = config + '''\
+            config = config + f'''\
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Since the first build.py we have had two bugs. Dev deploys would regularly
re-deploy the router service in the default namespace. The more recent bug
is that the router port ought to be 443, not 80. Any time we dev deploy,
I suppose we have broken the mainline, but this must have been resolved by
deploys that came shortly thereafter.