### PR TITLE
[query/stypes] Introduce SCode

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir
 import is.hail.expr.ir.{EmitClassBuilder, EmitMethodBuilder, EmitRegion, ParamType}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.SCode
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -231,13 +232,14 @@ class StagedRegionValueBuilder private (val mb: EmitMethodBuilder[_], val typ: P
   def addIRIntermediate(t: PType): (Code[_]) => Code[Unit] =
     addIRIntermediate(t, deepCopy = false)
 
-  def addIRIntermediate(v: PCode, deepCopy: Boolean): Code[Unit] = {
-
-    addIRIntermediate(v.pt, deepCopy)(v.code)
+  def addIRIntermediate(v: SCode, deepCopy: Boolean): Code[Unit] = {
+    val pc = v.asPCode
+    addIRIntermediate(pc.pt, deepCopy)(pc.code)
   }
 
-  def addIRIntermediate(v: PCode): Code[Unit] =
-    addIRIntermediate(v.pt, deepCopy = false)(v.code)
+  def addIRIntermediate(v: SCode): Code[Unit] =
+    addIRIntermediate(v, false)
+
 
   def addWithDeepCopy(t: PType, v: Code[_]): Code[Unit] = {
     if (!(t.fundamentalType isOfType currentPType()))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -824,7 +824,7 @@ class Emit[C](
 
               def makeStridesBuilder(sourceShape: PBaseStructValue, isRowMajor: Code[Boolean], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit] = { srvb => EmitCodeBuilder.scopedVoid(mb) { cb =>
                 def shapeCodeSeq1 = (0 until nDims).map { i =>
-                  sourceShape.loadField(cb, i).get(cb).memoize(cb, s"make_ndarray_shape_${i}").asPValue.asInstanceOf[Value[Long]]
+                  sourceShape.loadField(cb, i).get(cb).memoize(cb, s"make_ndarray_shape_${i}").asPValue.value.asInstanceOf[Value[Long]]
                 }
 
                 cb.ifx(isRowMajor, {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -392,13 +392,13 @@ class EmitClassBuilder[C](
       val lits = cb.emb.newPLocal("lits", litType)
       val ib = cb.newLocal[InputBuffer]("ib",
         spec.buildCodeInputBuffer(Code.newInstance[ByteArrayInputStream, Array[Byte]](allEncodedFields(0))))
-      cb.assign(lits, litSType.loadFrom(cb, partitionRegion, litType, dec(partitionRegion, ib)))
+      cb.assign(lits, litSType.loadFrom(cb, partitionRegion, litType, dec(partitionRegion, ib)).asPCode)
       literals.zipWithIndex.foreach { case (((_, _), f), i) =>
         lits.asInstanceOf[PBaseStructValue]
           .loadField(cb, i)
           .consume(cb,
             cb._fatal("expect non-missing literals!"),
-            { pc => f.store(cb, pc) })
+            { pc => f.store(cb, pc.asPCode) })
       }
       // Handle the pre-encoded literals, which only need to be decoded.
       preEncodedLiterals.zipWithIndex.foreach { case ((encLit, f), index) =>
@@ -409,7 +409,7 @@ class EmitClassBuilder[C](
         // Because 0th index is for the regular literals
         cb.assign(ib, spec.buildCodeInputBuffer(Code.newInstance[ByteArrayInputStream, Array[Byte]](allEncodedFields(index + 1))))
         f.store(cb, preEncLitRType.sType
-          .loadFrom(cb, partitionRegion, preEncLitRType, preEncLitDec(partitionRegion, ib)))
+          .loadFrom(cb, partitionRegion, preEncLitRType, preEncLitDec(partitionRegion, ib)).asPCode)
       }
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{coerce => _, _}
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.lir
+import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.{PCode, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -5,7 +5,10 @@ import is.hail.asm4s._
 import is.hail.asm4s.joinpoint.Ctrl
 import is.hail.services.shuffler._
 import is.hail.types.physical._
-import is.hail.types.physical.stypes._
+import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerSettable, SCanonicalShufflePointerCode, SCanonicalShufflePointerSettable, SIntervalPointer, SIntervalPointerSettable, SSubsetStruct, SSubsetStructCode}
+import is.hail.types.physical.stypes.{interfaces, _}
+import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode, SStruct}
+import is.hail.types.physical.stypes.primitives.SInt32Code
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -1426,7 +1429,7 @@ object EmitStream {
                     Code(i := i + 1,
                       push(
                         EmitCode.fromI(mb) { cb =>
-                          a.loadElement(cb, i - 1)
+                          a.loadElement(cb, i - 1).typecast[PCode]
                         })),
                     eos))
             }
@@ -1517,7 +1520,7 @@ object EmitStream {
                     EmitCode(
                       Code._empty,
                       false,
-                      SStreamCode(
+                      interfaces.SStreamCode(
                         innerType.sType,
                         unsized(inner)))
                   }
@@ -1541,7 +1544,7 @@ object EmitStream {
               groupBy(mb, nonMissingStream, innerType, key.toArray, eltRegion)
                 .map { inner =>
                   EmitCode.present(
-                    SStreamCode(
+                    interfaces.SStreamCode(
                       innerType.sType,
                       unsized { innerEltRegion =>
                         inner(innerEltRegion).map(EmitCode.present)
@@ -2211,7 +2214,7 @@ object EmitStream {
 
     COption.toEmitCode(ctx,
       _emitStream(streamIR0, outerRegion, env0).map { stream =>
-        SStreamCode(coerce[PCanonicalStream](streamIR0.pType).sType, stream)
+        interfaces.SStreamCode(coerce[PCanonicalStream](streamIR0.pType).sType, stream)
       }, mb)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -300,12 +300,14 @@ case class MatrixSpecWriter(path: String, typ: MatrixType, rowRelPath: String, g
     val i = cb.newLocal[Int]("i", 0)
     cb.assign(partCounts, Code.newArray[Long](n))
     cb.whileLoop(i < n, {
-      val count = a.loadElement(cb, i).get(cb, "part count can't be missing!")
+      val count = a.loadElement(cb, i).get(cb, "part count can't be missing!").asPCode
       cb += partCounts.update(i, count.tcode[Long])
       cb.assign(i, i + 1)
     })
     cb += cb.emb.getObject(new MatrixSpecHelper(path, rowRelPath, globalRelPath, colRelPath, entryRelPath, refRelPath, typ, log))
-      .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").get(cb).tcode[Long], partCounts)
+      .invoke[FS, Long, Array[Long], Unit]("write", cb.emb.getFS, c.loadField(cb, "cols").get(cb)
+        .asPCode
+        .tcode[Long], partCounts)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -627,7 +627,7 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
                     .consumeCode[Interval](cb,
                       Code._fatal[Interval](""),
                       { pc =>
-                        val pcm = pc.memoize(cb, "pnri_interval")
+                        val pcm = pc.memoize(cb, "pnri_interval").asPValue
                         Code.invokeScalaObject2[PType, Long, Interval](
                           PartitionBoundOrdering.getClass,
                           "regionValueToJavaObject",
@@ -744,7 +744,7 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
               .consumeCode[Interval](cb,
                 Code._fatal[Interval](""),
                 { pc =>
-                  val pcm = pc.memoize(cb, "pnri_interval")
+                  val pcm = pc.memoize(cb, "pnri_interval").asPValue
                   Code.invokeScalaObject2[PType, Long, Interval](
                     PartitionBoundOrdering.getClass,
                     "regionValueToJavaObject",

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -305,7 +305,7 @@ case class TableSpecWriter(path: String, typ: TableType, rowRelPath: String, glo
     cb.assign(partCounts, Code.newArray[Long](n))
     cb.whileLoop(i < n, {
       val count = a.loadElement(cb, i).get(cb, "part count can't be missing!")
-      cb += partCounts.update(i, count.tcode[Long])
+      cb += partCounts.update(i, count.asLong.longCode(cb))
       cb.assign(i, i + 1)
     })
     cb += cb.emb.getObject(new TableSpecHelper(path, rowRelPath, globalRelPath, refRelPath, typ, log))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{coerce => _, _}
 import is.hail.types.{coerce => _, _}
 import is.hail.expr.ir._
+import is.hail.types.physical.stypes.SCode
 import is.hail.types.physical.{PArray, PCode, PFloat64, PIndexableCode, PInt32, PType}
 import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 
@@ -43,9 +44,9 @@ object GenotypeFunctions extends RegistryFunctions {
         cb.ifx(gpv.loadLength().cne(3),
           cb._fatal(const("length of gp array must be 3, got ").concat(gpv.loadLength().toS)))
 
-        gpv.loadElement(cb, 1).flatMap(cb) { (_1: PCode) =>
-          gpv.loadElement(cb, 2).map(cb) { (_2: PCode) =>
-            PCode(rt, _1.tcode[Double] + _2.tcode[Double] * 2.0)
+        gpv.loadElement(cb, 1).flatMap(cb) { (_1: SCode) =>
+          gpv.loadElement(cb, 2).map(cb) { (_2: SCode) =>
+            PCode(rt, _1.asDouble.doubleCode(cb) + _2.asDouble.doubleCode(cb) * 2.0)
           }
         }
       }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -2,15 +2,13 @@ package is.hail.expr.ir.functions
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.types
-import is.hail.asm4s
-import is.hail.expr.ir.EmitMethodBuilder
-import is.hail.variant._
-import is.hail.expr.ir._
+import is.hail.expr.ir.{EmitMethodBuilder, _}
+import is.hail.{asm4s, types}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.{SCanonicalLocusPointer, SCanonicalLocusPointerCode}
+import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerCode}
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.variant._
 
 object LocusFunctions extends RegistryFunctions {
 
@@ -164,7 +162,7 @@ object LocusFunctions extends RegistryFunctions {
     registerPCode1("contig", tlocus("T"), TString,
       (_: Type, x: PType) => x.asInstanceOf[PLocus].contigType) {
       case (r, cb, rt, locus: PLocusCode) =>
-        locus.contig(cb)
+        locus.contig(cb).asPCode
     }
 
     registerCode1("position", tlocus("T"), TInt32, (_: Type, x: PType) => x.asInstanceOf[PLocus].positionType) {

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -13,10 +13,13 @@ import is.hail.utils._
 import scala.language.implicitConversions
 import java.util.UUID
 
+import is.hail.types.physical.stypes.SCode
+
 package object ir {
   type TokenIterator = BufferedIterator[Token]
 
   type IEmitCode = IEmitCodeGen[PCode]
+  type IEmitSCode = IEmitCodeGen[SCode]
 
   var uidCounter: Long = 0
 

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -9,7 +9,7 @@ import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.rvd.AbstractRVDSpec
 import is.hail.types
-import is.hail.types.physical.stypes.{SBaseStructPointer, SBaseStructPointerSettable}
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerSettable}
 import is.hail.types.physical.{PBaseStructValue, PCanonicalArray, PCanonicalStruct, PCode, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -3,12 +3,12 @@ package is.hail.io.index
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, SettableBuilder, Value}
 import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.io.OutputBuffer
 import is.hail.types
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerSettable}
 import is.hail.types.virtual.{TStruct, Type}
-import is.hail.io.OutputBuffer
-import is.hail.types.physical.stypes.{SBaseStructPointer, SBaseStructPointerSettable}
 
 object InternalNodeBuilder {
   def virtualType(keyType: Type, annotationType: Type): TStruct = typ(PType.canonical(keyType), PType.canonical(annotationType)).virtualType
@@ -84,19 +84,19 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
     ab.addChild(cb)
     ab.setFieldValue(cb, "index_file_offset", PCode(PInt64(), indexFileOffset))
     ab.setFieldValue(cb, "first_idx", PCode(PInt64(), firstIndex))
-    ab.setField(cb, "first_key", firstChild.loadField(cb, childtyp.fieldIdx("key")))
-    ab.setField(cb, "first_record_offset", firstChild.loadField(cb, childtyp.fieldIdx("offset")))
-    ab.setField(cb, "first_annotation", firstChild.loadField(cb, childtyp.fieldIdx("annotation")))
+    ab.setField(cb, "first_key", firstChild.loadField(cb, childtyp.fieldIdx("key")).typecast[PCode])
+    ab.setField(cb, "first_record_offset", firstChild.loadField(cb, childtyp.fieldIdx("offset")).typecast[PCode])
+    ab.setField(cb, "first_annotation", firstChild.loadField(cb, childtyp.fieldIdx("annotation")).typecast[PCode])
   }
 
   def add(cb: EmitCodeBuilder, indexFileOffset: Code[Long], firstChild: PBaseStructValue): Unit = {
     val childtyp = types.coerce[PBaseStruct](firstChild.pt)
     ab.addChild(cb)
     ab.setFieldValue(cb, "index_file_offset", PCode(PInt64(), indexFileOffset))
-    ab.setField(cb, "first_idx", firstChild.loadField(cb, childtyp.fieldIdx("first_idx")))
-    ab.setField(cb, "first_key", firstChild.loadField(cb, childtyp.fieldIdx("first_key")))
-    ab.setField(cb, "first_record_offset", firstChild.loadField(cb, childtyp.fieldIdx("first_record_offset")))
-    ab.setField(cb, "first_annotation", firstChild.loadField(cb, childtyp.fieldIdx("first_annotation")))
+    ab.setField(cb, "first_idx", firstChild.loadField(cb, childtyp.fieldIdx("first_idx")).typecast[PCode])
+    ab.setField(cb, "first_key", firstChild.loadField(cb, childtyp.fieldIdx("first_key")).typecast[PCode])
+    ab.setField(cb, "first_record_offset", firstChild.loadField(cb, childtyp.fieldIdx("first_record_offset")).typecast[PCode])
+    ab.setField(cb, "first_annotation", firstChild.loadField(cb, childtyp.fieldIdx("first_annotation")).typecast[PCode])
   }
 
   def loadChild(cb: EmitCodeBuilder, idx: Code[Int]): Unit = ab.loadChild(cb, idx)

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -3,11 +3,11 @@ package is.hail.io.index
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, SettableBuilder, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
+import is.hail.io.OutputBuffer
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerSettable}
 import is.hail.types.virtual.{TStruct, Type}
-import is.hail.io.OutputBuffer
-import is.hail.types.physical.stypes.{SBaseStructPointer, SBaseStructPointerSettable}
 import is.hail.utils._
 
 object LeafNodeBuilder {

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -76,7 +76,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
     val writeElemF = elementType.buildEncoder(pt.elementType, cb.emb.ecb)
     cb.forLoop(cb.assign(i, 0), i < prefixLen, cb.assign(i, i + 1), {
       arr.loadElement(cb, i).consume(cb, { /* do nothing */ }, { pc =>
-        cb += writeElemF(pc.code, out)
+        cb += writeElemF(pc.asPCode.code, out)
       })
     })
   }

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -139,7 +139,8 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
 
     // Write fields
     fields.foreach { ef =>
-      pv.loadField(cb, ef.name).consume(cb, { /* do nothing */ }, { pc =>
+      pv.loadField(cb, ef.name).consume(cb, { /* do nothing */ }, { _pc =>
+        val pc = _pc.asPCode
         val encodeField = ef.typ.buildEncoder(pc.pt, cb.emb.ecb)
         cb += encodeField(pc.code, out)
       })

--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -47,13 +47,13 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
     if (encodeRowMajor) {
       cb.forLoop(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
         cb.forLoop(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
-          cb += writeElemF(ndarray.loadElement(FastIndexedSeq(i, j), cb).code, out)
+          cb += writeElemF(ndarray.loadElement(FastIndexedSeq(i, j), cb).asPCode.code, out)
         })
       })
     } else {
       cb.forLoop(cb.assign(j, 0L), j < c, cb.assign(j, j + 1L), {
         cb.forLoop(cb.assign(i, 0L), i < r, cb.assign(i, i + 1L), {
-          cb += writeElemF(ndarray.loadElement(FastIndexedSeq(i, j), cb).code, out)
+          cb += writeElemF(ndarray.loadElement(FastIndexedSeq(i, j), cb).asPCode.code, out)
         })
       })
     }

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -30,7 +30,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     shapes.foreach(s => cb += out.writeLong(s))
 
     val idxVars = Array.tabulate(ndarray.pt.nDims)(i => cb.newLocal[Long](s"idx_$i"))
-    cb += idxVars.zipWithIndex.foldLeft(writeElemF(ndarray.loadElement(idxVars, cb).code, out))
+    cb += idxVars.zipWithIndex.foldLeft(writeElemF(ndarray.loadElement(idxVars, cb).asPCode.code, out))
     { case (innerLoops, (dimVar, dimIdx)) =>
       Code(
         dimVar := 0L,

--- a/hail/src/main/scala/is/hail/types/encoded/ETransposedArrayOfStructs.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ETransposedArrayOfStructs.scala
@@ -224,7 +224,7 @@ final case class ETransposedArrayOfStructs(
           array.loadElement(cb, j).consume(cb, { /* do nothing */ }, { pbsc =>
             // FIXME may be bad if structs get memoized into their fields, otherwise
             // probably fine
-            cb.assign(pbss, pbsc)
+            cb.assign(pbss, pbsc.asPCode)
             cb.assign(b, b | (pbsv.isFieldMissing(fidx).toI << (presentIdx & 7)))
             cb.assign(presentIdx, presentIdx + 1)
             cb.ifx((presentIdx & 7).ceq(0), {
@@ -237,8 +237,8 @@ final case class ETransposedArrayOfStructs(
 
       cb.forLoop(cb.assign(j, 0), j < len, cb.assign(j, j + 1), {
         array.loadElement(cb, j).flatMap(cb) { pbsc =>
-          cb.assign(pbss, pbsc)
-          pbsv.loadField(cb, fidx)
+          cb.assign(pbss, pbsc.asPCode)
+          pbsv.loadField(cb, fidx).typecast[PCode]
         }
         .consume(cb, { /* do nothing */ }, { pc =>
           cb += encodeFieldF(pc.code, out)

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -1,9 +1,11 @@
 package is.hail.types.physical
 
 import is.hail.annotations.{Region, UnsafeOrdering}
-import is.hail.asm4s.{Code, MethodBuilder, Value}
+import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SContainer, SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode}
+import is.hail.types.physical.stypes.interfaces.SContainer
 
 trait PArrayBackedContainer extends PContainer {
   val arrayRep: PArray
@@ -148,8 +150,8 @@ trait PArrayBackedContainer extends PContainer {
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SIndexablePointerCode(SIndexablePointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value, deepCopy)
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value, deepCopy)
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit =
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit =
     arrayRep.storeAtAddress(cb, addr, region, value, deepCopy)
 }

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.check.Gen
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue}
 import is.hail.utils._
 
 object PBaseStruct {
@@ -189,22 +190,16 @@ abstract class PBaseStruct extends PType {
   }
 }
 
-abstract class PBaseStructValue extends PValue {
+abstract class PBaseStructValue extends PValue with SBaseStructValue {
   def pt: PBaseStruct
-
-  def isFieldMissing(fieldIdx: Int): Code[Boolean]
-
-  def isFieldMissing(fieldName: String): Code[Boolean] = isFieldMissing(pt.fieldIdx(fieldName))
-
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode
-
-  def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadField(cb, pt.fieldIdx(fieldName))
 }
 
-abstract class PBaseStructCode extends PCode {
+abstract class PBaseStructCode extends PCode with SBaseStructCode {
   def pt: PBaseStruct
 
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PBaseStructValue
 }
+
+trait PStructSettable extends PBaseStructValue with PSettable

--- a/hail/src/main/scala/is/hail/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBinary.scala
@@ -6,6 +6,7 @@ import is.hail.asm4s._
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.physical.stypes.interfaces.{SBinaryCode, SBinaryValue}
 import is.hail.types.virtual.TBinary
 
 abstract class PBinary extends PType {
@@ -101,7 +102,7 @@ abstract class PBinary extends PType {
   def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit]
 }
 
-abstract class PBinaryValue extends PValue {
+abstract class PBinaryValue extends PValue with SBinaryValue {
   def loadLength(): Code[Int]
 
   def loadBytes(): Code[Array[Byte]]
@@ -109,7 +110,7 @@ abstract class PBinaryValue extends PValue {
   def loadByte(i: Code[Int]): Code[Byte]
 }
 
-abstract class PBinaryCode extends PCode {
+abstract class PBinaryCode extends PCode with SBinaryCode {
   def pt: PBinary
 
   def loadLength(): Code[Int]

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.Code
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SBoolean, SBooleanCode}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanCode}
 import is.hail.types.virtual.TBoolean
 
 case object PBooleanOptional extends PBoolean(false)
@@ -36,7 +37,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
 
   def sType: SBoolean = SBoolean(required)
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit = {
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit = {
     cb += Region.storeBoolean(addr, value.asBoolean.boolCode(cb))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCall.scala
@@ -3,12 +3,13 @@ package is.hail.types.physical
 import is.hail.asm4s._
 import is.hail.types.virtual.TCall
 import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.{SCallCode, SCallValue}
 
 abstract class PCall extends PType {
   lazy val virtualType: TCall.type = TCall
 }
 
-abstract class PCallValue extends PValue {
+abstract class PCallValue extends PValue with SCallValue {
   def ploidy(): Code[Int]
 
   def isPhased(): Code[Boolean]
@@ -16,7 +17,7 @@ abstract class PCallValue extends PValue {
   def forEachAllele(cb: EmitCodeBuilder)(alleleCode: Value[Int] => Unit): Unit
 }
 
-abstract class PCallCode extends PCode {
+abstract class PCallCode extends PCode with SCallCode {
   def pt: PCall
 
   def ploidy(): Code[Int]

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -3,7 +3,9 @@ package is.hail.types.physical
 import is.hail.annotations.{Region, _}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SContainer, SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable}
+import is.hail.types.physical.stypes.interfaces.SContainer
 import is.hail.types.virtual.{TArray, Type}
 import is.hail.utils._
 
@@ -408,7 +410,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SIndexablePointerCode(SIndexablePointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SIndexablePointer(PCanonicalArray(otherElementType, _)) if otherElementType == elementType =>
         if (deepCopy) {
@@ -443,7 +445,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -4,7 +4,9 @@ import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.BaseStruct
-import is.hail.types.physical.stypes.{SBaseStructPointer, SBaseStructPointerCode, SBaseStructPointerSettable, SStruct}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerCode, SBaseStructPointerSettable}
+import is.hail.types.physical.stypes.interfaces.SStruct
 import is.hail.utils._
 
 abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct {
@@ -170,7 +172,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SBaseStructPointerCode(SBaseStructPointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SBaseStructPointer(t) if t.equalModuloRequired(this) && !deepCopy =>
         value.asInstanceOf[SBaseStructPointerCode].a
@@ -182,7 +184,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SBaseStructPointer(t) if t.equalModuloRequired(this) =>
         val pcs = value.asBaseStruct.memoize(cb, "pcbasestruct_store_src").asInstanceOf[SBaseStructPointerSettable]

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -3,7 +3,9 @@ package is.hail.types.physical
 import is.hail.annotations.{CodeOrdering, Region, UnsafeOrdering}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCall, SCanonicalCall, SCanonicalCallCode}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SCanonicalCall, SCanonicalCallCode}
+import is.hail.types.physical.stypes.interfaces.SCall
 import is.hail.utils._
 
 final case class PCanonicalCall(required: Boolean = false) extends PCall {
@@ -47,7 +49,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SCanonicalCallCode(required, Region.loadInt(addr))
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SCanonicalCall(r) =>
         val newAddr = cb.newLocal[Long]("pcanonicalcall_store_addr", region.allocate(representation.alignment, representation.byteSize))
@@ -56,7 +58,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     cb += Region.storeInt(addr, value.asInstanceOf[SCanonicalCallCode].call)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -2,10 +2,10 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.physical.stypes.{SIntervalPointer, SIntervalPointerCode, SType}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SIntervalPointer, SIntervalPointerCode}
 import is.hail.types.virtual.{TInterval, Type}
-import is.hail.utils.FastIndexedSeq
 
 final case class PCanonicalInterval(pointType: PType, override val required: Boolean = false) extends PInterval {
 
@@ -73,14 +73,14 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SIntervalPointerCode(SIntervalPointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SIntervalPointer(t: PCanonicalInterval) =>
         representation.store(cb, region, t.representation.loadCheapPCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SIntervalPointer(t: PCanonicalInterval) =>
         representation.storeAtAddress(cb, addr, region, t.representation.loadCheapPCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -3,8 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SBinary, SBinaryPointer, SBinaryPointerCode, SBinaryPointerSettable, SCanonicalLocusPointer, SCanonicalLocusPointerCode, SCanonicalLocusPointerSettable, SLocus}
-import is.hail.utils.FastIndexedSeq
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerCode}
 import is.hail.variant._
 
 object PCanonicalLocus {
@@ -128,14 +128,14 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SCanonicalLocusPointerCode(sType, addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SCanonicalLocusPointer(pt) =>
         representation.store(cb, region, pt.representation.loadCheapPCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SCanonicalLocusPointer(pt) =>
         representation.storeAtAddress(cb, addr, region, pt.representation.loadCheapPCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -1,9 +1,10 @@
 package is.hail.types.physical
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder, UnsafeOrdering}
-import is.hail.asm4s.{Code, MethodBuilder, _}
+import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCall, SCanonicalCall, SCanonicalCallCode, SNDArrayPointer, SNDArrayPointerCode}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SNDArrayPointer, SNDArrayPointerCode}
 import is.hail.types.virtual.{TNDArray, Type}
 import is.hail.utils.FastIndexedSeq
 
@@ -226,14 +227,14 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SNDArrayPointerCode(sType, addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SNDArrayPointer(t) if t.equalModuloRequired(this) =>
           representation.store(cb, region, representation.loadCheapPCode(cb, value.asInstanceOf[SNDArrayPointerCode].a), deepCopy)
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SNDArrayPointer(t) if t.equalModuloRequired(this) =>
         representation.storeAtAddress(cb, addr, region, representation.loadCheapPCode(cb, value.asInstanceOf[SNDArrayPointerCode].a), deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.types.physical.stypes.{SBinaryPointerCode, SCanonicalShufflePointer, SCanonicalShufflePointerCode}
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SBinaryPointerCode, SCanonicalShufflePointer, SCanonicalShufflePointerCode}
 import is.hail.types.virtual._
 
 final case class PCanonicalShuffle(
@@ -51,14 +52,14 @@ final case class PCanonicalShuffle(
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SCanonicalShufflePointerCode(sType, representation.loadCheapPCode(cb, addr))
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SCanonicalShufflePointer(t) =>
         representation.store(cb, region, value.asInstanceOf[SCanonicalShufflePointerCode].shuffle, deepCopy)
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SCanonicalShufflePointer(t) =>
         representation.storeAtAddress(cb, addr, region, value.asInstanceOf[SCanonicalShufflePointerCode].shuffle, deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -3,9 +3,10 @@ package is.hail.types.physical
 import is.hail.annotations.UnsafeOrdering
 import is.hail.asm4s.Code
 import is.hail.expr.ir.EmitStream.SizedStream
+import is.hail.expr.ir.{EmitCode, Stream}
+import is.hail.types.physical.stypes.interfaces
+import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode}
 import is.hail.types.virtual.{TStream, Type}
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, Stream}
-import is.hail.types.physical.stypes.{SStream, SStreamCode, SType}
 
 final case class PCanonicalStream(elementType: PType, separateRegions: Boolean = false, required: Boolean = false) extends PStream {
   override val fundamentalType: PStream = {
@@ -33,5 +34,5 @@ final case class PCanonicalStream(elementType: PType, separateRegions: Boolean =
 
   def setRequired(required: Boolean): PCanonicalStream = if(required == this.required) this else this.copy(required = required)
 
-  override def sType: SStream = SStream(elementType.sType)
+  override def sType: SStream = interfaces.SStream(elementType.sType)
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -1,10 +1,10 @@
 package is.hail.types.physical
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, MethodBuilder, Value}
+import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SBaseStructPointer, SBaseStructPointerCode, SString, SStringPointer, SStringPointerCode, SStruct}
-import is.hail.utils.FastIndexedSeq
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.{SStringPointer, SStringPointerCode}
 
 case object PCanonicalStringOptional extends PCanonicalString(false)
 
@@ -64,7 +64,7 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SStringPointerCode(SStringPointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SStringPointer(t) if t.equalModuloRequired(this) && !deepCopy =>
         value.asInstanceOf[SStringPointerCode].a
@@ -73,7 +73,7 @@ class PCanonicalString(val required: Boolean) extends PString {
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
+import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SIndexableValue}
 
 abstract class PContainer extends PIterable {
   override def containsPointers: Boolean = true
@@ -88,20 +89,10 @@ abstract class PContainer extends PIterable {
   def nextElementAddress(currentOffset: Code[Long]): Code[Long]
 }
 
-abstract class PIndexableValue extends PValue {
-  def loadLength(): Value[Int]
+abstract class PIndexableValue extends PValue with SIndexableValue
 
-  def isElementMissing(i: Code[Int]): Code[Boolean]
-
-  def isElementDefined(i: Code[Int]): Code[Boolean] = !isElementMissing(i)
-
-  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode
-}
-
-abstract class PIndexableCode extends PCode {
+abstract class PIndexableCode extends PCode with SIndexableCode {
   def pt: PContainer
-
-  def loadLength(): Code[Int]
 
   def memoize(cb: EmitCodeBuilder, name: String): PIndexableValue
 

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SFloat32, SFloat32Code, SType}
+import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat32Code}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.virtual.TFloat32
 
 case object PFloat32Optional extends PFloat32(false)
@@ -58,7 +59,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat32(required)
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeFloat(addr, value.asFloat.floatCode(cb)))
 
   override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SFloat32Code(required, Region.loadFloat(addr))

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SFloat64, SFloat64Code, SType}
+import is.hail.types.physical.stypes.primitives.{SFloat64, SFloat64Code}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.virtual.TFloat64
 
 case object PFloat64Optional extends PFloat64(false)
@@ -59,7 +60,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat64(required)
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeDouble(addr, value.asDouble.doubleCode(cb)))
 
   override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SFloat64Code(required, Region.loadDouble(addr))

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.{Code, coerce, const, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SInt32, SInt32Code, SType}
+import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.virtual.TInt32
 
 case object PInt32Optional extends PInt32(false)
@@ -55,7 +56,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt32(required)
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeInt(addr, value.asInt.intCode(cb)))
 
   override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SInt32Code(required, Region.loadInt(addr))

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.{Code, coerce, const, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SInt64, SInt64Code, SType}
+import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Code}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.virtual.TInt64
 
 case object PInt64Optional extends PInt64(false)
@@ -56,7 +57,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt64(required)
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeLong(addr, value.asLong.longCode(cb)))
 
   override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SInt64Code(required, Region.loadLong(addr))

--- a/hail/src/main/scala/is/hail/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PLocus.scala
@@ -1,7 +1,8 @@
 package is.hail.types.physical
 
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.{SLocusCode, SLocusValue}
 import is.hail.types.virtual.TLocus
 import is.hail.variant._
 
@@ -23,23 +24,10 @@ abstract class PLocus extends PType {
   def positionType: PInt32
 }
 
-abstract class PLocusValue extends PValue {
-  def contig(cb: EmitCodeBuilder): PStringCode
+abstract class PLocusValue extends PValue with SLocusValue
 
-  def position(cb: EmitCodeBuilder): Code[Int]
-
-  def getLocusObj(cb: EmitCodeBuilder): Code[Locus] = Code.invokeStatic2[Locus, String, Int, Locus]("apply",
-    contig(cb).loadString(), position(cb))
-}
-
-abstract class PLocusCode extends PCode {
+abstract class PLocusCode extends PCode with SLocusCode {
   def pt: PLocus
-
-  def contig(cb: EmitCodeBuilder): PStringCode
-
-  def position(cb: EmitCodeBuilder): Code[Int]
-
-  def getLocusObj(cb: EmitCodeBuilder): Code[Locus]
 
   def memoize(cb: EmitCodeBuilder, name: String): PLocusValue
 

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.Nat
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.physical.stypes.interfaces.{SNDArrayCode, SNDArrayValue}
 import is.hail.types.virtual.TNDArray
 
 final class StaticallyKnownField[T, U](
@@ -62,26 +63,12 @@ abstract class PNDArray extends PType {
   ): PNDArrayCode
 }
 
-abstract class PNDArrayValue extends PValue {
-  def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): PCode
-
-  def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
-
-  def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
-
+abstract class PNDArrayValue extends PValue with SNDArrayValue {
   def pt: PNDArray
-
-  def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean]
-
-  def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int = -1): Code[Unit]
-
-  def sameShape(other: PNDArrayValue, cb: EmitCodeBuilder): Code[Boolean]
 }
 
-abstract class PNDArrayCode extends PCode {
+abstract class PNDArrayCode extends PCode with SNDArrayCode {
   def pt: PNDArray
-
-  def shape: PBaseStructCode
 
   def memoize(cb: EmitCodeBuilder, name: String): PNDArrayValue
 }

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.physical.stypes.SCode
 import is.hail.utils._
 
 trait PPrimitive extends PType {
@@ -30,18 +31,18 @@ trait PPrimitive extends PType {
     Region.copyFrom(srcAddress, addr, byteSize)
   }
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = {
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     val newAddr = cb.newLocal[Long]("pprimitive_store_addr", region.allocate(alignment, byteSize))
     storeAtAddress(cb, newAddr, region, value, deepCopy)
     newAddr
   }
 
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     storePrimitiveAtAddress(cb, addr, value)
   }
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: PCode): Unit
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit
 
   def setRequired(required: Boolean): PPrimitive = {
     if (required == this.required)

--- a/hail/src/main/scala/is/hail/types/physical/PShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PShuffle.scala
@@ -1,8 +1,9 @@
 package is.hail.types.physical
 
 import is.hail.asm4s._
-import is.hail.types.virtual._
 import is.hail.expr.ir._
+import is.hail.types.physical.stypes.interfaces.{SShuffleCode, SShuffleValue}
+import is.hail.types.virtual._
 
 abstract class PShuffle extends PType {
   def tShuffle: TShuffle
@@ -10,13 +11,13 @@ abstract class PShuffle extends PType {
   def virtualType: TShuffle = tShuffle
 }
 
-abstract class PShuffleValue extends PValue {
+abstract class PShuffleValue extends PValue with SShuffleValue {
   def loadLength(): Code[Int]
 
   def loadBytes(): Code[Array[Byte]]
 }
 
-abstract class PShuffleCode extends PCode {
+abstract class PShuffleCode extends PCode with SShuffleCode {
   def pt: PShuffle
 
   def memoize(cb: EmitCodeBuilder, name: String): PShuffleValue

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -4,6 +4,7 @@ import is.hail.asm4s._
 import is.hail.annotations.CodeOrdering
 import is.hail.annotations.{UnsafeOrdering, _}
 import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.types.physical.stypes.interfaces.{SStringCode, SStringValue}
 import is.hail.types.virtual.TString
 
 abstract class PString extends PType {
@@ -35,16 +36,12 @@ abstract class PString extends PType {
   def allocateAndStoreString(mb: EmitMethodBuilder[_], region: Value[Region], str: Code[String]): Code[Long]
 }
 
-abstract class PStringCode extends PCode {
+abstract class PStringCode extends PCode with SStringCode {
   def pt: PString
-
-  def loadLength(): Code[Int]
-
-  def loadString(): Code[String]
 
   def asBytes(): PBinaryCode
 }
 
-abstract class PStringValue extends PValue {
+abstract class PStringValue extends PValue with SStringValue {
   def pt: PString
 }

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -4,7 +4,9 @@ import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s.{Code, Settable, SettableBuilder, Value, coerce, const}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
 import is.hail.types.BaseStruct
-import is.hail.types.physical.stypes.{SStruct, SSubsetStruct, SType}
+import is.hail.types.physical.stypes.interfaces.SStruct
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.concrete.SSubsetStruct
 import is.hail.types.virtual.TStruct
 import is.hail.utils._
 
@@ -127,9 +129,9 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: Array[String]) extends 
 
   def sType: SSubsetStruct = SSubsetStruct(ps.sType.asInstanceOf[SStruct], _fieldNames)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = throw new UnsupportedOperationException
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = throw new UnsupportedOperationException
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     throw new UnsupportedOperationException
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -6,7 +6,7 @@ import is.hail.asm4s._
 import is.hail.check.{Arbitrary, Gen}
 import is.hail.expr.ir
 import is.hail.expr.ir._
-import is.hail.types.physical.stypes.SType
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.virtual._
 import is.hail.types.{Requiredness, coerce}
 import is.hail.utils._
@@ -453,10 +453,10 @@ abstract class PType extends Serializable with Requiredness {
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode
 
   // stores a stack value as a region value of this type
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long]
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long]
 
   // stores a stack value inside pre-allocated memory of this type (in a nested structure, for instance).
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, TypeInfo, Value}
 import is.hail.expr.ir.{Ascending, Descending, EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.SCode
 
 trait PUnrealizable extends PType {
   private def unsupported: Nothing =
@@ -32,9 +33,9 @@ trait PUnrealizable extends PType {
 
   override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = unsupported
 
-  override def store(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): Code[Long] = unsupported
+  override def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = unsupported
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: PCode, deepCopy: Boolean): Unit = unsupported
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = unsupported
 
   override def encodableType: PType = unsupported
 

--- a/hail/src/main/scala/is/hail/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PVoid.scala
@@ -3,7 +3,8 @@ package is.hail.types.physical
 import is.hail.annotations.UnsafeOrdering
 import is.hail.asm4s.{Code, TypeInfo, UnitInfo}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.{SType, SVoid}
+import is.hail.types.physical.stypes.SType
+import is.hail.types.physical.stypes.interfaces.SVoid
 import is.hail.types.virtual.{TVoid, Type}
 
 case object PVoid extends PType with PUnrealizable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -49,7 +49,6 @@ abstract class SCode {
 
   def asStream: SStreamCode = asInstanceOf[SStreamCode]
 
-  java.lang.Double
   def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: PType): SCode =
     castTo(cb, region, destType, false)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -1,0 +1,93 @@
+package is.hail.types.physical.stypes
+
+import is.hail.annotations.Region
+import is.hail.asm4s.{Code, Settable, Value}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.primitives._
+import is.hail.types.physical.{PCode, PIntervalCode, PNDArrayCode, PType, PValue}
+
+abstract class SCode {
+
+  def st: SType
+
+  def codeTuple(): IndexedSeq[Code[_]]
+
+  def asBoolean: SBooleanCode = asInstanceOf[SBooleanCode]
+
+  def asInt: SInt32Code = asInstanceOf[SInt32Code]
+
+  def asInt32: SInt32Code = asInstanceOf[SInt32Code]
+
+  def asLong: SInt64Code = asInstanceOf[SInt64Code]
+
+  def asInt64: SInt64Code = asInstanceOf[SInt64Code]
+
+  def asFloat: SFloat32Code = asInstanceOf[SFloat32Code]
+
+  def asFloat32: SFloat32Code = asInstanceOf[SFloat32Code]
+
+  def asFloat64: SFloat64Code = asInstanceOf[SFloat64Code]
+
+  def asDouble: SFloat64Code = asInstanceOf[SFloat64Code]
+
+  def asBinary: SBinaryCode = asInstanceOf[SBinaryCode]
+
+  def asIndexable: SIndexableCode = asInstanceOf[SIndexableCode]
+
+  def asBaseStruct: SBaseStructCode = asInstanceOf[SBaseStructCode]
+
+  def asString: SStringCode = asInstanceOf[SStringCode]
+
+  def asInterval: PIntervalCode = asInstanceOf[PIntervalCode]
+
+  def asNDArray: PNDArrayCode = asInstanceOf[PNDArrayCode]
+
+  def asLocus: SLocusCode = asInstanceOf[SLocusCode]
+
+  def asCall: SCallCode = asInstanceOf[SCallCode]
+
+  def asStream: SStreamCode = asInstanceOf[SStreamCode]
+
+  def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: PType): SCode =
+    castTo(cb, region, destType, false)
+
+
+  def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: PType, deepCopy: Boolean): SCode = {
+    destType.sType.coerceOrCopy(cb, region, this, deepCopy)
+  }
+
+  def copyToRegion(cb: EmitCodeBuilder, region: Value[Region]): SCode =
+    copyToRegion(cb, region, st.pType)
+
+  def copyToRegion(cb: EmitCodeBuilder, region: Value[Region], destType: PType): SCode =
+    destType.sType.coerceOrCopy(cb, region, this, deepCopy = true)
+
+  def memoize(cb: EmitCodeBuilder, name: String): SValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SValue
+
+  def toPCode(cb: EmitCodeBuilder, region: Value[Region]): PCode
+
+  // This method is a very temporary patch. Clients should use `toPCode`.
+  def asPCode: PCode = asInstanceOf[PCode]
+}
+
+trait SValue {
+  def st: SType
+
+  def get: SCode
+
+  def asPValue: PValue = asInstanceOf[PValue]
+}
+
+
+trait SSettable extends SValue {
+  def store(cb: EmitCodeBuilder, v: SCode): Unit
+
+  def settableTuple(): IndexedSeq[Settable[_]]
+
+  def load(): SCode = get
+}
+
+

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -49,6 +49,7 @@ abstract class SCode {
 
   def asStream: SStreamCode = asInstanceOf[SStreamCode]
 
+  java.lang.Double
   def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: PType): SCode =
     castTo(cb, region, destType, false)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -9,9 +9,9 @@ import is.hail.types.physical.{PCode, PType}
 trait SType {
   def pType: PType
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]]
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -1,24 +1,24 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
+
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
-import is.hail.types.physical.{PBaseStruct, PBaseStructCode, PBaseStructValue, PCanonicalBaseStruct, PCode, PSettable, PStruct, PType}
+import is.hail.types.physical.stypes.interfaces.{SStruct, SStructSettable}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PBaseStruct, PBaseStructCode, PBaseStructValue, PCode, PStructSettable, PType}
 import is.hail.utils.FastIndexedSeq
 
-trait SStruct extends SType
-
-trait SStructSettable extends PBaseStructValue with PSettable
 
 case class SBaseStructPointer(pType: PBaseStruct) extends SStruct {
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SBaseStructPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     if (pt == this.pType)
       new SBaseStructPointerCode(this, addr)
     else
@@ -36,7 +36,7 @@ object SBaseStructPointerSettable {
 class SBaseStructPointerSettable(
   val st: SBaseStructPointer,
   val a: Settable[Long]
-) extends SStructSettable {
+) extends PStructSettable {
   val pt: PBaseStruct = st.pType
 
   def get: PBaseStructCode = new SBaseStructPointerCode(st, a)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -1,23 +1,24 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PBinary, PBinaryCode, PBinaryValue, PCanonicalBinary, PCode, PSettable, PType}
+import is.hail.types.physical.stypes.interfaces.SBinary
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PBinary, PBinaryCode, PBinaryValue, PCode, PSettable, PType}
 import is.hail.utils._
 
-trait SBinary extends SType
 
 case class SBinaryPointer(pType: PBinary) extends SBinary {
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SBinaryPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     if (pt == this.pType)
       new SBinaryPointerCode(this, addr)
     else

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -1,20 +1,21 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.interfaces.SCall
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PCall, PCallCode, PCallValue, PCanonicalCall, PCode, PSettable, PType}
 import is.hail.utils._
 import is.hail.variant.Genotype
 
-trait SCall extends SType
 
 case class SCanonicalCall(required: Boolean) extends SCall {
   override def pType: PCall = PCanonicalCall(required)
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SCanonicalCall(_) =>
         new SCanonicalCallCode(required, value.asInstanceOf[SCanonicalCallCode].call)
@@ -23,7 +24,7 @@ case class SCanonicalCall(required: Boolean) extends SCall {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(IntInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case PCanonicalCall(_) =>
         new SCanonicalCallCode(required, Region.loadInt(addr))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -1,24 +1,25 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PCanonicalCall, PCanonicalLocus, PCanonicalString, PCode, PLocus, PLocusCode, PLocusValue, PSettable, PStringCode, PType}
+import is.hail.types.physical.stypes.interfaces.SLocus
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PCanonicalLocus, PCode, PLocusCode, PLocusValue, PSettable, PStringCode, PType}
 import is.hail.utils.FastIndexedSeq
 import is.hail.variant.Locus
 
-trait SLocus extends SType
 
 case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SCanonicalLocusPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case PCanonicalLocus(_, _) =>
         new SCanonicalLocusPointerCode(this, addr)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -1,23 +1,25 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, IntInfo, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
-import is.hail.types.physical.{PArray, PCode, PContainer, PIndexableCode, PIndexableValue, PSettable, PType}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.interfaces.SContainer
+import is.hail.types.physical.{PCode, PContainer, PIndexableCode, PIndexableValue, PSettable, PType}
 import is.hail.utils.FastIndexedSeq
 
-trait SContainer extends SType
+
 
 case class SIndexablePointer(pType: PContainer) extends SContainer {
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SIndexablePointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo, IntInfo, LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     if (pt == this.pType)
       new SIndexablePointerCode(this, addr)
     else

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -1,29 +1,29 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.interfaces.SString
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PBinaryCode, PCanonicalString, PCode, PSettable, PString, PStringCode, PStringValue, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
-trait SString extends SType
 
 case class SStringPointer(pType: PString) extends SString {
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SStringPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case _: PCanonicalString =>
         new SStringPointerCode(this, addr)
     }
   }
-
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -1,0 +1,27 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.Code
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.PValue
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SBinary extends SType
+
+trait SBinaryValue extends SValue {
+  def loadLength(): Code[Int]
+
+  def loadBytes(): Code[Array[Byte]]
+
+  def loadByte(i: Code[Int]): Code[Byte]
+}
+
+trait SBinaryCode extends SCode {
+  def loadLength(): Code[Int]
+
+  def loadBytes(): Code[Array[Byte]]
+
+  def memoize(cb: EmitCodeBuilder, name: String): SBinaryValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SBinaryValue
+}
+

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SCall.scala
@@ -1,0 +1,26 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.physical.{PCode, PValue}
+
+trait SCall extends SType
+
+trait SCallValue extends SValue {
+  def ploidy(): Code[Int]
+
+  def isPhased(): Code[Boolean]
+
+  def forEachAllele(cb: EmitCodeBuilder)(alleleCode: Value[Int] => Unit): Unit
+}
+
+trait SCallCode extends SCode {
+  def ploidy(): Code[Int]
+
+  def isPhased(): Code[Boolean]
+
+  def memoize(cb: EmitCodeBuilder, name: String): SCallValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SCallValue
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -1,0 +1,26 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitSCode}
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SContainer extends SType
+
+trait SIndexableValue extends SValue {
+  def loadLength(): Value[Int]
+
+  def isElementMissing(i: Code[Int]): Code[Boolean]
+
+  def isElementDefined(i: Code[Int]): Code[Boolean] = !isElementMissing(i)
+
+  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitSCode
+}
+
+trait SIndexableCode extends SCode {
+  def loadLength(): Code[Int]
+
+  def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SIndexableValue
+}
+

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -1,0 +1,36 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitSCode}
+import is.hail.types.physical.PInterval
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SInterval extends SType
+
+trait SIntervalValue extends SValue {
+  def includesStart(): Value[Boolean]
+
+  def includesEnd(): Value[Boolean]
+
+  def loadStart(cb: EmitCodeBuilder): IEmitSCode
+
+  def startDefined(cb: EmitCodeBuilder): Code[Boolean]
+
+  def loadEnd(cb: EmitCodeBuilder): IEmitSCode
+
+  def endDefined(cb: EmitCodeBuilder): Code[Boolean]
+
+  def isEmpty(cb: EmitCodeBuilder): Code[Boolean]
+}
+
+trait SIntervalCode extends SCode {
+  def pt: PInterval
+
+  def includesStart(): Code[Boolean]
+
+  def includesEnd(): Code[Boolean]
+
+  def memoize(cb: EmitCodeBuilder, name: String): SIntervalValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SIntervalValue
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -24,8 +24,6 @@ trait SIntervalValue extends SValue {
 }
 
 trait SIntervalCode extends SCode {
-  def pt: PInterval
-
   def includesStart(): Code[Boolean]
 
   def includesEnd(): Code[Boolean]

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -1,0 +1,30 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.Code
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.{PCode, PLocus, PStringCode, PValue}
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.variant.Locus
+
+trait SLocus extends SType
+
+trait SLocusValue extends SValue {
+  def contig(cb: EmitCodeBuilder): SStringCode
+
+  def position(cb: EmitCodeBuilder): Code[Int]
+
+  def getLocusObj(cb: EmitCodeBuilder): Code[Locus] = Code.invokeStatic2[Locus, String, Int, Locus]("apply",
+    contig(cb).loadString(), position(cb))
+}
+
+trait SLocusCode extends SCode {
+  def contig(cb: EmitCodeBuilder): SStringCode
+
+  def position(cb: EmitCodeBuilder): Code[Int]
+
+  def getLocusObj(cb: EmitCodeBuilder): Code[Locus]
+
+  def memoize(cb: EmitCodeBuilder, name: String): SLocusValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SLocusValue
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -1,0 +1,28 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.{PBaseStructCode, PCode, PNDArray, PValue}
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SNDArray extends SType
+
+trait SNDArrayValue extends SValue {
+  def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
+
+  def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
+
+  def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
+
+  def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean]
+
+  def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int = -1): Code[Unit]
+
+  def sameShape(other: SNDArrayValue, cb: EmitCodeBuilder): Code[Boolean]
+}
+
+trait SNDArrayCode extends SCode {
+  def shape: SBaseStructCode
+
+  def memoize(cb: EmitCodeBuilder, name: String): SNDArrayValue
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SShuffle.scala
@@ -14,8 +14,6 @@ trait SShuffleValue extends SValue {
 }
 
 trait SShuffleCode extends SCode {
-  def pt: PShuffle
-
   def memoize(cb: EmitCodeBuilder, name: String): SShuffleValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SShuffleValue

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SShuffle.scala
@@ -1,0 +1,22 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.Code
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.PShuffle
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SShuffle extends SType
+
+trait SShuffleValue extends SValue {
+  def loadLength(): Code[Int]
+
+  def loadBytes(): Code[Array[Byte]]
+}
+
+trait SShuffleCode extends SCode {
+  def pt: PShuffle
+
+  def memoize(cb: EmitCodeBuilder, name: String): SShuffleValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SShuffleValue
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -1,15 +1,16 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.interfaces
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, TypeInfo, Value}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
 import is.hail.expr.ir.EmitStream.SizedStream
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PCanonicalStream, PCode, PStream, PStreamCode, PType, PValue}
 
 case class SStream(elementType: SType, separateRegions: Boolean = false) extends SType {
   def pType: PStream = PCanonicalStream(elementType.pType, separateRegions, false)
 
-  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     if (deepCopy) throw new UnsupportedOperationException
 
     assert(value.st == this)
@@ -20,7 +21,7 @@ case class SStream(elementType: SType, separateRegions: Boolean = false) extends
 
   override def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = throw new UnsupportedOperationException
 
-  override def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = throw new UnsupportedOperationException
+  override def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = throw new UnsupportedOperationException
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
@@ -1,0 +1,16 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.Code
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+
+trait SString extends SType
+
+trait SStringValue extends SValue
+
+trait SStringCode extends SCode {
+  def loadLength(): Code[Int]
+
+  def loadString(): Code[String]
+
+  def asBytes(): SBinaryCode
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
@@ -1,0 +1,31 @@
+package is.hail.types.physical.stypes.interfaces
+
+import is.hail.asm4s.Code
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitSCode}
+import is.hail.types.physical.{PBaseStruct, PBaseStructValue, PSettable}
+import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
+
+trait SStruct extends SType
+
+trait SStructSettable extends SBaseStructValue with SSettable
+
+trait SBaseStructValue extends SValue {
+  def pt: PBaseStruct
+
+  def isFieldMissing(fieldIdx: Int): Code[Boolean]
+
+  def isFieldMissing(fieldName: String): Code[Boolean] = isFieldMissing(pt.fieldIdx(fieldName))
+
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitSCode
+
+  def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitSCode = loadField(cb, pt.fieldIdx(fieldName))
+}
+
+trait SBaseStructCode extends SCode {
+  def pt: PBaseStruct
+
+  def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue
+}
+

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
@@ -22,8 +22,6 @@ trait SBaseStructValue extends SValue {
 }
 
 trait SBaseStructCode extends SCode {
-  def pt: PBaseStruct
-
   def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -1,21 +1,22 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.interfaces
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, TypeInfo, UnitInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PCode, PType, PUnrealizableCode, PValue, PVoid}
 
 case object SVoid extends SType {
 
   override def pType: PType = PVoid
 
-  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = value
+  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = value
 
   override def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = throw new UnsupportedOperationException
 
   override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = IndexedSeq()
 
-  override def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = throw new UnsupportedOperationException
+  override def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = throw new UnsupportedOperationException
 }
 
 case object PVoidCode extends PCode with PUnrealizableCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -1,9 +1,10 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.primitives
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{BooleanInfo, Code, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PBoolean, PCanonicalCall, PCode, PSettable, PType, PValue}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PBoolean, PCode, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
 
@@ -12,7 +13,7 @@ case class SBoolean(required: Boolean) extends SType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SBoolean(_) =>
         value.asInstanceOf[SBooleanCode]
@@ -21,7 +22,7 @@ case class SBoolean(required: Boolean) extends SType {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(BooleanInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case PBoolean(_) =>
         new SBooleanCode(required: Boolean, Region.loadBoolean(addr))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -1,9 +1,10 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.primitives
 
 import is.hail.annotations.{CodeOrdering, Region}
-import is.hail.asm4s.{Code, IntInfo, FloatInfo, Settable, SettableBuilder, TypeInfo, Value}
+import is.hail.asm4s.{Code, FloatInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PCanonicalCall, PCode, PFloat32, PSettable, PType, PValue}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PCode, PFloat32, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
 case class SFloat32(required: Boolean) extends SType {
@@ -11,7 +12,7 @@ case class SFloat32(required: Boolean) extends SType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SFloat32(r) =>
         if (r == required)
@@ -23,7 +24,7 @@ case class SFloat32(required: Boolean) extends SType {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(FloatInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case _: PFloat32 =>
         new SFloat32Code(required, Region.loadFloat(addr))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -1,9 +1,10 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.primitives
 
 import is.hail.annotations.{CodeOrdering, Region}
-import is.hail.asm4s.{Code, IntInfo, DoubleInfo, Settable, SettableBuilder, TypeInfo, Value}
+import is.hail.asm4s.{Code, DoubleInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PCanonicalCall, PCode, PFloat64, PSettable, PType, PValue}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PCode, PFloat64, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
 case class SFloat64(required: Boolean) extends SType {
@@ -11,7 +12,7 @@ case class SFloat64(required: Boolean) extends SType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SFloat64(r) =>
         if (r == required)
@@ -23,7 +24,7 @@ case class SFloat64(required: Boolean) extends SType {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(DoubleInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case _: PFloat64 =>
         new SFloat64Code(required, Region.loadDouble(addr))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -1,8 +1,9 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.primitives
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, IntInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PCode, PInt32, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
@@ -11,7 +12,7 @@ case class SInt32(required: Boolean) extends SType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SInt32(r) =>
         if (r == required)
@@ -23,7 +24,7 @@ case class SInt32(required: Boolean) extends SType {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(IntInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case _: PInt32 =>
         new SInt32Code(required, Region.loadInt(addr))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -1,9 +1,10 @@
-package is.hail.types.physical.stypes
+package is.hail.types.physical.stypes.primitives
 
 import is.hail.annotations.{CodeOrdering, Region}
-import is.hail.asm4s.{Code, IntInfo, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
+import is.hail.asm4s.{Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.{PCanonicalCall, PCode, PInt64, PSettable, PType, PValue}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PCode, PInt64, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
 case class SInt64(required: Boolean) extends SType {
@@ -11,7 +12,7 @@ case class SInt64(required: Boolean) extends SType {
 
   def codeOrdering(mb: EmitMethodBuilder[_], other: SType, so: SortOrder): CodeOrdering = pType.codeOrdering(mb, other.pType, so)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: PCode, deepCopy: Boolean): PCode = {
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SInt64(r) =>
         if (r == required)
@@ -23,7 +24,7 @@ case class SInt64(required: Boolean) extends SType {
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): PCode = {
+  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
     pt match {
       case _: PInt64 =>
         new SInt64Code(required, Region.loadLong(addr))


### PR DESCRIPTION
This commit introduces the SCode hierarchy. How are SCodes different
from PCodes? SCodes are what we want PCodes to be. They don't have
the methods `code / tcode`, which gives us a way to implement new
performance-improving types like SStackStruct with well-defined
boundaries around that functionality.

Currently, the `asPCode` and `IEmitCode.typecast` methods break this
boundary, and I added these as a short-term mechanism to avoid another
very spicy meatball.

This commit is entirely reorganizational, with no semantic changes
to the compiler.