### PR TITLE
[ci] ci-utils depends on service-base, not base

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -20,7 +20,7 @@ build-ci-utils:
 	$(MAKE) -C ../docker build
 	-docker pull $(CI_UTILS_LATEST)
 	python3 jinja2_render.py '{"service_base_image":{"image":"service-base"}}' Dockerfile.ci-utils Dockerfile.ci-utils.out
-	docker build -t ci-utils -f Dockerfile.ci-utils.out --cache-from ci-utils,$(CI_UTILS_LATEST),base .
+	docker build -t ci-utils -f Dockerfile.ci-utils.out --cache-from ci-utils,$(CI_UTILS_LATEST),service-base .
 
 .PHONY: push-ci-utils
 push-ci-utils: build-ci-utils


### PR DESCRIPTION
This might explain long build times redeploying CI by hand.