### PR TITLE
Rename EmitValue.get to EmitValue.load

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -290,7 +290,7 @@ class EmitClassBuilder[C](
 
     def pt: PType = _pt
 
-    def get: EmitCode = EmitCode(Code._empty,
+    def load: EmitCode = EmitCode(Code._empty,
       if (_pt.required) false else ms.get,
       vs.get)
 
@@ -331,7 +331,7 @@ class EmitClassBuilder[C](
   def newPresentEmitSettable(_pt: PType, ps: PSettable): PresentEmitSettable = new PresentEmitSettable {
     def pt: PType = _pt
 
-    def get: EmitCode = EmitCode(Code._empty, const(false), ps.load())
+    def load: EmitCode = EmitCode(Code._empty, const(false), ps.load())
 
     def store(cb: EmitCodeBuilder, pv: PCode): Unit = ps.store(cb, pv)
   }
@@ -1011,7 +1011,7 @@ class EmitMethodBuilder[C](
     new EmitValue {
       val pt: PType = _pt
 
-      def get: EmitCode = {
+      def load: EmitCode = {
         new EmitCode(Code._empty,
           if (pt.required)
             const(false)
@@ -1185,7 +1185,7 @@ class DependentEmitFunctionBuilder[F](
     new EmitValue {
       def pt: PType = _pt
 
-      def get: EmitCode = EmitCode(Code._empty, m.load(), PCode(_pt, v.load()))
+      def load: EmitCode = EmitCode(Code._empty, m.load(), PCode(_pt, v.load()))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1315,7 +1315,7 @@ object EmitStream {
       val atEnd = mb.genFieldThisRef[Boolean]()
       val x = mb.newEmitField(eltType)
       val Lpush = CodeLabel()
-      val source = stream(Code(atEnd := true, Lpush.goto), a => Code(EmitCodeBuilder.scopedVoid(mb)(_.assign(x, a)), Lpush, push(COption(atEnd.get, x.get))))
+      val source = stream(Code(atEnd := true, Lpush.goto), a => Code(EmitCodeBuilder.scopedVoid(mb)(_.assign(x, a)), Lpush, push(COption(atEnd.get, x.load))))
       Source[COption[EmitCode]](
         setup0 = source.setup0,
         close0 = source.close0,
@@ -1370,7 +1370,7 @@ object EmitStream {
           val ev = env.lookup(name)
           if (ev.pt != typ)
             throw new RuntimeException(s"PValue type did not match inferred ptype:\n name: $name\n  pv: ${ ev.pt }\n  ir: $typ")
-          COption.fromEmitCode(ev.get).map(_.asStream.stream)
+          COption.fromEmitCode(ev.load).map(_.asStream.stream)
 
         case x@StreamRange(startIR, stopIR, stepIR, _) =>
           val eltType = coerce[PStream](x.pType).elementType
@@ -2037,7 +2037,7 @@ object EmitStream {
                     cb.assign(xElt, eltt)
                     cb.assign(xResult, postt)
                     cb.append(seqPerElt)
-                    xResult.get
+                    xResult.load
                   }
                 },
                 setup0 = Some(aggSetup),

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -84,7 +84,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     new EmitValue {
       def pt: PType = elt
 
-      def get: EmitCode = {
+      def load: EmitCode = {
         val t = mb.newLocal[Int]("sab_applyEV_i")
         EmitCode(t := i, isMissing(t), PCode(elt, apply(t)))
       }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -175,7 +175,7 @@ package object ir {
 
   implicit def toRichIndexedSeqEmitSettable(s: IndexedSeq[EmitSettable]): RichIndexedSeqEmitSettable = new RichIndexedSeqEmitSettable(s)
 
-  implicit def emitValueToCode(ev: EmitValue): EmitCode = ev.get
+  implicit def emitValueToCode(ev: EmitValue): EmitCode = ev.load
 
   implicit def toCodeParamType(ti: TypeInfo[_]): CodeParamType = CodeParamType(ti)
 


### PR DESCRIPTION
This is in anticipation of a new `EmitVale.get` that returns a `PValue`. 