### PR TITLE
[batch] automatically set GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -683,11 +683,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     if user != 'ci':
                         raise web.HTTPBadRequest(reason=f'unauthorized secret {(secret["namespace"], secret["name"])}')
 
-                env = spec.get('env')
-                if not env:
-                    env = []
-                    spec['env'] = env
-
                 spec['secrets'] = secrets
                 secrets.append({
                     'namespace': DEFAULT_NAMESPACE,
@@ -695,7 +690,12 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     'mount_path': '/gsa-key',
                     'mount_in_copy': True
                 })
-                if all('GOOGLE_APPLICATION_CREDENTIALS' != envvar['name'] for envvar in spec.env):
+
+                env = spec.get('env')
+                if not env:
+                    env = []
+                    spec['env'] = env
+                if all(envvar['name'] != 'GOOGLE_APPLICATION_CREDENTIALS' for envvar in spec.env):
                     spec.env.append(
                         {'name': 'GOOGLE_APPLICATION_CREDENTIALS', 'value': '/gsa-key/key.json'})
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -695,8 +695,10 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if not env:
                     env = []
                     spec['env'] = env
-                if all(envvar['name'] != 'GOOGLE_APPLICATION_CREDENTIALS' for envvar in spec.env):
-                    spec.env.append(
+                assert isinstance(spec['env'], list)
+
+                if all(envvar['name'] != 'GOOGLE_APPLICATION_CREDENTIALS' for envvar in spec['env']):
+                    spec['env'].append(
                         {'name': 'GOOGLE_APPLICATION_CREDENTIALS', 'value': '/gsa-key/key.json'})
 
                 if spec.get('mount_tokens', False):

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -33,7 +33,7 @@ async def dev_client():
 
 @pytest.fixture(scope='module')
 def get_billing_project_name():
-    prefix = f'__testproject_{secrets.token_urlsafe(15)}'
+    prefix = f'__testproject_{os.environ["HAIL_TOKEN"]}'
     projects = []
     def get_name():
         name = f'{prefix}_{len(projects)}'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -601,7 +601,7 @@ def test_verify_no_access_to_metadata_server(client):
 def test_can_use_hailctl_auth(client):
     builder = client.create_batch()
     j = builder.create_job(os.environ['CI_UTILS_IMAGE'],
-                           'gcloud', 'auth', 'list')
+                           ['gcloud', 'auth', 'list'])
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     log = j.log()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -606,7 +606,7 @@ def test_can_use_hailctl_auth(client):
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     log = j.log()
-    assert '*       test-665@hail-vdc.iam.gserviceaccount.com' in log, f'{j.log(), status}'
+    assert '*       test-665@hail-vdc.iam.gserviceaccount.com' in log['main'], f'{j.log(), status}'
 
 
 def test_user_authentication_within_job(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -598,6 +598,16 @@ def test_verify_no_access_to_metadata_server(client):
     assert "Connection timed out" in j.log()['main'], (j.log()['main'], status)
 
 
+def test_can_use_hailctl_auth(client):
+    builder = client.create_batch()
+    j = builder.create_job(os.environ['CI_UTILS_IMAGE'],
+                           'gcloud', 'auth', 'list')
+    status = j.wait()
+    assert status['state'] == 'Success', f'{j.log(), status}'
+    log = j.log()
+    assert '*       test-665@hail-vdc.iam.gserviceaccount.com' in log, f'{j.log(), status}'
+
+
 def test_user_authentication_within_job(client):
     batch = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -602,6 +602,7 @@ def test_can_use_hailctl_auth(client):
     builder = client.create_batch()
     j = builder.create_job(os.environ['CI_UTILS_IMAGE'],
                            ['gcloud', 'auth', 'list'])
+    builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
     log = j.log()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -8,7 +8,7 @@ import aiohttp
 import pytest
 import json
 
-from hailtop.config import get_deploy_config
+from hailtop.config import get_deploy_config, get_user_config
 from hailtop.auth import service_auth_headers, get_userinfo
 from hailtop.utils import (retry_response_returning_functions,
                            external_requests_client_session)
@@ -598,15 +598,38 @@ def test_verify_no_access_to_metadata_server(client):
     assert "Connection timed out" in j.log()['main'], (j.log()['main'], status)
 
 
-def test_can_use_hailctl_auth(client):
+def test_can_use_google_credentials(client):
+    token = os.environ["HAIL_TOKEN"]
+    bucket_name = get_user_config().get('batch', 'bucket')
     builder = client.create_batch()
-    j = builder.create_job(os.environ['CI_UTILS_IMAGE'],
-                           ['gcloud', 'auth', 'list'])
+    script = f'''import hail as hl
+location = "gs://{ bucket_name }/{ token }/test_can_use_hailctl_auth.t"
+hl.utils.range_table(10).write(location)
+hl.read_table(location).show()
+'''
+    j = builder.create_job(os.environ['HAIL_HAIL_BASE_IMAGE'], ['python3', '-c', script])
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', f'{j.log(), status}'
+    expected_log = '''+-------+
+|   idx |
++-------+
+| int32 |
++-------+
+|     0 |
+|     1 |
+|     2 |
+|     3 |
+|     4 |
+|     5 |
+|     6 |
+|     7 |
+|     8 |
+|     9 |
++-------+
+'''
     log = j.log()
-    assert '*       test-665@hail-vdc.iam.gserviceaccount.com' in log['main'], f'{j.log(), status}'
+    assert expected_log in log['main'], f'{j.log(), status}'
 
 
 def test_user_authentication_within_job(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -600,10 +600,11 @@ def test_verify_no_access_to_metadata_server(client):
 
 def test_can_use_google_credentials(client):
     token = os.environ["HAIL_TOKEN"]
+    attempt_token = secrets.token_urlsafe(5)
     bucket_name = get_user_config().get('batch', 'bucket')
     builder = client.create_batch()
     script = f'''import hail as hl
-location = "gs://{ bucket_name }/{ token }/test_can_use_hailctl_auth.t"
+location = "gs://{ bucket_name }/{ token }/{ attempt_token }/test_can_use_hailctl_auth.t"
 hl.utils.range_table(10).write(location)
 hl.read_table(location).show()
 '''

--- a/build.yaml
+++ b/build.yaml
@@ -2316,6 +2316,7 @@ steps:
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2383,6 +2384,7 @@ steps:
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2450,6 +2452,7 @@ steps:
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2517,6 +2520,7 @@ steps:
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \

--- a/build.yaml
+++ b/build.yaml
@@ -2244,9 +2244,11 @@ steps:
      export HAIL_CURL_IMAGE={{ curl_image.image }}
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
      hailctl config set batch/bucket hail-test-dmk9z
      python3 -m pytest \
              --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2290,6 +2292,7 @@ steps:
     - default_ns
     - copy_files
     - base_image
+    - hail_base_image
     - batch_image
     - ci_utils_image
     - deploy_batch
@@ -2309,6 +2312,7 @@ steps:
      export HAIL_CURL_IMAGE={{ curl_image.image }}
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
@@ -2355,6 +2359,7 @@ steps:
     - create_accounts
     - copy_files
     - base_image
+    - hail_base_image
     - batch_image
     - ci_utils_image
     - deploy_batch
@@ -2374,6 +2379,7 @@ steps:
      export HAIL_CURL_IMAGE={{ curl_image.image }}
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
@@ -2420,6 +2426,7 @@ steps:
     - default_ns
     - copy_files
     - base_image
+    - hail_base_image
     - batch_image
     - ci_utils_image
     - deploy_batch
@@ -2439,6 +2446,7 @@ steps:
      export HAIL_CURL_IMAGE={{ curl_image.image }}
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
@@ -2485,6 +2493,7 @@ steps:
     - default_ns
     - copy_files
     - base_image
+    - hail_base_image
     - batch_image
     - ci_utils_image
     - deploy_batch
@@ -2504,6 +2513,7 @@ steps:
      export HAIL_CURL_IMAGE={{ curl_image.image }}
      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
      export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+     export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
      export DOCKER_ROOT_IMAGE="gcr.io/{{ global.project }}/ubuntu:18.04"
      export HAIL_TEST_TOKEN_FILE=/user-tokens/tokens.json
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
@@ -2550,6 +2560,7 @@ steps:
     - default_ns
     - copy_files
     - base_image
+    - hail_base_image
     - batch_image
     - ci_utils_image
     - deploy_batch

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -31,8 +31,11 @@ async def async_get_userinfo(*, deploy_config=None, session_id=None, client_sess
             raise
 
 
-def get_userinfo(deploy_config=None):
-    return async_to_blocking(async_get_userinfo(deploy_config=deploy_config))
+def get_userinfo(deploy_config=None, session_id=None, client_session=None):
+    return async_to_blocking(async_get_userinfo(
+        deploy_config=deploy_config,
+        session_id=session_id,
+        client_session=client_session))
 
 
 def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, token_file=None):


### PR DESCRIPTION
gcloud uses this variable to find the tokens file. We should set it so
that users do not need to configure anything. I also fixed some
missing arguments in the non-async get_userinfo.