### PR TITLE
[httpx] add Hail httpx library

### DIFF
--- a/address/address/address.py
+++ b/address/address/address.py
@@ -9,7 +9,7 @@ import kubernetes_asyncio as kube
 from gear import (setup_aiohttp_session, web_authenticated_developers_only,
                   rest_authenticated_users_only)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -161,4 +161,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -2,8 +2,7 @@ import pytest
 import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import in_cluster_no_hostname_checks_ssl_client_connection
-from hailtop.utils import request_retry_transient_errors
+from hailtop import httpx
 
 
 deploy_config = get_deploy_config()
@@ -11,12 +10,7 @@ deploy_config = get_deploy_config()
 
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
-    async with in_cluster_no_hostname_checks_ssl_client_connection(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60),
-            headers=service_auth_headers(deploy_config, 'address')) as session:
-        address, port = await deploy_config.address('address')
-        await request_retry_transient_errors(
-            session,
-            'GET',
-            f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
+    async with httpx.client_session(
+            headers=service_auth_headers(deploy_config, 'address'),
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
+        await session.get(deploy_config.url('address', '/api/address', use_address=True))

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -9,7 +9,7 @@ import aiohttp_jinja2
 
 from hailtop.utils import time_msecs, secret_alnum_string
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.config import get_deploy_config
 from hailtop import aiogoogle
 from gear import (Database, setup_aiohttp_session,
@@ -351,4 +351,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -9,7 +9,7 @@ import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop.utils import secret_alnum_string
 from gear import (
@@ -582,4 +582,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -1,9 +1,9 @@
-import aiohttp
 import datetime
 import logging
 import secrets
 import humanize
 from hailtop.utils import time_msecs, time_msecs_str
+from hailtop import httpx
 
 from ..database import check_call_procedure
 from ..globals import INSTANCE_VERSION
@@ -135,8 +135,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
     async def check_is_active_and_healthy(self):
         if self._state == 'active' and self.ip_address:
             try:
-                async with aiohttp.ClientSession(
-                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     async with session.get(f'http://{self.ip_address}:5000/healthcheck') as resp:
                         actual_name = (await resp.json()).get('name')
                         if actual_name and actual_name != self.name:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -18,10 +18,10 @@ from gear import (Database, setup_aiohttp_session,
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import time_msecs, RateLimit, serialization, retry_long_running
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop import aiogoogle, aiotools
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
-    set_message
+from web_common import (setup_aiohttp_jinja2, setup_common_static_routes,
+                        render_template, set_message)
 import googlecloudprofiler
 import uvloop
 
@@ -818,4 +818,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -18,11 +18,12 @@ import concurrent
 import aiodocker
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import (time_msecs, request_retry_transient_errors,
-                           RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
-                           CalledProcessError, blocking_to_async, check_shell_output,
+from hailtop.utils import (time_msecs, RETRY_FUNCTION_SCRIPT, sleep_and_backoff,
+                           retry_all_errors, check_shell, CalledProcessError,
+                           blocking_to_async, check_shell_output,
                            retry_long_running, run_if_changed)
-from hailtop.tls import get_context_specific_ssl_client_session
+
+from hailtop import httpx
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 from hailtop import aiotools
@@ -1098,8 +1099,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with get_context_specific_ssl_client_session(
-                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
                     # gone (e.g. testing a PR), this would go into an
@@ -1152,8 +1152,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with get_context_specific_ssl_client_session(
-                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+                async with httpx.client_session(retry_transient=False) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
                         json=body, headers=self.headers)
@@ -1207,10 +1206,8 @@ class Worker:
             'status': status
         }
 
-        async with get_context_specific_ssl_client_session(
-                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-            await request_retry_transient_errors(
-                session, 'POST',
+        async with httpx.client_session() as session:
+            await session.post(
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/job_started'),
                 json=body, headers=self.headers)
 
@@ -1221,17 +1218,16 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with get_context_specific_ssl_client_session(
-                raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-            resp = await request_retry_transient_errors(
-                session, 'POST',
-                deploy_config.url('batch-driver', '/api/v1alpha/instances/activate'),
-                json={'ip_address': os.environ['IP_ADDRESS']},
-                headers={
-                    'X-Hail-Instance-Name': NAME,
-                    'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
-                })
-            resp_json = await resp.json()
+        async with httpx.client_session(
+                timeout=aiohttp.ClientTimeout(total=60)) as session:
+            async with session.post(
+                    deploy_config.url('batch-driver', '/api/v1alpha/instances/activate'),
+                    json={'ip_address': os.environ['IP_ADDRESS']},
+                    headers={
+                        'X-Hail-Instance-Name': NAME,
+                        'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
+                    }) as resp:
+                resp_json = await resp.json()
             self.headers = {
                 'X-Hail-Instance-Name': NAME,
                 'Authorization': f'Bearer {resp_json["token"]}'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -628,7 +628,7 @@ hl.read_table(location).show()
     assert expected_log in log['main'], f'{j.log(), status}'
 
 
-def test_user_authentication_within_job(client):
+def test_no_user_authentication_within_job(client):
     batch = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']
     no_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import aiohttp
 from aiohttp import web
 import logging
 from gear import setup_aiohttp_session, web_authenticated_developers_only

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -4,8 +4,9 @@ import aiohttp
 from aiohttp import web
 import logging
 from gear import setup_aiohttp_session, web_authenticated_developers_only
+from hailtop import httpx
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger, configure_logging
 from hailtop.utils import retry_long_running, collect_agen, humanize_timedelta_msecs
 from hailtop import aiotools
@@ -439,7 +440,7 @@ async def github_polling_loop(app):
 
 async def on_startup(app):
     app['gs_reader'] = ReadGoogleStorage(service_account_key_file='/benchmark-gsa-key/key.json')
-    app['github_client'] = gidgethub.aiohttp.GitHubAPI(aiohttp.ClientSession(),
+    app['github_client'] = gidgethub.aiohttp.GitHubAPI(httpx.client_session(),
                                                        'hail-is/hail',
                                                        oauth_token=oauth_token)
     app['batch_client'] = await bc.BatchClient(billing_project='benchmark')
@@ -466,4 +467,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/benchmark-service/test/test_update_commits.py
+++ b/benchmark-service/test/test_update_commits.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session, get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -22,29 +22,25 @@ async def test_update_commits():
     headers = service_auth_headers(deploy_config, 'benchmark')
     commit_benchmark_url = deploy_config.url('benchmark', f'/api/v1alpha/benchmark/commit/{sha}')
 
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60)) as session:
-
+    async with client_session() as session:
         commit = None
 
-        await utils.request_retry_transient_errors(
-            session, 'DELETE', f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
+        await session.delete(f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
 
-        resp_status = await utils.request_retry_transient_errors(
-            session, 'GET', f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
+        resp_status = await session.get(
+            f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
         commit = await resp_status.json()
         assert commit['status'] is None, commit
 
-        resp_commit = await utils.request_retry_transient_errors(
-            session, 'POST', f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
+        resp_commit = await session.post(
+            f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
         commit = await resp_commit.json()
 
         async def wait_forever():
             nonlocal commit
             while commit is None or not commit['status']['complete']:
-                resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
+                resp = await session.get(
+                    f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
                 commit = await resp.json()
                 await asyncio.sleep(5)
                 print(commit['status'])

--- a/build.yaml
+++ b/build.yaml
@@ -1785,6 +1785,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /deploy-config
+    - name: ssl-config-auth-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
    dependsOn:
     - default_ns
     - create_accounts
@@ -1832,6 +1836,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /deploy-config
+    - name: ssl-config-auth-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
    dependsOn:
     - default_ns
     - create_accounts
@@ -2978,6 +2986,10 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /user-tokens
+    - name: ssl-config-batch-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
     - name: test-gsa-key
       namespace:
         valueFrom: default_ns.name

--- a/build.yaml
+++ b/build.yaml
@@ -2062,10 +2062,15 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /deploy-config
+    - name: ssl-config-create-billing-projects
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
    dependsOn:
     - default_ns
     - service_base_image
     - create_deploy_config
+    - create_certs
     - create_accounts
     - deploy_batch
  - kind: deploy

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -12,9 +12,9 @@ from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
-from hailtop import aiotools
+from hailtop import aiotools, httpx
 from gear import (setup_aiohttp_session, rest_authenticated_developers_only,
                   web_authenticated_developers_only, check_csrf_token,
                   create_database_pool)
@@ -403,7 +403,7 @@ async def update_loop(app):
 
 async def on_startup(app):
     app['github_client'] = gh_aiohttp.GitHubAPI(
-        aiohttp.ClientSession(
+        httpx.client_session(
             timeout=aiohttp.ClientTimeout(total=60)),
         'ci',
         oauth_token=oauth_token)
@@ -438,4 +438,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop import httpx
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,17 +19,15 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with in_cluster_ssl_client_session(
-            raise_for_status=True,
+    async with httpx.client_session(
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 
         async def wait_forever():
             deploy_state = None
             failure_information = None
             while deploy_state is None:
-                resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{ci_deploy_status_url}', headers=headers)
-                deploy_statuses = await resp.json()
+                async with session.get(f'{ci_deploy_status_url}', headers=headers) as resp:
+                    deploy_statuses = await resp.json()
                 log.info(f'deploy_statuses:\n{json.dumps(deploy_statuses, indent=2)}')
                 assert len(deploy_statuses) == 1, deploy_statuses
                 deploy_status = deploy_statuses[0]

--- a/dev-docs/hail-overview.md
+++ b/dev-docs/hail-overview.md
@@ -116,6 +116,7 @@ Libraries for services:
 * $HAIL/hail/python/hailtop/auth: user authorization library
 * $HAIL/hail/python/hailtop/config: user and deployment configuration library
 * $HAIL/hail/python/hailtop/tls.py: TLS utilities for services
+* $HAIL/hail/python/hailtop/httpx.py: HTTP(S) client utilities for services
 * $HAIL/hail/python/hailtop/utils: various
 * $HAIL/tls: for TLS configuration and deployment
 * $HAIL/web_common: service HTML templates

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -5,8 +5,8 @@ from typing import Iterable, List, Optional, Set, Tuple, Union
 
 import hail as hl
 import pkg_resources
-from hailtop.utils import (retry_response_returning_functions,
-                           external_requests_client_session)
+
+from hailtop import httpx
 
 from .lens import MatrixRows, TableRows
 from ..expr import StructExpression
@@ -348,9 +348,8 @@ class DB:
                 with open(config_path) as f:
                     config = json.load(f)
             else:
-                session = external_requests_client_session()
-                response = retry_response_returning_functions(session.get, url)
-                config = response.json()
+                with httpx.blocking_client_session() as session, session.get(url) as resp:
+                    config = resp.json()
             assert isinstance(config, dict)
         else:
             if not isinstance(config, dict):

--- a/hail/python/hailtop/aiogoogle/auth/access_token.py
+++ b/hail/python/hailtop/aiogoogle/auth/access_token.py
@@ -1,5 +1,7 @@
 import time
 
+from ... import httpx
+
 
 class AccessToken:
     def __init__(self, credentials):
@@ -7,7 +9,7 @@ class AccessToken:
         self._access_token = None
         self._expires_at = None
 
-    async def auth_headers(self, session):
+    async def auth_headers(self, session: httpx.ClientSession):
         now = time.time()
         if self._access_token is None or now > self._expires_at:
             self._access_token = await self.credentials.get_access_token(session)

--- a/hail/python/hailtop/aiogoogle/auth/session.py
+++ b/hail/python/hailtop/aiogoogle/auth/session.py
@@ -1,10 +1,11 @@
 from types import TracebackType
 from typing import Optional, Type, TypeVar
 import abc
-import aiohttp
-from hailtop.utils import request_retry_transient_errors, RateLimit, RateLimiter
+from hailtop.utils import RateLimit, RateLimiter
 from .credentials import Credentials
 from .access_token import AccessToken
+
+from ... import httpx
 
 SessionType = TypeVar('SessionType', bound='BaseSession')
 
@@ -60,25 +61,25 @@ class RateLimitedSession(BaseSession):
 
 
 class Session(BaseSession):
-    _session: Optional[aiohttp.ClientSession]
+    _session: Optional[httpx.ClientSession]
     _access_token: Optional[AccessToken]
 
     def __init__(self, *, credentials: Credentials = None, **kwargs):
         if credentials is None:
             credentials = Credentials.default_credentials()
 
-        if 'raise_for_status' not in kwargs:
-            kwargs['raise_for_status'] = True
-        self._session = aiohttp.ClientSession(**kwargs)
+        self._session = httpx.client_session(**kwargs)
         self._access_token = AccessToken(credentials)
 
     async def request(self, method: str, url: str, **kwargs):
+        assert self._access_token is not None
+        assert self._session is not None
         auth_headers = await self._access_token.auth_headers(self._session)
         if 'headers' in kwargs:
             kwargs['headers'].update(auth_headers)
         else:
             kwargs['headers'] = auth_headers
-        return await request_retry_transient_errors(self._session, method, url, **kwargs)
+        return await self._session.request(method, url, **kwargs)
 
     async def close(self) -> None:
         if self._session is not None:

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -8,7 +8,7 @@ import functools
 import sys
 import time
 
-from hailtop.utils import secret_alnum_string, partition
+from hailtop.utils import (secret_alnum_string, partition, async_to_blocking)
 import hailtop.batch_client.aioclient as low_level_batch_client
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 
@@ -36,10 +36,6 @@ def chunk(fn):
     def chunkedfn(*args):
         return [fn(*arglist) for arglist in zip(*args)]
     return chunkedfn
-
-
-def async_to_blocking(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 class BatchPoolExecutor:

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -1,11 +1,7 @@
 from typing import Optional
-import asyncio
 
 from . import aioclient
-
-
-def async_to_blocking(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from hailtop.utils import async_to_blocking
 
 
 def sync_anext(ait):
@@ -205,10 +201,10 @@ class BatchBuilder:
 
 
 class BatchClient:
-    def __init__(self, billing_project, deploy_config=None, session=None,
-                 headers=None, _token=None):
+    def __init__(self, billing_project, deploy_config=None, headers=None,
+                 _token=None):
         self._async_client = async_to_blocking(
-            aioclient.BatchClient(billing_project, deploy_config, session, headers=headers, _token=_token))
+            aioclient.BatchClient(billing_project, deploy_config, headers=headers, _token=_token))
 
     @property
     def bucket(self):

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Optional
 import aiohttp
 import random
 import os

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -94,8 +94,9 @@ async def async_main(args):
     if args.namespace:
         deploy_config = deploy_config.with_default_namespace(args.namespace)
     headers = namespace_auth_headers(deploy_config, deploy_config.default_namespace(), authorize_target=False)
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+    async with httpx.client_session(
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         await auth_flow(deploy_config, deploy_config.default_namespace(), session)
 
 

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -1,9 +1,9 @@
-import asyncio
 import aiohttp
+import asyncio
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -20,8 +20,9 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with get_context_specific_ssl_client_session(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+    async with httpx.client_session(
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60)) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass
     auth_ns = deploy_config.service_ns('auth')

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -1,11 +1,11 @@
+import aiohttp
 import asyncio
 import webbrowser
-import aiohttp
 import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -27,8 +27,10 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = get_context_specific_ssl_client_session(
-            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+        self._session = httpx.client_session(
+            raise_for_status=False,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60))
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -54,7 +54,8 @@ class QueryClient:
         headers = service_auth_headers(self._deploy_config, 'query')
         self._session = httpx.client_session(
             headers=headers,
-            timeout=aiohttp.ClientTimeout(total=60))
+            timeout=aiohttp.ClientTimeout(total=60),
+            raise_for_status=False)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -1,10 +1,10 @@
-import asyncio
 import aiohttp
+import asyncio
 import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 
 def init_parser(parser):
@@ -52,8 +52,9 @@ class QueryClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'query')
-        self._session = get_context_specific_ssl_client_session(
-            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+        self._session = httpx.client_session(
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=60))
         return self
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -91,7 +91,7 @@ class QueryClient:
             try:
                 def raise_flag_not_found(status, text):
                     error = text.split('\n')[0].strip()
-                    if status == 500 and 'java.util.NoSuchElementException: key not found: ' in error:
+                    if status == 400 and 'is.hail.utils.HailException: No such flag ' in error:
                         raise KeyError(error[49:])
                 flags[name] = await self.get_request(f'flags/get/{name}', handler=raise_flag_not_found)
             except KeyError as e:

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -89,10 +89,10 @@ class QueryClient:
         invalid = []
         for name in names:
             try:
-                def raise_flag_not_found(status, text):
+                def raise_flag_not_found(status, text, captured_name=name):
                     error = text.split('\n')[0].strip()
                     if status == 400 and 'is.hail.utils.HailException: No such flag ' in error:
-                        raise KeyError(error[49:])
+                        raise KeyError(captured_name)
                 flags[name] = await self.get_request(f'flags/get/{name}', handler=raise_flag_not_found)
             except KeyError as e:
                 invalid.append(str(e))

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -1,0 +1,466 @@
+from typing import (Dict, Any, List, Tuple, Optional, Type, Awaitable,
+                    Generator)
+from types import TracebackType
+import aiohttp
+import socket
+import logging
+from hailtop.config import get_deploy_config
+from .tls import internal_client_ssl_context, external_client_ssl_context
+from .utils import async_to_blocking, retry_transient_errors
+
+log = logging.getLogger('hailtop.httpx')
+
+
+def client_session(*args,
+                   retry_transient: bool = True,
+                   raise_for_status: bool = True,
+                   **kwargs) -> 'ClientSession':
+    assert 'connector' not in kwargs
+    if get_deploy_config().location() == 'external':
+        kwargs['connector'] = aiohttp.TCPConnector(
+            ssl=external_client_ssl_context())
+    else:
+        kwargs['connector'] = aiohttp.TCPConnector(
+            ssl=internal_client_ssl_context(),
+            resolver=HailResolver())
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = aiohttp.ClientTimeout(total=5)
+    kwargs['raise_for_status'] = False
+    return ClientSession(
+        aiohttp.ClientSession(*args, **kwargs),
+        retry_transient=retry_transient,
+        raise_for_status=raise_for_status)
+
+
+def blocking_client_session(*args, **kwargs) -> 'BlockingClientSession':
+    return BlockingClientSession(client_session(*args, **kwargs))
+
+
+class ResponseManager:
+    def __init__(self, response_coroutine: Awaitable[aiohttp.ClientResponse]):
+        self.response_coroutine = response_coroutine
+        self.response: Optional[aiohttp.ClientResponse] = None
+
+    async def __aenter__(self) -> aiohttp.ClientResponse:
+        self.response = await self.response_coroutine
+        return self.response
+
+    def __await__(self) -> Generator[Any, None, aiohttp.ClientResponse]:
+        assert self.response is None
+        return self.response_coroutine.__await__()
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc: Optional[BaseException],
+                        tb: Optional[TracebackType]) -> None:
+        assert self.response is not None
+        self.response.release()
+
+
+class WebSocketResponseManager:
+    def __init__(self, websocket_coroutine: Awaitable[aiohttp.ClientWebSocketResponse]):
+        self.websocket_coroutine = websocket_coroutine
+        self.websocket: Optional[aiohttp.ClientWebSocketResponse] = None
+
+    async def __aenter__(self) -> aiohttp.ClientWebSocketResponse:
+        self.websocket = await self.websocket_coroutine
+        return self.websocket
+
+    def __await__(self) -> Generator[Any, None, aiohttp.ClientWebSocketResponse]:
+        assert self.websocket is None
+        return self.websocket_coroutine.__await__()
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc: Optional[BaseException],
+                        tb: Optional[TracebackType]) -> None:
+        assert self.websocket is not None
+        await self.websocket.close()
+
+
+class ClientSession:
+    def __init__(self, session: aiohttp.ClientSession, retry_transient: bool, raise_for_status: bool):
+        self.session = session
+        self.retry_transient = retry_transient
+        self.raise_for_status = raise_for_status
+
+    async def _request_and_raise_for_status(self,
+                                            method: str,
+                                            url: aiohttp.typedefs.StrOrURL,
+                                            **kwargs: Any) -> aiohttp.ClientResponse:
+        raise_for_status = kwargs.pop('raise_for_status', self.raise_for_status)
+        response = await self.session._request(method, url, **kwargs)
+        if raise_for_status and response.status >= 400:
+            message = response.reason or ''
+            try:
+                message = message + '\n' + await response.text()
+            except Exception as exc:
+                message = message + f'\ncould not fetch text due to: {exc}'
+            raise aiohttp.ClientResponseError(
+                response.request_info,
+                response.history,
+                status=response.status,
+                message=message,
+                headers=response.headers)
+        return response
+
+    def ws_connect(self, url: aiohttp.typedefs.StrOrURL, **kwargs: Any):
+        retry_transient = kwargs.pop('retry_transient', self.retry_transient)
+        if retry_transient:
+            coroutine = retry_transient_errors(self.session._ws_connect(url, **kwargs))
+        else:
+            coroutine = self.session._ws_connect(url, **kwargs)
+        return WebSocketResponseManager(coroutine)
+
+    def request(self,
+                method: str,
+                url: aiohttp.typedefs.StrOrURL,
+                **kwargs: Any) -> ResponseManager:
+        retry_transient = kwargs.pop('retry_transient', self.retry_transient)
+        if retry_transient:
+            coroutine = retry_transient_errors(
+                self._request_and_raise_for_status, method, url, **kwargs)
+        else:
+            coroutine = self._request_and_raise_for_status(method, url, **kwargs)
+        return ResponseManager(coroutine)
+
+    def get(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            allow_redirects: bool = True,
+            **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_GET, url, allow_redirects=allow_redirects, **kwargs)
+
+    def options(self,
+                url: aiohttp.typedefs.StrOrURL,
+                *,
+                allow_redirects: bool = True,
+                **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_OPTIONS, url, allow_redirects=allow_redirects, **kwargs)
+
+    def head(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             allow_redirects: bool = False,
+             **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_HEAD, url, allow_redirects=allow_redirects, **kwargs)
+
+    def post(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             data: Any = None, **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_POST, url, data=data, **kwargs)
+
+    def put(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            data: Any = None,
+            **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_PUT, url, data=data, **kwargs)
+
+    def patch(self,
+              url: aiohttp.typedefs.StrOrURL,
+              *,
+              data: Any = None,
+              **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_PATCH, url, data=data, **kwargs)
+
+    def delete(self,
+               url: aiohttp.typedefs.StrOrURL,
+               **kwargs: Any) -> ResponseManager:
+        return self.request(
+            aiohttp.hdrs.METH_DELETE, url, **kwargs)
+
+    async def close(self) -> None:
+        await self.session.close()
+
+    @property
+    def closed(self) -> bool:
+        return self.session.closed
+
+    @property
+    def cookie_jar(self) -> aiohttp.abc.AbstractCookieJar:
+        return self.session.cookie_jar
+
+    @property
+    def version(self) -> Tuple[int, int]:
+        return self.session.version
+
+    async def __aenter__(self) -> 'ClientSession':
+        self.session = await self.session.__aenter__()
+        return self
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> None:
+        await self.session.close()
+
+
+class HailResolver(aiohttp.abc.AbstractResolver):
+    """Use Hail in-cluster DNS with fallback."""
+    def __init__(self):
+        self.dns = None
+        self.deploy_config = get_deploy_config()
+
+    async def resolve(self, host: str, port: int, family: int) -> List[Dict[str, Any]]:
+        if self.dns is None:
+            # the AsyncResolver must be created from an async function:
+            # https://github.com/aio-libs/aiohttp/issues/3573#issuecomment-456742539
+            self.dns = aiohttp.DefaultResolver()
+        if family in (0, socket.AF_INET, socket.AF_INET6):
+            maybe_address_and_port = await self.deploy_config.maybe_address(host)
+            if maybe_address_and_port is not None:
+                address, resolved_port = maybe_address_and_port
+                return [{'hostname': host,
+                         'host': address,
+                         'port': resolved_port,
+                         'family': family if family != 0 else socket.AF_INET,
+                         'proto': 0,
+                         'flags': 0}]
+        return await self.dns.resolve(host, port, family)
+
+    async def close(self) -> None:
+        if self.dns is not None:
+            await self.dns.close()
+
+
+class BlockingClientResponse:
+    def __init__(self, client_response: aiohttp.ClientResponse):
+        self.client_response = client_response
+
+    def read(self) -> bytes:
+        return async_to_blocking(self.client_response.read())
+
+    def text(self, encoding: Optional[str] = None, errors: str = 'strict') -> str:
+        return async_to_blocking(self.client_response.text(
+            encoding=encoding, errors=errors))
+
+    def json(self, *,
+             encoding: str = None,
+             loads: aiohttp.typedefs.JSONDecoder = aiohttp.typedefs.DEFAULT_JSON_DECODER,
+             content_type: Optional[str] = 'application/json') -> Any:
+        return async_to_blocking(self.client_response.json(
+            encoding=encoding, loads=loads, content_type=content_type))
+
+    def __del__(self):
+        self.client_response.__del__()
+
+    def history(self) -> Tuple[aiohttp.ClientResponse, ...]:
+        return self.client_response.history()
+
+    def __repr__(self) -> str:
+        return f'BlcokingClientRepsonse({repr(self.client_response)})'
+
+    @property
+    def status(self) -> int:
+        return self.client_response.status
+
+    def raise_for_status(self) -> None:
+        self.client_response.raise_for_status()
+
+
+class BlockingWebSocketClientResponse:
+    def __init__(self, ws: aiohttp.ClientWebSocketResponse):
+        self.ws = ws
+
+    @property
+    def closed(self) -> bool:
+        return self.ws.closed
+
+    @property
+    def close_code(self) -> Optional[int]:
+        return self.ws.close_code
+
+    @property
+    def protocol(self) -> Optional[int]:
+        return self.ws.protocol
+
+    @property
+    def compress(self) -> int:
+        return self.ws.compress
+
+    @property
+    def client_notakeover(self) -> bool:
+        return self.ws.client_notakeover
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        return self.ws.get_extra_info(name, default)
+
+    def exception(self) -> Optional[BaseException]:
+        return self.ws.exception()
+
+    def ping(self, message: bytes = b'') -> None:
+        async_to_blocking(self.ws.ping(message))
+
+    def pong(self, message: bytes = b'') -> None:
+        async_to_blocking(self.ws.pong(message))
+
+    def send_str(self, data: str,
+                 compress: Optional[int] = None) -> None:
+        return async_to_blocking(self.ws.send_str(data, compress))
+
+    def send_bytes(self, data: bytes,
+                   compress: Optional[int] = None) -> None:
+        return async_to_blocking(self.ws.send_bytes(data, compress))
+
+    def send_json(self, data: Any,
+                  compress: Optional[int] = None,
+                  *, dumps: aiohttp.typedefs.JSONEncoder = aiohttp.typedefs.DEFAULT_JSON_ENCODER) -> None:
+        return async_to_blocking(self.ws.send_json(data, compress, dumps=dumps))
+
+    def close(self, *, code: int = 1000, message: bytes = b'') -> bool:
+        return async_to_blocking(self.ws.close(code=code, message=message))
+
+    def receive(self, timeout: Optional[float] = None) -> aiohttp.WSMessage:
+        return async_to_blocking(self.ws.receive(timeout))
+
+    def receive_str(self, *, timeout: Optional[float] = None) -> str:
+        return async_to_blocking(self.ws.receive_str(timeout))
+
+    def receive_bytes(self, *, timeout: Optional[float] = None) -> bytes:
+        return async_to_blocking(self.ws.receive_bytes(timeout))
+
+    def receive_json(self,
+                     *, loads: aiohttp.typedefs.JSONDecoder = aiohttp.typedefs.DEFAULT_JSON_DECODER,
+                     timeout: Optional[float] = None) -> Any:
+        return async_to_blocking(self.ws.receive_json(loads=loads, timeout=timeout))
+
+    def __iter__(self) -> 'BlockingWebSocketClientResponse':
+        return self
+
+    def __next__(self) -> aiohttp.WSMessage:
+        try:
+            return async_to_blocking(self.ws.__anext__())
+        except StopAsyncIteration as exc:
+            raise StopIteration() from exc
+
+
+class BlockingContextManager:
+    def __init__(self, context_manager):
+        self.context_manager = context_manager
+
+    def __enter__(self) -> BlockingClientResponse:
+        return BlockingClientResponse(async_to_blocking(self.context_manager.__aenter__()))
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc: Optional[BaseException],
+                 tb: Optional[TracebackType]) -> None:
+        async_to_blocking(self.context_manager.__aexit__(exc_type, exc, tb))
+
+
+class BlockingWebSocketContextManager:
+    def __init__(self, context_manager):
+        self.context_manager = context_manager
+
+    def __enter__(self) -> BlockingWebSocketClientResponse:
+        return BlockingWebSocketClientResponse(async_to_blocking(self.context_manager.__aenter__()))
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc: Optional[BaseException],
+                 tb: Optional[TracebackType]) -> None:
+        async_to_blocking(self.context_manager.__aexit__(exc_type, exc, tb))
+
+
+class BlockingClientSession:
+    def __init__(self, session: ClientSession):
+        self.session = session
+
+    def request(self,
+                method: str,
+                url: aiohttp.typedefs.StrOrURL,
+                **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.request(
+            method, url, **kwargs))
+
+    def ws_connect(self,
+                   url: aiohttp.typedefs.StrOrURL,
+                   **kwargs: Any) -> 'BlockingWebSocketContextManager':
+        return BlockingWebSocketContextManager(self.session.ws_connect(
+            url, **kwargs))
+
+    def get(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            allow_redirects: bool = True,
+            **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.get(
+            url, allow_redirects=allow_redirects, **kwargs))
+
+    def options(self,
+                url: aiohttp.typedefs.StrOrURL,
+                *,
+                allow_redirects: bool = True,
+                **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.options(
+            url, allow_redirects=allow_redirects, **kwargs))
+
+    def head(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             allow_redirects: bool = False,
+             **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.head(
+            url, allow_redirects=allow_redirects, **kwargs))
+
+    def post(self,
+             url: aiohttp.typedefs.StrOrURL,
+             *,
+             data: Any = None, **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.post(
+            url, data=data, **kwargs))
+
+    def put(self,
+            url: aiohttp.typedefs.StrOrURL,
+            *,
+            data: Any = None,
+            **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.put(
+            url, data=data, **kwargs))
+
+    def patch(self,
+              url: aiohttp.typedefs.StrOrURL,
+              *,
+              data: Any = None,
+              **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.patch(
+            url, data=data, **kwargs))
+
+    def delete(self,
+               url: aiohttp.typedefs.StrOrURL,
+               **kwargs: Any) -> 'BlockingContextManager':
+        return BlockingContextManager(self.session.delete(
+            url, **kwargs))
+
+    def close(self) -> None:
+        async_to_blocking(self.session.close())
+
+    @property
+    def closed(self) -> bool:
+        return self.session.closed
+
+    @property
+    def cookie_jar(self) -> aiohttp.abc.AbstractCookieJar:
+        return self.session.cookie_jar
+
+    @property
+    def version(self) -> Tuple[int, int]:
+        return self.session.version
+
+    def __enter__(self) -> 'BlockingClientSession':
+        self.session = async_to_blocking(self.session.__aenter__())
+        return self
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> None:
+        self.close()

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -109,7 +109,7 @@ class ClientSession:
         retry_transient = kwargs.pop('retry_transient', self.retry_transient)
         if retry_transient:
             coroutine = retry_transient_errors(
-                self.session._ws_connect, url, **kwargs))
+                self.session._ws_connect, url, **kwargs)
         else:
             coroutine = self.session._ws_connect(url, **kwargs)
         return WebSocketResponseManager(coroutine)

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -1,18 +1,13 @@
 from typing import Dict
-import aiohttp
 import logging
 import json
 import os
 import ssl
 from ssl import Purpose
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.poolmanager import PoolManager
 
-log = logging.getLogger('hailtop.ssl')
-server_ssl_context = None
-client_ssl_context = None
-no_hostname_checks_client_ssl_context = None
+log = logging.getLogger('hailtop.tls')
+_server_ssl_context = None
+_client_ssl_context = None
 
 
 class NoSSLConfigFound(Exception):
@@ -30,92 +25,6 @@ def _get_ssl_config() -> Dict[str, str]:
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')
 
 
-def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
-    global server_ssl_context
-    if server_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        server_ssl_context = ssl.create_default_context(
-            purpose=Purpose.CLIENT_AUTH,
-            cafile=ssl_config['incoming_trust'])
-        server_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
-        server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
-        # FIXME: mTLS
-        # server_ssl_context.verify_mode = ssl.CERT_REQURIED
-        server_ssl_context.check_hostname = False  # clients have no hostnames
-    return server_ssl_context
-
-
-def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
-    global client_ssl_context
-    if client_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        client_ssl_context = ssl.create_default_context(
-            purpose=Purpose.SERVER_AUTH,
-            cafile=ssl_config['outgoing_trust'])
-        client_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
-        client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        client_ssl_context.check_hostname = True
-    return client_ssl_context
-
-
-def get_in_cluster_no_hostname_checks_client_ssl_context() -> ssl.SSLContext:
-    global no_hostname_checks_client_ssl_context
-    if no_hostname_checks_client_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        no_hostname_checks_client_ssl_context = ssl.create_default_context(
-            purpose=Purpose.SERVER_AUTH,
-            cafile=ssl_config['outgoing_trust'])
-        no_hostname_checks_client_ssl_context.load_cert_chain(
-            ssl_config['cert'],
-            keyfile=ssl_config['key'],
-            password=None)
-        no_hostname_checks_client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        no_hostname_checks_client_ssl_context.check_hostname = False
-    return no_hostname_checks_client_ssl_context
-
-
-def get_context_specific_client_ssl_context() -> ssl.SSLContext:
-    try:
-        return get_in_cluster_client_ssl_context()
-    except NoSSLConfigFound:
-        log.info('no ssl config file found, using external configuration. This '
-                 'context cannot connect directly to services inside the cluster.')
-        return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
-
-
-def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def in_cluster_no_hostname_checks_ssl_client_connection(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_no_hostname_checks_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def get_context_specific_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_context_specific_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def in_cluster_ssl_requests_client_session() -> requests.Session:
-    session = requests.Session()
-    ssl_config = _get_ssl_config()
-    session.mount('https://', TLSAdapter(ssl_config['cert'],
-                                         ssl_config['key'],
-                                         ssl_config['outgoing_trust'],
-                                         max_retries=1,
-                                         timeout=5))
-    return session
-
-
 def check_ssl_config(ssl_config: Dict[str, str]):
     for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
         assert ssl_config.get(key) is not None, key
@@ -125,23 +34,41 @@ def check_ssl_config(ssl_config: Dict[str, str]):
     log.info('using tls and verifying client and server certificates')
 
 
-class TLSAdapter(HTTPAdapter):
-    def __init__(self, ssl_cert, ssl_key, ssl_ca, max_retries, timeout):
-        super().__init__()
-        self.ssl_cert = ssl_cert
-        self.ssl_key = ssl_key
-        self.ssl_ca = ssl_ca
-        self.max_retries = max_retries
-        self.timeout = timeout
+def internal_server_ssl_context() -> ssl.SSLContext:
+    global _server_ssl_context
+    if _server_ssl_context is None:
+        ssl_config = _get_ssl_config()
+        _server_ssl_context = ssl.create_default_context(
+            purpose=Purpose.CLIENT_AUTH,
+            cafile=ssl_config['incoming_trust'])
+        _server_ssl_context.load_cert_chain(ssl_config['cert'],
+                                            keyfile=ssl_config['key'],
+                                            password=None)
+        _server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
+        # FIXME: mTLS
+        # _server_ssl_context.verify_mode = ssl.CERT_REQURIED
+        _server_ssl_context.check_hostname = False  # clients have no hostnames
+    return _server_ssl_context
 
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            key_file=self.ssl_key,
-            cert_file=self.ssl_cert,
-            ca_certs=self.ssl_ca,
-            assert_hostname=True,
-            retries=self.max_retries,
-            timeout=self.timeout)
+
+def internal_client_ssl_context() -> ssl.SSLContext:
+    global _client_ssl_context
+    if _client_ssl_context is None:
+        ssl_config = _get_ssl_config()
+        _client_ssl_context = ssl.create_default_context(
+            purpose=Purpose.SERVER_AUTH,
+            cafile=ssl_config['outgoing_trust'])
+        # setting cafile in `create_default_context` ignores the system default
+        # certificates. We must explicitly request them again with
+        # load_default_certs.
+        _client_ssl_context.load_default_certs()
+        _client_ssl_context.load_cert_chain(ssl_config['cert'],
+                                            keyfile=ssl_config['key'],
+                                            password=None)
+        _client_ssl_context.verify_mode = ssl.CERT_REQUIRED
+        _client_ssl_context.check_hostname = True
+    return _client_ssl_context
+
+
+def external_client_ssl_context() -> ssl.SSLContext:
+    return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,14 +1,10 @@
 from .time import time_msecs, time_msecs_str, humanize_timedelta_msecs
 from .utils import (
-    unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool,
-    bounded_gather, grouped, sleep_and_backoff, is_transient_error,
-    request_retry_transient_errors, request_raise_transient_errors,
-    collect_agen, retry_all_errors, retry_transient_errors,
+    unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, bounded_gather, grouped,
+    sleep_and_backoff, is_transient_error, collect_agen, retry_all_errors, retry_transient_errors,
     retry_long_running, run_if_changed, run_if_changed_idempotent, LoggingTimer,
-    WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
-    retry_response_returning_functions, first_extant_file, secret_alnum_string,
-    flatten, partition, cost_str, external_requests_client_session, url_basename,
-    url_join, cost_str)
+    WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors, first_extant_file,
+    secret_alnum_string, flatten, partition, cost_str, url_basename, url_join)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -60,7 +56,6 @@ __all__ = [
     'RateLimiter',
     'partition',
     'cost_str',
-    'external_requests_client_session',
     'url_basename',
     'url_join',
     'serialization'

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -8,7 +8,7 @@ from .utils import (
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
-    url_join)
+    url_join, cost_str)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -45,14 +45,11 @@ __all__ = [
     'run_if_changed_idempotent',
     'LoggingTimer',
     'WaitableSharedPool',
-    'request_retry_transient_errors',
-    'request_raise_transient_errors',
     'collect_agen',
     'tqdm',
     'TQDM_DEFAULT_DISABLE',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
-    'retry_response_returning_functions',
     'first_extant_file',
     'secret_alnum_string',
     'rate_gib_hour_to_mib_msec',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -15,8 +15,6 @@ import requests
 import google.auth.exceptions
 import time
 import weakref
-from requests.adapters import HTTPAdapter
-from urllib3.poolmanager import PoolManager
 
 from .time import time_msecs
 
@@ -387,7 +385,7 @@ async def retry_transient_errors(f: Callable[..., Awaitable[T]], *args, **kwargs
         delay = await sleep_and_backoff(delay)
 
 
-def sync_retry_transient_errors(f, *args, **kwargs):
+def sync_retry_transient_errors(f: Callable[..., T], *args, **kwargs) -> T:
     delay = 0.1
     errors = 0
     while True:
@@ -402,61 +400,6 @@ def sync_retry_transient_errors(f, *args, **kwargs):
             else:
                 raise
         delay = sync_sleep_and_backoff(delay)
-
-
-async def request_retry_transient_errors(session, method, url, **kwargs):
-    return await retry_transient_errors(session.request, method, url, **kwargs)
-
-
-async def request_raise_transient_errors(session, method, url, **kwargs):
-    try:
-        return await session.request(method, url, **kwargs)
-    except Exception as e:
-        if is_transient_error(e):
-            log.exception('request failed with transient exception: {method} {url}')
-            raise web.HTTPServiceUnavailable()
-        raise
-
-
-def retry_response_returning_functions(fun, *args, **kwargs):
-    delay = 0.1
-    errors = 0
-    response = sync_retry_transient_errors(
-        fun, *args, **kwargs)
-    while response.status_code in RETRYABLE_HTTP_STATUS_CODES:
-        errors += 1
-        if errors % 10 == 0:
-            log.warning(f'encountered {errors} bad status codes, most recent '
-                        f'one was {response.status_code}')
-        response = sync_retry_transient_errors(
-            fun, *args, **kwargs)
-        delay = sync_sleep_and_backoff(delay)
-    return response
-
-
-def external_requests_client_session(headers=None, timeout=5) -> requests.Session:
-    session = requests.Session()
-    adapter = TimeoutHTTPAdapter(max_retries=1, timeout=timeout)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
-    if headers:
-        session.headers = headers
-    return session
-
-
-class TimeoutHTTPAdapter(HTTPAdapter):
-    def __init__(self, max_retries, timeout):
-        self.max_retries = max_retries
-        self.timeout = timeout
-        super().__init__(max_retries=max_retries)
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            retries=self.max_retries,
-            timeout=self.timeout)
 
 
 async def collect_agen(agen):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -6,7 +6,6 @@ import random
 import logging
 import asyncio
 import aiohttp
-from aiohttp import web
 import urllib
 import urllib3
 import secrets

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -8,7 +8,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
         self.assertEqual(deploy_config.service_ns('foo'), 'default')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
         self.assertEqual(deploy_config.domain('quam'), 'quam.organization.tld')
@@ -23,7 +23,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'bar')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')
@@ -37,7 +37,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
         self.assertEqual(deploy_config.service_ns('foo'), 'default')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
         self.assertEqual(deploy_config.domain('quam'), 'quam.default')
@@ -52,7 +52,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.service_ns('quam'), 'bar')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
-        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.scheme('batch'), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -53,6 +53,8 @@ object HailContext {
 
   def backend: Backend = get.backend
 
+  def isValidFlag(flag: String): Boolean = get.flags.exists(flag)
+
   def getFlag(flag: String): String = get.flags.get(flag)
 
   def setFlag(flag: String, value: String): Unit = get.flags.set(flag, value)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -339,6 +339,9 @@ class ServiceBackend() extends Backend {
 
   def getFlag(name: String): Response = {
     statusForException {
+      if (!HailContext.isValidFlag(name)) {
+        fatal(s"No such flag ${name}")
+      }
       val v = HailContext.getFlag(name)
       JsonMethods.compact(if (v == null) JNull else JString(v))
     }
@@ -346,6 +349,9 @@ class ServiceBackend() extends Backend {
 
   def setFlag(name: String, value: String): Response = {
     statusForException {
+      if (!HailContext.isValidFlag(name)) {
+        fatal(s"No such flag ${name}")
+      }
       val v = HailContext.getFlag(name)
       HailContext.setFlag(name, value)
       JsonMethods.compact(if (v == null) JNull else JString(v))
@@ -354,6 +360,9 @@ class ServiceBackend() extends Backend {
 
   def unsetFlag(name: String): Response = {
     statusForException {
+      if (!HailContext.isValidFlag(name)) {
+        fatal(s"No such flag ${name}")
+      }
       val v = HailContext.getFlag(name)
       HailContext.setFlag(name, null)
       JsonMethods.compact(if (v == null) JNull else JString(v))

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -12,7 +12,7 @@ import kubernetes_asyncio as kube
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors
 from gear import setup_aiohttp_session, rest_authenticated_users_only
 
@@ -131,4 +131,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -10,7 +10,7 @@ from hailtop import aiogoogle, aiotools
 from hailtop.aiogoogle import BigQueryClient
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import run_if_changed_idempotent, retry_long_running, time_msecs, cost_str
 from gear import (Database, setup_aiohttp_session,
                   web_authenticated_developers_only, rest_authenticated_developers_only,
@@ -252,4 +252,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -12,7 +12,7 @@ from kubernetes_asyncio import client, config
 import kubernetes_asyncio as kube
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, create_database_pool,
                   web_authenticated_users_only, web_maybe_authenticated_user,
@@ -814,4 +814,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from hailtop.hail_logging import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop import httpx
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with get_context_specific_ssl_client_session(raise_for_status=True) as session:
+    async with httpx.client_session() as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/query/Makefile
+++ b/query/Makefile
@@ -32,5 +32,5 @@ push: build
 deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	kubectl -n $(NAMESPACE) apply -f service-account.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -10,7 +10,7 @@ import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, rest_authenticated_users_only, rest_authenticated_developers_only
 
@@ -233,4 +233,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/query/test/test_query.py
+++ b/query/test/test_query.py
@@ -2,6 +2,7 @@ import pytest
 import hail as hl
 from hailtop.hailctl.dev.query import cli
 
+
 def test_simple_table():
     t = hl.utils.range_table(50, 3)
     t = t.filter((t.idx % 3 == 0) | ((t.idx / 7) % 3 == 0))

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -5,7 +5,7 @@ import aiohttp_session
 from kubernetes_asyncio import client, config
 import logging
 from hailtop.auth import async_get_userinfo
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import configure_logging
 from gear import setup_aiohttp_session
 
@@ -102,4 +102,4 @@ app.on_startup.append(on_startup)
 web.run_app(app,
             host='0.0.0.0',
             port=5000,
-            ssl_context=get_in_cluster_server_ssl_context())
+            ssl_context=internal_server_ssl_context())

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -98,3 +98,6 @@ principals:
 - name: auth-tests
   domain: auth-tests
   kind: json
+- name: create-billing-projects
+  domain: create-billing-projects
+  kind: json

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -95,3 +95,6 @@ principals:
 - name: atgu
   domain: atgu
   kind: json
+- name: auth-tests
+  domain: auth-tests
+  kind: json


### PR DESCRIPTION
I simplified the TLS context methods into three cases: internal server, external
client session, internal client.

I added a blocking shim around aiohttp so that all our HTTP goes through
aiohttp. I added automatic retrying directly into the httpx library.