### PR TITLE
[batch] change worker to default to the private network

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -697,12 +697,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         'mount_path': '/user-tokens',
                         'mount_in_copy': True
                     })
-                    secrets.append({
-                        'namespace': DEFAULT_NAMESPACE,
-                        'name': 'gce-deploy-config',
-                        'mount_path': '/deploy-config',
-                        'mount_in_copy': True
-                    })
 
                 sa = spec.get('service_account')
                 check_service_account_permissions(user, sa)

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -304,7 +304,7 @@ class Container:
 
         network = self.spec.get('network')
         if network is None:
-            network = 'private'
+            network = 'public'
         host_config['NetworkMode'] = network  # not documented, I used strace to inspect the packets
 
         config['HostConfig'] = host_config


### PR DESCRIPTION
At this point, every job that needs the private network specifies
it (https://github.com/hail-is/hail/pull/9380). This change moves jobs with
unspecified `network` to the private network.

I removed the gce-deploy-config because jobs should not, by default, assume they
are on the private network. The GCE Deploy Config instructs you to enter GKE
using the internal-gateway, which is on our private network.