### PR TITLE
[batch] change worker to default to the private network

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -697,12 +697,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         'mount_path': '/user-tokens',
                         'mount_in_copy': True
                     })
-                    secrets.append({
-                        'namespace': DEFAULT_NAMESPACE,
-                        'name': 'gce-deploy-config',
-                        'mount_path': '/deploy-config',
-                        'mount_in_copy': True
-                    })
 
                 sa = spec.get('service_account')
                 check_service_account_permissions(user, sa)

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -304,7 +304,7 @@ class Container:
 
         network = self.spec.get('network')
         if network is None:
-            network = 'private'
+            network = 'public'
         host_config['NetworkMode'] = network  # not documented, I used strace to inspect the packets
 
         config['HostConfig'] = host_config

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -601,20 +601,8 @@ def test_verify_no_access_to_metadata_server(client):
 def test_user_authentication_within_job(client):
     batch = client.create_batch()
     cmd = ['bash', '-c', 'hailctl auth user']
-    with_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=True)
     no_token = batch.create_job(os.environ['CI_UTILS_IMAGE'], cmd, mount_tokens=False)
     batch.submit()
-
-    with_token_status = with_token.wait()
-    assert with_token_status['state'] == 'Success', f'{(with_token.log(), with_token_status)}'
-
-    username = get_userinfo()['username']
-
-    try:
-        job_userinfo = json.loads(with_token.log()['main'].strip())
-    except Exception:
-        job_userinfo = None
-    assert job_userinfo is not None and job_userinfo["username"] == username, (username, with_token.log()['main'])
 
     no_token_status = no_token.wait()
     assert no_token_status['state'] == 'Failed', f'{(no_token.log(), no_token_status)}'


### PR DESCRIPTION
At this point, every job that needs the private network specifies
it (https://github.com/hail-is/hail/pull/9380). This change moves jobs with
unspecified `network` to the private network.

I removed the gce-deploy-config because jobs should not, by default, assume they
are on the private network. The GCE Deploy Config instructs you to enter GKE
using the internal-gateway, which is on our private network.