### PR TITLE
[query] Add or_error method to SwitchBuilder

### DIFF
--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -83,7 +83,7 @@ class SwitchBuilder(ConditionalBuilder):
     @typecheck_method(value=expr_any, then=expr_any)
     def when(self, value, then) -> 'SwitchBuilder':
         """Add a value test. If the `base` expression is equal to `value`, then
-         returns `then`.
+        returns `then`.
 
         Warning
         -------
@@ -173,6 +173,28 @@ class SwitchBuilder(ConditionalBuilder):
             raise ExpressionException("'or_missing' cannot be called without at least one 'when' call")
         from hail.expr.functions import null
         return self._finish(null(self._ret_type))
+
+    @typecheck_method(message=expr_str)
+    def or_error(self, message):
+        """Finish the switch statement by throwing an error with the given message.
+
+        Notes
+        -----
+        If no value from a :meth:`.SwitchBuilder.when` call is matched, then an
+        error is thrown.
+
+        Parameters
+        ----------
+        message : :class:`.Expression` of type :obj:`.tstr`
+
+        Returns
+        -------
+        :class:`.Expression`
+        """
+        if len(self._cases) == 0:
+            raise ExpressionException("'or_error' cannot be called without at least one 'when' call")
+        error_expr = construct_expr(ir.Die(message._ir, self._ret_type), self._ret_type)
+        return self._finish(error_expr)
 
 
 class CaseBuilder(ConditionalBuilder):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1182,6 +1182,10 @@ class Tests(unittest.TestCase):
             .default(4))
         self.assertEqual(hl.eval(expr5), -1)
 
+        with pytest.raises(hl.utils.java.HailUserError) as exc:
+            hl.eval(hl.switch(x).when('0', 0).or_error("foo"))
+        assert '.or_error("foo")' in str(exc.value)
+
     def test_case(self):
         def make_case(x):
             x = hl.literal(x)


### PR DESCRIPTION
CaseBuilder has an `or_error` method to throw an error if no `when` conditions are true. Currently, SwitchBuilder does not have an equivalent method: it only supports returning a default value or missing. The option to throw an error on an unhandled value can be useful for making sure that all possible values for an enum expression have been accounted for in switch cases.