### PR TITLE
[query] Fix bug with constructing an array of empty structs

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -158,7 +158,7 @@ def impute_type(x):
             raise ExpressionException("Cannot impute type of empty list. Use 'hl.empty_array' to create an empty array.")
         ts = {impute_type(element) for element in x}
         unified_type = unify_types_limited(*ts)
-        if not unified_type:
+        if unified_type is None:
             raise ExpressionException("Hail does not support heterogeneous arrays: "
                                       "found list with elements of types {} ".format(list(ts)))
         return tarray(unified_type)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2396,6 +2396,11 @@ class Tests(unittest.TestCase):
         assert hl.eval(a.index(lambda x: x % 2 == 0) == 1)
         assert hl.eval(a.index(lambda x: x > 5)) is None
 
+    def test_array_empty_struct(self):
+        a = hl.array([hl.struct()])
+        b = hl.literal([hl.struct()])
+        assert hl.eval(a) == hl.eval(b)
+
     def test_bool_r_ops(self):
         self.assertTrue(hl.eval(hl.literal(True) & True))
         self.assertTrue(hl.eval(True & hl.literal(True)))


### PR DESCRIPTION
Fixes #9750 

The problem was that `bool(hl.struct())` is `False`. 