### PR TITLE
[batch] better status information for jobs

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1228,7 +1228,8 @@ async def ui_get_job(request, userdata):
     job_specification = dictfix.dictfix(job_specification,
                                         dictfix.NoneOr({'image': str,
                                                         'command': list,
-                                                        'resources': dict()}))
+                                                        'resources': dict(),
+                                                        'env': list}))
 
     page_context = {
         'batch_id': batch_id,

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -8,39 +8,39 @@
 <table class="data-table">
   <thead>
     <tr>
-	    <th>Attempt ID</th>
-	    <th>Instance</th>
-	    <th>Start</th>
-	    <th>End</th>
-	    <th>Duration</th>
-	    <th>Reason</th>
+      <th>Attempt ID</th>
+      <th>Instance</th>
+      <th>Start</th>
+      <th>End</th>
+      <th>Duration</th>
+      <th>Reason</th>
     </tr>
   </thead>
   <tbody>
     {% for attempt in attempts %}
     <tr>
-	    <td class="numeric-cell">{{ attempt['attempt_id'] }}</td>
-	    <td>{{ attempt['instance_name'] }}</td>
-	    <td>
-	      {% if 'start_time' in attempt and attempt['start_time'] is not none %}
-	      {{ attempt['start_time'] }}
-	      {% endif %}
-	    </td>
-	    <td>
-	      {% if 'end_time' in attempt and attempt['end_time'] is not none %}
-	      {{ attempt['end_time'] }}
-	      {% endif %}
-	    </td>
-	    <td>
-	      {% if 'duration' in attempt and attempt['duration'] is not none %}
-	      {{ attempt['duration'] }}
-	      {% endif %}
-	    </td>
-	    <td>
-	      {% if 'reason' in attempt and attempt['reason'] is not none %}
-	      {{ attempt['reason'] }}
-	      {% endif %}
-	    </td>
+      <td class="numeric-cell">{{ attempt['attempt_id'] }}</td>
+      <td>{{ attempt['instance_name'] }}</td>
+      <td>
+        {% if 'start_time' in attempt and attempt['start_time'] is not none %}
+        {{ attempt['start_time'] }}
+        {% endif %}
+      </td>
+      <td>
+        {% if 'end_time' in attempt and attempt['end_time'] is not none %}
+        {{ attempt['end_time'] }}
+        {% endif %}
+      </td>
+      <td>
+        {% if 'duration' in attempt and attempt['duration'] is not none %}
+        {{ attempt['duration'] }}
+        {% endif %}
+      </td>
+      <td>
+        {% if 'reason' in attempt and attempt['reason'] is not none %}
+        {{ attempt['reason'] }}
+        {% endif %}
+      </td>
     </tr>
     {% endfor %}
   </tbody>
@@ -53,29 +53,29 @@
 <table class="data-table">
   <thead>
     <tr>
-	    <th>Job Step</th>
-	    <th>Image Pulling Time (s)</th>
-	    <th>Running Time (s)</th>
-	    <th>Exceeded Memory Limits?</th>
-	    <th>State</th>
+      <th>Job Step</th>
+      <th>Image Pulling Time (s)</th>
+      <th>Running Time (s)</th>
+      <th>Exceeded Memory Limits?</th>
+      <th>State</th>
     </tr>
   </thead>
   <tbody>
     {% for step in step_statuses %}
     {% if step %}
     <tr>
-	    <td>{{ step['name'] }}</td>
-	    <td>
+      <td>{{ step['name'] }}</td>
+      <td>
         {% if step['timing']['pulling'] %}
         {{ step['timing']['pulling']['duration'] / 1000.0 }}
         {% endif %}
       </td>
-	    <td>
+      <td>
         {% if step['timing']['running'] %}
         {{ step['timing']['running']['duration'] / 1000.0 }}
         {% endif %}
       </td>
-	    {% if step['container_status']['out_of_memory'] %}
+      {% if step['container_status']['out_of_memory'] %}
       <td class="data-table-bad" >Yes</td>
       {% else %}
       <td>No</td>
@@ -112,8 +112,8 @@
 <table class="data-table">
   <thead>
     <tr>
-	    <th>Name</th>
-	    <th>Value</th>
+      <th>Name</th>
+      <th>Value</th>
     </tr>
   </thead>
   {% if job_specification %}

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -136,6 +136,26 @@
   {% endif %}
 </table>
 
+<h2>Job Environment Variables</h2>
+<table class="data-table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  {% if job_specification %}
+  <tbody>
+  {% for envvar in job_specification['env'] %}
+    <tr>
+      <td>{{ envvar['name'] }}</td>
+      <td>{{ envvar['value'] }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+  {% endif %}
+</table>
+
 <h2>Status</h2>
 <pre>{{ job_status_str }}</pre>
 {% endblock %}

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -1,73 +1,141 @@
 {% extends "layout.html" %}
 {% block title %}Batch {{ batch_id }} Job {{ job_id }}{% endblock %}
 {% block content %}
-  <h1>Batch {{ batch_id }} Job {{ job_id }}</h1>
+<h1>Batch {{ batch_id }} Job {{ job_id }}</h1>
 
-  <h2>Attempts</h2>
-  {% if attempts %}
-  <table class="data-table">
-    <thead>
-      <tr>
-	<th>Attempt ID</th>
-	<th>Instance</th>
-	<th>Start</th>
-	<th>End</th>
-	<th>Duration</th>
-	<th>Reason</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for attempt in attempts %}
-      <tr>
-	<td class="numeric-cell">{{ attempt['attempt_id'] }}</td>
-	<td>{{ attempt['instance_name'] }}</td>
-	<td>
-	  {% if 'start_time' in attempt and attempt['start_time'] is not none %}
-	  {{ attempt['start_time'] }}
-	  {% endif %}
-	</td>
-	<td>
-	  {% if 'end_time' in attempt and attempt['end_time'] is not none %}
-	  {{ attempt['end_time'] }}
-	  {% endif %}
-	</td>
-	<td>
-	  {% if 'duration' in attempt and attempt['duration'] is not none %}
-	  {{ attempt['duration'] }}
-	  {% endif %}
-	</td>
-	<td>
-	  {% if 'reason' in attempt and attempt['reason'] is not none %}
-	  {{ attempt['reason'] }}
-	  {% endif %}
-	</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p>No attempts</p>
+<h2>Attempts</h2>
+{% if attempts %}
+<table class="data-table">
+  <thead>
+    <tr>
+	    <th>Attempt ID</th>
+	    <th>Instance</th>
+	    <th>Start</th>
+	    <th>End</th>
+	    <th>Duration</th>
+	    <th>Reason</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for attempt in attempts %}
+    <tr>
+	    <td class="numeric-cell">{{ attempt['attempt_id'] }}</td>
+	    <td>{{ attempt['instance_name'] }}</td>
+	    <td>
+	      {% if 'start_time' in attempt and attempt['start_time'] is not none %}
+	      {{ attempt['start_time'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'end_time' in attempt and attempt['end_time'] is not none %}
+	      {{ attempt['end_time'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'duration' in attempt and attempt['duration'] is not none %}
+	      {{ attempt['duration'] }}
+	      {% endif %}
+	    </td>
+	    <td>
+	      {% if 'reason' in attempt and attempt['reason'] is not none %}
+	      {{ attempt['reason'] }}
+	      {% endif %}
+	    </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No attempts</p>
+{% endif %}
+
+<h2>Step Status</h2>
+<table class="data-table">
+  <thead>
+    <tr>
+	    <th>Job Step</th>
+	    <th>Image Pulling Time (s)</th>
+	    <th>Running Time (s)</th>
+	    <th>Exceeded Memory Limits?</th>
+	    <th>State</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for step in step_statuses %}
+    {% if step %}
+    <tr>
+	    <td>{{ step['name'] }}</td>
+	    <td>
+        {% if step['timing']['pulling'] %}
+        {{ step['timing']['pulling']['duration'] / 1000.0 }}
+        {% endif %}
+      </td>
+	    <td>
+        {% if step['timing']['running'] %}
+        {{ step['timing']['running']['duration'] / 1000.0 }}
+        {% endif %}
+      </td>
+	    {% if step['container_status']['out_of_memory'] %}
+      <td class="data-table-bad" >Yes</td>
+      {% else %}
+      <td>No</td>
+      {% endif %}
+      <td {% if step['state'] in ['failed', 'error'] %}class="data-table-bad"{% endif %}>
+        {{ step['state'] }}
+      </td>
+    </tr>
+    {% endif %}
+    {% endfor %}
+  </tbody>
+</table>
+
+{% if job_log %}
+<h2>Log</h2>
+
+{% if 'input' in job_log %}
+<h3>Input</h3>
+<pre>{{ job_log['input'] }}</pre>
+{% endif %}
+
+{% if 'main' in job_log %}
+<h3>Main</h3>
+<pre>{{ job_log['main'] }}</pre>
+{% endif %}
+
+{% if 'output' in job_log %}
+<h3>Output</h3>
+<pre>{{ job_log['output'] }}</pre>
+{% endif %}
+{% endif %}
+
+<h2>Job Specification</h2>
+<table class="data-table">
+  <thead>
+    <tr>
+	    <th>Name</th>
+	    <th>Value</th>
+    </tr>
+  </thead>
+  {% if job_specification %}
+  <tbody>
+    <tr>
+      <td>image</td>
+      <td>{{ job_specification['image'] }}</td>
+    </tr>
+    <tr>
+      <td>command</td>
+      <td><pre style="max-height: 10em; max-width: 80em;">{{ "'" + (job_specification['command'] | join("' '")) + "'" }}</pre></td>
+    </tr>
+    {% for resource, value in job_specification['resources'].items() %}
+    <tr>
+      <td>{{ resource }}</td>
+      <td>{{ value }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
   {% endif %}
+</table>
 
-  {% if job_log %}
-    <h2>Log</h2>
-
-    {% if 'input' in job_log %}
-      <h3>Input</h3>
-      <pre>{{ job_log['input'] }}</pre>
-    {% endif %}
-
-    {% if 'main' in job_log %}
-      <h3>Main</h3>
-      <pre>{{ job_log['main'] }}</pre>
-    {% endif %}
-
-    {% if 'output' in job_log %}
-      <h3>Output</h3>
-      <pre>{{ job_log['output'] }}</pre>
-    {% endif %}
-  {% endif %}
-
-  <h2>Status</h2>
-  <pre>{{ job_status }}</pre>
+<h2>Status</h2>
+<pre>{{ job_status_str }}</pre>
 {% endblock %}

--- a/hail/python/hailtop/dictfix.py
+++ b/hail/python/hailtop/dictfix.py
@@ -19,9 +19,7 @@ def _dictfix(x, spec):
         if x is None:
             x = dict()
         for k, subspec in spec.items():
-            v = None
-            if k in x:
-                v = x.get(k)
+            v = x.get(k)
             try:
                 x[k] = _dictfix(v, subspec)
             except AssertionError as err:

--- a/hail/python/hailtop/dictfix.py
+++ b/hail/python/hailtop/dictfix.py
@@ -5,7 +5,7 @@ class NoneOr:
 
 def dictfix(x, spec):
     assert isinstance(x, dict) or x is None
-    assert isinstance(spec, dict) or isinstance(spec, NoneOr)
+    assert isinstance(spec, (NoneOr, dict))
     return _dictfix(x, spec)
 
 
@@ -26,7 +26,7 @@ def _dictfix(x, spec):
             try:
                 x[k] = _dictfix(v, subspec)
             except AssertionError as err:
-                raise AssertionError(f'{k}:{v}', err)
+                raise AssertionError(f'{k}:{v}') from err
     else:
         if x is None:
             x = spec

--- a/hail/python/hailtop/dictfix.py
+++ b/hail/python/hailtop/dictfix.py
@@ -16,7 +16,6 @@ def _dictfix(x, spec):
     elif isinstance(spec, type):
         assert isinstance(x, spec), f'{x!r} should be {spec!r}'
     elif isinstance(spec, dict):
-
         if x is None:
             x = dict()
         for k, subspec in spec.items():

--- a/hail/python/hailtop/dictfix.py
+++ b/hail/python/hailtop/dictfix.py
@@ -1,0 +1,33 @@
+class NoneOr:
+    def __init__(self, subspec):
+        self.subspec = subspec
+
+
+def dictfix(x, spec):
+    assert isinstance(x, dict) or x is None
+    assert isinstance(spec, dict) or isinstance(spec, NoneOr)
+    return _dictfix(x, spec)
+
+
+def _dictfix(x, spec):
+    if isinstance(spec, NoneOr):
+        if x is not None:
+            x = _dictfix(x, spec.subspec)
+    elif isinstance(spec, type):
+        assert isinstance(x, spec), f'{x!r} should be {spec!r}'
+    elif isinstance(spec, dict):
+
+        if x is None:
+            x = dict()
+        for k, subspec in spec.items():
+            v = None
+            if k in x:
+                v = x.get(k)
+            try:
+                x[k] = _dictfix(v, subspec)
+            except AssertionError as err:
+                raise AssertionError(f'{k}:{v}', err)
+    else:
+        if x is None:
+            x = spec
+    return x

--- a/hail/python/test/hailtop/test_dictfix.py
+++ b/hail/python/test/hailtop/test_dictfix.py
@@ -56,14 +56,6 @@ def test_type_asserts():
     else:
         assert False, actual
 
-    actual = {'x': 'hi'}
-    try:
-        dictfix.dictfix(actual, {'x': int})
-    except AssertionError:
-        pass
-    else:
-        assert False, actual
-
 
 def test_defaults():
     actual = {'x': None}

--- a/hail/python/test/hailtop/test_dictfix.py
+++ b/hail/python/test/hailtop/test_dictfix.py
@@ -83,5 +83,5 @@ def test_defaults():
     assert actual == {'x': 0}
 
     actual = None
-    dictfix.dictfix(actual, {'x': 3})
+    actual = dictfix.dictfix(actual, {'x': 3})
     assert actual == {'x': 3}

--- a/hail/python/test/hailtop/test_dictfix.py
+++ b/hail/python/test/hailtop/test_dictfix.py
@@ -1,0 +1,87 @@
+from hailtop import dictfix
+
+
+def test_batch_example():
+    spec = {'input': dictfix.NoneOr({'logs': None}),
+            'main': dictfix.NoneOr({'logs': None}),
+            'output': dictfix.NoneOr({'logs': None})}
+
+    expected = {'input': None, 'main': None, 'output': None}
+
+    actual = dict()
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+    actual = {'input': None}
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+    actual = {'main': None}
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+    actual = {'main': None, 'output': None}
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+    expected = {'input': None,
+                'main': {'id': 3, 'logs': None},
+                'output': None}
+    actual = {'main': {'id': 3}, 'output': None}
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+    expected = {'input': None,
+                'main': {'id': 3, 'logs': 'abc\n123'},
+                'output': {'id': 4, 'logs': None}}
+    actual = {'main': {'id': 3, 'logs': 'abc\n123'}, 'output': {'id': 4}}
+    dictfix.dictfix(actual, spec)
+    assert actual == expected
+
+
+def test_type_asserts():
+    actual = {'x': 1}
+    try:
+        dictfix.dictfix(actual, {'x': str})
+    except AssertionError:
+        pass
+    else:
+        assert False, actual
+
+    actual = {'x': 'hi'}
+    try:
+        dictfix.dictfix(actual, {'x': int})
+    except AssertionError:
+        pass
+    else:
+        assert False, actual
+
+    actual = {'x': 'hi'}
+    try:
+        dictfix.dictfix(actual, {'x': int})
+    except AssertionError:
+        pass
+    else:
+        assert False, actual
+
+
+def test_defaults():
+    actual = {'x': None}
+    dictfix.dictfix(actual, {'x': 3})
+    assert actual == {'x': 3}
+
+    actual = dict()
+    dictfix.dictfix(actual, {'x': 3})
+    assert actual == {'x': 3}
+
+    actual = {'y': 1}
+    dictfix.dictfix(actual, {'x': 3})
+    assert actual == {'x': 3, 'y': 1}
+
+    actual = {'x': 0}
+    dictfix.dictfix(actual, {'x': 3})
+    assert actual == {'x': 0}
+
+    actual = None
+    dictfix.dictfix(actual, {'x': 3})
+    assert actual == {'x': 3}

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -241,10 +241,18 @@ a {
         &:nth-of-type(even) {
             background-color: #f2f2f2;
         }
+        td.data-table-bad {
+          color: red;
+          border-color: red;
+          background-color: #ffeaea;
+        }
     }
 
     tbody tr:hover {
         background-color: #ddd;
+        td.data-table-bad {
+          background-color: #ebd8d8;
+        }
     }
 }
 
@@ -410,4 +418,10 @@ a {
         transform: scale(1);
         opacity: 0;
     }
+}
+
+pre {
+  overflow: auto;
+  word-wrap: normal;
+  white-space: pre;
 }


### PR DESCRIPTION
1. Add `dictfix`, a little tool for wrangling json-like data into a sensible,
   standardized format.

2. Modify job.html to include a simple table of important parts of the job
   specification such as the command and the requests of cpu, memory, and
   storage.

3. Modify job.html to include a simple table summarizing the status and runtime
   of each step of the job.


My apologies for reformatting the whole file to have no excess spaces. Use the no whitespace diff option in GitHub for a better diff.
