### PR TITLE
[query] Warn in export_vcf if info field names are invalid in VCF v4.3

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from hail.typecheck import typecheck, nullable, oneof, dictof, anytype, \
     sequenceof, enumeration, sized_tupleof, numeric, table_key_type, char
@@ -504,6 +505,13 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
 
     require_col_key_str(dataset, 'export_vcf')
     require_row_key_variant(dataset, 'export_vcf')
+
+    info_fields = list(dataset.info) if "info" in dataset.row else []
+    invalid_info_fields = [f for f in info_fields if not re.fullmatch(r"^([A-Za-z_][0-9A-Za-z_.]*|1000G)", f)]
+    if invalid_info_fields:
+        invalid_info_str = ''.join(f'\n    {f!r}' for f in invalid_info_fields)
+        warning('export_vcf: the following info field names are invalid in VCF 4.3 and may not work with some tools: ' + invalid_info_str)
+
     row_fields_used = {'rsid', 'info', 'filters', 'qual'}
 
     fields_dropped = []


### PR DESCRIPTION
gnomAD v3.1 VCFs have many fields containing "-" ("AC-non_neuro-nfe-XX", etc). Someone pointed out that those are invalid in [VCF v4.3](https://samtools.github.io/hts-specs/VCFv4.3.pdf). Item 8 of section 1.6.1 of the specification says:

> INFO keys must match the regular expression ^([A-Za-z ][0-9A-Za-z .]*|1000G)$, please note that “1000G”
is allowed as a special legacy value. 

VCFs created by `hl.export_vcf` are marked as v4.2. However, it may still be useful to warn about these fields as it seems some tools expect the v4.3 pattern (samtools/bcftools#1335).