### PR TITLE
[query] Fix column major test to avoid extra copying

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -11,15 +11,18 @@ object LinalgCodeUtils {
   def checkColumnMajor(pndv: PNDArrayValue, cb: EmitCodeBuilder): Value[Boolean] = {
     val answer = cb.newField[Boolean]("checkColumnMajorResult")
     val shapes = pndv.shapes(cb)
+    val strides = pndv.strides(cb)
     val runningProduct = cb.newLocal[Long]("check_column_major_running_product")
 
     val elementType = pndv.pt.elementType
     val nDims = pndv.pt.nDims
+
+    cb.assign(answer, true)
     cb.append(Code(
       runningProduct := elementType.byteSize,
       Code.foreach(0 until nDims){ index =>
         Code(
-          answer := answer & (shapes(index) ceq runningProduct),
+          answer := answer & (strides(index) ceq runningProduct),
           runningProduct := runningProduct * (shapes(index) > 0L).mux(shapes(index), 1L)
         )
       }


### PR DESCRIPTION
There were two bugs when checking if an ndarray is column major, causing it to always return false. This method is used to decide whether we need to copy the ndarray into a column major form. By fixing this bug, we now don't have to copy both arrays before every matrix multiply.

Benchmark: linear_regression_rows_nd

Before fix timings:

[50.794169104999995, 51.562208821, 60.402329871999996]

After fix timings: 

[38.504665161, 39.919831891, 37.882298633999994]