### PR TITLE
[hail-ubuntu] fix warning

### DIFF
--- a/docker/hail-ubuntu/pip.conf
+++ b/docker/hail-ubuntu/pip.conf
@@ -1,6 +1,5 @@
 [global]
 timeout = 5
-use-feature = 2020-resolver
 upgrade = true
 no-cache-dir = true
 retries = 5


### PR DESCRIPTION
From the logs:
```
WARNING: --use-feature=2020-resolver no longer has any effect, since it is now the default dependency resolver in pip. This will become an error in pip 21.0.
```