### PR TITLE
[query] Clarify matrix table distinct methods

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3948,7 +3948,7 @@ class MatrixTable(ExprContainer):
         return MatrixTable(ir.MatrixRename(self._mir, global_map, col_map, row_map, entry_map))
 
     def distinct_by_row(self) -> 'MatrixTable':
-        """Remove rows with a duplicate row key, keeping only one row for each unique key.
+        """Remove rows with a duplicate row key, keeping exactly one row for each unique key.
 
         Returns
         -------
@@ -3957,7 +3957,7 @@ class MatrixTable(ExprContainer):
         return MatrixTable(ir.MatrixDistinctByRow(self._mir))
 
     def distinct_by_col(self) -> 'MatrixTable':
-        """Remove columns with a duplicate row key, keeping only one column for each unique key.
+        """Remove columns with a duplicate row key, keeping exactly one column for each unique key.
 
         Returns
         -------

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3948,7 +3948,7 @@ class MatrixTable(ExprContainer):
         return MatrixTable(ir.MatrixRename(self._mir, global_map, col_map, row_map, entry_map))
 
     def distinct_by_row(self) -> 'MatrixTable':
-        """Remove rows with a duplicate row key.
+        """Remove rows with a duplicate row key, keeping only one row for each unique key.
 
         Returns
         -------
@@ -3957,7 +3957,7 @@ class MatrixTable(ExprContainer):
         return MatrixTable(ir.MatrixDistinctByRow(self._mir))
 
     def distinct_by_col(self) -> 'MatrixTable':
-        """Remove columns with a duplicate row key.
+        """Remove columns with a duplicate row key, keeping only one column for each unique key.
 
         Returns
         -------

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3374,7 +3374,7 @@ class Table(ExprContainer):
             hl.struct(**{name: hl.agg.collect(self.row_value)})._ir))
 
     def distinct(self) -> 'Table':
-        """Deduplicate keys, keeping only one row for each unique key.
+        """Deduplicate keys, keeping exactly one row for each unique key.
 
         .. include:: _templates/req_keyed_table.rst
 


### PR DESCRIPTION
Clarified that matrix table distinct methods keep one value per key after a user asked if it deleted all rows that had a key duplicated somewhere or all but one of them. 