### PR TITLE
[batch] Refactor scheduler code for multiple instance pools

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -157,7 +157,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
     scheduler_state_changed = app['scheduler_state_changed']
     cancel_ready_state_changed = app['cancel_ready_state_changed']
     db = app['db']
-    inst_pool = app['inst_pool']
+    inst_monitor = app['inst_monitor']
 
     id = (batch_id, job_id)
 
@@ -179,7 +179,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
     cancel_ready_state_changed.set()
 
     if instance_name:
-        instance = inst_pool.name_instance.get(instance_name)
+        instance = inst_monitor.name_instance.get(instance_name)
         if instance:
             if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
                 # may also create scheduling opportunities, set above
@@ -260,7 +260,7 @@ async def unschedule_job(app, record):
     cancel_ready_state_changed = app['cancel_ready_state_changed']
     scheduler_state_changed = app['scheduler_state_changed']
     db = app['db']
-    inst_pool = app['inst_pool']
+    inst_monitor = app['inst_monitor']
 
     batch_id = record['batch_id']
     job_id = record['job_id']
@@ -287,7 +287,7 @@ async def unschedule_job(app, record):
     # job that was running is now ready to be cancelled
     cancel_ready_state_changed.set()
 
-    instance = inst_pool.name_instance.get(instance_name)
+    instance = inst_monitor.name_instance.get(instance_name)
     if not instance:
         log.warning(f'unschedule job {id}, attempt {attempt_id}: unknown instance {instance_name}')
         return

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -43,6 +43,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                  time_created, failed_request_count, last_updated, ip_address,
                  version, zone):
         self.db = app['db']
+        self.inst_monitor = app['inst_monitor']
         self.inst_pool = app['inst_pool']
         self.scheduler_state_changed = app['scheduler_state_changed']
         # pending, active, inactive, deleted
@@ -69,10 +70,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             'CALL activate_instance(%s, %s, %s);',
             (self.name, ip_address, timestamp))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'active'
         self.ip_address = ip_address
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
         self.scheduler_state_changed.set()
 
@@ -93,10 +94,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             log.info(f'{self} with in-memory state {self._state} was already deactivated; {rv}')
             assert rv['cur_state'] in ('inactive', 'deleted')
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'inactive'
         self._free_cores_mcpu = self.cores_mcpu
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
         # there might be jobs to reschedule
         self.scheduler_state_changed.set()
@@ -115,18 +116,18 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             log.info(f'{self} with in-memory state {self._state} could not be marked deleted; {rv}')
             assert rv['cur_state'] == 'deleted'
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'deleted'
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def free_cores_mcpu(self):
         return self._free_cores_mcpu
 
     def adjust_free_cores_in_memory(self, delta_mcpu):
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._free_cores_mcpu += delta_mcpu
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def failed_request_count(self):
@@ -166,10 +167,10 @@ WHERE name = %s;
 ''',
             (now, self.name))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._failed_request_count = 0
         self._last_updated = now
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     async def incr_failed_request_count(self):
         await self.db.execute_update(
@@ -179,9 +180,9 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
 ''',
             (self.name,))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._failed_request_count += 1
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def last_updated(self):
@@ -193,9 +194,9 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
             'UPDATE instances SET last_updated = %s WHERE name = %s;',
             (now, self.name))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._last_updated = now
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     def time_created_str(self):
         return time_msecs_str(self.time_created)

--- a/batch/batch/driver/instance_monitor.py
+++ b/batch/batch/driver/instance_monitor.py
@@ -1,0 +1,291 @@
+import re
+import asyncio
+import aiohttp
+import logging
+import collections
+import datetime
+import sortedcontainers
+import dateutil.parser
+
+from hailtop import aiotools
+from hailtop.utils import time_msecs, secret_alnum_string
+
+from .instance import Instance
+from ..batch_configuration import PROJECT
+
+log = logging.getLogger('instance_monitor')
+
+
+def parse_resource_name(resource_name):
+    match = RESOURCE_NAME_REGEX.fullmatch(resource_name)
+    assert match
+    return match.groupdict()
+
+
+RESOURCE_NAME_REGEX = re.compile('projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instances/(?P<name>.+)')
+
+
+class InstanceMonitor:
+    def __init__(self, app, machine_name_prefix):
+        self.app = app
+        self.db = app['db']
+        self.compute_client = app['compute_client']
+        self.logging_client = app['logging_client']
+        self.log_store = app['log_store']
+        self.zone_monitor = app['zone_monitor']
+
+        self.machine_name_prefix = machine_name_prefix
+
+        self.instances_by_last_updated = sortedcontainers.SortedSet(
+            key=lambda instance: instance.last_updated)
+
+        self.name_instance = {}
+
+        self.n_instances_by_state = {
+            'pending': 0,
+            'active': 0,
+            'inactive': 0,
+            'deleted': 0
+        }
+
+        # pending and active
+        self.live_free_cores_mcpu = 0
+        self.live_total_cores_mcpu = 0
+
+        self.task_manager = aiotools.BackgroundTaskManager()
+
+    async def async_init(self):
+        log.info('initializing instance monitor')
+
+        async for record in self.db.select_and_fetchall(
+                'SELECT * FROM instances WHERE removed = 0;'):
+            instance = Instance.from_record(self.app, record)
+            self.add_instance(instance)
+
+        log.info('finished initializing instance monitor')
+
+    async def run(self):
+        self.task_manager.ensure_future(self.event_loop())
+        self.task_manager.ensure_future(self.instance_monitoring_loop())
+
+    def shutdown(self):
+        self.task_manager.shutdown()
+
+    def unique_machine_name(self):
+        while True:
+            # 36 ** 5 = ~60M
+            suffix = secret_alnum_string(5, case='lower')
+            machine_name = f'{self.machine_name_prefix}{suffix}'
+            if machine_name not in self.name_instance:
+                break
+        return machine_name
+
+    def adjust_for_remove_instance(self, instance):
+        assert instance in self.instances_by_last_updated
+
+        self.instances_by_last_updated.remove(instance)
+        self.n_instances_by_state[instance.state] -= 1
+
+        if instance.state in ('pending', 'active'):
+            self.live_free_cores_mcpu -= max(0, instance.free_cores_mcpu)
+            self.live_total_cores_mcpu -= instance.cores_mcpu
+
+        instance.inst_pool.adjust_for_remove_instance(instance)
+
+    async def remove_instance(self, instance, reason, timestamp=None):
+        await instance.deactivate(reason, timestamp)
+
+        await self.db.just_execute(
+            'UPDATE instances SET removed = 1 WHERE name = %s;', (instance.name,))
+
+        self.adjust_for_remove_instance(instance)
+        del self.name_instance[instance.name]
+
+    def adjust_for_add_instance(self, instance):
+        assert instance not in self.instances_by_last_updated
+
+        self.instances_by_last_updated.add(instance)
+        self.n_instances_by_state[instance.state] += 1
+
+        if instance.state in ('pending', 'active'):
+            self.live_free_cores_mcpu += max(0, instance.free_cores_mcpu)
+            self.live_total_cores_mcpu += instance.cores_mcpu
+
+        instance.inst_pool.adjust_for_add_instance(instance)
+
+    def add_instance(self, instance):
+        assert instance.name not in self.name_instance
+        self.name_instance[instance.name] = instance
+        self.adjust_for_add_instance(instance)
+
+    async def call_delete_instance(self, instance, reason, timestamp=None, force=False):
+        if instance.state == 'deleted' and not force:
+            return
+        if instance.state not in ('inactive', 'deleted'):
+            await instance.deactivate(reason, timestamp)
+
+        try:
+            await self.compute_client.delete(
+                f'/zones/{instance.zone}/instances/{instance.name}')
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                log.info(f'{instance} already delete done')
+                await self.remove_instance(instance, reason, timestamp)
+                return
+            raise
+
+    async def handle_preempt_event(self, instance, timestamp):
+        await self.call_delete_instance(instance, 'preempted', timestamp=timestamp)
+
+    async def handle_delete_done_event(self, instance, timestamp):
+        await self.remove_instance(instance, 'deleted', timestamp)
+
+    async def handle_call_delete_event(self, instance, timestamp):
+        await instance.mark_deleted('deleted', timestamp)
+
+    async def handle_event(self, event):
+        payload = event.get('protoPayload')
+        if payload is None:
+            log.warning('event has no payload')
+            return
+
+        timestamp = dateutil.parser.isoparse(event['timestamp']).timestamp() * 1000
+
+        resource_type = event['resource']['type']
+        if resource_type != 'gce_instance':
+            log.warning(f'unknown event resource type {resource_type}')
+            return
+
+        operation_started = event['operation'].get('first', False)
+        if operation_started:
+            event_type = 'STARTED'
+        else:
+            event_type = 'COMPLETED'
+
+        event_subtype = payload['methodName']
+        resource = event['resource']
+        name = parse_resource_name(payload['resourceName'])['name']
+
+        log.info(f'event {resource_type} {event_type} {event_subtype} {name}')
+
+        if not name.startswith(self.machine_name_prefix):
+            log.warning(f'event for unknown machine {name}')
+            return
+
+        if event_subtype == 'v1.compute.instances.insert':
+            if event_type == 'COMPLETED':
+                severity = event['severity']
+                operation_id = event['operation']['id']
+                success = (severity != 'ERROR')
+                self.zone_monitor.zone_success_rate.push(resource['labels']['zone'], operation_id, success)
+        else:
+            instance = self.name_instance.get(name)
+            if not instance:
+                log.warning(f'event for unknown instance {name}')
+                return
+
+            if event_subtype == 'v1.compute.instances.preempted':
+                log.info(f'event handler: handle preempt {instance}')
+                await self.handle_preempt_event(instance, timestamp)
+            elif event_subtype == 'v1.compute.instances.delete':
+                if event_type == 'COMPLETED':
+                    log.info(f'event handler: delete {instance} done')
+                    await self.handle_delete_done_event(instance, timestamp)
+                elif event_type == 'STARTED':
+                    log.info(f'event handler: handle call delete {instance}')
+                    await self.handle_call_delete_event(instance, timestamp)
+
+    async def event_loop(self):
+        log.info('starting event loop')
+        while True:
+            try:
+                row = await self.db.select_and_fetchone('SELECT * FROM `gevents_mark`;')
+                mark = row['mark']
+                if mark is None:
+                    mark = datetime.datetime.utcnow().isoformat() + 'Z'
+                    await self.db.execute_update(
+                        'UPDATE `gevents_mark` SET mark = %s;',
+                        (mark,))
+
+                filter = f'''
+logName="projects/{PROJECT}/logs/cloudaudit.googleapis.com%2Factivity" AND
+resource.type=gce_instance AND
+protoPayload.resourceName:"{self.machine_name_prefix}" AND
+timestamp >= "{mark}"
+'''
+
+                new_mark = None
+                async for event in await self.logging_client.list_entries(
+                        body={
+                            'resourceNames': [f'projects/{PROJECT}'],
+                            'orderBy': 'timestamp asc',
+                            'pageSize': 100,
+                            'filter': filter
+                        }):
+                    # take the last, largest timestamp
+                    new_mark = event['timestamp']
+                    await self.handle_event(event)
+
+                if new_mark is not None:
+                    await self.db.execute_update(
+                        'UPDATE `gevents_mark` SET mark = %s;',
+                        (new_mark,))
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:
+                log.exception('in event loop')
+            await asyncio.sleep(15)
+
+    async def check_on_instance(self, instance):
+        active_and_healthy = await instance.check_is_active_and_healthy()
+        if active_and_healthy:
+            return
+
+        try:
+            spec = await self.compute_client.get(
+                f'/zones/{instance.zone}/instances/{instance.name}')
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                await self.remove_instance(instance, 'does_not_exist')
+                return
+            raise
+
+        # PROVISIONING, STAGING, RUNNING, STOPPING, TERMINATED
+        gce_state = spec['status']
+        log.info(f'{instance} gce_state {gce_state}')
+
+        if gce_state in ('STOPPING', 'TERMINATED'):
+            log.info(f'{instance} live but stopping or terminated, deactivating')
+            await instance.deactivate('terminated')
+
+        if (gce_state in ('STAGING', 'RUNNING')
+                and instance.state == 'pending'
+                and time_msecs() - instance.time_created > 5 * 60 * 1000):
+            # FIXME shouldn't count time in PROVISIONING
+            log.info(f'{instance} did not activate within 5m, deleting')
+            await self.call_delete_instance(instance, 'activation_timeout')
+
+        if instance.state == 'inactive':
+            log.info(f'{instance} is inactive, deleting')
+            await self.call_delete_instance(instance, 'inactive')
+
+        await instance.update_timestamp()
+
+    async def instance_monitoring_loop(self):
+        log.info('starting instance monitoring loop')
+
+        while True:
+            try:
+                if self.instances_by_last_updated:
+                    # 0 is the smallest (oldest)
+                    instance = self.instances_by_last_updated[0]
+                    since_last_updated = time_msecs() - instance.last_updated
+                    if since_last_updated > 60 * 1000:
+                        log.info(f'checking on {instance}, last updated {since_last_updated / 1000}s ago')
+                        await self.check_on_instance(instance)
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:
+                log.exception('in monitor instances loop')
+
+            await asyncio.sleep(1)

--- a/batch/batch/driver/instance_monitor.py
+++ b/batch/batch/driver/instance_monitor.py
@@ -2,7 +2,6 @@ import re
 import asyncio
 import aiohttp
 import logging
-import collections
 import datetime
 import sortedcontainers
 import dateutil.parser

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -3,15 +3,11 @@ import re
 import secrets
 import random
 import json
-import datetime
 import asyncio
 import logging
 import base64
-import dateutil.parser
 import sortedcontainers
-import aiohttp
 from hailtop import aiotools
-from hailtop.utils import time_msecs, secret_alnum_string
 
 from ..batch_configuration import DEFAULT_NAMESPACE, PROJECT, \
     WORKER_MAX_IDLE_TIME_MSECS, STANDING_WORKER_MAX_IDLE_TIME_MSECS, \
@@ -36,7 +32,7 @@ def parse_resource_name(resource_name):
 
 
 class InstancePool:
-    def __init__(self, app, machine_name_prefix):
+    def __init__(self, app):
         self.app = app
         self.instance_id = app['instance_id']
         self.log_store = app['log_store']
@@ -44,8 +40,8 @@ class InstancePool:
         self.db = app['db']
         self.compute_client = app['compute_client']
         self.logging_client = app['logging_client']
-        self.machine_name_prefix = machine_name_prefix
 
+        self.inst_monitor = app['inst_monitor']
         self.zone_monitor = app['zone_monitor']
 
         # set in async_init
@@ -57,9 +53,6 @@ class InstancePool:
         self.standing_worker_cores = None
         self.max_instances = None
         self.pool_size = None
-
-        self.instances_by_last_updated = sortedcontainers.SortedSet(
-            key=lambda instance: instance.last_updated)
 
         self.healthy_instances_by_free_cores = sortedcontainers.SortedSet(
             key=lambda instance: instance.free_cores_mcpu)
@@ -75,7 +68,7 @@ class InstancePool:
         self.live_free_cores_mcpu = 0
         self.live_total_cores_mcpu = 0
 
-        self.name_instance = {}
+        self.n_instances = 0
 
         self.task_manager = aiotools.BackgroundTaskManager()
 
@@ -98,14 +91,8 @@ FROM globals;
         self.max_instances = row['max_instances']
         self.pool_size = row['pool_size']
 
-        async for record in self.db.select_and_fetchall(
-                'SELECT * FROM instances WHERE removed = 0;'):
-            instance = Instance.from_record(self.app, record)
-            self.add_instance(instance)
-
-        self.task_manager.ensure_future(self.event_loop())
+    async def run(self):
         self.task_manager.ensure_future(self.control_loop())
-        self.task_manager.ensure_future(self.instance_monitoring_loop())
 
     def shutdown(self):
         self.task_manager.shutdown()
@@ -148,16 +135,9 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
         self.max_instances = max_instances
         self.pool_size = pool_size
 
-    @property
-    def n_instances(self):
-        return len(self.name_instance)
-
     def adjust_for_remove_instance(self, instance):
-        assert instance in self.instances_by_last_updated
-
-        self.instances_by_last_updated.remove(instance)
-
         self.n_instances_by_state[instance.state] -= 1
+        self.n_instances -= 1
 
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu -= max(0, instance.free_cores_mcpu)
@@ -165,21 +145,10 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
         if instance in self.healthy_instances_by_free_cores:
             self.healthy_instances_by_free_cores.remove(instance)
 
-    async def remove_instance(self, instance, reason, timestamp=None):
-        await instance.deactivate(reason, timestamp)
-
-        await self.db.just_execute(
-            'UPDATE instances SET removed = 1 WHERE name = %s;', (instance.name,))
-
-        self.adjust_for_remove_instance(instance)
-        del self.name_instance[instance.name]
-
     def adjust_for_add_instance(self, instance):
-        assert instance not in self.instances_by_last_updated
-
         self.n_instances_by_state[instance.state] += 1
+        self.n_instances += 1
 
-        self.instances_by_last_updated.add(instance)
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu += max(0, instance.free_cores_mcpu)
             self.live_total_cores_mcpu += instance.cores_mcpu
@@ -187,24 +156,13 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
                 and instance.failed_request_count <= 1):
             self.healthy_instances_by_free_cores.add(instance)
 
-    def add_instance(self, instance):
-        assert instance.name not in self.name_instance
-
-        self.name_instance[instance.name] = instance
-        self.adjust_for_add_instance(instance)
-
     async def create_instance(self, cores=None, max_idle_time_msecs=None):
         if cores is None:
             cores = self.worker_cores
         if max_idle_time_msecs is None:
             max_idle_time_msecs = WORKER_MAX_IDLE_TIME_MSECS
 
-        while True:
-            # 36 ** 5 = ~60M
-            suffix = secret_alnum_string(5, case='lower')
-            machine_name = f'{self.machine_name_prefix}{suffix}'
-            if machine_name not in self.name_instance:
-                break
+        machine_name = self.inst_monitor.unique_machine_name()
 
         if self.live_total_cores_mcpu // 1000 < 4_000:
             zone = random.choice(self.zone_monitor.init_zones)
@@ -225,7 +183,7 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
 
         activation_token = secrets.token_urlsafe(32)
         instance = await Instance.create(self.app, machine_name, activation_token, cores * 1000, zone)
-        self.add_instance(instance)
+        self.inst_monitor.add_instance(instance)
 
         log.info(f'created {instance}')
 
@@ -528,124 +486,6 @@ gsutil -m cp dockerd.log gs://$WORKER_LOGS_BUCKET_NAME/batch/logs/$INSTANCE_ID/w
         log.info(f'created machine {machine_name} for {instance} '
                  f' with logs at {self.log_store.worker_log_path(machine_name, "worker.log")}')
 
-    async def call_delete_instance(self, instance, reason, timestamp=None, force=False):
-        if instance.state == 'deleted' and not force:
-            return
-        if instance.state not in ('inactive', 'deleted'):
-            await instance.deactivate(reason, timestamp)
-
-        try:
-            await self.compute_client.delete(
-                f'/zones/{instance.zone}/instances/{instance.name}')
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                log.info(f'{instance} already delete done')
-                await self.remove_instance(instance, reason, timestamp)
-                return
-            raise
-
-    async def handle_preempt_event(self, instance, timestamp):
-        await self.call_delete_instance(instance, 'preempted', timestamp=timestamp)
-
-    async def handle_delete_done_event(self, instance, timestamp):
-        await self.remove_instance(instance, 'deleted', timestamp)
-
-    async def handle_call_delete_event(self, instance, timestamp):
-        await instance.mark_deleted('deleted', timestamp)
-
-    async def handle_event(self, event):
-        payload = event.get('protoPayload')
-        if payload is None:
-            log.warning('event has no payload')
-            return
-
-        timestamp = dateutil.parser.isoparse(event['timestamp']).timestamp() * 1000
-
-        resource_type = event['resource']['type']
-        if resource_type != 'gce_instance':
-            log.warning(f'unknown event resource type {resource_type}')
-            return
-
-        operation_started = event['operation'].get('first', False)
-        if operation_started:
-            event_type = 'STARTED'
-        else:
-            event_type = 'COMPLETED'
-
-        event_subtype = payload['methodName']
-        resource = event['resource']
-        name = parse_resource_name(payload['resourceName'])['name']
-
-        log.info(f'event {resource_type} {event_type} {event_subtype} {name}')
-
-        if not name.startswith(self.machine_name_prefix):
-            log.warning(f'event for unknown machine {name}')
-            return
-
-        if event_subtype == 'v1.compute.instances.insert':
-            if event_type == 'COMPLETED':
-                severity = event['severity']
-                operation_id = event['operation']['id']
-                success = (severity != 'ERROR')
-                self.zone_monitor.zone_success_rate.push(resource['labels']['zone'], operation_id, success)
-        else:
-            instance = self.name_instance.get(name)
-            if not instance:
-                log.warning(f'event for unknown instance {name}')
-                return
-
-            if event_subtype == 'v1.compute.instances.preempted':
-                log.info(f'event handler: handle preempt {instance}')
-                await self.handle_preempt_event(instance, timestamp)
-            elif event_subtype == 'v1.compute.instances.delete':
-                if event_type == 'COMPLETED':
-                    log.info(f'event handler: delete {instance} done')
-                    await self.handle_delete_done_event(instance, timestamp)
-                elif event_type == 'STARTED':
-                    log.info(f'event handler: handle call delete {instance}')
-                    await self.handle_call_delete_event(instance, timestamp)
-
-    async def event_loop(self):
-        log.info('starting event loop')
-        while True:
-            try:
-                row = await self.db.select_and_fetchone('SELECT * FROM `gevents_mark`;')
-                mark = row['mark']
-                if mark is None:
-                    mark = datetime.datetime.utcnow().isoformat() + 'Z'
-                    await self.db.execute_update(
-                        'UPDATE `gevents_mark` SET mark = %s;',
-                        (mark,))
-
-                filter = f'''
-logName="projects/{PROJECT}/logs/cloudaudit.googleapis.com%2Factivity" AND
-resource.type=gce_instance AND
-protoPayload.resourceName:"{self.machine_name_prefix}" AND
-timestamp >= "{mark}"
-'''
-
-                new_mark = None
-                async for event in await self.logging_client.list_entries(
-                        body={
-                            'resourceNames': [f'projects/{PROJECT}'],
-                            'orderBy': 'timestamp asc',
-                            'pageSize': 100,
-                            'filter': filter
-                        }):
-                    # take the last, largest timestamp
-                    new_mark = event['timestamp']
-                    await self.handle_event(event)
-
-                if new_mark is not None:
-                    await self.db.execute_update(
-                        'UPDATE `gevents_mark` SET mark = %s;',
-                        (new_mark,))
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                raise
-            except Exception:
-                log.exception('in event loop')
-            await asyncio.sleep(15)
-
     async def control_loop(self):
         log.info('starting control loop')
         while True:
@@ -693,57 +533,3 @@ FROM ready_cores;
             except Exception:
                 log.exception('in control loop')
             await asyncio.sleep(15)
-
-    async def check_on_instance(self, instance):
-        active_and_healthy = await instance.check_is_active_and_healthy()
-        if active_and_healthy:
-            return
-
-        try:
-            spec = await self.compute_client.get(
-                f'/zones/{instance.zone}/instances/{instance.name}')
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                await self.remove_instance(instance, 'does_not_exist')
-                return
-            raise
-
-        # PROVISIONING, STAGING, RUNNING, STOPPING, TERMINATED
-        gce_state = spec['status']
-        log.info(f'{instance} gce_state {gce_state}')
-
-        if gce_state in ('STOPPING', 'TERMINATED'):
-            log.info(f'{instance} live but stopping or terminated, deactivating')
-            await instance.deactivate('terminated')
-
-        if (gce_state in ('STAGING', 'RUNNING')
-                and instance.state == 'pending'
-                and time_msecs() - instance.time_created > 5 * 60 * 1000):
-            # FIXME shouldn't count time in PROVISIONING
-            log.info(f'{instance} did not activate within 5m, deleting')
-            await self.call_delete_instance(instance, 'activation_timeout')
-
-        if instance.state == 'inactive':
-            log.info(f'{instance} is inactive, deleting')
-            await self.call_delete_instance(instance, 'inactive')
-
-        await instance.update_timestamp()
-
-    async def instance_monitoring_loop(self):
-        log.info('starting instance monitoring loop')
-
-        while True:
-            try:
-                if self.instances_by_last_updated:
-                    # 0 is the smallest (oldest)
-                    instance = self.instances_by_last_updated[0]
-                    since_last_updated = time_msecs() - instance.last_updated
-                    if since_last_updated > 60 * 1000:
-                        log.info(f'checking on {instance}, last updated {since_last_updated / 1000}s ago')
-                        await self.check_on_instance(instance)
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                raise
-            except Exception:
-                log.exception('in monitor instances loop')
-
-            await asyncio.sleep(1)

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -757,6 +757,9 @@ SELECT worker_type, worker_cores, worker_disk_size_gb,
     log_store = LogStore(BATCH_BUCKET_NAME, WORKER_LOGS_BUCKET_NAME, instance_id, pool, credentials=credentials)
     app['log_store'] = log_store
 
+    async_worker_pool = AsyncWorkerPool(parallelism=100, queue_size=100)
+    app['async_worker_pool'] = async_worker_pool
+
     zone_monitor = ZoneMonitor(app)
     app['zone_monitor'] = zone_monitor
     await zone_monitor.async_init()
@@ -772,9 +775,6 @@ SELECT worker_type, worker_cores, worker_disk_size_gb,
 
     await inst_monitor.run()
     await inst_pool.run()
-
-    async_worker_pool = AsyncWorkerPool(parallelism=100, queue_size=100)
-    app['async_worker_pool'] = async_worker_pool
 
     app['check_incremental_error'] = None
     app['check_resource_aggregation_error'] = None


### PR DESCRIPTION
Stacked on #9772 

This code accounts for a scheduler per instance pool even though right now there is only one instance pool. In the future when we add job private instance scheduling, then we'll need to rethink how this code is structured. For now, it should be fine.