### PR TITLE
[ci] create global-config in "default" namespaces created by CI

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -632,7 +632,12 @@ date
 echo {shq(config)} | kubectl apply -f -
 '''
 
-        if self.secrets and not scope == 'deploy':
+        if self.secrets and scope != 'deploy':
+            if self.namespace_name == 'default':
+                script += f'''
+kubectl -n {self.namespace_name} get -o json secret global-config | jq '.data.default_namespace |= ("{self._name}" | @base64)' | kubectl apply -f -
+'''
+
             for s in self.secrets:
                 script += f'''
 kubectl -n {self.namespace_name} get -o json --export secret {s} | jq '.metadata.name = "{s}"' | kubectl -n {self._name} apply -f -


### PR DESCRIPTION
Motivation for this change: I want to keep the global configuration information in one place, and that's going to be the K8s default/global-config secret.  In particular, I want to get rid of config.mk and just pull the relevant information from K8s.  The secret currently like this:

```
$ k get -o json secret global-config | jq '.data | map_values(@base64d)'
{
  "default_namespace": "...",
  "docker_root_image": "...",
  "domain": "...",
  "gcp_project": "...",
  "gcp_region": "...",
  "gcp_zone": "...",
  "gsuite_organization": "...",
  "internal_ip": "...",
  "ip": "...",
  "kubernetes_server_url": "..."
}
```

default_namespace will always be the name of the namespace the secret is in.

This adds gsuite_organization which will be used by auth to restrict logins to a fixed GSuite organization, e.g. broadinstitute.org.

I have created this secret on our production K8s cluster.  The Terraform script will also create it.

With this change, CI creates global-config in test and dev "default" namespaces based on the one from where CI is operating.  The only field that currently needs to be updated is default_namespace.

The plan is to pull from global-config in deployments instead of threading these global configuration(s) through CI.  I made this change in the CI tests.

FYI @lgruen.  I'm going to break up the infra-1 work into a few separate PRs to keep it all clear and manageable.