### PR TITLE
[batch] Add SQL infrastructure to support multiple pools

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -157,7 +157,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
     scheduler_state_changed = app['scheduler_state_changed']
     cancel_ready_state_changed = app['cancel_ready_state_changed']
     db = app['db']
-    inst_pool = app['inst_pool']
+    inst_monitor = app['inst_monitor']
 
     id = (batch_id, job_id)
 
@@ -179,7 +179,7 @@ async def mark_job_complete(app, batch_id, job_id, attempt_id, instance_name, ne
     cancel_ready_state_changed.set()
 
     if instance_name:
-        instance = inst_pool.name_instance.get(instance_name)
+        instance = inst_monitor.name_instance.get(instance_name)
         if instance:
             if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
                 # may also create scheduling opportunities, set above
@@ -260,7 +260,7 @@ async def unschedule_job(app, record):
     cancel_ready_state_changed = app['cancel_ready_state_changed']
     scheduler_state_changed = app['scheduler_state_changed']
     db = app['db']
-    inst_pool = app['inst_pool']
+    inst_monitor = app['inst_monitor']
 
     batch_id = record['batch_id']
     job_id = record['job_id']
@@ -287,7 +287,7 @@ async def unschedule_job(app, record):
     # job that was running is now ready to be cancelled
     cancel_ready_state_changed.set()
 
-    instance = inst_pool.name_instance.get(instance_name)
+    instance = inst_monitor.name_instance.get(instance_name)
     if not instance:
         log.warning(f'unschedule job {id}, attempt {attempt_id}: unknown instance {instance_name}')
         return

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -31,7 +31,7 @@ class Instance:
         await db.just_execute(
             '''
 INSERT INTO instances (name, state, activation_token, token, cores_mcpu, free_cores_mcpu, time_created, last_updated, version, zone, pool)
-VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
             (name, state, activation_token, token, worker_cores_mcpu,
              worker_cores_mcpu, now, now, INSTANCE_VERSION, zone, pool_name))

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -22,7 +22,7 @@ class Instance:
             record['zone'])
 
     @staticmethod
-    async def create(app, name, activation_token, worker_cores_mcpu, zone):
+    async def create(app, name, activation_token, worker_cores_mcpu, zone, pool_name):
         db = app['db']
 
         state = 'pending'
@@ -30,11 +30,11 @@ class Instance:
         token = secrets.token_urlsafe(32)
         await db.just_execute(
             '''
-INSERT INTO instances (name, state, activation_token, token, cores_mcpu, free_cores_mcpu, time_created, last_updated, version, zone)
+INSERT INTO instances (name, state, activation_token, token, cores_mcpu, free_cores_mcpu, time_created, last_updated, version, zone, pool)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
             (name, state, activation_token, token, worker_cores_mcpu,
-             worker_cores_mcpu, now, now, INSTANCE_VERSION, zone))
+             worker_cores_mcpu, now, now, INSTANCE_VERSION, zone, pool_name))
         return Instance(
             app, name, state, worker_cores_mcpu, worker_cores_mcpu, now,
             0, now, None, INSTANCE_VERSION, zone)

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -43,6 +43,7 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                  time_created, failed_request_count, last_updated, ip_address,
                  version, zone):
         self.db = app['db']
+        self.inst_monitor = app['inst_monitor']
         self.inst_pool = app['inst_pool']
         self.scheduler_state_changed = app['scheduler_state_changed']
         # pending, active, inactive, deleted
@@ -69,10 +70,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             'CALL activate_instance(%s, %s, %s);',
             (self.name, ip_address, timestamp))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'active'
         self.ip_address = ip_address
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
         self.scheduler_state_changed.set()
 
@@ -93,10 +94,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             log.info(f'{self} with in-memory state {self._state} was already deactivated; {rv}')
             assert rv['cur_state'] in ('inactive', 'deleted')
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'inactive'
         self._free_cores_mcpu = self.cores_mcpu
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
         # there might be jobs to reschedule
         self.scheduler_state_changed.set()
@@ -115,18 +116,18 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             log.info(f'{self} with in-memory state {self._state} could not be marked deleted; {rv}')
             assert rv['cur_state'] == 'deleted'
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._state = 'deleted'
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def free_cores_mcpu(self):
         return self._free_cores_mcpu
 
     def adjust_free_cores_in_memory(self, delta_mcpu):
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._free_cores_mcpu += delta_mcpu
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def failed_request_count(self):
@@ -166,10 +167,10 @@ WHERE name = %s;
 ''',
             (now, self.name))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._failed_request_count = 0
         self._last_updated = now
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     async def incr_failed_request_count(self):
         await self.db.execute_update(
@@ -179,9 +180,9 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
 ''',
             (self.name,))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._failed_request_count += 1
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     @property
     def last_updated(self):
@@ -193,9 +194,9 @@ SET failed_request_count = failed_request_count + 1 WHERE name = %s;
             'UPDATE instances SET last_updated = %s WHERE name = %s;',
             (now, self.name))
 
-        self.inst_pool.adjust_for_remove_instance(self)
+        self.inst_monitor.adjust_for_remove_instance(self)
         self._last_updated = now
-        self.inst_pool.adjust_for_add_instance(self)
+        self.inst_monitor.adjust_for_add_instance(self)
 
     def time_created_str(self):
         return time_msecs_str(self.time_created)

--- a/batch/batch/driver/instance_monitor.py
+++ b/batch/batch/driver/instance_monitor.py
@@ -1,0 +1,291 @@
+import re
+import asyncio
+import aiohttp
+import logging
+import collections
+import datetime
+import sortedcontainers
+import dateutil.parser
+
+from hailtop import aiotools
+from hailtop.utils import time_msecs, secret_alnum_string
+
+from .instance import Instance
+from ..batch_configuration import PROJECT
+
+log = logging.getLogger('instance_monitor')
+
+
+def parse_resource_name(resource_name):
+    match = RESOURCE_NAME_REGEX.fullmatch(resource_name)
+    assert match
+    return match.groupdict()
+
+
+RESOURCE_NAME_REGEX = re.compile('projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instances/(?P<name>.+)')
+
+
+class InstanceMonitor:
+    def __init__(self, app, machine_name_prefix):
+        self.app = app
+        self.db = app['db']
+        self.compute_client = app['compute_client']
+        self.logging_client = app['logging_client']
+        self.log_store = app['log_store']
+        self.zone_monitor = app['zone_monitor']
+
+        self.machine_name_prefix = machine_name_prefix
+
+        self.instances_by_last_updated = sortedcontainers.SortedSet(
+            key=lambda instance: instance.last_updated)
+
+        self.name_instance = {}
+
+        self.n_instances_by_state = {
+            'pending': 0,
+            'active': 0,
+            'inactive': 0,
+            'deleted': 0
+        }
+
+        # pending and active
+        self.live_free_cores_mcpu = 0
+        self.live_total_cores_mcpu = 0
+
+        self.task_manager = aiotools.BackgroundTaskManager()
+
+    async def async_init(self):
+        log.info('initializing instance monitor')
+
+        async for record in self.db.select_and_fetchall(
+                'SELECT * FROM instances WHERE removed = 0;'):
+            instance = Instance.from_record(self.app, record)
+            self.add_instance(instance)
+
+        log.info('finished initializing instance monitor')
+
+    async def run(self):
+        self.task_manager.ensure_future(self.event_loop())
+        self.task_manager.ensure_future(self.instance_monitoring_loop())
+
+    def shutdown(self):
+        self.task_manager.shutdown()
+
+    def unique_machine_name(self):
+        while True:
+            # 36 ** 5 = ~60M
+            suffix = secret_alnum_string(5, case='lower')
+            machine_name = f'{self.machine_name_prefix}{suffix}'
+            if machine_name not in self.name_instance:
+                break
+        return machine_name
+
+    def adjust_for_remove_instance(self, instance):
+        assert instance in self.instances_by_last_updated
+
+        self.instances_by_last_updated.remove(instance)
+        self.n_instances_by_state[instance.state] -= 1
+
+        if instance.state in ('pending', 'active'):
+            self.live_free_cores_mcpu -= max(0, instance.free_cores_mcpu)
+            self.live_total_cores_mcpu -= instance.cores_mcpu
+
+        instance.inst_pool.adjust_for_remove_instance(instance)
+
+    async def remove_instance(self, instance, reason, timestamp=None):
+        await instance.deactivate(reason, timestamp)
+
+        await self.db.just_execute(
+            'UPDATE instances SET removed = 1 WHERE name = %s;', (instance.name,))
+
+        self.adjust_for_remove_instance(instance)
+        del self.name_instance[instance.name]
+
+    def adjust_for_add_instance(self, instance):
+        assert instance not in self.instances_by_last_updated
+
+        self.instances_by_last_updated.add(instance)
+        self.n_instances_by_state[instance.state] += 1
+
+        if instance.state in ('pending', 'active'):
+            self.live_free_cores_mcpu += max(0, instance.free_cores_mcpu)
+            self.live_total_cores_mcpu += instance.cores_mcpu
+
+        instance.inst_pool.adjust_for_add_instance(instance)
+
+    def add_instance(self, instance):
+        assert instance.name not in self.name_instance
+        self.name_instance[instance.name] = instance
+        self.adjust_for_add_instance(instance)
+
+    async def call_delete_instance(self, instance, reason, timestamp=None, force=False):
+        if instance.state == 'deleted' and not force:
+            return
+        if instance.state not in ('inactive', 'deleted'):
+            await instance.deactivate(reason, timestamp)
+
+        try:
+            await self.compute_client.delete(
+                f'/zones/{instance.zone}/instances/{instance.name}')
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                log.info(f'{instance} already delete done')
+                await self.remove_instance(instance, reason, timestamp)
+                return
+            raise
+
+    async def handle_preempt_event(self, instance, timestamp):
+        await self.call_delete_instance(instance, 'preempted', timestamp=timestamp)
+
+    async def handle_delete_done_event(self, instance, timestamp):
+        await self.remove_instance(instance, 'deleted', timestamp)
+
+    async def handle_call_delete_event(self, instance, timestamp):
+        await instance.mark_deleted('deleted', timestamp)
+
+    async def handle_event(self, event):
+        payload = event.get('protoPayload')
+        if payload is None:
+            log.warning('event has no payload')
+            return
+
+        timestamp = dateutil.parser.isoparse(event['timestamp']).timestamp() * 1000
+
+        resource_type = event['resource']['type']
+        if resource_type != 'gce_instance':
+            log.warning(f'unknown event resource type {resource_type}')
+            return
+
+        operation_started = event['operation'].get('first', False)
+        if operation_started:
+            event_type = 'STARTED'
+        else:
+            event_type = 'COMPLETED'
+
+        event_subtype = payload['methodName']
+        resource = event['resource']
+        name = parse_resource_name(payload['resourceName'])['name']
+
+        log.info(f'event {resource_type} {event_type} {event_subtype} {name}')
+
+        if not name.startswith(self.machine_name_prefix):
+            log.warning(f'event for unknown machine {name}')
+            return
+
+        if event_subtype == 'v1.compute.instances.insert':
+            if event_type == 'COMPLETED':
+                severity = event['severity']
+                operation_id = event['operation']['id']
+                success = (severity != 'ERROR')
+                self.zone_monitor.zone_success_rate.push(resource['labels']['zone'], operation_id, success)
+        else:
+            instance = self.name_instance.get(name)
+            if not instance:
+                log.warning(f'event for unknown instance {name}')
+                return
+
+            if event_subtype == 'v1.compute.instances.preempted':
+                log.info(f'event handler: handle preempt {instance}')
+                await self.handle_preempt_event(instance, timestamp)
+            elif event_subtype == 'v1.compute.instances.delete':
+                if event_type == 'COMPLETED':
+                    log.info(f'event handler: delete {instance} done')
+                    await self.handle_delete_done_event(instance, timestamp)
+                elif event_type == 'STARTED':
+                    log.info(f'event handler: handle call delete {instance}')
+                    await self.handle_call_delete_event(instance, timestamp)
+
+    async def event_loop(self):
+        log.info('starting event loop')
+        while True:
+            try:
+                row = await self.db.select_and_fetchone('SELECT * FROM `gevents_mark`;')
+                mark = row['mark']
+                if mark is None:
+                    mark = datetime.datetime.utcnow().isoformat() + 'Z'
+                    await self.db.execute_update(
+                        'UPDATE `gevents_mark` SET mark = %s;',
+                        (mark,))
+
+                filter = f'''
+logName="projects/{PROJECT}/logs/cloudaudit.googleapis.com%2Factivity" AND
+resource.type=gce_instance AND
+protoPayload.resourceName:"{self.machine_name_prefix}" AND
+timestamp >= "{mark}"
+'''
+
+                new_mark = None
+                async for event in await self.logging_client.list_entries(
+                        body={
+                            'resourceNames': [f'projects/{PROJECT}'],
+                            'orderBy': 'timestamp asc',
+                            'pageSize': 100,
+                            'filter': filter
+                        }):
+                    # take the last, largest timestamp
+                    new_mark = event['timestamp']
+                    await self.handle_event(event)
+
+                if new_mark is not None:
+                    await self.db.execute_update(
+                        'UPDATE `gevents_mark` SET mark = %s;',
+                        (new_mark,))
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:
+                log.exception('in event loop')
+            await asyncio.sleep(15)
+
+    async def check_on_instance(self, instance):
+        active_and_healthy = await instance.check_is_active_and_healthy()
+        if active_and_healthy:
+            return
+
+        try:
+            spec = await self.compute_client.get(
+                f'/zones/{instance.zone}/instances/{instance.name}')
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                await self.remove_instance(instance, 'does_not_exist')
+                return
+            raise
+
+        # PROVISIONING, STAGING, RUNNING, STOPPING, TERMINATED
+        gce_state = spec['status']
+        log.info(f'{instance} gce_state {gce_state}')
+
+        if gce_state in ('STOPPING', 'TERMINATED'):
+            log.info(f'{instance} live but stopping or terminated, deactivating')
+            await instance.deactivate('terminated')
+
+        if (gce_state in ('STAGING', 'RUNNING')
+                and instance.state == 'pending'
+                and time_msecs() - instance.time_created > 5 * 60 * 1000):
+            # FIXME shouldn't count time in PROVISIONING
+            log.info(f'{instance} did not activate within 5m, deleting')
+            await self.call_delete_instance(instance, 'activation_timeout')
+
+        if instance.state == 'inactive':
+            log.info(f'{instance} is inactive, deleting')
+            await self.call_delete_instance(instance, 'inactive')
+
+        await instance.update_timestamp()
+
+    async def instance_monitoring_loop(self):
+        log.info('starting instance monitoring loop')
+
+        while True:
+            try:
+                if self.instances_by_last_updated:
+                    # 0 is the smallest (oldest)
+                    instance = self.instances_by_last_updated[0]
+                    since_last_updated = time_msecs() - instance.last_updated
+                    if since_last_updated > 60 * 1000:
+                        log.info(f'checking on {instance}, last updated {since_last_updated / 1000}s ago')
+                        await self.check_on_instance(instance)
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                raise
+            except Exception:
+                log.exception('in monitor instances loop')
+
+            await asyncio.sleep(1)

--- a/batch/batch/driver/instance_monitor.py
+++ b/batch/batch/driver/instance_monitor.py
@@ -2,7 +2,6 @@ import re
 import asyncio
 import aiohttp
 import logging
-import collections
 import datetime
 import sortedcontainers
 import dateutil.parser

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -3,15 +3,11 @@ import re
 import secrets
 import random
 import json
-import datetime
 import asyncio
 import logging
 import base64
-import dateutil.parser
 import sortedcontainers
-import aiohttp
 from hailtop import aiotools
-from hailtop.utils import time_msecs, secret_alnum_string
 
 from ..batch_configuration import DEFAULT_NAMESPACE, PROJECT, \
     WORKER_MAX_IDLE_TIME_MSECS, STANDING_WORKER_MAX_IDLE_TIME_MSECS, \
@@ -36,7 +32,7 @@ def parse_resource_name(resource_name):
 
 
 class InstancePool:
-    def __init__(self, app, machine_name_prefix):
+    def __init__(self, app):
         self.app = app
         self.instance_id = app['instance_id']
         self.log_store = app['log_store']
@@ -44,8 +40,8 @@ class InstancePool:
         self.db = app['db']
         self.compute_client = app['compute_client']
         self.logging_client = app['logging_client']
-        self.machine_name_prefix = machine_name_prefix
 
+        self.inst_monitor = app['inst_monitor']
         self.zone_monitor = app['zone_monitor']
 
         # set in async_init
@@ -57,9 +53,6 @@ class InstancePool:
         self.standing_worker_cores = None
         self.max_instances = None
         self.pool_size = None
-
-        self.instances_by_last_updated = sortedcontainers.SortedSet(
-            key=lambda instance: instance.last_updated)
 
         self.healthy_instances_by_free_cores = sortedcontainers.SortedSet(
             key=lambda instance: instance.free_cores_mcpu)
@@ -75,7 +68,7 @@ class InstancePool:
         self.live_free_cores_mcpu = 0
         self.live_total_cores_mcpu = 0
 
-        self.name_instance = {}
+        self.n_instances = 0
 
         self.task_manager = aiotools.BackgroundTaskManager()
 
@@ -98,14 +91,8 @@ FROM globals;
         self.max_instances = row['max_instances']
         self.pool_size = row['pool_size']
 
-        async for record in self.db.select_and_fetchall(
-                'SELECT * FROM instances WHERE removed = 0;'):
-            instance = Instance.from_record(self.app, record)
-            self.add_instance(instance)
-
-        self.task_manager.ensure_future(self.event_loop())
+    async def run(self):
         self.task_manager.ensure_future(self.control_loop())
-        self.task_manager.ensure_future(self.instance_monitoring_loop())
 
     def shutdown(self):
         self.task_manager.shutdown()
@@ -148,16 +135,9 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
         self.max_instances = max_instances
         self.pool_size = pool_size
 
-    @property
-    def n_instances(self):
-        return len(self.name_instance)
-
     def adjust_for_remove_instance(self, instance):
-        assert instance in self.instances_by_last_updated
-
-        self.instances_by_last_updated.remove(instance)
-
         self.n_instances_by_state[instance.state] -= 1
+        self.n_instances -= 1
 
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu -= max(0, instance.free_cores_mcpu)
@@ -165,21 +145,10 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
         if instance in self.healthy_instances_by_free_cores:
             self.healthy_instances_by_free_cores.remove(instance)
 
-    async def remove_instance(self, instance, reason, timestamp=None):
-        await instance.deactivate(reason, timestamp)
-
-        await self.db.just_execute(
-            'UPDATE instances SET removed = 1 WHERE name = %s;', (instance.name,))
-
-        self.adjust_for_remove_instance(instance)
-        del self.name_instance[instance.name]
-
     def adjust_for_add_instance(self, instance):
-        assert instance not in self.instances_by_last_updated
-
         self.n_instances_by_state[instance.state] += 1
+        self.n_instances += 1
 
-        self.instances_by_last_updated.add(instance)
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu += max(0, instance.free_cores_mcpu)
             self.live_total_cores_mcpu += instance.cores_mcpu
@@ -187,24 +156,13 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
                 and instance.failed_request_count <= 1):
             self.healthy_instances_by_free_cores.add(instance)
 
-    def add_instance(self, instance):
-        assert instance.name not in self.name_instance
-
-        self.name_instance[instance.name] = instance
-        self.adjust_for_add_instance(instance)
-
     async def create_instance(self, cores=None, max_idle_time_msecs=None):
         if cores is None:
             cores = self.worker_cores
         if max_idle_time_msecs is None:
             max_idle_time_msecs = WORKER_MAX_IDLE_TIME_MSECS
 
-        while True:
-            # 36 ** 5 = ~60M
-            suffix = secret_alnum_string(5, case='lower')
-            machine_name = f'{self.machine_name_prefix}{suffix}'
-            if machine_name not in self.name_instance:
-                break
+        machine_name = self.inst_monitor.unique_machine_name()
 
         if self.live_total_cores_mcpu // 1000 < 4_000:
             zone = random.choice(self.zone_monitor.init_zones)
@@ -225,7 +183,7 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
 
         activation_token = secrets.token_urlsafe(32)
         instance = await Instance.create(self.app, machine_name, activation_token, cores * 1000, zone)
-        self.add_instance(instance)
+        self.inst_monitor.add_instance(instance)
 
         log.info(f'created {instance}')
 
@@ -528,124 +486,6 @@ gsutil -m cp dockerd.log gs://$WORKER_LOGS_BUCKET_NAME/batch/logs/$INSTANCE_ID/w
         log.info(f'created machine {machine_name} for {instance} '
                  f' with logs at {self.log_store.worker_log_path(machine_name, "worker.log")}')
 
-    async def call_delete_instance(self, instance, reason, timestamp=None, force=False):
-        if instance.state == 'deleted' and not force:
-            return
-        if instance.state not in ('inactive', 'deleted'):
-            await instance.deactivate(reason, timestamp)
-
-        try:
-            await self.compute_client.delete(
-                f'/zones/{instance.zone}/instances/{instance.name}')
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                log.info(f'{instance} already delete done')
-                await self.remove_instance(instance, reason, timestamp)
-                return
-            raise
-
-    async def handle_preempt_event(self, instance, timestamp):
-        await self.call_delete_instance(instance, 'preempted', timestamp=timestamp)
-
-    async def handle_delete_done_event(self, instance, timestamp):
-        await self.remove_instance(instance, 'deleted', timestamp)
-
-    async def handle_call_delete_event(self, instance, timestamp):
-        await instance.mark_deleted('deleted', timestamp)
-
-    async def handle_event(self, event):
-        payload = event.get('protoPayload')
-        if payload is None:
-            log.warning('event has no payload')
-            return
-
-        timestamp = dateutil.parser.isoparse(event['timestamp']).timestamp() * 1000
-
-        resource_type = event['resource']['type']
-        if resource_type != 'gce_instance':
-            log.warning(f'unknown event resource type {resource_type}')
-            return
-
-        operation_started = event['operation'].get('first', False)
-        if operation_started:
-            event_type = 'STARTED'
-        else:
-            event_type = 'COMPLETED'
-
-        event_subtype = payload['methodName']
-        resource = event['resource']
-        name = parse_resource_name(payload['resourceName'])['name']
-
-        log.info(f'event {resource_type} {event_type} {event_subtype} {name}')
-
-        if not name.startswith(self.machine_name_prefix):
-            log.warning(f'event for unknown machine {name}')
-            return
-
-        if event_subtype == 'v1.compute.instances.insert':
-            if event_type == 'COMPLETED':
-                severity = event['severity']
-                operation_id = event['operation']['id']
-                success = (severity != 'ERROR')
-                self.zone_monitor.zone_success_rate.push(resource['labels']['zone'], operation_id, success)
-        else:
-            instance = self.name_instance.get(name)
-            if not instance:
-                log.warning(f'event for unknown instance {name}')
-                return
-
-            if event_subtype == 'v1.compute.instances.preempted':
-                log.info(f'event handler: handle preempt {instance}')
-                await self.handle_preempt_event(instance, timestamp)
-            elif event_subtype == 'v1.compute.instances.delete':
-                if event_type == 'COMPLETED':
-                    log.info(f'event handler: delete {instance} done')
-                    await self.handle_delete_done_event(instance, timestamp)
-                elif event_type == 'STARTED':
-                    log.info(f'event handler: handle call delete {instance}')
-                    await self.handle_call_delete_event(instance, timestamp)
-
-    async def event_loop(self):
-        log.info('starting event loop')
-        while True:
-            try:
-                row = await self.db.select_and_fetchone('SELECT * FROM `gevents_mark`;')
-                mark = row['mark']
-                if mark is None:
-                    mark = datetime.datetime.utcnow().isoformat() + 'Z'
-                    await self.db.execute_update(
-                        'UPDATE `gevents_mark` SET mark = %s;',
-                        (mark,))
-
-                filter = f'''
-logName="projects/{PROJECT}/logs/cloudaudit.googleapis.com%2Factivity" AND
-resource.type=gce_instance AND
-protoPayload.resourceName:"{self.machine_name_prefix}" AND
-timestamp >= "{mark}"
-'''
-
-                new_mark = None
-                async for event in await self.logging_client.list_entries(
-                        body={
-                            'resourceNames': [f'projects/{PROJECT}'],
-                            'orderBy': 'timestamp asc',
-                            'pageSize': 100,
-                            'filter': filter
-                        }):
-                    # take the last, largest timestamp
-                    new_mark = event['timestamp']
-                    await self.handle_event(event)
-
-                if new_mark is not None:
-                    await self.db.execute_update(
-                        'UPDATE `gevents_mark` SET mark = %s;',
-                        (new_mark,))
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                raise
-            except Exception:
-                log.exception('in event loop')
-            await asyncio.sleep(15)
-
     async def control_loop(self):
         log.info('starting control loop')
         while True:
@@ -693,57 +533,3 @@ FROM ready_cores;
             except Exception:
                 log.exception('in control loop')
             await asyncio.sleep(15)
-
-    async def check_on_instance(self, instance):
-        active_and_healthy = await instance.check_is_active_and_healthy()
-        if active_and_healthy:
-            return
-
-        try:
-            spec = await self.compute_client.get(
-                f'/zones/{instance.zone}/instances/{instance.name}')
-        except aiohttp.ClientResponseError as e:
-            if e.status == 404:
-                await self.remove_instance(instance, 'does_not_exist')
-                return
-            raise
-
-        # PROVISIONING, STAGING, RUNNING, STOPPING, TERMINATED
-        gce_state = spec['status']
-        log.info(f'{instance} gce_state {gce_state}')
-
-        if gce_state in ('STOPPING', 'TERMINATED'):
-            log.info(f'{instance} live but stopping or terminated, deactivating')
-            await instance.deactivate('terminated')
-
-        if (gce_state in ('STAGING', 'RUNNING')
-                and instance.state == 'pending'
-                and time_msecs() - instance.time_created > 5 * 60 * 1000):
-            # FIXME shouldn't count time in PROVISIONING
-            log.info(f'{instance} did not activate within 5m, deleting')
-            await self.call_delete_instance(instance, 'activation_timeout')
-
-        if instance.state == 'inactive':
-            log.info(f'{instance} is inactive, deleting')
-            await self.call_delete_instance(instance, 'inactive')
-
-        await instance.update_timestamp()
-
-    async def instance_monitoring_loop(self):
-        log.info('starting instance monitoring loop')
-
-        while True:
-            try:
-                if self.instances_by_last_updated:
-                    # 0 is the smallest (oldest)
-                    instance = self.instances_by_last_updated[0]
-                    since_last_updated = time_msecs() - instance.last_updated
-                    if since_last_updated > 60 * 1000:
-                        log.info(f'checking on {instance}, last updated {since_last_updated / 1000}s ago')
-                        await self.check_on_instance(instance)
-            except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                raise
-            except Exception:
-                log.exception('in monitor instances loop')
-
-            await asyncio.sleep(1)

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -502,7 +502,7 @@ gsutil -m cp dockerd.log gs://$WORKER_LOGS_BUCKET_NAME/batch/logs/$INSTANCE_ID/w
 SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu
 FROM user_pool_resources
 WHERE pool = %s
-LOCK IN SHARED MODE;
+LOCK IN SHARE MODE;
 ''',
                     (self.name,))
                 ready_cores_mcpu = ready_cores['ready_cores_mcpu']

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -500,8 +500,11 @@ gsutil -m cp dockerd.log gs://$WORKER_LOGS_BUCKET_NAME/batch/logs/$INSTANCE_ID/w
                 ready_cores = await self.db.select_and_fetchone(
                     '''
 SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu
-FROM ready_cores;
-''')
+FROM user_pool_resources
+WHERE pool = %s
+LOCK IN SHARED MODE;
+''',
+                    (self.name,))
                 ready_cores_mcpu = ready_cores['ready_cores_mcpu']
 
                 free_cores_mcpu = sum([

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -33,8 +33,9 @@ def parse_resource_name(resource_name):
 
 
 class InstancePool:
-    def __init__(self, app):
+    def __init__(self, app, name):
         self.app = app
+        self.name = name
         self.instance_id = app['instance_id']
         self.log_store = app['log_store']
         self.db = app['db']
@@ -188,7 +189,7 @@ SET worker_type = %s, worker_cores = %s, worker_disk_size_gb = %s,
             zone = random.choices(zones, zone_prob_weights)[0]
 
         activation_token = secrets.token_urlsafe(32)
-        instance = await Instance.create(self.app, machine_name, activation_token, cores * 1000, zone)
+        instance = await Instance.create(self.app, machine_name, activation_token, cores * 1000, zone, self.name)
         self.inst_monitor.add_instance(instance)
 
         log.info(f'created {instance}')

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -310,7 +310,8 @@ async def get_index(request, userdata):
     ready_cores = await db.select_and_fetchone(
         '''
 SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu
-FROM ready_cores;
+FROM user_pool_resources
+LOCK IN SHARED MODE;
 ''')
     ready_cores_mcpu = ready_cores['ready_cores_mcpu']
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -465,7 +465,7 @@ LOCK IN SHARE MODE;
         user_pool_resources = {(record['user'], record['pool']): record async for record in user_pool_resources}
 
         computed_user_pool_resources = tx.execute_and_fetchall('''
-SELECT user,
+SELECT user, pool,
     COALESCE(SUM(state = 'Ready' AND runnable), 0) as n_ready_jobs,
     COALESCE(SUM(IF(state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as ready_cores_mcpu,
     COALESCE(SUM(state = 'Running' AND NOT cancelled), 0) as n_running_jobs,

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -757,6 +757,9 @@ SELECT worker_type, worker_cores, worker_disk_size_gb,
     log_store = LogStore(BATCH_BUCKET_NAME, WORKER_LOGS_BUCKET_NAME, instance_id, pool, credentials=credentials)
     app['log_store'] = log_store
 
+    async_worker_pool = AsyncWorkerPool(parallelism=100, queue_size=100)
+    app['async_worker_pool'] = async_worker_pool
+
     zone_monitor = ZoneMonitor(app)
     app['zone_monitor'] = zone_monitor
     await zone_monitor.async_init()
@@ -772,9 +775,6 @@ SELECT worker_type, worker_cores, worker_disk_size_gb,
 
     await inst_monitor.run()
     await inst_pool.run()
-
-    async_worker_pool = AsyncWorkerPool(parallelism=100, queue_size=100)
-    app['async_worker_pool'] = async_worker_pool
 
     app['check_incremental_error'] = None
     app['check_resource_aggregation_error'] = None

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -311,7 +311,7 @@ async def get_index(request, userdata):
         '''
 SELECT CAST(COALESCE(SUM(ready_cores_mcpu), 0) AS SIGNED) AS ready_cores_mcpu
 FROM user_pool_resources
-LOCK IN SHARED MODE;
+LOCK IN SHARE MODE;
 ''')
     ready_cores_mcpu = ready_cores['ready_cores_mcpu']
 

--- a/batch/batch/driver/scheduler.py
+++ b/batch/batch/driver/scheduler.py
@@ -184,7 +184,7 @@ WHERE user = %s AND `state` = 'running';
                     async for record in self.db.select_and_fetchall(
                             '''
 SELECT jobs.job_id
-FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_pool_cancelled)
 WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND pool = %s
 LIMIT %s;
 ''',
@@ -196,7 +196,7 @@ LIMIT %s;
                     async for record in self.db.select_and_fetchall(
                             '''
 SELECT jobs.job_id
-FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_pool_cancelled)
 WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND pool = %s AND cancelled = 1
 LIMIT %s;
 ''',
@@ -275,7 +275,7 @@ WHERE user = %s AND `state` = 'running' AND cancelled = 1;
                 async for record in self.db.select_and_fetchall(
                         '''
 SELECT jobs.job_id, attempts.attempt_id, attempts.instance_name
-FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_pool_cancelled)
 STRAIGHT_JOIN attempts
   ON attempts.batch_id = jobs.batch_id AND attempts.job_id = jobs.job_id
 WHERE jobs.batch_id = %s AND state = 'Running' AND always_run = 0 AND pool = %s AND cancelled = 0
@@ -343,7 +343,7 @@ WHERE user = %s AND `state` = 'running';
                 async for record in self.db.select_and_fetchall(
                         '''
 SELECT job_id, spec, cores_mcpu
-FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_pool_cancelled)
 WHERE batch_id = %s AND state = 'Ready' AND always_run = 1 AND pool = %s
 LIMIT %s;
 ''',
@@ -358,7 +358,7 @@ LIMIT %s;
                     async for record in self.db.select_and_fetchall(
                             '''
 SELECT job_id, spec, cores_mcpu
-FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_cancelled)
+FROM jobs FORCE INDEX(jobs_batch_id_state_always_run_pool_cancelled)
 WHERE batch_id = %s AND state = 'Ready' AND always_run = 0 AND pool = %s AND cancelled = 0
 LIMIT %s;
 ''',

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -264,14 +264,14 @@ BEGIN
       END IF;
 
       INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
-      SELECT user, pool, 0, COALESCE(SUM(staging_n_ready_jobs), 0), COALESCE(SUM(staging_ready_cores_mcpu), 0)
+      SELECT user, pool, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
       FROM batches_pool_staging
       JOIN batches ON batches.id = batches_pool_staging.batch_id
       WHERE batch_id = in_batch_id
-      GROUP BY user, pool
+      GROUP BY `user`, pool
       ON DUPLICATE KEY UPDATE
-        n_ready_jobs = n_ready_jobs + COALESCE(SUM(staging_n_ready_jobs), 0),
-        ready_cores_mcpu = ready_cores_mcpu + COALESCE(SUM(staging_ready_cores_mcpu), 0);
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
 
       DELETE FROM batches_pool_staging WHERE batch_id = in_batch_id;
 

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -34,6 +34,7 @@ DROP TABLE `ready_cores`;
 
 DELIMITER $$
 
+DROP TRIGGER IF EXISTS jobs_after_update $$
 CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
 FOR EACH ROW
 BEGIN
@@ -152,6 +153,7 @@ BEGIN
   END IF;
 END $$
 
+DROP PROCEDURE IF EXISTS recompute_incremental $$
 CREATE PROCEDURE recompute_incremental(
 ) BEGIN
 
@@ -282,6 +284,7 @@ BEGIN
   END IF;
 END $$
 
+DROP PROCEDURE IF EXISTS cancel_batch $$
 CREATE PROCEDURE cancel_batch(
   IN in_batch_id VARCHAR(100)
 )

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -6,30 +6,27 @@ CREATE TABLE IF NOT EXISTS `pools` (
 
 INSERT INTO pools (`name`, `type`) VALUES ('standard', 'standard');
 
-ALTER TABLE instances ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+ALTER TABLE instances ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
 
-ALTER TABLE jobs ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+ALTER TABLE jobs ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
 DROP INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs`;
 CREATE INDEX `jobs_batch_id_state_always_run_pool_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `pool`, `cancelled`);
 
 ALTER TABLE user_resources RENAME user_pool_resources;
 ALTER TABLE user_pool_resources ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
-ALTER TABLE user_pool_resources DROP PRIMARY KEY;
-ALTER TABLE user_pool_resources ADD PRIMARY KEY (`user`, pool, token);
+ALTER TABLE user_pool_resources DROP PRIMARY KEY, ADD PRIMARY KEY (`user`, pool, token);
 ALTER TABLE user_pool_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `user_pool_resources_pool` ON `user_pool_resources` (`pool`);
 
 ALTER TABLE batches_staging RENAME batches_pool_staging;
-ALTER TABLE batches_pool_staging ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
-ALTER TABLE batches_pool_staging DROP PRIMARY KEY;
-ALTER TABLE batches_pool_staging ADD PRIMARY KEY (batch_id, pool, token);
+ALTER TABLE batches_pool_staging ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
+ALTER TABLE batches_pool_staging DROP PRIMARY KEY, ADD PRIMARY KEY (batch_id, pool, token);
 ALTER TABLE batches_pool_staging ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `batches_pool_staging_pool` ON `batches_pool_staging` (`pool`);
 
 ALTER TABLE batch_cancellable_resources RENAME batch_pool_cancellable_resources;
-ALTER TABLE batch_pool_cancellable_resources ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
-ALTER TABLE batch_pool_cancellable_resources DROP PRIMARY KEY;
-ALTER TABLE batch_pool_cancellable_resources ADD PRIMARY KEY (batch_id, pool, token);
+ALTER TABLE batch_pool_cancellable_resources ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
+ALTER TABLE batch_pool_cancellable_resources DROP PRIMARY KEY, ADD PRIMARY KEY (batch_id, pool, token);
 ALTER TABLE batch_pool_cancellable_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `batch_pool_cancellable_resources_pool` ON `batch_pool_cancellable_resources` (`pool`);
 

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -15,21 +15,21 @@ CREATE INDEX `jobs_batch_id_state_always_run_pool_cancelled` ON `jobs` (`batch_i
 ALTER TABLE user_resources RENAME user_pool_resources;
 ALTER TABLE user_pool_resources ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
 ALTER TABLE user_pool_resources DROP PRIMARY KEY;
-ALTER TABLE user_pool_resources ADD PRIMARY (`user`, pool, token);
+ALTER TABLE user_pool_resources ADD PRIMARY KEY (`user`, pool, token);
 ALTER TABLE user_pool_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `user_pool_resources_pool` ON `user_pool_resources` (`pool`);
 
 ALTER TABLE batches_staging RENAME batches_pool_staging;
 ALTER TABLE batches_pool_staging ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
 ALTER TABLE batches_pool_staging DROP PRIMARY KEY;
-ALTER TABLE batches_pool_staging ADD PRIMARY (batch_id, pool, token);
+ALTER TABLE batches_pool_staging ADD PRIMARY KEY (batch_id, pool, token);
 ALTER TABLE batches_pool_staging ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `batches_pool_staging_pool` ON `batches_pool_staging` (`pool`);
 
 ALTER TABLE batch_cancellable_resources RENAME batch_pool_cancellable_resources;
 ALTER TABLE batch_pool_cancellable_resources ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
 ALTER TABLE batch_pool_cancellable_resources DROP PRIMARY KEY;
-ALTER TABLE batch_pool_cancellable_resources ADD PRIMARY (batch_id, pool, token);
+ALTER TABLE batch_pool_cancellable_resources ADD PRIMARY KEY (batch_id, pool, token);
 ALTER TABLE batch_pool_cancellable_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
 CREATE INDEX `batch_pool_cancellable_resources_pool` ON `batch_pool_cancellable_resources` (`pool`);
 

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -68,7 +68,7 @@ BEGIN
     ELSE
       # runnable
       INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
-      VALUES (cur_user, OLD.pool rand_token, -1, -OLD.cores_mcpu)
+      VALUES (cur_user, OLD.pool, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_jobs = n_ready_jobs - 1,
         ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;

--- a/batch/sql/add-pools.sql
+++ b/batch/sql/add-pools.sql
@@ -1,0 +1,336 @@
+CREATE TABLE IF NOT EXISTS `pools` (
+  `name` VARCHAR(255) NOT NULL,
+  `type` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`name`)
+) ENGINE = InnoDB;
+
+INSERT INTO pools (`name`, `type`) VALUES ('standard', 'standard');
+
+ALTER TABLE instances ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+
+ALTER TABLE jobs ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+DROP INDEX `jobs_batch_id_state_always_run_cancelled` ON `jobs`;
+CREATE INDEX `jobs_batch_id_state_always_run_pool_cancelled` ON `jobs` (`batch_id`, `state`, `always_run`, `pool`, `cancelled`);
+
+ALTER TABLE user_resources RENAME user_pool_resources;
+ALTER TABLE user_pool_resources ADD COLUMN `pool` VARCHAR(255) DEFAULT 'standard';
+ALTER TABLE user_pool_resources DROP PRIMARY KEY;
+ALTER TABLE user_pool_resources ADD PRIMARY (`user`, pool, token);
+ALTER TABLE user_pool_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
+CREATE INDEX `user_pool_resources_pool` ON `user_pool_resources` (`pool`);
+
+ALTER TABLE batches_staging RENAME batches_pool_staging;
+ALTER TABLE batches_pool_staging ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+ALTER TABLE batches_pool_staging DROP PRIMARY KEY;
+ALTER TABLE batches_pool_staging ADD PRIMARY (batch_id, pool, token);
+ALTER TABLE batches_pool_staging ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
+CREATE INDEX `batches_pool_staging_pool` ON `batches_pool_staging` (`pool`);
+
+ALTER TABLE batch_cancellable_resources RENAME batch_pool_cancellable_resources;
+ALTER TABLE batch_pool_cancellable_resources ADD COLUMN `pool` VARCHAR(255) NOT NULL DEFAULT 'standard';
+ALTER TABLE batch_pool_cancellable_resources DROP PRIMARY KEY;
+ALTER TABLE batch_pool_cancellable_resources ADD PRIMARY (batch_id, pool, token);
+ALTER TABLE batch_pool_cancellable_resources ADD FOREIGN KEY (`pool`) REFERENCES pools(`name`) ON DELETE CASCADE;
+CREATE INDEX `batch_pool_cancellable_resources_pool` ON `batch_pool_cancellable_resources` (`pool`);
+
+DROP TABLE `ready_cores`;
+
+DELIMITER $$
+
+CREATE TRIGGER jobs_after_update AFTER UPDATE ON jobs
+FOR EACH ROW
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_cancelled BOOLEAN;
+  DECLARE cur_n_tokens INT;
+  DECLARE rand_token INT;
+
+  SELECT user, cancelled INTO cur_user, cur_batch_cancelled FROM batches
+  WHERE id = NEW.batch_id
+  LOCK IN SHARE MODE;
+
+  SELECT n_tokens INTO cur_n_tokens FROM globals LOCK IN SHARE MODE;
+  SET rand_token = FLOOR(RAND() * cur_n_tokens);
+
+  IF OLD.state = 'Ready' THEN
+    IF NOT (OLD.always_run OR OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_pool_cancellable_resources (batch_id, pool, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, OLD.pool, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs - 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    IF NOT OLD.always_run AND (OLD.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_pool_resources (user, pool, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, OLD.pool, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs - 1;
+    ELSE
+      # runnable
+      INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, OLD.pool rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs - 1,
+        ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  ELSEIF OLD.state = 'Running' THEN
+    IF NOT (OLD.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_pool_cancellable_resources (batch_id, pool, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (OLD.batch_id, OLD.pool, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs - 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT OLD.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_pool_resources (user, pool, token, n_cancelled_running_jobs)
+      VALUES (cur_user, OLD.pool, rand_token, -1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs - 1;
+    ELSE
+      # running
+      INSERT INTO user_pool_resources (user, pool, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, OLD.pool, rand_token, -1, -OLD.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs - 1,
+        running_cores_mcpu = running_cores_mcpu - OLD.cores_mcpu;
+    END IF;
+  END IF;
+
+  IF NEW.state = 'Ready' THEN
+    IF NOT (NEW.always_run OR NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_pool_cancellable_resources (batch_id, pool, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, NEW.pool, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_cancellable_jobs = n_ready_cancellable_jobs + 1,
+        ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    IF NOT NEW.always_run AND (NEW.cancelled OR cur_batch_cancelled) THEN
+      # cancelled
+      INSERT INTO user_pool_resources (user, pool, token, n_cancelled_ready_jobs)
+      VALUES (cur_user, NEW.pool, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_ready_jobs = n_cancelled_ready_jobs + 1;
+    ELSE
+      # runnable
+      INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
+      VALUES (cur_user, NEW.pool, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + 1,
+        ready_cores_mcpu = ready_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  ELSEIF NEW.state = 'Running' THEN
+    IF NOT (NEW.always_run OR cur_batch_cancelled) THEN
+      # cancellable
+      INSERT INTO batch_pool_cancellable_resources (batch_id, pool, token, n_running_cancellable_jobs, running_cancellable_cores_mcpu)
+      VALUES (NEW.batch_id, NEW.pool, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_cancellable_jobs = n_running_cancellable_jobs + 1,
+        running_cancellable_cores_mcpu = running_cancellable_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+
+    # state = 'Running' jobs cannot be cancelled at the job level
+    IF NOT NEW.always_run AND cur_batch_cancelled THEN
+      # cancelled
+      INSERT INTO user_pool_resources (user, pool, token, n_cancelled_running_jobs)
+      VALUES (cur_user, NEW.pool, rand_token, 1)
+      ON DUPLICATE KEY UPDATE
+        n_cancelled_running_jobs = n_cancelled_running_jobs + 1;
+    ELSE
+      # running
+      INSERT INTO user_pool_resources (user, pool, token, n_running_jobs, running_cores_mcpu)
+      VALUES (cur_user, NEW.pool, rand_token, 1, NEW.cores_mcpu)
+      ON DUPLICATE KEY UPDATE
+        n_running_jobs = n_running_jobs + 1,
+        running_cores_mcpu = running_cores_mcpu + NEW.cores_mcpu;
+    END IF;
+  END IF;
+END $$
+
+CREATE PROCEDURE recompute_incremental(
+) BEGIN
+
+  DELETE FROM batches_pool_staging;
+  DELETE FROM batch_pool_cancellable_resources;
+  DELETE FROM user_pool_resources;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_pool_resources`;
+
+  CREATE TEMPORARY TABLE `tmp_batch_pool_resources` AS (
+    SELECT batch_id, batch_state, batch_cancelled, user, job_pool,
+      COALESCE(SUM(1), 0) as n_jobs,
+      COALESCE(SUM(job_state = 'Ready' AND cancellable), 0) as n_ready_cancellable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND cancellable, cores_mcpu, 0)), 0) as ready_cancellable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Running' AND NOT cancelled), 0) as n_running_jobs,
+      COALESCE(SUM(IF(job_state = 'Running' AND NOT cancelled, cores_mcpu, 0)), 0) as running_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND runnable), 0) as n_runnable_jobs,
+      COALESCE(SUM(IF(job_state = 'Ready' AND runnable, cores_mcpu, 0)), 0) as runnable_cores_mcpu,
+      COALESCE(SUM(job_state = 'Ready' AND cancelled), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(job_state = 'Running' AND cancelled), 0) as n_cancelled_running_jobs
+    FROM (
+      SELECT batches.user,
+        batches.id as batch_id,
+        batches.state as batch_state,
+        batches.cancelled as batch_cancelled,
+        jobs.pool as job_pool,
+        jobs.state as job_state,
+        jobs.cores_mcpu,
+        NOT (jobs.always_run OR jobs.cancelled OR batches.cancelled) AS cancellable,
+        (jobs.always_run OR NOT (jobs.cancelled OR batches.cancelled)) AS runnable,
+        (NOT jobs.always_run AND (jobs.cancelled OR batches.cancelled)) AS cancelled
+      FROM jobs
+      INNER JOIN batches
+        ON batches.id = jobs.batch_id
+      LOCK IN SHARE MODE) as t
+    GROUP BY batch_id, batch_state, batch_cancelled, user, job_pool
+  );
+
+  INSERT INTO batches_pool_staging (batch_id, pool, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
+  SELECT batch_id, job_pool, 0, n_jobs, n_runnable_jobs, runnable_cores_mcpu
+  FROM tmp_batch_pool_resources
+  WHERE batch_state = 'open';
+
+  INSERT INTO batch_pool_cancellable_resources (batch_id, pool, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
+  SELECT batch_id, job_pool, 0, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu
+  FROM tmp_batch_pool_resources
+  WHERE NOT batch_cancelled;
+
+  INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu,
+    n_running_jobs, running_cores_mcpu,
+    n_cancelled_ready_jobs, n_cancelled_running_jobs)
+  SELECT t.user, t.job_pool, 0, t.n_runnable_jobs, t.runnable_cores_mcpu,
+    t.n_running_jobs, t.running_cores_mcpu,
+    t.n_cancelled_ready_jobs, t.n_cancelled_running_jobs
+  FROM (SELECT user, job_pool,
+      COALESCE(SUM(n_running_jobs), 0) as n_running_jobs,
+      COALESCE(SUM(running_cores_mcpu), 0) as running_cores_mcpu,
+      COALESCE(SUM(n_runnable_jobs), 0) as n_runnable_jobs,
+      COALESCE(SUM(runnable_cores_mcpu), 0) as runnable_cores_mcpu,
+      COALESCE(SUM(n_cancelled_ready_jobs), 0) as n_cancelled_ready_jobs,
+      COALESCE(SUM(n_cancelled_running_jobs), 0) as n_cancelled_running_jobs
+    FROM tmp_batch_pool_resources
+    WHERE batch_state != 'open'
+    GROUP by user, job_pool) as t;
+
+  DROP TEMPORARY TABLE IF EXISTS `tmp_batch_pool_resources`;
+
+END $$
+
+DROP PROCEDURE IF EXISTS close_batch $$
+CREATE PROCEDURE close_batch(
+  IN in_batch_id BIGINT,
+  IN in_timestamp BIGINT
+)
+BEGIN
+  DECLARE cur_batch_state VARCHAR(40);
+  DECLARE expected_n_jobs INT;
+  DECLARE staging_n_jobs INT;
+  DECLARE staging_n_ready_jobs INT;
+  DECLARE staging_ready_cores_mcpu BIGINT;
+  DECLARE cur_user VARCHAR(100);
+
+  START TRANSACTION;
+
+  SELECT `state`, n_jobs INTO cur_batch_state, expected_n_jobs FROM batches
+  WHERE id = in_batch_id AND NOT deleted
+  FOR UPDATE;
+
+  IF cur_batch_state != 'open' THEN
+    COMMIT;
+    SELECT 0 as rc;
+  ELSE
+    SELECT COALESCE(SUM(n_jobs), 0), COALESCE(SUM(n_ready_jobs), 0), COALESCE(SUM(ready_cores_mcpu), 0)
+    INTO staging_n_jobs, staging_n_ready_jobs, staging_ready_cores_mcpu
+    FROM batches_pool_staging
+    WHERE batch_id = in_batch_id
+    FOR UPDATE;
+
+    SELECT user INTO cur_user FROM batches WHERE id = in_batch_id;
+
+    IF staging_n_jobs = expected_n_jobs THEN
+      IF expected_n_jobs = 0 THEN
+        UPDATE batches SET `state` = 'complete', time_completed = in_timestamp, time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      ELSE
+        UPDATE batches SET `state` = 'running', time_closed = in_timestamp
+          WHERE id = in_batch_id;
+      END IF;
+
+      INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
+      SELECT user, pool, 0, COALESCE(SUM(staging_n_ready_jobs), 0), COALESCE(SUM(staging_ready_cores_mcpu), 0)
+      FROM batches_pool_staging
+      JOIN batches ON batches.id = batches_pool_staging.batch_id
+      WHERE batch_id = in_batch_id
+      GROUP BY user, pool
+      ON DUPLICATE KEY UPDATE
+        n_ready_jobs = n_ready_jobs + COALESCE(SUM(staging_n_ready_jobs), 0),
+        ready_cores_mcpu = ready_cores_mcpu + COALESCE(SUM(staging_ready_cores_mcpu), 0);
+
+      DELETE FROM batches_pool_staging WHERE batch_id = in_batch_id;
+
+      COMMIT;
+      SELECT 0 as rc;
+    ELSE
+      ROLLBACK;
+      SELECT 2 as rc, expected_n_jobs, staging_n_jobs as actual_n_jobs, 'wrong number of jobs' as message;
+    END IF;
+  END IF;
+END $$
+
+CREATE PROCEDURE cancel_batch(
+  IN in_batch_id VARCHAR(100)
+)
+BEGIN
+  DECLARE cur_user VARCHAR(100);
+  DECLARE cur_batch_state VARCHAR(40);
+  DECLARE cur_cancelled BOOLEAN;
+  DECLARE cur_n_cancelled_ready_jobs INT;
+  DECLARE cur_cancelled_ready_cores_mcpu BIGINT;
+  DECLARE cur_n_cancelled_running_jobs INT;
+  DECLARE cur_cancelled_running_cores_mcpu BIGINT;
+
+  START TRANSACTION;
+
+  SELECT user, `state`, cancelled INTO cur_user, cur_batch_state, cur_cancelled FROM batches
+  WHERE id = in_batch_id
+  FOR UPDATE;
+
+  IF cur_batch_state = 'running' AND NOT cur_cancelled THEN
+    INSERT INTO user_pool_resources (user, pool, token,
+      n_ready_jobs, ready_cores_mcpu,
+      n_running_jobs, running_cores_mcpu,
+      n_cancelled_ready_jobs, n_cancelled_running_jobs)
+    SELECT user, pool, 0,
+      -1 * COALESCE(SUM(n_ready_cancellable_jobs), 0), -1 * COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+      -1 * COALESCE(SUM(n_running_cancellable_jobs), 0), -1 * COALESCE(SUM(running_cancellable_cores_mcpu), 0),
+      COALESCE(SUM(n_ready_cancellable_jobs), 0), COALESCE(SUM(n_running_cancellable_jobs), 0)
+    FROM batch_pool_cancellable_resources
+    JOIN batches ON batches.id = batch_pool_cancellable_resources.batch_id
+    WHERE batch_id = in_batch_id
+    GROUP BY user, pool
+    ON DUPLICATE KEY UPDATE
+      n_ready_jobs = n_ready_jobs - COALESCE(SUM(n_ready_cancellable_jobs), 0),
+      ready_cores_mcpu = ready_cores_mcpu - COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+      n_running_jobs = n_running_jobs - COALESCE(SUM(n_running_cancellable_jobs), 0),
+      running_cores_mcpu = running_cores_mcpu - COALESCE(SUM(running_cancellable_cores_mcpu), 0),
+      n_cancelled_ready_jobs = n_cancelled_ready_jobs + COALESCE(SUM(n_ready_cancellable_jobs), 0),
+      n_cancelled_running_jobs = n_cancelled_running_jobs + COALESCE(SUM(n_running_cancellable_jobs), 0);
+
+    # there are no cancellable jobs left, they have been cancelled
+    DELETE FROM batch_pool_cancellable_resources WHERE batch_id = in_batch_id;
+
+    UPDATE batches SET cancelled = 1 WHERE id = in_batch_id;
+  END IF;
+
+  COMMIT;
+END $$
+
+DELIMITER ;

--- a/batch/sql/delete-batch-tables.sql
+++ b/batch/sql/delete-batch-tables.sql
@@ -20,7 +20,8 @@ DROP TABLE IF EXISTS `aggregated_billing_project_resources`;
 DROP TABLE IF EXISTS `aggregated_batch_resources`;
 DROP TABLE IF EXISTS `aggregated_job_resources`;
 DROP TABLE IF EXISTS `attempt_resources`;
-DROP TABLE IF EXISTS `batch_cancellable_resources`;
+DROP TABLE IF EXISTS `batch_cancellable_resources`;  # deprecated
+DROP TABLE IF EXISTS `batch_pool_cancellable_resources`;
 DROP TABLE IF EXISTS `globals`;
 DROP TABLE IF EXISTS `attempts`;
 DROP TABLE IF EXISTS `batch_attributes`;
@@ -30,10 +31,13 @@ DROP TABLE IF EXISTS `batch_bunches`;
 DROP TABLE IF EXISTS `ready_cores`;
 DROP TABLE IF EXISTS `gevents_mark`;
 DROP TABLE IF EXISTS `jobs`;
-DROP TABLE IF EXISTS `batches_staging`;
+DROP TABLE IF EXISTS `batches_staging`;  # deprecated
+DROP TABLE IF EXISTS `batches_pool_staging`;
 DROP TABLE IF EXISTS `batches`;
-DROP TABLE IF EXISTS `user_resources`;
+DROP TABLE IF EXISTS `user_resources`;  # deprecated
+DROP TABLE IF EXISTS `user_pool_resources`;
 DROP TABLE IF EXISTS `instances`;
+DROP TABLE IF EXISTS `pools`;
 DROP TABLE IF EXISTS `billing_project_users`;
 DROP TABLE IF EXISTS `billing_projects`;
 DROP TABLE IF EXISTS `batch_migration_version`;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -384,7 +384,7 @@ BEGIN
     ELSE
       # runnable
       INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
-      VALUES (cur_user, OLD.pool rand_token, -1, -OLD.cores_mcpu)
+      VALUES (cur_user, OLD.pool, rand_token, -1, -OLD.cores_mcpu)
       ON DUPLICATE KEY UPDATE
         n_ready_jobs = n_ready_jobs - 1,
         ready_cores_mcpu = ready_cores_mcpu - OLD.cores_mcpu;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -747,20 +747,22 @@ BEGIN
       n_running_jobs, running_cores_mcpu,
       n_cancelled_ready_jobs, n_cancelled_running_jobs)
     SELECT user, pool, 0,
-      -1 * COALESCE(SUM(n_ready_cancellable_jobs), 0), -1 * COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
-      -1 * COALESCE(SUM(n_running_cancellable_jobs), 0), -1 * COALESCE(SUM(running_cancellable_cores_mcpu), 0),
+      @n_ready_cancellable_jobs := -1 * COALESCE(SUM(n_ready_cancellable_jobs), 0),
+      @ready_cancellable_cores_mcpu := -1 * COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
+      @n_running_cancellable_jobs := -1 * COALESCE(SUM(n_running_cancellable_jobs), 0),
+      @running_cancellable_cores_mcpu := -1 * COALESCE(SUM(running_cancellable_cores_mcpu), 0),
       COALESCE(SUM(n_ready_cancellable_jobs), 0), COALESCE(SUM(n_running_cancellable_jobs), 0)
     FROM batch_pool_cancellable_resources
     JOIN batches ON batches.id = batch_pool_cancellable_resources.batch_id
     WHERE batch_id = in_batch_id
     GROUP BY user, pool
     ON DUPLICATE KEY UPDATE
-      n_ready_jobs = n_ready_jobs - COALESCE(SUM(n_ready_cancellable_jobs), 0),
-      ready_cores_mcpu = ready_cores_mcpu - COALESCE(SUM(ready_cancellable_cores_mcpu), 0),
-      n_running_jobs = n_running_jobs - COALESCE(SUM(n_running_cancellable_jobs), 0),
-      running_cores_mcpu = running_cores_mcpu - COALESCE(SUM(running_cancellable_cores_mcpu), 0),
-      n_cancelled_ready_jobs = n_cancelled_ready_jobs + COALESCE(SUM(n_ready_cancellable_jobs), 0),
-      n_cancelled_running_jobs = n_cancelled_running_jobs + COALESCE(SUM(n_running_cancellable_jobs), 0);
+      n_ready_jobs = n_ready_jobs - @n_ready_cancellable_jobs,
+      ready_cores_mcpu = ready_cores_mcpu - @ready_cancellable_cores_mcpu,
+      n_running_jobs = n_running_jobs - @n_running_cancellable_jobs,
+      running_cores_mcpu = running_cores_mcpu - @running_cancellable_cores_mcpu,
+      n_cancelled_ready_jobs = n_cancelled_ready_jobs + @n_ready_cancellable_jobs,
+      n_cancelled_running_jobs = n_cancelled_running_jobs + @n_running_cancellable_jobs;
 
     # there are no cancellable jobs left, they have been cancelled
     DELETE FROM batch_pool_cancellable_resources WHERE batch_id = in_batch_id;

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -79,7 +79,7 @@ CREATE INDEX `instances_pool` ON `instances` (`pool`);
 
 CREATE TABLE IF NOT EXISTS `user_pool_resources` (
   `user` VARCHAR(100) NOT NULL,
-  `pool` VARCHAR(255) NOT NULL,
+  `pool` VARCHAR(255),
   `token` INT NOT NULL,
   `n_ready_jobs` INT NOT NULL DEFAULT 0,
   `n_running_jobs` INT NOT NULL DEFAULT 0,
@@ -124,7 +124,7 @@ CREATE INDEX `batches_billing_project_state` ON `batches` (`billing_project`, `s
 
 CREATE TABLE IF NOT EXISTS `batches_pool_staging` (
   `batch_id` BIGINT NOT NULL,
-  `pool` VARCHAR(255) NOT NULL,
+  `pool` VARCHAR(255),
   `token` INT NOT NULL,
   `n_jobs` INT NOT NULL DEFAULT 0,
   `n_ready_jobs` INT NOT NULL DEFAULT 0,
@@ -137,7 +137,7 @@ CREATE INDEX `batches_pool_staging_pool` ON `batches_pool_staging` (`pool`);
 
 CREATE TABLE `batch_pool_cancellable_resources` (
   `batch_id` BIGINT NOT NULL,
-  `pool` VARCHAR(255) NOT NULL,
+  `pool` VARCHAR(255),
   `token` INT NOT NULL,
   # neither run_always nor cancelled
   `n_ready_cancellable_jobs` INT NOT NULL DEFAULT 0,

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -703,14 +703,14 @@ BEGIN
       END IF;
 
       INSERT INTO user_pool_resources (user, pool, token, n_ready_jobs, ready_cores_mcpu)
-      SELECT user, pool, 0, COALESCE(SUM(staging_n_ready_jobs), 0), COALESCE(SUM(staging_ready_cores_mcpu), 0)
+      SELECT user, pool, 0, @n_ready_jobs := COALESCE(SUM(n_ready_jobs), 0), @ready_cores_mcpu := COALESCE(SUM(ready_cores_mcpu), 0)
       FROM batches_pool_staging
       JOIN batches ON batches.id = batches_pool_staging.batch_id
       WHERE batch_id = in_batch_id
-      GROUP BY user, pool
+      GROUP BY `user`, pool
       ON DUPLICATE KEY UPDATE
-        n_ready_jobs = n_ready_jobs + COALESCE(SUM(staging_n_ready_jobs), 0),
-        ready_cores_mcpu = ready_cores_mcpu + COALESCE(SUM(staging_ready_cores_mcpu), 0);
+        n_ready_jobs = n_ready_jobs + @n_ready_jobs,
+        ready_cores_mcpu = ready_cores_mcpu + @ready_cores_mcpu;
 
       DELETE FROM batches_pool_staging WHERE batch_id = in_batch_id;
 

--- a/build.yaml
+++ b/build.yaml
@@ -1958,6 +1958,8 @@ steps:
       script: /io/sql/add-status-flag-billing-projects.sql
     - name: add-aggregated-billing-project-resources
       script: /io/sql/add-aggregated-billing-project-resources.sql
+    - name: add-pools
+      script: /io/sql/add-pools.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/


### PR DESCRIPTION
Stacked on #9774 

This PR leaves the system in a state that has multiple pools in the SQL code, but the instance pool is hard coded as standard and there's only one of them. The global variables of local ssd, standing worker cores, etc. are still in globals and not per pool yet. This is because I need to write the code for the instance pool manager which will be in subsequent PRs so that we can configure each pool individually.

The goal of this PR is to make sure the incremental data structures are correct for supporting multiple pools.