### PR TITLE
[query] Remove strides and dimensionLength from PNDArray

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -24,14 +24,9 @@ abstract class PNDArray extends PType {
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering = throw new UnsupportedOperationException
 
   val shape: StaticallyKnownField[PTuple, Long]
-  val strides: StaticallyKnownField[PTuple, Long]
   val data: StaticallyKnownField[PArray, Long]
 
   val representation: PStruct
-
-  def dimensionLength(off: Code[Long], idx: Int): Code[Long] = {
-    Region.loadLong(shape.pType.fieldOffset(shape.load(off), idx))
-  }
 
   def loadShape(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 


### PR DESCRIPTION
`strides` shouldn't be a public field on `PNDArray` interface, just an internal detail of `PCanonicalNDArray`. 

`dimensionLength` was just loading the shape, should never have been its own method.


There's a lot more interface clean up to do, these two were just easy