### PR TITLE
[batch] a few fixups of front end jobs page

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -460,7 +460,7 @@ async def schedule_job(app, record, instance):
                 'user': record['user'],
                 'state': 'error',
                 'error': traceback.format_exc(),
-                'container_statuses': {k: {} for k in tasks}
+                'container_statuses': {k: None for k in tasks}
             }
 
             if format_version.has_full_status_in_gcs():

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1215,8 +1215,8 @@ async def ui_get_job(request, userdata):
     job_status_status = job_status['status']
     container_status_spec = dictfix.NoneOr({
         'name': str,
-        'timing': {'pulling': dictfix.NoneOr({'duration': Number}),
-                   'running': dictfix.NoneOr({'duration': Number})},
+        'timing': {'pulling': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)}),
+                   'running': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)})},
         'container_status': {'out_of_memory': False},
         'state': str})
     job_status_status_spec = {

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -66,12 +66,12 @@
     <tr>
       <td>{{ step['name'] }}</td>
       <td>
-        {% if step['timing']['pulling'] %}
+        {% if step['timing']['pulling'] and step['timing']['pulling']['duration'] %}
         {{ step['timing']['pulling']['duration'] / 1000.0 }}
         {% endif %}
       </td>
       <td>
-        {% if step['timing']['running'] %}
+        {% if step['timing']['running'] and step['timing']['running']['duration'] %}
         {{ step['timing']['running']['duration'] / 1000.0 }}
         {% endif %}
       </td>

--- a/hail/python/hailtop/dictfix.py
+++ b/hail/python/hailtop/dictfix.py
@@ -23,7 +23,7 @@ def _dictfix(x, spec):
             try:
                 x[k] = _dictfix(v, subspec)
             except AssertionError as err:
-                raise AssertionError(f'{k}:{v}') from err
+                raise AssertionError(f'{k}:{v}, {err.args[0]}') from err
     else:
         if x is None:
             x = spec


### PR DESCRIPTION
- I am now enforcing that container statuses are None if there is no information
- The duration can be missing even if the timing struct is not (for example, in progress jobs).