### PR TITLE
Add domain to the deploy config.

### DIFF
--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -59,12 +59,13 @@ def copy_paste_login(copy_paste_token, namespace=None):
 
 async def async_copy_paste_login(copy_paste_token, namespace=None):
     deploy_config = get_deploy_config()
+
     if namespace is not None:
-        auth_ns = namespace
-        deploy_config = deploy_config.with_service('auth', auth_ns)
+        deploy_config = deploy_config.with_default_namespace(namespace)
     else:
-        auth_ns = deploy_config.service_ns('auth')
-    headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
+        namespace = deploy_config.default_namespace()
+
+    headers = namespace_auth_headers(deploy_config, namespace, authorize_target=False)
 
     async with aiohttp.ClientSession(
             raise_for_status=True,
@@ -78,10 +79,10 @@ async def async_copy_paste_login(copy_paste_token, namespace=None):
     username = resp['username']
 
     tokens = get_tokens()
-    tokens[auth_ns] = token
+    tokens[namespace] = token
     dot_hail_dir = os.path.expanduser('~/.hail')
     if not os.path.exists(dot_hail_dir):
         os.mkdir(dot_hail_dir, mode=0o700)
     tokens.write()
 
-    return auth_ns, username
+    return namespace, username

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -15,7 +15,7 @@ class DeployConfig:
     @staticmethod
     def from_config(config):
         domain = config.get('domain', 'hail.is')
-        return DeployConfig(config['location'], config['default_namespace'], config['domain'])
+        return DeployConfig(config['location'], config['default_namespace'], domain)
 
     def get_config(self):
         return {
@@ -51,10 +51,16 @@ class DeployConfig:
         self._default_namespace = default_namespace
         self._domain = domain
 
+    def with_default_namespace(self, default_namespace):
+        return DeployConfig(self._location, default_namespace, self._domain)
+
+    def default_namespace(self):
+        return self._default_namespace
+
     def location(self):
         return self._location
 
-    def service_ns(self, service):
+    def service_ns(self, service):  # pylint: disable=unused-argument
         return self._default_namespace
 
     def scheme(self, base_scheme='http'):

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -14,7 +14,15 @@ log = logging.getLogger('deploy_config')
 class DeployConfig:
     @staticmethod
     def from_config(config):
-        return DeployConfig(config['location'], config['default_namespace'], config['service_namespace'])
+        domain = config.get('domain', 'hail.is')
+        return DeployConfig(config['location'], config['default_namespace'], config['domain'])
+
+    def get_config(self):
+        return {
+            'location': self._location,
+            'default_namespace': self._default_namespace,
+            'domain': self._domain
+        }
 
     @staticmethod
     def from_config_file(config_file=None):
@@ -33,24 +41,21 @@ class DeployConfig:
             config = {
                 'location': 'external',
                 'default_namespace': 'default',
-                'service_namespace': {}
+                'domain': 'hail.is'
             }
         return DeployConfig.from_config(config)
 
-    def __init__(self, location, default_namespace, service_namespace):
+    def __init__(self, location, default_namespace, domain):
         assert location in ('external', 'k8s', 'gce')
         self._location = location
         self._default_namespace = default_namespace
-        self._service_namespace = service_namespace
-
-    def with_service(self, service, ns):
-        return DeployConfig(self._location, self._default_namespace, {**self._service_namespace, service: ns})
+        self._domain = domain
 
     def location(self):
         return self._location
 
     def service_ns(self, service):
-        return self._service_namespace.get(service, self._default_namespace)
+        return self._default_namespace
 
     def scheme(self, base_scheme='http'):
         # FIXME: should depend on ssl context
@@ -66,8 +71,8 @@ class DeployConfig:
             return 'internal.hail'
         assert self._location == 'external'
         if ns == 'default':
-            return f'{service}.hail.is'
-        return 'internal.hail.is'
+            return f'{service}.{self._domain}'
+        return f'internal.{self._domain}'
 
     def base_path(self, service):
         ns = self.service_ns(service)
@@ -90,8 +95,8 @@ class DeployConfig:
     def external_url(self, service, path, base_scheme='http'):
         ns = self.service_ns(service)
         if ns == 'default':
-            return f'{base_scheme}s://{service}.hail.is{path}'
-        return f'{base_scheme}s://internal.hail.is/{ns}/{service}{path}'
+            return f'{base_scheme}s://{service}.{self._domain}{path}'
+        return f'{base_scheme}s://internal.{self._domain}/{ns}/{service}{path}'
 
     def prefix_application(self, app, service, **kwargs):
         base_path = self.base_path(service)

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -44,7 +44,7 @@ async def start_server():
     return (runner, port)
 
 
-async def auth_flow(deploy_config, auth_ns, session):
+async def auth_flow(deploy_config, default_ns, session):
     runner, port = await start_server()
 
     async with session.get(deploy_config.url('auth', '/api/v1alpha/login'),
@@ -77,29 +77,26 @@ Opening in your browser.
     username = resp['username']
 
     tokens = get_tokens()
-    tokens[auth_ns] = token
+    tokens[default_ns] = token
     dot_hail_dir = os.path.expanduser('~/.hail')
     if not os.path.exists(dot_hail_dir):
         os.mkdir(dot_hail_dir, mode=0o700)
     tokens.write()
 
-    if auth_ns == 'default':
+    if default_ns == 'default':
         print(f'Logged in as {username}.')
     else:
-        print(f'Logged into namespace {auth_ns} as {username}.')
+        print(f'Logged into namespace {default_ns} as {username}.')
 
 
 async def async_main(args):
     deploy_config = get_deploy_config()
     if args.namespace:
-        auth_ns = args.namespace
-        deploy_config = deploy_config.with_service('auth', auth_ns)
-    else:
-        auth_ns = deploy_config.service_ns('auth')
-    headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
+        deploy_config = deploy_config.with_default_namespace(args.namespace)
+    headers = namespace_auth_headers(deploy_config, deploy_config.default_namespace(), authorize_target=False)
     async with get_context_specific_ssl_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
-        await auth_flow(deploy_config, auth_ns, session)
+        await auth_flow(deploy_config, deploy_config.default_namespace(), session)
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument

--- a/hail/python/hailtop/hailctl/curl.py
+++ b/hail/python/hailtop/hailctl/curl.py
@@ -13,9 +13,10 @@ def main(args):
     svc = args[1]
     path = args[2]
     deploy_config = get_deploy_config()
+    deploy_config = deploy_config.with_default_namespace(ns)
     headers = namespace_auth_headers(deploy_config, ns)
     headers = [x
                for k, v in headers.items()
                for x in ['-H', f'{k}: {v}']]
-    path = deploy_config.with_service(svc, ns).url(svc, path)
+    path = deploy_config.url(svc, path)
     os.execvp('curl', ['curl', *headers, *args[3:], path])

--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -1,5 +1,3 @@
-import sys
-
 import argparse
 
 from . import config
@@ -14,7 +12,7 @@ def parser():
     # we have to set dest becuase of a rendering bug in argparse
     # https://bugs.python.org/issue29298
     main_subparsers = main_parser.add_subparsers(title='hailctl subcommand', dest='hailctl subcommand', required=True)
-    
+
     dev_parser = main_subparsers.add_parser(
         'dev',
         help='Developer tools.',

--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -11,6 +11,8 @@ def parser():
     main_parser = argparse.ArgumentParser(
         prog='hailctl',
         description='Manage Hail development utilities.')
+    # we have to set dest becuase of a rendering bug in argparse
+    # https://bugs.python.org/issue29298
     main_subparsers = main_parser.add_subparsers(title='hailctl subcommand', dest='hailctl subcommand', required=True)
     
     dev_parser = main_subparsers.add_parser(

--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -37,7 +37,7 @@ def parser():
         'query',
         help='Set dev settings on query service',
         description='Set dev settings on query service')
-    deploy_parser.set_defaults(module='query')
+    query_parser.set_defaults(module='query')
     query.cli.init_parser(query_parser)
 
     return main_parser

--- a/hail/python/hailtop/hailctl/dev/config/cli.py
+++ b/hail/python/hailtop/hailctl/dev/config/cli.py
@@ -1,8 +1,6 @@
-import os
-import json
-
 from . import set_property
 from . import show
+
 
 def init_parser(config_parser):
     subparsers = config_parser.add_subparsers(title='hailctl dev config subcommand', dest='hailctl dev config subcommand', required=True)
@@ -22,6 +20,7 @@ def init_parser(config_parser):
 
     show_parser.set_defaults(module='hailctl dev config show')
     show.init_parser(show_parser)
+
 
 def main(args):
     if args.module == 'hailctl dev config set':

--- a/hail/python/hailtop/hailctl/dev/config/set_property.py
+++ b/hail/python/hailtop/hailctl/dev/config/set_property.py
@@ -7,7 +7,7 @@ from hailtop.config import get_deploy_config
 def init_parser(parser):
     parser.add_argument("property", type=str,
                         help="Property to set.",
-                        choices=['location', 'default', 'domain'])
+                        choices=['location', 'default_namespace', 'domain'])
     parser.add_argument("value", type=str,
                         help="Value to set property to.")
 
@@ -17,8 +17,6 @@ def main(args):
     config = deploy_config.get_config()
 
     p = args.property
-    if p == 'default':
-        p = 'default_namespace'
     config[p] = args.value
 
     config_file = os.environ.get(

--- a/hail/python/hailtop/hailctl/dev/config/set_property.py
+++ b/hail/python/hailtop/hailctl/dev/config/set_property.py
@@ -1,0 +1,27 @@
+import os
+import json
+
+from hailtop.config import get_deploy_config
+
+
+def init_parser(parser):
+    parser.add_argument("property", type=str,
+                        help="Property to set.",
+                        choices=['location', 'default', 'domain'])
+    parser.add_argument("value", type=str,
+                        help="Value to set property to.")
+
+
+def main(args):
+    deploy_config = get_deploy_config()
+    config = deploy_config.get_config()
+
+    p = args.property
+    if p == 'default':
+        p = 'default_namespace'
+    config[p] = args.value
+
+    config_file = os.environ.get(
+        'HAIL_DEPLOY_CONFIG_FILE', os.path.expanduser('~/.hail/deploy-config.json'))
+    with open(config_file, 'w') as f:
+        json.dump(config, f)

--- a/hail/python/hailtop/hailctl/dev/config/show.py
+++ b/hail/python/hailtop/hailctl/dev/config/show.py
@@ -1,0 +1,10 @@
+from hailtop.config import get_deploy_config
+
+def init_parser(parser):
+    pass
+
+def main(args):
+    deploy_config = get_deploy_config()
+    print(f'  location: {deploy_config.location()}')
+    print(f'  default: {deploy_config._default_namespace}')
+    print(f'  domain: {deploy_config._domain}')

--- a/hail/python/hailtop/hailctl/dev/config/show.py
+++ b/hail/python/hailtop/hailctl/dev/config/show.py
@@ -1,9 +1,11 @@
 from hailtop.config import get_deploy_config
 
-def init_parser(parser):
+
+def init_parser(parser):  # pylint: disable=unused-argument
     pass
 
-def main(args):
+
+def main(args):  # pylint: disable=unused-argument
     deploy_config = get_deploy_config()
     print(f'  location: {deploy_config.location()}')
     print(f'  default: {deploy_config._default_namespace}')

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -18,13 +18,13 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
 
     def test_deploy_external_bar(self):
-        deploy_config = DeployConfig('external', 'bar')
+        deploy_config = DeployConfig('external', 'bar', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'bar')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
         self.assertEqual(deploy_config.scheme(), 'https')
-        self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
+        self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')
         self.assertEqual(deploy_config.base_url('foo'), 'https://internal.organization.tld/bar/foo')
@@ -50,10 +50,10 @@ class Test(unittest.TestCase):
         deploy_config = DeployConfig('k8s', 'bar', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'k8s')
-        self.assertEqual(deploy_config.service_ns('quam'), 'default')
-        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.service_ns('quam'), 'bar')
+        self.assertEqual(deploy_config.service_ns('foo'), 'bar')
         self.assertEqual(deploy_config.scheme(), 'https')
-        self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
+        self.assertEqual(deploy_config.auth_session_cookie_name(), 'sesh')
 
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')
         self.assertEqual(deploy_config.base_url('foo'), 'https://foo.bar/bar/foo')

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -3,7 +3,7 @@ from hailtop.config.deploy_config import DeployConfig
 
 class Test(unittest.TestCase):
     def test_deploy_external_default(self):
-        deploy_config = DeployConfig('external', 'default', {'foo': 'bar'})
+        deploy_config = DeployConfig('external', 'default', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')

--- a/hail/python/test/hailtop/config/test_deploy_config.py
+++ b/hail/python/test/hailtop/config/test_deploy_config.py
@@ -7,27 +7,36 @@ class Test(unittest.TestCase):
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
+        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
+
+        self.assertEqual(deploy_config.domain('quam'), 'quam.organization.tld')
+        self.assertEqual(deploy_config.base_path('quam'), '')
+        self.assertEqual(deploy_config.base_url('quam'), 'https://quam.organization.tld')
+        self.assertEqual(deploy_config.url('quam', '/moo'), 'https://quam.organization.tld/moo')
+        self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
+
+    def test_deploy_external_bar(self):
+        deploy_config = DeployConfig('external', 'bar')
+
+        self.assertEqual(deploy_config.location(), 'external')
+        self.assertEqual(deploy_config.service_ns('quam'), 'bar')
         self.assertEqual(deploy_config.service_ns('foo'), 'bar')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
-        self.assertEqual(deploy_config.domain('quam'), 'quam.hail.is')
-        self.assertEqual(deploy_config.base_path('quam'), '')
-        self.assertEqual(deploy_config.base_url('quam'), 'https://quam.hail.is')
-        self.assertEqual(deploy_config.url('quam', '/moo'), 'https://quam.hail.is/moo')
-        self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.hail.is/moo')
-
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')
-        self.assertEqual(deploy_config.base_url('foo'), 'https://internal.hail.is/bar/foo')
-        self.assertEqual(deploy_config.url('foo', '/moo'), 'https://internal.hail.is/bar/foo/moo')
-        self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.hail.is/bar/foo/moo')
+        self.assertEqual(deploy_config.base_url('foo'), 'https://internal.organization.tld/bar/foo')
+        self.assertEqual(deploy_config.url('foo', '/moo'), 'https://internal.organization.tld/bar/foo/moo')
+        self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.organization.tld/bar/foo/moo')
 
     def test_deploy_k8s_default(self):
-        deploy_config = DeployConfig('k8s', 'default', {'foo': 'bar'})
+        deploy_config = DeployConfig('k8s', 'default', 'organization.tld')
 
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
-        self.assertEqual(deploy_config.service_ns('foo'), 'bar')
+        self.assertEqual(deploy_config.service_ns('foo'), 'default')
         self.assertEqual(deploy_config.scheme(), 'https')
         self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
@@ -35,9 +44,18 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.base_path('quam'), '')
         self.assertEqual(deploy_config.base_url('quam'), 'https://quam.default')
         self.assertEqual(deploy_config.url('quam', '/moo'), 'https://quam.default/moo')
-        self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.hail.is/moo')
+        self.assertEqual(deploy_config.external_url('quam', '/moo'), 'https://quam.organization.tld/moo')
+
+    def test_deploy_k8s_bar(self):
+        deploy_config = DeployConfig('k8s', 'bar', 'organization.tld')
+
+        self.assertEqual(deploy_config.location(), 'k8s')
+        self.assertEqual(deploy_config.service_ns('quam'), 'default')
+        self.assertEqual(deploy_config.service_ns('foo'), 'default')
+        self.assertEqual(deploy_config.scheme(), 'https')
+        self.assertEqual(deploy_config.auth_session_cookie_name(), 'session')
 
         self.assertEqual(deploy_config.base_path('foo'), '/bar/foo')
         self.assertEqual(deploy_config.base_url('foo'), 'https://foo.bar/bar/foo')
         self.assertEqual(deploy_config.url('foo', '/moo'), 'https://foo.bar/bar/foo/moo')
-        self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.hail.is/bar/foo/moo')
+        self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.organization.tld/bar/foo/moo')

--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -51,7 +51,7 @@ object DeployConfig {
     new DeployConfig(
       (config \ "location").extract[String],
       (config \ "default_namespace").extract[String],
-      (config \ "domain").extract[String])
+      (config \ "domain").extract[Option[String]].getOrElse("hail.is"))
   }
 }
 

--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -43,7 +43,7 @@ object DeployConfig {
       new DeployConfig(
         "external",
         "default",
-        Map())
+        "hail.is")
   }
 
   def fromConfig(config: JValue): DeployConfig = {
@@ -51,14 +51,14 @@ object DeployConfig {
     new DeployConfig(
       (config \ "location").extract[String],
       (config \ "default_namespace").extract[String],
-      (config \ "service_namespace").extract[Map[String, String]])
+      (config \ "domain").extract[String])
   }
 }
 
 class DeployConfig(
   val location: String,
   val defaultNamespace: String,
-  val serviceNamespace: Map[String, String]) {
+  val domain: String) {
   import DeployConfig._
 
   def scheme(baseScheme: String = "http"): String = {
@@ -69,7 +69,7 @@ class DeployConfig(
   }
 
   def getServiceNamespace(service: String): String = {
-    serviceNamespace.getOrElse(service, defaultNamespace)
+    defaultNamespace
   }
 
   def domain(service: String): String = {
@@ -84,9 +84,9 @@ class DeployConfig(
           "internal.hail"
       case "external" =>
         if (ns == "default")
-          s"$service.hail.is"
+          s"$service.$domain"
         else
-          "internal.hail.is"
+          s"internal.$domain"
     }
   }
 


### PR DESCRIPTION
Modify hailctl dev config to let you set the domain.  Note, this is an
interface change since I changed `hailctl dev config` to act like
gcloud/kubectl `... set property value`.

The hardest part of this was getting a doubly-nested subcommand to work in argprase.  The existing code is wack, but I will change everything to work like hailctl dev/dev config does below.