### PR TITLE
[web_common] fix hardcoded Batch docs URL

### DIFF
--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -101,6 +101,8 @@ class DeployConfig:
     def external_url(self, service, path, base_scheme='http'):
         ns = self.service_ns(service)
         if ns == 'default':
+            if service == 'www':
+                return f'{base_scheme}s://{self._domain}{path}'
             return f'{base_scheme}s://{service}.{self._domain}{path}'
         return f'{base_scheme}s://internal.{self._domain}/{ns}/{service}{path}'
 

--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -15,4 +15,3 @@ query.@domain@
 workshop.@domain@
 atgu.@domain@
 amundsen-frontend.@domain@
-site.@domain@

--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -15,3 +15,4 @@ query.@domain@
 workshop.@domain@
 atgu.@domain@
 amundsen-frontend.@domain@
+site.@domain@

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -1,5 +1,5 @@
 server {
-    server_name @domain@ www.* site.*;
+    server_name @domain@ www.*;
 
     location = /healthcheck {
       return 204;

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -34,7 +34,7 @@
         <a class="header-dropdown-menu-link" href="{{ batch_base_url }}/billing">Billing</a>
         <a class="header-dropdown-menu-link" href="{{ batch_driver_base_url }}/user_resources">User Resources</a>
         {% endif %}
-        <a class="header-dropdown-menu-link" href="https://hail.is/docs/batch/">Docs</a>
+        <a class="header-dropdown-menu-link" href="{{ www_base_url }}/docs/batch/">Docs</a>
       </div>
     </div>
   </div>

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -57,6 +57,7 @@ def base_context(session, userdata, service):
     context = {
         'base_path': deploy_config.base_path(service),
         'base_url': deploy_config.external_url(service, ''),
+        'www_base_url': deploy_config.external_url('www', ''),
         'notebook_base_url': deploy_config.external_url('notebook', ''),
         'workshop_base_url': deploy_config.external_url('workshop', ''),
         'auth_base_url': deploy_config.external_url('auth', ''),


### PR DESCRIPTION
The slight subtly was that the internal URL (internal.hail.is/namespace/service) requires a service, so you can't link to "hail.is".  I used www instead.