### PR TITLE
Fix blockmatrix_write_from_entry_expr_range_mt_standardize benchmark

### DIFF
--- a/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/linalg_benchmarks.py
@@ -46,7 +46,7 @@ def blockmatrix_write_from_entry_expr_range_mt():
 def blockmatrix_write_from_entry_expr_range_mt_standardize():
     mt = hl.utils.range_matrix_table(40_000, 40_000, n_partitions=4)
     path = hl.utils.new_temp_file(extension='bm')
-    hl.linalg.BlockMatrix.write_from_entry_expr(mt.row_idx + mt.col_idx, path, mean_inpute=True, center=True,
+    hl.linalg.BlockMatrix.write_from_entry_expr(mt.row_idx + mt.col_idx, path, mean_impute=True, center=True,
                                                 normalize=True)
 
 


### PR DESCRIPTION
There was a typo in the term `mean_impute`. I assume this benchmark has never actually worked, so it's troubling we haven't ever noticed it was broken for such a silly reason. 