### PR TITLE
[ksync] fix use of ksync in benchmark

### DIFF
--- a/benchmark-service/deployment.yaml
+++ b/benchmark-service/deployment.yaml
@@ -27,10 +27,10 @@ spec:
           command:
 {% if not deploy %}
            - /controller.sh
+{% endif %}
            - "python3"
            - "-m"
            - "benchmark"
-{% endif %}
           image: "{{ benchmark_image.image }}"
           env:
           - name: HAIL_DOMAIN


### PR DESCRIPTION
An empty command probably uses the default Docker image command which is not right. Currently
causing CrashLoopBackoff in default.