### PR TITLE
Removed an internal use of cond to avoid deprecation warnings

### DIFF
--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -237,11 +237,11 @@ class CaseBuilder(ConditionalBuilder):
     def _finish(self, default):
         assert len(self._cases) > 0
 
-        from hail.expr.functions import cond
+        from hail.expr.functions import if_else
 
         expr = default
         for conditional, then in self._cases[::-1]:
-            expr = cond(conditional, then, expr, missing_false=self._missing_false)
+            expr = if_else(conditional, then, expr, missing_false=self._missing_false)
         return expr
 
     @typecheck_method(condition=expr_bool, then=expr_any)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -256,11 +256,11 @@ def cond(condition,
     --------
 
     >>> x = 5
-    >>> hl.eval(hl.if_else(x < 2, 'Hi', 'Bye'))
+    >>> hl.eval(hl.cond(x < 2, 'Hi', 'Bye'))
     'Bye'
 
     >>> a = hl.literal([1, 2, 3, 4])
-    >>> hl.eval(hl.if_else(hl.len(a) > 0, 2.0 * a, a / 2.0))
+    >>> hl.eval(hl.cond(hl.len(a) > 0, 2.0 * a, a / 2.0))
     [2.0, 4.0, 6.0, 8.0]
 
     Notes


### PR DESCRIPTION
Also fixed examples in `cond` doc to call `cond` instead of `if_else`. 