### PR TITLE
[hail] include the diagonal in PCRelate

### DIFF
--- a/hail/python/hail/methods/relatedness/pc_relate.py
+++ b/hail/python/hail/methods/relatedness/pc_relate.py
@@ -17,7 +17,8 @@ from ..pca import hwe_normalized_pca
            scores_expr=nullable(expr_array(expr_float64)),
            min_kinship=nullable(numeric),
            statistics=enumeration('kin', 'kin2', 'kin20', 'all'),
-           block_size=nullable(int))
+           block_size=nullable(int),
+           include_self_kinship=bool)
 def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
               min_kinship=None, statistics="all", block_size=None,
               include_self_kinship=False) -> Table:

--- a/hail/python/hail/methods/relatedness/pc_relate.py
+++ b/hail/python/hail/methods/relatedness/pc_relate.py
@@ -19,7 +19,8 @@ from ..pca import hwe_normalized_pca
            statistics=enumeration('kin', 'kin2', 'kin20', 'all'),
            block_size=nullable(int))
 def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
-              min_kinship=None, statistics="all", block_size=None) -> Table:
+              min_kinship=None, statistics="all", block_size=None,
+              include_self_kinship=False) -> Table:
     r"""Compute relatedness estimates between individuals using a variant of the
     PC-Relate method.
 
@@ -278,6 +279,9 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
     block_size : :obj:`int`, optional
         Block size of block matrices used in the algorithm.
         Default given by :meth:`.BlockMatrix.default_block_size`.
+    include_self_kinship: :obj:`bool`
+        If ``True``, include entries for an individual's estimated kinship with
+        themselves. Defaults to ``False``.
 
     Returns
     -------
@@ -329,6 +333,9 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
         ht = ht.drop('ibd0', 'ibd1')
     elif statistics == 'kin20':
         ht = ht.drop('ibd1')
+
+    if not include_self_kinship:
+        ht = ht.filter(ht.i == ht.j, keep=False)
 
     col_keys = hl.literal(mt.select_cols().key_cols_by().cols().collect(), dtype=tarray(mt.col_key.dtype))
     return ht.key_by(i=col_keys[ht.i], j=col_keys[ht.j])

--- a/hail/python/test/hail/methods/relatedness/test_pc_relate.py
+++ b/hail/python/test/hail/methods/relatedness/test_pc_relate.py
@@ -80,6 +80,25 @@ def test_pcrelate_paths():
     assert kin3.count() > 0
     assert kin3.filter(kin3.kin < 0.1).count() == 0
 
+@skip_unless_spark_backend()
+def test_self_kinship():
+    mt = hl.balding_nichols_model(3, 10, 50)
+    with_self = hl.pc_relate(mt.GT, 0.10, k=2, statistics='kin20', block_size=16, include_self_kinship=True)
+    without_self = hl.pc_relate(mt.GT, 0.10, k=2, statistics='kin20', block_size=16)
+
+    assert with_self.count() == 55
+    assert without_self.count() == 45
+
+    with_self_self_kin_only = with_self.filter(with_self.i.sample_idx == with_self.j.sample_idx)
+    assert with_self_self_kin_only.count() == 10, with_self_self_kin_only.collect()
+
+    with_self_no_self_kin = with_self.filter(with_self.i.sample_idx != with_self.j.sample_idx)
+    assert with_self_no_self_kin.count() == 45, with_self_no_self_kin.collect()
+    assert with_self_no_self_kin._same(without_self)
+
+    without_self_self_kin_only = without_self.filter(without_self.i.sample_idx == without_self.j.sample_idx)
+    assert without_self_self_kin_only.count() == 0, without_self_self_kin_only.collect()
+
 
 @skip_unless_spark_backend()
 def test_pcrelate_issue_5263():

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -87,7 +87,7 @@ object PCRelate {
         var jj = 0
         while (jj < lmPhi.cols) {
           var ii = 0
-          val nRowsAboveDiagonal = if (i < j) lmPhi.rows else jj // assumes square blocks on diagonal
+          val nRowsAboveDiagonal = if (i < j) lmPhi.rows else (jj + 1) // assumes square blocks on diagonal
           while (ii < nRowsAboveDiagonal) {
             val kin = lmPhi(ii, jj)
             if (kin >= minKinship) {


### PR DESCRIPTION
CHANGELOG: `hl.pc_relate` now includes values on the diagonal of kinship, IBD-0, IBD-1, and IBD-2