### PR TITLE
[aiotools, aiogoogle] AsyncFS.listfiles raises FileNotFoundError if the directory doesn't exist

### DIFF
--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,6 +1,6 @@
 flake8==3.7.8
 mypy==0.780
-pylint==2.5.3
+pylint==2.6.0
 pytest==4.6.3
 pytest-html==1.20.0
 pytest-xdist==1.28

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -256,7 +256,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         try:
             n = await it.__anext__()
         except StopAsyncIteration:
-            raise FileNotFoundError(url)
+            raise FileNotFoundError(url)  # pylint: disable=raise-missing-from
 
         async def cons(n, it):
             yield n
@@ -291,7 +291,7 @@ class GoogleStorageAsyncFS(AsyncFS):
             prefixes = page.get('prefixes')
             items = page.get('items')
             return prefixes or items
-        raise UnreachableError()
+        assert False  # unreachable
 
     async def remove(self, url: str) -> None:
         bucket, name = self._get_bucket_name(url)

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -254,12 +254,12 @@ class GoogleStorageAsyncFS(AsyncFS):
 
         it = it.__aiter__()
         try:
-            n = await it.__anext__()
+            first_entry = await it.__anext__()
         except StopAsyncIteration:
             raise FileNotFoundError(url)  # pylint: disable=raise-missing-from
 
         async def cons(n, it):
-            yield n
+            yield first_entry
             try:
                 while True:
                     yield await it.__anext__()

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -258,7 +258,7 @@ class GoogleStorageAsyncFS(AsyncFS):
         except StopAsyncIteration:
             raise FileNotFoundError(url)  # pylint: disable=raise-missing-from
 
-        async def cons(n, it):
+        async def cons(first_entry, it):
             yield first_entry
             try:
                 while True:
@@ -266,7 +266,7 @@ class GoogleStorageAsyncFS(AsyncFS):
             except StopAsyncIteration:
                 pass
 
-        return cons(n, it)
+        return cons(first_entry, it)
 
     async def isfile(self, url: str) -> bool:
         try:

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -198,14 +198,13 @@ class LocalAsyncFS(AsyncFS):
                     yield subfile
 
     async def _listfiles_flat(self, url: str, entries) -> AsyncIterator[FileListEntry]:
-        path = self._get_path(url)
         with entries:
             for entry in entries:
                 yield LocalFileListEntry(self._thread_pool, url, entry)
 
     async def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
         path = self._get_path(url)
-        entries = await blocking_to_async(self._thread_pool, os.scandir, path) 
+        entries = await blocking_to_async(self._thread_pool, os.scandir, path)
         if recursive:
             return self._listfiles_recursive(url, entries)
         return self._listfiles_flat(url, entries)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -67,7 +67,7 @@ class AsyncFS(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
+    async def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
         pass
 
     @abc.abstractmethod
@@ -175,24 +175,40 @@ class LocalAsyncFS(AsyncFS):
             raise FileNotFoundError(f'is directory: {url}')
         return LocalStatFileStatus(stat_result)
 
-    async def _listfiles_recursive(self, url: str) -> AsyncIterator[FileListEntry]:
-        async for file in self._listfiles_flat(url):
+    # entries has no type hint because the return type of os.scandir
+    # appears to be a private type, posix.ScandirIterator.
+    # >>> import os
+    # >>> entries = os.scandir('.')
+    # >>> type(entries)
+    # <class 'posix.ScandirIterator'>
+    # >>> import posix
+    # >>> posix.ScandirIterator
+    # Traceback (most recent call last):
+    #   File "<stdin>", line 1, in <module>
+    # AttributeError: module 'posix' has no attribute 'ScandirIterator'
+    async def _listfiles_recursive(self, url: str, entries) -> AsyncIterator[FileListEntry]:
+        async for file in self._listfiles_flat(url, entries):
             if await file.is_file():
                 yield file
             else:
-                async for subfile in self._listfiles_recursive(await file.url()):
+                new_url = await file.url()
+                new_path = self._get_path(new_url)
+                new_entries = await blocking_to_async(self._thread_pool, os.scandir, new_path)
+                async for subfile in self._listfiles_recursive(new_url, new_entries):
                     yield subfile
 
-    async def _listfiles_flat(self, url: str) -> AsyncIterator[FileListEntry]:
+    async def _listfiles_flat(self, url: str, entries) -> AsyncIterator[FileListEntry]:
         path = self._get_path(url)
-        with await blocking_to_async(self._thread_pool, os.scandir, path) as it:
-            for entry in it:
+        with entries:
+            for entry in entries:
                 yield LocalFileListEntry(self._thread_pool, url, entry)
 
-    def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
+    async def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
+        path = self._get_path(url)
+        entries = await blocking_to_async(self._thread_pool, os.scandir, path) 
         if recursive:
-            return self._listfiles_recursive(url)
-        return self._listfiles_flat(url)
+            return self._listfiles_recursive(url, entries)
+        return self._listfiles_flat(url, entries)
 
     async def mkdir(self, url: str) -> None:
         path = self._get_path(url)
@@ -263,9 +279,9 @@ class RouterAsyncFS(AsyncFS):
         fs = self._get_fs(url)
         return await fs.statfile(url)
 
-    def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
+    async def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
         fs = self._get_fs(url)
-        return fs.listfiles(url, recursive)
+        return await fs.listfiles(url, recursive)
 
     async def mkdir(self, url: str) -> None:
         fs = self._get_fs(url)


### PR DESCRIPTION
Existence of directories is filesystem dependent, and they exist on Google if there is an object with that directory name a prefix.

This required a little refactoring that changed fs.listfiles to return a coroutine that gives an iterator, rather than returning an iterator directly.  This is because, if you use the `async def foo ... yield ...` syntax, it is not possible to write any code that will run between calling the async genreator function `foo` and the first call to `__anext__`.