### PR TITLE
[hail] relax pandas requirement

### DIFF
--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,6 +1,6 @@
 flake8==3.7.8
 mypy==0.780
-pylint==2.5.3
+pylint==2.6.0
 pytest==4.6.3
 pytest-html==1.20.0
 pytest-xdist==1.28

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,7 +10,7 @@ humanize==1.0.0
 hurry.filesize==0.9
 nest_asyncio
 numpy<2
-pandas>=1.1.0,<1.1.5
+pandas>=1.1.0,<1.2.0
 parsimonious<0.9
 PyJWT
 pyspark>=2.4,<2.4.2


### PR DESCRIPTION
Pandas only releases [breaking changes in major versions](https://pandas.pydata.org/docs/development/policies.html). It seems safe
to be flexible on patch version. Just today I had an issue where I ran `pip install pandas` to
upgrade from an old pandas version and I landed on 1.1.5.