### PR TITLE
[utils] provide default for max in from_named_type()

### DIFF
--- a/hail/python/hail/utils/placement_tree.py
+++ b/hail/python/hail/utils/placement_tree.py
@@ -17,7 +17,7 @@ class PlacementTree:
             return PlacementTree(name, 1, 0, [])
         children = [PlacementTree.from_named_type(name, dtype) for name, dtype in dtype.items()]
         width = sum(child.width for child in children)
-        height = max(child.height for child in children) + 1
+        height = max([child.height for child in children], default=0) + 1
         return PlacementTree(name, width, height, children)
 
     def to_grid(self):

--- a/hail/python/test/hail/utils/test_placement_tree.py
+++ b/hail/python/test/hail/utils/test_placement_tree.py
@@ -21,6 +21,8 @@ info: struct{
   NEGATIVE_TRAIN_SITE: bool,
   HWP: float64,
   AC: array<int32>},
+empty_struct: struct{
+},
 variant_qc: struct{
   dp_stats: struct{
     mean: float64,
@@ -42,20 +44,20 @@ variant_qc: struct{
         assert len(grid) == 4
 
         row1 = grid[1]
-        assert len(row1) == 7
+        assert len(row1) == 8
         for i in range(5):
             assert row1[i] == (None, 1)
         assert row1[5] == (None, 3)
-        assert row1[6] == ('variant_qc', 13)
+        assert row1[7] == ('variant_qc', 13)
 
         row2 = grid[2]
-        assert len(row2) == 13
+        assert len(row2) == 14
         for i in range(5):
             assert row2[i] == (None, 1)
         assert row2[5] == ('info', 3)
-        assert row2[6] == ('dp_stats', 4)
-        assert row2[7] == ('gq_stats', 4)
-        for i in range(8, 13):
+        assert row2[7] == ('dp_stats', 4)
+        assert row2[8] == ('gq_stats', 4)
+        for i in range(9, 13):
             assert row2[i] == (None, 1)
 
         row3 = grid[3]


### PR DESCRIPTION
Proposed fix for https://github.com/hail-is/hail/issues/9833

Summary: fix run time error when a matrix table row has an empty struct.

Example: `info` field below is an empty struct
```
----------------------------------------
Global fields:
    None
----------------------------------------
Row fields:
    'locus': locus<GRCh38> 
    'alleles': array<str> 
    'rsid': str 
    'qual': float64 
    'filters': set<str> 
    'info': struct {} 
----------------------------------------
Key: ['locus', 'alleles']
----------------------------------------
```

The function `max` will throw this error
```
ValueError: max() arg is an empty sequence
```