### PR TITLE
[hail] Add two new forms to any all

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3200,7 +3200,7 @@ def all(*args) -> BooleanExpression:
     The first form:
 
     >>> hl.eval(hl.all())
-    False
+    True
 
     >>> hl.eval(hl.all(True))
     True

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3208,16 +3208,19 @@ def all(*args) -> BooleanExpression:
     >>> hl.eval(hl.all(False))
     False
 
-    >>> hl.eval(hl.all(False, False, True, False))
+    >>> hl.eval(hl.all(True, True, True))
     True
+
+    >>> hl.eval(hl.all(False, False, True, False))
+    False
 
     The second form:
 
     >>> hl.eval(hl.all([False, True, False]))
-    True
-
-    >>> hl.eval(hl.all([False, False, False]))
     False
+
+    >>> hl.eval(hl.all([True, True, True]))
+    True
 
     The third form:
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3176,9 +3176,9 @@ def any(*args) -> BooleanExpression:
             f = arg_check(args[0], 'any', 'f', any_to_bool_type)
             collection = arg_check(args[1], 'any', 'collection', collection_type)
             return collection.any(f)
-    n_args = len(args)
+    n_args = builtins.len(args)
     args = [args_check(x, 'any', 'exprs', i, n_args, expr_bool)
-            for i, x in enumerate(args)]
+            for i, x in builtins.enumerate(args)]
     return functools.reduce(operator.ior, args, base)
 
 
@@ -3248,9 +3248,9 @@ def all(*args) -> BooleanExpression:
             f = arg_check(args[0], 'all', 'f', any_to_bool_type)
             collection = arg_check(args[1], 'all', 'collection', collection_type)
             return collection.all(f)
-    n_args = len(args)
+    n_args = builtins.len(args)
     args = [args_check(x, 'all', 'exprs', i, n_args, expr_bool)
-            for i, x in enumerate(args)]
+            for i, x in builtins.enumerate(args)]
     return functools.reduce(operator.iand, args, base)
 
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3113,7 +3113,7 @@ any_to_bool_type = func_spec(1, expr_bool)
 def any(*args) -> BooleanExpression:
     """Check for any ``True`` in boolean expressions or collections of booleans.
 
-    :func:`.any` comes in three forms:
+    :func:`~.any` comes in three forms:
 
     1. ``hl.any(boolean, ...)``. Is at least one argument ``True``?
 
@@ -3160,8 +3160,7 @@ def any(*args) -> BooleanExpression:
 
     Notes
     -----
-    :func:`.any` returns ``False` when given an empty array or empty argument
-    list.
+    :func:`~.any` returns ``False`` when given an empty array or empty argument list.
     """
     base = hl.literal(False)
     if builtins.len(args) == 0:
@@ -3186,7 +3185,7 @@ def any(*args) -> BooleanExpression:
 def all(*args) -> BooleanExpression:
     """Check for all ``True`` in boolean expressions or collections of booleans.
 
-    :func:`.all` comes in three forms:
+    :func:`~.all` comes in three forms:
 
     1. ``hl.all(boolean, ...)``. Are all arguments ``True``?
 
@@ -3233,8 +3232,7 @@ def all(*args) -> BooleanExpression:
 
     Notes
     -----
-    :func:`.all` returns ``True` when given an empty array or empty argument
-    list.
+    :func:`~.all` returns ``True`` when given an empty array or empty argument list.
     """
     base = hl.literal(True)
     if builtins.len(args) == 0:

--- a/hail/python/hail/typecheck/__init__.py
+++ b/hail/python/hail/typecheck/__init__.py
@@ -1,7 +1,9 @@
-from .check import TypeChecker, typecheck, typecheck_method, anytype, anyfunc, \
-    nullable, sequenceof, tupleof, sized_tupleof, sliceof, dictof, \
-    linked_list, setof, oneof, exactly, numeric, char, lazy, enumeration, \
-    identity, transformed, func_spec, table_key_type, TypecheckFailure
+from .check import (TypeChecker, typecheck, typecheck_method, anytype, anyfunc,
+                    nullable, sequenceof, tupleof, sized_tupleof, sliceof,
+                    dictof, linked_list, setof, oneof, exactly, numeric, char,
+                    lazy, enumeration, identity, transformed, func_spec,
+                    table_key_type, TypecheckFailure, arg_check, args_check,
+                    kwargs_check)
 
 __all__ = [
     'TypeChecker',
@@ -27,5 +29,8 @@ __all__ = [
     'transformed',
     'func_spec',
     'table_key_type',
-    'TypecheckFailure'
+    'TypecheckFailure',
+    'arg_check',
+    'args_check',
+    'kwargs_check'
 ]

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -534,9 +534,8 @@ def check_all(f, args, kwargs, checks, is_method):
         assert isinstance(param, inspect.Parameter)
 
         treated_as_positional = (
-            param.kind == param.POSITIONAL_ONLY
-            or
-            param.kind == param.POSITIONAL_OR_KEYWORD and i < len(args))
+            param.kind == param.POSITIONAL_ONLY or
+            (param.kind == param.POSITIONAL_OR_KEYWORD and i < len(args)))
 
         if treated_as_positional:
             if i >= len(args):

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -533,11 +533,10 @@ def check_all(f, args, kwargs, checks, is_method):
         checker = checks[arg_name]
         assert isinstance(param, inspect.Parameter)
 
-        treated_as_positional = (
-            param.kind == param.POSITIONAL_ONLY or
-            (param.kind == param.POSITIONAL_OR_KEYWORD and i < len(args)))
+        keyword_passed_as_positional = param.kind == param.POSITIONAL_OR_KEYWORD and i < len(args)
+        necessarily_positional = param.kind == param.POSITIONAL_ONLY
 
-        if treated_as_positional:
+        if necessarily_positional or keyword_passed_as_positional:
             if i >= len(args):
                 raise TypeError(
                     f'Expected {n_pos_args} positional arguments, found {len(args)}')

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -532,68 +532,33 @@ def check_all(f, args, kwargs, checks, is_method):
             continue
         checker = checks[arg_name]
         assert isinstance(param, inspect.Parameter)
-        if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY):
-            try:
-                if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD):
-                    # must be positional
-                    if i < len(args):
-                        arg = args[i]
-                        args_.append(checker.check(arg, name, arg_name))
-                    # passed as keyword
-                    else:
-                        if arg_name in kwargs:
-                            arg = kwargs.pop(arg_name)
-                        else:
-                            if param.default is inspect._empty:
-                                raise TypeError(f'Expected {n_pos_args} positional arguments, '
-                                                f'found {len(args)}')
-                            arg = param.default
-                        args_.append(checker.check(arg, name, arg_name))
-                else:
-                    if arg_name in kwargs:
-                        arg = kwargs.pop(arg_name)
-                    else:
-                        if param.default is inspect._empty:
-                            raise TypeError(f"{name}() missing required keyword-only argument '{arg_name}'")
-                        arg = param.default
-                    kwargs_[arg_name] = checker.check(arg, name, arg_name)
-            except TypecheckFailure as e:
-                raise TypeError("{fname}: parameter '{argname}': "
-                                "expected {expected}, found {found}".format(
-                                    fname=name,
-                                    argname=arg_name,
-                                    expected=checker.expects(),
-                                    found=checker.format(arg)
-                                )) from e
+
+        treated_as_positional = (
+            param.kind == param.POSITIONAL_ONLY
+            or
+            param.kind == param.POSITIONAL_OR_KEYWORD and i < len(args))
+
+        if treated_as_positional:
+            if i >= len(args):
+                raise TypeError(
+                    f'Expected {n_pos_args} positional arguments, found {len(args)}')
+            args_.append(arg_check(args[i], name, arg_name, checker))
+        elif param.kind in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD):
+            arg = kwargs.pop(arg_name, param.default)
+            if arg is inspect._empty:
+                raise TypeError(
+                    f"{name}() missing required keyword-only argument '{arg_name}'")
+            kwargs_[arg_name] = arg_check(arg, name, arg_name, checker)
         elif param.kind == param.VAR_POSITIONAL:
             # consume the rest of the positional arguments
             varargs = args[i:]
             for j, arg in enumerate(varargs):
-                try:
-                    args_.append(checker.check(arg, name, arg_name))
-                except TypecheckFailure as e:
-                    raise TypeError("{fname}: parameter '*{argname}' (arg {idx} of {tot}): "
-                                    "expected {expected}, found {found}".format(
-                                        fname=name,
-                                        argname=arg_name,
-                                        idx=j,
-                                        tot=len(varargs),
-                                        expected=checker.expects(),
-                                        found=checker.format(arg)
-                                    )) from e
+                args_.append(args_check(arg, name, arg_name, j, len(varargs), checker))
         else:
             assert param.kind == param.VAR_KEYWORD
             # kwargs now holds all variable kwargs
             for kwarg_name, arg in kwargs.items():
-                try:
-                    kwargs_[kwarg_name] = checker.check(arg, name, arg_name)
-                except TypecheckFailure as e:
-                    raise TypeError("{fname}: keyword argument '{argname}': "
-                                    "expected {expected}, found {found}".format(
-                                        fname=name,
-                                        argname=kwarg_name,
-                                        expected=checker.expects(),
-                                        found=checker.format(arg))) from e
+                kwargs_[kwarg_name] = kwargs_check(arg, name, kwarg_name, checker)
     return args_, kwargs_
 
 
@@ -614,3 +579,48 @@ def _make_dec(checkers, is_method):
         return __original_func(*args_, **kwargs_)
 
     return wrapper
+
+
+def arg_check(arg, function_name: str, arg_name: str, checker: TypeChecker):
+    try:
+        return checker.check(arg, function_name, arg_name)
+    except TypecheckFailure as e:
+        raise TypeError("{fname}: parameter '{argname}': "
+                        "expected {expected}, found {found}".format(
+                            fname=function_name,
+                            argname=arg_name,
+                            expected=checker.expects(),
+                            found=checker.format(arg)
+                        )) from e
+
+
+def args_check(arg,
+               function_name: str,
+               arg_name: str,
+               index: int,
+               total_varargs: int,
+               checker: TypeChecker):
+    try:
+        return checker.check(arg, function_name, arg_name)
+    except TypecheckFailure as e:
+        raise TypeError("{fname}: parameter '*{argname}' (arg {idx} of {tot}): "
+                        "expected {expected}, found {found}".format(
+                            fname=function_name,
+                            argname=arg_name,
+                            idx=index,
+                            tot=total_varargs,
+                            expected=checker.expects(),
+                            found=checker.format(arg)
+                        )) from e
+
+
+def kwargs_check(arg, function_name: str, kwarg_name: str, checker: TypeChecker):
+    try:
+        return checker.check(arg, function_name, kwarg_name)
+    except TypecheckFailure as e:
+        raise TypeError("{fname}: keyword argument '{argname}': "
+                        "expected {expected}, found {found}".format(
+                            fname=function_name,
+                            argname=kwarg_name,
+                            expected=checker.expects(),
+                            found=checker.format(arg))) from e

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2301,13 +2301,59 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.zip(a3, a2, a1)),
                          [([1], 'a', 1)])
 
-    def test_array_methods(self):
+    def test_any_form_1(self):
+        self.assertEqual(hl.eval(hl.any()), False)
+
+        self.assertEqual(hl.eval(hl.any(True)), True)
+        self.assertEqual(hl.eval(hl.any(False)), False)
+
+        self.assertEqual(hl.eval(hl.any(True, True)), True)
+        self.assertEqual(hl.eval(hl.any(True, False)), True)
+        self.assertEqual(hl.eval(hl.any(False, True)), True)
+        self.assertEqual(hl.eval(hl.any(False, False)), False)
+
+    def test_all_form_1(self):
+        self.assertEqual(hl.eval(hl.all()), True)
+
+        self.assertEqual(hl.eval(hl.all(True)), True)
+        self.assertEqual(hl.eval(hl.all(False)), False)
+
+        self.assertEqual(hl.eval(hl.all(True, True)), True)
+        self.assertEqual(hl.eval(hl.all(True, False)), False)
+        self.assertEqual(hl.eval(hl.all(False, True)), False)
+        self.assertEqual(hl.eval(hl.all(False, False)), False)
+
+    def test_any_form_2(self):
+        self.assertEqual(hl.eval(hl.any(hl.empty_array(hl.tbool))), False)
+
+        self.assertEqual(hl.eval(hl.any([True])), True)
+        self.assertEqual(hl.eval(hl.any([False])), False)
+
+        self.assertEqual(hl.eval(hl.any([True, True])), True)
+        self.assertEqual(hl.eval(hl.any([True, False])), True)
+        self.assertEqual(hl.eval(hl.any([False, True])), True)
+        self.assertEqual(hl.eval(hl.any([False, False])), False)
+
+    def test_all_form_2(self):
+        self.assertEqual(hl.eval(hl.all(hl.empty_array(hl.tbool))), True)
+
+        self.assertEqual(hl.eval(hl.all([True])), True)
+        self.assertEqual(hl.eval(hl.all([False])), False)
+
+        self.assertEqual(hl.eval(hl.all([True, True])), True)
+        self.assertEqual(hl.eval(hl.all([True, False])), False)
+        self.assertEqual(hl.eval(hl.all([False, True])), False)
+        self.assertEqual(hl.eval(hl.all([False, False])), False)
+
+    def test_any_form_3(self):
         self.assertEqual(hl.eval(hl.any(lambda x: x % 2 == 0, [1, 3, 5])), False)
         self.assertEqual(hl.eval(hl.any(lambda x: x % 2 == 0, [1, 3, 5, 6])), True)
 
+    def test_all_form_3(self):
         self.assertEqual(hl.eval(hl.all(lambda x: x % 2 == 0, [1, 3, 5, 6])), False)
         self.assertEqual(hl.eval(hl.all(lambda x: x % 2 == 0, [2, 6])), True)
 
+    def test_array_methods(self):
         self.assertEqual(hl.eval(hl.map(lambda x: x % 2 == 0, [0, 1, 4, 6])), [True, False, True, True])
 
         self.assertEqual(hl.eval(hl.len([0, 1, 4, 6])), 4)


### PR DESCRIPTION
CHANGELOG: `hl.any` and `hl.all` now also support a single collection argument and a varargs of Boolean expressions

Any and all currently take two arguments: a function and a collection. This
differs from the Python `any` and `all` which take only a collection and check
for truthy values.

We rectify this situation by supporting three forms:

1. ``hl.all(boolean, ...)``, are all arguments ``True``?
2. ``hl.all(collection)``, are all elements of the collection ``True``?
3. ``hl.all(function, collection)``, does ``function`` return ``True`` for
    all values in this collection?