### PR TITLE
[query] Allow bit shifts by zero bits

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -5486,7 +5486,7 @@ def _shift_op(x, y, op):
     return hl.bind(lambda x, y: (
         hl.case()
         .when(y >= word_size, hl.sign(x) if op == '>>' else zero)
-        .when(y > 0, construct_expr(ir.ApplyBinaryPrimOp(op, x._ir, y._ir), t, indices, aggregations))
+        .when(y >= 0, construct_expr(ir.ApplyBinaryPrimOp(op, x._ir, y._ir), t, indices, aggregations))
         .or_error('cannot shift by a negative value: ' + hl.str(x) + f" {op} " + hl.str(y))), x, y)
 
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3263,6 +3263,15 @@ class Tests(unittest.TestCase):
         assert hl.bit_not(1).dtype == hl.tint32
         assert hl.bit_not(hl.int64(1)).dtype == hl.tint64
 
+    def test_bit_shifts(self):
+        assert hl.eval(hl.bit_lshift(hl.int(8), 2)) == 32
+        assert hl.eval(hl.bit_rshift(hl.int(8), 2)) == 2
+        assert hl.eval(hl.bit_lshift(hl.int(8), 0)) == 8
+
+        assert hl.eval(hl.bit_lshift(hl.int64(8), 2)) == 32
+        assert hl.eval(hl.bit_rshift(hl.int64(8), 2)) == 2
+        assert hl.eval(hl.bit_lshift(hl.int64(8), 0)) == 8
+
     def test_bit_shift_edge_cases(self):
         assert hl.eval(hl.bit_lshift(hl.int(1), 32)) == 0
         assert hl.eval(hl.bit_rshift(hl.int(1), 32)) == 1


### PR DESCRIPTION
Currently, attempting to bit shift by zero bits throws an error.

```
$ hl.eval(hl.bit_rshift(4, 0))
HailUserError: Error summary: HailException: cannot shift by a negative value: 4 >> 0
```