### PR TITLE
[pylintrc] remove some ignores

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -26,5 +26,3 @@ const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
 
 # Maximum number of characters on a single line.
 max-line-length=120
-
-ignore-patterns=.*_flymake\.py,flycheck_.*\.py


### PR DESCRIPTION
These ignores prevent my Emacs from running pylint. I mistakenly added these
here long ago.