### PR TITLE
[query] shuffle in the service

### DIFF
--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -323,8 +323,6 @@ iptables -I DOCKER-USER -d 169.254.169.254 -p udp -m udp --destination-port 53 -
 
 docker network create public --opt com.docker.network.bridge.name=public
 docker network create private --opt com.docker.network.bridge.name=private
-# make the internal network not route-able
-iptables -I DOCKER-USER -i public -d 10.0.0.0/8 -j DROP
 # make other docker containers not route-able
 iptables -I DOCKER-USER -i public -d 172.16.0.0/12 -j DROP
 # not used, but ban it anyway!

--- a/batch/batch/driver/instance_pool.py
+++ b/batch/batch/driver/instance_pool.py
@@ -473,6 +473,8 @@ docker run \
     $BATCH_WORKER_IMAGE \
     python3 -u -m batch.worker.worker >worker.log 2>&1
 
+[ $? -eq 0 ] || tail -n 1000 worker.log
+
 while true; do
   gcloud -q compute instances delete $NAME --zone=$ZONE
   sleep 1

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -698,7 +698,19 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         'namespace': DEFAULT_NAMESPACE,
                         'name': userdata['tokens_secret_name'],
                         'mount_path': '/user-tokens',
-                        'mount_in_copy': True
+                        'mount_in_copy': False
+                    })
+                    secrets.append({
+                        'namespace': DEFAULT_NAMESPACE,
+                        'name': 'gce-deploy-config',
+                        'mount_path': '/deploy-config',
+                        'mount_in_copy': False
+                    })
+                    secrets.append({
+                        'namespace': DEFAULT_NAMESPACE,
+                        'name': 'ssl-config-batch-user-code',
+                        'mount_path': '/ssl-config',
+                        'mount_in_copy': False
                     })
 
                 sa = spec.get('service_account')

--- a/batch/batch/public_gcr_images.py
+++ b/batch/batch/public_gcr_images.py
@@ -1,3 +1,5 @@
+from .batch_configuration import PROJECT
+
 PUBLIC_GCR_IMAGES = (
-    'gcr.io/hail-vdc/' + name
+    f'gcr.io/{PROJECT}/{name}'
     for name in ('query',))

--- a/batch/batch/public_gcr_images.py
+++ b/batch/batch/public_gcr_images.py
@@ -1,5 +1,7 @@
-from .batch_configuration import PROJECT
+from typing import List
 
-PUBLIC_GCR_IMAGES = (
-    f'gcr.io/{PROJECT}/{name}'
-    for name in ('query',))
+
+def public_gcr_images(project: str) -> List[str]:
+    # the worker cannot import batch_configuration because it does not have all the environment
+    # variables
+    return [f'gcr.io/{project}/{name}' for name in ('query',)]

--- a/batch/batch/public_gcr_images.py
+++ b/batch/batch/public_gcr_images.py
@@ -1,0 +1,3 @@
+PUBLIC_GCR_IMAGES = (
+    'gcr.io/hail-vdc/' + name
+    for name in ('query',))

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -39,7 +39,7 @@ from ..log_store import LogStore
 from ..globals import HTTP_CLIENT_MAX_SIZE, STATUS_FORMAT_VERSION
 from ..batch_format_version import BatchFormatVersion
 from ..worker_config import WorkerConfig
-from ..public_gcr_images import PUBLIC_GCR_IMAGES
+from ..public_gcr_images import public_gcr_images
 
 from .flock import Flock
 
@@ -60,6 +60,7 @@ IP_ADDRESS = os.environ['IP_ADDRESS']
 BATCH_LOGS_BUCKET_NAME = os.environ['BATCH_LOGS_BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
 PROJECT = os.environ['PROJECT']
+PUBLIC_GCR_IMAGES = public_gcr_images(PROJECT)
 WORKER_CONFIG = json.loads(base64.b64decode(os.environ['WORKER_CONFIG']).decode())
 MAX_IDLE_TIME_MSECS = int(os.environ['MAX_IDLE_TIME_MSECS'])
 WORKER_DATA_DISK_MOUNT = os.environ['WORKER_DATA_DISK_MOUNT']

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -39,7 +39,6 @@ from ..log_store import LogStore
 from ..globals import HTTP_CLIENT_MAX_SIZE, STATUS_FORMAT_VERSION
 from ..batch_format_version import BatchFormatVersion
 from ..worker_config import WorkerConfig
-from ..batch_configuration import PROJECT
 from ..public_gcr_images import PUBLIC_GCR_IMAGES
 
 from .flock import Flock
@@ -60,6 +59,7 @@ NAMESPACE = os.environ['NAMESPACE']
 IP_ADDRESS = os.environ['IP_ADDRESS']
 BATCH_LOGS_BUCKET_NAME = os.environ['BATCH_LOGS_BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
+PROJECT = os.environ['PROJECT']
 WORKER_CONFIG = json.loads(base64.b64decode(os.environ['WORKER_CONFIG']).decode())
 MAX_IDLE_TIME_MSECS = int(os.environ['MAX_IDLE_TIME_MSECS'])
 WORKER_DATA_DISK_MOUNT = os.environ['WORKER_DATA_DISK_MOUNT']

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -24,7 +24,7 @@ from hailtop.utils import (time_msecs, request_retry_transient_errors,
 from hailtop.httpx import client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
-from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
+from hailtop.batch.hail_genetics_images import HAIL_GENETICS, HAIL_GENETICS_IMAGES
 from hailtop import aiotools
 # import uvloop
 
@@ -244,8 +244,8 @@ class Container:
             log.info(f'adding latest tag to image {self.spec["image"]} for {self}')
             image += ':latest'
         if image in HAIL_GENETICS_IMAGES:
-            prefix = 'hailgenetics/'
-            self.image = 'gcr.io/' + PROJECT + '/' + image[len(prefix):]
+            image_name_without_prefix = image[len(HAIL_GENETICS):]
+            self.image = 'gcr.io/' + PROJECT + '/' + image_name_without_prefix
         else:
             self.image = image
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -60,7 +60,6 @@ NAMESPACE = os.environ['NAMESPACE']
 IP_ADDRESS = os.environ['IP_ADDRESS']
 BATCH_LOGS_BUCKET_NAME = os.environ['BATCH_LOGS_BUCKET_NAME']
 INSTANCE_ID = os.environ['INSTANCE_ID']
-PROJECT = os.environ['PROJECT']
 WORKER_CONFIG = json.loads(base64.b64decode(os.environ['WORKER_CONFIG']).decode())
 MAX_IDLE_TIME_MSECS = int(os.environ['MAX_IDLE_TIME_MSECS'])
 WORKER_DATA_DISK_MOUNT = os.environ['WORKER_DATA_DISK_MOUNT']

--- a/build.yaml
+++ b/build.yaml
@@ -2108,6 +2108,45 @@ steps:
      - default_ns
      - create_certs
      - deploy_benchmark
+ - kind: buildImage
+   name: address_image
+   dockerFile: address/Dockerfile
+   contextPath: .
+   publishAs: address
+   dependsOn:
+     - service_base_image
+ - kind: runImage
+   name: check_address
+   image:
+     valueFrom: address_image.image
+   script: |
+     set -ex
+     SITE_PACKAGES=$(pip3 show address | grep Location | sed 's/Location: //')
+     python3 -m flake8 $SITE_PACKAGES/address
+     python3 -m pylint --rcfile pylintrc address
+   dependsOn:
+     - address_image
+ - kind: deploy
+   name: deploy_address_sa
+   namespace:
+     valueFrom: default_ns.name
+   config: address/service-account.yaml
+   dependsOn:
+    - default_ns
+ - kind: deploy
+   name: deploy_address
+   namespace:
+     valueFrom: default_ns.name
+   config: address/deployment.yaml
+   wait:
+    - kind: Service
+      name: address
+      for: alive
+   dependsOn:
+    - default_ns
+    - deploy_router
+    - address_image
+    - create_certs
  - kind: deploy
    name: deploy_query
    namespace:
@@ -2123,6 +2162,7 @@ steps:
     - deploy_shuffler
     - query_image
     - deploy_query_sa
+    - deploy_address
     - create_certs
  - kind: deploy
    name: deploy_memory
@@ -3290,45 +3330,6 @@ steps:
      - genetics_public_image
    scopes:
     - dev
- - kind: buildImage
-   name: address_image
-   dockerFile: address/Dockerfile
-   contextPath: .
-   publishAs: address
-   dependsOn:
-     - service_base_image
- - kind: runImage
-   name: check_address
-   image:
-     valueFrom: address_image.image
-   script: |
-     set -ex
-     SITE_PACKAGES=$(pip3 show address | grep Location | sed 's/Location: //')
-     python3 -m flake8 $SITE_PACKAGES/address
-     python3 -m pylint --rcfile pylintrc address
-   dependsOn:
-     - address_image
- - kind: deploy
-   name: deploy_address_sa
-   namespace:
-     valueFrom: default_ns.name
-   config: address/service-account.yaml
-   dependsOn:
-    - default_ns
- - kind: deploy
-   name: deploy_address
-   namespace:
-     valueFrom: default_ns.name
-   config: address/deployment.yaml
-   wait:
-    - kind: Service
-      name: address
-      for: alive
-   dependsOn:
-    - default_ns
-    - deploy_router
-    - address_image
-    - create_certs
  - kind: runImage
    name: test_address
    image:

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -11,6 +11,7 @@ import warnings
 
 from hailtop.config import get_deploy_config, get_user_config
 from hailtop.utils import is_google_registry_image
+from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 import hailtop.batch_client.client as bc
 from hailtop.batch_client.client import BatchClient
 
@@ -473,7 +474,7 @@ class ServiceBackend(Backend):
                 resources['storage'] = job._storage
 
             image = job._image if job._image else default_image
-            if not is_google_registry_image(image):
+            if not is_google_registry_image(image) and image not in HAIL_GENETICS_IMAGES:
                 warnings.warn(f'Using an image {image} not in GCR. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 

--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -1,3 +1,4 @@
+HAIL_GENETICS = 'hailgenetics/'
 HAIL_GENETICS_IMAGES = (
-    'hailgenetics/' + name
-    for name in ('hail', 'python-dill', 'hail'))
+    HAIL_GENETICS + name
+    for name in ('hail', 'python-dill'))

--- a/hail/python/hailtop/batch/hail_genetics_images.py
+++ b/hail/python/hailtop/batch/hail_genetics_images.py
@@ -1,0 +1,3 @@
+HAIL_GENETICS_IMAGES = (
+    'hailgenetics/' + name
+    for name in ('hail', 'python-dill', 'hail'))

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -71,7 +71,8 @@ object HailContext {
       logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
       logProps.put("log4j.appender.logfile.layout.ConversionPattern", HailContext.logFormat)
 
-      logProps.put("log4j.logger.is.hail.shuffler.server", "INFO, AlwaysOnConsoleAppender")
+      logProps.put("log4j.logger.is.hail.services", "INFO, AlwaysOnConsoleAppender")
+      logProps.put("log4j.logger.is.hail.backend.service", "INFO, AlwaysOnConsoleAppender")
       logProps.put("log4j.appender.AlwaysOnConsoleAppender", "org.apache.log4j.ConsoleAppender")
       logProps.put("log4j.appender.AlwaysOnConsoleAppender.layout", "org.apache.log4j.PatternLayout")
       logProps.put("log4j.appender.AlwaysOnConsoleAppender.layout.ConversionPattern", HailContext.logFormat)

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -242,6 +242,7 @@ object Region {
     case _: PFloat64 => loadDouble
     case _: PArray => loadAddress
     case _: PBinary => loadAddress
+    case _: PShuffle => loadAddress
     case _: PBaseStruct => off => off
   }
 
@@ -290,6 +291,9 @@ object Region {
       case t: PString =>
         v.visitString(t.loadString(off))
       case t: PBinary =>
+        val b = t.loadBytes(off)
+        v.visitBinary(b)
+      case t: PShuffle =>
         val b = t.loadBytes(off)
         v.visitBinary(b)
       case t: PContainer =>

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -293,9 +293,6 @@ object Region {
       case t: PBinary =>
         val b = t.loadBytes(off)
         v.visitBinary(b)
-      case t: PShuffle =>
-        val b = t.loadBytes(off)
-        v.visitBinary(b)
       case t: PContainer =>
         val aoff = off
         val pt = t

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -419,6 +419,7 @@ class RegionValueBuilder(var region: Region) {
         case TFloat64 => addDouble(a.asInstanceOf[Double])
         case TString => addString(a.asInstanceOf[String])
         case TBinary => addBinary(a.asInstanceOf[Array[Byte]])
+        case _: TShuffle => addBinary(a.asInstanceOf[Array[Byte]])
 
         case t: TArray =>
           a match {

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -4,7 +4,7 @@ import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.{ExecuteContext, IR, SortField}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.linalg.BlockMatrix
-import is.hail.types.BlockMatrixType
+import is.hail.types._
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
@@ -43,5 +43,11 @@ abstract class Backend {
   def asSpark(op: String): SparkBackend =
     fatal(s"${ getClass.getSimpleName }: $op requires SparkBackend")
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Map[String, IR]): TableStage
+  def lowerDistributedSort(
+    ctx: ExecuteContext,
+    stage: TableStage,
+    sortFields: IndexedSeq[SortField],
+    relationalLetsAbove: Map[String, IR],
+    tableTypeRequiredness: RTable
+  ): TableStage
 }

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -13,7 +13,7 @@ import is.hail.io.fs.{FS, HadoopFS}
 import is.hail.io.plink.LoadPlink
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.linalg.BlockMatrix
-import is.hail.types.BlockMatrixType
+import is.hail.types._
 import is.hail.types.encoded.EType
 import is.hail.types.physical.{PTuple, PType, PVoid}
 import is.hail.types.virtual.TVoid
@@ -265,7 +265,13 @@ class LocalBackend(
     }
   }
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Map[String, IR]): TableStage = {
+  def lowerDistributedSort(
+    ctx: ExecuteContext,
+    stage: TableStage,
+    sortFields: IndexedSeq[SortField],
+    relationalLetsAbove: Map[String, IR],
+    tableTypeRequiredness: RTable
+  ): TableStage = {
     // Use a local sort for the moment to enable larger pipelines to run
     LowerDistributedSort.localSort(ctx, stage, sortFields, relationalLetsAbove)
   }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -385,8 +385,8 @@ class ServiceBackend() extends Backend {
     val region = ctx.r
     val rowType = stage.rowType
     val keyType = rowType.typeAfterSelectNames(sortFields.map(_.field))
-    val rowEType = EType.fromTypeAndAnalysis(rowType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct] // FIXME(danking): Probably not kosher
-    val keyEType = EType.fromTypeAndAnalysis(keyType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct] // FIXME(danking): Probably not kosher
+    val rowEType = EType.fromTypeAndAnalysis(rowType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct]
+    val keyEType = EType.fromTypeAndAnalysis(keyType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct]
     val shuffleType = TShuffle(sortFields, rowType, rowEType, keyEType)
     val shuffleClient = new ShuffleClient(shuffleType, ctx)
     assert(keyType == shuffleClient.codecs.keyType)
@@ -406,7 +406,7 @@ class ServiceBackend() extends Backend {
         stage.mapCollect(relationalLetsAbove)(
           ShuffleWrite(Literal(shuffleType, uuid), _)))
 
-      val partitionBoundsPointers = shuffleClient.partitionBounds(region, stage.numPartitions) // FIXME(danking): number of partitions should be configurable?
+      val partitionBoundsPointers = shuffleClient.partitionBounds(region, stage.numPartitions)
       val partitionIntervals = partitionBoundsPointers.zip(partitionBoundsPointers.drop(1)).map { case (l, r) =>
         Interval(SafeRow(keyDecodedPType, l), SafeRow(keyDecodedPType, r), includesStart = true, includesEnd = false)
       }

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -384,9 +384,10 @@ class ServiceBackend() extends Backend {
   ): TableStage = {
     val region = ctx.r
     val rowType = stage.rowType
-    val keyType = rowType.typeAfterSelectNames(sortFields.map(_.field))
+    val keyFields = sortFields.map(_.field).toArray
+    val keyType = rowType.typeAfterSelectNames(keyFields)
     val rowEType = EType.fromTypeAndAnalysis(rowType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct]
-    val keyEType = EType.fromTypeAndAnalysis(keyType, tableTypeRequiredness.rowType).asInstanceOf[EBaseStruct]
+    val keyEType = EType.fromTypeAndAnalysis(keyType, tableTypeRequiredness.rowType.select(keyFields)).asInstanceOf[EBaseStruct]
     val shuffleType = TShuffle(sortFields, rowType, rowEType, keyEType)
     val shuffleClient = new ShuffleClient(shuffleType, ctx)
     assert(keyType == shuffleClient.codecs.keyType)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -386,9 +386,15 @@ class ServiceBackend() extends Backend {
     assert(keyType == shuffleClient.codecs.keyType)
     val keyDecodedPType = shuffleClient.codecs.keyDecodedPType
     shuffleClient.start()
-    try {
-      val uuid = shuffleClient.uuid
+    val uuid = shuffleClient.uuid
 
+    ctx.ownCleanup({ () =>
+      using(new ShuffleClient(shuffleType, uuid, ctx)) { shuffleClient =>
+        shuffleClient.stop()
+      }
+    })
+
+    try {
       val successfulPartitionIds = execute(
         ctx,
         stage.mapCollect(relationalLetsAbove)(

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -31,7 +31,7 @@ import is.hail.io.vcf.VCFsReader
 import is.hail.linalg.{BlockMatrix, RowMatrix}
 import is.hail.rvd.RVD
 import is.hail.stats.LinearMixedModel
-import is.hail.types.BlockMatrixType
+import is.hail.types._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -622,7 +622,13 @@ class SparkBackend(
     }
   }
 
-  def lowerDistributedSort(ctx: ExecuteContext, stage: TableStage, sortFields: IndexedSeq[SortField], relationalLetsAbove: Map[String, IR]): TableStage = {
+  def lowerDistributedSort(
+    ctx: ExecuteContext,
+    stage: TableStage,
+    sortFields: IndexedSeq[SortField],
+    relationalLetsAbove: Map[String, IR],
+    tableTypeRequiredness: RTable
+  ): TableStage = {
     val (globals, rvd) = TableStageToRVD(ctx, stage, relationalLetsAbove)
 
     if (sortFields.forall(_.sortOrder == Ascending)) {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1619,6 +1619,8 @@ class Emit[C](
       case ShuffleWrite(idIR, rowsIR) =>
         val shuffleType = coerce[TShuffle](idIR.typ)
         val rowsPType = coerce[PStream](rowsIR.pType)
+        assert(shuffleType.rowEType._encodeCompatible(rowsPType.elementType),
+          s"Incompatible:\n${shuffleType.rowEType}\n\n${rowsPType.elementType}")
         val uuid = emitI(idIR)
           .get(cb, "shuffle ID must be non-missing")
           .asInstanceOf[SCanonicalShufflePointerCode]

--- a/hail/src/main/scala/is/hail/services/DeployConfig.scala
+++ b/hail/src/main/scala/is/hail/services/DeployConfig.scala
@@ -102,9 +102,8 @@ class DeployConfig(
     s"${ scheme(baseScheme) }://${ domain(service) }${ basePath(service) }"
   }
 
-  private[this] lazy val addressRequester = new Requester("address")
-
-  def addresses(service: String): Seq[(String, Int)] = {
+  def addresses(service: String, tokens: Tokens = Tokens.get): Seq[(String, Int)] = {
+    val addressRequester = new Requester(tokens, "address")
     implicit val formats: Formats = DefaultFormats
 
     val addressBaseUrl = baseUrl("address")
@@ -116,17 +115,17 @@ class DeployConfig(
     addresses.map(x => ((x \ "address").extract[String], (x \ "port").extract[Int]))
   }
 
-  def address(service: String): (String, Int) = {
-    val serviceAddresses = addresses(service)
+  def address(service: String, tokens: Tokens = Tokens.get): (String, Int) = {
+    val serviceAddresses = addresses(service, tokens)
     val n = serviceAddresses.length
     assert(n > 0)
     serviceAddresses(Random.nextInt(n))
   }
 
-  def socket(service: String): Socket = {
+  def socket(service: String, tokens: Tokens = Tokens.get): Socket = {
     val (host, port) = location match {
       case "k8s" | "gce" =>
-        address(service)
+        address(service, tokens)
       case "external" =>
         throw new IllegalStateException(
           s"Cannot open a socket from an external client to a service.")

--- a/hail/src/main/scala/is/hail/services/shuffler/LSM.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/LSM.scala
@@ -156,7 +156,7 @@ class LSM (
   private[this] var sorted = false
   private[this] var samplesEnd = 0
 
-  private[this] def maybeSample(k: Long): Unit = {
+  private[this] def maybeSample(k: Long): Unit = synchronized {
     if      (processed == 0)
       assert(least == -1 && greatest == -1)
     else if (processed == 1)
@@ -206,12 +206,12 @@ class LSM (
         samples(rnd.nextInt(samplesEnd)) = insertMe
       }
     }
+    processed += 1
   }
 
   def put(k: Long, v: Long): Unit = {
     maybeSample(k)
     store.put(k, v)
-    processed += 1
   }
 
   def iterator(startKey: Long, inclusive: Boolean) = {

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleClient.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleClient.scala
@@ -146,6 +146,9 @@ class ShuffleClient (
   def this(shuffleType: TShuffle, uuid: Array[Byte], rowEncodingPType: PType, keyEncodingPType: PType) =
     this(shuffleType, uuid, Option(rowEncodingPType), Option(keyEncodingPType), None)
 
+  def this(shuffleType: TShuffle, uuid: Array[Byte], ctx: ExecuteContext) =
+    this(shuffleType, uuid, None, None, Some(ctx))
+
   def this(shuffleType: TShuffle, uuid: Array[Byte]) =
     this(shuffleType, uuid, None, None, None)
 
@@ -308,6 +311,6 @@ class ShuffleClient (
     out.writeByte(Wire.EOS)
     out.flush()
     assert(in.readByte() == Wire.EOS)
-    using(s) { _ => () }  // close with proper exception suppression notices
+    s.close()
   }
 }

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
@@ -22,9 +22,13 @@ class ShuffleCodecSpec(
   val keyEncodingPType = _keyEncodingPType.getOrElse(keyDecodedPType)
   val makeKeyEncoder = shuffleType.keyEType.buildEncoder(ctx, keyEncodingPType)
 
-  val keyPSubsetStruct = new PSubsetStruct(
-    rowDecodedPType,
-    shuffleType.keyFields.map(_.field).toArray)
+  val keyPSubsetStruct = {
+    if (keyDecodedPType == rowDecodedPType) {
+      rowDecodedPType
+    } else {
+      new PSubsetStruct(rowDecodedPType, shuffleType.keyFields.map(_.field))
+    }
+  }
   def constructKeyFromDecodedRow(r: Region, row: Long): Long =
     keyDecodedPType.copyFromAddress(r, keyPSubsetStruct, row, false)
 }

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
@@ -16,15 +16,15 @@ class ShuffleCodecSpec(
   val rowEncodingPType = _rowEncodingPType.getOrElse(rowDecodedPType)
   val makeRowEncoder = shuffleType.rowEType.buildEncoder(ctx, rowEncodingPType)
 
-  val keyDecodedSubsetPType = new PSubsetStruct(
-    rowDecodedPType,
-    shuffleType.keyFields.map(_.field).toArray)
-  def constructKeyFromDecodedRow(r: Region, row: Long): Long =
-    keyDecodedSubsetPType.copyFromAddress(r, rowDecodedPType, row, false)
-
   val keyType = shuffleType.keyType
   val (keyDecodedPType, makeKeyDecoder) = shuffleType.keyEType.buildStructDecoder(ctx, shuffleType.keyType)
   assert(keyDecodedPType == shuffleType.keyDecodedPType)
   val keyEncodingPType = _keyEncodingPType.getOrElse(keyDecodedPType)
   val makeKeyEncoder = shuffleType.keyEType.buildEncoder(ctx, keyEncodingPType)
+
+  val keyPSubsetStruct = new PSubsetStruct(
+    rowDecodedPType,
+    shuffleType.keyFields.map(_.field).toArray)
+  def constructKeyFromDecodedRow(r: Region, row: Long): Long =
+    keyDecodedPType.copyFromAddress(r, keyPSubsetStruct, row, false)
 }

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
@@ -26,7 +26,7 @@ class ShuffleCodecSpec(
     if (keyDecodedPType == rowDecodedPType) {
       rowDecodedPType
     } else {
-      new PSubsetStruct(rowDecodedPType, shuffleType.keyFields.map(_.field))
+      new PSubsetStruct(rowDecodedPType, shuffleType.keyFields.map(_.field).toArray)
     }
   }
   def constructKeyFromDecodedRow(r: Region, row: Long): Long =

--- a/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/ShuffleCodecSpec.scala
@@ -3,6 +3,7 @@ package is.hail.services.shuffler
 import is.hail.expr.ir._
 import is.hail.types.virtual._
 import is.hail.types.physical._
+import is.hail.annotations.Region
 
 class ShuffleCodecSpec(
   ctx: ExecuteContext,
@@ -14,6 +15,12 @@ class ShuffleCodecSpec(
   assert(rowDecodedPType == shuffleType.rowDecodedPType)
   val rowEncodingPType = _rowEncodingPType.getOrElse(rowDecodedPType)
   val makeRowEncoder = shuffleType.rowEType.buildEncoder(ctx, rowEncodingPType)
+
+  val keyDecodedSubsetPType = new PSubsetStruct(
+    rowDecodedPType,
+    shuffleType.keyFields.map(_.field).toArray)
+  def constructKeyFromDecodedRow(r: Region, row: Long): Long =
+    keyDecodedSubsetPType.copyFromAddress(r, rowDecodedPType, row, false)
 
   val keyType = shuffleType.keyType
   val (keyDecodedPType, makeKeyDecoder) = shuffleType.keyEType.buildStructDecoder(ctx, shuffleType.keyType)

--- a/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
@@ -166,7 +166,7 @@ class Shuffle (
     assert(hasNext != -1)
     while (hasNext == 1) {
       val off = decoder.readRegionValue(region)
-      val koff = codecs.keyDecodedPType.copyFromAddress(region, codecs.rowDecodedPType, off, false)
+      val koff = codecs.constructKeyFromDecodedRow(region, off)
       store.put(koff, off)
       hasNext = in.readByte()
     }

--- a/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
@@ -142,6 +142,10 @@ class Shuffle (
       }
     }
   }
+  log.info(s"rowDecodedPType: ${codecs.rowDecodedPType}")
+  log.info(s"rowEncodingPType: ${codecs.rowEncodingPType}")
+  log.info(s"keyDecodedPType: ${codecs.keyDecodedPType}")
+  log.info(s"keyEncodingPType: ${codecs.keyEncodingPType}")
 
   private[this] val store = new LSM(s"/tmp/${uuidToString(uuid)}", codecs, pool)
 
@@ -207,8 +211,7 @@ class Shuffle (
     val keyEncoder = codecs.makeKeyEncoder(out)
 
     val keys = store.partitionKeys(nPartitions)
-    val printableKeys = keys.map(key => new UnsafeRow(codecs.keyEncodingPType.asInstanceOf[PBaseStruct], null, key))
-    log.info(s"partitionBounds ${nPartitions} ${printableKeys}")
+    log.info(s"partitionBounds ${nPartitions}")
     assert((nPartitions == 0 && keys.length == 0) ||
       keys.length == nPartitions + 1)
     writeRegionValueArray(keyEncoder, keys)

--- a/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/server/ShuffleServer.scala
@@ -4,10 +4,11 @@ import java.net._
 import java.security.SecureRandom
 import java.util.concurrent.{ConcurrentSkipListMap, Executors, _}
 
-import is.hail.annotations.{Region, RegionPool}
+import is.hail.annotations._
 import is.hail.expr.ir._
 import is.hail.types.encoded._
 import is.hail.types.virtual._
+import is.hail.types.physical._
 import is.hail.io._
 import is.hail.services.tls._
 import is.hail.services.shuffler._
@@ -205,8 +206,9 @@ class Shuffle (
 
     val keyEncoder = codecs.makeKeyEncoder(out)
 
-    log.info(s"partitionBounds ${nPartitions}")
     val keys = store.partitionKeys(nPartitions)
+    val printableKeys = keys.map(key => new UnsafeRow(codecs.keyEncodingPType.asInstanceOf[PBaseStruct], null, key))
+    log.info(s"partitionBounds ${nPartitions} ${printableKeys}")
     assert((nPartitions == 0 && keys.length == 0) ||
       keys.length == nPartitions + 1)
     writeRegionValueArray(keyEncoder, keys)

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -371,6 +371,8 @@ case class RStruct(fields: IndexedSeq[RField]) extends RBaseStruct {
     assert(newChildren.length == fields.length)
     RStruct(Array.tabulate(fields.length)(i => fields(i).name -> coerce[TypeWithRequiredness](newChildren(i))))
   }
+  def select(newFields: Array[String]): RStruct =
+    RStruct(Array.tabulate(newFields.length)(i => RField(newFields(i), field(newFields(i)), i)))
   def _toString: String = s"RStruct[${ fields.map(f => s"${ f.name }: ${ f.typ.toString }").mkString(",") }]"
 }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EShuffle.scala
@@ -1,0 +1,56 @@
+package is.hail.types.encoded
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCodeBuilder}
+import is.hail.types.BaseType
+import is.hail.types.physical._
+import is.hail.types.virtual._
+import is.hail.io.{InputBuffer, OutputBuffer}
+import is.hail.utils._
+
+case object EShuffleOptional extends EShuffle(false)
+case object EShuffleRequired extends EShuffle(true)
+
+class EShuffle(override val required: Boolean) extends EFundamentalType {
+  def _buildFundamentalEncoder(cb: EmitCodeBuilder, pt: PType, v: Value[_], out: Value[OutputBuffer]): Unit = {
+    val addr = coerce[Long](v)
+    val bT = pt.asInstanceOf[PShuffle]
+    val len = cb.newLocal[Int]("len", bT.loadLength(addr))
+    cb += out.writeInt(len)
+    cb += out.writeBytes(bT.bytesAddress(addr), len)
+  }
+
+  def _buildFundamentalDecoder(
+    cb: EmitCodeBuilder,
+    pt: PType,
+    region: Value[Region],
+    in: Value[InputBuffer]
+  ): Code[_] = {
+    val bT = pt.asInstanceOf[PShuffle]
+    val len = cb.newLocal[Int]("len", in.readInt())
+    val barray = cb.newLocal[Long]("barray", bT.allocate(region, len))
+    cb += bT.storeLength(barray, len)
+    cb += in.readBytes(region, bT.bytesAddress(barray), len)
+    barray.load()
+  }
+
+  def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {
+    cb += in.skipBytes(in.readInt())
+  }
+
+  override def _compatible(pt: PType): Boolean = pt.isInstanceOf[PShuffle]
+
+  def _decodedPType(requestedType: Type): PType = requestedType match {
+    case t: TShuffle => PCanonicalShuffle(t, required)
+  }
+
+  def _asIdent = "Shuffle"
+  def _toPretty = "EShuffle"
+
+  def setRequired(newRequired: Boolean): EShuffle = EShuffle(newRequired)
+}
+
+object EShuffle {
+  def apply(required: Boolean = false): EShuffle = if (required) EShuffleRequired else EShuffleOptional
+}

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -289,6 +289,7 @@ object EType {
       case t: PFloat64 => EFloat64(t.required)
       case t: PBoolean => EBoolean(t.required)
       case t: PBinary => EBinary(t.required)
+      case t: PShuffle => EShuffle(t.required)
       // FIXME(chrisvittal): turn this on when performance is adequate
       case t: PArray if t.elementType.fundamentalType.isOfType(PInt32(t.elementType.required)) &&
           HailContext.getFlag("use_packed_int_encoding") != null =>

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -32,7 +32,7 @@ final case class PCanonicalShuffle(
 
   override def fundamentalType: PType = representation.fundamentalType
 
-  override def encodableType: PType = representation.encodableType
+  override def encodableType: PType = this
 
   override def containsPointers: Boolean = representation.containsPointers
 
@@ -64,7 +64,22 @@ final case class PCanonicalShuffle(
       case SCanonicalShufflePointer(t) =>
         representation.storeAtAddress(cb, addr, region, value.asInstanceOf[SCanonicalShufflePointerCode].shuffle, deepCopy)
     }
-
   }
+
+  def loadLength(bAddress: Long): Int = representation.loadLength(bAddress)
+
+  def loadLength(bAddress: Code[Long]): Code[Int] = representation.loadLength(bAddress)
+
+  def bytesAddress(boff: Long): Long = representation.bytesAddress(boff)
+
+  def bytesAddress(boff: Code[Long]): Code[Long] = representation.bytesAddress(boff)
+
+  def storeLength(boff: Long, len: Int): Unit = representation.storeLength(boff, len)
+
+  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit] = representation.storeLength(boff, len)
+
+  def allocate(region: Region, length: Int): Long = representation.allocate(region, length)
+
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long] = representation.allocate(region, length)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -154,6 +154,8 @@ object PSettable {
       SCanonicalCallSettable(sb, name, pt.required)
     case pt: PCanonicalNDArray =>
       SNDArrayPointerSettable(sb, SNDArrayPointer(pt), name)
+    case pt: PCanonicalShuffle =>
+      SCanonicalShufflePointerSettable(sb, SCanonicalShufflePointer(pt), name)
     case pt: PCanonicalStream =>
       throw new UnsupportedOperationException(s"Can't PCode.apply unrealizable PType: $pt")
     case PVoid =>

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -102,7 +102,8 @@ object PCode {
     case pt: PCanonicalBinary =>
       new SBinaryPointerCode(SBinaryPointer(pt), coerce[Long](code))
     case pt: PCanonicalShuffle =>
-      new SCanonicalShufflePointerCode(SCanonicalShufflePointer(pt), coerce[Long](code))
+      new SCanonicalShufflePointerCode(SCanonicalShufflePointer(pt),
+        new SBinaryPointerCode(SBinaryPointer(pt), coerce[Long](code)))
     case pt: PCanonicalString =>
       new SStringPointerCode(SStringPointer(pt), coerce[Long](code))
     case pt: PCanonicalInterval =>

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -103,7 +103,7 @@ object PCode {
       new SBinaryPointerCode(SBinaryPointer(pt), coerce[Long](code))
     case pt: PCanonicalShuffle =>
       new SCanonicalShufflePointerCode(SCanonicalShufflePointer(pt),
-        new SBinaryPointerCode(SBinaryPointer(pt), coerce[Long](code)))
+        new SBinaryPointerCode(SBinaryPointer(pt.representation), coerce[Long](code)))
     case pt: PCanonicalString =>
       new SStringPointerCode(SStringPointer(pt), coerce[Long](code))
     case pt: PCanonicalInterval =>

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -101,6 +101,8 @@ object PCode {
       new SBaseStructPointerCode(SBaseStructPointer(pt), coerce[Long](code))
     case pt: PCanonicalBinary =>
       new SBinaryPointerCode(SBinaryPointer(pt), coerce[Long](code))
+    case pt: PCanonicalShuffle =>
+      new SCanonicalShufflePointerCode(SCanonicalShufflePointer(pt), coerce[Long](code))
     case pt: PCanonicalString =>
       new SStringPointerCode(SStringPointer(pt), coerce[Long](code))
     case pt: PCanonicalInterval =>

--- a/hail/src/main/scala/is/hail/types/physical/PShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PShuffle.scala
@@ -1,5 +1,6 @@
 package is.hail.types.physical
 
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.types.physical.stypes.interfaces.{SShuffleCode, SShuffleValue}
@@ -9,6 +10,22 @@ abstract class PShuffle extends PType {
   def tShuffle: TShuffle
 
   def virtualType: TShuffle = tShuffle
+
+  def loadLength(bAddress: Long): Int
+
+  def loadLength(bAddress: Code[Long]): Code[Int]
+
+  def bytesAddress(boff: Long): Long
+
+  def bytesAddress(boff: Code[Long]): Code[Long]
+
+  def storeLength(boff: Long, len: Int): Unit
+
+  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit]
+
+  def allocate(region: Region, length: Int): Long
+
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long]
 }
 
 abstract class PShuffleValue extends PValue with SShuffleValue {

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -145,6 +145,7 @@ object PType {
       case t: PFloat64 => PFloat64(t.required)
       case t: PBoolean => PBoolean(t.required)
       case t: PBinary => PCanonicalBinary(t.required)
+      case t: PShuffle => PCanonicalShuffle(t.tShuffle, t.required)
       case t: PString => PCanonicalString(t.required)
       case t: PCall => PCanonicalCall(t.required)
       case t: PLocus => PCanonicalLocus(t.rg, t.required)
@@ -445,7 +446,10 @@ abstract class PType extends Serializable with Requiredness {
     // no requirement for requiredness
     // this can have more/less requiredness than srcPType
     // if value is not compatible with this, an exception will be thrown
-    assert(virtualType == srcPType.virtualType)
+    (virtualType, srcPType.virtualType) match {
+      case (l: TBaseStruct, r: TBaseStruct) => assert(l.isCompatibleWith(r))
+      case _ => assert(virtualType == srcPType.virtualType)
+    }
     _copyFromAddress(region, srcPType, srcAddress, deepCopy)
   }
 

--- a/hail/src/main/scala/is/hail/types/virtual/TShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TShuffle.scala
@@ -30,6 +30,8 @@ case class TShuffle (
 
   val keyDecodedPType = keyCodecSpec.decodedPType()
 
+  assert(keyDecodedPType == rowDecodedPType.subsetTo(keyType))
+
   def _toPretty: String = {
     val sb = new StringBuilder()
     sb.append("Shuffle{")

--- a/query/test/test_query.py
+++ b/query/test/test_query.py
@@ -9,6 +9,12 @@ def test_simple_table():
     print(f'n {n}')
     assert n == 17
 
+def test_simple_shuffle():
+    expected = [hl.Struct(idx=i) for i in range(99, -1, -1)]
+    t = hl.utils.range_table(100)
+    actual = t.order_by(-t.idx).collect()
+    assert actual == expected
+
 @pytest.mark.asyncio
 async def test_flags():
     async with cli.QueryClient() as client:

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -95,3 +95,6 @@ principals:
 - name: atgu
   domain: atgu
   kind: json
+- name: batch-user-code
+  domain: batch-user-code
+  kind: json


### PR DESCRIPTION
This PR enables shuffling in the service. It is stacked on several other PRs, so look only at the
most recent commit.

Some highlights:
- Open the public network back up. We should probably make query jobs special so that they can
  access the internal network. To do that, batch would need to accept a "acting on behalf of" user
  account: Query submits the job using its account "acting on behalf of" the user. Batch allows
  query to use the private network, but for all other purposes, the job is owned by the user.

- Allow public access to some the `gcr.io/hail-vdc/query` Docker image.

- Automatically rewrite uses of `hailgenetics/` Docker images to their `gcr.io` equivalents.

- Move `deploy_address` above `deploy_query` so that query can depend on address (necessary for
  shufles).

- Fix logging configuration. Services team wants all logs all the time to go to stdout.

- Implement lowerDistributedSort using the shuffler.

- Allow shuffle ids to be encoded so they can be used in `Literal`.
Unified Split
