### PR TITLE
[query] Remove code generating folds from AppendOnlyBTree

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -178,7 +178,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
     val node = get.getCodeParam[Long](1)
     val k = get.getEmitParam(2)
 
-    val code = EmitCodeBuilder.scopedCode(get) { cb =>
+    get.emitWithBuilder { cb =>
       val cmp = cb.newLocal("cmp", -1)
       val keyV = cb.newLocal("keyV", 0L)
 
@@ -210,8 +210,6 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], key: BTreeKey, region: Value[Regi
       })
       keyV.get
     }
-
-    get.emit(code)
     get
   }
 


### PR DESCRIPTION
This is a series of small refactorings in AppendOnlyBTree that removes
the folds in code generation, replacing a pattern that I find difficult
to follow with a more imperative CodeBuilder style that is necessary for
future changes to proceed as the folding style does not work well with
functions that need code builders.
