### PR TITLE
[query] NDArray Java Representation

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/hail/src/main/scala/is/hail/annotations/Annotation.scala
@@ -37,7 +37,7 @@ object Annotation {
 
       case t: TNDArray =>
         val nd = a.asInstanceOf[NDArray]
-        new SafeNDArray(nd.shape, nd.elements)
+        new SafeNDArray(nd.shape, nd.getRowMajorElements())
 
       case TInt32 | TInt64 | TFloat32 | TFloat64 | TBoolean | TString | TCall | _: TLocus | TBinary => a
     }

--- a/hail/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/hail/src/main/scala/is/hail/annotations/Annotation.scala
@@ -35,7 +35,9 @@ object Annotation {
         val i = a.asInstanceOf[Interval]
         i.copy(start = Annotation.copy(t.pointType, i.start), end = Annotation.copy(t.pointType, i.end))
 
-      case t: TNDArray => copy(t.representation, a)
+      case t: TNDArray =>
+        val nd = a.asInstanceOf[NDArray]
+        new SafeNDArray(nd.shape, nd.elements)
 
       case TInt32 | TInt64 | TFloat32 | TFloat64 | TBoolean | TString | TCall | _: TLocus | TBinary => a
     }

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -490,17 +490,17 @@ class RegionValueBuilder(var region: Region) {
             ("data", TArray(elementType))
           )
           val ptype = currentType().asInstanceOf[PBaseStruct]
-          val shapeRow = a.asInstanceOf[Row](0).asInstanceOf[Row]
-          val shapeArray = shapeRow.toSeq.toIndexedSeq.map(x => x.asInstanceOf[Long])
+          val aNDArray = a.asInstanceOf[NDArray]
+          val shapeRow = Annotation.fromSeq(aNDArray.shape)
           var runningProduct = ptype.fieldType("data").asInstanceOf[PArray].elementType.byteSize
-          val stridesArray = new Array[Long](shapeArray.size)
-          ((shapeArray.size - 1) to 0 by -1).foreach { i =>
+          val stridesArray = new Array[Long](aNDArray.shape.size)
+          ((aNDArray.shape.size - 1) to 0 by -1).foreach { i =>
             stridesArray(i) = runningProduct
-            runningProduct = runningProduct * (if (shapeArray(i) > 0L) shapeArray(i) else 1L)
+            runningProduct = runningProduct * (if (aNDArray.shape(i) > 0L) aNDArray.shape(i) else 1L)
           }
           val stridesRow = Row(stridesArray:_*)
 
-          addAnnotation(structWithStrides, Row(shapeRow, stridesRow, a.asInstanceOf[Row](1)))
+          addAnnotation(structWithStrides, Row(shapeRow, stridesRow, aNDArray.elements))
       }
   }
 

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -500,7 +500,7 @@ class RegionValueBuilder(var region: Region) {
           }
           val stridesRow = Row(stridesArray:_*)
 
-          addAnnotation(structWithStrides, Row(shapeRow, stridesRow, aNDArray.elements))
+          addAnnotation(structWithStrides, Row(shapeRow, stridesRow, aNDArray.getRowMajorElements()))
       }
   }
 

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -354,5 +354,6 @@ class UnsafeNDArray(val pnd: PNDArray, val region: Region, val ndAddr: Long) ext
 }
 
 class SafeNDArray(val shape: IndexedSeq[Long], rowMajorElements: IndexedSeq[Annotation]) extends NDArray {
+  assert(shape.foldLeft(1L)(_ * _) == rowMajorElements.size)
   override def getRowMajorElements: IndexedSeq[Annotation] = rowMajorElements
 }

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -306,7 +306,7 @@ class SelectFieldsRow(
 
 trait NDArray {
   val shape: IndexedSeq[Long]
-  val numElements = shape.foldLeft(1L)(_ * _)
+  lazy val numElements = shape.foldLeft(1L)(_ * _)
   def lookupElement(indices: IndexedSeq[Long]): Annotation
   def getRowMajorElements(): IndexedSeq[Annotation]
   def forall(pred: Annotation => Boolean): Boolean

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -307,6 +307,15 @@ class SelectFieldsRow(
 trait NDArray {
   val shape: IndexedSeq[Long]
   def getRowMajorElements(): IndexedSeq[Annotation]
+
+  override def equals(that: Any): Boolean = {
+    if (that.isInstanceOf[NDArray]) {
+      val thatNd = that.asInstanceOf[NDArray]
+      this.shape == thatNd.shape && this.getRowMajorElements() == thatNd.getRowMajorElements()
+    } else {
+      false
+    }
+  }
 }
 
 class UnsafeNDArray(val pnd: PNDArray, val region: Region, val ndAddr: Long) extends NDArray {

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -39,6 +39,12 @@ class UnsafeIndexedSeq(
   override def toString: String = s"[${this.mkString(",")}]"
 }
 
+class UnsafeNDArray(val pnd: PNDArray, val region: Region, val ndAddr: Long) {
+  val shape: IndexedSeq[Long] = ???
+  val elements: IndexedSeq[Annotation] = ???
+  val elementType = pnd.elementType.virtualType
+}
+
 class UnsafeIndexedSeqRowMajorView(val wrapped: UnsafeIndexedSeq, shape: IndexedSeq[Long], strides: IndexedSeq[Long]) extends IndexedSeq[Annotation] {
   val coordStorageArray = new Array[Long](shape.size)
   val shapeProduct = shape.foldLeft(1L )(_ * _)

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -1,6 +1,6 @@
 package is.hail.expr
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, UnsafeNDArray}
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.types.physical.{PBoolean, PCanonicalArray, PCanonicalBinary, PCanonicalString, PCanonicalStruct, PFloat32, PFloat64, PInt32, PInt64, PType}
 import is.hail.types.virtual._
@@ -132,7 +132,11 @@ object JSONAnnotationImpex {
           val row = a.asInstanceOf[Row]
           JArray(List.tabulate(row.size) { i => exportAnnotation(row.get(i), types(i).typ) })
         case t: TNDArray =>
-          exportAnnotation(a, t.representation)
+          val jnd = a.asInstanceOf[UnsafeNDArray]
+          JObject(
+            "shape" -> JArray(jnd.shape.map(shapeEntry => JInt(shapeEntry)).toList),
+            "data" -> JArray(jnd.elements.map(a => exportAnnotation(a, jnd.elementType)).toList)
+          )
       }
     }
 

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -1,6 +1,6 @@
 package is.hail.expr
 
-import is.hail.annotations.{Annotation, UnsafeNDArray}
+import is.hail.annotations.{Annotation, NDArray, SafeNDArray, UnsafeNDArray}
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.types.physical.{PBoolean, PCanonicalArray, PCanonicalBinary, PCanonicalString, PCanonicalStruct, PFloat32, PFloat64, PInt32, PInt64, PType}
 import is.hail.types.virtual._
@@ -131,11 +131,11 @@ object JSONAnnotationImpex {
         case TTuple(types) =>
           val row = a.asInstanceOf[Row]
           JArray(List.tabulate(row.size) { i => exportAnnotation(row.get(i), types(i).typ) })
-        case t: TNDArray =>
-          val jnd = a.asInstanceOf[UnsafeNDArray]
+        case TNDArray(elementType, _) =>
+          val jnd = a.asInstanceOf[NDArray]
           JObject(
             "shape" -> JArray(jnd.shape.map(shapeEntry => JInt(shapeEntry)).toList),
-            "data" -> JArray(jnd.elements.map(a => exportAnnotation(a, jnd.elementType)).toList)
+            "data" -> JArray(jnd.elements.map(a => exportAnnotation(a, elementType)).toList)
           )
       }
     }
@@ -248,8 +248,12 @@ object JSONAnnotationImpex {
         }
       case (_, TLocus(_)) =>
         jv.extract[Locus]
-      case (JObject(_), t@TNDArray(_, _)) =>
-        imp(jv, t.representation, parent)
+      case (JObject(List(("shape", shapeJson: JArray), ("data", dataJson: JArray))), t@TNDArray(_, _)) => {
+        val shapeArray = shapeJson.arr.map(imp(_, TInt64, parent)).map(_.asInstanceOf[Long]).toIndexedSeq
+        val dataArray = dataJson.arr.map(imp(_, t.elementType, parent)).toIndexedSeq
+
+        new SafeNDArray(shapeArray, dataArray)
+      }
       case (_, TInterval(pointType)) =>
         jv match {
           case JObject(list) =>
@@ -276,9 +280,6 @@ object JSONAnnotationImpex {
 
       case (JArray(a), TSet(elementType)) =>
         a.iterator.map(jv2 => imp(jv2, elementType, parent + "[element]")).toSet[Any]
-
-      case (j, t: TNDArray) => importAnnotation(j, t.representation)
-
       case _ =>
         warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
         null

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -135,7 +135,7 @@ object JSONAnnotationImpex {
           val jnd = a.asInstanceOf[NDArray]
           JObject(
             "shape" -> JArray(jnd.shape.map(shapeEntry => JInt(shapeEntry)).toList),
-            "data" -> JArray(jnd.elements.map(a => exportAnnotation(a, elementType)).toList)
+            "data" -> JArray(jnd.getRowMajorElements().map(a => exportAnnotation(a, elementType)).toList)
           )
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -6,6 +6,7 @@ import is.hail.types._
 import is.hail.types.physical.{PStream, PType}
 import is.hail.types.virtual._
 import is.hail.utils._
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 
 import scala.collection.mutable
 
@@ -438,7 +439,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TableToValueApply(t, ForceCountTable()) =>
 
       case _: NA => requiredness.union(false)
-      case Literal(t, a) => requiredness.unionLiteral(a)
+      case x@Literal(t, a) => requiredness.unionLiteral(a)
       case EncodedLiteral(codec, value) => requiredness.fromPType(codec.decodedPType())
 
       case Coalesce(values) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -439,7 +439,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case TableToValueApply(t, ForceCountTable()) =>
 
       case _: NA => requiredness.union(false)
-      case x@Literal(t, a) => requiredness.unionLiteral(a)
+      case Literal(t, a) => requiredness.unionLiteral(a)
       case EncodedLiteral(codec, value) => requiredness.fromPType(codec.decodedPType())
 
       case Coalesce(values) =>

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -1,6 +1,6 @@
 package is.hail.types
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, NDArray}
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval}
@@ -246,7 +246,7 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
 }
 case class RNDArray(override val elementType: TypeWithRequiredness) extends RIterable(elementType, true) {
   override def _unionLiteral(a: Annotation): Unit = {
-    val data = a.asInstanceOf[Row].getAs[Iterable[Any]](1)
+    val data = a.asInstanceOf[NDArray].elements
     data.asInstanceOf[Iterable[_]].foreach { elt =>
       if (elt != null)
         elementType.unionLiteral(elt)

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -246,7 +246,7 @@ case class RDict(keyType: TypeWithRequiredness, valueType: TypeWithRequiredness)
 }
 case class RNDArray(override val elementType: TypeWithRequiredness) extends RIterable(elementType, true) {
   override def _unionLiteral(a: Annotation): Unit = {
-    val data = a.asInstanceOf[NDArray].elements
+    val data = a.asInstanceOf[NDArray].getRowMajorElements()
     data.asInstanceOf[Iterable[_]].foreach { elt =>
       if (elt != null)
         elementType.unionLiteral(elt)

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -88,7 +88,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       }
       PCanonicalTuple(pFields, required)
     case t: TNDArray =>
-      val elementType = _decodedPType(t.representation).asInstanceOf[PStruct].fieldType("data").asInstanceOf[PArray].elementType
+      val elementType = _decodedPType(t.elementType)
       PCanonicalNDArray(elementType, t.nDims, required)
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -30,6 +30,8 @@ abstract class PNDArray extends PType {
 
   def loadShape(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 
+  def loadShape(off: Long, idx: Int): Long
+
   def loadStride(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 
   def numElements(shape: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Long]
@@ -41,6 +43,8 @@ abstract class PNDArray extends PType {
   def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
 
   def setElement(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], newElement: Code[_], mb: EmitMethodBuilder[_]): Code[Unit]
+
+  def getElementAddress(indices: IndexedSeq[Long], nd: Long): Long
 
   def loadElement(cb: EmitCodeBuilder, indices: IndexedSeq[Value[Long]], ndAddress: Value[Long]): Code[Long]
   def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], mb: EmitMethodBuilder[_]): Code[_]

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -27,13 +27,18 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
   override def fundamentalType: Type = representation.fundamentalType
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean = {
-    val aNd1 = a1.asInstanceOf[NDArray]
-    val aNd2 = a2.asInstanceOf[NDArray]
+    if (a1 == null || a2 == null) {
+      a1 == a2
+    }
+    else {
+      val aNd1 = a1.asInstanceOf[NDArray]
+      val aNd2 = a2.asInstanceOf[NDArray]
 
-    val sameShape = aNd1.shape == aNd2.shape
-    val sameData = aNd1.getRowMajorElements().zip(aNd2.getRowMajorElements()).forall{ case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance, absolute)}
+      val sameShape = aNd1.shape == aNd2.shape
+      val sameData = aNd1.getRowMajorElements().zip(aNd2.getRowMajorElements()).forall{ case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance, absolute)}
 
-    sameShape && sameData
+      sameShape && sameData
+    }
   }
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -1,6 +1,6 @@
 package is.hail.types.virtual
 
-import is.hail.annotations.{Annotation, ExtendedOrdering, UnsafeIndexedSeq}
+import is.hail.annotations.{Annotation, ExtendedOrdering, NDArray, UnsafeIndexedSeq}
 import is.hail.expr.{Nat, NatBase}
 import is.hail.types.physical.PNDArray
 import org.apache.spark.sql.Row
@@ -46,11 +46,11 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   override def str(a: Annotation): String = {
     if (a == null) "NA" else {
-      val a_row = a.asInstanceOf[Row]
-      val shape = a_row(this.representation.fieldIdx("shape")).asInstanceOf[Row].toSeq.asInstanceOf[Seq[Long]].map(_.toInt)
-      val data = a_row(this.representation.fieldIdx("data")).asInstanceOf[IndexedSeq[Any]]
+      val aNd = a.asInstanceOf[NDArray]
+      val shape = aNd.shape
+      val data = aNd.elements
 
-      def dataToNestedString(data: Iterator[Annotation], shape: Seq[Int], sb: StringBuilder):Unit  = {
+      def dataToNestedString(data: Iterator[Annotation], shape: Seq[Long], sb: StringBuilder):Unit  = {
         if (shape.isEmpty) {
           sb.append(data.next().toString)
         }

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -26,6 +26,16 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   override def fundamentalType: Type = representation.fundamentalType
 
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean = {
+    val aNd1 = a1.asInstanceOf[NDArray]
+    val aNd2 = a2.asInstanceOf[NDArray]
+
+    val sameShape = aNd1.shape == aNd2.shape
+    val sameData = aNd1.getRowMajorElements().zip(aNd2.getRowMajorElements()).forall{ case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance, absolute)}
+
+    sameShape && sameData
+  }
+
   override def pyString(sb: StringBuilder): Unit = {
     sb.append("ndarray<")
     elementType.pyString(sb)

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -48,7 +48,7 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
     if (a == null) "NA" else {
       val aNd = a.asInstanceOf[NDArray]
       val shape = aNd.shape
-      val data = aNd.elements
+      val data = aNd.getRowMajorElements()
 
       def dataToNestedString(data: Iterator[Annotation], shape: Seq[Long], sb: StringBuilder):Unit  = {
         if (shape.isEmpty) {

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -109,13 +109,18 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
-  def _typeCheck(a: Any): Boolean = representation._typeCheck(a)
+  def _typeCheck(a: Annotation): Boolean = { a match {
+    case nd: NDArray => nd.forall(e => elementType.typeCheck(e))
+    case _ => false
+  }
+
+  }
 
   override def mkOrdering(missingEqual: Boolean): ExtendedOrdering = null
 
   lazy val shapeType: TTuple = TTuple(Array.fill(nDims)(TInt64): _*)
 
-  lazy val representation = TStruct(
+  private lazy val representation = TStruct(
     ("shape", shapeType),
     ("data", TArray(elementType))
   )

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.HailSuite
-import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
+import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeNDArray, SafeRow}
 import is.hail.types.encoded._
 import is.hail.types.physical.{PCanonicalArray, PCanonicalNDArray, PCanonicalStringOptional, PCanonicalStringRequired, PCanonicalStruct, PFloat32Required, PFloat64Required, PInt32Optional, PInt32Required, PInt64Optional, PInt64Required, PType}
 import is.hail.io.{InputBuffer, MemoryBuffer, MemoryInputBuffer, MemoryOutputBuffer, OutputBuffer}
@@ -113,28 +113,28 @@ class ETypeSuite extends HailSuite {
   @Test def testNDArrayEncodeDecode(): Unit = {
     val pTypeInt0 = PCanonicalNDArray(PInt32Required, 0, true)
     val eTypeInt0 = ENDArrayColumnMajor(EInt32Required, 0, true)
-    val dataInt0 = Row(Row(), FastIndexedSeq(0))
+    val dataInt0 = new SafeNDArray(IndexedSeq[Long](), FastIndexedSeq(0))
 
     assertEqualEncodeDecode(pTypeInt0, eTypeInt0, pTypeInt0, dataInt0)
 
     val pTypeFloat1 = PCanonicalNDArray(PFloat32Required, 1, true)
     val eTypeFloat1 = ENDArrayColumnMajor(EFloat32Required, 1, true)
-    val dataFloat1 = Row(Row(5L), (0 until 5).map(_.toFloat))
+    val dataFloat1 = new SafeNDArray(IndexedSeq(5L), (0 until 5).map(_.toFloat))
 
     assertEqualEncodeDecode(pTypeFloat1, eTypeFloat1, pTypeFloat1, dataFloat1)
 
     val pTypeInt2 = PCanonicalNDArray(PInt32Required, 2, true)
     val eTypeInt2 = ENDArrayColumnMajor(EInt32Required, 2, true)
-    val dataInt2 = Row(Row(2L, 2L), FastIndexedSeq(10, 20, 30, 40))
+    val dataInt2 = new SafeNDArray(IndexedSeq(2L, 2L), FastIndexedSeq(10, 20, 30, 40))
 
     assertEqualEncodeDecode(pTypeInt2, eTypeInt2, pTypeInt2, dataInt2)
 
     val pTypeDouble3 = PCanonicalNDArray(PFloat64Required, 3, false)
     val eTypeDouble3 = ENDArrayColumnMajor(EFloat64Required, 3, false)
-    val dataDouble3 = Row(Row(3L, 2L, 1L), FastIndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+    val dataDouble3 = new SafeNDArray(IndexedSeq(3L, 2L, 1L), FastIndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
 
     assert(encodeDecode(pTypeDouble3, eTypeDouble3, pTypeDouble3, dataDouble3) ==
-      Row(Row(3L, 2L, 1L), FastIndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)))
+      new SafeNDArray(IndexedSeq(3L, 2L, 1L), FastIndexedSeq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0)))
 
     // Test for skipping
     val pStructContainingNDArray = PCanonicalStruct(true,
@@ -156,7 +156,7 @@ class ETypeSuite extends HailSuite {
     assert(encodeDecode(pStructContainingNDArray, eStructContainingNDArray, pOnlyReadB, dataStruct) ==
       Row(3))
 
-    // Try reading a EBaseStruct into a PNDArray, old method.
+    // Try reading a EBaseStruct into a PNDArray, backwards compatibility.
     val shapeAndStrideType = EBaseStruct(FastIndexedSeq(
       EField("0", EInt64Required, 0),
       EField("1", EInt64Required, 1)
@@ -169,8 +169,8 @@ class ETypeSuite extends HailSuite {
       ),
       true)
     val dataStructInt2 = Row(Row(2L, 2L), Row(4L, 8L), FastIndexedSeq(10, 20, 30, 40))
+    val outputNDArray = new SafeNDArray(IndexedSeq(2L, 2L), FastIndexedSeq(10, 30, 20, 40))
 
-
-    encodeDecode(pTypeInt2.representation, eTypeStructInt2, pTypeInt2, dataStructInt2)
+    assert(encodeDecode(pTypeInt2.representation, eTypeStructInt2, pTypeInt2, dataStructInt2) == outputNDArray)
   }
 }

--- a/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PNDArraySuite.scala
@@ -1,7 +1,7 @@
 package is.hail.types.physical
 
 import is.hail.HailSuite
-import is.hail.annotations.{Annotation, Region, ScalaToRegionValue}
+import is.hail.annotations.{Annotation, Region, SafeNDArray, ScalaToRegionValue}
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitFunctionBuilder
 import is.hail.utils._
@@ -10,7 +10,7 @@ import org.testng.annotations.Test
 class PNDArraySuite extends PhysicalTestUtils {
   @Test def copyTests() {
     def runTests(deepCopy: Boolean, interpret: Boolean = false) {
-      copyTestExecutor(PCanonicalNDArray(PInt64(true), 1), PCanonicalNDArray(PInt64(true), 1), Annotation(Annotation(1L), IndexedSeq(4L,5L,6L)),
+      copyTestExecutor(PCanonicalNDArray(PInt64(true), 1), PCanonicalNDArray(PInt64(true), 1), new SafeNDArray(IndexedSeq(3L), IndexedSeq(4L,5L,6L)),
         deepCopy = deepCopy, interpret = interpret)
     }
 


### PR DESCRIPTION
Part of a refactoring effort. I need to break the model that a `TNDArray` is represented by an underlying `TStruct` and `TArray`. This adds an `UnsafeNDArray` Java representation, rather than the old model which was just to use`UnsafeRow` like it was a struct. 


cc @tpoterba 