### PR TITLE
[batch] rewrite schema validation so that schema description is working validation function

### DIFF
--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -65,7 +65,7 @@ job_validator = keyed({
         required('namespace'): k8s_str,
         required('name'): k8s_str
     }),
-    'timeout': numeric(**{"x > 0", lambda x: x > 0})
+    'timeout': numeric(**{"x > 0": lambda x: x > 0})
 })
 
 batch_validator = keyed({

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -57,7 +57,7 @@ job_validator = keyed({
         'storage': regex(MEMORY_REGEXPAT, MEMORY_REGEX)
     }),
     'secrets': listof(keyed({
-        required('namespace': k8s_str,
+        required('namespace'): k8s_str,
         required('name'): k8s_str,
         required('mount_path'): str_type
     })),

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -1,9 +1,8 @@
-import re
-
 from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
                                         CPU_REGEX, CPU_REGEXPAT)
 
-from hailtop.utils.validate import *
+from hailtop.utils.validate import bool_type, dictof, keyed, listof, int_type, nullable, \
+    numeric, oneof, regex, required, str_type, switch, ValidationError
 
 k8s_str = regex(r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*', maxlen=253)
 
@@ -77,7 +76,6 @@ batch_validator = keyed({
 })
 
 
-
 def validate_and_clean_jobs(jobs):
     if not isinstance(jobs, list):
         raise ValidationError('jobs is not list')
@@ -91,7 +89,6 @@ def handle_deprecated_job_keys(i, job):
         if 'resources' in job and 'storage' in job['resources']:
             raise ValidationError(f"jobs[{i}].resources.storage is already defined, but "
                                   f"deprecated key 'pvc_size' is also present.")
-        deprecated_msg = "[pvc_size key is DEPRECATED. Use resources.storage]"
         pvc_size = job['pvc_size']
         try:
             job_validator['resources']['storage'].validate(f"jobs[{i}].pvc_size", job['pvc_size'])
@@ -106,9 +103,6 @@ def handle_deprecated_job_keys(i, job):
 
     if 'process' not in job:
         process_keys = ['command', 'image', 'mount_docker_socket']
-        deprecated_msg = "[command, image, mount_docker_socket keys are DEPRECATED. " \
-                         "Use process.command, process.image, process.mount_docker_socket " \
-                         "with process.type = 'docker'.]"
         if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
 
             raise ValidationError(f'jobs[{i}].process is not defined, but deprecated keys {[k for k in process_keys if k not in job]} are not in jobs[{i}]')

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -107,7 +107,7 @@ def handle_deprecated_job_keys(i, job):
         if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
             raise ValidationError(f'jobs[{i}].process is not defined, but '
                                   f'deprecated keys {[k for k in process_keys if k not in job]} '
-                                  f'are not in jobs[{i}]') from e
+                                  f'are not in jobs[{i}]')
         command = job['command']
         image = job['image']
         mount_docker_socket = job['mount_docker_socket']

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -70,7 +70,7 @@ job_validator = keyed({
 batch_validator = keyed({
     'attributes': nullable(dictof(str_type)),
     required('billing_project'): str_type,
-    'callback': nullable(str),
+    'callback': nullable(str_type),
     required('n_jobs'): int_type,
     required('token'): str_type
 })

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -72,7 +72,7 @@ batch_validator = keyed({
     required('billing_project'): str_type,
     'callback': nullable(str),
     required('n_jobs'): int_type,
-    'token': str_type
+    required('token'): str_type
 })
 
 

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -3,76 +3,138 @@ import re
 from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
                                         CPU_REGEX, CPU_REGEXPAT)
 
-# rough schema (without requiredness, value validation):
+class required:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
 
-# DEPRECATED:
-# command -> process/command
-# image -> process/image
-# mount_docker_socket -> process/mount_docker_socket
-# pvc_size -> resources/storage
-#
-# jobs_schema = [{
-#   'always_run': bool,
-#   'attributes': {str: str},
-#   'env': [{
-#     'name': str,
-#     'value': str
-#   }],
-#   'gcsfuse': [{"bucket": str, "mount_path": str, "read_only": bool}],
-#   'input_files': [{"from": str, "to": str}],
-#   'job_id': int,
-#   'output_files': [{"from": str, "to": str}],
-#   'parent_ids': [int],
-#   'port': int,
-#   'process': {
-#     'type': str,
-#     **process_schema[process_type]
-#   },
-#   'requester_pays_project': str,
-#   'network': str,
-#   'resources': {
-#     'memory': str,
-#     'cpu': str,
-#     'storage': str
-#   },
-#   'secrets': [{
-#     'namespace': str,
-#     'name': str,
-#     'mount_path': str
-#   }],
-#   'service_account': {
-#     'namespace': str,
-#     'name': str
-#   },
-#   'timeout': float or int
-# }]
-#
-# process_schema = {
-#     'docker': {
-#         'command': str,
-#         'image': str,
-#         'mount_docker_socket': str
-#     }
-# }
 
-JOB_KEYS = {'always_run', 'attributes', 'env', 'gcsfuse',
-            'input_files', 'job_id', 'mount_tokens',
-            'output_files', 'parent_ids', 'port', 'process',
-            'requester_pays_project', 'network', 'resources', 'secrets',
-            'service_account', 'timeout'}
+class TypedValidator:
+    def __init__(self, t):
+        self.t = t
 
-ENV_VAR_KEYS = {'name', 'value'}
+    def validate(self, name, obj):
+        if not isinstance(obj, self.t):
+            raise ValidationError(f'{name} is not {self.t}')
 
-SECRET_KEYS = {'namespace', 'name', 'mount_path'}
 
-RESOURCES_KEYS = {'memory', 'cpu', 'storage'}
+class dictof(TypedValidator):
+    def __init__(self, vchecker):
+        super().__init__(dict)
+        self.vchecker = vchecker
 
-FILE_KEYS = {'from', 'to'}
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                raise ValidationError(f'{name} has non-str key')
+            self.vchecker.validate(f"{name}[{k}]", obj[k])
 
-GCSFUSE_KEYS = {'bucket', 'mount_path', 'read_only'}
 
-K8S_NAME_REGEXPAT = r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*'
-K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
+class keyed(TypedValidator):
+    def __init__(self, keyed_checkers):
+        super().__init__(dict)
+        self.checkers = keyed_checkers
+
+    def __getitem__(self, key):
+        return self.checkers[key]
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        for k in obj:
+            if k not in self.checkers:
+                raise ValidationError(f'unknown key in {name}: {k}')
+        for k, checker in self.checkers.items():
+            if isinstance(checker, required):
+                if k not in obj:
+                    raise ValidationError(f'{name} missing required key {k}.')
+                else:
+                    checker.wrapped.validate(f"{name}.{key}", obj[k])
+            elif k in obj:
+                checker.validate(f"{name}.{key}", obj[k])
+
+
+class listof(TypedValidator):
+    def __init__(self, checker):
+        super().__init__(list)
+        self.checker = checker
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        for i, elt in enumerate(obj):
+            self.checker.validate(f"{name}[{i}]", elt)
+
+
+class in_set:
+    def __init__(self, *valid):
+        self.valid = set(valid)
+
+    def validate(self, name, obj):
+        if obj not in self.valid:
+            raise ValidationError(f'{name} must be one of: {self.valid}')
+
+
+class regex(TypedValidator):
+    def __init__(self, pattern, re_obj=None, maxlen=None):
+        super().__init__(str)
+        self.pattern = pattern
+        self.re_obj = re_obj if re_obj is not None else re.compile(pattern)
+        self.maxlen = maxlen
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        if self.maxlen is not None and len(obj) > self.maxlen:
+            raise ValidationError(f'length of {name} must be <= {self.maxlen}')
+        if not self.re_obj.fullmatch(obj):
+            raise ValidationError(f'{name} must match regex: {self.pattern}')
+
+
+class numeric:
+    def __init__(self, **conditions):
+        self.conditions = conditions
+
+    def validate(self, name, obj):
+        if not isinstance(obj, int) and not isinstance(obj, float):
+            raise ValidationError(f'{name} is not numeric')
+        for text, condition in self.conditions.items():
+            if not condition(obj):
+                raise ValidationError(f'{name} does not satisfy the condition {text}')
+
+
+class switch(TypedValidator):
+    def __init__(self, key, checkers):
+        super().__init__(dict)
+        self.key = key
+        self.valid_key = required(in_set(*checkers.keys()))
+        self.checkers = {k: keyed({key: self.valid_key, **fields}) for k, fields in checkers.items()}
+
+    def __getitem__(self, key):
+        return self.checkers[key]
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        key = obj[self.key]
+        self.valid_key.validate(f"{name}.{key}", key)
+        self.checkers[key].validate(obj)
+
+
+class nullable:
+    def __init__(self, wrapped):
+        self.checker = wrapped
+
+    def validate(self, name, obj):
+        if obj is not None:
+            self.checker.validate(obj)
+
+
+str_type = TypedValidator(str)
+bool_type = TypedValidator(bool)
+int_type = TypedValidator(int)
+
+k8s_str = regex(r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*', maxlen=253)
+
+# FIXME validate image
+# https://github.com/docker/distribution/blob/master/reference/regexp.go#L68
+image_str = str_type
 
 
 class ValidationError(Exception):
@@ -85,21 +147,21 @@ def validate_and_clean_jobs(jobs):
     if not isinstance(jobs, list):
         raise ValidationError('jobs is not list')
     for i, job in enumerate(jobs):
-        handle_deprecated_args(i, job)
-        validate_job(i, job)
+        handle_deprecated_job_keys(i, job)
+        job_validator.validate(f"jobs[{i}]", job)
 
 
-def handle_deprecated_args(i, job):
+def handle_deprecated_job_keys(i, job):
     if 'pvc_size' in job:
         if 'resources' in job and 'storage' in job['resources']:
             raise ValidationError(f"jobs[{i}].resources.storage is already defined, but "
                                   f"deprecated key 'pvc_size' is also present.")
         deprecated_msg = "[pvc_size key is DEPRECATED. Use resources.storage]"
         pvc_size = job['pvc_size']
-        if not isinstance(pvc_size, str):
-            raise ValidationError(f'{deprecated_msg} jobs[{i}].pvc_size not str.')
-        if not MEMORY_REGEX.fullmatch(pvc_size):
-            raise ValidationError(f'{deprecated_msg} jobs[{i}].pvc_size must match regex: {MEMORY_REGEXPAT}')
+        try:
+            job_validator['resources']['storage'].validate(f"jobs[{i}].pvc_size", job['pvc_size'])
+        except ValidationError as e:
+            raise ValidationError(f"[pvc_size key is DEPRECATED. Use resources.storage] {e.reason}")
         resources = job.get('resources')
         if resources is None:
             resources = {}
@@ -108,27 +170,24 @@ def handle_deprecated_args(i, job):
         del job['pvc_size']
 
     if 'process' not in job:
+        process_keys = ['command', 'image', 'mount_docker_socket']
         deprecated_msg = "[command, image, mount_docker_socket keys are DEPRECATED. " \
                          "Use process.command, process.image, process.mount_docker_socket " \
                          "with process.type = 'docker'.]"
         if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
-            keys = {'command', 'image', 'mount_docker_socket'}
-            raise ValidationError(f'{deprecated_msg} required keys {[k for k in keys if k not in job]} not in jobs[{i}]')
+
+            raise ValidationError(f'jobs[{i}].process is not defined, but deprecated keys {[k for k in process_keys if k not in job]} are not in jobs[{i}]')
         command = job['command']
         image = job['image']
         mount_docker_socket = job['mount_docker_socket']
-        if not isinstance(command, list):
-            raise ValidationError(f'{deprecated_msg} jobs[{i}].command not list')
-        for j, a in enumerate(command):
-            if not isinstance(a, str):
-                raise ValidationError(f'{deprecated_msg} jobs[{i}].command[{j}] is not str')
-
-        if not isinstance(image, str):
-            raise ValidationError(f'{deprecated_msg} jobs[{i}].image is not str')
-        # FIXME validate image
-        # https://github.com/docker/distribution/blob/master/reference/regexp.go#L68
-        if not isinstance(mount_docker_socket, bool):
-            raise ValidationError(f'{deprecated_msg} jobs[{i}].mount_docker_socket not bool')
+        try:
+            for k in process_keys:
+                job_validator['process']['docker'][k].validate(f"jobs[{i}].{k}", job[k])
+        except ValidationError as e:
+            raise ValidationError(f"[command, image, mount_docker_socket keys are "
+                                  f"DEPRECATED. Use process.command, process.image, "
+                                  f"process.mount_docker_socket with process.type = 'docker'.] "
+                                  f"{e.reason}")
 
         job['process'] = {'command': command,
                           'image': image,
@@ -145,360 +204,69 @@ def handle_deprecated_args(i, job):
                                   f"Please remove deprecated keys.")
 
 
-def validate_job(i, job):
-    if not isinstance(job, dict):
-        raise ValidationError(f'jobs[{i}] not dict')
+# DEPRECATED:
+# command -> process/command
+# image -> process/image
+# mount_docker_socket -> process/mount_docker_socket
+# pvc_size -> resources/storage
 
-    for k in job:
-        if k not in JOB_KEYS:
-            raise ValidationError(f'unknown key in jobs[{i}]: {k}')
+job_validator = keyed({
+    'always_run': bool_type,
+    'attributes': dictof(str_type),
+    'env': listof(keyed({
+        'name': str_type,
+        'value': str_type
+    })),
+    'gcsfuse': listof(keyed({
+        'bucket': required(str_type),
+        'mount_path': required(str_type),
+        'read_only': required(bool_type),
+    })),
+    'input_files': listof(keyed({
+        'from': required(str_type),
+        'to': required(str_type)
+    })),
+    'job_id': required(int_type),
+    'mount_tokens': bool_type,
+    'network': in_set('public', 'private'),
+    'output_files': listof(keyed({
+        'from': required(str_type),
+        'to': required(str_type)
+    })),
+    'parent_ids': required(listof(int_type)),
+    'port': int_type,
+    'process': required(switch('type', {
+        'docker': {
+            'command': required(listof(str_type)),
+            'image': required(image_str),
+            'mount_docker_socket': required(bool_type)
+        }
+    })),
+    'requester_pays_project': str_type,
+    'resources': keyed({
+        'memory': regex(MEMORY_REGEXPAT, MEMORY_REGEX),
+        'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
+        'storage': regex(MEMORY_REGEXPAT, MEMORY_REGEX)
+    }),
+    'secrets': listof(keyed({
+        'namespace': required(k8s_str),
+        'name': required(k8s_str),
+        'mount_path': required(str_type)
+    })),
+    'service_account': keyed({
+        'namespace': required(k8s_str),
+        'name': required(k8s_str)
+    }),
+    'timeout': numeric(**{"x > 0", lambda x: x > 0})
+})
 
-    if 'always_run' in job:
-        always_run = job['always_run']
-        if not isinstance(always_run, bool):
-            raise ValidationError(f'jobs[{i}].always_run is not bool')
-
-    if 'attributes' in job:
-        attributes = job['attributes']
-        if not isinstance(attributes, dict):
-            raise ValidationError(f'jobs[{i}].attributes is not dict')
-        for k, v in attributes.items():
-            if not isinstance(k, str):
-                raise ValidationError(f'jobs[{i}].attributes has non-str key')
-            if not isinstance(v, str):
-                raise ValidationError(f'jobs[{i}].attributes has non-str value')
-
-    if 'env' in job:
-        env = job['env']
-        if not isinstance(env, list):
-            raise ValidationError(f'jobs[{i}].env is not list')
-        for j, e in enumerate(env):
-            if not isinstance(e, dict):
-                raise ValidationError(f'jobs[{i}].env[{j}] is not dict')
-            for k in e:
-                if k not in ENV_VAR_KEYS:
-                    raise ValidationError(f'unknown key in jobs[{i}].env[{j}]: {k}')
-            if 'name' not in e:
-                raise ValidationError(f'no required key name in jobs[{i}].env[{j}]')
-            name = e['name']
-            if not isinstance(name, str):
-                raise ValidationError(f'jobs[{i}].env[{j}].name is not str')
-            if 'value' not in e:
-                raise ValidationError(f'no required key value in jobs[{i}].env[{j}]')
-            value = e['value']
-            if not isinstance(value, str):
-                raise ValidationError(f'jobs[{i}].env[{j}].value is not str')
-
-    if 'gcsfuse' in job:
-        gcsfuse = job['gcsfuse']
-        if not isinstance(gcsfuse, list):
-            raise ValidationError(f'jobs[{i}].gcsfuse not list')
-
-        for j, b in enumerate(gcsfuse):
-            if not isinstance(b, dict):
-                raise ValidationError(f'jobs[{i}].gcsfuse[{j}] not dict')
-
-            for k in b:
-                if k not in GCSFUSE_KEYS:
-                    raise ValidationError(f'unknown key in jobs[{i}].gcsfuse[{j}]: {k}')
-
-            if 'bucket' not in b:
-                raise ValidationError(f'no required key bucket in jobs[{i}].gcsfuse[{j}]')
-            bucket = b['bucket']
-            if not isinstance(bucket, str):
-                raise ValidationError(f'jobs[{i}].gcsfuse[{j}].bucket is not str')
-
-            if 'mount_path' not in b:
-                raise ValidationError(f'no required key mount_path in jobs[{i}].gcsfuse[{j}]')
-            mount_path = b['mount_path']
-            if not isinstance(mount_path, str):
-                raise ValidationError(f'jobs[{i}].gcsfuse[{j}].mount_path is not str')
-
-            if 'read_only' not in b:
-                raise ValidationError(f'no required key read_only in jobs[{i}].gcsfuse[{j}]')
-            read_only = b['read_only']
-            if not isinstance(read_only, bool):
-                raise ValidationError(f'jobs[{i}].gcsfuse[{j}].read_only is not bool')
-
-    if 'input_files' in job:
-        input_files = job['input_files']
-        if not isinstance(input_files, list):
-            raise ValidationError(f'jobs[{i}].input_files not list')
-
-        for j, f in enumerate(input_files):
-            if not isinstance(f, dict):
-                raise ValidationError(f'jobs[{i}].input_files[{j}] not dict')
-            for k in f:
-                if k not in FILE_KEYS:
-                    raise ValidationError(f'unknown key in jobs[{i}].input_files[{j}]: {k}')
-
-            if 'from' not in f:
-                raise ValidationError(f'no required key from in jobs[{i}].input_files[{j}]')
-            src = f['from']
-            if not isinstance(src, str):
-                raise ValidationError(f'jobs[{i}].input_files[{j}].from is not str')
-
-            if 'to' not in f:
-                raise ValidationError(f'no required key to in jobs[{i}].input_files[{j}]')
-            dst = f['to']
-            if not isinstance(dst, str):
-                raise ValidationError(f'jobs[{i}].input_files[{j}].to is not str')
-
-    if 'job_id' not in job:
-        raise ValidationError(f'no required key job_id in jobs[{i}]')
-    job_id = job['job_id']
-    if not isinstance(job_id, int):
-        raise ValidationError(f'jobs[{i}].job_id is not int')
-
-    if 'mount_tokens' in job:
-        mount_tokens = job['mount_tokens']
-        if not isinstance(mount_tokens, bool):
-            raise ValidationError(f'jobs[{i}].mount_tokens is not bool')
-
-    if 'output_files' in job:
-        output_files = job['output_files']
-        if not isinstance(output_files, list):
-            raise ValidationError(f'jobs[{i}].output_files not list')
-
-        for j, f in enumerate(output_files):
-            if not isinstance(f, dict):
-                raise ValidationError(f'jobs[{i}].output_files[{j}] not dict')
-
-            for k in f:
-                if k not in FILE_KEYS:
-                    raise ValidationError(f'unknown key in jobs[{i}].output_files[{j}]: {k}')
-
-            if 'from' not in f:
-                raise ValidationError(f'no required key from in jobs[{i}].output_files[{j}]')
-            src = f['from']
-            if not isinstance(src, str):
-                raise ValidationError(f'jobs[{i}].output_files[{j}].from is not str')
-
-            if 'to' not in f:
-                raise ValidationError(f'no required key to in jobs[{i}].output_files[{j}]')
-            dst = f['to']
-            if not isinstance(dst, str):
-                raise ValidationError(f'jobs[{i}].output_files[{j}].to is not str')
-
-    if 'parent_ids' not in job:
-        raise ValidationError(f'no required key parent_ids in jobs[{i}]')
-    parent_ids = job['parent_ids']
-    if not isinstance(parent_ids, list):
-        raise ValidationError(f'jobs[{i}].job_id is not list')
-    for j, id in enumerate(parent_ids):
-        if not isinstance(id, int):
-            raise ValidationError(f'jobs[{i}].parent_ids[{j} is not int')
-
-    if 'port' in job:
-        port = job['port']
-        if not isinstance(port, int):
-            raise ValidationError(f'jobs[{i}].port not int')
-
-    if 'process' not in job:
-        raise ValidationError(f'no required key process in jobs[{i}]')
-    validate_process(i, job['process'])
-
-    if 'requester_pays_project' in job:
-        requester_pays_project = job['requester_pays_project']
-        if not isinstance(requester_pays_project, str):
-            raise ValidationError(f'jobs[{i}].requester_pays_project not str')
-
-    if 'network' in job:
-        network = job['network']
-        if not isinstance(network, str):
-            raise ValidationError(f'jobs[{i}].network not str')
-        if network not in ('public', 'private'):
-            raise ValidationError(f'jobs[{i}].network not "public" or "private"')
-
-    if 'resources' in job:
-        resources = job['resources']
-        if not isinstance(resources, dict):
-            raise ValidationError(f'jobs[{i}].resources is not dict')
-        for k in resources:
-            if k not in RESOURCES_KEYS:
-                raise ValidationError(f'unknown key in jobs[{i}].resources: {k}')
-
-        if 'memory' in resources:
-            memory = resources['memory']
-            if not isinstance(memory, str):
-                raise ValidationError(f'jobs[{i}].resources.memory is not str')
-            if not MEMORY_REGEX.fullmatch(memory):
-                raise ValidationError(f'jobs[{i}].resources.memory must match regex: {MEMORY_REGEXPAT}')
-
-        if 'cpu' in resources:
-            cpu = resources['cpu']
-            if not isinstance(cpu, str):
-                raise ValidationError(f'jobs[{i}].resources.cpu is not str')
-            if not CPU_REGEX.fullmatch(cpu):
-                raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
-
-        if 'storage' in resources:
-            storage = resources['storage']
-            if not isinstance(storage, str):
-                raise ValidationError(f'jobs[{i}].resources.storage is not str')
-            if not MEMORY_REGEX.fullmatch(storage):
-                raise ValidationError(f'jobs[{i}].resources.storage must match regex: {MEMORY_REGEXPAT}')
-
-    if 'secrets' in job:
-        secrets = job['secrets']
-        if not isinstance(secrets, list):
-            raise ValidationError(f'jobs[{i}].secrets is not list')
-        for j, secret in enumerate(secrets):
-            if not isinstance(secret, dict):
-                raise ValidationError(f'jobs[{i}].secrets[{j}] is not dict')
-            for k in secret:
-                if k not in SECRET_KEYS:
-                    raise ValidationError(f'unknown key in jobs[{i}].secrets[{j}]: {k}')
-
-                if 'namespace' not in secret:
-                    raise ValidationError(f'no required key namespace in jobs[{i}].secrets[{j}]')
-                namespace = secret['namespace']
-                if not isinstance(namespace, str):
-                    raise ValidationError(f'jobs[{i}].secrets[{j}].namespace is not str')
-                if len(namespace) > 253:
-                    raise ValidationError(f'length of jobs[{i}].secrets[{j}].namespace must be <= 253')
-                if not K8S_NAME_REGEX.fullmatch(namespace):
-                    raise ValidationError(f'jobs[{i}].secrets[{j}].namespace must match regex: {K8S_NAME_REGEXPAT}')
-
-                if 'name' not in secret:
-                    raise ValidationError(f'no required key name in jobs[{i}].secrets[{j}]')
-                name = secret['name']
-                if not isinstance(name, str):
-                    raise ValidationError(f'jobs[{i}].secrets[{j}].name is not str')
-                if len(name) > 253:
-                    raise ValidationError(f'length of jobs[{i}].secrets[{j}].name must be <= 253')
-                if not K8S_NAME_REGEX.fullmatch(name):
-                    raise ValidationError(f'jobs[{i}].secrets[{j}].name must match regex: {K8S_NAME_REGEXPAT}')
-
-                if 'mount_path' not in secret:
-                    raise ValidationError(f'no required key mount_path in jobs[{i}].secrets[{j}]')
-                if not isinstance(name, str):
-                    raise ValidationError(f'jobs[{i}].secrets[{j}].mount_path is not str')
-
-    if 'service_account' in job:
-        service_account = job['service_account']
-        if not isinstance(service_account, dict):
-            raise ValidationError(f'jobs[{i}].service_account is not dict')
-
-        if 'namespace' not in service_account:
-            raise ValidationError(f'no required key namespace in jobs[{i}].service_account')
-        namespace = service_account['namespace']
-        if not isinstance(namespace, str):
-            raise ValidationError(f'jobs[{i}].service_account.namespace is not str')
-        if len(namespace) > 253:
-            raise ValidationError(f'length of jobs[{i}].service_account.namespace must be <= 253')
-        if not K8S_NAME_REGEX.fullmatch(namespace):
-            raise ValidationError(f'jobs[{i}].service_account.namespace must match regex: {K8S_NAME_REGEXPAT}')
-
-        if 'name' not in service_account:
-            raise ValidationError(f'no required key name in jobs[{i}].service_account')
-        name = service_account['name']
-        if not isinstance(name, str):
-            raise ValidationError(f'jobs[{i}].service_account.name not str')
-        if len(name) > 253:
-            raise ValidationError(f'length of jobs[{i}].service_account.name must be <= 253')
-        if not K8S_NAME_REGEX.fullmatch(name):
-            raise ValidationError(f'jobs[{i}].service_account.name must match regex: {K8S_NAME_REGEXPAT}')
-
-    if 'timeout' in job:
-        timeout = job['timeout']
-        if not isinstance(timeout, float) and not isinstance(timeout, int):
-            raise ValidationError(f'jobs[{i}].timeout not numeric')
-        if timeout < 0:
-            raise ValidationError(f'jobs[{i}].timeout is not a positive number')
-
-
-PROCESS_TYPES = {
-    'docker': {'command', 'image', 'mount_docker_socket', 'type'}
-}
-
-
-def validate_process(i, process):
-    if 'type' not in process:
-        raise ValidationError(f'no required key type in jobs[{i}].process')
-    type = process['type']
-    if type not in PROCESS_TYPES:
-        raise ValidationError(f'jobs[{i}].process.type must be in set {PROCESS_TYPES.keys()}.')
-    for k in process:
-        if k != 'type' and k not in PROCESS_TYPES[type]:
-            raise ValidationError(f'unknown key in jobs[{i}].process for type {type}: {k}')
-
-    if type == 'docker':
-        if 'command' not in process:
-            raise ValidationError(f'no required key command in jobs[{i}].process (type=docker)')
-        command = process['command']
-        if not isinstance(command, list):
-            raise ValidationError(f'jobs[{i}].process.command not list')
-        for j, a in enumerate(command):
-            if not isinstance(a, str):
-                raise ValidationError(f'jobs[{i}].process.command[{j}] is not str')
-
-        if 'image' not in process:
-            raise ValidationError(f'no required key image in jobs[{i}].process (type=docker)')
-        image = process['image']
-        if not isinstance(image, str):
-            raise ValidationError(f'jobs[{i}].process.image is not str')
-        # FIXME validate image
-        # https://github.com/docker/distribution/blob/master/reference/regexp.go#L68
-
-        if 'mount_docker_socket' not in process:
-            raise ValidationError(f'no required key mount_docker_socket in jobs[{i}].process (type=docker)')
-        mount_docker_socket = process['mount_docker_socket']
-        if not isinstance(mount_docker_socket, bool):
-            raise ValidationError(f'jobs[{i}].process.mount_docker_socket not bool')
-
-
-# rough schema
-# batch_schema = {
-#   'attributes': {str: str},
-#   'billing_project': str,
-#   'callback': str,
-#   'n_jobs': int,
-#   'token': str
-# }
-
-BATCH_KEYS = {
-    'attributes', 'billing_project', 'callback', 'n_jobs', 'token'
-}
-
+batch_validator = keyed({
+    'attributes': nullable(dictof(str_type)),
+    'billing_project': required(str_type),
+    'callback': nullable(str),
+    'n_jobs': required(int_type),
+    'token': str_type
+})
 
 def validate_batch(batch):
-    if not isinstance(batch, dict):
-        raise ValidationError('batch not dict')
-
-    for k in batch:
-        if k not in BATCH_KEYS:
-            raise ValidationError(f'unknown key in batch: {k}')
-
-    attributes = batch.get('attributes')
-    if attributes is not None:
-        if not isinstance(attributes, dict):
-            raise ValidationError('batch.attributes is not dict')
-        for k, v in attributes.items():
-            if not isinstance(k, str):
-                raise ValidationError('batch.attributes has non-str key')
-            if not isinstance(v, str):
-                raise ValidationError('batch.attributes has non-str value')
-
-    if 'billing_project' not in batch:
-        raise ValidationError('no required key billing_project in batch')
-    billing_project = batch['billing_project']
-    if not isinstance(billing_project, str):
-        raise ValidationError('batch.billing_project is not str')
-
-    callback = batch.get('callback')
-    if callback is not None:
-        if not isinstance(callback, str):
-            raise ValidationError('batch.callback not str')
-
-    if 'n_jobs' not in batch:
-        raise ValidationError('no required key n_jobs in batch')
-    n_jobs = batch['n_jobs']
-    if not isinstance(n_jobs, int):
-        raise ValidationError('batch.n_jobs is not int')
-
-    if 'token' not in batch:
-        raise ValidationError('no required key token in batch')
-    token = batch['token']
-    if not isinstance(token, str):
-        raise ValidationError('batch.token is not str')
+    batch_validator.validate('batch', batch)

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -3,132 +3,7 @@ import re
 from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
                                         CPU_REGEX, CPU_REGEXPAT)
 
-class required:
-    def __init__(self, wrapped):
-        self.wrapped = wrapped
-
-
-class TypedValidator:
-    def __init__(self, t):
-        self.t = t
-
-    def validate(self, name, obj):
-        if not isinstance(obj, self.t):
-            raise ValidationError(f'{name} is not {self.t}')
-
-
-class dictof(TypedValidator):
-    def __init__(self, vchecker):
-        super().__init__(dict)
-        self.vchecker = vchecker
-
-    def validate(self, name, obj):
-        super().validate(name, obj)
-        for k, v in obj.items():
-            if not isinstance(k, str):
-                raise ValidationError(f'{name} has non-str key')
-            self.vchecker.validate(f"{name}[{k}]", obj[k])
-
-
-class keyed(TypedValidator):
-    def __init__(self, keyed_checkers):
-        super().__init__(dict)
-        self.checkers = keyed_checkers
-
-    def __getitem__(self, key):
-        return self.checkers[key]
-
-    def validate(self, name, obj):
-        super().validate(name, obj)
-        for k in obj:
-            if k not in self.checkers:
-                raise ValidationError(f'unknown key in {name}: {k}')
-        for k, checker in self.checkers.items():
-            if isinstance(checker, required):
-                if k not in obj:
-                    raise ValidationError(f'{name} missing required key {k}.')
-                else:
-                    checker.wrapped.validate(f"{name}.{key}", obj[k])
-            elif k in obj:
-                checker.validate(f"{name}.{key}", obj[k])
-
-
-class listof(TypedValidator):
-    def __init__(self, checker):
-        super().__init__(list)
-        self.checker = checker
-
-    def validate(self, name, obj):
-        super().validate(name, obj)
-        for i, elt in enumerate(obj):
-            self.checker.validate(f"{name}[{i}]", elt)
-
-
-class in_set:
-    def __init__(self, *valid):
-        self.valid = set(valid)
-
-    def validate(self, name, obj):
-        if obj not in self.valid:
-            raise ValidationError(f'{name} must be one of: {self.valid}')
-
-
-class regex(TypedValidator):
-    def __init__(self, pattern, re_obj=None, maxlen=None):
-        super().__init__(str)
-        self.pattern = pattern
-        self.re_obj = re_obj if re_obj is not None else re.compile(pattern)
-        self.maxlen = maxlen
-
-    def validate(self, name, obj):
-        super().validate(name, obj)
-        if self.maxlen is not None and len(obj) > self.maxlen:
-            raise ValidationError(f'length of {name} must be <= {self.maxlen}')
-        if not self.re_obj.fullmatch(obj):
-            raise ValidationError(f'{name} must match regex: {self.pattern}')
-
-
-class numeric:
-    def __init__(self, **conditions):
-        self.conditions = conditions
-
-    def validate(self, name, obj):
-        if not isinstance(obj, int) and not isinstance(obj, float):
-            raise ValidationError(f'{name} is not numeric')
-        for text, condition in self.conditions.items():
-            if not condition(obj):
-                raise ValidationError(f'{name} does not satisfy the condition {text}')
-
-
-class switch(TypedValidator):
-    def __init__(self, key, checkers):
-        super().__init__(dict)
-        self.key = key
-        self.valid_key = required(in_set(*checkers.keys()))
-        self.checkers = {k: keyed({key: self.valid_key, **fields}) for k, fields in checkers.items()}
-
-    def __getitem__(self, key):
-        return self.checkers[key]
-
-    def validate(self, name, obj):
-        super().validate(name, obj)
-        key = obj[self.key]
-        self.valid_key.validate(f"{name}.{key}", key)
-        self.checkers[key].validate(obj)
-
-
-class nullable:
-    def __init__(self, wrapped):
-        self.checker = wrapped
-
-    def validate(self, name, obj):
-        if obj is not None:
-            self.checker.validate(obj)
-
-
-str_type = TypedValidator(str)
-bool_type = TypedValidator(bool)
-int_type = TypedValidator(int)
+from hailtop.utils.validate import *
 
 k8s_str = regex(r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*', maxlen=253)
 
@@ -137,10 +12,70 @@ k8s_str = regex(r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0
 image_str = str_type
 
 
-class ValidationError(Exception):
-    def __init__(self, reason):
-        super().__init__()
-        self.reason = reason
+# DEPRECATED:
+# command -> process/command
+# image -> process/image
+# mount_docker_socket -> process/mount_docker_socket
+# pvc_size -> resources/storage
+
+job_validator = keyed({
+    'always_run': bool_type,
+    'attributes': dictof(str_type),
+    'env': listof(keyed({
+        'name': str_type,
+        'value': str_type
+    })),
+    'gcsfuse': listof(keyed({
+        required('bucket'): str_type,
+        required('mount_path'): str_type,
+        required('read_only'): bool_type,
+    })),
+    'input_files': listof(keyed({
+        required('from'): str_type,
+        required('to'): str_type
+    })),
+    required('job_id'): int_type,
+    'mount_tokens': bool_type,
+    'network': oneof('public', 'private'),
+    'output_files': listof(keyed({
+        required('from'): str_type,
+        required('to'): str_type
+    })),
+    required('parent_ids'): listof(int_type),
+    'port': int_type,
+    required('process'): switch('type', {
+        'docker': {
+            required('command'): listof(str_type),
+            required('image'): image_str,
+            required('mount_docker_socket'): bool_type
+        }
+    }),
+    'requester_pays_project': str_type,
+    'resources': keyed({
+        'memory': regex(MEMORY_REGEXPAT, MEMORY_REGEX),
+        'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
+        'storage': regex(MEMORY_REGEXPAT, MEMORY_REGEX)
+    }),
+    'secrets': listof(keyed({
+        required('namespace': k8s_str,
+        required('name'): k8s_str,
+        required('mount_path'): str_type
+    })),
+    'service_account': keyed({
+        required('namespace'): k8s_str,
+        required('name'): k8s_str
+    }),
+    'timeout': numeric(**{"x > 0", lambda x: x > 0})
+})
+
+batch_validator = keyed({
+    'attributes': nullable(dictof(str_type)),
+    required('billing_project'): str_type,
+    'callback': nullable(str),
+    required('n_jobs'): int_type,
+    'token': str_type
+})
+
 
 
 def validate_and_clean_jobs(jobs):
@@ -203,70 +138,6 @@ def handle_deprecated_job_keys(i, job):
                                   f"'mount_docker_socket' are also present. "
                                   f"Please remove deprecated keys.")
 
-
-# DEPRECATED:
-# command -> process/command
-# image -> process/image
-# mount_docker_socket -> process/mount_docker_socket
-# pvc_size -> resources/storage
-
-job_validator = keyed({
-    'always_run': bool_type,
-    'attributes': dictof(str_type),
-    'env': listof(keyed({
-        'name': str_type,
-        'value': str_type
-    })),
-    'gcsfuse': listof(keyed({
-        'bucket': required(str_type),
-        'mount_path': required(str_type),
-        'read_only': required(bool_type),
-    })),
-    'input_files': listof(keyed({
-        'from': required(str_type),
-        'to': required(str_type)
-    })),
-    'job_id': required(int_type),
-    'mount_tokens': bool_type,
-    'network': in_set('public', 'private'),
-    'output_files': listof(keyed({
-        'from': required(str_type),
-        'to': required(str_type)
-    })),
-    'parent_ids': required(listof(int_type)),
-    'port': int_type,
-    'process': required(switch('type', {
-        'docker': {
-            'command': required(listof(str_type)),
-            'image': required(image_str),
-            'mount_docker_socket': required(bool_type)
-        }
-    })),
-    'requester_pays_project': str_type,
-    'resources': keyed({
-        'memory': regex(MEMORY_REGEXPAT, MEMORY_REGEX),
-        'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
-        'storage': regex(MEMORY_REGEXPAT, MEMORY_REGEX)
-    }),
-    'secrets': listof(keyed({
-        'namespace': required(k8s_str),
-        'name': required(k8s_str),
-        'mount_path': required(str_type)
-    })),
-    'service_account': keyed({
-        'namespace': required(k8s_str),
-        'name': required(k8s_str)
-    }),
-    'timeout': numeric(**{"x > 0", lambda x: x > 0})
-})
-
-batch_validator = keyed({
-    'attributes': nullable(dictof(str_type)),
-    'billing_project': required(str_type),
-    'callback': nullable(str),
-    'n_jobs': required(int_type),
-    'token': str_type
-})
 
 def validate_batch(batch):
     batch_validator.validate('batch', batch)

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -118,7 +118,7 @@ def handle_deprecated_job_keys(i, job):
             raise ValidationError(f"[command, image, mount_docker_socket keys are "
                                   f"DEPRECATED. Use process.command, process.image, "
                                   f"process.mount_docker_socket with process.type = 'docker'.] "
-                                  f"{e.reason}")
+                                  f"{e.reason}") from e
 
         job['process'] = {'command': command,
                           'image': image,

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -93,7 +93,8 @@ def handle_deprecated_job_keys(i, job):
         try:
             job_validator['resources']['storage'].validate(f"jobs[{i}].pvc_size", job['pvc_size'])
         except ValidationError as e:
-            raise ValidationError(f"[pvc_size key is DEPRECATED. Use resources.storage] {e.reason}")
+            raise ValidationError(f"[pvc_size key is DEPRECATED. Use "
+                                  f"resources.storage] {e.reason}") from e
         resources = job.get('resources')
         if resources is None:
             resources = {}
@@ -104,8 +105,9 @@ def handle_deprecated_job_keys(i, job):
     if 'process' not in job:
         process_keys = ['command', 'image', 'mount_docker_socket']
         if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
-
-            raise ValidationError(f'jobs[{i}].process is not defined, but deprecated keys {[k for k in process_keys if k not in job]} are not in jobs[{i}]')
+            raise ValidationError(f'jobs[{i}].process is not defined, but '
+                                  f'deprecated keys {[k for k in process_keys if k not in job]} '
+                                  f'are not in jobs[{i}]') from e
         command = job['command']
         image = job['image']
         mount_docker_socket = job['mount_docker_socket']

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -68,4 +68,5 @@ __all__ = [
     'url_join',
     'serialization',
     'is_google_registry_image',
+    'validate',
 ]

--- a/hail/python/hailtop/utils/validate/__init__.py
+++ b/hail/python/hailtop/utils/validate/__init__.py
@@ -1,0 +1,17 @@
+from .validate import bool_type, dictof, keyed, listof, int_type, nullable, \
+    numeric, oneof, regex, required, str_type, switch
+
+__all__ = [
+    'bool_type',
+    'dictof',
+    'keyed',
+    'listof',
+    'int_type',
+    'nullable',
+    'numeric',
+    'oneof',
+    'regex',
+    'required',
+    'str_type',
+    'switch'
+]

--- a/hail/python/hailtop/utils/validate/__init__.py
+++ b/hail/python/hailtop/utils/validate/__init__.py
@@ -1,5 +1,5 @@
 from .validate import bool_type, dictof, keyed, listof, int_type, nullable, \
-    numeric, oneof, regex, required, str_type, switch
+    numeric, oneof, regex, required, str_type, switch, ValidationError
 
 __all__ = [
     'bool_type',
@@ -13,5 +13,6 @@ __all__ = [
     'regex',
     'required',
     'str_type',
-    'switch'
+    'switch',
+    'ValidationError'
 ]

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -1,3 +1,5 @@
+import re
+
 class ValidationError(Exception):
     def __init__(self, reason):
         super().__init__()
@@ -107,8 +109,8 @@ class SwitchValidator(TypedValidator):
     def __init__(self, key, checkers):
         super().__init__(dict)
         self.key = key
-        self.valid_key = required(in_set(*checkers.keys()))
-        self.checkers = {k: keyed({key: self.valid_key, **fields}) for k, fields in checkers.items()}
+        self.valid_key = oneof(*checkers.keys())
+        self.checkers = {k: keyed({required(key): self.valid_key, **fields}) for k, fields in checkers.items()}
 
     def __getitem__(self, key):
         return self.checkers[key]
@@ -126,7 +128,7 @@ class NullableValidator:
 
     def validate(self, name, obj):
         if obj is not None:
-            self.checker.validate(obj)
+            self.checker.validate(name, obj)
 
 
 required = RequiredKey

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -1,3 +1,4 @@
+from typing import Union, List, Dict, Pattern, Callable, Any
 import re
 
 
@@ -8,7 +9,7 @@ class ValidationError(Exception):
 
 
 class RequiredKey:
-    def __init__(self, key):
+    def __init__(self, key: str):
         self.key = key
 
 
@@ -22,11 +23,11 @@ class TypedValidator:
 
 
 class DictValidator(TypedValidator):
-    def __init__(self, vchecker):
+    def __init__(self, vchecker: 'Validator'):
         super().__init__(dict)
         self.vchecker = vchecker
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         super().validate(name, obj)
         for k, v in obj.items():
             if not isinstance(k, str):
@@ -35,7 +36,7 @@ class DictValidator(TypedValidator):
 
 
 class KeyedValidator(TypedValidator):
-    def __init__(self, keyed_checkers):
+    def __init__(self, keyed_checkers: Dict[Key, 'Validator']):
         super().__init__(dict)
         self.checkers = {}
         for k, v in keyed_checkers.items():
@@ -44,10 +45,10 @@ class KeyedValidator(TypedValidator):
             else:
                 self.checkers[k] = (v, False)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Key):
         return self.checkers[key][0]
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         super().validate(name, obj)
         unknown_keys = set(obj.keys()) - set(self.checkers.keys())
         if len(unknown_keys) != 0:
@@ -60,11 +61,11 @@ class KeyedValidator(TypedValidator):
 
 
 class ListValidator(TypedValidator):
-    def __init__(self, checker):
+    def __init__(self, checker: 'Validator'):
         super().__init__(list)
         self.checker = checker
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         super().validate(name, obj)
         for i, elt in enumerate(obj):
             self.checker.validate(f"{name}[{i}]", elt)
@@ -74,19 +75,19 @@ class SetValidator:
     def __init__(self, valid):
         self.valid = valid
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         if obj not in self.valid:
             raise ValidationError(f'{name} must be one of: {self.valid}')
 
 
 class RegexValidator(TypedValidator):
-    def __init__(self, pattern, re_obj, maxlen):
+    def __init__(self, pattern: str, re_obj: Pattern, maxlen: int):
         super().__init__(str)
         self.pattern = pattern
         self.re_obj = re_obj if re_obj is not None else re.compile(pattern)
         self.maxlen = maxlen
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         super().validate(name, obj)
         if self.maxlen is not None and len(obj) > self.maxlen:
             raise ValidationError(f'length of {name} must be <= {self.maxlen}')
@@ -95,10 +96,10 @@ class RegexValidator(TypedValidator):
 
 
 class NumericValidator:
-    def __init__(self, conditions):
+    def __init__(self, conditions: Dict[str, Callable[[Any], Any]]):
         self.conditions = conditions
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         if not isinstance(obj, int) and not isinstance(obj, float):
             raise ValidationError(f'{name} is not numeric')
         for text, condition in self.conditions.items():
@@ -107,16 +108,17 @@ class NumericValidator:
 
 
 class SwitchValidator(TypedValidator):
-    def __init__(self, key, checkers):
+    def __init__(self, key: str, checkers: Dict[str, Dict[Key, 'Validator']]):
         super().__init__(dict)
         self.key = key
         self.valid_key = oneof(*checkers.keys())
-        self.checkers = {k: keyed({required(key): self.valid_key, **fields}) for k, fields in checkers.items()}
+        self.checkers = {k: keyed({required(key): self.valid_key, **fields})
+                         for k, fields in checkers.items()}
 
     def __getitem__(self, key):
         return self.checkers[key]
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         super().validate(name, obj)
         key = obj[self.key]
         self.valid_key.validate(f"{name}.{key}", key)
@@ -124,15 +126,15 @@ class SwitchValidator(TypedValidator):
 
 
 class NullableValidator:
-    def __init__(self, wrapped):
+    def __init__(self, wrapped: 'Validator'):
         self.checker = wrapped
 
-    def validate(self, name, obj):
+    def validate(self, name: str, obj):
         if obj is not None:
             self.checker.validate(name, obj)
 
 
-def required(key):
+def required(key: str):
     return RequiredKey(key)
 
 
@@ -140,16 +142,19 @@ str_type = TypedValidator(str)
 bool_type = TypedValidator(bool)
 int_type = TypedValidator(int)
 
+Key = Union[str, RequiredKey]
+Validator = Union[TypedValidator, NumericValidator, NullableValidator, SetValidator]
 
-def dictof(vchecker):
+
+def dictof(vchecker: Validator):
     return DictValidator(vchecker)
 
 
-def keyed(checkers):
+def keyed(checkers: Dict[Key, Validator]):
     return KeyedValidator(checkers)
 
 
-def listof(checker):
+def listof(checker: Validator):
     return ListValidator(checker)
 
 
@@ -161,13 +166,13 @@ def regex(pattern, re_obj=None, maxlen=None):
     return RegexValidator(pattern, re_obj, maxlen)
 
 
-def nullable(wrapped):
+def nullable(wrapped: Validator):
     return NullableValidator(wrapped)
 
 
-def numeric(**conditions):
+def numeric(**conditions: Callable[[Any], Any]):
     return NumericValidator(conditions)
 
 
-def switch(key, checkers):
+def switch(key: str, checkers: Dict[str, Dict[Key, Validator]]):
     return SwitchValidator(key, checkers)

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -145,7 +145,6 @@ str_type = TypedValidator(str)
 bool_type = TypedValidator(bool)
 int_type = TypedValidator(int)
 
-Key = Union[str, RequiredKey]
 Validator = Union[TypedValidator, NumericValidator, NullableValidator, SetValidator]
 
 

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -1,5 +1,6 @@
 import re
 
+
 class ValidationError(Exception):
     def __init__(self, reason):
         super().__init__()
@@ -133,6 +134,7 @@ class NullableValidator:
 
 def required(key):
     return RequiredKey(key)
+
 
 str_type = TypedValidator(str)
 bool_type = TypedValidator(bool)

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -1,0 +1,145 @@
+class ValidationError(Exception):
+    def __init__(self, reason):
+        super().__init__()
+        self.reason = reason
+
+
+class RequiredKey:
+    def __init__(self, key):
+        self.key = key
+
+
+class TypedValidator:
+    def __init__(self, t):
+        self.t = t
+
+    def validate(self, name, obj):
+        if not isinstance(obj, self.t):
+            raise ValidationError(f'{name} is not {self.t}')
+
+
+class DictValidator(TypedValidator):
+    def __init__(self, vchecker):
+        super().__init__(dict)
+        self.vchecker = vchecker
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                raise ValidationError(f'{name} has non-str key')
+            self.vchecker.validate(f"{name}[{k}]", obj[k])
+
+
+class KeyedValidator(TypedValidator):
+    def __init__(self, keyed_checkers):
+        super().__init__(dict)
+        self.checkers = {}
+        for k, v in keyed_checkers.items():
+            if isinstance(k, RequiredKey):
+                self.checkers[k.key] = (v, True)
+            else:
+                self.checkers[k] = (v, False)
+
+    def __getitem__(self, key):
+        return self.checkers[key][0]
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        unknown_keys = set(obj.keys()) - set(self.checkers.keys())
+        if len(unknown_keys) != 0:
+            raise ValidationError(f'unknown keys in {name}: {unknown_keys}')
+        for k, (checker, required) in self.checkers.items():
+            if required and k not in obj:
+                raise ValidationError(f'{name} missing required key {k}.')
+            elif k in obj:
+                checker.validate(f"{name}.{k}", obj[k])
+
+
+class ListValidator(TypedValidator):
+    def __init__(self, checker):
+        super().__init__(list)
+        self.checker = checker
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        for i, elt in enumerate(obj):
+            self.checker.validate(f"{name}[{i}]", elt)
+
+
+class SetValidator:
+    def __init__(self, *valid):
+        self.valid = set(valid)
+
+    def validate(self, name, obj):
+        if obj not in self.valid:
+            raise ValidationError(f'{name} must be one of: {self.valid}')
+
+
+class RegexValidator(TypedValidator):
+    def __init__(self, pattern, re_obj=None, maxlen=None):
+        super().__init__(str)
+        self.pattern = pattern
+        self.re_obj = re_obj if re_obj is not None else re.compile(pattern)
+        self.maxlen = maxlen
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        if self.maxlen is not None and len(obj) > self.maxlen:
+            raise ValidationError(f'length of {name} must be <= {self.maxlen}')
+        if not self.re_obj.fullmatch(obj):
+            raise ValidationError(f'{name} must match regex: {self.pattern}')
+
+
+class NumericValidator:
+    def __init__(self, **conditions):
+        self.conditions = conditions
+
+    def validate(self, name, obj):
+        if not isinstance(obj, int) and not isinstance(obj, float):
+            raise ValidationError(f'{name} is not numeric')
+        for text, condition in self.conditions.items():
+            if not condition(obj):
+                raise ValidationError(f'{name} does not satisfy the condition {text}')
+
+
+class SwitchValidator(TypedValidator):
+    def __init__(self, key, checkers):
+        super().__init__(dict)
+        self.key = key
+        self.valid_key = required(in_set(*checkers.keys()))
+        self.checkers = {k: keyed({key: self.valid_key, **fields}) for k, fields in checkers.items()}
+
+    def __getitem__(self, key):
+        return self.checkers[key]
+
+    def validate(self, name, obj):
+        super().validate(name, obj)
+        key = obj[self.key]
+        self.valid_key.validate(f"{name}.{key}", key)
+        self.checkers[key].validate(obj)
+
+
+class NullableValidator:
+    def __init__(self, wrapped):
+        self.checker = wrapped
+
+    def validate(self, name, obj):
+        if obj is not None:
+            self.checker.validate(obj)
+
+
+required = RequiredKey
+
+str_type = TypedValidator(str)
+bool_type = TypedValidator(bool)
+int_type = TypedValidator(int)
+
+dictof = DictValidator
+keyed = KeyedValidator
+listof = ListValidator
+oneof = SetValidator
+regex = RegexValidator
+nullable = NullableValidator
+numeric = NumericValidator
+switch = SwitchValidator

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -120,7 +120,7 @@ class SwitchValidator(TypedValidator):
         super().validate(name, obj)
         key = obj[self.key]
         self.valid_key.validate(f"{name}.{key}", key)
-        self.checkers[key].validate(obj)
+        self.checkers[key].validate(f"{name}", obj)
 
 
 class NullableValidator:

--- a/hail/python/hailtop/utils/validate/validate.py
+++ b/hail/python/hailtop/utils/validate/validate.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict, Pattern, Callable, Any
+from typing import Union, Dict, Pattern, Callable, Any
 import re
 
 
@@ -11,6 +11,9 @@ class ValidationError(Exception):
 class RequiredKey:
     def __init__(self, key: str):
         self.key = key
+
+
+Key = Union[str, RequiredKey]
 
 
 class TypedValidator:
@@ -45,7 +48,7 @@ class KeyedValidator(TypedValidator):
             else:
                 self.checkers[k] = (v, False)
 
-    def __getitem__(self, key: Key):
+    def __getitem__(self, key: str):
         return self.checkers[key][0]
 
     def validate(self, name: str, obj):


### PR DESCRIPTION
I thought about porting some of the typechecker stuff from hail, but they don't serve quite the same purpose, and the functions themselves are pretty simple. This does move the schema definitions to the bottom of the file rather than at the top, but this way we have a schema description that includes requiredness and is guaranteed to be the thing we're actually validating on.