### PR TITLE
[tls] clean up TLS

### DIFF
--- a/address/address/address.py
+++ b/address/address/address.py
@@ -9,7 +9,7 @@ import kubernetes_asyncio as kube
 from gear import (setup_aiohttp_session, web_authenticated_developers_only,
                   rest_authenticated_users_only)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
@@ -161,4 +161,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -1,8 +1,9 @@
+import ssl
 import pytest
 import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import in_cluster_no_hostname_checks_ssl_client_connection
+from hailtop.tls import _get_ssl_config
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -11,7 +12,19 @@ deploy_config = get_deploy_config()
 
 @pytest.mark.asyncio
 async def test_connect_to_address_on_pod_ip():
-    async with in_cluster_no_hostname_checks_ssl_client_connection(
+    ssl_config = _get_ssl_config()
+    client_ssl_context = ssl.create_default_context(
+        purpose=ssl.Purpose.SERVER_AUTH,
+        cafile=ssl_config['outgoing_trust'])
+    client_ssl_context.load_default_certs()
+    client_ssl_context.load_cert_chain(ssl_config['cert'],
+                                       keyfile=ssl_config['key'],
+                                       password=None)
+    client_ssl_context.verify_mode = ssl.CERT_REQUIRED
+    client_ssl_context.check_hostname = True
+
+    async with aiohttp.clientSession(
+            connector=aiohttp.TCPConnector(ssl=client_ssl_context),
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60),
             headers=service_auth_headers(deploy_config, 'address')) as session:

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -23,7 +23,7 @@ async def test_connect_to_address_on_pod_ip():
     client_ssl_context.verify_mode = ssl.CERT_REQUIRED
     client_ssl_context.check_hostname = True
 
-    async with aiohttp.clientSession(
+    async with aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=client_ssl_context),
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60),

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -21,7 +21,7 @@ async def test_connect_to_address_on_pod_ip():
                                        keyfile=ssl_config['key'],
                                        password=None)
     client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-    client_ssl_context.check_hostname = True
+    client_ssl_context.check_hostname = False
 
     async with aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(ssl=client_ssl_context),

--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -9,7 +9,7 @@ import aiohttp_jinja2
 
 from hailtop.utils import time_msecs, secret_alnum_string
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.config import get_deploy_config
 from hailtop import aiogoogle
 from gear import (Database, setup_aiohttp_session,
@@ -351,4 +351,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -9,7 +9,7 @@ import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop.utils import secret_alnum_string
 from gear import (
@@ -582,4 +582,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -8,7 +8,7 @@ import traceback
 from hailtop.utils import (
     time_msecs, sleep_and_backoff, is_transient_error,
     time_msecs_str, humanize_timedelta_msecs)
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 from gear import transaction
 
 from .globals import complete_states, tasks, STATUS_FORMAT_VERSION
@@ -123,7 +123,7 @@ GROUP BY batches.id;
 
     if record['user'] == 'ci':
         # only jobs from CI may use batch's TLS identity
-        make_client_session = in_cluster_ssl_client_session
+        make_client_session = client_session
     else:
         make_client_session = aiohttp.ClientSession
     try:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -18,7 +18,7 @@ from gear import (Database, setup_aiohttp_session,
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import time_msecs, RateLimit, serialization, retry_long_running
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop import aiogoogle, aiotools
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
     set_message
@@ -816,4 +816,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -22,7 +22,8 @@ from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context, in_cluster_ssl_client_session
+from hailtop.tls import internal_server_ssl_context
+from hailtop.httpx import client_session
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools, dictfix
 from gear import (Database, setup_aiohttp_session,
@@ -992,7 +993,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await request_retry_transient_errors(
             session, 'PATCH',
@@ -1802,7 +1803,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 
 
 async def cancel_batch_loop_body(app):
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',
@@ -1814,7 +1815,7 @@ async def cancel_batch_loop_body(app):
 
 
 async def delete_batch_loop_body(app):
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         await request_retry_transient_errors(
             session, 'POST',
@@ -1901,4 +1902,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -21,7 +21,7 @@ import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError, check_shell_output, is_google_registry_image)
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
 from hailtop import aiotools
@@ -1045,7 +1045,7 @@ class Worker:
                     idle_duration = time_msecs() - self.last_updated
                 log.info(f'idle {idle_duration} ms, exiting')
 
-                async with get_context_specific_ssl_client_session(
+                async with client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     # Don't retry.  If it doesn't go through, the driver
                     # monitoring loops will recover.  If the driver is
@@ -1099,7 +1099,7 @@ class Worker:
         delay_secs = 0.1
         while True:
             try:
-                async with get_context_specific_ssl_client_session(
+                async with client_session(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
@@ -1154,7 +1154,7 @@ class Worker:
             'status': status
         }
 
-        async with get_context_specific_ssl_client_session(
+        async with client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             await request_retry_transient_errors(
                 session, 'POST',
@@ -1168,7 +1168,7 @@ class Worker:
             log.exception(f'error while posting {job} started')
 
     async def activate(self):
-        async with get_context_specific_ssl_client_session(
+        async with client_session(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             resp = await request_retry_transient_errors(
                 session, 'POST',

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,14 +1,14 @@
 import aiohttp
 
 from hailtop.utils import async_to_blocking
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 
 
 class FailureInjectingClientSession:
     def __init__(self, should_fail):
         self.should_fail = should_fail
-        self.real_session = in_cluster_ssl_client_session(raise_for_status=True,
-                                                          timeout=aiohttp.ClientTimeout(total=60))
+        self.real_session = client_session(raise_for_status=True,
+                                           timeout=aiohttp.ClientTimeout(total=60))
 
     def __enter__(self):
         return self

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,7 +18,7 @@ async def test_invariants():
     deploy_config = get_deploy_config()
     url = deploy_config.url('batch-driver', '/check_invariants')
     headers = service_auth_headers(deploy_config, 'batch-driver')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -5,7 +5,7 @@ from aiohttp import web
 import logging
 from gear import setup_aiohttp_session, web_authenticated_developers_only
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger, configure_logging
 from hailtop.utils import retry_long_running, collect_agen, humanize_timedelta_msecs
 from hailtop import aiotools
@@ -466,4 +466,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/benchmark-service/test/test_update_commits.py
+++ b/benchmark-service/test/test_update_commits.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session, get_context_specific_ssl_client_session
+from hailtop.tls import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -22,7 +22,7 @@ async def test_update_commits():
     headers = service_auth_headers(deploy_config, 'benchmark')
     commit_benchmark_url = deploy_config.url('benchmark', f'/api/v1alpha/benchmark/commit/{sha}')
 
-    async with get_context_specific_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/benchmark-service/test/test_update_commits.py
+++ b/benchmark-service/test/test_update_commits.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -12,7 +12,7 @@ from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
 from gear import (setup_aiohttp_session, rest_authenticated_developers_only,
@@ -438,4 +438,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -19,7 +19,7 @@ async def test_deploy():
     deploy_config = get_deploy_config()
     ci_deploy_status_url = deploy_config.url('ci', '/api/v1alpha/deploy_status')
     headers = service_auth_headers(deploy_config, 'ci')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -2,7 +2,7 @@ import os
 import aiohttp
 from hailtop.config import get_deploy_config
 from hailtop.utils import async_to_blocking, request_retry_transient_errors
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session as http_client_session
 
 from .tokens import get_tokens
 
@@ -11,7 +11,7 @@ async def async_get_userinfo(*, deploy_config=None, session_id=None, client_sess
     if deploy_config is None:
         deploy_config = get_deploy_config()
     if client_session is None:
-        client_session = get_context_specific_ssl_client_session(
+        client_session = http_client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5))
 
     if session_id is None:

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -12,7 +12,7 @@ from asyncinit import asyncinit
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 from .globals import tasks, complete_states
 
@@ -600,7 +600,7 @@ class BatchClient:
         self.url = deploy_config.base_url('batch')
 
         if session is None:
-            session = get_context_specific_ssl_client_session(
+            session = client_session(
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60))
         self._session = session

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -6,7 +6,7 @@ import json
 import logging
 from aiohttp import web
 from ..utils import retry_transient_errors, first_extant_file
-from ..tls import get_context_specific_ssl_client_session
+from ..tls import internal_client_ssl_context
 
 log = logging.getLogger('deploy_config')
 
@@ -127,7 +127,8 @@ class DeployConfig:
         from ..auth import service_auth_headers  # pylint: disable=cyclic-import,import-outside-toplevel
         namespace = self.service_ns(service)
         headers = service_auth_headers(self, namespace)
-        async with get_context_specific_ssl_client_session(
+        async with aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(ssl=internal_client_ssl_context()),
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=5),
                 headers=headers) as session:

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 
 def init_parser(parser):
@@ -94,7 +94,7 @@ async def async_main(args):
     if args.namespace:
         deploy_config = deploy_config.with_default_namespace(args.namespace)
     headers = namespace_auth_headers(deploy_config, deploy_config.default_namespace(), authorize_target=False)
-    async with get_context_specific_ssl_client_session(
+    async with client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         await auth_flow(deploy_config, deploy_config.default_namespace(), session)
 

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -3,7 +3,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens, service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -20,7 +20,7 @@ async def async_main():
         return
 
     headers = service_auth_headers(deploy_config, 'auth')
-    async with get_context_specific_ssl_client_session(
+    async with client_session(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):
             pass

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 
 def init_parser(parser):
@@ -27,7 +27,7 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = get_context_specific_ssl_client_session(
+        self._session = client_session(
             timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
 

--- a/hail/python/hailtop/hailctl/dev/query/cli.py
+++ b/hail/python/hailtop/hailctl/dev/query/cli.py
@@ -4,7 +4,7 @@ import sys
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 
 def init_parser(parser):
@@ -52,7 +52,7 @@ class QueryClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'query')
-        self._session = get_context_specific_ssl_client_session(
+        self._session = client_session(
             timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -11,8 +11,12 @@ def client_session(*args, **kwargs) -> aiohttp.ClientSession:
     location = get_deploy_config().location()
     if location == 'external':
         tls = external_client_ssl_context()
-    else:
+    elif location == 'k8s':
         tls = internal_client_ssl_context()
+    else:
+        assert location == 'gce'
+        # no encryption on the internal gateway
+        tls = external_client_ssl_context()
 
     assert 'connector' not in kwargs
     kwargs['connector'] = aiohttp.TCPConnector(ssl=tls)

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -1,0 +1,53 @@
+import requests
+import aiohttp
+from requests.adapters import HTTPAdapter
+from urllib3.poolmanager import PoolManager
+
+from .tls import internal_client_ssl_context, external_client_ssl_context, _get_ssl_config
+from .config.deploy_config import get_deploy_config
+
+
+def client_session(*args, **kwargs) -> aiohttp.ClientSession:
+    location = get_deploy_config().location()
+    if location == 'external':
+        tls = external_client_ssl_context()
+    else:
+        tls = internal_client_ssl_context()
+
+    assert 'connector' not in kwargs
+    kwargs['connector'] = aiohttp.TCPConnector(ssl=tls)
+
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class TLSAdapter(HTTPAdapter):
+    def __init__(self, ssl_cert, ssl_key, ssl_ca, max_retries, timeout):
+        super().__init__()
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
+        self.ssl_ca = ssl_ca
+        self.max_retries = max_retries
+        self.timeout = timeout
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            key_file=self.ssl_key,
+            cert_file=self.ssl_cert,
+            ca_certs=self.ssl_ca,
+            assert_hostname=True,
+            retries=self.max_retries,
+            timeout=self.timeout)
+
+
+def blocking_client_session() -> requests.Session:
+    session = requests.Session()
+    ssl_config = _get_ssl_config()
+    session.mount('https://', TLSAdapter(ssl_config['cert'],
+                                         ssl_config['key'],
+                                         ssl_config['outgoing_trust'],
+                                         max_retries=1,
+                                         timeout=5))
+    return session

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -1,18 +1,13 @@
 from typing import Dict
-import aiohttp
 import logging
 import json
 import os
 import ssl
 from ssl import Purpose
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.poolmanager import PoolManager
 
-log = logging.getLogger('hailtop.ssl')
-server_ssl_context = None
-client_ssl_context = None
-no_hostname_checks_client_ssl_context = None
+log = logging.getLogger('hailtop.tls')
+_server_ssl_context = None
+_client_ssl_context = None
 
 
 class NoSSLConfigFound(Exception):
@@ -30,92 +25,6 @@ def _get_ssl_config() -> Dict[str, str]:
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')
 
 
-def get_in_cluster_server_ssl_context() -> ssl.SSLContext:
-    global server_ssl_context
-    if server_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        server_ssl_context = ssl.create_default_context(
-            purpose=Purpose.CLIENT_AUTH,
-            cafile=ssl_config['incoming_trust'])
-        server_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
-        server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
-        # FIXME: mTLS
-        # server_ssl_context.verify_mode = ssl.CERT_REQURIED
-        server_ssl_context.check_hostname = False  # clients have no hostnames
-    return server_ssl_context
-
-
-def get_in_cluster_client_ssl_context() -> ssl.SSLContext:
-    global client_ssl_context
-    if client_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        client_ssl_context = ssl.create_default_context(
-            purpose=Purpose.SERVER_AUTH,
-            cafile=ssl_config['outgoing_trust'])
-        client_ssl_context.load_cert_chain(ssl_config['cert'],
-                                           keyfile=ssl_config['key'],
-                                           password=None)
-        client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        client_ssl_context.check_hostname = True
-    return client_ssl_context
-
-
-def get_in_cluster_no_hostname_checks_client_ssl_context() -> ssl.SSLContext:
-    global no_hostname_checks_client_ssl_context
-    if no_hostname_checks_client_ssl_context is None:
-        ssl_config = _get_ssl_config()
-        no_hostname_checks_client_ssl_context = ssl.create_default_context(
-            purpose=Purpose.SERVER_AUTH,
-            cafile=ssl_config['outgoing_trust'])
-        no_hostname_checks_client_ssl_context.load_cert_chain(
-            ssl_config['cert'],
-            keyfile=ssl_config['key'],
-            password=None)
-        no_hostname_checks_client_ssl_context.verify_mode = ssl.CERT_REQUIRED
-        no_hostname_checks_client_ssl_context.check_hostname = False
-    return no_hostname_checks_client_ssl_context
-
-
-def get_context_specific_client_ssl_context() -> ssl.SSLContext:
-    try:
-        return get_in_cluster_client_ssl_context()
-    except NoSSLConfigFound:
-        log.info('no ssl config file found, using external configuration. This '
-                 'context cannot connect directly to services inside the cluster.')
-        return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)
-
-
-def in_cluster_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def in_cluster_no_hostname_checks_ssl_client_connection(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_in_cluster_no_hostname_checks_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def get_context_specific_ssl_client_session(*args, **kwargs) -> aiohttp.ClientSession:
-    assert 'connector' not in kwargs
-    kwargs['connector'] = aiohttp.TCPConnector(ssl=get_context_specific_client_ssl_context())
-    return aiohttp.ClientSession(*args, **kwargs)
-
-
-def in_cluster_ssl_requests_client_session() -> requests.Session:
-    session = requests.Session()
-    ssl_config = _get_ssl_config()
-    session.mount('https://', TLSAdapter(ssl_config['cert'],
-                                         ssl_config['key'],
-                                         ssl_config['outgoing_trust'],
-                                         max_retries=1,
-                                         timeout=5))
-    return session
-
-
 def check_ssl_config(ssl_config: Dict[str, str]):
     for key in ('cert', 'key', 'outgoing_trust', 'incoming_trust'):
         assert ssl_config.get(key) is not None, key
@@ -125,23 +34,41 @@ def check_ssl_config(ssl_config: Dict[str, str]):
     log.info('using tls and verifying client and server certificates')
 
 
-class TLSAdapter(HTTPAdapter):
-    def __init__(self, ssl_cert, ssl_key, ssl_ca, max_retries, timeout):
-        super().__init__()
-        self.ssl_cert = ssl_cert
-        self.ssl_key = ssl_key
-        self.ssl_ca = ssl_ca
-        self.max_retries = max_retries
-        self.timeout = timeout
+def internal_server_ssl_context() -> ssl.SSLContext:
+    global _server_ssl_context
+    if _server_ssl_context is None:
+        ssl_config = _get_ssl_config()
+        _server_ssl_context = ssl.create_default_context(
+            purpose=Purpose.CLIENT_AUTH,
+            cafile=ssl_config['incoming_trust'])
+        _server_ssl_context.load_cert_chain(ssl_config['cert'],
+                                            keyfile=ssl_config['key'],
+                                            password=None)
+        _server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
+        # FIXME: mTLS
+        # _server_ssl_context.verify_mode = ssl.CERT_REQURIED
+        _server_ssl_context.check_hostname = False  # clients have no hostnames
+    return _server_ssl_context
 
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            key_file=self.ssl_key,
-            cert_file=self.ssl_cert,
-            ca_certs=self.ssl_ca,
-            assert_hostname=True,
-            retries=self.max_retries,
-            timeout=self.timeout)
+
+def internal_client_ssl_context() -> ssl.SSLContext:
+    global _client_ssl_context
+    if _client_ssl_context is None:
+        ssl_config = _get_ssl_config()
+        _client_ssl_context = ssl.create_default_context(
+            purpose=Purpose.SERVER_AUTH,
+            cafile=ssl_config['outgoing_trust'])
+        # setting cafile in `create_default_context` ignores the system default
+        # certificates. We must explicitly request them again with
+        # load_default_certs.
+        _client_ssl_context.load_default_certs()
+        _client_ssl_context.load_cert_chain(ssl_config['cert'],
+                                            keyfile=ssl_config['key'],
+                                            password=None)
+        _client_ssl_context.verify_mode = ssl.CERT_REQUIRED
+        _client_ssl_context.check_hostname = True
+    return _client_ssl_context
+
+
+def external_client_ssl_context() -> ssl.SSLContext:
+    return ssl.create_default_context(purpose=Purpose.SERVER_AUTH)

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 from hailtop.utils import request_retry_transient_errors
 
 
@@ -31,7 +31,7 @@ class MemoryClient:
 
     async def async_init(self):
         if self._session is None:
-            self._session = get_context_specific_ssl_client_session(
+            self._session = client_session(
                 raise_for_status=True,
                 timeout=aiohttp.ClientTimeout(total=60))
         if 'Authorization' not in self._headers:

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -12,7 +12,7 @@ import kubernetes_asyncio as kube
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors
 from gear import setup_aiohttp_session, rest_authenticated_users_only
 
@@ -131,4 +131,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -10,7 +10,7 @@ from hailtop import aiogoogle, aiotools
 from hailtop.aiogoogle import BigQueryClient
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import run_if_changed_idempotent, retry_long_running, time_msecs, cost_str
 from gear import (Database, setup_aiohttp_session,
                   web_authenticated_developers_only, rest_authenticated_developers_only,
@@ -252,4 +252,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -5,7 +5,7 @@ import aiohttp
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
-from hailtop.tls import in_cluster_ssl_client_session
+from hailtop.httpx import client_session
 import hailtop.utils as utils
 
 pytestmark = pytest.mark.asyncio
@@ -18,7 +18,7 @@ async def test_billing_monitoring():
     deploy_config = get_deploy_config()
     monitoring_deploy_config_url = deploy_config.url('monitoring', '/api/v1alpha/billing')
     headers = service_auth_headers(deploy_config, 'monitoring')
-    async with in_cluster_ssl_client_session(
+    async with client_session(
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=60)) as session:
 

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -12,7 +12,7 @@ from kubernetes_asyncio import client, config
 import kubernetes_asyncio as kube
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import (setup_aiohttp_session, create_database_pool,
                   web_authenticated_users_only, web_maybe_authenticated_user,
@@ -814,4 +814,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -8,7 +8,7 @@ import numpy as np
 from hailtop.hail_logging import configure_logging
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_context_specific_ssl_client_session
+from hailtop.httpx import client_session
 
 configure_logging()
 log = logging.getLogger('nb-scale-test')
@@ -26,7 +26,7 @@ def get_cookie(session, name):
 async def run(args, i):
     headers = service_auth_headers(deploy_config, 'workshop', authorize_target=False)
 
-    async with get_context_specific_ssl_client_session(raise_for_status=True) as session:
+    async with client_session(raise_for_status=True) as session:
         # make sure notebook is up
         async with session.get(
                 deploy_config.url('workshop', ''),

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -10,7 +10,7 @@ import kubernetes_asyncio as kube
 from py4j.java_gateway import JavaGateway, GatewayParameters, launch_gateway
 from hailtop.utils import blocking_to_async, retry_transient_errors
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from gear import setup_aiohttp_session, rest_authenticated_users_only, rest_authenticated_developers_only
 
@@ -233,4 +233,4 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=get_in_cluster_server_ssl_context())
+        ssl_context=internal_server_ssl_context())

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -5,7 +5,7 @@ import aiohttp_session
 from kubernetes_asyncio import client, config
 import logging
 from hailtop.auth import async_get_userinfo
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import configure_logging
 from gear import setup_aiohttp_session
 
@@ -102,4 +102,4 @@ app.on_startup.append(on_startup)
 web.run_app(app,
             host='0.0.0.0',
             port=5000,
-            ssl_context=get_in_cluster_server_ssl_context())
+            ssl_context=internal_server_ssl_context())

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -11,7 +11,7 @@ import logging
 from collections import defaultdict
 
 from hailtop.config import get_deploy_config
-from hailtop.tls import get_in_cluster_server_ssl_context
+from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
 from gear import setup_aiohttp_session, web_maybe_authenticated_user
@@ -438,4 +438,4 @@ def run():
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,
-                ssl_context=get_in_cluster_server_ssl_context())
+                ssl_context=internal_server_ssl_context())


### PR DESCRIPTION
`tls.py` has many different functions with long names. This change reduces it to three functions:

- internal_server_ssl_context
- internal_client_ssl_context
- external_client_ssl_context

I also added `httpx.py` which contains the HTTPS-related functions that `tls.py` previously
contained. I also simplified the HTTPS-related functions to just:

- client_session
- blocking_client_session

I determine internal vs. external using the deploy config.

---

An [`ssl.SSLContext`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext) defines how a
network library (such as `aiohttp`) should perform SSL/TLS. Let's look at an example:

```python3
server_ssl_context = ssl.create_default_context(
    purpose=Purpose.CLIENT_AUTH,
    cafile='/incoming.cacerts')
server_ssl_context.load_cert_chain(ssl_config['cert'],
                                   keyfile=ssl_config['key'],
                                   password=None)
server_ssl_context.verify_mode = ssl.CERT_OPTIONAL
server_ssl_context.check_hostname = False
```

The first function call states that we are a *server* performing *client
authentication* (`Purpose.CLIENT_AUTH`). We also state that anyone who sends requests to us will be
identified by a certificate that is trusted by our certificate database: `/incoming.cacerts` (which
is a file).

`load_cert_chain` states where to find the certificates and secret key that prove who we are. The
certificate and secret key together are like a property title that proves someone owns a house. The
`password=None` means that our secret key has no password. Some keys are themselves locked by a
password.

`verify_mode` means what do we expect our clients to have. `CERT_OPTIONAL` means anonymous clients
are OK. This is how servers normally operate (https://google.com does not care who you are).

`check_hostname` means should we verify that the client certificate matches the client's
hostname. Since we allow anonymous clients, this must be `False`.

---

`test-address.py` is a gross hack. It will disappear in subsequent PRs. For now, I pushed all the
gross hack stuff into that file alone.