### PR TITLE
[query] Aggregator package SCode omnibus commit

### DIFF
--- a/hail/python/test/hail/experimental/test_codec.py
+++ b/hail/python/test/hail/experimental/test_codec.py
@@ -1,6 +1,8 @@
 import hail as hl
 from test.hail.helpers import *
 
+setUpModule = startTestHailContext
+tearDownModule = stopTestHailContext
 
 UNBLOCKED_UNBUFFERED_SPEC = '{"name":"StreamBufferSpec"}'
 BLOCKED_UNBUFFERED_SPEC = '''{"name":"BlockingBufferSpec","blockSize":65536,

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -5,6 +5,8 @@ import pytest
 
 from hail.utils.java import FatalError, HailUserError
 
+setUpModule = startTestHailContext
+tearDownModule = stopTestHailContext
 
 def assert_ndarrays(asserter, exprs_and_expecteds):
     exprs, expecteds = zip(*exprs_and_expecteds)

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -898,6 +898,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
   def toD: Code[Double] = Code(lhs, lir.insn1(L2D))
 
   def toS: Code[String] = Code.invokeStatic1[java.lang.Long, Long, String]("toString", lhs)
+
+  def hexString: Code[String] = Code.invokeStatic1[java.lang.Long, Long, String]("toHexString", lhs)
 }
 
 class CodeFloat(val lhs: Code[Float]) extends AnyVal {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1474,9 +1474,8 @@ class Emit[C](
         }
 
       case x@ResultOp(start, sig) =>
-        val newRegion = cb.newField("resultop_region", region.code)
         val AggContainer(aggs, sc, _) = container.get
-        val srvb = new StagedRegionValueBuilder(cb.emb, x.pType, newRegion)
+        val srvb = new StagedRegionValueBuilder(cb.emb, x.pType, region.code)
         cb += srvb.start()
 
         (0 until aggs.length).foreach { j =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -662,6 +662,7 @@ class EmitClassBuilder[C](
     val codeArgsInfo = argsInfo.flatMap {
       case CodeParamType(ti) => FastIndexedSeq(ti)
       case EmitParamType(pt) => EmitCode.codeTupleTypes(pt)
+      case PCodeParamType(pt) => pt.codeTupleTypes()
     }
     val codeReturnInfo = returnInfo match {
       case CodeParamType(ti) => ti

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -103,6 +103,8 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
       val codeArgs = args.flatMap {
         case CodeParam(c) =>
           FastIndexedSeq(c)
+        case PCodeParam(pc) =>
+          pc.codeTuple()
         case EmitParam(ec) =>
           if (ec.pt.required) {
             append(ec.setup)
@@ -122,7 +124,12 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   }
 
   def invokeCode[T](callee: EmitMethodBuilder[_], args: Param*): Code[T] = {
-    assert(callee.emitReturnType.isInstanceOf[CodeParamType])
+    callee.emitReturnType match {
+      case CodeParamType(UnitInfo) =>
+        throw new AssertionError("CodeBuilder.invokeCode had unit return type, use invokeVoid")
+      case _: CodeParamType =>
+      case x => throw new AssertionError(s"CodeBuilder.invokeCode expects CodeParamType return, got $x")
+    }
     _invoke[T](callee, args: _*)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -144,4 +144,9 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   def printRegionValue(value: Code[_], typ: PType, region: Value[Region]): Unit = {
     append(Code._println(StringFunctions.boxArg(EmitRegion(emb, region), typ)(value)))
   }
+
+  // for debugging
+  def strValue(r: Value[Region], t: PType, code: Code[_]): Code[String] = {
+    StringFunctions.boxArg(EmitRegion(emb, r), t)(code).invoke[String]("toString")
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1247,7 +1247,8 @@ object EmitStream {
                     keyRegion.clear(),
                     EmitCodeBuilder.scopedVoid(mb) { cb =>
                       val pc = new SSubsetStructCode(keyViewType, xCurElt.load().asBaseStruct)
-                      cb.assign(xCurKey, pc.castTo(cb, keyRegion.code, keyType))},
+                      cb.assign(xCurKey, pc.castTo(cb, keyRegion.code, keyType, deepCopy = true))
+                    },
                     xInOuter.mux(
                       LouterPush.goto,
                       Code(xNextGrpReady := true, LinnerEos.goto)))))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -952,7 +952,8 @@ object Interpret {
           ctx.r.pool.scopedRegion { r =>
             val resF = f(0, r)
             resF.setAggState(rv.region, rv.offset)
-            val res = SafeRow(rTyp, resF(r, globalsOffset))
+            val resAddr = resF(r, globalsOffset)
+            val res = SafeRow(rTyp, resAddr)
             resF.storeAggsToRegion()
             rv.region.invalidate()
             res

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir.functions.RelationalFunctions
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.types.encoded._
-import is.hail.types.{MatrixType, TableType}
+import is.hail.types.{MatrixType, TableType, TypeWithRequiredness, VirtualTypeWithReq}
 import is.hail.expr.{JSONAnnotationImpex, Nat, ParserUtils}
 import is.hail.io.{AbstractTypedCodecSpec, BufferSpec}
 import is.hail.rvd.{AbstractRVDSpec, RVDType}
@@ -366,6 +366,11 @@ object IRParser {
     struct_field(type_expr(env))(it)
   }
 
+  def vtwr_expr(env: TypeParserEnvironment)(it: TokenIterator): VirtualTypeWithReq = {
+    val pt = ptype_expr(env)(it)
+    VirtualTypeWithReq(pt)
+  }
+
   def ptype_expr(env: TypeParserEnvironment)(it: TokenIterator): PType = {
     val req = it.head match {
       case x: PunctuationToken if x.value == "+" =>
@@ -651,30 +656,30 @@ object IRParser {
     punctuation(it, "(")
     val sig = identifier(it) match {
       case "TypedStateSig" =>
-        val pt = ptype_expr(env)(it)
+        val pt = vtwr_expr(env)(it)
         TypedStateSig(pt)
       case "DownsampleStateSig" =>
-        val labelType = ptype_expr(env)(it)
-        DownsampleStateSig(coerce[PArray](labelType))
+        val labelType = vtwr_expr(env)(it)
+        DownsampleStateSig(labelType)
       case "TakeStateSig" =>
-        val pt = ptype_expr(env)(it)
+        val pt = vtwr_expr(env)(it)
         TakeStateSig(pt)
       case "TakeByStateSig" =>
-        val vt = ptype_expr(env)(it)
-        val kt = ptype_expr(env)(it)
+        val vt = vtwr_expr(env)(it)
+        val kt = vtwr_expr(env)(it)
         TakeByStateSig(vt, kt, Ascending)
       case "CollectStateSig" =>
-        val pt = ptype_expr(env)(it)
+        val pt = vtwr_expr(env)(it)
         CollectStateSig(pt)
       case "CollectAsSetStateSig" =>
-        val pt = ptype_expr(env)(it)
+        val pt = vtwr_expr(env)(it)
         CollectAsSetStateSig(pt)
       case "CallStatsStateSig" => CallStatsStateSig()
       case "ArrayAggStateSig" =>
         val nested = agg_state_signatures(env)(it)
         ArrayAggStateSig(nested)
       case "GroupedStateSig" =>
-        val kt = ptype_expr(env)(it)
+        val kt = vtwr_expr(env)(it)
         val nested = agg_state_signatures(env)(it)
         GroupedStateSig(kt, nested)
       case "ApproxCDFStateSig" => ApproxCDFStateSig()
@@ -693,7 +698,7 @@ object IRParser {
     punctuation(it, "(")
     val sig = identifier(it) match {
       case "Grouped" =>
-        val pt = ptype_expr(env)(it)
+        val pt = vtwr_expr(env)(it)
         val nested = p_agg_sigs(env)(it)
         GroupedAggSig(pt, nested)
       case "ArrayLen" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -93,7 +93,7 @@ object Pretty {
   def prettyPhysicalAggSig(aggSig: PhysicalAggSig): Doc = {
     aggSig match {
       case GroupedAggSig(t, nested) =>
-        fillList("Grouped", t.toString, prettyPhysicalAggSigs(nested))
+        fillList("Grouped", t.canonicalPType.toString, prettyPhysicalAggSigs(nested))
       case ArrayLenAggSig(kl, nested) =>
         fillList("ArrayLen", prettyBooleanLiteral(kl), prettyPhysicalAggSigs(nested))
       case AggElementsAggSig(nested) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -83,8 +83,8 @@ object Pretty {
 
   def prettyAggStateSignature(state: AggStateSig): Doc =
     fillList(state.n match {
-      case None => text(prettyClass(state)) +: state.t.view.map(typ => text(typ.toString))
-      case Some(nested) => text(prettyClass(state)) +: state.t.view.map(typ => text(typ.toString)) :+ prettyAggStateSignatures(nested)
+      case None => text(prettyClass(state)) +: state.t.view.map(typ => text(typ.canonicalPType.toString))
+      case Some(nested) => text(prettyClass(state)) +: state.t.view.map(typ => text(typ.canonicalPType.toString)) :+ prettyAggStateSignatures(nested)
     })
 
   def prettyPhysicalAggSigs(aggSigs: Seq[PhysicalAggSig]): Doc =

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -1,10 +1,12 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
-import is.hail.asm4s.{coerce, _}
+import is.hail.annotations.Region
+import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.types.physical._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.SCode
 import is.hail.utils._
 
 trait AggregatorState {
@@ -15,13 +17,15 @@ trait AggregatorState {
   def regionSize: Int = Region.TINY
 
   def createState(cb: EmitCodeBuilder): Unit
-  def newState(off: Code[Long]): Code[Unit]
+
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit
 
   // null to safeguard against users of off
-  def newState(): Code[Unit] = newState(null)
+  def newState(cb: EmitCodeBuilder): Unit = newState(cb, null)
 
-  def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit]
-  def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit]
+  def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Code[Long]): Unit
+
+  def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Code[Long]): Unit
 
   def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit
 
@@ -55,16 +59,20 @@ trait RegionBackedAggState extends AggregatorState {
   protected val r: Settable[Region] = kb.genFieldThisRef[Region]()
   val region: Value[Region] = r
 
-  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(const(regionSize))
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(const(regionSize))
 
   def createState(cb: EmitCodeBuilder): Unit = {
     cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
   }
 
-  def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] = regionLoader(r)
+  def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Code[Long]): Unit = regionLoader(cb, r)
 
-  def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    region.isValid.orEmpty(Code(regionStorer(region), region.invalidate()))
+  def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Code[Long]): Unit =
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        cb += region.invalidate()
+      })
 }
 
 trait PointerBasedRVAState extends RegionBackedAggState {
@@ -73,45 +81,73 @@ trait PointerBasedRVAState extends RegionBackedAggState {
 
   override val regionSize: Int = Region.TINIER
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code(super.load(regionLoader, src), off := Region.loadAddress(src))
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Code[Long]): Unit = {
+    super.load(cb, regionLoader, src)
+    cb.assign(off, Region.loadAddress(src))
+  }
 
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    Code(region.isValid.orEmpty(Region.storeAddress(dest, off)), super.store(regionStorer, dest))
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, dest: Code[Long]): Unit = {
+    cb.ifx(region.isValid,
+      {
+        cb += Region.storeAddress(dest, off)
+        super.store(cb, regionStorer, dest)
+      })
+  }
 
   def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = copyFromAddress(cb, Region.loadAddress(src))
 
   def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit
 }
 
-class TypedRegionBackedAggState(val typ: PType, val kb: EmitClassBuilder[_]) extends RegionBackedAggState {
+class TypedRegionBackedAggState(val typ: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) extends AbstractTypedRegionBackedAggState(typ.canonicalPType)
+
+abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends RegionBackedAggState {
+
   override val regionSize: Int = Region.TINIER
-  val storageType: PTuple = PCanonicalTuple(required = true, typ)
+  val storageType: PTuple = PCanonicalTuple(required = true, ptype)
   val off: Settable[Long] = kb.genFieldThisRef[Long]()
 
-  override def newState(): Code[Unit] = Code(region.getNewRegion(const(regionSize)), off := storageType.allocate(region))
-  override def newState(src: Code[Long]): Code[Unit] = Code(off := src, super.newState(off))
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code(super.load(r => r.invalidate(), src), off := src)
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    Code.memoize(dest, "trbas_dest") { dest =>
-      Code(region.isValid.orEmpty(dest.cne(off).orEmpty(
-        Region.copyFrom(off, dest, const(storageType.byteSize)))),
-        super.store(regionStorer, dest))
-    }
+  override def newState(cb: EmitCodeBuilder): Unit = {
+    cb += region.getNewRegion(const(regionSize))
+    cb.assign(off, storageType.allocate(region))
+  }
 
-  def storeMissing(): Code[Unit] = storageType.setFieldMissing(off, 0)
-  def storeNonmissing(v: Code[_]): Code[Unit] = Code(
-    region.getNewRegion(const(regionSize)),
-    storageType.setFieldPresent(off, 0),
-    StagedRegionValueBuilder.deepCopy(kb, region, typ, v, storageType.fieldOffset(off, 0)))
+  override def newState(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
+    cb.assign(off, src)
+    super.newState(cb, off)
+  }
+
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Code[Long]): Unit = {
+    super.load(cb, { (cb: EmitCodeBuilder, r: Value[Region]) => cb += r.invalidate() }, src)
+    cb.assign(off, src)
+  }
+
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    val dest = cb.newLocal[Long]("trbas_dest", destc)
+    cb.ifx(region.isValid,
+      cb.ifx(dest.cne(off),
+        cb += Region.copyFrom(off, dest, const(storageType.byteSize))))
+    super.store(cb, regionStorer, dest)
+  }
+
+  def storeMissing(cb: EmitCodeBuilder): Unit = {
+    cb += storageType.setFieldMissing(off, 0)
+  }
+
+  def storeNonmissing(cb: EmitCodeBuilder, sc: SCode): Unit = {
+    cb += region.getNewRegion(const(regionSize))
+    cb += storageType.setFieldPresent(off, 0)
+    ptype.storeAtAddress(cb, storageType.fieldOffset(off, 0), region, sc, deepCopy = true)
+  }
 
   def get(): EmitCode = EmitCode(Code._empty,
     storageType.isFieldMissing(off, 0),
-    PCode(typ, Region.loadIRIntermediate(typ)(storageType.fieldOffset(off, 0))))
+    PCode(ptype, Region.loadIRIntermediate(ptype)(storageType.fieldOffset(off, 0))))
 
-  def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit =
-    cb += Code(newState(off), StagedRegionValueBuilder.deepCopy(kb, region, storageType, src, off))
+  def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
+    newState(cb, off)
+    storageType.storeAtAddress(cb, off, region, storageType.loadCheapPCode(cb, src), deepCopy = true)
+  }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     val enc = TypedCodecSpec(storageType, codec).buildTypedEmitEncoderF[Long](storageType, kb)
@@ -125,73 +161,81 @@ class TypedRegionBackedAggState(val typ: PType, val kb: EmitClassBuilder[_]) ext
   }
 }
 
-class PrimitiveRVAState(val types: Array[PType], val kb: EmitClassBuilder[_]) extends AggregatorState {
+class PrimitiveRVAState(val vtypes: Array[VirtualTypeWithReq], val kb: EmitClassBuilder[_]) extends AggregatorState {
+  private[this] val ptypes = vtypes.map(_.canonicalPType)
   type ValueField = (Option[Settable[Boolean]], Settable[_], PType)
-  assert(types.forall(_.isPrimitive))
+  assert(ptypes.forall(_.isPrimitive))
 
-  val nFields: Int = types.length
+  val nFields: Int = ptypes.length
   val fields: Array[ValueField] = Array.tabulate(nFields) { i =>
-    val m = if (types(i).required) None else Some(kb.genFieldThisRef[Boolean](s"primitiveRVA_${i}_m"))
-    val v = kb.genFieldThisRef(s"primitiveRVA_${i}_v")(typeToTypeInfo(types(i)))
-    (m, v, types(i))
+    val m = if (ptypes(i).required) None else Some(kb.genFieldThisRef[Boolean](s"primitiveRVA_${ i }_m"))
+    val v = kb.genFieldThisRef(s"primitiveRVA_${ i }_v")(typeToTypeInfo(ptypes(i)))
+    (m, v, ptypes(i))
   }
-  val storageType: PTuple = PCanonicalTuple(false, types: _*)
+  val storageType: PTuple = PCanonicalTuple(true, ptypes: _*)
 
-  def foreachField(f: (Int, ValueField) => Code[Unit]): Code[Unit] =
-    Code(Array.tabulate(nFields)(i => f(i, fields(i))))
+  def foreachField(f: (Int, ValueField) => Unit): Unit = {
+    (0 until nFields).foreach { i =>
+      f(i, fields(i))
+    }
+  }
 
-  def newState(off: Code[Long]): Code[Unit] = Code._empty
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = {}
+
   def createState(cb: EmitCodeBuilder): Unit = {}
 
-  private[this] def loadVarsFromRegion(src: Code[Long]): Code[Unit] =
+  private[this] def loadVarsFromRegion(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal("prim_rvastate_load_vars_src", srcc)
     foreachField {
       case (i, (None, v, t)) =>
-        v.storeAny(Region.loadPrimitive(t)(storageType.fieldOffset(src, i)))
+        cb.assignAny(v, Region.loadPrimitive(t)(storageType.fieldOffset(src, i)))
       case (i, (Some(m), v, t)) =>
-        Code.memoize(src, "prim_rvastate_load_vars_src") { src =>
-          Code(
-            m := storageType.isFieldMissing(src, i),
-            m.mux(Code._empty,
-              v.storeAny(Region.loadPrimitive(t)(storageType.fieldOffset(src, i)))))
-        }
+        cb.assign(m, storageType.isFieldMissing(src, i))
+        cb.ifx(!m, cb.assignAny(v, Region.loadPrimitive(t)(storageType.fieldOffset(src, i))))
     }
+  }
 
-  def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    loadVarsFromRegion(src)
+  def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, src: Code[Long]): Unit = {
+    loadVarsFromRegion(cb, src)
+  }
 
-  def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-      foreachField {
-        case (i, (None, v, t)) =>
-          Region.storePrimitive(t, storageType.fieldOffset(dest, i))(v)
-        case (i, (Some(m), v, t)) =>
-          Code.memoize(dest, "prim_rvastate_store_dest") { dest =>
-            m.mux(storageType.setFieldMissing(dest, i),
-              Code(storageType.setFieldPresent(dest, i),
-                Region.storePrimitive(t, storageType.fieldOffset(dest, i))(v)))
-          }
-      }
+  def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    foreachField({
+      case (i, (None, v, t)) =>
+        cb += Region.storePrimitive(t, storageType.fieldOffset(destc, i))(v)
+      case (i, (Some(m), v, t)) =>
+        val dest = cb.newLocal("prim_rvastate_store_dest", destc)
+        cb.ifx(m,
+          cb += storageType.setFieldMissing(dest, i),
+          {
+            cb += storageType.setFieldPresent(dest, i)
+            cb += Region.storePrimitive(t, storageType.fieldOffset(dest, i))(v)
+          })
+    })
+  }
 
-  def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = cb += loadVarsFromRegion(src)
+  def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = loadVarsFromRegion(cb, src)
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     (cb, ob: Value[OutputBuffer]) =>
-      cb += (foreachField {
-        case (_, (None, v, t)) => ob.writePrimitive(t)(v)
-        case (_, (Some(m), v, t)) => Code(
-          ob.writeBoolean(m),
-          m.mux(Code._empty, ob.writePrimitive(t)(v)))
-      })
+      foreachField {
+        case (_, (None, v, t)) =>
+          cb += ob.writePrimitive(t)(v)
+        case (_, (Some(m), v, t)) =>
+          cb += ob.writeBoolean(m)
+          cb.ifx(!m, cb += ob.writePrimitive(t)(v))
+      }
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     (cb, ib: Value[InputBuffer]) =>
-      cb += (foreachField {
+      foreachField {
         case (_, (None, v, t)) =>
-          v.storeAny(ib.readPrimitive(t))
-        case (_, (Some(m), v, t)) => Code(
-          m := ib.readBoolean(),
-          m.mux(Code._empty, v.storeAny(ib.readPrimitive(t))))
-      })
+          cb.assignAny(v, ib.readPrimitive(t))
+        case (_, (Some(m), v, t)) =>
+          cb.assign(m, ib.readBoolean())
+          cb.ifx(!m, cb.assignAny(v, ib.readPrimitive(t)))
+      }
   }
 }
 
@@ -205,9 +249,9 @@ case class StateTuple(states: Array[AggregatorState]) {
     states(i)
   }
 
-  def toCode(cb: EmitCodeBuilder, f: (EmitCodeBuilder, Int, AggregatorState) => Unit): Unit = {
+  def toCode(f: (Int, AggregatorState) => Unit): Unit = {
     (0 until nStates).foreach { i =>
-      f(cb, i, states(i))
+      f(i, states(i))
     }
   }
 
@@ -223,30 +267,34 @@ case class StateTuple(states: Array[AggregatorState]) {
   }
 
   def createStates(cb: EmitCodeBuilder): Unit =
-    toCode(cb, (cb, i, s) => s.createState(cb))
+    toCode((i, s) => s.createState(cb))
 }
 
 class TupleAggregatorState(val kb: EmitClassBuilder[_], val states: StateTuple, val topRegion: Value[Region], val off: Value[Long], val rOff: Value[Int] = const(0)) {
   val storageType: PTuple = states.storageType
-  private def getRegion(i: Int): Value[Region] => Code[Unit] = { r: Value[Region] =>
-    r.setFromParentReference(topRegion, rOff + const(i), states(i).regionSize) }
-  private def setRegion(i: Int): Value[Region] => Code[Unit] = { r: Value[Region] =>
-    topRegion.setParentReference(r, rOff + const(i))
+
+  private def getRegion(i: Int): (EmitCodeBuilder, Value[Region]) => Unit = { (cb: EmitCodeBuilder, r: Value[Region]) =>
+    cb += r.setFromParentReference(topRegion, rOff + const(i), states(i).regionSize)
   }
+
+  private def setRegion(i: Int): (EmitCodeBuilder, Value[Region]) => Unit = { (cb: EmitCodeBuilder, r: Value[Region]) =>
+    cb += topRegion.setParentReference(r, rOff + const(i))
+  }
+
   private def getStateOffset(i: Int): Code[Long] = storageType.loadField(off, i)
 
-  def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
-    Code(Array.tabulate(states.nStates)(i => f(i, states(i))))
+  def toCode(f: (Int, AggregatorState) => Unit): Unit =
+    (0 until states.nStates).foreach(i => f(i, states(i)))
 
-  def newState(i: Int): Code[Unit] = states(i).newState(getStateOffset(i))
+  def newState(cb: EmitCodeBuilder, i: Int): Unit = states(i).newState(cb, getStateOffset(i))
 
-  def newState(cb: EmitCodeBuilder): Unit = states.toCode(cb, (cb, i, s) => cb += s.newState(getStateOffset(i)))
+  def newState(cb: EmitCodeBuilder): Unit = states.toCode((i, s) => s.newState(cb, getStateOffset(i)))
 
   def load(cb: EmitCodeBuilder): Unit =
-    states.toCode(cb, (cb, i, s) => cb += s.load(getRegion(i), getStateOffset(i)))
+    states.toCode((i, s) => s.load(cb, getRegion(i), getStateOffset(i)))
 
   def store(cb: EmitCodeBuilder): Unit = {
-    states.toCode(cb, (cb, i, s) => cb += s.store(setRegion(i), getStateOffset(i)))
+    states.toCode((i, s) => s.store(cb, setRegion(i), getStateOffset(i)))
   }
 
   def copyFrom(cb: EmitCodeBuilder, statesOffset: Code[Long]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -237,8 +237,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     val node = get.getCodeParam[Long](1)
     val k = get.getEmitParam(2)
     get.emitWithBuilder { cb =>
-      val cmp = cb.newLocal("cmp", -1)
-      val keyV = cb.newLocal("keyV", 0L)
+      val cmp = cb.newLocal("btree_get_cmp", -1)
+      val keyV = cb.newLocal("btree_get_keyV", 0L)
 
       def insertOrGetAt(i: Int) = {
         cb.ifx(isLeaf(node), {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -3,8 +3,9 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
-import is.hail.types.physical.{PBooleanRequired, PCanonicalStruct, PFloat64, PInt32Required, PStruct, PType}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
+import is.hail.types.physical.{PBooleanRequired, PCanonicalStruct, PInt32Required, PStruct}
+import is.hail.types.virtual.{TFloat64, TInt32, TInt64, Type}
 import is.hail.utils._
 
 class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
@@ -25,53 +26,53 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   private val k = kb.genFieldThisRef[Int]("k")
   private val kOffset: Code[Long] => Code[Long] = storageType.loadField(_, "k")
 
-  def init(k: Code[Int]): Code[Unit] = {
-    Code(
-      this.k := k,
-      aggr := Code.newInstance[ApproxCDFStateManager, Int](this.k),
-      id := region.storeJavaObject(aggr),
-      this.initialized := true
-    )
+  def init(cb: EmitCodeBuilder, k: Code[Int]): Unit = {
+      cb.assign(this.k, k)
+      cb.assign(aggr, Code.newInstance[ApproxCDFStateManager, Int](this.k))
+      cb.assign(id, region.storeJavaObject(aggr))
+      cb.assign(this.initialized, true)
   }
 
-  def seq(x: Code[Double]): Code[Unit] = {
-    aggr.invoke[Double, Unit]("seqOp", x)
+  def seq(cb: EmitCodeBuilder, x: Code[Double]): Unit = {
+    cb += aggr.invoke[Double, Unit]("seqOp", x)
   }
 
-  def comb(other: ApproxCDFState): Code[Unit] = {
-    aggr.invoke[ApproxCDFStateManager, Unit]("combOp", other.aggr)
+  def comb(cb: EmitCodeBuilder, other: ApproxCDFState): Unit = {
+    cb += aggr.invoke[ApproxCDFStateManager, Unit]("combOp", other.aggr)
   }
 
-  def result(srvb: StagedRegionValueBuilder): Code[Unit] = {
-    srvb.addIRIntermediate(QuantilesAggregator.resultType)(aggr.invoke[Region, Long]("rvResult", srvb.region))
+  def result(cb: EmitCodeBuilder, srvb: StagedRegionValueBuilder): Unit = {
+    cb += srvb.addIRIntermediate(QuantilesAggregator.resultType)(aggr.invoke[Region, Long]("rvResult", srvb.region))
   }
 
-  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
     cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code.memoize(src, "acdfa_load_src") { src =>
-      Code(
-        regionLoader(r),
-        id := Region.loadInt(idOffset(src)),
-        initialized := Region.loadBoolean(initializedOffset(src)),
-        initialized.orEmpty(Code(
-          aggr := Code.checkcast[ApproxCDFStateManager](region.lookupJavaObject(id)),
-          k := Region.loadInt(kOffset(src)))))
-    }
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal("acdfa_load_src", srcc)
+    regionLoader(cb, r)
+    cb.assign(id, Region.loadInt(idOffset(src)))
+    cb.assign(initialized, Region.loadBoolean(initializedOffset(src)))
+    cb.ifx(initialized,
+      {
+        cb.assign(aggr, Code.checkcast[ApproxCDFStateManager](region.lookupJavaObject(id)))
+        cb.assign(k, Region.loadInt(kOffset(src)))
+      })
+  }
 
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    Code.memoize(dest, "acdfa_store_dest") { dest =>
-      region.isValid.orEmpty(
-        Code(
-          regionStorer(region),
-          region.invalidate(),
-          Region.storeInt(idOffset(dest), id),
-          Region.storeInt(kOffset(dest), k),
-          Region.storeBoolean(initializedOffset(dest), initialized)))
-    }
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    val dest = cb.newLocal("acdfa_store_dest", destc)
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        cb += region.invalidate()
+        cb += Region.storeInt(idOffset(dest), id)
+        cb += Region.storeInt(kOffset(dest), k)
+        cb += Region.storeBoolean(initializedOffset(dest), initialized)
+      })
+  }
 
   override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     (cb, ob: Value[OutputBuffer]) =>
@@ -111,34 +112,31 @@ class ApproxCDFAggregator extends StagedAggregator {
   type State = ApproxCDFState
 
   def resultType: PStruct = QuantilesAggregator.resultType
-  val initOpTypes: Seq[PType] = FastSeq(PInt32Required)
-  val seqOpTypes: Seq[PType] = FastSeq(PFloat64())
+  val initOpTypes: Seq[Type] = FastSeq(TInt32)
+  val seqOpTypes: Seq[Type] = FastSeq(TFloat64)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val Array(k) = init
-    cb += Code(
-      k.setup,
-      k.m.mux(
-        Code._fatal[Unit]("approx_cdf: 'k' may not be missing"),
-        state.init(k.v.asInstanceOf[Code[Int]])
-      ))
+    k.toI(cb)
+      .consume(cb,
+        cb += Code._fatal[Unit]("approx_cdf: 'k' may not be missing"),
+        pv => state.init(cb, pv.asInt.intCode(cb)))
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(x) = seq
-    cb += Code(
-      x.setup,
-      x.m.mux(
-        Code._empty,
-        state.seq(x.v.asInstanceOf[Code[Double]])
-      ))
+    x.toI(cb)
+      .consume(cb,
+        {},
+        pv => state.seq(cb, pv.asDouble.doubleCode(cb))
+      )
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
-    cb += state.comb(other)
+    state.comb(cb, other)
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
-    cb += state.result(srvb)
+    state.result(cb, srvb)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -1,18 +1,23 @@
 package is.hail.expr.ir.agg
 
-import is.hail.asm4s._
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.asm4s._
 import is.hail.expr.ir._
-import is.hail.types.physical._
-import is.hail.utils._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical._
+import is.hail.types.virtual.Type
+import is.hail.utils._
 
-class CollectAggState(val elemType: PType, val kb: EmitClassBuilder[_]) extends AggregatorState {
+class CollectAggState(val elemVType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) extends AggregatorState {
+  private val elemType = elemVType.canonicalPType
+
   val r = kb.genFieldThisRef[Region]()
   val region: Value[Region] = r
   val bll = new StagedBlockLinkedList(elemType, kb)
 
   def storageType = bll.storageType
+
   override def regionSize: Region.Size = Region.REGULAR
 
   def createState(cb: EmitCodeBuilder): Unit =
@@ -21,55 +26,62 @@ class CollectAggState(val elemType: PType, val kb: EmitClassBuilder[_]) extends 
       cb += region.invalidate()
     })
 
-  def newState(off: Code[Long]): Code[Unit] =
-    region.getNewRegion(regionSize)
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
 
-  def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code(
-      regionLoader(region),
-      bll.load(src))
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
+    regionLoader(cb, region)
+    bll.load(cb, srcc)
+  }
 
-  def store(regionStorer: Value[Region] => Code[Unit], dst: Code[Long]): Code[Unit] =
-    region.isValid.orEmpty(Code(
-      regionStorer(region),
-      bll.store(dst),
-      region.invalidate()))
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        bll.store(cb, destc)
+        cb += region.invalidate()
+      })
+  }
 
   def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
     val copyBll = new StagedBlockLinkedList(elemType, kb)
-    cb += Code(
-      copyBll.load(src),
-      bll.initWithDeepCopy(region, copyBll))
+    copyBll.load(cb, src)
+    bll.initWithDeepCopy(cb, region, copyBll)
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
-    { (cb, ib) => cb += bll.serialize(region, ib) }
+    { (cb, ib) => bll.serialize(cb, region, ib) }
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
-    { (cb, ib) => cb += Code(bll.init(region), bll.deserialize(region, ib)) }
+    { (cb, ib) =>
+      bll.init(cb, region)
+      bll.deserialize(cb, region, ib)
+    }
   }
 }
 
-class CollectAggregator(val elemType: PType) extends StagedAggregator {
+class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregator {
   type State = CollectAggState
 
-  assert(elemType.isCanonical)
-  val resultType = PCanonicalArray(elemType, required = true)
-  val initOpTypes: Seq[PType] = Array[PType]()
-  val seqOpTypes: Seq[PType] = Array[PType](elemType)
+  val resultType = PCanonicalArray(elemType.canonicalPType, required = true)
+  val initOpTypes: Seq[Type] = Array[Type]()
+  val seqOpTypes: Seq[Type] = Array[Type](elemType.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, args: Array[EmitCode]): Unit = {
     assert(args.isEmpty)
-    cb += state.bll.init(state.region)
+    state.bll.init(cb, state.region)
   }
 
-  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit =
-    cb += state.bll.push(state.region, seq(0))
+  protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+    state.bll.push(cb, state.region, seq(0))
+  }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit =
-    cb += state.bll.append(state.region, other.bll)
+    state.bll.append(cb, state.region, other.bll)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit =
-    cb += srvb.addArray(resultType, state.bll.writeToSRVB(cb.emb, _))
+  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
+    cb += srvb.addArray(resultType, { srvb =>
+      EmitCodeBuilder.scopedVoid(cb.emb)(state.bll.writeToSRVB(_, srvb))
+    })
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -3,59 +3,61 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion}
+import is.hail.io._
+import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
-import is.hail.io._
+import is.hail.types.virtual.Type
 import is.hail.utils._
 
 class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) extends BTreeKey {
-  val inline: Boolean = typ.isPrimitive
-  val storageType: PTuple = PCanonicalTuple(false, if (inline) typ else PInt64(typ.required), PCanonicalTuple(false))
+  val storageType: PTuple = PCanonicalTuple(false, typ, PCanonicalTuple(false))
   val compType: PType = typ
   private val kcomp = kb.getCodeOrdering(typ, CodeOrdering.Compare(), ignoreMissingness = false)
 
   def isKeyMissing(src: Code[Long]): Code[Boolean] = storageType.isFieldMissing(src, 0)
-  def loadKey(src: Code[Long]): Code[_] = Region.loadIRIntermediate(if (inline) typ else PInt64(typ.required))(storageType.fieldOffset(src, 0))
+
+  def loadKey(src: Code[Long]): Code[_] = Region.loadIRIntermediate(typ)(storageType.fieldOffset(src, 0))
 
   def isEmpty(off: Code[Long]): Code[Boolean] = storageType.isFieldMissing(off, 1)
-  def initializeEmpty(off: Code[Long]): Code[Unit] =
-    storageType.setFieldMissing(off, 1)
 
-  def store(dest: Code[Long], m: Code[Boolean], v: Code[_]): Code[Unit] = {
-    Code.memoize(dest, "casa_store_dest") { dest =>
-      val c = {
-        if (typ.isPrimitive)
-          Region.storeIRIntermediate(typ)(storageType.fieldOffset(dest, 0), v)
-        else
-          Region.storeAddress(storageType.fieldOffset(dest, 0), StagedRegionValueBuilder.deepCopyFromOffset(kb, region, typ, coerce[Long](v)))
-      }
-      if (!typ.required)
-        m.mux(
-          Code(storageType.setFieldPresent(dest, 1), storageType.setFieldMissing(dest, 0)),
-          Code(storageType.stagedInitialize(dest), c))
-      else
-        Code(storageType.setFieldPresent(dest, 1), c)
-    }
+  def initializeEmpty(cb: EmitCodeBuilder, off: Code[Long]): Unit =
+    cb += storageType.setFieldMissing(off, 1)
+
+  def store(cb: EmitCodeBuilder, destc: Code[Long], k: EmitCode): Unit = {
+    val dest = cb.newLocal("casa_store_dest", destc)
+
+    cb += storageType.setFieldPresent(dest, 1)
+    k.toI(cb)
+      .consume(cb,
+        {
+          cb += storageType.setFieldMissing(dest, 0)
+        },
+        { sc =>
+          cb += storageType.setFieldPresent(dest, 0)
+          typ.storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)
+        })
   }
 
-  def copy(src: Code[Long], dest: Code[Long]): Code[Unit] =
-    Region.copyFrom(src, dest, storageType.byteSize)
+  def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
+    cb += Region.copyFrom(src, dest, storageType.byteSize)
 
-  def deepCopy(er: EmitRegion, dest: Code[Long], src: Code[Long]): Code[Unit] = {
-    if (inline)
-      StagedRegionValueBuilder.deepCopy(er, storageType, src, dest)
-    else
-      Region.storeAddress(dest, StagedRegionValueBuilder.deepCopyFromOffset(er, storageType, src))
+  def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], src: Code[Long]): Unit = {
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapPCode(cb, src), deepCopy = true)
   }
 
-  def compKeys(k1: EmitCode, k2: EmitCode): Code[Int] =
-    Code(k1.setup, k2.setup, kcomp(k1.m -> k1.v, k2.m -> k2.v))
+  def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {
+    cb += k1.setup
+    cb += k2.setup
+    kcomp(k1.m -> k1.v, k2.m -> k2.v)
+  }
 
-  def loadCompKey(off: Value[Long]): EmitCode =
+  def loadCompKey(cb: EmitCodeBuilder, off: Value[Long]): EmitCode =
     EmitCode(Code._empty, isKeyMissing(off), PCode(typ, loadKey(off)))
 }
 
-class AppendOnlySetState(val kb: EmitClassBuilder[_], t: PType) extends PointerBasedRVAState {
+class AppendOnlySetState(val kb: EmitClassBuilder[_], vt: VirtualTypeWithReq) extends PointerBasedRVAState {
+  private val t = vt.canonicalPType
   val root: Settable[Long] = kb.genFieldThisRef[Long]()
   val size: Settable[Int] = kb.genFieldThisRef[Int]()
   val key = new TypedKey(t, kb, region)
@@ -67,24 +69,26 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], t: PType) extends PointerB
     "size" -> PInt32(true),
     "tree" -> PInt64(true))
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] = {
-    Code(super.load(regionLoader, src),
-      off.ceq(0L).mux(Code._empty,
-        Code(
-          size := Region.loadInt(typ.loadField(off, 0)),
-          root := Region.loadAddress(typ.loadField(off, 1)))))
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
+    super.load(cb, regionLoader, srcc)
+    cb.ifx(off.cne(0L),
+      {
+        cb.assign(size, Region.loadInt(typ.loadField(off, 0)))
+        cb.assign(root, Region.loadAddress(typ.loadField(off, 1)))
+      })
   }
 
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] = {
-    Code(
-      Region.storeInt(typ.fieldOffset(off, 0), size),
-      Region.storeAddress(typ.fieldOffset(off, 1), root),
-      super.store(regionStorer, dest))
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    cb += Region.storeInt(typ.fieldOffset(off, 0), size)
+    cb += Region.storeAddress(typ.fieldOffset(off, 1), root)
+    super.store(cb, regionStorer, destc)
   }
 
-  def init: Code[Unit] = Code(
-    off := region.allocate(typ.alignment, typ.byteSize),
-    size := 0, tree.init)
+  def init(cb: EmitCodeBuilder): Unit = {
+    cb.assign(off, region.allocate(typ.alignment, typ.byteSize))
+    cb.assign(size, 0)
+    tree.init(cb)
+  }
 
   private val _elt = kb.genFieldThisRef[Long]()
   private val _v = kb.newEmitField(t)
@@ -94,7 +98,7 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], t: PType) extends PointerB
     cb.assign(_elt, tree.getOrElseInitialize(cb, _v))
     cb.ifx(key.isEmpty(_elt), {
       cb.assign(size, size + 1)
-      cb += key.store(_elt, _v.m, _v.v)
+      key.store(cb, _elt, _v)
     })
   }
 
@@ -105,14 +109,13 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], t: PType) extends PointerB
       f(cb, EmitCode(Code._empty, key.isKeyMissing(eoff), PCode(t, key.loadKey(eoff))))
     }
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit =
-    cb += Code.memoize(src, "aoss_copy_from_addr_src") { src =>
-      Code(
-        off := region.allocate(typ.alignment, typ.byteSize),
-        size := Region.loadInt(typ.loadField(src, 0)),
-        tree.init,
-        tree.deepCopy(Region.loadAddress(typ.loadField(src, 1))))
-    }
+  def copyFromAddress(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal[Long]("aoss_copy_from_addr_src", srcc)
+    cb.assign(off, region.allocate(typ.alignment, typ.byteSize))
+    cb.assign(size, Region.loadInt(typ.loadField(src, 0)))
+    tree.init(cb)
+    tree.deepCopy(cb, Region.loadAddress(typ.loadField(src, 1)))
+  }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     val kEnc = et.buildEncoderMethod(t, kb)
@@ -134,30 +137,30 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], t: PType) extends PointerB
     val kv = kb.genFieldThisRef("kv")(typeToTypeInfo(t))
 
     { (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
-      cb += init
+      init(cb)
       tree.bulkLoad(cb, ib) { (cb, ib, dest) =>
         cb.assign(km, ib.readBoolean())
         cb.ifx(!km, {
           cb += kv.storeAny(kDec.invokeCode(region, ib))
         })
-        cb += key.store(dest, km, kv)
+        key.store(cb, dest, EmitCode(Code._empty, km, PCode(t, kv)))
         cb.assign(size, size + 1)
       }
     }
   }
 }
 
-class CollectAsSetAggregator(t: PType) extends StagedAggregator {
+class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator {
   type State = AppendOnlySetState
 
-  assert(t.isCanonical)
-  val resultType: PSet = PCanonicalSet(t)
-  val initOpTypes: Seq[PType] = Array[PType]()
-  val seqOpTypes: Seq[PType] = Array[PType](t)
+  private val elemPType = elem.canonicalPType
+  val resultType: PSet = PCanonicalSet(elemPType)
+  val initOpTypes: Seq[Type] = Array[Type]()
+  val seqOpTypes: Seq[Type] = Array[Type](elem.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
-    cb += state.init
+    state.init(cb)
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
@@ -165,21 +168,24 @@ class CollectAsSetAggregator(t: PType) extends StagedAggregator {
     state.insert(cb, elt)
   }
 
-  protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit =
+  protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
     other.foreach(cb) { (cb, k) => state.insert(cb, k) }
+  }
 
-  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit =
+  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
     cb += srvb.addArray(resultType.arrayFundamentalType, { sab =>
       EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
         cb += sab.start(state.size)
         state.foreach(cb) { (cb, k) =>
-          cb.ifx(k.m, {
-            cb += sab.setMissing()
-          }, {
-            cb += sab.addWithDeepCopy(t, k.value[Long])
-          })
+          k.toI(cb)
+            .consume(cb,
+              cb += sab.setMissing(),
+              { pc =>
+                cb += sab.addIRIntermediate(pc, deepCopy = true)
+              })
           cb += sab.advance()
         }
       }
     })
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -4,33 +4,38 @@ import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.types.physical._
+import is.hail.types.virtual.Type
 
 object CountAggregator extends StagedAggregator {
   type State = PrimitiveRVAState
 
   val resultType: PType = PInt64(true)
-  val initOpTypes: Seq[PType] = Array[PType]()
-  val seqOpTypes: Seq[PType] = Array[PType]()
+  val initOpTypes: Seq[Type] = Array[Type]()
+  val seqOpTypes: Seq[Type] = Array[Type]()
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
+    assert(state.vtypes.head.r.required)
     val (_, v, _) = state.fields(0)
     cb.assignAny(v, 0L)
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     assert(seq.length == 0)
+    assert(state.vtypes.head.r.required)
     val (_, v, _) = state.fields(0)
     cb.assignAny(v, coerce[Long](v) + 1L)
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
+    assert(state.vtypes.head.r.required)
     val (_, v1, _) = state.fields(0)
     val (_, v2, _) = other.fields(0)
     cb.assignAny(v1, coerce[Long](v1) + coerce[Long](v2))
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
+    assert(state.vtypes.head.r.required)
     val (_, v, _) = state.fields(0)
     cb += srvb.addLong(coerce[Long](v))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -2,11 +2,12 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitRegion, ParamType}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitParamType, EmitRegion, ParamType}
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
+import is.hail.types.VirtualTypeWithReq
 import is.hail.utils._
 
 
@@ -21,21 +22,24 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
 
   def isEmpty(off: Code[Long]): Code[Boolean] = coerce[Boolean](Region.loadIRIntermediate(PBooleanRequired)(storageType.fieldOffset(off, "empty")))
 
-  def initializeEmpty(off: Code[Long]): Code[Unit] = Region.storeBoolean(storageType.fieldOffset(off, "empty"), true)
+  def initializeEmpty(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += Region.storeBoolean(storageType.fieldOffset(off, "empty"), true)
 
-  def copy(src: Code[Long], dest: Code[Long]): Code[Unit] = Region.copyFrom(src, dest, storageType.byteSize)
+  def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit = cb += Region.copyFrom(src, dest, storageType.byteSize)
 
-  def deepCopy(er: EmitRegion, src: Code[Long], dest: Code[Long]): Code[Unit] =
-    Code.memoize(src, "dsa_deep_copy_src") { src =>
-      Code(
-        Region.loadBoolean(storageType.loadField(src, "empty")).orEmpty(Code._fatal[Unit]("key empty!!")),
-        StagedRegionValueBuilder.deepCopy(er, storageType, src, dest))
-    }
+  def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, srcc: Code[Long], dest: Code[Long]): Unit = {
+    val src = cb.newLocal[Long]("dsa_deep_copy_src", srcc)
+    cb.ifx(Region.loadBoolean(storageType.loadField(src, "empty")),
+      cb += Code._fatal[Unit]("key empty!"))
+    storageType.storeAtAddress(cb, dest, er.region, storageType.loadCheapPCode(cb, src), deepCopy = true)
+  }
 
-  def compKeys(k1: EmitCode, k2: EmitCode): Code[Int] =
-    Code(k1.setup, k2.setup, kcomp(k1.m -> k1.v, k2.m -> k2.v))
+  def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {
+    cb += k1.setup
+    cb += k2.setup
+    kcomp(k1.m -> k1.v, k2.m -> k2.v)
+  }
 
-  def loadCompKey(off: Value[Long]): EmitCode = EmitCode.present(binType, storageType.loadField(off, "bin"))
+  def loadCompKey(cb: EmitCodeBuilder, off: Value[Long]): EmitCode = EmitCode.present(binType, storageType.loadField(off, "bin"))
 }
 
 
@@ -43,19 +47,20 @@ object DownsampleState {
   val serializationEndMarker: Int = 883625255
 }
 
-class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferSize: Int = 256) extends AggregatorState {
+class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq, maxBufferSize: Int = 256) extends AggregatorState {
+  private val labelPType = labelType.canonicalPType
   val r: Settable[Region] = kb.genFieldThisRef[Region]("region")
   val region: Value[Region] = r
 
   val oldRegion: Settable[Region] = kb.genFieldThisRef[Region]("old_region")
 
-  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
     cb.ifx(region.isNull, cb.assign(r, Region.stagedCreate(regionSize, kb.pool())))
 
   val binType = PCanonicalStruct(required = true, "x" -> PInt32Required, "y" -> PInt32Required)
-  val pointType = PCanonicalStruct(required = true, "x" -> PFloat64Required, "y" -> PFloat64Required, "label" -> labelType)
+  val pointType = PCanonicalStruct(required = true, "x" -> PFloat64Required, "y" -> PFloat64Required, "label" -> labelPType)
 
   private val binET = EType.defaultFromPType(binType)
   private val pointET = EType.defaultFromPType(pointType)
@@ -99,85 +104,93 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
 
   override val regionSize: Int = Region.SMALL
 
-  def allocateSpace(): Code[Unit] =
-    off := region.allocate(storageType.alignment, storageType.byteSize)
+  def allocateSpace(cb: EmitCodeBuilder): Unit =
+    cb.assign(off, region.allocate(storageType.alignment, storageType.byteSize))
 
-  def init(nDivisions: Code[Int]): Code[Unit] = {
+  def init(cb: EmitCodeBuilder, nDivisions: Code[Int]): Unit = {
     val mb = kb.genEmitMethod("downsample_init", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
-    mb.emit(Code(FastIndexedSeq(
-      allocateSpace(),
-      this.nDivisions := mb.getCodeParam[Int](1),
-      (this.nDivisions < 4).orEmpty(Code._fatal[Unit](const("downsample: require n_divisions >= 4, found ").concat(this.nDivisions.toS))),
-      left := 0d,
-      right := 0d,
-      bottom := 0d,
-      top := 0d,
-      treeSize := 0,
-      tree.init,
-      buffer.initialize())))
-    mb.invokeCode(nDivisions)
+    mb.voidWithBuilder { cb =>
+      allocateSpace(cb)
+      cb.assign(this.nDivisions, mb.getCodeParam[Int](1).load())
+
+      cb.ifx(this.nDivisions < 4, cb += Code._fatal[Unit](const("downsample: require n_divisions >= 4, found ").concat(this.nDivisions.toS)))
+
+      cb.assign(left, 0d)
+      cb.assign(right, 0d)
+      cb.assign(bottom, 0d)
+      cb.assign(top, 0d)
+      cb.assign(treeSize, 0)
+      tree.init(cb)
+      buffer.initialize(cb)
+    }
+    cb.invokeVoid(mb, nDivisions)
   }
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] = {
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
     val mb = kb.genEmitMethod("downsample_load", FastIndexedSeq[ParamType](), UnitInfo)
-    mb.emit(
-      Code(FastIndexedSeq(
-        off := src,
-        nDivisions := Region.loadInt(storageType.loadField(off, "nDivisions")),
-        treeSize := Region.loadInt(storageType.loadField(off, "treeSize")),
-        left := Region.loadDouble(storageType.loadField(off, "left")),
-        right := Region.loadDouble(storageType.loadField(off, "right")),
-        bottom := Region.loadDouble(storageType.loadField(off, "bottom")),
-        top := Region.loadDouble(storageType.loadField(off, "top")),
-        bufferLeft := Region.loadDouble(storageType.loadField(off, "bufferLeft")),
-        bufferRight := Region.loadDouble(storageType.loadField(off, "bufferRight")),
-        bufferBottom := Region.loadDouble(storageType.loadField(off, "bufferBottom")),
-        bufferTop := Region.loadDouble(storageType.loadField(off, "bufferTop")),
-        buffer.loadFrom(storageType.fieldOffset(off, "buffer")),
-        root := Region.loadAddress(storageType.fieldOffset(off, "tree"))
-      )))
-    Code(regionLoader(r), mb.invokeCode())
+    mb.voidWithBuilder { cb =>
+
+      cb.assign(nDivisions, Region.loadInt(storageType.loadField(off, "nDivisions")))
+      cb.assign(treeSize, Region.loadInt(storageType.loadField(off, "treeSize")))
+      cb.assign(left, Region.loadDouble(storageType.loadField(off, "left")))
+      cb.assign(right, Region.loadDouble(storageType.loadField(off, "right")))
+      cb.assign(bottom, Region.loadDouble(storageType.loadField(off, "bottom")))
+      cb.assign(top, Region.loadDouble(storageType.loadField(off, "top")))
+      cb.assign(bufferLeft, Region.loadDouble(storageType.loadField(off, "bufferLeft")))
+      cb.assign(bufferRight, Region.loadDouble(storageType.loadField(off, "bufferRight")))
+      cb.assign(bufferBottom, Region.loadDouble(storageType.loadField(off, "bufferBottom")))
+      cb.assign(bufferTop, Region.loadDouble(storageType.loadField(off, "bufferTop")))
+      buffer.loadFrom(cb, storageType.fieldOffset(off, "buffer"))
+      cb.assign(root, Region.loadAddress(storageType.fieldOffset(off, "tree")))
+    }
+    cb.assign(off, srcc)
+    regionLoader(cb, r)
+    cb.invokeVoid(mb)
   }
 
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] = {
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
     val mb = kb.genEmitMethod("downsample_store", FastIndexedSeq[ParamType](), UnitInfo)
-    mb.emit(Code(FastIndexedSeq(
-      off := dest,
-      Region.storeInt(storageType.fieldOffset(off, "nDivisions"), nDivisions),
-      Region.storeInt(storageType.fieldOffset(off, "treeSize"), treeSize),
-      Region.storeDouble(storageType.fieldOffset(off, "left"), left),
-      Region.storeDouble(storageType.fieldOffset(off, "right"), right),
-      Region.storeDouble(storageType.fieldOffset(off, "bottom"), bottom),
-      Region.storeDouble(storageType.fieldOffset(off, "top"), top),
-      Region.storeDouble(storageType.fieldOffset(off, "bufferLeft"), bufferLeft),
-      Region.storeDouble(storageType.fieldOffset(off, "bufferRight"), bufferRight),
-      Region.storeDouble(storageType.fieldOffset(off, "bufferBottom"), bufferBottom),
-      Region.storeDouble(storageType.fieldOffset(off, "bufferTop"), bufferTop),
-      buffer.storeTo(storageType.fieldOffset(off, "buffer")),
-      Region.storeAddress(storageType.fieldOffset(off, "tree"), root)
-    )))
+    mb.voidWithBuilder { cb =>
+      cb += Region.storeInt(storageType.fieldOffset(off, "nDivisions"), nDivisions)
+      cb += Region.storeInt(storageType.fieldOffset(off, "treeSize"), treeSize)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "left"), left)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "right"), right)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "bottom"), bottom)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "top"), top)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "bufferLeft"), bufferLeft)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "bufferRight"), bufferRight)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "bufferBottom"), bufferBottom)
+      cb += Region.storeDouble(storageType.fieldOffset(off, "bufferTop"), bufferTop)
+      buffer.storeTo(cb, storageType.fieldOffset(off, "buffer"))
+      cb += Region.storeAddress(storageType.fieldOffset(off, "tree"), root)
+    }
 
-    Code(
-      mb.invokeCode(),
-      region.isValid.orEmpty(Code(regionStorer(region), region.invalidate())))
+    cb.assign(off, destc)
+    cb.invokeVoid(mb)
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        cb += region.invalidate()
+      })
   }
 
   def copyFrom(cb: EmitCodeBuilder, _src: Code[Long]): Unit = {
     val mb = kb.genEmitMethod("downsample_copy", FastIndexedSeq[ParamType](LongInfo), UnitInfo)
 
     val src = mb.getCodeParam[Long](1)
-    mb.emit(Code(FastIndexedSeq(
-      allocateSpace(),
-      nDivisions := Region.loadInt(storageType.loadField(src, "nDivisions")),
-      treeSize := Region.loadInt(storageType.loadField(src, "treeSize")),
-      left := Region.loadDouble(storageType.loadField(src, "left")),
-      right := Region.loadDouble(storageType.loadField(src, "right")),
-      bottom := Region.loadDouble(storageType.loadField(src, "top")),
-      top := Region.loadDouble(storageType.loadField(src, "bottom")),
-      treeSize := Region.loadInt(storageType.loadField(src, "treeSize")),
-      tree.deepCopy(Region.loadAddress(storageType.loadField(src, "tree"))),
-      buffer.copyFrom(storageType.loadField(src, "buffer")))))
-    cb += mb.invokeCode(_src)
+    mb.voidWithBuilder { cb =>
+      allocateSpace(cb)
+      cb.assign(nDivisions, Region.loadInt(storageType.loadField(src, "nDivisions")))
+      cb.assign(treeSize, Region.loadInt(storageType.loadField(src, "treeSize")))
+      cb.assign(left, Region.loadDouble(storageType.loadField(src, "left")))
+      cb.assign(right, Region.loadDouble(storageType.loadField(src, "right")))
+      cb.assign(bottom, Region.loadDouble(storageType.loadField(src, "top")))
+      cb.assign(top, Region.loadDouble(storageType.loadField(src, "bottom")))
+      cb.assign(treeSize, Region.loadInt(storageType.loadField(src, "treeSize")))
+      tree.deepCopy(cb, Region.loadAddress(storageType.loadField(src, "tree")))
+      buffer.copyFrom(cb, storageType.loadField(src, "buffer"))
+    }
+    cb.invokeVoid(mb, _src)
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
@@ -188,7 +201,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
       val mb = kb.genEmitMethod("downsample_serialize", FastIndexedSeq[ParamType](typeInfo[OutputBuffer]), UnitInfo)
       mb.emitWithBuilder { cb =>
         val ob = mb.getCodeParam[OutputBuffer](1)
-        cb += dumpBuffer()
+        dumpBuffer(cb)
         cb += ob.writeInt(nDivisions)
         cb += ob.writeInt(treeSize)
         cb += ob.writeDouble(left)
@@ -199,14 +212,14 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
         tree.bulkStore(cb, ob) { (cb, ob, srcCode) =>
           val src = cb.newLocal("downsample_state_ser_src", srcCode)
           cb += Region.loadBoolean(key.storageType.loadField(src, "empty")).orEmpty(Code._fatal[Unit]("bad"))
-          cb += binEnc.invokeCode(key.storageType.loadField(src, "bin"), ob)
-          cb += pointEnc.invokeCode(key.storageType.loadField(src, "point"), ob)
+          cb.invokeVoid(binEnc, key.storageType.loadField(src, "bin"), ob)
+          cb.invokeVoid(pointEnc, key.storageType.loadField(src, "point"), ob)
         }
         cb += ob.writeInt(DownsampleState.serializationEndMarker)
         Code._empty
       }
 
-      cb += mb.invokeCode(ob)
+      cb.invokeVoid(mb, ob)
     }
   }
 
@@ -219,7 +232,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
       mb.emitWithBuilder { cb =>
         val ib = cb.emb.getCodeParam[InputBuffer](1)
         val serializationEndTag = cb.newLocal[Int]("de_end_tag")
-        cb += allocateSpace()
+        allocateSpace(cb)
         cb.assign(nDivisions, ib.readInt())
         cb.assign(treeSize, ib.readInt())
         cb.assign(left, ib.readDouble())
@@ -231,21 +244,21 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
         cb.assign(bufferBottom, bottom)
         cb.assign(bufferTop, top)
         cb.assign(treeSize, ib.readInt())
-        cb += tree.init
+        tree.init(cb)
         tree.bulkLoad(cb, ib) { (cb, ib, destCode) =>
           val dest = cb.newLocal("dss_deser_dest", destCode)
           cb += binDec.invokeCode(region, key.storageType.fieldOffset(dest, "bin"), ib)
           cb += pointDec.invokeCode(region, key.storageType.fieldOffset(dest, "point"), ib)
           cb += Region.storeBoolean(key.storageType.fieldOffset(dest, "empty"), false)
         }
-        cb += buffer.initialize()
+        buffer.initialize(cb)
         cb.assign(serializationEndTag, ib.readInt())
         cb.ifx(serializationEndTag.cne(DownsampleState.serializationEndMarker), {
           cb._fatal("downsample aggregator failed to serialize!")
         })
         Code._empty
       }
-      cb += mb.invokeCode(ib)
+      cb.invokeVoid(mb, ib)
     }
   }
 
@@ -263,7 +276,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
     mb.invokeCode(_)
   }
 
-  def insertIntoTree(binX: Code[Int], binY: Code[Int], point: Code[Long], deepCopy: Boolean): Code[Unit] = {
+  def insertIntoTree(cb: EmitCodeBuilder, binX: Code[Int], binY: Code[Int], point: Code[Long], deepCopy: Boolean): Unit = {
     val name = s"downsample_insert_into_tree_${ deepCopy.toString }"
     val mb = kb.getOrGenEmitMethod(name, (this, name, deepCopy), FastIndexedSeq[ParamType](IntInfo, IntInfo, LongInfo), UnitInfo) { mb =>
       val binX = mb.getCodeParam[Int](1)
@@ -274,7 +287,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
       val insertedPointOffset = mb.newLocal[Long]("inserted_point_offset")
       val binStaging = mb.newLocal[Long]("binStaging")
 
-      mb.emitWithBuilder { cb =>
+      mb.voidWithBuilder { cb =>
         cb.assign(binStaging, storageType.loadField(off, "binStaging"))
         cb += Region.storeInt(binType.fieldOffset(binStaging, "x"), binX)
         cb += Region.storeInt(binType.fieldOffset(binStaging, "y"), binY)
@@ -285,44 +298,39 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
           cb += Region.storeInt(binType.loadField(binOffset, "x"), binX)
           cb += Region.storeInt(binType.loadField(binOffset, "y"), binY)
           cb.assign(insertedPointOffset, key.storageType.loadField(insertOffset, "point"))
-          if (deepCopy)
-            cb += StagedRegionValueBuilder.deepCopy(kb, region, pointType, point, insertedPointOffset)
-          else
-            cb += Region.copyFrom(point, insertedPointOffset, pointType.byteSize)
+          pointType.storeAtAddress(cb, insertedPointOffset, region, pointType.loadCheapPCode(cb, point), deepCopy = deepCopy)
           cb += Region.storeBoolean(key.storageType.loadField(insertOffset, "empty"), false)
           cb.assign(treeSize, treeSize + 1)
         })
-        Code._empty
       }
     }
 
-    mb.invokeCode(binX, binY, point)
+    cb.invokeVoid(mb, binX, binY, point)
   }
 
-  def copyFromTree(other: AppendOnlyBTree): Code[Unit] = {
+  def copyFromTree(cb: EmitCodeBuilder, other: AppendOnlyBTree): Unit = {
     val mb = kb.genEmitMethod("downsample_copy_from_tree", FastIndexedSeq[ParamType](), UnitInfo)
 
-    mb.emitWithBuilder { cb =>
-        other.foreach(cb) { (cb, v) =>
+    mb.voidWithBuilder { cb =>
+      other.foreach(cb) { (cb, v) =>
         val mb = kb.genEmitMethod("downsample_copy_from_tree_foreach", FastIndexedSeq[ParamType](LongInfo), UnitInfo)
         val value = mb.getCodeParam[Long](1)
         val point = mb.newLocal[Long]("point_offset")
         val pointX = mb.newLocal[Double]("point_x")
         val pointY = mb.newLocal[Double]("point_y")
         val lm = mb.newLocal[Boolean]("lm")
-        mb.emit(Code(
-          point := key.storageType.loadField(value, "point"),
-          pointX := Region.loadDouble(pointType.loadField(point, "x")),
-          pointY := Region.loadDouble(pointType.loadField(point, "y")),
-          lm := pointType.isFieldMissing(point, "label"),
-          insertIntoTree(xBinCoordinate(pointX), yBinCoordinate(pointY), point, deepCopy = true)
-        ))
-        cb += mb.invokeCode(v)
+        mb.voidWithBuilder { cb =>
+          cb.assign(point, key.storageType.loadField(value, "point"))
+          cb.assign(pointX, Region.loadDouble(pointType.loadField(point, "x")))
+          cb.assign(pointY, Region.loadDouble(pointType.loadField(point, "y")))
+          cb.assign(lm, pointType.isFieldMissing(point, "label"))
+          insertIntoTree(cb, xBinCoordinate(pointX), yBinCoordinate(pointY), point, deepCopy = true)
+        }
+        cb.invokeVoid(mb, v)
       }
-      Code._empty
     }
 
-    mb.invokeCode()
+    cb.invokeVoid(mb)
   }
 
   def min(a: Code[Double], b: Code[Double]): Code[Double] =
@@ -336,59 +344,61 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
 
   def isFinite(a: Code[Double]): Code[Boolean] = Code.invokeStatic1[java.lang.Double, Double, Boolean]("isFinite", a)
 
-  def dumpBuffer(): Code[Unit] = {
+  def dumpBuffer(cb: EmitCodeBuilder): Unit = {
     val name = "downsample_dump_buffer"
     val mb = kb.getOrGenEmitMethod(name, (this, name), FastIndexedSeq[ParamType](), UnitInfo) { mb =>
       val i = mb.newLocal[Int]("i")
       val point = mb.newLocal[Long]("elt")
       val x = mb.newLocal[Double]("x")
       val y = mb.newLocal[Double]("y")
-      mb.emit(Code(FastIndexedSeq(
-        buffer.size.ceq(0).orEmpty(Code._return(Code._empty)),
-        left := min(left, bufferLeft),
-        right := max(right, bufferRight),
-        bottom := min(bottom, bufferBottom),
-        top := max(top, bufferTop),
-        oldRegion := region,
-        oldRoot := root,
-        r := Region.stagedCreate(regionSize, region.getPool()),
-        treeSize := 0,
-        tree.init,
-        copyFromTree(oldRootBTree),
-        i := 0,
-        Code.whileLoop(i < buffer.size,
-          EmitCodeBuilder.scopedVoid(mb)(cb => cb.assign(point, buffer.loadElement(cb, i).value)),
-          x := Region.loadDouble(pointType.loadField(point, "x")),
-          y := Region.loadDouble(pointType.loadField(point, "y")),
-          insertIntoTree(xBinCoordinate(x), yBinCoordinate(y), point, deepCopy = true),
-          i := i + 1),
-        buffer.initialize(),
-        oldRegion.invalidate(),
-        allocateSpace()
-      )))
+      mb.voidWithBuilder { cb =>
+        cb.ifx(buffer.size.ceq(0), cb += Code._return[Unit](Code._empty))
+        cb.assign(left, min(left, bufferLeft))
+        cb.assign(right, max(right, bufferRight))
+        cb.assign(bottom, min(bottom, bufferBottom))
+        cb.assign(top, max(top, bufferTop))
+        cb.assign(oldRegion, region)
+        cb.assign(oldRoot, root)
+        cb.assign(r, Region.stagedCreate(regionSize, region.getPool()))
+        cb.assign(treeSize, 0)
+        tree.init(cb)
+        copyFromTree(cb, oldRootBTree)
+        cb.assign(i, 0)
+        cb.whileLoop(i < buffer.size,
+          {
+            cb.assign(point, buffer.loadElement(cb, i).value)
+            cb.assign(x, Region.loadDouble(pointType.loadField(point, "x")))
+            cb.assign(y, Region.loadDouble(pointType.loadField(point, "y")))
+            insertIntoTree(cb, xBinCoordinate(x), yBinCoordinate(y), point, deepCopy = true)
+            cb.assign(i, i + 1)
+          })
+        buffer.initialize(cb)
+        cb += oldRegion.invalidate()
+        allocateSpace(cb)
+      }
     }
 
-    mb.invokeCode()
+    cb.invokeVoid(mb)
   }
 
-  def insertPointIntoBuffer(x: Code[Double], y: Code[Double], point: Code[Long], deepCopy: Boolean): Code[Unit] = {
+  def insertPointIntoBuffer(cb: EmitCodeBuilder, x: Code[Double], y: Code[Double], point: Code[Long], deepCopy: Boolean): Unit = {
     val name = "downsample_insert_into_buffer"
     val mb = kb.getOrGenEmitMethod(name, (this, name, deepCopy), FastIndexedSeq[ParamType](DoubleInfo, DoubleInfo, LongInfo), UnitInfo) { mb =>
       val x = mb.getCodeParam[Double](1)
       val y = mb.getCodeParam[Double](2)
       val point = mb.getCodeParam[Long](3)
 
-      mb.emit(Code(
-        bufferLeft := min(bufferLeft, x),
-        bufferRight := max(bufferRight, x),
-        bufferBottom := min(bufferBottom, y),
-        bufferTop := max(bufferTop, y),
-        buffer.append(point, deepCopy = deepCopy),
-        (buffer.size >= maxBufferSize).orEmpty(dumpBuffer())
-      ))
+      mb.voidWithBuilder { cb =>
+        cb.assign(bufferLeft, min(bufferLeft, x))
+        cb.assign(bufferRight, max(bufferRight, x))
+        cb.assign(bufferBottom, min(bufferBottom, y))
+        cb.assign(bufferTop, max(bufferTop, y))
+        buffer.append(cb, pointType.loadCheapPCode(cb, point))
+        cb.ifx(buffer.size >= maxBufferSize, dumpBuffer(cb))
+      }
     }
 
-    mb.invokeCode(x, y, point)
+    cb.invokeVoid(mb, x, y, point)
   }
 
   def checkBounds(xBin: Code[Int], yBin: Code[Int]): Code[Boolean] = {
@@ -409,7 +419,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
     mb.invokeCode(xBin, yBin)
   }
 
-  def binAndInsert(x: Code[Double], y: Code[Double], point: Code[Long], deepCopy: Boolean): Code[Unit] = {
+  def binAndInsert(cb: EmitCodeBuilder, x: Code[Double], y: Code[Double], point: Code[Long], deepCopy: Boolean): Unit = {
     val name = "downsample_bin_and_insert"
     val mb = kb.getOrGenEmitMethod(name, (this, name, deepCopy), FastIndexedSeq[ParamType](DoubleInfo, DoubleInfo, LongInfo), UnitInfo) { mb =>
       val x = mb.getCodeParam[Double](1)
@@ -419,50 +429,65 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
       val binX = mb.newLocal[Int]("bin_x")
       val binY = mb.newLocal[Int]("bin_y")
 
-      mb.emit(Code(
-        binX := xBinCoordinate(x),
-        binY := yBinCoordinate(y),
-        checkBounds(binX, binY).mux(
-          insertPointIntoBuffer(x, y, point, deepCopy = deepCopy),
-          insertIntoTree(binX, binY, point, deepCopy = deepCopy))))
+      mb.voidWithBuilder { cb =>
+        cb.assign(binX, xBinCoordinate(x))
+        cb.assign(binY, yBinCoordinate(y))
+        cb.ifx(checkBounds(binX, binY),
+          insertPointIntoBuffer(cb, x, y, point, deepCopy = deepCopy),
+          insertIntoTree(cb, binX, binY, point, deepCopy = deepCopy)
+        )
+      }
     }
-    mb.invokeCode(x, y, point)
+    cb.invokeVoid(mb, x, y, point)
   }
 
-  def insert(x: Code[Double], y: Code[Double], lm: Code[Boolean], l: Code[Long]): Code[Unit] = {
+  def insert(cb: EmitCodeBuilder, x: EmitCode, y: EmitCode, l: EmitCode): Unit = {
     val name = "downsample_insert"
-    val mb = kb.getOrGenEmitMethod(name, (this, name), FastIndexedSeq[ParamType](DoubleInfo, DoubleInfo, BooleanInfo, LongInfo), UnitInfo) { mb =>
-      val x = mb.getCodeParam[Double](1)
-      val y = mb.getCodeParam[Double](2)
-      val lm = mb.getCodeParam[Boolean](3)
-      val l = mb.getCodeParam[Long](4)
+    val mb = kb.getOrGenEmitMethod(name, (this, name), FastIndexedSeq[ParamType](x.pv.st.pType.asParam, y.pv.st.pType.asParam, EmitParamType(l.pv.st.pType)), UnitInfo) { mb =>
+      val x = mb.getPCodeParam(1)
+      val y = mb.getPCodeParam(2)
+      val l = mb.getEmitParam(3)
 
       val pointStaging = mb.newLocal[Long]("pointStaging")
-      mb.emit(Code(
-        (!(isFinite(x) && isFinite(y))).orEmpty(Code._return[Unit](Code._empty)),
-        pointStaging := storageType.loadField(off, "pointStaging"),
-        Region.storeDouble(pointType.fieldOffset(pointStaging, "x"), x),
-        Region.storeDouble(pointType.fieldOffset(pointStaging, "y"), y),
-        (if (labelType.required)
-          StagedRegionValueBuilder.deepCopy(kb, region, labelType, l, pointType.fieldOffset(pointStaging, "label"))
-        else
-          lm.mux(
-            pointType.setFieldMissing(pointStaging, "label"),
-            Code(
-              pointType.setFieldPresent(pointStaging, "label"),
-              StagedRegionValueBuilder.deepCopy(kb, region, labelType, l, pointType.fieldOffset(pointStaging, "label"))))),
-        binAndInsert(x, y, pointStaging, deepCopy = false)))
+      mb.voidWithBuilder { cb =>
+
+        def xx = x.asDouble.doubleCode(cb)
+
+        def yy = y.asDouble.doubleCode(cb)
+
+        cb.ifx((!(isFinite(xx) && isFinite(yy))), cb += Code._return[Unit](Code._empty))
+        cb.assign(pointStaging, storageType.loadField(off, "pointStaging"))
+        pointType.fieldType("x").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "x"), region, x, deepCopy = true)
+        pointType.fieldType("y").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "y"), region, y, deepCopy = true)
+        l.toI(cb)
+          .consume(cb,
+            cb += pointType.setFieldMissing(pointStaging, "label"),
+            { sc =>
+              cb += pointType.setFieldPresent(pointStaging, "label")
+              pointType.fieldType("label").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "label"), region, sc, deepCopy = true)
+            }
+          )
+        binAndInsert(cb, xx, yy, pointStaging, deepCopy = false)
+      }
     }
 
-    val lmField = kb.genFieldThisRef[Boolean]("lm_field")
-
-    Code(
-      lmField := lm,
-      mb.invokeCode(x, y, lmField, lmField.mux(0L, l))
-    )
+    x.toI(cb)
+      .consume(cb,
+        {
+          /* do nothing if x is missing */
+        },
+        { xcode =>
+          y.toI(cb)
+            .consume(cb,
+              {
+                /* do nothing if y is missing */
+              },
+              ycode => cb.invokeVoid(mb, xcode, ycode, l)
+            )
+        })
   }
 
-  def deepCopyAndInsertPoint(point: Code[Long]): Code[Unit] = {
+  def deepCopyAndInsertPoint(cb: EmitCodeBuilder, point: Code[Long]): Unit = {
     val name = "downsample_deep_copy_insert_point"
     val mb = kb.getOrGenEmitMethod(name, (this, name), IndexedSeq[ParamType](LongInfo), UnitInfo) { mb =>
       val point = mb.getCodeParam[Long](1)
@@ -470,14 +495,14 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
       val x = mb.newLocal[Double]("x")
       val y = mb.newLocal[Double]("y")
 
-      mb.emit(Code(
-        x := Region.loadDouble(pointType.loadField(point, "x")),
-        y := Region.loadDouble(pointType.loadField(point, "y")),
-        binAndInsert(x, y, point, deepCopy = true)
-      ))
+      mb.voidWithBuilder { cb =>
+        cb.assign(x, Region.loadDouble(pointType.loadField(point, "x")))
+        cb.assign(y, Region.loadDouble(pointType.loadField(point, "y")))
+        binAndInsert(cb, x, y, point, deepCopy = true)
+      }
     }
 
-    mb.invokeCode(point)
+    cb.invokeVoid(mb, point)
   }
 
   def merge(cb: EmitCodeBuilder, other: DownsampleState): Unit = {
@@ -487,45 +512,46 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: PArray, maxBufferS
     mb.emitWithBuilder { cb =>
       cb.assign(i, 0)
       cb.whileLoop(i < other.buffer.size, {
-        cb += deepCopyAndInsertPoint(other.buffer.loadElement(cb, i).value)
+        deepCopyAndInsertPoint(cb, other.buffer.loadElement(cb, i).value)
         cb.assign(i, i + 1)
       })
       other.tree.foreach(cb) { (cb, value) =>
-        cb += deepCopyAndInsertPoint(key.storageType.loadField(value, "point"))
+        deepCopyAndInsertPoint(cb, key.storageType.loadField(value, "point"))
       }
       Code._empty
     }
-    cb += mb.invokeCode()
+    cb.invokeVoid(mb)
   }
 
-  def result(mb: EmitMethodBuilder[_], srvb: StagedRegionValueBuilder, resultType: PArray): Code[Unit] = {
+  def result(cb: EmitCodeBuilder, srvb: StagedRegionValueBuilder, resultType: PArray): Unit = {
     val eltType = resultType.elementType.asInstanceOf[PBaseStruct]
-    Code(
-      dumpBuffer(),
-      srvb.addArray(resultType, { srvb => EmitCodeBuilder.scopedVoid(mb) { cb =>
-          cb += srvb.start(treeSize)
-          cb.ifx(treeSize > 0, {
-            tree.foreach(cb) { (cb, tv) =>
-              val point = mb.newLocal[Long]("point_offset")
-              cb += Code(
-                point := key.storageType.loadField(tv, "point"),
-                srvb.addBaseStruct(eltType, { srvb =>
-                  Code(
-                    srvb.start(),
-                    srvb.addDouble(Region.loadDouble(pointType.loadField(point, "x"))),
-                    srvb.advance(),
-                    srvb.addDouble(Region.loadDouble(pointType.loadField(point, "y"))),
-                    srvb.advance(),
-                    pointType.isFieldDefined(point, "label").mux(
-                      srvb.addWithDeepCopy(labelType, pointType.loadField(point, "label")),
-                      srvb.setMissing()
-                    )
+    dumpBuffer(cb)
+    cb += srvb.addArray(resultType, { srvb =>
+      EmitCodeBuilder.scopedVoid(cb.emb) { cb =>
+        cb += srvb.start(treeSize)
+        cb.ifx(treeSize > 0, {
+          tree.foreach(cb) { (cb, tv) =>
+            val point = cb.newLocal[Long]("point_offset")
+            cb += Code(
+              point := key.storageType.loadField(tv, "point"),
+              srvb.addBaseStruct(eltType, { srvb =>
+                Code(
+                  srvb.start(),
+                  srvb.addDouble(Region.loadDouble(pointType.loadField(point, "x"))),
+                  srvb.advance(),
+                  srvb.addDouble(Region.loadDouble(pointType.loadField(point, "y"))),
+                  srvb.advance(),
+                  pointType.isFieldDefined(point, "label").mux(
+                    srvb.addWithDeepCopy(labelPType, pointType.loadField(point, "label")),
+                    srvb.setMissing()
                   )
-                }),
-                srvb.advance())
-            }
-          })
-      }}))
+                )
+              }),
+              srvb.advance())
+          }
+        })
+      }
+    })
   }
 }
 
@@ -533,40 +559,31 @@ object DownsampleAggregator {
   val resultType: TArray = TArray(TTuple(TFloat64, TFloat64, TArray(TString)))
 }
 
-class DownsampleAggregator(arrayType: PArray) extends StagedAggregator {
+class DownsampleAggregator(arrayType: VirtualTypeWithReq) extends StagedAggregator {
   type State = DownsampleState
 
-  val resultType: PArray = PCanonicalArray(PCanonicalTuple(required = true, PFloat64(true), PFloat64(true), PType.canonical(arrayType)))
+  val resultType: PArray = PCanonicalArray(PCanonicalTuple(required = true, PFloat64(true), PFloat64(true), arrayType.canonicalPType))
 
-  val initOpTypes: Seq[PType] = Array(PInt32(true))
-  val seqOpTypes: Seq[PType] = Array(PFloat64(), PFloat64(), PType.canonical(arrayType))
+  val initOpTypes: Seq[Type] = Array(TInt32)
+  val seqOpTypes: Seq[Type] = Array(TFloat64, TFloat64, arrayType.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val Array(nDivisions) = init
-    cb += Code(
-      nDivisions.setup,
-      nDivisions.m.mux(
-        Code._fatal[Unit]("downsample: n_divisions may not be missing"),
-        state.init(coerce[Int](nDivisions.v))
+    nDivisions.toI(cb)
+      .consume(cb,
+        cb += Code._fatal[Unit]("downsample: n_divisions may not be missing"),
+        sc => state.init(cb, sc.asInt.intCode(cb))
       )
-    )
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(x, y, label) = seq
 
-    cb += Code(
-      x.setup,
-      y.setup,
-      label.setup,
-      (!(x.m || y.m)).orEmpty(
-        state.insert(coerce[Double](x.v), coerce[Double](y.v), label.m, coerce[Long](label.v))
-      )
-    )
+    state.insert(cb, x, y, label)
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.merge(cb, other)
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit =
-    cb += state.result(cb.emb, srvb, resultType)
+    state.result(cb, srvb, resultType)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -6,7 +6,7 @@ import is.hail.backend.HailTaskContext
 import is.hail.expr.ir
 import is.hail.expr.ir._
 import is.hail.io.BufferSpec
-import is.hail.types.TypeWithRequiredness
+import is.hail.types.{RField, RIterable, RPrimitive, RTuple, TypeWithRequiredness, VirtualTypeWithReq, virtual}
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -24,40 +24,40 @@ object AggStateSig {
     apply(op, inits, seqs)
   }
   def apply(op: AggOp, initOpArgs: Seq[(IR, TypeWithRequiredness)], seqOpArgs: Seq[(IR, TypeWithRequiredness)]): AggStateSig = {
-    val seqPTypes = seqOpArgs.map { case (a, r) => if (a.typ == TVoid) PVoid else r.canonicalPType(a.typ) }
+    val seqVTypes = seqOpArgs.map { case (a, r) => VirtualTypeWithReq(a.typ, r) }
     op match {
-      case Sum() | Product() => TypedStateSig(seqPTypes.head.setRequired(true))
-      case Min() | Max()  => TypedStateSig(seqPTypes.head.setRequired(false))
-      case Count() => TypedStateSig(PInt64(true))
-      case Take() => TakeStateSig(seqPTypes.head)
+      case Sum() | Product() => TypedStateSig(seqVTypes.head.setRequired(true))
+      case Min() | Max()  => TypedStateSig(seqVTypes.head.setRequired(false))
+      case Count() => TypedStateSig(VirtualTypeWithReq.fullyOptional(TInt64).setRequired(true))
+      case Take() => TakeStateSig(seqVTypes.head)
       case TakeBy(reverse) =>
-        val Seq(vt, kt) = seqPTypes
+        val Seq(vt, kt) = seqVTypes
         TakeByStateSig(vt, kt, reverse)
       case CallStats() => CallStatsStateSig()
-      case PrevNonnull() => TypedStateSig(seqPTypes.head.setRequired(false))
-      case CollectAsSet() => CollectAsSetStateSig(seqPTypes.head)
-      case Collect() => CollectStateSig(seqPTypes.head)
-      case LinearRegression() => TypedStateSig(LinearRegressionAggregator.stateType)
+      case PrevNonnull() => TypedStateSig(seqVTypes.head.setRequired(false))
+      case CollectAsSet() => CollectAsSetStateSig(seqVTypes.head)
+      case Collect() => CollectStateSig(seqVTypes.head)
+      case LinearRegression() => LinearRegressionStateSig()
       case ApproxCDF() => ApproxCDFStateSig()
       case Downsample() =>
-        val Seq(_, _, labelType: PArray) = seqPTypes
+        val Seq(_, _, labelType) = seqVTypes
         DownsampleStateSig(labelType)
       case ImputeType() => ImputeTypeStateSig()
-      case NDArraySum() => TypedStateSig(PCanonicalTuple(true, seqPTypes(0).setRequired(false)))
+      case NDArraySum() => NDArraySumStateSig(seqVTypes.head.setRequired(false)) // set required to false to handle empty aggs
       case _ => throw new UnsupportedExtraction(op.toString)
     }
   }
   def grouped(k: IR, aggs: Seq[AggStateSig], r: RequirednessAnalysis): GroupedStateSig =
-    GroupedStateSig(r(k).canonicalPType(k.typ), aggs)
+    GroupedStateSig(VirtualTypeWithReq(k.typ, r(k)), aggs)
   def arrayelements(aggs: Seq[AggStateSig]): ArrayAggStateSig =
     ArrayAggStateSig(aggs)
 
   def getState(sig: AggStateSig, cb: EmitClassBuilder[_]): AggregatorState = sig match {
-    case TypedStateSig(pt) if pt.isPrimitive => new PrimitiveRVAState(Array(pt), cb)
-    case TypedStateSig(pt) => new TypedRegionBackedAggState(pt, cb)
+    case TypedStateSig(vt) if vt.t.isPrimitive => new PrimitiveRVAState(Array(vt), cb)
+    case TypedStateSig(vt) => new TypedRegionBackedAggState(vt, cb)
     case DownsampleStateSig(labelType) => new DownsampleState(cb, labelType)
-    case TakeStateSig(pt) => new TakeRVAS(pt, PCanonicalArray(pt, required = true), cb)
-    case TakeByStateSig(vt, kt, so) => new TakeByRVAS(vt, kt, PCanonicalArray(vt, required = true), cb, so)
+    case TakeStateSig(vt) => new TakeRVAS(vt, cb)
+    case TakeByStateSig(vt, kt, so) => new TakeByRVAS(vt, kt, cb, so)
     case CollectStateSig(pt) => new CollectAggState(pt, cb)
     case CollectAsSetStateSig(pt) => new AppendOnlySetState(cb, pt)
     case CallStatsStateSig() => new CallStatsState(cb)
@@ -65,21 +65,27 @@ object AggStateSig {
     case ImputeTypeStateSig() => new ImputeTypeState(cb)
     case ArrayAggStateSig(nested) => new ArrayElementState(cb, StateTuple(nested.map(sig => AggStateSig.getState(sig, cb)).toArray))
     case GroupedStateSig(kt, nested) => new DictState(cb, kt, StateTuple(nested.map(sig => AggStateSig.getState(sig, cb)).toArray))
+    case NDArraySumStateSig(nda) => new TypedRegionBackedAggState(nda, cb)
+    case LinearRegressionStateSig() => new LinearRegressionAggregatorState(cb)
   }
 }
 
-sealed abstract class AggStateSig(val t: Seq[PType], val n: Option[Seq[AggStateSig]])
-case class TypedStateSig(pt: PType) extends AggStateSig(Array(pt), None)
-case class DownsampleStateSig(labelType: PArray) extends AggStateSig(Array(labelType), None)
-case class TakeStateSig(pt: PType) extends AggStateSig(Array(pt), None)
-case class TakeByStateSig(vt: PType, kt: PType, so: SortOrder) extends AggStateSig(Array(vt, kt), None)
-case class CollectStateSig(pt: PType) extends AggStateSig(Array(pt), None)
-case class CollectAsSetStateSig(pt: PType) extends AggStateSig(Array(pt), None)
-case class CallStatsStateSig() extends AggStateSig(Array[PType](), None)
-case class ImputeTypeStateSig() extends AggStateSig(Array[PType](), None)
-case class ArrayAggStateSig(nested: Seq[AggStateSig]) extends AggStateSig(Array[PType](), Some(nested))
-case class GroupedStateSig(kt: PType, nested: Seq[AggStateSig]) extends AggStateSig(Array(kt), Some(nested))
-case class ApproxCDFStateSig() extends AggStateSig(Array[PType](), None)
+sealed abstract class AggStateSig(val t: Seq[VirtualTypeWithReq], val n: Option[Seq[AggStateSig]])
+case class TypedStateSig(pt: VirtualTypeWithReq) extends AggStateSig(Array(pt), None)
+case class DownsampleStateSig(labelType: VirtualTypeWithReq) extends AggStateSig(Array(labelType), None)
+case class TakeStateSig(pt: VirtualTypeWithReq) extends AggStateSig(Array(pt), None)
+case class TakeByStateSig(vt: VirtualTypeWithReq, kt: VirtualTypeWithReq, so: SortOrder) extends AggStateSig(Array(vt, kt), None)
+case class CollectStateSig(pt: VirtualTypeWithReq) extends AggStateSig(Array(pt), None)
+case class CollectAsSetStateSig(pt: VirtualTypeWithReq) extends AggStateSig(Array(pt), None)
+case class CallStatsStateSig() extends AggStateSig(Array[VirtualTypeWithReq](), None)
+case class ImputeTypeStateSig() extends AggStateSig(Array[VirtualTypeWithReq](), None)
+case class ArrayAggStateSig(nested: Seq[AggStateSig]) extends AggStateSig(Array[VirtualTypeWithReq](), Some(nested))
+case class GroupedStateSig(kt: VirtualTypeWithReq, nested: Seq[AggStateSig]) extends AggStateSig(Array(kt), Some(nested))
+case class ApproxCDFStateSig() extends AggStateSig(Array[VirtualTypeWithReq](), None)
+case class LinearRegressionStateSig() extends AggStateSig(Array[VirtualTypeWithReq](), None)
+case class NDArraySumStateSig(nda: VirtualTypeWithReq) extends AggStateSig(Array[VirtualTypeWithReq](nda), None) {
+  require(!nda.r.required)
+}
 
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
@@ -88,15 +94,15 @@ object PhysicalAggSig {
 
 class PhysicalAggSig(val op: AggOp, val state: AggStateSig, val nestedOps: Array[AggOp]) {
   val allOps: Array[AggOp] = nestedOps :+ op
-  def initOpTypes: IndexedSeq[Type] = Extract.getAgg(this).initOpTypes.map(_.virtualType).toFastIndexedSeq
-  def seqOpTypes: IndexedSeq[Type] = Extract.getAgg(this).seqOpTypes.map(_.virtualType).toFastIndexedSeq
+  def initOpTypes: IndexedSeq[Type] = Extract.getAgg(this).initOpTypes.toFastIndexedSeq
+  def seqOpTypes: IndexedSeq[Type] = Extract.getAgg(this).seqOpTypes.toFastIndexedSeq
   def pResultType: PType = Extract.getAgg(this).resultType
   def resultType: Type = pResultType.virtualType
 }
 
 case class BasicPhysicalAggSig(override val op: AggOp, override val state: AggStateSig) extends PhysicalAggSig(op, state, Array())
 
-case class GroupedAggSig(kt: PType, nested: Seq[PhysicalAggSig]) extends
+case class GroupedAggSig(kt: VirtualTypeWithReq, nested: Seq[PhysicalAggSig]) extends
   PhysicalAggSig(Group(), GroupedStateSig(kt, nested.map(_.state)), nested.flatMap(sig => sig.allOps).toArray)
 case class AggElementsAggSig(nested: Seq[PhysicalAggSig]) extends
   PhysicalAggSig(AggElements(), ArrayAggStateSig(nested.map(_.state)), nested.flatMap(sig => sig.allOps).toArray)
@@ -293,30 +299,29 @@ object Extract {
     case _ => throw new UnsupportedExtraction(aggSig.toString)  }
 
   def getAgg(sig: PhysicalAggSig): StagedAggregator = sig match {
-    case PhysicalAggSig(Sum(), TypedStateSig(t)) => new SumAggregator(t)
-    case PhysicalAggSig(Product(), TypedStateSig(t)) => new ProductAggregator(t)
-    case PhysicalAggSig(Min(), TypedStateSig(t)) => new MinAggregator(t)
-    case PhysicalAggSig(Max(), TypedStateSig(t)) => new MaxAggregator(t)
+    case PhysicalAggSig(Sum(), TypedStateSig(t)) => new SumAggregator(t.t)
+    case PhysicalAggSig(Product(), TypedStateSig(t)) => new ProductAggregator(t.t)
+    case PhysicalAggSig(Min(), TypedStateSig(t)) => new MinAggregator(t.t)
+    case PhysicalAggSig(Max(), TypedStateSig(t)) => new MaxAggregator(t.t)
     case PhysicalAggSig(PrevNonnull(), TypedStateSig(t)) => new PrevNonNullAggregator(t)
     case PhysicalAggSig(Count(), TypedStateSig(_)) => CountAggregator
     case PhysicalAggSig(Take(), TakeStateSig(t)) => new TakeAggregator(t)
     case PhysicalAggSig(TakeBy(_), TakeByStateSig(v, k, _)) => new TakeByAggregator(v, k)
-    case PhysicalAggSig(CallStats(), CallStatsStateSig()) => new CallStatsAggregator(PCanonicalCall()) // FIXME CallStatsAggregator shouldn't take type
+    case PhysicalAggSig(CallStats(), CallStatsStateSig()) => new CallStatsAggregator()
     case PhysicalAggSig(Collect(), CollectStateSig(t)) => new CollectAggregator(t)
     case PhysicalAggSig(CollectAsSet(), CollectAsSetStateSig(t)) => new CollectAsSetAggregator(t)
-    case PhysicalAggSig(LinearRegression(), TypedStateSig(_)) => new LinearRegressionAggregator(PFloat64(), PCanonicalArray(PFloat64())) // FIXME LinRegAggregator shouldn't take type
+    case PhysicalAggSig(LinearRegression(), LinearRegressionStateSig()) => new LinearRegressionAggregator()
     case PhysicalAggSig(ApproxCDF(), ApproxCDFStateSig()) => new ApproxCDFAggregator
     case PhysicalAggSig(Downsample(), DownsampleStateSig(labelType)) => new DownsampleAggregator(labelType)
-    case PhysicalAggSig(ImputeType(), ImputeTypeStateSig()) => new ImputeTypeAggregator(PCanonicalString())
+    case PhysicalAggSig(ImputeType(), ImputeTypeStateSig()) => new ImputeTypeAggregator()
     case ArrayLenAggSig(knownLength, nested) => //FIXME nested things shouldn't need to know state
       new ArrayElementLengthCheckAggregator(nested.map(getAgg).toArray, knownLength)
     case AggElementsAggSig(nested) =>
       new ArrayElementwiseOpAggregator(nested.map(getAgg).toArray)
     case GroupedAggSig(k, nested) =>
       new GroupedAggregator(k, nested.map(getAgg).toArray)
-    case PhysicalAggSig(NDArraySum(), TypedStateSig(pt: PTuple)) =>{
-      new NDArraySumAggregator(pt.types(0).asInstanceOf[PNDArray])
-    }
+    case PhysicalAggSig(NDArraySum(), NDArraySumStateSig(nda)) =>
+      new NDArraySumAggregator(nda)
   }
 
   def apply(ir: IR, resultName: String, r: RequirednessAnalysis, isScan: Boolean = false): Aggs = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -86,17 +86,15 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
     container.store(cb)
   }
 
-  def compKeys(cb: EmitCodeBuilder, k1c: EmitCode, k2c: EmitCode): Code[Int] = {
-    val k1 = cb.memoize(k1c, "k1c")
-    val k2 = cb.memoize(k2c, "k2c")
-
+  def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {
+    cb += k1.setup
+    cb += k2.setup
     val kcomp = kb.getCodeOrdering(k1.pt, k2.pt, CodeOrdering.Compare(), ignoreMissingness = false)
     kcomp(k1.m -> k1.v, k2.m -> k2.v)
   }
 
   def loadCompKey(cb: EmitCodeBuilder, off: Value[Long]): EmitCode = {
-    val off_ = cb.newLocal[Long]("off", off)
-    EmitCode(Code._empty, isKeyMissing(off), compType.loadCheapPCode(cb, storageType.loadField(off_, 0)))
+    EmitCode(Code._empty, isKeyMissing(off), compType.loadCheapPCode(cb, storageType.loadField(off, 0)))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -48,8 +48,7 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
         {
           cb += storageType.setFieldMissing(dest, 0)
         },
-        { ssc =>
-          val sc = ssc.memoize(cb, "s")
+        { sc =>
           cb += storageType.setFieldPresent(dest, 0)
           storageType.fieldType("kt")
             .storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -3,7 +3,9 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
+import is.hail.types.{RPrimitive, VirtualTypeWithReq}
 import is.hail.types.physical._
+import is.hail.types.virtual.{TInt32, TString, Type}
 import is.hail.utils._
 
 import scala.language.existentials
@@ -48,7 +50,7 @@ object ImputeTypeState {
 
 }
 
-class ImputeTypeState(kb: EmitClassBuilder[_]) extends PrimitiveRVAState(Array(PInt32Required), kb) {
+class ImputeTypeState(kb: EmitClassBuilder[_]) extends PrimitiveRVAState(Array(VirtualTypeWithReq(TInt32,RPrimitive()).setRequired(true)), kb) {
 
   private val repr = fields(0)._2.asInstanceOf[Settable[Int]]
 
@@ -118,10 +120,10 @@ class ImputeTypeState(kb: EmitClassBuilder[_]) extends PrimitiveRVAState(Array(P
   }
 }
 
-class ImputeTypeAggregator(st: PType) extends StagedAggregator {
+class ImputeTypeAggregator() extends StagedAggregator {
 
-  val initOpTypes: Seq[PType] = FastSeq()
-  val seqOpTypes: Seq[PType] = FastSeq(st)
+  val initOpTypes: Seq[Type] = FastSeq()
+  val seqOpTypes: Seq[Type] = FastSeq(TString)
 
   type State = ImputeTypeState
 
@@ -134,7 +136,6 @@ class ImputeTypeAggregator(st: PType) extends StagedAggregator {
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(s) = seq
-    assert(s.pt == st)
 
     state.seqOp(cb, s)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -4,8 +4,15 @@ import breeze.linalg.{DenseMatrix, DenseVector, diag, inv}
 import is.hail.annotations.{Region, RegionValueBuilder, StagedRegionValueBuilder, UnsafeRow}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
+import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 import is.hail.utils.FastIndexedSeq
+
+class LinearRegressionAggregatorState(val kb: EmitClassBuilder[_]) extends AbstractTypedRegionBackedAggState(LinearRegressionAggregator.stateType)
 
 object LinearRegressionAggregator {
 
@@ -80,106 +87,111 @@ object LinearRegressionAggregator {
   }
 }
 
-class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends StagedAggregator {
-
+class LinearRegressionAggregator() extends StagedAggregator {
   import LinearRegressionAggregator._
 
-  type State = TypedRegionBackedAggState
+  type State = AbstractTypedRegionBackedAggState
 
   override def resultType: PType = LinearRegressionAggregator.resultType
-  val initOpTypes: Seq[PType] = Array(PInt32(true), PInt32(true))
-  val seqOpTypes: Seq[PType] = Array(yt, xt)
+  val initOpTypes: Seq[Type] = Array(TInt32, TInt32)
+  val seqOpTypes: Seq[Type] = Array(TFloat64, TArray(TFloat64))
 
-  def initOpF(state: State)(mb: EmitMethodBuilder[_], k: Code[Int], k0: Code[Int]): Code[Unit] =
-    Code.memoize(k, "lra_init_k", k0, "lra_init_k0") { (k, k0) =>
-      Code(
-        (k0 < 0 | k0 > k).mux(
-          Code._fatal[Unit](const("linreg: `nested_dim` must be between 0 and the number (")
-            .concat(k.toS)
-            .concat(") of covariates, inclusive")),
-          Code._empty),
-        state.off := stateType.allocate(state.region),
-        Region.storeAddress(
-          stateType.fieldOffset(state.off, 0),
-          vector.zeroes(mb, state.region, k)),
-        Region.storeAddress(
-          stateType.fieldOffset(state.off, 1),
-          vector.zeroes(mb, state.region, k * k)),
-        Region.storeInt(
-          stateType.loadField(state.off, 2),
-          k0))
-    }
+  def initOpF(state: State)(cb: EmitCodeBuilder, kc: Code[Int], k0c: Code[Int]): Unit = {
+    val k = cb.newLocal[Int]("lra_init_k", kc)
+    val k0 = cb.newLocal[Int]("lra_init_k0", k0c)
+    cb.ifx((k0 < 0) || (k0 > k),
+      cb += Code._fatal[Unit](const("linreg: `nested_dim` must be between 0 and the number (")
+        .concat(k.toS)
+        .concat(") of covariates, inclusive"))
+    )
+    cb.assign(state.off, stateType.allocate(state.region))
+    cb += Region.storeAddress(stateType.fieldOffset(state.off, 0), vector.zeroes(cb.emb, state.region, k))
+    cb +=  Region.storeAddress(stateType.fieldOffset(state.off, 1), vector.zeroes(cb.emb, state.region, k * k))
+    cb += Region.storeInt(stateType.loadField(state.off, 2), k0)
+  }
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val Array(kt, k0t) = init
-    cb += (Code(kt.setup, kt.m) || Code(k0t.setup, k0t.m)).mux(
-      Code._fatal[Unit]("linreg: init args may not be missing"),
-      initOpF(state)(cb.emb, coerce[Int](kt.v), coerce[Int](k0t.v)))
+    kt.toI(cb)
+        .consume(cb,
+        { cb += Code._fatal[Unit]("linreg: init args may not be missing") },
+        { ktCode =>
+          k0t.toI(cb)
+            .consume(cb,
+              { cb += Code._fatal[Unit]("linreg: init args may not be missing") },
+              k0tCode => initOpF(state)(cb, ktCode.asInt.intCode(cb), k0tCode.asInt.intCode(cb))
+            )
+        })
   }
 
-  def seqOpF(state: State)(mb: EmitMethodBuilder[_], y: Code[Double], x: Code[Long]): Code[Unit] = {
-    val k = mb.newLocal[Int]()
-    val i = mb.newLocal[Int]()
-    val j = mb.newLocal[Int]()
-    val sptr = mb.newLocal[Long]()
-    val xptr = mb.newLocal[Long]()
-    val xptr2 = mb.newLocal[Long]()
-    val xty = mb.newLocal[Long]()
-    val xtx = mb.newLocal[Long]()
+  def seqOpF(state: State)(cb: EmitCodeBuilder, y: Code[Double], xc: SCode): Unit = {
+    val k = cb.newLocal[Int]("linreg_agg_seqop_k")
+    val i = cb.newLocal[Int]("linreg_agg_seqop_i")
+    val j = cb.newLocal[Int]("linreg_agg_seqop_j")
+    val sptr = cb.newLocal[Long]("linreg_agg_seqop_sptr")
+    val xty = cb.newLocal[Long]("linreg_agg_seqop_xty")
+    val xtx = cb.newLocal[Long]("linreg_agg_seqop_xtx")
 
-    Code.memoize(x, "lra_seqop_x") { x =>
-      val body = Code(FastIndexedSeq(
-        xty := stateType.loadField(state.off, 0),
-        xtx := stateType.loadField(state.off, 1),
-        sptr := vector.firstElementOffset(xty, k),
-        xptr := xt.firstElementOffset(x, k),
-        k := vector.loadLength(xty),
-        i := 0,
-        Code.whileLoop(i < k, Code(
-          Region.storeDouble(sptr, Region.loadDouble(sptr)
-            + (Region.loadDouble(xptr) * y)),
-          i := i + 1,
-          sptr := sptr + scalar.byteSize,
-          xptr := xptr + scalar.byteSize
-        )),
+    val x = xc.memoize(cb, "lra_seqop_x").asInstanceOf[SIndexableValue]
 
-        i := 0,
-        sptr := vector.firstElementOffset(xtx),
-        xptr := xt.firstElementOffset(x, k),
-        Code.whileLoop(i < k, Code(
-          j := 0,
-          xptr2 := xt.firstElementOffset(x, k),
-          Code.whileLoop(j < k, Code(
-            Region.storeDouble(sptr, Region.loadDouble(sptr)
-              + (Region.loadDouble(xptr) * Region.loadDouble(xptr2))),
-            j += 1,
-            sptr := sptr + scalar.byteSize,
-            xptr2 := xptr2 + xt.elementByteSize)),
-          i += 1,
-          xptr := xptr + scalar.byteSize))))
+    cb.ifx(!x.hasMissingValues(cb),
+      {
+        cb.assign(xty, stateType.loadField(state.off, 0))
+        cb.assign(xtx, stateType.loadField(state.off, 1))
+        cb.assign(k, vector.loadLength(xty))
+        cb.assign(sptr, vector.firstElementOffset(xty, k))
+        cb.assign(i, 0)
+        cb.whileLoop(i < k,
+        {
+          cb += Region.storeDouble(sptr, Region.loadDouble(sptr) + x.loadElement(cb, i).get(cb).asDouble.doubleCode(cb) * y)
+          cb.assign(i, i + 1)
+          cb.assign(sptr, sptr + scalar.byteSize)
+        })
 
-      xt.hasMissingValues(x).mux(Code._empty, body)
-    }
+        cb.assign(i, 0)
+        cb.assign(sptr, vector.firstElementOffset(xtx, k))
+
+        cb.whileLoop(i < k,
+        {
+          cb.assign(j, 0)
+          cb.whileLoop(j < k,
+          {
+            // add x[i] * x[j] to the value at sptr
+            cb += Region.storeDouble(sptr, Region.loadDouble(sptr) +
+              (x.loadElement(cb, i).get(cb).asDouble.doubleCode(cb) * x.loadElement(cb, j).get(cb).asDouble.doubleCode(cb)))
+            cb.assign(j, j + 1)
+            cb.assign(sptr, sptr + scalar.byteSize)
+          })
+          cb.assign(i, i + 1)
+        })
+      })
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(y, x) = seq
-    cb += (Code(y.setup, y.m) || Code(x.setup, x.m)).mux(
-      Code._empty,
-      seqOpF(state)(cb.emb, coerce[Double](y.v), coerce[Long](x.v)))
+    y.toI(cb)
+        .consume(cb,
+        {},
+        { yCode =>
+          x.toI(cb)
+            .consume(cb,
+              {},
+              xCode => seqOpF(state)(cb, yCode.asDouble.doubleCode(cb), xCode)
+            )
+        })
   }
 
-  def combOpF(state: State, other: State)(mb: EmitMethodBuilder[_]): Code[Unit] = {
-    val n = mb.newLocal[Int]()
-    val i = mb.newLocal[Int]()
-    val sptr = mb.newLocal[Long]()
-    val optr = mb.newLocal[Long]()
-    val xty = mb.newLocal[Long]()
-    val xtx = mb.newLocal[Long]()
-    val oxty = mb.newLocal[Long]()
-    val oxtx = mb.newLocal[Long]()
+  def combOpF(state: State, other: State)(cb: EmitCodeBuilder): Unit = {
+    val n = cb.newLocal[Int]("n")
+    val i = cb.newLocal[Int]("i")
+    val sptr = cb.newLocal[Long]("sptr")
+    val optr = cb.newLocal[Long]("optr")
+    val xty = cb.newLocal[Long]("xty")
+    val xtx = cb.newLocal[Long]("xtx")
+    val oxty = cb.newLocal[Long]("oxty")
+    val oxtx = cb.newLocal[Long]("oxtx")
 
-    Code(FastIndexedSeq(
+    cb += Code(FastIndexedSeq(
       xty := stateType.loadField(state.off, 0),
       xtx := stateType.loadField(state.off, 1),
       oxty := stateType.loadField(other.off, 0),
@@ -206,7 +218,7 @@ class LinearRegressionAggregator(yt: PFloat64, xt: PCanonicalArray) extends Stag
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
-    cb += combOpF(state, other)(cb.emb)
+    combOpF(state, other)(cb)
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -51,15 +51,12 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     cb.ifx(eltm,
       {},
       cb.assign(eltv, elt.value))
-//    println("seqop")
     combine(cb, mOpt, v, Some(eltm), eltv)
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
     val (m1, v1, _) = state.fields(0)
     val (m2, v2, _) = other.fields(0)
-//    println("comb op")
-//    cb += Code._printlns(const("in combop, v1="), v1.load().asInstanceOf[Code[Long]].toS, ", v2=", v2.load().asInstanceOf[Code[Long]].toS)
     combine(cb, m1, v1, m2.map(_.load), v2.load)
   }
 
@@ -85,8 +82,6 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     val ti = typeToTypeInfo(typ)
     ti match {
       case ti: TypeInfo[t] =>
-//        println(s"$monoid, $m1Opt, $m2Opt")
-//        cb += Code._println(const("before monoid combine, value is ").concat(v1.load().asInstanceOf[Code[Double]].toS))
         (m1Opt, m2Opt) match {
           case (None, None) =>
             cb.assignAny(v1, monoid(v1, v2))
@@ -118,7 +113,6 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
               })
         }
     }
-//    cb += Code._println(const("after monoid combine, value is ").concat(v1.load().asInstanceOf[Code[Long]].toS))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -4,31 +4,41 @@ import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
 import is.hail.expr.ir.{coerce => _, _}
 import is.hail.expr.ir.functions.UtilFunctions
-import is.hail.types.physical.{PInt32, PInt64, PFloat32, PFloat64, PType, typeToTypeInfo}
+import is.hail.types.physical.{PFloat32, PFloat64, PInt32, PInt64, PType, typeToTypeInfo}
+import is.hail.types.virtual.{TFloat32, TFloat64, TInt32, TInt64, Type}
 
 import scala.language.existentials
 import scala.reflect.ClassTag
 
 trait StagedMonoidSpec {
-  val typ: PType
+  val typ: Type
+
   def neutral: Option[Code[_]]
+
   def apply(v1: Code[_], v2: Code[_]): Code[_]
 }
 
 class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
   type State = PrimitiveRVAState
-  val typ: PType = monoid.typ
-  val resultType: PType = typ.setRequired(monoid.neutral.isDefined)
-  val initOpTypes: Seq[PType] = Array[PType]()
-  val seqOpTypes: Seq[PType] = Array[PType](typ)
+  val typ: PType = PType.canonical(monoid.typ, required = monoid.neutral.isDefined)
+
+  def resultType: PType = typ
+
+  val initOpTypes: Seq[Type] = Array[Type]()
+  val seqOpTypes: Seq[Type] = Array[Type](monoid.typ)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
+    val stateRequired = state.vtypes.head.r.required
     val (mOpt, v, _) = state.fields(0)
-    cb += { (mOpt, monoid.neutral) match {
-      case (Some(m), _)  => m.store(true)
-      case (_, Some(v0)) => v.storeAny(v0)
-    }}
+    (mOpt, monoid.neutral) match {
+      case (Some(m), _) =>
+        assert(!stateRequired, s"monoid=$monoid, stateRequired=$stateRequired")
+        cb.assign(m, true)
+      case (_, Some(v0)) =>
+        assert(stateRequired, s"monoid=$monoid, stateRequired=$stateRequired")
+        cb.assignAny(v, v0)
+    }
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
@@ -36,114 +46,135 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     val (mOpt, v, _) = state.fields(0)
     val eltm = state.kb.genFieldThisRef[Boolean]()
     val eltv = state.kb.genFieldThisRef()(typeToTypeInfo(typ))
-    cb += Code(elt.setup,
-      eltm := elt.m,
-      eltm.mux(Code._empty, eltv := elt.value),
-      combine(mOpt, v, Some(eltm), eltv)
-    )
+    cb += elt.setup
+    cb.assign(eltm, elt.m)
+    cb.ifx(eltm,
+      {},
+      cb.assign(eltv, elt.value))
+//    println("seqop")
+    combine(cb, mOpt, v, Some(eltm), eltv)
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
     val (m1, v1, _) = state.fields(0)
     val (m2, v2, _) = other.fields(0)
-    cb += combine(m1, v1, m2.map(_.load), v2.load)
+//    println("comb op")
+//    cb += Code._printlns(const("in combop, v1="), v1.load().asInstanceOf[Code[Long]].toS, ", v2=", v2.load().asInstanceOf[Code[Long]].toS)
+    combine(cb, m1, v1, m2.map(_.load), v2.load)
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
     val (mOpt, v, _) = state.fields(0)
-    cb += { mOpt match {
-      case None => srvb.addIRIntermediate(typ)(v)
+    mOpt match {
+      case None =>
+        cb += srvb.addIRIntermediate(typ)(v)
       case Some(m) =>
-        m.mux(
-          srvb.setMissing(),
-          srvb.addIRIntermediate(typ)(v))
-    }}
+        cb.ifx(m,
+          cb += srvb.setMissing(),
+          cb += srvb.addIRIntermediate(typ)(v))
+    }
   }
 
   private def combine(
+    cb: EmitCodeBuilder,
     m1Opt: Option[Settable[Boolean]],
     v1: Settable[_],
     m2Opt: Option[Code[Boolean]],
     v2: Code[_]
-  ): Code[Unit] = {
-    val ti = typeToTypeInfo(monoid.typ)
+  ): Unit = {
+    val ti = typeToTypeInfo(typ)
     ti match {
       case ti: TypeInfo[t] =>
+//        println(s"$monoid, $m1Opt, $m2Opt")
+//        cb += Code._println(const("before monoid combine, value is ").concat(v1.load().asInstanceOf[Code[Double]].toS))
         (m1Opt, m2Opt) match {
           case (None, None) =>
-            v1.storeAny(monoid(v1, v2))
+            cb.assignAny(v1, monoid(v1, v2))
           case (None, Some(m2)) =>
             // only update if the element is not missing
-            m2.mux(Code._empty, v1.storeAny(monoid(v1, v2)))
+            cb.ifx(!m2, cb.assignAny(v1, monoid(v1, v2)))
           case (Some(m1), None) =>
-            Code.memoize(coerce[t](v2), "mon_agg_combine_v2") { v2 =>
-              m1.mux(
-                Code(m1.store(false), v1.storeAny(v2)),
-                v1.storeAny(monoid(v1, v2)))
-            }(ti)
+            val v2var = cb.newLocalAny("mon_agg_combine_v2", v2)(ti)
+            cb.ifx(m1,
+              {
+                cb.assign(m1, false)
+                cb.assignAny(v1, v2var)
+              },
+              {
+                cb.assignAny(v1, monoid(v1, v2))
+              })
           case (Some(m1), Some(m2)) =>
-            Code.memoize(m2, "mon_agg_combine_m2", coerce[t](v2), "mon_agg_combine_v2") { (m2, v2) =>
-              m1.mux(
-                // if the current state is missing, then just copy the other
-                // element + its missingness
-                Code(m1.store(m2), v1.storeAny(v2)),
-                m2.mux(Code._empty, v1.storeAny(monoid(v1, v2))))
-            }(BooleanInfo, ti)
+            val m2var = cb.newLocal[Boolean]("mon_agg_combine_m2", m2)
+            val v2var = cb.newLocalAny("mon_agg_combine_v2", v2)(ti)
+            cb.ifx(m1,
+              {
+                cb.assign(m1, m2var)
+                cb.assignAny(v1, v2var)
+              },
+              {
+                cb.ifx(m2var,
+                  {},
+                  cb.assignAny(v1, monoid(v1, v2var)))
+              })
         }
     }
+//    cb += Code._println(const("after monoid combine, value is ").concat(v1.load().asInstanceOf[Code[Long]].toS))
   }
 }
 
-class ComparisonMonoid(val typ: PType, val functionName: String) extends StagedMonoidSpec {
+class ComparisonMonoid(val typ: Type, val functionName: String) extends StagedMonoidSpec {
 
   def neutral: Option[Code[_]] = None
 
   private def cmp[T](v1: Code[T], v2: Code[T])(implicit tct: ClassTag[T]): Code[T] =
-    Code.invokeStatic2[Math,T,T,T](functionName, v1, v2)
+    Code.invokeStatic2[Math, T, T, T](functionName, v1, v2)
 
   private def nancmp[T](v1: Code[T], v2: Code[T])(implicit tct: ClassTag[T]): Code[T] =
-    Code.invokeScalaObject2[T,T,T](UtilFunctions.getClass, "nan" + functionName, v1, v2)
+    Code.invokeScalaObject2[T, T, T](UtilFunctions.getClass, "nan" + functionName, v1, v2)
 
   def apply(v1: Code[_], v2: Code[_]): Code[_] = typ match {
-    case _: PInt32 => cmp[Int](coerce(v1), coerce(v2))
-    case _: PInt64 => cmp[Long](coerce(v1), coerce(v2))
-    case _: PFloat32 => nancmp[Float](coerce(v1), coerce(v2))
-    case _: PFloat64 => nancmp[Double](coerce(v1), coerce(v2))
+    case TInt32 => cmp[Int](coerce(v1), coerce(v2))
+    case TInt64 => cmp[Long](coerce(v1), coerce(v2))
+    case TFloat32 => nancmp[Float](coerce(v1), coerce(v2))
+    case TFloat64 => nancmp[Double](coerce(v1), coerce(v2))
     case _ => throw new UnsupportedOperationException(s"can't $functionName over type $typ")
   }
 }
 
-class SumMonoid(val typ: PType) extends StagedMonoidSpec {
+class SumMonoid(val typ: Type) extends StagedMonoidSpec {
 
   def neutral: Option[Code[_]] = Some(typ match {
-    case _: PInt64 => const(0L)
-    case _: PFloat64 => const(0.0d)
+    case TInt64 => const(0L)
+    case TFloat64 => const(0.0d)
     case _ => throw new UnsupportedOperationException(s"can't sum over type $typ")
   })
 
   def apply(v1: Code[_], v2: Code[_]): Code[_] = typ match {
-    case _: PInt64 => coerce[Long](v1) + coerce[Long](v2)
-    case _: PFloat64 => coerce[Double](v1) + coerce[Double](v2)
+    case TInt64 => coerce[Long](v1) + coerce[Long](v2)
+    case TFloat64 => coerce[Double](v1) + coerce[Double](v2)
     case _ => throw new UnsupportedOperationException(s"can't sum over type $typ")
   }
 }
 
-class ProductMonoid(val typ: PType) extends StagedMonoidSpec {
+class ProductMonoid(val typ: Type) extends StagedMonoidSpec {
 
   def neutral: Option[Code[_]] = Some(typ match {
-    case _: PInt64 => const(1L)
-    case _: PFloat64 => const(1.0d)
+    case TInt64 => const(1L)
+    case TFloat64 => const(1.0d)
     case _ => throw new UnsupportedOperationException(s"can't product over type $typ")
   })
 
   def apply(v1: Code[_], v2: Code[_]): Code[_] = typ match {
-    case _: PInt64 => coerce[Long](v1) * coerce[Long](v2)
-    case _: PFloat64 => coerce[Double](v1) * coerce[Double](v2)
+    case TInt64 => coerce[Long](v1) * coerce[Long](v2)
+    case TFloat64 => coerce[Double](v1) * coerce[Double](v2)
     case _ => throw new UnsupportedOperationException(s"can't product over type $typ")
   }
 }
 
-class MinAggregator(typ: PType) extends MonoidAggregator(new ComparisonMonoid(typ, "min"))
-class MaxAggregator(typ: PType) extends MonoidAggregator(new ComparisonMonoid(typ, "max"))
-class SumAggregator(typ: PType) extends MonoidAggregator(new SumMonoid(typ))
-class ProductAggregator(typ: PType) extends MonoidAggregator(new ProductMonoid(typ))
+class MinAggregator(typ: Type) extends MonoidAggregator(new ComparisonMonoid(typ, "min"))
+
+class MaxAggregator(typ: Type) extends MonoidAggregator(new ComparisonMonoid(typ, "max"))
+
+class SumAggregator(typ: Type) extends MonoidAggregator(new SumMonoid(typ))
+
+class ProductAggregator(typ: Type) extends MonoidAggregator(new ProductMonoid(typ))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -3,26 +3,28 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, coerce}
-import is.hail.types.physical.{PCanonicalTuple, PNDArray, PNDArrayCode, PNDArrayValue, PNumeric, PType}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical.{PCanonicalNDArray, PNDArrayCode, PNDArrayValue, PNumeric, PType}
+import is.hail.types.virtual.Type
 import is.hail.utils._
 
-class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
+class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator {
+  private val ndTyp = ndVTyp.canonicalPType.setRequired(false).asInstanceOf[PCanonicalNDArray]
+
   override type State = TypedRegionBackedAggState
 
   override def resultType: PType = ndTyp
 
-  val stateType = PCanonicalTuple(true, ndTyp)
+  override def initOpTypes: Seq[Type] = Array[Type]()
 
-  override def initOpTypes: Seq[PType] = Array[PType]()
-
-  override def seqOpTypes: Seq[PType] = Array(ndTyp)
+  override def seqOpTypes: Seq[Type] = Array(ndVTyp.t)
 
   val ndarrayFieldNumber = 0
 
   override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val initMethod = cb.emb.genEmitMethod[Unit]("ndarray_sum_aggregator_init_op")
     initMethod.voidWithBuilder(cb =>
-      cb.append(stateType.setFieldMissing(state.off, ndarrayFieldNumber))
+      state.storeMissing(cb)
     )
     cb.invokeVoid(initMethod)
   }
@@ -31,21 +33,16 @@ class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
     val Array(nextNDCode) = seq
     val seqOpMethod = cb.emb.genEmitMethod("ndarray_sum_aggregator_seq_op", FastIndexedSeq(EmitParamType(nextNDCode.pt)), CodeParamType(UnitInfo))
 
-    seqOpMethod.voidWithBuilder(cb => {
+    seqOpMethod.voidWithBuilder { cb =>
       val nextNDInput = seqOpMethod.getEmitParam(1)
-      val statePV = stateType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_seq_op_state")
-      nextNDInput.toI(cb).consume(cb, {}, {case nextNDArrayPCode: PNDArrayCode =>
+      nextNDInput.toI(cb).consume(cb, {}, { case nextNDArrayPCode: PNDArrayCode =>
         val nextNDPV = nextNDArrayPCode.memoize(cb, "ndarray_sum_seqop_next")
+        val statePV = state.storageType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_seq_op_state")
         statePV.loadField(cb, ndarrayFieldNumber).consume(cb,
           {
-            cb.append(state.region.getNewRegion(Region.TINY))
-            cb.append(stateType.setFieldPresent(state.off, ndarrayFieldNumber))
-            ndTyp.storeAtAddress(
-              cb,
-              stateType.fieldOffset(state.off, ndarrayFieldNumber),
-              state.region,
-              nextNDPV,
-              true)
+            cb += (state.region.getNewRegion(Region.TINY))
+            cb += state.storageType.setFieldPresent(state.off, ndarrayFieldNumber)
+            state.storeNonmissing(cb, nextNDPV)
           },
           { currentNDPCode =>
             val currentNDPValue = currentNDPCode.asNDArray.memoize(cb, "ndarray_sum_seqop_current")
@@ -53,30 +50,30 @@ class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
           }
         )
       })
-    })
+    }
     cb.invokeVoid(seqOpMethod, nextNDCode)
   }
 
   override protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
     val combOpMethod = cb.emb.genEmitMethod[Unit]("ndarray_sum_aggregator_comb_op")
 
-    combOpMethod.voidWithBuilder(cb => {
-      val rightPV = stateType.loadCheapPCode(cb, other.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_right")
+    combOpMethod.voidWithBuilder { cb =>
+      val rightPV = other.storageType.loadCheapPCode(cb, other.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_right")
       rightPV.loadField(cb, ndarrayFieldNumber).consume(cb, {},
         { rightNDPC =>
-          val leftPV = stateType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_left")
+          val rightNdValue = rightNDPC.asNDArray.memoize(cb, "right_ndarray_sum_agg")
+          val leftPV = state.storageType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_left")
           leftPV.loadField(cb, ndarrayFieldNumber).consume(cb,
             {
-              cb.append(state.storeNonmissing(other.off))
+              state.storeNonmissing(cb, rightNdValue)
             },
             { leftNDPC =>
               val leftNdValue = leftNDPC.asNDArray.memoize(cb, "left_ndarray_sum_agg")
-              val rightNdValue = rightNDPC.asNDArray.memoize(cb, "right_ndarray_sum_agg")
               addValues(cb, leftNdValue, rightNdValue)
             })
         }
       )
-    })
+    }
 
     cb.invokeVoid(combOpMethod)
   }
@@ -111,19 +108,16 @@ class NDArraySumAggregator (ndTyp: PNDArray) extends StagedAggregator {
       )
     }
 
-    cb.append(sameShape.mux(
-      columnMajorLoops,
-      Code._fatal[Unit]("Can't sum ndarrays of different shapes.")
-    ))
+    cb.ifx(!sameShape,
+      cb += Code._fatal[Unit]("Can't sum ndarrays of different shapes."))
+    cb += columnMajorLoops
   }
 
   override protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {
-    val t = state.get()
-    cb.append(t.setup)
-    cb.append(
-      stateType.isFieldDefined(state.off, ndarrayFieldNumber).mux(
-        srvb.addWithDeepCopy(resultType, stateType.loadField(state.off, ndarrayFieldNumber)),
-        srvb.setMissing()
-    ))
+    state.get()
+      .toI(cb)
+      .consume(cb,
+        cb += srvb.setMissing(),
+        { nda => cb += srvb.addIRIntermediate(nda, deepCopy = true) })
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -3,38 +3,39 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.{Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
+import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
+import is.hail.types.virtual.Type
 import is.hail.utils._
 
-class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
+class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   type State = TypedRegionBackedAggState
-  assert(PType.canonical(typ) == typ)
-  val resultType: PType = typ
-  val initOpTypes: Seq[PType] = Array[PType]()
-  val seqOpTypes: Seq[PType] = Array[PType](typ)
+  private val pt = typ.canonicalPType.setRequired(false)
+  val resultType: PType = pt
+  val initOpTypes: Seq[Type] = Array[Type]()
+  val seqOpTypes: Seq[Type] = Array[Type](typ.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 0)
-    cb += state.storeMissing()
+    state.storeMissing(cb)
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(elt: EmitCode) = seq
-    val v = state.kb.genFieldThisRef()(typeToTypeInfo(typ))
-    cb += Code(
-      elt.setup,
-      elt.m.mux(Code._empty,
-        Code(v := elt.value, state.storeNonmissing(v)))
-    )
+    elt.toI(cb)
+      .consume(cb,
+        { /* do nothing if missing */ },
+        sc => state.storeNonmissing(cb, sc)
+      )
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = {
-    val t = other.get()
-    val v = state.kb.genFieldThisRef()(typeToTypeInfo(typ))
-    cb += Code(
-      t.setup,
-      t.m.mux(Code._empty,
-        Code(v := t.value, state.storeNonmissing(v))))
+    other.get()
+      .toI(cb)
+      .consume(cb,
+        { /* do nothing if missing */ },
+        sc => state.storeNonmissing(cb, sc)
+      )
   }
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -4,13 +4,14 @@ import is.hail.annotations.StagedRegionValueBuilder
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.types.physical.PType
+import is.hail.types.virtual.Type
 
 abstract class StagedAggregator {
   type State <: AggregatorState
 
   def resultType: PType
-  def initOpTypes: Seq[PType]
-  def seqOpTypes: Seq[PType]
+  def initOpTypes: Seq[Type]
+  def seqOpTypes: Seq[Type]
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode])
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -2,141 +2,140 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitFunctionBuilder}
-import is.hail.types.physical._
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical._
+import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
 
-class TakeRVAS(val eltType: PType, val resultType: PArray, val kb: EmitClassBuilder[_]) extends AggregatorState {
+class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) extends AggregatorState {
+  val eltPType = eltType.canonicalPType
+
   private val r: ThisFieldRef[Region] = kb.genFieldThisRef[Region]()
   val region: Value[Region] = r
 
-  val builder = new StagedArrayBuilder(eltType, kb, region)
+  val builder = new StagedArrayBuilder(eltPType, kb, region)
   val storageType: PCanonicalTuple = PCanonicalTuple(true, PInt32Required, builder.stateType)
   private val maxSize = kb.genFieldThisRef[Int]()
   private val maxSizeOffset: Code[Long] => Code[Long] = storageType.loadField(_, 0)
   private val builderStateOffset: Code[Long] => Code[Long] = storageType.loadField(_, 1)
 
-  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
-    cb.ifx(region.isNull, { cb.assign(r, Region.stagedCreate(regionSize, kb.pool())) })
+    cb.ifx(region.isNull, {
+      cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
+    })
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code.memoize(src, "take_rvas_src") { src =>
-      Code(
-        regionLoader(r),
-        maxSize := Region.loadInt(maxSizeOffset(src)),
-        builder.loadFrom(builderStateOffset(src)))
-    }
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal[Long]("take_rvas_src", srcc)
+    regionLoader(cb, r)
+    cb.assign(maxSize, Region.loadInt(maxSizeOffset(src)))
+    builder.loadFrom(cb, builderStateOffset(src))
+  }
 
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    Code.memoize(dest, "ta_store_dest") { dest =>
-      region.isValid.orEmpty(
-        Code(
-          regionStorer(region),
-          region.invalidate(),
-          Region.storeInt(maxSizeOffset(dest), maxSize),
-          builder.storeTo(builderStateOffset(dest))))
-    }
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    val dest = cb.newLocal[Long]("ta_store_dest", destc)
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        cb += region.invalidate()
+        cb += Region.storeInt(maxSizeOffset(dest), maxSize)
+        builder.storeTo(cb, builderStateOffset(dest))
+      })
+  }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     { (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) =>
       cb += ob.writeInt(maxSize)
-      cb += builder.serialize(codec)(ob)
+      builder.serialize(codec)(cb, ob)
     }
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     { (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
       cb.assign(maxSize, ib.readInt())
-      cb += builder.deserialize(codec)(ib)
+      builder.deserialize(codec)(cb, ib)
     }
   }
 
-  def init(_maxSize: Code[Int]): Code[Unit] = {
-    Code(
-      maxSize := _maxSize,
-      builder.initialize()
-    )
+  def init(cb: EmitCodeBuilder, _maxSize: Code[Int]): Unit = {
+    cb.assign(maxSize, _maxSize)
+    builder.initialize(cb)
   }
 
-  def seqOp(elt: EmitCode): Code[Unit] = {
-    Code(
-      elt.setup,
-      (builder.size < maxSize)
-        .orEmpty(
-          elt.m.mux(
-            builder.setMissing(),
-            builder.append(elt.value))
-        )
-    )
+  def seqOp(cb: EmitCodeBuilder, elt: EmitCode): Unit = {
+    cb.ifx(builder.size < maxSize,
+      elt.toI(cb)
+        .consume(cb,
+          builder.setMissing(cb),
+          sc => builder.append(cb, sc)))
   }
 
   def combine(cb: EmitCodeBuilder, other: TakeRVAS): Unit = {
     val j = kb.genFieldThisRef[Int]()
     val elt = other.builder.loadElement(cb, j)
 
-    cb += Code(
-      j := const(0),
-      Code.whileLoop((builder.size < maxSize) & (j < other.builder.size),
-        elt.setup,
-        elt.m.mux(
-          builder.setMissing(),
-          builder.append(elt.v)
-        ),
-        j := j + 1
-      )
-    )
+    cb.assign(j, 0)
+    cb.whileLoop((builder.size < maxSize) && (j < other.builder.size),
+      {
+        elt.toI(cb)
+          .consume(cb,
+            builder.setMissing(cb),
+            sc => builder.append(cb, sc))
+        cb.assign(j, j + 1)
+      })
   }
 
-  def result(srvb: StagedRegionValueBuilder): Code[Unit] = {
-    srvb.addArray(resultType, { rvb =>
-      val elt = EmitCodeBuilder.scopedEmitCode(srvb.mb)(cb => builder.loadElement(cb, rvb.arrayIdx))
-      Code(
-        rvb.start(builder.size),
-        Code.whileLoop(rvb.arrayIdx < builder.size,
-          elt.setup,
-          elt.m.mux(
-            rvb.setMissing(),
-            rvb.addWithDeepCopy(eltType, elt.v)
-          ),
-          rvb.advance()))
-      })
+  def result(cb: EmitCodeBuilder, resultType: PArray, srvb: StagedRegionValueBuilder): Unit = {
+    cb += srvb.addArray(resultType, { rvb =>
+      EmitCodeBuilder.scopedVoid(srvb.mb) { cb =>
+        cb += rvb.start(builder.size)
+        cb.whileLoop(rvb.arrayIdx < builder.size,
+          {
+            builder.loadElement(cb, rvb.arrayIdx)
+              .toI(cb)
+              .consume(cb,
+                cb += rvb.setMissing(),
+                sc => cb += rvb.addIRIntermediate(sc))
+            cb += rvb.advance()
+          })
+      }
+    })
   }
 
   def copyFrom(cb: EmitCodeBuilder, srcCode: Code[Long]): Unit = {
     val src = cb.newLocal("takervas_copy_from_src", srcCode)
     cb.assign(maxSize, Region.loadInt(maxSizeOffset(src)))
-    cb += builder.copyFrom(builderStateOffset(src))
+    builder.copyFrom(cb, builderStateOffset(src))
   }
 }
 
-class TakeAggregator(typ: PType) extends StagedAggregator {
-  assert(typ.isCanonical)
-
+class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   type State = TakeRVAS
 
-  val resultType: PCanonicalArray = PCanonicalArray(typ, required = true)
-  val initOpTypes: Seq[PType] = Array(PInt32Required)
-  val seqOpTypes: Seq[PType] = Array(typ)
+  private val pt = typ.canonicalPType
+  val resultType: PCanonicalArray = PCanonicalArray(pt, required = true)
+  val initOpTypes: Seq[Type] = Array(TInt32)
+  val seqOpTypes: Seq[Type] = Array(typ.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
-    cb += Code(
-      sizeTriplet.setup,
-      sizeTriplet.m.orEmpty(Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing")),
-      state.init(coerce[Int](sizeTriplet.v))
-    )
+    sizeTriplet.toI(cb)
+      .consume(cb,
+        cb += Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing"),
+        sc => state.init(cb, sc.asInt.intCode(cb))
+      )
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(elt: EmitCode) = seq
-    cb += state.seqOp(elt)
+    state.seqOp(cb, elt)
   }
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.combine(cb, other)
 
-  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = cb += state.result(srvb)
+  protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit = state.result(cb, resultType, srvb)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -98,7 +98,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
               .toI(cb)
               .consume(cb,
                 cb += rvb.setMissing(),
-                sc => cb += rvb.addIRIntermediate(sc))
+                sc => cb += rvb.addIRIntermediate(sc, deepCopy = true))
             cb += rvb.advance()
           })
       }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -4,16 +4,21 @@ import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{Ascending, EmitClassBuilder, EmitCode, EmitCodeBuilder, ParamType, SortOrder}
-import is.hail.types.physical._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical._
+import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
 
 object TakeByRVAS {
   val END_SERIALIZATION: Int = 0x1324
 }
 
-class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArray, val kb: EmitClassBuilder[_], so: SortOrder = Ascending) extends AggregatorState {
+class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWithReq, val kb: EmitClassBuilder[_], so: SortOrder = Ascending) extends AggregatorState {
   private val r: Settable[Region] = kb.genFieldThisRef[Region]("takeby_region")
+
+  val valueType: PType  = valueVType.canonicalPType
+  val keyType: PType = keyVType.canonicalPType
 
   val region: Value[Region] = r
 
@@ -44,17 +49,17 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
         ("max_size", PInt32Required)) ++ garbageFields: _*
     )
 
-  private val compareKey: (EmitCodeBuilder, EmitCode, EmitCode) => Code[Int] = {
-    val cmp = kb.genEmitMethod("compare", FastIndexedSeq[ParamType](keyType.asEmitParam, keyType.asEmitParam), IntInfo)
-    val ord = keyType.codeOrdering(cmp, so)
-    val k1 = cmp.getEmitParam(1)
-    val k2 = cmp.getEmitParam(2)
+  def compareKey(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {
+    val cmp = kb.genEmitMethod("compare", FastIndexedSeq[ParamType](k1.pv.st.pType.asEmitParam, k2.pv.st.pType.asEmitParam), IntInfo)
+    val ord = k1.pv.st.pType.codeOrdering(cmp, k2.pv.st.pType, so)
 
-    cmp.emit(
+    cmp.emit {
+      val k1 = cmp.getEmitParam(1)
+      val k2 = cmp.getEmitParam(2)
       ord.compare(k1.m -> coerce(k1.v), k2.m -> coerce(k2.v))
-    )
+    }
 
-    (cb, k1, k2) => cb.invokeCode(cmp, k1, k2)
+    cb.invokeCode(cmp, k1, k2)
   }
 
   private val compareIndexedKey: (Code[Long], Code[Long]) => Code[Int] = {
@@ -69,13 +74,18 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     cmp.invokeCode(_, _)
   }
 
-  private def maybeGCCode(alwaysRun: Code[Unit]*)(runIfGarbage: => Array[Code[Unit]], runBefore: Boolean = false): Code[Unit] = {
-    val gcCodes = (if (canHaveGarbage) runIfGarbage else Array[Code[Unit]]())
-    val allCode = if (runBefore) (gcCodes ++ alwaysRun) else (alwaysRun.toArray ++ gcCodes)
-    Code(allCode)
+  private def maybeGCCode(cb: EmitCodeBuilder, alwaysRun: EmitCodeBuilder => Unit)(runIfGarbage: EmitCodeBuilder => Unit, runBefore: Boolean = false): Unit = {
+    val gc = (if (canHaveGarbage) runIfGarbage else (cb: EmitCodeBuilder) => ())
+    if (runBefore) {
+      gc(cb)
+      alwaysRun(cb)
+    } else {
+      alwaysRun(cb)
+      gc(cb)
+    }
   }
 
-  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
+  def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
 
   def createState(cb: EmitCodeBuilder): Unit =
     cb.ifx(region.isNull, {
@@ -83,103 +93,117 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
       cb += region.invalidate()
     })
 
-  override def load(regionLoader: Value[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code(
-      regionLoader(r),
-      loadFields(src))
-
-  override def store(regionStorer: Value[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    region.isValid.orEmpty(
-      Code(
-        regionStorer(region),
-        region.invalidate(),
-        storeFields(dest)))
-
-  private def initStaging(): Code[Unit] = Code(
-    staging := eltTuple.allocate(region),
-    keyStage := indexedKeyType.allocate(region)
-  )
-
-  def initialize(_maxSize: Code[Int]): Code[Unit] = {
-    maybeGCCode(
-      maxIndex := 0L,
-      maxSize := _maxSize,
-      (maxSize < 0).orEmpty(Code._fatal[Unit](const("'take': 'n' cannot be negative, found '").concat(maxSize.toS))),
-      initStaging(),
-      ab.initialize()
-    )(Array(
-      garbage := 0,
-      maxGarbage := Code.invokeStatic2[Math, Int, Int, Int]("max", maxSize * 2, 256)
-    ))
+  override def load(cb: EmitCodeBuilder, regionLoader: (EmitCodeBuilder, Value[Region]) => Unit, srcc: Code[Long]): Unit = {
+    regionLoader(cb, r)
+    loadFields(cb, srcc)
   }
 
-  private def storeFields(dest: Code[Long]): Code[Unit] = {
-    Code.memoize(dest, "tba_store_fields_dest") { dest =>
-      maybeGCCode(
-        ab.storeTo(storageType.fieldOffset(dest, 0)),
-        Region.storeAddress(storageType.fieldOffset(dest, 1), staging),
-        Region.storeAddress(storageType.fieldOffset(dest, 2), keyStage),
-        Region.storeLong(storageType.fieldOffset(dest, 3), maxIndex),
-        Region.storeInt(storageType.fieldOffset(dest, 4), maxSize)
-      )(Array(
-        Region.storeInt(storageType.fieldOffset(dest, 5), garbage),
-        Region.storeInt(storageType.fieldOffset(dest, 6), maxGarbage)))
-    }
+  override def store(cb: EmitCodeBuilder, regionStorer: (EmitCodeBuilder, Value[Region]) => Unit, destc: Code[Long]): Unit = {
+    cb.ifx(region.isValid,
+      {
+        regionStorer(cb, region)
+        cb += region.invalidate()
+        storeFields(cb, destc)
+      })
   }
 
-  private def loadFields(src: Code[Long]): Code[Unit] =
-    Code.memoize(src, "takeby_rvas_load_fields_src") { src =>
-      maybeGCCode(
-        ab.loadFrom(storageType.fieldOffset(src, 0)),
-        staging := Region.loadAddress(storageType.fieldOffset(src, 1)),
-        keyStage := Region.loadAddress(storageType.fieldOffset(src, 2)),
-        maxIndex := Region.loadLong(storageType.fieldOffset(src, 3)),
-        maxSize := Region.loadInt(storageType.fieldOffset(src, 4))
-      )(Array(
-        garbage := Region.loadInt(storageType.fieldOffset(src, 5)),
-        maxGarbage := Region.loadInt(storageType.fieldOffset(src, 6))
-      ))
-    }
+  private def initStaging(cb: EmitCodeBuilder): Unit = {
+    cb.assign(staging, eltTuple.allocate(region))
+    cb.assign(keyStage, indexedKeyType.allocate(region))
+  }
 
-  def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
-    cb += Code.memoize(src, "tba_copy_from_src") { src =>
-      maybeGCCode(
-        initStaging(),
-        ab.copyFrom(storageType.fieldOffset(src, 0)),
-        maxIndex := Region.loadLong(storageType.fieldOffset(src, 3)),
-        maxSize := Region.loadInt(storageType.fieldOffset(src, 4)))(
-        Array(
-          maxGarbage := Region.loadInt(storageType.fieldOffset(src, 4))))
+  def initialize(cb: EmitCodeBuilder, _maxSize: Code[Int]): Unit = {
+    maybeGCCode(cb,
+      { cb =>
+        cb.assign(maxIndex, 0L)
+        cb.assign(maxSize, _maxSize)
+        cb.ifx(maxSize < 0,
+          cb += Code._fatal[Unit](const("'take': 'n' cannot be negative, found '").concat(maxSize.toS)))
+        initStaging(cb)
+        ab.initialize(cb)
+      })({ cb =>
+      cb.assign(garbage, 0)
+      cb.assign(maxGarbage, Code.invokeStatic2[Math, Int, Int, Int]("max", maxSize * 2, 256))
+    })
+  }
+
+  private def storeFields(cb: EmitCodeBuilder, destc: Code[Long]): Unit = {
+    val dest = cb.newLocal("tba_store_fields_dest", destc)
+    maybeGCCode(cb,
+      { cb =>
+        ab.storeTo(cb, storageType.fieldOffset(dest, 0))
+        cb += Region.storeAddress(storageType.fieldOffset(dest, 1), staging)
+        cb += Region.storeAddress(storageType.fieldOffset(dest, 2), keyStage)
+        cb += Region.storeLong(storageType.fieldOffset(dest, 3), maxIndex)
+        cb += Region.storeInt(storageType.fieldOffset(dest, 4), maxSize)
+      }
+    )({ cb =>
+      cb += Region.storeInt(storageType.fieldOffset(dest, 5), garbage)
+      cb += Region.storeInt(storageType.fieldOffset(dest, 6), maxGarbage)
+    })
+  }
+
+  private def loadFields(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal("takeby_rvas_load_fields_src", srcc)
+    maybeGCCode(cb,
+      { cb =>
+        ab.loadFrom(cb, storageType.fieldOffset(src, 0))
+        cb.assign(staging, Region.loadAddress(storageType.fieldOffset(src, 1)))
+        cb.assign(keyStage, Region.loadAddress(storageType.fieldOffset(src, 2)))
+        cb.assign(maxIndex, Region.loadLong(storageType.fieldOffset(src, 3)))
+        cb.assign(maxSize, Region.loadInt(storageType.fieldOffset(src, 4)))
+      }
+    )({ cb =>
+      cb.assign(garbage, Region.loadInt(storageType.fieldOffset(src, 5)))
+      cb.assign(maxGarbage, Region.loadInt(storageType.fieldOffset(src, 6)))
     }
+    )
+  }
+
+  def copyFrom(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
+    val src = cb.newLocal("tba_copy_from_src", srcc)
+    maybeGCCode(cb,
+      { cb =>
+        initStaging(cb)
+        ab.copyFrom(cb, storageType.fieldOffset(src, 0))
+        cb.assign(maxIndex, Region.loadLong(storageType.fieldOffset(src, 3)))
+        cb.assign(maxSize, Region.loadInt(storageType.fieldOffset(src, 4)))
+      })({ cb =>
+      cb.assign(maxGarbage, Region.loadInt(storageType.fieldOffset(src, 4)))
+    })
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     { (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) =>
-      cb += maybeGCCode(
-        ob.writeLong(maxIndex),
-        ob.writeInt(maxSize),
-        ab.serialize(codec)(ob),
-        ob.writeInt(const(TakeByRVAS.END_SERIALIZATION))
-      )(Array(
-        ob.writeInt(maxGarbage)
-      ), runBefore = true)
+      maybeGCCode(cb,
+        { cb =>
+          cb += ob.writeLong(maxIndex)
+          cb += ob.writeInt(maxSize)
+          ab.serialize(codec)(cb, ob)
+          cb += ob.writeInt(const(TakeByRVAS.END_SERIALIZATION))
+        }
+      )({ cb =>
+        cb += ob.writeInt(maxGarbage)
+      }, runBefore = true)
     }
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
     { (cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
-      cb += maybeGCCode(
-        maxIndex := ib.readLong(),
-        maxSize := ib.readInt(),
-        ab.deserialize(codec)(ib),
-        initStaging(),
-        ib.readInt()
-          .cne(const(TakeByRVAS.END_SERIALIZATION))
-          .orEmpty(Code._fatal[Unit](s"StagedSizedKeyValuePriorityQueue serialization failed"))
-      )(Array(
-        maxGarbage := ib.readInt(),
-        garbage := 0
-      ), runBefore = true)
+      maybeGCCode(cb,
+        { cb =>
+          cb.assign(maxIndex, ib.readLong())
+          cb.assign(maxSize, ib.readInt())
+          ab.deserialize(codec)(cb, ib)
+          initStaging(cb)
+          cb += ib.readInt()
+            .cne(const(TakeByRVAS.END_SERIALIZATION))
+            .orEmpty(Code._fatal[Unit](s"StagedSizedKeyValuePriorityQueue serialization failed"))
+        }
+      )({ cb =>
+        cb.assign(maxGarbage, ib.readInt())
+        cb.assign(garbage, 0)
+      }, runBefore = true)
     }
   }
 
@@ -236,22 +260,22 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     mb.invokeCode(_, _)
   }
 
-  private val swap: (Code[Long], Code[Long]) => Code[Unit] = {
+  private val swap: (EmitCodeBuilder, Code[Long], Code[Long]) => Unit = {
     val mb = kb.genEmitMethod("swap", FastIndexedSeq[ParamType](LongInfo, LongInfo), UnitInfo)
     val i = mb.getCodeParam[Long](1)
     val j = mb.getCodeParam[Long](2)
 
-    mb.emit(
-      Code(
-        Region.copyFrom(i, staging, eltTuple.byteSize),
-        Region.copyFrom(j, i, eltTuple.byteSize),
-        Region.copyFrom(staging, j, eltTuple.byteSize))
-    )
-    mb.invokeCode(_, _)
+    mb.voidWithBuilder({ cb =>
+      cb += Region.copyFrom(i, staging, eltTuple.byteSize)
+      cb += Region.copyFrom(j, i, eltTuple.byteSize)
+      cb += Region.copyFrom(staging, j, eltTuple.byteSize)
+    })
+
+    (cb: EmitCodeBuilder, x: Code[Long], y: Code[Long]) => cb.invokeVoid(mb, x, y)
   }
 
 
-  private val rebalanceUp: Code[Int] => Code[Unit] = {
+  private val rebalanceUp: (EmitCodeBuilder, Code[Int]) => Unit = {
     val mb = kb.genEmitMethod("rebalance_up", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
     val idx = mb.getCodeParam[Int](1)
 
@@ -260,22 +284,24 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
 
     val parent = mb.newLocal[Int]("parent")
 
-    mb.emit(
-      (idx > 0).orEmpty(
-        Code(
-          parent := (idx + 1) / 2 - 1,
-          ii := elementOffset(idx),
-          jj := elementOffset(parent),
-          (compareElt(ii, jj) > 0).orEmpty(
-            Code(
-              swap(ii, jj),
-              mb.invokeCode(parent))
-          ))))
+    mb.voidWithBuilder { cb =>
+      cb.ifx(idx > 0,
+        {
+          cb.assign(parent, (idx + 1) / 2 - 1)
+          cb.assign(ii, elementOffset(idx))
+          cb.assign(jj, elementOffset(parent))
+          cb.ifx(compareElt(ii, jj) > 0,
+            {
+              swap(cb, ii, jj)
+              cb.invokeVoid(mb, parent)
+            })
+        })
+    }
 
-    mb.invokeCode(_)
+    (cb: EmitCodeBuilder, x: Code[Int]) => cb.invokeVoid(mb, x)
   }
 
-  private val rebalanceDown: Code[Int] => Code[Unit] = {
+  private val rebalanceDown: (EmitCodeBuilder, Code[Int]) => Unit = {
     val mb = kb.genEmitMethod("rebalance_down", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
     val idx = mb.getCodeParam[Int](1)
 
@@ -285,119 +311,126 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     val ii = mb.newLocal[Long]("ii")
     val jj = mb.newLocal[Long]("jj")
 
-    mb.emit(Code(
-      child1 := (idx + 1) * 2 - 1,
-      child2 := child1 + 1,
-      (child1 < ab.size).orEmpty(
-        Code(
-          minChild := (child2 >= ab.size || compareElt(elementOffset(child1), elementOffset(child2)) > 0).mux(child1, child2),
-          ii := elementOffset(minChild),
-          jj := elementOffset(idx),
-          (compareElt(ii, jj) > 0).mux(
-            Code(
-              swap(ii, jj),
-              mb.invokeCode(minChild)
-            ),
-            Code._empty
-          )))))
-    mb.invokeCode(_)
+    mb.voidWithBuilder { cb =>
+      cb.assign(child1, (idx + 1) * 2 - 1)
+      cb.assign(child2, child1 + 1)
+      cb.ifx(child1 < ab.size,
+        {
+          cb.assign(minChild, (child2 >= ab.size || compareElt(elementOffset(child1), elementOffset(child2)) > 0).mux(child1, child2))
+          cb.assign(ii, elementOffset(minChild))
+          cb.assign(jj, elementOffset(idx))
+          cb.ifx(compareElt(ii, jj) > 0,
+            {
+              swap(cb, ii, jj)
+              cb.invokeVoid(mb, minChild)
+            })
+        })
+    }
+    (cb: EmitCodeBuilder, x: Code[Int]) => cb.invokeVoid(mb, x)
   }
 
-  private lazy val gc: () => Code[Unit] = {
+  private lazy val gc: EmitCodeBuilder => Unit = {
     if (canHaveGarbage) {
       val mb = kb.genEmitMethod("take_by_garbage_collect", FastIndexedSeq[ParamType](), UnitInfo)
       val oldRegion = mb.newLocal[Region]("old_region")
-      mb.emit(
-        Code(
-          garbage := garbage + 1,
-          (garbage >= maxGarbage).orEmpty(Code(
-            oldRegion := region,
-            r := Region.stagedCreate(regionSize, kb.pool()),
-            ab.reallocateData(),
-            initStaging(),
-            garbage := 0,
-            oldRegion.invoke[Unit]("invalidate")
-          ))
-        ))
-      () => mb.invokeCode()
+      mb.voidWithBuilder { cb =>
+        cb.assign(garbage, garbage + 1)
+        cb.ifx(garbage >= maxGarbage,
+          {
+            cb.assign(oldRegion, region)
+            cb.assign(r, Region.stagedCreate(regionSize, kb.pool()))
+            ab.reallocateData(cb)
+            initStaging(cb)
+            cb.assign(garbage, 0)
+            cb += oldRegion.invoke[Unit]("invalidate")
+          })
+      }
+      (cb: EmitCodeBuilder) => cb.invokeVoid(mb)
     } else
-      () => Code._empty
+      (_: EmitCodeBuilder) => ()
   }
 
 
-  private def stageAndIndexKey(km: Code[Boolean], k: Code[_]): Code[Unit] = Code(
-    if (keyType.required)
-      Region.storeIRIntermediate(keyType)(indexedKeyType.fieldOffset(keyStage, 0), k)
-    else
-      km.mux(
-        indexedKeyType.setFieldMissing(keyStage, 0),
-        Code(
-          indexedKeyType.setFieldPresent(keyStage, 0),
-          Region.storeIRIntermediate(keyType)(indexedKeyType.fieldOffset(keyStage, 0), k)
-        )),
-    Region.storeLong(indexedKeyType.fieldOffset(keyStage, 1), maxIndex),
-    maxIndex := maxIndex + 1L
-  )
-
-  private def copyElementToStaging(o: Code[Long]): Code[Unit] = Region.copyFrom(o, staging, eltTuple.byteSize)
-
-  private def copyToStaging(value: Code[_], valueM: Code[Boolean], indexedKey: Code[Long]): Code[Unit] = {
-    Code(
-      staging.ceq(0L).orEmpty(Code._fatal[Unit]("staging is 0")),
-      Region.copyFrom(indexedKey, eltTuple.fieldOffset(staging, 0), indexedKeyType.byteSize),
-      if (valueType.required)
-        Region.storeIRIntermediate(valueType)(eltTuple.fieldOffset(staging, 1), value)
-      else
-        valueM.mux(
-          eltTuple.setFieldMissing(staging, 1),
-          Code(
-            eltTuple.setFieldPresent(staging, 1),
-            Region.storeIRIntermediate(valueType)(eltTuple.fieldOffset(staging, 1), value)
-          ))
-    )
+  private def stageAndIndexKey(cb: EmitCodeBuilder, k: EmitCode): Unit = {
+    k.toI(cb)
+      .consume(cb,
+        {
+          cb += indexedKeyType.setFieldMissing(keyStage, 0)
+        },
+        { sc =>
+          cb += indexedKeyType.setFieldPresent(keyStage, 0)
+          keyType.storeAtAddress(cb, indexedKeyType.fieldOffset(keyStage, 0), region, sc, deepCopy = false)
+        }
+      )
+    cb += Region.storeLong(indexedKeyType.fieldOffset(keyStage, 1), maxIndex)
+    cb.assign(maxIndex, maxIndex + 1L)
   }
 
-  private def swapStaging(): Code[Unit] = {
-    Code(
-      StagedRegionValueBuilder.deepCopy(kb, region, eltTuple, staging, ab.elementOffset(0)),
-      rebalanceDown(0)
-    )
+  private def copyElementToStaging(cb: EmitCodeBuilder, o: Code[Long]): Unit = cb += Region.copyFrom(o, staging, eltTuple.byteSize)
+
+  private def copyToStaging(cb: EmitCodeBuilder, value: EmitCode, indexedKey: Code[Long]): Unit = {
+    cb.ifx(staging.ceq(0L), cb += Code._fatal[Unit]("staging is 0"))
+    indexedKeyType.storeAtAddress(cb,
+      eltTuple.fieldOffset(staging, 0),
+      region,
+      indexedKeyType.loadCheapPCode(cb, indexedKey),
+      deepCopy = false)
+    value.toI(cb)
+      .consume(cb,
+        {
+          cb += eltTuple.setFieldMissing(staging, 1)
+        },
+        { v =>
+          cb += eltTuple.setFieldPresent(staging, 1)
+          valueType.storeAtAddress(cb, eltTuple.fieldOffset(staging, 1), region, v, deepCopy = false)
+        })
   }
 
-  private def enqueueStaging(): Code[Unit] = {
-    Code(
-      ab.append(Region.loadIRIntermediate(eltTuple)(staging)),
-      rebalanceUp(ab.size - 1))
+  private def swapStaging(cb: EmitCodeBuilder): Unit = {
+    eltTuple.storeAtAddress(cb, ab.elementOffset(0), region, eltTuple.loadCheapPCode(cb, staging), true)
+    rebalanceDown(cb, 0)
   }
 
-  val seqOp: (EmitCodeBuilder, EmitCode, EmitCode) => Unit = {
+  private def enqueueStaging(cb: EmitCodeBuilder): Unit = {
+    ab.append(cb, eltTuple.loadCheapPCode(cb, staging))
+    rebalanceUp(cb, ab.size - 1)
+  }
+
+  def seqOp(cb: EmitCodeBuilder, v: EmitCode, k: EmitCode): Unit = {
     val mb = kb.genEmitMethod("take_by_seqop",
-      FastIndexedSeq[ParamType](valueType.asEmitParam, keyType.asEmitParam),
+      FastIndexedSeq[ParamType](v.pv.st.pType.asEmitParam, k.pv.st.pType.asEmitParam),
       UnitInfo)
 
-    val value = mb.getEmitParam(1)
-    val key = mb.getEmitParam(2)
+    mb.voidWithBuilder { cb =>
+      val value = mb.getEmitParam(1)
+      val key = mb.getEmitParam(2)
 
-    mb.emitWithBuilder { cb =>
+//      key.toI(cb).consume(cb,
+//        cb += Code._printlns(s" >> running grouped seqop for k=NA"),
+//        k => cb += Code._printlns(s" >> running grouped seqop for k=", StringFunctions.boxArg(new EmitRegion(cb.emb, region), k.pt)(k.code).invoke[String]("toString"))
+//      )
+
+
       cb.ifx(maxSize > 0, {
         cb.ifx(ab.size < maxSize, {
-          cb += stageAndIndexKey(key.m, key.v)
-          cb += copyToStaging(value.v, value.m, keyStage)
-          cb += enqueueStaging()
+//          cb +=Code._printlns(s"LESSTHAN - ab.size=", ab.size.toS, ", maxSize=", maxSize.toS)
+          stageAndIndexKey(cb, key)
+          copyToStaging(cb, value, keyStage)
+          enqueueStaging(cb)
         }, {
+//          cb +=Code._printlns(s"GTEQ - ab.size=", ab.size.toS, ", maxSize=", maxSize.toS)
           cb.assign(tempPtr, eltTuple.loadField(elementOffset(0), 0))
           cb.ifx(compareKey(cb, key, loadKey(cb, tempPtr)) < 0, {
-            cb += stageAndIndexKey(key.m, key.v)
-            cb += copyToStaging(value.v, value.m, keyStage)
-            cb += swapStaging()
-            cb += gc()
+            stageAndIndexKey(cb, key)
+            copyToStaging(cb, value, keyStage)
+            swapStaging(cb)
+            gc(cb)
           })
         })
       })
-      Code._empty
     }
 
-    (cb: EmitCodeBuilder, v: EmitCode, k: EmitCode) => cb.invokeVoid(mb, v, k)
+    cb.invokeVoid(mb, v, k)
   }
 
   // for tests
@@ -407,35 +440,43 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     seqOp(cb, vec, kec)
   }
 
-  def combine(other: TakeByRVAS): Code[Unit] = {
+  def combine(cb: EmitCodeBuilder, other: TakeByRVAS): Unit = {
     val mb = kb.genEmitMethod("take_by_combop", FastIndexedSeq[ParamType](), UnitInfo)
 
-    val i = mb.newLocal[Int]("combine_i")
-    val offset = mb.newLocal[Long]("combine_offset")
-    val indexOffset = mb.newLocal[Long]("index_offset")
 
-    mb.emit(Code(
-      i := 0,
-      Code.whileLoop(i < other.ab.size,
-        offset := other.elementOffset(i),
-        indexOffset := indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1),
-        Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex),
-        (maxSize > 0).orEmpty(
-          (ab.size < maxSize).mux(
-            Code(
-              copyElementToStaging(offset),
-              enqueueStaging()),
-            Code(
-              tempPtr := elementOffset(0),
-              (compareElt(offset, tempPtr) < 0)
-                .orEmpty(Code(
-                  copyElementToStaging(offset),
-                  swapStaging(),
-                  gc()))))),
-        i := i + 1),
-      maxIndex := maxIndex + other.maxIndex))
+    mb.voidWithBuilder { cb =>
+      val i = cb.newLocal[Int]("combine_i")
+      val offset = cb.newLocal[Long]("combine_offset")
+      val indexOffset = cb.newLocal[Long]("index_offset")
+      cb.forLoop(
+        cb.assign(i, 0),
+        i < other.ab.size,
+        cb.assign(i, i + 1),
+        {
+          cb.assign(offset, other.elementOffset(i))
+          cb.assign(indexOffset, indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1))
+          cb += Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex)
+          cb.ifx(maxSize > 0,
+            cb.ifx(ab.size < maxSize,
+              {
+                copyElementToStaging(cb, offset)
+                enqueueStaging(cb)
+              },
+              {
+                cb.assign(tempPtr, elementOffset(0))
+                cb.ifx(compareElt(offset, tempPtr) < 0,
+                  {
+                    copyElementToStaging(cb, offset)
+                    swapStaging(cb)
+                    gc(cb)
+                  })
+              }
+            ))
+        })
+      cb.assign(maxIndex, maxIndex + other.maxIndex)
+    }
 
-    mb.invokeCode()
+    cb.invokeVoid(mb)
   }
 
   def result(_r: Code[Region], resultType: PArray): Code[Long] = {
@@ -556,34 +597,29 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
 
 }
 
-class TakeByAggregator(valueType: PType, keyType: PType) extends StagedAggregator {
+class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithReq) extends StagedAggregator {
 
-  assert(valueType.isCanonical)
-  assert(keyType.isCanonical)
   type State = TakeByRVAS
 
-  val resultType: PArray = PCanonicalArray(valueType, true)
-  val initOpTypes: Seq[PType] = Array(PInt32(true))
-  val seqOpTypes: Seq[PType] = Array(valueType, keyType)
+  val resultType: PArray = PCanonicalArray(valueType.canonicalPType, true)
+  val initOpTypes: Seq[Type] = Array(TInt32)
+  val seqOpTypes: Seq[Type] = Array(valueType.t, keyType.t)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 1)
     val Array(sizeTriplet) = init
-    cb += Code(
-      sizeTriplet.setup,
-      sizeTriplet.m.orEmpty(Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing")),
-      state.initialize(coerce[Int](sizeTriplet.v))
-    )
+    sizeTriplet.toI(cb)
+      .consume(cb,
+        cb += Code._fatal[Unit](s"argument 'n' for 'hl.agg.take' may not be missing"),
+        sc => state.initialize(cb, sc.asInt.intCode(cb)))
   }
 
   protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
     val Array(value: EmitCode, key: EmitCode) = seq
-    assert(value.pv.pt == valueType)
-    assert(key.pv.pt == keyType)
     state.seqOp(cb, value, key)
   }
 
-  protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = cb += state.combine(other)
+  protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.combine(cb, other)
 
   protected def _result(cb: EmitCodeBuilder, state: State, srvb: StagedRegionValueBuilder): Unit =
     cb += srvb.addIRIntermediate(resultType)(state.result(srvb.region, resultType))

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -2,6 +2,7 @@ package is.hail.types
 
 import is.hail.annotations.{Annotation, NDArray}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.SType
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval}
 import org.apache.spark.sql.Row
@@ -127,6 +128,49 @@ sealed abstract class BaseTypeWithRequiredness {
     change = false
     children.foreach { r => hasChanged |= r.probeChangedAndReset() }
     hasChanged
+  }
+
+  def hardSetRequiredness(newRequiredness: Boolean): Unit = {
+    _required = newRequiredness
+    change = false
+  }
+}
+
+object VirtualTypeWithReq {
+  def apply(pt: PType): VirtualTypeWithReq = {
+    val vt = pt.virtualType
+    val r = TypeWithRequiredness(vt)
+    r.fromPType(pt)
+    VirtualTypeWithReq(vt, r)
+  }
+
+  def fullyOptional(t: Type): VirtualTypeWithReq = {
+    val twr = TypeWithRequiredness(t)
+    twr.fromPType(PType.canonical(t))
+    assert(!twr.required)
+    VirtualTypeWithReq(t, twr)
+  }
+}
+
+case class VirtualTypeWithReq(t: Type, r: TypeWithRequiredness) {
+  lazy val canonicalPType: PType = r.canonicalPType(t)
+
+  def setRequired(newReq: Boolean): VirtualTypeWithReq = {
+    val newR = r.copy(r.children).asInstanceOf[TypeWithRequiredness]
+    newR.hardSetRequiredness(newReq)
+    assert(newR.required == newReq)
+    copy(r = newR)
+  }
+
+  override def toString: String = s"VirtualTypeWithReq($canonicalPType)"
+
+  override def equals(obj: Any): Boolean = obj match {
+    case t2: VirtualTypeWithReq => canonicalPType == t2.canonicalPType
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    canonicalPType.hashCode() + 37
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -91,7 +91,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
   final def buildInplaceDecoderMethod(pt: PType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
     if (!decodeCompatible(pt))
       throw new RuntimeException(s"decode incompatible:\n  PT: $pt\n  ET: ${ parsableString() }")
-    kb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }".take(50),
+    kb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }",
       (pt, this, "INPLACE_DECODE"),
       FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[Long], classInfo[InputBuffer]),
       UnitInfo)({ mb =>

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -91,7 +91,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
   final def buildInplaceDecoderMethod(pt: PType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {
     if (!decodeCompatible(pt))
       throw new RuntimeException(s"decode incompatible:\n  PT: $pt\n  ET: ${ parsableString() }")
-    kb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }",
+    kb.getOrGenEmitMethod(s"INPLACE_DECODE_${ asIdent }_TO_${ pt.asIdent }".take(50),
       (pt, this, "INPLACE_DECODE"),
       FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[Long], classInfo[InputBuffer]),
       UnitInfo)({ mb =>

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -3,8 +3,15 @@ package is.hail.types.physical.stypes
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, Settable, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.TypeWithRequiredness
 import is.hail.types.physical.{PCode, PType}
+import is.hail.types.virtual.Type
 
+object SType {
+  def canonical(t: Type, r: TypeWithRequiredness) = {
+
+  }
+}
 
 trait SType {
   def pType: PType

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -7,12 +7,6 @@ import is.hail.types.TypeWithRequiredness
 import is.hail.types.physical.{PCode, PType}
 import is.hail.types.virtual.Type
 
-object SType {
-  def canonical(t: Type, r: TypeWithRequiredness) = {
-
-  }
-}
-
 trait SType {
   def pType: PType
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -98,4 +98,6 @@ class SIndexablePointerSettable(
     cb.assign(length, pt.loadLength(a))
     cb.assign(elementsAddress, pt.firstElementOffset(a, length))
   }
+
+  override def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean] = pt.hasMissingValues(a)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -14,6 +14,8 @@ trait SIndexableValue extends SValue {
   def isElementDefined(i: Code[Int]): Code[Boolean] = !isElementMissing(i)
 
   def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitSCode
+
+  def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean]
 }
 
 trait SIndexableCode extends SCode {

--- a/hail/src/main/scala/is/hail/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/Type.scala
@@ -116,6 +116,11 @@ abstract class Type extends BaseType with Serializable {
 
   final def isCanonical: Boolean = _isCanonical && children.forall(_.isCanonical)
 
+  def isPrimitive: Boolean = this match {
+    case TInt32 | TInt64 | TFloat32 | TFloat64 | TBoolean => true
+    case _ => false
+  }
+
   def isBound: Boolean = children.forall(_.isBound)
 
   def subst(): Type = this

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -548,6 +548,14 @@ class AggregatorsSuite extends HailSuite {
   @Test
   def keyedCount() {
     runKeyedAggregator(Count(),
+      Ref("k", TInt32),
+      TStruct("k" -> TInt32),
+      FastIndexedSeq(Row(1), Row(2), Row(3), Row(1), Row(1), Row(null), Row(null)),
+      Map(1 -> 3L, 2 -> 1L, 3 -> 1L, (null, 2L)),
+      initOpArgs = FastIndexedSeq(),
+      seqOpArgs = FastIndexedSeq())
+
+    runKeyedAggregator(Count(),
       Ref("k", TBoolean),
       TStruct("k" -> TBoolean),
       FastIndexedSeq(Row(true), Row(true), Row(true), Row(false), Row(false), Row(null), Row(null)),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -8,7 +8,7 @@ import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions._
-import is.hail.types.{BlockMatrixType, TableType}
+import is.hail.types.{BlockMatrixType, TableType, VirtualTypeWithReq}
 import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.types.encoded._
@@ -3045,10 +3045,10 @@ class IRSuite extends HailSuite {
     val call = Ref("call", TCall)
 
     val collectSig = AggSignature(Collect(), Seq(), Seq(TInt32))
-    val pCollectSig = PhysicalAggSig(Collect(), CollectStateSig(PInt32()))
+    val pCollectSig = PhysicalAggSig(Collect(), CollectStateSig(VirtualTypeWithReq(PInt32())))
 
     val sumSig = AggSignature(Sum(), Seq(), Seq(TInt64))
-    val pSumSig = PhysicalAggSig(Sum(), TypedStateSig(PInt64(true)))
+    val pSumSig = PhysicalAggSig(Sum(), TypedStateSig(VirtualTypeWithReq(PInt64(true))))
 
     val callStatsSig = AggSignature(CallStats(), Seq(TInt32), Seq(TCall))
     val pCallStatsSig = PhysicalAggSig(CallStats(), CallStatsStateSig())
@@ -3058,7 +3058,7 @@ class IRSuite extends HailSuite {
     val countSig = AggSignature(Count(), Seq(), Seq())
     val count = ApplyAggOp(FastIndexedSeq.empty, FastIndexedSeq.empty, countSig)
 
-    val groupSignature = GroupedAggSig(PInt32(true), FastSeq(pSumSig))
+    val groupSignature = GroupedAggSig(VirtualTypeWithReq(PInt32(true)), FastSeq(pSumSig))
 
     val table = TableRange(100, 10)
 

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -5,7 +5,7 @@ import is.hail.HailSuite
 import scala.collection.generic.Growable
 import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue, StagedRegionValueBuilder}
 import is.hail.asm4s.Code
-import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, EmitRegion}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitFunctionBuilder, EmitRegion}
 import is.hail.types.physical._
 import is.hail.utils._
 import org.scalatest.testng.TestNGSuite
@@ -25,11 +25,12 @@ class StagedBlockLinkedListSuite extends HailSuite {
 
       val ptr = fb.genFieldThisRef[Long]()
       val r = fb.getCodeParam[Region](1)
-      fb.emit(Code(
-        ptr := r.allocate(sbll.storageType.alignment, sbll.storageType.byteSize),
-        sbll.init(r),
-        sbll.store(ptr),
-        ptr))
+      fb.emitWithBuilder[Long] { cb =>
+        cb.assign(ptr, r.allocate(sbll.storageType.alignment, sbll.storageType.byteSize))
+        sbll.init(cb, r)
+        sbll.store(cb, ptr)
+        ptr
+      }
 
       fb.result()()(_)
     }
@@ -42,12 +43,15 @@ class StagedBlockLinkedListSuite extends HailSuite {
       val r = fb.getCodeParam[Region](1)
       val ptr = fb.getCodeParam[Long](2)
       val eltOff = fb.getCodeParam[Long](3)
-      fb.emit(Code(
-        sbll.load(ptr),
-        sbll.push(r, EmitCode(Code._empty,
-          eltOff.get.ceq(0),
-          PCode(elemPType, Region.getIRIntermediate(elemPType)(eltOff)))),
-        sbll.store(ptr)))
+      fb.emitWithBuilder[Unit] { cb =>
+
+        sbll.load(cb, ptr)
+        sbll.push(cb, r, EmitCode(Code._empty,
+          eltOff.get.ceq(0L),
+          PCode(elemPType, Region.getIRIntermediate(elemPType)(eltOff))))
+        sbll.store(cb, ptr)
+        Code._empty
+      }
 
       val f = fb.result()()
       ({ (r, ptr, elt) =>
@@ -64,11 +68,13 @@ class StagedBlockLinkedListSuite extends HailSuite {
       val r = fb.getCodeParam[Region](1)
       val ptr1 = fb.getCodeParam[Long](2)
       val ptr2 = fb.getCodeParam[Long](3)
-      fb.emit(Code(
-        sbll1.load(ptr1),
-        sbll2.load(ptr2),
-        sbll1.append(r, sbll2),
-        sbll1.store(ptr1)))
+      fb.emitWithBuilder { cb =>
+        sbll1.load(cb, ptr1)
+        sbll2.load(cb, ptr2)
+        sbll1.append(cb, r, sbll2)
+        sbll1.store(cb, ptr1)
+        Code._empty
+      }
 
       val f = fb.result()()
       ({ (r, ptr, other) =>
@@ -85,12 +91,13 @@ class StagedBlockLinkedListSuite extends HailSuite {
       val rArg = fb.getCodeParam[Region](1)
       val ptr = fb.getCodeParam[Long](2)
       val rField = fb.genFieldThisRef[Region]()
-      val srvb = new StagedRegionValueBuilder(EmitRegion(fb.apply_method, rField), arrayPType)
-      fb.emit(Code(
-        rField := rArg,
-        sbll.load(ptr),
-        sbll.writeToSRVB(fb.emb, srvb),
-        srvb.end()))
+      fb.emitWithBuilder { cb =>
+        cb.assign(rField, rArg)
+        sbll.load(cb, ptr)
+        val srvb = new StagedRegionValueBuilder(EmitRegion(fb.apply_method, rField), arrayPType)
+        sbll.writeToSRVB(cb, srvb)
+        srvb.end()
+      }
 
       val f = fb.result()()
       ({ (r, ptr) =>
@@ -107,12 +114,13 @@ class StagedBlockLinkedListSuite extends HailSuite {
       val dstPtr = fb.genFieldThisRef[Long]()
       val r = fb.getCodeParam[Region](1)
       val srcPtr = fb.getCodeParam[Long](2)
-      fb.emit(Code(
-        dstPtr := r.allocate(sbll1.storageType.alignment, sbll1.storageType.byteSize),
-        sbll2.load(srcPtr),
-        sbll1.initWithDeepCopy(r, sbll2),
-        sbll1.store(dstPtr),
-        dstPtr))
+      fb.emitWithBuilder { cb =>
+        cb.assign(dstPtr, r.allocate(sbll1.storageType.alignment, sbll1.storageType.byteSize))
+        sbll2.load(cb, srcPtr)
+        sbll1.initWithDeepCopy(cb, r, sbll2)
+        sbll1.store(cb, dstPtr)
+        dstPtr
+      }
 
       val f = fb.result()()
       ({ (r, other) => f(r, other.ptr) })


### PR DESCRIPTION
This PR pushes aggregators much closer to where we want
them to be with regardes to SCodes/STypes. Here are the
important conceptual changes:
1. Aggregators are no longer parameterized by the ptypes
   of seqop and initop args. Instead, the state signature
   contains a sequence of VirtualTypeWithRequiredness, which
   is exactly what its name says. Aggregators use ptypes
   internally, but this is not in the state signature.
2. As a consequence of 1), we no longer cast argument types
   to seqop/initops. We are still able to, for instance,pass a seqop
   argument of a different type than the container type to
   the collect aggregator because the collect aggregator accepts
   an SCode argument, and uses the appropriate PType constructor to
   store that SCode (with a possible conversion if necessary, as here).
3. We codebuilder-ify most of the aggregator package. There are some
   straggling bits, but I will clean that up in a followup since the
   time to get a change in will scale super-linearly with its size.

Benchmarks forthcoming.

Agg SCodes hopefully done