### PR TITLE
[batch] Fix search queries with attributes

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -173,20 +173,17 @@ async def _query_batch_jobs(request, batch_id):
         if '=' in t:
             k, v = t.split('=', 1)
             condition = '''
-(EXISTS (SELECT * FROM `job_attributes`
-         WHERE `job_attributes`.batch_id = jobs.batch_id AND
-           `job_attributes`.job_id = jobs.job_id AND
-           `job_attributes`.`key` = %s AND
-           `job_attributes`.`value` = %s))
+((jobs.batch_id, jobs.job_id) IN
+ (SELECT batch_id, job_id FROM job_attributes
+  WHERE `key` = %s AND `value` = %s))
 '''
             args = [k, v]
         elif t.startswith('has:'):
             k = t[4:]
             condition = '''
-(EXISTS (SELECT * FROM `job_attributes`
-         WHERE `job_attributes`.batch_id = jobs.batch_id AND
-           `job_attributes`.job_id = jobs.job_id AND
-           `job_attributes`.`key` = %s))
+((jobs.batch_id, jobs.job_id) IN
+ (SELECT batch_id, job_id FROM job_attributes
+  WHERE `key` = %s))
 '''
             args = [k]
         elif t in state_query_values:
@@ -448,18 +445,17 @@ async def _query_batches(request, user):
         if '=' in t:
             k, v = t.split('=', 1)
             condition = '''
-(EXISTS (SELECT * FROM `batch_attributes`
-         WHERE `batch_attributes`.batch_id = id AND
-           `batch_attributes`.`key` = %s AND
-           `batch_attributes`.`value` = %s))
+((batches.id) IN
+ (SELECT batch_id FROM batch_attributes
+  WHERE `key` = %s AND `value` = %s))
 '''
             args = [k, v]
         elif t.startswith('has:'):
             k = t[4:]
             condition = '''
-(EXISTS (SELECT * FROM `batch_attributes`
-         WHERE `batch_attributes`.batch_id = id AND
-           `batch_attributes`.`key` = %s))
+((batches.id) IN
+ (SELECT batch_id FROM batch_attributes
+  WHERE `key` = %s))
 '''
             args = [k]
         elif t == 'open':


### PR DESCRIPTION
Found the problem where EXISTS in a correlated subquery should be rewritten as IN
https://dev.mysql.com/doc/refman/5.7/en/optimizing-subqueries.html

```
    -> FROM jobs
    -> INNER JOIN batches ON jobs.batch_id = batches.id
    -> LEFT JOIN aggregated_job_resources
    ->   ON jobs.batch_id = aggregated_job_resources.batch_id AND
    ->      jobs.job_id = aggregated_job_resources.job_id
    -> LEFT JOIN resources
    ->   ON aggregated_job_resources.resource = resources.resource
    -> INNER JOIN job_attributes
    ->   ON jobs.batch_id = job_attributes.batch_id AND
    ->      jobs.job_id = job_attributes.job_id AND
    ->      job_attributes.`key` = 'name'
    -> WHERE (jobs.batch_id = 14327) AND
    -> (jobs.batch_id, jobs.job_id) IN (SELECT batch_id, job_id FROM job_attributes WHERE `key` = 'pheno' AND `value` = '50')
    -> GROUP BY jobs.batch_id, jobs.job_id
    -> ORDER BY jobs.batch_id, jobs.job_id ASC
    -> LIMIT 50;
+----+-------------+--------------------------+------------+--------+--------------------------------------------------+--------------------------+---------+-----------------------------------------+------+----------+---------------------------------+
| id | select_type | table                    | partitions | type   | possible_keys                                    | key                      | key_len | ref                                     | rows | filtered | Extra                           |
+----+-------------+--------------------------+------------+--------+--------------------------------------------------+--------------------------+---------+-----------------------------------------+------+----------+---------------------------------+
|  1 | SIMPLE      | batches                  | NULL       | const  | PRIMARY                                          | PRIMARY                  | 8       | const                                   |    1 |   100.00 | Using temporary; Using filesort |
|  1 | SIMPLE      | job_attributes           | NULL       | ref    | PRIMARY,job_attributes_key_value                 | job_attributes_key_value | 1081    | const,const,const                       | 3057 |   100.00 | Using where                     |
|  1 | SIMPLE      | jobs                     | NULL       | eq_ref | PRIMARY,jobs_batch_id_state_always_run_cancelled | PRIMARY                  | 12      | const,batch.job_attributes.job_id       |    1 |   100.00 | NULL                            |
|  1 | SIMPLE      | job_attributes           | NULL       | eq_ref | PRIMARY,job_attributes_key_value                 | PRIMARY                  | 314     | const,batch.job_attributes.job_id,const |    1 |   100.00 | NULL                            |
|  1 | SIMPLE      | aggregated_job_resources | NULL       | ref    | PRIMARY                                          | PRIMARY                  | 12      | const,batch.job_attributes.job_id       |    5 |   100.00 | NULL                            |
|  1 | SIMPLE      | resources                | NULL       | eq_ref | PRIMARY                                          | PRIMARY                  | 302     | batch.aggregated_job_resources.resource |    1 |   100.00 | NULL                            |
+----+-------------+--------------------------+------------+--------+--------------------------------------------------+--------------------------+---------+-----------------------------------------+------+----------+---------------------------------+
6 rows in set, 1 warning (0.01 sec)
```