### PR TITLE
[query] NDArray Reshape Simplification

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -237,7 +237,9 @@ object Simplify {
     case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
       Let(name, value, x)
 
+    //TODO: A better system would push all reshapes down to the MakeNDArray calls if there aren't any shape dependent nodes in between.
     case NDArrayReshape(MakeNDArray(data, _, rowMajor), reshapedShape) => MakeNDArray(data, reshapedShape, rowMajor)
+    case NDArrayReshape(NDArrayMap(MakeNDArray(data, _, rowMajor), vName, body), newShape) => NDArrayMap(MakeNDArray(data, newShape, rowMajor), vName, body)
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -237,9 +237,8 @@ object Simplify {
     case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
       Let(name, value, x)
 
-    //TODO: A better system would push all reshapes down to the MakeNDArray calls if there aren't any shape dependent nodes in between.
     case NDArrayReshape(MakeNDArray(data, _, rowMajor), reshapedShape) => MakeNDArray(data, reshapedShape, rowMajor)
-    case NDArrayReshape(NDArrayMap(MakeNDArray(data, _, rowMajor), vName, body), newShape) => NDArrayMap(MakeNDArray(data, newShape, rowMajor), vName, body)
+    case NDArrayReshape(NDArrayMap(inner, vName, body), newShape) => NDArrayMap(NDArrayReshape(inner, newShape), vName, body)
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -237,6 +237,8 @@ object Simplify {
     case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
       Let(name, value, x)
 
+    case NDArrayReshape(MakeNDArray(data, _, rowMajor), reshapedShape) => MakeNDArray(data, reshapedShape, rowMajor)
+
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 
     case GetField(MakeStruct(fields), name) =>


### PR DESCRIPTION
I think there are a lot of situations like this, like `hl.nd.zeros(shape)`, which is implemented as:

`hl.nd.array(hl.range(total_num_elements)).map(lambda x: 0).reshape(shape)`. No reason to actually generate code for reshaping in these situations. 