### PR TITLE
[batch] pass credentials for both GCR and Artifact Registry images

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -341,7 +341,7 @@ class Container:
     async def run(self, worker):
         try:
             async with self.step('pulling'):
-                if self.image.startswith('gcr.io/'):
+                if self.image.startswith('gcr.io/') or 'docker.pkg.dev/' in self.image:
                     key = base64.b64decode(
                         self.job.gsa_key['key.json']).decode()
                     auth = {

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -20,7 +20,7 @@ from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            RETRY_FUNCTION_SCRIPT, sleep_and_backoff, retry_all_errors, check_shell,
-                           CalledProcessError, check_shell_output)
+                           CalledProcessError, check_shell_output, is_google_registry_image)
 from hailtop.tls import get_context_specific_ssl_client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes)
@@ -341,7 +341,7 @@ class Container:
     async def run(self, worker):
         try:
             async with self.step('pulling'):
-                if self.image.startswith('gcr.io/') or 'docker.pkg.dev/' in self.image:
+                if is_google_registry_image(self.image):
                     key = base64.b64decode(
                         self.job.gsa_key['key.json']).decode()
                     auth = {

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -10,6 +10,7 @@ import webbrowser
 import warnings
 
 from hailtop.config import get_deploy_config, get_user_config
+from hailtop.utils import is_google_registry_image
 import hailtop.batch_client.client as bc
 from hailtop.batch_client.client import BatchClient
 
@@ -472,7 +473,7 @@ class ServiceBackend(Backend):
                 resources['storage'] = job._storage
 
             image = job._image if job._image else default_image
-            if not (image.startswith('gcr.io/') or 'docker.pkg.dev/' in image):
+            if not is_google_registry_image(image):
                 warnings.warn(f'Using an image {image} not in GCR. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -472,7 +472,7 @@ class ServiceBackend(Backend):
                 resources['storage'] = job._storage
 
             image = job._image if job._image else default_image
-            if not image.startswith('gcr.io/'):
+            if not (image.startswith('gcr.io/') or 'docker.pkg.dev/' in image):
                 warnings.warn(f'Using an image {image} not in GCR. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -8,7 +8,7 @@ from .utils import (
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
-    url_join)
+    url_join, is_google_registry_image)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -66,5 +66,6 @@ __all__ = [
     'external_requests_client_session',
     'url_basename',
     'url_join',
-    'serialization'
+    'serialization',
+    'is_google_registry_image',
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -545,6 +545,7 @@ def url_join(url: str, path: str) -> str:
     parsed = urllib.parse.urlparse(url)
     return urllib.parse.urlunparse(parsed._replace(path=os.path.join(parsed.path, path)))
 
+
 def is_google_registry_image(path: str) -> bool:
     """Returns true if the given Docker image path points to either the Google
     Container Registry or the Artifact Registry."""

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -544,3 +544,9 @@ def url_join(url: str, path: str) -> str:
     """Join the (relative or absolute) path `path` to the URL `url`."""
     parsed = urllib.parse.urlparse(url)
     return urllib.parse.urlunparse(parsed._replace(path=os.path.join(parsed.path, path)))
+
+def is_google_registry_image(path: str) -> bool:
+    """Returns true if the given Docker image path points to either the Google
+    Container Registry or the Artifact Registry."""
+    host = path.partition('/')[0]
+    return host == 'gcr.io' or host.endswith('docker.pkg.dev')


### PR DESCRIPTION
The Artifact Registry is useful to avoid network egress costs for regions like Australia, where GCR doesn't provide local hosting.

Partially addresses #9872.