### PR TITLE
Revert "[query] NDArray Reshape Simplification"

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -237,9 +237,6 @@ object Simplify {
     case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
       Let(name, value, x)
 
-    case NDArrayReshape(MakeNDArray(data, _, rowMajor), reshapedShape) => MakeNDArray(data, reshapedShape, rowMajor)
-    case NDArrayReshape(NDArrayMap(inner, vName, body), newShape) => NDArrayMap(NDArrayReshape(inner, newShape), vName, body)
-
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
 
     case GetField(MakeStruct(fields), name) =>


### PR DESCRIPTION
Reverts hail-is/hail#9874

This is invalid, doesn't handle the fact that negative ones can be present in the shape. Unless we handle that in python/IR, we can't do this optimization.