### PR TITLE
[query] Add subset method to SBaseStructCode

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStruct.scala
@@ -2,8 +2,9 @@ package is.hail.types.physical.stypes.interfaces
 
 import is.hail.asm4s.Code
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitSCode}
-import is.hail.types.physical.{PBaseStruct, PBaseStructValue, PSettable}
+import is.hail.types.physical.PBaseStruct
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
+import is.hail.types.physical.stypes.concrete.{SSubsetStruct, SSubsetStructCode}
 
 trait SStruct extends SType {
   override def fromCodes(codes: IndexedSeq[Code[_]]): SBaseStructCode
@@ -23,9 +24,15 @@ trait SBaseStructValue extends SValue {
   def loadField(cb: EmitCodeBuilder, fieldName: String): IEmitSCode = loadField(cb, pt.fieldIdx(fieldName))
 }
 
-trait SBaseStructCode extends SCode {
+trait SBaseStructCode extends SCode { self =>
+  def st: SStruct
+
   def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue
-}
 
+  def subset(fieldNames: String*): SSubsetStructCode = {
+    val st = SSubsetStruct(self.st, fieldNames.toIndexedSeq)
+    new SSubsetStructCode(st, self.asPCode.asBaseStruct) // FIXME, should be sufficient to just use self here
+  }
+}


### PR DESCRIPTION
The subset method is used to construct SSubsetStructCode