### PR TITLE
[hail] remove dev requirement due to jupyter changes

### DIFF
--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -10,6 +10,5 @@ sphinx-autodoc-typehints==1.11.0
 nbsphinx==0.7.1
 sphinx_rtd_theme==0.4.2
 jupyter==1.0.0
-tornado<6
 sphinxcontrib.katex==0.5.1
 fswatch==0.1.1


### PR DESCRIPTION
Jupyter now requires tornado>=6. We added the tornado<6 requirement to prevent previous issues in
which the notebook package did not correctly specify its dependency on tornado<6.