### PR TITLE
[query] Clean up PNDArray / Improve loadElement performance

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -338,7 +338,7 @@ class UnsafeNDArray(val pnd: PNDArray, val region: Region, val ndAddr: Long) ext
     val flat = new Array[Annotation](numElements.toInt)
 
     if (numElements > Int.MaxValue) {
-      throw new IllegalArgumentException("Cannot make an UnsafeNDArray with greater than Int.MaxValue entries")
+      throw new IllegalArgumentException(s"Cannot make an UnsafeNDArray with greater than Int.MaxValue entries. Shape was ${shape}")
     }
 
     while (idxIntoFlat < numElements) {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -847,7 +847,7 @@ class Emit[C](
                 }
 
                 cb.ifx(isRowMajor, {
-                  cb += xP.makeRowMajorStridesBuilder(shapeCodeSeq1, cb)(srvb)
+                  cb += xP.makeRowMajorStridesStruct(shapeCodeSeq1, cb)(srvb)
                 }, {
                   cb += xP.makeColumnMajorStridesBuilder(shapeCodeSeq1, cb)(srvb)
                 })
@@ -1317,10 +1317,10 @@ class Emit[C](
 
             val hShapeArray = FastIndexedSeq[Value[Long]](N, M)
             val hShapeBuilder = hPType.makeShapeBuilder(hShapeArray)
-            val hStridesBuilder = hPType.makeRowMajorStridesBuilder(hShapeArray, cb)
+            val hStridesBuilder = hPType.makeRowMajorStridesStruct(hShapeArray, cb)
 
             val tauShapeBuilder = tauPType.makeShapeBuilder(FastIndexedSeq(K))
-            val tauStridesBuilder = tauPType.makeRowMajorStridesBuilder(FastIndexedSeq(K), cb)
+            val tauStridesBuilder = tauPType.makeRowMajorStridesStruct(FastIndexedSeq(K), cb)
 
             val h = hPType.construct(hShapeBuilder, hStridesBuilder, aAddressDGEQRF, cb, region.code)
             val tau = tauPType.construct(tauShapeBuilder, tauStridesBuilder, tauAddress, cb, region.code)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -992,8 +992,6 @@ class Emit[C](
                       (lStackVars :+ n :+ k, rStackVars :+ k :+ m)
                   }
 
-                  val lElem = leftPVal.loadElement(lIndices, cb)
-                  val rElem = rightPVal.loadElement(rIndices, cb)
                   val kLen = cb.newField[Long]("ndarray_matmul_kLen")
 
                   def multiply(l: PCode, r: PCode): Code[_] = {
@@ -1011,9 +1009,11 @@ class Emit[C](
 
                   cb.assign(kLen, lShape(lPType.nDims - 1))
                   cb.assign(element, numericElementType.zero)
-                  cb.forLoop(cb.assign(k, 0L), k < kLen, cb.assign(k, k + 1L),
+                  cb.forLoop(cb.assign(k, 0L), k < kLen, cb.assign(k, k + 1L), {
+                    val lElem = leftPVal.loadElement(lIndices, cb)
+                    val rElem = rightPVal.loadElement(rIndices, cb)
                     cb.assign(element, numericElementType.add(multiply(lElem.asPCode, rElem.asPCode), element))
-                  )
+                  })
 
                   PCode(outputPType.elementType, element)
                 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -883,7 +883,7 @@ class Emit[C](
                   srvb.addLong(if (index < childPType.nDims) childStrides(index) else 0L),
                   srvb.advance())
               })
-          }, childPType.dataArrayPointer(pndVal.tcode[Long]), cb, region.code)
+          }, childPType.dataPArrayPointer(pndVal.tcode[Long]), cb, region.code)
         }
 
       case NDArrayRef(nd, idxs, errorId) =>
@@ -924,8 +924,8 @@ class Emit[C](
             val outputPType = PCanonicalNDArray(lPType.elementType, TNDArray.matMulNDims(lPType.nDims, rPType.nDims), true)
 
             if ((lPType.elementType.isInstanceOf[PFloat64] || lPType.elementType.isInstanceOf[PFloat32]) && lPType.nDims == 2 && rPType.nDims == 2) {
-              val leftDataAddress = lPType.dataPointer(leftPVal.tcode[Long])
-              val rightDataAddress = rPType.dataPointer(rightPVal.tcode[Long])
+              val leftDataAddress = lPType.dataFirstElementPointer(leftPVal.tcode[Long])
+              val rightDataAddress = rPType.dataFirstElementPointer(rightPVal.tcode[Long])
 
               val answerPArrayAddress = mb.genFieldThisRef[Long]()
               val M = lShape(lPType.nDims - 2)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2855,10 +2855,13 @@ class Emit[C](
           ndI.map(cb){ ndPCode =>
             val ndPv = ndPCode.asNDArray.memoize(cb, "deforestNDArray_fall_through_ndarray")
             val shape = ndPv.shapes(cb)
+            val strides = ndPv.strides(cb)
+            val dataAddress = cb.newLocal[Long]("deforestNDArray_fall_through_ndarray_data")
+            cb.assign(dataAddress, ndPv.pt.dataPointer(ndPv.tcode[Long]))
 
             new NDArrayEmitter(shape) {
               override def outputElement(cb: EmitCodeBuilder, idxVars: IndexedSeq[Value[Long]]): PCode = {
-                ndPv.asInstanceOf[PNDArrayValue].loadElement(idxVars, cb).toPCode(cb, region.code)
+                ndPv.asInstanceOf[PNDArrayValue].loadElementFromDataPointerAndStrides(idxVars, dataAddress, strides, cb).toPCode(cb, region.code)
               }
             }
           }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1260,7 +1260,7 @@ class Emit[C](
 
           def LWORK = Region.loadDouble(LWORKAddress).toI
 
-          val dataAddress = pndValue.pt.data.load(pndValue.tcode[Long])
+          val dataAddress = pndValue.pt.dataPArrayPointer(pndValue.tcode[Long])
 
           val tauPType = PCanonicalArray(PFloat64Required, true)
           val tauAddress = cb.newLocal[Long]("ndarray_qr_tauAddress")

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -883,7 +883,7 @@ class Emit[C](
                   srvb.addLong(if (index < childPType.nDims) childStrides(index) else 0L),
                   srvb.advance())
               })
-          }, childPType.data.load(pndVal.tcode[Long]), mb, region.code)
+          }, childPType.dataArrayPointer(pndVal.tcode[Long]), mb, region.code)
         }
 
       case NDArrayRef(nd, idxs, errorId) =>
@@ -924,8 +924,8 @@ class Emit[C](
             val outputPType = PCanonicalNDArray(lPType.elementType, TNDArray.matMulNDims(lPType.nDims, rPType.nDims), true)
 
             if ((lPType.elementType.isInstanceOf[PFloat64] || lPType.elementType.isInstanceOf[PFloat32]) && lPType.nDims == 2 && rPType.nDims == 2) {
-              val leftDataAddress = lPType.data.load(leftPVal.tcode[Long])
-              val rightDataAddress = rPType.data.load(rightPVal.tcode[Long])
+              val leftDataAddress = lPType.dataPointer(leftPVal.tcode[Long])
+              val rightDataAddress = rPType.dataPointer(rightPVal.tcode[Long])
 
               val answerPArrayAddress = mb.genFieldThisRef[Long]()
               val M = lShape(lPType.nDims - 2)
@@ -948,9 +948,9 @@ class Emit[C](
                       N.toI,
                       K.toI,
                       1.0f,
-                      lPType.data.pType.firstElementOffset(leftDataAddress),
+                      leftDataAddress,
                       LDA.toI,
-                      rPType.data.pType.firstElementOffset(rightDataAddress),
+                      rightDataAddress,
                       LDB.toI,
                       0.0f,
                       outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),
@@ -964,9 +964,9 @@ class Emit[C](
                       N.toI,
                       K.toI,
                       1.0,
-                      lPType.data.pType.firstElementOffset(leftDataAddress),
+                      leftDataAddress,
                       LDA.toI,
-                      rPType.data.pType.firstElementOffset(rightDataAddress),
+                      rightDataAddress,
                       LDB.toI,
                       0.0,
                       outputPType.data.pType.firstElementOffset(answerPArrayAddress, (M * N).toI),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2855,13 +2855,10 @@ class Emit[C](
           ndI.map(cb){ ndPCode =>
             val ndPv = ndPCode.asNDArray.memoize(cb, "deforestNDArray_fall_through_ndarray")
             val shape = ndPv.shapes(cb)
-            val strides = ndPv.strides(cb)
-            val dataAddress = cb.newLocal[Long]("deforestNDArray_fall_through_ndarray_data")
-            cb.assign(dataAddress, ndPv.pt.dataPointer(ndPv.tcode[Long]))
 
             new NDArrayEmitter(shape) {
               override def outputElement(cb: EmitCodeBuilder, idxVars: IndexedSeq[Value[Long]]): PCode = {
-                ndPv.asInstanceOf[PNDArrayValue].loadElementFromDataPointerAndStrides(idxVars, dataAddress, strides, cb).toPCode(cb, region.code)
+                ndPv.asInstanceOf[PNDArrayValue].loadElement(idxVars, cb).toPCode(cb, region.code)
               }
             }
           }

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -33,14 +33,14 @@ object LinalgCodeUtils {
   def createColumnMajorCode(pndv: PNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): PNDArrayCode = {
     val shape = pndv.shapes(cb)
     val shapeBuilder = pndv.pt.makeShapeBuilder(shape)
-    val stridesBuilder = pndv.pt.makeColumnMajorStridesBuilder(shape, cb.emb)
-    val dataLength = pndv.pt.numElements(shape, cb.emb)
+    val stridesBuilder = pndv.pt.makeColumnMajorStridesBuilder(shape, cb)
+    val dataLength = pndv.pt.numElements(shape)
 
     val outputElementPType = pndv.pt.elementType
     val idxVars = Array.tabulate(pndv.pt.nDims) { _ => cb.emb.genFieldThisRef[Long]() }.toFastIndexedSeq
 
     def loadElement(ndValue: PNDArrayValue) = {
-      ndValue.pt.loadElementToIRIntermediate(idxVars, ndValue.value.asInstanceOf[Value[Long]], cb.emb)
+      ndValue.pt.loadElementToIRIntermediate(idxVars, ndValue.value.asInstanceOf[Value[Long]], cb)
     }
 
     val srvb = new StagedRegionValueBuilder(cb.emb, pndv.pt.data.pType, region)
@@ -66,7 +66,7 @@ object LinalgCodeUtils {
       columnMajorLoops
     ))
 
-    pndv.pt.construct(shapeBuilder, stridesBuilder, srvb.end(), cb.emb, region)
+    pndv.pt.construct(shapeBuilder, stridesBuilder, srvb.end(), cb, region)
   }
 
   def linearizeIndicesRowMajor(indices: IndexedSeq[Code[Long]], shapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Long] = {

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -32,8 +32,8 @@ object LinalgCodeUtils {
 
   def createColumnMajorCode(pndv: PNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): PNDArrayCode = {
     val shape = pndv.shapes(cb)
-    val shapeBuilder = pndv.pt.makeShapeBuilder(shape)
-    val stridesBuilder = pndv.pt.makeColumnMajorStridesBuilder(shape, cb)
+    val shapeStruct = pndv.pt.makeShapeStruct(shape, region, cb)
+    val stridesStruct = pndv.pt.makeColumnMajorStridesStruct(shape, region, cb)
     val dataLength = pndv.pt.numElements(shape)
 
     val outputElementPType = pndv.pt.elementType
@@ -66,7 +66,7 @@ object LinalgCodeUtils {
       columnMajorLoops
     ))
 
-    pndv.pt.construct(shapeBuilder, stridesBuilder, srvb.end(), cb, region)
+    pndv.pt.construct(shapeStruct, stridesStruct, srvb.end(), cb, region)
   }
 
   def linearizeIndicesRowMajor(indices: IndexedSeq[Code[Long]], shapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Long] = {

--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -89,7 +89,7 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
         srvb.advance())
     }
 
-    t.construct(shapeBuilder, stridesBuilder, data, cb.emb, region)
+    t.construct(shapeBuilder, stridesBuilder, data, cb, region)
       .tcode[Long]
   }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -79,17 +79,14 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
     cb.forLoop(cb.assign(i, 0), i < n, cb.assign(i, i + 1),
       cb += readElemF(region, t.data.pType.elementOffset(data, n, i), in))
 
-    val shapeBuilder = t.makeShapeBuilder(FastIndexedSeq(nRows, nCols))
-    val stridesBuilder = { srvb: StagedRegionValueBuilder =>
-      Code(
-        srvb.start(),
-        srvb.addLong(transpose.mux(nCols.toL * t.elementType.byteSize, t.elementType.byteSize)),
-        srvb.advance(),
-        srvb.addLong(transpose.mux(t.elementType.byteSize, nRows * t.elementType.byteSize)),
-        srvb.advance())
-    }
+    val shapeStruct = t.makeShapeStruct(FastIndexedSeq(nRows, nCols), region, cb)
 
-    t.construct(shapeBuilder, stridesBuilder, data, cb, region)
+    val stride0 = cb.newLocal[Long]("stride0", transpose.mux(nCols.toL * t.elementType.byteSize, t.elementType.byteSize))
+    val stride1 = cb.newLocal[Long]("stride1", transpose.mux(t.elementType.byteSize, nRows * t.elementType.byteSize))
+
+    val stridesBuilder = t.makeShapeStruct(FastIndexedSeq(stride0, stride1), region, cb)
+
+    t.construct(shapeStruct, stridesBuilder, data, cb, region)
       .tcode[Long]
   }
 

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -65,8 +65,8 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     cb.forLoop(cb.assign(dataIdx, 0), dataIdx < totalNumElements.toI, cb.assign(dataIdx, dataIdx + 1),
       cb += readElemF(region, pnd.data.pType.elementOffset(dataAddress, totalNumElements.toI, dataIdx), in))
 
-    pnd.construct(pnd.makeShapeBuilder(shapeVars),
-      pnd.makeColumnMajorStridesBuilder(shapeVars, cb),
+    pnd.construct(pnd.makeShapeStruct(shapeVars, region, cb),
+      pnd.makeColumnMajorStridesStruct(shapeVars, region, cb),
       dataAddress, cb, region)
       .tcode[Long]
   }

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -29,17 +29,28 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     val shapes = ndarray.shapes(cb)
     shapes.foreach(s => cb += out.writeLong(s))
 
-    val idxVars = Array.tabulate(ndarray.pt.nDims)(i => cb.newLocal[Long](s"idx_$i"))
-    cb += idxVars.zipWithIndex.foldLeft(writeElemF(ndarray.loadElement(idxVars, cb).asPCode.code, out))
-    { case (innerLoops, (dimVar, dimIdx)) =>
-      Code(
-        dimVar := 0L,
-        Code.whileLoop(dimVar < shapes(dimIdx),
-          innerLoops,
-          dimVar := dimVar + 1L
+    val idxVars = Array.tabulate(ndarray.pt.nDims)(i => cb.newLocal[Long](s"ndarray_encoder_idxVar_$i"))
+
+    def recurLoopBuilder(dimIdx: Int, innerLambda: () => Unit): Unit = {
+      if (dimIdx == nDims) {
+        innerLambda()
+      }
+      else {
+        val dimVar = idxVars(dimIdx)
+
+        recurLoopBuilder(dimIdx + 1,
+          () => {cb.forLoop({cb.assign(dimVar, 0L)},  dimVar < shapes(dimIdx), {cb.assign(dimVar, dimVar + 1L)},
+            innerLambda()
+          )}
         )
-      )
+      }
     }
+
+    val body = () => {
+      cb += writeElemF(ndarray.loadElement(idxVars, cb).asPCode.code, out)
+    }
+
+    recurLoopBuilder(0, body)
   }
 
   def _buildDecoder(

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -66,8 +66,8 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
       cb += readElemF(region, pnd.data.pType.elementOffset(dataAddress, totalNumElements.toI, dataIdx), in))
 
     pnd.construct(pnd.makeShapeBuilder(shapeVars),
-      pnd.makeColumnMajorStridesBuilder(shapeVars, cb.emb),
-      dataAddress, cb.emb, region)
+      pnd.makeColumnMajorStridesBuilder(shapeVars, cb),
+      dataAddress, cb, region)
       .tcode[Long]
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -247,8 +247,8 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     }
   }
 
-  override def dataPointer(ndAddr: Code[Long]): Code[Long] = data.pType.firstElementOffset(this.dataArrayPointer(ndAddr))
+  override def dataFirstElementPointer(ndAddr: Code[Long]): Code[Long] = data.pType.firstElementOffset(this.dataPArrayPointer(ndAddr))
 
-  override def dataArrayPointer(ndAddr: Code[Long]): Code[Long] = data.load(ndAddr)
+  override def dataPArrayPointer(ndAddr: Code[Long]): Code[Long] = data.load(ndAddr)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -227,5 +227,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
         representation.storeAtAddress(cb, addr, region, representation.loadCheapPCode(cb, value.asInstanceOf[SNDArrayPointerCode].a), deepCopy)
     }
   }
+
+  override def dataPointer(ndAddr: Code[Long]): Code[Long] = data.pType.firstElementOffset(this.dataPointer(ndAddr))
+
+  override def dataArrayPointer(ndAddr: Code[Long]): Code[Long] = data.load(ndAddr)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -155,8 +155,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     elementType.storeAtAddress(cb, getElementAddress(indices, ndAddress, cb), region, newElement, deepCopy)
   }
 
-  private def getElementAddressFromDataPointerAndStrides(indices: IndexedSeq[Value[Long]], ndData: Value[Long], strides: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Long] = {
-    val stridesTuple = strides
+  private def getElementAddressFromDataPointerAndStrides(indices: IndexedSeq[Value[Long]], dataFirstElementPointer: Value[Long], strides: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Long] = {
     val bytesAway = cb.newLocal[Long]("nd_get_element_address_bytes_away")
 
     coerce[Long](Code(
@@ -164,9 +163,9 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       indices.zipWithIndex.foldLeft(Code._empty) { case (codeSoFar: Code[_], (requestedIndex: Value[Long], strideIndex: Int)) =>
         Code(
           codeSoFar,
-          bytesAway := bytesAway + requestedIndex * stridesTuple(strideIndex))
+          bytesAway := bytesAway + requestedIndex * strides(strideIndex))
       },
-      bytesAway + ndData)
+      bytesAway + dataFirstElementPointer)
     )
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.{CodeOrdering, Region, StagedRegionValueBuilder}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.Nat
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.interfaces.{SNDArrayCode, SNDArrayValue}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SNDArrayCode, SNDArrayValue}
 import is.hail.types.virtual.TNDArray
 
 final class StaticallyKnownField[T, U](
@@ -41,9 +41,9 @@ abstract class PNDArray extends PType {
 
   def makeShapeBuilder(shapeArray: IndexedSeq[Value[Long]]): StagedRegionValueBuilder => Code[Unit]
 
-  def makeRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): StagedRegionValueBuilder => Code[Unit]
+  def makeRowMajorStridesStruct(sourceShapeArray: IndexedSeq[Value[Long]], region: Value[Region], cb: EmitCodeBuilder): SBaseStructCode
 
-  def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): StagedRegionValueBuilder => Code[Unit]
+  def makeColumnMajorStridesStruct(sourceShapeArray: IndexedSeq[Value[Long]], region: Value[Region], cb: EmitCodeBuilder): SBaseStructCode
 
   def getElementAddress(indices: IndexedSeq[Long], nd: Long): Long
 

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -28,8 +28,8 @@ abstract class PNDArray extends PType {
 
   val representation: PStruct
 
-  def dataPointer(ndAddr: Code[Long]): Code[Long]
-  def dataArrayPointer(ndAddr: Code[Long]): Code[Long]
+  def dataFirstElementPointer(ndAddr: Code[Long]): Code[Long]
+  def dataPArrayPointer(ndAddr: Code[Long]): Code[Long]
 
   def loadShape(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -37,24 +37,24 @@ abstract class PNDArray extends PType {
 
   def loadStride(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 
-  def numElements(shape: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): Code[Long]
+  def numElements(shape: IndexedSeq[Value[Long]]): Code[Long]
 
   def makeShapeBuilder(shapeArray: IndexedSeq[Value[Long]]): StagedRegionValueBuilder => Code[Unit]
 
-  def makeRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+  def makeRowMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): StagedRegionValueBuilder => Code[Unit]
 
-  def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], mb: EmitMethodBuilder[_]): StagedRegionValueBuilder => Code[Unit]
+  def makeColumnMajorStridesBuilder(sourceShapeArray: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): StagedRegionValueBuilder => Code[Unit]
 
   def getElementAddress(indices: IndexedSeq[Long], nd: Long): Long
 
   def loadElement(cb: EmitCodeBuilder, indices: IndexedSeq[Value[Long]], ndAddress: Value[Long]): Code[Long]
-  def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], mb: EmitMethodBuilder[_]): Code[_]
+  def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], cb: EmitCodeBuilder): Code[_]
 
   def construct(
     shapeBuilder: StagedRegionValueBuilder => Code[Unit],
     stridesBuilder: StagedRegionValueBuilder => Code[Unit],
     data: Code[Long],
-    mb: EmitMethodBuilder[_],
+    mb: EmitCodeBuilder,
     region: Value[Region]
   ): PNDArrayCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -28,6 +28,9 @@ abstract class PNDArray extends PType {
 
   val representation: PStruct
 
+  def dataPointer(ndAddr: Code[Long]): Code[Long]
+  def dataArrayPointer(ndAddr: Code[Long]): Code[Long]
+
   def loadShape(cb: EmitCodeBuilder, off: Code[Long], idx: Int): Code[Long]
 
   def loadShape(off: Long, idx: Int): Long

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -39,7 +39,7 @@ abstract class PNDArray extends PType {
 
   def numElements(shape: IndexedSeq[Value[Long]]): Code[Long]
 
-  def makeShapeBuilder(shapeArray: IndexedSeq[Value[Long]]): StagedRegionValueBuilder => Code[Unit]
+  def makeShapeStruct(shapeArray: IndexedSeq[Value[Long]], region: Value[Region], cb: EmitCodeBuilder): SBaseStructCode
 
   def makeRowMajorStridesStruct(sourceShapeArray: IndexedSeq[Value[Long]], region: Value[Region], cb: EmitCodeBuilder): SBaseStructCode
 
@@ -51,8 +51,8 @@ abstract class PNDArray extends PType {
   def loadElementToIRIntermediate(indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], cb: EmitCodeBuilder): Code[_]
 
   def construct(
-    shapeBuilder: StagedRegionValueBuilder => Code[Unit],
-    stridesBuilder: StagedRegionValueBuilder => Code[Unit],
+    shapeCode: SBaseStructCode,
+    stridesCode: SBaseStructCode,
     data: Code[Long],
     mb: EmitCodeBuilder,
     region: Value[Region]

--- a/hail/src/main/scala/is/hail/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PTuple.scala
@@ -31,28 +31,3 @@ trait PTuple extends PBaseStruct {
 
   def identBase: String = "tuple"
 }
-
-class CodePTuple(
-  val pType: PTuple,
-  val offset: Value[Long]
-) {
-  def apply[T](i: Int): Value[T] =
-      new Value[T] {
-        def get: Code[T] = coerce[T](Region.loadIRIntermediate(pType.types(i))(pType.loadField(offset, i)))
-      }
-
-  def isMissing(i: Int): Code[Boolean] = {
-    pType.isFieldMissing(offset, i)
-  }
-
-  def withTypesAndIndices: IndexedSeq[(PType, Value[_], Int)] = (0 until pType.nFields).map(i => (pType.types(i), apply(i), i)).toFastIndexedSeq
-
-  def withTypes: IndexedSeq[(PType, Value[_])] = withTypesAndIndices.map(x => (x._1, x._2)).toFastIndexedSeq
-
-  def missingnessPattern: IndexedSeq[Code[Boolean]] = (0 until pType.nFields).map(isMissing)
-
-  def values[T, U, V]: (Value[T], Value[U], Value[V]) = {
-    assert(pType.nFields == 3)
-    (apply[T](0), apply[U](1), apply[V](2))
-  }
-}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s.{Code, IntInfo, LongInfo, Settable, SettableBuilder, TypeIn
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayValue}
 import is.hail.types.physical.stypes.{SCode, SType}
-import is.hail.types.physical.{PBaseStructCode, PCode, PNDArray, PNDArrayCode, PNDArrayValue, PSettable, PType, PValue}
+import is.hail.types.physical.{PBaseStructCode, PCanonicalNDArray, PCode, PNDArray, PNDArrayCode, PNDArrayValue, PSettable, PType, PValue}
 import is.hail.utils.FastIndexedSeq
 
 case class SNDArrayPointer(pType: PNDArray) extends SNDArray {
@@ -49,6 +49,10 @@ class SNDArrayPointerSettable(val st: SNDArrayPointer, val a: Settable[Long]) ex
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): PCode = {
     assert(indices.size == pt.nDims)
     pt.elementType.loadCheapPCode(cb, pt.loadElement(cb, indices, a))
+  }
+
+  def loadElementFromDataPointerAndStrides(indices: IndexedSeq[Value[Long]], ndArrayDataPointer: Value[Long], strides: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): PCode = {
+    pt.elementType.loadCheapPCode(cb, pt.asInstanceOf[PCanonicalNDArray].loadElementFromDataAndStrides(cb, indices, ndArrayDataPointer, strides))
   }
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -61,7 +61,7 @@ class SNDArrayPointerSettable(val st: SNDArrayPointer, val a: Settable[Long]) ex
     shape = Array.tabulate(pt.nDims)(i => cb.newLocal[Long](s"sndarray_shapes_$i", pt.loadShape(cb, a, i)))
     strides = Array.tabulate(pt.nDims)(i => cb.newLocal[Long](s"sndarray_strides_$i", pt.loadStride(cb, a, i)))
     dataFirstElement = cb.newLocal[Long]("sndarray_pointer_first_element")
-    cb.assign(dataFirstElement, pt.dataPointer(a))
+    cb.assign(dataFirstElement, pt.dataFirstElementPointer(a))
   }
 
   override def get: PCode = new SNDArrayPointerCode(st, a)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -10,8 +10,6 @@ trait SNDArray extends SType
 trait SNDArrayValue extends SValue {
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
 
-  def loadElementFromDataPointerAndStrides(indices: IndexedSeq[Value[Long]], ndArrayDataPointer: Value[Long], strides: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
-
   def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
 
   def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -10,6 +10,8 @@ trait SNDArray extends SType
 trait SNDArrayValue extends SValue {
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
 
+  def loadElementFromDataPointerAndStrides(indices: IndexedSeq[Value[Long]], ndArrayDataPointer: Value[Long], strides: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
+
   def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
 
   def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]


### PR DESCRIPTION
This PR:

- Pushes code builders through PNDArray interface instead of method builders
- Starts switching away from `PNDArray.data.load` to using methods like `dataPArrayPointer` and `dataFirstElementPointer`. All `dataPArrayPointer` calls will go away when ndarrays are no longer backed by `PArray`. 
- Speeds up repeated calls to `loadElement` on `SNDArrayPointerSettable`, which speeds up linear regression nd benchmark ~12%. Now we are approximately 60% slower than breeze linear regression.'
- Removes `CodePTuple`, since all instances of its use are removed now and it predated the current `PCode` system