### PR TITLE
[query] Remove specialized from several usages with arrays

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
 object OrderedRVIterator {
   def multiZipJoin(
     its: IndexedSeq[OrderedRVIterator]
-  ): Iterator[ArrayBuilder[(RegionValue, Int)]] = {
+  ): Iterator[BoxedArrayBuilder[(RegionValue, Int)]] = {
     require(its.length > 0)
     val first = its(0)
     val flipbooks = its.map(_.iterator.toFlipbookIterator)

--- a/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionMemory.scala
@@ -1,12 +1,12 @@
 package is.hail.annotations
 
-import is.hail.expr.ir.{LongArrayBuilder, LongMissingArrayBuilder}
+import is.hail.expr.ir.{AnyRefArrayBuilder, LongArrayBuilder, LongMissingArrayBuilder}
 import is.hail.utils._
 
 final class RegionMemory(pool: RegionPool) extends AutoCloseable {
   private val usedBlocks = new LongArrayBuilder(4)
   private val bigChunks = new LongArrayBuilder(4)
-  private val jObjects = new BoxedArrayBuilder[AnyRef](0)
+  private val jObjects = new AnyRefArrayBuilder[AnyRef](0)
 
   private var totalChunkMemory = 0L
   private var currentBlock: Long = 0L
@@ -18,12 +18,12 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
   private var blockThreshold: Long = _
   private var blockByteSize: Long = _
 
-  private val references = new BoxedArrayBuilder[RegionMemory](4)
+  private val references = new AnyRefArrayBuilder[RegionMemory](4)
   private var referenceCount: Long = _
 
   def storeJavaObject(obj: AnyRef): Int = {
     val idx = jObjects.size
-    jObjects += obj
+    jObjects.add(obj)
     pool.addJavaObject()
     idx
   }
@@ -211,12 +211,12 @@ final class RegionMemory(pool: RegionPool) extends AutoCloseable {
   def blockAddress: Long = currentBlock
 
   def addReferenceTo(r: RegionMemory): Unit = {
-    references += r
+    references.add(r)
     r.referenceCount += 1
   }
 
   def takeOwnershipOf(r: RegionMemory): Unit =
-    references += r
+    references.add(r)
 
   def nReferencedRegions(): Long = references.size
 

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -1,5 +1,6 @@
 package is.hail.annotations
 
+import is.hail.expr.ir.LongArrayBuilder
 import is.hail.utils._
 
 object RegionPool {
@@ -14,9 +15,9 @@ object RegionPool {
 
 final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, threadID: Long) extends AutoCloseable {
   log.info(s"RegionPool: initialized for thread $threadID: $threadName")
-  protected[annotations] val freeBlocks: Array[ArrayBuilder[Long]] = Array.fill[ArrayBuilder[Long]](4)(new ArrayBuilder[Long])
-  protected[annotations] val regions = new ArrayBuilder[RegionMemory]()
-  private val freeRegions = new ArrayBuilder[RegionMemory]()
+  protected[annotations] val freeBlocks: Array[LongArrayBuilder] = Array.fill[LongArrayBuilder](4)(new LongArrayBuilder(8))
+  protected[annotations] val regions = new BoxedArrayBuilder[RegionMemory]()
+  private val freeRegions = new BoxedArrayBuilder[RegionMemory]()
   private val blocks: Array[Long] = Array(0L, 0L, 0L, 0L)
   private var totalAllocatedBytes: Long = 0L
   private var allocationEchoThreshold: Long = 256 * 1024
@@ -62,7 +63,7 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
     Memory.malloc(size)
   }
 
-  protected[annotations] def freeChunks(ab: ArrayBuilder[Long], totalSize: Long): Unit = {
+  protected[annotations] def freeChunks(ab: LongArrayBuilder, totalSize: Long): Unit = {
     while (ab.size > 0) {
       val addr = ab.pop()
       Memory.free(addr)

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -12,10 +12,10 @@ class RegionValueBuilder(var region: Region) {
   var start: Long = _
   var root: PType = _
 
-  val typestk = new ArrayStack[PType]()
-  val indexstk = new ArrayStack[Int]()
-  val offsetstk = new ArrayStack[Long]()
-  val elementsOffsetstk = new ArrayStack[Long]()
+  val typestk = new ObjectArrayStack[PType]()
+  val indexstk = new IntArrayStack()
+  val offsetstk = new LongArrayStack()
+  val elementsOffsetstk = new LongArrayStack()
 
   def inactive: Boolean = root == null && typestk.isEmpty && offsetstk.isEmpty && elementsOffsetstk.isEmpty && indexstk.isEmpty
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2729,7 +2729,7 @@ class Emit[C](
 
               IEmitCode.multiFlatMap[Int, SCode, NDArrayEmitter](indexingIndices, indexingIndex => slicesValue.loadField(cb, indexingIndex), cb) { indexingSCodes =>
                 val indexingValues = indexingSCodes.map(sCode => sCode.memoize(cb, "ndarray_slice_indexer"))
-                val slicingValueTriples = new ArrayBuilder[(Value[Long], Value[Long], Value[Long])]()
+                val slicingValueTriples = new BoxedArrayBuilder[(Value[Long], Value[Long], Value[Long])]()
                 val outputShape = {
                   IEmitCode.multiFlatMap[Int, SCode, IndexedSeq[Value[Long]]](slicingIndices,
                     valueIdx => slicesValue.loadField(cb, valueIdx), cb) { sCodeSlices: IndexedSeq[SCode] =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -443,9 +443,9 @@ class EmitClassBuilder[C](
   }
 
   private[this] var _objectsField: Settable[Array[AnyRef]] = _
-  private[this] var _objects: ArrayBuilder[AnyRef] = _
+  private[this] var _objects: BoxedArrayBuilder[AnyRef] = _
 
-  private[this] var _mods: ArrayBuilder[(String, (Int, Region) => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])] = new ArrayBuilder()
+  private[this] var _mods: BoxedArrayBuilder[(String, (Int, Region) => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])] = new BoxedArrayBuilder()
   private[this] var _backendField: Settable[BackendUtils] = _
 
   private[this] var _aggSigs: Array[agg.AggStateSig] = _
@@ -557,7 +557,7 @@ class EmitClassBuilder[C](
     if (_objectsField == null) {
       cb.addInterface(typeInfo[FunctionWithObjects].iname)
       _objectsField = genFieldThisRef[Array[AnyRef]]()
-      _objects = new ArrayBuilder[AnyRef]()
+      _objects = new BoxedArrayBuilder[AnyRef]()
       val mb = newEmitMethod("setObjects", FastIndexedSeq[ParamType](typeInfo[Array[AnyRef]]), typeInfo[Unit])
       mb.emit(_objectsField := mb.getCodeParam[Array[AnyRef]](1))
     }
@@ -717,7 +717,7 @@ class EmitClassBuilder[C](
     new DependentEmitFunctionBuilder[F](this, dep_apply_method, emit_apply_method)
   }
 
-  val rngs: ArrayBuilder[(Settable[IRRandomness], Code[IRRandomness])] = new ArrayBuilder()
+  val rngs: BoxedArrayBuilder[(Settable[IRRandomness], Code[IRRandomness])] = new BoxedArrayBuilder()
 
   def makeAddPartitionRegion(): Unit = {
     cb.addInterface(typeInfo[FunctionWithPartitionRegion].iname)

--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.expr._
-import is.hail.utils.{ArrayBuilder, _}
+import is.hail.utils.{BoxedArrayBuilder, _}
 
 import scala.collection.mutable._
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -32,11 +32,11 @@ object InferPType {
 
   def apply(ir: IR): Unit = apply(ir, Env.empty)
 
-  private type AAB[T] = Array[ArrayBuilder[RecursiveArrayBuilderElement[T]]]
+  private type AAB[T] = Array[BoxedArrayBuilder[RecursiveArrayBuilderElement[T]]]
 
   case class RecursiveArrayBuilderElement[T](value: T, nested: Option[AAB[T]])
 
-  def newBuilder[T](n: Int): AAB[T] = Array.fill(n)(new ArrayBuilder[RecursiveArrayBuilderElement[T]])
+  def newBuilder[T](n: Int): AAB[T] = Array.fill(n)(new BoxedArrayBuilder[RecursiveArrayBuilderElement[T]])
 
   def apply(ir: IR, env: Env[PType]): Unit = {
     try {

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -394,8 +394,8 @@ object Interpret {
           if (seq.isEmpty)
             FastIndexedSeq[IndexedSeq[Row]]()
           else {
-            val outer = new ArrayBuilder[IndexedSeq[Row]]()
-            val inner = new ArrayBuilder[Row]()
+            val outer = new BoxedArrayBuilder[IndexedSeq[Row]]()
+            val inner = new BoxedArrayBuilder[Row]()
             val (kType, getKey) = structType.select(key)
             val keyOrd = TBaseStruct.getJoinOrdering(kType.types)
             var curKey: Row = getKey(seq.head)
@@ -517,7 +517,7 @@ object Interpret {
 
           for (i <- 0 until k) { advance(i) }
 
-          val builder = new ArrayBuilder[Row]()
+          val builder = new BoxedArrayBuilder[Row]()
           while (tournament(0) != k) {
             val i = tournament(0)
             val elt = streams(i)(heads(i))
@@ -558,7 +558,7 @@ object Interpret {
 
           for (i <- 0 until k) { advance(i) }
 
-          val builder = new ArrayBuilder[Any]()
+          val builder = new BoxedArrayBuilder[Any]()
           while (tournament(0) != k) {
             val i = tournament(0)
             val elt = Array.fill[Row](k)(null)

--- a/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftRelationalValues.scala
@@ -1,15 +1,15 @@
 package is.hail.expr.ir
 
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 
 object LiftRelationalValues {
 
   def apply(ir0: IR): IR = {
 
-    def rewrite(ir: BaseIR, ab: ArrayBuilder[(String, IR)]): BaseIR = ir match {
+    def rewrite(ir: BaseIR, ab: BoxedArrayBuilder[(String, IR)]): BaseIR = ir match {
       case RelationalLet(name, value, body) =>
         val value2 = rewrite(value, ab).asInstanceOf[IR]
-        val ab2 = new ArrayBuilder[(String, IR)]
+        val ab2 = new BoxedArrayBuilder[(String, IR)]
         val body2 = rewrite(body, ab2).asInstanceOf[IR]
         RelationalLet(name, value2, ab2.result().foldRight[IR](body2) { case ((name, value), acc) => RelationalLet(name, value, acc) })
       case LiftMeOut(child) =>
@@ -40,7 +40,7 @@ object LiftRelationalValues {
           ir.copy(rwChildren)
     }
 
-    val ab = new ArrayBuilder[(String, IR)]
+    val ab = new BoxedArrayBuilder[(String, IR)]
     val rw = rewrite(ir0, ab).asInstanceOf[IR]
     ab.result().foldRight[IR](rw) { case ((name, value), acc) => RelationalLet(name, value, acc)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -280,7 +280,7 @@ object IRParser {
     f: (TokenIterator) => T,
     sep: Token,
     end: Token)(implicit tct: ClassTag[T]): Array[T] = {
-    val xs = new ArrayBuilder[T]()
+    val xs = new BoxedArrayBuilder[T]()
     while (it.hasNext && it.head != end) {
       xs += f(it)
       if (it.head == sep)
@@ -292,7 +292,7 @@ object IRParser {
   def repUntil[T](it: TokenIterator,
     f: (TokenIterator) => StackFrame[T],
     end: Token)(implicit tct: ClassTag[T]): StackFrame[Array[T]] = {
-    val xs = new ArrayBuilder[T]()
+    val xs = new BoxedArrayBuilder[T]()
     var cont: T => StackFrame[Array[T]] = null
     def loop(): StackFrame[Array[T]] = {
       if (it.hasNext && it.head != end) {
@@ -311,7 +311,7 @@ object IRParser {
   def repUntilNonStackSafe[T](it: TokenIterator,
     f: (TokenIterator) => T,
     end: Token)(implicit tct: ClassTag[T]): Array[T] = {
-    val xs = new ArrayBuilder[T]()
+    val xs = new BoxedArrayBuilder[T]()
     while (it.hasNext && it.head != end) {
       xs += f(it)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -138,7 +138,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case RelationalLetTable(name, value, body) => addBinding(name, value)
       case TailLoop(loopName, params, body) =>
         addBinding(loopName, body)
-        val argDefs = Array.fill(params.length)(new ArrayBuilder[IR]())
+        val argDefs = Array.fill(params.length)(new BoxedArrayBuilder[IR]())
         refMap(loopName).map(_.t).foreach { case Recur(_, args, _) =>
           argDefs.zip(args).foreach { case (ab, d) => ab += d }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.asm4s._
 import is.hail.types.physical.{PCode, PType, PValue, typeToTypeInfo}
 import is.hail.types.virtual.Type
+import is.hail.utils.BoxedArrayBuilder
 
 import scala.reflect.ClassTag
 
@@ -11,35 +12,35 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
   val ti: TypeInfo[_] = typeToTypeInfo(elt)
 
   val ref: Value[Any] = coerce[Any](ti match {
-    case BooleanInfo => mb.genLazyFieldThisRef[BooleanArrayBuilder](Code.newInstance[BooleanArrayBuilder, Int](len), "zab")
-    case IntInfo => mb.genLazyFieldThisRef[IntArrayBuilder](Code.newInstance[IntArrayBuilder, Int](len), "iab")
-    case LongInfo => mb.genLazyFieldThisRef[LongArrayBuilder](Code.newInstance[LongArrayBuilder, Int](len), "jab")
-    case FloatInfo => mb.genLazyFieldThisRef[FloatArrayBuilder](Code.newInstance[FloatArrayBuilder, Int](len), "fab")
+    case BooleanInfo => mb.genLazyFieldThisRef[BooleanMissingArrayBuilder](Code.newInstance[BooleanMissingArrayBuilder, Int](len), "zab")
+    case IntInfo => mb.genLazyFieldThisRef[IntMissingArrayBuilder](Code.newInstance[IntMissingArrayBuilder, Int](len), "iab")
+    case LongInfo => mb.genLazyFieldThisRef[LongMissingArrayBuilder](Code.newInstance[LongMissingArrayBuilder, Int](len), "jab")
+    case FloatInfo => mb.genLazyFieldThisRef[FloatMissingArrayBuilder](Code.newInstance[FloatMissingArrayBuilder, Int](len), "fab")
     case DoubleInfo => mb.genLazyFieldThisRef[DoubleArrayBuilder](Code.newInstance[DoubleArrayBuilder, Int](len), "dab")
     case ti => throw new RuntimeException(s"unsupported typeinfo found: $ti")
   })
 
   def add(x: Code[_]): Code[Unit] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Boolean, Unit]("add", coerce[Boolean](x))
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](x))
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](x))
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](x))
+    case BooleanInfo => coerce[BooleanMissingArrayBuilder](ref).invoke[Boolean, Unit]("add", coerce[Boolean](x))
+    case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](x))
+    case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](x))
+    case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](x))
     case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](x))
   }
 
   def apply(i: Code[Int]): Code[_] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int, Boolean]("apply", i)
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Int]("apply", i)
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int, Long]("apply", i)
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int, Float]("apply", i)
+    case BooleanInfo => coerce[BooleanMissingArrayBuilder](ref).invoke[Int, Boolean]("apply", i)
+    case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Int]("apply", i)
+    case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Int, Long]("apply", i)
+    case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Int, Float]("apply", i)
     case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double]("apply", i)
   }
 
   def update(i: Code[Int], x: Code[_]): Code[Unit] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int, Boolean, Unit]("update", i, coerce[Boolean](x))
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Int, Unit]("update", i, coerce[Int](x))
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int, Long, Unit]("update", i, coerce[Long](x))
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int, Float, Unit]("update", i, coerce[Float](x))
+    case BooleanInfo => coerce[BooleanMissingArrayBuilder](ref).invoke[Int, Boolean, Unit]("update", i, coerce[Boolean](x))
+    case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Int, Unit]("update", i, coerce[Int](x))
+    case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Int, Long, Unit]("update", i, coerce[Long](x))
+    case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Int, Float, Unit]("update", i, coerce[Float](x))
     case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double, Unit]("update", i, coerce[Double](x))
   }
 
@@ -47,16 +48,16 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     ti match {
       case BooleanInfo =>
         type F = AsmFunction2[Boolean, Boolean, Boolean]
-        coerce[BooleanArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
+        coerce[BooleanMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
       case IntInfo =>
         type F = AsmFunction2[Int, Int, Boolean]
-        coerce[IntArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
+        coerce[IntMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
       case LongInfo =>
         type F = AsmFunction2[Long, Long, Boolean]
-        coerce[LongArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
+        coerce[LongMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
       case FloatInfo =>
         type F = AsmFunction2[Float, Float, Boolean]
-        coerce[FloatArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
+        coerce[FloatMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
       case DoubleInfo =>
         type F = AsmFunction2[Double, Double, Boolean]
         coerce[DoubleArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
@@ -128,7 +129,7 @@ sealed abstract class MissingArrayBuilder(initialCapacity: Int) {
   def clear() {  size_ = 0 }
 }
 
-class IntArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+class IntMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Int] = new Array[Int](initialCapacity)
 
   def apply(i: Int): Int = {
@@ -187,7 +188,7 @@ class IntArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialC
   }
 }
 
-class LongArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+class LongMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Long] = new Array[Long](initialCapacity)
 
   def apply(i: Int): Long = {
@@ -246,7 +247,7 @@ class LongArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initial
   }
 }
 
-class FloatArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+class FloatMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Float] = new Array[Float](initialCapacity)
 
   def apply(i: Int): Float = {
@@ -364,7 +365,7 @@ class DoubleArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initi
   }
 }
 
-class BooleanArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+class BooleanMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Boolean] = new Array[Boolean](initialCapacity)
 
   def apply(i: Int): Boolean = {
@@ -463,4 +464,121 @@ class ByteArrayArrayBuilder(initialCapacity: Int) {
   def clear() {  size_ = 0 }
 
   def result(): Array[Array[Byte]] = b.slice(0, size_)
+}
+
+
+class LongArrayBuilder(initialCapacity: Int) {
+
+  var size_ : Int = 0
+  var b: Array[Long] = new Array[Long](initialCapacity)
+
+  def size: Int = size_
+
+  def setSize(n: Int) {
+    require(n >= 0 && n <= size)
+    size_ = n
+  }
+
+  def apply(i: Int): Long = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int): Unit = {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Long](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Long): Unit = {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+
+  def update(i: Int, x: Long): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+  }
+
+  def clear() {  size_ = 0 }
+
+  def result(): Array[Long] = b.slice(0, size_)
+
+  def clearAndResize(): Unit = {
+    size_ = 0
+    if (b.length > initialCapacity)
+      b = new Array[Long](initialCapacity)
+  }
+  def appendFrom(ab2: LongArrayBuilder): Unit = {
+    ensureCapacity(size_ + ab2.size_)
+    System.arraycopy(ab2.b, 0, b, size_, ab2.size_)
+    size_ = size_ + ab2.size_
+  }
+
+  def pop(): Long = {
+    size_ -= 1
+    b(size)
+  }
+}
+
+class IntArrayBuilder(initialCapacity: Int) {
+
+  var size_ : Int = 0
+  var b: Array[Int] = new Array[Int](initialCapacity)
+
+  def size: Int = size_
+
+  def setSize(n: Int) {
+    require(n >= 0 && n <= size)
+    size_ = n
+  }
+
+  def apply(i: Int): Int = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int): Unit = {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Int](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Int): Unit = {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+
+  def update(i: Int, x: Int): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+  }
+
+  def clear() {  size_ = 0 }
+
+  def result(): Array[Int] = b.slice(0, size_)
+
+  def clearAndResize(): Unit = {
+    size_ = 0
+    if (b.length > initialCapacity)
+      b = new Array[Int](initialCapacity)
+  }
+  def appendFrom(ab2: IntArrayBuilder): Unit = {
+    ensureCapacity(size_ + ab2.size_)
+    System.arraycopy(ab2.b, 0, b, size_, ab2.size_)
+    size_ = size_ + ab2.size_
+  }
+
+  def pop(): Int = {
+    size_ -= 1
+    b(size)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -16,7 +16,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     case IntInfo => mb.genLazyFieldThisRef[IntMissingArrayBuilder](Code.newInstance[IntMissingArrayBuilder, Int](len), "iab")
     case LongInfo => mb.genLazyFieldThisRef[LongMissingArrayBuilder](Code.newInstance[LongMissingArrayBuilder, Int](len), "jab")
     case FloatInfo => mb.genLazyFieldThisRef[FloatMissingArrayBuilder](Code.newInstance[FloatMissingArrayBuilder, Int](len), "fab")
-    case DoubleInfo => mb.genLazyFieldThisRef[DoubleArrayBuilder](Code.newInstance[DoubleArrayBuilder, Int](len), "dab")
+    case DoubleInfo => mb.genLazyFieldThisRef[DoubleMissingArrayBuilder](Code.newInstance[DoubleMissingArrayBuilder, Int](len), "dab")
     case ti => throw new RuntimeException(s"unsupported typeinfo found: $ti")
   })
 
@@ -25,7 +25,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](x))
     case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](x))
     case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](x))
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](x))
+    case DoubleInfo => coerce[DoubleMissingArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](x))
   }
 
   def apply(i: Code[Int]): Code[_] = ti match {
@@ -33,7 +33,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Int]("apply", i)
     case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Int, Long]("apply", i)
     case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Int, Float]("apply", i)
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double]("apply", i)
+    case DoubleInfo => coerce[DoubleMissingArrayBuilder](ref).invoke[Int, Double]("apply", i)
   }
 
   def update(i: Code[Int], x: Code[_]): Code[Unit] = ti match {
@@ -41,7 +41,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
     case IntInfo => coerce[IntMissingArrayBuilder](ref).invoke[Int, Int, Unit]("update", i, coerce[Int](x))
     case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Int, Long, Unit]("update", i, coerce[Long](x))
     case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Int, Float, Unit]("update", i, coerce[Float](x))
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double, Unit]("update", i, coerce[Double](x))
+    case DoubleInfo => coerce[DoubleMissingArrayBuilder](ref).invoke[Int, Double, Unit]("update", i, coerce[Double](x))
   }
 
   def sort(compare: Code[AsmFunction2[_, _, _]]): Code[Unit] = {
@@ -60,7 +60,7 @@ class StagedArrayBuilder(val elt: PType, mb: EmitMethodBuilder[_], len: Code[Int
         coerce[FloatMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
       case DoubleInfo =>
         type F = AsmFunction2[Double, Double, Boolean]
-        coerce[DoubleArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
+        coerce[DoubleMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
     }
   }
 
@@ -129,7 +129,7 @@ sealed abstract class MissingArrayBuilder(initialCapacity: Int) {
   def clear() {  size_ = 0 }
 }
 
-class IntMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+final class IntMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Int] = new Array[Int](initialCapacity)
 
   def apply(i: Int): Int = {
@@ -188,7 +188,7 @@ class IntMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(i
   }
 }
 
-class LongMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+final class LongMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Long] = new Array[Long](initialCapacity)
 
   def apply(i: Int): Long = {
@@ -247,7 +247,7 @@ class LongMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(
   }
 }
 
-class FloatMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+final class FloatMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Float] = new Array[Float](initialCapacity)
 
   def apply(i: Int): Float = {
@@ -306,7 +306,7 @@ class FloatMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder
   }
 }
 
-class DoubleArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+final class DoubleMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Double] = new Array[Double](initialCapacity)
 
   def apply(i: Int): Double = {
@@ -365,7 +365,7 @@ class DoubleArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initi
   }
 }
 
-class BooleanMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
+final class BooleanMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(initialCapacity) {
   private var b: Array[Boolean] = new Array[Boolean](initialCapacity)
 
   def apply(i: Int): Boolean = {
@@ -424,7 +424,7 @@ class BooleanMissingArrayBuilder(initialCapacity: Int) extends MissingArrayBuild
   }
 }
 
-class ByteArrayArrayBuilder(initialCapacity: Int) {
+final class ByteArrayArrayBuilder(initialCapacity: Int) {
 
   var size_ : Int = 0
   private var b: Array[Array[Byte]] = new Array[Array[Byte]](initialCapacity)
@@ -467,7 +467,7 @@ class ByteArrayArrayBuilder(initialCapacity: Int) {
 }
 
 
-class LongArrayBuilder(initialCapacity: Int) {
+final class LongArrayBuilder(initialCapacity: Int= 16) {
 
   var size_ : Int = 0
   var b: Array[Long] = new Array[Long](initialCapacity)
@@ -525,7 +525,7 @@ class LongArrayBuilder(initialCapacity: Int) {
   }
 }
 
-class IntArrayBuilder(initialCapacity: Int) {
+final class IntArrayBuilder(initialCapacity: Int = 16) {
 
   var size_ : Int = 0
   var b: Array[Int] = new Array[Int](initialCapacity)
@@ -580,5 +580,135 @@ class IntArrayBuilder(initialCapacity: Int) {
   def pop(): Int = {
     size_ -= 1
     b(size)
+  }
+}
+
+final class DoubleArrayBuilder(initialCapacity: Int = 16) {
+
+  var size_ : Int = 0
+  var b: Array[Double] = new Array[Double](initialCapacity)
+
+  def size: Int = size_
+
+  def setSize(n: Int) {
+    require(n >= 0 && n <= size)
+    size_ = n
+  }
+
+  def apply(i: Int): Double = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int): Unit = {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Double](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Double): Unit = {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+
+  def update(i: Int, x: Double): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+  }
+
+  def clear() {  size_ = 0 }
+
+  def result(): Array[Double] = b.slice(0, size_)
+
+  def clearAndResize(): Unit = {
+    size_ = 0
+    if (b.length > initialCapacity)
+      b = new Array[Double](initialCapacity)
+  }
+  def appendFrom(ab2: DoubleArrayBuilder): Unit = {
+    ensureCapacity(size_ + ab2.size_)
+    System.arraycopy(ab2.b, 0, b, size_, ab2.size_)
+    size_ = size_ + ab2.size_
+  }
+
+  def pop(): Double = {
+    size_ -= 1
+    b(size)
+  }
+}
+
+final class AnyRefArrayBuilder[T <: AnyRef](initialCapacity: Int = 16)(implicit ct: ClassTag[T]) {
+
+  var size_ : Int = 0
+  var b: Array[T] = new Array[T](initialCapacity)
+
+  def size: Int = size_
+
+  def setSize(n: Int) {
+    require(n >= 0 && n <= size)
+    size_ = n
+  }
+
+  def apply(i: Int): T = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int): Unit = {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[T](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: T): Unit = {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+
+  def update(i: Int, x: T): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+  }
+
+  def clear() {  size_ = 0 }
+
+  def result(): Array[T] = b.slice(0, size_)
+
+  def clearAndResize(): Unit = {
+    size_ = 0
+    if (b.length > initialCapacity)
+      b = new Array[T](initialCapacity)
+  }
+  def appendFrom(ab2: AnyRefArrayBuilder[T]): Unit = {
+    ensureCapacity(size_ + ab2.size_)
+    System.arraycopy(ab2.b, 0, b, size_, ab2.size_)
+    size_ = size_ + ab2.size_
+  }
+
+  def pop(): T = {
+    size_ -= 1
+    b(size)
+  }
+
+  def clearAndSetNull(): Unit = {
+    clear()
+    var i = 0
+    while (i < b.length) {
+      b(i) = (null.asInstanceOf[T])
+      i += 1
+    }
+  }
+
+  def setSizeUninitialized(size: Int): Unit = {
+    ensureCapacity(size)
+    size_ = size
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1700,7 +1700,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
       keyFields ++ Array((fieldName, PCanonicalArray(
         PCanonicalStruct(required = false, valueFields: _*), required = true))): _*)
     val localDataLength = children.length
-    val rvMerger = { (ctx: RVDContext, it: Iterator[ArrayBuilder[(RegionValue, Int)]]) =>
+    val rvMerger = { (ctx: RVDContext, it: Iterator[BoxedArrayBuilder[(RegionValue, Int)]]) =>
       val rvb = new RegionValueBuilder()
       val newRegionValue = RegionValue()
 
@@ -1967,7 +1967,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         }
       }.collect()
 
-      val fileStack = new ArrayBuilder[Array[String]]()
+      val fileStack = new BoxedArrayBuilder[Array[String]]()
       var filesToMerge: Array[String] = files
       while (filesToMerge.length > 1) {
         val nToMerge = filesToMerge.length / 2
@@ -2010,7 +2010,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
         val partitionAggs = {
           var j = 0
           var x = i
-          val ab = new ArrayBuilder[String]
+          val ab = new BoxedArrayBuilder[String]
           while (j < fileStack.length) {
             assert(x <= fileStack(j).length)
             if (x % 2 != 0) {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir.agg
 
 import is.hail.annotations._
-import is.hail.expr.ir.IntArrayBuilder
+import is.hail.expr.ir.{DoubleArrayBuilder, IntArrayBuilder, LongArrayBuilder}
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PFloat64, PInt32, PInt64, PStruct, PType}
 import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
@@ -474,16 +474,16 @@ class ApproxCDFCombiner(
 
     val sorted = builder.result().sortBy(_._2)
 
-    val values = new BoxedArrayBuilder[Double]
-    val ranks = new BoxedArrayBuilder[Long]
+    val values = new DoubleArrayBuilder(16)
+    val ranks = new LongArrayBuilder(16)
     var rank: Long = 0
     var i = 0
-    ranks += 0
+    ranks.add(0)
     while (i < sorted.length) {
       rank += sorted(i)._1
       if (i == sorted.length - 1 || sorted(i)._2 != sorted(i + 1)._2) {
-        values += sorted(i)._2
-        ranks += rank
+        values.add(sorted(i)._2)
+        ranks.add(rank)
       }
       i += 1
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.agg
 
 import is.hail.annotations._
+import is.hail.expr.ir.IntArrayBuilder
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PFloat64, PInt32, PInt64, PStruct, PType}
 import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
@@ -458,7 +459,7 @@ class ApproxCDFCombiner(
   }
 
   def computeCDF(): (Array[Double], Array[Long]) = {
-    val builder: ArrayBuilder[(Long, Double)] = new ArrayBuilder(size)
+    val builder: BoxedArrayBuilder[(Long, Double)] = new BoxedArrayBuilder(size)
 
     var level = 0
     while (level < numLevels) {
@@ -473,8 +474,8 @@ class ApproxCDFCombiner(
 
     val sorted = builder.result().sortBy(_._2)
 
-    val values = new ArrayBuilder[Double]
-    val ranks = new ArrayBuilder[Long]
+    val values = new BoxedArrayBuilder[Double]
+    val ranks = new BoxedArrayBuilder[Long]
     var rank: Long = 0
     var i = 0
     ranks += 0
@@ -772,11 +773,11 @@ object QuantilesAggregator {
     math.max(m, depthCapacity(numLevels - level - 1, k))
 
   def capacities(k: Int, m: Int): Array[Int] = {
-    val buffer: ArrayBuilder[Int] = new ArrayBuilder()
+    val buffer: IntArrayBuilder = new IntArrayBuilder(8)
     var depth = 0
     var capacity = depthCapacity(depth, k)
     while (capacity > m) {
-      buffer += capacity
+      buffer.add(capacity)
       depth += 1
       capacity = depthCapacity(depth, k)
     }

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -108,7 +108,7 @@ object TextMatrixReader {
 
   def makePartitionerFromCounts(partitionCounts: Array[Long], kType: TStruct): (RVDPartitioner, Array[Int]) = {
     var includesStart = true
-    val keepPartitions = new ArrayBuilder[Int]()
+    val keepPartitions = new BoxedArrayBuilder[Int]()
     val rangeBoundIntervals = partitionCounts.zip(partitionCounts.tail).zipWithIndex.flatMap { case ((s, e), i) =>
       val interval = Interval.orNone(kType.ordering,
         Row(if (includesStart) s else s - 1),
@@ -596,7 +596,7 @@ class CompiledLineParser(
     var inputIndex = 0
     var outputIndex = 0
     assert(onDiskRowFieldsType.size >= rowFieldsType.size)
-    val ab = new ArrayBuilder[Code[Unit]]()
+    val ab = new BoxedArrayBuilder[Code[Unit]]()
     while (inputIndex < onDiskRowFieldsType.size) {
       val onDiskField = onDiskRowFieldsType.fields(inputIndex)
       val onDiskPType = PType.canonical(onDiskField.typ) // will always be optional

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -58,7 +58,7 @@ object BgenRDDPartitions extends Logging {
     val pord = keyType.ordering
     val bounds = fileMetadata.map(md => (md.path, md.rangeBounds))
 
-    val overlappingBounds = new ArrayBuilder[(String, Interval, String, Interval)]
+    val overlappingBounds = new BoxedArrayBuilder[(String, Interval, String, Interval)]
     var i = 0
     while (i < bounds.length) {
       var j = 0
@@ -128,8 +128,8 @@ object BgenRDDPartitions extends Logging {
     if (nonEmptyFilesAfterFilter.isEmpty) {
       (Array.empty, Array.empty)
     } else {
-      val partitions = new ArrayBuilder[Partition]()
-      val rangeBounds = new ArrayBuilder[Interval]()
+      val partitions = new BoxedArrayBuilder[Partition]()
+      val rangeBounds = new BoxedArrayBuilder[Interval]()
       var fileIndex = 0
       while (fileIndex < nonEmptyFilesAfterFilter.length) {
         val file = nonEmptyFilesAfterFilter(fileIndex)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -147,7 +147,7 @@ object LoadBgen {
   }
 
   def getAllFileStatuses(fs: FS, files: Array[String]): Array[FileStatus] = {
-    val badFiles = new ArrayBuilder[String]()
+    val badFiles = new BoxedArrayBuilder[String]()
 
     val statuses = files.flatMap { file =>
       val matches = fs.glob(file)

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.{RegionValue, UnsafeRow}
 import is.hail.expr.ir.{ExecuteContext, MatrixValue}
 import is.hail.types.physical.PStruct
 import is.hail.io.fs.FS
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 import is.hail.variant.{ArrayGenotypeView, RegionValueVariant, View}
 import is.hail.utils._
 import org.apache.hadoop.io.IOUtils
@@ -17,19 +17,19 @@ object BgenWriter {
   val phased: Byte = 0
   val totalProb: Int = 255
 
-  def shortToBytesLE(bb: ArrayBuilder[Byte], i: Int) {
+  def shortToBytesLE(bb: BoxedArrayBuilder[Byte], i: Int) {
     bb += (i & 0xff).toByte
     bb += ((i >>> 8) & 0xff).toByte
   }
 
-  def intToBytesLE(bb: ArrayBuilder[Byte], i: Int) {
+  def intToBytesLE(bb: BoxedArrayBuilder[Byte], i: Int) {
     bb += (i & 0xff).toByte
     bb += ((i >>> 8) & 0xff).toByte
     bb += ((i >>> 16) & 0xff).toByte
     bb += ((i >>> 24) & 0xff).toByte
   }
 
-  def stringToBytesWithShortLength(bb: ArrayBuilder[Byte], s: String): Int = {
+  def stringToBytesWithShortLength(bb: BoxedArrayBuilder[Byte], s: String): Int = {
     val bytes = s.getBytes
     val l = bytes.length
     shortToBytesLE(bb, l)
@@ -37,7 +37,7 @@ object BgenWriter {
     2 + l
   }
 
-  def stringToBytesWithIntLength(bb: ArrayBuilder[Byte], s: String): Int = {
+  def stringToBytesWithIntLength(bb: BoxedArrayBuilder[Byte], s: String): Int = {
     val bytes = s.getBytes
     val l = bytes.length
     intToBytesLE(bb, l)
@@ -45,7 +45,7 @@ object BgenWriter {
     4 + l
   }
 
-  def updateIntToBytesLE(bb: ArrayBuilder[Byte], i: Int, pos: Int) {
+  def updateIntToBytesLE(bb: BoxedArrayBuilder[Byte], i: Int, pos: Int) {
     bb(pos) = (i & 0xff).toByte
     bb(pos + 1) = ((i >>> 8) & 0xff).toByte
     bb(pos + 2) = ((i >>> 16) & 0xff).toByte
@@ -53,7 +53,7 @@ object BgenWriter {
   }
 
   def headerBlock(sampleIds: IndexedSeq[String], nVariants: Long): Array[Byte] = {
-    val bb = new ArrayBuilder[Byte]
+    val bb = new BoxedArrayBuilder[Byte]
     val nSamples = sampleIds.length
     assert(nVariants < (1L << 32))
 
@@ -93,8 +93,8 @@ object BgenWriter {
 class BgenPartitionWriter(rowPType: PStruct, nSamples: Int) {
   import BgenWriter._
 
-  val bb: ArrayBuilder[Byte] = new ArrayBuilder[Byte]
-  val uncompressedData: ArrayBuilder[Byte] = new ArrayBuilder[Byte]
+  val bb: BoxedArrayBuilder[Byte] = new BoxedArrayBuilder[Byte]
+  val uncompressedData: BoxedArrayBuilder[Byte] = new BoxedArrayBuilder[Byte]
   val gs = new ArrayGenotypeView(rowPType)
   val v = new RegionValueVariant(rowPType)
   val va = new GenAnnotationView(rowPType)
@@ -191,7 +191,7 @@ class BgenPartitionWriter(rowPType: PStruct, nSamples: Int) {
   }
 
   def roundWithConstantSum(input: Array[Double], fractional: Array[Double], index: Array[Int],
-    indexInverse: Array[Int], output: ArrayBuilder[Byte], expectedSize: Long) {
+    indexInverse: Array[Int], output: BoxedArrayBuilder[Byte], expectedSize: Long) {
     val n = input.length
     assert(fractional.length == n && index.length == n && indexInverse.length == n)
 

--- a/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -81,7 +81,7 @@ object LoadGen {
       if (gp.length != (3 * nSamples))
         fatal("Number of genotype probabilities does not match 3 * number of samples. If no chromosome column is included, use -c to input the chromosome.")
 
-      val gsb = new ArrayBuilder[Annotation]()
+      val gsb = new BoxedArrayBuilder[Annotation]()
 
       for (i <- gp.indices by 3) {
         val d0 = gp(i)

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -186,7 +186,7 @@ class IndexReader(fs: FS,
     getLeafNode(index, height - 1, metadata.rootOffset)
 
   def queryByKey(key: Annotation): Array[LeafChild] = {
-    val ab = new ArrayBuilder[LeafChild]()
+    val ab = new BoxedArrayBuilder[LeafChild]()
     keyIterator(key).foreach(ab += _)
     ab.result()
   }

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -192,9 +192,9 @@ class IndexWriterUtils(path: String, fs: FS, meta: StagedIndexMetadata) {
     using(fs.create(metadataPath)) { os => meta.serialize(os, height, rootOffset, nKeys) }
   }
 
-  val rBuilder = new ArrayBuilder[Region]()
-  val aBuilder = new ArrayBuilder[Long]()
-  val lBuilder = new ArrayBuilder[Int]()
+  val rBuilder = new BoxedArrayBuilder[Region]()
+  val aBuilder = new BoxedArrayBuilder[Long]()
+  val lBuilder = new BoxedArrayBuilder[Int]()
 
   def size: Int = rBuilder.size
 

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -28,7 +28,7 @@ object LoadPlink {
   def parseBim(fs: FS, bimPath: String, a2Reference: Boolean,
     contigRecoding: Map[String, String], rg: Option[ReferenceGenome], locusAllelesType: TStruct,
     skipInvalidLoci: Boolean): (Int, Array[PlinkVariant]) = {
-    val vs = new ArrayBuilder[PlinkVariant]()
+    val vs = new BoxedArrayBuilder[PlinkVariant]()
     var n = 0
     fs.readLines(bimPath) { lines =>
       lines.foreach { cline =>
@@ -81,8 +81,8 @@ object LoadPlink {
     val signature = PCanonicalStruct(("id", PCanonicalString()), ("fam_id", PCanonicalString()), ("pat_id", PCanonicalString()),
       ("mat_id", PCanonicalString()), ("is_female", PBoolean()), phenoSig)
 
-    val idBuilder = new ArrayBuilder[String]
-    val structBuilder = new ArrayBuilder[Row]
+    val idBuilder = new BoxedArrayBuilder[String]
+    val structBuilder = new BoxedArrayBuilder[Row]
 
     val m = fs.readLines(filename) {
       _.foreachLine { line =>
@@ -217,8 +217,8 @@ object MatrixPLINKReader {
     val partSize = partition(nVariants, nPartitions)
     val partScan = partSize.scanLeft(0)(_ + _)
 
-    val cb = new ArrayBuilder[Any]()
-    val ib = new ArrayBuilder[Interval]()
+    val cb = new BoxedArrayBuilder[Any]()
+    val ib = new BoxedArrayBuilder[Interval]()
 
     var p = 0
     var prevEnd = 0

--- a/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
+++ b/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
@@ -121,7 +121,7 @@ class TabixReader(val filePath: String, fs: FS, idxFilePath: Option[String] = No
     }
 
     // read the index
-    val indices = new ArrayBuilder[(mutable.HashMap[Int, Array[TbiPair]], Array[Long])](seqs.length)
+    val indices = new BoxedArrayBuilder[(mutable.HashMap[Int, Array[TbiPair]], Array[Long])](seqs.length)
     i = 0
     while (i < seqs.length) {
       // binning index
@@ -256,7 +256,7 @@ class TabixReader(val filePath: String, fs: FS, idxFilePath: Option[String] = No
       new Array[Int](0)
     else {
       var end = _end
-      val bins = new ArrayBuilder[Int](MaxBin)
+      val bins = new BoxedArrayBuilder[Int](MaxBin)
       if (end >= (1 << 29)) {
         end = 1 << 29
       }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1367,9 +1367,9 @@ object BlockMatrixFilterRDD {
     newGP: GridPartitioner): Array[Array[(Int, Array[Int], Array[Int])]] = {
 
     val blockSize = gp.blockSize
-    val ab = new ArrayBuilder[(Int, Array[Int], Array[Int])]()
-    val startIndices = new ArrayBuilder[Int]()
-    val endIndices = new ArrayBuilder[Int]()
+    val ab = new BoxedArrayBuilder[(Int, Array[Int], Array[Int])]()
+    val startIndices = new BoxedArrayBuilder[Int]()
+    val endIndices = new BoxedArrayBuilder[Int]()
 
     keep
       .grouped(blockSize)

--- a/hail/src/main/scala/is/hail/lir/PST.scala
+++ b/hail/src/main/scala/is/hail/lir/PST.scala
@@ -1,6 +1,6 @@
 package is.hail.lir
 
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 
 import scala.collection.mutable
 
@@ -105,7 +105,7 @@ class PSTBuilder(
 
   private def computeBackEdges(): Unit = {
     // recursion will blow out the stack
-    val stack = new ArrayBuilder[(Int, Iterator[Int])]()
+    val stack = new BoxedArrayBuilder[(Int, Iterator[Int])]()
     val onStack = mutable.Set[Int]()
     val visited = mutable.Set[Int]()
 
@@ -161,7 +161,7 @@ class PSTBuilder(
     var k = 0
 
     // recursion will blow out the stack
-    val stack = new ArrayBuilder[(Int, Iterator[Int])]()
+    val stack = new BoxedArrayBuilder[(Int, Iterator[Int])]()
 
     def push(b: Int): Unit = {
       val i = k
@@ -256,7 +256,7 @@ class PSTBuilder(
   private val regions: mutable.ArrayBuffer[PSTRegion] = mutable.ArrayBuffer[PSTRegion]()
 
   // regions with no parents
-  private val frontier = new ArrayBuilder[Int]()
+  private val frontier = new BoxedArrayBuilder[Int]()
 
   private def addRegion(start: Int, end: Int): Int = {
     var firstc = frontier.length
@@ -312,7 +312,7 @@ class PSTBuilder(
   // find regions in [start, end]
   // no edges from [0, start) target (start, end]
   private def findRegions(start: Int, end: Int): Unit = {
-    var regionStarts = new ArrayBuilder[Int]()
+    var regionStarts = new BoxedArrayBuilder[Int]()
     regionStarts += start
 
     // find subregions of [start, end]
@@ -381,8 +381,8 @@ class PSTBuilder(
     findRegions(0, nBlocks - 1)
     val root = addRoot()
 
-    val newBlocksB = new ArrayBuilder[Block]()
-    val newSplitBlock = new ArrayBuilder[Boolean]()
+    val newBlocksB = new BoxedArrayBuilder[Block]()
+    val newSplitBlock = new BoxedArrayBuilder[Boolean]()
 
     // split blocks, compute new blocks
     // in linearization order
@@ -426,7 +426,7 @@ class PSTBuilder(
 
     // compute new regions, including singletons
     // update children
-    val newRegionsB = new ArrayBuilder[PSTRegion]()
+    val newRegionsB = new BoxedArrayBuilder[PSTRegion]()
     val regionNewRegion = new Array[Int](regions.length)
     i = 0
     while (i < regions.length) {
@@ -442,7 +442,7 @@ class PSTBuilder(
         child = regions(children(c))
       }
 
-      val newChildren = new ArrayBuilder[Int]()
+      val newChildren = new BoxedArrayBuilder[Int]()
 
       var j = r.start
       var jincluded = false
@@ -491,7 +491,7 @@ class PSTBuilder(
     // but are not contained in region i
     def findLoopRegions(i: Int): Array[Int] = {
       val r = newRegions(i)
-      val backEdgeSourcesB = new ArrayBuilder[Int]()
+      val backEdgeSourcesB = new BoxedArrayBuilder[Int]()
       if (r.children.nonEmpty) {
         var c = 0
         while (c < r.children.length) {

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -199,9 +199,9 @@ class Method private[lir] (
   def genLocal(baseName: String, ti: TypeInfo[_]): Local = newLocal(genName("l", baseName), ti)
 
   def findBlocks(): Blocks = {
-    val blocksb = new ArrayBuilder[Block]()
+    val blocksb = new BoxedArrayBuilder[Block]()
 
-    val s = new ArrayStack[Block]()
+    val s = new ObjectArrayStack[Block]()
     val visited = mutable.Set[Block]()
 
     s.push(entry)
@@ -254,7 +254,7 @@ class Method private[lir] (
   }
 
   def findLocals(blocks: Blocks, verifyMethodAssignment: Boolean = false): Locals = {
-    val localsb = new ArrayBuilder[Local]()
+    val localsb = new BoxedArrayBuilder[Local]()
 
     var i = 0
     while (i < nParameters) {

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -86,7 +86,7 @@ case class LinearRegressionRowsSingle(
         val producerCtx = consumerCtx.freshContext
         val rvb = new RegionValueBuilder()
 
-        val missingCompleteCols = new ArrayBuilder[Int]
+        val missingCompleteCols = new BoxedArrayBuilder[Int]
         val data = new Array[Double](n * rowBlockSize)
 
         val blockWRVs = new Array[WritableRegionValue](rowBlockSize)
@@ -244,7 +244,7 @@ case class LinearRegressionRowsChained(
         val rvb = new RegionValueBuilder()
 
         val inputData = bc.value
-        val builder = new ArrayBuilder[Int]
+        val builder = new BoxedArrayBuilder[Int]
         val data = inputData.map(cri => new Array[Double](cri.n * rowBlockSize))
 
         val blockWRVs = new Array[WritableRegionValue](rowBlockSize)

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -94,7 +94,7 @@ case class LogisticRegression(
     val newRVD = mv.rvd.mapPartitions(newRVDType) { (ctx, it) =>
       val rvb = ctx.rvb
 
-      val missingCompleteCols = new ArrayBuilder[Int]()
+      val missingCompleteCols = new BoxedArrayBuilder[Int]()
       val _nullFits = nullFitBc.value
       val _yVecs = yVecsBc.value
       val X = XBc.value.copy

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -37,7 +37,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
 
     val allColValuesJSON = mv.colValues.javaValue.map(TableAnnotationImpex.exportAnnotation(_, mv.typ.colType)).toArray
 
-    val tempFolders = new ArrayBuilder[String]
+    val tempFolders = new BoxedArrayBuilder[String]
 
     info(s"exporting ${ mv.nCols } files in batches of $parallelism...")
     val nBatches = (mv.nCols + parallelism - 1) / parallelism

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -83,7 +83,7 @@ object PCRelate {
         val iOffset = i * blockSize
         val jOffset = j * blockSize
 
-        val pairs = new ArrayBuilder[Row]()
+        val pairs = new BoxedArrayBuilder[Row]()
         var jj = 0
         while (jj < lmPhi.cols) {
           var ii = 0

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -81,7 +81,7 @@ case class PoissonRegression(
     val newRVD = mv.rvd.mapPartitions(newRVDType) { (ctx, it) =>
       val rvb = ctx.rvb
 
-      val missingCompleteCols = new ArrayBuilder[Int]()
+      val missingCompleteCols = new BoxedArrayBuilder[Int]()
 
       val X = XBc.value.copy
       it.map { ptr =>

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -356,7 +356,7 @@ case class Skat(
         val key = Annotation.copy(keyType.virtualType, UnsafeRow.read(keyType, ctx.r, fullRowType.loadField(ptr, keyIndex)))
         val data = new Array[Double](n)
 
-        RegressionUtils.setMeanImputedDoubles(data, 0, completeColIdxBc.value, new ArrayBuilder[Int](),
+        RegressionUtils.setMeanImputedDoubles(data, 0, completeColIdxBc.value, new BoxedArrayBuilder[Int](),
           ptr, fullRowType, entryArrayType, entryType, entryArrayIdx, fieldIdx)
         Some(key -> (BDV(data) -> weight))
       } else None

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1514,7 +1514,7 @@ object RVD {
       new OriginUnionRDD(first.crdd.rdd.sparkContext, rvds.map(_.crdd.rdd), partF))
       .collect())
 
-    val fileDataByOrigin = Array.fill[ArrayBuilder[FileWriteMetadata]](nRVDs)(new ArrayBuilder())
+    val fileDataByOrigin = Array.fill[BoxedArrayBuilder[FileWriteMetadata]](nRVDs)(new BoxedArrayBuilder())
 
     for ((fd, oidx) <- partFilePartitionCounts) {
       fileDataByOrigin(oidx) += fd

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -411,7 +411,7 @@ object RVDPartitioner {
         intervals
       else {
         val unpruned = intervals.sorted(iord.toOrdering.asInstanceOf[Ordering[Interval]])
-        val ab = new ArrayBuilder[Interval](intervals.length)
+        val ab = new BoxedArrayBuilder[Interval](intervals.length)
         var tmp = unpruned(0)
         for (i <- unpruned.tail) {
           if (eord.gteq(tmp.right.coarsenRight(pk), i.left.coarsenLeft(pk)))

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -74,9 +74,9 @@ class BatchClient(
     request(new HttpDelete(s"$baseUrl$path"))
 
   def createJobs(batchID: Long, jobs: IndexedSeq[JObject]): Unit = {
-    val bunches = new ArrayBuilder[Array[Array[Byte]]]()
+    val bunches = new BoxedArrayBuilder[Array[Array[Byte]]]()
 
-    val bunchb = new ArrayBuilder[Array[Byte]]()
+    val bunchb = new BoxedArrayBuilder[Array[Byte]]()
 
     var i = 0
     var size = 0
@@ -97,7 +97,7 @@ class BatchClient(
     bunchb.clear()
     size = 0
 
-    val b = new ArrayBuilder[Byte]()
+    val b = new BoxedArrayBuilder[Byte]()
 
     i = 0 // reuse
     while (i < bunches.length) {

--- a/hail/src/main/scala/is/hail/services/shuffler/package.scala
+++ b/hail/src/main/scala/is/hail/services/shuffler/package.scala
@@ -36,9 +36,9 @@ package object shuffler {
   def readRegionValueArray(
     region: Region,
     decoder: Decoder,
-    sizeHint: Int = ArrayBuilder.defaultInitialCapacity
+    sizeHint: Int = BoxedArrayBuilder.defaultInitialCapacity
   ): Array[Long] = {
-    val ab = new ArrayBuilder[Long](sizeHint)
+    val ab = new BoxedArrayBuilder[Long](sizeHint)
 
     var hasNext = decoder.readByte()
     while (hasNext == 1) {

--- a/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -12,7 +12,7 @@ object RegressionUtils {
   def setMeanImputedDoubles(data: Array[Double],
     offset: Int,
     completeColIdx: Array[Int],
-    missingCompleteCols: ArrayBuilder[Int],
+    missingCompleteCols: BoxedArrayBuilder[Int],
     rv: Long,
     rvRowType: PStruct,
     entryArrayType: PArray,

--- a/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
@@ -5,7 +5,7 @@ import is.hail.types.virtual.{TFloat64, Type}
 import is.hail.linalg.BlockMatrix
 
 object BlockMatrixSparsity {
-  private val builder: ArrayBuilder[(Int, Int)] = new ArrayBuilder[(Int, Int)]
+  private val builder: BoxedArrayBuilder[(Int, Int)] = new BoxedArrayBuilder[(Int, Int)]
 
   val dense: BlockMatrixSparsity = BlockMatrixSparsity(None)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
@@ -49,7 +49,7 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
   def setRequired(required: Boolean): PCanonicalStruct = if(required == this.required) this else PCanonicalStruct(fields, required)
 
   def rename(m: Map[String, String]): PStruct = {
-    val newFieldsBuilder = new ArrayBuilder[(String, PType)]()
+    val newFieldsBuilder = new BoxedArrayBuilder[(String, PType)]()
     fields.foreach { fd =>
       val n = fd.name
       newFieldsBuilder += (m.getOrElse(n, n) -> fd.typ)
@@ -112,7 +112,7 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
     setFieldMissing(offset, fieldIdx(field))
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PStruct = {
-    val ab = new ArrayBuilder[PField](fields.length)
+    val ab = new BoxedArrayBuilder[PField](fields.length)
     var i = 0
     while (i < fields.length) {
       ab += fields(i)

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -161,9 +161,9 @@ object PType {
   }
 
   def literalPType(t: Type, a: Annotation): PType = {
-    val rb = new ArrayBuilder[Boolean]()
-    val crib = new ArrayBuilder[Int]()
-    val cib = new ArrayBuilder[Int]()
+    val rb = new BoxedArrayBuilder[Boolean]()
+    val crib = new BoxedArrayBuilder[Int]()
+    val cib = new BoxedArrayBuilder[Int]()
 
     def indexTypes(t: Type): Unit = {
       val ci = crib.size

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -184,8 +184,8 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   }
 
   def annotate(other: TStruct): (TStruct, Merger) = {
-    val newFieldsBuilder = new ArrayBuilder[(String, Type)]()
-    val fieldIdxBuilder = new ArrayBuilder[Int]()
+    val newFieldsBuilder = new BoxedArrayBuilder[(String, Type)]()
+    val fieldIdxBuilder = new BoxedArrayBuilder[Int]()
     // In fieldIdxBuilder, positive integers are field indices from the left.
     // Negative integers are the complement of field indices from the right.
 
@@ -237,7 +237,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   }
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, Type)]): TStruct = {
-    val ab = new ArrayBuilder[Field](fields.length)
+    val ab = new BoxedArrayBuilder[Field](fields.length)
     var i = 0
     while (i < fields.length) {
       ab += fields(i)
@@ -256,7 +256,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   }
 
   def rename(m: Map[String, String]): TStruct = {
-    val newFieldsBuilder = new ArrayBuilder[(String, Type)]()
+    val newFieldsBuilder = new BoxedArrayBuilder[(String, Type)]()
     fields.foreach { fd =>
       val n = fd.name
       newFieldsBuilder += (m.getOrElse(n, n) -> fd.typ)

--- a/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
@@ -76,7 +76,7 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
   def fieldType(name: String): Type = types(caseIdx(name))
 
   def rename(m: Map[String, String]): TUnion = {
-    val newFieldsBuilder = new ArrayBuilder[(String, Type)]()
+    val newFieldsBuilder = new BoxedArrayBuilder[(String, Type)]()
     cases.foreach { fd =>
       val n = fd.name
       newFieldsBuilder += (m.getOrElse(n, n) -> fd.typ)

--- a/hail/src/main/scala/is/hail/utils/ArrayStack.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayStack.scala
@@ -2,7 +2,7 @@ package is.hail.utils
 
 import scala.reflect.ClassTag
 
-final class ArrayStack[@specialized T](hintSize: Int = 16)(implicit tct: ClassTag[T]) {
+final class ObjectArrayStack[T](hintSize: Int = 16)(implicit tct: ClassTag[T]) {
   private var a = new Array[T](hintSize)
 
   private[this] var size_ = 0
@@ -55,4 +55,114 @@ final class ArrayStack[@specialized T](hintSize: Int = 16)(implicit tct: ClassTa
   }
 
   def toArray: Array[T] = (0 until size).map(apply).toArray
+}
+
+final class LongArrayStack(hintSize: Int = 16) {
+  private var a = new Array[Long](hintSize)
+
+  private[this] var size_ = 0
+
+  def size: Int = size_
+
+  def capacity: Int = a.length
+
+  def isEmpty: Boolean = size_ == 0
+
+  def nonEmpty: Boolean = size_ > 0
+
+  def clear(): Unit = {
+    size_ = 0
+  }
+
+  def top: Long = {
+    assert(size_ > 0)
+    a(size_ - 1)
+  }
+
+  def topOption: Option[Long] = if (size_ > 0) Some(top) else None
+
+  def push(x: Long) {
+    if (size_ == a.length) {
+      val newA = new Array[Long](size_ * 2)
+      System.arraycopy(a, 0, newA, 0, size_)
+      a = newA
+    }
+    a(size_) = x
+    size_ += 1
+  }
+
+  def pop(): Long = {
+    assert(size_ > 0)
+    size_ -= 1
+    val x = a(size_)
+    a(size_) = uninitialized[Long]
+    x
+  }
+
+  def update(i: Int, x: Long) {
+    assert(i >= 0 && i < size_)
+    a(size_ - i - 1) = x
+  }
+
+  def apply(i: Int): Long = {
+    assert(i >= 0 && i < size_)
+    a(size_ - i - 1)
+  }
+
+  def toArray: Array[Long] = (0 until size).map(apply).toArray
+}
+
+final class IntArrayStack(hintSize: Int = 16) {
+  private var a = new Array[Int](hintSize)
+
+  private[this] var size_ = 0
+
+  def size: Int = size_
+
+  def capacity: Int = a.length
+
+  def isEmpty: Boolean = size_ == 0
+
+  def nonEmpty: Boolean = size_ > 0
+
+  def clear(): Unit = {
+    size_ = 0
+  }
+
+  def top: Int = {
+    assert(size_ > 0)
+    a(size_ - 1)
+  }
+
+  def topOption: Option[Int] = if (size_ > 0) Some(top) else None
+
+  def push(x: Int) {
+    if (size_ == a.length) {
+      val newA = new Array[Int](size_ * 2)
+      System.arraycopy(a, 0, newA, 0, size_)
+      a = newA
+    }
+    a(size_) = x
+    size_ += 1
+  }
+
+  def pop(): Int = {
+    assert(size_ > 0)
+    size_ -= 1
+    val x = a(size_)
+    a(size_) = uninitialized[Int]
+    x
+  }
+
+  def update(i: Int, x: Int) {
+    assert(i >= 0 && i < size_)
+    a(size_ - i - 1) = x
+  }
+
+  def apply(i: Int): Int = {
+    assert(i >= 0 && i < size_)
+    a(size_ - i - 1)
+  }
+
+  def toArray: Array[Int] = (0 until size).map(apply).toArray
 }

--- a/hail/src/main/scala/is/hail/utils/BinaryHeap.scala
+++ b/hail/src/main/scala/is/hail/utils/BinaryHeap.scala
@@ -4,7 +4,7 @@ import Math.signum
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Double = null) {
+class BinaryHeap[T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Double = null) {
   private var ts: Array[T] = new Array[T](minimumCapacity)
   private var ranks: Array[Long] = new Array[Long](minimumCapacity)
   private val m: mutable.Map[T, Int] = new mutable.HashMap()

--- a/hail/src/main/scala/is/hail/utils/BoxedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/BoxedArrayBuilder.scala
@@ -2,15 +2,15 @@ package is.hail.utils
 
 import scala.reflect.ClassTag
 
-object ArrayBuilder {
+object BoxedArrayBuilder {
   final val defaultInitialCapacity: Int = 16
 }
 
-final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: ClassTag[T]) extends Serializable {
+final class BoxedArrayBuilder[T](initialCapacity: Int)(implicit tct: ClassTag[T]) extends Serializable {
   private[utils] var b: Array[T] = new Array[T](initialCapacity)
   private[utils] var size_ : Int = 0
 
-  def this()(implicit tct: ClassTag[T]) = this(ArrayBuilder.defaultInitialCapacity)
+  def this()(implicit tct: ClassTag[T]) = this(BoxedArrayBuilder.defaultInitialCapacity)
 
   def size: Int = size_
 
@@ -88,7 +88,7 @@ final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: Cla
     b(size)
   }
 
-  def appendFrom(ab2: ArrayBuilder[T]): Unit = {
+  def appendFrom(ab2: BoxedArrayBuilder[T]): Unit = {
     ensureCapacity(size_ + ab2.size_)
     System.arraycopy(ab2.b, 0, b, size_, ab2.size_)
     size_ = size_ + ab2.size_
@@ -99,18 +99,19 @@ final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: Cla
     size_ = size
   }
 
-  override def clone(): ArrayBuilder[T] = {
-    val ab = new ArrayBuilder[T]()
+  override def clone(): BoxedArrayBuilder[T] = {
+    val ab = new BoxedArrayBuilder[T]()
     ab.b = b.clone()
     ab.size_ = size_
     ab
   }
 
-  def clearAndSetMem(obj: T): Unit = {
+
+  def clearAndSetNull(): Unit = {
     clear()
     var i = 0
     while (i < b.length) {
-      b(i) = obj
+      b(i) = (null.asInstanceOf[T])
       i += 1
     }
   }

--- a/hail/src/main/scala/is/hail/utils/BoxedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/BoxedArrayBuilder.scala
@@ -105,14 +105,4 @@ final class BoxedArrayBuilder[T](initialCapacity: Int)(implicit tct: ClassTag[T]
     ab.size_ = size_
     ab
   }
-
-
-  def clearAndSetNull(): Unit = {
-    clear()
-    var i = 0
-    while (i < b.length) {
-      b(i) = (null.asInstanceOf[T])
-      i += 1
-    }
-  }
 }

--- a/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
+++ b/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
@@ -62,7 +62,7 @@ object ExecutionTimer {
 }
 
 class ExecutionTimer(val rootName: String) {
-  private[this] val stack = new ArrayStack[TimeBlock]()
+  private[this] val stack = new ObjectArrayStack[TimeBlock]()
 
   private[this] val rootBlock = new TimeBlock(rootName)
   stack.push(rootBlock)

--- a/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
@@ -90,13 +90,13 @@ object FlipbookIterator {
   def multiZipJoin[A: ClassTag](
     its: Array[FlipbookIterator[A]],
     ord: (A, A) => Int
-  ): FlipbookIterator[ArrayBuilder[(A, Int)]] = {
+  ): FlipbookIterator[BoxedArrayBuilder[(A, Int)]] = {
     object TmpOrd extends Ordering[(A, Int)] {
       def compare(x: (A, Int), y: (A, Int)): Int = ord(y._1, x._1)
     }
-    val sm = new StateMachine[ArrayBuilder[(A, Int)]] {
+    val sm = new StateMachine[BoxedArrayBuilder[(A, Int)]] {
       val q: PriorityQueue[(A, Int)] = new PriorityQueue()(TmpOrd)
-      val value = new ArrayBuilder[(A, Int)](its.length)
+      val value = new BoxedArrayBuilder[(A, Int)](its.length)
       var isValid = true
 
       var i = 0; while (i < its.length) {

--- a/hail/src/main/scala/is/hail/utils/HailIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/HailIterator.scala
@@ -8,7 +8,7 @@ abstract class HailIterator[@specialized T] {
   def hasNext: Boolean
 
   def toArray(implicit tct: ClassTag[T]): Array[T] = {
-    val b = new ArrayBuilder[T]()
+    val b = new BoxedArrayBuilder[T]()
     while (hasNext)
       b += next()
     b.result()

--- a/hail/src/main/scala/is/hail/utils/Interval.scala
+++ b/hail/src/main/scala/is/hail/utils/Interval.scala
@@ -235,7 +235,7 @@ object Interval {
 
     val sorted = xs.sortBy(_.left: Any)(ord.toOrdering)
 
-    val ab = new ArrayBuilder[Interval]()
+    val ab = new BoxedArrayBuilder[Interval]()
     var i = 0
     while (i < sorted.length) {
       var interval = sorted(i)
@@ -255,7 +255,7 @@ object Interval {
 
     var i = 0
     var j = 0
-    val ab = new ArrayBuilder[Interval]()
+    val ab = new BoxedArrayBuilder[Interval]()
 
     while (!(i >= x1.length || j >= x2.length)) {
       val l = x1(i)

--- a/hail/src/main/scala/is/hail/utils/MissingAnnotationArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingAnnotationArrayBuilder.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 class MissingAnnotationArrayBuilder extends Serializable {
   private var len = 0
-  private var elements = new ArrayBuilder[Annotation]()
+  private var elements = new BoxedArrayBuilder[Annotation]()
   private var isMissing = new mutable.BitSet()
 
   def addMissing() {

--- a/hail/src/main/scala/is/hail/utils/MissingArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingArrayBuilder.scala
@@ -7,7 +7,7 @@ final class MissingArrayBuilder[@specialized T](initialCapacity: Int)(implicit t
   private var missing: Array[Boolean] = new Array[Boolean](initialCapacity)
   private var size_ : Int = 0
 
-  def this()(implicit tct: ClassTag[T]) = this(ArrayBuilder.defaultInitialCapacity)
+  def this()(implicit tct: ClassTag[T]) = this(BoxedArrayBuilder.defaultInitialCapacity)
 
   def size: Int = size_
 

--- a/hail/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 class MissingDoubleArrayBuilder extends Serializable {
   private var len = 0
-  private var elements = new ArrayBuilder[Double]()
+  private var elements = new BoxedArrayBuilder[Double]()
   private var isMissing = new mutable.BitSet()
 
   def addMissing() {

--- a/hail/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 class MissingFloatArrayBuilder extends Serializable {
   private var len = 0
-  private var elements = new ArrayBuilder[Float]()
+  private var elements = new BoxedArrayBuilder[Float]()
   private var isMissing = new mutable.BitSet()
 
   def addMissing() {

--- a/hail/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 class MissingIntArrayBuilder extends Serializable {
   private var len = 0
-  private var elements = new ArrayBuilder[Int]()
+  private var elements = new BoxedArrayBuilder[Int]()
   private var isMissing = new mutable.BitSet()
 
   def addMissing() {

--- a/hail/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 
 class MissingLongArrayBuilder extends Serializable {
   private var len = 0
-  private var elements = new ArrayBuilder[Long]()
+  private var elements = new BoxedArrayBuilder[Long]()
   private var isMissing = new mutable.BitSet()
 
   def addMissing() {

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -59,13 +59,13 @@ case class TextTableReaderMetadata(fileStatuses: Array[FileStatus], header: Stri
 object TextTableReader {
 
   def splitLine(s: String, separator: String, quote: java.lang.Character): Array[String] =
-    splitLine(s, separator, quote, new ArrayBuilder[String], new StringBuilder)
+    splitLine(s, separator, quote, new BoxedArrayBuilder[String], new StringBuilder)
 
   def splitLine(
     s: String,
     separator: String,
     quote: java.lang.Character,
-    ab: ArrayBuilder[String],
+    ab: BoxedArrayBuilder[String],
     sb: StringBuilder): Array[String] = {
     ab.clear()
     sb.clear()
@@ -184,7 +184,7 @@ object TextTableReader {
     val (imputation, allDefined) = linesRDD.mapPartitions { it =>
       val allDefined = Array.fill(nFields)(true)
       val ma = MultiArray2.fill[Boolean](nFields, nMatchers + 1)(true)
-      val ab = new ArrayBuilder[String]
+      val ab = new BoxedArrayBuilder[String]
       val sb = new StringBuilder
       it.foreach { genericLine =>
         val line = genericLine.toString
@@ -355,7 +355,7 @@ class TextTableReader(
       { (region: Region, context: Any) =>
 
         val rvb = new RegionValueBuilder(region)
-        val ab = new ArrayBuilder[String]
+        val ab = new BoxedArrayBuilder[String]
         val sb = new StringBuilder
         linesBody(context)
           .filter { bline =>

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -584,10 +584,10 @@ package object utils extends Logging
   def partFile(d: Int, i: Int, ctx: TaskContext): String = s"${ partFile(d, i) }-${ partSuffix(ctx) }"
 
   def mangle(strs: Array[String], formatter: Int => String = "_%d".format(_)): (Array[String], Array[(String, String)]) = {
-    val b = new ArrayBuilder[String]
+    val b = new BoxedArrayBuilder[String]
 
     val uniques = new mutable.HashSet[String]()
-    val mapping = new ArrayBuilder[(String, String)]
+    val mapping = new BoxedArrayBuilder[(String, String)]
 
     strs.foreach { s =>
       var smod = s
@@ -792,7 +792,7 @@ package object utils extends Logging
     }
   }
 
-  def compress(bb: ArrayBuilder[Byte], input: Array[Byte]): Int = {
+  def compress(bb: BoxedArrayBuilder[Byte], input: Array[Byte]): Int = {
     val compressor = new Deflater()
     compressor.setInput(input)
     compressor.finish()

--- a/hail/src/main/scala/is/hail/utils/prettyPrint/PrettyPrintWriter.scala
+++ b/hail/src/main/scala/is/hail/utils/prettyPrint/PrettyPrintWriter.scala
@@ -3,7 +3,7 @@ package is.hail.utils.prettyPrint
 import java.io.{StringWriter, Writer}
 import java.util.ArrayDeque
 
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 
 import scala.annotation.tailrec
 
@@ -121,7 +121,7 @@ object Doc {
 
     def openGroups(): Unit = {
       while (pendingOpens > 0) {
-        pendingGroups.addLast(GroupN(new ArrayBuilder[ScannedNode](), globalPos, -1))
+        pendingGroups.addLast(GroupN(new BoxedArrayBuilder[ScannedNode](), globalPos, -1))
         pendingOpens -= 1
       }
     }
@@ -178,7 +178,7 @@ private[prettyPrint] case class Concat(it: Iterable[Doc]) extends Doc
 private[prettyPrint] abstract class ScannedNode
 private[prettyPrint] case class TextN(t: String) extends ScannedNode
 private[prettyPrint] case class LineN(indentation: Int, ifFlat: String) extends ScannedNode
-private[prettyPrint] case class GroupN(contents: ArrayBuilder[ScannedNode], start: Int, var end: Int) extends ScannedNode
+private[prettyPrint] case class GroupN(contents: BoxedArrayBuilder[ScannedNode], start: Int, var end: Int) extends ScannedNode
 
 private[prettyPrint] abstract class KontNode
 private[prettyPrint] case object PopGroupK extends KontNode

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRow.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRow.scala
@@ -1,6 +1,6 @@
 package is.hail.utils.richUtils
 
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 import org.apache.spark.sql.Row
 
 class RichRow(r: Row) {
@@ -19,14 +19,14 @@ class RichRow(r: Row) {
   }
 
   def append(a: Any): Row = {
-    val ab = new ArrayBuilder[Any]()
+    val ab = new BoxedArrayBuilder[Any]()
     ab ++= r.toSeq
     ab += a
     Row.fromSeq(ab.result())
   }
 
   def insertBefore(i: Int, a: Any): Row = {
-    val ab = new ArrayBuilder[Any]()
+    val ab = new BoxedArrayBuilder[Any]()
     (0 until i).foreach(ab += r.get(_))
     ab += a
     (i until r.size).foreach(ab += r.get(_))

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -619,8 +619,8 @@ object ReferenceGenome {
     fs.copyRecode(indexFile, localIndexFile)
     val index = new FastaSequenceIndex(new java.io.File(uriPath(localIndexFile)))
 
-    val contigs = new ArrayBuilder[String]
-    val lengths = new ArrayBuilder[(String, Int)]
+    val contigs = new BoxedArrayBuilder[String]
+    val lengths = new BoxedArrayBuilder[(String, Int)]
 
     index.iterator().asScala.foreach { entry =>
       val contig = entry.getContig

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -172,8 +172,8 @@ object TestUtils {
     optimize: Boolean = true
   ): Any = {
     ExecuteContext.scoped() { ctx =>
-      val inputTypesB = new ArrayBuilder[Type]()
-      val inputsB = new ArrayBuilder[Any]()
+      val inputTypesB = new BoxedArrayBuilder[Type]()
+      val inputsB = new BoxedArrayBuilder[Any]()
 
       args.foreach { case (v, t) =>
         inputsB += v

--- a/hail/src/test/scala/is/hail/TestUtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/TestUtilsSuite.scala
@@ -5,7 +5,7 @@ import java.lang.reflect.Modifier
 import java.net.URI
 
 import breeze.linalg.{DenseMatrix, DenseVector}
-import is.hail.utils.ArrayBuilder
+import is.hail.utils.BoxedArrayBuilder
 import org.testng.annotations.{DataProvider, Test}
 
 class TestUtilsSuite extends HailSuite {

--- a/hail/src/test/scala/is/hail/expr/ir/MissingArrayBuilderSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MissingArrayBuilderSuite.scala
@@ -93,11 +93,11 @@ class MissingArrayBuilderSuite extends TestNGSuite {
 
   @Test(dataProvider="sortDouble")
   def testSortOnDoubleArrayBuilder(array: IndexedSeq[java.lang.Double], expected: IndexedSeq[java.lang.Double]) {
-    val ab = new DoubleArrayBuilder(16)
+    val ab = new DoubleMissingArrayBuilder(16)
     addToArrayBuilder(ab, array) { (dab, d) => dab.add(d) }
 
     ab.sort(ordering[Double] { (i, j) => i < j })
-    val result = getResult[DoubleArrayBuilder, java.lang.Double](ab) { (dab, d) => Double.box(dab(d)) }
+    val result = getResult[DoubleMissingArrayBuilder, java.lang.Double](ab) { (dab, d) => Double.box(dab(d)) }
     assert(result sameElements expected)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/MissingArrayBuilderSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MissingArrayBuilderSuite.scala
@@ -42,11 +42,11 @@ class MissingArrayBuilderSuite extends TestNGSuite {
 
   @Test(dataProvider="sortInt")
   def testSortOnIntArrayBuilder(array: IndexedSeq[Integer], expected: IndexedSeq[Integer]) {
-    val ab = new IntArrayBuilder(16)
+    val ab = new IntMissingArrayBuilder(16)
     addToArrayBuilder(ab, array) { (iab, i) => iab.add(i) }
 
     ab.sort(ordering[Int] { (i, j) => i < j})
-    val result = getResult[IntArrayBuilder, Integer](ab) { (iab, i) => Int.box(iab(i)) }
+    val result = getResult[IntMissingArrayBuilder, Integer](ab) { (iab, i) => Int.box(iab(i)) }
     assert(result sameElements expected)
   }
 
@@ -59,11 +59,11 @@ class MissingArrayBuilderSuite extends TestNGSuite {
 
   @Test(dataProvider="sortLong")
   def testSortOnLongArrayBuilder(array: IndexedSeq[java.lang.Long], expected: IndexedSeq[java.lang.Long]) {
-    val ab = new LongArrayBuilder(16)
+    val ab = new LongMissingArrayBuilder(16)
     addToArrayBuilder(ab, array) { (jab, j) => jab.add(j) }
 
     ab.sort(ordering[Long] { (i, j) => i < j})
-    val result = getResult[LongArrayBuilder, java.lang.Long](ab) { (jab, j) => Long.box(jab(j)) }
+    val result = getResult[LongMissingArrayBuilder, java.lang.Long](ab) { (jab, j) => Long.box(jab(j)) }
     assert(result sameElements expected)
   }
 
@@ -76,11 +76,11 @@ class MissingArrayBuilderSuite extends TestNGSuite {
 
   @Test(dataProvider="sortFloat")
   def testSortOnFloatArrayBuilder(array: IndexedSeq[java.lang.Float], expected: IndexedSeq[java.lang.Float]) {
-    val ab = new FloatArrayBuilder(16)
+    val ab = new FloatMissingArrayBuilder(16)
     addToArrayBuilder(ab, array) { (fab, f) => fab.add(f) }
 
     ab.sort(ordering[Float] { (i, j) => i < j })
-    val result = getResult[FloatArrayBuilder, java.lang.Float](ab) { (fab, f) => Float.box(fab(f)) }
+    val result = getResult[FloatMissingArrayBuilder, java.lang.Float](ab) { (fab, f) => Float.box(fab(f)) }
     assert(result sameElements expected)
   }
 
@@ -110,11 +110,11 @@ class MissingArrayBuilderSuite extends TestNGSuite {
 
   @Test(dataProvider="sortBoolean")
   def testSortOnBooleanArrayBuilder(array: IndexedSeq[java.lang.Boolean], expected: IndexedSeq[java.lang.Boolean]) {
-    val ab = new BooleanArrayBuilder(16)
+    val ab = new BooleanMissingArrayBuilder(16)
     addToArrayBuilder(ab, array) { (bab, b) => bab.add(b) }
 
     ab.sort(ordering[Boolean] { (i, j) => i < j })
-    val result = getResult[BooleanArrayBuilder, java.lang.Boolean](ab) { (bab, b) => Boolean.box(bab(b)) }
+    val result = getResult[BooleanMissingArrayBuilder, java.lang.Boolean](ab) { (bab, b) => Boolean.box(bab(b)) }
     assert(result sameElements expected)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -187,8 +187,8 @@ class PruneSuite extends HailSuite {
   }
 
   def subsetTable(tt: TableType, fields: String*): TableType = {
-    val rowFields = new ArrayBuilder[TStruct]()
-    val globalFields = new ArrayBuilder[TStruct]()
+    val rowFields = new BoxedArrayBuilder[TStruct]()
+    val globalFields = new BoxedArrayBuilder[TStruct]()
     var noKey = false
     fields.foreach { f =>
       val split = f.split("\\.")
@@ -210,10 +210,10 @@ class PruneSuite extends HailSuite {
   }
 
   def subsetMatrixTable(mt: MatrixType, fields: String*): MatrixType = {
-    val rowFields = new ArrayBuilder[TStruct]()
-    val colFields = new ArrayBuilder[TStruct]()
-    val entryFields = new ArrayBuilder[TStruct]()
-    val globalFields = new ArrayBuilder[TStruct]()
+    val rowFields = new BoxedArrayBuilder[TStruct]()
+    val colFields = new BoxedArrayBuilder[TStruct]()
+    val entryFields = new BoxedArrayBuilder[TStruct]()
+    val globalFields = new BoxedArrayBuilder[TStruct]()
     var noRowKey = false
     var noColKey = false
     fields.foreach { f =>

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -8,7 +8,7 @@ import is.hail.types.physical._
 import is.hail.types.virtual._
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.stats.fetStruct
-import is.hail.utils.{ArrayBuilder, FastIndexedSeq, FastSeq}
+import is.hail.utils.{BoxedArrayBuilder, FastIndexedSeq, FastSeq}
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 
@@ -92,7 +92,7 @@ class RequirednessSuite extends HailSuite {
 
   @DataProvider(name="valueIR")
   def valueIR(): Array[Array[Any]] = {
-    val nodes = new ArrayBuilder[Array[Any]](50)
+    val nodes = new BoxedArrayBuilder[Array[Any]](50)
 
     val allRequired = Array(
       I32(5), I64(5), F32(3.14f), F64(3.14), Str("foo"), True(), False(),
@@ -251,7 +251,7 @@ class RequirednessSuite extends HailSuite {
 
   @DataProvider(name="tableIR")
   def tableIR(): Array[Array[Any]] = {
-    val nodes = new ArrayBuilder[Array[Any]](50)
+    val nodes = new BoxedArrayBuilder[Array[Any]](50)
 
     nodes += Array[Any](TableRange(1, 1), PCanonicalStruct(required, "idx" -> PInt32(required)), PCanonicalStruct.empty(required))
 
@@ -431,7 +431,7 @@ class RequirednessSuite extends HailSuite {
 
   @Test
   def testDataProviders(): Unit = {
-    val s = new ArrayBuilder[String]()
+    val s = new BoxedArrayBuilder[String]()
     valueIR().map(v => v(0) -> v(1)).foreach { case (n: IR, t: PType) =>
       if (n.typ != t.virtualType)
         s += s"${ n.typ } != ${ t.virtualType }: \n${ Pretty(n) }"

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -144,7 +144,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
 
   @Test def testPushStrsMissing() {
     pool.scopedRegion { region =>
-      val a = new ArrayBuilder[String]()
+      val a = new BoxedArrayBuilder[String]()
       val b = new BlockLinkedList[String](region, PCanonicalString())
       for (i <- 1 to 100) {
         val elt = if(i%3 == 0) null else i.toString()

--- a/hail/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -5,7 +5,7 @@ import is.hail.utils._
 import breeze.linalg._
 import org.testng.annotations.Test
 
-case class SkatAggForR(xs: ArrayBuilder[DenseVector[Double]], weights: ArrayBuilder[Double])
+case class SkatAggForR(xs: BoxedArrayBuilder[DenseVector[Double]], weights: BoxedArrayBuilder[Double])
 
 class SkatSuite extends HailSuite {
 

--- a/hail/src/test/scala/is/hail/services/shuffler/ShuffleSuite.scala
+++ b/hail/src/test/scala/is/hail/services/shuffler/ShuffleSuite.scala
@@ -40,7 +40,7 @@ class ShuffleSuite extends HailSuite {
       using(new ShuffleClient(shuffleType, rowPType, keyPType)) { c =>
         val rowDecodedPType = c.codecs.rowDecodedPType
 
-        val values = new ArrayBuilder[Long]()
+        val values = new BoxedArrayBuilder[Long]()
         pool.scopedRegion { region =>
           val rvb = new RegionValueBuilder(region)
           val nElements = 1000000
@@ -76,7 +76,7 @@ class ShuffleSuite extends HailSuite {
             c.get(region, left, true, right, false))
 
           i = 0
-          val ab = new ArrayBuilder[Long]()
+          val ab = new BoxedArrayBuilder[Long]()
           while (i < nPartitions) {
             ab ++= c.get(region,
               partitionBounds(i).offset, true,

--- a/hail/src/test/scala/is/hail/utils/ArrayBuilderSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/ArrayBuilderSuite.scala
@@ -5,7 +5,7 @@ import org.testng.annotations.Test
 
 class ArrayBuilderSuite extends TestNGSuite {
   @Test def addOneElement() {
-    val ab = new ArrayBuilder[Int](0)
+    val ab = new BoxedArrayBuilder[Int](0)
     ab += 3
     val a = ab.result()
     assert(a.length == 1)
@@ -13,13 +13,13 @@ class ArrayBuilderSuite extends TestNGSuite {
   }
 
   @Test def addArray() {
-    val ab = new ArrayBuilder[Int](0)
+    val ab = new BoxedArrayBuilder[Int](0)
     ab ++= Array.fill[Int](5)(2)
     val a = ab.result()
     assert(a.length == 5)
     assert(a.forall(_ == 2))
 
-    val ab2 = new ArrayBuilder[Int](0)
+    val ab2 = new BoxedArrayBuilder[Int](0)
     ab2 ++= (Array.fill[Int](4)(3), 2)
     val a2 = ab2.result()
     assert(a2.length == 2)
@@ -29,7 +29,7 @@ class ArrayBuilderSuite extends TestNGSuite {
     val ab2Update = ab2.result()
     assert(ab2Update sameElements Array(5, 3))
 
-    val ab3 = new ArrayBuilder[Int]
+    val ab3 = new BoxedArrayBuilder[Int]
     ab3 += 1
     ab3 += 5
     ab3 ++= Array.fill[Int](2)(3)

--- a/hail/src/test/scala/is/hail/utils/ArrayStackSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/ArrayStackSuite.scala
@@ -5,7 +5,7 @@ import org.testng.annotations.Test
 
 class ArrayStackSuite extends TestNGSuite {
   @Test def test() {
-    val s = new ArrayStack[Int](4)
+    val s = new IntArrayStack(4)
     assert(s.isEmpty)
     assert(!s.nonEmpty)
     assert(s.size == 0)

--- a/hail/src/test/scala/is/hail/utils/BinaryHeapSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/BinaryHeapSuite.scala
@@ -252,7 +252,7 @@ class BinaryHeapSuite {
   def successivelyMoreInserts() {
     for (count <- Seq(2, 4, 8, 16, 32)) {
       val bh = new BinaryHeap[Int](8)
-      val trace = new ArrayBuilder[String]()
+      val trace = new BoxedArrayBuilder[String]()
       trace += bh.toString()
       bh.checkHeapProperty()
       for (i <- 0 until count) {
@@ -296,7 +296,7 @@ class BinaryHeapSuite {
   @Test
   def shrinkCapacity() {
     val bh = new BinaryHeap[Int](8)
-    val trace = new ArrayBuilder[String]()
+    val trace = new BoxedArrayBuilder[String]()
     trace += bh.toString()
     bh.checkHeapProperty()
     for (i <- 0 until 64) {
@@ -366,7 +366,7 @@ class BinaryHeapSuite {
     forAll(ops) { opList =>
       val bh = new BinaryHeap[Long]()
       val ref = new LongPriorityQueueReference()
-      val trace = new ArrayBuilder[String]()
+      val trace = new BoxedArrayBuilder[String]()
       trace += bh.toString()
       opList.foreach {
         case Max() =>

--- a/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
@@ -276,7 +276,7 @@ class FlipbookIteratorSuite extends HailSuite {
     val three = makeTestIterator(2, 3, 4, 4, 5, 6, 1000, 1000)
     val its: Array[FlipbookIterator[Box[Int]]] = Array(one, two, three)
     val zipped = FlipbookIterator.multiZipJoin(its, boxIntOrd(missingValue = 1000))
-    def fillOut(ar: ArrayBuilder[(Box[Int], Int)], default: Box[Int]): Array[Box[Int]] = {
+    def fillOut(ar: BoxedArrayBuilder[(Box[Int], Int)], default: Box[Int]): Array[Box[Int]] = {
       val a: Array[Box[Int]] = Array.fill(3)(default)
       var i = 0; while (i < ar.size) {
         var v = ar(i)


### PR DESCRIPTION
Scala calls functions that match on the type to avoid boxing. This is
slightly better than allocating, but so much worse than plain array
operations.

Benchmarks forthcoming.