### PR TITLE
[query-service] enable public use of query image

### DIFF
--- a/hail/python/hailtop/batch_client/parse.py
+++ b/hail/python/hailtop/batch_client/parse.py
@@ -10,7 +10,7 @@ CPU_REGEX: Pattern = re.compile(CPU_REGEXPAT)
 
 # https://github.com/moby/moby/blob/master/image/spec/v1.md
 # https://github.com/moby/moby/blob/master/image/spec/v1.2.md
-IMAGE_REGEX: Pattern = re.compile(r"(.+/)?([^:]+)(:(.+))?")
+IMAGE_REGEX: Pattern = re.compile(r"(.+/|)([^:]+)(:(.+))?")
 
 
 def parse_cpu_in_mcpu(cpu_string: str) -> Optional[int]:

--- a/hail/python/hailtop/batch_client/parse.py
+++ b/hail/python/hailtop/batch_client/parse.py
@@ -1,4 +1,4 @@
-from typing import Optional, Mapping, Pattern
+from typing import Optional, Mapping, Pattern, Tuple
 import re
 import math
 
@@ -8,7 +8,9 @@ MEMORY_REGEX: Pattern = re.compile(MEMORY_REGEXPAT)
 CPU_REGEXPAT: str = r'[+]?((?:[0-9]*[.])?[0-9]+)([m])?'
 CPU_REGEX: Pattern = re.compile(CPU_REGEXPAT)
 
-IMAGE_REGEX: Pattern = re.compile(r"(?:.+/)?([^:]+)(:(.+))?")
+# https://github.com/moby/moby/blob/master/image/spec/v1.md
+# https://github.com/moby/moby/blob/master/image/spec/v1.2.md
+IMAGE_REGEX: Pattern = re.compile(r"(.+/)?([^:]+)(:(.+))?")
 
 
 def parse_cpu_in_mcpu(cpu_string: str) -> Optional[int]:
@@ -41,10 +43,10 @@ def parse_memory_in_bytes(memory_string: str) -> Optional[int]:
     return None
 
 
-def parse_image_tag(image_string: str) -> Optional[str]:
+def parse_image_tag(image_string: str) -> Optional[Tuple[str, str]]:
     match = IMAGE_REGEX.fullmatch(image_string)
     if match:
-        return match.group(3)
+        return match.group(1) + match.group(2), match.group(4)
     return None
 
 


### PR DESCRIPTION
I screwed this up in the Shuffler PR. I need to remove the "image tag suffix" (the stuff after the final colon) before comparing
to a string like "gcr.io/hail-vdc/query".

I used the terminology from the Docker image specs:
- https://github.com/moby/moby/blob/master/image/spec/v1.md
- https://github.com/moby/moby/blob/master/image/spec/v1.2.md

But this terminology is kind of confusing. In "gcr.io/hail-vdc/query" the "repository" is "gcr.io/hail-vdc/query" and the tag is
not present.