### PR TITLE
[batch] Fix broken batch worker image pulling

### DIFF
--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -112,6 +112,11 @@ iptables -I DOCKER-USER -i public -d 172.16.0.0/12 -j DROP
 # not used, but ban it anyway!
 iptables -I DOCKER-USER -i public -d 192.168.0.0/16 -j DROP
 
+# create network for batch-worker that allows metadata server
+docker network create batch-worker --opt com.docker.network.bridge.name=batch-worker
+iptables -I DOCKER-USER -i batch-worker -d 169.254.169.254 -j ACCEPT
+
+
 WORKER_DATA_DISK_NAME="{worker_data_disk_name}"
 
 # format local SSD
@@ -254,6 +259,7 @@ docker run \
 --device $XFS_DEVICE \
 --cap-add SYS_ADMIN \
 --security-opt apparmor:unconfined \
+--network batch-worker \
 $BATCH_WORKER_IMAGE \
 python3 -u -m batch.worker.worker >worker.log 2>&1
 

--- a/batch/batch/public_gcr_images.py
+++ b/batch/batch/public_gcr_images.py
@@ -1,7 +1,7 @@
 from typing import List
-
+from hailtop.batch import hail_genetics_images
 
 def public_gcr_images(project: str) -> List[str]:
     # the worker cannot import batch_configuration because it does not have all the environment
     # variables
-    return [f'gcr.io/{project}/{name}' for name in ('query',)]
+    return [f'gcr.io/{project}/{name}' for name in ('query', 'hail', 'python-dill')]

--- a/batch/batch/public_gcr_images.py
+++ b/batch/batch/public_gcr_images.py
@@ -1,5 +1,5 @@
 from typing import List
-from hailtop.batch import hail_genetics_images
+
 
 def public_gcr_images(project: str) -> List[str]:
     # the worker cannot import batch_configuration because it does not have all the environment

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -371,7 +371,7 @@ class Container:
         async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             async with session.post('http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
                                     headers={'Metadata-Flavor': 'Google'}) as resp:
-                access_token = resp.json()['access_token']
+                access_token = (await resp.json())['access_token']
                 return {'username': 'oauth2accesstoken', 'password': access_token}
 
     async def run(self, worker):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -757,6 +757,7 @@ class Job:
             main_spec['timeout'] = timeout
         network = job_spec.get('network')
         if network:
+            assert network in ('public', 'private')
             main_spec['network'] = network
         containers['main'] = Container(self, 'main', main_spec)
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import os
 import json
 import sys
@@ -82,11 +83,11 @@ assert worker_config.cores == CORES
 
 deploy_config = DeployConfig('gce', NAMESPACE, {})
 
-docker: aiodocker.Docker = None
+docker: Optional[aiodocker.Docker] = None
 
-port_allocator: 'PortAllocator' = None
+port_allocator: Optional['PortAllocator'] = None
 
-worker: 'Worker' = None
+worker: Optional['Worker'] = None
 
 
 class PortAllocator:


### PR DESCRIPTION
I thought that pulling with no auth would use the credential helper to use the machine's
credentials. AFAICT, the Docker HTTP API has no way to use the credential helper. You *must* provide
authentication in the HTTP request which means the HTTP client must obtain the credentials
themselves. The Docker docs note ["Authentication for registries is handled client side. The client
has to send authentication details to various endpoints that need to communicate with
registries"](https://docs.docker.com/engine/api/v1.41/#section/Authentication)

I request a short-lived oauth2 access token from the Google metadata endpoint. The google
[documentation obliquely notes that the username should be
`oauth2accesstoken`](https://cloud.google.com/container-registry/docs/advanced-authentication). I
use this only for retrieving a "public gcr image" which I fix in this PR to be images whose
"repository" [1] is one of these:
- gcr.io/PROJECT/query
- gcr.io/PROJECT/hail
- gcr.io/PROJECT/python-dill

A previous Shuffler PR taught worker.py to translate our `hailgenetics` Docker image names to
`gcr.io/PROJECT` image names.

I had to move the docker-worker into a new Docker network which allows it to access the metadata server. I think this is safe because we trust our own code.

From a relevant Docker worker log:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/batch/worker/worker.py", line 359, in ensure_image_is_pulled
    docker.images.get, self.image)
  File "/usr/local/lib/python3.7/site-packages/batch/worker/worker.py", line 111, in wrapper
    return await asyncio.wait_for(f(*args, **kwargs), timeout)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 442, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/usr/local/lib/python3.7/site-packages/aiodocker/images.py", line 46, in get
    return await self.inspect(name)
  File "/usr/local/lib/python3.7/site-packages/aiodocker/images.py", line 36, in inspect
    response = await self.docker._query_json("images/{name}/json".format(name=name))
  File "/usr/local/lib/python3.7/site-packages/aiodocker/docker.py", line 223, in _query_json
    path, method, params=params, data=data, headers=headers, timeout=timeout
  File "/usr/local/lib/python3.7/site-packages/aiodocker/docker.py", line 291, in __aenter__
    resp = await self._coro
  File "/usr/local/lib/python3.7/site-packages/aiodocker/docker.py", line 206, in _do_query
    raise DockerError(response.status, json.loads(what.decode("utf8")))
aiodocker.exceptions.DockerError: DockerError(404, 'no such image: gcr.io/hail-vdc/query:tfkm2kev7zcf: No such image: gcr.io/hail-vdc/query:tfkm2kev7zcf')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/batch/worker/worker.py", line 372, in run
    await self.ensure_image_is_pulled()
  File "/usr/local/lib/python3.7/site-packages/batch/worker/worker.py", line 363, in ensure_image_is_pulled
    docker.images.pull, self.image)
  File "/usr/local/lib/python3.7/site-packages/batch/worker/worker.py", line 111, in wrapper
    return await asyncio.wait_for(f(*args, **kwargs), timeout)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 442, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.7/asyncio/futures.py", line 181, in result
    raise self._exception
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/usr/local/lib/python3.7/site-packages/aiodocker/images.py", line 104, in _handle_list
    async with cm as response:
  File "/usr/local/lib/python3.7/site-packages/aiodocker/docker.py", line 291, in __aenter__
    resp = await self._coro
  File "/usr/local/lib/python3.7/site-packages/aiodocker/docker.py", line 206, in _do_query
    raise DockerError(response.status, json.loads(what.decode("utf8")))
aiodocker.exceptions.DockerError: DockerError(500, "unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication")
```

[1] The Docker specifications are confusing. After reading
[v1](https://github.com/moby/moby/blob/master/image/spec/v1.md) and
[v1.2](https://github.com/moby/moby/blob/master/image/spec/v1.2.md), it seems that the "repository"
is everything before the last colon and the "image name suffix" is everything after the last
colon. For example, in `server:8080/abc/def:123`, the repository is `server:8080/abc/def` and the
"image name suffix" is `123`.