### PR TITLE
[batch] restore internal network

### DIFF
--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -105,8 +105,6 @@ iptables -I DOCKER-USER -d 169.254.169.254 -p udp -m udp --destination-port 53 -
 
 docker network create public --opt com.docker.network.bridge.name=public
 docker network create private --opt com.docker.network.bridge.name=private
-# make the internal network not route-able
-iptables -I DOCKER-USER -i public -d 10.0.0.0/8 -j DROP
 # make other docker containers not route-able
 iptables -I DOCKER-USER -i public -d 172.16.0.0/12 -j DROP
 # not used, but ban it anyway!


### PR DESCRIPTION
We lost this in a rebase. Query jobs need to talk to the internal network because the shuffler
is on the internal network.