### PR TITLE
[hail] add jar-only hail build job

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -561,6 +561,28 @@ steps:
    dependsOn:
      - service_base_image
  - kind: runImage
+   name: build_hail_jar_only
+   image:
+     valueFrom: hail_build_image.image
+   resources:
+     memory: "7.5G"
+     cpu: "4"
+   script: |
+     set -ex
+     cd /io
+     rm -rf repo
+     mkdir repo
+     cd repo
+     {{ code.checkout_script }}
+     cd hail
+     time retry ./gradlew --version
+     time retry make shadowJar
+   outputs:
+     - from: /io/repo/hail/build/libs/hail-all-spark.jar
+       to: /just-jar/hail.jar
+   dependsOn:
+    - hail_build_image
+ - kind: runImage
    name: build_hail
    image:
      valueFrom: hail_build_image.image
@@ -650,11 +672,11 @@ steps:
    contextPath: .
    publishAs: query
    inputs:
-     - from: /hail.jar
+     - from: /just-jar/hail.jar
        to: /query/hail.jar
    dependsOn:
      - service_base_image
-     - build_hail
+     - build_hail_jar_only
  - kind: deploy
    name: deploy_query_sa
    namespace:
@@ -682,11 +704,11 @@ steps:
    contextPath: shuffler
    publishAs: shuffler
    inputs:
-     - from: /hail.jar
+     - from: /just-jar/hail.jar
        to: /hail.jar
    dependsOn:
      - service_base_image
-     - build_hail
+     - build_hail_jar_only
  - kind: deploy
    name: deploy_shuffler
    namespace:


### PR DESCRIPTION
Building the JAR only takes 5 minutes. Query and Shuffler don't need the other stuff, so it's better for services team if we can skip all that. I don't really care much about the added 5 compute minutes. It's worth the increase in developer velocity.