### PR TITLE
[batch] remove assertion that breaks the usage of Artifact Registry images

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -386,7 +386,6 @@ class Container:
                     auth = await self.batch_worker_access_token()
                     await self.ensure_image_is_pulled(auth=auth)
                 else:
-                    assert self.image.startswith('gcr.io/')
                     # Pull to verify this user has access to this
                     # image.
                     # FIXME improve the performance of this with a


### PR DESCRIPTION
Those image paths start with e.g. australia-southeast1-docker.pkg.dev/.