### PR TITLE
[logging] Add severity field to jsonlogger

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -17,7 +17,7 @@ log = logging.getLogger('ci')
 
 pretty_print_log = "jq -Rr '. as $raw | try \
 (fromjson | if .hail_log == 1 then \
-    ([.levelname, .asctime, .filename, .funcNameAndLine, .message, .exc_info] | @tsv) \
+    ([.severity, .asctime, .filename, .funcNameAndLine, .message, .exc_info] | @tsv) \
     else $raw end) \
 catch $raw'"
 

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -9,6 +9,8 @@ import time
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
+        # GCP Logging expects `severity` but JSONLogger uses `levelname`
+        log_record['severity'] = log_record['levelname']
         log_record['funcNameAndLine'] = "{}:{}".format(record.funcName, record.lineno)
         log_record['hail_log'] = 1
 

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -9,8 +9,8 @@ import time
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
-        # GCP Logging expects `severity` but JSONLogger uses `levelname`
-        log_record['severity'] = log_record['levelname']
+        # GCP Logging expects `severity` but jsonlogger uses `levelname`
+        log_record['severity'] = record.levelname
         log_record['funcNameAndLine'] = "{}:{}".format(record.funcName, record.lineno)
         log_record['hail_log'] = 1
 

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -16,7 +16,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 
 def configure_logging():
-    fmt = CustomJsonFormatter('(severity) (asctime) (filename) (funcNameAndLine) (message)')
+    fmt = CustomJsonFormatter('(severity) (levelname) (asctime) (filename) (funcNameAndLine) (message)')
 
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(logging.INFO)

--- a/hail/python/hailtop/hail_logging.py
+++ b/hail/python/hailtop/hail_logging.py
@@ -16,7 +16,7 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 
 def configure_logging():
-    fmt = CustomJsonFormatter('(levelname) (asctime) (filename) (funcNameAndLine) (message)')
+    fmt = CustomJsonFormatter('(severity) (asctime) (filename) (funcNameAndLine) (message)')
 
     stream_handler = logging.StreamHandler(stream=sys.stdout)
     stream_handler.setLevel(logging.INFO)


### PR DESCRIPTION
GCP Logging attempts to infer the severity of a log entry and defaults to labelling everything written to `stdout` as `INFO` and everything written to `stderr` as `ERROR`. There are some [LogEntry fields](https://cloud.google.com/logging/docs/structured-logging) that can be overwritten by fields in our JSON output, including `severity`. Until now we had been logging the severity level as `levelname`, which is the expectation of `jsonlogger`, but this means GCP's levels and ours do not necessarily match.  This adds another `severity` field to the logs so GCP can pick up the level.

This should get rid of a swath of non-error log messages written to `stderr` (only JSON though) and lets other levels like `WARNING` get marked as such.

GCP does quite literally extract the severity field though, so it does not appear in the `jsonPayload`. I've kept the `levelname` in then as a sanity check but am also happy to try to remove it.