### PR TITLE
[query] Add println to codebuilder

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -151,5 +151,5 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   }
 
   // for debugging
-  def println(cString: Code[String]) = this += Code._println(cString)
+  def println(cString: Code[String]*) = this += Code._printlns(cString:_*)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -149,4 +149,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   def strValue(r: Value[Region], t: PType, code: Code[_]): Code[String] = {
     StringFunctions.boxArg(EmitRegion(emb, r), t)(code).invoke[String]("toString")
   }
+
+  // for debugging
+  def println(cString: Code[String]) = this += Code._println(cString)
 }


### PR DESCRIPTION
This just adds a utility debugging method, instead of having to do `cb.append(Code._println(...))`. I find it helpful. 