### PR TITLE
port LowerBoundOnOrderedCollection to emitI

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -812,6 +812,14 @@ class Emit[C](
           ov.loadField(cb, oc.pt.asInstanceOf[PTuple].fieldIndex(i)).typecast[PCode]
         }
 
+      case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
+        emitI(orderedCollection).map(cb) { a =>
+          val typ: PContainer = coerce[PIterable](a.pt).asPContainer
+          val e = EmitCode.fromI(cb.emb)(cb => this.emitI(elem, cb, region, env, container, loopEnv))
+          val bs = new BinarySearch[C](mb, typ, e.pt, keyOnly = onKey)
+          PCode(pt, bs.getClosestIndex(a.tcode[Long], e.m, e.v))
+        }
+
       case x@MakeNDArray(dataIR, shapeIR, rowMajorIR) =>
         val xP = x.pType
         val dataContainer = dataIR.pType
@@ -1942,24 +1950,6 @@ class Emit[C](
         emitStream(a, outerRegion).map { stream =>
           EmitStream.toArray(ctx, mb, coerce[PArray](pt), stream.asStream, outerRegion)
         }
-
-      case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
-        val typ: PContainer = coerce[PIterable](orderedCollection.pType).asPContainer
-        val a = emit(orderedCollection)
-        val e = emit(elem)
-        val bs = new BinarySearch[C](mb, typ, elem.pType, keyOnly = onKey)
-
-        val localA = mb.newLocal[Long]()
-        val localElementMB = mb.newLocal[Boolean]()
-        val localElementValue = mb.newLocal()(typeToTypeInfo(elem.pType))
-        EmitCode(
-          Code(a.setup, e.setup),
-          a.m,
-          PCode(pt, Code(
-            localA := a.value[Long],
-            localElementMB := e.m,
-            localElementMB.mux(Code._empty, localElementValue.storeAny(e.v)),
-            bs.getClosestIndex(localA, localElementMB, localElementValue))))
 
       case GroupByKey(collection) =>
         // sort collection by group


### PR DESCRIPTION
A simplistic port that still uses an EmitCode for the element IR to keep
BinarySearch mostly happy