### PR TITLE
[hail] intelligently discover the spark home directory

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -19,6 +19,8 @@ from hail.utils.java import scala_package_object, scala_object
 from .py4j_backend import Py4JBackend, handle_java_exception
 from ..fs.local_fs import LocalFS
 from ..hail_logging import Logger
+from hailtop.utils import find_spark_home
+
 
 _installed = False
 _original = None
@@ -113,7 +115,7 @@ class Log4jLogger(Logger):
 class LocalBackend(Py4JBackend):
     def __init__(self, tmpdir, log, quiet, append, branching_factor,
                  skip_logging_configuration, optimizer_iterations):
-        SPARK_HOME = os.environ['SPARK_HOME']
+        spark_home = find_spark_home()
         hail_jar_path = os.environ.get('HAIL_JAR')
         if hail_jar_path is None:
             if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
@@ -124,8 +126,8 @@ class LocalBackend(Py4JBackend):
         port = launch_gateway(
             redirect_stdout=sys.stdout,
             redirect_stderr=sys.stderr,
-            jarpath=f'{SPARK_HOME}/jars/py4j-0.10.7.jar',
-            classpath=f'{SPARK_HOME}/jars/*:{hail_jar_path}',
+            jarpath=f'{spark_home}/jars/py4j-0.10.7.jar',
+            classpath=f'{spark_home}/jars/*:{hail_jar_path}',
             die_on_exit=True)
         self._gateway = JavaGateway(
             gateway_parameters=GatewayParameters(port=port, auto_convert=True))

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -8,7 +8,8 @@ from .utils import (
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
-    url_join, is_google_registry_image, url_scheme, Notice, periodically_call)
+    url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
+    find_spark_home)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -71,5 +72,6 @@ __all__ = [
     'url_scheme',
     'serialization',
     'Notice',
-    'periodically_call'
+    'periodically_call',
+    'find_spark_home'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1,4 +1,5 @@
 from typing import Callable, TypeVar, Awaitable
+import subprocess
 import traceback
 import os
 import errno
@@ -585,3 +586,19 @@ class Notice:
     def notify(self):
         for e in self.subscribers:
             e.set()
+
+
+def find_spark_home():
+    spark_home = os.environ.get('SPARK_HOME')
+    if spark_home is None:
+        find_spark_home = subprocess.run('find_spark_home.py',
+                                         capture_output=True,
+                                         check=False)
+        if find_spark_home.returncode != 0:
+            raise ValueError(f'''SPARK_HOME is not set and find_spark_home.py returned non-zero exit code:
+STDOUT:
+{find_spark_home.stdout}
+STDERR:
+{find_spark_home.stderr}''')
+        spark_home = find_spark_home.stdout.decode().strip()
+    return spark_home


### PR DESCRIPTION
If SPARK_HOME is not set, we might still be able to call find_spark_home.py and get the spark
home directory from that. We already do this in query.py. We now do this in local backend too.