### PR TITLE
[hail] make TableNativeZippedReader work

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1604,7 +1604,6 @@ class Tests(unittest.TestCase):
             mt.annotate_entries(x = mt2.af)
 
 
-@fails_local_backend()
 def test_read_write_all_types():
     mt = create_all_values_matrix_table()
     tmp_file = new_temp_file()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1005,8 +1005,16 @@ case class TableNativeZippedReader(
 
     def splitRequestedTypes(requestedType: Type): (TStruct, TStruct) = {
       val reqStruct = requestedType.asInstanceOf[TStruct]
-      val leftStruct = reqStruct.filterSet(specLeft.table_type.rowType.fieldNames.toSet)._1
-      val rightStruct = reqStruct.filterSet(specRight.table_type.rowType.fieldNames.toSet)._1
+      val neededFields = reqStruct.fieldNames.toSet
+
+      val leftProvidedFields = specLeft.table_type.rowType.fieldNames.toSet
+      val rightProvidedFields = specRight.table_type.rowType.fieldNames.toSet
+      val leftNeededFields = leftProvidedFields.intersect(neededFields)
+      val rightNeededFields = rightProvidedFields.intersect(neededFields)
+      assert(leftNeededFields.intersect(rightNeededFields).isEmpty)
+
+      val leftStruct = reqStruct.filterSet(leftNeededFields)._1
+      val rightStruct = reqStruct.filterSet(rightNeededFields)._1
       (leftStruct, rightStruct)
     }
 


### PR DESCRIPTION
`filterSet` requires the argument be a subset of the fields of the given struct. That is not
how `splitRequestedTypes` works. Instead, we explicitly compute the fields needed from each side
and pass those to `filterSet`.