### PR TITLE
[fs] add AsyncFS.multi_part_create interface

### DIFF
--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -1,11 +1,12 @@
 import os
-from typing import Tuple, Any, Set, Optional, Mapping, Dict, AsyncIterator, cast
+from typing import Tuple, Any, Set, Optional, Mapping, Dict, AsyncIterator, cast, Type
+from types import TracebackType
 import asyncio
 import urllib.parse
 import aiohttp
 from hailtop.aiotools import (
     FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
-    FeedableAsyncIterable, FileAndDirectoryError)
+    FeedableAsyncIterable, FileAndDirectoryError, MultiPartCreate)
 from multidict import CIMultiDictProxy  # pylint: disable=unused-import
 from .base_client import BaseClient
 
@@ -171,6 +172,25 @@ class GoogleStorageFileListEntry(FileListEntry):
         return self._status
 
 
+class GoogleStorageMultiPartCreate(MultiPartCreate):
+    def __init__(self, fs, url, num_parts):
+        self._fs = fs
+        self._url = url
+        self._num_parts = num_parts
+
+    async def create_part(self, number: int, start: int):
+        raise NotImplementedError
+
+    async def __aenter__(self) -> 'GoogleStorageMultiPartCreate':
+        raise NotImplementedError
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> None:
+        raise NotImplementedError
+
+
 class GoogleStorageAsyncFS(AsyncFS):
     def __init__(self, storage_client: Optional[StorageClient] = None):
         if not storage_client:
@@ -201,8 +221,8 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self._get_bucket_name(url)
         return await self._storage_client.insert_object(bucket, name)
 
-    async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
-        raise NotImplementedError
+    async def multi_part_create(self, url: str, num_parts: int) -> GoogleStorageMultiPartCreate:
+        return GoogleStorageMultiPartCreate(self, url, num_parts)
 
     async def staturl(self, url: str) -> str:
         assert not url.endswith('/')

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -201,6 +201,9 @@ class GoogleStorageAsyncFS(AsyncFS):
         bucket, name = self._get_bucket_name(url)
         return await self._storage_client.insert_object(bucket, name)
 
+    async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
+        raise NotImplementedError
+
     async def staturl(self, url: str) -> str:
         assert not url.endswith('/')
 

--- a/hail/python/hailtop/aiotools/__init__.py
+++ b/hail/python/hailtop/aiotools/__init__.py
@@ -1,5 +1,9 @@
-from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
-from .fs import FileStatus, FileListEntry, AsyncFS, LocalAsyncFS, RouterAsyncFS, Transfer, FileAndDirectoryError
+from .stream import (
+    ReadableStream, WritableStream, blocking_readable_stream_to_async,
+    blocking_writable_stream_to_async)
+from .fs import (
+    FileStatus, FileListEntry, AsyncFS, LocalAsyncFS, RouterAsyncFS, Transfer,
+    FileAndDirectoryError, MultiPartCreate)
 from .utils import FeedableAsyncIterable
 from .tasks import BackgroundTaskManager
 
@@ -16,5 +20,6 @@ __all__ = [
     'FeedableAsyncIterable',
     'BackgroundTaskManager',
     'Transfer',
-    'FileAndDirectoryError'
+    'FileAndDirectoryError',
+    'MultiPartCreate'
 ]

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -8,7 +8,7 @@ import shutil
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
-from hailtop.utils import blocking_to_async, url_basename, url_join, secret_alnum_string
+from hailtop.utils import blocking_to_async, url_basename, url_join
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 
 AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -8,7 +8,7 @@ import shutil
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
-from hailtop.utils import blocking_to_async, url_basename, url_join
+from hailtop.utils import blocking_to_async, url_basename, url_join, secret_alnum_string
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 
 AsyncFSType = TypeVar('AsyncFSType', bound='AsyncFS')
@@ -50,6 +50,23 @@ class FileListEntry(abc.ABC):
         pass
 
 
+class MultiPartCreate(abc.ABC):
+    @abc.abstractmethod
+    async def create_part(self, number: int, start: int):
+        pass
+
+    @abc.abstractmethod
+    async def __aenter__(self) -> 'MultiPartCreate':
+        pass
+
+    @abc.abstractmethod
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> None:
+        pass
+
+
 class AsyncFS(abc.ABC):
     FILE = 'file'
     DIR = 'dir'
@@ -64,6 +81,10 @@ class AsyncFS(abc.ABC):
 
     @abc.abstractmethod
     async def create(self, url: str) -> WritableStream:
+        pass
+
+    @abc.abstractmethod
+    async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
         pass
 
     @abc.abstractmethod
@@ -109,7 +130,7 @@ class AsyncFS(abc.ABC):
     async def close(self) -> None:
         pass
 
-    async def __aenter__(self: AsyncFSType) -> AsyncFSType:
+    async def __aenter__(self) -> AsyncFSType:
         return self
 
     async def __aexit__(self,
@@ -165,6 +186,33 @@ class LocalFileListEntry(FileListEntry):
         return self._status
 
 
+class LocalMultiPartCreate(MultiPartCreate):
+    def __init__(self, fs: AsyncFS, path: str, num_parts: int):
+        self._fs = fs
+        self._path = path
+        self._num_parts = num_parts
+
+    async def create_part(self, number: int, start: int):
+        assert 0 <= number < self._num_parts
+        assert (start & (8192 - 1)) == 0  # verify aligned to page boundary
+        f = await blocking_to_async(self._fs._thread_pool, open, self._path, 'ab')
+        f.seek(start)
+        return blocking_writable_stream_to_async(self._fs._thread_pool, cast(BinaryIO, f))
+
+    async def __aenter__(self) -> 'LocalMultiPartCreate':
+        return self
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> None:
+        if exc_val:
+            try:
+                await self._fs.remove(self._path)
+            except FileNotFoundError:
+                pass
+
+
 class LocalAsyncFS(AsyncFS):
     def __init__(self, thread_pool: ThreadPoolExecutor, max_workers=None):
         if not thread_pool:
@@ -182,10 +230,16 @@ class LocalAsyncFS(AsyncFS):
         return parsed.path
 
     async def open(self, url: str) -> ReadableStream:
-        return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, open(self._get_path(url), 'rb')))
+        f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'rb')
+        return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
 
     async def create(self, url: str) -> WritableStream:
-        return blocking_writable_stream_to_async(self._thread_pool, cast(BinaryIO, open(self._get_path(url), 'wb')))
+        f = await blocking_to_async(self._thread_pool, open, self._get_path(url), 'wb')
+        return blocking_writable_stream_to_async(self._thread_pool, cast(BinaryIO, f))
+
+    async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
+        path = self._get_path(url)
+        return LocalMultiPartCreate(self, path, num_parts)
 
     async def statfile(self, url: str) -> LocalStatFileStatus:
         path = self._get_path(url)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -597,6 +597,10 @@ class RouterAsyncFS(AsyncFS):
         fs = self._get_fs(url)
         return await fs.create(url)
 
+    async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
+        fs = self._get_fs(url)
+        return await fs.multi_part_create(url, num_parts)
+
     async def statfile(self, url: str) -> FileStatus:
         fs = self._get_fs(url)
         return await fs.statfile(url)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -239,7 +239,7 @@ class LocalAsyncFS(AsyncFS):
     async def multi_part_create(self, url: str, num_parts: int) -> MultiPartCreate:
         # create an empty file
         # will be opened r+b to write the parts
-        async with await self.create(url) as f:
+        async with await self.create(url):
             pass
         return LocalMultiPartCreate(self, self._get_path(url), num_parts)
 

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -276,8 +276,7 @@ async def test_listfiles(filesystem):
 async def test_multi_part_create(local_filesystem, permutation):
     fs, base = local_filesystem
 
-    # part_data = [secrets.token_bytes(s) for s in [8192, 8192, 8192]]
-    part_data = [b'a', b'bb', b'ccc']
+    part_data = [secrets.token_bytes(s) for s in [8192, 600, 20000]]
 
     s = 0
     part_start = []


### PR DESCRIPTION
implement in LocalAsyncFS with test.

AsynFS needs to support multi-part writes in order to parallelize transfers of large files.  Next PR will implement this for gs:// efficiently using a temporary file and the compose operation.
