### PR TITLE
[router-resolver][auth] fix latent bug in router-resolver

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -16,7 +16,7 @@ from gear import (
     setup_aiohttp_session,
     rest_authenticated_users_only, web_authenticated_developers_only,
     web_maybe_authenticated_user, web_authenticated_users_only, create_session,
-    check_csrf_token, transaction, Database
+    check_csrf_token, transaction, Database, maybe_parse_bearer_header
 )
 from web_common import (
     setup_aiohttp_jinja2, setup_common_static_routes, set_message,
@@ -532,7 +532,8 @@ async def userinfo(request):
         raise web.HTTPUnauthorized()
 
     auth_header = request.headers['Authorization']
-    if not auth_header.startswith('Bearer '):
+    session_id = maybe_parse_bearer_header(auth_header)
+    if not session_id:
         log.info('Bearer not in Authorization header')
         raise web.HTTPUnauthorized()
     session_id = auth_header[7:]

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -536,7 +536,6 @@ async def userinfo(request):
     if not session_id:
         log.info('Bearer not in Authorization header')
         raise web.HTTPUnauthorized()
-    session_id = auth_header[7:]
 
     # b64 encoding of 32-byte session ID is 44 bytes
     if len(session_id) != 44:

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -14,7 +14,7 @@ from prometheus_async.aio.web import server_stats
 from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_developers_only,
                   web_authenticated_developers_only, check_csrf_token,
-                  transaction)
+                  transaction, maybe_parse_bearer_header)
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import (time_msecs, RateLimit, serialization,
@@ -59,9 +59,10 @@ def authorization_token(request):
     auth_header = request.headers.get('Authorization')
     if not auth_header:
         return None
-    if not auth_header.startswith('Bearer '):
+    session_id = maybe_parse_bearer_header(auth_header)
+    if not session_id:
         return None
-    return auth_header[7:]
+    return session_id
 
 
 def batch_only(fun):

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -2,7 +2,7 @@ from .database import create_database_pool, Database, transaction
 from .session import setup_aiohttp_session
 from .auth import userdata_from_web_request, userdata_from_rest_request, \
     web_authenticated_users_only, web_maybe_authenticated_user, rest_authenticated_users_only, \
-    web_authenticated_developers_only, rest_authenticated_developers_only
+    web_authenticated_developers_only, rest_authenticated_developers_only, maybe_parse_bearer_header
 from .csrf import new_csrf_token, check_csrf_token
 from .auth_utils import insert_user, create_session
 
@@ -21,5 +21,6 @@ __all__ = [
     'check_csrf_token',
     'insert_user',
     'create_session',
-    'transaction'
+    'transaction',
+    'maybe_parse_bearer_header'
 ]

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import logging
 from functools import wraps
 import urllib.parse
@@ -10,6 +11,14 @@ from hailtop.auth import async_get_userinfo
 log = logging.getLogger('gear.auth')
 
 deploy_config = get_deploy_config()
+
+BEARER = 'Bearer '
+
+
+def maybe_parse_bearer_header(value: str) -> Optional[str]:
+    if value.startswith(BEARER):
+        return value[len(BEARER):]
+    return None
 
 
 async def _userdata_from_session_id(session_id):
@@ -34,8 +43,9 @@ async def userdata_from_rest_request(request):
     if 'Authorization' not in request.headers:
         return None
     auth_header = request.headers['Authorization']
-    if not auth_header.startswith('Bearer '):
-        return None
+    session_id = maybe_parse_bearer_header(auth_header)
+    if not session_id:
+        return session_id
     return await _userdata_from_session_id(auth_header[7:])
 
 

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -27,14 +27,17 @@ async def auth(request):
     namespace = request.match_info['namespace']
 
     if 'X-Hail-Internal-Authorization' in request.headers:
-        session_id = request.headers['X-Hail-Internal-Authorization']
+        session_id = maybe_parse_bearer(
+            request.headers['X-Hail-Internal-Authorization'])
     elif 'Authorization' in request.headers:
-        session_id = request.headers['Authorization']
+        session_id = maybe_parse_bearer(
+            request.headers['Authorization'])
     else:
         session = await aiohttp_session.get_session(request)
         session_id = session.get('session_id')
-        if not session_id:
-            raise web.HTTPUnauthorized()
+
+    if not session_id:
+        raise web.HTTPUnauthorized()
 
     userdata = await async_get_userinfo(session_id=session_id)
     is_developer = userdata is not None and userdata['is_developer'] == 1

--- a/router-resolver/router_resolver/router_resolver.py
+++ b/router-resolver/router_resolver/router_resolver.py
@@ -7,7 +7,7 @@ import logging
 from hailtop.auth import async_get_userinfo
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger, configure_logging
-from gear import setup_aiohttp_session
+from gear import setup_aiohttp_session, maybe_parse_bearer_header
 
 uvloop.install()
 
@@ -27,10 +27,10 @@ async def auth(request):
     namespace = request.match_info['namespace']
 
     if 'X-Hail-Internal-Authorization' in request.headers:
-        session_id = maybe_parse_bearer(
+        session_id = maybe_parse_bearer_header(
             request.headers['X-Hail-Internal-Authorization'])
     elif 'Authorization' in request.headers:
-        session_id = maybe_parse_bearer(
+        session_id = maybe_parse_bearer_header(
             request.headers['Authorization'])
     else:
         session = await aiohttp_session.get_session(request)


### PR DESCRIPTION
The router resolver incorrectly assumed the contents of the `Authorization` header was a session
id. In fact, the structure of that header and X-Hail-Internal-Authorization is:

```
Bearer SESSION_ID
```

where `SESSION_ID` is a 44 base64 characters representing a 32 byte secret session id.

I also took this opportunity to centralize the parsing of bearer headers as
`gear.maybe_parse_bearer_header`.

---

This caused a failure because router-resolver, when checking that a user is properly authenticated,
would send:

```
Bearer Bearer SESSION_ID
```

which failed the 44-byte length check in auth/front_end.py.