### PR TITLE
[router,gateway,site,blog,internal-gateway] Change nginx logs to JSON

### DIFF
--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -27,7 +27,7 @@ http {
    '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
-   '"request_start_time":"[$time_local]",'
+   '"request_start_time":"$time_local",'
    '"body_bytes_sent":"$body_bytes_sent",'
    '"http_referer":"$http_referer",'
    '"http_user_agent":"$http_user_agent"'

--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -21,10 +21,19 @@ http {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
 
-  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
-                              '$scheme "$request" $status $body_bytes_sent '
-                              '"$http_referer" "$http_user_agent"';
-  access_log /var/log/nginx/access.log combined_real_ip;
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":"$status",'
+   '"request_duration":"$request_time",'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"[$time_local]",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   gzip on;

--- a/blog/nginx.conf
+++ b/blog/nginx.conf
@@ -23,8 +23,8 @@ http {
 
   log_format json-log escape=json '{'
    '"message":"$scheme $request done in ${request_time}s: $status",'
-   '"response_status":"$status",'
-   '"request_duration":"$request_time",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
    '"request_start_time":"[$time_local]",'

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -24,8 +24,8 @@ http {
 
   log_format json-log escape=json '{'
    '"message":"$scheme $request done in ${request_time}s: $status",'
-   '"response_status":"$status",'
-   '"request_duration":"$request_time",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
    '"request_start_time":"[$time_local]",'

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -22,10 +22,19 @@ http {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
 
-  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
-                              '$scheme "$request" $status $body_bytes_sent '
-                              '"$http_referer" "$http_user_agent"';
-  access_log /var/log/nginx/access.log combined_real_ip;
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":"$status",'
+   '"request_duration":"$request_time",'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"[$time_local]",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   include /ssl-config/ssl-config-http.conf;

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -28,7 +28,7 @@ http {
    '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
-   '"request_start_time":"[$time_local]",'
+   '"request_start_time":"$time_local",'
    '"body_bytes_sent":"$body_bytes_sent",'
    '"http_referer":"$http_referer",'
    '"http_user_agent":"$http_user_agent"'

--- a/internal-gateway/nginx.conf
+++ b/internal-gateway/nginx.conf
@@ -24,8 +24,8 @@ http {
 
   log_format json-log escape=json '{'
    '"message":"$scheme $request done in ${request_time}s: $status",'
-   '"response_status":"$status",'
-   '"request_duration":"$request_time",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
    '"request_start_time":"[$time_local]",'

--- a/internal-gateway/nginx.conf
+++ b/internal-gateway/nginx.conf
@@ -22,10 +22,19 @@ http {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
 
-  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
-                              '$scheme "$request" $status $body_bytes_sent '
-                              '"$http_referer" "$http_user_agent"';
-  access_log /var/log/nginx/access.log combined_real_ip;
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":"$status",'
+   '"request_duration":"$request_time",'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"[$time_local]",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   include /ssl-config/ssl-config-http.conf;

--- a/internal-gateway/nginx.conf
+++ b/internal-gateway/nginx.conf
@@ -28,7 +28,7 @@ http {
    '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
-   '"request_start_time":"[$time_local]",'
+   '"request_start_time":"$time_local",'
    '"body_bytes_sent":"$body_bytes_sent",'
    '"http_referer":"$http_referer",'
    '"http_user_agent":"$http_user_agent"'

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -24,8 +24,8 @@ http {
 
   log_format json-log escape=json '{'
    '"message":"$scheme $request done in ${request_time}s: $status",'
-   '"response_status":"$status",'
-   '"request_duration":"$request_time",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
    '"request_start_time":"[$time_local]",'

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -22,10 +22,19 @@ http {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
 
-  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
-                              '$scheme "$request" $status $body_bytes_sent '
-                              '"$http_referer" "$http_user_agent"';
-  access_log /var/log/nginx/access.log combined_real_ip;
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":"$status",'
+   '"request_duration":"$request_time",'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"[$time_local]",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   include /ssl-config/ssl-config-http.conf;

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -28,7 +28,7 @@ http {
    '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
-   '"request_start_time":"[$time_local]",'
+   '"request_start_time":"$time_local",'
    '"body_bytes_sent":"$body_bytes_sent",'
    '"http_referer":"$http_referer",'
    '"http_user_agent":"$http_user_agent"'

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -27,7 +27,7 @@ http {
    '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
-   '"request_start_time":"[$time_local]",'
+   '"request_start_time":"$time_local",'
    '"body_bytes_sent":"$body_bytes_sent",'
    '"http_referer":"$http_referer",'
    '"http_user_agent":"$http_user_agent"'

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -21,10 +21,19 @@ http {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
   ssl_prefer_server_ciphers on;
 
-  log_format combined_real_ip '$http_x_real_ip - $remote_addr - $remote_user [$time_local] '
-                              '$scheme "$request" $status $body_bytes_sent '
-                              '"$http_referer" "$http_user_agent"';
-  access_log /var/log/nginx/access.log combined_real_ip;
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":"$status",'
+   '"request_duration":"$request_time",'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"[$time_local]",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
   error_log /var/log/nginx/error.log;
 
   gzip on;

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -23,8 +23,8 @@ http {
 
   log_format json-log escape=json '{'
    '"message":"$scheme $request done in ${request_time}s: $status",'
-   '"response_status":"$status",'
-   '"request_duration":"$request_time",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
    '"remote_address":"$remote_addr",'
    '"x_real_ip":"$http_x_real_ip",'
    '"request_start_time":"[$time_local]",'


### PR DESCRIPTION
- Basic JSON format for NGINX access logs
- `message`, `remote_address`, `request_duration`, `response_status` and `x_real_ip` should match the Python Access logger so we should be able to query these fields all at once
- Unfortunately the NGINX `error_log` does not allow the same custom formatter, but we can create multiple, [custom access logs](https://www.nginx.com/blog/diagnostic-logging-nginx-javascript-module/#proxy_next_upstream) based on arbitrary failure criteria if there's a particular class of error logs we want to get in the future.