### PR TITLE
[image-fetcher] only redirect errors to stderr and remove old Make rules

### DIFF
--- a/image-fetcher/Makefile
+++ b/image-fetcher/Makefile
@@ -5,20 +5,11 @@ include ../config.mk
 FETCH_LATEST = gcr.io/$(PROJECT)/image-fetcher:latest
 FETCH_IMAGE = gcr.io/$(PROJECT)/image-fetcher:$(shell docker images -q --no-trunc image-fetcher | sed -e 's,[^:]*:,,')
 
-fetch-image.sh: fetch-image.sh.in
-	sed -e "s,@project@,$(PROJECT)," \
-	  < fetch-image.sh.in > fetch-image.sh
-
-ifeq ($(IN_HAIL_CI),1)
 build: fetch-image.sh
 	docker pull gcr.io/$(PROJECT)/alpine:3.8
 	-docker pull $(FETCH_LATEST)
 	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}}' Dockerfile Dockerfile.out
 	docker build -f Dockerfile.out . -t image-fetcher --cache-from image-fetcher,$(FETCH_LATEST),gcr.io/$(PROJECT)/alpine:3.8
-else
-build: fetch-image.sh
-	docker build . -t image-fetcher
-endif
 
 push: build
 	docker tag image-fetcher $(FETCH_LATEST)
@@ -28,7 +19,5 @@ push: build
 
 deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
-	  -e "s,@image@,$(FETCH_IMAGE)," \
-	  < deployment.yaml.in > deployment.yaml
-	kubectl -n $(NAMESPACE) apply -f deployment.yaml
+	python3 ../ci/jinja2_render.py '{"deploy": $(DEPLOY), "code":{"sha": "$(shell git rev-parse --short=12 HEAD)"}, "image_fetcher_image":{"image":"$(FETCH_IMAGE)"}}' deployment.yaml deployment.yaml.out
+	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out


### PR DESCRIPTION
- Using `-x` prints every line of the script to an error log entry. The main thing we're concerned about here is if it can fetch from notebook, so capture that output in `image-fetch-output.log` and cat that out to `stderr` only if it failed so it shows up as errors in the logs.

- Removed old templating from before the `jinja2` times

cc @cseed 