### PR TITLE
[format] black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+        files: 'ci/.*'
+        args: ['--line-length=120', '--skip-string-normalization']

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -13,6 +13,7 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 check:
 	$(PYTHON) -m flake8 ci
 	$(PYTHON) -m pylint --rcfile ../pylintrc ci --score=n
+	$(PYTHON) -m black ci --check --line-length=120 --skip-string-normalization
 	../check-sql.sh
 
 .PHONY: build-ci-utils

--- a/ci/ci/__main__.py
+++ b/ci/ci/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -8,8 +8,16 @@ import yaml
 import jinja2
 from hailtop.utils import RETRY_FUNCTION_SCRIPT, flatten
 from .utils import generate_token
-from .environment import GCP_PROJECT, GCP_ZONE, DOMAIN, IP, CI_UTILS_IMAGE, \
-    DEFAULT_NAMESPACE, KUBERNETES_SERVER_URL, BUCKET
+from .environment import (
+    GCP_PROJECT,
+    GCP_ZONE,
+    DOMAIN,
+    IP,
+    CI_UTILS_IMAGE,
+    DEFAULT_NAMESPACE,
+    KUBERNETES_SERVER_URL,
+    BUCKET,
+)
 from .globals import is_test_deployment
 
 log = logging.getLogger('ci')
@@ -129,7 +137,9 @@ class BuildConfiguration:
         for step in self.steps:
             parent_jobs = flatten([parent_step.wrapped_job() for parent_step in step_to_parent_steps[step]])
 
-            log.info(f"Cleanup {step.name} after running {[parent_step.name for parent_step in step_to_parent_steps[step]]}")
+            log.info(
+                f"Cleanup {step.name} after running {[parent_step.name for parent_step in step_to_parent_steps[step]]}"
+            )
 
             if step.scopes is None or scope in step.scopes:
                 step.cleanup(batch, scope, parent_jobs)
@@ -141,10 +151,7 @@ class Step(abc.ABC):
 
         self.name = json['name']
         if 'dependsOn' in json:
-            duplicates = [
-                name
-                for name, count in Counter(json['dependsOn']).items()
-                if count > 1]
+            duplicates = [name for name, count in Counter(json['dependsOn']).items() if count > 1]
             if duplicates:
                 raise BuildConfigurationError(f'found duplicate dependencies of {self.name}: {duplicates}')
             self.deps = [params.name_step[d] for d in json['dependsOn'] if params.name_step[d]]
@@ -162,7 +169,7 @@ class Step(abc.ABC):
             'zone': GCP_ZONE,
             'domain': DOMAIN,
             'ip': IP,
-            'k8s_server_url': KUBERNETES_SERVER_URL
+            'k8s_server_url': KUBERNETES_SERVER_URL,
         }
         config['token'] = self.token
         config['deploy'] = scope == 'deploy'
@@ -242,23 +249,20 @@ class BuildImageStep(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return BuildImageStep(params,
-                              json['dockerFile'],
-                              json.get('contextPath'),
-                              json.get('publishAs'),
-                              json.get('inputs'))
+        return BuildImageStep(
+            params, json['dockerFile'], json.get('contextPath'), json.get('publishAs'), json.get('inputs')
+        )
 
     def config(self, scope):  # pylint: disable=unused-argument
-        return {
-            'token': self.token,
-            'image': self.image
-        }
+        return {'token': self.token, 'image': self.image}
 
     def build(self, batch, code, scope):
         if self.inputs:
             input_files = []
             for i in self.inputs:
-                input_files.append((f'gs://{BUCKET}/build/{batch.attributes["token"]}{i["from"]}', f'/io/{os.path.basename(i["to"])}'))
+                input_files.append(
+                    (f'gs://{BUCKET}/build/{batch.attributes["token"]}{i["from"]}', f'/io/{os.path.basename(i["to"])}')
+                )
         else:
             input_files = None
 
@@ -280,8 +284,10 @@ class BuildImageStep(Step):
             assert isinstance(self.dockerfile, str)
             render_dockerfile = ''
             unrendered_dockerfile = f'repo/{self.dockerfile}'
-        render_dockerfile += (f'time python3 jinja2_render.py {shq(json.dumps(config))} '
-                              f'{shq(unrendered_dockerfile)} {shq(rendered_dockerfile)}')
+        render_dockerfile += (
+            f'time python3 jinja2_render.py {shq(json.dumps(config))} '
+            f'{shq(unrendered_dockerfile)} {shq(rendered_dockerfile)}'
+        )
 
         if self.publish_as:
             published_latest = shq(f'gcr.io/{GCP_PROJECT}/{self.publish_as}:latest')
@@ -295,19 +301,25 @@ class BuildImageStep(Step):
 time retry docker push {self.image}
 '''
         if scope == 'deploy' and self.publish_as and not is_test_deployment:
-            push_image = f'''
+            push_image = (
+                f'''
 docker tag {shq(self.image)} {self.base_image}:latest
 time retry docker push {self.base_image}:latest
-''' + push_image
+'''
+                + push_image
+            )
 
         copy_inputs = ''
         if self.inputs:
             for i in self.inputs:
                 # to is relative to docker context
-                copy_inputs = copy_inputs + f'''
+                copy_inputs = (
+                    copy_inputs
+                    + f'''
 mkdir -p {shq(os.path.dirname(f'{context}{i["to"]}'))}
 cp {shq(f'/io/{os.path.basename(i["to"])}')} {shq(f'{context}{i["to"]}')}
 '''
+                )
 
         script = f'''
 set -ex
@@ -344,17 +356,21 @@ date
 
         log.info(f'step {self.name}, script:\n{script}')
 
-        self.job = batch.create_job(CI_UTILS_IMAGE,
-                                    command=['bash', '-c', script],
-                                    mount_docker_socket=True,
-                                    secrets=[{
-                                        'namespace': DEFAULT_NAMESPACE,
-                                        'name': 'gcr-push-service-account-key',
-                                        'mount_path': '/secrets/gcr-push-service-account-key'
-                                    }],
-                                    attributes={'name': self.name},
-                                    input_files=input_files,
-                                    parents=self.deps_parents())
+        self.job = batch.create_job(
+            CI_UTILS_IMAGE,
+            command=['bash', '-c', script],
+            mount_docker_socket=True,
+            secrets=[
+                {
+                    'namespace': DEFAULT_NAMESPACE,
+                    'name': 'gcr-push-service-account-key',
+                    'mount_path': '/secrets/gcr-push-service-account-key',
+                }
+            ],
+            attributes={'name': self.name},
+            input_files=input_files,
+            parents=self.deps_parents(),
+        )
 
     def cleanup(self, batch, scope, parents):
         if scope == 'deploy' and self.publish_as and not is_test_deployment:
@@ -377,21 +393,27 @@ date
 true
 '''
 
-        self.job = batch.create_job(CI_UTILS_IMAGE,
-                                    command=['bash', '-c', script],
-                                    attributes={'name': f'cleanup_{self.name}'},
-                                    secrets=[{
-                                        'namespace': DEFAULT_NAMESPACE,
-                                        'name': 'gcr-push-service-account-key',
-                                        'mount_path': '/secrets/gcr-push-service-account-key'
-                                    }],
-                                    parents=parents,
-                                    always_run=True,
-                                    network='private')
+        self.job = batch.create_job(
+            CI_UTILS_IMAGE,
+            command=['bash', '-c', script],
+            attributes={'name': f'cleanup_{self.name}'},
+            secrets=[
+                {
+                    'namespace': DEFAULT_NAMESPACE,
+                    'name': 'gcr-push-service-account-key',
+                    'mount_path': '/secrets/gcr-push-service-account-key',
+                }
+            ],
+            parents=parents,
+            always_run=True,
+            network='private',
+        )
 
 
 class RunImageStep(Step):
-    def __init__(self, params, image, script, inputs, outputs, port, resources, service_account, secrets, always_run, timeout):  # pylint: disable=unused-argument
+    def __init__(
+        self, params, image, script, inputs, outputs, port, resources, service_account, secrets, always_run, timeout
+    ):  # pylint: disable=unused-argument
         super().__init__(params)
         self.image = expand_value_from(image, self.input_config(params.code, params.scope))
         self.script = script
@@ -402,7 +424,7 @@ class RunImageStep(Step):
         if service_account:
             self.service_account = {
                 'name': service_account['name'],
-                'namespace': get_namespace(service_account['namespace'], self.input_config(params.code, params.scope))
+                'namespace': get_namespace(service_account['namespace'], self.input_config(params.code, params.scope)),
             }
         else:
             self.service_account = None
@@ -419,22 +441,22 @@ class RunImageStep(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return RunImageStep(params,
-                            json['image'],
-                            json['script'],
-                            json.get('inputs'),
-                            json.get('outputs'),
-                            json.get('port'),
-                            json.get('resources'),
-                            json.get('serviceAccount'),
-                            json.get('secrets'),
-                            json.get('alwaysRun', False),
-                            json.get('timeout', 3600))
+        return RunImageStep(
+            params,
+            json['image'],
+            json['script'],
+            json.get('inputs'),
+            json.get('outputs'),
+            json.get('port'),
+            json.get('resources'),
+            json.get('serviceAccount'),
+            json.get('secrets'),
+            json.get('alwaysRun', False),
+            json.get('timeout', 3600),
+        )
 
     def config(self, scope):  # pylint: disable=unused-argument
-        return {
-            'token': self.token
-        }
+        return {'token': self.token}
 
     def build(self, batch, code, scope):
         template = jinja2.Template(self.script, undefined=jinja2.StrictUndefined, trim_blocks=True, lstrip_blocks=True)
@@ -462,11 +484,7 @@ class RunImageStep(Step):
                 namespace = get_namespace(secret['namespace'], self.input_config(code, scope))
                 name = expand_value_from(secret['name'], self.input_config(code, scope))
                 mount_path = secret['mountPath']
-                secrets.append({
-                    'namespace': namespace,
-                    'name': name,
-                    'mount_path': mount_path
-                })
+                secrets.append({'namespace': namespace, 'name': name, 'mount_path': mount_path})
 
         self.job = batch.create_job(
             self.image,
@@ -481,7 +499,8 @@ class RunImageStep(Step):
             parents=self.deps_parents(),
             always_run=self.always_run,
             timeout=self.timeout,
-            network='private')
+            network='private',
+        )
 
     def cleanup(self, batch, scope, parents):
         pass
@@ -494,7 +513,9 @@ class CreateNamespaceStep(Step):
         if admin_service_account:
             self.admin_service_account = {
                 'name': admin_service_account['name'],
-                'namespace': get_namespace(admin_service_account['namespace'], self.input_config(params.code, params.scope))
+                'namespace': get_namespace(
+                    admin_service_account['namespace'], self.input_config(params.code, params.scope)
+                ),
             }
         else:
             self.admin_service_account = None
@@ -524,18 +545,16 @@ class CreateNamespaceStep(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return CreateNamespaceStep(params,
-                                   json['namespaceName'],
-                                   json.get('adminServiceAccount'),
-                                   json.get('public', False),
-                                   json.get('secrets'))
+        return CreateNamespaceStep(
+            params,
+            json['namespaceName'],
+            json.get('adminServiceAccount'),
+            json.get('public', False),
+            json.get('secrets'),
+        )
 
     def config(self, scope):  # pylint: disable=unused-argument
-        return {
-            'token': self.token,
-            'kind': 'createNamespace',
-            'name': self._name
-        }
+        return {'token': self.token, 'kind': 'createNamespace', 'name': self._name}
 
     def build(self, batch, code, scope):  # pylint: disable=unused-argument
         if is_test_deployment:
@@ -544,7 +563,9 @@ class CreateNamespaceStep(Step):
         config = ""
         if scope in ['deploy', 'test']:
             # FIXME label
-            config = config + f'''\
+            config = (
+                config
+                + f'''\
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -553,7 +574,10 @@ metadata:
     for: test
 ---
 '''
-        config = config + f'''\
+            )
+        config = (
+            config
+            + f'''\
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -584,11 +608,14 @@ roleRef:
   name: {self.namespace_name}-admin
   apiGroup: ""
 '''
+        )
 
         if self.admin_service_account:
             admin_service_account_name = self.admin_service_account['name']
             admin_service_account_namespace = self.admin_service_account['namespace']
-            config = config + f'''\
+            config = (
+                config
+                + f'''\
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -604,9 +631,12 @@ roleRef:
   name: {self.namespace_name}-admin
   apiGroup: ""
 '''
+            )
 
         if self.public:
-            config = config + f'''\
+            config = (
+                config
+                + f'''\
 ---
 apiVersion: v1
 kind: Service
@@ -624,6 +654,7 @@ spec:
   selector:
     app: router
 '''
+            )
 
         script = f'''
 set -ex
@@ -649,16 +680,15 @@ kubectl -n {self.namespace_name} get -o json --export secret {s} | jq '.metadata
 date
 '''
 
-        self.job = batch.create_job(CI_UTILS_IMAGE,
-                                    command=['bash', '-c', script],
-                                    attributes={'name': self.name},
-                                    # FIXME configuration
-                                    service_account={
-                                        'namespace': DEFAULT_NAMESPACE,
-                                        'name': 'ci-agent'
-                                    },
-                                    parents=self.deps_parents(),
-                                    network='private')
+        self.job = batch.create_job(
+            CI_UTILS_IMAGE,
+            command=['bash', '-c', script],
+            attributes={'name': self.name},
+            # FIXME configuration
+            service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
+            parents=self.deps_parents(),
+            network='private',
+        )
 
     def cleanup(self, batch, scope, parents):
         if scope in ['deploy', 'dev'] or is_test_deployment:
@@ -678,16 +708,15 @@ date
 true
 '''
 
-        self.job = batch.create_job(CI_UTILS_IMAGE,
-                                    command=['bash', '-c', script],
-                                    attributes={'name': f'cleanup_{self.name}'},
-                                    service_account={
-                                        'namespace': DEFAULT_NAMESPACE,
-                                        'name': 'ci-agent'
-                                    },
-                                    parents=parents,
-                                    always_run=True,
-                                    network='private')
+        self.job = batch.create_job(
+            CI_UTILS_IMAGE,
+            command=['bash', '-c', script],
+            attributes={'name': f'cleanup_{self.name}'},
+            service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
+            parents=parents,
+            always_run=True,
+            network='private',
+        )
 
 
 class DeployStep(Step):
@@ -707,17 +736,17 @@ class DeployStep(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return DeployStep(params,
-                          json['namespace'],
-                          # FIXME config_file
-                          json['config'],
-                          json.get('link'),
-                          json.get('wait'))
+        return DeployStep(
+            params,
+            json['namespace'],
+            # FIXME config_file
+            json['config'],
+            json.get('link'),
+            json.get('wait'),
+        )
 
     def config(self, scope):  # pylint: disable=unused-argument
-        return {
-            'token': self.token
-        }
+        return {'token': self.token}
 
     def build(self, batch, code, scope):
         with open(f'{code.repo_dir()}/{self.config_file}', 'r') as f:
@@ -765,7 +794,9 @@ set -e
                         get_cmd = f'kubectl -n {self.namespace} get statefulset -l app={name} -o yaml'
                     else:
                         assert resource_type == 'deployment'
-                        wait_cmd = f'kubectl -n {self.namespace} wait --timeout=1h --for=condition=available deployment {name}'
+                        wait_cmd = (
+                            f'kubectl -n {self.namespace} wait --timeout=1h --for=condition=available deployment {name}'
+                        )
                         get_cmd = f'kubectl -n {self.namespace} get deployment -l app={name} -o yaml'
 
                     script += f'''
@@ -803,16 +834,15 @@ date
             attrs['link'] = ','.join(self.link)
             attrs['domain'] = f'{self.namespace}.internal.{DOMAIN}'
 
-        self.job = batch.create_job(CI_UTILS_IMAGE,
-                                    command=['bash', '-c', script],
-                                    attributes=attrs,
-                                    # FIXME configuration
-                                    service_account={
-                                        'namespace': DEFAULT_NAMESPACE,
-                                        'name': 'ci-agent'
-                                    },
-                                    parents=self.deps_parents(),
-                                    network='private')
+        self.job = batch.create_job(
+            CI_UTILS_IMAGE,
+            command=['bash', '-c', script],
+            attributes=attrs,
+            # FIXME configuration
+            service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
+            parents=self.deps_parents(),
+            network='private',
+        )
 
     def cleanup(self, batch, scope, parents):  # pylint: disable=unused-argument
         if self.wait:
@@ -828,17 +858,16 @@ date
                     assert w['kind'] == 'Pod', w['kind']
                     script += f'kubectl -n {self.namespace} logs --tail=999999 {name} --all-containers=true | {pretty_print_log}\n'
             script += 'date\n'
-            self.job = batch.create_job(CI_UTILS_IMAGE,
-                                        command=['bash', '-c', script],
-                                        attributes={'name': self.name + '_logs'},
-                                        # FIXME configuration
-                                        service_account={
-                                            'namespace': DEFAULT_NAMESPACE,
-                                            'name': 'ci-agent'
-                                        },
-                                        parents=parents,
-                                        always_run=True,
-                                        network='private')
+            self.job = batch.create_job(
+                CI_UTILS_IMAGE,
+                command=['bash', '-c', script],
+                attributes={'name': self.name + '_logs'},
+                # FIXME configuration
+                service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
+                parents=parents,
+                always_run=True,
+                network='private',
+            )
 
 
 class CreateDatabaseStep(Step):
@@ -902,18 +931,20 @@ class CreateDatabaseStep(Step):
     @staticmethod
     def from_json(params):
         json = params.json
-        return CreateDatabaseStep(params,
-                                  json['databaseName'],
-                                  json['namespace'],
-                                  json['migrations'],
-                                  json.get('shutdowns', []),
-                                  json.get('inputs'))
+        return CreateDatabaseStep(
+            params,
+            json['databaseName'],
+            json['namespace'],
+            json['migrations'],
+            json.get('shutdowns', []),
+            json.get('inputs'),
+        )
 
     def config(self, scope):  # pylint: disable=unused-argument
         return {
             'token': self.token,
             'admin_secret_name': self.admin_secret_name,
-            'user_secret_name': self.user_secret_name
+            'user_secret_name': self.user_secret_name,
         }
 
     def build(self, batch, code, scope):  # pylint: disable=unused-argument
@@ -928,7 +959,7 @@ class CreateDatabaseStep(Step):
             'user_password_file': self.user_password_file,
             'cant_create_database': self.cant_create_database,
             'migrations': self.migrations,
-            'shutdowns': self.shutdowns
+            'shutdowns': self.shutdowns,
         }
 
         create_passwords_script = f'''
@@ -954,8 +985,12 @@ EOF
 
         if not self.cant_create_database:
             password_files_input = [
-                (f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.admin_password_file}', self.admin_password_file),
-                (f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.user_password_file}', self.user_password_file)]
+                (
+                    f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.admin_password_file}',
+                    self.admin_password_file,
+                ),
+                (f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.user_password_file}', self.user_password_file),
+            ]
             input_files.extend(password_files_input)
 
             self.create_passwords_job = batch.create_job(
@@ -963,24 +998,25 @@ EOF
                 command=['bash', '-c', create_passwords_script],
                 attributes={'name': self.name + "_create_passwords"},
                 output_files=[(x[1], x[0]) for x in password_files_input],
-                parents=self.deps_parents())
+                parents=self.deps_parents(),
+            )
 
         self.create_database_job = batch.create_job(
             CI_UTILS_IMAGE,
             command=['bash', '-c', create_database_script],
             attributes={'name': self.name},
-            secrets=[{
-                'namespace': self.database_server_config_namespace,
-                'name': 'database-server-config',
-                'mount_path': '/sql-config'
-            }],
-            service_account={
-                'namespace': DEFAULT_NAMESPACE,
-                'name': 'ci-agent'
-            },
+            secrets=[
+                {
+                    'namespace': self.database_server_config_namespace,
+                    'name': 'database-server-config',
+                    'mount_path': '/sql-config',
+                }
+            ],
+            service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             input_files=input_files,
             parents=[self.create_passwords_job] if self.create_passwords_job else self.deps_parents(),
-            network='private')
+            network='private',
+        )
 
     def cleanup(self, batch, scope, parents):
         if scope in ['deploy', 'dev'] or self.cant_create_database:
@@ -1009,15 +1045,15 @@ done
             CI_UTILS_IMAGE,
             command=['bash', '-c', cleanup_script],
             attributes={'name': f'cleanup_{self.name}'},
-            secrets=[{
-                'namespace': self.database_server_config_namespace,
-                'name': 'database-server-config',
-                'mount_path': '/sql-config'
-            }],
-            service_account={
-                'namespace': DEFAULT_NAMESPACE,
-                'name': 'ci-agent'
-            },
+            secrets=[
+                {
+                    'namespace': self.database_server_config_namespace,
+                    'name': 'database-server-config',
+                    'mount_path': '/sql-config',
+                }
+            ],
+            service_account={'namespace': DEFAULT_NAMESPACE, 'name': 'ci-agent'},
             parents=parents,
             always_run=True,
-            network='private')
+            network='private',
+        )

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -15,11 +15,14 @@ from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools
-from gear import (setup_aiohttp_session, rest_authenticated_developers_only,
-                  web_authenticated_developers_only, check_csrf_token,
-                  create_database_pool)
-from web_common import (setup_aiohttp_jinja2, setup_common_static_routes,
-                        render_template, set_message)
+from gear import (
+    setup_aiohttp_session,
+    rest_authenticated_developers_only,
+    web_authenticated_developers_only,
+    check_csrf_token,
+    create_database_pool,
+)
+from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
 
 from .environment import BUCKET
 from .github import Repo, FQBranch, WatchedBranch, UnwatchedBranch, MergeFailureBatch
@@ -83,9 +86,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
         }
         wb_configs.append(wb_config)
 
-    page_context = {
-        'watched_branches': wb_configs
-    }
+    page_context = {'watched_branches': wb_configs}
     return await render_template('ci', request, userdata, 'index.html', page_context)
 
 
@@ -124,11 +125,11 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
             page_context['artifacts'] = f'/{BUCKET}/build/{batch.attributes["token"]}'
         else:
             page_context['exception'] = '\n'.join(
-                traceback.format_exception(None, batch.exception, batch.exception.__traceback__))
+                traceback.format_exception(None, batch.exception, batch.exception.__traceback__)
+            )
 
     batch_client = request.app['batch_client']
-    batches = batch_client.list_batches(
-        f'test=1 pr={pr.number}')
+    batches = batch_client.list_batches(f'test=1 pr={pr.number}')
     batches = sorted([b async for b in batches], key=lambda b: b.id, reverse=True)
     page_context['history'] = [await b.last_known_status() for b in batches]
 
@@ -141,10 +142,7 @@ async def retry_pr(wb, pr, request):
 
     if pr.batch is None:
         log.info('retry cannot be requested for PR #{pr.number} because it has no batch')
-        set_message(
-            session,
-            f'Retry cannot be requested for PR #{pr.number} because it has no batch.',
-            'error')
+        set_message(session, f'Retry cannot be requested for PR #{pr.number} because it has no batch.', 'error')
         return
 
     batch_id = pr.batch.id
@@ -165,8 +163,7 @@ async def post_retry_pr(request, userdata):  # pylint: disable=unused-argument
     wb, pr = wb_and_pr_from_request(request)
 
     await asyncio.shield(retry_pr(wb, pr, request))
-    return web.HTTPFound(
-        deploy_config.external_url('ci', f'/watched_branches/{wb.index}/pr/{pr.number}'))
+    return web.HTTPFound(deploy_config.external_url('ci', f'/watched_branches/{wb.index}/pr/{pr.number}'))
 
 
 @routes.get('/batches')
@@ -175,9 +172,7 @@ async def get_batches(request, userdata):
     batch_client = request.app['batch_client']
     batches = [b async for b in batch_client.list_batches()]
     statuses = [await b.last_known_status() for b in batches]
-    page_context = {
-        'batches': statuses
-    }
+    page_context = {'batches': statuses}
     return await render_template('ci', request, userdata, 'batches.html', page_context)
 
 
@@ -191,10 +186,7 @@ async def get_batch(request, userdata):
     jobs = await collect_agen(b.jobs())
     for j in jobs:
         j['duration'] = humanize_timedelta_msecs(j['duration'])
-    page_context = {
-        'batch': status,
-        'jobs': jobs
-    }
+    page_context = {'batch': status, 'jobs': jobs}
     return await render_template('ci', request, userdata, 'batch.html', page_context)
 
 
@@ -210,7 +202,7 @@ async def get_job(request, userdata):
         'job_id': job_id,
         'job_log': await job.log(),
         'job_status': json.dumps(await job.status(), indent=2),
-        'attempts': await job.attempts()
+        'attempts': await job.attempts(),
     }
     return await render_template('ci', request, userdata, 'job.html', page_context)
 
@@ -229,13 +221,13 @@ async def post_authorized_source_sha(request, userdata):  # pylint: disable=unus
     log.info(f'authorized sha: {sha}')
     session = await aiohttp_session.get_session(request)
     set_message(session, f'SHA {sha} authorized.', 'info')
-    return web.HTTPFound(
-        deploy_config.external_url('ci', '/'))
+    return web.HTTPFound(deploy_config.external_url('ci', '/'))
 
 
 @routes.get('/healthcheck')
 async def healthcheck(request):  # pylint: disable=unused-argument
     return web.Response(status=200)
+
 
 gh_router = gh_routing.Router()
 
@@ -255,7 +247,7 @@ async def push_callback(event):
     data = event.data
     ref = data['ref']
     if ref.startswith('refs/heads/'):
-        branch_name = ref[len('refs/heads/'):]
+        branch_name = ref[len('refs/heads/') :]
         branch = FQBranch(Repo.from_gh_json(data['repository']), branch_name)
         for wb in watched_branches:
             if wb.branch == branch or any(pr.branch == branch for pr in wb.prs.values()):
@@ -312,17 +304,21 @@ async def deploy_status(request, userdata):  # pylint: disable=unused-argument
             log = await full_job.log()
             return {**full_job._status, 'log': log}
 
-        return await asyncio.gather(*[fetch_job_and_log(j)
-                                      for j in jobs
-                                      if j['state'] in ('Error', 'Failed')])
-    wb_configs = [{
-        'branch': wb.branch.short_str(),
-        'sha': wb.sha,
-        'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and hasattr(wb.deploy_batch, 'id') else None,
-        'deploy_state': wb.deploy_state,
-        'repo': wb.branch.repo.short_str(),
-        'failure_information': None if wb.deploy_state == 'success' else await get_failure_information(wb.deploy_batch)
-    } for wb in watched_branches]
+        return await asyncio.gather(*[fetch_job_and_log(j) for j in jobs if j['state'] in ('Error', 'Failed')])
+
+    wb_configs = [
+        {
+            'branch': wb.branch.short_str(),
+            'sha': wb.sha,
+            'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and hasattr(wb.deploy_batch, 'id') else None,
+            'deploy_state': wb.deploy_state,
+            'repo': wb.branch.repo.short_str(),
+            'failure_information': None
+            if wb.deploy_state == 'success'
+            else await get_failure_information(wb.deploy_batch),
+        }
+        for wb in watched_branches
+    ]
     return web.json_response(wb_configs)
 
 
@@ -377,8 +373,7 @@ async def dev_deploy_branch(request, userdata):
         batch_id = await unwatched_branch.deploy(batch_client, steps)
     except Exception as e:  # pylint: disable=broad-except
         message = traceback.format_exc()
-        raise web.HTTPBadRequest(
-            text=f'starting the deploy failed due to\n{message}') from e
+        raise web.HTTPBadRequest(text=f'starting the deploy failed due to\n{message}') from e
     return web.json_response({'sha': sha, 'batch_id': batch_id})
 
 
@@ -403,10 +398,7 @@ async def update_loop(app):
 
 async def on_startup(app):
     app['gh_client_session'] = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5))
-    app['github_client'] = gh_aiohttp.GitHubAPI(
-        app['gh_client_session'],
-        'ci',
-        oauth_token=oauth_token)
+    app['github_client'] = gh_aiohttp.GitHubAPI(app['gh_client_session'], 'ci', oauth_token=oauth_token)
     app['batch_client'] = await BatchClient('ci')
     app['dbpool'] = await create_database_pool()
 
@@ -436,8 +428,10 @@ def run():
     setup_common_static_routes(routes)
     app.add_routes(routes)
 
-    web.run_app(deploy_config.prefix_application(app, 'ci'),
-                host='0.0.0.0',
-                port=5000,
-                access_log_class=AccessLogger,
-                ssl_context=internal_server_ssl_context())
+    web.run_app(
+        deploy_config.prefix_application(app, 'ci'),
+        host='0.0.0.0',
+        port=5000,
+        access_log_class=AccessLogger,
+        ssl_context=internal_server_ssl_context(),
+    )

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -19,5 +19,5 @@ AUTHORIZED_USERS = {
     'pwc2',
     'lgruen',
     'CDiaz96',
-    'daniel-goldstein'
+    'daniel-goldstein',
 }

--- a/ci/jinja2_render.py
+++ b/ci/jinja2_render.py
@@ -2,20 +2,24 @@ import sys
 import jinja2
 import json
 
+
 def jinja2_render(config, input, output):
     with open(input, 'r') as f:
         template = jinja2.Template(f.read(), undefined=jinja2.StrictUndefined, trim_blocks=True, lstrip_blocks=True)
     with open(output, 'w') as f:
         f.write(template.render(**config))
 
+
 def usage():
     print(f'usage: {sys.argv[0]} <json-literal-config> <input-file> <output-file>', file=sys.stderr)
     sys.exit(1)
+
 
 def main():
     if len(sys.argv) != 4:
         usage()
     jinja2_render(json.loads(sys.argv[1]), sys.argv[2], sys.argv[3])
+
 
 if __name__ == "__main__":
     main()

--- a/ci/setup.py
+++ b/ci/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'ci',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Hail CI/CD System',
-    packages = find_packages(),
-    include_package_data=True
+    name='ci',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Hail CI/CD System',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/ci/test/resources/sql/insert.py
+++ b/ci/test/resources/sql/insert.py
@@ -6,8 +6,7 @@ async def async_main():
     db = Database()
     await db.async_init()
 
-    await db.just_execute(
-        f"INSERT INTO hello2 (greeting) VALUES ('hello, hello!');")
+    await db.just_execute(f"INSERT INTO hello2 (greeting) VALUES ('hello, hello!');")
 
 
 loop = asyncio.get_event_loop()

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -26,7 +26,8 @@ async def test_deploy():
             failure_information = None
             while deploy_state is None:
                 resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{ci_deploy_status_url}', headers=headers)
+                    session, 'GET', f'{ci_deploy_status_url}', headers=headers
+                )
                 deploy_statuses = await resp.json()
                 log.info(f'deploy_statuses:\n{json.dumps(deploy_statuses, indent=2)}')
                 assert len(deploy_statuses) == 1, deploy_statuses

--- a/ci/wait-for.py
+++ b/ci/wait-for.py
@@ -21,10 +21,7 @@ async def wait_for_pod_complete(v1, namespace, name):
     while True:
         try:
             try:
-                pod = await v1.read_namespaced_pod(
-                    name,
-                    namespace,
-                    _request_timeout=5.0)
+                pod = await v1.read_namespaced_pod(name, namespace, _request_timeout=5.0)
                 if pod and pod.status and pod.status.container_statuses:
                     container_statuses = pod.status.container_statuses
                     if all(cs.state and cs.state.terminated for cs in container_statuses):
@@ -67,6 +64,7 @@ async def main():
     t = wait_for_pod_complete(v1, args.namespace, args.name)
 
     await asyncio.gather(timeout(args.timeout_seconds), t)
+
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,6 +8,7 @@ aioredis==1.3.1
 async-timeout==3.0.1
 asyncinit==0.2.4
 Authlib==0.11
+black==20.8b1
 decorator==4.4.0
 dictdiffer==0.8.1
 dill>=0.3.1.1,<0.4

--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,6 +1,8 @@
 flake8==3.7.8
 mypy==0.780
 pylint==2.6.0
+pre-commit==2.9.2
+black==20.8b1
 pytest==4.6.3
 pytest-html==1.20.0
 pytest-xdist==1.28

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,9 @@
 [flake8]
 # E501 line too long
+# E203 whitespace before ':'
 # W503 line break before binary operator
 # E722 do not use bare 'except'
-ignore=E501,W503,E722
+ignore=E203,E501,W503,E722
 
 # E402 module level import not at top of file
 # E241 multiple spaces after ','


### PR DESCRIPTION
@danking Here's what it looks like running black on `ci.py` and `address.py` with only customizations being a line length of 120 (I personally prefer shorter but that's what we have currently) and no single quote -> double quote changes (`--skip-string-normalization`).

It is _super_ opinionated, so you have to like the defaults or be willing to roll with it on some calls. It took a lot of [discourse](https://github.com/psf/black/issues/118) just to allow single-quoting strings, but a commit hook to auto-format service code seems useful.