### PR TITLE
[copy] parallelize over chunks

### DIFF
--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -515,7 +515,7 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
 
                 chunk_names = [self._tmp_name(f'chunk-{secret_alnum_string()}') for _ in range(32)]
 
-                bounded_gather2(self._sema, *[
+                await bounded_gather2(self._sema, *[
                     tree_compose(c, n)
                     for c, n in zip(chunks, chunk_names)])
 

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -460,7 +460,7 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
         # compute dest_dirname so gs://{bucket}/{dest_dirname}file
         # refers to a file in dest_dirname with no double slashes
         dest_dirname = os.path.dirname(dest_name)
-        if not dest_dirname:
+        if dest_dirname:
             dest_dirname = dest_dirname + '/'
         self._dest_dirname = dest_dirname
 
@@ -473,19 +473,14 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
         return self._tmp_name(f'part-{number}')
 
     async def create_part(self, number: int, start: int) -> WritableStream:
-        return await self._fs._storage_client.insert_object(self._bucket, self._part_name(number))
+        part_name = self._part_name(number)
+        return await self._fs._storage_client.insert_object(self._bucket, part_name)
 
     async def __aenter__(self) -> 'GoogleStorageMultiPartCreate':
         return self
 
     async def _compose(self, names: List[str], dest_name: str):
-        print(f'in compose {names} {dest_name}')
-        try:
-            await self._fs._storage_client.compose(self._bucket, names, dest_name)
-        except Exception as e:
-            print(e)
-        finally:
-            print(f'in compose {dest_name} done')
+        await self._fs._storage_client.compose(self._bucket, names, dest_name)
 
     async def __aexit__(self,
                         exc_type: Optional[Type[BaseException]],

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -10,8 +10,7 @@ import urllib.parse
 import aiohttp
 from hailtop.utils import (
     secret_alnum_string, bounded_gather2, OnlineBoundedGather2,
-    TransientError, retry_transient_errors,
-    AsyncWorkerPool, WaitableSharedPool, secret_alnum_string)
+    TransientError, retry_transient_errors)
 from hailtop.aiotools import (
     FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
     FeedableAsyncIterable, FileAndDirectoryError, MultiPartCreate)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -129,7 +129,7 @@ class AsyncFS(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def rmtree(self, url: str) -> None:
+    async def rmtree(self, sema: asyncio.Semaphore, url: str) -> None:
         pass
 
     async def touch(self, url: str) -> None:
@@ -329,7 +329,7 @@ class LocalAsyncFS(AsyncFS):
         path = self._get_path(url)
         return os.remove(path)
 
-    async def rmtree(self, url: str) -> None:
+    async def rmtree(self, sema: asyncio.Semaphore, url: str) -> None:
         path = self._get_path(url)
         await blocking_to_async(self._thread_pool, shutil.rmtree, path)
 
@@ -838,9 +838,9 @@ class RouterAsyncFS(AsyncFS):
         fs = self._get_fs(url)
         return await fs.remove(url)
 
-    async def rmtree(self, url: str) -> None:
+    async def rmtree(self, sema: asyncio.Semaphore, url: str) -> None:
         fs = self._get_fs(url)
-        return await fs.rmtree(url)
+        return await fs.rmtree(sema, url)
 
     async def close(self) -> None:
         for fs in self._filesystems:

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -439,7 +439,7 @@ class SourceCopier:
     created for each source.
     '''
 
-    PART_SIZE = 8 * 1024 * 1024
+    PART_SIZE = 128 * 1024 * 1024
 
     def __init__(self, router_fs: 'RouterAsyncFS', src: str, dest: str, treat_dest_as: str, dest_type_task):
         self.router_fs = router_fs
@@ -665,7 +665,7 @@ class Copier:
     This class implements copy for a list of transfers.
     '''
 
-    BUFFER_SIZE = 8192
+    BUFFER_SIZE = 256 * 1024
 
     def __init__(self, router_fs):
         self.router_fs = router_fs
@@ -846,9 +846,7 @@ class RouterAsyncFS(AsyncFS):
         for fs in self._filesystems:
             await fs.close()
 
-    async def copy(self, transfer: Union[Transfer, List[Transfer]], return_exceptions=False):
-        sema = asyncio.Semaphore(50)
-
+    async def copy(self, sema: asyncio.Semaphore, transfer: Union[Transfer, List[Transfer]], return_exceptions=False):
         copier = Copier(self)
         copy_report = CopyReport(transfer)
         await copier.copy(sema, copy_report, transfer, return_exceptions)

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -377,12 +377,6 @@ class SourceReport:
                 'exception': exception
             }
 
-    def raise_first_exception(self):
-        if self._exception:
-            raise self._exception
-        if self._first_file_error:
-            raise self._first_file_error['exception']
-
 
 class TransferReport:
     def __init__(self, transfer: Transfer):
@@ -397,15 +391,6 @@ class TransferReport:
         assert not self._exception
         self._exception = exception
 
-    def raise_first_exception(self):
-        if self._exception:
-            raise self._exception
-        if isinstance(self._source_report, SourceReport):
-            self._source_report.raise_first_exception()
-        else:
-            for s in self._source_report:
-                s.raise_first_exception()
-
 
 class CopyReport:
     def __init__(self, transfer: Union[Transfer, List[Transfer]]):
@@ -418,15 +403,6 @@ class CopyReport:
     def set_exception(self, exception: Exception):
         assert not self._exception
         self._exception = exception
-
-    def raise_first_exception(self):
-        if self._exception:
-            raise self._exception
-        if isinstance(self._transfer_report, TransferReport):
-            self._transfer_report.raise_first_exception()
-        else:
-            for t in self._transfer_report:
-                t.raise_first_exception()
 
 
 class UnexpectedEOFError(Exception):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -9,7 +9,7 @@ from .utils import (
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
-    find_spark_home, TransientError, bounded_gather2)
+    find_spark_home, TransientError, bounded_gather2, OnlineBoundedGather2)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -76,5 +76,6 @@ __all__ = [
     'periodically_call',
     'find_spark_home',
     'TransientError',
-    'bounded_gather2'
+    'bounded_gather2',
+    'OnlineBoundedGather2'
 ]

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -9,7 +9,7 @@ from .utils import (
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
-    find_spark_home, TransientError)
+    find_spark_home, TransientError, bounded_gather2)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -75,5 +75,6 @@ __all__ = [
     'Notice',
     'periodically_call',
     'find_spark_home',
-    'TransientError'
+    'TransientError',
+    'bounded_gather2'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -458,11 +458,9 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *aws, cancel
     finally:
         _, exc, _ = sys.exc_info()
         if exc is not None:
-            tasks = []
             for task in tasks:
                 if not task.done():
                     task.cancel()
-                    tasks.append(task)
             if tasks:
                 await asyncio.wait(tasks)
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -366,7 +366,7 @@ class OnlineBoundedGather2:
             if not self._pending:
                 self._done_event.set()
 
-        assert self._pending
+        assert self._pending is not None
         t = asyncio.create_task(run_and_cleanup())
         self._pending[id] = t
         return t

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -454,9 +454,13 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *aws, cancel
     finally:
         _, exc, _ = sys.exc_info()
         if exc is not None:
+            tasks = []
             for task in tasks:
                 if not task.done():
                     task.cancel()
+                    tasks.append(task)
+            if tasks:
+                await asyncio.wait(tasks)
 
 
 async def bounded_gather2(sema: asyncio.Semaphore, *aws, return_exceptions: bool = False, cancel_on_error: bool = False):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -572,17 +572,17 @@ def url_join(url: str, path: str) -> str:
     return urllib.parse.urlunparse(parsed._replace(path=os.path.join(parsed.path, path)))
 
 
+def url_scheme(url: str) -> str:
+    """Return scheme of `url`, or the empty string if there is no scheme."""
+    parsed = urllib.parse.urlparse(url)
+    return parsed.scheme
+
+
 def is_google_registry_image(path: str) -> bool:
     """Returns true if the given Docker image path points to either the Google
     Container Registry or the Artifact Registry."""
     host = path.partition('/')[0]
     return host == 'gcr.io' or host.endswith('docker.pkg.dev')
-
-
-def url_scheme(url: str) -> str:
-    """Return scheme of `url`, or the empty string if there is no scheme."""
-    parsed = urllib.parse.urlparse(url)
-    return parsed.scheme
 
 
 class Notice:

--- a/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
+++ b/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
@@ -141,7 +141,8 @@ async def copy_test_specs():
 
                 test_specs.append(config)
 
-                await fs.rmtree(base)
+                sema = asyncio.Semaphore(10)
+                await fs.rmtree(sema, base)
                 assert not await fs.isdir(base)
 
     return test_specs

--- a/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
+++ b/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
@@ -73,7 +73,7 @@ def copy_test_configurations():
                             }
 
 
-async def run_test_spec(fs, spec, src_base, dest_base):
+async def run_test_spec(sema, fs, spec, src_base, dest_base):
     await create_test_data(fs, 'src', src_base, 'a', spec['src_type'])
     await create_test_data(fs, 'dest', dest_base, 'a', spec['dest_type'])
 
@@ -95,7 +95,7 @@ async def run_test_spec(fs, spec, src_base, dest_base):
     result = None
     exc_type = None
     try:
-        await fs.copy(Transfer(src, dest, treat_dest_as=spec['treat_dest_as']))
+        await fs.copy(sema, Transfer(src, dest, treat_dest_as=spec['treat_dest_as']))
     except Exception as e:
         exc_type = type(e)
         if exc_type not in (NotADirectoryError, IsADirectoryError, FileNotFoundError):
@@ -136,14 +136,15 @@ async def copy_test_specs():
                 async with await fs.create(f'{dest_base}keep'):
                     pass
 
-                result = await run_test_spec(fs, config, src_base, dest_base)
-                config['result'] = result
-
-                test_specs.append(config)
-
                 sema = asyncio.Semaphore(10)
-                await fs.rmtree(sema, base)
-                assert not await fs.isdir(base)
+                with sema:
+                    result = await run_test_spec(sema, fs, config, src_base, dest_base)
+                    config['result'] = result
+
+                    test_specs.append(config)
+
+                    await fs.rmtree(sema, base)
+                    assert not await fs.isdir(base)
 
     return test_specs
 

--- a/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
+++ b/hail/python/test/hailtop/aiotools/generate_copy_test_specs.py
@@ -136,7 +136,7 @@ async def copy_test_specs():
                 async with await fs.create(f'{dest_base}keep'):
                     pass
 
-                sema = asyncio.Semaphore(10)
+                sema = asyncio.Semaphore(50)
                 with sema:
                     result = await run_test_spec(sema, fs, config, src_base, dest_base)
                     config['result'] = result

--- a/hail/python/test/hailtop/aiotools/test_copy.py
+++ b/hail/python/test/hailtop/aiotools/test_copy.py
@@ -51,7 +51,8 @@ async def router_filesystem(request):
                 'gs': gs_base
             }
 
-            async with asyncio.Semaphore(10) as sema:
+            sema = asyncio.Semaphore(50)
+            async with sema:
                 yield (sema, fs, bases)
                 await bounded_gather2(sema,
                                       fs.rmtree(sema, file_base),

--- a/hail/python/test/hailtop/aiotools/test_copy.py
+++ b/hail/python/test/hailtop/aiotools/test_copy.py
@@ -51,9 +51,8 @@ async def router_filesystem(request):
                 'gs': gs_base
             }
 
-            yield (fs, bases)
-
             async with asyncio.Semaphore(10) as sema:
+                yield (sema, fs, bases)
                 await bounded_gather2(sema,
                                       fs.rmtree(sema, file_base),
                                       fs.rmtree(sema, gs_base))
@@ -70,7 +69,7 @@ async def fresh_dir(fs, bases, scheme):
 
 @pytest.fixture(params=['file/file', 'file/gs', 'gs/file', 'gs/gs'])
 async def copy_test_context(request, router_filesystem):
-    fs, bases = router_filesystem
+    sema, fs, bases = router_filesystem
 
     [src_scheme, dest_scheme] = request.param.split('/')
 
@@ -81,14 +80,14 @@ async def copy_test_context(request, router_filesystem):
     async with await fs.create(f'{dest_base}keep'):
         pass
 
-    yield fs, src_base, dest_base
+    yield sema, fs, src_base, dest_base
 
 
 @pytest.mark.asyncio
 async def test_copy_behavior(copy_test_context, test_spec):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
-    result = await run_test_spec(fs, test_spec, src_base, dest_base)
+    result = await run_test_spec(sema, fs, test_spec, src_base, dest_base)
     try:
         expected = test_spec['result']
 
@@ -139,33 +138,33 @@ class RaisesOrGS:
 
 @pytest.mark.asyncio
 async def test_copy_doesnt_exist(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     with pytest.raises(FileNotFoundError):
-        await fs.copy(Transfer(f'{src_base}a', dest_base))
+        await fs.copy(sema, Transfer(f'{src_base}a', dest_base))
 
 
 @pytest.mark.asyncio
 async def test_copy_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_large_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     # mainly needs to be larger than the transfer block size (8K)
     contents = secrets.token_bytes(1_000_000)
     async with await fs.create(f'{src_base}a') as f:
         await f.write(contents)
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
     async with await fs.open(f'{dest_base}a') as f:
         copy_contents = await f.read()
@@ -174,56 +173,56 @@ async def test_copy_large_file(copy_test_context):
 
 @pytest.mark.asyncio
 async def test_copy_rename_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}x'))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}x'))
 
     await expect_file(fs, f'{dest_base}x', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_rename_file_dest_target_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}x', treat_dest_as=Transfer.TARGET_FILE))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}x', treat_dest_as=Transfer.TARGET_FILE))
 
     await expect_file(fs, f'{dest_base}x', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_file_dest_target_directory_doesnt_exist(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
     # SourceCopier._copy_file creates destination directories as needed
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}x', treat_dest_as=Transfer.TARGET_DIR))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}x', treat_dest_as=Transfer.TARGET_DIR))
     await expect_file(fs, f'{dest_base}x/a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_overwrite_rename_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
     await create_test_file(fs, 'dest', dest_base, 'x')
 
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}x'))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}x'))
 
     await expect_file(fs, f'{dest_base}x', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_rename_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_dir(fs, 'src', src_base, 'a/')
 
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}x'))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}x'))
 
     await expect_file(fs, f'{dest_base}x/file1', 'src/a/file1')
     await expect_file(fs, f'{dest_base}x/subdir/file2', 'src/a/subdir/file2')
@@ -231,76 +230,76 @@ async def test_copy_rename_dir(copy_test_context):
 
 @pytest.mark.asyncio
 async def test_copy_file_dest_trailing_slash_target_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base, treat_dest_as=Transfer.TARGET_DIR))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base, treat_dest_as=Transfer.TARGET_DIR))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_file_dest_target_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_DIR))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_DIR))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_file_dest_target_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', f'{dest_base}a', treat_dest_as=Transfer.TARGET_FILE))
+    await fs.copy(sema, Transfer(f'{src_base}a', f'{dest_base}a', treat_dest_as=Transfer.TARGET_FILE))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_dest_target_file_is_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
     with RaisesOrGS(dest_base, IsADirectoryError):
-        await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
+        await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
 
 
 @pytest.mark.asyncio
 async def test_overwrite_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
     await create_test_file(fs, 'dest', dest_base, 'a')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
 
 
 @pytest.mark.asyncio
 async def test_copy_file_src_trailing_slash(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
     with pytest.raises(FileNotFoundError):
-        await fs.copy(Transfer(f'{src_base}a/', dest_base))
+        await fs.copy(sema, Transfer(f'{src_base}a/', dest_base))
 
 
 @pytest.mark.asyncio
 async def test_copy_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_dir(fs, 'src', src_base, 'a/')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
     await expect_file(fs, f'{dest_base}a/file1', 'src/a/file1')
     await expect_file(fs, f'{dest_base}a/subdir/file2', 'src/a/subdir/file2')
@@ -308,12 +307,12 @@ async def test_copy_dir(copy_test_context):
 
 @pytest.mark.asyncio
 async def test_overwrite_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_dir(fs, 'src', src_base, 'a/')
     await create_test_dir(fs, 'dest', dest_base, 'a/')
 
-    await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
     await expect_file(fs, f'{dest_base}a/file1', 'src/a/file1')
     await expect_file(fs, f'{dest_base}a/subdir/file2', 'src/a/subdir/file2')
@@ -322,12 +321,12 @@ async def test_overwrite_dir(copy_test_context):
 
 @pytest.mark.asyncio
 async def test_copy_multiple(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
     await create_test_file(fs, 'src', src_base, 'b')
 
-    await fs.copy(Transfer([f'{src_base}a', f'{src_base}b'], dest_base.rstrip('/')))
+    await fs.copy(sema, Transfer([f'{src_base}a', f'{src_base}b'], dest_base.rstrip('/')))
 
     await expect_file(fs, f'{dest_base}a', 'src/a')
     await expect_file(fs, f'{dest_base}b', 'src/b')
@@ -335,40 +334,40 @@ async def test_copy_multiple(copy_test_context):
 
 @pytest.mark.asyncio
 async def test_copy_multiple_dest_target_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
     await create_test_file(fs, 'src', src_base, 'b')
 
     with RaisesOrGS(dest_base, NotADirectoryError):
-        await fs.copy(Transfer([f'{src_base}a', f'{src_base}b'], dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
+        await fs.copy(sema, Transfer([f'{src_base}a', f'{src_base}b'], dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
 
 
 @pytest.mark.asyncio
 async def test_copy_multiple_dest_file(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
     await create_test_file(fs, 'src', src_base, 'b')
     await create_test_file(fs, 'dest', dest_base, 'x')
 
     with RaisesOrGS(dest_base, NotADirectoryError):
-        await fs.copy(Transfer([f'{src_base}a', f'{src_base}b'], f'{dest_base}x'))
+        await fs.copy(sema, Transfer([f'{src_base}a', f'{src_base}b'], f'{dest_base}x'))
 
 
 @pytest.mark.asyncio
 async def test_file_overwrite_dir(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_file(fs, 'src', src_base, 'a')
 
     with RaisesOrGS(dest_base, IsADirectoryError):
-        await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
+        await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_FILE))
 
 
 @pytest.mark.asyncio
 async def test_file_and_directory_error(router_filesystem):
-    fs, bases = router_filesystem
+    sema, fs, bases = router_filesystem
 
     src_base = await fresh_dir(fs, bases, 'gs')
     dest_base = await fresh_dir(fs, bases, 'file')
@@ -377,16 +376,16 @@ async def test_file_and_directory_error(router_filesystem):
     await create_test_file(fs, 'src', src_base, 'a/subfile')
 
     with pytest.raises(FileAndDirectoryError):
-        await fs.copy(Transfer(f'{src_base}a', dest_base.rstrip('/')))
+        await fs.copy(sema, Transfer(f'{src_base}a', dest_base.rstrip('/')))
 
 
 @pytest.mark.asyncio
 async def test_copy_src_parts(copy_test_context):
-    fs, src_base, dest_base = copy_test_context
+    sema, fs, src_base, dest_base = copy_test_context
 
     await create_test_dir(fs, 'src', src_base, 'a/')
 
-    await fs.copy(Transfer([f'{src_base}a/file1', f'{src_base}a/subdir'], dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_DIR))
+    await fs.copy(sema, Transfer([f'{src_base}a/file1', f'{src_base}a/subdir'], dest_base.rstrip('/'), treat_dest_as=Transfer.TARGET_DIR))
 
     await expect_file(fs, f'{dest_base}file1', 'src/a/file1')
     await expect_file(fs, f'{dest_base}subdir/file2', 'src/a/subdir/file2')

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -32,7 +32,8 @@ async def filesystem(request):
 
             await fs.mkdir(base)
             yield (fs, base)
-            await fs.rmtree(base)
+            async with asyncio.Semaphore(10) as sema:
+                await fs.rmtree(sema, base)
             assert not await fs.isdir(base)
 
 
@@ -45,7 +46,8 @@ async def local_filesystem(request):
             base = f'/tmp/{token}/'
             await fs.mkdir(base)
             yield (fs, base)
-            await fs.rmtree(base)
+            async with asyncio.Semaphore(10) as sema:
+                await fs.rmtree(sema, base)
             assert not await fs.isdir(base)
 
 
@@ -170,7 +172,8 @@ async def test_rmtree(filesystem):
 
     assert await fs.isdir(dir)
 
-    await fs.rmtree(dir)
+    async with asyncio.Semaphore(10) as sema:
+        await fs.rmtree(sema, dir)
 
     assert not await fs.isdir(dir)
 


### PR DESCRIPTION
This PR introduces async parallelism for copy.  Summary of changes:
 - add compose to aiogoogle StorageClient and use it to implement (hierarchical) multi-part write for the google AsyncFS
 - add AsyncFS.open_from, to open a file starting at a given offset,
 - PART_SIZE is the size of parts to transfer and the combine with a multi-part write when copying large files.  PART_SIZE is currently 128MB.
 - BUFFER_SIZE is the size we request when reading in the copy.  Change this to 256KB (from 8KB).
 - Copy files in parts and use multi-part writes when copying large files.
 - Parallelize rmtree (it now takes a semaphore for controlling parallelism)
 - Add new primitives for parallelization, bounded_gather2 and OnlineBoundedGather2.

bounded_gather2 was an interesting design problem.  I would describe it like this:

Say you have serial asyncio code with I/O (which will block the serial algorithm when the I/O is pending) which you'd like to parallelize.  You can't do this generically, so in addition I imagine there are parallelization fork/join points where you want to run a bunch of subcomputations in parallel, wait for them all to complete, and resume where you left off.

The code begins by creating a asyncio.Semaphore that globally bounds the parallelism of the code, and acquiring the semaphore before executing the code (since the entrypoint into the code accounts for one thread of control).  For example:

```
sema = asyncio.Semaphore(50)
async with sema:
    await copy(sema, ...)
```

Then, to run a set of operations in parallel, subject to the global parallelism bound, use bounded_gather2:

```
  await bounded_gather2(sema, *aws)
```

The naive implementation of bounded_gather2 doesn't work: bounded_gather2 cannot spawn a task for each awaitable and have it try to acquiare the semaphore, because this can lead to deadlock: if 50 tasks launch and wait for children, but none of those children can run because the parents have all the threads of control, the algorithm will deadlock.

The key is to make sure at least one child can always be running in a bounded_gather2.  But the caller of bounded_gather2 had a reserved thread of execution and it is blocking, so that thread of execution should be transferred to the children while the bounded_gather2 is blocked.  This is what bounded_gather2 does.

There is also an "online" version of bounded_gather2 which lets you schedule an unbounded number of children (potentially generated asynchronously).  OnlineBoundedGather2 is used in parallelizing file transfers generated by directory listings, for example, which are enumerated via an async generator, and are potentially very large.

I will try to replace bounded_gather and the async worker pool with this mechanism in a future PR.

The parameters will likely need additional tuning.  I have done some rough timing, and already this is beating gsutil:

- Transfer 10GB spread over 40K files (times in ms):

  {'upload': 95803,
   'download': 55240,
   'compare': 54117,
   'clean file': 632,
   'clean gs': 117263,
   'total': 323061}

  vs the gsutil transfer:

  real	11m14.153s
  user	14m28.789s
  sys	1m29.090s

  and gsutil cleanup (removing 40K files in gs://):

  real	10m12.236s
  user	3m33.382s
  sys	0m55.450s

 - Transfer 10GB in one file takes ~20s (up) and ~30s (down) for copy vs ~1m for gsutil.

I'm still working on the benchmark harness and will post more complete comparisons in a future PR.
