### PR TITLE
[query] Do not traverse entries to check type of a numpy array

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -202,14 +202,17 @@ def literal(x: Any, dtype: Optional[Union[HailType, str]] = None):
     if dtype is None:
         dtype = impute_type(x)
 
+    # Special handling of numpy. Have to extract from numpy scalars, do nothing on numpy arrays
     if isinstance(x, np.generic):
         x = x.item()
-
-    try:
-        dtype._traverse(x, typecheck_expr)
-    except TypeError as e:
-        raise TypeError("'literal': object did not match the passed type '{}'"
-                        .format(dtype)) from e
+    elif isinstance(x, np.ndarray):
+        pass
+    else:
+        try:
+            dtype._traverse(x, typecheck_expr)
+        except TypeError as e:
+            raise TypeError("'literal': object did not match the passed type '{}'"
+                            .format(dtype)) from e
 
     if wrapper['has_expr']:
         return literal(hl.eval(to_expr(x, dtype)), dtype)


### PR DESCRIPTION
Unlike a normal python array, there's no reason for us to traverse a numpy array to type check its entries. We know it is of uniform type. 