### PR TITLE
[address] Close all existing connections on cleanup

### DIFF
--- a/address/address/address.py
+++ b/address/address/address.py
@@ -143,7 +143,7 @@ async def on_cleanup(app):
         blocking_pool = app['blocking_pool']
         blocking_pool.shutdown()
         del app['cache'].k8s_client
-        await asyncio.get_event_loop().shutdown_asyncgens()
+        await asyncio.gather(*asyncio.all_tasks())
     finally:
         app['cache'].shutdown()
 

--- a/address/address/address.py
+++ b/address/address/address.py
@@ -143,7 +143,7 @@ async def on_cleanup(app):
         blocking_pool = app['blocking_pool']
         blocking_pool.shutdown()
         del app['cache'].k8s_client
-        await asyncio.gather(*asyncio.all_tasks())
+        await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
     finally:
         app['cache'].shutdown()
 

--- a/address/address/address.py
+++ b/address/address/address.py
@@ -142,6 +142,8 @@ async def on_cleanup(app):
     try:
         blocking_pool = app['blocking_pool']
         blocking_pool.shutdown()
+        del app['cache'].k8s_client
+        await asyncio.get_event_loop().shutdown_asyncgens()
     finally:
         app['cache'].shutdown()
 

--- a/build.yaml
+++ b/build.yaml
@@ -2198,6 +2198,7 @@ steps:
       for: alive
    dependsOn:
     - default_ns
+    - deploy_address_sa
     - deploy_router
     - address_image
     - create_certs


### PR DESCRIPTION
This ended up being a great lesson in `asyncio`!

`kubernetes_asyncio` has a deeply hidden `asyncio.ClientSession` that doesn't get properly closed when we restart services with `SIGINT`. Turns out the `__del__` method on the `RESTClient` deep inside the library that holds this client session sets up a future with asyncio to close the session, but I suspect that this object is getting deleted _after_ the event loop closes. As a result we get a bunch of garbage in the logs that
- the event loop is already closed when something is trying to happen
- a `ClientSession.close` was never properly awaited

I initially tried to explicitly close the client session but still dealt with the problem that the `k8s_client` was trying to interact with the even loop after it closed. Explicitly deleting the `k8s_client` on cleanup and then awaiting any remaining futures (so the client session `close`) appears to fix the problem as I get no more errors on shutdown, but let me know if this isn't kosher. If this is alright I'll see this through to the rest of the services.