### PR TITLE
[router] dont log lines of startup script

### DIFF
--- a/router/start-nginx.sh
+++ b/router/start-nginx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 case "$HAIL_DEFAULT_NAMESPACE" in
     default)


### PR DESCRIPTION
`-x` logs each line of `start-nginx.sh` that runs and I don't expect anything in here to fail / the code itself to provide useful context in a failure