### PR TITLE
[query] Do not permit storing to method parameters

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -991,7 +991,7 @@ class EmitMethodBuilder[C](
       i + paramType.nCodes
   }
 
-  def getCodeParam[T: TypeInfo](emitIndex: Int): Settable[T] = {
+  def getCodeParam[T: TypeInfo](emitIndex: Int): Value[T] = {
     if (emitIndex == 0 && !mb.isStatic)
       mb.getArg[T](0)
     else {
@@ -1137,7 +1137,7 @@ trait WrappedEmitMethodBuilder[C] extends WrappedEmitClassBuilder[C] {
   def emitWithBuilder[T](f: (EmitCodeBuilder) => Code[T]): Unit = emb.emitWithBuilder(f)
 
   // EmitMethodBuilder methods
-  def getCodeParam[T: TypeInfo](emitIndex: Int): Settable[T] = emb.getCodeParam[T](emitIndex)
+  def getCodeParam[T: TypeInfo](emitIndex: Int): Value[T] = emb.getCodeParam[T](emitIndex)
 
   def getEmitParam(emitIndex: Int): EmitValue = emb.getEmitParam(emitIndex)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -234,9 +234,9 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
   private def getF(cb: EmitCodeBuilder, root: Code[Long], kc: EmitCode): Code[Long] = {
     val get = kb.genEmitMethod("btree_get", FastIndexedSeq[ParamType](typeInfo[Long], kc.pv.st.pType.asEmitParam), typeInfo[Long])
-    val node = get.getCodeParam[Long](1)
-    val k = get.getEmitParam(2)
     get.emitWithBuilder { cb =>
+      val node = cb.newLocal[Long]("btree_getf_node", get.getCodeParam[Long](1))
+      val k = get.getEmitParam(2)
       val cmp = cb.newLocal("btree_get_cmp", -1)
       val keyV = cb.newLocal("btree_get_keyV", 0L)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -111,7 +111,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
     val mb = kb.genEmitMethod("downsample_init", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
     mb.voidWithBuilder { cb =>
       allocateSpace(cb)
-      cb.assign(this.nDivisions, mb.getCodeParam[Int](1).load())
+      cb.assign(this.nDivisions, mb.getCodeParam[Int](1))
 
       cb.ifx(this.nDivisions < 4, cb += Code._fatal[Unit](const("downsample: require n_divisions >= 4, found ").concat(this.nDivisions.toS)))
 

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -458,7 +458,7 @@ class OrderingSuite extends HailSuite {
         val eoff = rvb.end()
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int](ctx, "binary_search")
-        val cregion = fb.getCodeParam[Region](1).load()
+        val cregion = fb.getCodeParam[Region](1)
         val cset = fb.getCodeParam[Long](2)
         val cetuple = fb.getCodeParam[Long](3)
 


### PR DESCRIPTION
I have diagnosed the root cause of the issue observed by
both Patrick and Chris: incorrect spilling of method parameter variables.

This patch makes the bug impossible to replicate using proper interfaces,
though does not fix the underlying issue in LIR.

Here's a way to replicate:

```
      val mb = kb.genEmitMethod("btree_foo", FastIndexedSeq[ParamType](typeInfo[Long]), typeInfo[Unit])
      mb.voidWithBuilder { cb =>
        val arg = mb.getCodeParam[Long](1).asInstanceOf[Settable[Long]]

        cb.assign(arg, arg + 1L)

        (0 until 100).foreach { i =>
          cb.println(s"i=$i, arg=", arg.toS)
        }

      }
      cb.invokeVoid(mb,const( 0L))
```

called with `0`, this prints `1` until i=84, then starts printing 0 again.