### PR TITLE
[query] Fix LIR splitting of parameters with mutation

### DIFF
--- a/hail/src/main/scala/is/hail/lir/SplitMethod.scala
+++ b/hail/src/main/scala/is/hail/lir/SplitMethod.scala
@@ -134,10 +134,7 @@ class SplitMethod(
     def localField(l: Local): Field =
       l match {
         case p: Parameter =>
-          if (method eq m)
-            null
-          else
-            fields(p.i)
+          fields(p.i)
         case _ =>
           locals.getIndex(l) match {
             case Some(i) =>

--- a/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
+++ b/hail/src/test/scala/is/hail/lir/LIRSplitSuite.scala
@@ -1,0 +1,27 @@
+package is.hail.lir
+
+import is.hail.HailSuite
+import is.hail.expr.ir.{EmitFunctionBuilder, ParamType}
+import is.hail.asm4s._
+import org.testng.annotations.Test
+
+class LIRSplitSuite extends HailSuite {
+
+  @Test def testSplitPreservesParameterMutation() {
+    val f = EmitFunctionBuilder[Unit](ctx, "F")
+    f.emitWithBuilder { cb =>
+      val mb = f.newEmitMethod("m", IndexedSeq[ParamType](typeInfo[Long]), typeInfo[Unit])
+      mb.voidWithBuilder { cb =>
+        val arg = mb.getCodeParam[Long](1)
+
+        cb.assign(arg, 1000L)
+        (0 until 1000).foreach { i =>
+          cb.ifx(arg.cne(1000L), cb._fatal(s"bad split at $i!"))
+        }
+      }
+      cb.invokeVoid(mb, const(1L))
+      Code._empty
+    }
+    f.resultWithIndex()(0, ctx.r)()
+  }
+}


### PR DESCRIPTION
The match on method identity caused mismatches between the variable
stored in loaded across splits.