### PR TITLE
[auth-driver] Don't await BatchClient init

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -549,7 +549,7 @@ async def async_main():
         app['iam_client'] = aiogoogle.IAmClient(
             PROJECT, credentials=aiogoogle.Credentials.from_file('/gsa-key/key.json'))
 
-        app['batch_client'] = await bc.aioclient.BatchClient(None)
+        app['batch_client'] = bc.aioclient.BatchClient(None)
 
         users_changed_event = asyncio.Event()
         app['users_changed_event'] = users_changed_event
@@ -574,4 +574,5 @@ async def async_main():
                 if 'db_instance_pool' in app:
                     await app['db_instance_pool'].async_close()
             finally:
-                user_creation_loop.shutdown()
+                if user_creation_loop is not None:
+                    user_creation_loop.shutdown()

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -533,6 +533,7 @@ async def update_users(app):
 async def async_main():
     app = {}
 
+    user_creation_loop = None
     try:
         db = Database()
         await db.async_init(maxsize=50)


### PR DESCRIPTION
Think this should resolve this [error](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22auth-driver%22%0Aseverity%3DERROR;timeRange=PT3H?authuser=2&project=hail-vdc) where `auth-driver` is crashing on start