### PR TITLE
Add note about avoiding duplicate data to export_elasticsearch docs

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -2482,6 +2482,12 @@ def export_elasticsearch(t, host, port, index, index_type, block_size, config=No
 
     .. warning::
         :func:`.export_elasticsearch` is EXPERIMENTAL.
+
+    .. note::
+        Table rows may be exported more than once. For example, if a task has to be retried after being preempted
+        midway through processing a partition. To avoid duplicate documents in Elasticsearch, use a `config` with the
+        `es.mapping.id <https://www.elastic.co/guide/en/elasticsearch/hadoop/current/configuration.html#cfg-mapping>`__
+        option set to a field that contains a unique value for each row.
     """
 
     jdf = t.expand_types().to_spark(flatten=False)._jdf


### PR DESCRIPTION
Add information from https://discuss.hail.is/t/export-elasticsearch-function-documentation-for-updating-behavior/1899 to `export_elasticsearch` docs. This happens fairly often with preemptible Dataproc workers and has caused us some confusion in the past with the gnomAD browser. Without some understanding of how Hail works, it's not immediately clear why this happens.