### PR TITLE
[datasets] add gnomAD datasets

### DIFF
--- a/hail/python/hail/docs/datasets/schemas/clinvar_gene_summary.rst
+++ b/hail/python/hail/docs/datasets/schemas/clinvar_gene_summary.rst
@@ -5,7 +5,7 @@ clinvar_gene_summary
 
 *  **Versions:** 2019-07
 *  **Reference genome builds:** None
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (2019-07, None)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/clinvar_variant_summary.rst
+++ b/hail/python/hail/docs/datasets/schemas/clinvar_variant_summary.rst
@@ -5,7 +5,7 @@ clinvar_variant_summary
 
 *  **Versions:** 2019-07
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (2019-07, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/dbNSFP_genes.rst
+++ b/hail/python/hail/docs/datasets/schemas/dbNSFP_genes.rst
@@ -5,7 +5,7 @@ dbNSFP_genes
 
 *  **Versions:** 4.0
 *  **Reference genome builds:** None
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (4.0, None)
 ~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/dbNSFP_variants.rst
+++ b/hail/python/hail/docs/datasets/schemas/dbNSFP_variants.rst
@@ -5,7 +5,7 @@ dbNSFP_variants
 
 *  **Versions:** 4.0
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (4.0, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gencode.rst
+++ b/hail/python/hail/docs/datasets/schemas/gencode.rst
@@ -5,7 +5,7 @@ gencode
 
 *  **Versions:** v19, v31
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (v19, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gerp_elements.rst
+++ b/hail/python/hail/docs/datasets/schemas/gerp_elements.rst
@@ -5,7 +5,7 @@ gerp_elements
 
 *  **Versions:** hg19
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (hg19, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gerp_scores.rst
+++ b/hail/python/hail/docs/datasets/schemas/gerp_scores.rst
@@ -5,7 +5,7 @@ gerp_scores
 
 *  **Versions:** hg19
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (hg19, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gnomad_annotation_pext.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_annotation_pext.rst
@@ -1,0 +1,272 @@
+.. _gnomad_annotation_pext:
+
+gnomad_annotation_pext
+======================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Column fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'context': str
+        'vep': struct {
+            assembly_name: str,
+            allele_string: str,
+            ancestral: str,
+            colocated_variants: array<struct {
+                aa_allele: str,
+                aa_maf: float64,
+                afr_allele: str,
+                afr_maf: float64,
+                allele_string: str,
+                amr_allele: str,
+                amr_maf: float64,
+                clin_sig: array<str>,
+                end: int32,
+                eas_allele: str,
+                eas_maf: float64,
+                ea_allele: str,
+                ea_maf: float64,
+                eur_allele: str,
+                eur_maf: float64,
+                exac_adj_allele: str,
+                exac_adj_maf: float64,
+                exac_allele: str,
+                exac_afr_allele: str,
+                exac_afr_maf: float64,
+                exac_amr_allele: str,
+                exac_amr_maf: float64,
+                exac_eas_allele: str,
+                exac_eas_maf: float64,
+                exac_fin_allele: str,
+                exac_fin_maf: float64,
+                exac_maf: float64,
+                exac_nfe_allele: str,
+                exac_nfe_maf: float64,
+                exac_oth_allele: str,
+                exac_oth_maf: float64,
+                exac_sas_allele: str,
+                exac_sas_maf: float64,
+                id: str,
+                minor_allele: str,
+                minor_allele_freq: float64,
+                phenotype_or_disease: int32,
+                pubmed: array<int32>,
+                sas_allele: str,
+                sas_maf: float64,
+                somatic: int32,
+                start: int32,
+                strand: int32
+            }>,
+            context: str,
+            end: int32,
+            id: str,
+            input: str,
+            intergenic_consequences: array<struct {
+                allele_num: int32,
+                consequence_terms: array<str>,
+                impact: str,
+                minimised: int32,
+                variant_allele: str
+            }>,
+            most_severe_consequence: str,
+            motif_feature_consequences: array<struct {
+                allele_num: int32,
+                consequence_terms: array<str>,
+                high_inf_pos: str,
+                impact: str,
+                minimised: int32,
+                motif_feature_id: str,
+                motif_name: str,
+                motif_pos: int32,
+                motif_score_change: float64,
+                strand: int32,
+                variant_allele: str
+            }>,
+            regulatory_feature_consequences: array<struct {
+                allele_num: int32,
+                biotype: str,
+                consequence_terms: array<str>,
+                impact: str,
+                minimised: int32,
+                regulatory_feature_id: str,
+                variant_allele: str
+            }>,
+            seq_region_name: str,
+            start: int32,
+            strand: int32,
+            transcript_consequences: array<struct {
+                allele_num: int32,
+                amino_acids: str,
+                biotype: str,
+                canonical: int32,
+                ccds: str,
+                cdna_start: int32,
+                cdna_end: int32,
+                cds_end: int32,
+                cds_start: int32,
+                codons: str,
+                consequence_terms: array<str>,
+                distance: int32,
+                domains: array<struct {
+                    db: str,
+                    name: str
+                }>,
+                exon: str,
+                gene_id: str,
+                gene_pheno: int32,
+                gene_symbol: str,
+                gene_symbol_source: str,
+                hgnc_id: str,
+                hgvsc: str,
+                hgvsp: str,
+                hgvs_offset: int32,
+                impact: str,
+                intron: str,
+                lof: str,
+                lof_flags: str,
+                lof_filter: str,
+                lof_info: str,
+                minimised: int32,
+                polyphen_prediction: str,
+                polyphen_score: float64,
+                protein_end: int32,
+                protein_start: int32,
+                protein_id: str,
+                sift_prediction: str,
+                sift_score: float64,
+                strand: int32,
+                swissprot: str,
+                transcript_id: str,
+                trembl: str,
+                uniparc: str,
+                variant_allele: str
+            }>,
+            variant_class: str
+        }
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'a_index': int32
+        'was_split': bool
+        'methylation': struct {
+            NUM: int32,
+            MEAN: float64,
+            GTE50: int32,
+            GTE60: int32,
+            GTE70: int32,
+            GTE80: int32,
+            GTE90: int32,
+            GTE100: int32
+        }
+        'coverage': struct {
+            exomes: struct {
+                row_id: int64,
+                mean: float64,
+                median: int32,
+                over_1: float64,
+                over_5: float64,
+                over_10: float64,
+                over_15: float64,
+                over_20: float64,
+                over_25: float64,
+                over_30: float64,
+                over_50: float64,
+                over_100: float64
+            },
+            genomes: struct {
+                row_id: int64,
+                mean: float64,
+                median: int32,
+                over_1: float64,
+                over_5: float64,
+                over_10: float64,
+                over_15: float64,
+                over_20: float64,
+                over_25: float64,
+                over_30: float64,
+                over_50: float64,
+                over_100: float64
+            }
+        }
+        'gerp': float64
+        'tx_annotation': array<struct {
+            ensg: str,
+            csq: str,
+            symbol: str,
+            lof: str,
+            lof_flag: str,
+            Cells_Transformedfibroblasts: float64,
+            Prostate: float64,
+            Spleen: float64,
+            Brain_FrontalCortex_BA9_: float64,
+            SmallIntestine_TerminalIleum: float64,
+            MinorSalivaryGland: float64,
+            Artery_Coronary: float64,
+            Skin_SunExposed_Lowerleg_: float64,
+            Cells_EBV_transformedlymphocytes: float64,
+            Brain_Hippocampus: float64,
+            Esophagus_Muscularis: float64,
+            Brain_Nucleusaccumbens_basalganglia_: float64,
+            Artery_Tibial: float64,
+            Brain_Hypothalamus: float64,
+            Adipose_Visceral_Omentum_: float64,
+            Cervix_Ectocervix: float64,
+            Brain_Spinalcord_cervicalc_1_: float64,
+            Brain_CerebellarHemisphere: float64,
+            Nerve_Tibial: float64,
+            Breast_MammaryTissue: float64,
+            Liver: float64,
+            Skin_NotSunExposed_Suprapubic_: float64,
+            AdrenalGland: float64,
+            Vagina: float64,
+            Pancreas: float64,
+            Lung: float64,
+            FallopianTube: float64,
+            Pituitary: float64,
+            Muscle_Skeletal: float64,
+            Colon_Transverse: float64,
+            Artery_Aorta: float64,
+            Heart_AtrialAppendage: float64,
+            Adipose_Subcutaneous: float64,
+            Esophagus_Mucosa: float64,
+            Heart_LeftVentricle: float64,
+            Brain_Cerebellum: float64,
+            Brain_Cortex: float64,
+            Thyroid: float64,
+            Brain_Substantianigra: float64,
+            Kidney_Cortex: float64,
+            Uterus: float64,
+            Stomach: float64,
+            WholeBlood: float64,
+            Bladder: float64,
+            Brain_Anteriorcingulatecortex_BA24_: float64,
+            Brain_Putamen_basalganglia_: float64,
+            Brain_Caudate_basalganglia_: float64,
+            Colon_Sigmoid: float64,
+            Cervix_Endocervix: float64,
+            Ovary: float64,
+            Esophagus_GastroesophagealJunction: float64,
+            Testis: float64,
+            Brain_Amygdala: float64,
+            mean_proportion: float64
+        }>
+    ----------------------------------------
+    Entry fields:
+        None
+    ----------------------------------------
+    Column key: None
+    Row key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_base_pext.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_base_pext.rst
@@ -1,0 +1,80 @@
+.. _gnomad_base_pext:
+
+gnomad_base_pext
+================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'ensg': str
+        'locus': locus<GRCh37>
+        'symbol': str
+        'Cells_Transformedfibroblasts': float64
+        'Prostate': float64
+        'Spleen': float64
+        'Brain_FrontalCortex_BA9_': float64
+        'SmallIntestine_TerminalIleum': float64
+        'MinorSalivaryGland': float64
+        'Artery_Coronary': float64
+        'Skin_SunExposed_Lowerleg_': float64
+        'Cells_EBV_transformedlymphocytes': float64
+        'Brain_Hippocampus': float64
+        'Esophagus_Muscularis': float64
+        'Brain_Nucleusaccumbens_basalganglia_': float64
+        'Artery_Tibial': float64
+        'Brain_Hypothalamus': float64
+        'Adipose_Visceral_Omentum_': float64
+        'Cervix_Ectocervix': float64
+        'Brain_Spinalcord_cervicalc_1_': float64
+        'Brain_CerebellarHemisphere': float64
+        'Nerve_Tibial': float64
+        'Breast_MammaryTissue': float64
+        'Liver': float64
+        'Skin_NotSunExposed_Suprapubic_': float64
+        'AdrenalGland': float64
+        'Vagina': float64
+        'Pancreas': float64
+        'Lung': float64
+        'FallopianTube': float64
+        'Pituitary': float64
+        'Muscle_Skeletal': float64
+        'Colon_Transverse': float64
+        'Artery_Aorta': float64
+        'Heart_AtrialAppendage': float64
+        'Adipose_Subcutaneous': float64
+        'Esophagus_Mucosa': float64
+        'Heart_LeftVentricle': float64
+        'Brain_Cerebellum': float64
+        'Brain_Cortex': float64
+        'Thyroid': float64
+        'Brain_Substantianigra': float64
+        'Kidney_Cortex': float64
+        'Uterus': float64
+        'Stomach': float64
+        'WholeBlood': float64
+        'Bladder': float64
+        'Brain_Anteriorcingulatecortex_BA24_': float64
+        'Brain_Putamen_basalganglia_': float64
+        'Brain_Caudate_basalganglia_': float64
+        'Colon_Sigmoid': float64
+        'Cervix_Endocervix': float64
+        'Ovary': float64
+        'Esophagus_GastroesophagealJunction': float64
+        'Testis': float64
+        'Brain_Amygdala': float64
+        'mean_proportion': float64
+    ----------------------------------------
+    Key: ['locus']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_chrM_coverage.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_chrM_coverage.rst
@@ -1,0 +1,28 @@
+.. _gnomad_chrM_coverage:
+
+gnomad_chrM_coverage
+====================
+
+*  **Versions:** 3.1
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (3.1, GRCh38)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'mean': float64
+        'median': int32
+        'over_100': float64
+        'over_1000': float64
+    ----------------------------------------
+    Key: ['locus']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_chrM_sites.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_chrM_sites.rst
@@ -1,0 +1,243 @@
+.. _gnomad_chrM_sites:
+
+gnomad_chrM_sites
+=================
+
+*  **Versions:** 3.1
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (3.1, GRCh38)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'vep_version': str
+        'dbsnp_version': str
+        'hap_order': array<str>
+        'dp_hist_all_variants_bin_freq': array<int32>
+        'dp_hist_all_variants_n_larger': int32
+        'dp_hist_all_variants_bin_edges': array<float64>
+        'mq_hist_all_variants_bin_freq': array<int32>
+        'mq_hist_all_variants_n_larger': int32
+        'mq_hist_all_variants_bin_edges': array<float64>
+        'tlod_hist_all_variants_bin_freq': array<int32>
+        'tlod_hist_all_variants_n_larger': int32
+        'tlod_hist_all_variants_bin_edges': array<float64>
+        'age_hist_all_samples_bin_freq': array<int32>
+        'age_hist_all_samples_n_larger': int32
+        'age_hist_all_samples_n_smaller': int32
+        'age_hist_all_samples_bin_edges': array<float64>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'variant_collapsed': str
+        'hap_defining_variant': bool
+        'pon_mt_trna_prediction': str
+        'pon_ml_probability_of_pathogenicity': float64
+        'mitotip_score': float64
+        'mitotip_trna_prediction': str
+        'vep': struct {
+            assembly_name: str,
+            allele_string: str,
+            ancestral: str,
+            colocated_variants: array<struct {
+                aa_allele: str,
+                aa_maf: float64,
+                afr_allele: str,
+                afr_maf: float64,
+                allele_string: str,
+                amr_allele: str,
+                amr_maf: float64,
+                clin_sig: array<str>,
+                end: int32,
+                eas_allele: str,
+                eas_maf: float64,
+                ea_allele: str,
+                ea_maf: float64,
+                eur_allele: str,
+                eur_maf: float64,
+                exac_adj_allele: str,
+                exac_adj_maf: float64,
+                exac_allele: str,
+                exac_afr_allele: str,
+                exac_afr_maf: float64,
+                exac_amr_allele: str,
+                exac_amr_maf: float64,
+                exac_eas_allele: str,
+                exac_eas_maf: float64,
+                exac_fin_allele: str,
+                exac_fin_maf: float64,
+                exac_maf: float64,
+                exac_nfe_allele: str,
+                exac_nfe_maf: float64,
+                exac_oth_allele: str,
+                exac_oth_maf: float64,
+                exac_sas_allele: str,
+                exac_sas_maf: float64,
+                id: str,
+                minor_allele: str,
+                minor_allele_freq: float64,
+                phenotype_or_disease: int32,
+                pubmed: array<int32>,
+                sas_allele: str,
+                sas_maf: float64,
+                somatic: int32,
+                start: int32,
+                strand: int32
+            }>,
+            context: str,
+            end: int32,
+            id: str,
+            input: str,
+            intergenic_consequences: array<struct {
+                allele_num: int32,
+                consequence_terms: array<str>,
+                impact: str,
+                minimised: int32,
+                variant_allele: str
+            }>,
+            most_severe_consequence: str,
+            motif_feature_consequences: array<struct {
+                allele_num: int32,
+                consequence_terms: array<str>,
+                high_inf_pos: str,
+                impact: str,
+                minimised: int32,
+                motif_feature_id: str,
+                motif_name: str,
+                motif_pos: int32,
+                motif_score_change: float64,
+                strand: int32,
+                variant_allele: str
+            }>,
+            regulatory_feature_consequences: array<struct {
+                allele_num: int32,
+                biotype: str,
+                consequence_terms: array<str>,
+                impact: str,
+                minimised: int32,
+                regulatory_feature_id: str,
+                variant_allele: str
+            }>,
+            seq_region_name: str,
+            start: int32,
+            strand: int32,
+            transcript_consequences: array<struct {
+                allele_num: int32,
+                amino_acids: str,
+                appris: str,
+                biotype: str,
+                canonical: int32,
+                ccds: str,
+                cdna_start: int32,
+                cdna_end: int32,
+                cds_end: int32,
+                cds_start: int32,
+                codons: str,
+                consequence_terms: array<str>,
+                distance: int32,
+                domains: array<struct {
+                    db: str,
+                    name: str
+                }>,
+                exon: str,
+                gene_id: str,
+                gene_pheno: int32,
+                gene_symbol: str,
+                gene_symbol_source: str,
+                hgnc_id: str,
+                hgvsc: str,
+                hgvsp: str,
+                hgvs_offset: int32,
+                impact: str,
+                intron: str,
+                lof: str,
+                lof_flags: str,
+                lof_filter: str,
+                lof_info: str,
+                minimised: int32,
+                polyphen_prediction: str,
+                polyphen_score: float64,
+                protein_end: int32,
+                protein_start: int32,
+                protein_id: str,
+                sift_prediction: str,
+                sift_score: float64,
+                strand: int32,
+                swissprot: str,
+                transcript_id: str,
+                trembl: str,
+                tsl: int32,
+                uniparc: str,
+                variant_allele: str
+            }>,
+            variant_class: str
+        }
+        'common_low_heteroplasmy': bool
+        'base_qual_hist': array<int64>
+        'position_hist': array<int64>
+        'strand_bias_hist': array<int64>
+        'weak_evidence_hist': array<int64>
+        'contamination_hist': array<int64>
+        'heteroplasmy_below_10_percent_hist': array<int64>
+        'excluded_AC': int64
+        'AN': int64
+        'AC_hom': int64
+        'AC_het': int64
+        'hl_hist': struct {
+            bin_edges: array<float64>,
+            bin_freq: array<int64>,
+            n_smaller: int64,
+            n_larger: int64
+        }
+        'dp_hist_all': struct {
+            bin_edges: array<float64>,
+            bin_freq: array<int64>,
+            n_smaller: int64,
+            n_larger: int64
+        }
+        'dp_hist_alt': struct {
+            bin_edges: array<float64>,
+            bin_freq: array<int64>,
+            n_smaller: int64,
+            n_larger: int64
+        }
+        'dp_mean': float64
+        'mq_mean': float64
+        'tlod_mean': float64
+        'AF_hom': float32
+        'AF_het': float32
+        'max_hl': float64
+        'hap_AN': array<int64>
+        'hap_AC_het': array<int64>
+        'hap_AC_hom': array<int64>
+        'hap_AF_hom': array<float32>
+        'hap_AF_het': array<float32>
+        'hap_hl_hist': array<array<int64>>
+        'hap_faf_hom': array<float64>
+        'hapmax_AF_hom': str
+        'hapmax_AF_het': str
+        'faf_hapmax_hom': float64
+        'age_hist_hom': struct {
+            bin_edges: array<float64>,
+            bin_freq: array<int64>,
+            n_smaller: int64,
+            n_larger: int64
+        }
+        'age_hist_het': struct {
+            bin_edges: array<float64>,
+            bin_freq: array<int64>,
+            n_smaller: int64,
+            n_larger: int64
+        }
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_exome_coverage.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_exome_coverage.rst
@@ -1,0 +1,36 @@
+.. _gnomad_exome_coverage:
+
+gnomad_exome_coverage
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'row_id': int64
+        'locus': locus<GRCh37>
+        'mean': float64
+        'median': int32
+        'over_1': float64
+        'over_5': float64
+        'over_10': float64
+        'over_15': float64
+        'over_20': float64
+        'over_25': float64
+        'over_30': float64
+        'over_50': float64
+        'over_100': float64
+    ----------------------------------------
+    Key: ['locus']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_exome_sites.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_exome_sites.rst
@@ -5,7 +5,7 @@ gnomad_exome_sites
 
 *  **Versions:** 2.1.1
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (2.1.1, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gnomad_genome_coverage.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_genome_coverage.rst
@@ -1,0 +1,36 @@
+.. _gnomad_genome_coverage:
+
+gnomad_genome_coverage
+======================
+
+*  **Versions:** 2.1, 3.0.1
+*  **Reference genome builds:** GRCh37, GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'row_id': int64
+        'locus': locus<GRCh37>
+        'mean': float64
+        'median': int32
+        'over_1': float64
+        'over_5': float64
+        'over_10': float64
+        'over_15': float64
+        'over_20': float64
+        'over_25': float64
+        'over_30': float64
+        'over_50': float64
+        'over_100': float64
+    ----------------------------------------
+    Key: ['locus']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_genome_sites.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_genome_sites.rst
@@ -3,9 +3,9 @@
 gnomad_genome_sites
 ===================
 
-*  **Versions:** 2.1.1
+*  **Versions:** 2.1.1, 3.1
 *  **Reference genome builds:** GRCh37, GRCh38
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (2.1.1, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/gnomad_hgdp_1kg_callset.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_hgdp_1kg_callset.rst
@@ -5,10 +5,10 @@ gnomad_hgdp_1kg_callset
 
 *  **Versions:** 3.1
 *  **Reference genome builds:** GRCh38
-*  **Type:** :class:`.MatrixTable`
+*  **Type:** :class:`hail.MatrixTable`
 
 Schema (3.1, GRCh38)
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_afr.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_afr.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_afr:
+
+gnomad_ld_scores_afr
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_amr.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_amr.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_amr:
+
+gnomad_ld_scores_amr
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_asj.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_asj.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_asj:
+
+gnomad_ld_scores_asj
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_eas.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_eas.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_eas:
+
+gnomad_ld_scores_eas
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_est.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_est.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_est:
+
+gnomad_ld_scores_est
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_fin.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_fin.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_fin:
+
+gnomad_ld_scores_fin
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_nfe.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_nfe.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_nfe:
+
+gnomad_ld_scores_nfe
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_nwe.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_nwe.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_nwe:
+
+gnomad_ld_scores_nwe
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_seu.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_scores_seu.rst
@@ -1,0 +1,34 @@
+.. _gnomad_ld_scores_seu:
+
+gnomad_ld_scores_seu
+====================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+        'new_idx': int64
+        'ld_score': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_afr.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_afr.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_afr:
+
+gnomad_ld_variant_indices_afr
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_amr.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_amr.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_amr:
+
+gnomad_ld_variant_indices_amr
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_asj.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_asj.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_asj:
+
+gnomad_ld_variant_indices_asj
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_eas.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_eas.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_eas:
+
+gnomad_ld_variant_indices_eas
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_est.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_est.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_est:
+
+gnomad_ld_variant_indices_est
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_fin.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_fin.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_fin:
+
+gnomad_ld_variant_indices_fin
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_nfe.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_nfe.rst
@@ -1,0 +1,75 @@
+.. _gnomad_ld_variant_indices_nfe:
+
+gnomad_ld_variant_indices_nfe
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'min_af': float64
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_nwe.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_nwe.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_nwe:
+
+gnomad_ld_variant_indices_nwe
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_seu.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_ld_variant_indices_seu.rst
@@ -1,0 +1,74 @@
+.. _gnomad_ld_variant_indices_seu:
+
+gnomad_ld_variant_indices_seu
+=============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'age_distribution': array<int32>
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'alleles': array<str>
+        'pop_freq': struct {
+            AC: int32,
+            AF: float64,
+            AN: int32,
+            homozygote_count: int32
+        }
+        'idx': int64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d01.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d01.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d01:
+
+gnomad_mnv_genome_d01
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d02.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d02.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d02:
+
+gnomad_mnv_genome_d02
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d03.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d03.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d03:
+
+gnomad_mnv_genome_d03
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d04.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d04.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d04:
+
+gnomad_mnv_genome_d04
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d05.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d05.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d05:
+
+gnomad_mnv_genome_d05
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d06.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d06.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d06:
+
+gnomad_mnv_genome_d06
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d07.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d07.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d07:
+
+gnomad_mnv_genome_d07
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d08.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d08.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d08:
+
+gnomad_mnv_genome_d08
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d09.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d09.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d09:
+
+gnomad_mnv_genome_d09
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d10.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_mnv_genome_d10.rst
@@ -1,0 +1,35 @@
+.. _gnomad_mnv_genome_d10:
+
+gnomad_mnv_genome_d10
+=====================
+
+*  **Versions:** 2.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh37>
+        'refs': str
+        'alts': str
+        'distance': int32
+        'snp1': str
+        'snp2': str
+        'ac1': int32
+        'ac2': int32
+        'ac_mnv': int32
+        'ac1_adj': int32
+        'ac2_adj': int32
+        'ac_mnv_adj': int32
+    ----------------------------------------
+    Key: ['locus', 'refs', 'alts']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_plof_metrics_gene.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_plof_metrics_gene.rst
@@ -1,0 +1,100 @@
+.. _gnomad_plof_metrics_gene:
+
+gnomad_plof_metrics_gene
+========================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        None
+    ----------------------------------------
+    Row fields:
+        'gene': str
+        'transcript': str
+        'obs_mis': int32
+        'exp_mis': float64
+        'oe_mis': float64
+        'mu_mis': float64
+        'possible_mis': int32
+        'obs_mis_pphen': int32
+        'exp_mis_pphen': float64
+        'oe_mis_pphen': float64
+        'possible_mis_pphen': int32
+        'obs_syn': int32
+        'exp_syn': float64
+        'oe_syn': float64
+        'mu_syn': float64
+        'possible_syn': int32
+        'obs_lof': int32
+        'mu_lof': float64
+        'possible_lof': int32
+        'exp_lof': float64
+        'pLI': float64
+        'pNull': float64
+        'pRec': float64
+        'oe_lof': float64
+        'oe_syn_lower': float64
+        'oe_syn_upper': float64
+        'oe_mis_lower': float64
+        'oe_mis_upper': float64
+        'oe_lof_lower': float64
+        'oe_lof_upper': float64
+        'constraint_flag': str
+        'syn_z': float64
+        'mis_z': float64
+        'lof_z': float64
+        'oe_lof_upper_rank': int32
+        'oe_lof_upper_bin': int32
+        'oe_lof_upper_bin_6': int32
+        'n_sites': int32
+        'classic_caf': float64
+        'max_af': float64
+        'no_lofs': int32
+        'obs_het_lof': int32
+        'obs_hom_lof': int32
+        'defined': int32
+        'p': float64
+        'exp_hom_lof': float64
+        'classic_caf_afr': float64
+        'classic_caf_amr': float64
+        'classic_caf_asj': float64
+        'classic_caf_eas': float64
+        'classic_caf_fin': float64
+        'classic_caf_nfe': float64
+        'classic_caf_oth': float64
+        'classic_caf_sas': float64
+        'p_afr': float64
+        'p_amr': float64
+        'p_asj': float64
+        'p_eas': float64
+        'p_fin': float64
+        'p_nfe': float64
+        'p_oth': float64
+        'p_sas': float64
+        'transcript_type': str
+        'gene_id': str
+        'transcript_level': int32
+        'cds_length': int32
+        'num_coding_exons': int32
+        'gene_type': str
+        'gene_length': int32
+        'exac_pLI': float64
+        'exac_obs_lof': int32
+        'exac_exp_lof': float64
+        'exac_oe_lof': float64
+        'brain_expression': str
+        'chromosome': str
+        'start_position': int32
+        'end_position': int32
+    ----------------------------------------
+    Key: ['gene']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/gnomad_plof_metrics_transcript.rst
+++ b/hail/python/hail/docs/datasets/schemas/gnomad_plof_metrics_transcript.rst
@@ -1,0 +1,186 @@
+.. _gnomad_plof_metrics_transcript:
+
+gnomad_plof_metrics_transcript
+==============================
+
+*  **Versions:** 2.1.1
+*  **Reference genome builds:** GRCh37
+*  **Type:** :class:`hail.Table`
+
+Schema (2.1.1, GRCh37)
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'rf': struct {
+            variants_by_type: dict<str, int32>,
+            feature_medians: dict<str, struct {
+                variant_type: str,
+                n_alt_alleles: int32,
+                qd: float64,
+                pab_max: float64,
+                info_MQRankSum: float64,
+                info_SOR: float64,
+                info_InbreedingCoeff: float64,
+                info_ReadPosRankSum: float64,
+                info_FS: float64,
+                info_QD: float64,
+                info_MQ: float64,
+                info_DP: int32
+            }>,
+            test_intervals: array<interval<locus<GRCh37>>>,
+            test_results: array<struct {
+                rf_prediction: str,
+                rf_label: str,
+                n: int32
+            }>,
+            features_importance: dict<str, float64>,
+            features: array<str>,
+            vqsr_training: bool,
+            no_transmitted_singletons: bool,
+            adj: bool,
+            rf_hash: str,
+            rf_snv_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            },
+            rf_indel_cutoff: struct {
+                bin: int32,
+                min_score: float64
+            }
+        }
+        'freq_meta': array<dict<str, str>>
+        'freq_index_dict': dict<str, int32>
+        'popmax_index_dict': dict<str, int32>
+        'age_index_dict': dict<str, int32>
+        'faf_index_dict': dict<str, int32>
+        'syn_sd': float64
+        'mis_sd': float64
+        'lof_sd': float64
+    ----------------------------------------
+    Row fields:
+        'gene': str
+        'transcript': str
+        'canonical': bool
+        'obs_mis': int64
+        'exp_mis': float64
+        'oe_mis': float64
+        'mu_mis': float64
+        'possible_mis': int64
+        'exp_mis_global': array<float64>
+        'obs_mis_global': array<int64>
+        'exp_mis_afr': array<float64>
+        'obs_mis_afr': array<int64>
+        'exp_mis_amr': array<float64>
+        'obs_mis_amr': array<int64>
+        'exp_mis_eas': array<float64>
+        'obs_mis_eas': array<int64>
+        'exp_mis_nfe': array<float64>
+        'obs_mis_nfe': array<int64>
+        'exp_mis_sas': array<float64>
+        'obs_mis_sas': array<int64>
+        'obs_mis_pphen': int64
+        'exp_mis_pphen': float64
+        'oe_mis_pphen': float64
+        'possible_mis_pphen': int64
+        'obs_syn': int64
+        'exp_syn': float64
+        'oe_syn': float64
+        'mu_syn': float64
+        'possible_syn': int64
+        'exp_syn_global': array<float64>
+        'obs_syn_global': array<int64>
+        'exp_syn_afr': array<float64>
+        'obs_syn_afr': array<int64>
+        'exp_syn_amr': array<float64>
+        'obs_syn_amr': array<int64>
+        'exp_syn_eas': array<float64>
+        'obs_syn_eas': array<int64>
+        'exp_syn_nfe': array<float64>
+        'obs_syn_nfe': array<int64>
+        'exp_syn_sas': array<float64>
+        'obs_syn_sas': array<int64>
+        'obs_lof': int64
+        'mu_lof': float64
+        'possible_lof': int64
+        'exp_lof': float64
+        'exp_lof_global': array<float64>
+        'obs_lof_global': array<int64>
+        'exp_lof_afr': array<float64>
+        'obs_lof_afr': array<int64>
+        'exp_lof_amr': array<float64>
+        'obs_lof_amr': array<int64>
+        'exp_lof_eas': array<float64>
+        'obs_lof_eas': array<int64>
+        'exp_lof_nfe': array<float64>
+        'obs_lof_nfe': array<int64>
+        'exp_lof_sas': array<float64>
+        'obs_lof_sas': array<int64>
+        'pLI': float64
+        'pNull': float64
+        'pRec': float64
+        'oe_lof': float64
+        'oe_syn_lower': float64
+        'oe_syn_upper': float64
+        'oe_mis_lower': float64
+        'oe_mis_upper': float64
+        'oe_lof_lower': float64
+        'oe_lof_upper': float64
+        'constraint_flag': set<str>
+        'syn_z': float64
+        'mis_z': float64
+        'lof_z': float64
+        'oe_lof_upper_rank': int64
+        'oe_lof_upper_bin': int32
+        'oe_lof_upper_bin_6': int32
+        'n_sites': int64
+        'n_sites_array': array<int64>
+        'classic_caf': float64
+        'max_af': float64
+        'classic_caf_array': array<float64>
+        'no_lofs': int64
+        'obs_het_lof': int64
+        'obs_hom_lof': int64
+        'defined': int64
+        'pop_no_lofs': dict<str, int64>
+        'pop_obs_het_lof': dict<str, int64>
+        'pop_obs_hom_lof': dict<str, int64>
+        'pop_defined': dict<str, int64>
+        'p': float64
+        'pop_p': dict<str, float64>
+        'exp_hom_lof': float64
+        'classic_caf_afr': float64
+        'classic_caf_amr': float64
+        'classic_caf_asj': float64
+        'classic_caf_eas': float64
+        'classic_caf_fin': float64
+        'classic_caf_nfe': float64
+        'classic_caf_oth': float64
+        'classic_caf_sas': float64
+        'p_afr': float64
+        'p_amr': float64
+        'p_asj': float64
+        'p_eas': float64
+        'p_fin': float64
+        'p_nfe': float64
+        'p_oth': float64
+        'p_sas': float64
+        'transcript_type': str
+        'gene_id': str
+        'transcript_level': str
+        'cds_length': int64
+        'num_coding_exons': int64
+        'interval': interval<locus<GRCh37>>
+        'gene_type': str
+        'gene_length': int32
+        'exac_pLI': float64
+        'exac_obs_lof': int32
+        'exac_exp_lof': float64
+        'exac_oe_lof': float64
+        'brain_expression': float64
+    ----------------------------------------
+    Key: ['gene', 'transcript']
+    ----------------------------------------
+

--- a/hail/python/hail/docs/datasets/schemas/ldsc_baselineLD_annotations.rst
+++ b/hail/python/hail/docs/datasets/schemas/ldsc_baselineLD_annotations.rst
@@ -5,7 +5,7 @@ ldsc_baselineLD_annotations
 
 *  **Versions:** 2.2
 *  **Reference genome builds:** GRCh37
-*  **Type:** :class:`.Table`
+*  **Type:** :class:`hail.Table`
 
 Schema (2.2, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/ldsc_baselineLD_ldscores.rst
+++ b/hail/python/hail/docs/datasets/schemas/ldsc_baselineLD_ldscores.rst
@@ -5,7 +5,7 @@ ldsc_baselineLD_ldscores
 
 *  **Versions:** 2.2
 *  **Reference genome builds:** GRCh37
-*  **Type:** :class:`.MatrixTable`
+*  **Type:** :class:`hail.MatrixTable`
 
 Schema (2.2, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/docs/datasets/schemas/ldsc_baseline_ldscores.rst
+++ b/hail/python/hail/docs/datasets/schemas/ldsc_baseline_ldscores.rst
@@ -5,7 +5,7 @@ ldsc_baseline_ldscores
 
 *  **Versions:** 1.1
 *  **Reference genome builds:** GRCh37
-*  **Type:** :class:`.MatrixTable`
+*  **Type:** :class:`hail.MatrixTable`
 
 Schema (1.1, GRCh37)
 ~~~~~~~~~~~~~~~~~~~~

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -605,24 +605,6 @@
       }
     ]
   },
-  "gnomad_hgdp_1kg_callset": {
-    "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects. The samples included in this subset are drawn from the 1000 Genomes Project (n=2,435) and the Human Genome Diversity Project (n=780), which contain some of the most genetically diverse populations present in gnomAD.",
-    "url": "https://gnomad.broadinstitute.org/",
-    "versions": [
-      {
-        "reference_genome": "GRCh38",
-        "url": {
-          "aws": {
-            "us": "s3://gnomad-public-us-east-1/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt"
-          },
-          "gcp": {
-            "us": "gs://gcp-public-data--gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt"
-          }
-        },
-        "version": "3.1"
-      }
-    ]
-  },
   "gnomad_exome_sites": {
     "annotation_db": {
       "key_properties": [
@@ -702,6 +684,510 @@
           }
         },
         "version": "3.1"
+      }
+    ]
+  },
+  "gnomad_hgdp_1kg_callset": {
+    "description": "gnomAD: samples included in this subset are drawn from the 1000 Genomes Project (n=2,435) and the Human Genome Diversity Project (n=780), which contain some of the most genetically diverse populations present in gnomAD.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/3.1/mt/genomes/gnomad.genomes.v3.1.hgdp_1kg_subset.mt"
+          }
+        },
+        "version": "3.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_afr": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for African/African-American population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.afr.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.afr.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_amr": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for Latino/Admixed American population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.amr.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.amr.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_asj": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for Ashkenazi Jewish population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.asj.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.asj.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_eas": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for East Asian population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.eas.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.eas.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_est": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for Estonian population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.est.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.est.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_fin": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for European (Finnish) population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.fin.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.fin.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_nfe": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for European (non-Finnish) population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.nfe.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.nfe.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_nwe": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for North-western European population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.nwe.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.nwe.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_block_matrix_seu": {
+    "description": "gnomAD: linkage disequilibrium (LD) matrix Hail BlockMatrix for Southern European population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.seu.common.adj.ld.bm"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.seu.common.adj.ld.bm"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_afr": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for African/African-American population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.afr.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.afr.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_amr": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for Latino/Admixed American population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.amr.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.amr.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_asj": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for Ashkenazi Jewish population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.asj.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.asj.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_eas": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for East Asian population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.eas.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.eas.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_est": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for Estonian population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.est.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.est.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_fin": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for European (Finnish) population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.fin.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.fin.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_nfe": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for European (non-Finnish) population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.nfe.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.nfe.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_nwe": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for North-western European population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.nwe.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.nwe.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_scores_seu": {
+    "description": "gnomAD: linkage disequilibrium (LD) scores Hail Table for Southern European population.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.seu.adj.ld_scores.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/scores/gnomad.genomes.r2.1.1.seu.adj.ld_scores.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_afr": {
+    "description": "gnomAD: variant indices Hail Table for African/African-American population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.afr.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.afr.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_amr": {
+    "description": "gnomAD: variant indices Hail Table for Latino/Admixed American population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.amr.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.amr.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_asj": {
+    "description": "gnomAD: variant indices Hail Table for Ashkenazi Jewish population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.asj.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.asj.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_eas": {
+    "description": "gnomAD: variant indices Hail Table for East Asian population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.eas.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.eas.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_est": {
+    "description": "gnomAD: variant indices Hail Table for Estonian population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.est.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.est.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_fin": {
+    "description": "gnomAD: variant indices Hail Table for European (Finnish) population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.fin.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.fin.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_nfe": {
+    "description": "gnomAD: variant indices Hail Table for European (non-Finnish) population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.nfe.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.nfe.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_nwe": {
+    "description": "gnomAD: variant indices Hail Table for North-western European population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.nwe.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.nwe.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_ld_variant_indices_seu": {
+    "description": "gnomAD: variant indices Hail Table for Southern European population",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/ld/gnomad.genomes.r2.1.1.seu.common.adj.ld.variant_indices.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.seu.common.adj.ld.variant_indices.ht"
+          }
+        },
+        "version": "2.1.1"
       }
     ]
   },

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -605,13 +605,103 @@
       }
     ]
   },
+  "gnomad_annotation_pext": {
+    "description": "gnomAD: annotation-level proportion expressed across transcripts (pext) for all possible SNVs Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/papers/2019-tx-annotation/pre_computed/all.possible.snvs.tx_annotated.021520.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/pre_computed/all.possible.snvs.tx_annotated.021520.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_base_pext": {
+    "description": "gnomAD: base-level proportion expressed across transcripts (pext) Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/papers/2019-tx-annotation/gnomad_browser/all.baselevel.021620.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/papers/2019-tx-annotation/gnomad_browser/all.baselevel.021620.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_chrM_coverage": {
+    "description": "gnomAD: mitochondrial DNA (mtDNA) coverage Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/blog/2020-11-gnomad-v3-1-mitochondrial-dna-variants/",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/3.1/coverage/genomes/gnomad.genomes.v3.1.chrM.coverage.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/3.1/coverage/genomes/gnomad.genomes.v3.1.chrM.coverage.ht"
+          }
+        },
+        "version": "3.1"
+      }
+    ]
+  },
+  "gnomad_chrM_sites": {
+    "description": "gnomAD: mitochondrial DNA (mtDNA) sites Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/blog/2020-11-gnomad-v3-1-mitochondrial-dna-variants/",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/3.1/ht/genomes/gnomad.genomes.v3.1.sites.chrM.ht"
+          },
+          "gcp": {
+            "us": "gs://gnomad-public-requester-pays/release/3.1/ht/genomes/gnomad.genomes.v3.1.sites.chrM.ht"
+          }
+        },
+        "version": "3.1"
+      }
+    ]
+  },
+  "gnomad_exome_coverage": {
+    "description": "gnomAD: exome coverage Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/coverage/exomes/gnomad.exomes.r2.1.coverage.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/coverage/exomes/gnomad.exomes.r2.1.coverage.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
   "gnomad_exome_sites": {
     "annotation_db": {
       "key_properties": [
         "unique"
       ]
     },
-    "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+    "description": "gnomAD: exome sites Hail Table.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -640,13 +730,43 @@
       }
     ]
   },
+  "gnomad_genome_coverage": {
+    "description": "gnomAD: genome coverage Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/coverage/genomes/gnomad.genomes.r2.1.coverage.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/coverage/genomes/gnomad.genomes.r2.1.coverage.ht"
+          }
+        },
+        "version": "2.1"
+      },
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/3.0.1/coverage/genomes/gnomad.genomes.r3.0.1.coverage.ht"
+          }
+        },
+        "version": "3.0.1"
+      }
+    ]
+  },
   "gnomad_genome_sites": {
     "annotation_db": {
       "key_properties": [
         "unique"
       ]
     },
-    "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+    "description": "gnomAD: genome sites Hail Table.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1030,7 +1150,7 @@
     ]
   },
   "gnomad_ld_variant_indices_afr": {
-    "description": "gnomAD: variant indices Hail Table for African/African-American population",
+    "description": "gnomAD: variant indices Hail Table for African/African-American population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1048,7 +1168,7 @@
     ]
   },
   "gnomad_ld_variant_indices_amr": {
-    "description": "gnomAD: variant indices Hail Table for Latino/Admixed American population",
+    "description": "gnomAD: variant indices Hail Table for Latino/Admixed American population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1066,7 +1186,7 @@
     ]
   },
   "gnomad_ld_variant_indices_asj": {
-    "description": "gnomAD: variant indices Hail Table for Ashkenazi Jewish population",
+    "description": "gnomAD: variant indices Hail Table for Ashkenazi Jewish population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1084,7 +1204,7 @@
     ]
   },
   "gnomad_ld_variant_indices_eas": {
-    "description": "gnomAD: variant indices Hail Table for East Asian population",
+    "description": "gnomAD: variant indices Hail Table for East Asian population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1102,7 +1222,7 @@
     ]
   },
   "gnomad_ld_variant_indices_est": {
-    "description": "gnomAD: variant indices Hail Table for Estonian population",
+    "description": "gnomAD: variant indices Hail Table for Estonian population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1120,7 +1240,7 @@
     ]
   },
   "gnomad_ld_variant_indices_fin": {
-    "description": "gnomAD: variant indices Hail Table for European (Finnish) population",
+    "description": "gnomAD: variant indices Hail Table for European (Finnish) population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1138,7 +1258,7 @@
     ]
   },
   "gnomad_ld_variant_indices_nfe": {
-    "description": "gnomAD: variant indices Hail Table for European (non-Finnish) population",
+    "description": "gnomAD: variant indices Hail Table for European (non-Finnish) population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1156,7 +1276,7 @@
     ]
   },
   "gnomad_ld_variant_indices_nwe": {
-    "description": "gnomAD: variant indices Hail Table for North-western European population",
+    "description": "gnomAD: variant indices Hail Table for North-western European population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1174,7 +1294,7 @@
     ]
   },
   "gnomad_ld_variant_indices_seu": {
-    "description": "gnomAD: variant indices Hail Table for Southern European population",
+    "description": "gnomAD: variant indices Hail Table for Southern European population.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
@@ -1191,17 +1311,197 @@
       }
     ]
   },
-  "gnomad_lof_metrics": {
+  "gnomad_mnv_genome_d01": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 1.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d1.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d1.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d02": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 2.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d2.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d2.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d03": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 3.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d3.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d3.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d04": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 4.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d4.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d4.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d05": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 5.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d5.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d5.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d06": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 6.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d6.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d6.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d07": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 7.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d7.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d7.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d08": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 8.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d8.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d8.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d09": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 9.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d9.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d9.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_mnv_genome_d10": {
+    "description": "gnomAD: genome wide multi-nucleotide variants (MNVs) Hail Table, for distance between two SNVs of 10.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1/mnv/genome/gnomad_mnv_genome_d10.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1/mnv/genome/gnomad_mnv_genome_d10.ht"
+          }
+        },
+        "version": "2.1"
+      }
+    ]
+  },
+  "gnomad_plof_metrics_gene": {
     "annotation_db": {
       "key_properties": [
         "gene"
       ]
     },
-    "description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+    "description": "gnomAD: pLoF metrics by gene Hail Table.",
     "url": "https://gnomad.broadinstitute.org/",
     "versions": [
       {
-        "reference_genome": null,
+        "reference_genome": "GRCh37",
         "url": {
           "aws": {
             "us": "s3://hail-datasets-us-east-1/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht"
@@ -1209,6 +1509,24 @@
           "gcp": {
             "eu": "gs://hail-datasets-eu/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht",
             "us": "gs://hail-datasets-us/annotations/gnomad_v2.1.1_lof_metrics_by_gene.ht"
+          }
+        },
+        "version": "2.1.1"
+      }
+    ]
+  },
+  "gnomad_plof_metrics_transcript": {
+    "description": "gnomAD: pLoF metrics by transcript Hail Table.",
+    "url": "https://gnomad.broadinstitute.org/",
+    "versions": [
+      {
+        "reference_genome": "GRCh37",
+        "url": {
+          "aws": {
+            "us": "s3://gnomad-public-us-east-1/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
+          },
+          "gcp": {
+            "us": "gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
           }
         },
         "version": "2.1.1"

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -660,6 +660,11 @@
     ]
   },
   "gnomad_chrM_sites": {
+    "annotation_db": {
+      "key_properties": [
+        "unique"
+      ]
+    },
     "description": "gnomAD: mitochondrial DNA (mtDNA) sites Hail Table.",
     "url": "https://gnomad.broadinstitute.org/blog/2020-11-gnomad-v3-1-mitochondrial-dna-variants/",
     "versions": [

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -109,12 +109,12 @@ def load_dataset(name: str,
     if path.endswith('.ht'):
         try:
             dataset = hl.read_table(path)
-        except FatalError as e:
+        except FatalError:
             dataset = hl.read_matrix_table(path)
     elif path.endswith('.mt'):
         try:
             dataset = hl.read_matrix_table(path)
-        except FatalError as e:
+        except FatalError:
             dataset = hl.read_table(path)
     else:
         if not path.endswith('.bm'):

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -107,10 +107,12 @@ def load_dataset(name: str,
 
     if path.endswith('.ht'):
         dataset = hl.read_table(path)
+    elif path.endswith('.bm'):
+        dataset = hl.linalg.BlockMatrix.read(path)
     else:
         if not path.endswith('.mt'):
             raise ValueError(f'Invalid path {repr(path)}: can only load'
-                             f' datasets with .ht or .mt extensions.')
+                             f' datasets with .ht, .mt, or .bm extensions.')
         dataset = hl.read_matrix_table(path)
 
     return dataset

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import hail as hl
 import pkg_resources
+from hail.utils.java import FatalError
 
 
 def load_dataset(name: str,
@@ -106,13 +107,19 @@ def load_dataset(name: str,
     path = path[0]
 
     if path.endswith('.ht'):
-        dataset = hl.read_table(path)
-    elif path.endswith('.bm'):
-        dataset = hl.linalg.BlockMatrix.read(path)
+        try:
+            dataset = hl.read_table(path)
+        except FatalError as e:
+            dataset = hl.read_matrix_table(path)
+    elif path.endswith('.mt'):
+        try:
+            dataset = hl.read_matrix_table(path)
+        except FatalError as e:
+            dataset = hl.read_table(path)
     else:
-        if not path.endswith('.mt'):
+        if not path.endswith('.bm'):
             raise ValueError(f'Invalid path {repr(path)}: can only load'
                              f' datasets with .ht, .mt, or .bm extensions.')
-        dataset = hl.read_matrix_table(path)
+        dataset = hl.linalg.BlockMatrix.read(path)
 
     return dataset

--- a/hail/python/hail/experimental/datasets.py
+++ b/hail/python/hail/experimental/datasets.py
@@ -46,7 +46,7 @@ def load_dataset(name: str,
 
     Returns
     -------
-    :class:`.Table` or :class:`.MatrixTable`
+    :class:`.Table`, :class:`.MatrixTable`, or :class:`.BlockMatrix`
     """
 
     valid_regions = {'us', 'eu'}


### PR DESCRIPTION
To make existing gnomAD datasets (already in HailTable/MatrixTable form) available via `load_dataset`:
  - For v2 now includes multinucleotide variants (MNVs), proportion expressed across transcript (pext), and linkage disequilibrium (LD)
  - For v3 now includes mitochondrial DNA (mtDNA)

The `load_dataset` function now can open a `BlockMatrix` as well, so the gnomAD v2 LD matrices are available through the datasets API in addition to the tables.

Also added try/except blocks to `load_datasets`, to handle errors. For example the `gnomad_annotation_pext` dataset has a url of `gs://gcp-public-data--gnomad/papers/2019-tx-annotation/pre_computed/all.possible.snvs.tx_annotated.021520.ht`, but this is actually a `MatrixTable`.  So now when trying to open a `HailTable`, it will try to open as a `MatrixTable` if an error is encountered (and vice versa).