### PR TITLE
[query] remove uses of SRVB in EmitStream

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1591,6 +1591,12 @@ class Emit[C](
         val AggContainer(_, sc, _) = container.get
         presentC(sc.states(i).serializeToRegion(cb, coerce[PBinary](pt), region.code))
 
+      case ToArray(a) =>
+        val outerRegion = region.asParent(coerce[PStream](a.pType).separateRegions, "ToArray")
+        emitStream(a, outerRegion).map(cb) { stream =>
+          EmitStream.toArray(cb, coerce[PCanonicalArray](pt), stream.asStream, outerRegion)
+        }
+
       case x@StreamFold(a, zero, accumName, valueName, body) =>
         val streamType = coerce[PStream](a.pType)
         val eltType = streamType.elementType
@@ -1982,12 +1988,6 @@ class Emit[C](
       case CastToArray(a) =>
         val et = emit(a)
         EmitCode(et.setup, et.m, PCode(pt, et.v))
-
-      case ToArray(a) =>
-        val outerRegion = region.asParent(coerce[PStream](a.pType).separateRegions, "ToArray")
-        emitStream(a, outerRegion).map { stream =>
-          EmitStream.toArray(mb, coerce[PArray](pt), stream.asStream, outerRegion)
-        }
 
       case GroupByKey(collection) =>
         // sort collection by group

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -305,12 +305,12 @@ final case class StreamMultiMerge(as: IndexedSeq[IR], key: IndexedSeq[String]) e
 final case class StreamZipJoin(as: IndexedSeq[IR], key: IndexedSeq[String], curKey: String, curVals: String, joinF: IR) extends IR {
   override def typ: TStream = coerce[TStream](super.typ)
   override def pType: PStream = coerce[PStream](super.pType)
-  private var _curValsType: PArray = null
-  def getOrComputeCurValsType(valsType: => PType): PArray = {
-    if (_curValsType == null) _curValsType = valsType.asInstanceOf[PArray]
+  private var _curValsType: PCanonicalArray = null
+  def getOrComputeCurValsType(valsType: => PType): PCanonicalArray = {
+    if (_curValsType == null) _curValsType = valsType.asInstanceOf[PCanonicalArray]
     _curValsType
   }
-  def curValsType: PArray = {
+  def curValsType: PCanonicalArray = {
     assert(_curValsType != null)
     _curValsType
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -2,10 +2,10 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Region, _}
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, EmitValue, IEmitCode}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, EmitValue, ExecuteContext, IEmitCode, ParentStagedRegion, Stream}
 import is.hail.types.physical.stypes.SCode
 import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable}
-import is.hail.types.physical.stypes.interfaces.SContainer
+import is.hail.types.physical.stypes.interfaces.{SContainer, SStreamCode}
 import is.hail.types.virtual.{TArray, Type}
 import is.hail.utils._
 
@@ -502,6 +502,34 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
     val finish: EmitCodeBuilder => SIndexablePointerCode = _ => new SIndexablePointerCode(SIndexablePointer(this), addr)
     (addElement, finish)
+  }
+
+  def constructFromStream(
+    cb: EmitCodeBuilder,
+    elts: Stream[EmitCode],
+    region: Value[Region],
+    length: Value[Int],
+    deepCopy: Boolean
+  ): SIndexablePointerCode = {
+    val addr = cb.newLocal[Long]("pcarray_construct1_addr", allocate(region, length))
+    cb += stagedInitialize(addr, length, setMissing = false)
+    val i = cb.newLocal[Int]("pcarray_construct1_i", 0)
+
+    val firstElementAddr = firstElementOffset(addr, length)
+
+    elts.forEachI(cb, { et =>
+      et.toI(cb).consume(cb,
+        cb += setElementMissing(addr, i),
+        { sc =>
+          elementType.storeAtAddress(cb, elementOffsetFromFirst(firstElementAddr, i), region, sc, deepCopy = deepCopy)
+        })
+
+      cb.assign(i, i + 1)
+    })
+
+    cb.ifx(length.cne(i), cb._fatal("PCanonicalArray.constructFromStream: wrong stream length: expected ", length.toS, ", found ", i.toS))
+
+    new SIndexablePointerCode(SIndexablePointer(this), addr)
   }
 
   def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = Region.loadAddress(addr)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -311,10 +311,11 @@ class EmitStreamSuite extends HailSuite {
       TypeCheck(s)
       EmitStream.emit(ctx, new Emit(ctx, fb.ecb), s, mb, region, Env.empty, None)
     }
-    mb.emit {
-      val arrayt = stream.map(s => EmitStream.toArray(mb, PCanonicalArray(eltType), s.asStream, region))
-      Code(arrayt.setup, arrayt.m.mux(0L, arrayt.v))
-    }
+    mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
+      stream.toI(cb).consumeCode[Long](cb, 0L, { s =>
+        EmitStream.toArray(cb, PCanonicalArray(eltType), s.asStream, region).tcode[Long]
+      })
+    })
     val f = fb.resultWithIndex()
     (arg: T) => pool.scopedRegion { r =>
       val off = call(f(0, r), r, arg)


### PR DESCRIPTION
Also added a PCanonicalArray constructor that takes a stream of elements.