### PR TITLE
[query] Fix IEmitCode.present

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -212,8 +212,9 @@ object IEmitCode {
 
   def present[A](cb: EmitCodeBuilder, value: => A): IEmitCodeGen[A] = {
     val Lpresent = CodeLabel()
+    val res: A = value
     cb.goto(Lpresent)
-    IEmitCodeGen(CodeLabel(), Lpresent, value)
+    IEmitCodeGen(CodeLabel(), Lpresent, res)
   }
 
   def missing[A](cb: EmitCodeBuilder, defaultValue: A): IEmitCodeGen[A] = {


### PR DESCRIPTION
The existing implementation only worked when evaluating `value` did
not append any code to the code builder.