### PR TITLE
[address] retry with new IP as well

### DIFF
--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -28,7 +28,7 @@ async def test_connect_to_address_on_pod_ip():
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=5),
             headers=service_auth_headers(deploy_config, 'address')) as session:
-        def get():
+        async def get():
             address, port = await deploy_config.address('address')
             session.get(f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
         await retry_transient_errors(get)

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -4,7 +4,7 @@ import aiohttp
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.tls import _get_ssl_config
-from hailtop.utils import request_retry_transient_errors
+from hailtop.utils import retry_transient_errors
 
 
 deploy_config = get_deploy_config()
@@ -28,8 +28,7 @@ async def test_connect_to_address_on_pod_ip():
             raise_for_status=True,
             timeout=aiohttp.ClientTimeout(total=5),
             headers=service_auth_headers(deploy_config, 'address')) as session:
-        address, port = await deploy_config.address('address')
-        await request_retry_transient_errors(
-            session,
-            'GET',
-            f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
+        def get():
+            address, port = await deploy_config.address('address')
+            session.get(f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
+        await retry_transient_errors(get)


### PR DESCRIPTION
The IP address we got from `address` might be the IP of a pod that has been removed. When this happens
we get connection failed errors, which we treat as "transient". This change modifies the test to also
get a new IP address each time a transient error occurs. Not ideal, but more correct than previously.
There are forthcoming changes that I hope will more pervasively address this problem.