### PR TITLE
[k8s] Close k8s client on cleanup

### DIFF
--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -332,6 +332,10 @@ async def on_startup(app):
     app['storage_client'] = aiogoogle.StorageClient()
 
 
+async def on_cleanup(app):
+    await app['storage_client'].close()
+
+
 def run():
     app = web.Application()
 
@@ -345,6 +349,7 @@ def run():
     app.add_routes(routes)
 
     app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
 
     web.run_app(
         deploy_config.prefix_application(app, 'atgu'),

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -831,7 +831,11 @@ async def on_cleanup(app):
                         try:
                             app['gce_event_monitor'].shutdown()
                         finally:
-                            app['task_manager'].shutdown()
+                            try:
+                                app['task_manager'].shutdown()
+                            finally:
+                                del app['k8s_cache'].client
+                                await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
 
 
 def run():

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -114,7 +114,11 @@ async def on_cleanup(app):
         try:
             app['worker_pool'].shutdown()
         finally:
-            app['redis_pool'].close()
+            try:
+                app['redis_pool'].close()
+            finally:
+                del app['k8s_client']
+                await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
 
 
 def run():

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -776,6 +776,11 @@ async def on_startup(app):
     app['dbpool'] = await create_database_pool()
 
 
+async def on_cleanup(app):
+    del app['k8s_client']
+    await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
+
+
 def run():
     sass_compile('notebook')
     root = os.path.dirname(os.path.abspath(__file__))
@@ -796,6 +801,7 @@ def run():
     workshop_app = web.Application()
 
     workshop_app.on_startup.append(on_startup)
+    workshop_app.on_cleanup.append(on_cleanup)
 
     setup_aiohttp_jinja2(workshop_app, 'notebook')
     setup_aiohttp_session(workshop_app)

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -224,6 +224,11 @@ async def on_startup(app):
     app['k8s_client'] = k8s_client
 
 
+def on_cleanup(app):
+    del app['k8s_client']
+    await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
+
+
 def run():
     app = web.Application()
 
@@ -232,6 +237,7 @@ def run():
     app.add_routes(routes)
 
     app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
 
     deploy_config = get_deploy_config()
     web.run_app(

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -224,7 +224,7 @@ async def on_startup(app):
     app['k8s_client'] = k8s_client
 
 
-def on_cleanup(app):
+async def on_cleanup(app):
     del app['k8s_client']
     await asyncio.gather(*(t for t in asyncio.all_tasks() if t is not asyncio.current_task()))
 

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -418,9 +418,11 @@ async def on_startup(app):
 async def on_shutdown(app):
     try:
         await app['asana_client'].close()
-        await app['gh_session'].close()
     finally:
-        app['task_manager'].shutdown()
+        try:
+            await app['gh_session'].close()
+        finally:
+            app['task_manager'].shutdown()
 
 
 def run():

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -401,10 +401,10 @@ async def on_startup(app):
                                 '/secrets/scorecard-github-access-token.txt')
     with open(token_file, 'r') as f:
         token = f.read().strip()
-    session = aiohttp.ClientSession(
+    app['gh_session'] = aiohttp.ClientSession(
         raise_for_status=True,
         timeout=aiohttp.ClientTimeout(total=5))
-    gh_client = gidgethub.aiohttp.GitHubAPI(session, 'scorecard', oauth_token=token)
+    gh_client = gidgethub.aiohttp.GitHubAPI(app['gh_session'], 'scorecard', oauth_token=token)
     app['gh_client'] = gh_client
 
     asana_client = AsanaClient()
@@ -418,6 +418,7 @@ async def on_startup(app):
 async def on_shutdown(app):
     try:
         await app['asana_client'].close()
+        await app['gh_session'].close()
     finally:
         app['task_manager'].shutdown()
 


### PR DESCRIPTION
A follow-up on #9944 to make sure that client sessions used by the k8s client are closed on cleanup across all services that use it, along with a couple other client connections that need to get closed on shutdown.