### PR TITLE
[batch] retry EPIPE

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -316,12 +316,6 @@ def is_transient_error(e):
         # 408 request timeout, 500 internal server error, 502 bad gateway
         # 503 service unavailable, 504 gateway timeout
         return True
-    if (isinstance(e, aiohttp.ClientOSError)
-            and (e.errno == errno.ETIMEDOUT
-                 or e.errno == errno.ECONNREFUSED
-                 or e.errno == errno.EHOSTUNREACH
-                 or e.errno == errno.ECONNRESET)):
-        return True
     if isinstance(e, aiohttp.ServerTimeoutError):
         return True
     if isinstance(e, aiohttp.ServerDisconnectedError):
@@ -335,7 +329,8 @@ def is_transient_error(e):
                             errno.ECONNREFUSED,
                             errno.EHOSTUNREACH,
                             errno.ECONNRESET,
-                            errno.ENETUNREACH
+                            errno.ENETUNREACH,
+                            errno.EPIPE
                             )):
         return True
     if isinstance(e, urllib3.exceptions.ReadTimeoutError):


### PR DESCRIPTION
Ben W. experienced this while trying to submit a large batch. I eliminated ClientOSError because
it is a subtype of OSError.