### PR TITLE
[vep] Rework VEP with more visibility

### DIFF
--- a/hail/python/cluster-tests/cluster-vep-check-GRCh37.py
+++ b/hail/python/cluster-tests/cluster-vep-check-GRCh37.py
@@ -6,7 +6,7 @@ GOLD_STD_CSQ = 'gs://hail-us-vep/vep_examplars/vep_csq_4dc19bc1b.mt/'
 for path, csq in [(GOLD_STD, False), (GOLD_STD_CSQ, True)]:
     print(f"Checking 'hl.vep' replicates on '{path}'")
     expected = hl.read_matrix_table(path)
-    actual = hl.vep(expected.rows().select(), 'gs://hail-us-vep/vep85-loftee-gcloud-testing.json', csq=csq)
+    actual = hl.vep(expected.rows().select(), 'gs://hail-us-vep/vep85-loftee-gcloud-testing.json', csq=csq).drop('vep_proc_id')
     actual._force_count()
     # vep_result_agrees = actual._same(expected)
     # if vep_result_agrees:

--- a/hail/python/cluster-tests/cluster-vep-check-GRCh38.py
+++ b/hail/python/cluster-tests/cluster-vep-check-GRCh38.py
@@ -5,7 +5,7 @@ GNOMAD_CHR22_FIRST_1000 = "gs://hail-us-vep/vep_examplars/gnomad3_chr22_first_10
 for path, csq in [(GNOMAD_CHR22_FIRST_1000, False)]:
     print(f"Checking 'hl.vep' replicates on '{path}'")
     expected = hl.read_matrix_table(path)
-    actual = hl.vep(expected.rows().select(), 'gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json', csq=csq)
+    actual = hl.vep(expected.rows().select(), 'gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json', csq=csq).drop('vep_proc_id')
     actual._force_count()
     # vep_result_agrees = actual._same(expected)
     # if vep_result_agrees:

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -484,7 +484,7 @@ def concordance(left, right, *, _localize_global_statistics=True) -> Tuple[List[
            name=str,
            csq=bool,
            tolerate_parse_error=bool)
-def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='vep', csq=False, tolerate_parse_error=False):
+def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='vep', csq=False, *, tolerate_parse_error=False):
     """Annotate variants with VEP.
 
     .. include:: ../_templates/req_tvariant.rst

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3692,7 +3692,7 @@ class IRSuite extends HailSuite {
   @DataProvider(name = "relationalFunctions")
   def relationalFunctionsData(): Array[Array[Any]] = Array(
     Array(TableFilterPartitions(Array(1, 2, 3), keep = true)),
-    Array(VEP(fs, "src/test/resources/dummy_vep_config.json", false, 1)),
+    Array(VEP(fs, "src/test/resources/dummy_vep_config.json", false, 1, true)),
     Array(WrappedMatrixToTableFunction(LinearRegressionRowsSingle(Array("foo"), "bar", Array("baz"), 1, Array("a", "b")), "foo", "bar", FastIndexedSeq("ck"))),
     Array(LinearRegressionRowsSingle(Array("foo"), "bar", Array("baz"), 1, Array("a", "b"))),
     Array(LinearRegressionRowsChained(FastIndexedSeq(FastIndexedSeq("foo")), "bar", Array("baz"), 1, Array("a", "b"))),


### PR DESCRIPTION
1. Don't ignore parse errors by default. These shouldn't be happening
   with modern VEP versions anyway (they were caused by genes named NaN
   or something in older versions)
2. Don't silently drop variants that don't have a match in VEP. All keys
   coming in will have a row coming out with a VEP annotation (maybe NA)
   and a partition/block index.