### PR TITLE
 [query] Fix up some string functions using old-style registerCode 

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -8,6 +8,9 @@ import is.hail.utils._
 import is.hail.asm4s.coerce
 import is.hail.experimental.ExperimentalFunctions
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.interfaces.{SCall, SLocus, SString}
+import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 import is.hail.variant.Locus
 import org.apache.spark.sql.Row
@@ -264,16 +267,37 @@ abstract class RegistryFunctions {
         r.region, coerce[Long](c))
   }
 
-  def boxedTypeInfo(t: PType): TypeInfo[_ >: Null] = t match {
-    case _: PBoolean => classInfo[java.lang.Boolean]
-    case _: PInt32 => classInfo[java.lang.Integer]
-    case _: PInt64 => classInfo[java.lang.Long]
-    case _: PFloat32 => classInfo[java.lang.Float]
-    case _: PFloat64 => classInfo[java.lang.Double]
-    case _: PCall => classInfo[java.lang.Integer]
-    case t: PString => classInfo[java.lang.String]
-    case t: PLocus => classInfo[Locus]
+  def boxedTypeInfo(t: Type): TypeInfo[_ >: Null] = t match {
+    case TBoolean => classInfo[java.lang.Boolean]
+    case TInt32 => classInfo[java.lang.Integer]
+    case TInt64 => classInfo[java.lang.Long]
+    case TFloat32 => classInfo[java.lang.Float]
+    case TFloat64 => classInfo[java.lang.Double]
+    case TCall => classInfo[java.lang.Integer]
+    case TString => classInfo[java.lang.String]
+    case _: TLocus => classInfo[Locus]
     case _ => classInfo[AnyRef]
+  }
+
+  def scodeToJavaValue(cb: EmitCodeBuilder, r: Value[Region], sc: SCode): Code[AnyRef] = {
+    sc.st match {
+      case _: SInt32 => Code.boxInt(sc.asInt32.intCode(cb))
+      case _: SInt64 => Code.boxLong(sc.asInt64.longCode(cb))
+      case _: SFloat32 => Code.boxFloat(sc.asFloat32.floatCode(cb))
+      case _: SFloat64 => Code.boxDouble(sc.asFloat64.doubleCode(cb))
+      case _: SBoolean => Code.boxBoolean(sc.asBoolean.boolCode(cb))
+      case _: SCall => Code.boxInt(coerce[Int](sc.asPCode.code))
+      case _: SString => sc.asString.loadString()
+      case _: SLocus => sc.asLocus.getLocusObj(cb)
+      case t =>
+        val pt = t.canonicalPType()
+        val addr = pt.store(cb, r, sc, deepCopy = false)
+        Code.invokeScalaObject3[PType, Region, Long, AnyRef](
+          UnsafeRow.getClass, "readAnyRef",
+          cb.emb.getPType(pt),
+          r, addr)
+
+    }
   }
 
   def boxArg(r: EmitRegion, t: PType): Code[_] => Code[AnyRef] = t match {
@@ -561,16 +585,6 @@ abstract class RegistryFunctions {
       a3: (PType, Code[A3]) @unchecked)) => impl(r, rt, a1, a2, a3)
     }
 
-  def registerCode4[A1, A2, A3, A4](name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type, pt: (Type, PType, PType, PType, PType) => PType)
-    (impl: (EmitRegion, PType, (PType, Code[A1]), (PType, Code[A2]), (PType, Code[A3]), (PType, Code[A4])) => Code[_]): Unit =
-    registerCode(name, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt)) {
-      case (r, cb, rt, _, Array(
-      a1: (PType, Code[A1]) @unchecked,
-      a2: (PType, Code[A2]) @unchecked,
-      a3: (PType, Code[A3]) @unchecked,
-      a4: (PType, Code[A4]) @unchecked)) => impl(r, rt, a1, a2, a3, a4)
-    }
-
   def registerCode4t[A1, A2, A3, A4](name: String, typeParam1: Type, arg1: Type, arg2: Type, arg3: Type, arg4: Type, rt: Type, pt: (Type, PType, PType, PType, PType) => PType)
     (impl: (EmitRegion, PType, Type, (PType, Code[A1]), (PType, Code[A2]), (PType, Code[A3]), (PType, Code[A4])) => Code[_]): Unit =
     registerCode(name, Array(arg1, arg2, arg3, arg4), rt, unwrappedApply(pt), Array(typeParam1)) {
@@ -579,17 +593,6 @@ abstract class RegistryFunctions {
       a2: (PType, Code[A2]) @unchecked,
       a3: (PType, Code[A3]) @unchecked,
       a4: (PType, Code[A4]) @unchecked)) => impl(r, rt, t1, a1, a2, a3, a4)
-    }
-
-  def registerCode5[A1, A2, A3, A4, A5](name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, rt: Type, pt: (Type, PType, PType, PType, PType, PType) => PType)
-    (impl: (EmitRegion, PType, (PType, Code[A1]), (PType, Code[A2]), (PType, Code[A3]), (PType, Code[A4]), (PType, Code[A5])) => Code[_]): Unit =
-    registerCode(name, Array(mt1, mt2, mt3, mt4, mt5), rt, unwrappedApply(pt)) {
-      case (r, cb, rt, _, Array(
-      a1: (PType, Code[A1]) @unchecked,
-      a2: (PType, Code[A2]) @unchecked,
-      a3: (PType, Code[A3]) @unchecked,
-      a4: (PType, Code[A4]) @unchecked,
-      a5: (PType, Code[A5]) @unchecked)) => impl(r, rt, a1, a2, a3, a4, a5)
     }
 
   def registerIEmitCode1(name: String, mt1: Type, rt: Type, pt: (Type, PType) => PType)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -8,6 +8,8 @@ import is.hail.types.physical.{PCode, PType}
 import is.hail.types.virtual.Type
 
 trait SType {
+  def virtualType: Type = pType.virtualType
+
   def pType: PType
 
   def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode
@@ -21,4 +23,6 @@ trait SType {
   def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable
 
   def fromCodes(codes: IndexedSeq[Code[_]]): SCode
+
+  def canonicalPType(): PType
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -36,6 +36,8 @@ case class SBaseStructPointer(pType: PBaseStruct) extends SStruct {
     assert(a.ti == LongInfo)
     new SBaseStructPointerCode(this, a)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -36,6 +36,8 @@ case class SBinaryPointer(pType: PBinary) extends SBinary {
     assert(a.ti == LongInfo)
     new SBinaryPointerCode(this, a)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 object SBinaryPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -42,6 +42,8 @@ case class SCanonicalCall(required: Boolean) extends SCall {
     assert(call.ti == IntInfo)
     new SCanonicalCallCode(required, call)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 object SCanonicalCallSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -39,6 +39,8 @@ case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
     assert(a.ti == LongInfo)
     new SCanonicalLocusPointerCode(this, a)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
@@ -36,6 +36,8 @@ case class SCanonicalShufflePointer(pType: PCanonicalShuffle) extends SShuffle {
   def fromCodes(codes: IndexedSeq[Code[_]]): SCanonicalShufflePointerCode = {
     new SCanonicalShufflePointerCode(this, binarySType.fromCodes(codes))
   }
+
+  def canonicalPType(): PType = pType
 }
 
 object SCanonicalShufflePointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -38,6 +38,8 @@ case class SIndexablePointer(pType: PContainer) extends SContainer {
     assert(a.ti == LongInfo)
     new SIndexablePointerCode(this, a)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -40,6 +40,9 @@ case class SIntervalPointer(pType: PInterval) extends SInterval {
     assert(a.ti == LongInfo)
     new SIntervalPointerCode(this, a)
   }
+
+
+  def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -38,6 +38,8 @@ case class SNDArrayPointer(pType: PCanonicalNDArray) extends SNDArray {
     assert(a.ti == LongInfo)
     new SNDArrayPointerCode(this, a)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 object SNDArrayPointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s.{Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.stypes.interfaces.SString
+import is.hail.types.physical.stypes.interfaces.{SString, SStringCode}
 import is.hail.types.physical.stypes.{SCode, SType}
 import is.hail.types.physical.{PBinaryCode, PCanonicalString, PCode, PSettable, PString, PStringCode, PStringValue, PType, PValue}
 import is.hail.utils.FastIndexedSeq
@@ -36,6 +36,12 @@ case class SStringPointer(pType: PString) extends SString {
     assert(a.ti == LongInfo)
     new SStringPointerCode(this, a)
   }
+
+  def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringPointerCode = {
+    new SStringPointerCode(this, pType.allocateAndStoreString(cb.emb, r, s))
+  }
+
+  override def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -38,6 +38,8 @@ case class SSubsetStruct(parent: SStruct, fieldNames: IndexedSeq[String]) extend
   def fromCodes(codes: IndexedSeq[Code[_]]): SSubsetStructCode = {
     new SSubsetStructCode(this, parent.fromCodes(codes).asInstanceOf[PBaseStructCode])
   }
+
+  def canonicalPType(): PType = pType
 }
 
 // FIXME: prev should be SStructSettable, not PStructSettable

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -26,6 +26,8 @@ case class SStream(elementType: SType, separateRegions: Boolean = false) extends
   def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new UnsupportedOperationException
 
   def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new UnsupportedOperationException
+
+  def canonicalPType(): PType = pType
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
@@ -1,9 +1,13 @@
 package is.hail.types.physical.stypes.interfaces
 
-import is.hail.asm4s.Code
+import is.hail.annotations.Region
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 
-trait SString extends SType
+trait SString extends SType {
+  def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringCode
+}
 
 trait SStringValue extends SValue
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -21,6 +21,8 @@ case object SVoid extends SType {
   def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new UnsupportedOperationException
 
   def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new UnsupportedOperationException
+
+  def canonicalPType(): PType = pType
 }
 
 case object PVoidCode extends PCode with PUnrealizableCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/package.scala
@@ -1,7 +1,7 @@
 package is.hail.types.physical.stypes
 
 import is.hail.asm4s.Code
-import is.hail.types.physical.stypes.primitives.{SFloat32Code, SFloat64Code, SInt32Code, SInt64Code}
+import is.hail.types.physical.stypes.primitives.{SBooleanCode, SFloat32Code, SFloat64Code, SInt32Code, SInt64Code}
 
 package object interfaces {
 
@@ -9,4 +9,5 @@ package object interfaces {
   def primitive(x: Code[Int]): SInt32Code = new SInt32Code(true, x)
   def primitive(x: Code[Double]): SFloat64Code = new SFloat64Code(true, x)
   def primitive(x: Code[Float]): SFloat32Code = new SFloat32Code(true, x)
+  def primitive(x: Code[Boolean]): SBooleanCode = new SBooleanCode(true, x)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -40,6 +40,8 @@ case class SBoolean(required: Boolean) extends SType {
     assert(x.ti == BooleanInfo)
     new SBooleanCode(required, x)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 class SBooleanCode(required: Boolean, val code: Code[Boolean]) extends PCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -42,6 +42,8 @@ case class SFloat32(required: Boolean) extends SType {
     assert(x.ti == FloatInfo)
     new SFloat32Code(required, x)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 trait PFloat32Value extends PValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -42,6 +42,8 @@ case class SFloat64(required: Boolean) extends SType {
     assert(x.ti == DoubleInfo)
     new SFloat64Code(required, x)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 trait PFloat64Value extends PValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -42,6 +42,8 @@ case class SInt32(required: Boolean) extends SType {
     assert(x.ti == IntInfo)
     new SInt32Code(required, x)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 trait PInt32Value extends PValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -42,6 +42,8 @@ case class SInt64(required: Boolean) extends SType {
     assert(x.ti == LongInfo)
     new SInt64Code(required, x)
   }
+
+  def canonicalPType(): PType = pType
 }
 
 trait PInt64Value extends PValue {


### PR DESCRIPTION
Stacked on #9977 