### PR TITLE
[batch] eliminate expected exceptional log statement

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -148,7 +148,6 @@ async def create_container(config, name):
         try:
             return await docker.containers.create(config, name=name)
         except DockerError as e:
-            log.exception('while creating container')
             # 409 container with name already exists
             if e.status == 409:
                 try:


### PR DESCRIPTION
If there is a true issue, we raise the exception which is caught and printed by
docker_call_retry, or, if that re-raises, it is stored as an error and serialized
back to the driver in Container.run