### PR TITLE
[query] Rework PCArray.constructFromFunctions to track index internally

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -171,11 +171,9 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
 
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     assert(pt == resultType)
-    val (storeElement, finish) = arrayRep.constructFromFunctions(cb, region, state.size, deepCopy = true)
-    val idx = cb.newLocal[Int]("collect_as_set_result_i", 0)
+    val (pushElement, finish) = arrayRep.constructFromFunctions(cb, region, state.size, deepCopy = true)
     state.foreach(cb) { (cb, elt) =>
-      storeElement(cb, idx, elt.toI(cb))
-      cb.assign(idx, idx + 1)
+      pushElement(cb, elt.toI(cb))
     }
     // deepCopy is handled by `storeElement` above
     resultType.storeAtAddress(cb, addr, region, finish(cb), deepCopy = false)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -526,13 +526,11 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
 
     val eltType = resType.elementType.asInstanceOf[PCanonicalBaseStruct]
 
-    val (storeElement, finish) = resType.constructFromFunctions(cb, region, treeSize, deepCopy = true)
-    val idx = cb.newLocal[Int]("downsample_result_idx", 0)
+    val (pushElement, finish) = resType.constructFromFunctions(cb, region, treeSize, deepCopy = true)
     cb.ifx(treeSize > 0, {
       tree.foreach(cb) { (cb, tv) =>
         val pointCode = pointType.loadCheapPCode(cb, key.storageType.loadField(tv, "point"))
-        storeElement(cb, idx, IEmitCode.present(cb, pointCode))
-        cb.assign(idx, idx + 1)
+        pushElement(cb, IEmitCode.present(cb, pointCode))
       }
     })
     finish(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -191,11 +191,9 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
   }
 
   def resultArray(cb: EmitCodeBuilder, region: Value[Region], resType: PCanonicalArray): SIndexablePointerCode = {
-    val (storeElement, finish) = resType.constructFromFunctions(cb, region, totalCount, deepCopy = true)
-    val idx = cb.newLocal[Int]("sbll_resultarray_i", 0)
+    val (pushElement, finish) = resType.constructFromFunctions(cb, region, totalCount, deepCopy = true)
     foreach(cb) { (cb, elt) =>
-      storeElement(cb, idx, elt.toI(cb))
-      cb.assign(idx, idx + 1)
+      pushElement(cb, elt.toI(cb))
     }
     finish(cb)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -254,12 +254,11 @@ object LocusFunctions extends RegistryFunctions {
 
         def addIdxWithCondition(cb: EmitCodeBuilder)(cond: (EmitCodeBuilder, Value[Int], Value[Int], SIndexableValue) => Code[Boolean]): IEmitCode = {
 
-          val (addElement, finish) = arrayType.constructFromFunctions(cb, r.region, totalLen, deepCopy = false)
+          val (pushElement, finish) = arrayType.constructFromFunctions(cb, r.region, totalLen, deepCopy = false)
           val offset = cb.newLocal[Int]("locuswindows_offset", 0)
 
           val lastCoord = cb.newLocal[Double]("locuswindows_coord")
 
-          val arrayIndex = cb.newLocal[Int]("locuswindows_arrayidx", 0)
           forAllContigs(cb) { case (cb, contigIdx, coords) =>
             val i = cb.newLocal[Int]("locuswindows_i", 0)
             val idx = cb.newLocal[Int]("locuswindows_idx", 0)
@@ -297,16 +296,12 @@ object LocusFunctions extends RegistryFunctions {
               )
               cb.define(Lbreak)
 
-              addElement(cb, arrayIndex, IEmitCode.present(cb, PCode(arrayType.elementType, offset + idx)))
-              cb.assign(arrayIndex, arrayIndex + 1)
+              pushElement(cb, IEmitCode.present(cb, PCode(arrayType.elementType, offset + idx)))
 
               cb.assign(i, i + 1)
             })
             cb.assign(offset, offset + len)
           }
-
-          cb.ifx(arrayIndex.cne(totalLen),
-            cb._fatal("locuswindows: expected arrayIndex == totalLen, got arrayIndex=", arrayIndex.toS, ", totalLen=", totalLen.toS))
           IEmitCode.present(cb, finish(cb))
         }
 

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -296,14 +296,12 @@ object CompileDecoder {
       if (settings.hasField("alleles")) {
         val allelesType = settings.rowPType.field("alleles").typ.asInstanceOf[PCanonicalArray]
         val alleleStringType = allelesType.elementType.asInstanceOf[PCanonicalString]
-        val (addElement, finish) = allelesType.constructFromFunctions(cb, region, nAlleles, deepCopy = false)
+        val (pushElement, finish) = allelesType.constructFromFunctions(cb, region, nAlleles, deepCopy = false)
 
-        cb.assign(i, 0)
         cb.whileLoop(i < nAlleles, {
           val st = SStringPointer(alleleStringType)
           val strCode = st.constructFromString(cb, region, cbfis.invoke[Int, String]("readLengthAndString", 4))
-          addElement(cb, i, IEmitCode.present(cb, strCode))
-          cb.assign(i, i + 1)
+          pushElement(cb, IEmitCode.present(cb, strCode))
         })
 
         val allelesArr = finish(cb)
@@ -399,10 +397,10 @@ object CompileDecoder {
 
                     val gpType = entryType.field("GP").typ.asInstanceOf[PCanonicalArray]
 
-                    val (addElem, finish) = gpType.constructFromFunctions(cb, partRegion, 3, deepCopy = false)
-                    addElem(cb, 0, IEmitCode.present(cb, primitive(d0.toD / divisor)))
-                    addElem(cb, 1, IEmitCode.present(cb, primitive(d1.toD / divisor)))
-                    addElem(cb, 2, IEmitCode.present(cb, primitive(d2.toD / divisor)))
+                    val (pushElement, finish) = gpType.constructFromFunctions(cb, partRegion, 3, deepCopy = false)
+                    pushElement(cb, IEmitCode.present(cb, primitive(d0.toD / divisor)))
+                    pushElement(cb, IEmitCode.present(cb, primitive(d1.toD / divisor)))
+                    pushElement(cb, IEmitCode.present(cb, primitive(d2.toD / divisor)))
 
                     IEmitCode.present(cb, finish(cb))
                   }
@@ -422,7 +420,6 @@ object CompileDecoder {
             })
 
             cb.assign(memoizedEntryData, finish(cb).a)
-            //            cb.println(s"done building memoizedEntryData: ", memoizedEntryData.hexString)
             cb.assign(alreadyMemoized, true)
 
             cb.define(LnoOp)
@@ -508,7 +505,7 @@ object CompileDecoder {
 
           cb.invokeVoid(memoMB)
 
-          val (addElement, finish) = entriesArrayType.constructFromFunctions(cb, region, settings.nSamples, deepCopy = false)
+          val (pushElement, finish) = entriesArrayType.constructFromFunctions(cb, region, settings.nSamples, deepCopy = false)
 
           cb.assign(i, 0)
           cb.whileLoop(i < settings.nSamples, {
@@ -520,11 +517,10 @@ object CompileDecoder {
             val dataOffset = cb.newLocal[Int]("bgen_add_entries_offset", const(settings.nSamples + 10) + i * 2)
             val d0 = data(dataOffset) & 0xff
             val d1 = data(dataOffset + 1) & 0xff
-            //            cb.println(s"trying to copy entry from ", memoTyp.loadElement(memoizedEntryData, settings.nSamples, ((data(dataOffset) & 0xff) << 8) | (data(dataOffset + 1) & 0xff)).hexString)
             val pc = entryType.loadCheapPCode(cb, memoTyp.loadElement(memoizedEntryData, settings.nSamples, (d0 << 8) | d1))
             cb.goto(Lpresent)
             val iec = IEmitCode(Lmissing, Lpresent, pc)
-            addElement(cb, i, iec)
+            pushElement(cb, iec)
 
             cb.assign(i, i + 1)
           })

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -302,6 +302,7 @@ object CompileDecoder {
           val st = SStringPointer(alleleStringType)
           val strCode = st.constructFromString(cb, region, cbfis.invoke[Int, String]("readLengthAndString", 4))
           pushElement(cb, IEmitCode.present(cb, strCode))
+          cb.assign(i, i + 1)
         })
 
         val allelesArr = finish(cb)

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -36,11 +36,9 @@ object LinalgCodeUtils {
     val dataLength = cb.newLocal[Int]("nda_create_column_major_len", pt.numElements(shape).toI)
     val dataType = pt.dataType
 
-    val (addElem, finish) = dataType.constructFromFunctions(cb, region, dataLength, deepCopy = false)
-    val idx = cb.newLocal[Int]("nda_create_column_major_idx", 0)
+    val (pushElement, finish) = dataType.constructFromFunctions(cb, region, dataLength, deepCopy = false)
     SNDArray.forEachIndex(cb, shape, "nda_create_column_major") { case (cb, idxVars) =>
-      addElem(cb, idx, IEmitCode.present(cb, pndv.loadElement(idxVars, cb).asPCode))
-      cb.assign(idx, idx + 1)
+      pushElement(cb, IEmitCode.present(cb, pndv.loadElement(idxVars, cb).asPCode))
     }
     val newData = finish(cb)
     pndv.pt.construct(shape, strides, newData.a, cb, region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -495,25 +495,30 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     (nextAddr, setMissing, finish)
   }
 
-  // unsafe StagedArrayBuilder-like interface that gives caller control over adding elements and finishing
+  // unsafe StagedArrayBuilder-like interface that gives caller control over pushing elements and finishing
   def constructFromFunctions(cb: EmitCodeBuilder, region: Value[Region], length: Value[Int], deepCopy: Boolean):
-  (((EmitCodeBuilder, Value[Int], IEmitCode) => Unit, (EmitCodeBuilder => SIndexablePointerCode))) = {
+  (((EmitCodeBuilder, IEmitCode) => Unit, (EmitCodeBuilder => SIndexablePointerCode))) = {
 
     val addr = cb.newLocal[Long]("pcarray_construct2_addr", allocate(region, length))
     cb += stagedInitialize(addr, length, setMissing = false)
-    val i = cb.newLocal[Int]("pcarray_construct2_i", 0)
+    val currentElementIndex = cb.newLocal[Int]("pcarray_construct2_current_idx", 0)
+    val currentElementAddress = cb.newLocal[Long]("pcarray_construct2_current_addr", firstElementOffset(addr, length))
 
-    val firstElementAddr = cb.newLocal[Long]("pcarray_construct2_firstelementaddr", firstElementOffset(addr, length))
-
-    val addElement: (EmitCodeBuilder, Value[Int], IEmitCode) => Unit = { case (cb, i, iec) =>
+    val push: (EmitCodeBuilder, IEmitCode) => Unit = { case (cb, iec) =>
       iec.consume(cb,
-        cb += setElementMissing(addr, i),
+        cb += setElementMissing(addr, currentElementIndex),
         { sc =>
-          elementType.storeAtAddress(cb, elementOffsetFromFirst(firstElementAddr, i), region, sc, deepCopy = deepCopy)
+          elementType.storeAtAddress(cb, currentElementAddress, region, sc, deepCopy = deepCopy)
         })
+        cb.assign(currentElementIndex, currentElementIndex + 1)
+        cb.assign(currentElementAddress, currentElementAddress + elementByteSize)
     }
-    val finish: EmitCodeBuilder => SIndexablePointerCode = _ => new SIndexablePointerCode(SIndexablePointer(this), addr)
-    (addElement, finish)
+    val finish: EmitCodeBuilder => SIndexablePointerCode = { (cb: EmitCodeBuilder) =>
+      cb.ifx(currentElementIndex.cne(length), cb._fatal("PCanonicalArray.constructFromFunctions push was called the wrong number of times: len=",
+        length.toS, ", calls=", currentElementIndex.toS))
+      new SIndexablePointerCode(SIndexablePointer(this), addr)
+    }
+    (push, finish)
   }
 
   def constructFromStream(


### PR DESCRIPTION
Simpler and more ergonomic!