### PR TITLE
[batch] fix billing projects tests

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -41,11 +41,11 @@ async def delete_all_test_billing_projects():
     bc = BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
     try:
         for project in await bc.list_billing_projects():
-            if project.startswith(billing_project_prefix):
+            if project['name'].startswith(billing_project_prefix):
                 try:
-                    await bc.close_billing_project(project)
+                    await bc.close_billing_project(project['name'])
                 finally:
-                    await bc.delete_billing_project(project)
+                    await bc.delete_billing_project(project['name'])
     finally:
         await bc.close()
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -41,11 +41,11 @@ async def delete_all_test_billing_projects():
     bc = BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
     try:
         for project in await bc.list_billing_projects():
-            if project['name'].startswith(billing_project_prefix):
+            if project['billing_project'].startswith(billing_project_prefix):
                 try:
-                    await bc.close_billing_project(project['name'])
+                    await bc.close_billing_project(project['billing_project'])
                 finally:
-                    await bc.delete_billing_project(project['name'])
+                    await bc.delete_billing_project(project['billing_project'])
     finally:
         await bc.close()
 

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -32,12 +32,12 @@ async def dev_client():
     await bc.close()
 
 
-@pytest.fixture
-def billing_project_prefix():
+def get_billing_project_prefix():
     return f'__testproject_{os.environ["HAIL_TOKEN"]}'
 
 
-async def delete_all_test_billing_projects(billing_project_prefix):
+async def delete_all_test_billing_projects():
+    billing_project_prefix = get_billing_project_prefix()
     bc = BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
     try:
         for project in await bc.list_billing_projects():
@@ -51,7 +51,8 @@ async def delete_all_test_billing_projects(billing_project_prefix):
 
 
 @pytest.fixture(scope='module')
-def get_billing_project_name(billing_project_prefix):
+def get_billing_project_name():
+    billing_project_prefix = get_billing_project_prefix()
     attempt_prefix = f'{billing_project_prefix}_{secret_alnum_string(5)}'
     projects = []
     def get_name():

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -32,23 +32,26 @@ async def dev_client():
     await bc.close()
 
 
-billing_project_prefix = f'__testproject_{os.environ["HAIL_TOKEN"]}'
+@pytest.fixture
+def billing_project_prefix():
+    return f'__testproject_{os.environ["HAIL_TOKEN"]}'
 
-async def delete_all_test_billing_projects():
+
+async def delete_all_test_billing_projects(billing_project_prefix):
     bc = BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
     try:
-        for project in bc.list_billing_projects():
+        for project in await bc.list_billing_projects():
             if project.startswith(billing_project_prefix):
                 try:
-                    bc.close_billing_project(project)
+                    await bc.close_billing_project(project)
                 finally:
-                    bc.delete_billing_project(project)
+                    await bc.delete_billing_project(project)
     finally:
         await bc.close()
 
 
 @pytest.fixture(scope='module')
-def get_billing_project_name():
+def get_billing_project_name(billing_project_prefix):
     attempt_prefix = f'{billing_project_prefix}_{secret_alnum_string(5)}'
     projects = []
     def get_name():

--- a/build.yaml
+++ b/build.yaml
@@ -2609,7 +2609,8 @@ steps:
     - curl_image
  - kind: runImage
    name: delete_test_billing_projects
-   image: batch_image.image
+   image:
+     valueFrom: batch_image.image
    script: |
      export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
      export HAIL_TOKEN="{{ token }}"
@@ -2634,6 +2635,7 @@ steps:
       namespace:
         valueFrom: default_ns.name
       mountPath: /ssl-config
+   alwaysRun: true
    dependsOn:
     - create_deploy_config
     - create_accounts

--- a/build.yaml
+++ b/build.yaml
@@ -2618,7 +2618,7 @@ steps:
      python3 -c '
      import test_accounts
      import asyncio
-     asyncio.get_event_loop().run_until_complete(test_accounts.delete_test_billing_projects())'
+     asyncio.get_event_loop().run_until_complete(test_accounts.delete_all_test_billing_projects())'
    inputs:
     - from: /repo/batch/test
       to: /io/

--- a/build.yaml
+++ b/build.yaml
@@ -2608,6 +2608,45 @@ steps:
     - netcat_ubuntu_image
     - curl_image
  - kind: runImage
+   name: delete_test_billing_projects
+   image: batch_image.image
+   script: |
+     export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
+     export HAIL_TOKEN="{{ token }}"
+     cd /io/test
+     python3 -c '
+import test_accounts
+import asyncio
+asyncio.get_event_loop().run_until_complete(test_accounts.delete_test_billing_projects())'
+   inputs:
+    - from: /repo/batch/test
+      to: /io/
+   secrets:
+    - name: gce-deploy-config
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /deploy-config
+    - name: test-dev-tokens
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /dev-tokens
+    - name: ssl-config-batch-tests
+      namespace:
+        valueFrom: default_ns.name
+      mountPath: /ssl-config
+   dependsOn:
+    - create_deploy_config
+    - create_accounts
+    - default_ns
+    - copy_files
+    - batch_image
+    - deploy_batch
+    - test_batch_0
+    - test_batch_1
+    - test_batch_2
+    - test_batch_3
+    - test_batch_4
+ - kind: runImage
    name: create_ci_test_repo
    image:
      valueFrom: base_image.image

--- a/build.yaml
+++ b/build.yaml
@@ -2615,9 +2615,9 @@ steps:
      export HAIL_TOKEN="{{ token }}"
      cd /io/test
      python3 -c '
-import test_accounts
-import asyncio
-asyncio.get_event_loop().run_until_complete(test_accounts.delete_test_billing_projects())'
+     import test_accounts
+     import asyncio
+     asyncio.get_event_loop().run_until_complete(test_accounts.delete_test_billing_projects())'
    inputs:
     - from: /repo/batch/test
       to: /io/


### PR DESCRIPTION
These billing projects tests did not correctly handle multiple attempts. Instead,
we use one billing project prefix for the entire batch (based on the token) and
each attempt gets a unique prefix. After all batch tests are complete, a job runs
which deletes all billing projects for the current batch.