### PR TITLE
[pip] fix conflicting pip requirements between query and services

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -16,7 +16,7 @@ flake8==3.8.3
 Flask-Cors==3.0.8
 Flask-Sockets==0.2.1
 Flask==1.0.3
-gcsfs==0.2.1
+gcsfs==0.2.2
 gidgethub==4.1.0
 google-api-python-client==1.7.10
 google-cloud-logging==1.12.1


### PR DESCRIPTION
Matches up the `gcsfs` version between services and hail query. Right now services developers have to pip install the `docker/requirements.txt` to run stuff like `sync.py` or resolve imports in editor. Might not be ideal but this at least allows you to pip install all the different requirements together for now.