### PR TITLE
[query] Use `loadFromNested` rather than matching on fundamental type

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -124,7 +124,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
     cb.assign(arrayAddr,
       arrayStorageType.store(cb,
         region,
-        arrayStorageType.loadCheapPCode(cb, arrayStorageType.loadFromNested(cb, srcCode)),
+        arrayStorageType.loadCheapPCode(cb, arrayStorageType.loadFromNested(srcCode)),
         deepCopy = true))
     cb.assign(length, arrayStorageType.loadLength(arrayAddr))
   }

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -155,7 +155,7 @@ trait PArrayBackedContainer extends PContainer {
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit =
     arrayRep.storeAtAddress(cb, addr, region, value, deepCopy)
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = arrayRep.loadFromNested(cb, addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = arrayRep.loadFromNested(addr)
 
   def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeAddress(addr, unstagedStoreJavaObject(annotation, region))

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -157,6 +157,8 @@ trait PArrayBackedContainer extends PContainer {
 
   def loadFromNested(addr: Code[Long]): Code[Long] = arrayRep.loadFromNested(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = arrayRep.unstagedLoadFromNested(addr)
+
   def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeAddress(addr, unstagedStoreJavaObject(annotation, region))
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -336,14 +336,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       cb.ifx(isElementDefined(dstAddress, currentIdx),
         {
           cb.assign(currentElementAddress, elementOffset(dstAddress, len, currentIdx))
-          this.elementType.fundamentalType match {
-            // FIXME this logic needs to go before we can create new ptypes
-            case t@(_: PBinary | _: PArray) =>
-              t.storeAtAddress(cb, currentElementAddress, region, t.loadCheapPCode(cb, Region.loadAddress(currentElementAddress)), deepCopy = true)
-            case t: PCanonicalBaseStruct =>
-              t.deepPointerCopy(cb, region, currentElementAddress)
-            case t: PType => throw new RuntimeException(s"Type isn't supported ${ t }")
-          }
+          this.elementType.storeAtAddress(cb, currentElementAddress, region, this.elementType.loadCheapPCode(cb, this.elementType.loadFromNested(currentElementAddress)), true)
         }))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -171,20 +171,14 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def loadElement(aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
-    elementType.fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(off)
-      case _ => off
-    }
+    elementType.unstagedLoadFromNested(off)
   }
 
   def loadElement(aoff: Long, i: Int): Long = loadElement(aoff, loadLength(aoff), i)
 
   def loadElement(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = {
     val off = elementOffset(aoff, length, i)
-    elementType.fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(off)
-      case _ => off
-    }
+    elementType.loadFromNested(off)
   }
 
   def loadElement(aoff: Code[Long], i: Code[Int]): Code[Long] =

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -532,7 +532,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     new SIndexablePointerCode(SIndexablePointer(this), addr)
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     val is = annotation.asInstanceOf[IndexedSeq[Annotation]]

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -350,13 +350,8 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     while(currentIdx < numberOfElements) {
       if(this.isElementDefined(dstAddress, currentIdx)) {
         val currentElementAddress = this.elementOffset(dstAddress, numberOfElements, currentIdx)
-        this.elementType.fundamentalType match {
-          case t@(_: PBinary | _: PArray) =>
-            Region.storeAddress(currentElementAddress, t.copyFromAddress(region, t, Region.loadAddress(currentElementAddress), deepCopy = true))
-          case t: PCanonicalBaseStruct =>
-            t.deepPointerCopy(region, currentElementAddress)
-          case t: PType => fatal(s"Type isn't supported ${t}")
-        }
+        val currentElementAddressFromNested = this.elementType.unstagedLoadFromNested(currentElementAddress)
+        this.elementType.unstagedStoreAtAddress(currentElementAddress, region, this.elementType, currentElementAddressFromNested, true)
       }
 
       currentIdx += 1

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -534,6 +534,8 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = Region.loadAddress(addr)
+
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     val is = annotation.asInstanceOf[IndexedSeq[Annotation]]
     val valueAddress = allocate(region, is.length)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -114,15 +114,11 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
   def deepPointerCopy(region: Region, dstStructAddress: Long) {
     var i = 0
     while (i < this.size) {
-      val dstFieldType = this.fields(i).typ.fundamentalType
+      val dstFieldType = this.fields(i).typ
       if (dstFieldType.containsPointers && this.isFieldDefined(dstStructAddress, i)) {
         val dstFieldAddress = this.fieldOffset(dstStructAddress, i)
-        dstFieldType match {
-          case t@(_: PBinary | _: PArray) =>
-            Region.storeAddress(dstFieldAddress, t.copyFromAddress(region, dstFieldType, Region.loadAddress(dstFieldAddress), deepCopy = true))
-          case t: PCanonicalBaseStruct =>
-            t.deepPointerCopy(region, dstFieldAddress)
-        }
+        val dstFieldAddressFromNested = dstFieldType.unstagedLoadFromNested(dstFieldAddress)
+        dstFieldType.unstagedStoreAtAddress(dstFieldAddress, region, dstFieldType, dstFieldAddressFromNested, true)
       }
       i += 1
     }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -271,5 +271,5 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
 
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = addr
+  def loadFromNested(addr: Code[Long]): Code[Long] = addr
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -87,20 +87,14 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
 
   def loadField(offset: Long, fieldIdx: Int): Long = {
     val off = fieldOffset(offset, fieldIdx)
-    types(fieldIdx).fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(off)
-      case _ => off
-    }
+    types(fieldIdx).fundamentalType.unstagedLoadFromNested(off)
   }
 
   def loadField(offset: Code[Long], fieldIdx: Int): Code[Long] =
     loadField(fieldOffset(offset, fieldIdx), types(fieldIdx))
 
   private def loadField(fieldOffset: Code[Long], fieldType: PType): Code[Long] = {
-    fieldType.fundamentalType match {
-      case _: PArray | _: PBinary => Region.loadAddress(fieldOffset)
-      case _ => fieldOffset
-    }
+    fieldType.fundamentalType.loadFromNested(fieldOffset)
   }
 
   def deepPointerCopy(cb: EmitCodeBuilder, region: Value[Region], dstStructAddress: Code[Long]): Unit = {
@@ -272,4 +266,6 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = addr
+
+  override def unstagedLoadFromNested(addr: Long): Long = addr
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -163,6 +163,8 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 
   def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = Region.loadAddress(addr)
+
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeAddress(addr, unstagedStoreJavaObject(annotation, region))
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -161,7 +161,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 
   override val encodableType = this
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = Region.loadAddress(addr)
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeAddress(addr, unstagedStoreJavaObject(annotation, region))

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -64,6 +64,8 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
+
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     representation.unstagedStoreJavaObject(annotation, region)
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -62,7 +62,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
     cb += Region.storeInt(addr, value.asInstanceOf[SCanonicalCallCode].call)
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = representation.loadFromNested(cb, addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     representation.unstagedStoreJavaObject(annotation, region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -102,7 +102,7 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
     }
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = representation.loadFromNested(cb, addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     val jInterval = annotation.asInstanceOf[Interval]

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -104,6 +104,8 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
+
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     val jInterval = annotation.asInstanceOf[Interval]
     representation.unstagedStoreJavaObjectAtAddress(

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -117,6 +117,8 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
+  override def unstagedLoadFromNested(addr: Long): Long = addr
+
   def unstagedStoreLocus(addr: Long, contig: String, position: Int, region: Region): Unit = {
     contigType.unstagedStoreJavaObjectAtAddress(representation.fieldOffset(addr, 0), contig, region)
     positionType.unstagedStoreJavaObjectAtAddress(representation.fieldOffset(addr, 1), position, region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -115,7 +115,7 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
     }
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = addr
+  def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   def unstagedStoreLocus(addr: Long, contig: String, position: Int, region: Region): Unit = {
     contigType.unstagedStoreJavaObjectAtAddress(representation.fieldOffset(addr, 0), contig, region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -218,6 +218,8 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
+  override def unstagedLoadFromNested(addr: Long): Long = addr
+
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     val addr = this.representation.allocate(region)
     unstagedStoreJavaObjectAtAddress(addr, annotation, region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -144,12 +144,12 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def loadElement(cb: EmitCodeBuilder, indices: IndexedSeq[Value[Long]], ndAddress: Value[Long]): SCode = {
     val off = getElementAddress(cb, indices, ndAddress)
-    elementType.loadCheapPCode(cb, elementType.loadFromNested(cb, off))
+    elementType.loadCheapPCode(cb, elementType.loadFromNested(off))
   }
 
   def loadElementFromDataAndStrides(cb: EmitCodeBuilder, indices: IndexedSeq[Value[Long]], ndDataAddress: Value[Long], strides: IndexedSeq[Value[Long]]): Code[Long] = {
     val off = getElementAddressFromDataPointerAndStrides(indices, ndDataAddress, strides, cb)
-    elementType.loadFromNested(cb, off)
+    elementType.loadFromNested(off)
   }
 
   def construct(
@@ -216,7 +216,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   override def dataPArrayPointer(ndAddr: Code[Long]): Code[Long] = representation.loadField(ndAddr, "data")
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = addr
+  def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     val addr = this.representation.allocate(region)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -88,6 +88,6 @@ final case class PCanonicalShuffle(
 
   def allocate(region: Code[Region], length: Code[Int]): Code[Long] = representation.allocate(region, length)
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = representation.loadFromNested(cb, addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -89,5 +89,7 @@ final case class PCanonicalShuffle(
   def allocate(region: Code[Region], length: Code[Int]): Code[Long] = representation.allocate(region, length)
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)
+
+  def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -37,4 +37,6 @@ final case class PCanonicalStream(elementType: PType, separateRegions: Boolean =
   override def sType: SStream = interfaces.SStream(elementType.sType)
 
   def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
+
+  override def unstagedLoadFromNested(addr: Long): Long = throw new NotImplementedError()
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -36,5 +36,5 @@ final case class PCanonicalStream(elementType: PType, separateRegions: Boolean =
 
   override def sType: SStream = interfaces.SStream(elementType.sType)
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = throw new NotImplementedError()
+  def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -79,6 +79,8 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   def loadFromNested(addr: Code[Long]): Code[Long] = binaryFundamentalType.loadFromNested(addr)
 
+  override def unstagedLoadFromNested(addr: Long): Long = binaryFundamentalType.unstagedLoadFromNested(addr)
+
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     fundamentalType.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -77,7 +77,7 @@ class PCanonicalString(val required: Boolean) extends PString {
     cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = binaryFundamentalType.loadFromNested(cb, addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = binaryFundamentalType.loadFromNested(addr)
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     fundamentalType.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -63,5 +63,5 @@ trait PPrimitive extends PType {
       }
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = addr
+  def loadFromNested(addr: Code[Long]): Code[Long] = addr
 }

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -64,4 +64,6 @@ trait PPrimitive extends PType {
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = addr
+
+  override def unstagedLoadFromNested(addr: Long): Long = addr
 }

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -141,7 +141,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: Array[String]) extends 
     throw new UnsupportedOperationException
   }
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = addr
+  def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long =
     throw new UnsupportedOperationException

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -143,6 +143,8 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: Array[String]) extends 
 
   def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
+  override def unstagedLoadFromNested(addr: Long): Long = addr
+
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long =
     throw new UnsupportedOperationException
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -487,7 +487,7 @@ abstract class PType extends Serializable with Requiredness {
 
   // called to load a region value's start address from a nested representation.
   // Usually a no-op, but may need to dereference a pointer.
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long]
+  def loadFromNested(addr: Code[Long]): Code[Long]
 
   def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -489,6 +489,8 @@ abstract class PType extends Serializable with Requiredness {
   // Usually a no-op, but may need to dereference a pointer.
   def loadFromNested(addr: Code[Long]): Code[Long]
 
+  def unstagedLoadFromNested(addr: Long): Long
+
   def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long
 
   def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit

--- a/hail/src/main/scala/is/hail/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PVoid.scala
@@ -23,6 +23,6 @@ case object PVoid extends PType with PUnrealizable {
 
   override def unsafeOrdering(): UnsafeOrdering = throw new NotImplementedError()
 
-  def loadFromNested(cb: EmitCodeBuilder, addr: Code[Long]): Code[Long] = throw new NotImplementedError()
+  def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PVoid.scala
@@ -24,5 +24,7 @@ case object PVoid extends PType with PUnrealizable {
   override def unsafeOrdering(): UnsafeOrdering = throw new NotImplementedError()
 
   def loadFromNested(addr: Code[Long]): Code[Long] = throw new NotImplementedError()
+
+  override def unstagedLoadFromNested(addr: Long): Long = throw new NotImplementedError()
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -113,7 +113,7 @@ class SIndexablePointerSettable(
           cb.ifx(isElementMissing(idx),
             {}, // do nothing,
             {
-              val elt = et.loadCheapPCode(cb, et.loadFromNested(cb, elementPtr))
+              val elt = et.loadCheapPCode(cb, et.loadFromNested(elementPtr))
               f(cb, idx, elt)
             })
           cb.assign(idx, idx + 1)


### PR DESCRIPTION
This replaces any instances I know about where we were using `match` to decide whether we had to dereference a pointer. This makes it easier for me to add reference counted ndarrays, and it makes it easier for us to nix fundamental type altogether. 

I had to add `unstagedLoadFromNested` as well