### PR TITLE
[image-fetcher,site] clean up normal bash output from error logs

### DIFF
--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 set -e
 
-gcloud -q auth activate-service-account \
-  --key-file=/secrets/gcr-pull.json
+gcloud_auth() {
+    gcloud -q auth activate-service-account --key-file=/secrets/gcr-pull.json
+    gcloud -q auth configure-docker gcr.io
+}
 
-gcloud -q auth configure-docker
+if ! gcloud_auth > gcloud-auth.log 2>&1; then
+    1>&2 cat gcloud-auth.log
+else
+    cat gcloud-auth.log
+fi
 
 DEFAULT_NAMESPACE=$(jq -r '.default_namespace' < /deploy-config/deploy-config.json)
 case $DEFAULT_NAMESPACE in

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -2,12 +2,13 @@
 set -e
 
 gcloud_auth() {
-    gcloud -q auth activate-service-account --key-file=/secrets/gcr-pull.json
-    gcloud -q auth configure-docker gcr.io
+    gcloud -q auth activate-service-account --key-file=/secrets/gcr-pull.json && \
+        gcloud -q auth configure-docker gcr.io
 }
 
 if ! gcloud_auth > gcloud-auth.log 2>&1; then
     1>&2 cat gcloud-auth.log
+    exit 1
 else
     cat gcloud-auth.log
 fi

--- a/site/site.sh
+++ b/site/site.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 rewrite_conf_location=/etc/nginx/conf.d/rewrite-links-for-namespace.conf
 


### PR DESCRIPTION
the gcloud command write to `stderr` which gets interpreted as errors in the logs and causes [a lot of noise](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aseverity%3DERROR%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22image-fetcher%22;timeRange=PT3H?project=hail-vdc&folder=true&organizationId=548622027621&query=%0A). 

Added `gcr.io` because without it `configure-docker` would configure all the registries it can find, which is unnecessary. Also removed `-x` from the site script since each line of that goes to error logs and none of it is helpful. If errors occur they will show up in some other form.