### PR TITLE
[query] Translate BGEN import to codebuilder and new constructors

### DIFF
--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -99,7 +99,7 @@ case class BgenSettings(
     .fieldOption(MatrixType.entriesIdentifier)
     .map(f => f.typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct])
 
-  val rowPType: PStruct = PCanonicalStruct(required = true,
+  val rowPType: PCanonicalStruct = PCanonicalStruct(required = true,
     Array(
       "locus" -> PCanonicalLocus.schemaFromRG(rg, required = false),
       "alleles" -> PCanonicalArray(PCanonicalString(false), false),

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -484,6 +484,36 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   }
 
   // unsafe StagedArrayBuilder-like interface that gives caller control over adding elements and finishing
+  def constructFromNextAddress(cb: EmitCodeBuilder, region: Value[Region], length: Value[Int], deepCopy: Boolean):
+  ((EmitCodeBuilder => Value[Long], (EmitCodeBuilder => Unit), (EmitCodeBuilder => SIndexablePointerCode))) = {
+
+    val addr = cb.newLocal[Long]("pcarray_construct2_addr", allocate(region, length))
+    cb += stagedInitialize(addr, length, setMissing = false)
+    val currentIndex = cb.newLocal[Int]("pcarray_construct2_i", -1)
+
+    val currentElementAddress = cb.newLocal[Long]("pcarray_construct2_firstelementaddr", firstElementOffset(addr, length) - elementByteSize)
+
+    def nextAddr(cb: EmitCodeBuilder): Value[Long] = {
+      cb.assign(currentIndex, currentIndex + 1)
+      cb.assign(currentElementAddress, currentElementAddress + elementByteSize)
+      currentElementAddress
+    }
+
+    def setMissing(cb: EmitCodeBuilder): Unit = {
+      cb.assign(currentIndex, currentIndex + 1)
+      cb.assign(currentElementAddress, currentElementAddress + elementByteSize)
+      cb += this.setElementMissing(addr, currentIndex)
+    }
+
+    def finish(cb: EmitCodeBuilder): SIndexablePointerCode = {
+      cb.ifx((currentIndex + 1).cne(length), cb._fatal("PCanonicalArray.constructFromNextAddress nextAddress was called the wrong number of times: len=",
+        length.toS, ", calls=", (currentIndex + 1).toS))
+      new SIndexablePointerCode(SIndexablePointer(this), addr)
+    }
+    (nextAddr, setMissing, finish)
+  }
+
+  // unsafe StagedArrayBuilder-like interface that gives caller control over adding elements and finishing
   def constructFromFunctions(cb: EmitCodeBuilder, region: Value[Region], length: Value[Int], deepCopy: Boolean):
   (((EmitCodeBuilder, Value[Int], IEmitCode) => Unit, (EmitCodeBuilder => SIndexablePointerCode))) = {
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -2,18 +2,19 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.physical.stypes.SCode
-import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerCode}
+import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerCode, SStringPointer}
+import is.hail.types.physical.stypes.interfaces._
+import is.hail.utils.FastIndexedSeq
 import is.hail.variant._
-import org.apache.spark.sql.Row
 
 object PCanonicalLocus {
   def apply(rg: ReferenceGenome): PLocus = PCanonicalLocus(rg.broadcastRG)
 
   def apply(rg: ReferenceGenome, required: Boolean): PLocus = PCanonicalLocus(rg.broadcastRG, required)
 
-  private def representation(required: Boolean = false): PStruct = PCanonicalStruct(
+  private def representation(required: Boolean = false): PCanonicalStruct = PCanonicalStruct(
     required,
     "contig" -> PCanonicalString(required = true),
     "position" -> PInt32(required = true))
@@ -38,7 +39,7 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalLocus(this.rgBc, required)
 
-  val representation: PStruct = PCanonicalLocus.representation(required)
+  val representation: PCanonicalStruct = PCanonicalLocus.representation(required)
 
   private[physical] def contigAddr(address: Code[Long]): Code[Long] = representation.loadField(address, 0)
 
@@ -159,5 +160,12 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
     val addr = representation.allocate(region)
     unstagedStoreJavaObjectAtAddress(addr, annotation, region)
     addr
+  }
+
+  def constructFromPositionAndString(cb: EmitCodeBuilder, r: Value[Region], contig: Code[String], pos: Code[Int]): SCanonicalLocusPointerCode = {
+    val contigType = representation.fieldType("contig").asInstanceOf[PCanonicalString]
+    val contigCode = SStringPointer(contigType).constructFromString(cb, r, contig)
+    val repr = representation.constructFromFields(cb, r, FastIndexedSeq(EmitCode.present(contigCode), EmitCode.present(primitive(pos))), deepCopy = false)
+    new SCanonicalLocusPointerCode(SCanonicalLocusPointer(this), repr.a)
   }
 }


### PR DESCRIPTION
BGEN benchmarks before/after:
```
$ hb compare  0.2.61-ffa3169a657f-bgen-cb-before.json 0.2.61-126a8c8d5147-bgen-cb.json
                 Benchmark Name      Ratio     Time 1     Time 2
                 --------------      -----     ------     ------
    import_bgen_force_count_all      98.0%    144.232    141.289
       import_bgen_filter_count      97.9%    142.950    139.965
import_bgen_force_count_just_gp      96.1%    146.766    141.000
         import_bgen_info_score      95.0%    197.271    187.353
----------------------
Harmonic mean: 96.7%
Geometric mean: 96.7%
Arithmetic mean: 96.7%
Median:  97.0%
```

I think this is within noise of no change.