### PR TITLE
[gateway] redirect to auth on 401 in internal

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -57,6 +57,12 @@ server {
         # include /ssl-config/ssl-config-proxy.conf
     }
 
+    error_page 401 = @error401;
+
+    location @error401 {
+        return 302 https://auth.hail.is/login?next=https://$http_host$request_uri;
+    }
+
     listen [::]:443 ssl;
     listen 443 ssl;
     ssl_certificate /etc/letsencrypt/fullchain.pem;


### PR DESCRIPTION
Previously, unauthenticated developers would get a 401 nginx page when hitting an internal url. This now sends them through the auth flow.

In the spirit of deploying before merge, you can try this out!