### PR TITLE
[query] Add independent inference pass for stream memory management

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -48,6 +48,7 @@ object Compile {
 
     val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
     val requiredness = Requiredness.apply(ir, usesAndDefs, null, Env.empty) // Value IR inference doesn't need context
+    val smm = InferStreamMemoryManagement(ir, usesAndDefs)
     InferPType(ir, Env.empty, requiredness, usesAndDefs)
 
     val returnType = ir.pType
@@ -73,7 +74,7 @@ object Compile {
     assert(fb.mb.parameterTypeInfo == expectedCodeParamTypes, s"expected $expectedCodeParamTypes, got ${ fb.mb.parameterTypeInfo }")
     assert(fb.mb.returnTypeInfo == expectedCodeReturnType, s"expected $expectedCodeReturnType, got ${ fb.mb.returnTypeInfo }")
 
-    val emitContext = new EmitContext(ctx, requiredness)
+    val emitContext = new EmitContext(ctx, requiredness, smm)
     Emit(emitContext, ir, fb)
 
     val f = fb.resultWithIndex(print)
@@ -114,6 +115,7 @@ object CompileWithAggregators {
 
     val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
     val requiredness = Requiredness.apply(ir, usesAndDefs, null, Env.empty) // Value IR inference doesn't need context
+    val smm = InferStreamMemoryManagement(ir, usesAndDefs)
     InferPType(ir, Env.empty, requiredness, usesAndDefs)
 
     val returnType = ir.pType
@@ -135,7 +137,7 @@ object CompileWithAggregators {
     }
      */
 
-    val emitContext = new EmitContext(ctx, requiredness)
+    val emitContext = new EmitContext(ctx, requiredness, smm)
     Emit(emitContext, ir, fb, Some(aggSigs))
 
     val f = fb.resultWithIndex()
@@ -209,9 +211,10 @@ object CompileIterator {
 
     val usesAndDefs = ComputeUsesAndDefs(ir, errorIfFreeVariables = false)
     val requiredness = Requiredness.apply(ir, usesAndDefs, null, Env.empty) // Value IR inference doesn't need context
+    val smm = InferStreamMemoryManagement(ir, usesAndDefs)
     InferPType(ir, Env.empty, requiredness, usesAndDefs)
 
-    val emitContext = new EmitContext(ctx, requiredness)
+    val emitContext = new EmitContext(ctx, requiredness, smm)
     val emitter = new Emit(emitContext, stepFECB)
 
     val returnType = ir.pType.asInstanceOf[PStream].elementType.asInstanceOf[PStruct].setRequired(true)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1507,7 +1507,7 @@ object EmitStream {
 
             emitIR(size).map(cb) { s =>
 
-              val innerSeparateRegions = emitter.ctx.smm.lookup(a).nested.get.separateRegions
+              val innerSeparateRegions = emitter.ctx.smm.lookup(a).separateRegions
               assert(innerSeparateRegions == innerType.separateRegions)
 
               val newStream = (eltRegion: ChildStagedRegion) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -226,7 +226,7 @@ object InferPType {
         x.accPType.setRequired(requiredness(node).required)
       case x: StreamFold2 =>
         x.result.pType.setRequired(requiredness(node).required)
-      case x@StreamScan(a, _, _, _, _) =>
+      case x@StreamScan(a, _, _, _, body) =>
         val r = coerce[RIterable](requiredness(node))
         PCanonicalStream(
           x.accPType.setRequired(r.elementType.required),

--- a/hail/src/main/scala/is/hail/expr/ir/InferStreamMemoryManagement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferStreamMemoryManagement.scala
@@ -110,8 +110,6 @@ object InferStreamMemoryManagement {
           case StreamZipJoin(streams, _, _, _, joinF) =>
             val separateRegions = streams.map(m.lookup(_).separateRegions).reduce(_ || _)
             StreamMemoType(separateRegions, None)
-          case CollectDistributedArray(contexts, globals, cname, gname, body, tsd) =>
-            StreamMemoType(separateRegions, None)
         })
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/InferStreamMemoryManagement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferStreamMemoryManagement.scala
@@ -1,0 +1,113 @@
+package is.hail.expr.ir
+
+import is.hail.types.physical.PStream
+import is.hail.types.virtual.TStream
+
+
+class StreamMemoryManagement(val m: Memo[StreamMemoType]) {
+  def lookup(ir: IR): StreamMemoType = {
+    assert(ir.typ.isInstanceOf[TStream])
+    m.lookup(ir)
+  }
+}
+
+case class StreamMemoType(separateRegions: Boolean, nested: Option[StreamMemoType])
+
+object InferStreamMemoryManagement {
+  def apply(ir: IR, usesAndDefs: UsesAndDefs): StreamMemoryManagement = {
+    val m = Memo.empty[StreamMemoType]
+
+    def lookup(name: String, defNode: IR): StreamMemoType = defNode match {
+      case Let(`name`, value, _) =>
+        m.lookup(value)
+      case StreamMap(s, `name`, _) =>
+        m.lookup(s).nested.get
+      case x@StreamZip(as, _, _, _) =>
+        m.lookup(as(x.nameIdx(name))).nested.get
+      case StreamFilter(s, `name`, _) => m.lookup(s).nested.get
+      case StreamFlatMap(s, `name`, _) => m.lookup(s).nested.get
+      case StreamFor(s, `name`, _) => m.lookup(s).nested.get
+      case StreamFold(s, _, _, `name`, _) => m.lookup(s).nested.get
+      case StreamScan(s, _, _, `name`, _) => m.lookup(s).nested.get
+      case StreamFold2(s, _, `name`, _, _) => m.lookup(s).nested.get
+      case StreamJoinRightDistinct(left, _, _, _, `name`, _, _, _) => m.lookup(left).nested.get
+      case StreamJoinRightDistinct(_, right, _, _, _, `name`, _, _) => m.lookup(right).nested.get
+      case RunAggScan(s, `name`, _, _, _, _) => m.lookup(s).nested.get
+
+    }
+
+    def _inferBottomUp(x: IR): Unit = {
+      x.children.foreach {
+        case x: IR => _inferBottomUp(x)
+      }
+
+      if (x.typ.isInstanceOf[TStream]) {
+
+        def getOpt(ir: IR): Option[StreamMemoType] = ir.typ match {
+          case _: TStream => Some(m.lookup(ir))
+          case _ => None
+        }
+
+        m.bind(x, x match {
+          case ref: Ref => lookup(ref.name, usesAndDefs.defs.lookup(ref).asInstanceOf[IR])
+          case ReadPartition(_, _, _) =>
+            StreamMemoType(true, None)
+          case In(_, s: PStream) =>
+            StreamMemoType(s.separateRegions, None)
+          case MakeStream(_, _, separateRegions) =>
+            StreamMemoType(separateRegions, None)
+          case RunAggScan(s, _, _, _, _, _) =>
+            m.lookup(s)
+          case ShufflePartitionBounds(_, _) =>
+            StreamMemoType(false, None)
+          case ShuffleRead(_, _) =>
+            StreamMemoType(true, None)
+          case StreamJoinRightDistinct(left, right, _, _, _, _, join, _) =>
+            StreamMemoType(m.lookup(left).separateRegions || m.lookup(right).separateRegions, getOpt(join))
+          case StreamScan(s, _, _, _, _) =>
+            StreamMemoType(m.lookup(s).separateRegions, None)
+          case ToStream(_, separateRegions) =>
+            StreamMemoType(separateRegions, None)
+          case StreamTake(s, _) =>
+            m.lookup(s)
+          case StreamDrop(s, _) =>
+            m.lookup(s)
+          case StreamRange(_, _, _, separateRegions) =>
+            StreamMemoType(separateRegions, None)
+          case StreamGroupByKey(s, _) =>
+            m.lookup(s)
+          case StreamGrouped(s, _) =>
+            val parent = m.lookup(s)
+            StreamMemoType(parent.separateRegions, Some(parent))
+          case StreamFilter(s, _, _) =>
+            m.lookup(s)
+          case StreamMap(s, _, body) =>
+            StreamMemoType(m.lookup(s).separateRegions, getOpt(body))
+          case StreamFlatMap(s, _, body) =>
+            val nested = m.lookup(body)
+            StreamMemoType(m.lookup(s).separateRegions || nested.separateRegions, Some(nested))
+          case StreamMerge(l, r, _) =>
+            val ll = m.lookup(l)
+            val rr = m.lookup(r)
+            assert(ll.nested == rr.nested)
+            StreamMemoType(ll.separateRegions || rr.separateRegions, ll.nested)
+          case StreamMultiMerge(streams, _) =>
+            val separateRegions = streams.map(m.lookup(_).separateRegions).reduce(_ || _)
+            StreamMemoType(separateRegions, None)
+          case StreamZip(streams, _, body, _) =>
+            val separateRegions = streams.map(m.lookup(_).separateRegions).reduce(_ || _)
+            StreamMemoType(separateRegions, getOpt(body))
+          case StreamZipJoin(streams, _, _, _, joinF) =>
+            val separateRegions = streams.map(m.lookup(_).separateRegions).reduce(_ || _)
+            StreamMemoType(separateRegions, None)
+        })
+      }
+    }
+
+    _inferBottomUp(ir)
+
+    new StreamMemoryManagement(m)
+  }
+
+
+}


### PR DESCRIPTION
Currently, this is done in parallel with the existing memory management
tracking (in ptypes), and we assert that the two produce the same
result. This can give us confidence that removing InferPType will not
change semantics.