### PR TITLE
[query] Improve error message from hadoop_ls when file does not exist

### DIFF
--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -138,6 +138,9 @@ class Tests(unittest.TestCase):
         ls3 = hl.hadoop_ls(path3)
         assert len(ls3) == 2, ls3
 
+        with self.assertRaisesRegex(Exception, "FileNotFound"):
+            hl.hadoop_ls('a_file_that_does_not_exist')
+
     def test_linked_list(self):
         ll = LinkedList(int)
         self.assertEqual(list(ll), [])

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -101,10 +101,14 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
   def listStatus(filename: String): Array[FileStatus] = {
     val fs = getFileSystem(filename)
     val hPath = new hadoop.fs.Path(filename)
-    fs.globStatus(hPath)
-      .map(_.getPath)
-      .flatMap(fs.listStatus(_))
-      .map(new HadoopFileStatus(_))
+    var statuses = fs.globStatus(hPath)
+    if (statuses == null) {
+      throw new FileNotFoundException(filename)
+    } else {
+      statuses.map(_.getPath)
+        .flatMap(fs.listStatus(_))
+        .map(new HadoopFileStatus(_))
+    }
   }
 
   def mkDir(dirname: String): Unit = {


### PR DESCRIPTION
As described in #9600, `hl.hadoop_ls` currently raises a NullPointerException when called with a path that does not exist. The error originates in `is.hail.io.fs.HadoopFS.listStatus`.

The [hadoop.fs.FileSystem docs](https://hadoop.apache.org/docs/current/api/org/apache/hadoop/fs/FileSystem.html#globStatus-org.apache.hadoop.fs.Path-) list two forms of `globStatus`:
* public FileStatus[] globStatus(Path pathPattern)
* public FileStatus[] globStatus(Path pathPattern, PathFilter filter)

The first makes no mention of returning null. The second however, says:
> Returns: null if pathPattern has no glob and the path does not exist an empty array if pathPattern has a glob and no path matches it else an array of FileStatus objects matching the pattern

This matches the behavior seen with `hl.hadoop_ls`.

This change checks for a null value returned from `globStatus` and raises a `FileNotFoundException` in that case.

Resolves #9600