### PR TITLE
[query] Begin simplifying EmitCode constructors.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -139,11 +139,11 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     _invoke[T](callee, args: _*)
   }
 
-  def invokeEmit(callee: EmitMethodBuilder[_], args: Param*): EmitCode = {
+  def invokeEmit(cb: EmitCodeBuilder, callee: EmitMethodBuilder[_], args: Param*): IEmitCode = {
     val pt = callee.emitReturnType.asInstanceOf[EmitParamType].pt
     val r = newLocal("invokeEmit_r")(pt.codeReturnType())
-    EmitCode(r := _invoke(callee, args: _*),
-      EmitCode.fromCodeTuple(pt, Code.loadTuple(callee.modb, EmitCode.codeTupleTypes(pt), r)))
+    cb.assignAny(r, _invoke(callee, args: _*))
+    IEmitCode.fromCodeTuple(cb, pt, Code.loadTuple(callee.modb, EmitCode.codeTupleTypes(pt), r))
   }
 
   // for debugging

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -139,11 +139,11 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     _invoke[T](callee, args: _*)
   }
 
-  def invokeEmit(cb: EmitCodeBuilder, callee: EmitMethodBuilder[_], args: Param*): IEmitCode = {
+  def invokeEmit(callee: EmitMethodBuilder[_], args: Param*): IEmitCode = {
     val pt = callee.emitReturnType.asInstanceOf[EmitParamType].pt
     val r = newLocal("invokeEmit_r")(pt.codeReturnType())
-    cb.assignAny(r, _invoke(callee, args: _*))
-    IEmitCode.fromCodeTuple(cb, pt, Code.loadTuple(callee.modb, EmitCode.codeTupleTypes(pt), r))
+    assignAny(r, _invoke(callee, args: _*))
+    IEmitCode.fromCodeTuple(this, pt, Code.loadTuple(callee.modb, EmitCode.codeTupleTypes(pt), r))
   }
 
   // for debugging

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -7,7 +7,7 @@ import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.EmitStream.SizedStream
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.types.TableType
-import is.hail.types.physical.{PCanonicalStream, PStruct, PType}
+import is.hail.types.physical.{PCanonicalStream, PCode, PStruct, PType}
 import is.hail.types.virtual.{TArray, TStruct, Type}
 import is.hail.rvd.{RVD, RVDCoercer, RVDContext, RVDPartitioner, RVDType}
 import is.hail.sparkextras.ContextRDD
@@ -62,7 +62,7 @@ class PartitionIteratorLongReader(
                   region.code,
                   Code.invokeScalaObject3[PType, Region, Long, java.lang.Object](UnsafeRow.getClass, "read",
                     cb.emb.getPType(contextPC.pt), region.code, contextPC.tcode[Long]))))
-          .map(rv => EmitCode.present(eltPType, Region.loadIRIntermediate(eltPType)(rv)))
+          .map(rv => EmitCode.fromI(cb.emb)(cb => IEmitCode.present(cb, eltPType.loadCheapPCode(cb, rv))))
       }
 
       interfaces.SStreamCode(interfaces.SStream(eltPType.sType), newStream)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -501,7 +501,7 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
               hasNext.orEmpty(next := upcastF.invoke[Region, Long, Long]("apply", eltRegion.code, Code.longValue(iterator.invoke[java.lang.Long]("next")))),
               k(COption(!hasNext, next))))
           .map(
-            pc => EmitCode.present(upcastPType, pc),
+            pc => EmitCode.present(cb.emb, PCode(upcastPType, pc)),
             setup0 = None,
             setup = Some(Code(iterator := broadcastRVD.invoke[Int, Region, Region, Iterator[Long]](
               "computePartition", EmitCodeBuilder.scopedCode[Int](mb)(idx.asInt.intCode(_)), eltRegion.code, outerRegion.code),
@@ -556,7 +556,7 @@ case class PartitionNativeReader(spec: AbstractTypedCodecSpec) extends AbstractN
             hasNext.orEmpty(next := dec(eltRegion.code, xRowBuf)),
             k(COption(!hasNext, next))))
         .map(
-          pc => EmitCode.present(eltType, pc),
+          pc => EmitCode.present(cb.emb, PCode(eltType, pc)),
           setup0 = None,
           setup = Some(xRowBuf := spec
             .buildCodeInputBuffer(mb.open(pathString, true)))))
@@ -616,7 +616,7 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
             hasNext.orEmpty(next := it.invoke[Long]("_next")),
             k(COption(!hasNext, next))))
         .map(
-          pc => EmitCode.present(eltType, pc),
+          pc => EmitCode.present(cb.emb, PCode(eltType, pc)),
           setup0 = None,
           setup = Some(
             EmitCodeBuilder.scopedVoid(mb) { cb =>
@@ -790,7 +790,7 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
             hasNext.orEmpty(next := it.invoke[Long]("_next")),
             k(COption(!hasNext, next))))
         .map(
-          pc => EmitCode.present(eltType, pc),
+          pc => EmitCode.present(cb.emb, PCode(eltType, pc)),
           setup0 = None,
           setup = Some(
             EmitCodeBuilder.scopedVoid(mb) { cb =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -36,7 +36,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, kb: EmitC
 
   def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = kcomp(cb, k1, k2)
 
-  def loadCompKey(cb: EmitCodeBuilder, off: Value[Long]): EmitCode = EmitCode.present(binType, storageType.loadField(off, "bin"))
+  def loadCompKey(cb: EmitCodeBuilder, off: Value[Long]): EmitCode = EmitCode.present(cb.emb, binType.loadCheapPCode(cb, storageType.loadField(off, "bin")))
 }
 
 
@@ -289,7 +289,7 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         cb += Region.storeInt(binType.fieldOffset(binStaging, "x"), binX)
         cb += Region.storeInt(binType.fieldOffset(binStaging, "y"), binY)
         cb.assign(insertOffset,
-          tree.getOrElseInitialize(cb, EmitCode.present(storageType.fieldType("binStaging"), binStaging)))
+          tree.getOrElseInitialize(cb, EmitCode.present(cb.emb, storageType.fieldType("binStaging").loadCheapPCode(cb, binStaging))))
         cb.ifx(key.isEmpty(insertOffset), {
           cb.assign(binOffset, key.storageType.loadField(insertOffset, "bin"))
           cb += Region.storeInt(binType.loadField(binOffset, "x"), binX)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -68,7 +68,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     val k1 = cmp.getCodeParam(1)(indexedkeyTypeTypeInfo)
     val k2 = cmp.getCodeParam(2)(indexedkeyTypeTypeInfo)
 
-    cmp.emitWithBuilder(cb => ord.compare(cb , EmitCode.present(indexedKeyType, k1), EmitCode.present(indexedKeyType, k2)))
+    cmp.emitWithBuilder(cb => ord.compare(cb , EmitCode.present(cb.emb, PCode(indexedKeyType, k1)), EmitCode.present(cb.emb, PCode(indexedKeyType, k2))))
 
     cmp.invokeCode(_, _)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -153,7 +153,7 @@ object StringFunctions extends RegistryFunctions {
     }) { case (r, rt, a) =>
       val annotation = Code(a.setup, a.m).muxAny(Code._null(boxedTypeInfo(a.pt.virtualType)), boxArg(r, a.pt)(a.v))
       val str = r.mb.getType(a.pt.virtualType).invoke[Any, String]("showStr", annotation)
-      EmitCode.present(PCode(rt, unwrapReturn(r, rt)(str)))
+      EmitCode.present(r.mb, PCode(rt, unwrapReturn(r, rt)(str)))
     }
 
     registerEmitCode2("showStr", tv("T"), TInt32, TString, {

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -281,10 +281,10 @@ object CompileDecoder {
             val strT = t.field("contig").typ.asInstanceOf[PCanonicalString]
             val contigPC = SStringPointer(strT).constructFromString(cb, region, contigRecoded)
             t.constructFromFields(cb, region,
-              FastIndexedSeq(EmitCode.present(contigPC), EmitCode.present(primitive(position))),
+              FastIndexedSeq(EmitCode.present(cb.emb, contigPC), EmitCode.present(cb.emb, primitive(position))),
               deepCopy = false)
         }
-        structFieldCodes += EmitCode.present(pc)
+        structFieldCodes += EmitCode.present(cb.emb, pc)
       }
 
       cb.assign(nAlleles, cbfis.invoke[Int]("readShort"))
@@ -306,17 +306,17 @@ object CompileDecoder {
         })
 
         val allelesArr = finish(cb)
-        structFieldCodes += EmitCode.present(allelesArr)
+        structFieldCodes += EmitCode.present(cb.emb, allelesArr)
       }
 
       if (settings.hasField("rsid"))
-        structFieldCodes += EmitCode.present(SStringPointer(PCanonicalString(true)).constructFromString(cb, region, rsid))
+        structFieldCodes += EmitCode.present(cb.emb, SStringPointer(PCanonicalString(true)).constructFromString(cb, region, rsid))
       if (settings.hasField("varid"))
-        structFieldCodes += EmitCode.present(SStringPointer(PCanonicalString(true)).constructFromString(cb, region, varid))
+        structFieldCodes += EmitCode.present(cb.emb, SStringPointer(PCanonicalString(true)).constructFromString(cb, region, varid))
       if (settings.hasField("offset"))
-        structFieldCodes += EmitCode.present(primitive(offset))
+        structFieldCodes += EmitCode.present(cb.emb, primitive(offset))
       if (settings.hasField("file_idx"))
-        structFieldCodes += EmitCode.present(primitive(fileIdx))
+        structFieldCodes += EmitCode.present(cb.emb, primitive(fileIdx))
 
       cb.assign(dataSize, cbfis.invoke[Int]("readInt"))
       settings.entryType match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -139,7 +139,7 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
   def constructFromPositionAndString(cb: EmitCodeBuilder, r: Value[Region], contig: Code[String], pos: Code[Int]): SCanonicalLocusPointerCode = {
     val contigType = representation.fieldType("contig").asInstanceOf[PCanonicalString]
     val contigCode = SStringPointer(contigType).constructFromString(cb, r, contig)
-    val repr = representation.constructFromFields(cb, r, FastIndexedSeq(EmitCode.present(contigCode), EmitCode.present(primitive(pos))), deepCopy = false)
+    val repr = representation.constructFromFields(cb, r, FastIndexedSeq(EmitCode.present(cb.emb, contigCode), EmitCode.present(cb.emb, primitive(pos))), deepCopy = false)
     new SCanonicalLocusPointerCode(SCanonicalLocusPointer(this), repr.a)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -167,11 +167,11 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     cb.assign(ndAddr, this.representation.allocate(region))
     shapeType.storeAtAddressFromFields(cb, cb.newLocal[Long]("construct_shape", this.representation.fieldOffset(ndAddr, "shape")),
       region,
-      shape.map(s => EmitCode.present(primitive(s))),
+      shape.map(s => EmitCode.present(cb.emb, primitive(s))),
       false)
     strideType.storeAtAddressFromFields(cb, cb.newLocal[Long]("construct_strides", this.representation.fieldOffset(ndAddr, "strides")),
       region,
-      strides.map(s => EmitCode.present(primitive(s))),
+      strides.map(s => EmitCode.present(cb.emb, primitive(s))),
       false)
     cb.append(Region.storeLong(this.representation.fieldOffset(ndAddr, "data"), dataVal))
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations.UnsafeOrdering
 import is.hail.asm4s.Code
 import is.hail.expr.ir.EmitStream.SizedStream
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, Stream}
+import is.hail.expr.ir.{EmitCode, EmitMethodBuilder, Stream}
 import is.hail.types.physical.stypes.interfaces
 import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode}
 import is.hail.types.virtual.{TStream, Type}
@@ -24,8 +24,8 @@ final case class PCanonicalStream(elementType: PType, separateRegions: Boolean =
     sb.append("]")
   }
 
-  override def defaultValue: SStreamCode =
-    SStreamCode(SStream(elementType.sType, separateRegions), SizedStream(Code._empty, _ => Stream.empty(EmitCode.missing(elementType)), Some(0)))
+  override def defaultValue(mb: EmitMethodBuilder[_]): SStreamCode =
+    SStreamCode(SStream(elementType.sType, separateRegions), SizedStream(Code._empty, _ => Stream.empty(EmitCode.missing(mb, elementType)), Some(0)))
 
   override def deepRename(t: Type) = deepRenameStream(t.asInstanceOf[TStream])
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -466,7 +466,7 @@ abstract class PType extends Serializable with Requiredness {
 
   def deepRename(t: Type): PType = this
 
-  def defaultValue: PCode = PCode(this, is.hail.types.physical.defaultValue(this))
+  def defaultValue(mb: EmitMethodBuilder[_]): PCode = PCode(this, is.hail.types.physical.defaultValue(this))
 
   def ti: TypeInfo[_] = typeToTypeInfo(this)
 

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -39,7 +39,7 @@ class OrderingSuite extends HailSuite {
     val cv1 = Region.getIRIntermediate(t)(fb.getCodeParam[Long](2))
     val cv2 = Region.getIRIntermediate(t)(fb.getCodeParam[Long](3))
     fb.emitWithBuilder { cb =>
-      fb.apply_method.getCodeOrdering(t, op)(cb, EmitCode.present(t, cv1), EmitCode.present(t, cv2))
+      fb.apply_method.getCodeOrdering(t, op)(cb, EmitCode.present(cb.emb, PCode(t, cv1)), EmitCode.present(cb.emb, PCode(t, cv2)))
     }
     fb.resultWithIndex()(0, r)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -40,9 +40,9 @@ class DownsampleSuite extends HailSuite {
           cb.assign(y, rng.invoke[Double, Double, Double]("runif", 0d, 1d))
 
           ds1.insert(cb,
-            EmitCode.present(new SFloat64Code(true, x)),
-            EmitCode.present(new SFloat64Code(true, y)),
-            EmitCode.missing(PCanonicalArray(PCanonicalString())))
+            EmitCode.present(cb.emb, new SFloat64Code(true, x)),
+            EmitCode.present(cb.emb, new SFloat64Code(true, y)),
+            EmitCode.missing(cb.emb, PCanonicalArray(PCanonicalString())))
           cb.assign(i, i + const(1))
       })
       ds1.merge(cb, ds2)


### PR DESCRIPTION
This is the first step toward top-level requiredness being an attribute
of IEmitCode rather than PType.

* Take cb/mb when necessary.
* Remove unnecessary constructors