### PR TITLE
[query] Delete a bunch of static SRVB methods

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
@@ -90,7 +90,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   }
 
   def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
-    cb.assign(off, StagedRegionValueBuilder.deepCopyFromOffset(kb, region, CallStatsState.stateType, src))
+    cb.assign(off, CallStatsState.stateType.store(cb, region, CallStatsState.stateType.loadCheapPCode(cb, src), deepCopy = true))
     loadNAlleles(cb)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
@@ -37,11 +37,11 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
     cb.assign(tmpOff, src)
     cb.assign(size, Region.loadInt(currentSizeOffset(tmpOff)))
     cb.assign(capacity, Region.loadInt(capacityOffset(tmpOff)))
-    cb.assign(data, StagedRegionValueBuilder.deepCopyFromOffset(kb, region, eltArray, Region.loadAddress(dataOffset(tmpOff))))
+    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapPCode(cb, Region.loadAddress(dataOffset(tmpOff))), deepCopy = true))
   }
 
   def reallocateData(cb: EmitCodeBuilder): Unit = {
-    cb.assign(data, StagedRegionValueBuilder.deepCopyFromOffset(kb, region, eltArray, data))
+    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapPCode(cb, data), deepCopy = true))
   }
 
   def storeTo(cb: EmitCodeBuilder, dest: Code[Long]): Unit = {

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -475,11 +475,10 @@ class StagedRegionValueSuite extends HailSuite {
           val src = ScalaToRegionValue(srcRegion, t, a)
 
           val fb = EmitFunctionBuilder[Region, Long, Long](ctx, "deep_copy")
-          fb.emit(
-            StagedRegionValueBuilder.deepCopyFromOffset(
-              EmitRegion.default(fb.apply_method),
-              t,
-              fb.getCodeParam[Long](2)))
+          fb.emitWithBuilder[Long](cb => t.store(cb,
+            fb.apply_method.getCodeParam[Region](1),
+            t.loadCheapPCode(cb, fb.apply_method.getCodeParam[Long](2)),
+              deepCopy = true))
           val copyF = fb.resultWithIndex()(0, region)
           val newOff = copyF(region, src)
 


### PR DESCRIPTION
Replace with PType constructors.