### PR TITLE
[grafana] Add grafana service for metrics monitoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
-      - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black

--- a/build.yaml
+++ b/build.yaml
@@ -1575,6 +1575,18 @@ steps:
     - scorecard_image
     - deploy_router
     - create_certs
+ - kind: deploy
+   name: deploy_grafana
+   namespace:
+     valueFrom: default_ns.name
+   config: grafana/deployment.yaml
+   scopes:
+    - deploy
+    - dev
+  dependsOn:
+    - default_ns
+    - deploy_router
+    - create_certs
  - kind: runImage
    name: create_dummy_oauth2_client_secret
    image:

--- a/build.yaml
+++ b/build.yaml
@@ -1583,7 +1583,7 @@ steps:
    scopes:
     - deploy
     - dev
-  dependsOn:
+   dependsOn:
     - default_ns
     - deploy_router
     - create_certs

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -1,0 +1,7 @@
+include ../config.mk
+
+.PHONY: deploy
+deploy:
+	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"}}' deployment.yaml deployment.yaml.out
+	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             name: grafana-config
       containers:
        - name: grafana
-         image: grafana/grafana:latest
+         image: grafana/grafana:7.3.7
          volumeMounts:
           - mountPath: /var/lib/grafana
             name: grafana-storage

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  serviceName: "grafana"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      priorityClassName: infrastructure
+      securityContext:
+        fsGroup: 472
+        runAsNonRoot: true
+        runAsUser: 472
+      volumes:
+        - name: grafana-configmap-volume
+          configMap:
+            name: grafana-config
+      containers:
+       - name: grafana
+         image: grafana/grafana:latest
+         volumeMounts:
+          - mountPath: /var/lib/grafana
+            name: grafana-storage
+          - mountPath: /etc/grafana
+            name: grafana-configmap-volume
+         resources:
+           requests:
+             cpu: "10m"
+             memory: "10M"
+           limits:
+             cpu: "1"
+             memory: "1G"
+         ports:
+          - containerPort: 3000
+  volumeClaimTemplates:
+  - metadata:
+      name: grafana-storage
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-config
+data:
+  grafana.ini: |
+    [server]
+{% if deploy %}
+    domain = grafana.hail.is
+{% else %}
+    domain = internal.hail.is
+    root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
+    serve_from_sub_path = true
+{% endif %}

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -28,6 +28,18 @@ spec:
       containers:
        - name: grafana
          image: grafana/grafana:7.3.7
+         env:
+{% if deploy %}
+          - name: GF_SERVER_DOMAIN
+            value: grafana.hail.is
+          - name: GF_SERVER_ROOT_URL
+            value: "%(protocol)s://%(domain)s/"
+{% else %}
+          - name: GF_SERVER_DOMAIN
+            value: internal.hail.is
+          - name: GF_SERVER_ROOT_URL
+            value: "%(protocol)s://%(domain)s/{{ default_ns.name }}/grafana/"
+{% endif %}
          volumeMounts:
           - mountPath: /var/lib/grafana
             name: grafana-storage

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -271,6 +271,17 @@ spec:
   selector:
     app: atgu
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  ports:
+   - port: 80
+     targetPort: 3000
+  selector:
+    app: grafana
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -111,6 +111,22 @@ server {
 }
 
 server {
+    server_name grafana.*;
+
+    location / {
+        proxy_pass http://grafana/;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
+    }
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+}
+
+server {
     server_name notebook.*;
 
     # needed to correctly handle error_page with internal handles

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -98,3 +98,6 @@ principals:
 - name: batch-user-code
   domain: batch-user-code
   kind: json
+- name: grafana
+  domain: grafana
+  kind: json


### PR DESCRIPTION
Deploying grafana in our GKE cluster gives us instant and easy access to the stackdriver backend with the same querying capabilities of our current front-end, but without the clutter and insanely slow load times. See [here](https://internal.hail.is/dgoldste/grafana/d/TVkleyLMk/detailed-service-resource-utilization?orgId=1) for some example dashboards I set up to look at resources across our services (credentials are the default admin/admin).

This alleviates the immediate pain of using the console (for metrics only, not logging), but my longer aim is that getting more regular use out of our metrics can reveal deeper pain points of our monitoring stack and if/where we need to eat up more responsibility from google monitoring.

This is a StatefulSet, so configuration through the UI will persist and is done manually. If we find that our dashboards are stable and boilerplate enough, I'd like to move to a code-based dashboard configuration.

Sadly, `check-yaml` does not appreciate our jinja templating in yaml, so I've removed it for now.

cc: @cseed 