### PR TITLE
[auth] bump PyPI versions of google auth libs

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,8 +1,8 @@
 FROM {{ service_base_image.image }}
 
 RUN hail-pip-install \
-      google-auth-oauthlib==0.4.1 \
-      google-auth==1.21.1
+      google-auth-oauthlib==0.4.2 \
+      google-auth==1.25.0
 
 COPY auth/setup.py auth/MANIFEST.in /auth/
 COPY auth/auth /auth/auth/


### PR DESCRIPTION
There is a new version of google-cloud-core which is incompatible with google-auth 1.12.1. Rather than
pin to an old version of google-cloud-core, I bump us to the latest of both auth libraries.