### PR TITLE
[copy] fix overly strong assertion

### DIFF
--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -200,7 +200,10 @@ class ResumableInsertObjectStream(WritableStream):
                                            },
                                            raise_for_status=False)
             if resp.status >= 200 or resp.status < 300:
-                assert self._closed and self._write_buffer.size() == 0
+                assert self._closed
+                assert total_size is not None
+                self._write_buffer.advance_offset(total_size)
+                assert self._write_buffer.size() == 0
                 self._done = True
                 return
             if resp.status == 308:
@@ -283,6 +286,7 @@ class ResumableInsertObjectStream(WritableStream):
         assert self._write_buffer.size() < self._chunk_size
 
     async def _wait_closed(self):
+        assert self._closed
         assert self._write_buffer.size() < self._chunk_size
         while not self._done:
             await self._write_chunk()


### PR DESCRIPTION
If we find out the write is complete during a status check, we would assert the buffer is empty before advancing the the offset to the end.  This exit point now matches the exit point when we complete after a normal chunk write.

Also assert _closed in _wait_closed.  _write_chunk can only complete when we've closed and therefore know the final size, so make sure _closed so we don't accidentally get into an infinite loop waiting for _done.