### PR TITLE
[query] Fix bug where NaN values fell into first bin in `hl.agg.hist`

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -1283,7 +1283,7 @@ def hist(expr, start, end, bins) -> StructExpression:
             hl.tfloat64, hl.tfloat64, hl.tint32, hl.tfloat64, hl.tfloat64)
 
     freq_dict = hl.bind(
-        lambda expr: hl.agg.filter(hl.is_defined(expr),
+        lambda expr: hl.agg.filter(hl.is_defined(expr) & ~hl.is_nan(expr),
                                    hl.agg.group_by(
                                        _bin_idx_f(start, end, bins, hl.float64(end - start) / bins, expr),
                                        hl.agg.count())),

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -974,6 +974,13 @@ class Tests(unittest.TestCase):
         self.assertEqual(r.n_smaller, 0)
         self.assertEqual(r.n_larger, 1)
 
+    def test_aggregators_hist_nan(self):
+        ht = hl.utils.range_table(3).annotate(x=hl.float('nan'))
+        r = ht.aggregate(hl.agg.hist(ht.x, 0, 10, 2))
+        assert r.bin_freq == [0, 0]
+        assert r.n_smaller == 0
+        assert r.n_larger == 0
+
     def test_aggregator_cse(self):
         ht = hl.utils.range_table(10)
         x = hl.agg.count()


### PR DESCRIPTION
CHANGELOG: Fix mishandling of NaN values in `hl.agg.hist`, where they were unintentionally included in the first bin.