### PR TITLE
[batch] Fix bug in schedule_job

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -27,10 +27,6 @@ if TYPE_CHECKING:
 log = logging.getLogger('job')
 
 
-class BadSQLReturnValue(Exception):
-    pass
-
-
 async def notify_batch_job_complete(db, batch_id):
     record = await db.select_and_fetchone(
         '''
@@ -435,9 +431,6 @@ CALL schedule_job(%s, %s, %s, %s);
         if instance.state == 'active':
             instance.adjust_free_cores_in_memory(record['cores_mcpu'])
         return
-
-    if rv['delta_cores_mcpu'] is None:
-        raise BadSQLReturnValue(f'schedule job {id} on {instance}: delta_cores_mcpu is none: {rv}')
 
     if rv['delta_cores_mcpu'] != 0 and instance.state == 'active':
         instance.adjust_free_cores_in_memory(rv['delta_cores_mcpu'])

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -926,8 +926,7 @@ BEGIN
   INTO cur_job_state, cur_cores_mcpu, cur_attempt_id, cur_job_cancel
   FROM jobs
   INNER JOIN batches ON batches.id = jobs.batch_id
-  WHERE batch_id = in_batch_id AND batches.`state` = 'running'
-    AND job_id = in_job_id
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
   FOR UPDATE;
 
   SELECT is_pool

--- a/batch/sql/fix-schedule-job.sql
+++ b/batch/sql/fix-schedule-job.sql
@@ -1,0 +1,64 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS schedule_job $$
+CREATE PROCEDURE schedule_job(
+  IN in_batch_id BIGINT,
+  IN in_job_id INT,
+  IN in_attempt_id VARCHAR(40),
+  IN in_instance_name VARCHAR(100)
+)
+BEGIN
+  DECLARE cur_job_state VARCHAR(40);
+  DECLARE cur_cores_mcpu INT;
+  DECLARE cur_job_cancel BOOLEAN;
+  DECLARE cur_instance_state VARCHAR(40);
+  DECLARE cur_attempt_id VARCHAR(40);
+  DECLARE delta_cores_mcpu INT;
+  DECLARE cur_instance_is_pool BOOLEAN;
+
+  START TRANSACTION;
+
+  SELECT jobs.state, cores_mcpu, attempt_id,
+    (jobs.cancelled OR batches.cancelled) AND NOT always_run
+  INTO cur_job_state, cur_cores_mcpu, cur_attempt_id, cur_job_cancel
+  FROM jobs
+  INNER JOIN batches ON batches.id = jobs.batch_id
+  WHERE batch_id = in_batch_id AND job_id = in_job_id
+  FOR UPDATE;
+
+  SELECT is_pool
+  INTO cur_instance_is_pool
+  FROM instances
+  LEFT JOIN inst_colls ON instances.inst_coll = inst_colls.name
+  WHERE instances.name = in_instance_name;
+
+  CALL add_attempt(in_batch_id, in_job_id, in_attempt_id, in_instance_name, cur_cores_mcpu, delta_cores_mcpu);
+
+  IF cur_instance_is_pool THEN
+    IF delta_cores_mcpu = 0 THEN
+      SET delta_cores_mcpu = cur_cores_mcpu;
+    ELSE
+      SET delta_cores_mcpu = 0;
+    END IF;
+  END IF;
+
+  SELECT state INTO cur_instance_state FROM instances WHERE name = in_instance_name LOCK IN SHARE MODE;
+
+  IF (cur_job_state = 'Ready' OR cur_job_state = 'Creating') AND NOT cur_job_cancel AND cur_instance_state = 'active' THEN
+    UPDATE jobs SET state = 'Running', attempt_id = in_attempt_id WHERE batch_id = in_batch_id AND job_id = in_job_id;
+    COMMIT;
+    SELECT 0 as rc, in_instance_name, delta_cores_mcpu;
+  ELSE
+    COMMIT;
+    SELECT 1 as rc,
+      cur_job_state,
+      cur_job_cancel,
+      cur_instance_state,
+      in_instance_name,
+      cur_attempt_id,
+      delta_cores_mcpu,
+      'job not Ready or cancelled or instance not active, but attempt already exists' as message;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -1964,6 +1964,8 @@ steps:
       script: /io/sql/add-job-private-inst-coll.sql
     - name: insert-nonpreemptible-resources
       script: /io/sql/insert_nonpreemptible_resources.py
+    - name: fix-schedule-job
+      script: /io/sql/fix-schedule-job.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/


### PR DESCRIPTION
We had a bug yesterday where the return value for `delta_cores_mcpu` when scheduling a job was None instead of an integer. This messed up the instance collection data structures for that instance so we couldn't remove the instance and we couldn't handle the deactivate or delete events. Also, the instance was stuck with -1 free cores.

I think until we figure out why this happened, this is a perfectly good solution. If the job was actually scheduled correctly, then MJS will happen and the free cores will be correct.