### PR TITLE
[query] Fix 0-partition matrix table writes.

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1229,6 +1229,13 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertTrue(mt._same(mt2))
 
     @fails_service_backend()
+    def test_write_no_parts(self):
+        mt = hl.utils.range_matrix_table(10, 10, 2).filter_rows(False)
+        path = new_temp_file(extension='mt')
+        path2 = new_temp_file(extension='mt')
+        assert mt.checkpoint(path)._same(mt)
+        hl.read_matrix_table(path, _drop_rows=True).write(path2)
+
     def test_nulls_in_distinct_joins(self):
 
         # MatrixAnnotateRowsTable uses left distinct join

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -794,6 +794,14 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         t2 = hl.read_table(f)
         self.assertTrue(t._same(t2))
 
+    @fails_service_backend()
+    def test_write_no_parts(self):
+        ht = hl.utils.range_table(10, n_partitions=2).filter(False)
+        path = new_temp_file(extension='ht')
+        path2 = new_temp_file(extension='ht')
+        assert ht.checkpoint(path)._same(ht)
+        hl.read_table(path).write(path2)
+
     def test_min_partitions(self):
         assert hl.import_table(resource('variantAnnotations.tsv'), min_partitions=50).n_partitions() == 50
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -197,10 +197,13 @@ case class MatrixValue(
     val partitionBytesWritten = fileData.map(_.bytesWritten)
     val totalRowsEntriesBytes = partitionBytesWritten.sum
     val totalBytesWritten: Long = totalRowsEntriesBytes + colBytesWritten + globalBytesWritten
-    val smallestPartition = fileData.minBy(_.bytesWritten)
-    val largestPartition = fileData.maxBy(_.bytesWritten)
-    val smallestStr = s"${ smallestPartition.rowsWritten } rows (${ formatSpace(smallestPartition.bytesWritten) })"
-    val largestStr = s"${ largestPartition.rowsWritten } rows (${ formatSpace(largestPartition.bytesWritten) })"
+    val (smallestStr, largestStr) = if (fileData.isEmpty) ("N/A", "N/A") else {
+      val smallestPartition = fileData.minBy(_.bytesWritten)
+      val largestPartition = fileData.maxBy(_.bytesWritten)
+      val smallestStr = s"${ smallestPartition.rowsWritten } rows (${ formatSpace(smallestPartition.bytesWritten) })"
+      val largestStr = s"${ largestPartition.rowsWritten } rows (${ formatSpace(largestPartition.bytesWritten) })"
+      (smallestStr, largestStr)
+    }
 
     printer(s"wrote matrix table with $nRows ${ plural(nRows, "row") } " +
       s"and $nCols ${ plural(nCols, "column") } " +

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -140,7 +140,17 @@ object AbstractRVDSpec {
       specLeft.partFiles.map { p => (p, null) }
     } else {
       val partFiles = specLeft.partFiles
-      tmpPartitioner.rangeBounds.map { b => (partFiles(partitioner.lowerBoundInterval(b)), b) }
+
+      val iOrd = partitioner.kord.intervalEndpointOrdering
+      val includedIndices = (0 until partitioner.numPartitions).filter { i =>
+        val rb = partitioner.rangeBounds(i)
+        !rb.isDisjointFrom(iOrd, rb)
+      }.toArray
+
+      includedIndices.map { i =>
+        val b = tmpPartitioner.rangeBounds(i)
+        (partFiles(partitioner.lowerBoundInterval(b)), b)
+      }
     }
 
     val kSize = specLeft.key.size

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -201,7 +201,7 @@ object AbstractRVDSpec {
         val iOrd = partitioner.kord.intervalEndpointOrdering
         val includedIndices = (0 until partitioner.numPartitions).filter { i =>
           val rb = partitioner.rangeBounds(i)
-          rb.isDisjointFrom(iOrd, rb)
+          !rb.isDisjointFrom(iOrd, rb)
         }.toArray
         (includedIndices.map(specLeft.partFiles), partitioner.copy(rangeBounds = includedIndices.map(partitioner.rangeBounds)))
     }


### PR DESCRIPTION
CHANGELOG: Fix crashes when writing/reading matrix tables with 0 partitions.