### PR TITLE
[query] Removing fundamental types on strings

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -50,7 +50,7 @@ object UnsafeRow {
     new UnsafeRow(t, region, offset)
 
   def readString(boff: Long, t: PString): String =
-    new String(readBinary(boff, t.fundamentalType))
+    new String(readBinary(boff, t.binaryFundamentalType))
 
   def readLocus(offset: Long, t: PLocus): Locus = {
     Locus(

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -50,7 +50,7 @@ object UnsafeRow {
     new UnsafeRow(t, region, offset)
 
   def readString(boff: Long, t: PString): String =
-    new String(readBinary(boff, t.binaryFundamentalType))
+    new String(readBinary(boff, t.binaryRepresentation))
 
   def readLocus(offset: Long, t: PLocus): Locus = {
     Locus(

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -41,7 +41,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
     srcPType match {
-      case pt: PCanonicalLocus => representation._copyFromAddress(region, pt.representation, srcAddress, deepCopy)
+      case pt: PCanonicalCall => representation._copyFromAddress(region, pt.representation, srcAddress, deepCopy)
     }
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -22,26 +22,26 @@ class PCanonicalString(val required: Boolean) extends PString {
   override lazy val binaryEncodableType: PCanonicalBinary = PCanonicalBinary(required)
 
   def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    fundamentalType.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
+    binaryFundamentalType.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
 
   override def containsPointers: Boolean = true
 
   def loadLength(boff: Long): Int =
-    this.fundamentalType.loadLength(boff)
+    this.binaryFundamentalType.loadLength(boff)
 
   def loadLength(boff: Code[Long]): Code[Int] =
-    this.fundamentalType.loadLength(boff)
+    this.binaryFundamentalType.loadLength(boff)
 
   def loadString(bAddress: Long): String =
-    new String(this.fundamentalType.loadBytes(bAddress))
+    new String(this.binaryFundamentalType.loadBytes(bAddress))
 
   def loadString(bAddress: Code[Long]): Code[String] =
-    Code.newInstance[String, Array[Byte]](this.fundamentalType.loadBytes(bAddress))
+    Code.newInstance[String, Array[Byte]](this.binaryFundamentalType.loadBytes(bAddress))
 
   def allocateAndStoreString(region: Region, str: String): Long = {
     val byteRep = str.getBytes()
-    val dstAddrss = this.fundamentalType.allocate(region, byteRep.length)
-    this.fundamentalType.store(dstAddrss, byteRep)
+    val dstAddrss = this.binaryFundamentalType.allocate(region, byteRep.length)
+    this.binaryFundamentalType.store(dstAddrss, byteRep)
     dstAddrss
   }
 
@@ -50,13 +50,13 @@ class PCanonicalString(val required: Boolean) extends PString {
     val byteRep = mb.genFieldThisRef[Array[Byte]]()
     Code(
       byteRep := str.invoke[Array[Byte]]("getBytes"),
-      dstAddress := fundamentalType.allocate(region, byteRep.length),
-      fundamentalType.store(dstAddress, byteRep),
+      dstAddress := binaryFundamentalType.allocate(region, byteRep.length),
+      binaryFundamentalType.store(dstAddress, byteRep),
       dstAddress)
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    fundamentalType.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
+    binaryFundamentalType.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
 
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalString(required)
 
@@ -82,11 +82,11 @@ class PCanonicalString(val required: Boolean) extends PString {
   override def unstagedLoadFromNested(addr: Long): Long = binaryFundamentalType.unstagedLoadFromNested(addr)
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
-    fundamentalType.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
+    binaryFundamentalType.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
   }
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
-    fundamentalType.unstagedStoreJavaObjectAtAddress(addr, annotation.asInstanceOf[String].getBytes(), region)
+    binaryFundamentalType.unstagedStoreJavaObjectAtAddress(addr, annotation.asInstanceOf[String].getBytes(), region)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -17,31 +17,31 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   override def byteSize: Long = 8
 
-  lazy val binaryFundamentalType: PCanonicalBinary = PCanonicalBinary(required)
-  override lazy val fundamentalType: PCanonicalBinary = binaryFundamentalType
+  lazy val binaryRepresentation: PCanonicalBinary = PCanonicalBinary(required)
+  override lazy val fundamentalType: PCanonicalBinary = binaryRepresentation
   override lazy val binaryEncodableType: PCanonicalBinary = PCanonicalBinary(required)
 
   def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    binaryFundamentalType.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
+    binaryRepresentation.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
 
   override def containsPointers: Boolean = true
 
   def loadLength(boff: Long): Int =
-    this.binaryFundamentalType.loadLength(boff)
+    this.binaryRepresentation.loadLength(boff)
 
   def loadLength(boff: Code[Long]): Code[Int] =
-    this.binaryFundamentalType.loadLength(boff)
+    this.binaryRepresentation.loadLength(boff)
 
   def loadString(bAddress: Long): String =
-    new String(this.binaryFundamentalType.loadBytes(bAddress))
+    new String(this.binaryRepresentation.loadBytes(bAddress))
 
   def loadString(bAddress: Code[Long]): Code[String] =
-    Code.newInstance[String, Array[Byte]](this.binaryFundamentalType.loadBytes(bAddress))
+    Code.newInstance[String, Array[Byte]](this.binaryRepresentation.loadBytes(bAddress))
 
   def allocateAndStoreString(region: Region, str: String): Long = {
     val byteRep = str.getBytes()
-    val dstAddrss = this.binaryFundamentalType.allocate(region, byteRep.length)
-    this.binaryFundamentalType.store(dstAddrss, byteRep)
+    val dstAddrss = this.binaryRepresentation.allocate(region, byteRep.length)
+    this.binaryRepresentation.store(dstAddrss, byteRep)
     dstAddrss
   }
 
@@ -50,13 +50,13 @@ class PCanonicalString(val required: Boolean) extends PString {
     val byteRep = mb.genFieldThisRef[Array[Byte]]()
     Code(
       byteRep := str.invoke[Array[Byte]]("getBytes"),
-      dstAddress := binaryFundamentalType.allocate(region, byteRep.length),
-      binaryFundamentalType.store(dstAddress, byteRep),
+      dstAddress := binaryRepresentation.allocate(region, byteRep.length),
+      binaryRepresentation.store(dstAddress, byteRep),
       dstAddress)
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    binaryFundamentalType.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
+    binaryRepresentation.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
 
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalString(required)
 
@@ -69,7 +69,7 @@ class PCanonicalString(val required: Boolean) extends PString {
       case SStringPointer(t) if t.equalModuloRequired(this) && !deepCopy =>
         value.asInstanceOf[SStringPointerCode].a
       case _ =>
-        binaryFundamentalType.store(cb, region, value.asString.asBytes(), deepCopy)
+        binaryRepresentation.store(cb, region, value.asString.asBytes(), deepCopy)
     }
   }
 
@@ -77,16 +77,16 @@ class PCanonicalString(val required: Boolean) extends PString {
     cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 
-  def loadFromNested(addr: Code[Long]): Code[Long] = binaryFundamentalType.loadFromNested(addr)
+  def loadFromNested(addr: Code[Long]): Code[Long] = binaryRepresentation.loadFromNested(addr)
 
-  override def unstagedLoadFromNested(addr: Long): Long = binaryFundamentalType.unstagedLoadFromNested(addr)
+  override def unstagedLoadFromNested(addr: Long): Long = binaryRepresentation.unstagedLoadFromNested(addr)
 
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
-    binaryFundamentalType.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
+    binaryRepresentation.unstagedStoreJavaObject(annotation.asInstanceOf[String].getBytes(), region)
   }
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
-    binaryFundamentalType.unstagedStoreJavaObjectAtAddress(addr, annotation.asInstanceOf[String].getBytes(), region)
+    binaryRepresentation.unstagedStoreJavaObjectAtAddress(addr, annotation.asInstanceOf[String].getBytes(), region)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -21,11 +21,11 @@ abstract class PString extends PType {
     }
   }
 
-  val binaryFundamentalType: PBinary
-  override lazy val fundamentalType: PBinary = binaryFundamentalType
+  val binaryRepresentation: PBinary
+  override lazy val fundamentalType: PBinary = binaryRepresentation
 
   protected val binaryEncodableType: PBinary
-  override lazy val encodableType: PBinary = binaryFundamentalType
+  override lazy val encodableType: PBinary = binaryRepresentation
 
   def loadLength(boff: Long): Int
 

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -21,7 +21,7 @@ abstract class PString extends PType {
     }
   }
 
-  protected val binaryFundamentalType: PBinary
+  val binaryFundamentalType: PBinary
   override lazy val fundamentalType: PBinary = binaryFundamentalType
 
   protected val binaryEncodableType: PBinary

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -22,7 +22,7 @@ abstract class PString extends PType {
   }
 
   val binaryRepresentation: PBinary
-  override lazy val fundamentalType: PBinary = binaryRepresentation
+  override lazy val fundamentalType: PType = this
 
   protected val binaryEncodableType: PBinary
   override lazy val encodableType: PBinary = binaryRepresentation

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 package object physical {
   implicit def pvalueToPCode(pv: PValue): PCode = pv.get
 
-  def typeToTypeInfo(t: PType): TypeInfo[_] = t.fundamentalType match {
+  def typeToTypeInfo(t: PType): TypeInfo[_] = t match {
     case _: PInt32 => typeInfo[Int]
     case _: PInt64 => typeInfo[Long]
     case _: PFloat32 => typeInfo[Float]

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -20,6 +20,10 @@ package object physical {
     case _: PBaseStruct => typeInfo[Long]
     case _: PNDArray => typeInfo[Long]
     case _: PContainer => typeInfo[Long]
+    case _: PString => typeInfo[Long]
+    case _: PCanonicalCall => typeInfo[Int]
+    case _: PInterval => typeInfo[Long]
+    case _: PLocus => typeInfo[Long]
     case _ => throw new RuntimeException(s"unsupported type found, $t")
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -56,7 +56,7 @@ class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends PStr
 
   def loadString(): Code[String] = pt.loadString(a)
 
-  def asBytes(): PBinaryCode = new SBinaryPointerCode(SBinaryPointer(pt.fundamentalType), a)
+  def asBytes(): PBinaryCode = new SBinaryPointerCode(SBinaryPointer(pt.binaryFundamentalType), a)
 
   private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): PValue = {
     val s = new SStringPointerSettable(st, sb.newSettable[Long]("sstringpointer_memoize"))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -56,7 +56,7 @@ class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends PStr
 
   def loadString(): Code[String] = pt.loadString(a)
 
-  def asBytes(): PBinaryCode = new SBinaryPointerCode(SBinaryPointer(pt.binaryFundamentalType), a)
+  def asBytes(): PBinaryCode = new SBinaryPointerCode(SBinaryPointer(pt.binaryRepresentation), a)
 
   private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): PValue = {
     val s = new SStringPointerSettable(st, sb.newSettable[Long]("sstringpointer_memoize"))

--- a/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
@@ -20,7 +20,7 @@ abstract class PhysicalTestUtils extends HailSuite {
 
     if (interpret) {
       try {
-        val copyOff = destType.fundamentalType.copyFromAddress(region, sourceType.fundamentalType, srcAddress, deepCopy = deepCopy)
+        val copyOff = destType.copyFromAddress(region, sourceType, srcAddress, deepCopy = deepCopy)
         val copy = UnsafeRow.read(destType, region, copyOff)
 
         log.info(s"Copied value: ${copy}, Source value: ${sourceValue}")
@@ -54,7 +54,7 @@ abstract class PhysicalTestUtils extends HailSuite {
     val value = fb.getCodeParam[Long](2)
 
     try {
-      fb.emitWithBuilder(cb => destType.fundamentalType.store(cb, codeRegion, sourceType.fundamentalType.loadCheapPCode(cb, value), deepCopy = deepCopy))
+      fb.emitWithBuilder(cb => destType.store(cb, codeRegion, sourceType.loadCheapPCode(cb, value), deepCopy = deepCopy))
       compileSuccess = true
     } catch {
       case e: Throwable =>


### PR DESCRIPTION
Stop using fundamental type on PString where possible. We just will have a special  `binaryRepresentation` or whatever on strings to get the underlying binary representation as long as it exists. Also, pull out some other fundamentals I suspect are not needed