### PR TITLE
[query] Parallelize HadoopFS.listStatus

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -105,9 +105,10 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
     if (statuses == null) {
       throw new FileNotFoundException(filename)
     } else {
-      statuses.map(_.getPath)
+      statuses.par.map(_.getPath)
         .flatMap(fs.listStatus(_))
         .map(new HadoopFileStatus(_))
+        .toArray
     }
   }
 


### PR DESCRIPTION
This reduced the time to run `hl.hadoop_ls` on a glob that matches 1000 files in a GCS bucket from ~55s to ~10s. Still not as good as `gsutil ls -l`, which takes ~3s.

Related to #9895