### PR TITLE
[devbin] add devbin/functions.sh

### DIFF
--- a/dev-docs/development_process.md
+++ b/dev-docs/development_process.md
@@ -48,25 +48,26 @@ changed files every commit. For example, services code uses the
 to enforce PEP8 compliance.
 
 #### Services
-If you are working on a services project, make sure you have Docker and Kubernetes
-installed. Then install the [gcloud cli](https://cloud.google.com/sdk/docs/install)
-and run the following to connect `kubectl` to the `hail-vdc` cluster.
 
+Install and configure tools necessary for working on the Hail Services:
+
+1. Install [Docker](https://docker.com)
+2. Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+3. Install [`gcloud`](https://cloud.google.com/sdk/docs/install)
+4. Configure gcloud and Docker for Hail:
 ```
 gcloud auth login
 gcloud config set project hail-vdc
 gcloud container clusters get-credentials vdc --zone=us-central1-a
 gcloud auth configure-docker
 ```
-
-To use BuildKit with Docker for a much faster building experience, add
-
+5. Add these lines to `~/.zshrc` or `~/.bashrc` to configure your shell and environment for Hail:
 ```
+# BuildKit, a fast docker backend
 export DOCKER_BUILDKIT=1
+# Shell utilities for managing the Hail kubernetes cluster
+source /path/to/hail-repository/devbin/functions.sh
 ```
-
-to your `~/.bashrc` or `~/.zshrc`.
-
 
 ### Testing / Debugging
 There are different strategies for debugging depending on whether you are

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -162,10 +162,10 @@ download-secret() {
 }
 
 upload-secret() {
-    # upload-secret secret-name namespace
+    # upload-secret
     #
     # Upload a secret that has been previously downloaded using download-secret. If you intend to
-    # upload to a different namespace, ensure you've also modified contents.json.
+    # upload to a different namespace, ensure you've also modified secret.json.
 	  name=$(jq -r '.metadata.name' secret.json)
 	  namespace=$(jq -r '.metadata.namespace' secret.json)
 	  kubectl create secret generic $name --namespace $namespace $(for i in $(ls contents); do echo "--from-file=contents/$i" ; done) --dry-run -o yaml \

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -1,0 +1,173 @@
+kfind1() {
+    # kfind1 app [namespace]
+    #
+    # Print one pod from namespace `namespace` whose app label matches `app`.
+    #
+    # Example:
+    #
+    #     # kfind1 batch
+    #     batch-8c6c74ffd-d498g
+    kubectl -n ${2:-default} get pods -l app="$1" --no-headers | grep Running | awk '{ print $1 }' | head -n 1
+}
+
+klf() {
+    # klf app [namespace]
+    #
+    # Print the logs in real time from some matching pod.
+    #
+    # Example:
+    #
+    #     # klf batch
+    #     ... logs are streamed to your computer ...
+    kubectl -n ${2:-default} logs -f "$(kfind1 "$1" "$2")"
+}
+
+kssh() {
+    # kssh app [namespace]
+    #
+    # Connect to a bash session on some matching pod.
+    #
+    # Example:
+    #
+    #     # kssh admin-pod
+    #     root@admin-pod-5d77d69445-86m2h:/#
+    kubectl -n ${2:-default} exec -it "$(kfind1 "$1" "$2")" -- /bin/bash
+}
+
+klog() {
+    # klog app [namespace]
+    #
+    # Print all available non-healthcheck, non-metric logs for *all* matching pods in chronological
+    # order.
+    #
+    # Example:
+    #
+    #     # klog batch dking
+    #     ... logs ...
+    dir=$(mktemp -d)
+    mkdir -p $dir
+    for x in $(kubectl get pods -l app="${1}" -n "${2}" | tail -n +2 | awk '{print $1}')
+    do
+        kubectl logs --tail=999999999999999 $x -n "${2}" \
+            | grep -Ev 'healthcheck|metrics' \
+                   > $dir/$x &
+    done
+    wait
+    cat $dir/* | sort
+}
+
+kjlog() {
+    # kjlog app [namespace]
+    #
+    # Print all available non-healthcheck, non-metric logs for *all* matching pods in chronological
+    # order. Non-JSON logs are elided. Not all fields are shown.
+    #
+    # Example:
+    #
+    #     # kjlog batch dking
+    #     ...
+    #     {"asctime":"2021-02-12 16:58:49,540","container":"batch-8c6c74ffd-d498g","x_real_ip":"35.187.114.193","connection_id":null,"exc_info":null,"message":"https GET / done in 0.0015127049991860986s: 302"}
+    #     {"asctime":"2021-02-12 16:58:57,850","container":"batch-8c6c74ffd-lzfdh","x_real_ip":"104.197.30.241","connection_id":null,"exc_info":null,"message":"https GET / done in 0.0010090250007124268s: 302"}
+    #     {"asctime":"2021-02-12 16:59:11,747","container":"batch-8c6c74ffd-lzfdh","x_real_ip":"18.31.31.24","connection_id":null,"exc_info":null,"message":"https GET /api/v1alpha/batches/182764 done in 0.04281349099983345s: 200"}
+    #     {"asctime":"2021-02-12 16:59:12,907","container":"batch-8c6c74ffd-jmhmq","x_real_ip":"35.198.194.122","connection_id":null,"exc_info":null,"message":"https GET / done in 0.0008628759969724342s: 302"}
+    dir=$(mktemp -d)
+    mkdir -p $dir
+    for x in $(kubectl get pods -l app="${1}" -n "${2}" | tail -n +2 | awk '{print $1}')
+    do
+        kubectl logs --tail=999999999999999 $x -n "${2}" \
+            | grep -Ev 'healthcheck|metrics' \
+            | grep '^{' \
+            | jq -c '{asctime, container: "'$x'", x_real_ip, connection_id, exc_info, message}' \
+                 > $dir/$x &
+    done
+    wait
+    cat $dir/* | sort | jq -c '{asctime, container, x_real_ip, connection_id, exc_info, message}'
+}
+
+kjlogs() {
+    # kjlogs namespace app1 [app2 ...]
+    #
+    # Print all available non-healthcheck, non-metric logs for pods from any of the specified apps
+    # in chronological order. Non-JSON logs are elided. Not all fields are shown.
+    #
+    # Example:
+    #
+    #     # kjlogs default batch batch-driver
+    #     ...
+    #     {"asctime":"2021-02-12 17:01:53,832","container":"batch-8c6c74ffd-lzfdh","x_real_ip":null,"connection_id":null,"exc_info":null,"message":"https GET /api/v1alpha/batches/182767 done in 0.0401439390006999s: 200"}
+    #     {"asctime":"2021-02-12 17:01:55,553","container":"batch-driver-6748cd87f9-kdjv8","x_real_ip":null,"connection_id":null,"exc_info":null,"message":"marking job (182768, 140) complete new_state Success"}
+    dir=$(mktemp -d)
+    mkdir -p $dir
+    namespace="${1}"
+    shift
+    for app in $*
+    do
+        for x in $(kubectl get pods -l app="${app}" -n "${namespace}" | tail -n +2 | awk '{print $1}')
+        do
+            kubectl logs --tail=999999999999999 $x -n "${namespace}" \
+                | grep -Ev 'healthcheck|metrics' \
+                | grep '^{' \
+                | jq -c '{asctime, x_real_ip, connection_id, exc_info, message, container: "'$x'"}' \
+                     > $dir/$x &
+        done
+    done
+    wait
+    cat $dir/* | sort | jq -c '{asctime, container, x_real_ip, connection_id, exc_info, message}'
+}
+
+knodes() {
+    # knodes
+    #
+    # Print every kubernetes node and the non-kube-system pods resident on that node.
+    #
+    # Example:
+    #
+    #     # knodes
+    #     ...
+    #     ====== gke-vdc-preemptible-pool-3-770fae6d-zl4l =====
+    #     NAMESPACE     NAME                                                  READY   STATUS    RESTARTS   AGE   IP             NODE                                       NOMINATED NODE   READINESS GATES
+    #     default       address-6b465c7594-bk9lb                              1/1     Running   0          23m   10.32.34.39    gke-vdc-preemptible-pool-3-770fae6d-zl4l   <none>           <none>
+    #     default       scorecard-deployment-7f9c5b6569-bk2sx                 1/1     Running   6          25m   10.32.34.37    gke-vdc-preemptible-pool-3-770fae6d-zl4l   <none>           <none>
+    for i in $(kubectl get nodes | awk '{print $1}')
+    do
+        echo "====== $i ====="
+        kubectl get pods --all-namespaces -o wide --field-selector spec.nodeName=$i \
+          | awk '$1 != "kube-system" { print }'
+    done
+}
+
+download-secret() {
+    # download-secret secret-name namespace
+    #
+    # Download a secret, base64 unencode the contents, and write into files on your computer. Use
+    # `popd` to return to your previous working directory.
+    #
+    # Example:
+    #
+    #     # download-secret ssl-config-batch dking
+    #     /var/folders/cq/p_l4jm3x72j7wkxqxswccs180000gq/T/tmp.NTb5sZMX ~/projects/hail
+    #     (base) # ls contents
+    #     batch-cert.pem			batch-incoming-store.jks	batch-incoming.pem		batch-key-store.p12		batch-key.pem			batch-outgoing-store.jks	batch-outgoing.pem		ssl-config.json
+    #     (base) # ls
+    #     contents	secret.json
+	  name=$1
+	  namespace=${2:-default}
+	  pushd $(mktemp -d)
+	  kubectl get secret $name --namespace $namespace -o json > secret.json
+	  mkdir contents
+	  for field in $(jq -r  '.data | keys[]' secret.json)
+	  do
+		    jq -r '.data["'$field'"]' secret.json | base64 -D > contents/$field
+	  done
+}
+
+upload-secret() {
+    # upload-secret secret-name namespace
+    #
+    # Upload a secret that has been previously downloaded using download-secret. If you intend to
+    # upload to a different namespace, ensure you've also modified contents.json.
+	  name=$(jq -r '.metadata.name' secret.json)
+	  namespace=$(jq -r '.metadata.namespace' secret.json)
+	  kubectl create secret generic $name --namespace $namespace $(for i in $(ls contents); do echo "--from-file=contents/$i" ; done) --dry-run -o yaml \
+	      | kubectl apply -f -
+}


### PR DESCRIPTION
I use these functions to monitor the k8s cluster. These are useful in the interim while we
move towards more robust monitoring solutions. To make these accessible modify your ~/.bashrc
or ~/.zshrc to have this line:

    source /path/to/hail-repository/devbin/functions.sh

cc: services-team: @jigold @CDiaz96 @catoverdrive @cseed 