### PR TITLE
[site] Add robots.txt and favicon.ico symlink

### DIFF
--- a/site/pages/robots.txt
+++ b/site/pages/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+Allow: /

--- a/site/www/favicon.ico
+++ b/site/www/favicon.ico
@@ -1,0 +1,1 @@
+hail_logo_sq.ico


### PR DESCRIPTION
We're upsetting the robots of the world by not having a `robots.txt` to instruct how they should crawl the website. As retribution, they crawl everything, so this robots.txt doesn't change any indexing behavior but if there's anything we don't want indexed I can add here. Requests for `/robots.txt` and `/favicon.ico` make up a non-trivial amount of site's error logs now, so I also added a symlink to the image we use as our favicon. Hopefully this helps to further quiet the logs.