### PR TITLE
[query] Default to Spark 3

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -10,7 +10,7 @@ RUN hail-apt-get-install \
 COPY docker/hail-ubuntu/pip.conf /root/.config/pip/pip.conf
 COPY docker/hail-ubuntu/hail-pip-install /bin/hail-pip-install
 COPY docker/requirements.txt .
-RUN hail-pip-install -r requirements.txt pyspark==2.4.0
+RUN hail-pip-install -r requirements.txt pyspark==3.1.1
 
 ENV SPARK_HOME /usr/local/lib/python3.7/site-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"

--- a/build.yaml
+++ b/build.yaml
@@ -678,7 +678,7 @@ steps:
    dependsOn:
     - hail_build_image
  - kind: runImage
-   name: build_hail_spark3
+   name: build_hail_spark2
    image:
      valueFrom: hail_build_image.image
    resources:
@@ -693,7 +693,7 @@ steps:
      {{ code.checkout_script }}
      cd hail
      time retry ./gradlew --version
-     export SPARK_VERSION="3.0.1" SCALA_VERSION="2.12.12"
+     export SPARK_VERSION="2.4.5" SCALA_VERSION="2.11.12"
      time retry make jars python-version-info wheel
    dependsOn:
      - hail_build_image

--- a/build.yaml
+++ b/build.yaml
@@ -3248,7 +3248,7 @@ steps:
    script: |
      set -ex
      gcloud auth activate-service-account --key-file=/secrets/ci-deploy-0-1--hail-is-hail.json
-     SPARK_VERSION=2.4.5
+     SPARK_VERSION=3.1.1
      BRANCH=0.2
      SHA="{{ code.sha }}"
      GS_JAR=gs://hail-common/builds/${BRANCH}/jars/hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.jar

--- a/build.yaml
+++ b/build.yaml
@@ -677,26 +677,6 @@ steps:
        to: /cluster-tests.tar.gz
    dependsOn:
     - hail_build_image
- - kind: runImage
-   name: build_hail_spark2
-   image:
-     valueFrom: hail_build_image.image
-   resources:
-     memory: "7.5G"
-     cpu: "4"
-   script: |
-     set -ex
-     cd /
-     rm -rf repo
-     mkdir repo
-     cd repo
-     {{ code.checkout_script }}
-     cd hail
-     time retry ./gradlew --version
-     export SPARK_VERSION="2.4.5" SCALA_VERSION="2.11.12"
-     time retry make jars python-version-info wheel
-   dependsOn:
-     - hail_build_image
  - kind: buildImage
    name: batch_worker_image
    dockerFile: batch/Dockerfile.worker

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -26,7 +26,7 @@ RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
 ENV PATH $PATH:/google-cloud-sdk/bin
 
 COPY docker/requirements.txt .
-RUN hail-pip-install -r requirements.txt pyspark==2.4.0
+RUN hail-pip-install -r requirements.txt pyspark==3.1.1
 
 ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"

--- a/docker/Dockerfile.service-java-run-base
+++ b/docker/Dockerfile.service-java-run-base
@@ -8,7 +8,7 @@ RUN hail-apt-get-install \
     liblapack3
 
 COPY docker/requirements.txt .
-RUN hail-pip-install -r requirements.txt pyspark==2.4.0
+RUN hail-pip-install -r requirements.txt pyspark==3.1.1
 
 ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PYSPARK_PYTHON python3

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -10,8 +10,8 @@ MAKEFLAGS += --no-builtin-rules
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-SCALA_VERSION ?= 2.11.12
-SPARK_VERSION ?= 2.4.5
+SCALA_VERSION ?= 2.12.12
+SPARK_VERSION ?= 3.0.1
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 64
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -10,8 +10,8 @@ MAKEFLAGS += --no-builtin-rules
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-SCALA_VERSION ?= 2.12.12
-SPARK_VERSION ?= 3.0.1
+SCALA_VERSION ?= 2.12.13
+SPARK_VERSION ?= 3.0.2
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 64
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -59,11 +59,19 @@ SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
 PYTHON_JAR := python/hail/backend/hail-all-spark.jar
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 EGG := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3.6.egg
+ELASTICSEARCH_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT.jar
 
 GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION) -Delasticsearch.major-version=$(ELASTIC_MAJOR_VERSION)
 
+.PHONY: elasticsearchJar
+elasticsearchJar: $(ELASTICSEARCH_JAR)
+
+$(ELASTICSEARCH_JAR):
+	@mkdir -p libs
+	gsutil cp gs://hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT.jar  libs/
+
 .PHONY: shadowJar
-shadowJar: $(SHADOW_JAR)
+shadowJar: $(ELASTICSEARCH_JAR) $(SHADOW_JAR)
 
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt
@@ -83,7 +91,7 @@ endif
 $(SHADOW_TEST_JAR): $(SCALA_BUILD_INFO) $(JAR_SOURCES) $(JAR_TEST_SOURCES)
 	./gradlew shadowTestJar $(GRADLE_ARGS)
 
-jars: $(SHADOW_JAR) $(SHADOW_TEST_JAR)
+jars: $(ELASTICSEARCH_JAR) $(SHADOW_JAR) $(SHADOW_TEST_JAR)
 
 .PHONY: jvm-test
 ifdef HAIL_COMPILE_NATIVES

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -59,7 +59,7 @@ SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
 PYTHON_JAR := python/hail/backend/hail-all-spark.jar
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 EGG := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3.6.egg
-ELASTICSEARCH_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT.jar
+ELASTICSEARCH_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION) -Delasticsearch.major-version=$(ELASTIC_MAJOR_VERSION)
 
@@ -68,10 +68,13 @@ elasticsearchJar: $(ELASTICSEARCH_JAR)
 
 $(ELASTICSEARCH_JAR):
 	@mkdir -p libs
-	gsutil cp gs://hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT.jar  libs/
+	gsutil cp gs://hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar  libs/
 
 .PHONY: shadowJar
-shadowJar: $(ELASTICSEARCH_JAR) $(SHADOW_JAR)
+shadowJar: $(SHADOW_JAR)
+
+$(JAR_SOURCES): $(ELASTICSEARCH_JAR)
+$(JAR_TEST_SOURCES): $(ELASTICSEARCH_JAR)
 
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt
@@ -91,7 +94,7 @@ endif
 $(SHADOW_TEST_JAR): $(SCALA_BUILD_INFO) $(JAR_SOURCES) $(JAR_TEST_SOURCES)
 	./gradlew shadowTestJar $(GRADLE_ARGS)
 
-jars: $(ELASTICSEARCH_JAR) $(SHADOW_JAR) $(SHADOW_TEST_JAR)
+jars: $(SHADOW_JAR) $(SHADOW_TEST_JAR)
 
 .PHONY: jvm-test
 ifdef HAIL_COMPILE_NATIVES
@@ -371,7 +374,10 @@ native-lib-prebuilt:
 native-lib-reset-prebuilt:
 	$(MAKE) -C src/main/c reset-prebuilt
 
-clean: clean-env native-lib-clean
+clean-libs:
+	rm -rf libs
+
+clean: clean-env clean-libs native-lib-clean
 	$(MAKE) -C python/hail/docs clean
 	$(MAKE) -C python/hailtop/batch/docs clean
 	./gradlew clean $(GRADLE_ARGS)

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -11,7 +11,7 @@ REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 SCALA_VERSION ?= 2.12.13
-SPARK_VERSION ?= 3.0.2
+SPARK_VERSION ?= 3.1.1
 HAIL_MAJOR_MINOR_VERSION := 0.2
 HAIL_PATCH_VERSION := 64
 HAIL_PIP_VERSION := $(HAIL_MAJOR_MINOR_VERSION).$(HAIL_PATCH_VERSION)

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -50,7 +50,13 @@ project.ext {
     cachedBreezeVersion = null
 
     sparkVersion = System.getProperty("spark.version", "3.1.1")
+    if (sparkVersion != "3.1.1") {
+        throw new UnsupportedOperationException("Hail currently only supports Spark 3.1.1")
+    }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
+    if (!scalaVersion.startsWith("2.12.")) {
+        throw new UnsupportedOperationException("Hail currently only supports Scala 2.12")
+    }
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
 }
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     bundled group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
     // This comes from a local libs directory, see Makefile
-    bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT'
+    bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
 
     bundled 'com.google.cloud:google-cloud-storage:1.106.0'
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -46,8 +46,8 @@ tasks.withType(JavaCompile) {
 project.ext {
     cachedBreezeVersion = null
 
-    sparkVersion = System.getProperty("spark.version", "2.4.5")
-    scalaVersion = System.getProperty("scala.version", "2.11.12")
+    sparkVersion = System.getProperty("spark.version", "3.0.1")
+    scalaVersion = System.getProperty("scala.version", "2.12.12")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
 }
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -50,8 +50,11 @@ project.ext {
     cachedBreezeVersion = null
 
     sparkVersion = System.getProperty("spark.version", "3.1.1")
-    if (sparkVersion != "3.1.1") {
-        throw new UnsupportedOperationException("Hail currently only supports Spark 3.1.1")
+    if (sparkVersion.startsWith("2.")) {
+        throw new UnsupportedOperationException("Hail no longer supports Spark 2.")
+    }
+    else if (sparkVersion != "3.1.1") {
+        project.logger.lifecycle("WARNING: Hail only tested with Spark 3.1.1, use other versions at your own risk.")
     }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
     if (!scalaVersion.startsWith("2.12.")) {

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -128,7 +128,7 @@ configurations {
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.json4s') {
                     // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.6.10')
+                    details.useVersion('3.5.3')
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -170,6 +170,10 @@ dependencies {
 
     bundled group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
+    def elasticMajorVersion = System.getProperty("elasticsearch.major-version", "7")
+    if (elasticMajorVersion != "7") {
+        throw new UnsupportedOperationException("elasticsearch.major-version must be 7")
+    }
     // This comes from a local libs directory, see Makefile
     bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -128,7 +128,7 @@ configurations {
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.json4s') {
                     // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.7.0-M10')
+                    details.useVersion('3.7.0-M5')
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -18,15 +18,13 @@ plugins {
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 repositories {
-    mavenCentral()
-    jcenter()
-    // Necessary for elasticsearch spark 3 snapshot.
-    // maven { url "https://oss.sonatype.org/content/repositories/snapshots/"}
-    maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
-    maven { url "https://repo.spring.io/plugins-release/" }
     flatDir {
         dirs 'libs'
     }
+    mavenCentral()
+    jcenter()
+    maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
+    maven { url "https://repo.spring.io/plugins-release/" }
 }
 
 sourceSets.main.scala.srcDir "src/main/java"
@@ -105,19 +103,6 @@ String breezeVersion() {
   return cachedBreezeVersion
 }
 
-String elasticHadoopVersion() {
-    def elasticMajorVersion = System.getProperty("elasticsearch.major-version", "7")
-    if (elasticMajorVersion == "6") {
-        return "6.8.13"
-    }
-    else if (elasticMajorVersion == "7") {
-        return "7.8.1"
-    }
-    else {
-        throw new UnsupportedOperationException("elasticsearch.major-version must be 6 or 7")
-    }
-}
-
 configurations {
     justSpark
 
@@ -185,6 +170,7 @@ dependencies {
 
     bundled group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
+    // This comes from a local libs directory, see Makefile
     bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT'
 
     bundled 'com.google.cloud:google-cloud-storage:1.106.0'
@@ -314,7 +300,6 @@ tasks.withType(ShadowJar) {
     // we should really shade indeed, but it has native libraries
     // relocate 'com.indeed', 'is.hail.relocated.com.indeed'
     relocate 'com.google.cloud', 'is.hail.relocated.com.google.cloud'
-    relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -46,8 +46,8 @@ tasks.withType(JavaCompile) {
 project.ext {
     cachedBreezeVersion = null
 
-    sparkVersion = System.getProperty("spark.version", "3.0.1")
-    scalaVersion = System.getProperty("scala.version", "2.12.12")
+    sparkVersion = System.getProperty("spark.version", "3.0.2")
+    scalaVersion = System.getProperty("scala.version", "2.12.13")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
 }
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -128,7 +128,7 @@ configurations {
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.json4s') {
                     // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.7.0-M5')
+                    details.useVersion('3.7.0-M10')
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -20,8 +20,13 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 repositories {
     mavenCentral()
     jcenter()
+    // Necessary for elasticsearch spark 3 snapshot.
+    // maven { url "https://oss.sonatype.org/content/repositories/snapshots/"}
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
     maven { url "https://repo.spring.io/plugins-release/" }
+    flatDir {
+        dirs 'libs'
+    }
 }
 
 sourceSets.main.scala.srcDir "src/main/java"
@@ -126,9 +131,8 @@ configurations {
                 }
 	        }
             eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.json4s') {
-                    // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.7.0-M5')
+                if (details.requested.group == 'org.apache.spark') {
+                    details.useVersion(sparkVersion)
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')
@@ -181,7 +185,7 @@ dependencies {
 
     bundled group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
-    bundled 'org.elasticsearch:elasticsearch-spark-20_2.11:' + elasticHadoopVersion()
+    bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT'
 
     bundled 'com.google.cloud:google-cloud-storage:1.106.0'
 

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -128,7 +128,7 @@ configurations {
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.json4s') {
                     // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.5.3')
+                    details.useVersion('3.7.0-M5')
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -46,7 +46,7 @@ tasks.withType(JavaCompile) {
 project.ext {
     cachedBreezeVersion = null
 
-    sparkVersion = System.getProperty("spark.version", "3.0.2")
+    sparkVersion = System.getProperty("spark.version", "3.1.1")
     scalaVersion = System.getProperty("scala.version", "2.12.13")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
 }

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -128,7 +128,7 @@ configurations {
             eachDependency { DependencyResolveDetails details ->
                 if (details.requested.group == 'org.json4s') {
                     // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.5.3')
+                    details.useVersion('3.6.10')
                 } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -126,7 +126,7 @@ class LocalBackend(Py4JBackend):
         port = launch_gateway(
             redirect_stdout=sys.stdout,
             redirect_stderr=sys.stderr,
-            jarpath=f'{spark_home}/jars/py4j-0.10.7.jar',
+            jarpath=f'{spark_home}/jars/py4j-0.10.9.jar',
             classpath=f'{spark_home}/jars/*:{hail_jar_path}',
             die_on_exit=True)
         self._gateway = JavaGateway(

--- a/hail/python/hail/docs/install/linux.rst
+++ b/hail/python/hail/docs/install/linux.rst
@@ -3,7 +3,7 @@ Install Hail on GNU/Linux
 =========================
 
 - Install Java 8.
-- Install Python 3.6 or 3.7.
+- Install Python 3.6+.
 - Install a recent version of the C and C++ standard libraries. GCC 5.0, LLVM
   version 3.4, or any later versions suffice.
 - Install BLAS and LAPACK.

--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -3,6 +3,6 @@ Install Hail on Mac OS X
 ========================
 
 - Install `Java 8 <https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html>`__.
-- Install Python 3.6 or 3.7. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__; however, the latest version of Miniconda installs Python 3.8 by default. Please follow `these instructions <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands>`__ to create a Python 3.6 or 3.7 environment.
+- Install Python 3.6+. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
 - Open Terminal.app and execute ``pip install hail``.
 - `Run your first Hail query! <try.rst>`__

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -5,13 +5,13 @@ Install Hail on a Spark Cluster
 If you are using Google Dataproc, please see `these simpler instructions
 <dataproc.rst>`__.
 
-Hail should work with any Spark 2.4.x cluster built with Scala 2.11.
+Hail should work with any Spark 3.1.1 cluster built with Scala 2.12.
 
 Hail needs to be built from source on the leader node. Building Hail from source
 requires:
 
 - Java 8 JDK.
-- Python 3.6 or 3.7.
+- Python 3.6+.
 - A recent C and a C++ compiler, GCC 5.0, LLVM 3.4, or later versions of either
   suffice.
 - BLAS and LAPACK.

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -136,7 +136,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu", "gnomad-public-requester-pays"]
 
-IMAGE_VERSION = '1.4-debian9'
+IMAGE_VERSION = '2.0-debian10'
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -136,7 +136,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu", "gnomad-public-requester-pays"]
 
-IMAGE_VERSION = '2.0.0-RC22-debian10'
+IMAGE_VERSION = '2.0.5-debian10'
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -136,7 +136,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu", "gnomad-public-requester-pays"]
 
-IMAGE_VERSION = '2.0.5-debian10'
+IMAGE_VERSION = '2.0.6-debian10'
 
 
 def init_parser(parser):

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -136,7 +136,7 @@ REGION_TO_REPLICATE_MAPPING = {
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us", "hail-datasets-eu", "gnomad-public-requester-pays"]
 
-IMAGE_VERSION = '2.0-debian10'
+IMAGE_VERSION = '2.0.0-RC22-debian10'
 
 
 def init_parser(parser):

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -13,7 +13,7 @@ numpy<2
 pandas>=1.1.0,<1.1.5
 parsimonious<0.9
 PyJWT
-pyspark>=3.0.0,<3.1.0
+pyspark>=3.1.1,<3.2.0
 python-json-logger==0.1.11
 requests==2.22.0
 scipy>1.2,<1.7

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -13,7 +13,7 @@ numpy<2
 pandas>=1.1.0,<1.1.5
 parsimonious<0.9
 PyJWT
-pyspark>=2.4,<2.4.2
+pyspark>=3.0.0,<3.1.0
 python-json-logger==0.1.11
 requests==2.22.0
 scipy>1.2,<1.7

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -4,7 +4,6 @@ import java.io._
 import java.net._
 import java.nio.charset.StandardCharsets
 import java.util.concurrent._
-
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
@@ -33,6 +32,7 @@ import org.json4s.{DefaultFormats, Formats}
 import org.newsclub.net.unix.{AFUNIXSocket, AFUNIXSocketAddress, AFUNIXServerSocket}
 
 
+import java.nio.charset.Charset
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.annotation.switch
@@ -89,7 +89,7 @@ object Worker {
 
     val fs = retryTransientErrors {
       using(new FileInputStream(s"$scratchDir/gsa-key/key.json")) { is =>
-        new GoogleStorageFS(IOUtils.toString(is))
+        new GoogleStorageFS(IOUtils.toString(is, Charset.defaultCharset()))
       }
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -21,8 +21,7 @@ object RelationalSpec {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
       classOf[ComponentSpec], classOf[RVDComponentSpec], classOf[PartitionCountsComponentSpec],
-      classOf[RelationalSpec], classOf[MatrixTableSpec], classOf[TableSpec]))
-    override val typeHintFieldName = "name"
+      classOf[RelationalSpec], classOf[MatrixTableSpec], classOf[TableSpec]), typeHintFieldName="name")
   } +
     new TableTypeSerializer +
     new MatrixTypeSerializer
@@ -150,8 +149,7 @@ object MatrixTableSpec {
   def fromJValue(fs: FS, path: String, jv: JValue): MatrixTableSpec = {
     implicit val formats: Formats = new DefaultFormats() {
       override val typeHints = ShortTypeHints(List(
-        classOf[ComponentSpec], classOf[RVDComponentSpec], classOf[PartitionCountsComponentSpec]))
-      override val typeHintFieldName = "name"
+        classOf[ComponentSpec], classOf[RVDComponentSpec], classOf[PartitionCountsComponentSpec]), typeHintFieldName = "name")
     } +
       new MatrixTypeSerializer
     val params = jv.extract[MatrixTableSpecParameters]

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -468,7 +468,7 @@ case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends Blo
 
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(lRows, rCols)
     val sparsity = if (left.typ.isSparse || right.typ.isSparse)
-      BlockMatrixSparsity(
+      BlockMatrixSparsity.constructFromShapeAndFunction(
         BlockMatrixType.numBlocks(lRows, blockSize),
         BlockMatrixType.numBlocks(rCols, blockSize)) { (i: Int, j: Int) =>
         Array.tabulate(BlockMatrixType.numBlocks(rCols, blockSize)) { k =>
@@ -538,14 +538,14 @@ case class BlockMatrixBroadcast(
             BlockMatrixSparsity.dense
           case IndexedSeq(0) => // broadcast col vector
             assert(Set(1, shape(0)) == Set(child.typ.nRows, child.typ.nCols))
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(0 -> j))
+            BlockMatrixSparsity.constructFromShapeAndFunction(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(0 -> j))
           case IndexedSeq(1) => // broadcast row vector
             assert(Set(1, shape(1)) == Set(child.typ.nRows, child.typ.nCols))
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(i -> 0))
+            BlockMatrixSparsity.constructFromShapeAndFunction(nRowBlocks, nColBlocks)((i: Int, j: Int) => child.typ.hasBlock(i -> 0))
           case IndexedSeq(0, 0) => // diagonal as col vector
             assert(shape(0) == 1L)
             assert(shape(1) == java.lang.Math.min(child.typ.nRows, child.typ.nCols))
-            BlockMatrixSparsity(nRowBlocks, nColBlocks)((_, j: Int) => child.typ.hasBlock(j -> j))
+            BlockMatrixSparsity.constructFromShapeAndFunction(nRowBlocks, nColBlocks)((_, j: Int) => child.typ.hasBlock(j -> j))
           case IndexedSeq(1, 0) => // transpose
             assert(child.typ.blockSize == blockSize)
             assert(shape(0) == child.typ.nCols && shape(1) == child.typ.nRows)
@@ -624,11 +624,11 @@ case class BlockMatrixAgg(
       outIndexExpr match {
         case IndexedSeq() => BlockMatrixSparsity.dense
         case IndexedSeq(1) => // col vector result; agg over row
-          BlockMatrixSparsity(child.typ.nRowBlocks, 1) { (i, _) =>
+          BlockMatrixSparsity.constructFromShapeAndFunction(child.typ.nRowBlocks, 1) { (i, _) =>
             (0 until child.typ.nColBlocks).exists(j => child.typ.hasBlock(i -> j))
           }
         case IndexedSeq(0) => // row vector result; agg over col
-          BlockMatrixSparsity(1, child.typ.nColBlocks) { (_, j) =>
+          BlockMatrixSparsity.constructFromShapeAndFunction(1, child.typ.nColBlocks) { (_, j) =>
             (0 until child.typ.nRowBlocks).exists(i => child.typ.hasBlock(i -> j))
           }
       }
@@ -744,7 +744,7 @@ case class BandSparsifier(blocksOnly: Boolean, l: Long, u: Long) extends BlockMa
     val leftBuffer = java.lang.Math.floorDiv(-l, childType.blockSize)
     val rightBuffer = java.lang.Math.floorDiv(u, childType.blockSize)
 
-    BlockMatrixSparsity(childType.nRowBlocks, childType.nColBlocks) { (i, j) =>
+    BlockMatrixSparsity.constructFromShapeAndFunction(childType.nRowBlocks, childType.nColBlocks) { (i, j) =>
       j >= (i - leftBuffer) && j <= (i + rightBuffer) && childType.hasBlock(i -> j)
     }
   }
@@ -764,7 +764,7 @@ case class RowIntervalSparsifier(blocksOnly: Boolean, starts: IndexedSeq[Long], 
     val blockStarts = starts.grouped(childType.blockSize).map(idxs => childType.getBlockIdx(idxs.min)).toArray
     val blockStops = stops.grouped(childType.blockSize).map(idxs => childType.getBlockIdx(idxs.max - 1)).toArray
 
-    BlockMatrixSparsity(childType.nRowBlocks, childType.nColBlocks) { (i, j) =>
+    BlockMatrixSparsity.constructFromShapeAndFunction(childType.nRowBlocks, childType.nColBlocks) { (i, j) =>
       blockStarts(i) <= j && blockStops(i) >= j && childType.hasBlock(i -> j)
     }
   }
@@ -811,7 +811,7 @@ case class PerBlockSparsifier(blocks: IndexedSeq[Int]) extends BlockMatrixSparsi
   val blockSet = blocks.toSet
 
   override def definedBlocks(childType: BlockMatrixType): BlockMatrixSparsity = {
-    BlockMatrixSparsity(childType.nRowBlocks, childType.nColBlocks){ case(i: Int, j: Int) =>
+    BlockMatrixSparsity.constructFromShapeAndFunction(childType.nRowBlocks, childType.nColBlocks){ case(i: Int, j: Int) =>
       blockSet.contains(i + j * childType.nRowBlocks)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -92,8 +92,8 @@ case class BlockMatrixRead(reader: BlockMatrixReader) extends BlockMatrixIR {
 object BlockMatrixReader {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(
-      List(classOf[BlockMatrixNativeReader], classOf[BlockMatrixBinaryReader], classOf[BlockMatrixPersistReader]))
-    override val typeHintFieldName: String = "name"
+      List(classOf[BlockMatrixNativeReader], classOf[BlockMatrixBinaryReader], classOf[BlockMatrixPersistReader]),
+      typeHintFieldName = "name")
   }
 
   def fromJValue(ctx: ExecuteContext, jv: JValue): BlockMatrixReader = {

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -22,8 +22,7 @@ object BlockMatrixWriter {
     override val typeHints = ShortTypeHints(
       List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter],
         classOf[BlockMatrixBinaryMultiWriter], classOf[BlockMatrixTextMultiWriter],
-        classOf[BlockMatrixPersistWriter], classOf[BlockMatrixNativeMultiWriter]))
-    override val typeHintFieldName: String = "name"
+        classOf[BlockMatrixPersistWriter], classOf[BlockMatrixNativeMultiWriter]), typeHintFieldName = "name")
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -649,9 +649,8 @@ object PartitionReader {
       classOf[PartitionNativeReaderIndexed],
       classOf[PartitionZippedNativeReader],
       classOf[AbstractTypedCodecSpec],
-      classOf[TypedCodecSpec])
-    ) + BufferSpec.shortTypeHints
-    override val typeHintFieldName = "name"
+      classOf[TypedCodecSpec]),
+      typeHintFieldName = "name") + BufferSpec.shortTypeHints
   }  +
     new TStructSerializer +
     new TypeSerializer +
@@ -664,9 +663,8 @@ object PartitionWriter {
     override val typeHints = ShortTypeHints(List(
       classOf[PartitionNativeWriter],
       classOf[AbstractTypedCodecSpec],
-      classOf[TypedCodecSpec])
+      classOf[TypedCodecSpec]), typeHintFieldName = "name"
     ) + BufferSpec.shortTypeHints
-    override val typeHintFieldName = "name"
   }  +
     new TStructSerializer +
     new TypeSerializer +
@@ -683,9 +681,9 @@ object MetadataWriter {
       classOf[RelationalWriter],
       classOf[RVDSpecMaker],
       classOf[AbstractTypedCodecSpec],
-      classOf[TypedCodecSpec])
+      classOf[TypedCodecSpec]),
+      typeHintFieldName = "name"
     ) + BufferSpec.shortTypeHints
-    override val typeHintFieldName = "name"
   }  +
     new TStructSerializer +
     new TypeSerializer +

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -28,8 +28,7 @@ object MatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(
       List(classOf[MatrixNativeWriter], classOf[MatrixVCFWriter], classOf[MatrixGENWriter],
-        classOf[MatrixBGENWriter], classOf[MatrixPLINKWriter], classOf[WrappedMatrixWriter]))
-    override val typeHintFieldName = "name"
+        classOf[MatrixBGENWriter], classOf[MatrixPLINKWriter], classOf[WrappedMatrixWriter]), typeHintFieldName = "name")
   }
 }
 
@@ -339,8 +338,7 @@ case class MatrixPLINKWriter(
 
 object MatrixNativeMultiWriter {
   implicit val formats: Formats = new DefaultFormats() {
-    override val typeHints = ShortTypeHints(List(classOf[MatrixNativeMultiWriter]))
-    override val typeHintFieldName = "name"
+    override val typeHints = ShortTypeHints(List(classOf[MatrixNativeMultiWriter]), typeHintFieldName = "name")
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -21,10 +21,9 @@ import is.hail.variant.ReferenceGenome
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 
 object TableWriter {
-  implicit val formats: Formats = new DefaultFormats() {
+  implicit val formats: Formats = new DefaultFormats()  {
     override val typeHints = ShortTypeHints(
-      List(classOf[TableNativeWriter], classOf[TableTextWriter]))
-    override val typeHintFieldName = "name"
+      List(classOf[TableNativeWriter], classOf[TableTextWriter]), typeHintFieldName = "name")
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -130,7 +130,7 @@ object RelationalFunctions {
     classOf[WrappedMatrixToTableFunction],
     classOf[WrappedMatrixToValueFunction],
     classOf[PCRelate]
-  ))
+  ), typeHintFieldName = "name")
 
   def extractTo[T: Manifest](ctx: ExecuteContext, config: String): T = {
     val jv = JsonMethods.parse(config)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -5,6 +5,7 @@ import is.hail.types.virtual.Type
 import is.hail.types.{BlockMatrixType, MatrixType, RTable, TableType, TypeWithRequiredness}
 import is.hail.linalg.BlockMatrix
 import is.hail.methods._
+import is.hail.utils._
 import is.hail.rvd.RVDType
 import org.json4s.{Extraction, JValue, ShortTypeHints}
 import org.json4s.jackson.{JsonMethods, Serialization}
@@ -135,8 +136,10 @@ object RelationalFunctions {
     val jv = JsonMethods.parse(config)
     (jv \ "name").extract[String] match {
       case "VEP" => VEP.fromJValue(ctx.fs, jv).asInstanceOf[T]
-      case _ =>
+      case _ => {
+        log.info("JSON: " + jv.toString)
         jv.extract[T]
+      }
     }
   }
 

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -66,7 +66,7 @@ object BufferSpec {
       classOf[LEB128BufferSpec],
       classOf[BlockingBufferSpec],
       classOf[StreamBufferSpec]
-    ))
+    ), typeHintFieldName = "name")
 }
 
 trait BufferSpec extends Spec {

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -30,9 +30,8 @@ object AbstractRVDSpec {
       classOf[compatibility.IndexSpec],
       classOf[compatibility.UnpartitionedRVDSpec],
       classOf[AbstractTypedCodecSpec],
-      classOf[TypedCodecSpec])
-    ) + BufferSpec.shortTypeHints
-    override val typeHintFieldName = "name"
+      classOf[TypedCodecSpec]),
+    typeHintFieldName = "name") + BufferSpec.shortTypeHints
   }  +
     new TStructSerializer +
     new TypeSerializer +

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -21,7 +21,7 @@ import org.json4s.{DefaultFormats, Formats, JValue, ShortTypeHints}
 object AbstractRVDSpec {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
-//      classOf[AbstractRVDSpec],
+      classOf[AbstractRVDSpec],
       classOf[OrderedRVDSpec2],
       classOf[IndexedRVDSpec2],
       classOf[IndexSpec2],
@@ -29,7 +29,7 @@ object AbstractRVDSpec {
       classOf[compatibility.IndexedRVDSpec],
       classOf[compatibility.IndexSpec],
       classOf[compatibility.UnpartitionedRVDSpec],
-//      classOf[AbstractTypedCodecSpec],
+      classOf[AbstractTypedCodecSpec],
       classOf[TypedCodecSpec]),
     typeHintFieldName = "name") + BufferSpec.shortTypeHints
   }  +

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -21,7 +21,7 @@ import org.json4s.{DefaultFormats, Formats, JValue, ShortTypeHints}
 object AbstractRVDSpec {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
-      classOf[AbstractRVDSpec],
+//      classOf[AbstractRVDSpec],
       classOf[OrderedRVDSpec2],
       classOf[IndexedRVDSpec2],
       classOf[IndexSpec2],
@@ -29,7 +29,7 @@ object AbstractRVDSpec {
       classOf[compatibility.IndexedRVDSpec],
       classOf[compatibility.IndexSpec],
       classOf[compatibility.UnpartitionedRVDSpec],
-      classOf[AbstractTypedCodecSpec],
+//      classOf[AbstractTypedCodecSpec],
       classOf[TypedCodecSpec]),
     typeHintFieldName = "name") + BufferSpec.shortTypeHints
   }  +

--- a/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
@@ -11,7 +11,7 @@ object BlockMatrixSparsity {
 
   def apply(definedBlocks: IndexedSeq[(Int, Int)]): BlockMatrixSparsity = BlockMatrixSparsity(Some(definedBlocks))
 
-  def apply(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean): BlockMatrixSparsity = {
+  def constructFromShapeAndFunction(nRows: Int, nCols: Int)(exists: (Int, Int) => Boolean): BlockMatrixSparsity = {
     var i = 0
     builder.clear()
     while (i < nRows) {
@@ -47,7 +47,7 @@ case class BlockMatrixSparsity(definedBlocks: Option[IndexedSeq[(Int, Int)]]) {
   def condense(blockOverlaps: => (Array[Array[Int]], Array[Array[Int]])): BlockMatrixSparsity = {
     definedBlocks.map { _ =>
       val (ro, co) = blockOverlaps
-      BlockMatrixSparsity(ro.length, co.length) { (i, j) =>
+      BlockMatrixSparsity.constructFromShapeAndFunction(ro.length, co.length) { (i, j) =>
         ro(i).exists(ii => co(j).exists(jj => hasBlock(ii -> jj)))
       }
     }.getOrElse(BlockMatrixSparsity.dense)

--- a/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
@@ -7,7 +7,7 @@ import is.hail.linalg.BlockMatrix
 object BlockMatrixSparsity {
   private val builder: BoxedArrayBuilder[(Int, Int)] = new BoxedArrayBuilder[(Int, Int)]
 
-  val dense: BlockMatrixSparsity = BlockMatrixSparsity(None)
+  val dense: BlockMatrixSparsity = new BlockMatrixSparsity(None: Option[IndexedSeq[(Int, Int)]])
 
   def apply(definedBlocks: IndexedSeq[(Int, Int)]): BlockMatrixSparsity = BlockMatrixSparsity(Some(definedBlocks))
 


### PR DESCRIPTION
This PR:

- Changes default hail Spark version to Spark 3
- Changes default hail Scala version to 2.12
- ~Changes the `build_hail_spark3` rule to `build_hail_spark2`. I don't know how long we will care if we still build under Spark 2.~ Scratch that, I deleted this. We don't support spark 2 anymore.  
- Changes the dataproc image used in `hailctl dataproc start` to one that uses Spark 3.1.1.
