### PR TITLE
[hailctl dev] deploy cli: fix printing remote traceback

### DIFF
--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -27,7 +27,9 @@ class CIClient:
 
     async def __aenter__(self):
         headers = service_auth_headers(self._deploy_config, 'ci')
-        self._session = client_session(timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+        self._session = client_session(
+            raise_for_status=False,
+            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):


### PR DESCRIPTION
Hi, just proposing a possible fix (at least it fixes things for me).

After `raise_for_status=True` [was set](https://github.com/hail-is/hail/pull/9864/files) to default to True for `ClientSession` objects, [these lines](https://github.com/hail-is/hail/blob/9303a3aeccc3c374130b845bdaa5b22a84a64ea5/hail/python/hailtop/hailctl/dev/deploy/cli.py#L48-L53) that handle the response and redirect the remote traceback locally, are no longer reachable.

This PR sets `raise_for_status=False` for dev deploy, similar to how it [was handled for dev query](https://github.com/hail-is/hail/pull/9864/files#diff-3d7267e81281c8027cba60607e398a7d5fbfcc16481cddf45017948889b15715).


Thanks @lgruen for helping to locate the issue!