### PR TITLE
[query] Remove PType.fundamentalType

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -218,20 +218,22 @@ object Region {
     false
   }
 
-  def loadPrimitive(typ: PType): Code[Long] => Code[_] = typ.fundamentalType match {
+  def loadPrimitive(typ: PType): Code[Long] => Code[_] = typ match {
     case _: PBoolean => loadBoolean
     case _: PInt32 => loadInt
     case _: PInt64 => loadLong
     case _: PFloat32 => loadFloat
     case _: PFloat64 => loadDouble
+    case _: PCanonicalCall => loadInt
   }
 
-  def storePrimitive(typ: PType, dest: Code[Long]): Code[_] => Code[Unit] = typ.fundamentalType match {
+  def storePrimitive(typ: PType, dest: Code[Long]): Code[_] => Code[Unit] = typ match {
     case _: PBoolean => v => storeBoolean(dest, coerce[Boolean](v))
     case _: PInt32 => v => storeInt(dest, coerce[Int](v))
     case _: PInt64 => v => storeLong(dest, coerce[Long](v))
     case _: PFloat32 => v => storeFloat(dest, coerce[Float](v))
     case _: PFloat64 => v => storeDouble(dest, coerce[Double](v))
+    case _: PCanonicalCall => v => storeInt(dest, coerce[Int](v))
   }
 
   def stagedCreate(blockSize: Size, pool: Code[RegionPool]): Code[Region] =

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -224,7 +224,6 @@ object Region {
     case _: PInt64 => loadLong
     case _: PFloat32 => loadFloat
     case _: PFloat64 => loadDouble
-    case _: PCanonicalCall => loadInt
   }
 
   def storePrimitive(typ: PType, dest: Code[Long]): Code[_] => Code[Unit] = typ match {
@@ -233,7 +232,6 @@ object Region {
     case _: PInt64 => v => storeLong(dest, coerce[Long](v))
     case _: PFloat32 => v => storeFloat(dest, coerce[Float](v))
     case _: PFloat64 => v => storeDouble(dest, coerce[Double](v))
-    case _: PCanonicalCall => v => storeInt(dest, coerce[Int](v))
   }
 
   def stagedCreate(blockSize: Size, pool: Code[RegionPool]): Code[Region] =

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -18,8 +18,6 @@ trait PArrayBackedContainer extends PContainer {
 
   override lazy val byteSize: Long = arrayRep.byteSize
 
-  override lazy val fundamentalType = PCanonicalArray(elementType.fundamentalType, required)
-
   def loadLength(aoff: Long): Int =
     arrayRep.loadLength(aoff)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -30,14 +30,6 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   override val byteSize: Long = 8
 
-  override val fundamentalType: PCanonicalArray = {
-    if (elementType == elementType.fundamentalType) {
-      this
-    } else {
-      this.copy(elementType = elementType.fundamentalType)
-    }
-  }
-
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalArray(elementType, required)
 
   def loadLength(aoff: Long): Int =
@@ -313,7 +305,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   }
 
   def deepPointerCopy(cb: EmitCodeBuilder, region: Value[Region], dstAddressCode: Code[Long], len: Value[Int]): Unit = {
-    if (!this.elementType.fundamentalType.containsPointers) {
+    if (!this.elementType.containsPointers) {
       return
     }
 
@@ -333,7 +325,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   }
 
   def deepPointerCopy(region: Region, dstAddress: Long) {
-    if(!this.elementType.fundamentalType.containsPointers) {
+    if(!this.elementType.containsPointers) {
       return
     }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -87,14 +87,14 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
 
   def loadField(offset: Long, fieldIdx: Int): Long = {
     val off = fieldOffset(offset, fieldIdx)
-    types(fieldIdx).fundamentalType.unstagedLoadFromNested(off)
+    types(fieldIdx).unstagedLoadFromNested(off)
   }
 
   def loadField(offset: Code[Long], fieldIdx: Int): Code[Long] =
     loadField(fieldOffset(offset, fieldIdx), types(fieldIdx))
 
   private def loadField(fieldOffset: Code[Long], fieldType: PType): Code[Long] = {
-    fieldType.fundamentalType.loadFromNested(fieldOffset)
+    fieldType.loadFromNested(fieldOffset)
   }
 
   def deepPointerCopy(cb: EmitCodeBuilder, region: Value[Region], dstStructAddress: Code[Long]): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -17,7 +17,6 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   def byteSize: Long = representation.byteSize
   override def alignment: Long = representation.alignment
-  override lazy val fundamentalType: PInt32 = representation
 
   override def unsafeOrdering(): UnsafeOrdering = representation.unsafeOrdering() // this was a terrible idea
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -13,7 +13,6 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   def byteSize: Long = representation.byteSize
   override def alignment: Long = representation.alignment
-  override lazy val fundamentalType: PStruct = representation.fundamentalType
 
   def _asIdent = s"interval_of_${ pointType.asIdent }"
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -29,7 +29,6 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def byteSize: Long = representation.byteSize
   override def alignment: Long = representation.alignment
-  override lazy val fundamentalType: PStruct = representation.fundamentalType
 
   def rg: ReferenceGenome = rgBc.value
 
@@ -56,19 +55,17 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   // FIXME: Remove when representation of contig/position is a naturally-ordered Long
   override def unsafeOrdering(): UnsafeOrdering = {
-    val repr = representation.fundamentalType
-
     val localRGBc = rgBc
-    val binaryOrd = repr.fieldType("contig").asInstanceOf[PBinary].unsafeOrdering()
+    val binaryOrd = representation.fieldType("contig").asInstanceOf[PBinary].unsafeOrdering()
 
     new UnsafeOrdering {
       def compare(o1: Long, o2: Long): Int = {
-        val cOff1 = repr.loadField(o1, 0)
-        val cOff2 = repr.loadField(o2, 0)
+        val cOff1 = representation.loadField(o1, 0)
+        val cOff2 = representation.loadField(o2, 0)
 
         if (binaryOrd.compare(cOff1, cOff2) == 0) {
-          val posOff1 = repr.loadField(o1, 1)
-          val posOff2 = repr.loadField(o2, 1)
+          val posOff1 = representation.loadField(o1, 1)
+          val posOff2 = representation.loadField(o2, 1)
           java.lang.Integer.compare(Region.loadInt(posOff1), Region.loadInt(posOff2))
         } else {
           val contig1 = contigType.loadString(cOff1)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -56,7 +56,7 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
   // FIXME: Remove when representation of contig/position is a naturally-ordered Long
   override def unsafeOrdering(): UnsafeOrdering = {
     val localRGBc = rgBc
-    val binaryOrd = representation.fieldType("contig").asInstanceOf[PBinary].unsafeOrdering()
+    val binaryOrd = representation.fieldType("contig").unsafeOrdering()
 
     new UnsafeOrdering {
       def compare(o1: Long, o2: Long): Int = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -44,7 +44,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       cb.assign(settables(dimIdx), shapeTuple.loadField(cb, dimIdx).get(cb).asLong.longCode(cb))
     }
   }
-  
+
   def loadStrides(cb: EmitCodeBuilder, addr: Value[Long], settables: IndexedSeq[Settable[Long]]): Unit = {
     assert(settables.length == nDims)
     val strideTuple = strideType.loadCheapPCode(cb, representation.loadField(addr, "strides"))
@@ -53,8 +53,8 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       cb.assign(settables(dimIdx), strideTuple.loadField(cb, dimIdx).get(cb).asLong.longCode(cb))
     }
   }
-  
-  val dataType: PCanonicalArray = PCanonicalArray(elementType, required = true)  
+
+  val dataType: PCanonicalArray = PCanonicalArray(elementType, required = true)
 
   lazy val representation: PCanonicalStruct = {
     PCanonicalStruct(required,
@@ -68,8 +68,6 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   override lazy val alignment: Long = representation.alignment
 
   override def unsafeOrdering(): UnsafeOrdering = representation.unsafeOrdering()
-
-  override lazy val fundamentalType: PType = representation.fundamentalType
 
   def numElements(shape: IndexedSeq[Value[Long]]): Code[Long] = {
     shape.foldLeft(1L: Code[Long])(_ * _)
@@ -190,7 +188,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   def setRequired(required: Boolean) = if(required == this.required) this else PCanonicalNDArray(elementType, nDims, required)
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    this.fundamentalType.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
+    representation.unstagedStoreAtAddress(addr, region, srcPType.asInstanceOf[PCanonicalNDArray].representation, srcAddress, deepCopy)
 
   def sType: SNDArrayPointer = SNDArrayPointer(this)
 
@@ -242,4 +240,3 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     dataType.unstagedStoreJavaObjectAtAddress(curAddr, aNDArray.getRowMajorElements(), region)
   }
 }
-

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -30,8 +30,6 @@ final case class PCanonicalShuffle(
 
   override def alignment: Long = representation.alignment
 
-  override def fundamentalType: PType = representation.fundamentalType
-
   override def containsPointers: Boolean = representation.containsPointers
 
   def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {
@@ -42,7 +40,7 @@ final case class PCanonicalShuffle(
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    this.representation.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
+    this.representation.unstagedStoreAtAddress(addr, region, srcPType.asInstanceOf[PCanonicalShuffle].representation, srcAddress, deepCopy)
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit =
     this.representation.unstagedStoreJavaObjectAtAddress(addr, annotation, region)
@@ -90,4 +88,3 @@ final case class PCanonicalShuffle(
 
   def unstagedLoadFromNested(addr: Long): Long = representation.unstagedLoadFromNested(addr)
 }
-

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStream.scala
@@ -9,13 +9,6 @@ import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode}
 import is.hail.types.virtual.{TStream, Type}
 
 final case class PCanonicalStream(elementType: PType, separateRegions: Boolean = false, required: Boolean = false) extends PStream {
-  override val fundamentalType: PStream = {
-    if (elementType == elementType.fundamentalType)
-      this
-    else
-      this.copy(elementType = elementType.fundamentalType)
-  }
-
   override def unsafeOrdering(): UnsafeOrdering = throw new NotImplementedError()
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -18,10 +18,9 @@ class PCanonicalString(val required: Boolean) extends PString {
   override def byteSize: Long = 8
 
   lazy val binaryRepresentation: PCanonicalBinary = PCanonicalBinary(required)
-  override lazy val fundamentalType: PCanonicalBinary = binaryRepresentation
 
   def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
-    binaryRepresentation.copyFromAddress(region, srcPType.asInstanceOf[PString].fundamentalType, srcAddress, deepCopy)
+    binaryRepresentation.copyFromAddress(region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
 
   override def containsPointers: Boolean = true
 
@@ -55,7 +54,7 @@ class PCanonicalString(val required: Boolean) extends PString {
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
-    binaryRepresentation.unstagedStoreAtAddress(addr, region, srcPType.fundamentalType, srcAddress, deepCopy)
+    binaryRepresentation.unstagedStoreAtAddress(addr, region, srcPType.asInstanceOf[PString].binaryRepresentation, srcAddress, deepCopy)
 
   def setRequired(required: Boolean) = if (required == this.required) this else PCanonicalString(required)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
@@ -76,16 +76,6 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
     }
   }
 
-  lazy val structFundamentalType: PStruct = {
-    val fundamentalFieldTypes = fields.map(f => f.typ.fundamentalType)
-    if ((fields, fundamentalFieldTypes).zipped
-      .forall { case (f, ft) => f.typ == ft })
-      this
-    else {
-      PCanonicalStruct(required, (fields, fundamentalFieldTypes).zipped.map { case (f, ft) => (f.name, ft) }: _*)
-    }
-  }
-
   def loadField(offset: Code[Long], fieldName: String): Code[Long] =
     loadField(offset, fieldIdx(fieldName))
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalTuple.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalTuple.scala
@@ -23,15 +23,6 @@ final case class PCanonicalTuple(_types: IndexedSeq[PTupleField], override val r
     sb += ']'
   }
 
-  lazy val tupleFundamentalType: PTuple = {
-    val fundamentalFieldTypes = _types.map(tf => tf.copy(typ = tf.typ.fundamentalType))
-    if ((_types, fundamentalFieldTypes).zipped
-      .forall { case (t, ft) => t == ft })
-      this
-    else
-      PCanonicalTuple(fundamentalFieldTypes, required)
-  }
-
   override def deepRename(t: Type) = deepTupleRename(t.asInstanceOf[TTuple])
 
   private def deepTupleRename(t: TTuple) = {

--- a/hail/src/main/scala/is/hail/types/physical/PDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PDict.scala
@@ -13,8 +13,6 @@ abstract class PDict extends PContainer {
 
   def elementType: PStruct
 
-  def arrayFundamentalType: PArray = fundamentalType.asInstanceOf[PArray]
-
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering = {
     assert(other isOfType this)
     CodeOrdering.mapOrdering(this, other.asInstanceOf[PDict], mb)

--- a/hail/src/main/scala/is/hail/types/physical/PSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSet.scala
@@ -8,8 +8,6 @@ import is.hail.types.virtual.TSet
 abstract class PSet extends PContainer {
   lazy val virtualType: TSet = TSet(elementType.virtualType)
 
-  def arrayFundamentalType: PArray = fundamentalType.asInstanceOf[PArray]
-
   def codeOrdering(mb: EmitMethodBuilder[_], other: PType): CodeOrdering = {
     assert(other isOfType this)
     CodeOrdering.setOrdering(this, other.asInstanceOf[PSet], mb)

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -22,7 +22,6 @@ abstract class PString extends PType {
   }
 
   val binaryRepresentation: PBinary
-  override lazy val fundamentalType: PType = this
 
   def loadLength(boff: Long): Int
 

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -44,9 +44,6 @@ trait PStruct extends PBaseStruct {
 
   final def typeAfterSelect(keep: IndexedSeq[Int]): PCanonicalStruct = PCanonicalStruct(required, keep.map(i => fieldNames(i) -> types(i)): _*)
 
-  val structFundamentalType: PStruct
-  override lazy val fundamentalType: PStruct = structFundamentalType
-
   def loadField(offset: Code[Long], fieldName: String): Code[Long]
 
   final def isFieldDefined(offset: Code[Long], fieldName: String): Code[Boolean] = !isFieldMissing(offset, fieldName)

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -35,7 +35,6 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: Array[String]) extends 
   override lazy val virtualType = TStruct(fields.map(f => (f.name -> f.typ.virtualType)):_*)
   override val types: Array[PType] = fields.map(_.typ).toArray
 
-  lazy val structFundamentalType: PStruct = PSubsetStruct(ps.structFundamentalType, _fieldNames)
   override val byteSize: Long = 8
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean) {

--- a/hail/src/main/scala/is/hail/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PTuple.scala
@@ -17,9 +17,6 @@ trait PTuple extends PBaseStruct {
   lazy val fields: IndexedSeq[PField] = _types.zipWithIndex.map { case (PTupleField(tidx, t), i) => PField(s"$tidx", t, i) }
   lazy val nFields: Int = fields.size
 
-  protected val tupleFundamentalType: PTuple
-  override lazy val fundamentalType: PTuple = tupleFundamentalType
-
   final def codeOrdering(mb: EmitMethodBuilder[_], other: PType, so: Array[SortOrder], missingFieldsEqual: Boolean): CodeOrdering = {
     assert(other isOfType this, s"$other != $this")
     assert(so == null || so.size == types.size)

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -360,10 +360,6 @@ abstract class PType extends Serializable with Requiredness {
 
   def alignment: Long = byteSize
 
-  /*  Fundamental types are types that can be handled natively by RegionValueBuilder: primitive
-      types, Array and Struct. */
-  def fundamentalType: PType = this
-
   final def unary_+(): PType = setRequired(true)
 
   final def unary_-(): PType = setRequired(false)
@@ -382,15 +378,16 @@ abstract class PType extends Serializable with Requiredness {
   final def isOfType(t: PType): Boolean = this.virtualType == t.virtualType
 
   final def isPrimitive: Boolean =
-    fundamentalType.isInstanceOf[PBoolean] || isNumeric
+    isInstanceOf[PBoolean] || isNumeric
 
   final def isRealizable: Boolean = !isInstanceOf[PUnrealizable]
 
   final def isNumeric: Boolean =
-    fundamentalType.isInstanceOf[PInt32] ||
-      fundamentalType.isInstanceOf[PInt64] ||
-      fundamentalType.isInstanceOf[PFloat32] ||
-      fundamentalType.isInstanceOf[PFloat64]
+    isInstanceOf[PInt32] ||
+      isInstanceOf[PInt64] ||
+      isInstanceOf[PFloat32] ||
+      isInstanceOf[PFloat64] ||
+      isInstanceOf[PCanonicalCall] // :(
 
   def containsPointers: Boolean
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -386,8 +386,7 @@ abstract class PType extends Serializable with Requiredness {
     isInstanceOf[PInt32] ||
       isInstanceOf[PInt64] ||
       isInstanceOf[PFloat32] ||
-      isInstanceOf[PFloat64] ||
-      isInstanceOf[PCanonicalCall] // :(
+      isInstanceOf[PFloat64]
 
   def containsPointers: Boolean
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -87,11 +87,12 @@ class RichCodeInputBuffer(
       ib.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
   }
 
-  def readPrimitive(typ: PType): Code[_] = typ.fundamentalType match {
+  def readPrimitive(typ: PType): Code[_] = typ match {
     case _: PBoolean => readBoolean()
     case _: PInt32 => readInt()
     case _: PInt64 => readLong()
     case _: PFloat32 => readFloat()
     case _: PFloat64 => readDouble()
+    case _: PCanonicalCall => readInt()
   }
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -93,6 +93,5 @@ class RichCodeInputBuffer(
     case _: PInt64 => readLong()
     case _: PFloat32 => readFloat()
     case _: PFloat64 => readDouble()
-    case _: PCanonicalCall => readInt()
   }
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -62,6 +62,5 @@ class RichCodeOutputBuffer(
     case _: PInt64 => v => writeLong(coerce[Long](v))
     case _: PFloat32 => v => writeFloat(coerce[Float](v))
     case _: PFloat64 => v => writeDouble(coerce[Double](v))
-    case _: PCanonicalCall => v => writeInt(coerce[Int](v))
   }
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -56,11 +56,12 @@ class RichCodeOutputBuffer(
   def writeUTF(s: Code[String]): Code[Unit] =
     ob.invoke[String, Unit]("writeUTF", s)
 
-  def writePrimitive(typ: PType): Code[_] => Code[Unit] = typ.fundamentalType match {
+  def writePrimitive(typ: PType): Code[_] => Code[Unit] = typ match {
     case _: PBoolean => v => writeBoolean(coerce[Boolean](v))
     case _: PInt32 => v => writeInt(coerce[Int](v))
     case _: PInt64 => v => writeLong(coerce[Long](v))
     case _: PFloat32 => v => writeFloat(coerce[Float](v))
     case _: PFloat64 => v => writeDouble(coerce[Double](v))
+    case _: PCanonicalCall => v => writeInt(coerce[Int](v))
   }
 }

--- a/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
+++ b/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
@@ -10,7 +10,6 @@ class RegionValueVariant(rowType: PStruct) extends View {
   private val allelesField = rowType.fieldByName("alleles")
   private val locusIdx = locusField.index
   private val allelesIdx = allelesField.index
-  private val tl: PStruct = locusPType.fundamentalType.asInstanceOf[PStruct]
   private val taa: PArray = allelesField.typ.asInstanceOf[PArray]
   private val allelePType = taa.elementType.asInstanceOf[PString]
   private var locusAddress: Long = _
@@ -37,9 +36,7 @@ class RegionValueVariant(rowType: PStruct) extends View {
     cachedContig
   }
 
-  def position(): Int = {
-    Region.loadInt(tl.loadField(locusAddress, 1))
-  }
+  def position(): Int = locusPType.position(locusAddress)
 
   def alleles(): Array[String] = {
     if (cachedAlleles == null) {


### PR DESCRIPTION
Fundamental types seem like a good idea, but using them in code generation at any stage but point manipulation of values can constrain our ability to use other representations for a given type.