### PR TITLE
[query] Array Copy Fast Path

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -421,7 +421,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         cb += stagedInitialize(newAddr, length, setMissing = false)
 
         val otherType = pcInd.st.pType.asInstanceOf[PCanonicalArray]
-        cb += Region.copyFrom(otherType.firstElementOffset(pcInd.a), this.firstElementOffset(newAddr), contentsByteSize(pcInd.length))
+        cb += Region.copyFrom(otherType.firstElementOffset(pcInd.a), this.firstElementOffset(newAddr), pcInd.length.toL * otherType.elementByteSize)
         if (deepCopy)
           deepPointerCopy(cb, region, newAddr, pcInd.length)
         newAddr

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -407,6 +407,24 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         } else {
           value.asInstanceOf[SIndexablePointerCode].a
         }
+      case SIndexablePointer(PCanonicalArray(otherElementType, _)) if otherElementType.equalModuloRequired(elementType) =>
+        val newAddr = cb.newLocal[Long]("pcarray_store_newaddr")
+        val pcInd = value.memoize(cb, "pcarray_store_src_difftype").asInstanceOf[SIndexablePointerSettable]
+        val length = pcInd.loadLength()
+        cb.assign(newAddr, allocate(region, length))
+
+        // other is optional, constructing required
+        if (elementType.required) {
+          cb.ifx(pcInd.hasMissingValues(cb),
+            cb._fatal("tried to copy array with missing values to array of required elements"))
+        }
+        cb += stagedInitialize(newAddr, length, setMissing = false)
+
+        val otherType = pcInd.st.pType.asInstanceOf[PCanonicalArray]
+        cb += Region.copyFrom(otherType.firstElementOffset(pcInd.a), this.firstElementOffset(newAddr), contentsByteSize(pcInd.length))
+        if (deepCopy)
+          deepPointerCopy(cb, region, newAddr, pcInd.length)
+        newAddr
       case _ =>
         val newAddr = cb.newLocal[Long]("pcarray_store_newaddr")
         val indexable = value.asIndexable.memoize(cb, "pcarray_store_src_difftype")


### PR DESCRIPTION
Want to use memcpy when possible. 