### PR TITLE
[batch] Fix provisioning bugs

### DIFF
--- a/batch/batch/driver/instance_collection.py
+++ b/batch/batch/driver/instance_collection.py
@@ -143,15 +143,21 @@ class InstanceCollection:
 
         log.info(f'{instance} gce_state {gce_state} last_start_timestamp {last_start_timestamp}')
 
+        if (gce_state == 'PROVISIONING'
+                and instance.state == 'pending'
+                and time_msecs() - instance.time_created > 5 * 60 * 1000):
+            log.info(f'{instance} did not provision within 5m after creation, deleting')
+            await self.call_delete_instance(instance, 'activation_timeout')
+
         if gce_state in ('STOPPING', 'TERMINATED'):
             log.info(f'{instance} live but stopping or terminated, deactivating')
             await instance.deactivate('terminated')
 
-        if (gce_state in ('PROVISIONING', 'STAGING', 'RUNNING')
+        if (gce_state in ('STAGING', 'RUNNING')
                 and instance.state == 'pending'
                 and last_start_time_msecs is not None
-                and time_msecs() - last_start_time_msecs > 60 * 1000):
-            log.info(f'{instance} did not activate within 1m after starting, deleting')
+                and time_msecs() - last_start_time_msecs > 5 * 60 * 1000):
+            log.info(f'{instance} did not activate within 5m after starting, deleting')
             await self.call_delete_instance(instance, 'activation_timeout')
 
         if instance.state == 'inactive':

--- a/batch/batch/driver/instance_collection.py
+++ b/batch/batch/driver/instance_collection.py
@@ -140,7 +140,7 @@ class InstanceCollection:
         if (gce_state == 'PROVISIONING'
                 and instance.state == 'pending'
                 and time_msecs() - instance.time_created > 5 * 60 * 1000):
-            log.info(f'{instance} did not provision within 5m after creation, deleting')
+            log.exception(f'{instance} did not provision within 5m after creation, deleting')
             await self.call_delete_instance(instance, 'activation_timeout')
 
         if gce_state in ('STOPPING', 'TERMINATED'):
@@ -154,7 +154,7 @@ class InstanceCollection:
             
             if (instance.state == 'pending'
                     and time_msecs() - last_start_time_msecs > 5 * 60 * 1000):
-                log.info(f'{instance} did not activate within 5m after starting, deleting')
+                log.exception(f'{instance} did not activate within 5m after starting, deleting')
                 await self.call_delete_instance(instance, 'activation_timeout')
 
         if instance.state == 'inactive':

--- a/batch/batch/driver/instance_collection.py
+++ b/batch/batch/driver/instance_collection.py
@@ -151,7 +151,7 @@ class InstanceCollection:
             last_start_timestamp = spec.get('lastStartTimestamp')
             assert last_start_timestamp is not None, f'lastStartTimestamp does not exist {spec}'
             last_start_time_msecs = dateutil.parser.isoparse(last_start_timestamp).timestamp() * 1000
-            
+
             if (instance.state == 'pending'
                     and time_msecs() - last_start_time_msecs > 5 * 60 * 1000):
                 log.exception(f'{instance} did not activate within 5m after starting, deleting')

--- a/batch/sql/estimated-current.sql
+++ b/batch/sql/estimated-current.sql
@@ -325,6 +325,11 @@ BEGIN
     SET NEW.start_time = OLD.start_time;
   END IF;
 
+  # for job private instances that do not finish creating
+  IF NEW.reason = 'activation_timeout' THEN
+    SET NEW.start_time = NULL;
+  END IF;
+
   IF OLD.reason IS NOT NULL AND (OLD.end_time IS NULL OR NEW.end_time IS NULL OR NEW.end_time >= OLD.end_time) THEN
     SET NEW.end_time = OLD.end_time;
     SET NEW.reason = OLD.reason;

--- a/batch/sql/fix-provisioning-bug.sql
+++ b/batch/sql/fix-provisioning-bug.sql
@@ -1,0 +1,22 @@
+DELIMITER $$
+
+DROP TRIGGER IF EXISTS attempts_before_update;
+CREATE TRIGGER attempts_before_update BEFORE UPDATE ON attempts
+FOR EACH ROW
+BEGIN
+  IF OLD.start_time IS NOT NULL AND (NEW.start_time IS NULL OR OLD.start_time < NEW.start_time) THEN
+    SET NEW.start_time = OLD.start_time;
+  END IF;
+
+  # for job private instances that do not finish creating
+  IF NEW.reason = 'activation_timeout' THEN
+    SET NEW.start_time = NULL;
+  END IF;
+
+  IF OLD.reason IS NOT NULL AND (OLD.end_time IS NULL OR NEW.end_time IS NULL OR NEW.end_time >= OLD.end_time) THEN
+    SET NEW.end_time = OLD.end_time;
+    SET NEW.reason = OLD.reason;
+  END IF;
+END $$
+
+DELIMITER ;

--- a/build.yaml
+++ b/build.yaml
@@ -2021,6 +2021,8 @@ steps:
       script: /io/sql/fix-schedule-job.sql
     - name: increase-test-and-dev-pool-sizes
       script: /io/sql/increase-test-and-dev-pool-sizes.py
+    - name: fix-provisioning-bug
+      script: /io/sql/fix-provisioning-bug.sql
    inputs:
     - from: /repo/batch/sql
       to: /io/sql


### PR DESCRIPTION
The issue is we start billing for instances as soon as they're created with the API. However, if an instance is stuck in provisioning and never activates, we never update the start billing time to account for the lack of resource. This PR uses the `lastStartTimestamp` in the [Google REST API](https://cloud.google.com/compute/docs/reference/rest/v1/instances/get). This value is in RFC3339 format. I think this is the same format the timestamp in the activity logs, so I copied how we parse that value. If we delete the instance due to activation timeout, then we set the attempt start time to NULL so it's not billed.

I couldn't find good documentation on this, but it seems like the `lastStartTimestamp` approximates what we care about for the purposes of checking for stuck workers. I checked it on an instance that was provisioning and the value was missing. Once the instance was in starting, the value was about 10 seconds after the `creationTimestamp`. 

QUESTION: This does raise a question on whether we should be using the `lastStartTimestamp` when billing users if the difference is around 10 seconds. That will be a harder change, but is probably doable. We can't access the `lastStartTimestamp` through the metadata on the worker which would have been the easiest solution. We can get the compute client on the worker and access the `lastStartTimestamp` that way and set the job start time to the instance start time. I'd need to change the database for the attempts trigger to account for this. For the scenario where a job private job is cancelled while creating the instance, we would either need to make the additional API call or we just leave the time we created the instance.

Thoughts?