### PR TITLE
[query] Reorganize linreg globals computation

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -459,12 +459,12 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
             # sample_ys is an array of samples, with each element being an array of the y_values
             return hl.enumerate(sample_ys).filter(
                 lambda idx_and_y_values: all_covs_defined[idx_and_y_values[0]] & no_missing(idx_and_y_values[1])
-            ).map(lambda idx_and_y_values: hl.struct(idx=idx_and_y_values[0], ys=idx_and_y_values[1], covs=ht.cov_arrays[idx_and_y_values[0]]))
+            ).map(lambda idx_and_y_values: hl.struct(idx=idx_and_y_values[0], ys=idx_and_y_values[1]))
 
         kept_data_per_y_group = ht.y_arrays_per_group.map(make_idx_ys_covs_struct)
         kept_samples = kept_data_per_y_group.idx
         y_nds = kept_data_per_y_group.ys.map(lambda y_2d: hl.nd.array(y_2d))
-        cov_nds = kept_data_per_y_group.covs.map(lambda cov_2d: hl.nd.array(cov_2d))
+        cov_nds = kept_samples.map(lambda group: hl.nd.array(group.map(lambda idx: ht.cov_arrays[idx])))
 
         k = builtins.len(covariates)
         ns = kept_samples.map(lambda one_sample_set: hl.len(one_sample_set))

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -425,13 +425,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
     num_y_lists = len(y_field_name_groups)
 
-    def all_defined(struct_root, field_names):
-        if field_names:
-            defined_array = hl.array([hl.is_defined(struct_root[field_name]) for field_name in field_names])
-            return defined_array.all(lambda a: a)
-        else:
-            return hl.bool(True)
-
     # Given a hail array, get the mean of the nonmissing entries and
     # return new array where the missing entries are the mean.
     def mean_impute(hl_array):
@@ -443,9 +436,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
     def dot_rows_with_themselves(matrix):
         return (matrix * matrix) @ hl.nd.ones(matrix.shape[1])
-
-    def array_from_struct(struct, field_names):
-        return hl.array([struct[field_name] for field_name in field_names])
 
     def no_missing(hail_array):
         return hail_array.all(lambda element: hl.is_defined(element))

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -462,9 +462,6 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
         )
         all_covs_defined = ht.cov_arrays.map(lambda sample_covs: sample_covs.all(lambda a: hl.is_defined(a)))
 
-        # Create a hail array of length g (g is number of groups / length of `y_field_name_groups`
-        # Each entry will be a list of structs. Each struct will contain an `idx`, an array `ys`, and an array `covs`
-
         def make_idx_ys_covs_struct(sample_ys):
             # sample_ys is an array of samples, with each element being an array of the y_values
             return hl.enumerate(sample_ys).filter(

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -446,7 +446,11 @@ def _linear_regression_rows_nd(y, x, covariates, block_size=16, pass_through=())
 
     def setup_globals(ht):
         # cov_arrays is per sample, then per cov.
-        ht = ht.annotate_globals(cov_arrays=ht[sample_field_name].map(lambda sample_struct: [sample_struct[cov_name] for cov_name in cov_field_names]))
+        if covariates:
+            ht = ht.annotate_globals(cov_arrays=ht[sample_field_name].map(lambda sample_struct: [sample_struct[cov_name] for cov_name in cov_field_names]))
+        else:
+            ht = ht.annotate_globals(cov_arrays=ht[sample_field_name].map(lambda sample_struct: hl.empty_array(hl.tfloat64)))
+
         ht = ht.annotate_globals(
             y_arrays_per_group=[ht[sample_field_name].map(lambda sample_struct: [sample_struct[y_name] for y_name in one_y_field_name_set]) for one_y_field_name_set in y_field_name_groups]
         )

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -54,7 +54,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.impute_sex(ds.GT)._same(hl.impute_sex(ds.GT, aaf='aaf')))
 
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
-    linreg_functions = [hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
+    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -77,19 +77,19 @@ class Tests(unittest.TestCase):
                 y=mt.pheno, x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
             t2 = t2.select(p=t2.p_value)
 
-            # t3 = linreg_function(
-            #     y=[mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
-            # t3 = t3.select(p=t3.p_value[0])
-            #
-            # t4 = linreg_function(
-            #     y=[mt.pheno, mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
-            # t4a = t4.select(p=t4.p_value[0])
-            # t4b = t4.select(p=t4.p_value[1])
+            t3 = linreg_function(
+                y=[mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
+            t3 = t3.select(p=t3.p_value[0])
+
+            t4 = linreg_function(
+                y=[mt.pheno, mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
+            t4a = t4.select(p=t4.p_value[0])
+            t4b = t4.select(p=t4.p_value[1])
 
             self.assertTrue(t1._same(t2))
-            # self.assertTrue(t1._same(t3))
-            # self.assertTrue(t1._same(t4a))
-            # self.assertTrue(t1._same(t4b))
+            self.assertTrue(t1._same(t3))
+            self.assertTrue(t1._same(t4a))
+            self.assertTrue(t1._same(t4b))
 
     def test_linreg_pass_through(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -54,7 +54,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.impute_sex(ds.GT)._same(hl.impute_sex(ds.GT, aaf='aaf')))
 
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
-    linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
+    linreg_functions = [hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
@@ -77,19 +77,19 @@ class Tests(unittest.TestCase):
                 y=mt.pheno, x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
             t2 = t2.select(p=t2.p_value)
 
-            t3 = linreg_function(
-                y=[mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
-            t3 = t3.select(p=t3.p_value[0])
-
-            t4 = linreg_function(
-                y=[mt.pheno, mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
-            t4a = t4.select(p=t4.p_value[0])
-            t4b = t4.select(p=t4.p_value[1])
+            # t3 = linreg_function(
+            #     y=[mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
+            # t3 = t3.select(p=t3.p_value[0])
+            #
+            # t4 = linreg_function(
+            #     y=[mt.pheno, mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2])
+            # t4a = t4.select(p=t4.p_value[0])
+            # t4b = t4.select(p=t4.p_value[1])
 
             self.assertTrue(t1._same(t2))
-            self.assertTrue(t1._same(t3))
-            self.assertTrue(t1._same(t4a))
-            self.assertTrue(t1._same(t4b))
+            # self.assertTrue(t1._same(t3))
+            # self.assertTrue(t1._same(t4a))
+            # self.assertTrue(t1._same(t4b))
 
     def test_linreg_pass_through(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),


### PR DESCRIPTION
This change simplifies the logic to create the various globals when computing linear regression, cuts the size of the IR in half, and makes the code faster in the process

Benchmark times for linear_regression_rows_nd on my laptop:

Before this PR: [37.80013062, 37.84073734200001, 38.025162351999995]
After this PR: [31.85279850500001, 33.12659071399999, 31.33206254000001]

So about 15% faster, but still not fast enough. Regular linear regression is 22 seconds on my laptop. 