### PR TITLE
[hail] fix bug in PartitionZippedNativeReader

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -683,8 +683,16 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
 
   private[this] def splitRequestedTypes(requestedType: Type): (TStruct, TStruct) = {
     val reqStruct = requestedType.asInstanceOf[TStruct]
-    val leftStruct = reqStruct.filterSet(specLeft.encodedVirtualType.asInstanceOf[TStruct].fieldNames.toSet)._1
-    val rightStruct = reqStruct.filterSet(specRight.encodedVirtualType.asInstanceOf[TStruct].fieldNames.toSet)._1
+    val neededFields = reqStruct.fieldNames.toSet
+
+    val leftProvidedFields = specLeft.encodedVirtualType.asInstanceOf[TStruct].fieldNames.toSet
+    val rightProvidedFields = specRight.encodedVirtualType.asInstanceOf[TStruct].fieldNames.toSet
+    val leftNeededFields = leftProvidedFields.intersect(neededFields)
+    val rightNeededFields = rightProvidedFields.intersect(neededFields)
+    assert(leftNeededFields.intersect(rightNeededFields).isEmpty)
+
+    val leftStruct = reqStruct.filterSet(leftNeededFields)._1
+    val rightStruct = reqStruct.filterSet(rightNeededFields)._1
     (leftStruct, rightStruct)
   }
 


### PR DESCRIPTION
The left and right sources may provide more fields than are necessary. This is OK, but
previously this caused an error because `filterSet` expects the argument to be a subset
of the `self` argument.