### PR TITLE
[hail] stop testing head, avoiding deprecation warning

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2459,11 +2459,6 @@ class Tests(unittest.TestCase):
             self.assertEqual(hl.eval(hl._sort_by([hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5, hl.missing(hl.tint32)]], lambda l, r: l.x < r.x)),
                              [hl.Struct(x=i, y="foo", z=5.5) for i in [2, 3, 5, 5, 8, None]])
 
-    def test_array_head(self):
-        a = hl.array([1,2,3])
-        assert hl.eval(a.head()) == 1
-        assert hl.eval(a.filter(lambda x: x > 5).head()) is None
-
     def test_array_first(self):
         a = hl.array([1,2,3])
         assert hl.eval(a.first()) == 1


### PR DESCRIPTION
Its definition is literally first so I do not think we need this test