### PR TITLE
[auth] Add endpoint to get current server hail version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@ hail/.bloop/
 hail/.gradle/
 hail/.idea/
 hail/.pytest_cache/
-.git/
 hail/.ensime.cache.d/
 hail/.ensime_cache.d/
 hail/.ensime_cache/

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,6 +8,7 @@ import uvloop
 import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
+from hailtop.hailctl import version
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
@@ -556,6 +557,14 @@ WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions
     user = users[0]
 
     return web.json_response(user)
+
+
+@routes.get('/api/v1alpha/version')
+async def rest_get_version(request):  # pylint: disable=W0613
+    try:
+        return web.Response(text=version())
+    except Exception as e:
+        return web.json_response({"error": str(e)})
 
 
 async def on_startup(app):

--- a/docker/Dockerfile.service-base
+++ b/docker/Dockerfile.service-base
@@ -7,6 +7,11 @@ RUN hail-pip-install -r service-base-requirements.txt
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py
 COPY hail/python/hailtop /hailtop/hailtop/
+COPY hail/Makefile hail/env_var.mk .git/ hailtop/
+RUN mkdir -p hailtop/python/hail hailtop/python/hailtop/hailctl hailtop/python/hail/docs/_static && \
+    (cd hailtop && echo $(pwd) && make python-version-info) && \
+    cp hailtop/python/hail/hail_*version hailtop/hailtop/hailctl && \
+    rm -rf hailtop/Makefile hailtop/env_var.mk .git/
 RUN hail-pip-install /hailtop && rm -rf /hailtop
 
 COPY gear/setup.py /gear/setup.py


### PR DESCRIPTION
Based on conversation in Zulip: https://hail.zulipchat.com/#narrow/stream/123000-general/topic/Server.20hail.20version.20through.20API/near/226462327

Add version endpoint to auth API.

As suggested, I've added the the `make python-version-info` to generate the `hail_version`, but this requires the git history within the docker, as the short commit hash is added to the end.

I've just cherry-picked the [merge commit](https://github.com/populationgenomics/hail/commit/700a0cf9d6e05827feca6bdd9c455e2b261e72db) from our populationgenomics fork.