### PR TITLE
[ci] dont say a merge conflict is an exception

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -409,8 +409,6 @@ mkdir -p {shq(repo_dir)}
         except concurrent.futures.CancelledError:
             raise
         except Exception as e:  # pylint: disable=broad-except
-            log.exception('could not start build')
-
             # FIXME save merge failure output for UI
             self.batch = MergeFailureBatch(
                 e,


### PR DESCRIPTION
I've only ever seen this for merge conflicts, which doesn't seem "exceptional" for a CI system.