### PR TITLE
[query] MakeNDArray uses Better Python Error system

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -641,12 +641,15 @@ class StreamGrouped(IR):
 
 
 class MakeNDArray(IR):
-    @typecheck_method(data=IR, shape=IR, row_major=IR)
-    def __init__(self, data, shape, row_major):
+    @typecheck_method(data=IR, shape=IR, row_major=IR, error_id=nullable(int), stack_trace=nullable(str))
+    def __init__(self, data, shape, row_major, error_id=None, stack_trace=None):
         super().__init__(data, shape, row_major)
         self.data = data
         self.shape = shape
         self.row_major = row_major
+
+        if error_id is None or stack_trace is None:
+            self.save_error_info()
 
     @typecheck_method(data=IR, shape=IR, row_major=IR)
     def copy(self, data, shape, row_major):
@@ -657,6 +660,9 @@ class MakeNDArray(IR):
         self.shape._compute_type(env, agg_env)
         self.row_major._compute_type(env, agg_env)
         self._type = tndarray(self.data.typ.element_type, len(self.shape.typ))
+
+    def head_str(self):
+        return f'{self._error_id}'
 
 
 class NDArrayShape(IR):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -647,13 +647,15 @@ class MakeNDArray(IR):
         self.data = data
         self.shape = shape
         self.row_major = row_major
+        self._error_id = error_id
+        self._stack_trace = stack_trace
 
         if error_id is None or stack_trace is None:
             self.save_error_info()
 
     @typecheck_method(data=IR, shape=IR, row_major=IR)
     def copy(self, data, shape, row_major):
-        return MakeNDArray(data, shape, row_major)
+        return MakeNDArray(data, shape, row_major, self._error_id, self._stack_trace)
 
     def _compute_type(self, env, agg_env):
         self.data._compute_type(env, agg_env)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -215,6 +215,9 @@ def test_ndarray_eval():
         hl.nd.array(mishapen_data_list3)
     assert "inner dimensions do not match" in str(exc.value)
 
+    with pytest.raises(HailUserError) as exc:
+        hl.eval(hl.nd.array([1, hl.null(hl.tint32), 3]))
+
 
 def test_ndarray_shape():
     np_e = np.array(3)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -60,7 +60,7 @@ object Children {
       Array(start, stop, step)
     case ArrayZeros(length) =>
       Array(length)
-    case MakeNDArray(data, shape, rowMajor) =>
+    case MakeNDArray(data, shape, rowMajor, _) =>
       Array(data, shape, rowMajor)
     case NDArrayShape(nd) =>
       Array(nd)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -75,9 +75,9 @@ object Copy {
       case ArrayZeros(_) =>
         assert(newChildren.length == 1)
         ArrayZeros(newChildren(0).asInstanceOf[IR])
-      case MakeNDArray(_, _, _) =>
+      case MakeNDArray(_, _, _, errorId) =>
         assert(newChildren.length == 3)
-        MakeNDArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
+        MakeNDArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR], errorId)
       case NDArrayShape(_) =>
         assert(newChildren.length == 1)
         NDArrayShape(newChildren(0).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1084,9 +1084,12 @@ class Emit[C](
           emitI(shapeIR).flatMap(cb) { case shapeTupleCode: PBaseStructCode =>
             emitI(dataIR).map(cb) { case dataCode: PIndexableCode =>
               val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
-              val memoData = dataCode.memoize(cb, "make_nd_array_memoizd_data")
+              val memoData = dataCode.memoize(cb, "make_nd_array_memoized_data")
 
-              cb.ifx(memoData.hasMissingValues(cb), {cb._fatal("Cannot construct an ndarray with missing values.")})
+              cb.ifx(memoData.hasMissingValues(cb), {
+                cb.append(Code._throw[HailException, Unit](Code.newInstance[HailException, String, Int](
+                    "Cannot construct an ndarray with missing values.", errorId
+              )))})
 
               (0 until nDims).foreach { index =>
                 cb.ifx(shapeTupleValue.isFieldMissing(index),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1075,7 +1075,7 @@ class Emit[C](
           dictTyp.construct(finishOuter(cb))
         }
 
-      case x@MakeNDArray(dataIR, shapeIR, rowMajorIR) =>
+      case x@MakeNDArray(dataIR, shapeIR, rowMajorIR, errorId) =>
         val xP = coerce[PCanonicalNDArray](x.pType)
         val shapePType = coerce[PTuple](shapeIR.pType)
         val nDims = shapePType.size

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1087,9 +1087,9 @@ class Emit[C](
               val memoData = dataCode.memoize(cb, "make_nd_array_memoized_data")
 
               cb.ifx(memoData.hasMissingValues(cb), {
-                cb.append(Code._throw[HailException, Unit](Code.newInstance[HailException, String, Int](
+                cb._throw(Code.newInstance[HailException, String, Int](
                     "Cannot construct an ndarray with missing values.", errorId
-              )))})
+              ))})
 
               (0 until nDims).foreach { index =>
                 cb.ifx(shapeTupleValue.isFieldMissing(index),

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -406,10 +406,10 @@ object MakeNDArray {
   def fill(elt: IR, shape: IndexedSeq[Long], rowMajor: IR): MakeNDArray =
     MakeNDArray(
       ToArray(StreamMap(StreamRange(0, shape.product.toInt, 1), genUID(), elt)),
-      MakeTuple.ordered(shape.map(I64)), rowMajor)
+      MakeTuple.ordered(shape.map(I64)), rowMajor, ErrorIDs.NO_ERROR)
 }
 
-final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends NDArrayIR
+final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR, errorId: Int) extends NDArrayIR
 
 final case class NDArrayShape(nd: IR) extends IR
 
@@ -550,7 +550,7 @@ final case class In(i: Int, _typ: PType) extends IR
 
 // FIXME: should be type any
 object Die {
-  def apply(message: String, typ: Type): Die = Die(Str(message), typ, -1)
+  def apply(message: String, typ: Type): Die = Die(Str(message), typ, ErrorIDs.NO_ERROR)
   def apply(message: String, typ: Type, errorId: Int): Die = Die(Str(message), typ, errorId)
 }
 
@@ -804,3 +804,7 @@ final case class ShuffleRead(
   id: IR,
   keyRange: IR
 ) extends IR
+
+object ErrorIDs {
+  val NO_ERROR = -1
+}

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -137,7 +137,7 @@ object InferPType {
         env.lookup(x.name)
       case x: BaseRef =>
         lookup(x.name, requiredness(node), usesAndDefs.defs.lookup(node).asInstanceOf[IR])
-      case MakeNDArray(data, shape, rowMajor) =>
+      case MakeNDArray(data, shape, rowMajor, _) =>
         val nElem = shape.pType.asInstanceOf[PTuple].size
         PCanonicalNDArray(coerce[PArray](data.pType).elementType.setRequired(true), nElem, requiredness(node).required)
       case StreamRange(start: IR, stop: IR, step: IR, separateRegions) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -30,7 +30,7 @@ object InferType {
       case In(_, t) => t.virtualType
       case MakeArray(_, t) => t
       case MakeStream(_, t, _) => t
-      case MakeNDArray(data, shape, _) =>
+      case MakeNDArray(data, shape, _, _) =>
         TNDArray(coerce[TArray](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case _: ArrayLen => TInt32
       case _: StreamRange => TStream(TInt32)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -908,14 +908,11 @@ object IRParser {
           lessThan <- ir_value_expr(env + (l -> elt) + (r -> elt))(it)
         } yield ArraySort(a, l, r, lessThan)
       case "MakeNDArray" =>
-        val dataA = ir_value_expr(env)(it)
-        val shapeA = ir_value_expr(env)(it)
-        val rowMajorA = ir_value_expr(env)(it)
         val errorId = int32_literal(it)
         for {
-          data <- dataA
-          shape <- shapeA
-          rowMajor <- rowMajorA
+          data <- ir_value_expr(env)(it)
+          shape <- ir_value_expr(env)(it)
+          rowMajor <- ir_value_expr(env)(it)
         } yield MakeNDArray(data, shape, rowMajor, errorId)
       case "NDArrayShape" => ir_value_expr(env)(it).map(NDArrayShape)
       case "NDArrayReshape" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -908,11 +908,15 @@ object IRParser {
           lessThan <- ir_value_expr(env + (l -> elt) + (r -> elt))(it)
         } yield ArraySort(a, l, r, lessThan)
       case "MakeNDArray" =>
+        val dataA = ir_value_expr(env)(it)
+        val shapeA = ir_value_expr(env)(it)
+        val rowMajorA = ir_value_expr(env)(it)
+        val errorId = int32_literal(it)
         for {
-          data <- ir_value_expr(env)(it)
-          shape <- ir_value_expr(env)(it)
-          rowMajor <- ir_value_expr(env)(it)
-        } yield MakeNDArray(data, shape, rowMajor)
+          data <- dataA
+          shape <- shapeA
+          rowMajor <- rowMajorA
+        } yield MakeNDArray(data, shape, rowMajor, errorId)
       case "NDArrayShape" => ir_value_expr(env)(it).map(NDArrayShape)
       case "NDArrayReshape" =>
         for {

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -336,6 +336,7 @@ object Pretty {
     case WriteValue(_, _, spec) => single(prettyStringLiteral(spec.toString))
     case x@ShuffleWith(_, _, _, _, name, _, _) =>
       FastSeq(x.shuffleType.parsableString(), prettyIdentifier(name))
+    case MakeNDArray(_, _, _, errorId) => FastSeq(errorId.toString)
 
     case _ => Iterable.empty
   }

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1129,7 +1129,7 @@ object PruneDeadFields {
           bodyEnv.deleteEval(valueName),
           memoizeValueIR(a, TStream(valueType), memo)
         )
-      case MakeNDArray(data, shape, rowMajor) =>
+      case MakeNDArray(data, shape, rowMajor, errorId) =>
         val elementType = requestedType.asInstanceOf[TNDArray].elementType
         unifyEnvs(
           memoizeValueIR(data, TArray(elementType), memo),
@@ -1835,11 +1835,11 @@ object PruneDeadFields {
         val et = a2.typ.asInstanceOf[TStream].elementType
         val lessThan2 = rebuildIR(lessThan, env.bindEval(left -> et, right -> et), memo)
         ArraySort(a2, left, right, lessThan2)
-      case MakeNDArray(data, shape, rowMajor) =>
+      case MakeNDArray(data, shape, rowMajor, errorId) =>
         val data2 = rebuildIR(data, env, memo)
         val shape2 = rebuildIR(shape, env, memo)
         val rowMajor2 = rebuildIR(rowMajor, env, memo)
-        MakeNDArray(data2, shape2, rowMajor2)
+        MakeNDArray(data2, shape2, rowMajor2, errorId)
       case NDArrayMap(nd, valueName, body) =>
         val nd2 = rebuildIR(nd, env, memo)
         NDArrayMap(nd2, valueName, rebuildIR(body, env.bindEval(valueName, nd2.typ.asInstanceOf[TNDArray].elementType), memo))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -568,7 +568,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           initOpArgs.map(i => i -> lookup(i)),
           seqOpArgs.map(s => s -> lookup(s)))).pResultType
         requiredness.fromPType(pResult)
-      case MakeNDArray(data, shape, rowMajor) =>
+      case MakeNDArray(data, shape, rowMajor, _) =>
         requiredness.unionFrom(lookup(data))
         requiredness.union(lookup(shape).required)
       case NDArrayShape(nd) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -148,7 +148,7 @@ object TypeCheck {
         assert(c.typ == TInt32)
       case x@ArrayZeros(length) =>
         assert(length.typ == TInt32)
-      case x@MakeNDArray(data, shape, rowMajor) =>
+      case x@MakeNDArray(data, shape, rowMajor, _) =>
         assert(data.typ.isInstanceOf[TArray])
         assert(shape.typ.asInstanceOf[TTuple].types.forall(t => t == TInt64))
         assert(rowMajor.typ == TBoolean)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2032,7 +2032,7 @@ class IRSuite extends HailSuite {
   }
 
   def makeNDArray(data: Seq[Double], shape: Seq[Long], rowMajor: IR): MakeNDArray = {
-    MakeNDArray(MakeArray(data.map(F64), TArray(TFloat64)), MakeTuple.ordered(shape.map(I64)), rowMajor)
+    MakeNDArray(MakeArray(data.map(F64), TArray(TFloat64)), MakeTuple.ordered(shape.map(I64)), rowMajor, ErrorIDs.NO_ERROR)
   }
 
   def makeNDArrayRef(nd: IR, indxs: IndexedSeq[Long]): NDArrayRef = NDArrayRef(nd, indxs.map(I64), -1)
@@ -2102,7 +2102,7 @@ class IRSuite extends HailSuite {
       MakeArray(ndData.map { case (values, nRows, nCols) =>
         if (values == null) NA(TNDArray(TInt32, Nat(2))) else
           MakeNDArray(Literal(TArray(TInt32), values),
-            Literal(TTuple(TInt64, TInt64), Row(nRows, nCols)), True())
+            Literal(TTuple(TInt64, TInt64), Row(nRows, nCols)), True(), ErrorIDs.NO_ERROR)
       }, TArray(TNDArray(TInt32, Nat(2))))
     }
 
@@ -2158,13 +2158,13 @@ class IRSuite extends HailSuite {
     assertEvalsTo(makeNDArrayRef(positives, FastSeq(1L, 0L)), 5.0)
     assertEvalsTo(makeNDArrayRef(negatives, FastSeq(1L, 0L)), -5.0)
 
-    val trues = MakeNDArray(MakeArray(data.map(_ => True()), TArray(TBoolean)), MakeTuple.ordered(shape.map(I64)), True())
+    val trues = MakeNDArray(MakeArray(data.map(_ => True()), TArray(TBoolean)), MakeTuple.ordered(shape.map(I64)), True(), ErrorIDs.NO_ERROR)
     val falses = NDArrayMap(trues, "e", ApplyUnaryPrimOp(Bang(), Ref("e", TBoolean)))
     assertEvalsTo(makeNDArrayRef(trues, FastSeq(1L, 0L)), true)
     assertEvalsTo(makeNDArrayRef(falses, FastSeq(1L, 0L)), false)
 
     val bools = MakeNDArray(MakeArray(data.map(i => if (i % 2 == 0) True() else False()), TArray(TBoolean)),
-      MakeTuple.ordered(shape.map(I64)), False())
+      MakeTuple.ordered(shape.map(I64)), False(), ErrorIDs.NO_ERROR)
     val boolsToBinary = NDArrayMap(bools, "e", If(Ref("e", TBoolean), I64(1L), I64(0L)))
     val one = makeNDArrayRef(boolsToBinary, FastSeq(0L, 0L))
     val zero = makeNDArrayRef(boolsToBinary, FastSeq(1L, 1L))
@@ -2176,8 +2176,8 @@ class IRSuite extends HailSuite {
     implicit val execStrats: Set[ExecStrategy] = ExecStrategy.compileOnly
 
     val shape = MakeTuple.ordered(FastSeq(2L, 2L).map(I64))
-    val numbers = MakeNDArray(MakeArray((0 until 4).map { i => F64(i.toDouble) }, TArray(TFloat64)), shape, True())
-    val bools = MakeNDArray(MakeArray(Seq(True(), False(), False(), True()), TArray(TBoolean)), shape, True())
+    val numbers = MakeNDArray(MakeArray((0 until 4).map { i => F64(i.toDouble) }, TArray(TFloat64)), shape, True(), ErrorIDs.NO_ERROR)
+    val bools = MakeNDArray(MakeArray(Seq(True(), False(), False(), True()), TArray(TBoolean)), shape, True(), ErrorIDs.NO_ERROR)
 
     val actual = NDArrayMap2(numbers, bools, "n", "b",
       ApplyBinaryPrimOp(Add(), Ref("n", TFloat64), If(Ref("b", TBoolean), F64(10), F64(20))))
@@ -3075,7 +3075,7 @@ class IRSuite extends HailSuite {
     val blockMatrixMultiWriter = BlockMatrixBinaryMultiWriter("/path/to/prefix", false)
     val nd = MakeNDArray(MakeArray(FastSeq(I32(-1), I32(1)), TArray(TInt32)),
       MakeTuple.ordered(FastSeq(I64(1), I64(2))),
-      True())
+      True(), ErrorIDs.NO_ERROR)
 
     val irs = Array(
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -552,7 +552,7 @@ class PruneSuite extends HailSuite {
   val ref = Ref("x", TStruct("a" -> TInt32, "b" -> TInt32, "c" -> TInt32))
   val arr = MakeArray(FastIndexedSeq(ref, ref), TArray(ref.typ))
   val st = MakeStream(FastIndexedSeq(ref, ref), TStream(ref.typ))
-  val ndArr = MakeNDArray(arr, MakeTuple(IndexedSeq((0, I64(2l)))), True())
+  val ndArr = MakeNDArray(arr, MakeTuple(IndexedSeq((0, I64(2l)))), True(), ErrorIDs.NO_ERROR)
   val empty = TStruct.empty
   val justA = TStruct("a" -> TInt32)
   val justB = TStruct("b" -> TInt32)
@@ -702,7 +702,7 @@ class PruneSuite extends HailSuite {
       MakeNDArray(
         Ref("x", TArray(TStruct("a" -> TInt32, "b" -> TInt64))),
         Ref("y", TTuple(TInt32, TInt32)),
-        True()),
+        True(), ErrorIDs.NO_ERROR),
       TNDArray(TStruct("a" -> TInt32), Nat(2)),
       Array(
         TArray(TStruct("a" -> TInt32)),
@@ -1309,7 +1309,7 @@ class PruneSuite extends HailSuite {
       })
   }
 
-  val ndArrayTS = MakeNDArray(MakeArray(ArrayBuffer(NA(ts)), TArray(ts)), MakeTuple(IndexedSeq((0, I64(1l)))), True())
+  val ndArrayTS = MakeNDArray(MakeArray(ArrayBuffer(NA(ts)), TArray(ts)), MakeTuple(IndexedSeq((0, I64(1l)))), True(), ErrorIDs.NO_ERROR)
 
   @Test def testNDArrayMapRebuild() {
     checkRebuild(NDArrayMap(ndArrayTS, "x", Ref("x", ts)), TNDArray(subsetTS("b"), Nat(1)),


### PR DESCRIPTION
Add errorId tracking to MakeNDArray, allowing user to get a good python error highlighting where an error is thrown from. 