### PR TITLE
[query] frozendict

### DIFF
--- a/hail/python/hail/docs/utils/index.rst
+++ b/hail/python/hail/docs/utils/index.rst
@@ -7,6 +7,7 @@ utils
 
     Interval
     Struct
+    frozendict
     hadoop_open
     hadoop_copy
     hadoop_exists
@@ -22,6 +23,7 @@ utils
 
 .. autoclass:: Interval
 .. autoclass:: Struct
+.. autoclass:: frozendict
 .. autofunction:: hadoop_open
 .. autofunction:: hadoop_copy
 .. autofunction:: hadoop_exists

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -390,7 +390,7 @@ def collect_as_set(expr) -> SetExpression:
     Collect the unique `ID` field where `HT` is greater than 68:
 
     >>> table1.aggregate(hl.agg.filter(table1.HT > 68, hl.agg.collect_as_set(table1.ID)))
-    {2, 3}
+    frozenset({2, 3})
 
     Warning
     -------
@@ -548,7 +548,7 @@ def counter(expr, *, weight=None) -> DictExpression:
     Count the number of individuals for each unique `SEX` value:
 
     >>> table1.aggregate(hl.agg.counter(table1.SEX))
-    {'F': 2, 'M': 2}
+    frozendict({'F': 2, 'M': 2})
     <BLANKLINE>
 
     Compute the total height for each unique `SEX` value:
@@ -1022,7 +1022,7 @@ def explode(f, array_agg_expr) -> Expression:
     Compute the set of all observed elements in the `filters` field (``Set[String]``):
 
     >>> dataset.aggregate_rows(hl.agg.explode(lambda elt: hl.agg.collect_as_set(elt), dataset.filters))
-    {'VQSRTrancheINDEL97.00to99.00'}
+    frozenset({'VQSRTrancheINDEL97.00to99.00'})
 
     Notes
     -----

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -554,7 +554,7 @@ def counter(expr, *, weight=None) -> DictExpression:
     Compute the total height for each unique `SEX` value:
 
     >>> table1.aggregate(hl.agg.counter(table1.SEX, weight=table1.HT))
-    {'F': 130, 'M': 137}
+    frozendict({'F': 130, 'M': 137})
     <BLANKLINE>
 
     Notes

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Mapping
 import numpy as np
 
 import hail
@@ -171,7 +171,7 @@ def impute_type(x):
             raise ExpressionException("Hail does not support heterogeneous sets: "
                                       "found set with elements of types {} ".format(list(ts)))
         return tset(unified_type)
-    elif isinstance(x, dict):
+    elif isinstance(x, Mapping):
         if len(x) == 0:
             raise ExpressionException("Cannot impute type of empty dict. Use 'hl.empty_dict' to create an empty dict.")
         kts = {impute_type(element) for element in x.keys()}

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -319,7 +319,7 @@ class CollectionExpression(Expression):
         [1.0, 8.0, 27.0, 64.0, 125.0]
 
         >>> hl.eval(s3.map(lambda x: x.length()))
-        {3, 5, 7}
+        frozenset({3, 5, 7})
 
         Parameters
         ----------
@@ -1083,7 +1083,7 @@ class SetExpression(CollectionExpression):
         --------
 
         >>> hl.eval(s1.remove(1))
-        {2, 3}
+        frozenset({2, 3})
 
         Parameters
         ----------
@@ -1167,7 +1167,7 @@ class SetExpression(CollectionExpression):
         --------
 
         >>> hl.eval(s1.intersection(s2))
-        {1, 3}
+        frozenset({1, 3})
 
         Parameters
         ----------
@@ -1222,7 +1222,7 @@ class SetExpression(CollectionExpression):
         --------
 
         >>> hl.eval(s1.union(s2))
-        {1, 2, 3, 5}
+        frozenset({1, 2, 3, 5})
 
         Parameters
         ----------

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -77,7 +77,7 @@ class CollectionExpression(Expression):
         [2, 4]
 
         >>> hl.eval(s3.filter(lambda x: ~(x[-1] == 'e')))  # doctest: +SKIP_OUTPUT_CHECK
-        {'Bob'}
+        frozenset({'Bob'})
 
         Notes
         -----
@@ -1138,10 +1138,10 @@ class SetExpression(CollectionExpression):
         --------
 
         >>> hl.eval(s1.difference(s2))
-        {2}
+        frozenset({2})
 
         >>> hl.eval(s2.difference(s1))
-        {5}
+        frozenset({5})
 
         Parameters
         ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4209,7 +4209,7 @@ def empty_set(t: Union[HailType, builtins.str]) -> SetExpression:
     --------
 
     >>> hl.eval(hl.empty_set(hl.tstr))
-    set()
+    frozenset()
 
     Parameters
     ----------
@@ -4385,7 +4385,7 @@ def empty_dict(key_type: Union[HailType, builtins.str], value_type: Union[HailTy
     --------
 
     >>> hl.eval(hl.empty_dict(hl.tstr, hl.tint32))
-    {}
+    frozendict({})
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3119,7 +3119,7 @@ def filter(f: Callable, collection):
     [2, 4]
 
     >>> hl.eval(hl.filter(lambda x: ~(x[-1] == 'e'), s))
-    {'Bob'}
+    frozenset({'Bob'})
 
     Notes
     -----

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -13,6 +13,7 @@ from .type_parsing import type_grammar, type_node_visitor
 from hail.genetics.reference_genome import reference_genome_type
 from hail.typecheck import typecheck, typecheck_method, oneof, transformed
 from hail.utils.java import escape_parsable
+from hail.utils import frozendict
 
 __all__ = [
     'dtype',
@@ -993,8 +994,8 @@ class tdict(HailType):
         return "Dict[{},{}]".format(self.key_type._parsable_string(), self.value_type._parsable_string())
 
     def _convert_from_json(self, x):
-        return {self.key_type._convert_from_json_na(elt['key']): self.value_type._convert_from_json_na(elt['value']) for
-                elt in x}
+        return frozendict({self.key_type._convert_from_json_na(elt['key']): self.value_type._convert_from_json_na(elt['value']) for
+                            elt in x})
 
     def _convert_to_json(self, x):
         return [{'key': self.key_type._convert_to_json(k),

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -978,8 +978,8 @@ class tdict(HailType):
 
     def _typecheck_one_level(self, annotation):
         if annotation is not None:
-            if not isinstance(annotation, dict):
-                raise TypeError("type 'dict' expected Python 'dict', but found type '%s'" % type(annotation))
+            if not isinstance(annotation, Mapping):
+                raise TypeError("type 'dict' expected Python 'Mapping', but found type '%s'" % type(annotation))
 
     def __str__(self):
         return "dict<{}, {}>".format(self.key_type, self.value_type)

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -828,6 +828,7 @@ class tstream(HailType):
     def _get_context(self):
         return self.element_type.get_context()
 
+
 def is_setlike(maybe_setlike):
     return isinstance(maybe_setlike, set) or isinstance(maybe_setlike, frozenset)
 

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -828,6 +828,9 @@ class tstream(HailType):
     def _get_context(self):
         return self.element_type.get_context()
 
+def is_setlike(maybe_setlike):
+    return isinstance(maybe_setlike, set) or isinstance(maybe_setlike, frozenset)
+
 
 class tset(HailType):
     """Hail type for collections of distinct elements.
@@ -873,7 +876,7 @@ class tset(HailType):
 
     def _typecheck_one_level(self, annotation):
         if annotation is not None:
-            if not isinstance(annotation, set):
+            if not is_setlike(annotation):
                 raise TypeError("type 'set' expected Python 'set', but found type '%s'" % type(annotation))
 
     def __str__(self):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -994,8 +994,7 @@ class tdict(HailType):
         return "Dict[{},{}]".format(self.key_type._parsable_string(), self.value_type._parsable_string())
 
     def _convert_from_json(self, x):
-        return frozendict({self.key_type._convert_from_json_na(elt['key']): self.value_type._convert_from_json_na(elt['value']) for
-                            elt in x})
+        return frozendict({self.key_type._convert_from_json_na(elt['key']): self.value_type._convert_from_json_na(elt['value']) for elt in x})
 
     def _convert_to_json(self, x):
         return [{'key': self.key_type._convert_to_json(k),

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -890,7 +890,7 @@ class tset(HailType):
         return "Set[" + self.element_type._parsable_string() + "]"
 
     def _convert_from_json(self, x):
-        return {self.element_type._convert_from_json_na(elt) for elt in x}
+        return frozenset({self.element_type._convert_from_json_na(elt) for elt in x})
 
     def _convert_to_json(self, x):
         return [self.element_type._convert_to_json_na(elt) for elt in x]

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -3,6 +3,7 @@ from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir
 from .struct import Struct
 from .linkedlist import LinkedList
 from .interval import Interval
+from .frozendict import frozendict
 from .java import error, warning, info, FatalError, HailUserError
 from .tutorial import get_1kg, get_movie_lens
 from .deduplicate import deduplicate
@@ -26,6 +27,7 @@ __all__ = ['hadoop_open',
            'run_command',
            'Struct',
            'Interval',
+           'frozendict',
            'error',
            'warning',
            'info',

--- a/hail/python/hail/utils/frozendict.py
+++ b/hail/python/hail/utils/frozendict.py
@@ -11,6 +11,10 @@ class frozendict(Mapping):
 
     >>> my_frozen_dict = hl.utils.frozendict({1:2, 7:5})
 
+    To get a normal python dictionary with the same elements from a `frozendict`:
+
+    >>> dict(frozendict({'a': 1, 'b': 2}))
+
     Note
     ----
     This object refers to the Python value returned by taking or collecting
@@ -35,3 +39,6 @@ class frozendict(Mapping):
 
     def __iter__(self):
         return iter(self.d)
+
+    def __repr__(self): 
+        return f'frozendict({self.d!r})'  

--- a/hail/python/hail/utils/frozendict.py
+++ b/hail/python/hail/utils/frozendict.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 T = TypeVar("T")
 U = TypeVar("U")
 
+
 class frozendict(Mapping):
     """
     An object representing an immutable dictionary.

--- a/hail/python/hail/utils/frozendict.py
+++ b/hail/python/hail/utils/frozendict.py
@@ -5,6 +5,21 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 class frozendict(Mapping):
+    """
+    An object representing an immutable dictionary.
+
+    >>> my_frozen_dict = hl.utils.frozendict({1:2, 7:5})
+
+    Note
+    ----
+    This object refers to the Python value returned by taking or collecting
+    Hail expressions, e.g. ``mt.my_dict.take(5)``. This is rare; it is much
+    more common to manipulate the :class:`.DictExpression` object, which is
+    constructed using :func:`.dict`. This class is necessary because hail
+    supports using dicts as keys to other dicts or as elements in sets, while
+    python does not.
+
+    """
     def __init__(self, d: Dict[T, U]):
         self.d = d.copy()
 

--- a/hail/python/hail/utils/frozendict.py
+++ b/hail/python/hail/utils/frozendict.py
@@ -40,5 +40,5 @@ class frozendict(Mapping):
     def __iter__(self):
         return iter(self.d)
 
-    def __repr__(self): 
-        return f'frozendict({self.d!r})'  
+    def __repr__(self):
+        return f'frozendict({self.d!r})'

--- a/hail/python/hail/utils/frozendict.py
+++ b/hail/python/hail/utils/frozendict.py
@@ -1,0 +1,21 @@
+from typing import TypeVar, Dict
+from collections.abc import Mapping
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+class frozendict(Mapping):
+    def __init__(self, d: Dict[T, U]):
+        self.d = d.copy()
+
+    def __getitem__(self, k: T) -> U:
+        return self.d[k]
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self.items()))
+
+    def __len__(self) -> int:
+        return len(self.d)
+
+    def __iter__(self):
+        return iter(self.d)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3249,6 +3249,10 @@ class Tests(unittest.TestCase):
         # Test that it's evalable, since python dicts aren't hashable.
         assert hl.eval(dict_with_dict_key) == {hl.utils.frozendict({1:2, 3:5}): 4}
 
+    def test_frozendict_as_literal(self):
+        fd = hl.utils.frozendict({"a": 4, "b": 8})
+        assert hl.eval(hl.literal(fs)) == hl.utils.frozendict({"a": 4, "b": 8})
+
     def test_nan_roundtrip(self):
         a = [math.nan, math.inf, -math.inf, 0, 1]
         round_trip = hl.eval(hl.literal(a))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3251,7 +3251,7 @@ class Tests(unittest.TestCase):
 
     def test_frozendict_as_literal(self):
         fd = hl.utils.frozendict({"a": 4, "b": 8})
-        assert hl.eval(hl.literal(fs)) == hl.utils.frozendict({"a": 4, "b": 8})
+        assert hl.eval(hl.literal(fd)) == hl.utils.frozendict({"a": 4, "b": 8})
 
     def test_nan_roundtrip(self):
         a = [math.nan, math.inf, -math.inf, 0, 1]

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3244,6 +3244,11 @@ class Tests(unittest.TestCase):
         # Test that it's evalable, since python sets aren't hashable.
         assert hl.eval(dict_with_set_key) == {frozenset([1, 2, 3]): 4}
 
+    def test_dict_keyed_by_dict(self):
+        dict_with_dict_key = hl.dict({hl.dict({1:2, 3:5}): 4})
+        # Test that it's evalable, since python dicts aren't hashable.
+        assert hl.eval(dict_with_dict_key) == {hl.utils.frozendict({1:2, 3:5}): 4}
+
     def test_nan_roundtrip(self):
         a = [math.nan, math.inf, -math.inf, 0, 1]
         round_trip = hl.eval(hl.literal(a))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3239,6 +3239,11 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.eval(s.contains(5)))
         self.assertTrue(hl.eval(~s.contains(2)))
 
+    def test_dict_keyed_by_set(self):
+        dict_with_set_key = hl.dict({hl.set([1, 2, 3]): 4})
+        # Test that it's evalable, since python sets aren't hashable.
+        assert hl.eval(dict_with_set_key) == {frozenset([1, 2, 3]): 4}
+
     def test_nan_roundtrip(self):
         a = [math.nan, math.inf, -math.inf, 0, 1]
         round_trip = hl.eval(hl.literal(a))

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -225,3 +225,11 @@ class Tests(unittest.TestCase):
         self.assertEqual(escape_id("cat"), "cat")
         self.assertEqual(escape_id("abc123"), "abc123")
         self.assertEqual(escape_id("123abc"), "`123abc`")
+
+    def test_frozen_dict(self):
+        self.assertEqual(frozendict({1:2, 4:7}), frozendict({1:2, 4:7}))
+        my_frozen_dict = frozendict({"a": "apple", "h": "hail"})
+        self.assertEqual(my_frozen_dict["a"], "apple")
+
+        with pytest.raises(TypeError, match="does not support item assignment"):
+            my_frozen_dict["a"] = "b"

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -231,5 +231,11 @@ class Tests(unittest.TestCase):
         my_frozen_dict = frozendict({"a": "apple", "h": "hail"})
         self.assertEqual(my_frozen_dict["a"], "apple")
 
+        # Make sure mutating old dict doesn't change frozen counterpart.
+        regular_dict = {"a": "b"}
+        frozen_counterpart = frozendict(regular_dict)
+        regular_dict["a"] = "d"
+        self.assertEqual(frozen_counterpart["a"], "b")
+
         with pytest.raises(TypeError, match="does not support item assignment"):
             my_frozen_dict["a"] = "b"


### PR DESCRIPTION
CHANGELOG: Evaluating hail expressions in python will now return `frozendict`, an immutable dictionary type. Sets will return python's `frozenset`.

This is necessary because hail supports hashable dicts, but python does not. Same with sets. 