### PR TITLE
[k8s] set consistent resource requests for better node packing

### DIFF
--- a/address/deployment.yaml
+++ b/address/deployment.yaml
@@ -50,11 +50,11 @@ spec:
          - containerPort: 5000
         resources:
           requests:
-            memory: "5M"
-            cpu: "5m"
+            cpu: "20m"
+            memory: "20M"
           limits:
-            memory: "1G"
             cpu: "1"
+            memory: "1G"
         env:
          - name: HAIL_DOMAIN
            value: "{{ global.domain }}"

--- a/amundsen/deployment.yaml
+++ b/amundsen/deployment.yaml
@@ -34,8 +34,11 @@ spec:
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "1G"
+            cpu: "20m"
+            memory: "20M"
+          limits:
             cpu: "1"
+            memory: "1G"
         ports:
           - containerPort: 5000
         env:

--- a/atgu/deployment.yaml
+++ b/atgu/deployment.yaml
@@ -49,11 +49,11 @@ spec:
          - containerPort: 5000
         resources:
           requests:
-            memory: "5M"
-            cpu: "5m"
+            cpu: "20m"
+            memory: "20M"
           limits:
-            memory: "1G"
             cpu: "1"
+            memory: "1G"
         env:
          - name: HAIL_DOMAIN
            value: "{{ global.domain }}"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -55,11 +55,11 @@ spec:
                 key: gsuite_organization
          resources:
            requests:
-             memory: "75M"
-             cpu: "100m"
+             cpu: "20m"
+             memory: "20M"
            limits:
-             memory: "1G"
              cpu: "1"
+             memory: "1G"
          volumeMounts:
           - name: deploy-config
             mountPath: /deploy-config
@@ -165,11 +165,11 @@ spec:
                 key: gsuite_organization
          resources:
            requests:
-             memory: "50M"
-             cpu: "15m"
+             cpu: "20m"
+             memory: "20M"
            limits:
-             memory: "1G"
              cpu: "1"
+             memory: "1G"
          volumeMounts:
           - name: deploy-config
             mountPath: /deploy-config

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -43,8 +43,11 @@ spec:
          - batch.driver
         resources:
           requests:
-            memory: "1G"
+            cpu: "600m"
+            memory: "2150M"
+          limits:
             cpu: "1"
+            memory: "2.5G"
         env:
          - name: HAIL_DOMAIN
            value: "{{ global.domain }}"
@@ -239,11 +242,11 @@ spec:
          - containerPort: 5000
         resources:
           requests:
-            memory: "100M"
-            cpu: "100m"
+            cpu: "20m"
+            memory: "20M"
           limits:
-            memory: "1G"
             cpu: "1"
+            memory: "1G"
         volumeMounts:
          - name: deploy-config
            mountPath: /deploy-config

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           requests:
             cpu: "600m"
-            memory: "2150M"
+            memory: "2G"
           limits:
             cpu: "1"
             memory: "2.5G"

--- a/benchmark-service/deployment.yaml
+++ b/benchmark-service/deployment.yaml
@@ -60,11 +60,11 @@ spec:
             - containerPort: 5000
           resources:
             requests:
-              memory: "10M"
-              cpu: "40m"
+              cpu: "20m"
+              memory: "20M"
             limits:
-              memory: "1G"
               cpu: "1"
+              memory: "1G"
           volumeMounts:
             - name: session-secret-key
               mountPath: /session-secret-key

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "215M"
+            memory: "200M"
           limits:
             cpu: "1"
             memory: "1G"

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -87,11 +87,11 @@ spec:
             name: blog-content
         resources:
           requests:
-            memory: 250Mi
-            cpu: 300m
+            cpu: "100m"
+            memory: "215M"
           limits:
-            memory: 250Mi
             cpu: "1"
+            memory: "1G"
   volumeClaimTemplates:
     - metadata:
         name: blog-content

--- a/bootstrap-gateway/deployment.yaml
+++ b/bootstrap-gateway/deployment.yaml
@@ -37,8 +37,11 @@ spec:
          image: "{{ gateway_image.image }}"
          resources:
            requests:
-             memory: "250M"
              cpu: "100m"
+             memory: "215M"
+           limits:
+             cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 80
           - containerPort: 443

--- a/bootstrap-gateway/deployment.yaml
+++ b/bootstrap-gateway/deployment.yaml
@@ -38,7 +38,7 @@ spec:
          resources:
            requests:
              cpu: "100m"
-             memory: "215M"
+             memory: "200M"
            limits:
              cpu: "1"
              memory: "1G"

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -33,11 +33,11 @@ spec:
           image: "{{ ci_image.image }}"
           resources:
             requests:
-              memory: "200M"
               cpu: "100m"
+              memory: "215M"
             limits:
-              memory: "1G"
               cpu: "1"
+              memory: "1G"
           env:
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "215M"
+              memory: "200M"
             limits:
               cpu: "1"
               memory: "1G"

--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -26,8 +26,11 @@ spec:
           image: "{{ hello_image.image }}"
           resources:
             requests:
-              memory: "0.5G"
-              cpu: "0.5"
+              cpu: "20m"
+              memory: "20M"
+            limits:
+              cpu: "1"
+              memory: "1G"
           ports:
             - containerPort: 5000
           livenessProbe:

--- a/ci/test/resources/statefulset.yaml
+++ b/ci/test/resources/statefulset.yaml
@@ -25,8 +25,11 @@ spec:
           image: "{{ hello_image.image }}"
           resources:
             requests:
-              memory: "0.5G"
-              cpu: "0.5"
+              cpu: "20m"
+              memory: "20M"
+            limits:
+              cpu: "1"
+              memory: "1G"
           ports:
             - containerPort: 5000
           livenessProbe:

--- a/echo/deployment.yaml
+++ b/echo/deployment.yaml
@@ -29,8 +29,11 @@ spec:
         image: "{{ echo_image.image }}"
         resources:
           requests:
-            memory: "100M"
-            cpu: "100m"
+            cpu: "20m"
+            memory: "20M"
+          limits:
+            cpu: "1"
+            memory: "1G"
         ports:
         - containerPort: 5000
         readinessProbe:

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -37,8 +37,11 @@ spec:
          image: "{{ gateway_image.image }}"
          resources:
            requests:
-             memory: "250M"
-             cpu: "100m"
+             cpu: "20m"
+             memory: "20M"
+           limits:
+             cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 80
           - containerPort: 443

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -48,7 +48,7 @@ spec:
          resources:
            requests:
              cpu: "100m"
-             memory: "215M"
+             memory: "200M"
            limits:
              cpu: "1"
              memory: "1G"

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -47,8 +47,8 @@ spec:
             name: grafana-configmap-volume
          resources:
            requests:
-             cpu: "10m"
-             memory: "100M"
+             cpu: "100m"
+             memory: "215M"
            limits:
              cpu: "1"
              memory: "1G"

--- a/image-fetcher/deployment.yaml
+++ b/image-fetcher/deployment.yaml
@@ -23,8 +23,11 @@ spec:
         image: "{{ image_fetcher_image.image }}"
         resources:
           requests:
-            cpu: 50m
-            memory: 100Mi
+            cpu: "20m"
+            memory: "20M"
+          limits:
+            cpu: "1"
+            memory: "1G"
         volumeMounts:
          - name: deploy-config
            mountPath: /deploy-config

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -38,7 +38,7 @@ spec:
          resources:
            requests:
              cpu: "100m"
-             memory: "215M"
+             memory: "200M"
            limits:
              cpu: "1"
              memory: "1G"

--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -37,8 +37,11 @@ spec:
          image: "{{ internal_gateway_image.image }}"
          resources:
            requests:
-             memory: "250M"
-             cpu: "200m"
+             cpu: "100m"
+             memory: "215M"
+           limits:
+             cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 80
          volumeMounts:

--- a/memory/deployment.yaml
+++ b/memory/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             requests:
               cpu: "600m"
-              memory: "2150M"
+              memory: "2G"
             limits:
               cpu: "1"
               memory: "2.5G"

--- a/memory/deployment.yaml
+++ b/memory/deployment.yaml
@@ -25,11 +25,11 @@ spec:
           image: gcr.io/{{ global.project }}/redis:6.0.6-alpine
           command:
            - redis-server
-           - --port 
+           - --port
            - "0"
            - --unixsocket
            - /redis/redis.sock
-           - --timeout 
+           - --timeout
            - "0"
            - --maxmemory
            - 2gb
@@ -40,16 +40,16 @@ spec:
              mountPath: /redis
           resources:
             requests:
-              memory: "2.5G"
-              cpu: "400m"
+              cpu: "600m"
+              memory: "2150M"
             limits:
-              memory: "3.75G"
               cpu: "1"
+              memory: "2.5G"
           readinessProbe:
             exec:
               command:
                - redis-cli
-               - -s 
+               - -s
                - /redis/redis.sock
                - ping
             initialDelaySeconds: 5

--- a/monitoring/deployment.yaml
+++ b/monitoring/deployment.yaml
@@ -46,11 +46,11 @@ spec:
             - containerPort: 5000
           resources:
             requests:
+              cpu: "20m"
               memory: "20M"
-              cpu: "10m"
             limits:
-              memory: "1G"
               cpu: "1"
+              memory: "1G"
           volumeMounts:
             - name: session-secret-key
               mountPath: /session-secret-key

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -62,11 +62,11 @@ spec:
              readOnly: true
           resources:
             requests:
-              memory: "3.75G"
-              cpu: "800m"
+              cpu: "600m"
+              memory: "2150M"
             limits:
-              memory: "3.75G"
               cpu: "1"
+              memory: "2.5G"
           readinessProbe:
             tcpSocket:
               port: 5000

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           resources:
             requests:
               cpu: "600m"
-              memory: "2150M"
+              memory: "2G"
             limits:
               cpu: "1"
               memory: "2.5G"

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -70,11 +70,11 @@ spec:
             value: /deploy-config/deploy-config.json
          resources:
            requests:
-             memory: "5M"
-             cpu: "50m"
+             cpu: "20m"
+             memory: "20M"
            limits:
-             memory: "1G"
              cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 5000
          volumeMounts:

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -323,11 +323,11 @@ spec:
          image: {{ router_image.image }}
          resources:
            requests:
-             memory: "5M"
-             cpu: "10m"
+             cpu: "20m"
+             memory: "20M"
            limits:
-             memory: "250M"
              cpu: "1"
+             memory: "1G"
          env:
           - name: HAIL_DOMAIN
             value: {{ global.domain }}

--- a/shuffler/deployment.yaml
+++ b/shuffler/deployment.yaml
@@ -48,11 +48,11 @@ spec:
              readOnly: true
           resources:
             requests:
-              memory: "3.75G"
-              cpu: "800m"
+              cpu: "600m"
+              memory: "2150M"
             limits:
-              memory: "3.75G"
               cpu: "1"
+              memory: "2.5G"
       volumes:
        - name: deploy-config
          secret:

--- a/shuffler/deployment.yaml
+++ b/shuffler/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           resources:
             requests:
               cpu: "600m"
-              memory: "2150M"
+              memory: "2G"
             limits:
               cpu: "1"
               memory: "2.5G"

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -39,11 +39,11 @@ spec:
          image: "{{ site_image.image }}"
          resources:
            requests:
+             cpu: "20m"
              memory: "20M"
-             cpu: "10m"
            limits:
-             memory: "1G"
              cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 443
          env:

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -38,7 +38,7 @@ spec:
          resources:
            requests:
              cpu: "100m"
-             memory: "215M"
+             memory: "200M"
            limits:
              cpu: "1"
              memory: "1G"
@@ -87,7 +87,7 @@ spec:
          resources:
            requests:
              cpu: "100m"
-             memory: "215M"
+             memory: "200M"
            limits:
              cpu: "1"
              memory: "1G"

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -37,11 +37,11 @@ spec:
          imagePullPolicy: Always
          resources:
            requests:
-             memory: "3.75G"
-             cpu: "800m"
+             cpu: "100m"
+             memory: "215M"
            limits:
-             memory: "3.75G"
              cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 80
             protocol: TCP
@@ -86,11 +86,11 @@ spec:
          imagePullPolicy: Always
          resources:
            requests:
-             memory: "3.75G"
-             cpu: "800m"
+             cpu: "100m"
+             memory: "215M"
            limits:
-             memory: "3.75G"
              cpu: "1"
+             memory: "1G"
          ports:
           - containerPort: 3838
             protocol: TCP


### PR DESCRIPTION
Our GKE nodes come with 2 CPU and 7.5 GB each, but not all of that is allocatable to our pods. In reality, somewhere between 5.7-5.9GB ([GCP Docs](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture) say 5.7, GKE console says 5.9) of memory and 1.9CPU are available for us to use. Some of our Big services request 1 CPU and 3.75GB, but then we can never fit two big pods on one node. This is an attempt to standardize our requests so their easier to reason about while hopefully getting better packing.  

| resource | Big | Medium | Small |
| --- | --- | --- | --- |
| CPU        | 600m   | 100m | 20m |
| Memory  | 2G | 200M | 20M |

The intentions here are:
- always be able to comfortably get 2 Big pods on a node
- medium pods shouldn't have to force new nodes to spin up just because there's a Big pod there already
- small pods take up minimal resources
- there's ample room for small pods (which are mostly on HPA) to scale up considering most nodes shouldn't be at their medium pod capacity

The ratios don't match exactly, because I didn't want to assign CPU lower than 20m to prevent HPA thrashing we saw with auth and see a bit now with router. Setting it to 20m should hopefully convince k8s that idle small apps don't need to be scaled up under normal fluctuation.

## Big
- query
- batch-driver
- shuffler
- memory

## Medium
- grafana
- ukbb-browser
- ukbb-static
- blog
- ci
- internal-gateway

## Small
- amundsen
- router
- gateway
- site
- batch
- address
- atgu
- router-resolver
- ci/test statefulset & deployment
- auth-driver
- echo
- benchmark
- image-fetcher

### Fun surprises I found along the way
- CI test statefulsets and deployment are getting .5GB and .5 CPU each
- We run a lot of image fetchers because a daemon set gets added per PR namespace


EDIT: It seems that discrepancy between GCP docs and GKE console is the console counts kube-system pods in "Allocatable Memory", and it really does take 2GB to run the Kubernetes Engine 🙃 