### PR TITLE
[aiohttp] bump aiohttp version and sync some other dependencies

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@ aiodns==2.0.0
 aiodocker==0.17.0
 aiohttp-jinja2==1.1.1
 aiohttp-session==2.7.0
-aiohttp==3.6.0
+aiohttp==3.7.4
 aiomysql==0.0.20
 aioredis==1.3.1
 async-timeout==3.0.1

--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.7.8
+flake8==3.8.3
 mypy==0.780
 pylint==2.6.0
 astroid<2.5  # https://github.com/PyCQA/pylint/issues/4131

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -59,7 +59,7 @@ class BlockingClientResponse:
         self.client_response.__del__()
 
     def history(self) -> Tuple[aiohttp.ClientResponse, ...]:
-        return self.client_response.history()
+        return self.client_response.history
 
     def __repr__(self) -> str:
         return f'BlockingClientRepsonse({repr(self.client_response)})'

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.6,<3.7
+aiohttp==3.7.4
 aiohttp_session>=2.7,<2.8
 asyncinit>=0.2.4,<0.3
 bokeh>1.3,<2.0


### PR DESCRIPTION
Bump aiohttp version and fix some discrepancies between requirements files.

Cleaned out my virtual env and made sure I could `make -C hail install-deps` and `pip install -r docker/requirements.txt`