### PR TITLE
[ci] fix flexbox alignment and clean up css

### DIFF
--- a/ci/ci/templates/dev-deploy-table.html
+++ b/ci/ci/templates/dev-deploy-table.html
@@ -1,29 +1,36 @@
 {% macro dev_deploy_table(dev_deploys) %}
-<table id="dev-deploys" class="data-table">
-  <thead>
-    <th>ID</th>
-    <th>Branch</th>
-    <th>Deploy State</th>
-  </thead>
-  <tbody>
-    {% for batch in dev_deploys %}
-    <tr>
-      <td class="numeric-cell">
-        <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
-      </td>
-      <td>
-        {{ batch['attributes']['target_branch'] }}
-      </td>
-      <td>
-        {% if 'state' in batch and batch['state'] %}
-        {{ batch['state'] }}
-        {% endif %}
-        {% if not batch['complete'] %}
-        running
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+{% block head %}
+    <script src="{{ base_path }}/common_static/search_bar.js"></script>
+    <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
+{% endblock %}
+<div class="searchbar-table">
+  <input type="text" id="devDepSearchBar" onkeyup="searchTable('dev-deploys', 'devDepSearchBar')" placeholder="Search terms...">
+  <table id="dev-deploys" class="data-table">
+    <thead>
+      <th>ID</th>
+      <th>Branch</th>
+      <th>Deploy State</th>
+    </thead>
+    <tbody>
+      {% for batch in dev_deploys %}
+      <tr>
+        <td class="numeric-cell">
+          <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
+        </td>
+        <td>
+          {{ batch['attributes']['target_branch'] }}
+        </td>
+        <td>
+          {% if 'state' in batch and batch['state'] %}
+          {{ batch['state'] }}
+          {% endif %}
+          {% if not batch['complete'] %}
+          running
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endmacro %}

--- a/ci/ci/templates/job-table.html
+++ b/ci/ci/templates/job-table.html
@@ -4,7 +4,7 @@
     <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
 {% endblock %}
 <div class="searchbar-table">
-  <input type="text" id="searchBar" onkeyup="searchTable('jobs', 'searchBar')" placeholder="Search terms...">
+  <input type="text" id="jobsSearchBar" onkeyup="searchTable('jobs', 'jobsSearchBar')" placeholder="Search terms...">
   <table id='jobs' class="data-table" style="line-height: 175%">
     <thead>
       <tr>

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -1,7 +1,7 @@
-{% macro pr_table(wb) %}
+{% macro pr_table(wb, id) %}
 <div class="searchbar-table">
-  <input type="text" id="searchBar" onkeyup="searchTable('prs', 'searchBar')" placeholder="Search terms..."/>
-  <table id="prs" class="data-table">
+  <input type="text" id="{{ id }}SearchBar" onkeyup="searchTable('prs', 'prSearchBar')" placeholder="Search terms..."/>
+  <table id={{ id }} class="data-table">
   <thead>
     <tr>
       <th>PR</th>

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -1,6 +1,6 @@
 {% macro pr_table(wb, id) %}
 <div class="searchbar-table">
-  <input type="text" id="{{ id }}SearchBar" onkeyup="searchTable('prs', 'prSearchBar')" placeholder="Search terms..."/>
+  <input type="text" id="{{ id }}SearchBar" onkeyup="searchTable('prs', '{{ id }}SearchBar')" placeholder="Search terms..."/>
   <table id={{ id }} class="data-table">
   <thead>
     <tr>

--- a/ci/ci/templates/user.html
+++ b/ci/ci/templates/user.html
@@ -5,41 +5,64 @@
 
 {% block title %}User Homepage{% endblock %}
 
+{% block head %}
+<style>
+.dashboard-grid {
+  display: flex;
+  flex-flow: row wrap;
+  width: 100%;
+}
+
+.col {
+  flex: 50%;
+  align-self: flex-start;
+}
+
+.col > * {
+  margin-bottom: 5%;
+}
+
+.searchbar-table {
+  align-items: flex-start;
+}
+</style>
+{% endblock %}
+
 {% block content %}
 <h1>Welcome, {{ username }}!</h1>
 
 GitHub username: {{ gh_username }}
-
-<div style='display: flex; flex-flow: row wrap;'>
-  <div style='flex: 40%'>
-    <div style='margin-bottom: 5%'>
-      <h2>My PRs</h2>
+<br/>
+<div class="dashboard-grid">
+  <div class="col">
+    <div>
       {% for wb in pr_wbs %}
       {% if wb.prs is not none %}
-      <h3 class="stacked-header">{{ wb.branch }}</h3>
-      {{ pr_table(wb) }}
+      <h2>{{ wb.branch }} PRs</h2>
+      {{ pr_table(wb, "myprs") }}
       {% endif %}
       {% endfor %}
     </div>
 
-    <div style='margin-bottom: 5%'>
-      <h2>Assigned Reviews</h2>
+    <div>
       {% for wb in review_wbs %}
       {% if wb.prs is not none %}
-      <h3 class="stacked-header">{{ wb.branch }}</h3>
-      {{ pr_table(wb) }}
+      <h2>{{ wb.branch }} Assigned Reviews</h2>
+      {{ pr_table(wb, "reviews") }}
       {% endif %}
       {% endfor %}
     </div>
 
-    <div style='margin-bottom: 5%'>
+    <div>
       {{ team_table(team_member) }}
     </div>
   </div>
 
-  <div style='flex: 40%; padding-left: 10px'>
-    <h2>Dev Deploys</h2>
-    {{ dev_deploy_table(dev_deploys) }}
+  <div class="col">
+    <div>
+      <h2>Dev Deploys</h2>
+      {{ dev_deploy_table(dev_deploys) }}
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
The divs for the two columns now span the whole screen, so there is room to breathe between the dev deploy and PR tables. Fixed a spacing bug in the PR tables by aligning them to the start of the flexbox column and standardized on header / searchbox / table per card. This should take up more of the screen, but is not explicitly "centered", basically the tables start at 0% and 50%. Unfortunately it's a painful process to fiddle with the test repo to get anything good to look at on a development CI. I'll start thinking automatically writing out test data to better test UI changes, but for now I just want to see this in main.