### PR TITLE
[query] simplify strange stdev formula

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -862,8 +862,7 @@ def stats(expr) -> StructExpression:
             lambda aggs: hl.bind(
                 lambda mean: hl.struct(
                     mean=mean,
-                    stdev=hl.sqrt(hl.float64(
-                        aggs.sumsq - (2 * mean * aggs.sum) + (aggs.n_def * mean ** 2)) / aggs.n_def),
+                    stdev=hl.sqrt(hl.float64(aggs.sumsq - mean * aggs.sum) / aggs.n_def),
                     min=hl.float64(aggs.min),
                     max=hl.float64(aggs.max),
                     n=aggs.n_def,


### PR DESCRIPTION
The previous formula, `(1/n) (sumsq - (2 * mean * sum) + (n * mean^2))` was weirdly redundant, since `mean * sum == n * mean^2`. This was added by #6728, which ported stats from Scala, but the weird formula did not come from the Scala implementation. I have no clue where this came from. The only reason for doing something like this might be for improved numerical stability, but that doesn't seem to be the case here.

In fact, this current method of computing the variance (pre or post this pr) is known to be unstable when the mean is much larger than the stdev (as is easy to see: you're subtracting two nearly equal positive numbers). The Scala implementation used the spark `StatCounter`, which uses the more stable [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm). We should probably fix any variance or stdev computation to use a stable method, which I think requires a dedicated stats aggregator that maintains count, mean, and variance in a smart way.