### PR TITLE
[query] teach king to treat filtered entries as missing

### DIFF
--- a/hail/python/hail/methods/relatedness/king.py
+++ b/hail/python/hail/methods/relatedness/king.py
@@ -220,6 +220,7 @@ def king(call_expr, *, block_size=None):
        `call-expr`'s column keys. It has one entry field, `phi`.
     """
     mt = matrix_table_source('king/call_expr', call_expr)
+    mt = mt.unfilter_entries()
 
     is_hom_ref = Env.get_uid()
     is_het = Env.get_uid()

--- a/hail/python/hail/methods/relatedness/king.py
+++ b/hail/python/hail/methods/relatedness/king.py
@@ -220,9 +220,9 @@ def king(call_expr, *, block_size=None):
        `call-expr`'s column keys. It has one entry field, `phi`.
     """
     mt = matrix_table_source('king/call_expr', call_expr)
+    call = Env.get_uid()
     mt = mt.annotate_entries(**{call: call_expr})
 
-    call = Env.get_uid()
     is_hom_ref = Env.get_uid()
     is_het = Env.get_uid()
     is_hom_var = Env.get_uid()

--- a/hail/python/hail/methods/relatedness/king.py
+++ b/hail/python/hail/methods/relatedness/king.py
@@ -220,18 +220,20 @@ def king(call_expr, *, block_size=None):
        `call-expr`'s column keys. It has one entry field, `phi`.
     """
     mt = matrix_table_source('king/call_expr', call_expr)
+    mt = mt.annotate_entries(**{call: call_expr})
 
+    call = Env.get_uid()
     is_hom_ref = Env.get_uid()
     is_het = Env.get_uid()
     is_hom_var = Env.get_uid()
     is_defined = Env.get_uid()
-    mt = mt.select_entries(**{
-        is_hom_ref: hl.float(hl.or_else(call_expr.is_hom_ref(), 0)),
-        is_het: hl.float(hl.or_else(call_expr.is_het(), 0)),
-        is_hom_var: hl.float(hl.or_else(call_expr.is_hom_var(), 0)),
-        is_defined: hl.float(hl.is_defined(call_expr))
-    })
     mt = mt.unfilter_entries()
+    mt = mt.select_entries(**{
+        is_hom_ref: hl.float(hl.or_else(mt[call].is_hom_ref(), 0)),
+        is_het: hl.float(hl.or_else(mt[call].is_het(), 0)),
+        is_hom_var: hl.float(hl.or_else(mt[call].is_hom_var(), 0)),
+        is_defined: hl.float(hl.is_defined(mt[call]))
+    })
     ref = hl.linalg.BlockMatrix.from_entry_expr(mt[is_hom_ref], block_size=block_size)
     het = hl.linalg.BlockMatrix.from_entry_expr(mt[is_het], block_size=block_size)
     var = hl.linalg.BlockMatrix.from_entry_expr(mt[is_hom_var], block_size=block_size)

--- a/hail/python/hail/methods/relatedness/king.py
+++ b/hail/python/hail/methods/relatedness/king.py
@@ -220,7 +220,6 @@ def king(call_expr, *, block_size=None):
        `call-expr`'s column keys. It has one entry field, `phi`.
     """
     mt = matrix_table_source('king/call_expr', call_expr)
-    mt = mt.unfilter_entries()
 
     is_hom_ref = Env.get_uid()
     is_het = Env.get_uid()
@@ -232,6 +231,7 @@ def king(call_expr, *, block_size=None):
         is_hom_var: hl.float(hl.or_else(call_expr.is_hom_var(), 0)),
         is_defined: hl.float(hl.is_defined(call_expr))
     })
+    mt = mt.unfilter_entries()
     ref = hl.linalg.BlockMatrix.from_entry_expr(mt[is_hom_ref], block_size=block_size)
     het = hl.linalg.BlockMatrix.from_entry_expr(mt[is_het], block_size=block_size)
     var = hl.linalg.BlockMatrix.from_entry_expr(mt[is_hom_var], block_size=block_size)

--- a/hail/python/test/hail/methods/test_king.py
+++ b/hail/python/test/hail/methods/test_king.py
@@ -51,3 +51,13 @@ def test_king_large():
                          reference_genome=None)
     kinship = hl.king(mt.GT)
     assert_c_king_same_as_hail_king(resource('fastlmmTest.kin0.bgz'), kinship)
+
+
+@fails_local_backend()
+def test_king_filtered_entries_no_error():
+    plink_path = resource('balding-nichols-1024-variants-4-samples-3-populations')
+    mt = hl.import_plink(bed=f'{plink_path}.bed',
+                         bim=f'{plink_path}.bim',
+                         fam=f'{plink_path}.fam')
+    mt = mt.filter_entries(hl.rand_bool(0.5))
+    hl.king(mt.GT)._force_count_rows()


### PR DESCRIPTION
CHANGELOG: Teach `hl.king` to treat filtered entries as missing values.