### PR TITLE
[ci] fix missing id css bug

### DIFF
--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -32,7 +32,7 @@
     <h2>PRs</h2>
     {% if wb.prs is not none %}
     {% if wb.prs|length > 0 %}
-    {{ pr_table(wb, "prs") }}
+    {{ pr_table(wb, "prs", "prsSearchBar") }}
     {% else %}
     No PRs.
     {% endif %}
@@ -49,6 +49,6 @@
       <button type="submit">Authorize</button>
     </form>
     <script type="text/javascript">
-      focusOnSlash("searchBar");
+      focusOnSlash("prsSearchBar");
     </script>
 {% endblock %}

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -32,7 +32,7 @@
     <h2>PRs</h2>
     {% if wb.prs is not none %}
     {% if wb.prs|length > 0 %}
-    {{ pr_table(wb) }}
+    {{ pr_table(wb, "prs") }}
     {% else %}
     No PRs.
     {% endif %}

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -1,7 +1,7 @@
-{% macro pr_table(wb, id) %}
+{% macro pr_table(wb, id, searchBarId) %}
 <div class="searchbar-table">
-  <input type="text" id="{{ id }}SearchBar" onkeyup="searchTable('prs', '{{ id }}SearchBar')" placeholder="Search terms..."/>
-  <table id={{ id }} class="data-table">
+  <input type="text" id="{{ searchBarId }}" onkeyup="searchTable('{{ id }}', '{{ searchBarId }}')" placeholder="Search terms..."/>
+  <table id="{{ id }}" class="data-table">
   <thead>
     <tr>
       <th>PR</th>

--- a/ci/ci/templates/user.html
+++ b/ci/ci/templates/user.html
@@ -39,7 +39,7 @@ GitHub username: {{ gh_username }}
       {% for wb in pr_wbs %}
       {% if wb.prs is not none %}
       <h2>{{ wb.branch }} PRs</h2>
-      {{ pr_table(wb, "myprs") }}
+      {{ pr_table(wb, "myprs", "myprsSearchBar") }}
       {% endif %}
       {% endfor %}
     </div>
@@ -48,7 +48,7 @@ GitHub username: {{ gh_username }}
       {% for wb in review_wbs %}
       {% if wb.prs is not none %}
       <h2>{{ wb.branch }} Assigned Reviews</h2>
-      {{ pr_table(wb, "reviews") }}
+      {{ pr_table(wb, "reviews", "reviewsSearchBar") }}
       {% endif %}
       {% endfor %}
     </div>


### PR DESCRIPTION
I added an `id` input to the jinja macro for PR tables. The index page wasn't passing in the second input and the class attribute got smashed into the `id` attribute for the div (`id="class="data-table""`), so the table lost all styling. 