### PR TITLE
[batch] Fix last updated on worker when deleting jobs

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1267,6 +1267,8 @@ class Worker:
         if job is None:
             raise web.HTTPNotFound()
 
+        self.last_updated = time_msecs()
+
         self.task_manager.ensure_future(job.delete())
 
         return web.Response()


### PR DESCRIPTION
When a bunch of longer running jobs got deleted at once, we instantly deleted the app. We should update the last_updated time when a delete operation comes in.