### PR TITLE
[ci] add authorize sha and action items table to user page

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -61,6 +61,7 @@ async def pr_config(app, pr: PR) -> Dict[str, Any]:
         'review_state': pr.review_state,
         'author': pr.author,
         'assignees': pr.assignees,
+        'reviewers': pr.reviewers,
         'out_of_date': pr.build_state in ['failure', 'success', None] and not pr.is_up_to_date(),
     }
 
@@ -218,7 +219,7 @@ def is_pr_author(gh_username, pr_config):
 
 
 def is_pr_reviewer(gh_username, pr_config):
-    return gh_username in pr_config['assignees']
+    return gh_username in pr_config['assignees'] or gh_username in pr_config['reviewers']
 
 
 def pr_requires_action(gh_username, pr_config):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -157,7 +157,7 @@ fi
 
 
 class PR(Code):
-    def __init__(self, number, title, source_branch, source_sha, target_branch, author, assignees, labels):
+    def __init__(self, number, title, source_branch, source_sha, target_branch, author, assignees, reviewers, labels):
         self.number = number
         self.title = title
         self.source_branch = source_branch
@@ -165,6 +165,7 @@ class PR(Code):
         self.target_branch = target_branch
         self.author = author
         self.assignees = assignees
+        self.reviewers = reviewers
         self.labels = labels
 
         # pending, changes_requested, approve
@@ -258,6 +259,7 @@ class PR(Code):
             target_branch,
             gh_json['user']['login'],
             {user['login'] for user in gh_json['assignees']},
+            {user['login'] for user in gh_json['requested_reviewers']},
             {label['name'] for label in gh_json['labels']},
         )
 

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -1,6 +1,9 @@
 {% from "job-table.html" import job_table with context %}
 {% extends "layout.html" %}
 {% block title %}Batch {{ batch['id'] }}{% endblock %}
+{% block head %}
+    <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
+{% endblock %}
 {% block content %}
     <h1>Batch {{ batch['id'] }}</h1>
     <h2>Timing</h2>
@@ -20,5 +23,8 @@
     </div>
     {% endif %}
     <h2>Jobs</h2>
-    {{ job_table(jobs) }}
+    {{ job_table(jobs, "jobs", "jobsSearchBar") }}
+    <script type="text/javascript">
+      focusOnSlash("jobsSearchBar");
+    </script>
 {% endblock %}

--- a/ci/ci/templates/dev-deploy-table.html
+++ b/ci/ci/templates/dev-deploy-table.html
@@ -24,9 +24,6 @@
           {% if 'state' in batch and batch['state'] %}
           {{ batch['state'] }}
           {% endif %}
-          {% if not batch['complete'] %}
-          running
-          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/ci/ci/templates/job-table.html
+++ b/ci/ci/templates/job-table.html
@@ -1,11 +1,10 @@
-{% macro job_table(jobs) %}
+{% macro job_table(jobs, id, searchBarId) %}
 {% block head %}
     <script src="{{ base_path }}/common_static/search_bar.js"></script>
-    <script src="{{ base_path }}/common_static/focus_on_keyup.js"></script>
 {% endblock %}
 <div class="searchbar-table">
-  <input type="text" id="jobsSearchBar" onkeyup="searchTable('jobs', 'jobsSearchBar')" placeholder="Search terms...">
-  <table id='jobs' class="data-table" style="line-height: 175%">
+  <input type="text" id="{{ searchBarId }}" onkeyup="searchTable('{{ id }}', '{{ searchBarId }}')" placeholder="Search terms...">
+  <table id="{{ id }}" class="data-table" style="line-height: 175%">
     <thead>
       <tr>
         <th>id</th>

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -49,9 +49,6 @@
             {% if 'state' in batch and batch['state'] %}
             {{ batch['state'] }}
             {% endif %}
-            {% if not batch['complete'] %}
-            running
-            {% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/ci/ci/templates/user.html
+++ b/ci/ci/templates/user.html
@@ -36,6 +36,15 @@ GitHub username: {{ gh_username }}
 <div class="dashboard-grid">
   <div class="col">
     <div>
+      {% for wb in actionable_wbs %}
+      {% if wb.prs is not none %}
+      <h2>{{ wb.branch }} Awaiting Action</h2>
+      {{ pr_table(wb, "actionitems", "actionitemsSearchBar") }}
+      {% endif %}
+      {% endfor %}
+    </div>
+
+    <div>
       {% for wb in pr_wbs %}
       {% if wb.prs is not none %}
       <h2>{{ wb.branch }} PRs</h2>
@@ -47,10 +56,20 @@ GitHub username: {{ gh_username }}
     <div>
       {% for wb in review_wbs %}
       {% if wb.prs is not none %}
-      <h2>{{ wb.branch }} Assigned Reviews</h2>
+      <h2>{{ wb.branch }} Reviews</h2>
       {{ pr_table(wb, "reviews", "reviewsSearchBar") }}
       {% endif %}
       {% endfor %}
+    </div>
+
+    <div>
+      <h2>Authorize SHA</h2>
+      <form action="{{ base_path }}/authorize_source_sha" method="post">
+        <label for="sha">SHA:</label>
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
+        <input type="text" name="sha" id="sha">
+        <button type="submit">Authorize</button>
+      </form>
     </div>
 
     <div>


### PR DESCRIPTION
This kind of does a lot of small things:

- Adds a table at the top of the page that is all the PRs that require the user's attention, meaning: a personally authored PR where the build has failed or there are changes requested, or a PR for review that the user has not yet reviewed.

- Under PRs that require a review, a user now sees those where they are listed under `Assignees` *as well as* under `Reviewers`. We have been using assignees to assign reviews, but outside collaborators are unable to do so or dismiss reviews. This is because we don't really align with GitHub's semantics for these labels. Per GitHub, Assignees are organization members responsible for the supervision of a PR, whether the author or the final merge sign-off. Meanwhile, reviewers are what they suggest. If an outside contributor submits a PR, they can request a review from organization members in the `Reviewers` box, and then re-request review once they are ready for the PR to be looked at again. We should probably just abandon assignees given how we currently use them, but I just wanted to first get all of the information onto CI so nothing falls through the cracks.

- Adds authorize SHA input

- Fixes some small cosmetic bugs like a repeated "running" statement in batch tables and enables '/' focus on the jobs table in a batch.