### PR TITLE
[query] Get json4s in the hail jar

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -194,6 +194,10 @@ dependencies {
     bundled group: 'org.ow2.asm', name: 'asm-util', version: '7.3.1'
     bundled group: 'org.ow2.asm', name: 'asm-analysis', version: '7.3.1'
 
+    bundled group: 'org.json4s', name: 'json4s-core_' + scalaMajorVersion, version: '3.5.3'
+    bundled group: 'org.json4s', name: 'json4s-ast_' + scalaMajorVersion, version: '3.5.3'
+    bundled group: 'org.json4s', name: 'json4s-jackson_' + scalaMajorVersion, version: '3.5.3'
+
     bundled 'net.java.dev.jna:jna:4.2.2'
     bundled('net.sourceforge.jdistlib:jdistlib:0.4.5') {
         transitive = false
@@ -314,6 +318,7 @@ tasks.withType(ShadowJar) {
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
+    relocate 'org.json4s', 'is.hail.org.json4s'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'
@@ -331,3 +336,5 @@ task shadowTestJar(type: ShadowJar) {
     from project.sourceSets.main.output, project.sourceSets.test.output
     configurations = [project.configurations.hailTestJar]
 }
+
+assemble.dependsOn shadowJar

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -126,10 +126,7 @@ configurations {
                 }
 	        }
             eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.json4s') {
-                    // JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507)
-                    details.useVersion('3.5.3')
-                } else if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
+                if (details.requested.group == 'org.scalanlp' && details.requested.version == '1.0') {
                     // Breeze 1.0 contains a known bug (https://github.com/scalanlp/breeze/issues/772)
                     details.useVersion('1.1')
                 }
@@ -194,6 +191,8 @@ dependencies {
     bundled group: 'org.ow2.asm', name: 'asm-util', version: '7.3.1'
     bundled group: 'org.ow2.asm', name: 'asm-analysis', version: '7.3.1'
 
+    // Spark 3 and spark 2 use different, incompatible versions of this package. Pin and relocate 3.5.3
+    // Also: JSON4S 3.6.0+ contain a known bug (https://github.com/json4s/json4s/issues/507).
     bundled group: 'org.json4s', name: 'json4s-core_' + scalaMajorVersion, version: '3.5.3'
     bundled group: 'org.json4s', name: 'json4s-ast_' + scalaMajorVersion, version: '3.5.3'
     bundled group: 'org.json4s', name: 'json4s-jackson_' + scalaMajorVersion, version: '3.5.3'
@@ -318,7 +317,7 @@ tasks.withType(ShadowJar) {
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
-    relocate 'org.json4s', 'is.hail.org.json4s'
+    relocate 'org.json4s', 'is.hail.org.relocated.json4s'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -17,6 +17,11 @@ import org.testng.annotations.Test
 
 class Aggregators2Suite extends HailSuite {
 
+  def printVersion(clazz: Class[_]): Unit = {
+    val p = clazz.getPackage
+    System.out.printf("%s%n  Title: %s%n  Version: %s%n  Vendor: %s%n", clazz.getName, p.getImplementationTitle, p.getImplementationVersion, p.getImplementationVendor)
+  }
+
   def assertAggEqualsProcessed(
     aggSig: PhysicalAggSig,
     initOp: IR,
@@ -166,6 +171,7 @@ class Aggregators2Suite extends HailSuite {
 
   @Test def TestCount() {
     val seqOpArgs = Array.fill(rows.length)(FastIndexedSeq[IR]())
+    printVersion(org.json4s.JArray.getClass)
     assertAggEquals(countAggSig, FastIndexedSeq(), seqOpArgs, expected = rows.length.toLong, args = FastIndexedSeq(("rows", (arrayType, rows))))
   }
 


### PR DESCRIPTION
For Spark 3 support to work, I think the solution is that `json4s` needs to be relocated inside our hail jar. Let's see if spark 3 even builds with this (my current experience trying to build it on my laptop suggests it won't)