### PR TITLE
[copy] fix overly agressive cleanup

### DIFF
--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -542,7 +542,7 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
                     [self._part_name(i) for i in range(self._num_parts)],
                     self._dest_name)
             finally:
-                await self._fs.rmtree(self._sema, f'gs://{self._bucket}/{self._dest_dirname}_')
+                await self._fs.rmtree(self._sema, f'gs://{self._bucket}/{self._dest_dirname}_/{self._token}')
                 # after the rmtree, all temporary files should be gone
                 # cancel any cleanup tasks that are still running
                 # exiting the pool will wait for everything to finish


### PR DESCRIPTION
Multi-part uploads put their scratch data in `<dest-dir>/_/<token>`, however, they deleted `<dest-dir>/_`.  Therefore, if two multi-part uploads were happening to the same destination directory, they would potentially delete the other's uploads causing a 404.  I will hand merge this because it will fail the build.