### PR TITLE
[query-service] maybe fix event loop not initialized

### DIFF
--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -22,5 +22,9 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_this)
 
 @pytest.fixture(scope="session", autouse=True)
-def ensure_event_loop_is_initialized_in_main_thread():
-    asyncio.get_event_loop()
+def ensure_event_loop_is_initialized_in_test_thread():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError as err:
+        assert err.args[0] == "There is no current event loop in thread 'Dummy-1'"
+        asyncio.set_event_loop(asyncio.new_event_loop())

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import os
 
@@ -19,3 +20,7 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if not digest(item.name) % n_splits == split_index:
             item.add_marker(skip_this)
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_event_loop_is_initialized_in_main_thread():
+    asyncio.get_event_loop()

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -13,11 +13,6 @@ _initialized = False
 
 
 def startTestHailContext():
-    try:
-        asyncio.get_event_loop()
-    except RuntimeError as err:
-        if 'There is no current event loop in thread' in err.args[0]:
-            asyncio.set_event_loop(asyncio.new_event_loop())
     global _initialized
     if not _initialized:
         backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')


### PR DESCRIPTION
The event loop is supposed to be initialized in the main thread. Sometimes
our tests get placed in the non-main thread (always a thread named Dummy-1).
Hopefully the session-scoped fixture is run in the main thread.