### PR TITLE
[query] Add json warn context to `parse_json`

### DIFF
--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -140,10 +140,10 @@ object JSONAnnotationImpex {
       }
     }
 
-  def irImportAnnotation(s: String, t: Type): Row = {
+  def irImportAnnotation(s: String, t: Type, warnContext: mutable.HashSet[String]): Row = {
     try {
       // wraps in a Row to handle returned missingness
-      Row(importAnnotation(JsonMethods.parse(s), t, true, null))
+      Row(importAnnotation(JsonMethods.parse(s), t, true, warnContext))
     } catch {
       case e: Throwable =>
         fatal(s"Error parsing JSON:\n  type: $t\n  value: $s", e)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -299,8 +299,11 @@ object StringFunctions extends RegistryFunctions {
       (rType: Type, _: Seq[PType]) => PType.canonical(rType, true), typeParameters = Array(tv("T"))
     ) { case (er, cb, _, resultType, Array(s: PStringCode)) =>
 
-      val row = Code.invokeScalaObject2[String, Type, Row](JSONAnnotationImpex.getClass, "irImportAnnotation",
-        s.loadString(), er.mb.ecb.getType(resultType.virtualType.asInstanceOf[TTuple].types(0)))
+      val warnCtx = cb.emb.genFieldThisRef[mutable.HashSet[String]]("parse_json_context")
+      cb.ifx(warnCtx.load().isNull, cb.assign(warnCtx, Code.newInstance[mutable.HashSet[String]]()))
+
+      val row = Code.invokeScalaObject3[String, Type, mutable.HashSet[String], Row](JSONAnnotationImpex.getClass, "irImportAnnotation",
+        s.loadString(), er.mb.ecb.getType(resultType.virtualType.asInstanceOf[TTuple].types(0)), warnCtx)
 
       unwrapReturn(cb, er.region, resultType, row)
     }


### PR DESCRIPTION
We don't test the logs, but I did test this manually, it works as
expected.