### PR TITLE
[query] Add `source_file_field` to `import_table`

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -23,7 +23,7 @@ from .register_functions import register_functions
 from .register_aggregators import register_aggregators
 from .table_ir import MatrixRowsTable, TableJoin, TableLeftJoinRightDistinct, \
     TableIntervalJoin, TableUnion, TableRange, TableMapGlobals, TableExplode, \
-    TableKeyBy, TableMapRows, TableRead, TableImport, MatrixEntriesTable, \
+    TableKeyBy, TableMapRows, TableRead, MatrixEntriesTable, \
     TableFilter, TableKeyByAndAggregate, \
     TableAggregateByKey, MatrixColsTable, TableParallelize, TableHead, \
     TableTail, TableOrderBy, TableDistinct, RepartitionStrategy, \
@@ -272,7 +272,6 @@ __all__ = [
     'TableMapRows',
     'TableMapPartitions',
     'TableRead',
-    'TableImport',
     'MatrixEntriesTable',
     'TableFilter',
     'TableKeyByAndAggregate',

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -1,5 +1,3 @@
-import json
-
 import hail as hl
 from hail.expr.types import dtype
 from hail.ir.base_ir import BaseIR, TableIR

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -250,26 +250,6 @@ class TableRead(TableIR):
         self._type = Env.backend().table_type(self)
 
 
-class TableImport(TableIR):
-    def __init__(self, paths, typ, reader_options):
-        super().__init__()
-        self.paths = paths
-        self._typ = typ
-        self.reader_options = reader_options
-
-    def head_str(self):
-        return '(({}) {} {}'.format(
-            ' '.join([escape_str(path) for path in self.paths]),
-            self._typ._parsable_string(),
-            escape_str(json.dumps(self.reader_options)))
-
-    def _eq(self, other):
-        return self.paths == other.paths and self.typ == other.typ and self.reader_options == other.reader_options
-
-    def _compute_type(self):
-        self._type = Env.backend().table_type(self)
-
-
 class MatrixEntriesTable(TableIR):
     def __init__(self, child):
         super().__init__(child)

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -67,7 +67,7 @@ class TextTableReader(TableReader):
     def __init__(self, paths, min_partitions, types, comment,
                  delimiter, missing, no_header, quote,
                  skip_blank_lines, force_bgz, filter, find_replace,
-                 force_gz):
+                 force_gz, source_file_field):
         self.config = {
             'files': paths,
             'typeMapStr': {f: t._parsable_string() for f, t in types.items()},
@@ -80,7 +80,8 @@ class TextTableReader(TableReader):
             'skipBlankLines': skip_blank_lines,
             'forceBGZ': force_bgz,
             'filterAndReplace': make_filter_and_replace(filter, find_replace),
-            'forceGZ': force_gz
+            'forceGZ': force_gz,
+            'sourceFileField': source_file_field
         }
 
     def render(self):

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1317,7 +1317,8 @@ def import_gen(path,
            force_bgz=bool,
            filter=nullable(str),
            find_replace=nullable(sized_tupleof(str, str)),
-           force=bool)
+           force=bool,
+           source_file_field=nullable(str))
 def import_table(paths,
                  key=None,
                  min_partitions=None,
@@ -1332,7 +1333,8 @@ def import_table(paths,
                  force_bgz=False,
                  filter=None,
                  find_replace=None,
-                 force=False) -> Table:
+                 force=False,
+                 source_file_field=None) -> Table:
     """Import delimited text file (text table) as :class:`.Table`.
 
     The resulting :class:`.Table` will have no key fields. Use
@@ -1520,7 +1522,9 @@ def import_table(paths,
         If ``True``, load gzipped files serially on one core. This should
         be used only when absolutely necessary, as processing time will be
         increased due to lack of parallelism.
-
+    source_file_field : :class:`str`, optional
+        If defined, the source file name for each line will be a field of the table
+        with this name. Can be useful when importing multiple tables using glob patterns.
     Returns
     -------
     :class:`.Table`
@@ -1532,7 +1536,7 @@ def import_table(paths,
     tr = ir.TextTableReader(paths, min_partitions, types, comment,
                             delimiter, missing, no_header, quote,
                             skip_blank_lines, force_bgz, filter, find_replace,
-                            force)
+                            force, source_file_field)
     ht = Table(ir.TableRead(tr))
 
     strs = []
@@ -1572,7 +1576,7 @@ def import_table(paths,
         tr = ir.TextTableReader(paths, min_partitions, all_types, comment,
                                 delimiter, missing, no_header, quote,
                                 skip_blank_lines, force_bgz, filter, find_replace,
-                                force)
+                                force, source_file_field)
         ht = Table(ir.TableRead(tr))
 
     else:

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1976,6 +1976,15 @@ class ImportTableTests(unittest.TestCase):
         ]
         return hl.Table.parallelize(data, key='Sample')
 
+    def test_source_file(self):
+        ht = hl.import_table(resource('variantAnnotations.split.*.tsv'), source_file_field='source')
+        ht = ht.add_index()
+        assert ht.aggregate(hl.agg.all(
+            hl.if_else(ht.idx < 239,
+                       ht.source.endswith('variantAnnotations.split.1.tsv'),
+                       ht.source.endswith('variantAnnotations.split.2.tsv'))))
+
+
     @fails_service_backend()
     def test_read_write_identity(self):
         ht = self.small_dataset_1()

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1451,7 +1451,6 @@ object IRParser {
   }
 
   def table_ir_1(env: IRParserEnvironment)(it: TokenIterator): StackFrame[TableIR] = {
-    // FIXME TableImport
     identifier(it) match {
       case "TableKeyBy" =>
         val keys = identifiers(it)


### PR DESCRIPTION
CHANGELOG: Add `source_file_field` parameter to `hl.import_table` to allow lines to be associated with their original source file.