### PR TITLE
[prometheus] add prometheus to track SLIs

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -11,12 +11,10 @@ import asyncio
 import aiohttp
 from aiohttp import web
 import aiohttp_session
-import prometheus_client as pc
 import pymysql
-from prometheus_async.aio import time as prom_async_time
-from prometheus_async.aio.web import server_stats
 import google.oauth2.service_account
 import google.api_core.exceptions
+from prometheus_async.aio.web import server_stats  # type: ignore
 from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
                            request_retry_transient_errors, run_if_changed,
                            retry_long_running, LoggingTimer, cost_str)
@@ -31,7 +29,8 @@ from gear import (Database, setup_aiohttp_session,
                   rest_authenticated_users_only,
                   web_authenticated_users_only,
                   web_authenticated_developers_only,
-                  check_csrf_token, transaction)
+                  check_csrf_token, transaction,
+                  monitor_endpoint)
 from web_common import (setup_aiohttp_jinja2, setup_common_static_routes,
                         render_template, set_message)
 
@@ -55,42 +54,6 @@ from .validate import ValidationError, validate_batch, validate_and_clean_jobs
 # uvloop.install()
 
 log = logging.getLogger('batch.front_end')
-
-REQUEST_TIME = pc.Summary('batch_request_latency_seconds', 'Batch request latency in seconds', ['endpoint', 'verb'])
-REQUEST_TIME_GET_JOBS = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs', verb="GET")
-REQUEST_TIME_GET_JOB = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id', verb="GET")
-REQUEST_TIME_GET_JOB_LOG = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id/log', verb="GET")
-REQUEST_TIME_GET_ATTEMPTS = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/job_id/attempts', verb="GET")
-REQUEST_TIME_GET_BATCHES = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches', verb="GET")
-REQUEST_TIME_POST_CREATE_JOBS = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/jobs/create', verb="POST")
-REQUEST_TIME_POST_CREATE_BATCH = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/create', verb='POST')
-REQUEST_TIME_POST_GET_BATCH = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id', verb='GET')
-REQUEST_TIME_PATCH_CANCEL_BATCH = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/cancel', verb="PATCH")
-REQUEST_TIME_PATCH_CLOSE_BATCH = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id/close', verb="PATCH")
-REQUEST_TIME_DELETE_BATCH = REQUEST_TIME.labels(endpoint='/api/v1alpha/batches/batch_id', verb="DELETE")
-REQUEST_TIME_GET_BATCH_UI = REQUEST_TIME.labels(endpoint='/batches/batch_id', verb='GET')
-REQUEST_TIME_POST_CANCEL_BATCH_UI = REQUEST_TIME.labels(endpoint='/batches/batch_id/cancel', verb='POST')
-REQUEST_TIME_POST_DELETE_BATCH_UI = REQUEST_TIME.labels(endpoint='/batches/batch_id/delete', verb='POST')
-REQUEST_TIME_GET_BATCHES_UI = REQUEST_TIME.labels(endpoint='/batches', verb='GET')
-REQUEST_TIME_GET_JOB_UI = REQUEST_TIME.labels(endpoint='/batches/batch_id/jobs/job_id', verb="GET")
-REQUEST_TIME_GET_BILLING_PROJECTS = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects', verb="GET")
-REQUEST_TIME_GET_BILLING_PROJECT = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/billing_project', verb="GET")
-REQUEST_TIME_GET_BILLING_LIMITS_UI = REQUEST_TIME.labels(endpoint='/billing_limits', verb="GET")
-REQUEST_TIME_POST_BILLING_LIMITS_EDIT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/billing_project/edit', verb="POST")
-REQUEST_TIME_POST_BILLING_LIMITS_EDIT = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/billing_project/edit', verb="POST")
-REQUEST_TIME_GET_BILLING_UI = REQUEST_TIME.labels(endpoint='/billing', verb="GET")
-REQUEST_TIME_GET_BILLING_PROJECTS_UI = REQUEST_TIME.labels(endpoint='/billing_projects', verb="GET")
-REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_UI = REQUEST_TIME.labels(endpoint='/billing_projects/billing_project/users/user/remove', verb="POST")
-REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/billing_project/users/{user}/remove', verb="POST")
-REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_UI = REQUEST_TIME.labels(endpoint='/billing_projects/billing_project/users/add', verb="POST")
-REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/users/{user}/add', verb="POST")
-REQUEST_TIME_POST_CREATE_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/create', verb="POST")
-REQUEST_TIME_POST_CREATE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/create', verb="POST")
-REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/{billing_project}/close', verb="POST")
-REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/close', verb="POST")
-REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_UI = REQUEST_TIME.labels(endpoint='/billing_projects/{billing_project}/reopen', verb="POST")
-REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/reopen', verb="POST")
-REQUEST_TIME_POST_DELETE_BILLING_PROJECT_API = REQUEST_TIME.labels(endpoint='/api/v1alpha/billing_projects/{billing_project}/reopen', verb="POST")
 
 routes = web.RouteTableDef()
 
@@ -291,7 +254,7 @@ LIMIT 50;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs')
-@prom_async_time(REQUEST_TIME_GET_JOBS)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def get_jobs(request, userdata, batch_id):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -465,7 +428,7 @@ async def _get_full_job_status(app, record):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-@prom_async_time(REQUEST_TIME_GET_JOB_LOG)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -582,7 +545,7 @@ LIMIT 51;
 
 
 @routes.get('/api/v1alpha/batches')
-@prom_async_time(REQUEST_TIME_GET_BATCHES)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def get_batches(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
@@ -610,7 +573,7 @@ def check_service_account_permissions(user, sa):
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
-@prom_async_time(REQUEST_TIME_POST_CREATE_JOBS)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def create_jobs(request, userdata):
     app = request.app
@@ -932,7 +895,7 @@ VALUES (%s, %s, %s);
 
 
 @routes.post('/api/v1alpha/batches/create')
-@prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def create_batch(request, userdata):
     app = request.app
@@ -1055,14 +1018,14 @@ WHERE id = %s AND NOT deleted;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}')
-@prom_async_time(REQUEST_TIME_POST_GET_BATCH)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def get_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     return web.json_response(await _get_batch(request.app, batch_id))
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
-@prom_async_time(REQUEST_TIME_PATCH_CANCEL_BATCH)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _handle_api_error(_cancel_batch, request.app, batch_id)
@@ -1070,7 +1033,7 @@ async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
-@prom_async_time(REQUEST_TIME_PATCH_CLOSE_BATCH)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
@@ -1111,7 +1074,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
 
 @routes.delete('/api/v1alpha/batches/{batch_id}')
-@prom_async_time(REQUEST_TIME_DELETE_BATCH)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _delete_batch(request.app, batch_id)
@@ -1119,7 +1082,7 @@ async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.get('/batches/{batch_id}')
-@prom_async_time(REQUEST_TIME_GET_BATCH_UI)
+@monitor_endpoint
 @web_billing_project_users_only()
 async def ui_batch(request, userdata, batch_id):
     app = request.app
@@ -1142,7 +1105,7 @@ async def ui_batch(request, userdata, batch_id):
 
 
 @routes.post('/batches/{batch_id}/cancel')
-@prom_async_time(REQUEST_TIME_POST_CANCEL_BATCH_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 async def ui_cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
@@ -1155,7 +1118,7 @@ async def ui_cancel_batch(request, userdata, batch_id):  # pylint: disable=unuse
 
 
 @routes.post('/batches/{batch_id}/delete')
-@prom_async_time(REQUEST_TIME_POST_DELETE_BATCH_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 async def ui_delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
@@ -1167,7 +1130,7 @@ async def ui_delete_batch(request, userdata, batch_id):  # pylint: disable=unuse
 
 
 @routes.get('/batches', name='batches')
-@prom_async_time(REQUEST_TIME_GET_BATCHES_UI)
+@monitor_endpoint
 @web_authenticated_users_only()
 async def ui_batches(request, userdata):
     user = userdata['username']
@@ -1265,7 +1228,7 @@ WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/attempts')
-@prom_async_time(REQUEST_TIME_GET_ATTEMPTS)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -1274,7 +1237,7 @@ async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
-@prom_async_time(REQUEST_TIME_GET_JOB)
+@monitor_endpoint
 @rest_billing_project_users_only
 async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -1283,7 +1246,7 @@ async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argume
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}')
-@prom_async_time(REQUEST_TIME_GET_JOB_UI)
+@monitor_endpoint
 @web_billing_project_users_only()
 async def ui_get_job(request, userdata, batch_id):
     app = request.app
@@ -1336,7 +1299,7 @@ async def ui_get_job(request, userdata, batch_id):
 
 
 @routes.get('/billing_limits')
-@prom_async_time(REQUEST_TIME_GET_BILLING_LIMITS_UI)
+@monitor_endpoint
 @web_authenticated_users_only()
 async def ui_get_billing_limits(request, userdata):
     app = request.app
@@ -1397,7 +1360,7 @@ UPDATE billing_projects SET `limit` = %s WHERE name = %s;
 
 
 @routes.post('/api/v1alpha/billing_limits/{billing_project}/edit')
-@prom_async_time(REQUEST_TIME_POST_BILLING_LIMITS_EDIT)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1409,7 +1372,7 @@ async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused
 
 
 @routes.post('/billing_limits/{billing_project}/edit')
-@prom_async_time(REQUEST_TIME_POST_BILLING_LIMITS_EDIT_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_edit_billing_limits_ui(request, userdata):  # pylint: disable=unused-argument
@@ -1493,7 +1456,7 @@ GROUP BY billing_project, `user`;
 
 
 @routes.get('/billing')
-@prom_async_time(REQUEST_TIME_GET_BILLING_UI)
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def ui_get_billing(request, userdata):
     billing, start, end = await _query_billing(request)
@@ -1534,7 +1497,7 @@ async def ui_get_billing(request, userdata):
 
 
 @routes.get('/billing_projects')
-@prom_async_time(REQUEST_TIME_GET_BILLING_PROJECTS_UI)
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def ui_get_billing_projects(request, userdata):
     db: Database = request.app['db']
@@ -1547,7 +1510,7 @@ async def ui_get_billing_projects(request, userdata):
 
 
 @routes.get('/api/v1alpha/billing_projects')
-@prom_async_time(REQUEST_TIME_GET_BILLING_PROJECTS)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def get_billing_projects(request, userdata):
     db: Database = request.app['db']
@@ -1563,7 +1526,7 @@ async def get_billing_projects(request, userdata):
 
 
 @routes.get('/api/v1alpha/billing_projects/{billing_project}')
-@prom_async_time(REQUEST_TIME_GET_BILLING_PROJECT)
+@monitor_endpoint
 @rest_authenticated_users_only
 async def get_billing_project(request, userdata):
     db: Database = request.app['db']
@@ -1617,7 +1580,7 @@ WHERE billing_project = %s AND user = %s;
 
 
 @routes.post('/billing_projects/{billing_project}/users/{user}/remove')
-@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
@@ -1633,7 +1596,7 @@ async def post_billing_projects_remove_user(request, userdata):  # pylint: disab
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/remove')
-@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_REMOVE_USER_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_get_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1676,7 +1639,7 @@ VALUES (%s, %s);
 
 
 @routes.post('/billing_projects/{billing_project}/users/add')
-@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
@@ -1694,7 +1657,7 @@ async def post_billing_projects_add_user(request, userdata):  # pylint: disable=
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/add')
-@prom_async_time(REQUEST_TIME_POST_BILLING_PROJECT_ADD_USER_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1728,7 +1691,7 @@ VALUES (%s);
 
 
 @routes.post('/billing_projects/create')
-@prom_async_time(REQUEST_TIME_POST_CREATE_BILLING_PROJECT_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
@@ -1745,7 +1708,7 @@ async def post_create_billing_projects(request, userdata):  # pylint: disable=un
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/create')
-@prom_async_time(REQUEST_TIME_POST_CREATE_BILLING_PROJECT_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_get_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1782,7 +1745,7 @@ WHERE name = %s LIMIT 1 FOR UPDATE;
 
 
 @routes.post('/billing_projects/{billing_project}/close')
-@prom_async_time(REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
@@ -1797,7 +1760,7 @@ async def post_close_billing_projects(request, userdata):  # pylint: disable=unu
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/close')
-@prom_async_time(REQUEST_TIME_POST_CLOSE_BILLING_PROJECT_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1828,7 +1791,7 @@ async def _reopen_billing_project(db, billing_project):
 
 
 @routes.post('/billing_projects/{billing_project}/reopen')
-@prom_async_time(REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_UI)
+@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 async def post_reopen_billing_projects(request, userdata):  # pylint: disable=unused-argument
@@ -1843,7 +1806,7 @@ async def post_reopen_billing_projects(request, userdata):  # pylint: disable=un
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/reopen')
-@prom_async_time(REQUEST_TIME_POST_REOPEN_BILLING_PROJECT_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_reopen_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1873,7 +1836,7 @@ async def _delete_billing_project(db, billing_project):
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/delete')
-@prom_async_time(REQUEST_TIME_POST_DELETE_BILLING_PROJECT_API)
+@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_delete_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']

--- a/build.yaml
+++ b/build.yaml
@@ -1683,6 +1683,54 @@ steps:
     - deploy_router
     - create_certs
  - kind: runImage
+   name: render_prom_nginx_conf
+   image:
+     valueFrom: service_base_image.image
+   script: |
+     set -ex
+     cd /io
+     rm -rf repo
+     mkdir repo
+     cd repo
+     {{ code.checkout_script }}
+     cd prometheus
+     {% if deploy %}
+     DEPLOY=true
+     {% else %}
+     DEPLOY=false
+     {% endif %}
+     python3 ../ci/jinja2_render.py '{"deploy": '${DEPLOY}', "default_ns": {"name": "{{ default_ns.name }}"}}' nginx.conf nginx.conf.out
+   outputs:
+     - from: /io/repo/prometheus/nginx.conf.out
+       to: /nginx.conf.out
+   dependsOn:
+     - default_ns
+     - service_base_image
+ - kind: buildImage
+   name: prom_nginx_image
+   dockerFile: prometheus/Dockerfile.nginx
+   contextPath: prometheus
+   publishAs: prometheus
+   inputs:
+     - from: /nginx.conf.out
+       to: /nginx.conf.out
+   dependsOn:
+     - hail_ubuntu_image
+     - render_prom_nginx_conf
+ - kind: deploy
+   name: deploy_prometheus
+   namespace:
+     valueFrom: default_ns.name
+   config: prometheus/prometheus.yaml
+   scopes:
+    - deploy
+    - dev
+   dependsOn:
+    - default_ns
+    - prom_nginx_image
+    - deploy_router
+    - create_certs
+ - kind: runImage
    name: create_dummy_oauth2_client_secret
    image:
      valueFrom: base_image.image

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -8,6 +8,7 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session  # type: ignore
 import uvloop  # type: ignore
+from prometheus_async.aio.web import server_stats  # type: ignore
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
 from hailtop.utils import collect_agen, humanize_timedelta_msecs
 from hailtop.batch_client.aioclient import BatchClient
@@ -21,6 +22,7 @@ from gear import (
     web_authenticated_developers_only,
     check_csrf_token,
     create_database_pool,
+    monitor_endpoint,
 )
 import random
 from typing import Dict, Any, Optional
@@ -85,6 +87,7 @@ async def watched_branch_config(app, wb: WatchedBranch, index: int) -> Dict[str,
 
 @routes.get('')
 @routes.get('/')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def index(request, userdata):  # pylint: disable=unused-argument
     wb_configs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
@@ -106,6 +109,7 @@ def wb_and_pr_from_request(request):
 
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_pr(request, userdata):  # pylint: disable=unused-argument
     wb, pr = wb_and_pr_from_request(request)
@@ -160,6 +164,7 @@ async def retry_pr(wb, pr, request):
 
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
 @check_csrf_token
+@monitor_endpoint
 @web_authenticated_developers_only(redirect=False)
 async def post_retry_pr(request, userdata):  # pylint: disable=unused-argument
     wb, pr = wb_and_pr_from_request(request)
@@ -169,6 +174,7 @@ async def post_retry_pr(request, userdata):  # pylint: disable=unused-argument
 
 
 @routes.get('/batches')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_batches(request, userdata):
     batch_client = request.app['batch_client']
@@ -179,6 +185,7 @@ async def get_batches(request, userdata):
 
 
 @routes.get('/batches/{batch_id}')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
@@ -193,6 +200,7 @@ async def get_batch(request, userdata):
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_job(request, userdata):
     batch_id = int(request.match_info['batch_id'])
@@ -214,6 +222,7 @@ def filter_wbs(wbs, pred):
 
 
 @routes.get('/me')
+@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_user(request, userdata):
     username = userdata['username']
@@ -248,6 +257,7 @@ async def get_user(request, userdata):
 
 @routes.post('/authorize_source_sha')
 @check_csrf_token
+@monitor_endpoint
 @web_authenticated_developers_only(redirect=False)
 async def post_authorized_source_sha(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -329,6 +339,7 @@ async def batch_callback_handler(request):
 
 
 @routes.get('/api/v1alpha/deploy_status')
+@monitor_endpoint
 @rest_authenticated_developers_only
 async def deploy_status(request, userdata):  # pylint: disable=unused-argument
     batch_client = request.app['batch_client']
@@ -362,6 +373,7 @@ async def deploy_status(request, userdata):  # pylint: disable=unused-argument
 
 
 @routes.post('/api/v1alpha/update')
+@monitor_endpoint
 @rest_authenticated_developers_only
 async def post_update(request, userdata):  # pylint: disable=unused-argument
     log.info('developer triggered update')
@@ -375,6 +387,7 @@ async def post_update(request, userdata):  # pylint: disable=unused-argument
 
 
 @routes.post('/api/v1alpha/dev_deploy_branch')
+@monitor_endpoint
 @rest_authenticated_developers_only
 async def dev_deploy_branch(request, userdata):
     app = request.app
@@ -417,6 +430,7 @@ async def dev_deploy_branch(request, userdata):
 
 
 @routes.post('/api/v1alpha/batch_callback')
+@monitor_endpoint
 async def batch_callback(request):
     await asyncio.shield(batch_callback_handler(request))
     return web.Response(status=200)
@@ -466,6 +480,7 @@ def run():
 
     setup_common_static_routes(routes)
     app.add_routes(routes)
+    app.router.add_get("/metrics", server_stats)
 
     web.run_app(
         deploy_config.prefix_application(app, 'ci'),

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: ci
         hail.is/sha: "{{ code.sha }}"
+        grafanak8sapp: "true"
     spec:
 {% if deploy %}
       priorityClassName: production

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -5,6 +5,7 @@ from .auth import userdata_from_web_request, userdata_from_rest_request, \
     web_authenticated_developers_only, rest_authenticated_developers_only, maybe_parse_bearer_header
 from .csrf import new_csrf_token, check_csrf_token
 from .auth_utils import insert_user, create_session
+from .metrics import monitor_endpoint
 
 __all__ = [
     'create_database_pool',
@@ -22,5 +23,6 @@ __all__ = [
     'insert_user',
     'create_session',
     'transaction',
-    'maybe_parse_bearer_header'
+    'maybe_parse_bearer_header',
+    'monitor_endpoint'
 ]

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import prometheus_client as pc  # type: ignore
 from prometheus_async.aio import time as prom_async_time  # type: ignore
 
@@ -6,6 +7,7 @@ REQUEST_COUNT = pc.Counter('http_request_count', 'Number of HTTP requests', ['en
 
 
 def monitor_endpoint(handler):
+    @wraps(handler)
     async def wrapped(request, *args, **kwargs):
         # Use the path template given to @route.<METHOD>, not the fully resolved one
         endpoint = request.match_info.route.resource.canonical

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -1,0 +1,16 @@
+import prometheus_client as pc  # type: ignore
+from prometheus_async.aio import time as prom_async_time  # type: ignore
+
+REQUEST_TIME = pc.Summary('http_request_latency_seconds', 'Endpoint latency in seconds', ['endpoint', 'verb'])
+REQUEST_COUNT = pc.Counter('http_request_count', 'Number of HTTP requests', ['endpoint', 'verb', 'status'])
+
+
+def monitor_endpoint(handler):
+    async def wrapped(request, *args, **kwargs):
+        # Use the path template given to @route.<METHOD>, not the fully resolved one
+        endpoint = request.match_info.route.resource.canonical
+        verb = request.method
+        response = await prom_async_time(REQUEST_TIME.labels(endpoint=endpoint, verb=verb), handler(request, *args, **kwargs))
+        REQUEST_COUNT.labels(endpoint=endpoint, verb=verb, status=response.status).inc()
+        return response
+    return wrapped

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -117,6 +117,10 @@ class DeployConfig:
         async def get_healthcheck(request):  # pylint: disable=unused-argument,unused-variable
             return web.Response()
 
+        @root_routes.get('/metrics')
+        async def get_metrics(request):  # pylint: disable=unused-argument,unused-variable
+            return web.HTTPFound(location=f'{base_path}/metrics')
+
         root_app = web.Application(**kwargs)
         root_app.add_routes(root_routes)
         root_app.add_subapp(base_path, app)

--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -15,3 +15,4 @@ query.{{ domain }}
 workshop.{{ domain }}
 atgu.{{ domain }}
 grafana.{{ domain }}
+prometheus.{{ domain }}

--- a/prometheus/Dockerfile.nginx
+++ b/prometheus/Dockerfile.nginx
@@ -1,0 +1,12 @@
+FROM {{ hail_ubuntu_image.image }}
+
+RUN hail-apt-get-install nginx
+
+RUN rm -f /etc/nginx/sites-enabled/default && \
+    rm -f /etc/nginx/nginx.conf
+ADD nginx.conf.out /etc/nginx/nginx.conf
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/prometheus/Makefile
+++ b/prometheus/Makefile
@@ -1,0 +1,24 @@
+include ../config.mk
+
+.PHONY: build push deploy
+
+PROM_NGINX_LATEST = gcr.io/$(PROJECT)/prom_nginx:latest
+PROM_NGINX_IMAGE = gcr.io/$(PROJECT)/prom_nginx:$(shell docker images -q --no-trunc prom_nginx | sed -e 's,[^:]*:,,')
+
+build:
+	$(MAKE) -C ../docker hail-ubuntu
+	-docker pull $(PROM_NGINX_LATEST)
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image": {"image": "hail-ubuntu"}}' Dockerfile.nginx Dockerfile.nginx.out
+	python3 ../ci/jinja2_render.py '{"deploy": $(DEPLOY), "default_ns": {"name": "$(NAMESPACE)"}}' nginx.conf nginx.conf.out
+	docker build -t prom_nginx -f Dockerfile.nginx.out --cache-from prom_nginx,$(PROM_NGINX_LATEST),hail-ubuntu .
+
+push: build
+	docker tag prom_nginx $(PROM_NGINX_LATEST)
+	docker push $(PROM_NGINX_LATEST)
+	docker tag prom_nginx $(PROM_NGINX_IMAGE)
+	docker push $(PROM_NGINX_IMAGE)
+
+deploy: push
+	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"}, "prom_nginx_image": {"image": "$(PROM_NGINX_IMAGE)"}}' prometheus.yaml prometheus.yaml.out
+	kubectl -n $(NAMESPACE) apply -f prometheus.yaml.out

--- a/prometheus/nginx.conf
+++ b/prometheus/nginx.conf
@@ -1,0 +1,101 @@
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 768;
+}
+
+http {
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  server_names_hash_bucket_size 128;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
+
+  log_format json-log escape=json '{'
+   '"message":"$scheme $request done in ${request_time}s: $status",'
+   '"response_status":$status,'
+   '"request_duration":$request_time,'
+   '"remote_address":"$remote_addr",'
+   '"x_real_ip":"$http_x_real_ip",'
+   '"request_start_time":"$time_local",'
+   '"body_bytes_sent":"$body_bytes_sent",'
+   '"http_referer":"$http_referer",'
+   '"http_user_agent":"$http_user_agent"'
+ '}';
+
+  access_log /var/log/nginx/access.log json-log;
+  error_log /var/log/nginx/error.log;
+
+  gzip on;
+
+  include /ssl-config/ssl-config-http.conf;
+  map $http_x_forwarded_proto $updated_scheme {
+       default $http_x_forwarded_proto;
+       '' $scheme;
+  }
+  map $http_x_forwarded_host $updated_host {
+       default $http_x_forwarded_host;
+       '' $http_host;
+  }
+  map $http_upgrade $connection_upgrade {
+      default upgrade;
+      ''      close;
+  }
+
+  server {
+    server_name prometheus.*;
+
+    location = /auth {
+        internal;
+{% if deploy %}
+        proxy_pass https://auth/api/v1alpha/verify_dev_credentials;
+{% else %}
+        proxy_pass https://auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
+{% endif %}
+        include /ssl-config/ssl-config-proxy.conf;
+    }
+
+    location = /healthcheck {
+        return 204;
+    }
+
+    location / {
+        auth_request /auth;
+
+        proxy_pass http://127.0.0.1:9090/;
+
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    error_page 401 = @error401;
+
+    location @error401 {
+{% if deploy %}
+        return 302 https://auth.hail.is/login?next=https://$http_host$request_uri;
+{% else %}
+        return 302 https://internal.hail.is/{{ default_ns.name }}/auth/login?next=https://internal.hail.is/{{ default_ns.name }}/prometheus;
+{% endif %}
+    }
+
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+  }
+}

--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: {{ default_ns.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+  namespace: {{ default_ns.name }}
+rules:
+ - apiGroups: [""]
+   resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+   verbs: ["get", "list", "watch"]
+ - apiGroups:
+    - extensions
+   resources:
+    - ingresses
+   verbs: ["get", "list", "watch"]
+ - nonResourceURLs: ["/metrics"]
+   verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+ - kind: ServiceAccount
+   name: prometheus
+   namespace: {{ default_ns.name }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-prometheus
+  namespace: {{ default_ns.name }}
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+     - job_name: "kubernetes-kubelet"
+       scheme: https
+       tls_config:
+         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+         insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - role: node
+       relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc.cluster.local:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics
+     - job_name: "kubernetes-cadvisor"
+       scheme: https
+       tls_config:
+         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+         insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - role: node
+       relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc.cluster.local:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+     - job_name: "kubernetes-apiservers"
+       scheme: https
+       tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - api_server: null
+          role: endpoints
+          namespaces:
+            names: []
+       relabel_configs:
+       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+         separator: ;
+         regex: default;kubernetes;https
+         replacement: $1
+         action: keep
+     - job_name: "kubernetes-pods"
+       scheme: https
+       tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - role: pod
+       relabel_configs:
+       - source_labels: [__meta_kubernetes_pod_label_grafanak8sapp]
+         action: keep
+         regex: true
+       - action: labelmap
+         regex: __meta_kubernetes_pod_label_(.+)
+       - source_labels: [__meta_kubernetes_namespace]
+         action: replace
+         target_label: kubernetes_namespace
+       - source_labels: [__meta_kubernetes_pod_name]
+         action: replace
+         target_label: kubernetes_pod_name
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: prometheus
+  name: prometheus
+  namespace: {{ default_ns.name }}
+spec:
+  serviceName: "prometheus"
+  selector:
+    matchLabels:
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      priorityClassName: infrastructure
+      serviceAccountName: prometheus
+      containers:
+       - name: prometheus
+         image: prom/prometheus:v2.19.2
+         imagePullPolicy: Always
+         command:
+          - "/bin/prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--storage.tsdb.path=/prometheus"
+          - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+          - "--web.console.templates=/usr/share/prometheus/consoles"
+          - "--web.enable-lifecycle"
+{% if deploy %}
+          - "--web.external-url=https://prometheus.hail.is/"
+          - "--web.route-prefix=/"
+{% else %}
+          - "--web.external-url=https://internal.hail.is/{{ default_ns.name }}/prometheus/"
+          - "--web.route-prefix=/{{ default_ns.name }}/prometheus/"
+{% endif %}
+         ports:
+          - containerPort: 9090
+            protocol: TCP
+         volumeMounts:
+          - mountPath: "/etc/prometheus"
+            name: etc-prometheus
+          - mountPath: "/prometheus"
+            name: prometheus-storage
+         resources:
+           requests:
+             cpu: "1"
+             memory: 5G
+           limits:
+             cpu: "1"
+             memory: 10G
+       - name: nginx
+         image: {{ prom_nginx_image.image }}
+         resources:
+           requests:
+             cpu: "20m"
+             memory: "20M"
+           limits:
+             cpu: "1"
+             memory: "1G"
+         ports:
+          - containerPort: 443
+         volumeMounts:
+          - name: ssl-config-prometheus
+            mountPath: /ssl-config
+            readOnly: true
+         readinessProbe:
+           tcpSocket:
+             port: 443
+           initialDelaySeconds: 5
+           periodSeconds: 5
+      volumes:
+       - name: etc-prometheus
+         configMap:
+           name: etc-prometheus
+       - name: ssl-config-prometheus
+         secret:
+           optional: false
+           secretName: ssl-config-prometheus
+  volumeClaimTemplates:
+    - metadata:
+        name: prometheus-storage
+        namespace: {{ default_ns.name }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -269,6 +269,18 @@ spec:
   selector:
     app: grafana
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  ports:
+   - port: 443
+     protocol: TCP
+     targetPort: 443
+  selector:
+    app: prometheus
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -112,6 +112,18 @@ server {
 }
 
 server {
+    server_name prometheus.*;
+
+    location / {
+        proxy_pass https://prometheus/;
+        include /etc/nginx/proxy.conf;
+    }
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+}
+
+server {
     server_name notebook.*;
 
     # needed to correctly handle error_page with internal handles

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -98,3 +98,6 @@ principals:
 - name: grafana
   domain: grafana
   kind: nginx
+- name: prometheus
+  domain: prometheus
+  kind: nginx


### PR DESCRIPTION
This adds a prometheus statefulset to track metrics like API request latency and uptime. It scrapes pods on a 15s interval and collects prometheus metrics from any container in a pod with `grafanak8sapp` label that exposes an https endpoint `/metrics`.
The batch front end was already exposing prometheus metrics, but I changed it up slightly. For any http endpoint there should be a single metric, `http_request_latency`. Prometheus adds app and namespace metrics so seeing latencies for batch in particular is just a filter applied to this single metric. You can track latency of an endpoint by adding the `@monitor_endpoint` decorator defined in `metrics.py`, which tracks latency as well as number of requests and status code per request, available in the `http_request_count` metric. I also added monitoring to all CI endpoints.

This also includes an `up` metric for tracking uptime at the same 15s granularity.

I'm not convinced prometheus will suit our finer-grained needs surrounding batch, but it should do well enough in the meantime for our more traditional SLIs and allows to focus on one problem at a time.