### PR TITLE
[dev-docs] update PR process

### DIFF
--- a/dev-docs/development_process.md
+++ b/dev-docs/development_process.md
@@ -128,7 +128,10 @@ Once you have a branch that you are happy with, then you create a Pull Request
 on the GitHub UI.
 
 You’ll want to add an appropriate reviewer in the "Reviewers" box on the
-right hand side of the page.
+right hand side of the page. If you are an outside contributor and cannot
+request reviews, you can have CI automatically assign a reviewer. By writing
+`#assign services` or `#assign compiler` in the PR body, CI will randomly select
+a collaborator on the relevant team and assign them for you.
 
 You can also give the PR a set of labels. The important ones are “WIP” to make
 sure the pull request doesn’t get merged accidentally until you are ready,

--- a/dev-docs/development_process.md
+++ b/dev-docs/development_process.md
@@ -127,7 +127,7 @@ $ mysql
 Once you have a branch that you are happy with, then you create a Pull Request
 on the GitHub UI.
 
-You’ll want to add an appropriate reviewer as an “assignee” which is on the
+You’ll want to add an appropriate reviewer in the "Reviewers" box on the
 right hand side of the page.
 
 You can also give the PR a set of labels. The important ones are “WIP” to make
@@ -172,7 +172,7 @@ logs for your PR at [ci.hail.is](https://ci.hail.is).
 
 ## Review
 
-Once the PR has been created, it is the responsibility of the assignee(s) to
+Once the PR has been created, it is the responsibility of the reviewer(s) to
 review the PR. Our goal as a team is to give comments within 24 hours. To review
 someone else’s changes, click on “Files changed”. This will show the diff
 between the old code and the new proposed changes. You can make comments on
@@ -190,8 +190,13 @@ can “Approve” the PR.
 
 If you are the person whose code is being reviewed and your PR is in the Request
 Changes state, then you’ll need to address their comments by pushing new commit
-changes or answering questions. Once you are done, then you can dismiss their
-review towards the bottom of the Conversation page.
+changes or answering questions. Once you are done, then you can re-request a review
+in the "Reviewers" box.
+
+If your review is requested on a PR submitted by an outside contributor, you should
+"assign" yourself or the appropriate team member to the PR. The assignee is
+responsible for ensuring that the PR does not go stale and is eventually
+merged or closed.
 
 ![](dismiss_review.png)
 


### PR DESCRIPTION
re: conversation over Zulip. ci.hail.is/me now includes PRs where you've been requested as a reviewer, not just assigned.