### PR TITLE
[query] Check loop return type matches before checking tail recursiveness

### DIFF
--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -155,8 +155,9 @@ def loop(f: Callable, typ, *args):
         uid_irs.append((uid, expr._ir))
 
     loop_f = to_expr(f(make_loop, *loop_vars))
+    if loop_f.dtype != typ:
+        raise TypeError(f"requested type {typ} does not match inferred type {loop_f.dtype}")
     check_tail_recursive(loop_f._ir)
     indices, aggregations = unify_all(*args, loop_f)
-    if loop_f.dtype != typ:
-        raise TypeError(f"requested type {typ} does not match inferred type {loop_f.typ}")
+
     return construct_expr(ir.TailLoop(loop_name, loop_f._ir, uid_irs), loop_f.dtype, indices, aggregations)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -1,6 +1,7 @@
 import numpy as np
 import hail as hl
 import unittest
+import pytest
 from ..helpers import *
 from hail.utils import new_temp_file
 
@@ -430,3 +431,11 @@ class Tests(unittest.TestCase):
             'int32', 0, 0)
 
         assert_evals_to(calls_recur_from_nested_loop, 15 + 10 + 6 + 3 + 1)
+
+    def test_loop_errors(self):
+        with pytest.raises(TypeError, match="requested type ndarray<int32, 2> does not match inferred type ndarray<float64, 2>"):
+            result = hl.experimental.loop(
+                lambda f, my_nd:
+                hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
+                hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
+


### PR DESCRIPTION
CHANGELOG: Fixed incorrect error message when incorrect type specifid with hl.loop

I added a test that gave a bad error message, then rearranged code in `hl.loop` to improve the error message. Prior to this change, the error a user would get here is that they wrote a loop that isn't tail recursive, because hail would insert an implicit cast when trying to unify types, and the casting would wrap the recursive loop call. Now, we check to make sure the loop's return type is correct before analyzing whether it's tail recursive, which I believe removes the possibility of getting a tail recursion error when you should be getting a type error.