### PR TITLE
[gateway] move ukbb routing into gateway

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -97,3 +97,38 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
+
+server {
+    server_name ukbb-rg.hail.is;
+
+    location /rg_browser {
+        proxy_pass http://ukbb-rg-browser.ukbb-rg;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 20d;
+        proxy_buffering off;
+    }
+
+    location / {
+        proxy_pass http://ukbb-rg-static.ukbb-rg;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host  $updated_host;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Real-IP         $http_x_real_ip;
+    }
+
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -236,37 +236,6 @@ server {
 }
 
 server {
-    server_name ukbb-rg.*;
-
-    location /rg_browser {
-        proxy_pass http://ukbb-rg-browser.ukbb-rg;
-        proxy_set_header Host              $http_host;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host  $updated_host;
-        proxy_set_header X-Forwarded-Proto $updated_scheme;
-        proxy_set_header X-Real-IP         $http_x_real_ip;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_read_timeout 20d;
-        proxy_buffering off;
-    }
-
-    location / {
-        proxy_pass http://ukbb-rg-static.ukbb-rg;
-        proxy_set_header Host              $http_host;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host  $updated_host;
-        proxy_set_header X-Forwarded-Proto $updated_scheme;
-        proxy_set_header X-Real-IP         $http_x_real_ip;
-    }
-
-    listen 443 ssl;
-    listen [::]:443 ssl;
-}
-
-server {
     server_name auth.*;
 
     location / {


### PR DESCRIPTION
One more step of stripping down router. ukbb lives in its own namespace and we never run dev versions of it so it's pretty much a drop-in.