### PR TITLE
[query] Fix filter intervals (keep=False) memory leak

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -629,15 +629,15 @@ class RVD(
     val kRowFieldIdx = typ.kFieldIdx
     val rowPType = typ.rowType
 
-    mapPartitions(typ) { (ctx, it) =>
-      val kUR = new UnsafeRow(kPType)
-      it.filter { ptr =>
+    filterWithContext[UnsafeRow](
+      { (_, _) => new UnsafeRow(kPType) },
+      { case (kUR, ctx, ptr) =>
         ctx.rvb.start(kType)
         ctx.rvb.selectRegionValue(rowPType, kRowFieldIdx, ctx.r, ptr)
         kUR.set(ctx.region, ctx.rvb.end())
         !intervalsBc.value.contains(kUR)
       }
-    }
+    )
   }
 
   def filterToIntervals(intervals: RVDPartitioner): RVD = {


### PR DESCRIPTION
EDIT from John for future readers: The issue here is that in general we only expect consumers to free memory after they're done processing a row. So when doing any sort of filtering operation, we want to make our own region that we clear after each row is filtered out, otherwise the garbage rows will continue to accumulate until we finally find a row to keep. `filterWithContext` demonstrates the correct way to do this, and so switching to use that method fixes the problem. 