### PR TITLE
[query-service] teach query service to read MTs and Ts created by Spark

### DIFF
--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -317,9 +317,9 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
     val blobs = storage.list(bucket, BlobListOption.prefix(path), BlobListOption.currentDirectory())
 
     blobs.getValues.iterator.asScala
-      .filter(b => b.getName != path)  // elide directory markers created by Hadoop
-      .map(b => GoogleStorageFileStatus(b))
-      .filter(fs => !fs.isDirectory)
+      .map(b => (b, GoogleStorageFileStatus(b)))
+      .filter { case (b, fs) => !(fs.isDirectory && b.getName == path) } // elide directory markers created by Hadoop
+      .map { case (b, fs) => fs }
       .toArray
   }
 

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -317,8 +317,9 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
     val blobs = storage.list(bucket, BlobListOption.prefix(path), BlobListOption.currentDirectory())
 
     blobs.getValues.iterator.asScala
+      .filter(b => b.getName != path)  // elide directory markers created by Hadoop
       .map(b => GoogleStorageFileStatus(b))
-      .filter(fs => !(fs.isDirectory && fs.getPath == path))
+      .filter(fs => !fs.isDirectory)
       .toArray
   }
 


### PR DESCRIPTION
Hail-on-Spark uses HadoopFS which emulates directories by creating size-zero files with
the name `gs://bucket/dirname/`. Note: the object name literally ends in a slash. Such files
should not be included in `listStatus` (they should always be empty anyway). Unfortunately,
my fix in https://github.com/hail-is/hail/pull/9914 was wrong because `GoogleStorageFileStatus` removes
the trailing slash. This prevented the path from matching `path`, which always ends in a `/`.

Sorry @jigold, you're now on the reviewers list for the Query Service with Arcturus's departure.