### PR TITLE
Overwrite ssl-config-hail-root secret for dev

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -170,7 +170,7 @@ steps:
          kubectl delete secret -n {{ default_ns.name }} ssl-config-hail-root
      done     
      openssl req -new -x509 -subj /CN=hail-root -nodes -newkey rsa:4096 -keyout hail-root-key.pem -out hail-root-cert.pem
-     until kubectl get secret -n {{ default_ns.name }} ssl-config-hail-root
+     until kubectl get secret -n {{ default_ns.name }} ssl-config-hail-root 2>/dev/null
      do
          kubectl create secret generic -n {{ default_ns.name }} ssl-config-hail-root \
                  --from-file=hail-root-key.pem \

--- a/build.yaml
+++ b/build.yaml
@@ -162,6 +162,13 @@ steps:
    image:
      valueFrom: create_certs_image.image
    script: |
+     # Create dev certificates, or overwrite the existing ones. The usecase for 
+     # overwriting is to update the dev certificates, as they expire after 30 days
+     # (the default `-days` parameter value for `openssl req`).
+     until ! kubectl get secret -n {{ default_ns.name }} ssl-config-hail-root 2>/dev/null
+     do
+         kubectl delete secret -n {{ default_ns.name }} ssl-config-hail-root
+     done     
      openssl req -new -x509 -subj /CN=hail-root -nodes -newkey rsa:4096 -keyout hail-root-key.pem -out hail-root-cert.pem
      until kubectl get secret -n {{ default_ns.name }} ssl-config-hail-root
      do


### PR DESCRIPTION
Dev certificates expire in 30 days, and rerunning `kubectl create secret` doesn't update the secret if it already exists. So adding a `kubectl delete secret` line to make sure the new secret will be added.

Though I'm not familiar with the `test` scope and not sure if it will break something for it?