### PR TITLE
[query] call init_service from init based on HAIL_QUERY_BACKEND value

### DIFF
--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -88,6 +88,8 @@ class ServiceBackend(Backend):
         if bucket is None:
             bucket = get_user_config().get('batch', 'bucket', fallback=None)
         if bucket is None:
+            bucket = os.environ.get('HAIL_BUCKET')
+        if bucket is None:
             raise ValueError(
                 'the bucket parameter of ServiceBackend must be set '
                 'or run `hailctl config set batch/bucket '


### PR DESCRIPTION
The idea is to allow the execution on both `SparkBackend` and `ServiceBackend` without code changes, simply switching to the Query service by setting the environment variables `HAIL_QUERY_BACKEND`, `HAIL_BILLING_PROJECT`, and `HAIL_BUCKET`.