### PR TITLE
[website] dont jinja render any of the batch docs when serving

### DIFF
--- a/website/website/website.py
+++ b/website/website/website.py
@@ -47,9 +47,7 @@ redirect('/docs/0.2/', 'index.html')
 DOCS_PATH = f'{MODULE_PATH}/docs/'
 STATIC_DOCS_PATHS = ['0.2/_static',
                      '0.2/_sources',
-                     'batch/_static',
-                     'batch/_images',
-                     'batch/_sources']
+                     'batch']
 FQ_STATIC_DOCS_PATHS: Set[str] = set()
 
 


### PR DESCRIPTION
the batch tutorial contained some `{{` that made for an invalid jinja template, which caused a 500. The batch docs in general don't seem to need any additional rendering at runtime so this treats all the batch docs as static files.