### PR TITLE
[ci] make test hello speak https

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2811,6 +2811,8 @@ steps:
      mkdir -p ./ci/test ./hail/python
      cp /repo/hail/ci/test/resources/build.yaml ./
      cp -R /repo/hail/ci/test/resources ./ci/test/
+     cp /repo/hail/tls/Dockerfile ./ci/test/resources/Dockerfile.certs
+     cp /repo/hail/tls/create_certs.py ./ci/test/resources/
      cp /repo/hail/pylintrc ./
      cp /repo/hail/setup.cfg ./
      cp -R /repo/hail/docker ./

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -53,6 +53,36 @@ steps:
    dependsOn:
     - base_image
  - kind: buildImage
+   name: create_certs_image
+   dockerFile: ci/test/resources/Dockerfile.certs
+   contextPath: ci/test/resources
+   publishAs: test_hello_create_certs_image
+   dependsOn:
+     - service_base_image
+ - kind: runImage
+   name: create_certs
+   image:
+     valueFrom: create_certs_image.image
+   script: |
+     set -ex
+     python3 create_certs.py \
+             {{ default_ns.name }} \
+             config.yaml \
+             /ssl-config-hail-root/hail-root-key.pem \
+             /ssl-config-hail-root/hail-root-cert.pem
+   serviceAccount:
+     name: admin
+     namespace:
+       valueFrom: default_ns.name
+   secrets:
+     - name: ssl-config-hail-root
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config-hail-root
+   dependsOn:
+     - default_ns
+     - create_certs_image
+ - kind: buildImage
    name: hello_image
    dockerFile: ci/test/resources/Dockerfile
    contextPath: .

--- a/ci/test/resources/config.yaml
+++ b/ci/test/resources/config.yaml
@@ -1,0 +1,4 @@
+principals:
+- name: hello
+  domain: hello
+  kind: json

--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -50,6 +50,9 @@ spec:
            - name: session-secret-key
              mountPath: /session-secret-key
              readOnly: true
+           - name: ssl-config
+             mountPath: /ssl-config
+             readOnly: true
           env:
            - name: HAIL_IP
              valueFrom:
@@ -74,6 +77,10 @@ spec:
          secret:
            optional: false
            secretName: session-secret-key
+       - name: ssl-config
+         secret:
+           optional: false
+           secretName: ssl-config-hello
 ---
 apiVersion: v1
 kind: Service
@@ -83,8 +90,7 @@ metadata:
     app: hello
 spec:
   ports:
-    - name: http
-      port: 80
+    - port: 443
       protocol: TCP
       targetPort: 5000
   selector:

--- a/ci/test/resources/hello.py
+++ b/ci/test/resources/hello.py
@@ -15,12 +15,12 @@ SHA = os.environ['HAIL_SHA']
 
 
 @routes.get('/healthcheck')
-async def get_healthcheck(request):  # pylint: disable=W0613
+async def get_healthcheck(request):  # pylint: disable=unused-argument
     return web.Response()
 
 
 @routes.get('/sha')
-async def get_sha(request):  # pylint: disable=W0613
+async def get_sha(request):  # pylint: disable=unused-argument
     return web.Response(text=SHA)
 
 

--- a/ci/test/resources/hello.py
+++ b/ci/test/resources/hello.py
@@ -2,6 +2,7 @@ import os
 from aiohttp import web
 
 from hailtop.config import get_deploy_config
+from hailtop.tls import internal_server_ssl_context
 from gear import setup_aiohttp_session
 
 
@@ -19,10 +20,12 @@ async def get_healthcheck(request):  # pylint: disable=W0613
 
 
 @routes.get('/sha')
-async def get_sha(request):
+async def get_sha(request):  # pylint: disable=W0613
     return web.Response(text=SHA)
 
 
 setup_aiohttp_session(app)
 app.add_routes(routes)
-web.run_app(deploy_config.prefix_application(app, 'hello'), host='0.0.0.0', port=5000)
+web.run_app(
+    deploy_config.prefix_application(app, 'hello'), host='0.0.0.0', port=5000, ssl_context=internal_server_ssl_context()
+)

--- a/ci/test/resources/statefulset.yaml
+++ b/ci/test/resources/statefulset.yaml
@@ -49,6 +49,9 @@ spec:
            - name: session-secret-key
              mountPath: /session-secret-key
              readOnly: true
+           - name: ssl-config
+             mountPath: /ssl-config
+             readOnly: true
           env:
            - name: HAIL_IP
              value: "{{ global.ip }}"
@@ -67,6 +70,10 @@ spec:
          secret:
            optional: false
            secretName: session-secret-key
+       - name: ssl-config
+         secret:
+           optional: false
+           secretName: ssl-config-hello
 ---
 apiVersion: v1
 kind: Service
@@ -76,8 +83,7 @@ metadata:
     app: hello-stateful-set
 spec:
   ports:
-    - name: http
-      port: 80
+    - port: 443
       protocol: TCP
       targetPort: 5000
   selector:

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -176,8 +176,7 @@ metadata:
     app: hello
 spec:
   ports:
-    - name: http
-      port: 80
+    - port: 443
       protocol: TCP
       targetPort: 5000
   selector:

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -66,7 +66,7 @@ server {
     server_name hello.*;
 
     location / {
-        proxy_pass http://hello/;
+        proxy_pass https://hello/;
         include /etc/nginx/proxy.conf;
     }
 


### PR DESCRIPTION
This is one piece of a multi-part saga to use tls for any and all communication between pods. This basically just required adding the `create_certs` step to the ci test `build.yaml` so we can create a ssl config for `hello`.