### PR TITLE
[query] BlockMatrix map

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1376,7 +1376,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
         """
         if isinstance(b, (int, float)):
-            return self.map_dense(lambda entry: entry + b)
+            return self._map_dense(lambda entry: entry + b)
         return self._apply_map2(BlockMatrix._binary_op('+'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1392,7 +1392,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
         """
         if isinstance(b, (int, float)):
-            return self.map_dense(lambda entry: entry - b)
+            return self._map_dense(lambda entry: entry - b)
         return self._apply_map2(BlockMatrix._binary_op('-'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1409,7 +1409,7 @@ class BlockMatrix(object):
         """
         if isinstance(b, (int, float)):
             # sparse since multiplying by zero is zero
-            return self.map_sparse(lambda entry: entry * b)
+            return self._map_sparse(lambda entry: entry * b)
         return self._apply_map2(BlockMatrix._binary_op('*'), b, sparsity_strategy="Intersection")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1426,7 +1426,7 @@ class BlockMatrix(object):
         """
         if isinstance(b, (int, float)):
             # sparse since dividing by zero is zero
-            return self.map_sparse(lambda entry: entry / b)
+            return self._map_sparse(lambda entry: entry / b)
         return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense")
 
     @typecheck_method(b=numeric)
@@ -1538,10 +1538,10 @@ class BlockMatrix(object):
         """
         return self._apply_map(lambda i: i ** x, needs_dense=False)
 
-    def map_dense(self, func):
+    def _map_dense(self, func):
         return self._apply_map(func, True)
 
-    def map_sparse(self, func):
+    def _map_sparse(self, func):
         return self._apply_map(func, False)
 
     def sqrt(self):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1375,6 +1375,8 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
+        if isinstance(b, (int, float)):
+            return self.map_dense(lambda entry: entry + b)
         return self._apply_map2(BlockMatrix._binary_op('+'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1389,6 +1391,8 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
+        if isinstance(b, (int, float)):
+            return self.map_dense(lambda entry: entry - b)
         return self._apply_map2(BlockMatrix._binary_op('-'), b, sparsity_strategy="Union")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1403,6 +1407,9 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
+        if isinstance(b, (int, float)):
+            # sparse since multiplying by zero is zero
+            return self.map_sparse(lambda entry: entry * b)
         return self._apply_map2(BlockMatrix._binary_op('*'), b, sparsity_strategy="Intersection")
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
@@ -1417,6 +1424,9 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
+        if isinstance(b, (int, float)):
+            # sparse since dividing by zero is zero
+            return self.map_sparse(lambda entry: entry / b)
         return self._apply_map2(BlockMatrix._binary_op('/'), b, sparsity_strategy="NeedsDense")
 
     @typecheck_method(b=numeric)
@@ -1528,8 +1538,11 @@ class BlockMatrix(object):
         """
         return self._apply_map(lambda i: i ** x, needs_dense=False)
 
-    def map(self, func):
+    def map_dense(self, func):
         return self._apply_map(func, True)
+
+    def map_sparse(self, func):
+        return self._apply_map(func, False)
 
     def sqrt(self):
         """Element-wise square root.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1528,6 +1528,9 @@ class BlockMatrix(object):
         """
         return self._apply_map(lambda i: i ** x, needs_dense=False)
 
+    def map(self, func):
+        return self._apply_map(func, True)
+
     def sqrt(self):
         """Element-wise square root.
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -311,7 +311,13 @@ object LowerBlockMatrixIR {
             MakeTuple.ordered(FastSeq(rows, cols))
           }.mapBody { (ctx, body) => NDArraySlice(body, GetField(ctx, "new")) }
 
-      case BlockMatrixDensify(child) => unimplemented(bmir)
+      case BlockMatrixDensify(child) =>
+        val isSparse = child.typ.isSparse
+        if (isSparse) {
+          unimplemented(bmir)
+        } else {
+          lower(child)
+        }
       case BlockMatrixSparsify(child, sparsifier) => unimplemented(bmir)
       case RelationalLetBlockMatrix(name, value, body) => unimplemented(bmir)
       case ValueToBlockMatrix(child, shape, blockSize) if !child.typ.isInstanceOf[TArray] =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -311,14 +311,10 @@ object LowerBlockMatrixIR {
             MakeTuple.ordered(FastSeq(rows, cols))
           }.mapBody { (ctx, body) => NDArraySlice(body, GetField(ctx, "new")) }
 
-      case BlockMatrixDensify(child) =>
-        val isSparse = child.typ.isSparse
-        if (isSparse) {
-          unimplemented(bmir)
-        } else {
-          lower(child)
-        }
-      case BlockMatrixSparsify(child, sparsifier) => unimplemented(bmir)
+      // Both densify and sparsify change the sparsity pattern tracked on the BlockMatrixType.
+      case BlockMatrixDensify(child) => lower(child)
+      case BlockMatrixSparsify(child, sparsifier) => lower(child)
+
       case RelationalLetBlockMatrix(name, value, body) => unimplemented(bmir)
       case ValueToBlockMatrix(child, shape, blockSize) if !child.typ.isInstanceOf[TArray] =>
         throw new LowererUnsupportedOperation("use explicit broadcast for scalars!")


### PR DESCRIPTION
This adds an arbitrary mapping operation to `BlockMatrix`. We already had the IR for this and supported it in the lowerer. We don't support this in the unlowered `execute` infrastructure, so I had to add a check to prevent that from happening.

I'm not sure how to document the fact that this operation is unavailable in Spark. I don't think we've had to do that yet. 

I'm also curious if you think `map_dense` and `map_sparse` are good names, or if you think we ought to just have one `map` with a boolean. I do worry what `sparse` is a funny name for this, since when I think of a sparse matrix I think of something closer to Spark's `CoordinateMatrix` (very few, random entries with no structure), as opposed to the block sparsity we have.

This PR also changes the implementation of adding/subtracting/multiplying/dividing a constant to BlockMatrix, making it use `BlockMatrixMap` instead of `BlockMatrixMap2`