### PR TITLE
[website] fix resource path for non-html files in the docs

### DIFF
--- a/website/website/website.py
+++ b/website/website/website.py
@@ -9,7 +9,7 @@ import glob
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
-from gear import setup_aiohttp_session, web_maybe_authenticated_user
+from gear import setup_aiohttp_session, web_maybe_authenticated_user, monitor_endpoint
 from web_common import (setup_aiohttp_jinja2, setup_common_static_routes, render_template,
                         sass_compile)
 
@@ -57,20 +57,21 @@ for path in STATIC_DOCS_PATHS:
 
 
 docs_pages = set(
-    x[0][len(DOCS_PATH):] + '/' + y
-    for x in os.walk(DOCS_PATH)
-    if x[0] not in FQ_STATIC_DOCS_PATHS
-    for y in x[2])
+    dirname[len(DOCS_PATH):] + '/' + file
+    for dirname, _, filenames in os.walk(DOCS_PATH)
+    if dirname not in FQ_STATIC_DOCS_PATHS
+    for file in filenames)
 
 
 @routes.get('/docs/{tail:.*}')
+@monitor_endpoint
 @web_maybe_authenticated_user
 async def serve_docs(request, userdata):
     tail = request.match_info['tail']
     if tail in docs_pages:
         if tail.endswith('.html'):
             return await render_template('website', request, userdata, tail, dict())
-        return web.FileResponse(tail)
+        return web.FileResponse(f'{DOCS_PATH}/{tail}')
     raise web.HTTPNotFound()
 
 


### PR DESCRIPTION
We track valid docs paths in `docs_pages` relative to the docs directory, so e.g. `0.2/objects.inv` is a valid path, making `/docs/0.2/objects.inv` a valid route, but `0.2/objects.inv` is not a valid path on the host. To actually find and serve the file we have to use `f'{DOCS_PATH}/0.2/objects.inv`. We initialize jinja to know to look at the `docs` directory for templates but `web.FileResponse` takes a path to the specified file (all I could get from the documentation). Verified I receive `objects.inv` and get a 200 in my namespace.