### PR TITLE
[cpp] add support for tuple

### DIFF
--- a/libhail/CMakeLists.txt
+++ b/libhail/CMakeLists.txt
@@ -28,7 +28,9 @@ add_executable(main
   src/hail/query/backend/compile.cpp
   src/hail/query/backend/jit.cpp
   src/hail/query/backend/stype.cpp
-  src/hail/query/backend/svalue.cpp)
+  src/hail/query/backend/svalue.cpp
+  # runtime
+  src/hail/runtime/runtime.cpp)
 
 llvm_config(main x86asmparser x86codegen orcjit)
 

--- a/libhail/src/hail/allocators.cpp
+++ b/libhail/src/hail/allocators.cpp
@@ -26,7 +26,7 @@ RawArenaAllocator::allocate_in_new_block(size_t align, size_t size) {
   assert(is_power_of_two(align) && align <= 8);
   assert(size <= block_size);
 
-  char *new_block = static_cast<char *>(heap.malloc(block_size));
+  char *new_block = (char *)heap.malloc(block_size);
   blocks.push_back(new_block);
   free_start = new_block + size;
   block_end = new_block + block_size;

--- a/libhail/src/hail/allocators.cpp
+++ b/libhail/src/hail/allocators.cpp
@@ -2,12 +2,13 @@
 
 namespace hail {
 
-void
-ArenaAllocator::free() {
-  for (auto &d : destructors)
-    d.invoke();
-  destructors.clear();
+RawArenaAllocator::RawArenaAllocator(HeapAllocator &heap)
+  : heap(heap),
+    free_start(nullptr),
+    block_end(nullptr) {}
 
+void
+RawArenaAllocator::free() {
   for (void *chunk : chunks)
     heap.free(chunk);
   chunks.clear();
@@ -15,16 +16,17 @@ ArenaAllocator::free() {
   for (void *block : blocks)
     heap.free(block);
   blocks.clear();
+
+  free_start = nullptr;
+  block_end = nullptr;
 }
 
 void *
-ArenaAllocator::allocate_in_new_block(size_t align, size_t size) {
+RawArenaAllocator::allocate_in_new_block(size_t align, size_t size) {
   assert(is_power_of_two(align) && align <= 8);
   assert(size <= block_size);
 
   char *new_block = static_cast<char *>(heap.malloc(block_size));
-  assert(is_aligned(new_block, align));
-
   blocks.push_back(new_block);
   free_start = new_block + size;
   block_end = new_block + block_size;
@@ -33,7 +35,7 @@ ArenaAllocator::allocate_in_new_block(size_t align, size_t size) {
 }
 
 void *
-ArenaAllocator::allocate_as_chunk(size_t align, size_t size) {
+RawArenaAllocator::allocate_as_chunk(size_t align, size_t size) {
   assert(is_power_of_two(align) && align <= 8);
 
   void *p = heap.malloc(size);
@@ -41,6 +43,23 @@ ArenaAllocator::allocate_as_chunk(size_t align, size_t size) {
 
   chunks.push_back(p);
   return p;
+}
+
+void *
+RawArenaAllocator::allocate_slow(size_t align, size_t size) {
+  if (size > block_size / 4)
+    return allocate_as_chunk(align, size);
+
+  return allocate_in_new_block(align, size);
+}
+
+void
+ArenaAllocator::free() {
+  for (auto &d : destructors)
+    d.invoke();
+  destructors.clear();
+
+  raw_arena.free();
 }
 
 }

--- a/libhail/src/hail/allocators.hpp
+++ b/libhail/src/hail/allocators.hpp
@@ -54,6 +54,40 @@ public:
   }
 };
 
+class RawArenaAllocator {
+  static const size_t block_size = 64 * 1024;
+
+  HeapAllocator &heap;
+  std::vector<void *> blocks;
+  std::vector<void *> chunks;
+
+  char *free_start;
+  char *block_end;
+
+public:
+  RawArenaAllocator(HeapAllocator &heap);
+  ~RawArenaAllocator() { free(); }
+
+  void *allocate_in_new_block(size_t align, size_t size);
+
+  void *allocate_as_chunk(size_t align, size_t size);
+
+  void *allocate_slow(size_t align, size_t size);
+
+  void *allocate(size_t align, size_t size) {
+    char *p = make_aligned(free_start, align);
+    if (size <= block_end - p) {
+      free_start = p + size;
+      return p;
+    }
+
+    return allocate_slow(align, size);
+  }
+
+  void free();
+};
+
+
 /* Arena allocator with high-level `make<T>(...)` object
    constructor */
 class ArenaAllocator {
@@ -70,45 +104,21 @@ class ArenaAllocator {
     }
   };
 
-  static const size_t block_size = 8 * 1024;
-
-  HeapAllocator &heap;
+  RawArenaAllocator raw_arena;
   std::vector<DestructorClosure> destructors;
-  std::vector<void *> blocks;
-  std::vector<void *> chunks;
-
-  char *free_start;
-  char *block_end;
 
 public:
   ArenaAllocator(HeapAllocator &heap)
-    : heap(heap),
-      free_start(nullptr),
-      block_end(nullptr) {}
-   ~ArenaAllocator() { free(); }
-
-  void *allocate_in_new_block(size_t align, size_t size);
-
-  void *allocate_as_chunk(size_t align, size_t size);
+    : raw_arena(heap) {}
+  ~ArenaAllocator() { free(); }
 
   void *allocate(size_t align, size_t size) {
-    if (size > block_size / 4)
-      return allocate_as_chunk(align, size);
-
-    char *p = make_aligned(free_start, align);
-    if (size <= block_end - p) {
-      free_start = p + size;
-      return p;
-    }
-
-    return allocate_in_new_block(align, size);
+    return raw_arena.allocate(align, size);
   }
-
-  void free();
 
   template<typename T, typename... Args> T *
   make(Args &&... args) {
-    void *p = allocate(alignof(T), sizeof(T));
+    void *p = raw_arena.allocate(alignof(T), sizeof(T));
     new (p) T(std::forward<Args>(args)...);
     destructors.emplace_back(p,
 			     [](void *p) {
@@ -116,6 +126,8 @@ public:
 			     });
     return static_cast<T *>(p);
   }
+
+  void free();
 };
 
 }

--- a/libhail/src/hail/allocators.hpp
+++ b/libhail/src/hail/allocators.hpp
@@ -104,10 +104,12 @@ class ArenaAllocator {
     }
   };
 
-  RawArenaAllocator raw_arena;
   std::vector<DestructorClosure> destructors;
 
 public:
+  // FIXME public?  pass in?
+  RawArenaAllocator raw_arena;
+
   ArenaAllocator(HeapAllocator &heap)
     : raw_arena(heap) {}
   ~ArenaAllocator() { free(); }

--- a/libhail/src/hail/format.cpp
+++ b/libhail/src/hail/format.cpp
@@ -59,6 +59,11 @@ write_with_iostream(FormatStream &s, T v) {
 }
 
 void
+format1(FormatStream &s, bool v) {
+  s.puts(v ? "true" : "false");
+}
+
+void
 format1(FormatStream &s, signed char v) {
   write_with_iostream<signed char>(s, v);
 }

--- a/libhail/src/hail/format.hpp
+++ b/libhail/src/hail/format.hpp
@@ -18,6 +18,7 @@ public:
 
 extern FormatStream &outs, &errs;
 
+extern void format1(FormatStream &s, bool v);
 extern void format1(FormatStream &s, signed char v);
 extern void format1(FormatStream &s, unsigned char v);
 extern void format1(FormatStream &s, short v);

--- a/libhail/src/hail/hash.hpp
+++ b/libhail/src/hail/hash.hpp
@@ -32,6 +32,20 @@ hash<tuple<T...>>::operator()(const tuple<T...> &t) const {
   return hash_tuple_impl(t, std::make_index_sequence<sizeof...(T)>{});
 }
 
+
+template<typename T>
+struct hash<vector<T>> {
+  size_t operator()(const vector<T> &v) const;
+};
+
+template<typename T> size_t
+hash<vector<T>>::operator()(const vector<T> &v) const {
+  size_t h = v.size();
+  for (const auto &x : v)
+    hash_combine(h, x);
+  return h;
+}
+
 }
 
 #endif

--- a/libhail/src/hail/main.cpp
+++ b/libhail/src/hail/main.cpp
@@ -75,7 +75,7 @@ main() {
       param_vtypes.push_back(tc.get_vtype(t));
     const VType *return_vtype = tc.get_vtype(return_type);
 
-    auto compiled = jit.compile(tc, m, param_vtypes, return_vtype);
+    auto compiled = jit.compile(heap, tc, m, param_vtypes, return_vtype);
 
     auto vt = cast<VTuple>(tc.get_vtype(param_type));
     auto tv = Value::make_tuple(vt, region);

--- a/libhail/src/hail/main.cpp
+++ b/libhail/src/hail/main.cpp
@@ -57,9 +57,14 @@ main() {
     param_types.push_back(param_type);
     const Type *return_type = tc.tbool;
 
+    Value i(vint32, 5);
+
     Function *f = xc.make_function(m, "main", param_types, return_type);
     auto body = f->get_body();
-    body->set_child(0, body->make_get_tuple_element(body->make_input(0), 1));
+    body->set_child(0, body->make_tuple({
+          body->make_na(tc.tint32),
+	  body->make_literal(i)
+	}));
 
     m->pretty_self(outs);
 

--- a/libhail/src/hail/main.cpp
+++ b/libhail/src/hail/main.cpp
@@ -53,9 +53,7 @@ main() {
     Module *m = xc.make_module();
 
     std::vector<const Type *> param_types;
-    const Type *param_type = tc.ttuple({tc.tint32, tc.tbool});
-    param_types.push_back(param_type);
-    const Type *return_type = tc.tbool;
+    const Type *return_type = tc.ttuple({tc.tint32, tc.tint32});
 
     Value i(vint32, 5);
 
@@ -77,13 +75,7 @@ main() {
 
     auto compiled = jit.compile(heap, tc, m, param_vtypes, return_vtype);
 
-    auto vt = cast<VTuple>(tc.get_vtype(param_type));
-    auto tv = Value::make_tuple(vt, region);
-    tv.set_element_missing(0, true);
-    tv.set_element_missing(1, false);
-    tv.set_element(1, Value(vbool, false));
-
-    auto return_value = compiled.invoke(region, {tv});
+    auto return_value = compiled.invoke(region, {});
     print("return_value: ", return_value);
   }
 

--- a/libhail/src/hail/query/backend/compile.cpp
+++ b/libhail/src/hail/query/backend/compile.cpp
@@ -41,6 +41,7 @@ CompileFunction::CompileFunction(TypeContext &tc,
     ir_type(tc, function) {
   auto llvm_ft = llvm::FunctionType::get(llvm::Type::getVoidTy(llvm_context),
 					 {llvm::Type::getInt8PtrTy(llvm_context),
+					  llvm::Type::getInt8PtrTy(llvm_context),
 					  llvm::Type::getInt8PtrTy(llvm_context)},
 					 false);
   llvm_function = llvm::Function::Create(llvm_ft,
@@ -57,7 +58,7 @@ CompileFunction::CompileFunction(TypeContext &tc,
   result.get_constituent_values(result_llvm_values);
   assert(result_llvm_values.size() == 2);
 
-  auto return_address = llvm_function->getArg(0);
+  auto return_address = llvm_function->getArg(1);
   llvm_ir_builder.CreateStore(result_llvm_values[0], return_address);
 
   llvm::Value *value_address = llvm_ir_builder.CreateGEP(return_address,
@@ -116,7 +117,7 @@ CompileFunction::emit(Input *x) {
     assert(constituent_types.size() == 2);
     assert(constituent_types[0] == PrimitiveType::INT8);
 
-    auto params_address = llvm_function->getArg(1);
+    auto params_address = llvm_function->getArg(2);
     auto param_address = llvm_ir_builder.CreateGEP(params_address,
 						   {llvm::ConstantInt::get(llvm_context, llvm::APInt(64, x->index * 16))});
     auto m = llvm_ir_builder.CreateLoad(get_llvm_type(constituent_types[0]),

--- a/libhail/src/hail/query/backend/compile.cpp
+++ b/libhail/src/hail/query/backend/compile.cpp
@@ -220,6 +220,20 @@ CompileFunction::emit(IsNA *x) {
 }
 
 EmitValue
+CompileFunction::emit(MakeTuple *x) {
+  std::vector<const SType *> element_stypes;
+  std::vector<EmitDataValue> element_emit_values;
+  for (auto c : x->get_children()) {
+    auto cv = emit(c).as_data(*this);
+    element_stypes.push_back(cv.svalue->stype);
+    element_emit_values.push_back(cv);
+  }
+  return EmitValue(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0),
+		   new SStackTupleValue(new SStackTuple(ir_type(x), element_stypes),
+					element_emit_values));
+}
+
+EmitValue
 CompileFunction::emit(GetTupleElement *x) {
   auto t = emit(x->get_child(0)).as_control(*this);
 

--- a/libhail/src/hail/query/backend/compile.cpp
+++ b/libhail/src/hail/query/backend/compile.cpp
@@ -6,28 +6,32 @@
 namespace hail {
 
 CompileModule::CompileModule(TypeContext &tc,
+			     STypeContext &stc,
 			     Module *module,
 			     const std::vector<EmitType> &param_types,
 			     EmitType return_type,
 			     llvm::LLVMContext &llvm_context,
 			     llvm::Module *llvm_module)
   : tc(tc),
+    stc(stc),
     llvm_context(llvm_context),
     llvm_module(llvm_module) {
   auto main = module->get_function("main");
   // FIXME
   assert(main);
 
-  CompileFunction(tc, main, param_types, return_type, llvm_context, llvm_module);
+  CompileFunction(tc, stc, main, param_types, return_type, llvm_context, llvm_module);
 }
 
 CompileFunction::CompileFunction(TypeContext &tc,
+				 STypeContext &stc,
 				 Function *function,
 				 const std::vector<EmitType> &param_types,
 				 EmitType return_type,
 				 llvm::LLVMContext &llvm_context,
 				 llvm::Module *llvm_module)
   : tc(tc),
+    stc(stc),
     function(function),
     param_types(param_types),
     return_type(return_type),
@@ -47,7 +51,7 @@ CompileFunction::CompileFunction(TypeContext &tc,
   auto entry = llvm::BasicBlock::Create(llvm_context, "entry", llvm_function);
   llvm_ir_builder.SetInsertPoint(entry);
 
-  auto result = emit(function->get_body()).as_data(*this);
+  auto result = emit(function->get_body()).cast_to(*this, return_type).as_data(*this);
 
   std::vector<llvm::Value *> result_llvm_values;
   result.get_constituent_values(result_llvm_values);
@@ -135,15 +139,15 @@ const SType *
 CompileFunction::get_default_stype(const Type *t) {
   switch (t->tag) {
   case Type::Tag::BOOL:
-    return new SBool(t);
+    return stc.sbool;
   case Type::Tag::INT32:
-    return new SInt32(t);
+    return stc.sint32;
   case Type::Tag::INT64:
-    return new SInt64(t);
+    return stc.sint64;
   case Type::Tag::FLOAT32:
-    return new SFloat32(t);
+    return stc.sfloat32;
   case Type::Tag::FLOAT64:
-    return new SFloat64(t);
+    return stc.sfloat64;
   default:
     abort();
   }
@@ -161,31 +165,31 @@ CompileFunction::emit(Literal *x) {
     {
       auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
       auto c = llvm::ConstantInt::get(llvm_context, llvm::APInt(1, x->value.as_bool()));
-      return EmitValue(m, new SBoolValue(new SBool(t), c));
+      return EmitValue(m, new SBoolValue(stc.sbool, c));
     }
   case Type::Tag::INT32:
     {
       auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
       auto c = llvm::ConstantInt::get(llvm_context, llvm::APInt(32, x->value.as_int32()));
-      return EmitValue(m, new SInt32Value(new SInt32(t), c));
+      return EmitValue(m, new SInt32Value(stc.sint32, c));
     }
   case Type::Tag::INT64:
     {
       auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
       auto c = llvm::ConstantInt::get(llvm_context, llvm::APInt(64, x->value.as_int64()));
-      return EmitValue(m, new SInt64Value(new SInt32(t), c));
+      return EmitValue(m, new SInt64Value(stc.sint64, c));
     }
   case Type::Tag::FLOAT32:
     {
       auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
       auto c = llvm::ConstantFP::get(llvm_context, llvm::APFloat(x->value.as_float32()));
-      return EmitValue(m, new SFloat32Value(new SFloat32(t), c));
+      return EmitValue(m, new SFloat32Value(stc.sfloat32, c));
     }
   case Type::Tag::FLOAT64:
     {
   auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
       auto c = llvm::ConstantFP::get(llvm_context, llvm::APFloat(x->value.as_float64()));
-      return EmitValue(m, new SFloat64Value(new SFloat64(t), c));
+      return EmitValue(m, new SFloat64Value(stc.sfloat64, c));
     }
   default:
     abort();
@@ -204,32 +208,33 @@ CompileFunction::emit(IsNA *x) {
   llvm::AllocaInst *l = make_entry_alloca(llvm::Type::getInt8Ty(llvm_context));
 
   auto merge_bb = llvm::BasicBlock::Create(llvm_context, "isna_merge", llvm_function);
-  llvm_ir_builder.SetInsertPoint(cond.missing_block);
-  llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 1), l);
+
+  // present
+  llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0), l);
   llvm_ir_builder.CreateBr(merge_bb);
 
-  llvm_ir_builder.SetInsertPoint(cond.present_block);
-  llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0), l);
+  llvm_ir_builder.SetInsertPoint(cond.missing_block);
+  llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 1), l);
   llvm_ir_builder.CreateBr(merge_bb);
 
   llvm_ir_builder.SetInsertPoint(merge_bb);
   llvm::Value *v = llvm_ir_builder.CreateLoad(l);
 
   auto m = llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0);
-  return EmitValue(m, new SBoolValue(new SBool(ir_type(x)), v));
+  return EmitValue(m, new SBoolValue(stc.sbool, v));
 }
 
 EmitValue
 CompileFunction::emit(MakeTuple *x) {
-  std::vector<const SType *> element_stypes;
+  std::vector<EmitType> element_stypes;
   std::vector<EmitDataValue> element_emit_values;
   for (auto c : x->get_children()) {
     auto cv = emit(c).as_data(*this);
-    element_stypes.push_back(cv.svalue->stype);
+    element_stypes.push_back(cv.get_type());
     element_emit_values.push_back(cv);
   }
   return EmitValue(llvm::ConstantInt::get(llvm::Type::getInt8Ty(llvm_context), 0),
-		   new SStackTupleValue(new SStackTuple(ir_type(x), element_stypes),
+		   new SStackTupleValue(stc.stack_stuple(ir_type(x), element_stypes),
 					element_emit_values));
 }
 
@@ -237,14 +242,13 @@ EmitValue
 CompileFunction::emit(GetTupleElement *x) {
   auto t = emit(x->get_child(0)).as_control(*this);
 
-  llvm_ir_builder.SetInsertPoint(t.present_block);
   // FIXME any tuple value
   auto elem = cast<SCanonicalTupleValue>(t.svalue)->get_element(*this, x->index).as_control(*this);
 
   llvm_ir_builder.SetInsertPoint(elem.missing_block);
   llvm_ir_builder.CreateBr(t.missing_block);
 
-  return EmitValue(elem.present_block, t.missing_block, elem.svalue);
+  return EmitValue(t.missing_block, elem.svalue);
 }
 
 EmitValue

--- a/libhail/src/hail/query/backend/compile.hpp
+++ b/libhail/src/hail/query/backend/compile.hpp
@@ -24,10 +24,12 @@ class Function;
 class CompileModule {
 public:
   TypeContext &tc;
+  STypeContext &stc;
   llvm::LLVMContext &llvm_context;
   llvm::Module *llvm_module;
 
   CompileModule(TypeContext &tc,
+		STypeContext &stc,
 		Module *module,
 		const std::vector<EmitType> &param_types,
 		EmitType return_type,
@@ -38,6 +40,7 @@ public:
 class CompileFunction {
 public:
   TypeContext &tc;
+  STypeContext &stc;
   Function *function;
   const std::vector<EmitType> &param_types;
   EmitType return_type;
@@ -70,6 +73,7 @@ public:
   EmitValue emit(IR *x);
 
   CompileFunction(TypeContext &tc,
+		  STypeContext &stc,
 		  Function *function,
 		  const std::vector<EmitType> &param_types,
 		  EmitType return_type,

--- a/libhail/src/hail/query/backend/compile.hpp
+++ b/libhail/src/hail/query/backend/compile.hpp
@@ -65,6 +65,7 @@ public:
   EmitValue emit(Literal *x);
   EmitValue emit(NA *x);
   EmitValue emit(IsNA *x);
+  EmitValue emit(MakeTuple *x);
   EmitValue emit(GetTupleElement *x);
   EmitValue emit(IR *x);
 

--- a/libhail/src/hail/query/backend/compile.hpp
+++ b/libhail/src/hail/query/backend/compile.hpp
@@ -56,7 +56,7 @@ public:
 
   // FIXME move to SType
   const SType *get_default_stype(const Type *t);
-  
+
   llvm::Type *get_llvm_type(PrimitiveType pt) const;
   llvm::AllocaInst *make_entry_alloca(llvm::Type *llvm_type);
 
@@ -65,6 +65,7 @@ public:
   EmitValue emit(Literal *x);
   EmitValue emit(NA *x);
   EmitValue emit(IsNA *x);
+  EmitValue emit(GetTupleElement *x);
   EmitValue emit(IR *x);
 
   CompileFunction(TypeContext &tc,

--- a/libhail/src/hail/query/backend/jit.cpp
+++ b/libhail/src/hail/query/backend/jit.cpp
@@ -81,8 +81,10 @@ JITModule::invoke(std::shared_ptr<ArenaAllocator> region, const std::vector<Valu
     raw_args[i] = args[i];
   Value::Raw raw_return_value;
 
-  reinterpret_cast<void (*)(char *, char *)>(address)(reinterpret_cast<char *>(&raw_return_value),
-						      reinterpret_cast<char *>(&raw_args));
+  reinterpret_cast<void (*)(char *, char *, char *)>
+    (address)(reinterpret_cast<char *>(&region->raw_arena),
+	      reinterpret_cast<char *>(&raw_return_value),
+	      reinterpret_cast<char *>(&raw_args));
 
   return Value(return_vtype, std::move(region), raw_return_value);
 }

--- a/libhail/src/hail/query/backend/jit.hpp
+++ b/libhail/src/hail/query/backend/jit.hpp
@@ -34,7 +34,8 @@ public:
   JIT();
   ~JIT();
 
-  JITModule compile(TypeContext &tc,
+  JITModule compile(HeapAllocator &heap,
+		    TypeContext &tc,
 		    Module *m,
 		    const std::vector<const VType *> &param_vtypes,
 		    const VType *return_vtype);

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -98,28 +98,109 @@ SType::load_from_address(CompileFunction &cf, llvm::Value *address) const {
   }
 }
 
-SBool::SBool(const Type *type)
-  : SType(self_tag, type) {}
+const SValue *
+SType::construct_from_value(CompileFunction &cf, const SValue *from) const {
+  if (from->stype == this)
+    return from;
 
-SInt32::SInt32(const Type *type)
-  : SType(self_tag, type) {}
+  abort();
 
-SInt64::SInt64(const Type *type)
-  : SType(self_tag, type) {}
+  // auto address = ...;
+  // return construct_at_address_from_value(cf, address, from);
+}
 
-SFloat32::SFloat32(const Type *type)
-  : SType(self_tag, type) {}
+void
+SType::construct_at_address_from_value(CompileFunction &cf, llvm::Value *address, const SValue *from) const {
+  switch (tag) {
+  case SType::Tag::BOOL:
+    cf.llvm_ir_builder.CreateStore(address, cast<SBoolValue>(from)->value);
+    break;
+  case SType::Tag::INT32:
+    cf.llvm_ir_builder.CreateStore(cf.llvm_ir_builder.CreateBitCast(address,
+								    llvm::PointerType::get(llvm::Type::getInt32Ty(cf.llvm_context), 0)),
+				   cast<SInt32Value>(from)->value);
+    break;
+  case SType::Tag::INT64:
+    cf.llvm_ir_builder.CreateStore(cf.llvm_ir_builder.CreateBitCast(address,
+								    llvm::PointerType::get(llvm::Type::getInt64Ty(cf.llvm_context), 0)),
+				   cast<SInt64Value>(from)->value);
+    break;
+  case SType::Tag::FLOAT32:
+    cf.llvm_ir_builder.CreateStore(cf.llvm_ir_builder.CreateBitCast(address,
+								    llvm::PointerType::get(llvm::Type::getFloatTy(cf.llvm_context), 0)),
+				   cast<SFloat32Value>(from)->value);
+    break;
+  case SType::Tag::FLOAT64:
+    cf.llvm_ir_builder.CreateStore(cf.llvm_ir_builder.CreateBitCast(address,
+								    llvm::PointerType::get(llvm::Type::getDoubleTy(cf.llvm_context), 0)),
+				   cast<SFloat64Value>(from)->value);
+    break;
+  case SType::Tag::CANONICALTUPLE:
+    {
+      auto t = cast<SCanonicalTuple>(this);
+      auto v = cast<STupleValue>(from);
+      for (size_t i = 0; i < t->element_offsets.size(); ++i) {
+	auto c = v->get_element(cf, i).as_control(cf);
 
-SFloat64::SFloat64(const Type *type)
-  : SType(self_tag, type) {}
+	auto merge_block = llvm::BasicBlock::Create(cf.llvm_context, "make_tuple_after_element", cf.llvm_function);
 
-SCanonicalTuple::SCanonicalTuple(const Type *type, std::vector<const SType *> element_stypes, std::vector<size_t> element_offsets)
-  : SType(self_tag, type),
+	auto element_address = cf.llvm_ir_builder.CreateGEP(address,
+							    llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(64, t->element_offsets[i])));
+
+	t->set_element_missing(cf, address, i, 0);
+	t->element_stypes[i].stype->construct_at_address_from_value(cf, element_address, c.svalue);
+	cf.llvm_ir_builder.CreateBr(merge_block);
+
+	cf.llvm_ir_builder.SetInsertPoint(c.missing_block);
+	t->set_element_missing(cf, address, i, 1);
+	cf.llvm_ir_builder.CreateBr(merge_block);
+
+	cf.llvm_ir_builder.SetInsertPoint(merge_block);
+      }
+    }
+    break;
+  default:
+    abort();
+  }
+}
+
+SBool::SBool(STypeContextToken, const Type *type)
+  : SType(Tag::BOOL, type) {}
+
+SInt32::SInt32(STypeContextToken, const Type *type)
+  : SType(Tag::INT32, type) {}
+
+SInt64::SInt64(STypeContextToken, const Type *type)
+  : SType(Tag::INT64, type) {}
+
+SFloat32::SFloat32(STypeContextToken, const Type *type)
+  : SType(Tag::FLOAT32, type) {}
+
+SFloat64::SFloat64(STypeContextToken, const Type *type)
+  : SType(Tag::FLOAT64, type) {}
+
+SCanonicalTuple::SCanonicalTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes, std::vector<size_t> element_offsets)
+  : SType(Tag::CANONICALTUPLE, type),
     element_stypes(std::move(element_stypes)),
     element_offsets(std::move(element_offsets)) {}
 
-SStackTuple::SStackTuple(const Type *type, std::vector<const SType *> element_stypes)
-  : SType(self_tag, type),
+void
+SCanonicalTuple::set_element_missing(CompileFunction &cf, llvm::Value *address, size_t i, bool missing) const {
+  llvm::Value *missing_address =
+    cf.llvm_ir_builder.CreateGEP(address,
+				 llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(64, i >> 3)));
+  llvm::Value *b = cf.llvm_ir_builder.CreateLoad(missing_address);
+  if (missing)
+    b = cf.llvm_ir_builder.CreateOr(b,
+				    llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, 1 << (i & 0x7))));
+  else
+    b = cf.llvm_ir_builder.CreateAnd(b,
+				     llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, ~(1 << (i & 0x7)))));
+  cf.llvm_ir_builder.CreateStore(missing_address, b);
+}
+
+SStackTuple::SStackTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes)
+  : SType(Tag::STACKTUPLE, type),
     element_stypes(std::move(element_stypes)) {}
 
 void
@@ -147,6 +228,69 @@ EmitType::make_na(CompileFunction &cf) const {
   auto svalue = stype->from_llvm_values(llvm_values, 0);
 
   return EmitValue(m, svalue);
+}
+
+STypeContext::STypeContext(HeapAllocator &heap, TypeContext &tc)
+  : tc(tc),
+    arena(heap),
+    sbool(arena.make<SBool>(STypeContextToken(), tc.tbool)),
+    sint32(arena.make<SInt32>(STypeContextToken(), tc.tint32)),
+    sint64(arena.make<SInt64>(STypeContextToken(), tc.tint64)),
+    sfloat32(arena.make<SFloat32>(STypeContextToken(), tc.tfloat32)),
+    sfloat64(arena.make<SFloat64>(STypeContextToken(), tc.tfloat64)) {}
+
+const SCanonicalTuple *
+STypeContext::canonical_stuple(const Type *type, const std::vector<EmitType> &element_types, const std::vector<size_t> &element_offsets) {
+  // FIXME offsets not hashed
+  auto p = canonical_stuples.insert({element_types, nullptr});
+  if (!p.second)
+    return p.first->second;
+
+  const SCanonicalTuple *t = arena.make<SCanonicalTuple>(STypeContextToken(), type, element_types, element_offsets);
+  p.first->second = t;
+  return t;
+}
+
+const SStackTuple *
+STypeContext::stack_stuple(const Type *type, const std::vector<EmitType> &element_types) {
+  auto p = stack_stuples.insert({element_types, nullptr});
+  if (!p.second)
+    return p.first->second;
+
+  const SStackTuple *t = arena.make<SStackTuple>(STypeContextToken(), type, element_types);
+  p.first->second = t;
+  return t;
+}
+
+EmitType
+STypeContext::emit_type_from(const VType *vtype) {
+  return EmitType(stype_from(vtype));
+}
+
+const SType *
+STypeContext::stype_from(const VType *vtype) {
+  switch (vtype->tag) {
+  case VType::Tag::BOOL:
+    return sbool;
+  case VType::Tag::INT32:
+    return sint32;
+  case VType::Tag::INT64:
+    return sint64;
+  case VType::Tag::FLOAT32:
+    return sfloat32;
+  case VType::Tag::FLOAT64:
+    return sfloat64;
+  case VType::Tag::TUPLE:
+    {
+      const VTuple *vt = cast<VTuple>(vtype);
+      std::vector<EmitType> element_types;
+      for (auto et : vt->element_vtypes)
+	element_types.push_back(emit_type_from(et));
+      return canonical_stuple(vt->type, element_types, vt->element_offsets);
+    }
+  default:
+    abort();
+  }
 }
 
 }

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -25,6 +25,9 @@ SType::get_constituent_types(std::vector<PrimitiveType> &constituent_types) cons
   case SType::Tag::FLOAT64:
     constituent_types.push_back(PrimitiveType::FLOAT64);
     break;
+  case SType::Tag::CANONICALTUPLE:
+    constituent_types.push_back(PrimitiveType::POINTER);
+    break;
   default:
     abort();
   }
@@ -43,6 +46,53 @@ SType::from_llvm_values(const std::vector<llvm::Value *> &llvm_values, size_t i)
     return new SFloat32Value(this, llvm_values[i]);
   case SType::Tag::FLOAT64:
     return new SFloat64Value(this, llvm_values[i]);
+  case SType::Tag::CANONICALTUPLE:
+    return new SCanonicalTupleValue(this, llvm_values[i]);
+  default:
+    abort();
+  }
+}
+
+const SValue *
+SType::load_from_address(CompileFunction &cf, llvm::Value *address) const {
+  switch (tag) {
+  case SType::Tag::BOOL:
+    {
+      auto v = cf.llvm_ir_builder.CreateLoad(address);
+      return new SBoolValue(this, v);
+    }
+  case SType::Tag::INT32:
+    {
+      auto typed_address = cf.llvm_ir_builder.CreateBitCast(address,
+							    llvm::PointerType::get(llvm::Type::getInt32Ty(cf.llvm_context), 0));
+      auto v = cf.llvm_ir_builder.CreateLoad(typed_address);
+      return new SInt32Value(this, v);
+    }
+  case SType::Tag::INT64:
+    {
+      auto typed_address = cf.llvm_ir_builder.CreateBitCast(address,
+							    llvm::PointerType::get(llvm::Type::getInt64Ty(cf.llvm_context), 0));
+      auto v = cf.llvm_ir_builder.CreateLoad(typed_address);
+      return new SInt64Value(this, v);
+    }
+  case SType::Tag::FLOAT32:
+    {
+      auto typed_address = cf.llvm_ir_builder.CreateBitCast(address,
+							    llvm::PointerType::get(llvm::Type::getFloatTy(cf.llvm_context), 0));
+      auto v = cf.llvm_ir_builder.CreateLoad(typed_address);
+      return new SFloat32Value(this, v);
+    }
+  case SType::Tag::FLOAT64:
+    {
+      auto typed_address = cf.llvm_ir_builder.CreateBitCast(address,
+							    llvm::PointerType::get(llvm::Type::getDoubleTy(cf.llvm_context), 0));
+      auto v = cf.llvm_ir_builder.CreateLoad(typed_address);
+      return new SFloat64Value(this, v);
+    }
+  case SType::Tag::CANONICALTUPLE:
+    {
+      return new SCanonicalTupleValue(this, address);
+    }
   default:
     abort();
   }
@@ -62,6 +112,11 @@ SFloat32::SFloat32(const Type *type)
 
 SFloat64::SFloat64(const Type *type)
   : SType(self_tag, type) {}
+
+SCanonicalTuple::SCanonicalTuple(const Type *type, std::vector<const SType *> element_stypes, std::vector<size_t> element_offsets)
+  : SType(self_tag, type),
+    element_stypes(std::move(element_stypes)),
+    element_offsets(std::move(element_offsets)) {}
 
 void
 EmitType::get_constituent_types(std::vector<PrimitiveType> &constituent_types) const {

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -221,10 +221,10 @@ SCanonicalTuple::set_element_missing(CompileFunction &cf, llvm::Value *address, 
   llvm::Value *b = cf.llvm_ir_builder.CreateLoad(missing_address);
   if (missing)
     b = cf.llvm_ir_builder.CreateOr(b,
-				    llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, 1 << (i & 0x7))));
+				    llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, 1 << (i & 7))));
   else
     b = cf.llvm_ir_builder.CreateAnd(b,
-				     llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, ~(1 << (i & 0x7)))));
+				     llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, ~(1 << (i & 7)))));
   cf.llvm_ir_builder.CreateStore(b, missing_address);
 }
 

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -118,6 +118,10 @@ SCanonicalTuple::SCanonicalTuple(const Type *type, std::vector<const SType *> el
     element_stypes(std::move(element_stypes)),
     element_offsets(std::move(element_offsets)) {}
 
+SStackTuple::SStackTuple(const Type *type, std::vector<const SType *> element_stypes)
+  : SType(self_tag, type),
+    element_stypes(std::move(element_stypes)) {}
+
 void
 EmitType::get_constituent_types(std::vector<PrimitiveType> &constituent_types) const {
   constituent_types.push_back(PrimitiveType::INT8);

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -161,12 +161,12 @@ SType::construct_at_address_from_value(CompileFunction &cf, llvm::Value *address
 	auto element_address = cf.llvm_ir_builder.CreateGEP(address,
 							    llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(64, t->element_offsets[i])));
 
-	t->set_element_missing(cf, address, i, 0);
+	t->set_element_missing(cf, address, i, false);
 	t->element_types[i].stype->construct_at_address_from_value(cf, element_address, c.svalue);
 	cf.llvm_ir_builder.CreateBr(merge_block);
 
 	cf.llvm_ir_builder.SetInsertPoint(c.missing_block);
-	t->set_element_missing(cf, address, i, 1);
+	t->set_element_missing(cf, address, i, true);
 	cf.llvm_ir_builder.CreateBr(merge_block);
 
 	cf.llvm_ir_builder.SetInsertPoint(merge_block);

--- a/libhail/src/hail/query/backend/stype.hpp
+++ b/libhail/src/hail/query/backend/stype.hpp
@@ -3,6 +3,7 @@
 
 #include <llvm/IR/Value.h>
 #include <hail/hash.hpp>
+#include <hail/tunion.hpp>
 #include <hail/type.hpp>
 #include <vector>
 
@@ -12,6 +13,8 @@ class EmitType;
 class SValue;
 class EmitValue;
 class CompileFunction;
+class MemorySize;
+class VTuple;
 
 enum class PrimitiveType {
   VOID,
@@ -32,15 +35,11 @@ class SType {
 public:
   using BaseType = SType;
   enum class Tag {
-    VOID,
     BOOL,
     INT32,
     INT64,
     FLOAT32,
     FLOAT64,
-    STR,
-    ARRAY,
-    STREAM,
     CANONICALTUPLE,
     STACKTUPLE
   };
@@ -59,44 +58,69 @@ public:
   const SValue *construct_from_value(CompileFunction &cf, const SValue *from) const;
 
   void construct_at_address_from_value(CompileFunction &cf, llvm::Value *address, const SValue *from) const;
+
+  MemorySize get_memory_size() const;
+
+  template<typename F> auto dispatch(F f) const;
 };
 
-class SBool : public SType {
+class MemorySize {
+public:
+  const size_t byte_size;
+  const size_t alignment;
+
+public:
+  MemorySize(size_t byte_size, size_t alignment)
+    : byte_size(byte_size), alignment(alignment) {}
+};
+
+template<typename T> inline constexpr bool
+is_heap_stype() {
+  static_assert(std::is_base_of_v<SType, T>);
+  return std::is_base_of_v<MemorySize, T>;
+}
+
+class SBool : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::BOOL; }
   SBool(STypeContextToken, const Type *type);
 };
 
-class SInt32 : public SType {
+class SInt32 : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::INT32; }
   SInt32(STypeContextToken, const Type *type);
 };
 
-class SInt64 : public SType {
+class SInt64 : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::INT64; }
   SInt64(STypeContextToken, const Type *type);
 };
 
-class SFloat32 : public SType {
+class SFloat32 : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::FLOAT32; }
   SFloat32(STypeContextToken, const Type *type);
 };
 
-class SFloat64 : public SType {
+class SFloat64 : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::FLOAT64; }
   SFloat64(STypeContextToken, const Type *type);
 };
 
-class SCanonicalTuple : public SType {
+class SCanonicalTuple : public SType, public MemorySize {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::CANONICALTUPLE; }
-  std::vector<EmitType> element_stypes;
+  std::vector<EmitType> element_types;
   std::vector<size_t> element_offsets;
-  SCanonicalTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes, std::vector<size_t> element_offsets);
+  SCanonicalTuple(STypeContextToken,
+		  const Type *type,
+		  std::vector<EmitType> element_types,
+		  size_t byte_size,
+		  size_t alignment,
+		  std::vector<size_t> element_offsets);
 
   void set_element_missing(CompileFunction &cf, llvm::Value *address, size_t i, bool missing) const;
 };
@@ -104,8 +128,8 @@ public:
 class SStackTuple : public SType {
 public:
   static bool is_instance_tag(Tag tag) { return tag == SType::Tag::STACKTUPLE; }
-  std::vector<EmitType> element_stypes;
-  SStackTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes);
+  std::vector<EmitType> element_types;
+  SStackTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_types);
 };
 
 class EmitType {
@@ -155,13 +179,28 @@ public:
 
   STypeContext(HeapAllocator &heap, TypeContext &tc);
 
-  const SCanonicalTuple *canonical_stuple(const Type *type, const std::vector<EmitType> &element_types, const std::vector<size_t> &element_offsets);
+  const SCanonicalTuple *canonical_stuple(const Type *type, const std::vector<EmitType> &element_types, const VTuple *vtuple);
   const SStackTuple *stack_stuple(const Type *type, const std::vector<EmitType> &element_types);
 
   EmitType emit_type_from(const VType *vtype);
 
   const SType *stype_from(const VType *vtype);
 };
+
+template<typename F> auto
+SType::dispatch(F f) const {
+  switch(tag) {
+  case Tag::BOOL: return f(cast<SBool>(this));
+  case Tag::INT32: return f(cast<SInt32>(this));
+  case Tag::INT64: return f(cast<SInt64>(this));
+  case Tag::FLOAT32: return f(cast<SFloat32>(this));
+  case Tag::FLOAT64: return f(cast<SFloat64>(this));
+  case Tag::CANONICALTUPLE: return f(cast<SCanonicalTuple>(this));
+  case Tag::STACKTUPLE: return f(cast<SStackTuple>(this));
+  default:
+    abort();
+  }
+}
 
 }
 

--- a/libhail/src/hail/query/backend/stype.hpp
+++ b/libhail/src/hail/query/backend/stype.hpp
@@ -34,7 +34,7 @@ public:
     STR,
     ARRAY,
     STREAM,
-    TUPLE
+    CANONICALTUPLE
   };
   const Tag tag;
   const Type *const type;
@@ -45,6 +45,8 @@ public:
   void get_constituent_types(std::vector<PrimitiveType> &constituent_types) const;
 
   SValue *from_llvm_values(const std::vector<llvm::Value *> &llvm_values, size_t i) const;
+
+  const SValue *load_from_address(CompileFunction &cf, llvm::Value *address) const;
 };
 
 class SBool : public SType {
@@ -75,6 +77,14 @@ class SFloat64 : public SType {
 public:
   static const Tag self_tag = SType::Tag::FLOAT64;
   SFloat64(const Type *type);
+};
+
+class SCanonicalTuple : public SType {
+public:
+  static const Tag self_tag = SType::Tag::CANONICALTUPLE;
+  std::vector<const SType *> element_stypes;
+  std::vector<size_t> element_offsets;
+  SCanonicalTuple(const Type *type, std::vector<const SType *> element_stypes, std::vector<size_t> element_offsets);
 };
 
 class EmitType {

--- a/libhail/src/hail/query/backend/stype.hpp
+++ b/libhail/src/hail/query/backend/stype.hpp
@@ -34,7 +34,8 @@ public:
     STR,
     ARRAY,
     STREAM,
-    CANONICALTUPLE
+    CANONICALTUPLE,
+    STACKTUPLE
   };
   const Tag tag;
   const Type *const type;
@@ -85,6 +86,13 @@ public:
   std::vector<const SType *> element_stypes;
   std::vector<size_t> element_offsets;
   SCanonicalTuple(const Type *type, std::vector<const SType *> element_stypes, std::vector<size_t> element_offsets);
+};
+
+class SStackTuple : public SType {
+public:
+  static const Tag self_tag = SType::Tag::STACKTUPLE;
+  std::vector<const SType *> element_stypes;
+  SStackTuple(const Type *type, std::vector<const SType *> element_stypes);
 };
 
 class EmitType {

--- a/libhail/src/hail/query/backend/stype.hpp
+++ b/libhail/src/hail/query/backend/stype.hpp
@@ -2,11 +2,13 @@
 #define HAIL_QUERY_BACKEND_STYPE_HPP_INCLUDED 1
 
 #include <llvm/IR/Value.h>
+#include <hail/hash.hpp>
 #include <hail/type.hpp>
 #include <vector>
 
 namespace hail {
 
+class EmitType;
 class SValue;
 class EmitValue;
 class CompileFunction;
@@ -19,6 +21,11 @@ enum class PrimitiveType {
   FLOAT32,
   FLOAT64,
   POINTER
+};
+
+class STypeContextToken {
+  friend class STypeContext;
+  STypeContextToken() {}
 };
 
 class SType {
@@ -48,51 +55,57 @@ public:
   SValue *from_llvm_values(const std::vector<llvm::Value *> &llvm_values, size_t i) const;
 
   const SValue *load_from_address(CompileFunction &cf, llvm::Value *address) const;
+
+  const SValue *construct_from_value(CompileFunction &cf, const SValue *from) const;
+
+  void construct_at_address_from_value(CompileFunction &cf, llvm::Value *address, const SValue *from) const;
 };
 
 class SBool : public SType {
 public:
-  static const Tag self_tag = SType::Tag::BOOL;
-  SBool(const Type *type);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::BOOL; }
+  SBool(STypeContextToken, const Type *type);
 };
 
 class SInt32 : public SType {
 public:
-  static const Tag self_tag = SType::Tag::INT32;
-  SInt32(const Type *type);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::INT32; }
+  SInt32(STypeContextToken, const Type *type);
 };
 
 class SInt64 : public SType {
 public:
-  static const Tag self_tag = SType::Tag::INT64;
-  SInt64(const Type *type);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::INT64; }
+  SInt64(STypeContextToken, const Type *type);
 };
 
 class SFloat32 : public SType {
 public:
-  static const Tag self_tag = SType::Tag::FLOAT32;
-  SFloat32(const Type *type);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::FLOAT32; }
+  SFloat32(STypeContextToken, const Type *type);
 };
 
 class SFloat64 : public SType {
 public:
-  static const Tag self_tag = SType::Tag::FLOAT64;
-  SFloat64(const Type *type);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::FLOAT64; }
+  SFloat64(STypeContextToken, const Type *type);
 };
 
 class SCanonicalTuple : public SType {
 public:
-  static const Tag self_tag = SType::Tag::CANONICALTUPLE;
-  std::vector<const SType *> element_stypes;
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::CANONICALTUPLE; }
+  std::vector<EmitType> element_stypes;
   std::vector<size_t> element_offsets;
-  SCanonicalTuple(const Type *type, std::vector<const SType *> element_stypes, std::vector<size_t> element_offsets);
+  SCanonicalTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes, std::vector<size_t> element_offsets);
+
+  void set_element_missing(CompileFunction &cf, llvm::Value *address, size_t i, bool missing) const;
 };
 
 class SStackTuple : public SType {
 public:
-  static const Tag self_tag = SType::Tag::STACKTUPLE;
-  std::vector<const SType *> element_stypes;
-  SStackTuple(const Type *type, std::vector<const SType *> element_stypes);
+  static bool is_instance_tag(Tag tag) { return tag == SType::Tag::STACKTUPLE; }
+  std::vector<EmitType> element_stypes;
+  SStackTuple(STypeContextToken, const Type *type, std::vector<EmitType> element_stypes);
 };
 
 class EmitType {
@@ -101,11 +114,53 @@ public:
 
   EmitType(const SType *stype) : stype(stype) {}
 
+  bool operator==(EmitType that) const { return stype == that.stype; }
+  bool operator!=(EmitType that) const { return stype != that.stype; }
+
   void get_constituent_types(std::vector<PrimitiveType> &constituent_types) const;
 
   EmitValue from_llvm_values(const std::vector<llvm::Value *> &llvm_values, size_t i) const;
 
   EmitValue make_na(CompileFunction &cf) const;
+};
+
+}
+
+namespace std {
+
+template<>
+struct hash<hail::EmitType> {
+  size_t operator()(hail::EmitType emit_type) const {
+    return hash_value(emit_type.stype);
+  }
+};
+
+}
+
+namespace hail {
+
+class STypeContext {
+  TypeContext &tc;
+  ArenaAllocator arena;
+
+  std::unordered_map<std::vector<EmitType>, const SCanonicalTuple *> canonical_stuples;
+  std::unordered_map<std::vector<EmitType>, const SStackTuple *> stack_stuples;
+
+public:
+  const SBool *const sbool;
+  const SInt32 *const sint32;
+  const SInt64 *const sint64;
+  const SFloat32 *const sfloat32;
+  const SFloat64 *const sfloat64;
+
+  STypeContext(HeapAllocator &heap, TypeContext &tc);
+
+  const SCanonicalTuple *canonical_stuple(const Type *type, const std::vector<EmitType> &element_types, const std::vector<size_t> &element_offsets);
+  const SStackTuple *stack_stuple(const Type *type, const std::vector<EmitType> &element_types);
+
+  EmitType emit_type_from(const VType *vtype);
+
+  const SType *stype_from(const VType *vtype);
 };
 
 }

--- a/libhail/src/hail/query/backend/svalue.cpp
+++ b/libhail/src/hail/query/backend/svalue.cpp
@@ -46,6 +46,39 @@ SFloat32Value::SFloat32Value(const SType *stype, llvm::Value *value)
 SFloat64Value::SFloat64Value(const SType *stype, llvm::Value *value)
   : SValue(self_tag, stype), value(value) {}
 
+STupleValue::STupleValue(Tag tag, const SType *stype)
+  : SValue(tag, stype) {}
+
+SCanonicalTupleValue::SCanonicalTupleValue(const SType *stype, llvm::Value *address)
+  : STupleValue(self_tag, stype), address(address) {}
+
+EmitValue
+SCanonicalTupleValue::get_element(CompileFunction &cf, size_t i) const {
+  const SCanonicalTuple *st = cast<SCanonicalTuple>(stype);
+
+  auto missing_bb = llvm::BasicBlock::Create(cf.llvm_context, "gettupleelement_missing", cf.llvm_function);
+  auto present_bb = llvm::BasicBlock::Create(cf.llvm_context, "gettupleelement_present", cf.llvm_function);
+
+  llvm::Value *missing_address =
+    cf.llvm_ir_builder.CreateGEP(address,
+				 llvm::ConstantInt::get(cf.llvm_context,
+							llvm::APInt(64, i >> 3)));
+  llvm::Value *mask = llvm::ConstantInt::get(cf.llvm_context,
+					     llvm::APInt(8, 1 << (i & 0x7)));
+  llvm::Value *b = cf.llvm_ir_builder.CreateLoad(missing_address);
+  llvm::Value *cond = cf.llvm_ir_builder.CreateICmpEQ(cf.llvm_ir_builder.CreateAnd(b, mask), mask);
+  cf.llvm_ir_builder.CreateCondBr(cond, missing_bb, present_bb);
+
+  cf.llvm_ir_builder.SetInsertPoint(present_bb);
+  llvm::Value *element_address =
+    cf.llvm_ir_builder.CreateGEP(address,
+				 llvm::ConstantInt::get(cf.llvm_context,
+							llvm::APInt(64, st->element_offsets[i])));
+  const SValue *sv = st->element_stypes[i]->load_from_address(cf, element_address);
+
+  return EmitValue(present_bb, missing_bb, sv);
+}
+
 void
 EmitDataValue::get_constituent_values(std::vector<llvm::Value *> &llvm_values) const {
   llvm_values.push_back(missing);
@@ -84,21 +117,35 @@ EmitValue::as_data(CompileFunction &cf) const {
   if (missing)
     return EmitDataValue(missing, svalue);
 
-  llvm::AllocaInst *l = cf.make_entry_alloca(llvm::Type::getInt8Ty(cf.llvm_context));
-
   auto merge_bb = llvm::BasicBlock::Create(cf.llvm_context, "as_data", cf.llvm_function);
+
   cf.llvm_ir_builder.SetInsertPoint(missing_block);
-  cf.llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(cf.llvm_context), 1), l);
   cf.llvm_ir_builder.CreateBr(merge_bb);
 
   cf.llvm_ir_builder.SetInsertPoint(present_block);
-  cf.llvm_ir_builder.CreateStore(llvm::ConstantInt::get(llvm::Type::getInt8Ty(cf.llvm_context), 0), l);
   cf.llvm_ir_builder.CreateBr(merge_bb);
 
   cf.llvm_ir_builder.SetInsertPoint(merge_bb);
-  llvm::Value *m = cf.llvm_ir_builder.CreateLoad(l);
+  llvm::PHINode *phi_m = cf.llvm_ir_builder.CreatePHI(llvm::Type::getInt8Ty(cf.llvm_context), 2);
+  phi_m->addIncoming(llvm::ConstantInt::get(llvm::Type::getInt8Ty(cf.llvm_context), 1),
+		     missing_block);
+  phi_m->addIncoming(llvm::ConstantInt::get(llvm::Type::getInt8Ty(cf.llvm_context), 0),
+		     present_block);
 
-  return EmitDataValue(m, svalue);
+  std::vector<llvm::Value *> llvm_values;
+  svalue->get_constituent_values(llvm_values);
+
+  std::vector<llvm::Value *> llvm_phi_values;
+  for (auto v : llvm_values) {
+    llvm::PHINode *phi = cf.llvm_ir_builder.CreatePHI(v->getType(), 2);
+    phi->addIncoming(llvm::UndefValue::get(v->getType()), missing_block);
+    phi->addIncoming(v, present_block);
+    llvm_phi_values.push_back(phi);
+  }
+
+  auto new_svalue = svalue->stype->from_llvm_values(llvm_phi_values, 0);
+
+  return EmitDataValue(phi_m, new_svalue);
 }
 
 }

--- a/libhail/src/hail/query/backend/svalue.cpp
+++ b/libhail/src/hail/query/backend/svalue.cpp
@@ -88,7 +88,7 @@ SCanonicalTupleValue::get_element(CompileFunction &cf, size_t i) const {
     cf.llvm_ir_builder.CreateGEP(address,
 				 llvm::ConstantInt::get(cf.llvm_context,
 							llvm::APInt(64, st->element_offsets[i])));
-  const SValue *sv = st->element_stypes[i].stype->load_from_address(cf, element_address);
+  const SValue *sv = st->element_types[i].stype->load_from_address(cf, element_address);
 
   return EmitValue(missing_bb, sv);
 }

--- a/libhail/src/hail/query/backend/svalue.cpp
+++ b/libhail/src/hail/query/backend/svalue.cpp
@@ -37,41 +37,48 @@ SValue::get_constituent_values(std::vector<llvm::Value *> &llvm_values) const {
   }
 }
 
+const SValue *
+SValue::cast_to(CompileFunction &cf, const SType *desired_type) const {
+  if (desired_type == stype)
+    return this;
+
+  return desired_type->construct_from_value(cf, this);
+}
+
 SBoolValue::SBoolValue(const SType *stype, llvm::Value *value)
-  : SValue(self_tag, stype), value(value) {}
+  : SValue(Tag::BOOL, stype), value(value) {}
 
 
 SInt32Value::SInt32Value(const SType *stype, llvm::Value *value)
-  : SValue(self_tag, stype), value(value) {}
+  : SValue(Tag::INT32, stype), value(value) {}
 
 SInt64Value::SInt64Value(const SType *stype, llvm::Value *value)
-  : SValue(self_tag, stype), value(value) {}
+  : SValue(Tag::INT64, stype), value(value) {}
 
 SFloat32Value::SFloat32Value(const SType *stype, llvm::Value *value)
-  : SValue(self_tag, stype), value(value) {}
+  : SValue(Tag::FLOAT32, stype), value(value) {}
 
 SFloat64Value::SFloat64Value(const SType *stype, llvm::Value *value)
-  : SValue(self_tag, stype), value(value) {}
+  : SValue(Tag::FLOAT64, stype), value(value) {}
 
 STupleValue::STupleValue(Tag tag, const SType *stype)
   : SValue(tag, stype) {}
 
 SCanonicalTupleValue::SCanonicalTupleValue(const SType *stype, llvm::Value *address)
-  : STupleValue(self_tag, stype), address(address) {}
+  : STupleValue(Tag::CANONICALTUPLE, stype), address(address) {}
 
 EmitValue
 SCanonicalTupleValue::get_element(CompileFunction &cf, size_t i) const {
   const SCanonicalTuple *st = cast<SCanonicalTuple>(stype);
 
-  auto missing_bb = llvm::BasicBlock::Create(cf.llvm_context, "gettupleelement_missing", cf.llvm_function);
   auto present_bb = llvm::BasicBlock::Create(cf.llvm_context, "gettupleelement_present", cf.llvm_function);
+  auto missing_bb = llvm::BasicBlock::Create(cf.llvm_context, "gettupleelement_missing", cf.llvm_function);
 
   llvm::Value *missing_address =
     cf.llvm_ir_builder.CreateGEP(address,
 				 llvm::ConstantInt::get(cf.llvm_context,
 							llvm::APInt(64, i >> 3)));
-  llvm::Value *mask = llvm::ConstantInt::get(cf.llvm_context,
-					     llvm::APInt(8, 1 << (i & 0x7)));
+  llvm::Value *mask = llvm::ConstantInt::get(cf.llvm_context, llvm::APInt(8, 1 << (i & 0x7)));
   llvm::Value *b = cf.llvm_ir_builder.CreateLoad(missing_address);
   llvm::Value *cond = cf.llvm_ir_builder.CreateICmpEQ(cf.llvm_ir_builder.CreateAnd(b, mask), mask);
   cf.llvm_ir_builder.CreateCondBr(cond, missing_bb, present_bb);
@@ -81,13 +88,13 @@ SCanonicalTupleValue::get_element(CompileFunction &cf, size_t i) const {
     cf.llvm_ir_builder.CreateGEP(address,
 				 llvm::ConstantInt::get(cf.llvm_context,
 							llvm::APInt(64, st->element_offsets[i])));
-  const SValue *sv = st->element_stypes[i]->load_from_address(cf, element_address);
+  const SValue *sv = st->element_stypes[i].stype->load_from_address(cf, element_address);
 
-  return EmitValue(present_bb, missing_bb, sv);
+  return EmitValue(missing_bb, sv);
 }
 
 SStackTupleValue::SStackTupleValue(const SType *stype, std::vector<EmitDataValue> element_emit_values)
-  : STupleValue(self_tag, stype), element_emit_values(std::move(element_emit_values)) {}
+  : STupleValue(Tag::STACKTUPLE, stype), element_emit_values(std::move(element_emit_values)) {}
 
 EmitValue
 SStackTupleValue::get_element(CompileFunction &cf, size_t i) const {
@@ -102,32 +109,44 @@ EmitDataValue::get_constituent_values(std::vector<llvm::Value *> &llvm_values) c
 
 EmitValue::EmitValue(llvm::Value *missing, const SValue *svalue)
   : missing(missing),
-    present_block(nullptr),
     missing_block(nullptr),
     svalue(svalue) {}
 
-EmitValue::EmitValue(llvm::BasicBlock *present_block, llvm::BasicBlock *missing_block, const SValue *svalue)
+EmitValue::EmitValue(llvm::BasicBlock *missing_block, const SValue *svalue)
   : missing(nullptr),
-    present_block(present_block),
     missing_block(missing_block),
     svalue(svalue) {}
 
 EmitValue::EmitValue(const EmitDataValue &data_value)
   : missing(data_value.missing),
-    present_block(nullptr),
     missing_block(nullptr),
     svalue(data_value.svalue) {}
 
 EmitValue:: EmitValue(const EmitControlValue &control_value)
   : missing(nullptr),
-    present_block(control_value.present_block),
     missing_block(control_value.missing_block),
     svalue(control_value.svalue) {}
 
+EmitType
+EmitDataValue::get_type() const {
+  return EmitType(svalue->stype);
+}
+
+EmitType
+EmitControlValue::get_type() const {
+  return EmitType(svalue->stype);
+}
+
+EmitType
+EmitValue::get_type() const {
+  return EmitType(svalue->stype);
+
+}
+
 EmitControlValue
 EmitValue::as_control(CompileFunction &cf) const {
-  if (!missing)
-    return EmitControlValue(present_block, missing_block, svalue);
+  if (missing_block)
+    return EmitControlValue(missing_block, svalue);
 
   auto present_bb = llvm::BasicBlock::Create(cf.llvm_context, "as_control_present", cf.llvm_function);
   auto missing_bb = llvm::BasicBlock::Create(cf.llvm_context, "as_control_missing", cf.llvm_function);
@@ -136,7 +155,9 @@ EmitValue::as_control(CompileFunction &cf) const {
   auto cond = cf.llvm_ir_builder.CreateICmpNE(missing, i8zero);
   cf.llvm_ir_builder.CreateCondBr(cond, missing_bb, present_bb);
 
-  return EmitControlValue(present_bb, missing_bb, svalue);
+  cf.llvm_ir_builder.SetInsertPoint(present_bb);
+
+  return EmitControlValue(missing_bb, svalue);
 }
 
 EmitDataValue
@@ -144,12 +165,12 @@ EmitValue::as_data(CompileFunction &cf) const {
   if (missing)
     return EmitDataValue(missing, svalue);
 
+  auto present_block = cf.llvm_ir_builder.GetInsertBlock();
   auto merge_bb = llvm::BasicBlock::Create(cf.llvm_context, "as_data", cf.llvm_function);
 
-  cf.llvm_ir_builder.SetInsertPoint(missing_block);
   cf.llvm_ir_builder.CreateBr(merge_bb);
 
-  cf.llvm_ir_builder.SetInsertPoint(present_block);
+  cf.llvm_ir_builder.SetInsertPoint(missing_block);
   cf.llvm_ir_builder.CreateBr(merge_bb);
 
   cf.llvm_ir_builder.SetInsertPoint(merge_bb);
@@ -173,6 +194,16 @@ EmitValue::as_data(CompileFunction &cf) const {
   auto new_svalue = svalue->stype->from_llvm_values(llvm_phi_values, 0);
 
   return EmitDataValue(phi_m, new_svalue);
+}
+
+EmitValue
+EmitValue::cast_to(CompileFunction &cf, EmitType desired_type) {
+  if (desired_type == get_type())
+    return *this;
+
+  auto c = as_control(cf);
+  auto casted_svalue = c.svalue->cast_to(cf, desired_type.stype);
+  return EmitControlValue(c.missing_block, casted_svalue);
 }
 
 }

--- a/libhail/src/hail/query/backend/svalue.hpp
+++ b/libhail/src/hail/query/backend/svalue.hpp
@@ -8,6 +8,8 @@ namespace hail {
 
 class CompileFunction;
 class SType;
+class EmitValue;
+class EmitDataValue;
 
 class SValue {
 public:
@@ -18,7 +20,8 @@ public:
     INT64,
     FLOAT32,
     FLOAT64,
-    CANONICALTUPLE
+    CANONICALTUPLE,
+    STACKTUPLE
   };
   const Tag tag;
   const SType *const stype;
@@ -78,6 +81,14 @@ public:
   EmitValue get_element(CompileFunction &cf, size_t i) const;
 };
 
+class SStackTupleValue : public STupleValue {
+public:
+  static const Tag self_tag = SValue::Tag::STACKTUPLE;
+  std::vector<EmitDataValue> element_emit_values;
+  SStackTupleValue(const SType *stype, std::vector<EmitDataValue> element_emit_values);
+  EmitValue get_element(CompileFunction &cf, size_t i) const;
+};
+
 class EmitControlValue {
 public:
   llvm::BasicBlock *present_block;
@@ -113,6 +124,8 @@ class EmitValue {
 public:
   EmitValue(llvm::Value *missing, const SValue *svalue);
   EmitValue(llvm::BasicBlock *present_block, llvm::BasicBlock *missing_block, const SValue *svalue);
+  EmitValue(const EmitDataValue &data_value);
+  EmitValue(const EmitControlValue &data_value);
 
   EmitControlValue as_control(CompileFunction &cf) const;
   EmitDataValue as_data(CompileFunction &cf) const;

--- a/libhail/src/hail/query/backend/svalue.hpp
+++ b/libhail/src/hail/query/backend/svalue.hpp
@@ -17,7 +17,8 @@ public:
     INT32,
     INT64,
     FLOAT32,
-    FLOAT64
+    FLOAT64,
+    CANONICALTUPLE
   };
   const Tag tag;
   const SType *const stype;
@@ -61,6 +62,20 @@ public:
   static const Tag self_tag = SValue::Tag::FLOAT64;
   llvm::Value *value;
   SFloat64Value(const SType *stype, llvm::Value *value);
+};
+
+class STupleValue : public SValue {
+public:
+  STupleValue(Tag tag, const SType *stype);
+  virtual EmitValue get_element(CompileFunction &cf, size_t i) const = 0;
+};
+
+class SCanonicalTupleValue : public STupleValue {
+public:
+  static const Tag self_tag = SValue::Tag::CANONICALTUPLE;
+  llvm::Value *address;
+  SCanonicalTupleValue(const SType *stype, llvm::Value *address);
+  EmitValue get_element(CompileFunction &cf, size_t i) const;
 };
 
 class EmitControlValue {

--- a/libhail/src/hail/query/backend/svalue.hpp
+++ b/libhail/src/hail/query/backend/svalue.hpp
@@ -30,52 +30,58 @@ public:
   virtual ~SValue();
 
   void get_constituent_values(std::vector<llvm::Value *> &llvm_values) const;
+
+  const SValue *cast_to(CompileFunction &cf, const SType *desired_type) const;
 };
 
 class SBoolValue : public SValue {
 public:
-  static const Tag self_tag = SValue::Tag::BOOL;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::BOOL; }
   llvm::Value *value;
   SBoolValue(const SType *stype, llvm::Value *value);
 };
 
 class SInt32Value : public SValue {
 public:
-  static const Tag self_tag = SValue::Tag::INT32;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::INT32; }
   llvm::Value *value;
   SInt32Value(const SType *stype, llvm::Value *value);
 };
 
 class SInt64Value : public SValue {
 public:
-  static const Tag self_tag = SValue::Tag::INT64;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::INT64; }
   llvm::Value *value;
   SInt64Value(const SType *stype, llvm::Value *value);
 };
 
 class SFloat32Value : public SValue {
 public:
-  static const Tag self_tag = SValue::Tag::FLOAT32;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::FLOAT32; }
   llvm::Value *value;
   SFloat32Value(const SType *stype, llvm::Value *value);
 };
 
 class SFloat64Value : public SValue {
 public:
-  static const Tag self_tag = SValue::Tag::FLOAT64;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::FLOAT64; }
   llvm::Value *value;
   SFloat64Value(const SType *stype, llvm::Value *value);
 };
 
 class STupleValue : public SValue {
 public:
+  static bool is_instance_tag(Tag tag) {
+    return (SValue::Tag::CANONICALTUPLE <= tag &&
+	    tag <= SValue::Tag::STACKTUPLE);
+  }
   STupleValue(Tag tag, const SType *stype);
   virtual EmitValue get_element(CompileFunction &cf, size_t i) const = 0;
 };
 
 class SCanonicalTupleValue : public STupleValue {
 public:
-  static const Tag self_tag = SValue::Tag::CANONICALTUPLE;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::CANONICALTUPLE; }
   llvm::Value *address;
   SCanonicalTupleValue(const SType *stype, llvm::Value *address);
   EmitValue get_element(CompileFunction &cf, size_t i) const;
@@ -83,7 +89,7 @@ public:
 
 class SStackTupleValue : public STupleValue {
 public:
-  static const Tag self_tag = SValue::Tag::STACKTUPLE;
+  static bool is_instance_tag(Tag tag) { return tag == SValue::Tag::STACKTUPLE; }
   std::vector<EmitDataValue> element_emit_values;
   SStackTupleValue(const SType *stype, std::vector<EmitDataValue> element_emit_values);
   EmitValue get_element(CompileFunction &cf, size_t i) const;
@@ -91,16 +97,15 @@ public:
 
 class EmitControlValue {
 public:
-  llvm::BasicBlock *present_block;
   llvm::BasicBlock *missing_block;
   const SValue *svalue;
 
-  EmitControlValue(llvm::BasicBlock *present_block,
-		   llvm::BasicBlock *missing_block,
+  EmitControlValue(llvm::BasicBlock *missing_block,
 		   const SValue *svalue)
-    : present_block(present_block),
-      missing_block(missing_block),
+    : missing_block(missing_block),
       svalue(svalue) {}
+
+  EmitType get_type() const;
 };
 
 class EmitDataValue {
@@ -113,22 +118,27 @@ public:
     : missing(missing),
       svalue(svalue) {}
 
+  EmitType get_type() const;
+
   void get_constituent_values(std::vector<llvm::Value *> &llvm_values) const;
 };
 
 class EmitValue {
   llvm::Value *missing;
-  llvm::BasicBlock *present_block;
   llvm::BasicBlock *missing_block;
   const SValue *svalue;
 public:
   EmitValue(llvm::Value *missing, const SValue *svalue);
-  EmitValue(llvm::BasicBlock *present_block, llvm::BasicBlock *missing_block, const SValue *svalue);
+  EmitValue(llvm::BasicBlock *missing_block, const SValue *svalue);
   EmitValue(const EmitDataValue &data_value);
   EmitValue(const EmitControlValue &data_value);
 
+  EmitType get_type() const;
+
   EmitControlValue as_control(CompileFunction &cf) const;
   EmitDataValue as_data(CompileFunction &cf) const;
+
+  EmitValue cast_to(CompileFunction &cf, EmitType desired_type);
 };
 
 }

--- a/libhail/src/hail/query/ir.cpp
+++ b/libhail/src/hail/query/ir.cpp
@@ -110,6 +110,27 @@ Function::pretty_self(FormatStream &s, int indent) {
   format(s, "\n");
 }
 
+const std::vector<std::string> IR::tag_name = {
+  "block",
+  "input",
+  "literal",
+  "na",
+  "isna",
+  "mux",
+  "unary",
+  "binary",
+  "makearray",
+  "arraylen",
+  "arrayref",
+  "maketuple",
+  "gettupleelement",
+  "tostream",
+  "streammap",
+  "streamflatmap",
+  "streamfilter",
+  "streamfold"
+};
+
 IR::IR(Tag tag, Block *parent, size_t arity)
   : tag(tag), parent(parent), children(arity) {}
 
@@ -143,7 +164,7 @@ IR::set_child(size_t i, IR *x) {
 
 void
 IR::pretty_self(FormatStream &s, int indent) {
-  format(s, FormatAddress(this), Indent(indent), "???");
+  format(s, FormatAddress(this), Indent(indent), "(", tag_name[static_cast<int>(tag)], " ...)");
 }
 
 void
@@ -211,6 +232,11 @@ Block::make_is_na(IR *x) {
 Mux *
 Block::make_mux(IR *x, IR *true_value, IR *false_value) {
   return xc.arena.make<Mux>(IRContextToken(), this, x, true_value, false_value);
+}
+
+GetTupleElement *
+Block::make_get_tuple_element(IR *t, int i) {
+  return xc.arena.make<GetTupleElement>(IRContextToken(), this, t, i);
 }
 
 }

--- a/libhail/src/hail/query/ir.cpp
+++ b/libhail/src/hail/query/ir.cpp
@@ -178,13 +178,13 @@ pretty(FormatStream &s, IR *x, int indent) {
 }
 
 Block::Block(IRContextToken, IRContext &xc, Function *function_parent, Block *parent, std::vector<IR *> children, size_t input_arity)
-  : IR(self_tag, parent, std::move(children)),
+  : IR(Tag::BLOCK, parent, std::move(children)),
     xc(xc),
     function_parent(function_parent),
     inputs(input_arity) {}
 
 Block::Block(IRContextToken, IRContext &xc, Function *function_parent, Block *parent, size_t arity, size_t input_arity)
-  : IR(self_tag, parent, arity),
+  : IR(Tag::BLOCK, parent, arity),
     xc(xc),
     function_parent(function_parent),
     inputs(input_arity) {}

--- a/libhail/src/hail/query/ir.cpp
+++ b/libhail/src/hail/query/ir.cpp
@@ -234,6 +234,11 @@ Block::make_mux(IR *x, IR *true_value, IR *false_value) {
   return xc.arena.make<Mux>(IRContextToken(), this, x, true_value, false_value);
 }
 
+MakeTuple *
+Block::make_tuple(std::vector<IR *> elements) {
+  return xc.arena.make<MakeTuple>(IRContextToken(), this, std::move(elements));
+}
+
 GetTupleElement *
 Block::make_get_tuple_element(IR *t, int i) {
   return xc.arena.make<GetTupleElement>(IRContextToken(), this, t, i);

--- a/libhail/src/hail/query/ir.hpp
+++ b/libhail/src/hail/query/ir.hpp
@@ -186,7 +186,7 @@ public:
   MakeArray *make_make_array(std::vector<IR *> elements);
   MakeArray *make_make_array(const Type *element_type, std::vector<IR *> children);
   ArrayLen *make_array_len(IR *a, IR *x);
-  MakeTuple *make_make_tuple(std::vector<IR *> elements);
+  MakeTuple *make_tuple(std::vector<IR *> elements);
   GetTupleElement *make_get_tuple_element(IR *t, int i);
 };
 
@@ -263,6 +263,7 @@ IR::dispatch(F f) {
   case IR::Tag::LITERAL: return f(cast<Literal>(this));
   case IR::Tag::NA: return f(cast<NA>(this));
   case IR::Tag::ISNA: return f(cast<IsNA>(this));
+  case IR::Tag::MAKETUPLE: return f(cast<MakeTuple>(this));
   case IR::Tag::GETTUPLEELEMENT: return f(cast<GetTupleElement>(this));
   default:
     abort();

--- a/libhail/src/hail/query/ir.hpp
+++ b/libhail/src/hail/query/ir.hpp
@@ -125,6 +125,7 @@ public:
     STREAMFOLD
   };
   const Tag tag;
+  static const std::vector<std::string> tag_name;
 private:
   Block *parent;
   std::vector<IR *> children;
@@ -262,6 +263,7 @@ IR::dispatch(F f) {
   case IR::Tag::LITERAL: return f(cast<Literal>(this));
   case IR::Tag::NA: return f(cast<NA>(this));
   case IR::Tag::ISNA: return f(cast<IsNA>(this));
+  case IR::Tag::GETTUPLEELEMENT: return f(cast<GetTupleElement>(this));
   default:
     abort();
   }

--- a/libhail/src/hail/query/ir.hpp
+++ b/libhail/src/hail/query/ir.hpp
@@ -162,7 +162,7 @@ class Block : public IR {
   Function *function_parent;
   std::unordered_set<IR *> nodes;
 public:
-  static const Tag self_tag = IR::Tag::BLOCK;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::BLOCK; }
   std::vector<Input *> inputs;
   Block(IRContextToken, IRContext &xc, Function *function_parent, Block *parent, std::vector<IR *> children, size_t input_arity);
   Block(IRContextToken, IRContext &xc, Function *function_parent, Block *parent, size_t arity, size_t input_arity);
@@ -192,67 +192,67 @@ public:
 
 class Input : public IR {
 public:
-  static const Tag self_tag = IR::Tag::INPUT;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::INPUT; }
   size_t index;
-  Input(IRContextToken, Block *parent, size_t index) : IR(self_tag, parent, 0), index(index) {}
+  Input(IRContextToken, Block *parent, size_t index) : IR(Tag::INPUT, parent, 0), index(index) {}
 };
 
 class Literal : public IR {
 public:
-  static const Tag self_tag = IR::Tag::LITERAL;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::LITERAL; }
   Value value;
-  Literal(IRContextToken, Block *parent, Value value) : IR(self_tag, parent, 0), value(std::move(value)) {}
+  Literal(IRContextToken, Block *parent, Value value) : IR(Tag::LITERAL, parent, 0), value(std::move(value)) {}
 };
 
 class NA : public IR {
 public:
-  static const Tag self_tag = IR::Tag::NA;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::NA; }
   const Type *type;
-  NA(IRContextToken, Block *parent, const Type *type) : IR(self_tag, parent, 0), type(type) {}
+  NA(IRContextToken, Block *parent, const Type *type) : IR(Tag::NA, parent, 0), type(type) {}
 };
 
 class Mux : public IR {
 public:
-  static const Tag self_tag = IR::Tag::MUX;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::MUX; }
   Mux(IRContextToken, Block *parent, IR *condition, IR *true_value, IR *false_value)
-    : IR(self_tag, parent, {condition, true_value, false_value}) {}
+    : IR(Tag::MUX, parent, {condition, true_value, false_value}) {}
 };
 
 class IsNA : public IR {
 public:
-  static const Tag self_tag = IR::Tag::ISNA;
-  IsNA(IRContextToken, Block *parent, IR *x) : IR(self_tag, parent, {x}) {}
+  static bool is_instance_tag(Tag tag) { return tag == Tag::ISNA; }
+  IsNA(IRContextToken, Block *parent, IR *x) : IR(Tag::ISNA, parent, {x}) {}
 };
 
 class MakeArray : public IR {
 public:
-  static const Tag self_tag = IR::Tag::MAKEARRAY;
-  MakeArray(IRContextToken, Block *parent, std::vector<IR *> elements) : IR(self_tag, parent, std::move(elements)) {}
+  static bool is_instance_tag(Tag tag) { return tag == Tag::MAKEARRAY; }
+  MakeArray(IRContextToken, Block *parent, std::vector<IR *> elements) : IR(Tag::MAKEARRAY, parent, std::move(elements)) {}
 };
 
 class ArrayLen : public IR {
 public:
-  static const Tag self_tag = IR::Tag::ARRAYLEN;
-  ArrayLen(IRContextToken, Block *parent, IR *a) : IR(self_tag, parent, {a}) {}
+  static bool is_instance_tag(Tag tag) { return tag == Tag::ARRAYLEN; }
+  ArrayLen(IRContextToken, Block *parent, IR *a) : IR(Tag::ARRAYLEN, parent, {a}) {}
 };
 
 class ArrayRef : public IR {
 public:
-  static const Tag self_tag = IR::Tag::ARRAYREF;
-  ArrayRef(IRContextToken, Block *parent, IR *a, IR *x) : IR(self_tag, parent, {a, x}) {}
+  static bool is_instance_tag(Tag tag) { return tag == Tag::ARRAYREF; }
+  ArrayRef(IRContextToken, Block *parent, IR *a, IR *x) : IR(Tag::ARRAYREF, parent, {a, x}) {}
 };
 
 class MakeTuple : public IR {
 public:
-  static const Tag self_tag = IR::Tag::MAKETUPLE;
-  MakeTuple(IRContextToken, Block *parent, std::vector<IR *> elements) : IR(self_tag, parent, std::move(elements)) {}
+  static bool is_instance_tag(Tag tag) { return tag == Tag::MAKETUPLE; }
+  MakeTuple(IRContextToken, Block *parent, std::vector<IR *> elements) : IR(Tag::MAKETUPLE, parent, std::move(elements)) {}
 };
 
 class GetTupleElement : public IR {
 public:
-  static const Tag self_tag = IR::Tag::GETTUPLEELEMENT;
+  static bool is_instance_tag(Tag tag) { return tag == Tag::GETTUPLEELEMENT; }
   size_t index;
-  GetTupleElement(IRContextToken, Block *parent, IR *t, size_t index) : IR(self_tag, parent, {t}), index(index) {}
+  GetTupleElement(IRContextToken, Block *parent, IR *t, size_t index) : IR(Tag::GETTUPLEELEMENT, parent, {t}), index(index) {}
 };
 
 template<typename F> auto

--- a/libhail/src/hail/query/ir_type.cpp
+++ b/libhail/src/hail/query/ir_type.cpp
@@ -44,6 +44,11 @@ IRType::infer(IsNA *x) {
 }
 
 const Type *
+IRType::infer(GetTupleElement *x) {
+  return cast<TTuple>(infer(x->get_child(0)))->element_types[x->index];
+}
+
+const Type *
 IRType::infer(IR *x) {
   auto p = ir_type.insert({x, nullptr});
   if (!p.second)

--- a/libhail/src/hail/query/ir_type.cpp
+++ b/libhail/src/hail/query/ir_type.cpp
@@ -44,6 +44,14 @@ IRType::infer(IsNA *x) {
 }
 
 const Type *
+IRType::infer(MakeTuple *x) {
+  std::vector<const Type *> element_types;
+  for (auto c : x->get_children())
+    element_types.push_back(infer(c));
+  return tc.ttuple(element_types);
+}
+
+const Type *
 IRType::infer(GetTupleElement *x) {
   return cast<TTuple>(infer(x->get_child(0)))->element_types[x->index];
 }

--- a/libhail/src/hail/query/ir_type.hpp
+++ b/libhail/src/hail/query/ir_type.hpp
@@ -23,6 +23,7 @@ class IRType {
   const Type *infer(Literal *x);
   const Type *infer(NA *x);
   const Type *infer(IsNA *x);
+  const Type *infer(MakeTuple *x);
   const Type *infer(GetTupleElement *x);
   const Type *infer(IR *x);
 

--- a/libhail/src/hail/query/ir_type.hpp
+++ b/libhail/src/hail/query/ir_type.hpp
@@ -23,6 +23,7 @@ class IRType {
   const Type *infer(Literal *x);
   const Type *infer(NA *x);
   const Type *infer(IsNA *x);
+  const Type *infer(GetTupleElement *x);
   const Type *infer(IR *x);
 
 public:

--- a/libhail/src/hail/runtime/runtime.cpp
+++ b/libhail/src/hail/runtime/runtime.cpp
@@ -1,0 +1,10 @@
+#include <hail/allocators.hpp>
+#include <hail/runtime/runtime.hpp>
+
+using namespace hail;
+
+char *
+hl_runtime_region_allocate(char *region, size_t align, size_t size) {
+  RawArenaAllocator &raw_arena = *reinterpret_cast<RawArenaAllocator *>(region);
+  return (char *)raw_arena.allocate(align, size);
+}

--- a/libhail/src/hail/runtime/runtime.hpp
+++ b/libhail/src/hail/runtime/runtime.hpp
@@ -1,0 +1,10 @@
+#ifndef HAIL_RUNTIME_RUNTIME_HPP_INCLUDED
+#define HAIL_RUNTIME_RUNTIME_HPP_INCLUDED 1
+
+extern "C" {
+
+char *hl_runtime_region_allocate(char *region, size_t align, size_t size);
+
+}
+
+#endif

--- a/libhail/src/hail/tunion.hpp
+++ b/libhail/src/hail/tunion.hpp
@@ -7,7 +7,7 @@ namespace hail {
 
 template<class T> bool
 isa(const typename T::BaseType *p) {
-  return p->tag == T::self_tag;
+  return T::is_instance_tag(p->tag);
 }
 
 template<class T> T *

--- a/libhail/src/hail/type.cpp
+++ b/libhail/src/hail/type.cpp
@@ -9,7 +9,7 @@ namespace hail {
 Type::~Type() {}
 
 TBlock::TBlock(TypeContextToken, std::vector<const Type *> input_types, std::vector<const Type *> output_types)
-  : Type(self_tag),
+  : Type(Type::Tag::BLOCK),
     input_types(std::move(input_types)),
     output_types(std::move(output_types)) {}
 

--- a/libhail/src/hail/type.hpp
+++ b/libhail/src/hail/type.hpp
@@ -45,7 +45,7 @@ void format1(FormatStream &s, const Type *v);
 
 class TBlock : public Type {
 public:
-  static const Tag self_tag = Type::Tag::BLOCK;
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::BLOCK; }
   std::vector<const Type *> input_types;
   std::vector<const Type *> output_types;
   TBlock(TypeContextToken,
@@ -55,65 +55,65 @@ public:
 
 class TVoid : public Type {
 public:
-  static const Tag self_tag = Type::Tag::VOID;
-  TVoid(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::VOID; }
+  TVoid(TypeContextToken) : Type(Type::Tag::VOID) {}
 };
 
 class TBool : public Type {
 public:
-  static const Tag self_tag = Type::Tag::BOOL;
-  TBool(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::BOOL; }
+  TBool(TypeContextToken) : Type(Type::Tag::BOOL) {}
 };
 
 class TInt32 : public Type {
 public:
-  static const Tag self_tag = Type::Tag::INT32;
-  TInt32(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::INT32; }
+  TInt32(TypeContextToken) : Type(Type::Tag::INT32) {}
 };
 
 class TInt64 : public Type {
 public:
-  static const Tag self_tag = Type::Tag::INT64;
-  TInt64(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::INT64; }
+  TInt64(TypeContextToken) : Type(Type::Tag::INT64) {}
 };
 
 class TFloat32 : public Type {
 public:
-  static const Tag self_tag = Type::Tag::FLOAT32;
-  TFloat32(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::FLOAT32; }
+  TFloat32(TypeContextToken) : Type(Type::Tag::FLOAT32) {}
 };
 
 class TFloat64 : public Type {
 public:
-  static const Tag self_tag = Type::Tag::FLOAT64;
-  TFloat64(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::FLOAT64; }
+  TFloat64(TypeContextToken) : Type(Type::Tag::FLOAT64) {}
 };
 
 class TStr : public Type {
 public:
-  static const Tag self_tag = Type::Tag::STR;
-  TStr(TypeContextToken) : Type(self_tag) {}
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::STR; }
+  TStr(TypeContextToken) : Type(Type::Tag::STR) {}
 };
 
 class TArray : public Type {
 public:
-  static const Tag self_tag = Type::Tag::ARRAY;
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::ARRAY; }
   const Type *const element_type;
-  TArray(TypeContextToken, const Type *element_type) : Type(self_tag), element_type(element_type) {}
+  TArray(TypeContextToken, const Type *element_type) : Type(Type::Tag::ARRAY), element_type(element_type) {}
 };
 
 class TStream : public Type {
 public:
-  static const Tag self_tag = Type::Tag::STREAM;
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::STREAM; }
   const Type *const element_type;
-  TStream(TypeContextToken, const Type *element_type) : Type(self_tag), element_type(element_type) {}
+  TStream(TypeContextToken, const Type *element_type) : Type(Type::Tag::STREAM), element_type(element_type) {}
 };
 
 class TTuple : public Type {
 public:
-  static const Tag self_tag = Type::Tag::TUPLE;
+  static bool is_instance_tag(Tag tag) { return tag == Type::Tag::TUPLE; }
   const std::vector<const Type *> element_types;
-  TTuple(TypeContextToken, std::vector<const Type *> element_types) : Type(self_tag), element_types(std::move(element_types)) {}
+  TTuple(TypeContextToken, std::vector<const Type *> element_types) : Type(Type::Tag::TUPLE), element_types(std::move(element_types)) {}
 };
 
 class TypeContext {

--- a/libhail/src/hail/value.hpp
+++ b/libhail/src/hail/value.hpp
@@ -355,8 +355,10 @@ TupleValue::get_element(size_t i) const {
 
 void
 TupleValue::set_element(size_t i, const Value &new_element) const {
-  set_element_missing(i, 0);
-  Value::store(p + vtype->element_offsets[i], new_element);
+  auto missing = new_element.get_missing();
+  set_element_missing(i, missing);
+  if (!missing)
+    Value::store(p + vtype->element_offsets[i], new_element);
 }
 
 void format1(FormatStream &s, const Value &value);

--- a/libhail/src/hail/value.hpp
+++ b/libhail/src/hail/value.hpp
@@ -347,11 +347,15 @@ TupleValue::operator Value() const {
 
 Value
 TupleValue::get_element(size_t i) const {
-  return Value::load(vtype->element_vtypes[i], region, p + vtype->element_offsets[i]);
+  if (get_element_missing(i))
+    return Value(vtype->element_vtypes[i]);
+  else
+    return Value::load(vtype->element_vtypes[i], region, p + vtype->element_offsets[i]);
 }
 
 void
 TupleValue::set_element(size_t i, const Value &new_element) const {
+  set_element_missing(i, 0);
   Value::store(p + vtype->element_offsets[i], new_element);
 }
 

--- a/libhail/src/hail/vtype.hpp
+++ b/libhail/src/hail/vtype.hpp
@@ -43,48 +43,48 @@ public:
 
 class VBool : public VType {
 public:
-  static const Tag self_tag = VType::Tag::BOOL;
-  VBool(TypeContextToken, const TBool *type) : VType(self_tag, type, 1, 1) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::BOOL; }
+  VBool(TypeContextToken, const TBool *type) : VType(VType::Tag::BOOL, type, 1, 1) {}
 };
 
 class VInt32 : public VType {
 public:
-  static const Tag self_tag = VType::Tag::INT32;
-  VInt32(TypeContextToken, const TInt32 *type) : VType(self_tag, type, 4, 4) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::INT32; }
+  VInt32(TypeContextToken, const TInt32 *type) : VType(VType::Tag::INT32, type, 4, 4) {}
 };
 
 class VInt64 : public VType {
 public:
-  static const Tag self_tag = VType::Tag::INT64;
-  VInt64(TypeContextToken, const TInt64 *type) : VType(self_tag, type, 8, 8) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::INT64; }
+  VInt64(TypeContextToken, const TInt64 *type) : VType(VType::Tag::INT64, type, 8, 8) {}
 };
 
 class VFloat32 : public VType {
 public:
-  static const Tag self_tag = VType::Tag::FLOAT32;
-  VFloat32(TypeContextToken, const TFloat32 *type) : VType(self_tag, type, 4, 4) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::FLOAT32; }
+  VFloat32(TypeContextToken, const TFloat32 *type) : VType(VType::Tag::FLOAT32, type, 4, 4) {}
 };
 
 class VFloat64 : public VType {
 public:
-  static const Tag self_tag = VType::Tag::FLOAT64;
-  VFloat64(TypeContextToken, const TFloat64 *type) : VType(self_tag, type, 8, 8) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::FLOAT64; }
+  VFloat64(TypeContextToken, const TFloat64 *type) : VType(VType::Tag::FLOAT64, type, 8, 8) {}
 };
 
 class VStr : public VType {
 public:
-  static const Tag self_tag = VType::Tag::STR;
-  VStr(TypeContextToken, const TStr *type) : VType(self_tag, type, 8, 8) {}
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::STR; }
+  VStr(TypeContextToken, const TStr *type) : VType(VType::Tag::STR, type, 8, 8) {}
 };
 
 class VArray : public VType {
 public:
-  static const Tag self_tag = VType::Tag::ARRAY;
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::ARRAY; }
   const VType *const element_vtype;
   size_t elements_alignment;
   size_t element_stride;
   VArray(TypeContextToken, const TArray *type, const VType *element_vtype)
-    : VType(self_tag, type, 8, 8),
+    : VType(VType::Tag::ARRAY, type, 8, 8),
       element_vtype(element_vtype),
       elements_alignment(make_aligned(element_vtype->byte_size, element_vtype->alignment)),
       element_stride(make_aligned(element_vtype->byte_size, element_vtype->alignment)) {}
@@ -93,7 +93,7 @@ public:
 class VTuple : public VType {
   friend class TypeContext;
 public:
-  static const Tag self_tag = VType::Tag::TUPLE;
+  static bool is_instance_tag(Tag tag) { return tag == VType::Tag::TUPLE; }
   const std::vector<const VType *> element_vtypes;
   const std::vector<size_t> element_offsets;
   VTuple(TypeContextToken,
@@ -102,7 +102,7 @@ public:
 	 std::vector<size_t> element_offsets,
 	 size_t alignment,
 	 size_t byte_size)
-    : VType(self_tag, type, alignment, byte_size),
+    : VType(VType::Tag::TUPLE, type, alignment, byte_size),
       element_vtypes(element_vtypes),
       element_offsets(element_offsets) {}
 };


### PR DESCRIPTION
And lots of other things along the way.  Summary of changes:
 - Add RawArenaAllocator
 - Add runtime to call arena allocate from generated code
 - Support MakeTuple, GetTupleElement
 - Intern STypes, add STypeContext
 - Add EmitValue.cast_to, SType.{load_from_address, construct_from_value, construct_at_address_from_value}
 - Add SType.get_memory_size, only works for types for which is_heap_stype<T>() is true
 - Use phi nodes to implement EmitValue.as_data()
 - isa now calls T::is_instance_tag rather than checking tag directly