### PR TITLE
[auth] add more options for obtaining session id for dev credentials

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,7 +8,6 @@ import uvloop
 import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
-from hailtop.auth import async_get_userinfo
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -526,18 +526,7 @@ async def rest_logout(request, userdata):
     return web.Response(status=200)
 
 
-@routes.get('/api/v1alpha/userinfo')
-async def userinfo(request):
-    if 'Authorization' not in request.headers:
-        log.info('Authorization not in request.headers')
-        raise web.HTTPUnauthorized()
-
-    auth_header = request.headers['Authorization']
-    session_id = maybe_parse_bearer_header(auth_header)
-    if not session_id:
-        log.info('Bearer not in Authorization header')
-        raise web.HTTPUnauthorized()
-
+async def get_userinfo(request, session_id):
     # b64 encoding of 32-byte session ID is 44 bytes
     if len(session_id) != 44:
         log.info('Session id != 44 bytes')
@@ -554,9 +543,22 @@ WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions
     if len(users) != 1:
         log.info(f'Unknown session id: {session_id}')
         raise web.HTTPUnauthorized()
-    user = users[0]
+    return users[0]
 
-    return web.json_response(user)
+
+@routes.get('/api/v1alpha/userinfo')
+async def userinfo(request):
+    if 'Authorization' not in request.headers:
+        log.info('Authorization not in request.headers')
+        raise web.HTTPUnauthorized()
+
+    auth_header = request.headers['Authorization']
+    session_id = maybe_parse_bearer_header(auth_header)
+    if not session_id:
+        log.info('Bearer not in Authorization header')
+        raise web.HTTPUnauthorized()
+
+    return web.json_response(await get_userinfo(request, session_id))
 
 
 async def get_session_id(request):
@@ -575,7 +577,7 @@ async def verify_dev_credentials(request):
     session_id = await get_session_id(request)
     if not session_id:
         raise web.HTTPUnauthorized()
-    userdata = await async_get_userinfo(session_id=session_id)
+    userdata = await get_userinfo(request, session_id)
     is_developer = userdata is not None and userdata['is_developer'] == 1
     if not is_developer:
         raise web.HTTPUnauthorized()


### PR DESCRIPTION
This is a preparatory PR for getting rid of router-resolver. Currently, the major role of router-resolver is:
- Find the user session in a request
- Make a call to default auth to verify the session and retrieve userdata
- If the user is a developer, return the router IP in the given namespace (given as input to router-resolver)

The code for this is [here](https://github.com/hail-is/hail/blob/466f3c32c7fed972dc9bf45834669fdff038224c/router-resolver/router_resolver/router_resolver.py#L24-L66).

This whole process can just be replaced by an auth endpoint that returns whether or not a request is coming in from a valid developer (we can rely on kubernetes services to find IP addresses on any of our deployments). This moves over the finding of the user session in router-resolver to make an auth endpoint that can replace router-resolver. I created this auth endpoint in #10139 with this ultimate goal in mind but did not incorporate the other places we store sessions.

EDIT: Second commit fixes a silly mistake that `verify_dev_credentials` makes a whole separate network call to the `userinfo` endpoint, when they should really just both use the same helper function. The semantics of both endpoints should remain unchanged.