### PR TITLE
[gateway] Cut out router and router-resolver from gateway internal routing

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -35,7 +35,7 @@ server {
         auth_request /auth;
 
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass https://router.$namespace.svc.cluster.local;
+        proxy_pass https://$service.$namespace.svc.cluster.local;
 
         proxy_set_header Host $service.internal;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -17,11 +17,6 @@ server {
     }
 }
 
-map $maybe_router_scheme $router_scheme {
-    default $maybe_router_scheme;
-    ''      http;
-}
-
 server {
     server_name internal.hail.is;
     client_max_body_size 8m;
@@ -29,7 +24,7 @@ server {
     location = /auth {
         internal;
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass https://router-resolver.default.svc.cluster.local/auth/$namespace;
+        proxy_pass https://auth/api/v1alpha/verify_dev_credentials;
         include /ssl-config/ssl-config-proxy.conf;
     }
 
@@ -38,10 +33,9 @@ server {
         set $service $2;
 
         auth_request /auth;
-        auth_request_set $router_ip $upstream_http_x_router_ip;
-        auth_request_set $maybe_router_scheme $upstream_http_x_router_scheme;
 
-        proxy_pass $router_scheme://$router_ip$request_uri;
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass https://router.$namespace.svc.cluster.local;
 
         proxy_set_header Host $service.internal;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This PR only impacts `internal.hail.is`.

The current internal flow is:
1. gateway receives request for `internal.hail.is/$namespace/$service`
2. `auth_request` to router-resolver for auth & router ip, and in router-resolver
  a. request to auth that the user is a signed in developer
  b. retrieve router ip from k8s
3. `proxy_pass` to router IP returned from router-resolver in $namespace which proxies to $service in $namespace

This changes the flow to:
1. gateway receives request for `internal.hail.is/$namespace/$service`
2. request to auth that the user is a signed in developer
3. `proxy_pass` to $service in $namespace

This does impose the restriction that there is an equivalence between subdomains and k8s Services. For the most part we enforce this just by convention, with the exception of `www` -> `website`. `router` currently does this mapping and is the only capability that this version drops. However, `www` in internal is already broken, I think because `website` does not consider `www` as potentially part of its base path, so that might need to be considered on its own. Aside from the `base_path` problem, I think it would make sense to create alias k8s Services like we do with notebook/workshop.