### PR TITLE
[k8s] never delete a secret

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -289,14 +289,18 @@ steps:
      cat > deploy-config.json <<EOF
      {"location":"k8s","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
      EOF
-     kubectl -n {{ default_ns.name }} delete --ignore-not-found secret deploy-config
-     kubectl -n {{ default_ns.name }} create secret generic deploy-config --from-file=./deploy-config.json
+     kubectl -n {{ default_ns.name }} create secret generic deploy-config \
+             --from-file=./deploy-config.json \
+             --save-config --dry-run=client -o yaml \
+         | kubectl -n {{ default_ns.name }} apply -f -
      # gce deploy config
      cat > deploy-config.json <<EOF
      {"location":"gce","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
      EOF
-     kubectl -n {{ default_ns.name }} delete --ignore-not-found secret gce-deploy-config
-     kubectl -n {{ default_ns.name }} create secret generic gce-deploy-config --from-file=./deploy-config.json
+     kubectl -n {{ default_ns.name }} create secret generic gce-deploy-config \
+             --from-file=./deploy-config.json \
+             --save-config --dry-run=client -o yaml \
+         | kubectl -n {{ default_ns.name }} apply -f -
    serviceAccount:
      name: admin
      namespace:

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -39,11 +39,10 @@ async def write_user_config(namespace: str, database_name: str, user: str, confi
     from_files = ' '.join(f'--from-file={f}' for f in files)
     await check_shell(
         f'''
-kubectl -n {shq(namespace)} delete --ignore-not-found=true secret {shq(secret_name)}
 kubectl -n {shq(namespace)} create secret generic \
         {shq(secret_name)} \
         {from_files} \
-        --dry-run=true \
+        --save-config --dry-run=client \
         -o yaml \
         | kubectl -n {shq(namespace)} apply -f -
 '''

--- a/dev-docs/tls-cookbook.md
+++ b/dev-docs/tls-cookbook.md
@@ -112,7 +112,9 @@ kubectl create secret generic \
         -n default ssl-config-hail-root \
         --from-file=hail-root-key.pem \
         --from-file=hail-root-cert.pem \
-        --dry-run -o yaml \
+        --save-config \
+        --dry-run=client \
+        -o yaml \
     | kubectl apply -f -
 ```
 

--- a/devbin/functions.sh
+++ b/devbin/functions.sh
@@ -168,6 +168,6 @@ upload-secret() {
     # upload to a different namespace, ensure you've also modified secret.json.
 	  name=$(jq -r '.metadata.name' secret.json)
 	  namespace=$(jq -r '.metadata.namespace' secret.json)
-	  kubectl create secret generic $name --namespace $namespace $(for i in $(ls contents); do echo "--from-file=contents/$i" ; done) --dry-run -o yaml \
+	  kubectl create secret generic $name --namespace $namespace $(for i in $(ls contents); do echo "--from-file=contents/$i" ; done) --save-config --dry-run=client -o yaml \
 	      | kubectl apply -f -
 }

--- a/tls/create_certs.py
+++ b/tls/create_certs.py
@@ -178,7 +178,7 @@ def create_principal(principal, domain, kind, key, cert, key_store, unmanaged):
              f'--from-file={outgoing_trust["trust"]}',
              f'--from-file={outgoing_trust["trust_store"]}',
              *[f'--from-file={c}' for c in configs],
-             '--dry-run', '-o', 'yaml'],
+             '--save-config', '--dry-run=client', '-o', 'yaml'],
             stdout=k8s_secret)
         sp.check_call(['kubectl', 'apply', '-f', k8s_secret.name])
 


### PR DESCRIPTION
For some reason we delete secrets when re-creating them. This creates a race condition which Batch
appears to encounter whenever it is under heavy load during a deploy.

@cseed, do you recall why you chose to delete and then use apply in ci/create_database.py?

I am using the command sequence suggested here: https://stackoverflow.com/questions/45879498/how-can-i-update-a-secret-on-kubernetes-when-it-is-generated-from-a-file.