### PR TITLE
[website] make www the website service and base path

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3472,7 +3472,7 @@ steps:
      valueFrom: service_base_image.image
    script: |
      set -ex
-     hailctl curl {{ default_ns.name }} website / \
+     hailctl curl {{ default_ns.name }} www / \
              -vvv \
              -fsSL \
              --retry 3 \

--- a/ci/test/resources/config.yaml
+++ b/ci/test/resources/config.yaml
@@ -1,4 +1,5 @@
 principals:
 - name: hello
-  domain: hello
+  domains:
+    - hello
   kind: json

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -27,14 +27,11 @@ principals:
   domains:
     - notebook
     - workshop
-- name: notebook
-  domains:
-    - notebook
-    - workshop
   kind: json
 - name: notebook
   domains:
     - notebook
+    - workshop
   kind: nginx
 - name: gateway
   domains:

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -1,102 +1,140 @@
 principals:
 - name: admin-pod
-  domain: admin-pod
+  domains:
+    - admin-pod
   kind: curl
 - name: auth-driver
-  domain: auth-driver
+  domains:
+    - auth-driver
   kind: json
 - name: auth
-  domain: auth
+  domains:
+    - auth
   kind: json
 - name: batch
-  domain: batch
+  domains:
+    - batch
   kind: json
 - name: batch-driver
-  domain: batch-driver
+  domains:
+    - batch-driver
   kind: json
 - name: ci
-  domain: ci
+  domains:
+    - ci
   kind: json
 - name: notebook-python
-  domain: notebook
+  domains:
+    - notebook
+    - workshop
+- name: notebook
+  domains:
+    - notebook
+    - workshop
   kind: json
 - name: notebook
   domain: notebook
   kind: nginx
 - name: gateway
-  domain: gateway
+  domains:
+    - gateway
   unmanged: True
   kind: nginx
 - name: router
-  domain: router
+  domains:
+    - router
   kind: nginx
-- name: www
-  domain: www
+- name: website
+  domains:
+    - website
+    - www
   kind: json
 - name: scorecard
-  domain: scorecard
+  domains:
+    - scorecard
   kind: json
 - name: image-fetcher
-  domain: image-fetcher
+  domains:
+    - image-fetcher
   kind: curl
 - name: blog
-  domain: blog
+  domains:
+    - blog
   kind: nginx
 - name: internal-gateway
-  domain: internal-gateway
+  domains:
+    - internal-gateway
   unmanged: True
   kind: nginx
 - name: batch-tests
-  domain: batch-tests
+  domains:
+    - batch-tests
   kind: json
 - name: ci-tests
-  domain: ci-tests
+  domains:
+    - ci-tests
   kind: json
 - name: memory
-  domain: memory
+  domains:
+    - memory
   kind: json
 - name: memory-tests
-  domain: memory-tests
+  domains:
+    - memory-tests
   kind: json
 - name: query
-  domain: query
+  domains:
+    - query
   kind: json
 - name: services-java-tests
-  domain: services-java-tests
+  domains:
+    - services-java-tests
   kind: json
 - name: query-tests
-  domain: query-tests
+  domains:
+    - query-tests
   kind: json
 - name: shuffler
-  domain: shuffler
+  domains:
+    - shuffler
   kind: json
 - name: benchmark
-  domain: benchmark
+  domains:
+    - benchmark
   kind: json
 - name: benchmark-tests
-  domain: benchmark-tests
+  domains:
+    - benchmark-tests
   kind: json
 - name: address
-  domain: address
+  domains:
+    - address
   kind: json
 - name: address-tests
-  domain: address-tests
+  domains:
+    - address-tests
   kind: json
 - name: monitoring
-  domain: monitoring
+  domains:
+    - monitoring
   kind: json
 - name: monitoring-tests
-  domain: monitoring-tests
+  domains:
+    - monitoring-tests
   kind: json
 - name: atgu
-  domain: atgu
+  domains:
+    - atgu
   kind: json
 - name: batch-user-code
-  domain: batch-user-code
+  domains:
+    - batch-user-code
   kind: json
 - name: grafana
-  domain: grafana
+  domains:
+    - grafana
   kind: nginx
 - name: prometheus
-  domain: prometheus
+  domains:
+    - prometheus
   kind: nginx

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -33,7 +33,8 @@ principals:
     - workshop
   kind: json
 - name: notebook
-  domain: notebook
+  domains:
+    - notebook
   kind: nginx
 - name: gateway
   domains:

--- a/tls/config.yaml
+++ b/tls/config.yaml
@@ -30,8 +30,8 @@ principals:
 - name: router
   domain: router
   kind: nginx
-- name: website
-  domain: website
+- name: www
+  domain: www
   kind: json
 - name: scorecard
   domain: scorecard

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -110,3 +110,18 @@ spec:
   selector:
     matchLabels:
       app: website
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: www
+  labels:
+    app: www
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: website

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           - name: session-secret-key
             mountPath: /session-secret-key
             readOnly: true
-          - name: ssl-config-www
+          - name: ssl-config-website
             mountPath: /ssl-config
             readOnly: true
          livenessProbe:
@@ -79,10 +79,10 @@ spec:
        - name: session-secret-key
          secret:
            secretName: session-secret-key
-       - name: ssl-config-www
+       - name: ssl-config-website
          secret:
            optional: false
-           secretName: ssl-config-www
+           secretName: ssl-config-website
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/website/deployment.yaml
+++ b/website/deployment.yaml
@@ -59,7 +59,7 @@ spec:
           - name: session-secret-key
             mountPath: /session-secret-key
             readOnly: true
-          - name: ssl-config-website
+          - name: ssl-config-www
             mountPath: /ssl-config
             readOnly: true
          livenessProbe:
@@ -79,10 +79,10 @@ spec:
        - name: session-secret-key
          secret:
            secretName: session-secret-key
-       - name: ssl-config-website
+       - name: ssl-config-www
          secret:
            optional: false
-           secretName: ssl-config-website
+           secretName: ssl-config-www
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -71,7 +71,7 @@ async def serve_docs(request, userdata):
     tail = request.match_info['tail']
     if tail in docs_pages:
         if tail.endswith('.html'):
-            return await render_template('website', request, userdata, tail, dict())
+            return await render_template('www', request, userdata, tail, dict())
         return web.FileResponse(f'{DOCS_PATH}/{tail}')
     raise web.HTTPNotFound()
 
@@ -80,13 +80,14 @@ def make_template_handler(template_fname):
     @web_maybe_authenticated_user
     async def serve(request, userdata):
         return await render_template(
-            'website', request, userdata, template_fname, dict())
+            'www', request, userdata, template_fname, dict())
     return serve
 
 
 for fname in os.listdir(f'{MODULE_PATH}/pages'):
     routes.get(f'/{fname}')(make_template_handler(fname))
     if fname == 'index.html':
+        routes.get('')(make_template_handler(fname))  # so internal.hail.is/<namespace>/www can work without a /
         routes.get('/')(make_template_handler(fname))
 
 
@@ -113,7 +114,7 @@ def run(local_mode):
     app.add_routes(routes)
     app.router.add_get("/metrics", server_stats)
     sass_compile('website')
-    web.run_app(deploy_config.prefix_application(app, 'website'),
+    web.run_app(deploy_config.prefix_application(app, 'www'),
                 host='0.0.0.0',
                 port=5000,
                 access_log_class=AccessLogger,


### PR DESCRIPTION
website is the only service that doesn't follow the subdomain == base_path convention, nor does the subdomain match the k8s service, which is website. This enforces that by adding a `www` k8s service and changes the base_path in `website.py`.