### PR TITLE
[query] Address some warnings

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -572,7 +572,7 @@ class _tbool(HailType):
         pass
 
     def to_numpy(self):
-        return np.bool
+        return bool
 
 
 class tndarray(HailType):

--- a/hail/python/hail/typecheck/check.py
+++ b/hail/python/hail/typecheck/check.py
@@ -95,7 +95,7 @@ class SequenceChecker(TypeChecker):
 
     def check(self, x, caller, param):
         # reject str because of errors due to sequenceof(strlike) permitting str
-        if not isinstance(x, collections.Sequence) or isinstance(x, str):
+        if not isinstance(x, collections.abc.Sequence) or isinstance(x, str):
             raise TypecheckFailure
         x_ = []
         tc = self.ec

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -218,7 +218,7 @@ def test_ndarray_eval():
     assert "inner dimensions do not match" in str(exc.value)
 
     with pytest.raises(HailUserError) as exc:
-        hl.eval(hl.nd.array([1, hl.null(hl.tint32), 3]))
+        hl.eval(hl.nd.array([1, hl.missing(hl.tint32), 3]))
 
 
 def test_ndarray_shape():


### PR DESCRIPTION
Was testing that we could run with newer pythons, encountered some warnings to clean up.

- We aren't supposed to use `collections.Sequence` anymore. It's `collections.abc.Sequence`. They said this wouldn't work in 3.9, but they decided to delay removal again to 3.10.
- `np.bool` is just the same as `bool`, so numpy has deprecated `np.bool`. 
- We deprecatd `hl.null` in favor of `hl.missing` a little while ago. 