### PR TITLE
[query] Fixed bug where hl.nd.qr didn't support 0 elements

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -743,6 +743,16 @@ def test_ndarray_qr():
 
     assert_same_qr(identity4, np_identity4)
 
+    np_size_zero_n = np.zeros((10, 0))
+    size_zero_n = hl.nd.zeros((10, 0))
+
+    assert_same_qr(size_zero_n, np_size_zero_n)
+
+    np_size_zero_m = np.zeros((0, 10))
+    size_zero_m = hl.nd.zeros((0, 10))
+
+    assert_same_qr(size_zero_m, np_size_zero_m)
+
     np_all3 = np.full((3, 3), 3)
     all3 = hl.nd.full((3, 3), 3)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1486,7 +1486,7 @@ class Emit[C](
 
           val shapeArray = pndValue.shapes(cb)
 
-          val LWORKAddress = mb.newLocal[Long]()
+          val LWORKAddress = cb.newLocal[Long]("dgeqrf_lwork_address")
 
           val M = shapeArray(0)
           val N = shapeArray(1)
@@ -1497,7 +1497,7 @@ class Emit[C](
             override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
           }
 
-          def LWORK = Region.loadDouble(LWORKAddress).toI
+          def LWORK = (Region.loadDouble(LWORKAddress).toI > 0).mux(Region.loadDouble(LWORKAddress).toI, 1)
 
           val ndPT = pndValue.pt.asInstanceOf[PCanonicalNDArray]
           val dataFirstElementAddress = pndValue.firstDataAddress(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1497,7 +1497,7 @@ class Emit[C](
             override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
           }
 
-          def LWORK = (Region.loadDouble(LWORKAddress).toI > 0).mux(Region.loadDouble(LWORKAddress).toI, 1)
+          def LWORK = Region.loadDouble(LWORKAddress).toI
 
           val ndPT = pndValue.pt.asInstanceOf[PCanonicalNDArray]
           val dataFirstElementAddress = pndValue.firstDataAddress(cb)
@@ -1534,7 +1534,7 @@ class Emit[C](
           ))
           cb.append(infoDGEQRFErrorTest("Failed size query."))
 
-          cb.assign(workAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L))
+          cb.assign(workAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", (LWORK > 0).mux(LWORK, 1).toL * 8L))
           cb.assign(infoDGEQRFResult, Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
             M.toI,
             N.toI,
@@ -1542,7 +1542,7 @@ class Emit[C](
             LDA.toI,
             tauFirstElementAddress,
             workAddress,
-            LWORK
+            (LWORK > 0).mux(LWORK, 1)
           ))
           cb.append(Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()))
           cb.append(infoDGEQRFErrorTest("Failed to compute H and Tau."))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1497,7 +1497,7 @@ class Emit[C](
             override def get: Code[Long] = (M > 1L).mux(M, 1L) // Possible stride tricks could change this in the future.
           }
 
-          def LWORK = Region.loadDouble(LWORKAddress).toI
+          def LWORK = (Region.loadDouble(LWORKAddress).toI > 0).mux(Region.loadDouble(LWORKAddress).toI, 1)
 
           val ndPT = pndValue.pt.asInstanceOf[PCanonicalNDArray]
           val dataFirstElementAddress = pndValue.firstDataAddress(cb)
@@ -1534,7 +1534,7 @@ class Emit[C](
           ))
           cb.append(infoDGEQRFErrorTest("Failed size query."))
 
-          cb.assign(workAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", (LWORK > 0).mux(LWORK, 1).toL * 8L))
+          cb.assign(workAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", LWORK.toL * 8L))
           cb.assign(infoDGEQRFResult, Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
             M.toI,
             N.toI,
@@ -1542,7 +1542,7 @@ class Emit[C](
             LDA.toI,
             tauFirstElementAddress,
             workAddress,
-            (LWORK > 0).mux(LWORK, 1)
+            LWORK
           ))
           cb.append(Code.invokeStatic1[Memory, Long, Unit]("free", workAddress.load()))
           cb.append(infoDGEQRFErrorTest("Failed to compute H and Tau."))


### PR DESCRIPTION
I'm not sure this is the right fix.  The segfault was coming from dgeqrf itself, and it was happening only when `N` is 0 (`M` being 0 was fine). The real issue is that when `N` is 0, LAPACK computes `LWORK` to be 0, meaning we don't actually allocate any memory for the `WORK` array and we segfault. To contrast, if I do a workspace size query for shape `(0, 10)`, I get `320` for `LWORK`. This also seems wrong though, as you shouldn't really need any work space for an empty matrix? 

Anyway, the segfault preventing fix was just to make sure LWORK was at least 1. I was hoping you (Patrick) could use Julia interface to play with the LAPACK functions and see what behavior you notice, and if it's consistent with the above. 