### PR TITLE
[notebook] fix resource requests so deployment can downscale

### DIFF
--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -67,10 +67,10 @@ spec:
          image: "{{ notebook_image.image }}"
          resources:
            requests:
-             memory: 1Mi
-             cpu: 1m
+             memory: 20M
+             cpu: 20m
            limits:
-             memory: 200Mi
+             memory: 200M
              cpu: "1"
          env:
           - name: HAIL_DEPLOY_CONFIG_FILE


### PR DESCRIPTION
This must have been skipped or lost in a rebase but keeping the resources at minimum is keeping the notebook deployment at max replicas after the workshop. Giving a bit higher request (what I set as the baseline in #10117) should encourage k8s to downscale back to 3 replicas.