### PR TITLE
[libhail] Add simple testing infrastructure

### DIFF
--- a/libhail/CMakeLists.txt
+++ b/libhail/CMakeLists.txt
@@ -15,12 +15,12 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-add_executable(main
+add_executable(test
   src/hail/allocators.cpp
   src/hail/format.cpp
-  src/hail/main.cpp
   src/hail/type.cpp
   src/hail/value.cpp
+  src/hail/test_value.cpp
   src/hail/vtype.cpp
   # query
   src/hail/query/ir.cpp
@@ -30,10 +30,11 @@ add_executable(main
   src/hail/query/backend/stype.cpp
   src/hail/query/backend/svalue.cpp
   # runtime
-  src/hail/runtime/runtime.cpp)
+  src/hail/runtime/runtime.cpp
+  src/hail/test.cpp)
 
-llvm_config(main x86asmparser x86codegen orcjit)
+llvm_config(test x86asmparser x86codegen orcjit)
 
-target_include_directories(main PRIVATE "src")
+target_include_directories(test PRIVATE "src")
 
-target_link_libraries(main ${llvm_libraries})
+target_link_libraries(test ${llvm_libraries})

--- a/libhail/CMakeLists.txt
+++ b/libhail/CMakeLists.txt
@@ -18,6 +18,7 @@ add_definitions(${LLVM_DEFINITIONS})
 add_executable(test
   src/hail/allocators.cpp
   src/hail/format.cpp
+  src/hail/test_format.cpp
   src/hail/type.cpp
   src/hail/value.cpp
   src/hail/test_value.cpp

--- a/libhail/src/hail/format.cpp
+++ b/libhail/src/hail/format.cpp
@@ -11,6 +11,35 @@ namespace hail {
 
 FormatStream::~FormatStream() {}
 
+StringFormatStream::StringFormatStream() {}
+StringFormatStream::~StringFormatStream() {}
+
+void
+StringFormatStream::write(const char *p, size_t n) {
+  const char *end = p + n;
+  for (; p < end; ++p)
+    contents.push_back(*p);
+}
+
+void
+StringFormatStream::putc(int c) {
+  contents.push_back(c);
+}
+
+void
+StringFormatStream::puts(const char *s) {
+  char c = *s;
+  while (c) {
+    contents.push_back(c);
+    c = *(++s);
+  }
+}
+
+std::string
+StringFormatStream::get_contents() {
+  return std::move(contents);
+}
+
 class StdFILEStream : public FormatStream {
   FILE *fp;
 
@@ -18,16 +47,16 @@ public:
   StdFILEStream(FILE *fp) : fp(fp) {}
   ~StdFILEStream();
 
-  void write(void *p, size_t n);
-  void putc(int c);
-  void puts(const char *s);
+  void write(const char *p, size_t n) override;
+  void putc(int c) override;
+  void puts(const char *s) override;
 };
 
 /* don't close standard streams */
 StdFILEStream::~StdFILEStream() {}
 
 void
-StdFILEStream::write(void *p, size_t n) {
+StdFILEStream::write(const char *p, size_t n) {
   int rc = fwrite(p, n, 1, fp);
   if (rc != 1)
     throw std::system_error(errno, std::generic_category(), "in fwrite");

--- a/libhail/src/hail/format.hpp
+++ b/libhail/src/hail/format.hpp
@@ -11,9 +11,23 @@ class FormatStream {
 public:
   virtual ~FormatStream();
 
-  virtual void write(void *p, size_t n) = 0;
+  virtual void write(const char *p, size_t n) = 0;
   virtual void putc(int c) = 0;
   virtual void puts(const char *s) = 0;
+};
+
+class StringFormatStream : public FormatStream {
+  std::string contents;
+
+public:
+  StringFormatStream();
+  ~StringFormatStream();
+
+  void write(const char *p, size_t n) override;
+  void putc(int c) override;
+  void puts(const char *s) override;
+
+  std::string get_contents();
 };
 
 extern FormatStream &outs, &errs;
@@ -53,6 +67,13 @@ extern void format1(FormatStream &s, Indent v);
 template<typename... Args> inline void
 format(FormatStream &s, Args &&... args) {
   (format1(s, std::forward<Args>(args)),...);
+}
+
+template<typename... Args> inline std::string
+render(Args &&... args) {
+  StringFormatStream s;
+  format(s, std::forward<Args>(args)...);
+  return std::move(s.get_contents());
 }
 
 template<typename... Args> inline void

--- a/libhail/src/hail/main.cpp
+++ b/libhail/src/hail/main.cpp
@@ -8,6 +8,7 @@
 #include <hail/query/backend/jit.hpp>
 #include <hail/query/ir.hpp>
 #include <hail/tunion.hpp>
+#include <hail/test.hpp>
 #include <hail/type.hpp>
 #include <hail/value.hpp>
 

--- a/libhail/src/hail/test.cpp
+++ b/libhail/src/hail/test.cpp
@@ -1,0 +1,34 @@
+#include <hail/format.hpp>
+#include <hail/test.hpp>
+
+namespace hail {
+
+Test::Test(std::string name, TestFunction *function)
+  : name(std::move(name)), function(function), next(Tests::head) {
+  Tests::head = this;
+}
+
+int
+Test::run() const {
+  format(errs, "RUN ", name, "\n");
+  function();
+  format(errs, "RUN ", name, " OK\n");
+  return 0;
+}
+
+Test *Tests::head = nullptr;
+
+int
+Tests::run_tests() {
+  for (const Test *t = head; t; t = t->next) {
+    t->run();
+  }
+  return 0;
+}
+
+}
+
+int
+main() {
+  hail::Tests::run_tests();
+}

--- a/libhail/src/hail/test.hpp
+++ b/libhail/src/hail/test.hpp
@@ -1,0 +1,40 @@
+#ifndef HAIL_TEST_HPP_INCLUDED
+#define HAIL_TEST_HPP_INCLUDED 1
+
+#include <string>
+#include <vector>
+
+namespace hail {
+
+using TestFunction = void();
+
+class Test {
+  friend class Tests;
+  
+  const std::string name;
+  TestFunction *const function;
+  Test *next;
+
+public:
+  Test(std::string name, TestFunction *function);
+
+  int run() const;
+};
+
+class Tests {
+  friend class Test;
+  
+  static Test *head;
+
+public:
+  static int run_tests();
+};
+
+#define TEST_CASE(test_name)				\
+static void test_name();				\
+static Test test_name##_obj(#test_name, test_name);	\
+void test_name()
+
+}
+
+#endif

--- a/libhail/src/hail/test.hpp
+++ b/libhail/src/hail/test.hpp
@@ -1,6 +1,7 @@
 #ifndef HAIL_TEST_HPP_INCLUDED
 #define HAIL_TEST_HPP_INCLUDED 1
 
+#include <hail/format.hpp>
 #include <string>
 #include <vector>
 
@@ -34,6 +35,21 @@ public:
 static void test_name();				\
 static Test test_name##_obj(#test_name, test_name);	\
 void test_name()
+
+template<typename L, typename R> void
+check_eq_impl(const char *lstr, const char *rstr, const L &l, const R &r) {
+  if (l != r) {
+    format(errs, __FILE__, ":", __LINE__, ": assert failed:\n");
+    format(errs, "  CHECK_EQ(", lstr, ", ", rstr, ")\n");
+    format(errs, "with values:\n");
+    // FIXME what if l, r don't support format?
+    format(errs, "  CHECK_EQ(", l, ", ", r, ")\n");
+    // FIXME throw so the rest of the tests run
+    abort();
+  }
+}
+
+#define CHECK_EQ(l, r)	check_eq_impl(#l, #r, l, r)
 
 }
 

--- a/libhail/src/hail/test_value.cpp
+++ b/libhail/src/hail/test_value.cpp
@@ -1,0 +1,55 @@
+#include <hail/allocators.hpp>
+#include <hail/test.hpp>
+#include <hail/type.hpp>
+#include <hail/value.hpp>
+#include <hail/vtype.hpp>
+
+namespace hail {
+
+TEST_CASE(test_bool_value) {
+  HeapAllocator heap;
+  ArenaAllocator arena(heap);
+  TypeContext tc(heap);
+  auto vbool = cast<VBool>(tc.get_vtype(tc.tbool));
+
+  Value tv(vbool, true);
+  assert(!tv.get_missing());
+  assert(tv.as_bool());
+
+  Value fv(vbool, false);
+  assert(!fv.get_missing());
+  assert(!fv.as_bool());
+
+  Value mv(vbool);
+  assert(mv.get_missing());
+}
+
+TEST_CASE(test_int32_value) {
+  HeapAllocator heap;
+  ArenaAllocator arena(heap);
+  TypeContext tc(heap);
+  auto vint32 = cast<VInt32>(tc.get_vtype(tc.tint32));
+
+  Value iv(vint32, 5);
+  assert(!iv.get_missing());
+  assert(iv.as_int32() == 5);
+
+  Value mv(vint32);
+  assert(mv.get_missing());
+}
+
+TEST_CASE(test_int64_value) {
+  HeapAllocator heap;
+  ArenaAllocator arena(heap);
+  TypeContext tc(heap);
+  auto vint64 = cast<VInt64>(tc.get_vtype(tc.tint64));
+
+  Value iv(vint64, 5);
+  assert(!iv.get_missing());
+  assert(iv.as_int64() == 5);
+
+  Value mv(vint64);
+  assert(mv.get_missing());
+}
+
+}

--- a/libhail/src/hail/value.hpp
+++ b/libhail/src/hail/value.hpp
@@ -96,6 +96,7 @@ class TupleValue {
 public:
   const VTuple *vtype;
 private:
+
   std::shared_ptr<ArenaAllocator> region;
   char *p;
 


### PR DESCRIPTION
Very preliminary.  Builds test instead of main by default, output looks like this:

```
~/hail/libhail/build$ ./test
RUN test_int64_value
RUN test_int64_value OK
RUN test_int32_value
RUN test_int32_value OK
RUN test_bool_value
RUN test_bool_value OK
...
```

Added `std::string render(...)` to format module.  Added some format tests.  Added `CHECK_EQ` macro that prints the details on failure:

```
../src/hail/test.hpp:42: assert failed:
  CHECK_EQ(render(FormatAddress(nullptr)), "0x0000000000000000")
with values:
  CHECK_EQ(0000000000000000, 0x0000000000000000)
```
