### PR TITLE
[query] Loop memory management

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -439,3 +439,10 @@ class Tests(unittest.TestCase):
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
 
+    def test_loop_memory(self):
+        result = hl.experimental.loop(
+            lambda f, my_nd:
+            hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
+            hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((40_000, 40_000), hl.tfloat64))
+
+        np_result = hl.eval(result)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -438,11 +438,3 @@ class Tests(unittest.TestCase):
                 lambda f, my_nd:
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
-
-    # def test_loop_memory(self):
-    #     result = hl.experimental.loop(
-    #         lambda f, my_nd:
-    #         hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
-    #         hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((10_000, 10_000), hl.tfloat64))
-    #
-    #     np_result = hl.eval(result)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -439,10 +439,10 @@ class Tests(unittest.TestCase):
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
 
-    def test_loop_memory(self):
-        result = hl.experimental.loop(
-            lambda f, my_nd:
-            hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
-            hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((10_000, 10_000), hl.tfloat64))
-
-        np_result = hl.eval(result)
+    # def test_loop_memory(self):
+    #     result = hl.experimental.loop(
+    #         lambda f, my_nd:
+    #         hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
+    #         hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((10_000, 10_000), hl.tfloat64))
+    #
+    #     np_result = hl.eval(result)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -438,3 +438,11 @@ class Tests(unittest.TestCase):
                 lambda f, my_nd:
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
+
+    def test_loop_with_struct_of_strings(self):
+        def loopFunc(recurF, my_struct):
+            return hl.if_else(hl.len(my_struct.s1) > hl.len(my_struct.s2),
+                              my_struct,
+                              recurF(hl.struct(s1=my_struct.s1 + my_struct.s2[-1], s2=my_struct.s2[:-1])))
+
+        print(hl.eval(hl.experimental.loop(loopFunc, hl.tstruct(s1=hl.tstr, s2=hl.tstr))))

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -439,10 +439,10 @@ class Tests(unittest.TestCase):
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
 
-    # def test_loop_memory(self):
-    #     result = hl.experimental.loop(
-    #         lambda f, my_nd:
-    #         hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
-    #         hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((40_000, 40_000), hl.tfloat64))
-    #
-    #     np_result = hl.eval(result)
+    def test_loop_memory(self):
+        result = hl.experimental.loop(
+            lambda f, my_nd:
+            hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
+            hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((10_000, 10_000), hl.tfloat64))
+
+        np_result = hl.eval(result)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -439,10 +439,10 @@ class Tests(unittest.TestCase):
                 hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
 
-    def test_loop_memory(self):
-        result = hl.experimental.loop(
-            lambda f, my_nd:
-            hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
-            hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((40_000, 40_000), hl.tfloat64))
-
-        np_result = hl.eval(result)
+    # def test_loop_memory(self):
+    #     result = hl.experimental.loop(
+    #         lambda f, my_nd:
+    #         hl.if_else(my_nd[0, 0] == 1000, my_nd, f(my_nd + 1)),
+    #         hl.tndarray(hl.tfloat64, 2), hl.nd.zeros((40_000, 40_000), hl.tfloat64))
+    #
+    #     np_result = hl.eval(result)

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -440,9 +440,10 @@ class Tests(unittest.TestCase):
                 hl.tndarray(hl.tint32, 2), hl.nd.zeros((20, 10), hl.tfloat64))
 
     def test_loop_with_struct_of_strings(self):
-        def loopFunc(recurF, my_struct):
+        def loop_func(recur_f, my_struct):
             return hl.if_else(hl.len(my_struct.s1) > hl.len(my_struct.s2),
                               my_struct,
-                              recurF(hl.struct(s1=my_struct.s1 + my_struct.s2[-1], s2=my_struct.s2[:-1])))
+                              recur_f(hl.struct(s1=my_struct.s1 + my_struct.s2[-1], s2=my_struct.s2[:-1])))
 
-        print(hl.eval(hl.experimental.loop(loopFunc, hl.tstruct(s1=hl.tstr, s2=hl.tstr))))
+        initial_struct = hl.struct(s1="a", s2="gfedcb")
+        assert hl.eval(hl.experimental.loop(loop_func, hl.tstruct(s1=hl.tstr, s2=hl.tstr), initial_struct)) == hl.Struct(s1="abcd", s2="gfe")

--- a/hail/src/main/scala/is/hail/annotations/RegionPool.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionPool.scala
@@ -23,6 +23,7 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
   private[this] var allocationEchoThreshold: Long = 256 * 1024
   private[this] var numJavaObjects: Long = 0L
   private[this] var maxNumJavaObjects: Long = 0L
+  private[this] var highestTotalUsage = 0L
 
   def addJavaObject(): Unit = {
     numJavaObjects += 1
@@ -34,11 +35,16 @@ final class RegionPool private(strictMemoryCheck: Boolean, threadName: String, t
 
   def getTotalAllocatedBytes: Long = totalAllocatedBytes
 
+  def getHighestTotalUsage: Long = highestTotalUsage
+
   private[annotations] def incrementAllocatedBytes(toAdd: Long): Unit = {
     totalAllocatedBytes += toAdd
     if (totalAllocatedBytes >= allocationEchoThreshold) {
       report("REPORT_THRESHOLD")
       allocationEchoThreshold *= 2
+    }
+    if (totalAllocatedBytes >= highestTotalUsage) {
+      highestTotalUsage = totalAllocatedBytes
     }
   }
 

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -388,7 +388,7 @@ class UnsafeNDArray(val pnd: PNDArray, val region: Region, val ndAddr: Long) ext
   }
 }
 
-class SafeNDArray(val shape: IndexedSeq[Long], rowMajorElements: IndexedSeq[Annotation]) extends NDArray {
+case class SafeNDArray(val shape: IndexedSeq[Long], rowMajorElements: IndexedSeq[Annotation]) extends NDArray {
   assert(shape.foldLeft(1L)(_ * _) == rowMajorElements.size)
   override def getRowMajorElements: IndexedSeq[Annotation] = rowMajorElements
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1944,7 +1944,12 @@ class Emit[C](
 
         cb.define(loopStartLabel)
 
-        emitI(body, env = argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRef)))
+        emitI(body, env = argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRef))).map(cb) { pc =>
+          val answerInRightRegion = pc.copyToRegion(cb, region.code)
+          cb.append(new RichCodeRegion(loopRef.r1).clear())
+          cb.append(new RichCodeRegion(loopRef.r2).clear())
+          answerInRightRegion
+        }
 
       case Recur(name, args, _) =>
         val loopRef = loopEnv.get.lookup(name)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1922,8 +1922,12 @@ class Emit[C](
         }
 
         cb.assign(loopRef.loopArgs, loopRef.tmpLoopArgs.load())
-        cb.append(loopRef.L.goto)
-        // dead code
+        cb.goto(loopRef.L)
+
+        // Dead code. The dead label is necessary because you can't append anything else to a code builder
+        // after a goto.
+        val deadLabel = CodeLabel()
+        cb.define(deadLabel)
         IEmitCode.missing(cb, pt.defaultValue(cb.emb))
 
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -65,7 +65,11 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     s.store(this, v)
   }
 
-  def assign(is: IndexedSeq[EmitSettable], ix: IndexedSeq[EmitCode]): Unit = {
+  def assignECs(is: IndexedSeq[EmitSettable], ix: IndexedSeq[EmitCode]): Unit = {
+    (is, ix).zipped.foreach { case (s, c) => s.store(this, c) }
+  }
+
+  def assign(is: IndexedSeq[EmitSettable], ix: IndexedSeq[IEmitCode]): Unit = {
     (is, ix).zipped.foreach { case (s, c) => s.store(this, c) }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -65,11 +65,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     s.store(this, v)
   }
 
-  def assignECs(is: IndexedSeq[EmitSettable], ix: IndexedSeq[EmitCode]): Unit = {
-    (is, ix).zipped.foreach { case (s, c) => s.store(this, c) }
-  }
-
-  def assign(is: IndexedSeq[EmitSettable], ix: IndexedSeq[IEmitCode]): Unit = {
+  def assign(is: IndexedSeq[EmitSettable], ix: IndexedSeq[EmitCode]): Unit = {
     (is, ix).zipped.foreach { case (s, c) => s.store(this, c) }
   }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -342,7 +342,7 @@ class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(metho
 
 class Block {
   // for debugging
-  val stack = Thread.currentThread().getStackTrace.mkString("\n")
+  // val stack = Thread.currentThread().getStackTrace.mkString("\n")
 
   var method: Method = _
 
@@ -352,10 +352,8 @@ class Block {
   val uses: mutable.Set[(ControlX, Int)] = mutable.Set[(ControlX, Int)]()
 
   def wellFormed: Boolean = {
-    if (first == null) {
-      assert(false, s"first was null, stack was ${stack}")
+    if (first == null)
       return false
-    }
 
     last match {
       case ctrl: ControlX =>
@@ -366,10 +364,7 @@ class Block {
           i += 1
         }
         true
-      case _ => {
-        assert(false, s"Last wasn't ctrl, it was ${last}")
-        false
-      }
+      case _ => false
     }
   }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -342,7 +342,7 @@ class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(metho
 
 class Block {
   // for debugging
-  // val stack = Thread.currentThread().getStackTrace
+  val stack = Thread.currentThread().getStackTrace.mkString("\n")
 
   var method: Method = _
 
@@ -352,8 +352,10 @@ class Block {
   val uses: mutable.Set[(ControlX, Int)] = mutable.Set[(ControlX, Int)]()
 
   def wellFormed: Boolean = {
-    if (first == null)
+    if (first == null) {
+      assert(false, s"first was null, stack was ${stack}")
       return false
+    }
 
     last match {
       case ctrl: ControlX =>
@@ -364,7 +366,10 @@ class Block {
           i += 1
         }
         true
-      case _ => false
+      case _ => {
+        assert(false, s"Last wasn't ctrl, it was ${last}")
+        false
+      }
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3800,12 +3800,12 @@ class IRSuite extends HailSuite {
     var memUsed = 0L
 
     ExecuteContext.scoped() { ctx =>
-      println(eval(ndSum, Env.empty, FastIndexedSeq(2 -> TInt32, startingArg -> ndType), None, None, true, ctx))
+      eval(ndSum, Env.empty, FastIndexedSeq(2 -> TInt32, startingArg -> ndType), None, None, true, ctx)
       memUsed = ctx.r.pool.getTotalAllocatedBytes
     }
 
     ExecuteContext.scoped() { ctx =>
-      println(eval(ndSum, Env.empty, FastIndexedSeq(20 -> TInt32, startingArg -> ndType), None, None, true, ctx))
+      eval(ndSum, Env.empty, FastIndexedSeq(20 -> TInt32, startingArg -> ndType), None, None, true, ctx)
       assert(memUsed == ctx.r.pool.getTotalAllocatedBytes)
     }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -3801,12 +3801,12 @@ class IRSuite extends HailSuite {
 
     ExecuteContext.scoped() { ctx =>
       eval(ndSum, Env.empty, FastIndexedSeq(2 -> TInt32, startingArg -> ndType), None, None, true, ctx)
-      memUsed = ctx.r.pool.getTotalAllocatedBytes
+      memUsed = ctx.r.pool.getHighestTotalUsage
     }
 
     ExecuteContext.scoped() { ctx =>
-      eval(ndSum, Env.empty, FastIndexedSeq(20 -> TInt32, startingArg -> ndType), None, None, true, ctx)
-      assert(memUsed == ctx.r.pool.getTotalAllocatedBytes)
+      eval(ndSum, Env.empty, FastIndexedSeq(100 -> TInt32, startingArg -> ndType), None, None, true, ctx)
+      assert(memUsed == ctx.r.pool.getHighestTotalUsage)
     }
   }
 


### PR DESCRIPTION
This PR changes the way loop memory management works.  

Previously, memory used while in the loop was allocated in one region, with no cleanup happening between loops. A long running loop that did a lot of allocation could therefore easily cause hail to run out of memory. This PR fixes that by creating two regions for each loop. Every iteration, we emit everything in region 1, copy the state that is necessary to region 2, then clear region 1. Then we swap the regions and repeat this until the loop terminates. 
