### PR TITLE
[ci] auto-assign member from team using #assign comment in PR body

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -24,12 +24,11 @@ from gear import (
     create_database_pool,
     monitor_endpoint,
 )
-import random
 from typing import Dict, Any, Optional
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
 
 from .environment import BUCKET
-from .github import Repo, FQBranch, WatchedBranch, UnwatchedBranch, MergeFailureBatch, PR
+from .github import Repo, FQBranch, WatchedBranch, UnwatchedBranch, MergeFailureBatch, PR, select_random_teammate
 from .constants import AUTHORIZED_USERS, TEAMS
 
 with open(os.environ.get('HAIL_CI_OAUTH_TOKEN', 'oauth-token/oauth-token'), 'r') as f:
@@ -260,9 +259,7 @@ async def get_user(request, userdata):
     dev_deploys = batch_client.list_batches(f'user={username} dev_deploy=1', limit=10)
     dev_deploys = sorted([b async for b in dev_deploys], key=lambda b: b.id, reverse=True)
 
-    team_random_member = {
-        team: random.choice([user for user in AUTHORIZED_USERS if team in user.teams]).gh_username for team in TEAMS
-    }
+    team_random_member = {team: select_random_teammate(team).gh_username for team in TEAMS}
 
     page_context = {
         'username': username,

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -2,7 +2,9 @@ from typing import Optional, List
 
 GITHUB_CLONE_URL = 'https://github.com/'
 GITHUB_STATUS_CONTEXT = 'ci-test'
-TEAMS = ['Services', 'Compiler']
+SERVICES_TEAM = 'Services'
+COMPILER_TEAM = 'Compiler'
+TEAMS = [SERVICES_TEAM, COMPILER_TEAM]
 
 
 class User:
@@ -14,20 +16,20 @@ class User:
 
 
 AUTHORIZED_USERS = [
-    User('danking', 'dking', ['Services']),
+    User('danking', 'dking', [SERVICES_TEAM]),
     User('cseed', 'cseed'),
     User('konradjk', 'konradk'),
-    User('jigold', 'jigold', ['Services']),
-    User('patrick-schultz', 'pschultz', ['Compiler']),
+    User('jigold', 'jigold', [SERVICES_TEAM]),
+    User('patrick-schultz', 'pschultz', [COMPILER_TEAM]),
     User('lfrancioli'),
-    User('tpoterba', 'tpoterba', ['Compiler']),
-    User('chrisvittal', 'cvittal', ['Compiler']),
-    User('johnc1231', 'johnc', ['Compiler']),
+    User('tpoterba', 'tpoterba', [COMPILER_TEAM]),
+    User('chrisvittal', 'cvittal', [COMPILER_TEAM]),
+    User('johnc1231', 'johnc', [COMPILER_TEAM]),
     User('nawatts'),
     User('mkveerapen'),
     User('bw2'),
     User('pwc2', 'pcumming'),
     User('lgruen'),
-    User('CDiaz96', 'carolin', ['Services']),
-    User('daniel-goldstein', 'dgoldste', ['Services']),
+    User('CDiaz96', 'carolin', [SERVICES_TEAM]),
+    User('daniel-goldstein', 'dgoldste', [SERVICES_TEAM]),
 ]

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -327,7 +327,9 @@ class PR(Code):
                 f'/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}', data=data
             )
         except gidgethub.HTTPException:
-            log.info(f'{self.short_str()}: notify github of build state failed due to exception: {data}', exc_info=True)
+            log.exception(
+                f'{self.short_str()}: notify github of build state failed due to exception: {data}', exc_info=True
+            )
         except aiohttp.client_exceptions.ClientResponseError:
             log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
@@ -344,7 +346,9 @@ class PR(Code):
                     f'/repos/{self.target_branch.branch.repo.short_str()}/issues/{self.number}/assignees', data=data
                 )
             except gidgethub.HTTPException:
-                log.info(f'{self.short_str()}: post assignees to github failed due to exception: {data}', exc_info=True)
+                log.exception(
+                    f'{self.short_str()}: post assignees to github failed due to exception: {data}', exc_info=True
+                )
             except aiohttp.client_exceptions.ClientResponseError:
                 log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
@@ -489,7 +493,7 @@ mkdir -p {shq(repo_dir)}
             try:
                 s = await b.status()
             except Exception:
-                log.info(f'failed to get the status for batch {b.id}', exc_info=True)
+                log.exception(f'failed to get the status for batch {b.id}', exc_info=True)
                 raise
             if s['state'] != 'cancelled':
                 if min_batch is None or b.id > min_batch.id:
@@ -548,7 +552,7 @@ mkdir -p {shq(repo_dir)}
             )
             return True
         except (gidgethub.HTTPException, aiohttp.client_exceptions.ClientResponseError):
-            log.info(f'merge {self.target_branch.branch.short_str()} {self.number} failed', exc_info=True)
+            log.exception(f'merge {self.target_branch.branch.short_str()} {self.number} failed', exc_info=True)
         return False
 
     def checkout_script(self):
@@ -715,7 +719,9 @@ class WatchedBranch(Code):
             try:
                 status = await self.deploy_batch.status()
             except aiohttp.client_exceptions.ClientResponseError as exc:
-                log.info(f'Could not update deploy_batch status due to exception {exc}, setting deploy_batch to None')
+                log.exception(
+                    f'Could not update deploy_batch status due to exception {exc}, setting deploy_batch to None'
+                )
                 self.deploy_batch = None
                 return
             if status['complete']:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -327,9 +327,7 @@ class PR(Code):
                 f'/repos/{self.target_branch.branch.repo.short_str()}/statuses/{self.source_sha}', data=data
             )
         except gidgethub.HTTPException:
-            log.exception(
-                f'{self.short_str()}: notify github of build state failed due to exception: {data}', exc_info=True
-            )
+            log.exception(f'{self.short_str()}: notify github of build state failed due to exception: {data}')
         except aiohttp.client_exceptions.ClientResponseError:
             log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
@@ -346,9 +344,7 @@ class PR(Code):
                     f'/repos/{self.target_branch.branch.repo.short_str()}/issues/{self.number}/assignees', data=data
                 )
             except gidgethub.HTTPException:
-                log.exception(
-                    f'{self.short_str()}: post assignees to github failed due to exception: {data}', exc_info=True
-                )
+                log.exception(f'{self.short_str()}: post assignees to github failed due to exception: {data}')
             except aiohttp.client_exceptions.ClientResponseError:
                 log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
@@ -493,7 +489,7 @@ mkdir -p {shq(repo_dir)}
             try:
                 s = await b.status()
             except Exception:
-                log.exception(f'failed to get the status for batch {b.id}', exc_info=True)
+                log.exception(f'failed to get the status for batch {b.id}')
                 raise
             if s['state'] != 'cancelled':
                 if min_batch is None or b.id > min_batch.id:
@@ -552,7 +548,7 @@ mkdir -p {shq(repo_dir)}
             )
             return True
         except (gidgethub.HTTPException, aiohttp.client_exceptions.ClientResponseError):
-            log.exception(f'merge {self.target_branch.branch.short_str()} {self.number} failed', exc_info=True)
+            log.exception(f'merge {self.target_branch.branch.short_str()} {self.number} failed')
         return False
 
     def checkout_script(self):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -548,7 +548,7 @@ mkdir -p {shq(repo_dir)}
             )
             return True
         except (gidgethub.HTTPException, aiohttp.client_exceptions.ClientResponseError):
-            log.exception(f'merge {self.target_branch.branch.short_str()} {self.number} failed')
+            log.info(f'merge {self.target_branch.branch.short_str()} {self.number} failed', exc_info=True)
         return False
 
     def checkout_script(self):


### PR DESCRIPTION
Outside collaborators have virtually no powers on the right-hand side of the PR page w.r.t. reviewers/assignees/labels, so this is my best shot at letting them get someone assigned on their PRs. If a PR does not have any assignees or reviewers, but has #assign services or #assign compiler in the PR body, CI will randomly select a collaborator from those teams and assign them (including both will assign one person from each). Outside collaborators can re-request reviews, so I think this solves the PR review problem.