### PR TITLE
[docs][website] remove border around blockquote

### DIFF
--- a/website/website/styles/style.scss
+++ b/website/website/styles/style.scss
@@ -719,13 +719,6 @@ pre, code {
   background-color: inherit;
 }
 
-pre, blockquote {
-  border: 1px solid;
-  border-color: inherit;
-  padding-right: 1em;
-  page-break-inside: avoid;
-}
-
 code {
   white-space: pre-wrap;
   padding: 3px;
@@ -733,6 +726,10 @@ code {
 }
 
 pre {
+  border: 1px solid;
+  border-color: inherit;
+  padding-right: 1em;
+  page-break-inside: avoid;
   display: block;
   padding: 9.5px;
   margin: 0 0 10px;


### PR DESCRIPTION
When I unified the CSS for the docs and the website, every block quote in
the docs (including all bulleted lists) received a border. `style.css` originally
came from the main Hail website (https://hail.is, https://hail.is/references.html, etc.).
I cannot find any place where we needed a border around a blockquote, so I
have removed the blockquote border rules and consolidated the pre rules into
one block.

@CDiaz96, can you check out this branch, run the website locally and poke around and make sure everything looks OK to you? The main page, the references.html page, etc. should all look these same as https://hail.is. The docs for PC Relate (currently deployed: https://hail.is/docs/0.2/methods/relatedness.html#hail.methods.pc_relate; URL for your laptop http://localhost:5000/docs/0.2/methods/relatedness.html#hail.methods.pc_relate) should not have a box around the unordered lists.