### PR TITLE
[batch] fix table row templating

### DIFF
--- a/batch/batch/front_end/templates/billing_projects.html
+++ b/batch/batch/front_end/templates/billing_projects.html
@@ -13,16 +13,18 @@
     {% for billing_project in billing_projects %}
     <tbody>
       <tr>
-        <td rowspan="{{ billing_project.size + 1 }}">
+        <td rowspan="{{ billing_project.size + 2 }}">
           {{ billing_project['billing_project'] }}
         </td>
-        <td rowspan="{{ billing_project.size + 1 }}">
+        <td rowspan="{{ billing_project.size + 2 }}">
           <form action="{{ base_path }}/billing_projects/{{ billing_project['billing_project'] }}/close" method="POST">
             <input type="hidden" name="_csrf" value="{{ csrf_token }}">
             <button class="dangerous">Close</button>
           </form>
         </td>
-        {% for user in billing_project['users'] %}
+      </tr>
+      {% for user in billing_project['users'] %}
+      <tr>
         <td>{{ user }}</td>
         <td>
           <form action="{{ base_path }}/billing_projects/{{ billing_project['billing_project'] }}/users/{{ user }}/remove" method="POST">
@@ -32,15 +34,15 @@
             </button>
           </form>
         </td>
-        {% endfor %}
       </tr>
+      {% endfor %}
       <tr>
         <form action="{{ base_path }}/billing_projects/{{ billing_project['billing_project'] }}/users/add" method="POST">
           <input type="hidden" name="_csrf" value="{{ csrf_token }}">
-            <td><input type="text" name="user"></td>
-            <td>
-              <button>Add</button>
-            </td>
+          <td><input type="text" name="user"></td>
+          <td>
+            <button>Add</button>
+          </td>
         </form>
       </tr>
     </tbody>


### PR DESCRIPTION
We were able to realign the users back to a vertical stack and increased the rowspan for each billing project to compensate for the `tr` of the billing project name.

HTML tables are reorganized somewhere along the way to the browser to not have nested rows. The template previously had 1 `tr` per billing project, which contained 3 `td`s, and then the user `td` had nested `tr`s. Inspecting on the dev console showed that each `tr` was pulled to the top level of the corresponding `tbody`, meaning that in total the number of `tr`s per billing project is
- 1 for the name and close button +
- `billing_project.size` user rows +
- 1 for the add button

So we changed the organization of the `tbody`s to not have nested `tr`s and adjusted the `rowspan` accordingly.

@CDiaz96 