### PR TITLE
[hailctl] use consistent names for variables

### DIFF
--- a/hail/python/hailtop/hailctl/dev/config/show.py
+++ b/hail/python/hailtop/hailctl/dev/config/show.py
@@ -8,5 +8,5 @@ def init_parser(parser):  # pylint: disable=unused-argument
 def main(args):  # pylint: disable=unused-argument
     deploy_config = get_deploy_config()
     print(f'  location: {deploy_config.location()}')
-    print(f'  default: {deploy_config._default_namespace}')
+    print(f'  default_namespace: {deploy_config._default_namespace}')
     print(f'  domain: {deploy_config._domain}')


### PR DESCRIPTION
`hailctl dev config show` is currently inconsistent with the verbiage used
to change those variables. This change ensures `hailctl dev config set k v`
is displayed as `k: v`.