### PR TITLE
[notebook] make notebook python https and fix metrics endpoint

### DIFF
--- a/notebook/nginx.conf
+++ b/notebook/nginx.conf
@@ -61,9 +61,9 @@ http {
       location = /auth {
           internal;
 {% if deploy %}
-          proxy_pass http://notebook.local:5000/auth/$notebook_token;
+          proxy_pass https://notebook.local:5000/auth/$notebook_token;
 {% else %}
-          proxy_pass http://notebook.local:5000/{{ default_ns.name }}/notebook/auth/$notebook_token;
+          proxy_pass https://notebook.local:5000/{{ default_ns.name }}/notebook/auth/$notebook_token;
 {% endif %}
       }
 
@@ -76,7 +76,7 @@ http {
           auth_request /auth;
           auth_request_set $auth_pod_ip $upstream_http_pod_ip;
 
-          proxy_pass http://$auth_pod_ip$request_uri;
+          proxy_pass https://$auth_pod_ip$request_uri;
 
           include /etc/nginx/proxy.conf;
           proxy_http_version 1.1;
@@ -101,7 +101,7 @@ http {
       }
 
       location / {
-          proxy_pass http://notebook.local:5000;
+          proxy_pass https://notebook.local:5000;
 
           # don't set Host, notebook dispatches off domain
           proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -129,9 +129,9 @@ http {
       location = /auth {
           internal;
 {% if deploy %}
-          proxy_pass http://workshop.local:5000/auth/$notebook_token;
+          proxy_pass https://workshop.local:5000/auth/$notebook_token;
 {% else %}
-          proxy_pass http://workshop.local:5000/{{ default_ns.name }}/workshop/auth/$notebook_token;
+          proxy_pass https://workshop.local:5000/{{ default_ns.name }}/workshop/auth/$notebook_token;
 {% endif %}
       }
 
@@ -144,7 +144,7 @@ http {
           auth_request /auth;
           auth_request_set $auth_pod_ip $upstream_http_pod_ip;
 
-          proxy_pass http://$auth_pod_ip$request_uri;
+          proxy_pass https://$auth_pod_ip$request_uri;
 
           include /etc/nginx/proxy.conf;
           proxy_http_version 1.1;
@@ -169,7 +169,7 @@ http {
       }
 
       location / {
-          proxy_pass http://workshop.local:5000;
+          proxy_pass https://workshop.local:5000;
 
           # don't set Host, notebook dispatches off domain
           proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -14,6 +14,7 @@ from prometheus_async.aio.web import server_stats  # type: ignore
 
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
+from hailtop.tls import internal_server_ssl_context
 from gear import (setup_aiohttp_session, create_database_pool,
                   web_authenticated_users_only, web_maybe_authenticated_user,
                   web_authenticated_developers_only, check_csrf_token,
@@ -808,6 +809,7 @@ def init_app(routes):
     routes.static('/static', f'{root}/static')
     setup_common_static_routes(routes)
     app.add_routes(routes)
+    app.router.add_get("/metrics", server_stats)
 
     return app
 
@@ -827,4 +829,5 @@ def run():
     web.run_app(root_app,
                 host='0.0.0.0',
                 port=5000,
-                access_log_class=AccessLogger)
+                access_log_class=AccessLogger,
+                ssl_context=internal_server_ssl_context())


### PR DESCRIPTION
Realized that the notebook python app should in fact speak https because it is exposed on the pod even though it does not have a service in front of it. For example, prometheus scrapes all visible ports on a pod and it anticipates https. This was triggering the deluge of errors from notebook and deploying this into default seems to have stopped them.