### PR TITLE
[query] use other IOUtils.toString method

### DIFF
--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -89,7 +89,7 @@ object Worker {
 
     val fs = retryTransientErrors {
       using(new FileInputStream(s"$scratchDir/gsa-key/key.json")) { is =>
-        new GoogleStorageFS(IOUtils.toString(is, Charset.defaultCharset()))
+        new GoogleStorageFS(IOUtils.toString(is, Charset.defaultCharset().toString()))
       }
     }
 


### PR DESCRIPTION
`IOUtils.toString(InputStream, Charset)` was only introduced in a later version of `commons-io` than we're stuck with because of Indeed's lsmtree. This workaround uses a method that we do have access to.