### PR TITLE
[query] Support older versions of Spark

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -49,16 +49,11 @@ project.ext {
     cachedBreezeVersion = null
 
     sparkVersion = System.getProperty("spark.version", "3.1.1")
-    if (sparkVersion.startsWith("2.")) {
-        throw new UnsupportedOperationException("Hail no longer supports Spark 2.")
-    }
-    else if (sparkVersion != "3.1.1") {
-        project.logger.lifecycle("WARNING: Hail only tested with Spark 3.1.1, use other versions at your own risk.")
+
+    if (sparkVersion != "3.1.1") {
+        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.1.1, use other versions at your own risk.")
     }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
-    if (!scalaVersion.startsWith("2.12.")) {
-        throw new UnsupportedOperationException("Hail currently only supports Scala 2.12")
-    }
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]
 }
 
@@ -162,6 +157,8 @@ dependencies {
     }
     unbundled 'org.apache.spark:spark-sql_' + scalaMajorVersion + ':' + sparkVersion
     unbundled 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
+
+    bundled 'org.json4s:json4s-jackson_' + scalaMajorVersion + ':3.7.0-M5'
 
     bundled 'org.lz4:lz4-java:1.4.0'
 
@@ -315,6 +312,8 @@ tasks.withType(ShadowJar) {
     relocate 'com.github.samtools', 'is.hail.relocated.com.github.samtools'
     relocate 'org.lz4', 'is.hail.relocated.org.lz4'
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
+    relocate 'org.json4s', 'is.hail.relocated.org.json4s'
+    relocate 'com.fasterxml.jackson', 'is.hail.relocated.com.fasterxml.jackson'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'


### PR DESCRIPTION
Support Spark 3.0.1 and 2.4.5 still by bundling and relocating json4s and jackson library that we need