### PR TITLE
Different elasticsearches per Spark version

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -59,22 +59,22 @@ SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
 PYTHON_JAR := python/hail/backend/hail-all-spark.jar
 WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 EGG := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3.6.egg
-ELASTICSEARCH_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
+ELASTICSEARCH_311_JAR := libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 GRADLE_ARGS += -Dscala.version=$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION) -Delasticsearch.major-version=$(ELASTIC_MAJOR_VERSION)
 
 .PHONY: elasticsearchJar
-elasticsearchJar: $(ELASTICSEARCH_JAR)
+elasticsearchJar: $(ELASTICSEARCH_311_JAR)
 
-$(ELASTICSEARCH_JAR):
+$(ELASTICSEARCH_311_JAR):
 	@mkdir -p libs
 	curl https://storage.googleapis.com/hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar >  libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)
 
-$(JAR_SOURCES): $(ELASTICSEARCH_JAR)
-$(JAR_TEST_SOURCES): $(ELASTICSEARCH_JAR)
+$(JAR_SOURCES): $(ELASTICSEARCH_311_JAR)
+$(JAR_TEST_SOURCES): $(ELASTICSEARCH_311_JAR)
 
 ifdef HAIL_COMPILE_NATIVES
 $(SHADOW_JAR): native-lib-prebuilt

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -68,7 +68,7 @@ elasticsearchJar: $(ELASTICSEARCH_JAR)
 
 $(ELASTICSEARCH_JAR):
 	@mkdir -p libs
-	gsutil cp gs://hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar  libs/
+	curl https://storage.googleapis.com/hail-common/elasticsearch-libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar >  libs/elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311.jar
 
 .PHONY: shadowJar
 shadowJar: $(SHADOW_JAR)

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -24,6 +24,8 @@ repositories {
     jcenter()
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
     maven { url "https://repo.spring.io/plugins-release/" }
+    // Necessary for elasticsearch spark 3.0.1 snapshot.
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/"}
 }
 
 sourceSets.main.scala.srcDir "src/main/java"
@@ -179,8 +181,20 @@ dependencies {
     if (elasticMajorVersion != "7") {
         throw new UnsupportedOperationException("elasticsearch.major-version must be 7")
     }
-    // This comes from a local libs directory, see Makefile
-    bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
+
+    if (sparkVersion == "3.1.1") {
+        // This comes from a local libs directory, see Makefile
+        assert(scalaMajorVersion == "2.12")
+        bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
+    }
+    else if (sparkVersion == "3.0.1") {
+        assert(scalaMajorVersion == "2.12")
+        bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:7.13.0-SNAPSHOT'
+    }
+    else if (sparkVersion.startsWith("2.4.")) {
+        assert(scalaMajorVersion == "2.11")
+        bundled 'org.elasticsearch:elasticsearch-spark-20_2.11:7.8.1'
+    }
 
     bundled 'com.google.cloud:google-cloud-storage:1.106.0'
 
@@ -314,6 +328,7 @@ tasks.withType(ShadowJar) {
     relocate 'org.freemarker', 'is.hail.relocated.org.freemarker'
     relocate 'org.json4s', 'is.hail.relocated.org.json4s'
     relocate 'com.fasterxml.jackson', 'is.hail.relocated.com.fasterxml.jackson'
+    relocate 'org.elasticsearch', 'is.hail.relocated.org.elasticsearch'
 
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.SF'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -182,18 +182,21 @@ dependencies {
         throw new UnsupportedOperationException("elasticsearch.major-version must be 7")
     }
 
-    if (sparkVersion == "3.1.1") {
+    if (sparkVersion.startsWith("3.1.")) {
         // This comes from a local libs directory, see Makefile
         assert(scalaMajorVersion == "2.12")
         bundled 'org.elasticsearch:elasticsearch-spark-30_2.12-8.0.0-SNAPSHOT-custom-hail-spark311'
     }
-    else if (sparkVersion == "3.0.1") {
+    else if (sparkVersion.startsWith("3.0.")) {
         assert(scalaMajorVersion == "2.12")
         bundled 'org.elasticsearch:elasticsearch-spark-30_2.12:7.13.0-SNAPSHOT'
     }
     else if (sparkVersion.startsWith("2.4.")) {
         assert(scalaMajorVersion == "2.11")
         bundled 'org.elasticsearch:elasticsearch-spark-20_2.11:7.8.1'
+    }
+    else {
+        throw new UnsupportedOperationException("Couldn't pick a valid elasticsearch.")
     }
 
     bundled 'com.google.cloud:google-cloud-storage:1.106.0'


### PR DESCRIPTION
Naturally, every possible Spark version uses a different elasticsearch library. 

This also uses curl instead of gsutil to download the jar, so we don't require people to have gsutil to make.