### PR TITLE
[query] fix asyncio.wait call in shutdown

### DIFF
--- a/query/query/query.py
+++ b/query/query/query.py
@@ -242,7 +242,7 @@ async def on_shutdown(_):
     # the current task we'll end up in a deadlock
     remaining_tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
     log.info(f"On shutdown request received, with {len(remaining_tasks)} remaining tasks")
-    await asyncio.wait(*remaining_tasks)
+    await asyncio.wait(remaining_tasks)
     log.info("All tasks on shutdown have completed")
 
 


### PR DESCRIPTION
asyncio.wait takes an [iterable of Tasks](https://docs.python.org/3/library/asyncio-task.html#waiting-primitives)