### PR TITLE
[prometheus] fix prometheus permissions and make non-preemptible in prod

### DIFF
--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -142,6 +142,15 @@ spec:
     spec:
       priorityClassName: infrastructure
       serviceAccountName: prometheus
+{% if deploy %}
+      nodeSelector:
+        preemptible: "false"
+{% else %}
+      nodeSelector:
+        preemptible: "true"
+{% endif %}
+      securityContext:
+        fsGroup: 65534
       containers:
        - name: prometheus
          image: prom/prometheus:v2.19.2
@@ -150,6 +159,7 @@ spec:
           - "/bin/prometheus"
           - "--config.file=/etc/prometheus/prometheus.yml"
           - "--storage.tsdb.path=/prometheus"
+          - "--storage.tsdb.retention.time=45d"
           - "--web.console.libraries=/usr/share/prometheus/console_libraries"
           - "--web.console.templates=/usr/share/prometheus/consoles"
           - "--web.enable-lifecycle"
@@ -212,7 +222,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 150Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
I think prometheus got forcibly shutdown and its volume got corrupted, which caused it to fail on startup. I had to wipe the volume. Starting with a new volume introduced permissions issues, I think because that volume claim might still have been there from the original time we were running prometheus.. Either way I was able to get this up and running in default. I had wanted to extend the retention time so we can see a full month of metrics instead of just two weeks, so I'm being extra nice with the volume and moving prometheus off of preemptibles in default.