### PR TITLE
[batch] fix exit_code computation in worker

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -597,12 +597,14 @@ class JVMProcess:
             self.state = 'failed'
 
     async def status(self, state=None):
-        return {
+        d = {
             'name': 'main',
             'state': self.state if not state else state,
-            'timing': self.timing,
-            'exit_code': self.proc.returncode
+            'timing': self.timing
         }
+        if self.proc is not None and self.proc.returncode is not None:
+            d['exit_code'] = self.proc.returncode
+        return d
 
     def get_log(self):
         return self.logbuffer.decode()


### PR DESCRIPTION
I broke this in a previous PR. It causes mark_job_started to fail because
there is no `self.proc` yet.