### PR TITLE
[tls] Make ssl configs use a relative path

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1039,15 +1039,15 @@ class JVMJob(Job):
 
         for envvar in self.env:
             assert envvar['name'] not in {'HAIL_DEPLOY_CONFIG_FILE', 'HAIL_TOKENS_FILE',
-                                          'HAIL_SSL_CONFIG_FILE', 'HAIL_GSA_KEY_FILE',
+                                          'HAIL_SSL_CONFIG_DIR', 'HAIL_GSA_KEY_FILE',
                                           'HAIL_WORKER_SCRATCH_DIR'}, envvar
 
         self.env.append({'name': 'HAIL_DEPLOY_CONFIG_FILE',
                          'value': f'{self.scratch}/secrets/deploy-config/deploy-config.json'})
         self.env.append({'name': 'HAIL_TOKENS_FILE',
                          'value': f'{self.scratch}/secrets/user-tokens/tokens.json'})
-        self.env.append({'name': 'HAIL_SSL_CONFIG_FILE',
-                         'value': f'{self.scratch}/secrets/ssl-config/ssl-config.json'})
+        self.env.append({'name': 'HAIL_SSL_CONFIG_DIR',
+                         'value': f'{self.scratch}/secrets/ssl-config'})
         self.env.append({'name': 'HAIL_GSA_KEY_FILE',
                          'value': f'{self.scratch}/secrets/gsa-key/key.json'})
         self.env.append({'name': 'HAIL_WORKER_SCRATCH_DIR', 'value': self.scratch})

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -5,6 +5,7 @@ import sys
 import json
 import logging
 from hailtop.config import get_deploy_config
+from hailtop.utils import first_extant_file
 
 log = logging.getLogger('gear')
 
@@ -24,7 +25,10 @@ class Tokens(collections.abc.MutableMapping):
         location = deploy_config.location()
         if location == 'external':
             return os.path.expanduser('~/.hail/tokens.json')
-        return '/user-tokens/tokens.json'
+        return first_extant_file(
+            os.environ.get('HAIL_TOKENS_FILE'),
+            '/user-tokens/tokens.json'
+        )
 
     @staticmethod
     def default_tokens():

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -15,11 +15,14 @@ class NoSSLConfigFound(Exception):
 
 
 def _get_ssl_config() -> Dict[str, str]:
-    config_file = os.environ.get('HAIL_SSL_CONFIG_FILE', '/ssl-config/ssl-config.json')
+    config_dir = os.environ.get('HAIL_SSL_CONFIG_DIR', '/ssl-config')
+    config_file = f'{config_dir}/ssl-config.json'
     if os.path.isfile(config_file):
         log.info(f'ssl config file found at {config_file}')
         with open(config_file, 'r') as f:
             ssl_config = json.load(f)
+            for config_name, rel_path in ssl_config.items():
+                ssl_config[config_name] = f'{config_dir}/{rel_path}'
         check_ssl_config(ssl_config)
         return ssl_config
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')

--- a/tls/create_certs.py
+++ b/tls/create_certs.py
@@ -106,13 +106,13 @@ def create_trust(principal, trust_type):  # pylint: disable=unused-argument
 
 def create_json_config(incoming_trust, outgoing_trust, key, cert, key_store):
     principal_config = {
-        'outgoing_trust': f'/ssl-config/{outgoing_trust["trust"]}',
-        'outgoing_trust_store': f'/ssl-config/{outgoing_trust["trust_store"]}',
-        'incoming_trust': f'/ssl-config/{incoming_trust["trust"]}',
-        'incoming_trust_store': f'/ssl-config/{incoming_trust["trust_store"]}',
-        'key': f'/ssl-config/{key}',
-        'cert': f'/ssl-config/{cert}',
-        'key_store': f'/ssl-config/{key_store}'
+        'outgoing_trust': outgoing_trust["trust"],
+        'outgoing_trust_store': outgoing_trust["trust_store"],
+        'incoming_trust': incoming_trust["trust"],
+        'incoming_trust_store': incoming_trust["trust_store"],
+        'key': key,
+        'cert': cert,
+        'key_store': key_store
     }
     config_file = 'ssl-config.json'
     with open(config_file, 'w') as out:


### PR DESCRIPTION
Now the `HAIL_SSL_CONFIG_DIR` environment variable can point to any absolute path. It must contain a `ssl-config.json` file that contains relative paths to `HAIL_SSL_CONFIG_DIR` for the rest of the ssl config files.

Also allows `HAIL_TOKENS_FILE` in python, which was already implemented in Scala.