### PR TITLE
[ci] allow dev deploy to forcibly exclude build steps

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -422,6 +422,7 @@ async def dev_deploy_branch(request, userdata):
     try:
         branch = FQBranch.from_short_str(params['branch'])
         steps = params['steps']
+        excluded_steps = params['excluded_steps']
     except Exception as e:
         message = f'parameters are wrong; check the branch and steps syntax.\n\n{params}'
         log.info('dev deploy failed: ' + message, exc_info=True)
@@ -443,7 +444,7 @@ async def dev_deploy_branch(request, userdata):
     batch_client = app['batch_client']
 
     try:
-        batch_id = await unwatched_branch.deploy(batch_client, steps)
+        batch_id = await unwatched_branch.deploy(batch_client, steps, excluded_steps=excluded_steps)
     except Exception as e:  # pylint: disable=broad-except
         message = traceback.format_exc()
         raise web.HTTPBadRequest(text=f'starting the deploy failed due to\n{message}') from e

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -843,7 +843,7 @@ class UnwatchedBranch(Code):
             'user': self.user,
         }
 
-    async def deploy(self, batch_client, steps):
+    async def deploy(self, batch_client, steps, excluded_steps=()):
         assert not self.deploy_batch
 
         deploy_batch = None
@@ -857,7 +857,9 @@ mkdir -p {shq(repo_dir)}
             )
             log.info(f'User {self.user} requested these steps for dev deploy: {steps}')
             with open(f'{repo_dir}/build.yaml', 'r') as f:
-                config = BuildConfiguration(self, f.read(), scope='dev', requested_step_names=steps)
+                config = BuildConfiguration(
+                    self, f.read(), scope='dev', requested_step_names=steps, excluded_step_names=excluded_steps
+                )
 
             log.info(f'creating dev deploy batch for {self.branch.short_str()} and user {self.user}')
 

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -6,6 +6,7 @@ import sys
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.httpx import client_session
+from hailtop.utils import unpack_comma_delimited_inputs
 
 
 def init_parser(parser):
@@ -60,12 +61,8 @@ class CIClient:
 
 async def submit(args):
     deploy_config = get_deploy_config()
-    steps = [s.strip() for steps in args.steps  # let's unpack this shall we?
-             for step in steps
-             for s in step.split(',') if s.strip()]
-    excluded_steps = [s.strip() for steps in args.excluded_steps
-                      for step in steps
-                      for s in step.split(',') if s.strip()]
+    steps = unpack_comma_delimited_inputs(args.steps)
+    excluded_steps = unpack_comma_delimited_inputs(args.excluded_steps)
     async with CIClient(deploy_config) as ci_client:
         batch_id = await ci_client.dev_deploy_branch(args.branch, steps, excluded_steps)
         url = deploy_config.url('ci', f'/batches/{batch_id}')

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -13,6 +13,8 @@ def init_parser(parser):
                         help="Fully-qualified branch, e.g., hail-is/hail:feature.", required=True)
     parser.add_argument("--steps", "-s", nargs='+', action='append',
                         help="Comma or space-separated list of steps to run.", required=True)
+    parser.add_argument("--excluded_steps", "-e", nargs='+', action='append', default=[],
+                        help="Comma or space-separated list of steps to forcibly exclude. Use with caution!")
     parser.add_argument("--open", "-o",
                         action="store_true",
                         help="Open the deploy batch page in a web browser.")
@@ -40,10 +42,11 @@ class CIClient:
             await self._session.close()
             self._session = None
 
-    async def dev_deploy_branch(self, branch, steps):
+    async def dev_deploy_branch(self, branch, steps, excluded_steps):
         data = {
             'branch': branch,
-            'steps': steps
+            'steps': steps,
+            'excluded_steps': excluded_steps
         }
         async with self._session.post(
                 self._deploy_config.url('ci', '/api/v1alpha/dev_deploy_branch'), json=data) as resp:
@@ -60,8 +63,11 @@ async def submit(args):
     steps = [s.strip() for steps in args.steps  # let's unpack this shall we?
              for step in steps
              for s in step.split(',') if s.strip()]
+    excluded_steps = [s.strip() for steps in args.excluded_steps
+                      for step in steps
+                      for s in step.split(',') if s.strip()]
     async with CIClient(deploy_config) as ci_client:
-        batch_id = await ci_client.dev_deploy_branch(args.branch, steps)
+        batch_id = await ci_client.dev_deploy_branch(args.branch, steps, excluded_steps)
         url = deploy_config.url('ci', f'/batches/{batch_id}')
         print(f'Created deploy batch, see {url}')
         if args.open:

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -9,7 +9,7 @@ from .utils import (
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
-    find_spark_home, TransientError, bounded_gather2, OnlineBoundedGather2)
+    find_spark_home, TransientError, bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -77,5 +77,6 @@ __all__ = [
     'find_spark_home',
     'TransientError',
     'bounded_gather2',
-    'OnlineBoundedGather2'
+    'OnlineBoundedGather2',
+    'unpack_comma_delimited_inputs'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -34,6 +34,13 @@ RETRY_FUNCTION_SCRIPT = """function retry() {
 }"""
 
 
+def unpack_comma_delimited_inputs(inputs):
+    return [s.strip()
+            for steps in inputs
+            for step in steps
+            for s in step.split(',') if s.strip()]
+
+
 def flatten(xxs):
     return [x for xs in xxs for x in xs]
 


### PR DESCRIPTION
Potential footgun but specifically limited to dev deploys. This allows you to explicitly exclude build steps when dev deploying. For example, `hailctl dev deploy -b … -s deploy_query --excluded_steps deploy_batch` would make sure that `deploy_batch` and any jobs only in the `deploy_batch` subtree are not run.

Thoughts?