### PR TITLE
Fix GitHub icon in top bar of docs

### DIFF
--- a/website/website/templates/nav-top.html
+++ b/website/website/templates/nav-top.html
@@ -30,7 +30,7 @@
         </li>
         <li class="nav-item" style='margin-top:-2px'>
           <a href="https://github.com/hail-is/hail" class='img-link' target='_blank'>
-            <i class="fab fa-github fa-2x"></i>
+            <i class="fa fa-github fa-2x"></i>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
Currently, the GitHub icon in the top bar of the Hail docs looks like this:

![Screen Shot 2021-04-05 at 11 19 36 AM](https://user-images.githubusercontent.com/1156625/113592139-c4282b80-9602-11eb-824c-6cda1ce284f2.png)

I don't know how to build the full website and the navigation bar doesn't show up in a local build of the docs, but changing `fab` to `fa` in the Chrome element inspector appears to fix it.

![Screen Shot 2021-04-05 at 11 28 08 AM](https://user-images.githubusercontent.com/1156625/113592191-d4d8a180-9602-11eb-95b7-cfd54c583b75.png)

Not sure how this works on other pages of the site but not on the docs.