### PR TITLE
[website] fix for issues raised in #10277

### DIFF
--- a/website/website/templates/base-foot.html
+++ b/website/website/templates/base-foot.html
@@ -1,0 +1,2 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-core.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-python.min.js"></script>

--- a/website/website/templates/base-head.html
+++ b/website/website/templates/base-head.html
@@ -1,0 +1,24 @@
+<meta charset="utf-8"/>
+<meta name="description" content="{% block meta_description %}{% endblock meta_description %}"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+
+<link rel="shortcut icon" href="{{ base_path }}/static/hail_logo_sq-sm-opt.ico" type="image/x-icon"/>
+
+<link rel="stylesheet" href="{{ base_path }}/static/css/style.css"/>
+<link rel="stylesheet" href="{{ base_path }}/static/css/navbar.css"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/themes/prism.min.css"/>
+
+<script src="https://kit.fontawesome.com/7cdc07e2ca.js" crossorigin="anonymous"></script>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-86050742-1', 'auto');
+  ga('send', 'pageview');
+</script>
+

--- a/website/website/templates/base.html
+++ b/website/website/templates/base.html
@@ -3,29 +3,7 @@
   <head>
     <title>Hail | {% block title %}{% endblock %}</title>
 
-    <meta charset="utf-8"/>
-    <meta name="description" content="{% block meta_description %}{% endblock meta_description %}"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
-
-    <link rel="shortcut icon" href="{{ base_path }}/static/hail_logo_sq-sm-opt.ico" type="image/x-icon"/>
-
-    <link rel="stylesheet" href="{{ base_path }}/static/css/style.css"/>
-    <link rel="stylesheet" href="{{ base_path }}/static/css/navbar.css"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/themes/prism.min.css"/>
-
-    <script src="https://kit.fontawesome.com/7cdc07e2ca.js" crossorigin="anonymous"></script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                              })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-86050742-1', 'auto');
-      ga('send', 'pageview');
-    </script>
+    {% include "base-head.html" %}
 
     {% block head %}{% endblock %}
   </head>
@@ -35,7 +13,6 @@
       {% block content %}{% endblock %}
     </div>
     {% include "nav-bottom.html" %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-python.min.js"></script>
+    {% include "base-foot.html" %}
   </body>
 </html>

--- a/website/website/templates/dynamic-base.html
+++ b/website/website/templates/dynamic-base.html
@@ -3,31 +3,9 @@
   <head>
     <title>Hail | {% block title %}{% endblock %}</title>
 
-    <meta charset="utf-8"/>
-    <meta name="description" content="{% block meta_description %}{% endblock meta_description %}"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
-
     {% raw %}
-    <link rel="shortcut icon" href="{{ base_path }}/static/hail_logo_sq-sm-opt.ico" type="image/x-icon"/>
-
-    <link rel="stylesheet" href="{{ base_path }}/static/css/style.css"/>
-    <link rel="stylesheet" href="{{ base_path }}/static/css/navbar.css"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/themes/prism.min.css"/>
+    {% include "base-head.html" %}
     {% endraw %}
-
-    <script src="https://kit.fontawesome.com/7cdc07e2ca.js" crossorigin="anonymous"></script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                              })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-86050742-1', 'auto');
-      ga('send', 'pageview');
-    </script>
 
     {% block head %}{% endblock %}
   </head>
@@ -42,8 +20,7 @@
     </div>
     {% raw %}
     {% include "nav-bottom.html" %}
+    {% include "base-foot.html" %}
     {% endraw %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/components/prism-python.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
@nawatts points out that the docs are missing the font-awesome icons. This new website
stuff is confusing! Here is how to think about it going forward:

This PR is the *long-term fix*. It will not resolve the current production issue. The easiest fix
for that is to release a new version of Hail, which will generate a new version of the docs. That
new version will be compatible with the currently released `website`.

We have two phases: docs-generation-time and serve-time. Importantly, we always need to support the
*previously released documentation* with the current `main` `website`.

This PR makes things work like this:

At docs-generation-time (which happens every time we release a new version of the Hail package to
PyPI), Sphinx uses `dynamic-base.html` to build the docs website. Those HTML files will look like
this:

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>Hail | {% block title %}{% endblock %}</title>

    {% include "base-head.html" %}

    <!-- Sphinx will insert some header stuff here -->
  </head>
  <body>
    {% include "nav-top.html" %}
    <div id="main">
      {% raw %}
      <!-- Sphinx will insert the actual documentation here -->
      {% endraw %}
    </div>
    {% include "nav-bottom.html" %}
    {% include "base-foot.html" %}
  </body>
</html>
```

Note that this is *still a Jinja2 template!*

At serve-time, `website` will run this through Jinja2 templating *a second time*. At this time,
we'll use the latest `base-head.html`.

In particular, suppose I need access to a new CSS file in `nav-top.html`. I can modify
`base-head.html`. Since `base-head.html` is added to the web page *at serve-time*, it will include
all the latest changes.

In contrast, everything inside the `#main` `div` *only changes when Hail is released* because it is
only updated at docs-generation-time.

cc: @daniel-goldstein 