### PR TITLE
[query-service] concurrently use multiple Hail Query JAR versions

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1463,11 +1463,11 @@ class Worker:
                 })
             resp_json = await resp.json()
 
-            with open('key.json', 'w') as f:
+            with open('/worker-key.json', 'w') as f:
                 f.write(json.dumps(resp_json['key']))
 
             credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                'key.json')
+                '/worker-key.json')
             self.log_store = LogStore(BATCH_LOGS_BUCKET_NAME, INSTANCE_ID, self.pool,
                                       project=PROJECT, credentials=credentials)
 

--- a/build.yaml
+++ b/build.yaml
@@ -361,6 +361,7 @@ steps:
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "batch-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "benchmark-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "ci-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
+     kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "query-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "test-dev-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
    scopes:
     - test
@@ -2315,6 +2316,40 @@ steps:
     - deploy_address_sa
     - address_image
     - create_certs
+ - kind: runImage
+   name: upload_query_jar
+   image:
+     valueFrom: base_image.image
+   script: |
+     set -ex
+     gcloud -q auth activate-service-account --key-file=/query-gsa-key/key.json
+
+     {% if deploy %}
+     destination=gs://$(cat /global-config/hail_query_bucket)/jars/
+     {% else %}
+     destination=gs://hail-test-dmk9z/{{ token }}/jars/
+     {% endif %}
+
+     gsutil -m cp /io/hail.jar ${destination}$(cat /io/git_version).jar
+   secrets:
+     - name: query-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /query-gsa-key
+     - name: global-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /global-config
+   inputs:
+     - from: /just-jar/hail.jar
+       to: /io/hail.jar
+     - from: /git_version
+       to: /io/git_version
+   dependsOn:
+     - default_ns
+     - base_image
+     - build_hail_jar_only
+     - copy_files
  - kind: deploy
    name: deploy_query
    namespace:
@@ -2332,6 +2367,7 @@ steps:
     - deploy_query_sa
     - deploy_address
     - create_certs
+    - upload_query_jar
  - kind: deploy
    name: deploy_memory
    namespace:
@@ -2347,6 +2383,156 @@ steps:
     - memory_image
     - deploy_memory_sa
     - create_certs
+ - kind: runImage
+   name: test_hail_python_service_backend_0
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=0
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
+ - kind: runImage
+   name: test_hail_python_service_backend_1
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=1
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
+ - kind: runImage
+   name: test_hail_python_service_backend_2
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=2
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
  - kind: runImage
    name: test_lsm
    image:
@@ -3689,6 +3875,9 @@ steps:
     - test_hailtop_batch_2
     - test_hailtop_batch_3
     - test_hailtop_batch_4
+    - test_hail_python_service_backend_0
+    - test_hail_python_service_backend_1
+    - test_hail_python_service_backend_2
  - kind: runImage
    name: delete_atgu_tables
    image:

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -54,7 +54,8 @@ async def main():
         ('benchmark', None, 0, 1),
         ('ci', None, 0, 1),
         ('test', None, 0, 0),
-        ('test-dev', None, 1, 0)
+        ('test-dev', None, 1, 0),
+        ('query', None, 0, 1),
     ]
 
     app = {}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -107,4 +107,4 @@ deploy: push
 
 .PHONY: clean
 clean:
-	rm -f base-stmp
+	rm -f base-stmp hail-ubuntu-stmp

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,12 +1,22 @@
+import pkg_resources
+import sys
+import asyncio
 import nest_asyncio
-nest_asyncio.apply()
-
-import pkg_resources  # noqa: E402
-import sys  # noqa: E402
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+
+if sys.version_info[:2] == (3, 6):
+    if asyncio._get_running_loop() is not None:
+        nest_asyncio.apply()
+else:
+    try:
+        asyncio.get_running_loop()
+        nest_asyncio.apply()
+    except RuntimeError as err:
+        assert 'no running event loop' in err.args[0]
+
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources

--- a/hail/src/main/scala/is/hail/backend/service/LoadSelfFirstURLClassLoader.scala
+++ b/hail/src/main/scala/is/hail/backend/service/LoadSelfFirstURLClassLoader.scala
@@ -1,0 +1,59 @@
+package is.hail.backend.service
+
+import java.net._
+import org.apache.log4j.Logger
+
+class LoadSelfFirstURLClassLoader(
+  urls: Array[URL]
+) extends URLClassLoader(urls) {
+  private[this] val log = Logger.getLogger(getClass.getName())
+
+  override protected def loadClass(name: String, resolve: Boolean): Class[_] = synchronized {
+    val klass = findLoadedClass(name)
+    if (klass != null) {
+      return klass
+    }
+    try {
+      val klass = findClass(name)
+      if (resolve)
+        resolveClass(klass)
+      klass
+    } catch {
+      case e: ClassNotFoundException =>
+        super.loadClass(name, resolve)
+    }
+  }
+
+  override def getResource(name: String): URL = {
+    val url = findResource(name)
+    if (url != null) {
+      return url
+    }
+    return super.getResource(name)
+  }
+
+  private[this] class PrependElementEnumeration[T](
+    private[this] val t: T,
+    private[this] val rest: java.util.Enumeration[T]
+  ) extends java.util.Enumeration[T] {
+    private[this] var consumed = false
+    def hasMoreElements() = !consumed || rest.hasMoreElements
+    def nextElement(): T = {
+      if (!consumed) {
+        consumed = true
+        t
+      } else {
+        rest.nextElement()
+      }
+    }
+  }
+
+  override def getResources(name: String): java.util.Enumeration[URL] = {
+    val url = findResource(name)
+    val rest = super.getResources(name)
+    if (url != null) {
+      return new PrependElementEnumeration(url, rest)
+    }
+    return rest
+  }
+}

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -138,6 +138,7 @@ object Worker {
         val localJarFile = new File(localJarLocation)
         if (!localJarFile.exists()) {
           log.info(s"$revision not in the disk cache")
+          localJarFile.getParentFile().mkdirs()
           downloadFile(workerGCSFS, remoteJarLocation, localJarLocation)
           log.info(s"$revision added to the disk cache at $localJarLocation")
         }

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -1,17 +1,41 @@
 package is.hail.backend.service
 
 import java.io._
-import java.nio.charset.Charset
+import java.net._
+import java.nio.charset.StandardCharsets
+import java.util.concurrent._
 
+
+
+import is.hail.HAIL_REVISION
 import is.hail.HailContext
-import is.hail.backend._
-import is.hail.io.fs._
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
+import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.lowering.{DArrayLowering, LoweringPipeline, TableStage, TableStageDependency}
+import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, Literal, MakeArray, MakeTuple, ShuffleRead, ShuffleWrite, SortField, ToStream}
+import is.hail.io.fs.GoogleStorageFS
+import is.hail.linalg.BlockMatrix
+import is.hail.rvd.RVDPartitioner
 import is.hail.services._
+import is.hail.services.batch_client.BatchClient
+import is.hail.services.shuffler.ShuffleClient
+import is.hail.types._
+import is.hail.types.encoded._
+import is.hail.types.physical._
+import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.variant.ReferenceGenome
 import org.apache.commons.io.IOUtils
 import org.apache.log4j.Logger
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods
+import org.json4s.{DefaultFormats, Formats}
+import org.newsclub.net.unix.{AFUNIXServerSocket, AFUNIXSocketAddress}
 
-import scala.collection.mutable
+import scala.annotation.switch
+import scala.reflect.ClassTag
 
 class ServiceTaskContext(val partitionId: Int) extends HailTaskContext {
   override type BackendType = ServiceBackend
@@ -44,21 +68,113 @@ class WorkerTimer() {
 }
 
 object Worker {
-  private val log = Logger.getLogger(getClass.getName())
+  val myRevision = HAIL_REVISION
+
+  private[this] val log = Logger.getLogger(getClass.getName())
+  private[this] val revisions = mutable.Map[String, Array[String] => Unit]()
+  private[this] val scratchDir = {
+    val x = System.getenv("HAIL_WORKER_SCRATCH_DIR")
+    if (x == null) "" else x
+  }
+  private[this] val workerGCSFS = retryTransientErrors {
+    using(new FileInputStream(s"/worker-key.json")) { is =>
+      new GoogleStorageFS(IOUtils.toString(is, Charset.defaultCharset().toString()))
+    }
+  }
+
+  private[this] def withThreadContextClassLoader[T](custom: ClassLoader)(f: => T): T = {
+    val original = Thread.currentThread().getContextClassLoader()
+    try {
+      Thread.currentThread().setContextClassLoader(custom)
+      f
+    } finally {
+      Thread.currentThread().setContextClassLoader(original)
+    }
+  }
+
+  private[this] val STRING_ARRAY_CLASS = Class.forName("[Ljava.lang.String;")
+  private[this] def loadMainFromLocalJar(revision: String, localJarURL: URL): Array[String] => Unit = {
+    val classLoader = new LoadSelfFirstURLClassLoader(Array(localJarURL))
+    val reflectedMain = withThreadContextClassLoader(classLoader) {
+      val workerClass = classLoader.loadClass("is.hail.backend.service.Worker")
+
+      val actualRevision = workerClass.getMethod("myRevision").invoke(null).asInstanceOf[String]
+      assert(revision == actualRevision, s"$revision != $actualRevision")
+
+      workerClass.getMethod("main", STRING_ARRAY_CLASS)
+    }
+
+    { (args: Array[String]) =>
+      withThreadContextClassLoader(classLoader) {
+        try {
+          reflectedMain.invoke(null, args): Unit
+        } catch {
+          case e: InvocationTargetException =>
+            throw e.getCause()
+        }
+      }
+    }
+  }
+
+  private[this] def downloadFile(remoteFS: FS, remote: String, local: String): Unit =
+    retryTransientErrors {
+      using(remoteFS.openNoCompression(remote)) { is =>
+        using(new FileOutputStream(local)) { os =>
+          IOUtils.copy(is, os)
+        }
+      }
+    }
+
+  private[this] def mainForRevision(revision: String, remoteJarLocation: String): Array[String] => Unit = {
+    revisions.get(revision) match {
+      case Some(mainMethod) =>
+        log.info(s"$revision found in the memory cache")
+        mainMethod
+      case None =>
+        log.info(s"$revision not in the memory cache")
+
+        val localJarLocation = s"/hail-jars/${revision}.jar"
+        val localJarFile = new File(localJarLocation)
+        if (!localJarFile.exists()) {
+          log.info(s"$revision not in the disk cache")
+          downloadFile(workerGCSFS, remoteJarLocation, localJarLocation)
+          log.info(s"$revision added to the disk cache at $localJarLocation")
+        }
+
+        val localJarURL = localJarFile.toURI().toURL()
+        val mainMethod = loadMainFromLocalJar(revision, localJarURL)
+        log.info(s"$revision loaded")
+        revisions.put(revision, mainMethod)
+        mainMethod
+    }
+  }
 
   def main(args: Array[String]): Unit = {
-    if (args.length != 2) {
-      throw new IllegalArgumentException(s"expected two arguments, not: ${ args.length }")
-    }
-    val root = args(0)
-    val i = args(1).toInt
     val timer = new WorkerTimer()
+    timer.start("main")
 
-    var scratchDir = System.getenv("HAIL_WORKER_SCRATCH_DIR")
-    if (scratchDir == null)
-      scratchDir = ""
+    log.info(s"is.hail.backend.service.Worker $myRevision")
+    if (args.length < 2) {
+      throw new IllegalArgumentException(s"expected at least two arguments, not: ${ args.length }")
+    }
 
-    log.info(s"running job $i at root $root wih scratch directory '$scratchDir'")
+    val revision = args(0)
+    val remoteJarLocation = args(1)
+    if (revision != myRevision) {
+      timer.start("classLoading")
+      log.info(s"received job for different revision: $revision; I am $myRevision")
+      val mainMethod = mainForRevision(revision, remoteJarLocation)
+      timer.end("classLoading")
+      return mainMethod(args)
+    }
+
+    if (args.length != 4) {
+      throw new IllegalArgumentException(s"expected at four arguments, not: ${ args.length }")
+    }
+    val root = args(2)
+    val i = args(3).toInt
+
+    log.info(s"running job $i at root $root with scratch directory '$scratchDir'")
 
     timer.start(s"Job $i")
     timer.start("readInputs")
@@ -98,7 +214,7 @@ object Worker {
     timer.start("executeFunction")
 
     val hailContext = HailContext(
-      ServiceBackend(), skipLoggingConfiguration = true, quiet = true)
+      new WorkerBackend(), skipLoggingConfiguration = true, quiet = true)
     val htc = new ServiceTaskContext(i)
     HailTaskContext.setTaskContext(htc)
     val result = f(context, htc)
@@ -112,6 +228,34 @@ object Worker {
     }
     timer.end("writeOutputs")
     timer.end(s"Job $i")
+    timer.end(s"main")
     log.info(s"finished job $i at root $root")
   }
+}
+
+class WorkerBackend extends Backend {
+  def defaultParallelism: Int = 1
+
+  def broadcast[T: ClassTag](value: T): BroadcastValue[T] = ???
+
+  def persist(backendContext: BackendContext, id: String, value: BlockMatrix, storageLevel: String): Unit = ???
+
+  def unpersist(backendContext: BackendContext, id: String): Unit = ???
+
+  def getPersistedBlockMatrix(backendContext: BackendContext, id: String): BlockMatrix = ???
+
+  def getPersistedBlockMatrixType(backendContext: BackendContext, id: String): BlockMatrixType = ???
+
+  def parallelizeAndComputeWithIndex(backendContext: BackendContext, collection: Array[Array[Byte]], dependency: Option[TableStageDependency] = None)(f: (Array[Byte], HailTaskContext) => Array[Byte]): Array[Array[Byte]] = ???
+
+  def stop(): Unit = {
+  }
+
+  def lowerDistributedSort(
+    ctx: ExecuteContext,
+    stage: TableStage,
+    sortFields: IndexedSeq[SortField],
+    relationalLetsAbove: Map[String, IR],
+    rowTypeRequiredness: RStruct
+  ): TableStage = ???
 }

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -167,7 +167,8 @@ object Worker {
       log.info(s"received job for different revision: $revision; I am $myRevision")
       val mainMethod = mainForRevision(revision, remoteJarLocation)
       timer.end("classLoading")
-      return mainMethod(args)
+      mainMethod(args)
+      return
     }
 
     if (args.length != 4) {

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -38,7 +38,10 @@ import scala.reflect.ClassTag
 import java.lang.reflect.InvocationTargetException
 import is.hail.io.fs.FS
 
-class ServiceTaskContext(val partitionId: Int) extends HailTaskContext {
+class ServiceTaskContext(
+  val partitionId: Int,
+  val gcsfs: GoogleStorageFS
+) extends HailTaskContext {
   override type BackendType = ServiceBackend
 
   override def stageId(): Int = 0
@@ -222,7 +225,7 @@ object Worker {
 
     val hailContext = HailContext(
       new WorkerBackend(), skipLoggingConfiguration = true, quiet = true)
-    val htc = new ServiceTaskContext(i)
+    val htc = new ServiceTaskContext(i, fs)
     HailTaskContext.setTaskContext(htc)
     val result = f(context, htc)
     HailTaskContext.finish()

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -2,10 +2,8 @@ package is.hail.backend.service
 
 import java.io._
 import java.net._
-import java.nio.charset.StandardCharsets
+import java.nio.charset._
 import java.util.concurrent._
-
-
 
 import is.hail.HAIL_REVISION
 import is.hail.HailContext
@@ -35,7 +33,10 @@ import org.json4s.{DefaultFormats, Formats}
 import org.newsclub.net.unix.{AFUNIXServerSocket, AFUNIXSocketAddress}
 
 import scala.annotation.switch
+import scala.collection.mutable
 import scala.reflect.ClassTag
+import java.lang.reflect.InvocationTargetException
+import is.hail.io.fs.FS
 
 class ServiceTaskContext(val partitionId: Int) extends HailTaskContext {
   override type BackendType = ServiceBackend

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -97,28 +97,18 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
 }
 
 class GoogleStorageFS(
-  @transient private[this] var serviceAccountKey: String
+  private[this] val serviceAccountKey: String
 ) extends FS {
   import GoogleStorageFS._
 
   @transient private lazy val storage: Storage = {
-    if (serviceAccountKey == null) {
-      HailTaskContext.get() match {
-        case x: ServiceTaskContext =>
-          x.gcsfs.storage
-        case _ =>
-          throw new RuntimeException(
-            s"Must provide serviceAccountKey outside Hail Service Worker")
-      }
-    } else {
-      StorageOptions.newBuilder()
-        .setCredentials(
-          ServiceAccountCredentials.fromStream(
-            new ByteArrayInputStream(
-              serviceAccountKey.getBytes)))
-        .build()
-        .getService
-    }
+    StorageOptions.newBuilder()
+      .setCredentials(
+        ServiceAccountCredentials.fromStream(
+          new ByteArrayInputStream(
+            serviceAccountKey.getBytes)))
+      .build()
+      .getService
   }
 
   def openNoCompression(filename: String): SeekableDataInputStream = {

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -101,7 +101,9 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
   @transient private lazy val storage: Storage = {
     StorageOptions.newBuilder()
       .setCredentials(
-        ServiceAccountCredentials.fromStream(new ByteArrayInputStream(serviceAccountKey.getBytes)))
+        ServiceAccountCredentials.fromStream(
+          new ByteArrayInputStream(
+            serviceAccountKey.getBytes)))
       .build()
       .getService
   }

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -95,6 +95,7 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
 }
 
 class GoogleStorageFS(serviceAccountKey: String) extends FS {
+  assert(serviceAccountKey != null)
   import GoogleStorageFS._
 
   @transient private lazy val storage: Storage = {

--- a/hail/src/main/scala/is/hail/services/Http.scala
+++ b/hail/src/main/scala/is/hail/services/Http.scala
@@ -1,0 +1,78 @@
+package is.hail.services
+
+import java.nio.charset.StandardCharsets
+
+import is.hail.utils._
+import is.hail.services._
+import org.apache.commons.io.IOUtils
+import org.apache.http.{HttpEntity, HttpEntityEnclosingRequest}
+import org.apache.http.client.methods.{HttpDelete, HttpGet, HttpPatch, HttpPost, HttpUriRequest}
+import org.apache.http.entity.{ByteArrayEntity, ContentType, StringEntity}
+import org.apache.http.impl.client.{CloseableHttpClient, HttpClients}
+import org.apache.http.util.EntityUtils
+import org.apache.log4j.{LogManager, Logger}
+import org.json4s.{DefaultFormats, Formats, JObject, JValue}
+import org.json4s.jackson.JsonMethods
+
+import scala.util.Random
+
+class ClientResponseException(
+  val status: Int,
+  message: String,
+  cause: Throwable
+) extends Exception(message, cause) {
+  def this(statusCode: Int) = this(statusCode, null, null)
+
+  def this(statusCode: Int, message: String) = this(statusCode, message, null)
+}
+
+object Http {
+  private[this] lazy val log: Logger = LogManager.getLogger("Http")
+  private[this] lazy val internalHttpClient: CloseableHttpClient = {
+    log.info("creating internal HttpClient")
+    HttpClients.custom()
+      .setSSLContext(tls.getSSLContext)
+      .build()
+  }
+
+  private[this] lazy val externalHttpClient: CloseableHttpClient = {
+    log.info("creating external HttpClient")
+    HttpClients.custom().build()
+  }
+
+  private[this] def requestString(httpClient: CloseableHttpClient, req: HttpUriRequest): String = {
+    log.info(s"request ${ req.getMethod } ${ req.getURI }")
+    retryTransientErrors {
+      using(httpClient.execute(req)) { resp =>
+        val statusCode = resp.getStatusLine.getStatusCode
+        log.info(s"request ${ req.getMethod } ${ req.getURI } response $statusCode")
+        if (statusCode < 200 || statusCode >= 300) {
+          val entity = resp.getEntity
+          val message =
+            if (entity != null)
+              EntityUtils.toString(entity)
+            else
+              null
+          throw new ClientResponseException(statusCode, message)
+        }
+        val entity: HttpEntity = resp.getEntity
+        if (entity != null) {
+          using(entity.getContent) { content =>
+            val s = IOUtils.toByteArray(content)
+            if (s.isEmpty)
+              null
+            else
+              new String(s)
+          }
+        } else
+            null
+      }
+    }
+  }
+
+  def internalRequestString(req: HttpUriRequest): String =
+    requestString(internalHttpClient, req)
+
+  def externalRequestString(req: HttpUriRequest): String =
+    requestString(externalHttpClient, req)
+}

--- a/hail/src/main/scala/is/hail/services/Requester.scala
+++ b/hail/src/main/scala/is/hail/services/Requester.scala
@@ -16,25 +16,8 @@ import org.json4s.jackson.JsonMethods
 
 import scala.util.Random
 
-class ClientResponseException(
-  val status: Int,
-  message: String,
-  cause: Throwable
-) extends Exception(message, cause) {
-  def this(statusCode: Int) = this(statusCode, null, null)
-
-  def this(statusCode: Int, message: String) = this(statusCode, message, null)
-}
-
 object Requester {
   lazy val log: Logger = LogManager.getLogger("Requester")
-
-  private val httpClient: CloseableHttpClient = {
-    log.info("creating HttpClient")
-    HttpClients.custom()
-      .setSSLContext(tls.getSSLContext)
-      .build()
-  }
 }
 
 class Requester(
@@ -46,39 +29,16 @@ class Requester(
   import Requester._
 
   def request(req: HttpUriRequest, body: HttpEntity = null): JValue = {
-    log.info(s"request ${ req.getMethod } ${ req.getURI }")
-
     if (body != null)
       req.asInstanceOf[HttpEntityEnclosingRequest].setEntity(body)
 
     tokens.addServiceAuthHeaders(service, req)
 
-    retryTransientErrors {
-      using(httpClient.execute(req)) { resp =>
-        val statusCode = resp.getStatusLine.getStatusCode
-        log.info(s"request ${ req.getMethod } ${ req.getURI } response $statusCode")
-        if (statusCode < 200 || statusCode >= 300) {
-          val entity = resp.getEntity
-          val message =
-            if (entity != null)
-              EntityUtils.toString(entity)
-            else
-              null
-          throw new ClientResponseException(statusCode, message)
-        }
-        val entity: HttpEntity = resp.getEntity
-        if (entity != null) {
-          using(entity.getContent) { content =>
-            val s = IOUtils.toByteArray(content)
-            if (s.isEmpty)
-              null
-            else
-              JsonMethods.parse(new String(s))
-
-          }
-        } else
-          null
-      }
+    val maybeString = Http.internalRequestString(req)
+    if (maybeString != null) {
+      JsonMethods.parse(maybeString)
+    } else {
+      null
     }
   }
 }

--- a/hail/src/main/scala/is/hail/services/package.scala
+++ b/hail/src/main/scala/is/hail/services/package.scala
@@ -4,6 +4,7 @@ import javax.net.ssl.SSLException
 import java.net.SocketException
 import java.io.EOFException
 import is.hail.utils._
+import com.google.cloud.storage.StorageException
 
 import org.apache.http.NoHttpResponseException
 import org.apache.http.conn.HttpHostConnectException
@@ -43,7 +44,7 @@ package object services {
       case e: EOFException =>
         e.getMessage != null && (
           e.getMessage.contains("SSL peer shut down incorrectly"))
-      case e: SSLException =>
+      case e @ (_: SSLException | _: StorageException) =>
         val cause = e.getCause
         cause != null && isTransientError(cause)
       case _ =>

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -16,6 +16,8 @@ variable "batch_gcp_regions" {}
 variable "gcp_project" {}
 variable "batch_logs_bucket_location" {}
 variable "batch_logs_bucket_storage_class" {}
+variable "hail_query_bucket_location" {}
+variable "hail_query_bucket_storage_class" {}
 variable "gcp_region" {}
 variable "gcp_zone" {}
 variable "domain" {}
@@ -203,6 +205,7 @@ resource "kubernetes_secret" "global_config" {
   data = {
     batch_gcp_regions = var.batch_gcp_regions
     batch_logs_bucket = google_storage_bucket.batch_logs.name
+    hail_query_bucket = google_storage_bucket.hail_query.name
     default_namespace = "default"
     docker_root_image = "gcr.io/${var.gcp_project}/ubuntu:18.04"
     domain = var.domain
@@ -468,6 +471,34 @@ resource "google_project_iam_member" "batch_storage_admin" {
   member = "serviceAccount:${google_service_account.batch.email}"
 }
 
+resource "random_id" "query_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_service_account" "query" {
+  account_id = "query-${random_id.query_name_suffix.hex}"
+}
+
+resource "google_service_account_key" "query_key" {
+  service_account_id = google_service_account.query.name
+}
+
+resource "kubernetes_secret" "query_gsa_key" {
+  metadata {
+    name = "query-gsa-key"
+  }
+
+  data = {
+    "key.json" = base64decode(google_service_account_key.query_key.private_key)
+  }
+}
+
+resource "google_storage_bucket_iam_member" "query_hail_query_bucket_storage_admin" {
+  bucket = google_storage_bucket.hail_query.name
+  role = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.query.email}"
+}
+
 resource "google_service_account" "benchmark" {
   account_id = "benchmark"
 }
@@ -670,6 +701,17 @@ resource "google_storage_bucket" "batch_logs" {
   location = var.batch_logs_bucket_location
   force_destroy = true
   storage_class = var.batch_logs_bucket_storage_class
+}
+
+resource "random_id" "hail_query_bucket_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_storage_bucket" "hail_query" {
+  name = "hail-query-${random_id.hail_query_bucket_name_suffix.hex}"
+  location = var.hail_query_bucket_location
+  force_destroy = true
+  storage_class = var.hail_query_bucket_storage_class
 }
 
 resource "google_dns_managed_zone" "dns_zone" {

--- a/query/.gitignore
+++ b/query/.gitignore
@@ -1,2 +1,4 @@
 /Dockerfile.out
 /deployment.yaml.out
+hail.jar
+query/git_version

--- a/query/Makefile
+++ b/query/Makefile
@@ -28,9 +28,13 @@ push: build
 	docker tag query $(QUERY_IMAGE)
 	docker push $(QUERY_IMAGE)
 
+UPLOAD_QUERY_JAR_TOKEN := $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+HAIL_REVISION := $(shell git rev-parse HEAD)
+
 .PHONY: deploy
 deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	kubectl -n $(NAMESPACE) apply -f service-account.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	gsutil cp ./hail.jar gs://hail-test-dmk9z/$(UPLOAD_QUERY_JAR_TOKEN)/jars/$(HAIL_REVISION).jar
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"},"upload_query_jar":{"token":"$(UPLOAD_QUERY_JAR_TOKEN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -92,6 +92,16 @@ spec:
              value: "{{ code.sha }}"
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
+{% if deploy %}
+           - name: HAIL_QUERY_GCS_BUCKET
+             valueFrom:
+             secretKeyRef:
+               name: global-config
+               key: hail_query_bucket
+{% else %}
+           - name: HAIL_QUERY_GCS_PATH
+             value: gs://hail-test-dmk9z/{{ upload_query_jar.token }}/jars/
+{% endif %}
           ports:
            - containerPort: 5000
           volumeMounts:


### PR DESCRIPTION
The high-level problem:

The Hail Query Service is redeployed with each commit to `main`. Each deployment has a new JAR file
whose ABI is backwards-incompatible.

The high-level solution:

Hail Batch Workers can load the JAR for a given Hail version on-demand. A fresh class loader for
each Hail version allows the classes to co-exist in the same JVM. We cache jars on the local
filesystem.

---

`javac` compiles Java files to JVM Bytecode. JVM Bytecode is normally stored in `class` files. A JAR
file is, essentially, a TAR file of a directory of class files.

`java` needs to find the `class` file that defines any Class. A `ClassLoader` defines:

1. (`findClass`) How to *find* the definition of a Class known to the current `ClassLoader`.

2. (`findResource`) How to *find* an arbitrary file known to the current `ClassLoader`.

3. (`loadClass` and `getResource`) The order in which to find a class in a set of
  `ClassLoader`s (e.g. if two `ClassLoader`s know about the same Class, which one should load the
  class?)

Every `ClassLoader` has a `parent` `ClassLoader`. The default implementation of `loadClass` and
`getResource` prefers loading classes from its parent ClassLoader before anything else. We invert
the loading order to allow multiple definitions of the same Class in the same JVM. In particular,
each instance of `LoadSelfFirstURLClassLoader` prefers to use its own definition of a Class. Each
`LoadSelfFirstURLClassLoader` instance knows about one version of the Hail JAR.

The remaining subtle issue is how to load resources. For example, `HailBuildInfo` needs to load the
build info resource file. To do so, you need an instance of a `ClassLoader` that can find the
file you want. Often times, you use `this.getClass().getClassLoader()`, which is the class loader
used to load the current class. Hail does not do this. I believe we do not do this because of issues
with how TestNG loads classes. :sigh: As a result, I also modify the worker Thread's
ContextClassLoader for the duration of the execution of an alternative version of Hail.

---

I've already updated the cluster with the new bucket and the corresponding change to the
`global-config` secret. We'll should notify Leo et al. about the Terraform changes.

---

Small changes and fixes:

- Rename `key.json` to `/worker-key.json` for clarity, this is the worker's own GCP service account
  key.
- Create a test query-gsa-key in test and dev namespaces.
- Add terraform rules for the query service account. It already existed, but it was missing from the
  Terraform file. You can verify the permissions grant by inspecting `gsutil iam get
  gs://hail-query`.
- The `query` user was missing from bootstrap-create-accounts.
- `hail-ubuntu-stmp` was missing from `docker/Makefile`'s `clean` rule
- Use a dummy `WorkerBackend` when we're on the worker. The worker isn't allowed to call these
  methods anyway, that would amount to Hail Queries inside of Hail Queries, madness!
- New transient error in Java.