### PR TITLE
[docker] use versioned URL for gcloud sdk

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -20,9 +20,11 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
 
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
-    mv /root/google-cloud-sdk / && \
-    /google-cloud-sdk/bin/gcloud -q components install beta kubectl
+RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
+    tar -xf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
+    mv ./google-cloud-sdk / && \
+    /google-cloud-sdk/bin/gcloud -q components install kubectl && \
+    gcloud version
 ENV PATH $PATH:/google-cloud-sdk/bin
 
 COPY docker/requirements.txt .

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -22,7 +22,6 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
     tar -xf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
-    mv ./google-cloud-sdk / && \
     /google-cloud-sdk/bin/gcloud -q components install kubectl && \
     gcloud version
 ENV PATH $PATH:/google-cloud-sdk/bin

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -25,7 +25,7 @@ RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google
     curl -sSLO https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 ENV PATH $PATH:/google-cloud-sdk/bin
-RUN gcloud version && kubectl version
+RUN gcloud version && kubectl version --client=true
 
 COPY docker/requirements.txt .
 RUN hail-pip-install -r requirements.txt pyspark==3.1.1

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -22,9 +22,10 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 && \
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN curl -sSLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
     tar -xf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
-    /google-cloud-sdk/bin/gcloud -q components install kubectl && \
-    gcloud version
+    curl -sSLO https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 ENV PATH $PATH:/google-cloud-sdk/bin
+RUN gcloud version && kubectl version
 
 COPY docker/requirements.txt .
 RUN hail-pip-install -r requirements.txt pyspark==3.1.1

--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -9,9 +9,9 @@ pytest==6.2.2
 pytest-html==1.20.0
 pytest-xdist==2.2.1
 pytest-instafail==0.4.2
-sphinx==3.2.1
-sphinx-autodoc-typehints==1.11.0
-nbsphinx==0.7.1
+sphinx==3.5.4
+sphinx-autodoc-typehints==1.11.1
+nbsphinx==0.8.3
 sphinx_rtd_theme==0.4.2
 jupyter==1.0.0
 sphinxcontrib.katex==0.5.1


### PR DESCRIPTION
This avoids confusing Docker cache behavior by baking the verison number into
the RUN command string.