### PR TITLE
[batch] Expose job private and nonpreemptible machines

### DIFF
--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -210,7 +210,6 @@ SELECT * FROM resources;
                     cores_mcpu=req_cores_mcpu,
                     memory_bytes=req_memory_bytes,
                     storage_bytes=req_storage_bytes)
-
             if result is not None:
                 return result
 

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -210,7 +210,9 @@ SELECT * FROM resources;
                     cores_mcpu=req_cores_mcpu,
                     memory_bytes=req_memory_bytes,
                     storage_bytes=req_storage_bytes)
-            return result
+
+            if result is not None:
+                return result
 
         # Determine if we can spin up a private machine that fulfills resource requests
         if machine_type is None:

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -816,10 +816,10 @@ def test_job_private_instance_cancel(client):
 
 def test_job_private_instance_nonpreemptible_from_resources(client):
     builder = client.create_batch()
-    resources = {'cpu': 1, 'memory': 'lowmem', 'preemptible': False}
+    resources = {'cpu': '1', 'memory': 'lowmem', 'preemptible': False}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', str(j.log()['main'], status)
     assert 'job-private' in status['status']['worker'], str(status)
-    assert 'n1-highcpu-2' in status['status']['resources']['machine_type'], str(status)
+    assert 'n1-standard-1' in status['status']['resources']['machine_type'], str(status)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -822,4 +822,4 @@ def test_job_private_instance_nonpreemptible_from_resources(client):
     status = j.wait()
     assert status['state'] == 'Success', str(j.log()['main'], status)
     assert 'job-private' in status['status']['worker'], str(status)
-    assert 'n1-standard-1' in status['status']['resources']['machine_type'], str(status)
+    assert status['spec']['resources']['machine_type'] == 'n1-standard-1', str(status)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -773,7 +773,7 @@ def test_pool_highcpu_instance(client):
     assert 'standard' in status['status']['worker'], str(status)
 
 
-def test_job_private_instance_preemptible(client):
+def test_job_private_instance_preemptible_from_machine_type(client):
     builder = client.create_batch()
     resources = {'machine_type': 'n1-standard-1'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
@@ -783,7 +783,7 @@ def test_job_private_instance_preemptible(client):
     assert 'job-private' in status['status']['worker'], str(status)
 
 
-def test_job_private_instance_nonpreemptible(client):
+def test_job_private_instance_nonpreemptible_from_machine_type(client):
     builder = client.create_batch()
     resources = {'machine_type': 'n1-standard-1', 'preemptible': False}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
@@ -812,3 +812,14 @@ def test_job_private_instance_cancel(client):
     b.cancel()
     status = j.wait()
     assert status['state'] == 'Cancelled', str(status)
+
+
+def test_job_private_instance_nonpreemptible_from_resources(client):
+    builder = client.create_batch()
+    resources = {'cpu': 1, 'memory': 'lowmem', 'preemptible': False}
+    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    builder.submit()
+    status = j.wait()
+    assert status['state'] == 'Success', str(j.log()['main'], status)
+    assert 'job-private' in status['status']['worker'], str(status)
+    assert 'n1-highcpu-2' in status['status']['resources']['machine_type'], str(status)

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -174,6 +174,10 @@ is standard. If a job is scheduled on this machine, then the cost per core hour 
     after running for 2 minutes and then runs successfully the next time it is scheduled, the
     total cost for that job will be 7 minutes.
 
+Batch also supports private instances that are created for a single job that specify :meth:`.Job.machine_type` or set
+:meth:`.Job.preemptible` to False. A job is billed for the entire time the machine is running including the activation
+time for the instance. The costs are the same as above except the cost for the Local SSD is omitted.
+
 
 Setup
 -----

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -174,9 +174,12 @@ is standard. If a job is scheduled on this machine, then the cost per core hour 
     after running for 2 minutes and then runs successfully the next time it is scheduled, the
     total cost for that job will be 7 minutes.
 
-Batch also supports private instances that are created for a single job that specify :meth:`.Job.machine_type` or set
-:meth:`.Job.preemptible` to False. A job is billed for the entire time the machine is running including the activation
-time for the instance. The costs are the same as above except the cost for the Local SSD is omitted.
+
+Batch also supports private instances that are created for a single job that specify
+:meth:`.Job.machine_type`, set :meth:`.Job.preemptible` to False, or request 32 or
+64 cores based on the combined cpu and memory requests. A job is billed for the entire
+time the machine is running including the activation time for the instance. The costs
+are the same as above except the cost for the Local SSD is omitted.
 
 
 Setup

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -246,7 +246,10 @@ class Job:
         Omitting a suffix means the value is in cpu.
 
         For the :class:`.ServiceBackend`, `cores` must be a power of
-        two between 0.25 and 16.
+        two between 0.25 and 64 in order for a job to be run on a shared
+        worker. If `cores` is equal to 32 or 64, then a private instance will
+        be created for the job with the optimal machine type based on the
+        cpu and memory requests.
 
         Examples
         --------
@@ -258,6 +261,14 @@ class Job:
         >>> (j.cpu('250m')
         ...   .command(f'echo "hello"'))
         >>> b.run()
+
+        Warning
+        -------
+
+        Jobs with `cores` equal to 32 or 64 will have a private instance created
+        specifically for that job. You will be billed for the entire time the
+        instance is running including the activation time. This option should
+        not be used for low latency jobs.
 
         Parameters
         ----------
@@ -280,12 +291,6 @@ class Job:
         -----
 
         Can only be used with the :class:`.backend.ServiceBackend`.
-
-        If `preemptible` is False, then a private instance will be
-        created for the job. Batch will automatically choose the
-        cheapest machine type given the CPU and memory settings.
-        See :meth:`.Job.machine_type` for more information about jobs
-        that run on a private machine.
 
         Examples
         --------
@@ -354,6 +359,13 @@ class Job:
         ...   .command(f'echo "hello"'))
         >>> b.run()
 
+        Warning
+        -------
+
+        If `preemptible` is `False`, we will create a private instance
+        specifically for this job. You will be billed for the entire time the
+        instance is running including the activation time. This option should
+        not be used for low latency jobs.
 
         Parameters
         ----------
@@ -441,7 +453,7 @@ class Job:
         self._timeout = timeout
         return self
 
-    def gcsfuse(self, bucket, mount_point, read_only=True):
+    def gcsfuse(self, bucket, mount_point, read_only=True) -> 'Job':
         """
         Add a bucket to mount with gcsfuse.
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -292,7 +292,7 @@ class Job:
 
         Set the job to be run on a preemptible machine:
 
-        >>> b = Batch()
+        >>> b = Batch(backend=backend.ServiceBackend('test'))
         >>> j = b.new_job()
         >>> (j.preemptible()
         ...   .command(f'echo "hello"'))
@@ -348,7 +348,7 @@ class Job:
 
         Set the job to be run on a private `n1-standard-1` machine:
 
-        >>> b = Batch()
+        >>> b = Batch(backend=backend.ServiceBackend('test'))
         >>> j = b.new_job()
         >>> (j.machine_type('n1-standard-1')
         ...   .command(f'echo "hello"'))

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -272,6 +272,107 @@ class Job:
         self._cpu = str(cores)
         return self
 
+    def preemptible(self, preemptible: bool = True) -> 'Job':
+        """
+        Set whether the job is preemptible.
+
+        Notes
+        -----
+
+        Can only be used with the :class:`.backend.ServiceBackend`.
+
+        If `preemptible` is False, then a private instance will be
+        created for the job. Batch will automatically choose the
+        cheapest machine type given the CPU and memory settings.
+        See :meth:`.Job.machine_type` for more information about jobs
+        that run on a private machine.
+
+        Examples
+        --------
+
+        Set the job to be run on a preemptible machine:
+
+        >>> b = Batch()
+        >>> j = b.new_job()
+        >>> (j.preemptible()
+        ...   .command(f'echo "hello"'))
+        >>> b.run()
+
+
+        Parameters
+        ----------
+        preemptible:
+            If `True`, the job is scheduled on a preemptible machine. If
+            `False`, the job is scheduled on a private nonpreemptible machine.
+
+        Returns
+        -------
+        Same job object with preemptible set.
+        """
+
+        if not isinstance(self._batch._backend, backend.ServiceBackend):
+            raise NotImplementedError("A ServiceBackend is required to use the 'preemptible' option")
+
+        self._preemptible = preemptible
+        return self
+
+    def machine_type(self, machine_type: str) -> 'Job':
+        """
+        Set whether the job should be run on a private machine with the
+        specified machine type.
+
+        Notes
+        -----
+
+        Can only be used with the :class:`.backend.ServiceBackend`.
+
+        Currently, only the `n1` family of machine types are supported. See
+        the `GCE documentation <https://cloud.google.com/compute/docs/machine-types#n1_machine_types>`__
+        for which machine types are available.
+
+        Any previously set parameters for :meth:`.Job.cpu` or :meth:`.Job.memory` will
+        be ignored.
+
+        The default storage is `100Gi` and is a persistent SSD. Use the :meth:`.Job.storage`
+        method to set the storage to a different value.
+
+        Warning
+        -------
+
+        Jobs that set the machine type will be billed for the entire time the
+        instance is running including the activation time. This option should
+        not be used for low latency jobs.
+
+        Examples
+        --------
+
+        Set the job to be run on a private `n1-standard-1` machine:
+
+        >>> b = Batch()
+        >>> j = b.new_job()
+        >>> (j.machine_type('n1-standard-1')
+        ...   .command(f'echo "hello"'))
+        >>> b.run()
+
+
+        Parameters
+        ----------
+        machine_type:
+            A string specifying the specific GCE machine type to use.
+
+        Returns
+        -------
+        Same job object with machine_type set.
+        """
+
+        if not isinstance(self._batch._backend, backend.ServiceBackend):
+            raise NotImplementedError("A ServiceBackend is required to use the 'machine_type' option")
+
+        self._machine_type = machine_type
+        self._cpu = None
+        self._memory = None
+        return self
+
     def always_run(self, always_run: bool = True) -> 'Job':
         """
         Set the job to always run, even if dependencies fail.


### PR DESCRIPTION
Stacked on #10097

- Expose `machine_type` and `preemptible` in hailtop.batch
- Sets default storage when specifying the machine type to 100Gi
- Selects the cheapest machine type automatically for the user when they want a nonpreemptible worker