### PR TITLE
[batch] Fix extra await in JVM job get_log

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1141,7 +1141,7 @@ class JVMJob(Job):
                     log.exception('while deleting volumes')
 
     async def get_log(self):
-        return {'main': await self.process.get_log()}
+        return {'main': self.process.get_log()}
 
     async def delete(self):
         log.info(f'deleting {self}')


### PR DESCRIPTION
`get_log` wasn't an async function.