### PR TITLE
[query] Fix assertions in PCDict/PCSet constructors

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -40,7 +40,7 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
   }
 
   def construct(contents: PIndexableCode): PIndexableCode = {
-    assert(contents.pt == arrayRep)
+    assert(contents.pt.equalModuloRequired(arrayRep), s"\n  contents:  ${ contents.pt }\n  arrayrep: ${ arrayRep }")
     new SIndexablePointerCode(SIndexablePointer(this), contents.tcode[Long])
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
@@ -31,7 +31,7 @@ final case class PCanonicalSet(elementType: PType,  required: Boolean = false) e
   }
 
   def construct(contents: PIndexableCode): PIndexableCode = {
-    assert(contents.pt == arrayRep)
+    assert(contents.pt.equalModuloRequired(arrayRep), s"\n  contents:  ${ contents.pt }\n  arrayrep: ${ arrayRep }")
     new SIndexablePointerCode(SIndexablePointer(this), contents.tcode[Long])
   }
 }


### PR DESCRIPTION
Rahul reported this failing on the following gnomad pipeline:

```
import hail as hl
from gnomad.utils.vep import process_consequences
from gnomad.resources.grch37 import gnomad

gnomad_v2_exomes = gnomad.public_release("exomes")
ht_exomes = gnomad_v2_exomes.ht()
ht_exomes_proc = process_consequences(ht_exomes)
ht_exomes_proc._force_count()
```

No test case included, but this kind of error will be impossible soon
(when requiredness exists on EmitType, not SType/PType).