### PR TITLE
[notebook] fix notebook service to expose nginx and use http with workers

### DIFF
--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -180,7 +180,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 5000
+    targetPort: 443
   selector:
     app: notebook
 ---
@@ -194,6 +194,6 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 5000
+    targetPort: 443
   selector:
     app: notebook

--- a/notebook/nginx.conf
+++ b/notebook/nginx.conf
@@ -76,7 +76,7 @@ http {
           auth_request /auth;
           auth_request_set $auth_pod_ip $upstream_http_pod_ip;
 
-          proxy_pass https://$auth_pod_ip$request_uri;
+          proxy_pass http://$auth_pod_ip$request_uri;
 
           include /etc/nginx/proxy.conf;
           proxy_http_version 1.1;
@@ -144,7 +144,7 @@ http {
           auth_request /auth;
           auth_request_set $auth_pod_ip $upstream_http_pod_ip;
 
-          proxy_pass https://$auth_pod_ip$request_uri;
+          proxy_pass http://$auth_pod_ip$request_uri;
 
           include /etc/nginx/proxy.conf;
           proxy_http_version 1.1;


### PR DESCRIPTION
The `notebook` and `workshop` services were incorrectly pointing to the python notebook app instead of its nginx proxy, which handles proxying to notebook workers. In #10250 I added back https to the notebook python app and accidentally changed the nginx -> notebook worker connection `https`, where it should not be. These combined meant that notebook was unable to proxy to notebook workers. I deployed this into default and verified that I can get to jupyter, and also run scale tests.