### PR TITLE
[batch,query,memory] add signal handler to dump task stacktraces

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -5,6 +5,7 @@ from functools import wraps
 import concurrent
 import copy
 import asyncio
+import signal
 import dictdiffer
 from aiohttp import web
 import aiohttp_session
@@ -18,7 +19,7 @@ from gear import (Database, setup_aiohttp_session,
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
 from hailtop.utils import (time_msecs, RateLimit, serialization,
-                           Notice, periodically_call, AsyncWorkerPool)
+                           Notice, periodically_call, AsyncWorkerPool, dump_all_stacktraces)
 from hailtop.tls import internal_server_ssl_context
 from hailtop import aiogoogle, aiotools
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, \
@@ -992,6 +993,8 @@ def run():
 
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
+
+    asyncio.get_event_loop().add_signal_handler(signal.SIGUSR1, dump_all_stacktraces)
 
     web.run_app(deploy_config.prefix_application(app,
                                                  'batch-driver',

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -9,6 +9,7 @@ import collections
 from functools import wraps
 import asyncio
 import aiohttp
+import signal
 from aiohttp import web
 import aiohttp_session
 import pymysql
@@ -17,7 +18,8 @@ import google.api_core.exceptions
 from prometheus_async.aio.web import server_stats  # type: ignore
 from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
                            request_retry_transient_errors, run_if_changed,
-                           retry_long_running, LoggingTimer, cost_str)
+                           retry_long_running, LoggingTimer, cost_str,
+                           dump_all_stacktraces)
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes,
                                         parse_storage_in_bytes)
 from hailtop.config import get_deploy_config
@@ -1946,6 +1948,8 @@ def run():
 
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
+
+    asyncio.get_event_loop().add_signal_handler(signal.SIGUSR1, dump_all_stacktraces)
 
     web.run_app(deploy_config.prefix_application(app,
                                                  'batch',

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -22,7 +22,7 @@ import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
                            sleep_and_backoff, retry_all_errors, check_shell,
                            CalledProcessError, check_shell_output, is_google_registry_image,
-                           find_spark_home)
+                           find_spark_home, dump_all_stacktraces)
 from hailtop.httpx import client_session
 from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes, parse_storage_in_bytes)
@@ -1503,12 +1503,6 @@ async def async_main():
         finally:
             await docker.close()
             log.info('docker closed')
-
-
-def dump_all_stacktraces():
-    for t in asyncio.all_tasks():
-        print(t)
-        t.print_stack()
 
 
 loop = asyncio.get_event_loop()

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -9,8 +9,8 @@ from .utils import (
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
-    dump_all_stacktraces,
-    find_spark_home, TransientError, bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs)
+    dump_all_stacktraces, find_spark_home, TransientError, bounded_gather2,
+    OnlineBoundedGather2, unpack_comma_delimited_inputs)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -75,6 +75,7 @@ __all__ = [
     'serialization',
     'Notice',
     'periodically_call',
+    'dump_all_stacktraces',
     'find_spark_home',
     'TransientError',
     'bounded_gather2',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -9,6 +9,7 @@ from .utils import (
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
+    dump_all_stacktraces,
     find_spark_home, TransientError, bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -709,6 +709,12 @@ async def collect_agen(agen):
     return [x async for x in agen]
 
 
+def dump_all_stacktraces():
+    for t in asyncio.all_tasks():
+        print(t)
+        t.print_stack()
+
+
 async def retry_long_running(name, f, *args, **kwargs):
     delay_secs = 0.1
     while True:

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -6,11 +6,12 @@ import concurrent
 import logging
 import uvloop
 import asyncio
+import signal
 from aiohttp import web
 import kubernetes_asyncio as kube
 from prometheus_async.aio.web import server_stats  # type: ignore
 from collections import defaultdict
-from hailtop.utils import blocking_to_async, retry_transient_errors
+from hailtop.utils import blocking_to_async, retry_transient_errors, dump_all_stacktraces
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
@@ -257,6 +258,8 @@ def run():
     app.on_cleanup.append(on_cleanup)
     app.on_shutdown.append(on_shutdown)
     app.router.add_get("/metrics", server_stats)
+
+    asyncio.get_event_loop().add_signal_handler(signal.SIGUSR1, dump_all_stacktraces)
 
     deploy_config = get_deploy_config()
     web.run_app(


### PR DESCRIPTION
Right now the query service is taking a long time to terminate and it seems it's waiting on a single task. We saw a similar thing happen with a zombie worker but found it difficult to attach a debugger into the process. This way if we ssh into the pod and send a `SIGUSR1` we can hopefully get some good information out.