### PR TITLE
[query] NDArray Matmul Better Error Message

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -616,7 +616,7 @@ def test_ndarray_matmul():
 
     with pytest.raises(FatalError) as exc:
         hl.eval(r @ r)
-    assert "Matrix dimensions incompatible: 3 2" in str(exc.value)
+    assert "Matrix dimensions incompatible: (2, 3) can't be multiplied by matrix with dimensions (2, 3)" in str(exc.value)
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.nd.array([1, 2]) @ hl.nd.array([1, 2, 3]))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2894,9 +2894,16 @@ object NDArrayEmitter {
       }
     }
 
+    val leftShapeString = const("(").concat(leftShape.map(_.toS).reduce((a, b) => a.concat(", ").concat(b))).concat(")")
+    val rightShapeString = const("(").concat(rightShape.map(_.toS).reduce((a, b) => a.concat(", ").concat(b))).concat(")")
+
+
     setup = Code(setup,
       (lK cne rK).orEmpty(
-        Code._fatal[Unit](const("Matrix dimensions incompatible: ").concat(lK.toS).concat(" ").concat(rK.toS))))
+        Code._fatal[Unit](const("Matrix dimensions incompatible: ")
+          .concat(leftShapeString)
+          .concat(" can't be multiplied by matrix with dimensions ")
+          .concat(rightShapeString))))
 
     cb.append(setup)
     shape


### PR DESCRIPTION
The old error message for matmul was impossible to read. This is much clearer. 