### PR TITLE
[website] minimal changes to enable downloading the tutorials.tar.gz

### DIFF
--- a/hail/python/hail/docs/tutorials-landing.rst
+++ b/hail/python/hail/docs/tutorials-landing.rst
@@ -4,9 +4,17 @@
 Hail Tutorials
 ==============
 
-To take Hail for a test drive, go through our tutorials. These can be viewed here in the documentation,
-but we recommend instead that you run them yourself with Jupyter by
-`downloading the archive (.tar.gz) <tutorials.tar.gz>`__ and running the following::
+.. raw:: html
+
+    <!-- for some reason, Safari is confused if we do not include the download attribute in the
+    anchor. At time of writing, there does not appear to be a way to tell Sphinx to include that
+    attribute. -->
+    <p>To take Hail for a test drive, go through our tutorials. These can be viewed here in the
+    documentation, but we recommend instead that you run them yourself with Jupyter by
+    <a class="reference external" href="tutorials.tar.gz" download>downloading the archive (.tar.gz)</a>
+    and running the following:</p>
+
+::
 
     pip install jupyter
     tar xf tutorials.tar.gz

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -71,7 +71,9 @@ async def serve_docs(request, userdata):
     if tail in docs_pages:
         if tail.endswith('.html'):
             return await render_template('www', request, userdata, tail, dict())
-        return web.FileResponse(f'{DOCS_PATH}/{tail}')
+        # Chrome fails to download the tutorials.tar.gz file without the Content-Type header.
+        return web.FileResponse(f'{DOCS_PATH}/{tail}',
+                                headers={'Content-Type': 'application/octet-stream'})
     raise web.HTTPNotFound()
 
 


### PR DESCRIPTION
The fix for Safari will take effect the next time the docs are deployed. In the meantime,
the docs are indeed downloaded, but Safari tells you there was a problem. If users navigate
to the Downloads directory, the file should indeed be present.