### PR TITLE
[shuffler][query] dump hs_err_pid file on segfault

### DIFF
--- a/docker/hail-ubuntu/controller.sh
+++ b/docker/hail-ubuntu/controller.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-COMMAND=$*
+COMMAND=("$@")
 
 restart() {
     kill $PID
@@ -13,7 +13,7 @@ restart() {
         kill -9 $PID || true
     fi
 
-    $COMMAND &
+    "${COMMAND[@]}" &
     PID=$!
     restarted=yes
 }
@@ -25,7 +25,7 @@ term() {
 trap term SIGTERM
 
 
-$COMMAND &
+"${COMMAND[@]}" &
 PID=$!
 restarted=yes
 

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -76,6 +76,8 @@ spec:
            - /controller.sh
 {% endif %}
            - java
+           - -XX:ErrorFile=hs_err.log
+           - '-XX:OnError=cat hs_err.log >&2'
            - -Dlog4j.configuration=file:/log4j.properties
            - -cp
            - /hail.jar:/usr/local/lib/python3.7/dist-packages/pyspark/jars/*

--- a/shuffler/deployment.yaml
+++ b/shuffler/deployment.yaml
@@ -27,6 +27,8 @@ spec:
             - /controller.sh
 {% endif %}
             - java
+            - -XX:ErrorFile=hs_err.log
+            - '-XX:OnError=cat hs_err.log >&2'
             - -cp
             - /usr/local/lib/python3.7/dist-packages/pyspark/jars/*:/hail.jar
             - is.hail.services.shuffler.server.ShuffleServer


### PR DESCRIPTION
I also fixed controller.sh to properly handle arguments with space. This syntax
is the Bash array syntax, AFAIK, it is the only way to properly save a command string.