### PR TITLE
[query] synchronize the code cache

### DIFF
--- a/hail/src/main/scala/is/hail/utils/Cache.scala
+++ b/hail/src/main/scala/is/hail/utils/Cache.scala
@@ -4,13 +4,13 @@ import java.util
 import java.util.Map.Entry
 
 class Cache[K, V](capacity: Int) {
-  val m = new util.LinkedHashMap[K, V](capacity, 0.75f, true) {
+  private[this] val m = new util.LinkedHashMap[K, V](capacity, 0.75f, true) {
     override def removeEldestEntry(eldest: Entry[K, V]): Boolean = size() > capacity
   }
 
-  def get(k: K): Option[V] = Option(m.get(k))
+  def get(k: K): Option[V] = synchronized { Option(m.get(k)) }
 
-  def +=(p: (K, V)): Unit = m.put(p._1, p._2)
+  def +=(p: (K, V)): Unit = synchronized { m.put(p._1, p._2) }
 
-  def size: Int = m.size()
+  def size: Int = synchronized { m.size() }
 }


### PR DESCRIPTION
Avoid query-service races when looking at the cache.