### PR TITLE
[docker][query] use newest gcsfs

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -17,7 +17,10 @@ flake8==3.8.3
 Flask-Cors==3.0.8
 Flask-Sockets==0.2.1
 Flask==1.0.3
-gcsfs==0.7.2
+# https://github.com/dask/gcsfs/issues/372
+gcsfs==0.8.0
+# https://github.com/dask/gcsfs/issues/372
+fsspec==0.9.0
 gidgethub==4.1.0
 google-api-python-client==1.7.10
 google-cloud-logging==1.12.1

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -5,7 +5,10 @@ bokeh>1.3,<2.0
 decorator<5
 Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4
-gcsfs==0.7.2
+# https://github.com/dask/gcsfs/issues/372
+gcsfs==0.8.0
+# https://github.com/dask/gcsfs/issues/372
+fsspec==0.9.0
 humanize==1.0.0
 hurry.filesize==0.9
 nest_asyncio


### PR DESCRIPTION
There is some version incompatibility issue waiting to hit us as soon as someone
triggers a rebuild of the base image (gcs does not properly pin fsspec).