### PR TITLE
[query-service] concurrently use multiple Hail Query JAR versions

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -46,5 +46,4 @@ COPY batch/setup.py batch/MANIFEST.in /batch/
 COPY batch/batch /batch/batch/
 RUN hail-pip-install --no-deps /batch && rm -rf /batch
 
-COPY batch/hail.jar /
 COPY query/log4j.properties /

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -28,9 +28,6 @@ build-batch: build-prereqs
 
 .PHONY: build-worker
 build-worker: build-prereqs
-	$(MAKE) -C ../hail shadowJar
-# janky
-	cp ../hail/build/libs/hail-all-spark.jar ./hail.jar
 	-docker pull $(BATCH_WORKER_LATEST)
 	python3 ../ci/jinja2_render.py '{"global":{"project":"$(PROJECT)"}, "service_base_image":{"image":"service-base"}}' Dockerfile.worker Dockerfile.worker.out
 	docker build -t batch-worker -f Dockerfile.worker.out --cache-from batch-worker,$(BATCH_WORKER_LATEST),service-base ..

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 import os
 import json
 import sys
@@ -17,6 +17,7 @@ from aiohttp import web
 import async_timeout
 import concurrent
 import aiodocker
+from collections import defaultdict
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
 from hailtop.utils import (time_msecs, request_retry_transient_errors,
@@ -28,6 +29,8 @@ from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_image_tag,
                                         parse_memory_in_bytes, parse_storage_in_bytes)
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS, HAIL_GENETICS_IMAGES
 from hailtop import aiotools
+from hailtop.aiotools.fs import RouterAsyncFS, LocalAsyncFS
+from hailtop.aiogoogle import GoogleStorageAsyncFS, Credentials
 # import uvloop
 
 from hailtop.config import DeployConfig
@@ -544,85 +547,6 @@ class Container:
         return f'container {self.job.id}/{self.name}'
 
 
-class JVMProcess:
-    classpath = f'{find_spark_home()}/jars/*:/hail.jar:/log4j.properties'
-    stack_size = 512 * 1024
-    thread_pool = None
-
-    def __init__(self, job, main_spec):
-        self.job = job
-        self.heap_size = main_spec['memory'] - self.stack_size
-        self.env = {}
-        for var in main_spec.get('env', []):
-            self.env[var['name']] = var['value']
-
-        self.flags = ['-classpath', self.classpath, f'-Xmx{self.heap_size}', f'-Xss{self.stack_size}']
-        self.java_args = main_spec['command']
-
-        self.proc = None
-        self.timing = {'running': dict()}
-        self.state = 'pending'
-        self.logbuffer = bytearray()
-
-    async def pipe_to_log(self, strm: asyncio.StreamReader):
-        while not strm.at_eof():
-            self.logbuffer.extend(await strm.readline())
-
-    async def run(self, worker):
-        log.info(f'running {self}')
-        self.timing['running']['start_time'] = time_msecs()
-        self.proc = await asyncio.create_subprocess_exec(
-            'java',
-            *self.flags,
-            *self.java_args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=self.env)
-
-        await asyncio.gather(self.pipe_to_log(self.proc.stdout),
-                             self.pipe_to_log(self.proc.stderr))
-        await self.proc.wait()
-
-        finish_time = time_msecs()
-        self.timing['running']['finish_time'] = finish_time
-        start_time = self.timing['running']['start_time']
-        self.timing['running']['duration'] = finish_time - start_time
-
-        log.info(f'finished {self} with return code {self.proc.returncode}')
-        log.info(f'log {self}: {self.get_log()}')
-
-        await worker.log_store.write_log_file(
-            self.job.format_version, self.job.batch_id,
-            self.job.job_id, self.job.attempt_id, 'main',
-            self.get_log())
-
-        if self.proc.returncode == 0:
-            self.state = 'succeeded'
-        else:
-            self.state = 'failed'
-
-    async def status(self, state=None):
-        d = {
-            'name': 'main',
-            'state': self.state if not state else state,
-            'timing': self.timing
-        }
-        if self.proc is not None and self.proc.returncode is not None:
-            d['exit_code'] = self.proc.returncode
-        return d
-
-    def get_log(self):
-        return self.logbuffer.decode()
-
-    async def delete(self):
-        log.info(f'deleting {self}')
-        if self.proc is not None and self.proc.returncode is None:
-            self.proc.kill()
-
-    def __str__(self):
-        return f'process {self.job.id}/main'
-
-
 def populate_secret_host_path(host_path, secret_data):
     os.makedirs(host_path)
     if secret_data is not None:
@@ -1030,6 +954,8 @@ class DockerJob(Job):
 
 
 class JVMJob(Job):
+    stack_size = 512 * 1024
+    thread_pool = None
 
     def secret_host_path(self, secret):
         return f'{self.scratch}/secrets{secret["mount_path"]}'
@@ -1072,7 +998,30 @@ class JVMJob(Job):
             'cpu': self.cpu_in_mcpu,
             'memory': self.memory_in_bytes,
         }
-        self.process = JVMProcess(self, self.main_spec)
+
+        self.heap_size = self.memory_in_bytes - self.stack_size
+
+        user_command_string = job_spec['process']['command']
+        assert len(user_command_string) >= 3, user_command_string
+        self.revision = user_command_string[1]
+        self.jar_url = user_command_string[2]
+        classpath = f'{find_spark_home()}/jars/*:/hail-jars/{self.revision}.jar:/log4j.properties'
+
+        self.command_string = [
+            'java',
+            '-classpath', classpath,
+            f'-Xmx{self.heap_size}',
+            f'-Xss{self.stack_size}',
+            *user_command_string]
+
+        self.process = None
+        self.timing: Dict[str, dict] = {'downloading_jar': dict(), 'running': dict()}
+        self.state = 'pending'
+        self.logbuffer = bytearray()
+
+    async def pipe_to_log(self, strm: asyncio.StreamReader):
+        while not strm.at_eof():
+            self.logbuffer.extend(await strm.readline())
 
     async def run(self, worker):
         async with worker.cpu_sem(self.cpu_in_mcpu):
@@ -1104,10 +1053,58 @@ class JVMJob(Job):
                 populate_secret_host_path(self.gsa_key_file_path(), self.gsa_key)
                 self.state = 'running'
 
-                log.info(f'{self}: running jvm process')
+                log.info(f'{self}: downloading JAR')
+                self.timing['downloading_jar']['start_time'] = time_msecs()
 
-                await self.process.run(worker)
-                self.state = self.process.state
+                async with worker.jar_download_locks[self.revision]:
+                    local_jar_location = f'/hail-jars/{self.revision}.jar'
+                    if not os.path.isfile(local_jar_location):
+                        user_fs = RouterAsyncFS(
+                            'file',
+                            [LocalAsyncFS(worker.pool),
+                             GoogleStorageAsyncFS(credentials=Credentials.from_file(
+                                 f'{self.scratch}/secrets/gsa-key/key.json'))])
+                        async with await user_fs.open(self.jar_url) as jar_data:
+                            await user_fs.makedirs('/hail-jars/', exist_ok=True)
+                            async with await user_fs.create(local_jar_location) as local_file:
+                                while True:
+                                    b = await jar_data.read(256 * 1024)
+                                    if not b:
+                                        break
+                                    written = await local_file.write(b)
+                                    assert written == len(b)
+
+                self.timing['downloading_jar']['finish_time'] = time_msecs()
+                self.timing['downloading_jar']['duration'] = (
+                    self.timing['downloading_jar']['finish_time'] - self.timing['downloading_jar']['start_time'])
+
+                log.info(f'{self}: running jvm process')
+                self.timing['running']['start_time'] = time_msecs()
+                self.process = await asyncio.create_subprocess_exec(
+                    *self.command_string,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env={envvar['name']: envvar['value'] for envvar in self.env})
+
+                await asyncio.gather(self.pipe_to_log(self.process.stdout),
+                                     self.pipe_to_log(self.process.stderr))
+                await self.process.wait()
+
+                self.timing['running']['finish_time'] = time_msecs()
+                self.timing['running']['duration'] = (
+                    self.timing['running']['finish_time'] - self.timing['running']['start_time'])
+
+                log.info(f'finished {self} with return code {self.process.returncode}')
+
+                await worker.log_store.write_log_file(
+                    self.format_version, self.batch_id,
+                    self.job_id, self.attempt_id, 'main',
+                    self.logbuffer.decode())
+
+                if self.process.returncode == 0:
+                    self.state = 'succeeded'
+                else:
+                    self.state = 'failed'
                 log.info(f'{self} main: {self.state}')
             except asyncio.CancelledError:
                 raise
@@ -1141,12 +1138,13 @@ class JVMJob(Job):
                     log.exception('while deleting volumes')
 
     async def get_log(self):
-        return {'main': self.process.get_log()}
+        return {'main': self.logbuffer.decode()}
 
     async def delete(self):
         log.info(f'deleting {self}')
         self.deleted = True
-        await self.process.delete()
+        if self.process is not None and self.process.returncode is None:
+            self.process.kill()
 
     # {
     #   version: int,
@@ -1165,7 +1163,14 @@ class JVMJob(Job):
     # }
     async def status(self):
         status = await super().status()
-        status['container_statuses'] = {'main': await self.process.status()}
+        status['container_statuses'] = dict()
+        status['container_statuses']['main'] = {
+            'name': 'main',
+            'state': self.state,
+            'timing': self.timing
+        }
+        if self.process is not None and self.process.returncode is not None:
+            status['container_statuses']['main']['exit_code'] = self.process.returncode
         return status
 
     def __str__(self):
@@ -1185,6 +1190,7 @@ class Worker:
         self.log_store = None
         self.headers = None
         self.task_manager = aiotools.BackgroundTaskManager()
+        self.jar_download_locks = defaultdict(asyncio.Lock)
 
     def shutdown(self):
         self.task_manager.shutdown()
@@ -1463,11 +1469,11 @@ class Worker:
                 })
             resp_json = await resp.json()
 
-            with open('key.json', 'w') as f:
+            with open('/worker-key.json', 'w') as f:
                 f.write(json.dumps(resp_json['key']))
 
             credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                'key.json')
+                '/worker-key.json')
             self.log_store = LogStore(BATCH_LOGS_BUCKET_NAME, INSTANCE_ID, self.pool,
                                       project=PROJECT, credentials=credentials)
 

--- a/build.yaml
+++ b/build.yaml
@@ -361,6 +361,7 @@ steps:
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "batch-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "benchmark-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "ci-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
+     kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "query-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "test-dev-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
    scopes:
     - test
@@ -715,12 +716,9 @@ steps:
    contextPath: .
    publishAs: batch-worker
    inputs:
-     - from: /just-jar/hail.jar
-       to: /batch/hail.jar
      - from: /hail_version
        to: /hail_version
    dependsOn:
-     - build_hail_jar_only
      - copy_files
  - kind: buildImage
    name: service_java_run_base_image
@@ -2315,6 +2313,40 @@ steps:
     - deploy_address_sa
     - address_image
     - create_certs
+ - kind: runImage
+   name: upload_query_jar
+   image:
+     valueFrom: base_image.image
+   script: |
+     set -ex
+     gcloud -q auth activate-service-account --key-file=/query-gsa-key/key.json
+
+     {% if deploy %}
+     destination=gs://$(cat /global-config/hail_query_bucket)/jars/
+     {% else %}
+     destination=gs://hail-test-dmk9z/{{ token }}/jars/
+     {% endif %}
+
+     gsutil -m cp /io/hail.jar ${destination}$(cat /io/git_version).jar
+   secrets:
+     - name: query-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /query-gsa-key
+     - name: global-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /global-config
+   inputs:
+     - from: /just-jar/hail.jar
+       to: /io/hail.jar
+     - from: /git_version
+       to: /io/git_version
+   dependsOn:
+     - default_ns
+     - base_image
+     - build_hail_jar_only
+     - copy_files
  - kind: deploy
    name: deploy_query
    namespace:
@@ -2332,6 +2364,7 @@ steps:
     - deploy_query_sa
     - deploy_address
     - create_certs
+    - upload_query_jar
  - kind: deploy
    name: deploy_memory
    namespace:
@@ -2343,10 +2376,159 @@ steps:
       for: alive
    dependsOn:
     - default_ns
-    - deploy_batch
     - memory_image
     - deploy_memory_sa
     - create_certs
+ - kind: runImage
+   name: test_hail_python_service_backend_0
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=0
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
+ - kind: runImage
+   name: test_hail_python_service_backend_1
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=1
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
+ - kind: runImage
+   name: test_hail_python_service_backend_2
+   image:
+     valueFrom: hail_run_image.image
+   script: |
+     set -ex
+     cd /io
+     tar xzf test.tar.gz
+     tar xvf wheel-container.tar
+     python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+     export PYTEST_SPLITS=3
+     export PYTEST_SPLIT_INDEX=2
+     export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+     export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+     export HAIL_QUERY_BACKEND=service
+     export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+     hailctl config set batch/billing_project test
+     hailctl config set batch/bucket hail-test-dmk9z
+     python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+   inputs:
+     - from: /wheel-container.tar
+       to: /io/wheel-container.tar
+     - from: /test.tar.gz
+       to: /io/test.tar.gz
+   secrets:
+     - name: gce-deploy-config
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /deploy-config
+     - name: test-tokens
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /user-tokens
+     - name: ssl-config-query-tests
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /ssl-config
+     - name: test-gsa-key
+       namespace:
+         valueFrom: default_ns.name
+       mountPath: /test-gsa-key
+   timeout: 3600
+   dependsOn:
+     - default_ns
+     - upload_test_resources_to_gcs
+     - deploy_query
+     - deploy_memory
+     - deploy_shuffler
+     - hail_run_image
+     - build_hail
  - kind: runImage
    name: test_lsm
    image:
@@ -3689,6 +3871,9 @@ steps:
     - test_hailtop_batch_2
     - test_hailtop_batch_3
     - test_hailtop_batch_4
+    - test_hail_python_service_backend_0
+    - test_hail_python_service_backend_1
+    - test_hail_python_service_backend_2
  - kind: runImage
    name: delete_atgu_tables
    image:

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -54,7 +54,8 @@ async def main():
         ('benchmark', None, 0, 1),
         ('ci', None, 0, 1),
         ('test', None, 0, 0),
-        ('test-dev', None, 1, 0)
+        ('test-dev', None, 1, 0),
+        ('query', None, 0, 1),
     ]
 
     app = {}

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,12 +1,22 @@
+import pkg_resources
+import sys
+import asyncio
 import nest_asyncio
-nest_asyncio.apply()
-
-import pkg_resources  # noqa: E402
-import sys  # noqa: E402
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+
+if sys.version_info[:2] == (3, 6):
+    if asyncio._get_running_loop() is not None:
+        nest_asyncio.apply()
+else:
+    try:
+        asyncio.get_running_loop()
+        nest_asyncio.apply()
+    except RuntimeError as err:
+        assert 'no running event loop' in err.args[0]
+
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources

--- a/hail/python/hail/backend/service_backend.py
+++ b/hail/python/hail/backend/service_backend.py
@@ -58,12 +58,12 @@ class ServiceSocket:
                 raise ValueError(f'bad response: {endpoint}; {data}; {response}')
             if response.type in (aiohttp.WSMsgType.CLOSE,
                                  aiohttp.WSMsgType.CLOSED):
-                warnings.warn(f'retrying after losing connection {endpoint}; {data}; {response}')
+                warnings.warn(f'retrying after losing connection {endpoint}; {json.dumps(data)}; {response}')
                 raise TransientError()
             assert response.type == aiohttp.WSMsgType.TEXT
             result = json.loads(response.data)
             if result['status'] != 200:
-                raise FatalError(f'Error from server: {result["value"]}')
+                raise FatalError(f'Error from server:\n\n{json.dumps(data)}\n\n{result["value"]}')
             return result['value']
 
     def request(self, endpoint, **data):

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -26,5 +26,5 @@ def ensure_event_loop_is_initialized_in_test_thread():
     try:
         asyncio.get_event_loop()
     except RuntimeError as err:
-        assert err.args[0] == "There is no current event loop in thread 'Dummy-1'"
+        assert err.args[0] == "There is no current event loop in thread 'Dummy-1'."
         asyncio.set_event_loop(asyncio.new_event_loop())

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -293,7 +293,6 @@ class Tests(unittest.TestCase):
         ht = hl.experimental.pc_project(mt_to_project.GT, loadings_ht.loadings, loadings_ht.af)
         assert ht._force_count() == 100
 
-    @fails_service_backend()
     def test_mt_full_outer_join(self):
         mt1 = hl.utils.range_matrix_table(10, 10)
         mt1 = mt1.annotate_cols(c1=hl.rand_unif(0, 1))
@@ -315,7 +314,6 @@ class Tests(unittest.TestCase):
 
         assert(mtj.count() == (15, 15))
 
-    @fails_service_backend()
     def test_mt_full_outer_join_self(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         jmt = hl.experimental.full_outer_join_mt(mt, mt)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -18,7 +18,6 @@ class Tests(unittest.TestCase):
     def collect_unindexed_expression(self):
         self.assertEqual(hl.array([4,1,2,3]).collect(), [4,1,2,3])
 
-    @fails_service_backend()
     def test_key_by_random(self):
         ht = hl.utils.range_table(10, 4)
         ht = ht.annotate(new_key=hl.rand_unif(0, 1))
@@ -829,7 +828,6 @@ class Tests(unittest.TestCase):
         assert t.annotate(x=hl.bind(lambda i: hl.scan.sum(t.idx + i), 1, _ctx='scan')).x.collect() == [0, 1, 3, 6, 10]
         assert t.aggregate(hl.bind(lambda i: hl.agg.collect(i), t.idx * t.idx, _ctx='agg')) == [0, 1, 4, 9, 16]
 
-    @fails_service_backend()
     def test_scan(self):
         table = hl.utils.range_table(10)
 
@@ -877,7 +875,6 @@ class Tests(unittest.TestCase):
         for aggregation, expected in tests:
             self.assertEqual(aggregation.collect(), expected)
 
-    @fails_service_backend()
     def test_scan_explode(self):
         t = hl.utils.range_table(5)
         tests = [
@@ -909,7 +906,6 @@ class Tests(unittest.TestCase):
         for aggregation, expected in tests:
             self.assertEqual(aggregation.collect(), expected)
 
-    @fails_service_backend()
     def test_scan_group_by(self):
         t = hl.utils.range_table(5)
         tests = [
@@ -992,7 +988,6 @@ class Tests(unittest.TestCase):
         assert r.n_smaller == 0
         assert r.n_larger == 0
 
-    @fails_service_backend()
     def test_aggregator_cse(self):
         ht = hl.utils.range_table(10)
         x = hl.agg.count()
@@ -1113,7 +1108,6 @@ class Tests(unittest.TestCase):
         r = ht.aggregate(hl.agg.downsample(ht.idx, ht.y, n_divisions=10))
         self.assertTrue(len(r) == 0)
 
-    @fails_service_backend()
     def test_downsample_in_array_agg(self):
         mt = hl.utils.range_matrix_table(50, 50)
         mt = mt.annotate_rows(y = hl.rand_unif(0, 1))

--- a/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
@@ -90,7 +90,6 @@ class Tests(unittest.TestCase):
         d = mt.group_cols_by(group5=(mt['group4']['a'] + 1)).aggregate_cols(x=hl.agg.count())
         self.assertRaises(ExpressionException, d.aggregate_cols, x=hl.agg.count()) # duplicate field
 
-    @fails_service_backend()
     def test_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(mt['group1']).aggregate(c=hl.agg.sum(mt['c']))
@@ -101,7 +100,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(b.count_cols(), 6)
         self.assertTrue('group3' in b.col_key)
 
-    @fails_service_backend()
     def test_nested_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(mt['group2']['a']).aggregate(c=hl.agg.sum(mt['c']))
@@ -112,7 +110,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(b.count_cols(), 6)
         self.assertTrue('a' in b.col_key)
 
-    @fails_service_backend()
     def test_named_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(group5=(mt['group2']['a'] + 1)).aggregate(c=hl.agg.sum(mt['c']))

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -275,7 +275,6 @@ class Tests(unittest.TestCase):
         self.assertTrue('GT' not in mt2.entry)
         mt2._force_count_rows()
 
-    @fails_service_backend()
     def test_explode_rows(self):
         mt = hl.utils.range_matrix_table(4, 4)
         mt = mt.annotate_entries(e=mt.row_idx * 10 + mt.col_idx)
@@ -288,7 +287,6 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_rows(x=hl.struct(y=hl.range(0, mt.row_idx)))
         self.assertEqual(mt.explode_rows(mt.x.y).count_rows(), 6)
 
-    @fails_service_backend()
     def test_explode_cols(self):
         mt = hl.utils.range_matrix_table(4, 4)
         mt = mt.annotate_entries(e=mt.row_idx * 10 + mt.col_idx)
@@ -317,7 +315,6 @@ class Tests(unittest.TestCase):
                .aggregate(x=hl.agg.collect_as_set(mt.col_idx + 5)))
         assert mt3.aggregate_entries(hl.agg.all(mt3.x == hl.set({5, 6, 7})))
 
-    @fails_service_backend()
     def test_aggregate_cols_by(self):
         mt = hl.utils.range_matrix_table(2, 4)
         mt = (mt.annotate_cols(group=mt.col_idx < 2)
@@ -475,7 +472,6 @@ class Tests(unittest.TestCase):
         with self.assertRaisesRegex(hl.expr.ExpressionException, "MatrixTable col key: *<<<empty key>>>"):
             mt.key_cols_by().index_cols(mt.col_idx)
 
-    @fails_service_backend()
     def test_table_join(self):
         ds = self.get_mt()
         # test different row schemas
@@ -559,13 +555,11 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(left.union_cols(right)._same(joined))
 
-    @fails_service_backend()
     def test_union_cols_distinct(self):
         mt = hl.utils.range_matrix_table(10, 10)
         mt = mt.key_rows_by(x = mt.row_idx // 2)
         assert mt.union_cols(mt).count_rows() == 5
 
-    @fails_service_backend()
     def test_union_cols_outer(self):
         r, c = 10, 10
         mt = hl.utils.range_matrix_table(2*r, c)
@@ -613,7 +607,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(ds.choose_cols(list(range(10))).s.collect(),
                          old_order[:10])
 
-    @fails_service_backend()
     def test_choose_cols_vs_explode(self):
         ds = self.get_mt()
 
@@ -621,7 +614,6 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(ds.choose_cols(sorted(list(range(ds.count_cols())) * 2))._same(ds2))
 
-    @fails_service_backend()
     def test_distinct_by_row(self):
         orig_mt = hl.utils.range_matrix_table(10, 10)
         mt = orig_mt.key_rows_by(row_idx=orig_mt.row_idx // 2)
@@ -629,7 +621,6 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(orig_mt.union_rows(orig_mt).distinct_by_row()._same(orig_mt))
 
-    @fails_service_backend()
     def test_distinct_by_col(self):
         orig_mt = hl.utils.range_matrix_table(10, 10)
         mt = orig_mt.key_cols_by(col_idx=orig_mt.col_idx // 2)
@@ -730,7 +721,6 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(mt_join_entries.all(mt_join_entries.x == mt_join_entries.x2))
 
-    @fails_service_backend()
     def test_entry_join_const(self):
         mt1 = hl.utils.range_matrix_table(10, 10, n_partitions=4)
         mt1 = mt1.annotate_entries(x=mt1.row_idx + mt1.col_idx)
@@ -836,7 +826,6 @@ class Tests(unittest.TestCase):
                 ds._filter_partitions([0, 3, 7]),
                 ds._filter_partitions([0, 3, 7], keep=False))))
 
-    @fails_service_backend()
     def test_from_rows_table(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         mt = mt.annotate_globals(foo='bar')
@@ -868,7 +857,6 @@ class Tests(unittest.TestCase):
         t = hl.read_table(f + '/rows')
         self.assertTrue(ds.rows()._same(t))
 
-    @fails_service_backend()
     def test_read_stored_globals(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x=5, baz='foo')
@@ -1047,7 +1035,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(ht.order_by(hl.asc('idx')).idx.collect(), list(range(10)))
         self.assertEqual(ht.order_by(hl.desc('idx')).idx.collect(), list(range(10))[::-1])
 
-    @fails_service_backend()
     def test_order_by_complex_exprs(self):
         ht = hl.utils.range_table(10)
         assert ht.order_by(-ht.idx).idx.collect() == list(range(10))[::-1]
@@ -1090,7 +1077,6 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_entries(x=mt.row_idx * mt.col_idx)
         self.assertEqual(mt.x.collect(), [])
 
-    @fails_service_backend()
     def test_make_table(self):
         mt = hl.utils.range_matrix_table(3, 2)
         mt = mt.select_entries(x=mt.row_idx * mt.col_idx)
@@ -1126,7 +1112,6 @@ class Tests(unittest.TestCase):
         t = mt.make_table(separator='__')
         assert list(t.row) == ['row_idx', '0__x', '1__x']
 
-    @fails_service_backend()
     def test_make_table_row_equivalence(self):
         mt = hl.utils.range_matrix_table(3, 3)
         mt = mt.annotate_rows(r1 = hl.rand_norm(), r2 = hl.rand_norm())
@@ -1233,6 +1218,7 @@ class Tests(unittest.TestCase):
         mt2 = hl.read_matrix_table(f)
         self.assertTrue(mt._same(mt2))
 
+    @fails_service_backend()
     def test_write_checkpoint_file(self):
         mt = self.get_mt()
         f = new_temp_file(extension='mt')
@@ -1502,7 +1488,6 @@ class Tests(unittest.TestCase):
                                                  fraction_filtered=hl.float32(0.0))})
         assert mt.aggregate_cols(hl.agg.all(mt.entry_stats_col == col_expected[mt.col_idx % 4 == 0]))
 
-    @fails_service_backend()
     def test_annotate_col_agg_lowering(self):
         mt = hl.utils.range_matrix_table(10, 10, 2)
         mt = mt.annotate_cols(c1=[mt.col_idx, mt.col_idx * 2])
@@ -1514,7 +1499,6 @@ class Tests(unittest.TestCase):
                               grouped=hl.agg.group_by(mt.e1 % 5, hl.agg.sum(mt.e1) + common_ref))
         mt.cols()._force_count()
 
-    @fails_service_backend()
     def test_annotate_rows_scan_lowering(self):
         mt = hl.utils.range_matrix_table(10, 10, 2)
         mt = mt.annotate_rows(r1=[mt.row_idx, mt.row_idx * 2])
@@ -1589,7 +1573,6 @@ class Tests(unittest.TestCase):
         ],
                    mt.filter_rows((mt.row_idx >= 5) & (mt.row_idx < 35)))
 
-    @fails_service_backend()
     def test_partitioned_write_coerce(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         parts = [
@@ -1616,12 +1599,10 @@ class Tests(unittest.TestCase):
         with pytest.raises(hl.utils.FatalError, match='metadata does not contain file version'):
             hl.read_matrix_table(resource('0.1-1fd5cc7.vds'))
 
-    @fails_service_backend()
     def test_legacy_files_with_required_globals(self):
         hl.read_table(resource('required_globals.ht'))._force_count()
         hl.read_matrix_table(resource('required_globals.mt'))._force_count_rows()
 
-    @fails_service_backend()
     def test_matrix_native_write_range(self):
         mt = hl.utils.range_matrix_table(11, 3, n_partitions=3)
         f = new_temp_file()
@@ -1646,7 +1627,6 @@ class Tests(unittest.TestCase):
         mt = mt.add_col_index()
         mt.show()
 
-    @fails_service_backend()
     def test_filtered_entries_group_rows_by(self):
         mt = hl.utils.range_matrix_table(1, 1)
         mt = mt.filter_entries(False)

--- a/hail/python/test/hail/methods/test_family_methods.py
+++ b/hail/python/test/hail/methods/test_family_methods.py
@@ -95,7 +95,6 @@ class Tests(unittest.TestCase):
         tt = hl.trio_matrix(mt, ped, complete_trios=True)
         self.assertEqual(tt.count_cols(), 0)
 
-    @fails_service_backend()
     def test_trio_matrix_incomplete_trios(self):
         ped = hl.Pedigree.read(resource('triomatrix.fam'))
         mt = hl.import_vcf(resource('triomatrix.vcf'))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -58,7 +58,6 @@ class VCFTests(unittest.TestCase):
         for f in _FLOAT_ARRAY_INFO_FIELDS:
             self.assertEqual(mt['info'][f].dtype, hl.tarray(hl.tfloat64))
 
-    @fails_service_backend()
     def test_glob(self):
         full = hl.import_vcf(resource('sample.vcf'))
         parts = hl.import_vcf(resource('samplepart*.vcf'))
@@ -1999,7 +1998,6 @@ class ImportTableTests(unittest.TestCase):
         ht.write(f)
         assert ht._same(hl.read_table(f))
 
-    @fails_service_backend()
     def test_import_same(self):
         ht = hl.import_table(resource('sampleAnnotations.tsv'))
         ht2 = hl.import_table(resource('sampleAnnotations.tsv'))

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1319,7 +1319,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(glob.bn.pop_dist), [1, 2])
         self.assertEqual(hl.eval(glob.bn.fst), [.02, .06])
 
-    @fails_service_backend()
     def test_balding_nichols_model_same_results(self):
         for mixture in [True, False]:
             hl.set_global_seed(1)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -210,7 +210,6 @@ class Tests(unittest.TestCase):
 
         assert re_mt.choose_cols(mapping).drop('col_idx')._same(mt.drop('col_idx'))
 
-    @fails_service_backend()
     def test_to_matrix_table_row_major(self):
         t = hl.utils.range_table(10)
         t = t.annotate(foo=t.idx, bar=2 * t.idx, baz=3 * t.idx)
@@ -252,7 +251,6 @@ class Tests(unittest.TestCase):
         assert r1.all(r1.n == 20)
         assert r2.all(r2.n == 20)
 
-    @fails_service_backend()
     def test_aggregate_by_key_partitioning(self):
         ht1 = hl.Table.parallelize([
             {'k': 'foo', 'b': 1},
@@ -574,7 +572,6 @@ class Tests(unittest.TestCase):
         with self.assertRaisesRegex(hl.expr.ExpressionException, "Table key: *<<<empty key>>>"):
             t[t.idx]
 
-    @fails_service_backend()
     def test_aggregation_with_no_aggregators(self):
         ht = hl.utils.range_table(3)
         self.assertEqual(ht.group_by(ht.idx).aggregate().count(), 3)
@@ -669,7 +666,6 @@ class Tests(unittest.TestCase):
         with self.assertRaises(LookupError):
             kt.rename({'hello': 'a'})
 
-    @fails_service_backend()
     def test_distinct(self):
         t1 = hl.Table.parallelize([
             {'a': 'foo', 'b': 1},
@@ -854,7 +850,6 @@ class Tests(unittest.TestCase):
             ht._filter_partitions([0, 7]).idx.collect(),
             [0, 1, 2, 21, 22])
 
-    @fails_service_backend()
     def test_localize_entries(self):
         ref_schema = hl.tstruct(row_idx=hl.tint32,
                                 __entries=hl.tarray(hl.tstruct(v=hl.tint32)))
@@ -867,7 +862,6 @@ class Tests(unittest.TestCase):
         t = mt._localize_entries('__entries', '__cols')
         self.assertTrue(t._same(ref_tab))
 
-    @fails_service_backend()
     def test_localize_self_join(self):
         ref_schema = hl.tstruct(row_idx=hl.tint32,
                                 __entries=hl.tarray(hl.tstruct(v=hl.tint32)))
@@ -1012,7 +1006,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
-    @fails_service_backend()
     def test_null_joins_2(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),
@@ -1145,7 +1138,6 @@ class Tests(unittest.TestCase):
         ht3 = ht1.join(ht2)
         assert ht3.filter(ht3.idx2 == 10).count() == 4
 
-    @fails_service_backend()
     def test_key_by_aggregate_rewriting(self):
         ht = hl.utils.range_table(10)
         ht = ht.group_by(x=ht.idx % 5).aggregate(aggr = hl.agg.count())
@@ -1182,7 +1174,6 @@ class Tests(unittest.TestCase):
         ht = hl.utils.range_table(10)
         assert hl.eval(ht.idx.collect(_localize=False)) == ht.idx.collect()
 
-    @fails_service_backend()
     def test_expr_collect(self):
         t = hl.utils.range_table(3)
 
@@ -1220,12 +1211,10 @@ class Tests(unittest.TestCase):
     def test_no_row_fields_show(self):
         hl.utils.range_table(5).key_by().select().show()
 
-    @fails_service_backend()
     def test_same_equal(self):
         t1 = hl.utils.range_table(1)
         self.assertTrue(t1._same(t1))
 
-    @fails_service_backend()
     def test_same_within_tolerance(self):
         t = hl.utils.range_table(1)
         t1 = t.annotate(x = 1.0)
@@ -1250,7 +1239,6 @@ class Tests(unittest.TestCase):
         t2 = t1.annotate_globals(x = 8)
         self.assertFalse(t1._same(t2))
 
-    @fails_service_backend()
     def test_same_different_rows(self):
         t1 = (hl.utils.range_table(2)
               .annotate(x = 7))
@@ -1352,7 +1340,6 @@ def test_large_number_of_fields(tmpdir):
 def test_import_many_fields():
     assert_time(lambda: hl.import_table(resource('many_cols.txt')), 5)
 
-@fails_service_backend()
 def test_segfault():
     t = hl.utils.range_table(1)
     t2 = hl.utils.range_table(3)
@@ -1363,7 +1350,6 @@ def test_segfault():
     assert joined.collect() == []
 
 
-@fails_service_backend()
 def test_maybe_flexindex_table_by_expr_direct_match():
     t1 = hl.utils.range_table(1)
     t2 = hl.utils.range_table(1)
@@ -1383,7 +1369,6 @@ def test_maybe_flexindex_table_by_expr_direct_match():
     assert t1._maybe_flexindex_table_by_expr(hl.str(mt1.row_key)) is None
 
 
-@fails_service_backend()
 def test_maybe_flexindex_table_by_expr_prefix_match():
     t1 = hl.utils.range_table(1)
     t2 = hl.utils.range_table(1)
@@ -1403,7 +1388,6 @@ def test_maybe_flexindex_table_by_expr_prefix_match():
     assert t1._maybe_flexindex_table_by_expr((hl.str(mt1.row_idx), mt1.row_idx)) is None
 
 
-@fails_service_backend()
 @fails_local_backend()
 def test_maybe_flexindex_table_by_expr_direct_interval_match():
     t1 = hl.utils.range_table(1)

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -5,6 +5,7 @@ import java.net._
 import java.nio.charset.StandardCharsets
 import java.util.concurrent._
 
+import is.hail.HAIL_REVISION
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
@@ -47,10 +48,6 @@ class ServiceBackendContext(
 
 object ServiceBackend {
   private val log = Logger.getLogger(getClass.getName())
-
-  def apply(): ServiceBackend = {
-    new ServiceBackend()
-  }
 }
 
 class User(
@@ -58,7 +55,9 @@ class User(
   val tmpdir: String,
   val fs: GoogleStorageFS)
 
-class ServiceBackend() extends Backend {
+class ServiceBackend(
+  private[this] val queryGCSPath: String
+) extends Backend {
   import ServiceBackend.log
 
   private[this] val users = new ConcurrentHashMap[String, User]()
@@ -133,6 +132,8 @@ class ServiceBackend() extends Backend {
           "process" -> JObject(
             "command" -> JArray(List(
               JString("is.hail.backend.service.Worker"),
+              JString(HAIL_REVISION),
+              JString(queryGCSPath + HAIL_REVISION + ".jar"),
               JString(root),
               JString(s"$i"))),
             "type" -> JString("jvm")),
@@ -327,7 +328,10 @@ class ServiceBackend() extends Backend {
           (relationalLetsAbove)
           { partition => ShuffleWrite(Literal(shuffleType, uuid), partition) }
           { (rows, globals) => MakeTuple.ordered(Seq(rows, globals)) })
-      val globals = successfulPartitionIdsAndGlobals.asInstanceOf[UnsafeRow].get(1)
+      val globals = SafeRow(
+        successfulPartitionIdsAndGlobals.asInstanceOf[UnsafeRow].t,
+        successfulPartitionIdsAndGlobals.asInstanceOf[UnsafeRow].offset
+      ).get(1)
 
       val partitionBoundsPointers = shuffleClient.partitionBounds(region, stage.numPartitions)
       val partitionIntervals = partitionBoundsPointers.zip(partitionBoundsPointers.drop(1)).map { case (l, r) =>
@@ -645,8 +649,16 @@ object ServiceBackendMain {
   def main(argv: Array[String]): Unit = {
     assert(argv.length == 1, argv.toFastIndexedSeq)
     val udsAddress = argv(0)
+    val queryGCSPathEnvVar = System.getenv("HAIL_QUERY_GCS_PATH")
+    val queryGCSBucketEnvVar = System.getenv("HAIL_QUERY_GCS_BUCKET")
+    val queryGCSPath = if (queryGCSPathEnvVar != null) {
+      assert(queryGCSBucketEnvVar == null, queryGCSBucketEnvVar)
+      queryGCSPathEnvVar
+    } else {
+      s"gs://${queryGCSBucketEnvVar}/jars/"
+    }
     val executor = Executors.newCachedThreadPool()
-    val backend = new ServiceBackend()
+    val backend = new ServiceBackend(queryGCSPath)
     HailContext(backend, "hail.log", false, false, 50, skipLoggingConfiguration = true, 3)
 
     val ss = AFUNIXServerSocket.newInstance()

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -1,11 +1,11 @@
 package is.hail.backend.service
 
 import java.io._
-import java.nio.charset.Charset
+import java.nio.charset._
 
-import is.hail.HailContext
-import is.hail.backend._
-import is.hail.io.fs._
+import is.hail.{HAIL_REVISION, HailContext}
+import is.hail.backend.HailTaskContext
+import is.hail.io.fs.GoogleStorageFS
 import is.hail.services._
 import is.hail.utils._
 import org.apache.commons.io.IOUtils
@@ -44,21 +44,20 @@ class WorkerTimer() {
 }
 
 object Worker {
-  private val log = Logger.getLogger(getClass.getName())
+  private[this] val log = Logger.getLogger(getClass.getName())
+  private[this] val myRevision = HAIL_REVISION
+  private[this] val scratchDir = sys.env.get("HAIL_WORKER_SCRATCH_DIR").getOrElse("")
 
   def main(args: Array[String]): Unit = {
-    if (args.length != 2) {
-      throw new IllegalArgumentException(s"expected two arguments, not: ${ args.length }")
+    if (args.length != 4) {
+      throw new IllegalArgumentException(s"expected at least four arguments, not: ${ args.length }")
     }
-    val root = args(0)
-    val i = args(1).toInt
+    val root = args(2)
+    val i = args(3).toInt
     val timer = new WorkerTimer()
 
-    var scratchDir = System.getenv("HAIL_WORKER_SCRATCH_DIR")
-    if (scratchDir == null)
-      scratchDir = ""
-
-    log.info(s"running job $i at root $root wih scratch directory '$scratchDir'")
+    log.info(s"is.hail.backend.service.Worker $myRevision")
+    log.info(s"running job $i at root $root with scratch directory '$scratchDir'")
 
     timer.start(s"Job $i")
     timer.start("readInputs")
@@ -98,7 +97,7 @@ object Worker {
     timer.start("executeFunction")
 
     val hailContext = HailContext(
-      ServiceBackend(), skipLoggingConfiguration = true, quiet = true)
+      new ServiceBackend(null), skipLoggingConfiguration = true, quiet = true)
     val htc = new ServiceTaskContext(i)
     HailTaskContext.setTaskContext(htc)
     val result = f(context, htc)

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -37,7 +37,7 @@ object GoogleStorageFS {
     val uri = new URI(filename).normalize()
 
     val scheme = uri.getScheme
-    assert(scheme != null && scheme == "gs", uri.getScheme)
+    assert(scheme != null && scheme == "gs", (uri.getScheme, filename))
 
     val bucket = uri.getHost
     assert(bucket != null)
@@ -94,7 +94,7 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
   def getOwner: String = null
 }
 
-class GoogleStorageFS(serviceAccountKey: String) extends FS {
+class GoogleStorageFS(var serviceAccountKey: String) extends FS {
   import GoogleStorageFS._
 
   @transient private lazy val storage: Storage = {
@@ -152,7 +152,7 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
         }
 
         pos += 1
-        bb.get()
+        bb.get().toInt & 0xff
       }
 
       override def read(bytes: Array[Byte], off: Int, len: Int): Int = {

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -133,8 +133,8 @@ object AbstractRVDSpec {
 
     val reader = PartitionZippedNativeReader(specLeft.typedCodecSpec, specRight.typedCodecSpec, indexSpecLeft, indexSpecRight, requestedKey)
 
-    val absPathLeft = uriPath(pathLeft)
-    val absPathRight = uriPath(pathRight)
+    val absPathLeft = removeFileProtocol(pathLeft)
+    val absPathRight = removeFileProtocol(pathRight)
     val partsAndIntervals: IndexedSeq[(String, Interval)] = if (specLeft.key.isEmpty) {
       specLeft.partFiles.map { p => (p, null) }
     } else {
@@ -501,7 +501,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
       val rSpec = typedCodecSpec
       val reader = ir.PartitionNativeReaderIndexed(rSpec, indexSpec, partitioner.kType.fieldNames)
 
-      val absPath = uriPath(path)
+      val absPath = removeFileProtocol(path)
       val partPaths = tmpPartitioner.rangeBounds.map { b => partFiles(partitioner.lowerBoundInterval(b)) }
 
 

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -264,6 +264,7 @@ object EType {
     case TFloat64 => EFloat64(r.required)
     case TBoolean => EBoolean(r.required)
     case TBinary => EBinary(r.required)
+    case _: TShuffle => EShuffle(r.required)
     case TString => EBinary(r.required)
     case TLocus(_) =>
       EBaseStruct(Array(

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -16,6 +16,7 @@ package object physical {
     case _: PBoolean => typeInfo[Boolean]
     case PVoid => typeInfo[Unit]
     case _: PBinary => typeInfo[Long]
+    case _: PShuffle => typeInfo[Long]
     case _: PStream => classInfo[StreamArgType]
     case _: PBaseStruct => typeInfo[Long]
     case _: PNDArray => typeInfo[Long]

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -310,6 +310,15 @@ package object utils extends Logging
 
   def uriPath(uri: String): String = new URI(uri).getPath
 
+  def removeFileProtocol(uriString: String): String = {
+    val uri = new URI(uriString)
+    if (uri.getScheme == "file") {
+      uri.getPath
+    } else {
+      uri.toString
+    }
+  }
+
   // NB: can't use Nothing here because it is not a super type of Null
   private object flattenOrNullInstance extends FlattenOrNull[Array]
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -16,6 +16,8 @@ variable "batch_gcp_regions" {}
 variable "gcp_project" {}
 variable "batch_logs_bucket_location" {}
 variable "batch_logs_bucket_storage_class" {}
+variable "hail_query_bucket_location" {}
+variable "hail_query_bucket_storage_class" {}
 variable "gcp_region" {}
 variable "gcp_zone" {}
 variable "domain" {}
@@ -203,6 +205,7 @@ resource "kubernetes_secret" "global_config" {
   data = {
     batch_gcp_regions = var.batch_gcp_regions
     batch_logs_bucket = google_storage_bucket.batch_logs.name
+    hail_query_bucket = google_storage_bucket.hail_query.name
     default_namespace = "default"
     docker_root_image = "gcr.io/${var.gcp_project}/ubuntu:18.04"
     domain = var.domain
@@ -468,6 +471,34 @@ resource "google_project_iam_member" "batch_storage_admin" {
   member = "serviceAccount:${google_service_account.batch.email}"
 }
 
+resource "random_id" "query_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_service_account" "query" {
+  account_id = "query-${random_id.query_name_suffix.hex}"
+}
+
+resource "google_service_account_key" "query_key" {
+  service_account_id = google_service_account.query.name
+}
+
+resource "kubernetes_secret" "query_gsa_key" {
+  metadata {
+    name = "query-gsa-key"
+  }
+
+  data = {
+    "key.json" = base64decode(google_service_account_key.query_key.private_key)
+  }
+}
+
+resource "google_storage_bucket_iam_member" "query_hail_query_bucket_storage_admin" {
+  bucket = google_storage_bucket.hail_query.name
+  role = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.query.email}"
+}
+
 resource "google_service_account" "benchmark" {
   account_id = "benchmark"
 }
@@ -670,6 +701,17 @@ resource "google_storage_bucket" "batch_logs" {
   location = var.batch_logs_bucket_location
   force_destroy = true
   storage_class = var.batch_logs_bucket_storage_class
+}
+
+resource "random_id" "hail_query_bucket_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_storage_bucket" "hail_query" {
+  name = "hail-query-${random_id.hail_query_bucket_name_suffix.hex}"
+  location = var.hail_query_bucket_location
+  force_destroy = true
+  storage_class = var.hail_query_bucket_storage_class
 }
 
 resource "google_dns_managed_zone" "dns_zone" {

--- a/query/Makefile
+++ b/query/Makefile
@@ -28,9 +28,13 @@ push: build
 	docker tag query $(QUERY_IMAGE)
 	docker push $(QUERY_IMAGE)
 
+UPLOAD_QUERY_JAR_TOKEN := $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+HAIL_REVISION := $(shell git rev-parse HEAD)
+
 .PHONY: deploy
 deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	kubectl -n $(NAMESPACE) apply -f service-account.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	gsutil cp ./hail.jar gs://hail-test-dmk9z/$(UPLOAD_QUERY_JAR_TOKEN)/jars/$(HAIL_REVISION).jar
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"},"upload_query_jar":{"token":"$(UPLOAD_QUERY_JAR_TOKEN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -92,6 +92,16 @@ spec:
              value: "{{ code.sha }}"
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
+{% if deploy %}
+           - name: HAIL_QUERY_GCS_BUCKET
+             valueFrom:
+             secretKeyRef:
+               name: global-config
+               key: hail_query_bucket
+{% else %}
+           - name: HAIL_QUERY_GCS_PATH
+             value: gs://hail-test-dmk9z/{{ upload_query_jar.token }}/jars/
+{% endif %}
           ports:
            - containerPort: 5000
           volumeMounts:


### PR DESCRIPTION
The high-level problem: 

The Hail Query Service is redeployed with each commit to `main`. Each deployment has a new JAR file
whose ABI is backwards-incompatible.

The high-level solution:

Hail Batch Workers can load the JAR for a given Hail version on-demand. Although not a long-term
solution, we currently start a fresh JVM for each job. As a result, we can simply start the JVM with
the correct JAR on its classpath. We cache jars on the local filesystem.

I had to abandon the old approach for two reasons:

1. Multiple JVMs race to download the JAR. In the new approach, the python worker process uses a
   lock to ensure at most one coroutine is downloading a given version of a JAR at the same time.

2. The JVM includes assumes that a child ClassLoader does not redefine a class from the parent
   ClassLoader. That's why ClassLoaders always prefer to load a class from the parent ClassLoader's
   classes.

When we decide to re-use JVMs or use a single multi-threaded JVM, we'll need to ensure the top-level
ClassLoader *does not have Hail on its classpath*. I looked briefly at this approach and found it
more work than the current approach.

---

My apologies for eliminating JVMProcess in this PR. It's an unrelated change which facilitated my
understanding of worker.py. I essentially inlined JVMProcess into JVMJob and eliminated any duplicative
code.

---

After making this change I restored the tests. Some tests had bitrotted. In the process of fixing
those tests, I found a few other bugs. Fixing these lower-level bugs unlocked a number of new
tests.

One test (which was added since the service tests were removed) had to be marked as failing. Some
Hail operations rely on writing to the local file system. Implementing that properly in the Query
Worker will take some thought.

Here are the bugs I fixed:

1. Correct the error message raised when tests are run in a non-main thread (we look for this
   message and start an event loop for Hail's async code because asyncio refuses to start an event
   loop in a non-main thread).

2. Use a `SafeRow` to copy the globals data out of a Region and into durable, GC'ed objects.

3. Re-enable serialization of GoogleStorageFS (including its private key, which we really shouldn't
   do; Tim is working on it), which was broken (presumably) when we changed Scala versions. The
   `var` modifier ensures the name is compiled as a JVM field.

4. Correctly convert from a `Byte` to an `Int`. By default `Byte` to `Int` conversion (which is done
   automatically when you return a `Byte` from a function whose return type is `Int`) is
   sign-preserving. That means that the byte `0000 1111` is converted to the `Int` 15 and the byte
   `1000 1111` is converted to the `Int` -113. The contract of
   [`InputStream.read`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read--)
   is to return the unsigned integeral value of the next `Byte` or `-1` if we've reached the end of
   the stream. `DataInputStream` treats any negative value as EOS which lead to perplexing EOSes
   when reading data from GCS.

5. Retain the `gs://` protocol when reading MTs and Ts. `uriPath` strips *all* protocols. Before the
   Query Service, these code paths were only used by the LocalBackend. In the LocalBackend, the only
   URIs generated are `file://`. However, UNIX/JVM file system operations do not support URIs, they
   want bare paths.

6. Implement missing cases for EShuffle and PShuffle.

---

I've already updated the cluster with the new bucket and the corresponding change to the
`global-config` secret. We'll should notify Leo et al. about the Terraform changes.

---

Small changes and fixes:

- Rename `key.json` to `/worker-key.json` for clarity, this is the worker's own GCP service account
  key.

- Create a test query-gsa-key in test and dev namespaces.

- Add terraform rules for the query service account. It already existed, but it was missing from the
  Terraform file. You can verify the permissions grant by inspecting `gsutil iam get
  gs://hail-query`.

- The `query` user was missing from bootstrap-create-accounts.

- `hail-ubuntu-stmp` was missing from `docker/Makefile`'s `clean` rule

- Only apply nest_asyncio when an event loop is already started.