### PR TITLE
[memory,query] Cache job function/context/outputs in memory service

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1025,7 +1025,7 @@ class DockerJob(Job):
 
     async def delete(self):
         await super().delete()
-        for _, c in self.containers.items():
+        for c in self.containers.values():
             await c.delete()
 
     async def status(self):

--- a/build.yaml
+++ b/build.yaml
@@ -2347,7 +2347,6 @@ steps:
         for: alive
     dependsOn:
       - default_ns
-      - deploy_batch
       - memory_image
       - deploy_memory_sa
       - create_certs

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -22,7 +22,8 @@ def _get_ssl_config() -> Dict[str, str]:
         with open(config_file, 'r') as f:
             ssl_config = json.load(f)
             for config_name, rel_path in ssl_config.items():
-                ssl_config[config_name] = f'{config_dir}/{rel_path}'
+                absolute_path = f'{config_dir}/{rel_path}'
+                ssl_config[config_name] = absolute_path
         check_ssl_config(ssl_config)
         return ssl_config
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')

--- a/hail/python/hailtop/tls.py
+++ b/hail/python/hailtop/tls.py
@@ -22,8 +22,7 @@ def _get_ssl_config() -> Dict[str, str]:
         with open(config_file, 'r') as f:
             ssl_config = json.load(f)
             for config_name, rel_path in ssl_config.items():
-                absolute_path = f'{config_dir}/{rel_path}'
-                ssl_config[config_name] = absolute_path
+                ssl_config[config_name] = f'{config_dir}/{rel_path}'
         check_ssl_config(ssl_config)
         return ssl_config
     raise NoSSLConfigFound(f'no ssl config found at {config_file}')

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -66,10 +66,11 @@ class ServiceBackend() extends Backend {
     assert(previous == null)
   }
 
+  // TODO Do we need the sessionID to be serialized at all?
   def userContext[T](username: String, sessionID: String, timer: ExecutionTimer)(f: (ExecuteContext) => T): T = {
     val user = users.get(username)
     assert(user != null, username)
-    ExecuteContext.scoped(user.tmpdir, "file:///tmp", this, user.fs.asCacheable(sessionID), timer, null)(f)
+    ExecuteContext.scoped(user.tmpdir, "file:///tmp", this, user.fs, timer, null)(f)
   }
 
   def defaultParallelism: Int = 10

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -155,7 +155,7 @@ class ServiceBackend() extends Backend {
 
     i = 0  // reusing
     while (i < n) {
-      r(i) = using(fs.openNoCompression(s"$root/result.$i")) { is =>
+      r(i) = using(fs.openCachedNoCompression(s"$root/result.$i")) { is =>
         IOUtils.toByteArray(is)
       }
       i += 1

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -144,7 +144,10 @@ trait FS extends Serializable {
 
   }
 
-  def open(path: String, gzAsBGZ: Boolean = false): InputStream =
+  def open(path: String): InputStream =
+    open(path, gzAsBGZ = false)
+
+  def open(path: String, gzAsBGZ: Boolean): InputStream =
     open(path, getCodecFromPath(path, gzAsBGZ))
 
   def create(path: String): OutputStream = {

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 object GoogleStorageFS {
-  val log = Logger.getLogger(getClass.getName())
+  private val log = Logger.getLogger(getClass.getName())
 
   def containsWildcard(path: String): Boolean = {
     var i = 0

--- a/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
@@ -1,0 +1,42 @@
+package is.hail.io.fs
+
+import java.io.InputStream
+
+import is.hail.services.memory_client.MemoryClient
+import is.hail.utils._
+
+trait ServiceCacheableFS extends FS {
+
+  def sessionID: String
+
+  def getEtagOrNone(filename: String): Option[String]
+
+  @transient private lazy val client: MemoryClient = {
+    if (sessionID != null)
+      MemoryClient.fromSessionID(sessionID)
+    else MemoryClient.get
+  }
+
+  def openCachedNoCompression(filename: String): SeekableDataInputStream = {
+    getEtagOrNone(filename).flatMap { etag =>
+      client.open(filename, etag).map(new WrappedSeekableDataInputStream(_))
+    }.getOrElse(openNoCompression(filename))
+  }
+
+  override def open(path: String, codec: CompressionCodec): InputStream =
+    open(path, codec, cache = false)
+
+  def open(path: String, codec: CompressionCodec, cache: Boolean): InputStream = {
+    val is = if (cache) openCachedNoCompression(path) else openNoCompression(path)
+    if (codec != null)
+      codec.makeInputStream(is)
+    else
+      is
+  }
+
+  override def open(path: String, gzAsBGZ: Boolean): InputStream =
+    open(path, getCodecFromPath(path, gzAsBGZ), cache = false)
+
+  def open(path: String, gzAsBGZ: Boolean, cache: Boolean): InputStream =
+    open(path, getCodecFromPath(path, gzAsBGZ))
+}

--- a/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/ServiceCacheableFS.scala
@@ -1,42 +1,62 @@
 package is.hail.io.fs
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
+import org.apache.log4j.Logger
+import scala.collection.mutable.ArrayBuffer
 
 import is.hail.services.memory_client.MemoryClient
+import is.hail.services.ClientResponseException
 import is.hail.utils._
 
 trait ServiceCacheableFS extends FS {
 
   def sessionID: String
 
-  def getEtagOrNone(filename: String): Option[String]
+  private val log = Logger.getLogger(getClass.getName())
 
-  @transient private lazy val client: MemoryClient = {
+  @transient lazy val client: MemoryClient = {
     if (sessionID != null)
       MemoryClient.fromSessionID(sessionID)
     else MemoryClient.get
   }
 
   def openCachedNoCompression(filename: String): SeekableDataInputStream = {
-    getEtagOrNone(filename).flatMap { etag =>
-      client.open(filename, etag).map(new WrappedSeekableDataInputStream(_))
-    }.getOrElse(openNoCompression(filename))
+    client.open(filename).map(new WrappedSeekableDataInputStream(_)).getOrElse(openNoCompression(filename))
   }
 
-  override def open(path: String, codec: CompressionCodec): InputStream =
-    open(path, codec, cache = false)
+  def createCachedNoCompression(filename: String): PositionedDataOutputStream = {
+    val os: PositionedOutputStream = new OutputStream with Positioned {
+      private[this] var closed: Boolean = false
+      private[this] val bb: ArrayBuffer[Byte] = new ArrayBuffer()
 
-  def open(path: String, codec: CompressionCodec, cache: Boolean): InputStream = {
-    val is = if (cache) openCachedNoCompression(path) else openNoCompression(path)
-    if (codec != null)
-      codec.makeInputStream(is)
-    else
-      is
+      override def flush(): Unit = {}
+
+      override def write(i: Int): Unit = {
+        bb += i.toByte
+      }
+
+      override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
+        bb ++= bytes.slice(off, off + len)
+      }
+
+      override def close(): Unit = {
+        if (!closed) {
+          val data = bb.toArray
+          try {
+            client.write(filename, data)
+          } catch { case e: Exception =>
+            log.error(s"Failed to upload $filename to memory service, falling back to GCS")
+            using(createNoCompression(filename)) { os =>
+              os.write(data)
+            }
+          }
+          closed = true
+        }
+      }
+
+      def getPosition: Long = bb.length
+    }
+
+    new WrappedPositionedDataOutputStream(os)
   }
-
-  override def open(path: String, gzAsBGZ: Boolean): InputStream =
-    open(path, getCodecFromPath(path, gzAsBGZ), cache = false)
-
-  def open(path: String, gzAsBGZ: Boolean, cache: Boolean): InputStream =
-    open(path, getCodecFromPath(path, gzAsBGZ))
 }

--- a/hail/src/main/scala/is/hail/services/Requester.scala
+++ b/hail/src/main/scala/is/hail/services/Requester.scala
@@ -31,7 +31,7 @@ class ClientResponseException(
 object Requester {
   lazy val log: Logger = LogManager.getLogger("Requester")
 
-  private val httpClient: CloseableHttpClient = {
+  val httpClient: CloseableHttpClient = {
     log.info("creating HttpClient")
     try {
       HttpClients.custom()
@@ -51,7 +51,6 @@ class Requester(
   def this(service: String) = this(Tokens.get, service)
 
   import Requester._
-
   def requestWithHandler[T >: Null](req: HttpUriRequest, body: HttpEntity, f: InputStream => T): T = {
     log.info(s"request ${ req.getMethod } ${ req.getURI }")
 
@@ -92,6 +91,5 @@ class Requester(
         null
       else
         JsonMethods.parse(new String(s))
-
     })
 }

--- a/hail/src/main/scala/is/hail/services/Tokens.scala
+++ b/hail/src/main/scala/is/hail/services/Tokens.scala
@@ -16,7 +16,9 @@ object Tokens {
     if (new File(file).isFile) {
       using(new FileInputStream(file)) { is =>
         implicit val formats: Formats = DefaultFormats
-        new Tokens(JsonMethods.parse(is).extract[Map[String, String]])
+        val tokens = JsonMethods.parse(is).extract[Map[String, String]]
+        log.info(s"tokens found for namespaces {${ tokens.keys.mkString(", ") }}")
+        new Tokens(tokens)
       }
     } else {
       log.info(s"tokens file not found: $file")

--- a/hail/src/main/scala/is/hail/services/memory_client/MemoryClient.scala
+++ b/hail/src/main/scala/is/hail/services/memory_client/MemoryClient.scala
@@ -1,0 +1,98 @@
+package is.hail.services.memory_client
+
+import java.io.{DataInputStream, IOException, InputStream}
+
+import is.hail.HailContext
+import is.hail.io.fs.Seekable
+import is.hail.services.{ClientResponseException, DeployConfig, Requester, Tokens}
+import org.apache.http.client.methods.{HttpGet, HttpUriRequest}
+import org.apache.http.client.utils.URIBuilder
+import org.apache.log4j.{LogManager, Logger}
+import org.json4s.JValue
+
+object MemoryClient {
+  lazy val log: Logger = LogManager.getLogger("MemoryClient")
+
+  def fromSessionID(sessionID: String): MemoryClient = {
+    val deployConfig = DeployConfig.get
+    new MemoryClient(deployConfig,
+      new Tokens(Map(
+        deployConfig.getServiceNamespace("memory") -> sessionID)))
+  }
+
+  def get: MemoryClient = new MemoryClient(DeployConfig.get, Tokens.get)
+}
+
+class MemoryClient(deployConfig: DeployConfig, tokens: Tokens) {
+    val requester = new Requester(tokens, "memory")
+
+    import MemoryClient.log
+    import requester.request
+
+    private[this] val baseUrl = deployConfig.baseUrl("memory")
+
+  def open(path: String, etag: String): Option[MemorySeekableInputStream] =
+    try {
+      Some(new MemorySeekableInputStream(requester, s"$baseUrl/api/v1alpha/objects", path, etag))
+    } catch { case e: ClientResponseException if e.status == 404 =>
+      None
+    }
+
+}
+
+class MemorySeekableInputStream(requester: Requester, objectEndpoint: String, fileURI: String, etag: String) extends InputStream with Seekable {
+  private[this] val uri = new URIBuilder(objectEndpoint)
+    .addParameter("q", fileURI)
+    .addParameter("etag", etag)
+  private[this] val req = new HttpGet(uri.build())
+
+  private[this] val _bytes = requester.requestAsByteStream(req)
+  private[this] var _pos: Int = 0
+  private[this] val _len: Int = _bytes.length
+
+  override def read(): Int = {
+    if (_pos >= _len) -1 else {
+      _pos += 1
+      _bytes(_pos.toInt - 1)
+    }
+  }
+
+  override def read(bytes: Array[Byte], off: Int, len: Int): Int = {
+    if (off < 0 || len < 0 || len > bytes.length - off)
+      throw new IndexOutOfBoundsException()
+    if (len == 0)
+      0
+    else if (_pos >= _len)
+      -1
+    else {
+      val n_read: Int = java.lang.Math.min(_len - _pos, len)
+      System.arraycopy(_bytes, _pos, bytes, off, n_read)
+      _pos += n_read
+      n_read
+    }
+  }
+
+  override def skip(n: Long): Long = {
+    if (n <= 0L)
+      0L
+    else {
+      if (_pos + n >= _len) {
+        val r = _len - _pos
+        _pos = _len
+        r
+      } else {
+        _pos = _pos + n.toInt
+        n
+      }
+    }
+  }
+
+  override def close(): Unit = {}
+
+  def getPosition: Long = _pos
+
+  def seek(pos: Long): Unit =
+    if (pos < 0 || pos > _len)
+      throw new IOException(s"Cannot seek to position $pos")
+    else _pos = pos.toInt
+}

--- a/hail/src/main/scala/is/hail/services/memory_client/MemoryClient.scala
+++ b/hail/src/main/scala/is/hail/services/memory_client/MemoryClient.scala
@@ -59,7 +59,7 @@ class MemorySeekableInputStream(requester: Requester, objectEndpoint: String, fi
   override def read(): Int = {
     if (_pos >= _len) -1 else {
       _pos += 1
-      _bytes(_pos.toInt - 1)
+      _bytes(_pos - 1).toInt & 0xff
     }
   }
 

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -1,7 +1,6 @@
 
 import aiohttp
 import concurrent
-import google.api_core.exceptions
 
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
@@ -36,11 +35,7 @@ class MemoryClient:
             self._headers.update(service_auth_headers(self._deploy_config, 'memory'))
 
     async def _get_file_if_exists(self, filename):
-        try:
-            etag = await self._fs.get_etag(filename)
-        except google.api_core.exceptions.NotFound:
-            return None
-        params = {'q': filename, 'etag': etag}
+        params = {'q': filename}
         try:
             url = f'{self.url}/api/v1alpha/objects'
             async with await request_retry_transient_errors(self._session,

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -60,7 +60,7 @@ class MemoryClient:
                                                         'post', self.objects_url,
                                                         params=params,
                                                         headers=self._headers,
-                                                        body=data) as response:
+                                                        data=data) as response:
             assert response.status == 200
 
     async def close(self):

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -22,7 +22,7 @@ from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_e
 uvloop.install()
 
 DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
-log = logging.getLogger('batch')
+log = logging.getLogger('memory')
 routes = web.RouteTableDef()
 
 socket = '/redis/redis.sock'

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -10,6 +10,7 @@ import signal
 from aiohttp import web
 import kubernetes_asyncio as kube
 from prometheus_async.aio.web import server_stats  # type: ignore
+from typing import Set
 
 from hailtop.config import get_deploy_config
 from hailtop.google_storage import GCS
@@ -36,16 +37,33 @@ async def healthcheck(request):  # pylint: disable=unused-argument
 @monitor_endpoint
 @rest_authenticated_users_only
 async def get_object(request, userdata):
-    filename = request.query.get('q')
-    etag = request.query.get('etag')
+    filepath = request.query.get('q')
     userinfo = await get_or_add_user(request.app, userdata)
     username = userdata['username']
-    log.info(f'memory: request for object {filename} from user {username}')
-    result = await get_file_or_none(request.app, username, userinfo, filename, etag)
-    if result is None:
+    log.info(f'memory: request for object {filepath} from user {username}')
+    maybe_file = await get_file_or_none(request.app, username, userinfo['fs'], filepath)
+    if maybe_file is None:
         raise web.HTTPNotFound()
-    etag, body = result
-    return web.Response(headers={'ETag': etag}, body=body)
+    return web.Response(body=maybe_file)
+
+
+@routes.post('/api/v1alpha/objects')
+@monitor_endpoint
+@rest_authenticated_users_only
+async def write_object(request, userdata):
+    filepath = request.query.get('q')
+    userinfo = await get_or_add_user(request.app, userdata)
+    username = userdata['username']
+    data = await request.read()
+    log.info(f'memory: post for object {filepath} from user {username}')
+
+    file_key = make_redis_key(username, filepath)
+    files = request.app['files_in_progress']
+    files.add(file_key)
+
+    await persist_in_gcs(userinfo['fs'], files, file_key, filepath, data)
+    await cache_file(request.app['redis_pool'], files, file_key, filepath, data)
+    return web.Response(status=200)
 
 
 async def get_or_add_user(app, userdata):
@@ -67,21 +85,21 @@ def make_redis_key(username, filepath):
     return f'{ username }_{ filepath }'
 
 
-async def get_file_or_none(app, username, userinfo, filepath, etag):
+async def get_file_or_none(app, username, fs, filepath):
     file_key = make_redis_key(username, filepath)
-    fs = userinfo['fs']
+    redis_pool: aioredis.ConnectionsPool = app['redis_pool']
 
-    cached_etag, result = await app['redis_pool'].execute('HMGET', file_key, 'etag', 'body')
-    if cached_etag is not None and cached_etag.decode('ascii') == etag:
-        log.info(f"memory: Retrieved file {filepath} for user {username} with etag'{etag}'")
-        return cached_etag.decode('ascii'), result
+    body, = await redis_pool.execute('HMGET', file_key, 'body')
+    if body is not None:
+        log.info(f"memory: Retrieved file {filepath} for user {username}")
+        return body
 
-    log.info(f"memory: Couldn't retrieve file {filepath} for user {username}: current version not in cache (requested '{etag}', found '{cached_etag}').")
+    log.info(f"memory: Couldn't retrieve file {filepath} for user {username}: current version not in cache")
     if file_key not in app['files_in_progress']:
         try:
             log.info(f"memory: Loading {filepath} to cache for user {username}")
-            app['worker_pool'].call_nowait(load_file, app['redis_pool'], app['files_in_progress'], file_key, fs, filepath)
             app['files_in_progress'].add(file_key)
+            app['worker_pool'].call_nowait(load_file, redis_pool, app['files_in_progress'], file_key, fs, filepath)
         except asyncio.QueueFull:
             pass
     return None
@@ -91,10 +109,28 @@ async def load_file(redis, files, file_key, fs, filepath):
     try:
         log.info(f"memory: {file_key}: reading.")
         data = await fs.read_binary_gs_file(filepath)
-        etag = await fs.get_etag(filepath)
-        log.info(f"memory: {file_key}: read {filepath} with etag {etag}")
-        await redis.execute('HMSET', file_key, 'etag', etag.encode('ascii'), 'body', data)
-        log.info(f"memory: {file_key}: stored {filepath} ('{etag}').")
+        log.info(f"memory: {file_key}: read {filepath}")
+    except Exception as e:
+        files.remove(file_key)
+        raise e
+
+    await cache_file(redis, files, file_key, filepath, data)
+
+
+async def persist_in_gcs(fs: GCS, files: Set[str], file_key: str, filepath: str, data: str):
+    try:
+        log.info(f"memory: {file_key}: persisting.")
+        await fs.write_gs_file_from_string(filepath, data)
+        log.info(f"memory: {file_key}: persisted {filepath}")
+    except Exception as e:
+        files.remove(file_key)
+        raise e
+
+
+async def cache_file(redis: aioredis.ConnectionsPool, files: Set[str], file_key: str, filepath: str, data: str):
+    try:
+        await redis.execute('HMSET', file_key, 'body', data)
+        log.info(f"memory: {file_key}: stored {filepath}")
     finally:
         files.remove(file_key)
 
@@ -107,7 +143,7 @@ async def on_startup(app):
     kube.config.load_incluster_config()
     k8s_client = kube.client.CoreV1Api()
     app['k8s_client'] = k8s_client
-    app['redis_pool'] = await aioredis.create_pool(socket)
+    app['redis_pool']: aioredis.ConnectionsPool = await aioredis.create_pool(socket)
 
 
 async def on_cleanup(app):

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -21,6 +21,9 @@ class BlockingMemoryClient:
     def read_file(self, filename):
         return async_to_blocking(self._client.read_file(filename))
 
+    def write_file(self, filename, data):
+        return async_to_blocking(self._client.write_file(filename, data))
+
     def close(self):
         return async_to_blocking(self._client.close())
 
@@ -48,7 +51,7 @@ class Tests(unittest.TestCase):
         for _ in range(3):
             self.assertIsNone(self.client._get_file_if_exists(f'{self.test_path}/nonexistent'))
 
-    def test_small(self):
+    def test_small_write_around(self):
         cases = [('empty_file', b''), ('null', b'\0'), ('small', b'hello world')]
         for file, data in cases:
             handle = self.add_temp_file_from_string(file, data)
@@ -60,3 +63,11 @@ class Tests(unittest.TestCase):
                 cached = self.client._get_file_if_exists(handle)
                 i += 1
             self.assertEqual(cached, expected)
+
+    def test_small_write_through(self):
+        cases = [('empty_file2', b''), ('null2', b'\0'), ('small2', b'hello world')]
+        for file, data in cases:
+            filename = f'{self.test_path}/{file}'
+            self.client.write_file(filename, data)
+            cached = self.client._get_file_if_exists(filename)
+            self.assertEqual(cached, data)

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -24,6 +24,7 @@ class BlockingMemoryClient:
     def close(self):
         return async_to_blocking(self._client.close())
 
+
 class Tests(unittest.TestCase):
     def setUp(self):
         bucket_name = get_user_config().get('batch', 'bucket')

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -63,32 +63,32 @@ def blocking_execute(userdata, body):
 def blocking_load_references_from_dataset(userdata, body):
     with connect_to_java() as java:
         return java.load_references_from_dataset(
-            userdata['username'], userdata['session_id'], body['billing_project'], body['bucket'], body['path'])
+            userdata['username'], body['billing_project'], body['bucket'], body['path'])
 
 
 def blocking_value_type(userdata, body):
     with connect_to_java() as java:
-        return java.value_type(userdata['username'], userdata['session_id'], body['code'])
+        return java.value_type(userdata['username'], body['code'])
 
 
 def blocking_table_type(userdata, body):
     with connect_to_java() as java:
-        return java.table_type(userdata['username'], userdata['session_id'], body['code'])
+        return java.table_type(userdata['username'], body['code'])
 
 
 def blocking_matrix_type(userdata, body):
     with connect_to_java() as java:
-        return java.matrix_table_type(userdata['username'], userdata['session_id'], body['code'])
+        return java.matrix_table_type(userdata['username'], body['code'])
 
 
 def blocking_blockmatrix_type(userdata, body):
     with connect_to_java() as java:
-        return java.block_matrix_type(userdata['username'], userdata['session_id'], body['code'])
+        return java.block_matrix_type(userdata['username'], body['code'])
 
 
 def blocking_get_reference(userdata, body):   # pylint: disable=unused-argument
     with connect_to_java() as java:
-        return java.reference_genome(userdata['username'], userdata['session_id'], body['name'])
+        return java.reference_genome(userdata['username'], body['name'])
 
 
 async def handle_ws_response(request, userdata, endpoint, f):

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -68,27 +68,27 @@ def blocking_load_references_from_dataset(userdata, body):
 
 def blocking_value_type(userdata, body):
     with connect_to_java() as java:
-        return java.value_type(userdata['username'], body['code'])
+        return java.value_type(userdata['username'], userdata['session_id'], body['code'])
 
 
 def blocking_table_type(userdata, body):
     with connect_to_java() as java:
-        return java.table_type(userdata['username'], body['code'])
+        return java.table_type(userdata['username'], userdata['session_id'], body['code'])
 
 
 def blocking_matrix_type(userdata, body):
     with connect_to_java() as java:
-        return java.matrix_table_type(userdata['username'], body['code'])
+        return java.matrix_table_type(userdata['username'], userdata['session_id'], body['code'])
 
 
 def blocking_blockmatrix_type(userdata, body):
     with connect_to_java() as java:
-        return java.block_matrix_type(userdata['username'], body['code'])
+        return java.block_matrix_type(userdata['username'], userdata['session_id'], body['code'])
 
 
 def blocking_get_reference(userdata, body):   # pylint: disable=unused-argument
     with connect_to_java() as java:
-        return java.reference_genome(userdata['username'], body['name'])
+        return java.reference_genome(userdata['username'], userdata['session_id'], body['name'])
 
 
 async def handle_ws_response(request, userdata, endpoint, f):

--- a/query/query/sockets.py
+++ b/query/query/sockets.py
@@ -115,9 +115,10 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def value_type(self, username: str, s: str):
+    def value_type(self, username: str, session_id: str, s: str):
         self.write_int(ServiceBackendSocketConnection.VALUE_TYPE)
         self.write_str(username)
+        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -129,9 +130,10 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def table_type(self, username: str, s: str):
+    def table_type(self, username: str, session_id: str, s: str):
         self.write_int(ServiceBackendSocketConnection.TABLE_TYPE)
         self.write_str(username)
+        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -143,9 +145,10 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def matrix_table_type(self, username: str, s: str):
+    def matrix_table_type(self, username: str, session_id: str, s: str):
         self.write_int(ServiceBackendSocketConnection.MATRIX_TABLE_TYPE)
         self.write_str(username)
+        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -157,9 +160,10 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def block_matrix_type(self, username: str, s: str):
+    def block_matrix_type(self, username: str, session_id: str, s: str):
         self.write_int(ServiceBackendSocketConnection.BLOCK_MATRIX_TYPE)
         self.write_str(username)
+        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -171,9 +175,10 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def reference_genome(self, username: str, name: str):
+    def reference_genome(self, username: str, session_id: str, name: str):
         self.write_int(ServiceBackendSocketConnection.REFERENCE_GENOME)
         self.write_str(username)
+        self.write_str(session_id)
         self.write_str(name)
         success = self.read_bool()
         if success:

--- a/query/query/sockets.py
+++ b/query/query/sockets.py
@@ -98,10 +98,9 @@ class ServiceBackendSocketConnection:
         b = self.read_bytes()
         return b.decode('utf-8')
 
-    def load_references_from_dataset(self, username: str, session_id: str, billing_project: str, bucket: str, path: str):
+    def load_references_from_dataset(self, username: str, billing_project: str, bucket: str, path: str):
         self.write_int(ServiceBackendSocketConnection.LOAD_REFERENCES_FROM_DATASET)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(billing_project)
         self.write_str(bucket)
         self.write_str(path)
@@ -115,10 +114,9 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def value_type(self, username: str, session_id: str, s: str):
+    def value_type(self, username: str, s: str):
         self.write_int(ServiceBackendSocketConnection.VALUE_TYPE)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -130,10 +128,9 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def table_type(self, username: str, session_id: str, s: str):
+    def table_type(self, username: str, s: str):
         self.write_int(ServiceBackendSocketConnection.TABLE_TYPE)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -145,10 +142,9 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def matrix_table_type(self, username: str, session_id: str, s: str):
+    def matrix_table_type(self, username: str, s: str):
         self.write_int(ServiceBackendSocketConnection.MATRIX_TABLE_TYPE)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -160,10 +156,9 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def block_matrix_type(self, username: str, session_id: str, s: str):
+    def block_matrix_type(self, username: str, s: str):
         self.write_int(ServiceBackendSocketConnection.BLOCK_MATRIX_TYPE)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(s)
         success = self.read_bool()
         if success:
@@ -175,10 +170,9 @@ class ServiceBackendSocketConnection:
         jstacktrace = self.read_str()
         raise ValueError(jstacktrace)
 
-    def reference_genome(self, username: str, session_id: str, name: str):
+    def reference_genome(self, username: str, name: str):
         self.write_int(ServiceBackendSocketConnection.REFERENCE_GENOME)
         self.write_str(username)
-        self.write_str(session_id)
         self.write_str(name)
         success = self.read_bool()
         if success:


### PR DESCRIPTION
Reading function/contexts from GCS on query workers can contribute a significant portion of the runtime for small jobs. For a simple query like `hl.utils.range_table(10).collect()`, the jobs in the batch can range in time from 5-9 seconds depending on GCS latency.

This builds on #9484 to add write-through capability to `memory` and a `ServiceCacheableFS` in Scala. The cacheable FS reads/writes through `memory` and falls back to GCS, so in the good path the ServiceBackend writes the compiled function and contexts to `memory`, workers read inputs and write outputs exclusively from/to memory, from which the ServiceBackend reads the results. From small benchmarks in dev, this cuts down read times on the workers by ~30-40% compared to the worst case GCS latencies and roughly matches the current implementation in the best case. Writing the outputs is comparable to writing through an already warmed up GCS connection.