### PR TITLE
[batch] cleanup error message for unknown instance

### DIFF
--- a/batch/batch/driver/gce.py
+++ b/batch/batch/driver/gce.py
@@ -95,9 +95,7 @@ class GCEEventMonitor:
         else:
             instance = self.inst_coll_manager.get_instance(name)
             if not instance:
-                record = await self.db.select_and_fetchone(f'''
-SELECT name FROM instances WHERE name = %s;
-''',
+                record = await self.db.select_and_fetchone('SELECT name FROM instances WHERE name = %s;',
                                                            (name,))
                 if not record:
                     log.error(f'event for unknown instance {name}: {json.dumps(event)}')

--- a/batch/batch/driver/gce.py
+++ b/batch/batch/driver/gce.py
@@ -95,7 +95,12 @@ class GCEEventMonitor:
         else:
             instance = self.inst_coll_manager.get_instance(name)
             if not instance:
-                log.warning(f'event for unknown instance {name}: {json.dumps(event)}')
+                record = await self.db.select_and_fetchone(f'''
+SELECT name FROM instances WHERE name = %s;
+''',
+                                                           (name,))
+                if not record:
+                    log.error(f'event for unknown instance {name}: {json.dumps(event)}')
                 return
 
             if event_subtype == 'v1.compute.instances.preempted':


### PR DESCRIPTION
If instance name isn't active, look to see whether it existed in the database before printing an error message about an unknown instance.