### PR TITLE
[hailtop][batch] Fix DockerHub

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -24,7 +24,7 @@ from hailtop.utils import (time_msecs, request_retry_transient_errors, sleep_and
                            is_google_registry_domain, find_spark_home, dump_all_stacktraces,
                            parse_docker_image_reference)
 from hailtop.httpx import client_session
-from hailtop.batch_client.parse import (parse_cpu_in_mcpu,parse_memory_in_bytes, parse_storage_in_bytes)
+from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes)
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS, HAIL_GENETICS_IMAGES
 from hailtop import aiotools
 # import uvloop

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -11,7 +11,7 @@ import webbrowser
 import warnings
 
 from hailtop.config import get_deploy_config, get_user_config
-from hailtop.utils import is_google_registry_image
+from hailtop.utils import is_google_registry_domain, parse_docker_image_reference
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 import hailtop.batch_client.client as bc
 from hailtop.batch_client.client import BatchClient
@@ -505,7 +505,8 @@ class ServiceBackend(Backend):
                 resources['preemptible'] = job._preemptible
 
             image = job._image if job._image else default_image
-            if not is_google_registry_image(image) and image not in HAIL_GENETICS_IMAGES:
+            image_ref = parse_docker_image_reference(image)
+            if not is_google_registry_domain(image_ref.domain) and image_ref.name() not in HAIL_GENETICS_IMAGES:
                 warnings.warn(f'Using an image {image} not in GCR. '
                               f'Jobs may fail due to Docker Hub rate limits.')
 

--- a/hail/python/hailtop/batch_client/parse.py
+++ b/hail/python/hailtop/batch_client/parse.py
@@ -1,4 +1,4 @@
-from typing import Optional, Mapping, Pattern, Tuple
+from typing import Optional, Mapping, Pattern
 import re
 import math
 
@@ -7,6 +7,7 @@ MEMORY_REGEX: Pattern = re.compile(MEMORY_REGEXPAT)
 
 CPU_REGEXPAT: str = r'[+]?((?:[0-9]*[.])?[0-9]+)([m])?'
 CPU_REGEX: Pattern = re.compile(CPU_REGEXPAT)
+
 
 def parse_cpu_in_mcpu(cpu_string: str) -> Optional[int]:
     match = CPU_REGEX.fullmatch(cpu_string)

--- a/hail/python/hailtop/batch_client/parse.py
+++ b/hail/python/hailtop/batch_client/parse.py
@@ -8,11 +8,6 @@ MEMORY_REGEX: Pattern = re.compile(MEMORY_REGEXPAT)
 CPU_REGEXPAT: str = r'[+]?((?:[0-9]*[.])?[0-9]+)([m])?'
 CPU_REGEX: Pattern = re.compile(CPU_REGEXPAT)
 
-# https://github.com/moby/moby/blob/master/image/spec/v1.md
-# https://github.com/moby/moby/blob/master/image/spec/v1.2.md
-IMAGE_REGEX: Pattern = re.compile(r"(.+/|)([^:]+)(:(.+))?")
-
-
 def parse_cpu_in_mcpu(cpu_string: str) -> Optional[int]:
     match = CPU_REGEX.fullmatch(cpu_string)
     if match:
@@ -40,13 +35,6 @@ def parse_memory_in_bytes(memory_string: str) -> Optional[int]:
         if suffix:
             return math.ceil(number * conv_factor[suffix])
         return math.ceil(number)
-    return None
-
-
-def parse_image_tag(image_string: str) -> Optional[Tuple[str, str]]:
-    match = IMAGE_REGEX.fullmatch(image_string)
-    if match:
-        return match.group(1) + match.group(2), match.group(4)
     return None
 
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -8,9 +8,9 @@ from .utils import (
     WaitableSharedPool, RETRY_FUNCTION_SCRIPT, sync_retry_transient_errors,
     retry_response_returning_functions, first_extant_file, secret_alnum_string,
     flatten, partition, cost_str, external_requests_client_session, url_basename,
-    url_join, is_google_registry_image, url_scheme, Notice, periodically_call,
-    dump_all_stacktraces, find_spark_home, TransientError, bounded_gather2,
-    OnlineBoundedGather2, unpack_comma_delimited_inputs)
+    url_join, is_google_registry_domain, parse_docker_image_reference,
+    url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
+    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, sync_check_shell,
     sync_check_shell_output)
@@ -69,7 +69,6 @@ __all__ = [
     'external_requests_client_session',
     'url_basename',
     'url_join',
-    'is_google_registry_image',
     'validate',
     'url_scheme',
     'serialization',
@@ -80,5 +79,7 @@ __all__ = [
     'TransientError',
     'bounded_gather2',
     'OnlineBoundedGather2',
-    'unpack_comma_delimited_inputs'
+    'unpack_comma_delimited_inputs',
+    'is_google_registry_domain',
+    'parse_docker_image_reference'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import traceback
 import sys
 import os
+import re
 import errno
 import random
 import logging
@@ -814,11 +815,47 @@ def url_scheme(url: str) -> str:
     return parsed.scheme
 
 
-def is_google_registry_image(path: str) -> bool:
+class ParsedDockerImageReference:
+    def __init__(self, domain: str, path: str, tag: str, digest: str):
+        self.domain = domain
+        self.path = path
+        self.tag = tag
+        self.digest = digest
+
+    def name(self):
+        if self.domain:
+            return self.domain + '/' + self.path
+        return self.path
+
+    def __str__(self):
+        s = self.name()
+        if self.tag is not None:
+            s += ':'
+            s += self.tag
+        if self.digest is not None:
+            s += '@'
+            s += self.digest
+        return s
+
+
+# https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
+DOCKER_IMAGE_REFERENCE_REGEX = re.compile(r"(?:([^/]+)/)?([^:@]+)(?::([^@]+))?(?:@(.+))?")
+
+
+def parse_docker_image_reference(reference_string: str) -> ParsedDockerImageReference:
+    match = DOCKER_IMAGE_REFERENCE_REGEX.fullmatch(reference_string)
+    if match is None:
+        raise ValueError(f'could not parse {reference_string!r} as a docker image reference')
+    domain, path, tag, digest = (match.group(i + 1) for i in range(4))
+    return ParsedDockerImageReference(domain, path, tag, digest)
+
+
+def is_google_registry_domain(domain: Optional[str]) -> bool:
     """Returns true if the given Docker image path points to either the Google
     Container Registry or the Artifact Registry."""
-    host = path.partition('/')[0]
-    return host == 'gcr.io' or host.endswith('docker.pkg.dev')
+    if domain is None:
+        return False
+    return domain == 'gcr.io' or domain.endswith('docker.pkg.dev')
 
 
 class Notice:

--- a/hail/python/test/hailtop/utils/test_utils.py
+++ b/hail/python/test/hailtop/utils/test_utils.py
@@ -1,4 +1,5 @@
-from hailtop.utils import partition, url_basename, url_join, url_scheme
+from hailtop.utils import (partition, url_basename, url_join, url_scheme,
+                           parse_docker_image_reference)
 
 
 def test_partition_zero_empty():
@@ -39,3 +40,76 @@ def test_url_join():
 def test_url_scheme():
     assert url_scheme('https://hail.is/path/to') == 'https'
     assert url_scheme('/path/to') == ''
+
+def test_parse_docker_image_reference():
+    x = parse_docker_image_reference('animage')
+    assert x.domain is None
+    assert x.path == 'animage'
+    assert x.tag is None
+    assert x.digest is None
+    assert x.name() == 'animage'
+    assert str(x) == 'animage'
+
+    x = parse_docker_image_reference('hailgenetics/animage')
+    assert x.domain == 'hailgenetics'
+    assert x.path == 'animage'
+    assert x.tag is None
+    assert x.digest is None
+    assert x.name() == 'hailgenetics/animage'
+    assert str(x) == 'hailgenetics/animage'
+
+    x = parse_docker_image_reference('localhost:5000/animage')
+    assert x.domain == 'localhost:5000'
+    assert x.path == 'animage'
+    assert x.tag is None
+    assert x.digest is None
+    assert x.name() == 'localhost:5000/animage'
+    assert str(x) == 'localhost:5000/animage'
+
+    x = parse_docker_image_reference('localhost:5000/a/b/name')
+    assert x.domain == 'localhost:5000'
+    assert x.path == 'a/b/name'
+    assert x.tag is None
+    assert x.digest is None
+    assert x.name() == 'localhost:5000/a/b/name'
+    assert str(x) == 'localhost:5000/a/b/name'
+
+    x = parse_docker_image_reference('localhost:5000/a/b/name:tag')
+    assert x.domain == 'localhost:5000'
+    assert x.path == 'a/b/name'
+    assert x.tag == 'tag'
+    assert x.digest is None
+    assert x.name() == 'localhost:5000/a/b/name'
+    assert str(x) == 'localhost:5000/a/b/name:tag'
+
+    x = parse_docker_image_reference('localhost:5000/a/b/name:tag@sha256:abc123')
+    assert x.domain == 'localhost:5000'
+    assert x.path == 'a/b/name'
+    assert x.tag == 'tag'
+    assert x.digest == 'sha256:abc123'
+    assert x.name() == 'localhost:5000/a/b/name'
+    assert str(x) == 'localhost:5000/a/b/name:tag@sha256:abc123'
+
+    x = parse_docker_image_reference('localhost:5000/a/b/name@sha256:abc123')
+    assert x.domain == 'localhost:5000'
+    assert x.path == 'a/b/name'
+    assert x.tag is None
+    assert x.digest == 'sha256:abc123'
+    assert x.name() == 'localhost:5000/a/b/name'
+    assert str(x) == 'localhost:5000/a/b/name@sha256:abc123'
+
+    x = parse_docker_image_reference('name@sha256:abc123')
+    assert x.domain is None
+    assert x.path == 'name'
+    assert x.tag is None
+    assert x.digest == 'sha256:abc123'
+    assert x.name() == 'name'
+    assert str(x) == 'name@sha256:abc123'
+
+    x = parse_docker_image_reference('gcr.io/hail-vdc/batch-worker:123fds312')
+    assert x.domain == 'gcr.io'
+    assert x.path == 'hail-vdc/batch-worker'
+    assert x.tag == '123fds312'
+    assert x.digest is None
+    assert x.name() == 'gcr.io/hail-vdc/batch-worker'
+    assert str(x) == 'gcr.io/hail-vdc/batch-worker:123fds312'

--- a/hail/python/test/hailtop/utils/test_utils.py
+++ b/hail/python/test/hailtop/utils/test_utils.py
@@ -113,3 +113,11 @@ def test_parse_docker_image_reference():
     assert x.digest is None
     assert x.name() == 'gcr.io/hail-vdc/batch-worker'
     assert str(x) == 'gcr.io/hail-vdc/batch-worker:123fds312'
+
+    x = parse_docker_image_reference('us-docker.pkg.dev/my-project/my-repo/test-image')
+    assert x.domain == 'us-docker.pkg.dev'
+    assert x.path == 'my-project/my-repo/test-image'
+    assert x.tag is None
+    assert x.digest is None
+    assert x.name() == 'us-docker.pkg.dev/my-project/my-repo/test-image'
+    assert str(x) == 'us-docker.pkg.dev/my-project/my-repo/test-image'


### PR DESCRIPTION
Tags and digests have no affect on whether an image is one of the hailgenetics
images that are stored in both GCR and DockerHub. This change ignores the tag and
digest when checking if we should warn about using DockerHub.

In doing this, I consolidated and made more robust our Docker-image-reference parsing.