### PR TITLE
[query]  StreamLen needs to consume elements

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1073,6 +1073,7 @@ class Emit[C](
             case None =>
               val count = cb.newLocal[Int]("stream_length", 0)
               producer.memoryManagedConsume(region, cb) { cb =>
+                producer.element.toI(cb).consume(cb, {}, _ => {})
                 cb.assign(count, count + 1)
               }
               producer.element.pv match {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1077,7 +1077,7 @@ class Emit[C](
                 cb.assign(count, count + 1)
               }
               producer.element.pv match {
-                case SStreamCode(_, nested) => StreamProducer.defineUnusedLabels(producer, mb)
+                case SStreamCode(_, nested) => StreamProducer.defineUnusedLabels(nested, mb)
                 case _ =>
               }
               PCode(x.pType, count)

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -342,7 +342,7 @@ class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(metho
 
 class Block {
   // for debugging
-  val stack = Thread.currentThread().getStackTrace.mkString("\n")
+  // val stack = Thread.currentThread().getStackTrace.mkString("\n")
 
   var method: Method = _
 
@@ -352,26 +352,19 @@ class Block {
   val uses: mutable.Set[(ControlX, Int)] = mutable.Set[(ControlX, Int)]()
 
   def wellFormed: Boolean = {
-    if (first == null) {
-      assert(false, s"first was null. Stack was \n${stack}")
+    if (first == null)
       return false
-    }
 
     last match {
       case ctrl: ControlX =>
         var i = 0
         while (i < ctrl.targetArity()) {
-          if (ctrl.target(i) == null) {
-            assert(false, s"ctrl.target ${i} was null")
+          if (ctrl.target(i) == null)
             return false
-          }
           i += 1
         }
         true
-      case _ => {
-        assert(false, s"last was not ctrl, it was ${last}")
-        false
-      }
+      case _ => false
     }
   }
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -342,7 +342,7 @@ class Parameter(method: Method, val i: Int, ti: TypeInfo[_]) extends Local(metho
 
 class Block {
   // for debugging
-  // val stack = Thread.currentThread().getStackTrace.mkString("\n")
+  val stack = Thread.currentThread().getStackTrace.mkString("\n")
 
   var method: Method = _
 
@@ -352,19 +352,26 @@ class Block {
   val uses: mutable.Set[(ControlX, Int)] = mutable.Set[(ControlX, Int)]()
 
   def wellFormed: Boolean = {
-    if (first == null)
+    if (first == null) {
+      assert(false, s"first was null. Stack was \n${stack}")
       return false
+    }
 
     last match {
       case ctrl: ControlX =>
         var i = 0
         while (i < ctrl.targetArity()) {
-          if (ctrl.target(i) == null)
+          if (ctrl.target(i) == null) {
+            assert(false, s"ctrl.target ${i} was null")
             return false
+          }
           i += 1
         }
         true
-      case _ => false
+      case _ => {
+        assert(false, s"last was not ctrl, it was ${last}")
+        false
+      }
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1789,6 +1789,11 @@ class IRSuite extends HailSuite {
 
     val filteredRange = StreamLen(StreamFilter(rangeIR(12), "x", irToPrimitiveIR(Ref("x", TInt32)) < 5))
     assertEvalsTo(filteredRange, 5)
+
+    val lenOfLet = StreamLen(bindIR(I32(5))(ref =>
+      StreamGrouped(mapIR(rangeIR(20))(range_element =>
+        InsertFields(MakeStruct(IndexedSeq(("num",  range_element + ref))), IndexedSeq(("y", 12)))), 3)))
+    assertEvalsTo(lenOfLet, 7)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -5,7 +5,7 @@ import is.hail.TestUtils._
 import is.hail.annotations.{BroadcastRow, Region, SafeNDArray}
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
-import is.hail.expr.ir.IRBuilder._
+import is.hail.expr.ir.IRBuilder.{irToProxy, _}
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions._
 import is.hail.types.{BlockMatrixType, TableType, VirtualTypeWithReq}
@@ -1794,6 +1794,12 @@ class IRSuite extends HailSuite {
       StreamGrouped(mapIR(rangeIR(20))(range_element =>
         InsertFields(MakeStruct(IndexedSeq(("num",  range_element + ref))), IndexedSeq(("y", 12)))), 3)))
     assertEvalsTo(lenOfLet, 7)
+  }
+
+  @Test def testStreamLenUnconsumedInnerStream(): Unit = {
+    assertEvalsTo(StreamLen(
+      mapIR(StreamGrouped(filterIR(rangeIR(10))(x => x.cne(I32(0))), 3))( group => ToArray(group))
+    ), 3)
   }
 
   @Test def testStreamTake() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -5,7 +5,7 @@ import is.hail.TestUtils._
 import is.hail.annotations.{BroadcastRow, Region, SafeNDArray}
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
-import is.hail.expr.ir.IRBuilder.{irToProxy, _}
+import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions._
 import is.hail.types.{BlockMatrixType, TableType, VirtualTypeWithReq}


### PR DESCRIPTION
We will get errors about methods not being well formed if we don't define every label on an IEmitCode, so we have to consume each one even if we  don't do anything with it. 

I also moved `StreamLen` to `emitI`, because we were pointlessly switching back and forth from `EmitCode` to `IEmitCode`