### PR TITLE
[datasets] add GTEx sQTL tissue specific tables

### DIFF
--- a/datasets/notebooks/gtex_datasets.ipynb
+++ b/datasets/notebooks/gtex_datasets.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -18,31 +16,34 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### GTEx v8 eQTL tissue-specific all SNP gene associations"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "### GTEx v8 eQTL tissue-specific all SNP gene associations"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Files in `gs://gtex-resources/GTEx_Analysis_v8_QTLs/GTEx_Analysis_v8_eQTL_all_associations/` were gzipped, so we need to get them bgzipped and moved over to `gs://hail-datasets-tmp`. First I generated a text file for the input paths and  a text file for desired output paths."
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Files in `gs://gtex-resources/GTEx_Analysis_v8_QTLs/GTEx_Analysis_v8_eQTL_all_associations/` were gzipped, so we need to get them bgzipped and moved over to `gs://hail-datasets-tmp`. First I generated a text file for the input paths and  a text file for desired output paths."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Generate list of all eQTL all association files in gs://gtex-resources\n",
@@ -64,16 +65,11 @@
     "    for eqtl_file in eqtl_files_gz:\n",
     "        eqtl_file_out = eqtl_file.replace(\"gs://gtex-resources\", \"gs://hail-datasets-tmp\").replace(\".gz\", \".bgz\")\n",
     "        f.write(f\"{eqtl_file_out}\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "After generating the text files as above, ran the below to get the files bgzipped so we can read them in and create Hail Tables.\n",
     "\n",
@@ -89,23 +85,23 @@
     "```\n",
     "\n",
     "Now can generate Hail Tables (do this on a cluster):"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "#### Create GTEx v8 Hail Tables"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "#### Create GTEx v8 eQTL Hail Tables"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Generate list of .bgz files in gs://hail-datasets-tmp\n",
@@ -153,35 +149,30 @@
     "        ht2.write(output_file, overwrite=False)\n",
     "\n",
     "    print(f\"Wrote {name} to Hail Table.\\n\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "#### Add entries for new Hail Tables to config"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "#### Add entries for eQTL Hail Tables to config"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now can create entries in `datasets.json` for new tables:"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Open our datasets config file so we can add our new entries\n",
@@ -234,26 +225,23 @@
     "# Write new entries back to datasets.json config:\n",
     "with open(datasets_path, \"w\") as f:\n",
     "    json.dump(datasets, f, sort_keys=True, ensure_ascii=False, indent=2)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "#### Create schemas for docs for new Hail Tables"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "#### Create schemas for docs for eQTL Hail Tables"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import textwrap\n",
@@ -322,25 +310,282 @@
     "     }\n",
     "    with open(output_dir + f\"/{name}.rst\", \"w\") as f:\n",
     "        f.write(template.format(**context).strip())"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "source": [
+    "### GTEx v8 sQTL tissue-specific all SNP gene associations"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "source": [],
+   "source": [
+    "# Generate list of all sQTL all association files in gs://gtex-resources\n",
+    "list_sqtl_files_gz = subprocess.run([\"gsutil\",\n",
+    "                                     \"-u\",\n",
+    "                                     \"broad-ctsa\",\n",
+    "                                     \"ls\",\n",
+    "                                     \"gs://gtex-resources/GTEx_Analysis_v8_QTLs/GTEx_Analysis_v8_sQTL_all_associations/\"],\n",
+    "                                stdout=subprocess.PIPE)\n",
+    "sqtl_files_gz = list_sqtl_files_gz.stdout.decode('utf-8').split()\n",
+    "\n",
+    "# Write sQTL file paths to text for input\n",
+    "with open(\"gtex_sQTL_paths_in.txt\", \"w\") as f:\n",
+    "    for sqtl_file in sqtl_files_gz:\n",
+    "        f.write(f\"{sqtl_file}\\n\")\n",
+    "\n",
+    "# Change bucket to \"gs://hail-datasets-tmp\" and filename extension to \".bgz\" and write to another text file for output\n",
+    "with open(\"gtex_sQTL_paths_out.txt\", \"w\") as f:\n",
+    "    for sqtl_file in sqtl_files_gz:\n",
+    "        sqtl_file_out = sqtl_file.replace(\"gs://gtex-resources\", \"gs://hail-datasets-tmp\").replace(\".gz\", \".bgz\")\n",
+    "        f.write(f\"{sqtl_file_out}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Files were converted from .gz to .bgz in same way as eQTL files were above.\n",
+    "```\n",
+    "paste gtex_sQTL_paths_in.txt gtex_sQTL_paths_out.txt |\n",
+    "while read infile outfile;\n",
+    "do\n",
+    "  gsutil -u broad-ctsa cat $infile |\n",
+    "  gzip -d |\n",
+    "  bgzip -c |\n",
+    "  gsutil cp - $outfile\n",
+    "done\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create GTEx v8 sQTL Hail Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate list of .bgz files in gs://hail-datasets-tmp\n",
+    "with open(\"gtex_sQTL_paths_out.txt\") as f:\n",
+    "    sqtl_files = f.read().splitlines()\n",
+    "\n",
+    "for sqtl_file in sqtl_files:\n",
+    "    print(sqtl_file)\n",
+    "    ht = hl.import_table(sqtl_file, \n",
+    "                         force_bgz=True,\n",
+    "                         types = {\"phenotype_id\": hl.tstr,\n",
+    "                                  \"variant_id\": hl.tstr,\n",
+    "                                  \"tss_distance\": hl.tint32,\n",
+    "                                  \"ma_samples\": hl.tint32,\n",
+    "                                  \"ma_count\": hl.tint32,\n",
+    "                                  \"maf\": hl.tfloat64,\n",
+    "                                  \"pval_nominal\": hl.tfloat64,\n",
+    "                                  \"slope\": hl.tfloat64,\n",
+    "                                  \"slope_se\": hl.tfloat64})\n",
+    "\n",
+    "    name = \"GTEx_sQTL_allpairs_\" + sqtl_file.split(\".\")[0].split(\"/\")[-1]\n",
+    "    version = \"v8\"\n",
+    "    build = \"GRCh38\"\n",
+    "\n",
+    "    ht2 = ht.annotate(intron = hl.locus_interval(ht.phenotype_id.split(\":\")[0],\n",
+    "                                                 hl.int32(ht.phenotype_id.split(\":\")[1]), \n",
+    "                                                 hl.int32(ht.phenotype_id.split(\":\")[2]), \n",
+    "                                                 reference_genome=\"GRCh38\"),\n",
+    "                      cluster = ht.phenotype_id.split(\":\")[-2],\n",
+    "                      gene_id = ht.phenotype_id.split(\":\")[-1],\n",
+    "                      locus = hl.locus(ht.variant_id.split(\"_\")[0], \n",
+    "                                       hl.int(ht.variant_id.split(\"_\")[1]), \n",
+    "                                       reference_genome=build),\n",
+    "                      alleles = [ht.variant_id.split(\"_\")[2], \n",
+    "                                 ht.variant_id.split(\"_\")[3]])\n",
+    "    ht2 = ht2.annotate(phenotype_id = hl.struct(intron=ht2.intron, \n",
+    "                                                cluster=ht2.cluster, \n",
+    "                                                gene_id=ht2.gene_id))\n",
+    "    ht2 = ht2.select(\"locus\", \"alleles\", \"phenotype_id\", \"tss_distance\", \n",
+    "                     \"ma_samples\", \"ma_count\", \"maf\", \"pval_nominal\", \"slope\", \"slope_se\")\n",
+    "\n",
+    "    n_rows = ht2.count()\n",
+    "    n_partitions = ht2.n_partitions()\n",
+    "\n",
+    "    ht2 = ht2.annotate_globals(metadata=hl.struct(name=name,\n",
+    "                                                  version=version,\n",
+    "                                                  reference_genome=build,\n",
+    "                                                  n_rows=n_rows,\n",
+    "                                                  n_partitions=n_partitions))\n",
+    "    ht2 = ht2.key_by(\"locus\", \"alleles\")\n",
+    "\n",
+    "    for region in [\"us\"]:\n",
+    "        output_file = f\"gs://hail-datasets-{region}/{name}_{version}_{build}.ht\"\n",
+    "        ht2.write(output_file, overwrite=False)\n",
+    "\n",
+    "    print(f\"Wrote {name} to Hail Table.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Add entries for sQTL Hail Tables to config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open our datasets config file so we can add our new entries\n",
+    "datasets_path = os.path.abspath(\"../../hail/python/hail/experimental/datasets.json\")\n",
+    "with open(datasets_path, \"r\") as f:\n",
+    "    datasets = json.load(f)\n",
+    "\n",
+    "# Get list of GTEx sQTL tables in hail-datasets-us\n",
+    "list_datasets = subprocess.run([\"gsutil\", \"-u\", \"broad-ctsa\", \"ls\", \"gs://hail-datasets-us\"], stdout=subprocess.PIPE)\n",
+    "all_datasets = list_datasets.stdout.decode('utf-8').split()\n",
+    "tables = [x.strip(\"/\") for x in all_datasets if \"GTEx_sQTL_allpairs_\" in x]\n",
+    "\n",
+    "for table in tables:\n",
+    "    gs_us_url = table\n",
+    "    gs_eu_url = table.replace(\"hail-datasets-us\", \"hail-datasets-eu\")\n",
+    "    aws_url = table.replace(\"gs\", \"s3\", 1).replace(\"hail-datasets-us\", \"hail-datasets-us-east-1\")\n",
+    "\n",
+    "    full_table_name = table.split(\"/\")[-1]\n",
+    "\n",
+    "    build = full_table_name.split(\"_\")[-1].replace(\".ht\", \"\")\n",
+    "    version = full_table_name.split(\"_\")[-2]\n",
+    "    tissue_name = full_table_name.replace(\"GTEx_sQTL_allpairs_\", \"\").replace(f\"_{version}_{build}.ht\", \"\")\n",
+    "\n",
+    "    json_entry = {\n",
+    "            \"annotation_db\": {\n",
+    "                \"key_properties\": []\n",
+    "            },\n",
+    "            \"description\": f\"GTEx: {tissue_name} sQTL tissue-specific all SNP gene \"\n",
+    "                           f\"associations Hail Table. All variant-gene cis-sQTL associations \"\n",
+    "                           f\"tested in each tissue (including non-significant associations).\",\n",
+    "            \"url\": \"https://gtexportal.org/home/datasets\",\n",
+    "            \"versions\": [\n",
+    "                {\n",
+    "                    \"reference_genome\": build,\n",
+    "                    \"url\": {\n",
+    "                        \"aws\": {\n",
+    "                            \"us\": f\"{aws_url}\"\n",
+    "                        },\n",
+    "                        \"gcp\": {\n",
+    "                            \"us\": f\"{gs_us_url}\",\n",
+    "                            \"eu\": f\"{gs_eu_url}\"\n",
+    "                        }\n",
+    "                    },\n",
+    "                    \"version\": version\n",
+    "                }\n",
+    "            ]\n",
+    "        }\n",
+    "    datasets[f\"GTEx_sQTL_allpairs_{tissue_name}\"] = json_entry\n",
+    "\n",
+    "# Write new entries back to datasets.json config:\n",
+    "with open(datasets_path, \"w\") as f:\n",
+    "    json.dump(datasets, f, sort_keys=True, ensure_ascii=False, indent=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create schemas for docs for sQTL Hail Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
-   }
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "import textwrap\n",
+    "\n",
+    "output_dir = os.path.abspath(\"../../hail/python/hail/docs/datasets/schemas\")\n",
+    "datasets_path = os.path.abspath(\"../../hail/python/hail/experimental/datasets.json\")\n",
+    "with open(datasets_path, \"r\") as f:\n",
+    "    datasets = json.load(f)\n",
+    "\n",
+    "names = [name for name in list(datasets.keys()) if \"GTEx_sQTL_allpairs_\" in name]\n",
+    "for name in names:\n",
+    "    versions = sorted(set(dataset[\"version\"] for dataset in datasets[name][\"versions\"]))\n",
+    "    if not versions:\n",
+    "        versions = [None]\n",
+    "    reference_genomes = sorted(set(dataset[\"reference_genome\"] for dataset in datasets[name][\"versions\"]))\n",
+    "    if not reference_genomes:\n",
+    "        reference_genomes = [None]\n",
+    "\n",
+    "    print(name)\n",
+    "    print(versions[0])\n",
+    "    print(reference_genomes[0] + \"\\n\")\n",
+    "\n",
+    "    path = [dataset[\"url\"][\"gcp\"][\"us\"]\n",
+    "            for dataset in datasets[name][\"versions\"]\n",
+    "            if all([dataset[\"version\"] == versions[0],\n",
+    "                    dataset[\"reference_genome\"] == reference_genomes[0]])]\n",
+    "    assert len(path) == 1\n",
+    "    path = path[0]\n",
+    "\n",
+    "    table = hl.methods.read_table(path)\n",
+    "    description = table.describe(handler=lambda x: str(x)).split(\"\\n\")\n",
+    "    description = \"\\n\".join([line.rstrip() for line in description])\n",
+    "\n",
+    "    if path.endswith(\".ht\"):\n",
+    "        table_class = \"hail.Table\"\n",
+    "    else:\n",
+    "        table_class = \"hail.MatrixTable\"\n",
+    "\n",
+    "    template = \"\"\".. _{dataset}:\n",
+    "\n",
+    "{dataset}\n",
+    "{underline1}\n",
+    "\n",
+    "*  **Versions:** {versions}\n",
+    "*  **Reference genome builds:** {ref_genomes}\n",
+    "*  **Type:** :class:`{class}`\n",
+    "\n",
+    "Schema ({version0}, {ref_genome0})\n",
+    "{underline2}\n",
+    "\n",
+    ".. code-block:: text\n",
+    "\n",
+    "{schema}\n",
+    "\n",
+    "\"\"\"\n",
+    "    context = {\n",
+    "        \"dataset\": name,\n",
+    "        \"underline1\": len(name) * \"=\",\n",
+    "        \"version0\": versions[0],\n",
+    "        \"ref_genome0\": reference_genomes[0],\n",
+    "        \"versions\": \", \".join([str(version) for version in versions]),\n",
+    "        \"ref_genomes\": \", \".join([str(reference_genome) for reference_genome in reference_genomes]),\n",
+    "        \"underline2\": len(\"\".join([\"Schema (\", str(versions[0]), \", \", str(reference_genomes[0]), \")\"])) * \"~\",\n",
+    "        \"schema\": textwrap.indent(description, \"    \"),\n",
+    "        \"class\": table_class\n",
+    "     }\n",
+    "    with open(output_dir + f\"/{name}.rst\", \"w\") as f:\n",
+    "        f.write(template.format(**context).strip())"
+   ]
   }
  ],
  "metadata": {
@@ -352,16 +597,16 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adipose_Subcutaneous.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adipose_Subcutaneous.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Adipose_Subcutaneous:
+
+GTEx_sQTL_allpairs_Adipose_Subcutaneous
+=======================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adipose_Visceral_Omentum.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adipose_Visceral_Omentum.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Adipose_Visceral_Omentum:
+
+GTEx_sQTL_allpairs_Adipose_Visceral_Omentum
+===========================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adrenal_Gland.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Adrenal_Gland.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Adrenal_Gland:
+
+GTEx_sQTL_allpairs_Adrenal_Gland
+================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Aorta.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Aorta.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Artery_Aorta:
+
+GTEx_sQTL_allpairs_Artery_Aorta
+===============================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Coronary.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Coronary.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Artery_Coronary:
+
+GTEx_sQTL_allpairs_Artery_Coronary
+==================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Tibial.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Artery_Tibial.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Artery_Tibial:
+
+GTEx_sQTL_allpairs_Artery_Tibial
+================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Amygdala.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Amygdala.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Amygdala:
+
+GTEx_sQTL_allpairs_Brain_Amygdala
+=================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24:
+
+GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24
+=======================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia:
+
+GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia
+==============================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere:
+
+GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere
+==============================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cerebellum.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cerebellum.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Cerebellum:
+
+GTEx_sQTL_allpairs_Brain_Cerebellum
+===================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cortex.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Cortex.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Cortex:
+
+GTEx_sQTL_allpairs_Brain_Cortex
+===============================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9:
+
+GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9
+===========================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Hippocampus.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Hippocampus.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Hippocampus:
+
+GTEx_sQTL_allpairs_Brain_Hippocampus
+====================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Hypothalamus.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Hypothalamus.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Hypothalamus:
+
+GTEx_sQTL_allpairs_Brain_Hypothalamus
+=====================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia:
+
+GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia
+========================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia:
+
+GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia
+==============================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1:
+
+GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1
+=================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Substantia_nigra.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Brain_Substantia_nigra.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Brain_Substantia_nigra:
+
+GTEx_sQTL_allpairs_Brain_Substantia_nigra
+=========================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Breast_Mammary_Tissue.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Breast_Mammary_Tissue.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Breast_Mammary_Tissue:
+
+GTEx_sQTL_allpairs_Breast_Mammary_Tissue
+========================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts:
+
+GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts
+=============================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes:
+
+GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes
+====================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Colon_Sigmoid.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Colon_Sigmoid.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Colon_Sigmoid:
+
+GTEx_sQTL_allpairs_Colon_Sigmoid
+================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Colon_Transverse.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Colon_Transverse.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Colon_Transverse:
+
+GTEx_sQTL_allpairs_Colon_Transverse
+===================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction:
+
+GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction
+======================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Mucosa.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Mucosa.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Esophagus_Mucosa:
+
+GTEx_sQTL_allpairs_Esophagus_Mucosa
+===================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Muscularis.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Esophagus_Muscularis.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Esophagus_Muscularis:
+
+GTEx_sQTL_allpairs_Esophagus_Muscularis
+=======================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Heart_Atrial_Appendage.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Heart_Atrial_Appendage.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Heart_Atrial_Appendage:
+
+GTEx_sQTL_allpairs_Heart_Atrial_Appendage
+=========================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Heart_Left_Ventricle.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Heart_Left_Ventricle.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Heart_Left_Ventricle:
+
+GTEx_sQTL_allpairs_Heart_Left_Ventricle
+=======================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Kidney_Cortex.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Kidney_Cortex.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Kidney_Cortex:
+
+GTEx_sQTL_allpairs_Kidney_Cortex
+================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Liver.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Liver.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Liver:
+
+GTEx_sQTL_allpairs_Liver
+========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Lung.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Lung.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Lung:
+
+GTEx_sQTL_allpairs_Lung
+=======================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Minor_Salivary_Gland.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Minor_Salivary_Gland.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Minor_Salivary_Gland:
+
+GTEx_sQTL_allpairs_Minor_Salivary_Gland
+=======================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Muscle_Skeletal.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Muscle_Skeletal.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Muscle_Skeletal:
+
+GTEx_sQTL_allpairs_Muscle_Skeletal
+==================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Nerve_Tibial.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Nerve_Tibial.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Nerve_Tibial:
+
+GTEx_sQTL_allpairs_Nerve_Tibial
+===============================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Ovary.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Ovary.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Ovary:
+
+GTEx_sQTL_allpairs_Ovary
+========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Pancreas.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Pancreas.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Pancreas:
+
+GTEx_sQTL_allpairs_Pancreas
+===========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Pituitary.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Pituitary.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Pituitary:
+
+GTEx_sQTL_allpairs_Pituitary
+============================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Prostate.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Prostate.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Prostate:
+
+GTEx_sQTL_allpairs_Prostate
+===========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic:
+
+GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic
+==================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg:
+
+GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg
+=============================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum:
+
+GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum
+=================================================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Spleen.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Spleen.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Spleen:
+
+GTEx_sQTL_allpairs_Spleen
+=========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Stomach.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Stomach.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Stomach:
+
+GTEx_sQTL_allpairs_Stomach
+==========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Testis.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Testis.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Testis:
+
+GTEx_sQTL_allpairs_Testis
+=========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Thyroid.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Thyroid.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Thyroid:
+
+GTEx_sQTL_allpairs_Thyroid
+==========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Uterus.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Uterus.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Uterus:
+
+GTEx_sQTL_allpairs_Uterus
+=========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Vagina.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Vagina.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Vagina:
+
+GTEx_sQTL_allpairs_Vagina
+=========================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Whole_Blood.rst
+++ b/hail/python/hail/docs/datasets/schemas/GTEx_sQTL_allpairs_Whole_Blood.rst
@@ -1,0 +1,42 @@
+.. _GTEx_sQTL_allpairs_Whole_Blood:
+
+GTEx_sQTL_allpairs_Whole_Blood
+==============================
+
+*  **Versions:** v8
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.Table`
+
+Schema (v8, GRCh38)
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'phenotype_id': struct {
+            intron: interval<locus<GRCh38>>,
+            cluster: str,
+            gene_id: str
+        }
+        'tss_distance': int32
+        'ma_samples': int32
+        'ma_count': int32
+        'maf': float64
+        'pval_nominal': float64
+        'slope': float64
+        'slope_se': float64
+    ----------------------------------------
+    Key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -1397,6 +1397,1084 @@
       }
     ]
   },
+  "GTEx_sQTL_allpairs_Adipose_Subcutaneous": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Adipose_Subcutaneous sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Adipose_Subcutaneous_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Adipose_Subcutaneous_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Adipose_Subcutaneous_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Adipose_Visceral_Omentum": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Adipose_Visceral_Omentum sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Adipose_Visceral_Omentum_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Adipose_Visceral_Omentum_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Adipose_Visceral_Omentum_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Adrenal_Gland": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Adrenal_Gland sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Adrenal_Gland_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Adrenal_Gland_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Adrenal_Gland_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Artery_Aorta": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Artery_Aorta sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Artery_Aorta_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Artery_Aorta_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Artery_Aorta_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Artery_Coronary": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Artery_Coronary sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Artery_Coronary_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Artery_Coronary_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Artery_Coronary_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Artery_Tibial": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Artery_Tibial sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Artery_Tibial_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Artery_Tibial_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Artery_Tibial_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Amygdala": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Amygdala sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Amygdala_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Amygdala_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Amygdala_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Anterior_cingulate_cortex_BA24 sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Anterior_cingulate_cortex_BA24_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Caudate_basal_ganglia sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Caudate_basal_ganglia_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Cerebellar_Hemisphere sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Cerebellar_Hemisphere_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Cerebellum": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Cerebellum sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Cerebellum_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Cerebellum_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Cerebellum_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Cortex": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Cortex sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Cortex_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Cortex_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Cortex_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Frontal_Cortex_BA9 sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Frontal_Cortex_BA9_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Hippocampus": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Hippocampus sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Hippocampus_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Hippocampus_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Hippocampus_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Hypothalamus": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Hypothalamus sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Hypothalamus_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Hypothalamus_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Hypothalamus_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Nucleus_accumbens_basal_ganglia sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Nucleus_accumbens_basal_ganglia_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Putamen_basal_ganglia sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Putamen_basal_ganglia_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Spinal_cord_cervical_c-1 sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Spinal_cord_cervical_c-1_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Brain_Substantia_nigra": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Brain_Substantia_nigra sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Brain_Substantia_nigra_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Brain_Substantia_nigra_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Brain_Substantia_nigra_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Breast_Mammary_Tissue": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Breast_Mammary_Tissue sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Breast_Mammary_Tissue_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Breast_Mammary_Tissue_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Breast_Mammary_Tissue_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Cells_Cultured_fibroblasts sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Cells_Cultured_fibroblasts_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Cells_EBV-transformed_lymphocytes sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Cells_EBV-transformed_lymphocytes_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Colon_Sigmoid": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Colon_Sigmoid sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Colon_Sigmoid_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Colon_Sigmoid_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Colon_Sigmoid_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Colon_Transverse": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Colon_Transverse sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Colon_Transverse_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Colon_Transverse_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Colon_Transverse_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Esophagus_Gastroesophageal_Junction sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Esophagus_Gastroesophageal_Junction_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Esophagus_Mucosa": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Esophagus_Mucosa sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Esophagus_Mucosa_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Esophagus_Mucosa_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Esophagus_Mucosa_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Esophagus_Muscularis": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Esophagus_Muscularis sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Esophagus_Muscularis_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Esophagus_Muscularis_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Esophagus_Muscularis_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Heart_Atrial_Appendage": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Heart_Atrial_Appendage sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Heart_Atrial_Appendage_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Heart_Atrial_Appendage_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Heart_Atrial_Appendage_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Heart_Left_Ventricle": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Heart_Left_Ventricle sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Heart_Left_Ventricle_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Heart_Left_Ventricle_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Heart_Left_Ventricle_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Kidney_Cortex": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Kidney_Cortex sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Kidney_Cortex_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Kidney_Cortex_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Kidney_Cortex_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Liver": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Liver sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Liver_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Liver_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Liver_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Lung": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Lung sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Lung_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Lung_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Lung_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Minor_Salivary_Gland": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Minor_Salivary_Gland sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Minor_Salivary_Gland_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Minor_Salivary_Gland_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Minor_Salivary_Gland_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Muscle_Skeletal": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Muscle_Skeletal sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Muscle_Skeletal_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Muscle_Skeletal_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Muscle_Skeletal_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Nerve_Tibial": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Nerve_Tibial sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Nerve_Tibial_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Nerve_Tibial_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Nerve_Tibial_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Ovary": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Ovary sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Ovary_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Ovary_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Ovary_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Pancreas": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Pancreas sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Pancreas_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Pancreas_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Pancreas_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Pituitary": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Pituitary sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Pituitary_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Pituitary_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Pituitary_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Prostate": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Prostate sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Prostate_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Prostate_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Prostate_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Skin_Not_Sun_Exposed_Suprapubic sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Skin_Not_Sun_Exposed_Suprapubic_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Skin_Sun_Exposed_Lower_leg sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Skin_Sun_Exposed_Lower_leg_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Small_Intestine_Terminal_Ileum sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Small_Intestine_Terminal_Ileum_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Spleen": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Spleen sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Spleen_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Spleen_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Spleen_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Stomach": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Stomach sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Stomach_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Stomach_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Stomach_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Testis": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Testis sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Testis_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Testis_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Testis_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Thyroid": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Thyroid sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Thyroid_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Thyroid_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Thyroid_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Uterus": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Uterus sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Uterus_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Uterus_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Uterus_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Vagina": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Vagina sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Vagina_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Vagina_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Vagina_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
+  "GTEx_sQTL_allpairs_Whole_Blood": {
+    "annotation_db": {
+      "key_properties": []
+    },
+    "description": "GTEx: Whole_Blood sQTL tissue-specific all SNP gene associations Hail Table. All variant-gene cis-sQTL associations tested in each tissue (including non-significant associations).",
+    "url": "https://gtexportal.org/home/datasets",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/GTEx_sQTL_allpairs_Whole_Blood_v8_GRCh38.ht"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/GTEx_sQTL_allpairs_Whole_Blood_v8_GRCh38.ht",
+            "us": "gs://hail-datasets-us/GTEx_sQTL_allpairs_Whole_Blood_v8_GRCh38.ht"
+          }
+        },
+        "version": "v8"
+      }
+    ]
+  },
   "UK_Biobank_Rapid_GWAS_both_sexes": {
     "description": "UK Biobank GWAS: GWAS analysis of 7,221 phenotypes across 6 continental ancestry groups in the UK Biobank.",
     "url": "http://www.nealelab.is/uk-biobank",


### PR DESCRIPTION
Adds the 49 [GTEx](https://gtexportal.org/home/datasets) sQTL tissue-specific all SNP gene association datasets as Hail Tables.

Sourced from `gs://gtex-resources/GTEx_Analysis_v8_QTLs/GTEx_Analysis_v8_sQTL_all_associations`. 

Files were .gz so had to be rewritten as .bgz before creating the Hail Tables.