### PR TITLE
[hail] ensure source distributions (setup.py sdist) can build

### DIFF
--- a/hail/python/MANIFEST.in
+++ b/hail/python/MANIFEST.in
@@ -5,3 +5,4 @@ include hail/backend/hail-all-spark.jar
 include hailtop/hail_version
 include hailtop/hailctl/deploy.yaml
 include hailtop/py.typed
+include requirements.txt


### PR DESCRIPTION
setup.py opens the requirements.txt file, because of this it must be in any source distribution.

This will become more relevant as we start distributing more (any) native code, reducing the number of platforms where `pip install hail` installs a binary distribution.

tested manually with:
```
make copy-py-files
cd build/deploy
python3 setup.py sdist
cd dist
tar xf hail-0.2.64.tar.gz
cd hail-0.2.64
python setup.py bdist_wheel
```