### PR TITLE
Clarify the behavior of OnlineBoundedGather2.

### DIFF
--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -392,7 +392,7 @@ class OnlineBoundedGather2:
         '''
 
         if self._pending is None:
-            raise PoolShutdownException
+            raise PoolShutdownError
 
         id = self._counter
         self._counter += 1
@@ -419,6 +419,7 @@ class OnlineBoundedGather2:
 
         t = asyncio.create_task(run_and_cleanup())
         self._pending[id] = t
+        self._done_event.clear()
         return t
 
     async def wait(self, tasks: List[asyncio.Task]) -> None:
@@ -454,6 +455,7 @@ class OnlineBoundedGather2:
             else:
                 log.info('discarding exception', exc_info=exc_val)
 
+        await self._done_event.wait()
         while self._pending:
             self._done_event.clear()
             await self._done_event.wait()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -335,7 +335,7 @@ class OnlineBoundedGather2:
     waits for all background tasks to complete on exit.
 
     `OnlineBoundedGather2` supports cancellation of background tasks.
-    When a background tasks raises `asyncio.CancelledError`, the task
+    When a background task raises `asyncio.CancelledError`, the task
     is considered complete and the pool and other background tasks
     continue runnning.
 


### PR DESCRIPTION
I think this should resolve the issues we were seeing with OnlineBoundedGather2.

Changes:
 - cancelled tasks (those that raise CancelledError) are ignored (we don't propagate cancelled out of background tasks)
 - Make sure all exceptions are either reraised or logged
 - The first exception is raised out of exit, not call
 - call raises PoolShutdownError if the pool is shutdown
 - _shutdown doesn't signal _done_event until all cancelled tasks are complete
 - call clears _done_event (not strictly necessary because exit checks pending, but seems safer)
 - added copious docstrings
