### PR TITLE
[libhail] restyle includes

### DIFF
--- a/libhail/src/hail/allocators.cpp
+++ b/libhail/src/hail/allocators.cpp
@@ -1,4 +1,4 @@
-#include <hail/allocators.hpp>
+#include "hail/allocators.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/format.cpp
+++ b/libhail/src/hail/format.cpp
@@ -5,7 +5,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include <hail/format.hpp>
+#include "hail/format.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/main.cpp
+++ b/libhail/src/hail/main.cpp
@@ -3,14 +3,14 @@
 
 #include <memory>
 
-#include <hail/allocators.hpp>
-#include <hail/format.hpp>
-#include <hail/query/backend/jit.hpp>
-#include <hail/query/ir.hpp>
-#include <hail/tunion.hpp>
-#include <hail/test.hpp>
-#include <hail/type.hpp>
-#include <hail/value.hpp>
+#include "hail/allocators.hpp"
+#include "hail/format.hpp"
+#include "hail/query/backend/jit.hpp"
+#include "hail/query/ir.hpp"
+#include "hail/tunion.hpp"
+#include "hail/test.hpp"
+#include "hail/type.hpp"
+#include "hail/value.hpp"
 
 using namespace hail;
 

--- a/libhail/src/hail/query/backend/compile.cpp
+++ b/libhail/src/hail/query/backend/compile.cpp
@@ -1,7 +1,8 @@
-#include <hail/query/backend/compile.hpp>
-#include <hail/query/backend/svalue.hpp>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
+
+#include "hail/query/backend/compile.hpp"
+#include "hail/query/backend/svalue.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/compile.hpp
+++ b/libhail/src/hail/query/backend/compile.hpp
@@ -2,8 +2,9 @@
 #define HAIL_QUERY_BACKEND_COMPILE_HPP_INCLUDED 1
 
 #include <llvm/IR/IRBuilder.h>
-#include <hail/query/backend/stype.hpp>
-#include <hail/query/ir_type.hpp>
+
+#include "hail/query/backend/stype.hpp"
+#include "hail/query/ir_type.hpp"
 
 namespace llvm {
 

--- a/libhail/src/hail/query/backend/jit.cpp
+++ b/libhail/src/hail/query/backend/jit.cpp
@@ -1,20 +1,21 @@
-#include <hail/format.hpp>
-#include <hail/query/backend/compile.hpp>
-#include <hail/query/backend/jit.hpp>
-#include <hail/query/backend/stype.hpp>
-#include <hail/query/backend/svalue.hpp>
-#include <hail/query/ir.hpp>
-#include <hail/query/ir_type.hpp>
-#include <hail/runtime/runtime.hpp>
-#include <hail/type.hpp>
-#include <hail/tunion.hpp>
-#include <hail/vtype.hpp>
-#include <hail/value.hpp>
 #include <llvm/IR/Type.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+
+#include "hail/format.hpp"
+#include "hail/query/backend/compile.hpp"
+#include "hail/query/backend/jit.hpp"
+#include "hail/query/backend/stype.hpp"
+#include "hail/query/backend/svalue.hpp"
+#include "hail/query/ir.hpp"
+#include "hail/query/ir_type.hpp"
+#include "hail/runtime/runtime.hpp"
+#include "hail/type.hpp"
+#include "hail/tunion.hpp"
+#include "hail/vtype.hpp"
+#include "hail/value.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/jit.hpp
+++ b/libhail/src/hail/query/backend/jit.hpp
@@ -1,8 +1,9 @@
 #ifndef HAIL_QUERY_BACKEND_JIT_HPP_INCLUDED
 #define HAIL_QUERY_BACKEND_JIT_HPP_INCLUDED 1
 
-#include <hail/vtype.hpp>
 #include <memory>
+
+#include "hail/vtype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/stype.cpp
+++ b/libhail/src/hail/query/backend/stype.cpp
@@ -1,7 +1,8 @@
-#include <hail/query/backend/compile.hpp>
-#include <hail/query/backend/stype.hpp>
-#include <hail/query/backend/svalue.hpp>
 #include <llvm/IR/Constants.h>
+
+#include "hail/query/backend/compile.hpp"
+#include "hail/query/backend/stype.hpp"
+#include "hail/query/backend/svalue.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/stype.hpp
+++ b/libhail/src/hail/query/backend/stype.hpp
@@ -1,11 +1,12 @@
 #ifndef HAIL_QUERY_BACKEND_STYPE_HPP_INCLUDED
 #define HAIL_QUERY_BACKEND_STYPE_HPP_INCLUDED 1
 
-#include <llvm/IR/Value.h>
-#include <hail/hash.hpp>
-#include <hail/tunion.hpp>
-#include <hail/type.hpp>
 #include <vector>
+#include <llvm/IR/Value.h>
+
+#include "hail/hash.hpp"
+#include "hail/tunion.hpp"
+#include "hail/type.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/svalue.cpp
+++ b/libhail/src/hail/query/backend/svalue.cpp
@@ -1,7 +1,8 @@
-#include <hail/query/backend/compile.hpp>
-#include <hail/query/backend/svalue.hpp>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/IRBuilder.h>
+
+#include "hail/query/backend/compile.hpp"
+#include "hail/query/backend/svalue.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/backend/svalue.hpp
+++ b/libhail/src/hail/query/backend/svalue.hpp
@@ -1,8 +1,9 @@
 #ifndef HAIL_QUERY_BACKEND_SVALUE_HPP_INCLUDED
 #define HAIL_QUERY_BACKEND_SVALUE_HPP_INCLUDED 1
 
-#include <hail/query/backend/stype.hpp>
 #include <vector>
+
+#include "hail/query/backend/stype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/query/ir.cpp
+++ b/libhail/src/hail/query/ir.cpp
@@ -1,13 +1,13 @@
 #include <exception>
 
-#include <hail/format.hpp>
-#include <hail/query/ir.hpp>
+#include "hail/format.hpp"
+#include "hail/query/ir.hpp"
 
 namespace hail {
 
 IRContext::IRContext(HeapAllocator &heap)
   : arena(heap) {}
-    
+
 IRContext::~IRContext() {}
 
 Module *

--- a/libhail/src/hail/query/ir.hpp
+++ b/libhail/src/hail/query/ir.hpp
@@ -5,10 +5,10 @@
 #include <unordered_set>
 #include <string>
 
-#include <hail/allocators.hpp>
-#include <hail/hash.hpp>
-#include <hail/type.hpp>
-#include <hail/value.hpp>
+#include "hail/allocators.hpp"
+#include "hail/hash.hpp"
+#include "hail/type.hpp"
+#include "hail/value.hpp"
 
 namespace hail {
 
@@ -52,7 +52,7 @@ class Module {
   friend class Function;
   friend class IR;
   friend void format1(FormatStream &s, const Module *m);
-  
+
   std::map<std::string, Function *> functions;
 
 public:
@@ -101,7 +101,7 @@ public:
 class IR {
   friend class Module;
   friend class Function;
-  
+
 public:
   using BaseType = IR;
   enum class Tag {

--- a/libhail/src/hail/query/ir_type.cpp
+++ b/libhail/src/hail/query/ir_type.cpp
@@ -1,6 +1,6 @@
-#include <hail/tunion.hpp>
-#include <hail/query/ir.hpp>
-#include <hail/query/ir_type.hpp>
+#include "hail/tunion.hpp"
+#include "hail/query/ir.hpp"
+#include "hail/query/ir_type.hpp"
 
 namespace hail {
 
@@ -61,7 +61,7 @@ IRType::infer(IR *x) {
   auto p = ir_type.insert({x, nullptr});
   if (!p.second)
     return p.first->second;
-  
+
   const Type *t = x->dispatch([this](auto x) {
 				return infer(x);
 			      });

--- a/libhail/src/hail/query/ir_type.hpp
+++ b/libhail/src/hail/query/ir_type.hpp
@@ -1,8 +1,9 @@
 #ifndef HAIL_IR_TYPE_HPP_INCLUDED
 #define HAIL_IR_TYPE_HPP_INCLUDED 1
 
-#include <hail/query/ir.hpp>
 #include <unordered_map>
+
+#include "hail/query/ir.hpp"
 
 namespace hail {
 
@@ -13,7 +14,7 @@ class IR;
 
 class IRType {
   friend class IRTypeVisitor;
-  
+
   TypeContext &tc;
 
   std::unordered_map<IR *, const Type *> ir_type;

--- a/libhail/src/hail/runtime/runtime.cpp
+++ b/libhail/src/hail/runtime/runtime.cpp
@@ -1,5 +1,5 @@
-#include <hail/allocators.hpp>
-#include <hail/runtime/runtime.hpp>
+#include "hail/allocators.hpp"
+#include "hail/runtime/runtime.hpp"
 
 using namespace hail;
 

--- a/libhail/src/hail/test.cpp
+++ b/libhail/src/hail/test.cpp
@@ -1,5 +1,5 @@
-#include <hail/format.hpp>
-#include <hail/test.hpp>
+#include "hail/format.hpp"
+#include "hail/test.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/test.hpp
+++ b/libhail/src/hail/test.hpp
@@ -1,9 +1,10 @@
 #ifndef HAIL_TEST_HPP_INCLUDED
 #define HAIL_TEST_HPP_INCLUDED 1
 
-#include <hail/format.hpp>
 #include <string>
 #include <vector>
+
+#include "hail/format.hpp"
 
 namespace hail {
 
@@ -11,7 +12,7 @@ using TestFunction = void();
 
 class Test {
   friend class Tests;
-  
+
   const std::string name;
   TestFunction *const function;
   Test *next;
@@ -24,7 +25,7 @@ public:
 
 class Tests {
   friend class Test;
-  
+
   static Test *head;
 
 public:

--- a/libhail/src/hail/test_format.cpp
+++ b/libhail/src/hail/test_format.cpp
@@ -1,10 +1,11 @@
 #include <cassert>
-#include <hail/allocators.hpp>
-#include <hail/format.hpp>
-#include <hail/test.hpp>
-#include <hail/type.hpp>
-#include <hail/value.hpp>
-#include <hail/vtype.hpp>
+
+#include "hail/allocators.hpp"
+#include "hail/format.hpp"
+#include "hail/test.hpp"
+#include "hail/type.hpp"
+#include "hail/value.hpp"
+#include "hail/vtype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/test_value.cpp
+++ b/libhail/src/hail/test_value.cpp
@@ -1,8 +1,8 @@
-#include <hail/allocators.hpp>
-#include <hail/test.hpp>
-#include <hail/type.hpp>
-#include <hail/value.hpp>
-#include <hail/vtype.hpp>
+#include "hail/allocators.hpp"
+#include "hail/test.hpp"
+#include "hail/type.hpp"
+#include "hail/value.hpp"
+#include "hail/vtype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/type.cpp
+++ b/libhail/src/hail/type.cpp
@@ -1,8 +1,9 @@
-#include <hail/format.hpp>
-#include <hail/tunion.hpp>
-#include <hail/type.hpp>
-#include <hail/vtype.hpp>
 #include <tuple>
+
+#include "hail/format.hpp"
+#include "hail/tunion.hpp"
+#include "hail/type.hpp"
+#include "hail/vtype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/type.hpp
+++ b/libhail/src/hail/type.hpp
@@ -3,7 +3,7 @@
 
 #include <map>
 
-#include <hail/allocators.hpp>
+#include "hail/allocators.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/value.cpp
+++ b/libhail/src/hail/value.cpp
@@ -1,7 +1,7 @@
 #include <cstring>
 
-#include <hail/format.hpp>
-#include <hail/value.hpp>
+#include "hail/format.hpp"
+#include "hail/value.hpp"
 
 namespace hail {
 
@@ -156,7 +156,7 @@ format1(FormatStream &s, const Value &value) {
     break;
   default:
     abort();
-    
+
   }
 }
 

--- a/libhail/src/hail/value.hpp
+++ b/libhail/src/hail/value.hpp
@@ -3,9 +3,9 @@
 
 #include <memory>
 
-#include <hail/allocators.hpp>
-#include <hail/tunion.hpp>
-#include <hail/vtype.hpp>
+#include "hail/allocators.hpp"
+#include "hail/tunion.hpp"
+#include "hail/vtype.hpp"
 
 namespace hail {
 
@@ -337,7 +337,7 @@ ArrayValue::get_element(size_t i) const {
 		     p->elements + i * vtype->element_stride);
 }
 
-void 
+void
 ArrayValue::set_element(size_t i, const Value &new_element) {
   Value::store(p->elements + i * vtype->element_stride, new_element);
 }

--- a/libhail/src/hail/vtype.cpp
+++ b/libhail/src/hail/vtype.cpp
@@ -1,4 +1,4 @@
-#include <hail/vtype.hpp>
+#include "hail/vtype.hpp"
 
 namespace hail {
 

--- a/libhail/src/hail/vtype.hpp
+++ b/libhail/src/hail/vtype.hpp
@@ -1,7 +1,7 @@
 #ifndef HAIL_VTYPE_HPP_INCLUDED
 #define HAIL_VTYPE_HPP_INCLUDED 1
 
-#include <hail/type.hpp>
+#include "hail/type.hpp"
 
 namespace hail {
 


### PR DESCRIPTION
Includes are grouped by source (system, LLVM, internal), the groups
themselves are then ordered stdlib, dependencies, internal. Ordering
within groups is alphabetical.

Also switch internal include style from #include <> to #include ""