### PR TITLE
[docker] add Boto3 dependency

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -57,7 +57,7 @@ sortedcontainers==2.1.0
 tabulate==0.8.3
 tqdm==4.42.1
 twine>=1.11.0
-urllib3==1.24.3
+urllib3==1.26.4
 uvloop==0.14.0
 Werkzeug==0.15.4
 wheel>=0.31.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -51,7 +51,7 @@ pytest-instafail==0.4.2
 pytest-xdist==2.2.1
 python-dateutil==2.8.1
 python-json-logger==0.1.11
-requests==2.22.0
+requests==2.25.1
 setuptools>=38.6.0
 sortedcontainers==2.1.0
 tabulate==0.8.3

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -29,6 +29,7 @@ google-cloud-logging==1.12.1
 google-cloud-storage==1.25.0
 humanize==1.0.0
 hurry.filesize==0.9
+janus==0.6.1
 Jinja2==2.11.3
 # keyrings.alt>3.1: https://bugs.launchpad.net/usd-importer/+bug/1794041/comments/6
 keyrings.alt>=3.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,6 +9,8 @@ async-timeout==3.0.1
 asyncinit==0.2.4
 Authlib==0.11
 black==20.8b1
+boto3==1.17.54
+botocore==1.20.54
 curlylint==0.12.0
 decorator==4.4.0
 dictdiffer==0.8.1

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -2,6 +2,8 @@ aiohttp==3.7.4
 aiohttp_session>=2.7,<2.8
 asyncinit>=0.2.4,<0.3
 bokeh>1.3,<2.0
+boto3>=1.17,<2.0
+botocore>=1.20,<2.0
 decorator<5
 Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -21,7 +21,7 @@ parsimonious<0.9
 PyJWT
 pyspark>=3.1.1,<3.2.0
 python-json-logger==0.1.11
-requests==2.22.0
+requests==2.25.1
 scipy>1.2,<1.7
 tabulate==0.8.3
 tqdm==4.42.1

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -13,6 +13,7 @@ gcsfs==0.8.0
 fsspec==0.9.0
 humanize==1.0.0
 hurry.filesize==0.9
+janus>=0.6,<0.7
 nest_asyncio
 numpy<2
 pandas>=1.1.0,<1.1.5


### PR DESCRIPTION
boto3 is the AWS Python client library.  This is for the upcoming S3AsyncFS.  FYI @tpoterba I also added it to the hail package requirements file because it will be exposed via `hailctl cp ...`, etc.