### PR TITLE
[hail-ubuntu] avoid software-properties-common, a huge package

### DIFF
--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -6,11 +6,7 @@ COPY hail-apt-get-install /bin/hail-apt-get-install
 COPY pip.conf /root/.config/pip/pip.conf
 COPY hail-pip-install /bin/hail-pip-install
 COPY controller.sh /
-RUN chmod 755 /bin/retry && \
-    chmod 755 /bin/hail-apt-get-install && \
-    chmod 755 /bin/hail-pip-install && \
-    chmod 755 /controller.sh && \
-    echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
+RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     mkdir -p /usr/share/keyrings/ && \
     hail-apt-get-install curl gpg && \
     curl -fSL 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \

--- a/docker/hail-ubuntu/Dockerfile
+++ b/docker/hail-ubuntu/Dockerfile
@@ -1,18 +1,25 @@
 FROM gcr.io/{{ global.project }}/ubuntu:focal-20201106
 ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
 COPY retry /bin/retry
 COPY hail-apt-get-install /bin/hail-apt-get-install
-# We need software-properties-common for add-apt-repository; however, that
-# package depends on Python 3.8, which installs PyGObject with missing
-# dependencies. This fails pip check, so we remove it after we're done.
-RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
-    hail-apt-get-install software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get autoremove -y software-properties-common
-RUN hail-apt-get-install python3.7-minimal python3.7-dev python3-pip && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
-    python3 -m pip check && \
-    python3 -m pip --version
 COPY pip.conf /root/.config/pip/pip.conf
 COPY hail-pip-install /bin/hail-pip-install
 COPY controller.sh /
+RUN chmod 755 /bin/retry && \
+    chmod 755 /bin/hail-apt-get-install && \
+    chmod 755 /bin/hail-pip-install && \
+    chmod 755 /controller.sh && \
+    echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
+    mkdir -p /usr/share/keyrings/ && \
+    hail-apt-get-install curl gpg && \
+    curl -fSL 'https://keyserver.ubuntu.com/pks/lookup?search=0xF23C5A6CF475977595C89F51BA6932366A755776&hash=on&exact=on&options=mr&op=get' \
+         | gpg --dearmor > /usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg && \
+    echo 'deb [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \
+         >> /etc/apt/sources.list && \
+    echo 'deb-src [signed-by=/usr/share/keyrings/deadsnakes-ppa-archive-keyring.gpg] http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main' \
+         >> /etc/apt/sources.list && \
+    hail-apt-get-install python3.7-minimal python3.7-dev python3-pip && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
+    python3 -m pip check && \
+    python3 -m pip --version


### PR DESCRIPTION
We can directly download the key and specify the repository. I used these instructions:
- https://wiki.debian.org/DebianRepository/UseThirdParty
- https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa

This builds in like 2 minutes rather than 4.

The frontend part avoids issues in downstream docker files where the installer might try to interact with the user. I noticed that some package was updated and now pulls in `tzdata` which asks you to select a timezone at install-time (if Debian frontend is interactive).