### PR TITLE
[query] fix annotation db test

### DIFF
--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -9,7 +9,7 @@ class AnnotationDBTests(unittest.TestCase):
     def setupAnnotationDBTests(cls):
         startTestHailContext()
         t = hl.utils.range_table(10)
-        t = t.annotate(locus=hl.locus('1', t.idx + 1))
+        t = t.key_by(locus=hl.locus('1', t.idx + 1))
         t = t.annotate(annotation=hl.str(t.idx))
         cls.tempdir_manager = hl.TemporaryDirectory()
         d = cls.tempdir_manager.__enter__()
@@ -51,7 +51,7 @@ class AnnotationDBTests(unittest.TestCase):
     def test_uniqueness(self):
         db = hl.experimental.DB(region='us', cloud='gcp', config=AnnotationDBTests.db_json)
         t = hl.utils.range_table(10)
-        t = t.annotate(locus=hl.locus('1', t.idx + 1))
+        t = t.key_by(locus=hl.locus('1', t.idx + 1))
         t = db.annotate_rows_db(t, 'unique_dataset', 'nonunique_dataset')
-        t.unique_dataset.dtype == hl.tstruct(annotation=hl.tstr)
-        t.nonunique_dataset.dtype == hl.tstruct(annotation=hl.tarray(hl.tstr))
+        assert t.unique_dataset.dtype == hl.dtype('struct{idx: int32, annotation: str}')
+        assert t.nonunique_dataset.dtype == hl.dtype('array<struct{idx: int32, annotation: str}>')


### PR DESCRIPTION
The test was lacking asserts, so it didn't fail even though it wasn't right. The tables were missing keys.