### PR TITLE
[datasets] [annotationdb] add column for cloud/regions to tables in docs

### DIFF
--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.html
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.html
@@ -45,6 +45,7 @@ mt = db.annotate_rows_db(mt)
       <th>description</th>
       <th>version</th>
       <th>reference genome</th>
+      <th>cloud: [regions]</th>
     </tr>
   </table>
 </div>

--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.js
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.js
@@ -26,6 +26,23 @@ $.ajax({
         }).reduce(function(i, j) {
           return i + "<br>" + j;
         });
+        let cloud_region_string = dataset.versions.map(function(i) {
+          let clouds = Object.keys(i["url"])
+          let cloud_region = {}
+          let output = []
+          if (clouds.includes("gcp")) {
+            cloud_region["gcp"] = Object.keys(i["url"]["gcp"])
+          }
+          if (clouds.includes("aws")) {
+            cloud_region["aws"] = Object.keys(i["url"]["aws"])
+          }
+          for (let [key, value] of Object.entries(cloud_region)) {
+            output = output.concat([`${key}:&nbsp[${value}]`])
+          }
+          return output.join(",&nbsp");
+        }).reduce(function(i, j) {
+          return i + "<br>" + j;
+        });
         let tr = $("<tr/>");
         tr.append(
             "<td><input type='checkbox' class='checkboxadd' value='" + name +
@@ -35,6 +52,7 @@ $.ajax({
             "'>link</a></td>");
         tr.append("<td>" + versions_string + "</td>");
         tr.append("<td>" + ref_genome_string + "</td>");
+        tr.append("<td>" + cloud_region_string + "</td>");
         $(".table1").append(tr);
       }
     }

--- a/hail/python/hail/docs/_static/datasets/datasets.html
+++ b/hail/python/hail/docs/_static/datasets/datasets.html
@@ -19,6 +19,7 @@
       <th>description</th>
       <th>version</th>
       <th>reference genome</th>
+      <th>cloud: [regions]</th>
     </tr>
   </table>
 </div>

--- a/hail/python/hail/docs/_static/datasets/datasets.js
+++ b/hail/python/hail/docs/_static/datasets/datasets.js
@@ -21,12 +21,30 @@ $.ajax({
       }).reduce(function(i, j) {
         return i + "<br>" + j;
       });
+      let cloud_region_string = dataset.versions.map(function(i) {
+        let clouds = Object.keys(i["url"])
+        let cloud_region = {}
+        let output = []
+        if (clouds.includes("gcp")) {
+          cloud_region["gcp"] = Object.keys(i["url"]["gcp"])
+        }
+        if (clouds.includes("aws")) {
+          cloud_region["aws"] = Object.keys(i["url"]["aws"])
+        }
+        for (let [key, value] of Object.entries(cloud_region)) {
+          output = output.concat([`${key}:&nbsp[${value}]`])
+        }
+        return output.join(",&nbsp");
+      }).reduce(function(i, j) {
+        return i + "<br>" + j;
+      });
       let tr = $("<tr/>");
       tr.append("<td>" + name + "</td>");
       tr.append("<td>" + dataset.description + "\n<a href='" + dataset.url +
           "'>link</a></td>");
       tr.append("<td>" + versions_string + "</td>");
       tr.append("<td>" + ref_genome_string + "</td>");
+      tr.append("<td>" + cloud_region_string + "</td>");
       $(".table1").append(tr);
     }
   },


### PR DESCRIPTION
Existing tables and matrix tables that we don't own/didn't create but are accessible via the datasets API are not always available on both GCS and S3 (e.g. pan UKB datasets are only on AWS S3), or are not available in an `eu` bucket on GCS (e.g. gnomAD datasets). 

This just adds a column `cloud: [regions]` to the tables on the datasets API and annotation DB docs pages to be more explicit about what datasets/versions are available on which cloud platform. 

So, for example, if a version of a dataset is in `gs://hail-datasets-us`, `gs://hail-datasets-eu`, and `s3://hail-datasets-us-east-1`, then under `cloud: [regions]` we would see `gcp: [eu,us], aws: [us]`.