### PR TITLE
[hailctl] fix dataproc

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -350,7 +350,7 @@ def main(args, pass_through_args):
     # command to start cluster
     cmd = conf.get_command(args.name)
 
-    if args.beta or args.max_idle or args.max_age:
+    if args.beta:
         cmd.insert(1, 'beta')
     if args.max_idle:
         cmd.append('--max-idle={}'.format(args.max_idle))


### PR DESCRIPTION
`max-idle` and `max-age` have been available since 258 https://cloud.google.com/sdk/docs/release-notes#25800_2019-08-13
We already require >=285 https://github.com/hail-is/hail/blob/main/hail/python/hailtop/hailctl/dataproc/cli.py#L16