### PR TITLE
[fs] LocalAsyncFS: validate file URL

### DIFF
--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -235,7 +235,15 @@ class LocalAsyncFS(AsyncFS):
     def _get_path(url):
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme and parsed.scheme != 'file':
-            raise ValueError(f"invalid scheme, expected file: {parsed.scheme}")
+            raise ValueError(f"invalid file URL: {url}, invalid scheme: expected file, got {parsed.scheme}")
+        if parsed.netloc and parsed.netloc != 'localhost':
+            raise ValueError(f"invalid file URL: {url}, invalid netloc: expected localhost or empty, got {parsed.netloc}")
+        if parsed.params:
+            raise ValueError(f"invalid file URL: params not allowed: {url}")
+        if parsed.query:
+            raise ValueError(f"invalid file URL: query not allowed: {url}")
+        if parsed.fragment:
+            raise ValueError(f"invalid file URL: fragment not allowed: {url}")
         return parsed.path
 
     async def open(self, url: str) -> ReadableStream:


### PR DESCRIPTION
The `//io/...` example you found now gives this:

```
ValueError: invalid file URL: //io/hail-ubuntu/Dockerfile.out, invalid netloc: expected localhost or empty, got io
```
