### PR TITLE
[query] only run nest_asyncio if asyncio is in use

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,12 +1,22 @@
+import pkg_resources
+import sys
+import asyncio
 import nest_asyncio
-nest_asyncio.apply()
-
-import pkg_resources  # noqa: E402
-import sys  # noqa: E402
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6 or later, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+
+if sys.version_info[:2] == (3, 6):
+    if asyncio._get_running_loop() is not None:
+        nest_asyncio.apply()
+else:
+    try:
+        asyncio.get_running_loop()
+        nest_asyncio.apply()
+    except RuntimeError as err:
+        assert 'no running event loop' in err.args[0]
+
 
 __pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources


### PR DESCRIPTION
I do not fully understand why, but pytest sometimes imports Hail in threads
other than the main thread. Asyncio raises an error if you try to start an
event loop in a non-main thread.

This PR only runs nest_asyncio if there is already a running event loop. If
there is no running event loop, we do not need to run nest_asyncio anyway! If
there is a running event loop, we can modify it to be nest-able even from
a non-main thread.