### PR TITLE
[batch] Make initializing GCS lazy when using PythonJob

### DIFF
--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -1,11 +1,8 @@
 import os
 import re
-import concurrent
 from typing import Optional, Dict, Union, List, Any, Set
 
 from hailtop.utils import secret_alnum_string
-
-from ..google_storage import GCS
 
 from . import backend as _backend, job, resource as _resource  # pylint: disable=cyclic-import
 from .exceptions import BatchException
@@ -130,11 +127,10 @@ class Batch:
         self._default_storage = default_storage
         self._default_timeout = default_timeout
         self._default_shell = default_shell
-
         self._default_python_image = default_python_image
 
-        self._gcs = GCS(blocking_pool=concurrent.futures.ThreadPoolExecutor(),
-                        project=project)
+        self._project = project
+        self._gcs = None
 
     def new_job(self,
                 name: Optional[str] = None,

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -139,7 +139,7 @@ class Batch:
     def _gcs(self):
         if self.__gcs is None:
             self.__gcs = GCS(blocking_pool=concurrent.futures.ThreadPoolExecutor(),
-                            project=self._project)
+                             project=self._project)
         return self._gcs
 
     def new_job(self,

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -140,7 +140,7 @@ class Batch:
         if self.__gcs is None:
             self.__gcs = GCS(blocking_pool=concurrent.futures.ThreadPoolExecutor(),
                              project=self._project)
-        return self._gcs
+        return self.__gcs
 
     def new_job(self,
                 name: Optional[str] = None,

--- a/hail/python/hailtop/batch/docs/change_log.rst
+++ b/hail/python/hailtop/batch/docs/change_log.rst
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+**Version 0.2.66**
+
+- Removed the need for the ``project`` argument in ``Batch()`` unless you are creating a PythonJob
+
 **Version 0.2.65**
 
 - Added ``PythonJob``

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -1,6 +1,5 @@
 import re
 import dill
-import concurrent
 import os
 import functools
 from io import BytesIO
@@ -8,8 +7,6 @@ from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast
 
 from . import backend, resource as _resource, batch  # pylint: disable=cyclic-import
 from .exceptions import BatchException
-
-from ..google_storage import GCS
 
 
 def _add_resource_to_set(resource_set, resource, include_rg=True):
@@ -911,10 +908,6 @@ class PythonJob(Job):
 
             job_path = os.path.dirname(result._get_path(remote_tmpdir))
             code_path = f'{job_path}/code{i}.p'
-
-            if self._batch._gcs is None:
-                self._batch._gcs = GCS(blocking_pool=concurrent.futures.ThreadPoolExecutor(),
-                                       project=self._batch._project)
 
             self._batch._gcs._write_gs_file_from_file_like_object(code_path, pipe)
 


### PR DESCRIPTION
See https://hail.zulipchat.com/#narrow/stream/223457-Batch-support/topic/GOOGLE_APPLICATION_CREDENTIALS.20issue/near/235884329

This way we maintain some backwards compatibility where project doesn't have to be defined when using the Batch constructor unless you use the new functionality.