### PR TITLE
[query] Vep Script Bugs

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
@@ -61,9 +61,7 @@ EOF
 chmod +x /vep.sh
 
 # Run VEP on the 1-variant VCF to create fasta.index file -- caution do not make fasta.index file writeable afterwards!
-gsutil cp gs://hail-common/vep/vep/loftee-beta/GRCh37/1var.vcf file:///1var.vcf
-
-cat /1var.vcf | docker run -i -v /vep_data:/root/.vep \
+cat /vep_data/loftee_data/1var.vcf | docker run -i -v /vep_data:/root/.vep \
     ${VEP_DOCKER_IMAGE} \
     perl /vep/ensembl-tools-release-85/scripts/variant_effect_predictor/variant_effect_predictor.pl \
     --format vcf \

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh37.sh
@@ -29,7 +29,6 @@ gsutil -u $PROJECT cp gs://hail-us-vep/vep85-loftee-gcloud.json /vep_data/vep85-
 ln -s /vep_data/vep85-gcloud.json $VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data
-gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/homo-sapiens/85_${ASSEMBLY}.tar | tar -xf - -C /vep_data/homo_sapiens
 docker pull ${VEP_DOCKER_IMAGE} &
 wait

--- a/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
+++ b/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh
@@ -29,7 +29,6 @@ gsutil -u $PROJECT cp gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json /vep_data
 ln -s /vep_data/vep95-GRCh38-gcloud.json $VEP_CONFIG_PATH
 
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/loftee-beta/${ASSEMBLY}.tar | tar -xf - -C /vep_data/ &
-gsutil -u $PROJECT cat gs://${VEP_BUCKET}/Plugins.tar /vep_data/Plugins.tar | tar -xf - -C /vep_data
 gsutil -u $PROJECT cat gs://${VEP_BUCKET}/homo-sapiens/95_${ASSEMBLY}.tar | tar -xf - -C /vep_data/homo_sapiens
 docker pull ${VEP_DOCKER_IMAGE} &
 wait


### PR DESCRIPTION
Deleted the `gsutil cat` line, it wasn't doing anything because of that erroneous `/vep_data/Plugins.tar`. I don't think plugin needs to be included here, as it's in the docker image. 

Deleted the `gsutil cp`, as the file it referenced did not exist. Grabbed the 1var.vcf from the already copied loftee_data. 

It's not clear to me why we don't do the `1var.vcf` vep run stuff when using `GRCh38`. 