### PR TITLE
[makefile] Fix install-on-cluster with requirements.txt dependencies

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -261,7 +261,7 @@ install: $(WHEEL)
 
 .PHONY: install-on-cluster
 install-on-cluster: $(WHEEL)
-	sed '/^pyspark/d' python/requirements.txt | xargs $(PIP) install -U
+	sed '/^pyspark/d' python/requirements.txt | grep -v '^#' | xargs $(PIP) install -U
 	-$(PIP) uninstall -y hail
 	$(PIP) install $(WHEEL) --no-deps
 


### PR DESCRIPTION
I tried to do this with process substitution instead of xargs (which pays python/pip startup many times) but it's annoying to get that to work in makefiles.
