### PR TITLE
[batch] Run job containers with crun

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM {{ global.docker_prefix }}/python:3.7-slim-stretch
+FROM {{ hail_ubuntu_image.image }} AS base
 
 COPY docker/hail-ubuntu/retry /bin/retry
 COPY docker/hail-ubuntu/hail-apt-get-install /bin/hail-apt-get-install
@@ -6,6 +6,8 @@ RUN chmod 755 /bin/retry && \
     chmod 755 /bin/hail-apt-get-install && \
     mkdir -p /usr/share/man/man1 /usr/share/man/man2
 RUN hail-apt-get-install \
+    iproute2 \
+    iptables \
     openjdk-8-jre-headless \
     liblapack3
 
@@ -15,7 +17,7 @@ COPY docker/requirements.txt .
 RUN chmod 755 /bin/hail-pip-install && \
     hail-pip-install -r requirements.txt pyspark==3.1.1
 
-ENV SPARK_HOME /usr/local/lib/python3.7/site-packages/pyspark
+ENV SPARK_HOME /usr/local/lib/python3.7/dist-packages/pyspark
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"
 ENV PYSPARK_PYTHON python3
 
@@ -30,6 +32,23 @@ RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     hail-apt-get-install fuse gcsfuse
 
+# Install crun runtime dependencies
+RUN hail-apt-get-install libyajl-dev
+
+# Build crun in separate build step
+FROM base AS crun_builder
+RUN hail-apt-get-install make git gcc build-essential pkgconf libtool \
+   libsystemd-dev libcap-dev libseccomp-dev \
+   go-md2man libtool autoconf automake
+RUN git clone --depth 1 --branch 0.19.1 https://github.com/containers/crun.git && \
+   cd crun && \
+   ./autogen.sh && \
+   ./configure && \
+   make && \
+   make install
+
+FROM base
+COPY --from=crun_builder /usr/local/bin/crun /usr/local/bin/crun
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -22,8 +22,8 @@ build-batch:
 	../docker-build.sh . Dockerfile.out $(BATCH_IMAGE)
 
 .PHONY: build-worker
-build-worker: src/main/java/is/hail/JVMEntryway.class jars/junixsocket-selftest-2.3.3-jar-with-dependencies.jar
-	python3 ../ci/jinja2_render.py '{"global":{"docker_prefix":"$(DOCKER_PREFIX)"}}' Dockerfile.worker Dockerfile.worker.out
+build-worker:
+	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"}}' Dockerfile.worker Dockerfile.worker.out
 	../docker-build.sh .. batch/Dockerfile.worker.out $(BATCH_WORKER_IMAGE)
 
 .PHONY: build

--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -145,7 +145,7 @@ sudo mkdir -p /etc/netns
 iptables --table nat --append POSTROUTING --source 10.0.0.0/15 --jump MASQUERADE
 
 # [public] Block public traffic to the metadata server
-iptables --table net --append PREROUTING --source 10.1.0.0/16 --destination 169.254.169.254 --jump DROP
+iptables --table net --append OUTPUT --source 10.1.0.0/16 --destination 169.254.169.254 --jump DROP
 
 CORES=$(nproc)
 NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")

--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -145,7 +145,7 @@ sudo mkdir -p /etc/netns
 iptables --table nat --append POSTROUTING --source 10.0.0.0/15 --jump MASQUERADE
 
 # [public] Block public traffic to the metadata server
-iptables --table net --append OUTPUT --source 10.1.0.0/16 --destination 169.254.169.254 --jump DROP
+iptables --insert FORWARD --source 10.1.0.0/16 --destination 169.254.169.254 --jump DROP
 
 CORES=$(nproc)
 NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -858,7 +858,7 @@ class Container:
 
     async def pipe_to_log(self, strm: Optional[asyncio.StreamReader]):
         if strm is not None:
-            while not strm.at_eof():
+            while not strm.at_eof() and not strm.exception():
                 self.logbuffer.extend(await strm.readline())
 
     def __str__(self):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -178,12 +178,12 @@ class NetworkNamespace:
         # Jobs on the private network should have access to the metadata server
         # and our vdc. The public network should not so we use google's public
         # resolver.
-        with open(f'/etc/netns/{self.network_ns_name}/resolv.conf', 'w') as hosts:
+        with open(f'/etc/netns/{self.network_ns_name}/resolv.conf', 'w') as resolv:
             if self.private:
-                hosts.write('nameserver 169.254.169.254\n')
-                hosts.write('search c.hail-vdc.internal google.internal\n')
+                resolv.write('nameserver 169.254.169.254\n')
+                resolv.write('search c.hail-vdc.internal google.internal\n')
             else:
-                hosts.write('nameserver 8.8.8.8\n')
+                resolv.write('nameserver 8.8.8.8\n')
 
     async def create_netns(self):
         await check_shell(
@@ -502,7 +502,7 @@ class Container:
                 self.short_error = 'image not found'
             raise
 
-        image_config, _ = await check_exec_output('docker', 'inspect', shq(self.image_ref_str))
+        image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def ensure_image_is_pulled(self, auth=None):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -230,8 +230,8 @@ iptables -w 10 --append FORWARD --out-interface {self.veth_host} --jump ACCEPT''
         self.port = None
         await check_shell(
             f'''
-ip netns delete {self.network_ns_name} && \
-ip link delete {self.veth_host}'''
+ip link delete {self.veth_host} && \
+ip netns delete {self.network_ns_name}'''
         )
         await self.create_netns()
 

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1375,7 +1375,7 @@ class DockerJob(Job):
 
     async def delete(self):
         await super().delete()
-        await asyncio.wait(c.delete() for c in self.containers.values())
+        await asyncio.wait([c.delete() for c in self.containers.values()])
 
     async def status(self):
         status = await super().status()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -16,10 +16,10 @@ import aiohttp.client_exceptions
 from aiohttp import web
 import async_timeout
 import concurrent
-import aiodocker
+import aiodocker  # type: ignore
 from collections import defaultdict
-from aiodocker.exceptions import DockerError
-import google.oauth2.service_account
+from aiodocker.exceptions import DockerError  # type: ignore
+import google.oauth2.service_account  # type: ignore
 from hailtop.utils import (
     time_msecs,
     request_retry_transient_errors,
@@ -27,6 +27,7 @@ from hailtop.utils import (
     retry_all_errors,
     check_shell,
     CalledProcessError,
+    check_exec_output,
     check_shell_output,
     is_google_registry_domain,
     find_spark_home,
@@ -55,6 +56,7 @@ from ..utils import (
     cores_mcpu_to_storage_bytes,
 )
 from ..semaphore import FIFOWeightedSemaphore
+from shlex import quote as shq
 from ..log_store import LogStore
 from ..globals import (
     HTTP_CLIENT_MAX_SIZE,
@@ -119,8 +121,15 @@ deploy_config = DeployConfig('gce', NAMESPACE, {})
 docker: Optional[aiodocker.Docker] = None
 
 port_allocator: Optional['PortAllocator'] = None
+network_allocator: Optional['NetworkAllocator'] = None
 
 worker: Optional['Worker'] = None
+
+image_configs: Dict[str, Dict[str, Any]] = dict()
+
+
+def get_image_digest(image_config) -> str:
+    return image_config['RepoDigests'][0].split('@')[1].split(':')[1]
 
 
 class PortAllocator:
@@ -135,6 +144,124 @@ class PortAllocator:
 
     def free(self, port):
         self.ports.put_nowait(port)
+
+
+class NetworkNamespace:
+    def __init__(self, subnet_index: int, private: bool):
+        assert subnet_index <= 255
+        self.subnet_index = subnet_index
+        self.private = private
+        self.network_ns_name = uuid.uuid4().hex[:5]
+        self.hostname = uuid.uuid4().hex[:10]
+        self.veth_host = self.network_ns_name + '-host'
+        self.veth_job = self.network_ns_name + '-job'
+
+        if private:
+            self.host_ip = f'10.0.{subnet_index}.10'
+            self.job_ip = f'10.0.{subnet_index}.11'
+        else:
+            self.host_ip = f'10.1.{subnet_index}.10'
+            self.job_ip = f'10.1.{subnet_index}.11'
+
+        self.port = None
+        self.host_port = None
+
+    async def init(self):
+        await check_shell(
+            f'''
+ip netns add {self.network_ns_name} && \
+ip link add name {self.veth_host} type veth peer name {self.veth_job} && \
+ip link set dev {self.veth_host} up && \
+ip link set {self.veth_job} netns {self.network_ns_name} && \
+ip address add {self.host_ip}/24 dev {self.veth_host}
+ip -n {self.network_ns_name} link set dev {self.veth_job} up && \
+ip -n {self.network_ns_name} link set dev lo up && \
+ip -n {self.network_ns_name} address add {self.job_ip}/24 dev {self.veth_job} && \
+ip -n {self.network_ns_name} route add default via {self.host_ip}'''
+        )
+
+        await self.iptables_forwarding(action='append')
+
+        os.makedirs(f'/etc/netns/{self.network_ns_name}')
+        with open(f'/etc/netns/{self.network_ns_name}/hosts', 'w') as hosts:
+            hosts.write('127.0.0.1 localhost\n')
+            hosts.write(f'{self.job_ip} {self.hostname}\n')
+
+        # Jobs on the private network should have access to the metadata server
+        # and our vdc. The public network should not so we use google's public
+        # resolver.
+        with open(f'/etc/netns/{self.network_ns_name}/resolv.conf', 'w') as hosts:
+            if self.private:
+                hosts.write('nameserver 169.254.169.254\n')
+                hosts.write('search c.hail-vdc.internal google.internal\n')
+            else:
+                hosts.write('nameserver 8.8.8.8\n')
+
+    async def expose_port(self, port, host_port):
+        self.port = port
+        self.host_port = host_port
+        await self.expose_port_rule(action='append')
+
+    async def expose_port_rule(self, action: str):
+        # Appending to PREROUTING means this is only exposed to external traffic.
+        # To expose for locally created packets, we would append instead to the OUTPUT chain.
+        await check_shell(
+            f'iptables --table nat --{action} PREROUTING \\ '
+            f'--match addrtype --dst-type LOCAL \\ '
+            f'--protocol tcp \\ '
+            f'--match tcp --dport {self.host_port} \\ '
+            f'--jump DNAT --to-destination {self.job_ip}:{self.port}'
+        )
+
+    async def iptables_forwarding(self, action: str):
+        await check_shell(
+            f'''
+iptables -w 10 --{action} FORWARD --in-interface {self.veth_host} --jump ACCEPT && \
+iptables -w 10 --{action} FORWARD --out-interface {self.veth_host} --jump ACCEPT'''
+        )
+
+    async def cleanup(self):
+        if self.host_port:
+            assert self.port
+            await self.expose_port_rule(action='delete')
+        await self.iptables_forwarding(action='delete')
+        # Also deletes associated veth-pairs
+        await check_shell(f'ip netns delete {self.network_ns_name}')
+        shutil.rmtree(f'/etc/netns/{self.network_ns_name}')
+
+
+class NetworkAllocator:
+    def __init__(self):
+        self.private_networks = asyncio.Queue()
+        self.public_networks = asyncio.Queue()
+
+    async def reserve(self, netns_pool_min_size: int = 64):
+        for subnet_index in range(netns_pool_min_size):
+            public = NetworkNamespace(subnet_index, private=False)
+            await public.init()
+            self.public_networks.put_nowait(public)
+
+            private = NetworkNamespace(subnet_index, private=True)
+            await private.init()
+            self.private_networks.put_nowait(private)
+
+    async def allocate_private(self) -> NetworkNamespace:
+        return await self.private_networks.get()
+
+    async def allocate_public(self) -> NetworkNamespace:
+        return await self.public_networks.get()
+
+    def free(self, netns: NetworkNamespace):
+        asyncio.ensure_future(self._free_and_enqueue_new(netns))
+
+    async def _free_and_enqueue_new(self, netns: NetworkNamespace):
+        await netns.cleanup()
+        netns = NetworkNamespace(netns.subnet_index, netns.private)
+        await netns.init()
+        if netns.private:
+            self.private_networks.put_nowait(netns)
+        else:
+            self.public_networks.put_nowait(netns)
 
 
 def docker_call_retry(timeout, name):
@@ -163,73 +290,6 @@ def docker_call_retry(timeout, name):
                 delay = await sleep_and_backoff(delay)
 
     return wrapper
-
-
-async def create_container(config, name):
-    delay = 0.1
-    error = 0
-
-    async def handle_error(e):
-        nonlocal error, delay
-        error += 1
-        if error < 10:
-            delay = await sleep_and_backoff(delay)
-            return
-        raise ValueError('encountered {error} failures in create_container; aborting') from e
-
-    while True:
-        try:
-            return await docker.containers.create(config, name=name)
-        except DockerError as e:
-            # 409 container with name already exists
-            if e.status == 409:
-                try:
-                    delay = await sleep_and_backoff(delay)
-                    return await docker.containers.get(name)
-                except DockerError as eget:
-                    # 404 No such container
-                    if eget.status == 404:
-                        await handle_error(eget)
-                        continue
-            # No such image: {DOCKER_PREFIX}/...
-            if e.status == 404 and 'No such image' in e.message:
-                await handle_error(e)
-                continue
-            raise
-
-
-async def start_container(container):
-    try:
-        return await container.start()
-    except DockerError as e:
-        # 304 container has already started
-        if e.status == 304:
-            return
-        if e.status == 500 and e.message == 'OCI runtime start failed: container process is already dead: unknown':
-            log.info(f'restarting container {container}')
-            return await container.restart()
-        raise
-
-
-async def stop_container(container):
-    try:
-        return await container.stop()
-    except DockerError as e:
-        # 304 container has already stopped
-        if e.status == 304:
-            return
-        raise
-
-
-async def delete_container(container, *args, **kwargs):
-    try:
-        return await container.delete(*args, **kwargs)
-    except DockerError as e:
-        # 404 container does not exist
-        # 409 removal of container is already in progress
-        if e.status in (404, 409):
-            return
-        raise
 
 
 class JobDeletedError(Exception):
@@ -294,7 +354,6 @@ class Container:
         self.spec = spec
 
         image_ref = parse_docker_image_reference(self.spec['image'])
-
         if image_ref.tag is None and image_ref.digest is None:
             log.info(f'adding latest tag to image {self.spec["image"]} for {self}')
             image_ref.tag = 'latest'
@@ -315,59 +374,90 @@ class Container:
 
         self.timeout = self.spec.get('timeout')
 
-        self.container = None
         self.state = 'pending'
-        self.short_error = None
         self.error = None
-        self.timings = Timings(self.is_job_deleted)
+        self.short_error = None
         self.container_status = None
-        self.log = None
+        self.started_at = None
+        self.finished_at = None
+
+        self.timings = Timings(self.is_job_deleted)
+
+        self.logbuffer = bytearray()
         self.overlay_path = None
 
-    def container_config(self):
-        weight = worker_fraction_in_1024ths(self.spec['cpu'])
-        host_config = {'CpuShares': weight, 'Memory': self.spec['memory'], 'BlkioWeight': min(weight, 1000)}
+        self.image_config = None
+        self.rootfs_path = None
+        self.container_name = f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}'
+        self.container_overlay_path = f'/host/containers/{self.container_name}'
+        self.config_path = f'/host/configs/{self.container_name}'
 
-        config = {
-            "AttachStdin": False,
-            "AttachStdout": False,
-            "AttachStderr": False,
-            "Tty": False,
-            'OpenStdin': False,
-            'Cmd': self.spec['command'],
-            'Image': self.image_ref_str,
-            'Entrypoint': '',
-        }
+        self.netns: Optional[NetworkNamespace] = None
+        self.proc = None
 
-        env = self.spec.get('env', [])
+    async def run(self, worker):
+        try:
+            with self.step('pulling'):
+                async with worker.rootfs_locks[self.image_ref_str]:
+                    last_fetched = worker.rootfs_last_fetched.get(self.image_ref_str)
+                    five_minutes_ago = time_msecs() - 5 * 60 * 1000
+                    if last_fetched and last_fetched < five_minutes_ago:
+                        assert self.image_ref_str in image_configs
+                        image_digest = get_image_digest(image_configs[self.image_ref_str])
+                        shutil.rmtree(f'/host/rootfs/{image_digest}')
+                    if not last_fetched or last_fetched < five_minutes_ago:
+                        worker.rootfs_last_fetched[self.image_ref_str] = time_msecs()
+                        await self.pull_image()
 
-        if self.port is not None:
-            assert self.host_port is not None
-            config['ExposedPorts'] = {f'{self.port}/tcp': {}}
-            host_config['PortBindings'] = {f'{self.port}/tcp': [{'HostIp': '', 'HostPort': str(self.host_port)}]}
-            env = list(env)
-            env.append(f'HAIL_BATCH_WORKER_PORT={self.host_port}')
-            env.append(f'HAIL_BATCH_WORKER_IP={IP_ADDRESS}')
+                    self.image_config = image_configs[self.image_ref_str]
+                    self.image_digest = get_image_digest(self.image_config)
+                    self.rootfs_path = f'/host/rootfs/{self.image_digest}'
+                    if not os.path.exists(self.rootfs_path):
+                        await self.extract_rootfs()
 
-        volume_mounts = self.spec.get('volume_mounts')
-        if volume_mounts:
-            host_config['Binds'] = volume_mounts
+            with self.step('setting up overlay'):
+                await self.setup_overlay()
 
-        if env:
-            config['Env'] = env
+            with self.step('setting up network'):
+                network = self.spec.get('network')
+                if network is None or network is True:
+                    self.netns = await network_allocator.allocate_public()
+                else:
+                    assert network == 'private'
+                    self.netns = await network_allocator.allocate_private()
+                if self.port is not None:
+                    self.host_port = await port_allocator.allocate()
+                    await self.netns.expose_port(self.port, self.host_port)
 
-        network = self.spec.get('network')
-        if network is None:
-            network = 'public'
-        host_config['NetworkMode'] = network  # not documented, I used strace to inspect the packets
+            with self.step('running'):
+                timed_out = await self.run_container()
 
-        unconfined = self.spec.get('unconfined')
-        if unconfined:
-            host_config['SecurityOpt'] = ["seccomp:unconfined", "apparmor:unconfined"]
+            self.container_status = await self.get_container_status()
 
-        config['HostConfig'] = host_config
+            with self.step('uploading_log'):
+                await self.upload_log()
 
-        return config
+            if timed_out:
+                self.short_error = 'timed out'
+                raise JobTimeoutError(f'timed out after {self.timeout}s')
+
+            if self.container_status['exit_code'] == 0:
+                self.state = 'succeeded'
+            else:
+                if self.container_status['out_of_memory']:
+                    self.short_error = 'out of memory'
+                self.state = 'failed'
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if not isinstance(e, (JobDeletedError, JobTimeoutError)):
+                log.exception(f'while running {self}')
+
+            self.state = 'error'
+            self.error = traceback.format_exc()
+        finally:
+            with self.step('deleting'):
+                await self.delete_container()
 
     def is_job_deleted(self) -> bool:
         return self.job.deleted
@@ -375,31 +465,34 @@ class Container:
     def step(self, name: str):
         return self.timings.step(name)
 
-    async def get_container_status(self):
-        if not self.container:
-            return None
+    async def pull_image(self):
+        is_google_image = is_google_registry_domain(self.image_ref.domain)
+        is_public_image = self.image_ref.name() in PUBLIC_IMAGES
 
         try:
-            c = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(self.container.show)
+            if not is_google_image:
+                await self.ensure_image_is_pulled()
+            elif is_public_image:
+                auth = await self.batch_worker_access_token()
+                await self.ensure_image_is_pulled(auth=auth)
+            else:
+                # Pull to verify this user has access to this
+                # image.
+                # FIXME improve the performance of this with a
+                # per-user image cache.
+                auth = self.current_user_access_token()
+                await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
+                    docker.images.pull, self.image_ref_str, auth=auth
+                )
         except DockerError as e:
-            if e.status == 404:
-                return None
+            if e.status == 404 and 'pull access denied' in e.message:
+                self.short_error = 'image cannot be pulled'
+            elif 'not found: manifest unknown' in e.message:
+                self.short_error = 'image not found'
             raise
 
-        cstate = c['State']
-        status = {
-            'state': cstate['Status'],
-            'started_at': cstate['StartedAt'],
-            'finished_at': cstate['FinishedAt'],
-            'out_of_memory': cstate['OOMKilled'],
-        }
-        cerror = cstate['Error']
-        if cerror:
-            status['error'] = cerror
-        else:
-            status['exit_code'] = cstate['ExitCode']
-
-        return status
+        image_config, _ = await check_exec_output('docker', 'inspect', shq(self.image_ref_str))
+        image_configs[self.image_ref_str] = json.loads(image_config)[0]
 
     async def ensure_image_is_pulled(self, auth=None):
         try:
@@ -409,10 +502,6 @@ class Container:
                 await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
                     docker.images.pull, self.image_ref_str, auth=auth
                 )
-
-    def current_user_access_token(self):
-        key = base64.b64decode(self.job.gsa_key['key.json']).decode()
-        return {'username': '_json_key', 'password': key}
 
     async def batch_worker_access_token(self):
         async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
@@ -425,137 +514,257 @@ class Container:
                 access_token = (await resp.json())['access_token']
                 return {'username': 'oauth2accesstoken', 'password': access_token}
 
-    async def run(self, worker):
-        try:
-            with self.step('pulling'):
-                is_google_image = is_google_registry_domain(self.image_ref.domain)
-                is_public_image = self.image_ref.name() in PUBLIC_IMAGES
+    def current_user_access_token(self):
+        key = base64.b64decode(self.job.gsa_key['key.json']).decode()
+        return {'username': '_json_key', 'password': key}
 
-                try:
-                    if not is_google_image:
-                        await self.ensure_image_is_pulled()
-                    elif is_public_image:
-                        auth = await self.batch_worker_access_token()
-                        await self.ensure_image_is_pulled(auth=auth)
-                    else:
-                        # Pull to verify this user has access to this
-                        # image.
-                        # FIXME improve the performance of this with a
-                        # per-user image cache.
-                        auth = self.current_user_access_token()
-                        await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                            docker.images.pull, self.image_ref_str, auth=auth
-                        )
-                except DockerError as e:
-                    if e.status == 404:
-                        if 'pull access denied' in e.message:
-                            self.short_error = 'image cannot be pulled'
-                        elif 'not found: manifest unknown' in e.message:
-                            self.short_error = 'image not found'
-                    raise
+    async def extract_rootfs(self):
+        assert self.rootfs_path
+        os.makedirs(self.rootfs_path)
+        await check_shell(f'docker export $(docker create {shq(self.image_ref_str)}) | tar -C {self.rootfs_path} -xf -')
+        log.info(f'Extracted rootfs for image {self.image_ref_str}')
 
-            if self.port is not None:
-                with self.step('allocating_port'):
-                    self.host_port = await port_allocator.allocate()
-
-            with self.step('creating'):
-                config = self.container_config()
-                log.info(f'starting {self}')
-                self.container = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    create_container, config, name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}'
-                )
-
-            c = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(self.container.show)
-
-            merged_overlay_path = c['GraphDriver']['Data']['MergedDir']
-            assert merged_overlay_path.endswith('/merged')
-            self.overlay_path = merged_overlay_path[:-7].replace(WORKER_DATA_DISK_MOUNT, '/host')
-            os.makedirs(f'{self.overlay_path}/', exist_ok=True)
-
-            await check_shell_output(
-                f'xfs_quota -x -c "project -s -p {self.overlay_path} {self.job.project_id}" /host/'
-            )
-
-            with self.step('starting'):
-                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(start_container, self.container)
-
-            timed_out = False
-            with self.step('running'):
-                try:
-                    async with async_timeout.timeout(self.timeout):
-                        await docker_call_retry(MAX_DOCKER_WAIT_SECS, f'{self}')(self.container.wait)
-                except asyncio.TimeoutError:
-                    timed_out = True
-
-            self.container_status = await self.get_container_status()
-
-            with self.step('uploading_log'):
-                await worker.log_store.write_log_file(
-                    self.job.format_version,
-                    self.job.batch_id,
-                    self.job.job_id,
-                    self.job.attempt_id,
-                    self.name,
-                    await self.get_container_log(),
-                )
-
-            with self.step('deleting'):
-                await self.delete_container()
-
-            if timed_out:
-                self.short_error = 'timed out'
-                raise JobTimeoutError(f'timed out after {self.timeout}s')
-
-            if self.container_status['out_of_memory']:
-                self.short_error = 'out of memory'
-
-            if 'error' in self.container_status:
-                self.state = 'error'
-            elif self.container_status['exit_code'] == 0:
-                self.state = 'succeeded'
-            else:
-                self.state = 'failed'
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            if not isinstance(e, (JobDeletedError, JobTimeoutError)) and not user_error(e):
-                log.exception(f'while running {self}')
-
-            self.state = 'error'
-            self.error = traceback.format_exc()
-        finally:
-            await self.delete_container()
-
-    async def get_container_log(self):
-        logs = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-            self.container.log, stderr=True, stdout=True
+    async def setup_overlay(self):
+        lower_dir = self.rootfs_path
+        upper_dir = f'{self.container_overlay_path}/upper'
+        work_dir = f'{self.container_overlay_path}/work'
+        merged_dir = f'{self.container_overlay_path}/merged'
+        for d in (upper_dir, work_dir, merged_dir):
+            os.makedirs(d)
+        await check_shell(
+            f'mount -t overlay overlay -o lowerdir={lower_dir},upperdir={upper_dir},workdir={work_dir} {merged_dir}'
         )
-        self.log = "".join(logs)
-        return self.log
+        await check_shell(f'xfs_quota -x -c "project -s -p {self.container_overlay_path} {self.job.project_id}" /host')
 
-    async def get_log(self):
-        if self.container:
-            return await self.get_container_log()
-        return self.log
+    async def run_container(self) -> bool:
+        self.started_at = time_msecs()
+        try:
+            await self.write_container_config()
+            async with async_timeout.timeout(self.timeout):
+                log.info('Creating the crun run process')
+                self.proc = await asyncio.create_subprocess_exec(
+                    'crun',
+                    'run',
+                    '--bundle',
+                    f'{self.container_overlay_path}/merged',
+                    '--config',
+                    f'{self.config_path}/config.json',
+                    self.container_name,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await asyncio.gather(self.pipe_to_log(self.proc.stdout), self.pipe_to_log(self.proc.stderr))
+                await self.proc.wait()
+                log.info('crun process completed')
+        except asyncio.TimeoutError:
+            return True
+        finally:
+            self.finished_at = time_msecs()
+
+        return False
+
+    async def write_container_config(self):
+        os.makedirs(self.config_path)
+        with open(f'{self.config_path}/config.json', 'w') as f:
+            f.write(json.dumps(await self.container_config()))
+
+    # https://github.com/opencontainers/runtime-spec/blob/master/config.md
+    async def container_config(self):
+        uid, gid = await self._get_in_container_user()
+        weight = worker_fraction_in_1024ths(self.spec['cpu'])
+        default_docker_capabilities = [
+            'CAP_CHOWN',
+            'CAP_DAC_OVERRIDE',
+            'CAP_FSETID',
+            'CAP_FOWNER',
+            'CAP_MKNOD',
+            'CAP_NET_RAW',
+            'CAP_SETGID',
+            'CAP_SETUID',
+            'CAP_SETFCAP',
+            'CAP_SETPCAP',
+            'CAP_NET_BIND_SERVICE',
+            'CAP_SYS_CHROOT',
+            'CAP_KILL',
+            'CAP_AUDIT_WRITE',
+        ]
+        config = {
+            'ociVersion': '1.0.1',
+            'root': {
+                'path': '.',
+                'readonly': False,
+            },
+            'hostname': self.netns.hostname,
+            'mounts': self._mounts(),
+            'process': {
+                'user': {  # uid/gid *inside the container*
+                    'uid': uid,
+                    'gid': gid,
+                },
+                'args': self.spec['command'],
+                'env': self._env(),
+                'cwd': '/',
+                'capabilities': {
+                    'bounding': default_docker_capabilities,
+                    'effective': default_docker_capabilities,
+                    'inheritable': default_docker_capabilities,
+                    'permitted': default_docker_capabilities,
+                },
+            },
+            'linux': {
+                'namespaces': [
+                    {'type': 'pid'},
+                    {
+                        'type': 'network',
+                        'path': f'/var/run/netns/{self.netns.network_ns_name}',
+                    },
+                    {'type': 'mount'},
+                    {'type': 'ipc'},
+                    {'type': 'uts'},
+                    {'type': 'cgroup'},
+                ],
+                'uidMappings': [],
+                'gidMappings': [],
+                'resources': {
+                    'cpu': {'shares': weight},
+                    'memory': {
+                        'limit': self.spec['memory'],
+                        'reservation': self.spec['memory'],
+                    },
+                    # 'blockIO': {'weight': min(weight, 1000)}, FIXME blkio.weight not supported
+                },
+                'maskedPaths': [
+                    '/proc/asound',
+                    '/proc/acpi',
+                    '/proc/kcore',
+                    '/proc/keys',
+                    '/proc/latency_stats',
+                    '/proc/timer_list',
+                    '/proc/timer_stats',
+                    '/proc/sched_debug',
+                    '/proc/scsi',
+                    '/sys/firmware',
+                ],
+                'readonlyPaths': [
+                    '/proc/bus',
+                    '/proc/fs',
+                    '/proc/irq',
+                    '/proc/sys',
+                    '/proc/sysrq-trigger',
+                ],
+            },
+        }
+
+        if self.spec.get('unconfined'):
+            config['linux']['maskedPaths'] = []
+            config['linux']['readonlyPaths'] = []
+            config['process']['apparmorProfile'] = 'unconfined'
+            config['linux']['seccomp'] = {'defaultAction': "SCMP_ACT_ALLOW"}
+
+        return config
+
+    async def _get_in_container_user(self):
+        user = self.image_config['Config']['User']
+        if not user:
+            uid, gid = 0, 0
+        elif ":" in user:
+            uid, gid = user.split(":")
+        else:
+            uid, gid = await self._read_user_from_rootfs(user)
+        return int(uid), int(gid)
+
+    async def _read_user_from_rootfs(self, user) -> Tuple[str, str]:
+        with open(f'{self.rootfs_path}/etc/passwd', 'r') as passwd:
+            for record in passwd:
+                if record.startswith(user):
+                    _, _, uid, gid, _, _, _ = record.split(":")
+                    return uid, gid
+            raise ValueError("Container user not found in image's /etc/passwd")
+
+    def _mounts(self):
+        return self.spec.get('volume_mounts') + [
+            {
+                'source': 'proc',
+                'destination': '/proc',
+                'type': 'proc',
+                'options': ['nosuid', 'noexec', 'nodev'],
+            },
+            {
+                'source': 'tmpfs',
+                'destination': '/dev',
+                'type': 'tmpfs',
+                'options': ['nosuid', 'strictatime', 'mode=755', 'size=65536k'],
+            },
+            {
+                'source': 'sysfs',
+                'destination': '/sys',
+                'type': 'sysfs',
+                'options': ['nosuid', 'noexec', 'nodev', 'ro'],
+            },
+            {
+                'source': 'cgroup',
+                'destination': '/sys/fs/cgroup',
+                'type': 'cgroup',
+                'options': ['nosuid', 'noexec', 'nodev', 'ro'],
+            },
+            {
+                'source': 'mqueue',
+                'destination': '/dev/mqueue',
+                'type': 'mqueue',
+                'options': ['nosuid', 'noexec', 'nodev'],
+            },
+            {
+                'source': 'shm',
+                'destination': '/dev/shm',
+                'type': 'tmpfs',
+                'options': ['nosuid', 'noexec', 'nodev', 'mode=1777', 'size=67108864'],
+            },
+            {
+                'source': f'/etc/netns/{self.netns.network_ns_name}/resolv.conf',
+                'destination': '/etc/resolv.conf',
+                'type': 'none',
+                'options': ['rbind', 'ro'],
+            },
+            {
+                'source': f'/etc/netns/{self.netns.network_ns_name}/hosts',
+                'destination': '/etc/hosts',
+                'type': 'none',
+                'options': ['rbind', 'ro'],
+            },
+        ]
+
+    def _env(self):
+        env = self.image_config['Config']['Env'] + self.spec.get('env', [])
+        if self.port is not None:
+            assert self.host_port is not None
+            env.append(f'HAIL_BATCH_WORKER_PORT={self.host_port}')
+            env.append(f'HAIL_BATCH_WORKER_IP={IP_ADDRESS}')
+        return env
 
     async def delete_container(self):
-        if self.container:
+        if self.container_is_running():
             try:
-                log.info(f'{self}: deleting container')
-                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(stop_container, self.container)
-                # v=True deletes anonymous volumes created by the container
-                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    delete_container, self.container, v=True
-                )
-                self.container = None
+                log.info(f'{self} container is still running, killing crun process')
+                self.proc.kill()
             except asyncio.CancelledError:
                 raise
             except Exception:
                 log.warning('while deleting container, ignoring', exc_info=True)
+        self.proc = None
 
         if self.host_port is not None:
             port_allocator.free(self.host_port)
             self.host_port = None
+
+        if self.netns:
+            network_allocator.free(self.netns)
+            self.netns = None
+
+        mount_point = f'{self.container_overlay_path}/merged'
+        if os.path.exists(mount_point):
+            await check_shell(f'umount {mount_point}')
+            shutil.rmtree(self.container_overlay_path)
+            shutil.rmtree(self.config_path)
 
     async def delete(self):
         log.info(f'deleting {self}')
@@ -567,12 +776,11 @@ class Container:
     #   timing: dict(str, float),
     #   error: str, (optional)
     #   short_error: str, (optional)
-    #   container_status: { (from docker container state)
+    #   container_status: {
     #     state: str,
     #     started_at: str, (date)
     #     finished_at: str, (date)
-    #     out_of_memory: bool
-    #     error: str, (one of error, exit_code will be present)
+    #     out_of_memory: bool,
     #     exit_code: int
     #   }
     # }
@@ -580,16 +788,59 @@ class Container:
         if not state:
             state = self.state
         status = {'name': self.name, 'state': state, 'timing': self.timings.to_dict()}
+        # TODO Remove
+        status['container_status'] = await self.get_container_status()
         if self.error:
             status['error'] = self.error
         if self.short_error:
             status['short_error'] = self.short_error
         if self.container_status:
             status['container_status'] = self.container_status
-        elif self.container:
+        elif self.container_is_running():
             status['container_status'] = await self.get_container_status()
+        return status
+
+    async def get_container_status(self):
+        if not self.proc:
+            return None
+
+        status = {
+            'started_at': self.started_at,
+            'finished_at': self.finished_at,
+        }
+        if self.container_is_running():
+            status['state'] = 'running'
+            status['out_of_memory'] = False
+        else:
+            status['state'] = 'finished'
+            status['exit_code'] = self.proc.returncode
+            status['out_of_memory'] = self.proc.returncode == 137
 
         return status
+
+    def container_is_running(self):
+        return self.proc is not None and self.proc.returncode is None
+
+    def container_finished(self):
+        return self.proc is not None and self.proc.returncode is not None
+
+    async def upload_log(self):
+        await worker.log_store.write_log_file(
+            self.job.format_version,
+            self.job.batch_id,
+            self.job.job_id,
+            self.job.attempt_id,
+            self.name,
+            await self.get_log(),
+        )
+
+    async def get_log(self):
+        return self.logbuffer.decode()
+
+    async def pipe_to_log(self, strm: Optional[asyncio.StreamReader]):
+        if strm is not None:
+            while not strm.at_eof():
+                self.logbuffer.extend(await strm.readline())
 
     def __str__(self):
         return f'container {self.job.id}/{self.name}'
@@ -639,7 +890,7 @@ def copy_container(job, name, files, volume_mounts, cpu, memory, requester_pays_
         'image': BATCH_WORKER_IMAGE,
         'name': name,
         'command': [
-            '/usr/local/bin/python3',
+            '/usr/bin/python3',
             '-m',
             'batch.copy',
             json.dumps(requester_pays_project),
@@ -762,7 +1013,12 @@ class Job:
         self.main_volume_mounts = []
         self.output_volume_mounts = []
 
-        io_volume_mount = f'{self.io_host_path()}:/io'
+        io_volume_mount = {
+            'source': self.io_host_path(),
+            'destination': '/io',
+            'type': 'none',
+            'options': ['rbind', 'rw'],
+        }
         self.input_volume_mounts.append(io_volume_mount)
         self.main_volume_mounts.append(io_volume_mount)
         self.output_volume_mounts.append(io_volume_mount)
@@ -771,7 +1027,14 @@ class Job:
         self.gcsfuse = gcsfuse
         if gcsfuse:
             for b in gcsfuse:
-                self.main_volume_mounts.append(f'{self.gcsfuse_path(b["bucket"])}:{b["mount_path"]}:shared')
+                self.main_volume_mounts.append(
+                    {
+                        'source': self.gcsfuse_path(b["bucket"]),
+                        'destination': b['mount_path'],
+                        'type': 'none',
+                        'options': ['rbind', 'rw', 'shared'],
+                    }
+                )
 
         secrets = job_spec.get('secrets')
         self.secrets = secrets
@@ -860,12 +1123,16 @@ class DockerJob(Job):
 
         requester_pays_project = job_spec.get('requester_pays_project')
 
-        if job_spec['process'].get('mount_docker_socket'):
-            self.main_volume_mounts.append('/var/run/docker.sock:/var/run/docker.sock')
+        self.timings = Timings(lambda: False)
 
         if self.secrets:
             for secret in self.secrets:
-                volume_mount = f'{self.secret_host_path(secret)}:{secret["mount_path"]}'
+                volume_mount = {
+                    'source': self.secret_host_path(secret),
+                    'destination': secret["mount_path"],
+                    'type': 'none',
+                    'options': ['rbind', 'rw'],
+                }
                 self.main_volume_mounts.append(volume_mount)
                 # this will be the user gsa-key
                 if secret.get('mount_in_copy', False):
@@ -924,6 +1191,9 @@ class DockerJob(Job):
 
         self.containers = containers
 
+    def step(self, name: str):
+        return self.timings.step(name)
+
     async def setup_io(self):
         if not worker_config.job_private:
             if worker.data_disk_space_remaining.value < self.external_storage_in_gib:
@@ -969,7 +1239,8 @@ class DockerJob(Job):
 
                 os.makedirs(f'{self.scratch}/')
 
-                await self.setup_io()
+                with self.step('setup_io'):
+                    await self.setup_io()
 
                 if not self.disk:
                     data_disk_storage_in_bytes = storage_gib_to_bytes(
@@ -978,25 +1249,28 @@ class DockerJob(Job):
                 else:
                     data_disk_storage_in_bytes = storage_gib_to_bytes(self.data_disk_storage_in_gib)
 
-                await check_shell_output(f'xfs_quota -x -c "project -s -p {self.scratch} {self.project_id}" /host/')
-                await check_shell_output(
-                    f'xfs_quota -x -c "limit -p bsoft={data_disk_storage_in_bytes} bhard={data_disk_storage_in_bytes} {self.project_id}" /host/'
-                )
+                with self.step('configuring xfsquota'):
+                    await check_shell_output(f'xfs_quota -x -c "project -s -p {self.scratch} {self.project_id}" /host/')
+                    await check_shell_output(
+                        f'xfs_quota -x -c "limit -p bsoft={data_disk_storage_in_bytes} bhard={data_disk_storage_in_bytes} {self.project_id}" /host/'
+                    )
 
-                if self.secrets:
-                    for secret in self.secrets:
-                        populate_secret_host_path(self.secret_host_path(secret), secret['data'])
+                with self.step('populating secrets'):
+                    if self.secrets:
+                        for secret in self.secrets:
+                            populate_secret_host_path(self.secret_host_path(secret), secret['data'])
 
-                if self.gcsfuse:
-                    populate_secret_host_path(self.gsa_key_file_path(), self.gsa_key)
-                    for b in self.gcsfuse:
-                        bucket = b['bucket']
-                        await add_gcsfuse_bucket(
-                            mount_path=self.gcsfuse_path(bucket),
-                            bucket=bucket,
-                            key_file=f'{self.gsa_key_file_path()}/key.json',
-                            read_only=b['read_only'],
-                        )
+                with self.step('adding gcsfuse bucket'):
+                    if self.gcsfuse:
+                        populate_secret_host_path(self.gsa_key_file_path(), self.gsa_key)
+                        for b in self.gcsfuse:
+                            bucket = b['bucket']
+                            await add_gcsfuse_bucket(
+                                mount_path=self.gcsfuse_path(bucket),
+                                bucket=bucket,
+                                key_file=f'{self.gsa_key_file_path()}/key.json',
+                                read_only=b['read_only'],
+                            )
 
                 self.state = 'running'
 
@@ -1037,16 +1311,17 @@ class DockerJob(Job):
                 self.state = 'error'
                 self.error = traceback.format_exc()
             finally:
-                if self.disk:
-                    try:
-                        await self.disk.delete()
-                        log.info(f'deleted disk {self.disk.name} for {self.id}')
-                    except Exception:
-                        log.exception(f'while detaching and deleting disk {self.disk.name} for {self.id}')
-                else:
-                    worker.data_disk_space_remaining.value += self.external_storage_in_gib
+                with self.step('post-job finally block'):
+                    if self.disk:
+                        try:
+                            await self.disk.delete()
+                            log.info(f'deleted disk {self.disk.name} for {self.id}')
+                        except Exception:
+                            log.exception(f'while detaching and deleting disk {self.disk.name} for {self.id}')
+                    else:
+                        worker.data_disk_space_remaining.value += self.external_storage_in_gib
 
-                await self.cleanup()
+                    await self.cleanup()
 
     async def cleanup(self):
         self.end_time = time_msecs()
@@ -1084,6 +1359,7 @@ class DockerJob(Job):
         status = await super().status()
         cstatuses = {name: await c.status() for name, c in self.containers.items()}
         status['container_statuses'] = cstatuses
+        status['timing'] = self.timings.to_dict()
 
         return status
 
@@ -1317,6 +1593,9 @@ class Worker:
         self.stop_event = asyncio.Event()
         self.task_manager = aiotools.BackgroundTaskManager()
         self.jar_download_locks = defaultdict(asyncio.Lock)
+
+        self.rootfs_locks = defaultdict(asyncio.Lock)
+        self.rootfs_last_fetched = {}
 
         # filled in during activation
         self.log_store = None
@@ -1634,11 +1913,14 @@ class Worker:
 
 
 async def async_main():
-    global port_allocator, worker, docker
+    global port_allocator, network_allocator, worker, docker
 
     docker = aiodocker.Docker()
 
     port_allocator = PortAllocator()
+    network_allocator = NetworkAllocator()
+    await network_allocator.reserve()
+
     worker = Worker()
     try:
         await worker.run()

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1305,6 +1305,7 @@ class DockerJob(Job):
                     data_disk_storage_in_bytes = storage_gib_to_bytes(self.data_disk_storage_in_gib)
 
                 with self.step('configuring xfsquota'):
+                    # Quota will not be applied to `/io` if the job has an attached disk mounted there
                     await check_shell_output(f'xfs_quota -x -c "project -s -p {self.scratch} {self.project_id}" /host/')
                     await check_shell_output(
                         f'xfs_quota -x -c "limit -p bsoft={data_disk_storage_in_bytes} bhard={data_disk_storage_in_bytes} {self.project_id}" /host/'

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -462,7 +462,7 @@ class Container:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            if not isinstance(e, (JobDeletedError, JobTimeoutError)):
+            if not isinstance(e, (JobDeletedError, JobTimeoutError)) and not user_error(e):
                 log.exception(f'while running {self}')
 
             self.state = 'error'

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -620,6 +620,13 @@ def test_verify_no_access_to_metadata_server(client):
     assert status['state'] == 'Failed', str(status)
     assert "Could not resolve host" in j.log()['main'], (str(j.log()['main']), status)
 
+    builder = client.create_batch()
+    j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
+    builder.submit()
+    status = j.wait()
+    assert status['state'] == 'Failed', str(status)
+    assert "Request timed out" in j.log()['main'], (str(j.log()['main']), status)
+
 
 def test_can_use_google_credentials(client):
     token = os.environ["HAIL_TOKEN"]

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -132,6 +132,18 @@ def test_out_of_storage(client):
     assert "fallocate failed: No space left on device" in j.log()['main']
 
 
+def test_quota_applies_to_volume(client):
+    builder = client.create_batch()
+    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '5Gi'}
+    j = builder.create_job(
+        os.environ['HAIL_VOLUME_IMAGE'], ['/bin/sh', '-c', 'fallocate -l 100GiB /data/foo'], resources=resources
+    )
+    builder.submit()
+    status = j.wait()
+    assert status['state'] == 'Failed', str(status)
+    assert "fallocate failed: No space left on device" in j.log()['main']
+
+
 def test_nonzero_storage(client):
     builder = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '20Gi'}

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -625,7 +625,7 @@ def test_verify_no_access_to_metadata_server(client):
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str(status)
-    assert "Request timed out" in j.log()['main'], (str(j.log()['main']), status)
+    assert "Connection timed out" in j.log()['main'], (str(j.log()['main']), status)
 
 
 def test_can_use_google_credentials(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -75,9 +75,7 @@ def test_bad_command(client):
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['sleep 5'])
     builder.submit()
     status = j.wait()
-    assert j._get_exit_codes(status) == {'main': None}, status
-    assert j._get_error(status, 'main') is not None
-    assert status['state'] == 'Error', str(status)
+    assert status['state'] == 'Failed', str(status)
 
 
 def test_invalid_resource_requests(client):
@@ -608,7 +606,7 @@ def test_verify_no_access_to_metadata_server(client):
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Failed', str(status)
-    assert "Connection timed out" in j.log()['main'], str(j.log()['main'], status)
+    assert "Could not resolve host" in j.log()['main'], (str(j.log()['main']), status)
 
 
 def test_can_use_google_credentials(client):

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -146,21 +146,21 @@ def test_quota_applies_to_volume(client):
 
 def test_quota_shared_by_io_and_rootfs(client):
     builder = client.create_batch()
-    resources = {'storage': '10Gi'}
+    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /foo'], resources=resources)
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', str(status)
 
     builder = client.create_batch()
-    resources = {'storage': '10Gi'}
+    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', str(status)
 
     builder = client.create_batch()
-    resources = {'storage': '10Gi'}
+    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
     j = builder.create_job(
         DOCKER_ROOT_IMAGE,
         ['/bin/sh', '-c', 'fallocate -l 7GiB /foo; fallocate -l 7GiB /io/foo'],

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -163,7 +163,7 @@ def test_quota_shared_by_io_and_rootfs(client):
     resources = {'storage': '10Gi'}
     j = builder.create_job(
         DOCKER_ROOT_IMAGE,
-        ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo; fallocate -l 7GiB /io/foo'],
+        ['/bin/sh', '-c', 'fallocate -l 7GiB /foo; fallocate -l 7GiB /io/foo'],
         resources=resources,
     )
     builder.submit()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -153,14 +153,14 @@ def test_quota_shared_by_io_and_rootfs(client):
     assert status['state'] == 'Success', str(status)
 
     builder = client.create_batch()
-    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
+    resources = {'storage': '10Gi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo'], resources=resources)
     builder.submit()
     status = j.wait()
     assert status['state'] == 'Success', str(status)
 
     builder = client.create_batch()
-    resources = {'cpu': '0.25', 'memory': '10M', 'storage': '10Gi'}
+    resources = {'storage': '10Gi'}
     j = builder.create_job(
         DOCKER_ROOT_IMAGE,
         ['/bin/sh', '-c', 'fallocate -l 7GiB /io/foo; fallocate -l 7GiB /io/foo'],

--- a/build.yaml
+++ b/build.yaml
@@ -62,7 +62,7 @@ steps:
     contextPath: /io/echo
     publishAs: echo
     resources:
-      storage: 50Gi
+      storage: 10Gi
       cpu: "2"
       memory: 7.5Gi
     inputs:

--- a/build.yaml
+++ b/build.yaml
@@ -130,6 +130,10 @@ steps:
     dockerFile: /io/repo/docker/Dockerfile.service-base
     contextPath: /io/repo
     publishAs: service-base
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: 7.5Gi
     dependsOn:
       - base_image
       - merge_code
@@ -787,6 +791,7 @@ steps:
         to: /io/repo/hail_version
     dependsOn:
       - merge_code
+      - hail_ubuntu_image
   - kind: buildImage2
     name: service_java_run_base_image
     dockerFile: /io/repo/docker/Dockerfile.service-java-run-base

--- a/build.yaml
+++ b/build.yaml
@@ -61,6 +61,10 @@ steps:
     dockerFile: /io/echo/Dockerfile
     contextPath: /io/echo
     publishAs: echo
+    resources:
+      storage: 50Gi
+      cpu: "2"
+      memory: 7.5Gi
     inputs:
       - from: /repo/echo
         to: /io/echo
@@ -2562,6 +2566,14 @@ steps:
     dependsOn:
       - hail_ubuntu_image
   - kind: buildImage2
+    name: volume_image
+    dockerFile:
+      inline: |
+        FROM {{ hail_ubuntu_image.image }}
+        VOLUME ["/data"]
+    dependsOn:
+      - hail_ubuntu_image
+  - kind: buildImage2
     name: curl_image
     dockerFile:
       inline: |
@@ -2623,6 +2635,7 @@ steps:
       export HAIL_CURL_IMAGE={{ curl_image.image }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+      export HAIL_VOLUME_IMAGE={{ volume_image.image }}
       export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
@@ -2678,6 +2691,7 @@ steps:
       - ci_utils_image
       - deploy_batch
       - netcat_ubuntu_image
+      - volume_image
       - curl_image
   - kind: runImage
     name: test_batch_1
@@ -2693,6 +2707,7 @@ steps:
       export HAIL_CURL_IMAGE={{ curl_image.image }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+      export HAIL_VOLUME_IMAGE={{ volume_image.image }}
       export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
@@ -2748,6 +2763,7 @@ steps:
       - ci_utils_image
       - deploy_batch
       - netcat_ubuntu_image
+      - volume_image
       - curl_image
   - kind: runImage
     name: test_batch_2
@@ -2763,6 +2779,7 @@ steps:
       export HAIL_CURL_IMAGE={{ curl_image.image }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+      export HAIL_VOLUME_IMAGE={{ volume_image.image }}
       export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
@@ -2818,6 +2835,7 @@ steps:
       - ci_utils_image
       - deploy_batch
       - netcat_ubuntu_image
+      - volume_image
       - curl_image
   - kind: runImage
     name: test_batch_3
@@ -2833,6 +2851,7 @@ steps:
       export HAIL_CURL_IMAGE={{ curl_image.image }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+      export HAIL_VOLUME_IMAGE={{ volume_image.image }}
       export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
@@ -2888,6 +2907,7 @@ steps:
       - ci_utils_image
       - deploy_batch
       - netcat_ubuntu_image
+      - volume_image
       - curl_image
   - kind: runImage
     name: test_batch_4
@@ -2903,6 +2923,7 @@ steps:
       export HAIL_CURL_IMAGE={{ curl_image.image }}
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
       export HAIL_NETCAT_UBUNTU_IMAGE={{ netcat_ubuntu_image.image }}
+      export HAIL_VOLUME_IMAGE={{ volume_image.image }}
       export HAIL_HAIL_BASE_IMAGE={{ hail_base_image.image }}
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
@@ -2958,6 +2979,7 @@ steps:
       - ci_utils_image
       - deploy_batch
       - netcat_ubuntu_image
+      - volume_image
       - curl_image
   - kind: runImage
     name: delete_test_billing_projects

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -319,7 +319,7 @@ set +x
 /bin/sh /home/user/convert-google-application-credentials-to-docker-auth-config
 set -x
 
-export BUILDKITD_FLAGS=--oci-worker-no-process-sandbox
+export BUILDKITD_FLAGS='--oci-worker-no-process-sandbox --oci-worker-snapshotter=overlayfs'
 export BUILDCTL_CONNECT_RETRIES_MAX=100 # https://github.com/moby/buildkit/issues/1423
 buildctl-daemonless.sh \
      build \

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -354,6 +354,7 @@ cat /home/user/trace
             resources=self.resources,
             input_files=input_files,
             parents=self.deps_parents(),
+            network='private',
             unconfined=True,
         )
 

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -94,6 +94,10 @@ steps:
     dockerFile: /io/repo/docker/Dockerfile.service-base
     contextPath: /io/repo/
     publishAs: service-base
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: 7.5Gi
     dependsOn:
       - base_image
       - merge_code
@@ -152,6 +156,10 @@ steps:
     dockerFile: /io/repo/ci/test/resources/Dockerfile
     contextPath: /io/repo
     publishAs: ci-hello
+    resources:
+      storage: 10Gi
+      cpu: "2"
+      memory: 7.5Gi
     inputs:
       - from: /repo
         to: /io/repo

--- a/dev-docs/batch-design.md
+++ b/dev-docs/batch-design.md
@@ -1,0 +1,60 @@
+# Container runtime
+
+Containers in batch are run using the [crun](https://github.com/containers/crun) container runtime.
+`crun` is a low-level container runtime like `runc` (what Docker uses) which implements the
+Open Container Initiative (OCI) specification for running containers given an image's filesystem and a
+[runtime configuration](https://github.com/opencontainers/runtime-spec/blob/master/config.md). The JSON
+configuration specifies, among other things, the linux namespaces and cgroups under which to run the container
+and the user command to run.
+
+All images run on a worker are preprocessed by extracting their root filesystem into `/host/rootfs/` and
+storing any additional image configuration like environment variables and users in memory in the worker
+process. These root filesystems are immutable and job containers cannot write to them. All directories and
+files relating to a user's job except for the underlying rootfs are stored under the job's scratch directory.
+The scratch directory contains directories for each container in the job (input, main, output) and an `io`
+directory that is mounted into each container. Each container directory contains
+- The upper, merged, and work directories for the overlay filesystem used in the container. For
+    a great explanation of how overlayfs works, see
+    [here](https://jvns.ca/blog/2019/11/18/how-containers-work--overlayfs/).
+- Any volumes specified in the user's image that are mounted into the container
+- The container's `config.json` that the worker creates and passes to `crun`.
+
+Batch uses [xfs_quota](https://man7.org/linux/man-pages/man8/xfs_quota.8.html) to enforce storage
+limits for jobs. Each job receives its own XFS project rooted at the scratch directory, so all storage used by
+the main container, input/output containers and anything written to `/io` count toward the overall job quota.
+
+Below is the layout of job's scratch directory on the worker. NOTE: Since the underlying image/root filesystem
+is not stored per-job, it does not contribute toward a job's storage quota.
+
+```
+scratch/
+├─ io/
+├─ input/
+│  ├─ rootfs_overlay/
+│  │  ├─ upperdir/ (writeable layer)
+│  │  ├─ merged/ (what the container sees as its root)
+│  │  │  ├─ bin/ (from the overlay's lowerdir [the image's rootfs])
+│  │  │  ├─ etc/ (from the overlay's lowerdir [the image's rootfs])
+│  │  │  ├─ ...
+│  │  │  ├─ io/ (bind mount)
+│  │  ├─ workdir/
+│  ├─ volumes/
+│  ├─ config/
+│  │  ├─ config.json
+├─ main/
+│  ├─ rootfs_overlay/
+│  │  ├─ upperdir/ (writeable layer)
+│  │  ├─ merged/ (what crun/the container sees as its root)
+│  │  │  ├─ bin/ (from the overlay's lowerdir [the image's rootfs])
+│  │  │  ├─ etc/ (from the overlay's lowerdir [the image's rootfs])
+│  │  │  ├─ ...
+│  │  │  ├─ io/ (bind mount)
+│  │  │  ├─ image/specified/volume/ (bind mount from volumes/)
+│  │  ├─ workdir/
+│  ├─ volumes/
+│  │  ├─ image/specified/volume/
+│  ├─ config/
+│  │  ├─ config.json
+├─ output/
+│  ├─ ...
+```

--- a/dev-docs/batch-design.md
+++ b/dev-docs/batch-design.md
@@ -20,15 +20,16 @@ directory that is mounted into each container. Each container directory contains
 - The container's `config.json` that the worker creates and passes to `crun`.
 
 Batch uses [xfs_quota](https://man7.org/linux/man-pages/man8/xfs_quota.8.html) to enforce storage
-limits for jobs. Each job receives its own XFS project rooted at the scratch directory, so all storage used by
-the main container, input/output containers and anything written to `/io` count toward the overall job quota.
+limits for jobs. Each job receives its own XFS project rooted at the scratch directory. Any writes from
+the main, input and output containers into their root filesystems contribute to the overall job storage quota.
+Storage in `/io` is subject to the user's quota *unless* `/io` is mounted from an external disk.
 
 Below is the layout of job's scratch directory on the worker. NOTE: Since the underlying image/root filesystem
 is not stored per-job, it does not contribute toward a job's storage quota.
 
 ```
 scratch/
-├─ io/
+├─ io/ (potentially mounted from an external disk)
 ├─ input/
 │  ├─ rootfs_overlay/
 │  │  ├─ upperdir/ (writeable layer)

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,4 @@
 /Dockerfile.service-base.out
+base-image-ref
+hail-ubuntu-image-ref
+service-base-image-ref

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -42,6 +42,7 @@ nest_asyncio==1.0.0
 parsimonious==0.8.1
 prometheus_async==19.2.0
 prometheus_client==0.7.1
+psutil==5.8.0
 pyjwt==1.7.1
 pylint==2.6.0
 astroid<2.5  # https://github.com/PyCQA/pylint/issues/4131

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -55,15 +55,15 @@ class Job:
         if not container_statuses:
             return None
 
-        container_status = container_statuses.get(task)
+        task_status = container_statuses.get(task)
+        if not task_status:
+            return None
+
+        container_status = task_status.get('container_status')
         if not container_status:
             return None
 
-        docker_container_status = container_status.get('container_status')
-        if not docker_container_status:
-            return None
-
-        return docker_container_status['out_of_memory']
+        return container_status['out_of_memory']
 
     @staticmethod
     def _get_container_status_exit_code(container_status):

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -35,15 +35,7 @@ class Job:
         if not container_status:
             return None
 
-        error = container_status.get('error')
-        if error:
-            return error
-
-        docker_container_status = container_status.get('container_status')
-        if not docker_container_status:
-            return None
-
-        return docker_container_status.get('error')
+        return container_status.get('error')
 
     @staticmethod
     def _get_out_of_memory(job_status, task):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -12,8 +12,8 @@ from .utils import (
     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
     bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times)
 from .process import (
-    CalledProcessError, check_shell, check_shell_output, sync_check_shell,
-    sync_check_shell_output)
+    CalledProcessError, check_shell, check_shell_output, check_exec_output,
+    sync_check_shell, sync_check_shell_output)
 from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
@@ -34,6 +34,7 @@ __all__ = [
     'CalledProcessError',
     'check_shell',
     'check_shell_output',
+    'check_exec_output',
     'sync_check_shell',
     'sync_check_shell_output',
     'bounded_gather',

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -28,6 +28,20 @@ async def check_shell_output(script, echo=False):
     return outerr
 
 
+async def check_exec_output(command, *args, echo=False):
+    if echo:
+        print([command, *args])
+    proc = await asyncio.create_subprocess_exec(
+        command, *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+    outerr = await proc.communicate()
+    if proc.returncode != 0:
+        script = ' '.join([command, *args])
+        raise CalledProcessError(script, proc.returncode, outerr)
+    return outerr
+
+
 async def check_shell(script, echo=False):
     # discard output
     await check_shell_output(script, echo)

--- a/hail/python/test/hailtop/batch/utils.py
+++ b/hail/python/test/hailtop/batch/utils.py
@@ -2,7 +2,7 @@ import hailtop.batch_client.client as bc
 
 
 def debug_info(batch: bc.Batch):
-    jobs = batch.jobs()
+    jobs = list(batch.jobs())
     for j_status in jobs:
         j_status['log'] = batch.get_job_log(j_status['job_id'])
     return str(jobs)


### PR DESCRIPTION
This is the first step to removing batch workers' reliance on the docker daemon and docker in general, in favor of a lower level of abstraction that gives us finer control over resources on the worker like overlays and network namespaces, allowing us to shortcut and pre-configure some of the overhead that goes into running a job.

## What this does differently
Currently, the high-level process for running a job involves communicating with the docker daemon to:
1. Pull an image for a job
2. Start a container from that image
3. Run the container
4. Delete the container and its associated resources

We offload some of these responsibilities into the worker code and onto [crun](https://github.com/containers/crun), a lightweight low-level runtime with the same API as `runc`, what docker uses to run containers. Once docker has retrieved an image, if we see that the pulled image has a new digest from one we currently have cached on the worker, we extract the image's filesystem into a directory on the worker's disk. We then:

- use `mount` to create an overlay on top of the image that the container will use as its rootfs
- use `xfs_quota` to limit the container's storage in the overlay
- invoke `crun` to run a container with the overlay as its root filesystem and an appropriate network namespace that we set up at worker-start time.

Since we control the overlay, we can set the XFS quota before creating the container. So what was separate calls to docker create/start/run/delete is just a single `crun run`. Fewer steps, less back and forth with a single daemon, and pre-configuring the networks gives some sizable performance gains reliable, as well as reliable and consistent performance.


## What this doesn't solve
- Docker is still running the worker container. I don't see any real challenge to this it's just a matter of translating the docker parameters
- Still using docker to pull images and extract filesystems / environment variables from them. I don't have a substitute for this at the moment.