### PR TITLE
[query][fs] fix local and google fs, port test_backward_compatability

### DIFF
--- a/hail/python/hail/fs/google_fs.py
+++ b/hail/python/hail/fs/google_fs.py
@@ -1,6 +1,6 @@
+from typing import Dict, List, Optional
 import os
 from stat import S_ISREG, S_ISDIR
-from typing import Dict, List
 import gcsfs
 from hurry.filesize import size
 from shutil import copy2, rmtree
@@ -86,11 +86,12 @@ class GoogleCloudStorageFS(FS):
 
         return self._format_stat_gs_file(self.client.info(path), path)
 
-    def _format_stat_gs_file(self, stats: Dict, path: str) -> Dict:
-        path_from_stats = stats.get('path')
+    def _format_stat_gs_file(self, stats: Dict, path: Optional[str] = None) -> Dict:
+        path_from_stats = stats.get('name')
         if path_from_stats is not None:
             path_from_stats = self._add_gs_path_prefix(path_from_stats)
         else:
+            assert path is not None
             path_from_stats = path
         return {
             'is_dir': self._stat_is_gs_dir(stats),
@@ -123,7 +124,8 @@ class GoogleCloudStorageFS(FS):
         if is_local:
             return [self._format_stat_local_file(os.stat(file), file) for file in os.listdir(path)]
 
-        return [self._format_stat_gs_file(file) for file in self.client.ls(path, detail=True)]
+        return [self._format_stat_gs_file(file)
+                for file in self.client.ls(path, detail=True)]
 
     def mkdir(self, path: str):
         pass

--- a/hail/python/hail/fs/local_fs.py
+++ b/hail/python/hail/fs/local_fs.py
@@ -56,7 +56,9 @@ class LocalFS(FS):
         return S_ISDIR(stats.st_mode)
 
     def ls(self, path: str) -> List[Dict]:
-        return [self._format_stat_local_file(os.stat(file), file) for file in os.listdir(path)]
+        return [self._format_stat_local_file(os.stat(os.path.join(path, file)),
+                                             os.path.join(path, file))
+                for file in os.listdir(path)]
 
     def mkdir(self, path: str):
         os.mkdir(path)

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -37,8 +37,8 @@ class Tests(unittest.TestCase):
     def test_write(self):
         create_backward_compatibility_files()
 
-    @fails_service_backend()
-    @fails_local_backend()
+    @fails_service_backend
+    @fails_local_backend
     def test_backward_compatability(self):
         import os
 
@@ -56,14 +56,15 @@ class Tests(unittest.TestCase):
         all_values_table, all_values_matrix_table = create_all_values_datasets()
 
         resource_dir = resource('backward_compatability')
-        versions = os.listdir(resource_dir)
+        fs = hl.current_backend().fs
+        versions = [os.path.basename(x['path']) for x in fs.ls(resource_dir)]
 
         n = 0
         for v in versions:
             table_dir = os.path.join(resource_dir, v, 'table')
             i = 0
             f = os.path.join(table_dir, '{}.ht'.format(i))
-            while os.path.exists(f):
+            while fs.exists(f):
                 ds = hl.read_table(f)
                 assert backward_compatible_same(all_values_table, ds)
                 i += 1
@@ -73,7 +74,7 @@ class Tests(unittest.TestCase):
             matrix_table_dir = os.path.join(resource_dir, v, 'matrix_table')
             i = 0
             f = os.path.join(matrix_table_dir, '{}.hmt'.format(i))
-            while os.path.exists(f):
+            while fs.exists(f):
                 ds = hl.read_matrix_table(f)
                 assert backward_compatible_same(all_values_matrix_table, ds)
                 i += 1

--- a/hail/python/test/hail/matrixtable/test_file_formats.py
+++ b/hail/python/test/hail/matrixtable/test_file_formats.py
@@ -37,8 +37,8 @@ class Tests(unittest.TestCase):
     def test_write(self):
         create_backward_compatibility_files()
 
-    @fails_service_backend
-    @fails_local_backend
+    @fails_service_backend()
+    @fails_local_backend()
     def test_backward_compatability(self):
         import os
 


### PR DESCRIPTION
I cannot enable these tests because both the local and service backend fail due to this error:

```
E               Java stack trace:
E               java.lang.AssertionError: assertion failed:
E                 ir key: [Ljava.lang.String;@28f4484b
E                 lowered key: WrappedArray()
E               	at scala.Predef$.assert(Predef.scala:223)
E               	at is.hail.expr.ir.lowering.LowerTableIR$.lower$1(LowerTableIR.scala:1101)
E               	at is.hail.expr.ir.lowering.LowerTableIR$.apply(LowerTableIR.scala:1118)
E               	at is.hail.expr.ir.lowering.LowerToCDA$.lower(LowerToCDA.scala:67)
E               	at is.hail.expr.ir.lowering.LowerToCDA$.lower(LowerToCDA.scala:36)
E               	at is.hail.expr.ir.lowering.LowerToCDA$.apply(LowerToCDA.scala:16)
E               	at is.hail.expr.ir.lowering.LowerToDistributedArrayPass.transform(LoweringPass.scala:75)
E               	at is.hail.expr.ir.lowering.LoweringPass.$anonfun$apply$3(LoweringPass.scala:15)
E               	at is.hail.utils.ExecutionTimer.time(ExecutionTimer.scala:81)
E               	at is.hail.expr.ir.lowering.LoweringPass.$anonfun$apply$1(LoweringPass.scala:15)
E               	at is.hail.utils.ExecutionTimer.time(ExecutionTimer.scala:81)
E               	at is.hail.expr.ir.lowering.LoweringPass.apply(LoweringPass.scala:13)
E               	at is.hail.expr.ir.lowering.LoweringPass.apply$(LoweringPass.scala:12)
E               	at is.hail.expr.ir.lowering.LowerToDistributedArrayPass.apply(LoweringPass.scala:70)
E               	at is.hail.expr.ir.lowering.LoweringPipeline.$anonfun$apply$1(LoweringPipeline.scala:14)
E               	at is.hail.expr.ir.lowering.LoweringPipeline.$anonfun$apply$1$adapted(LoweringPipeline.scala:12)
E               	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
E               	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
E               	at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:38)
E               	at is.hail.expr.ir.lowering.LoweringPipeline.apply(LoweringPipeline.scala:12)
E               	at is.hail.backend.local.LocalBackend._jvmLowerAndExecute(LocalBackend.scala:88)
E               	at is.hail.backend.local.LocalBackend._execute(LocalBackend.scala:124)
E               	at is.hail.backend.local.LocalBackend.$anonfun$execute$1(LocalBackend.scala:131)
E               	at is.hail.expr.ir.ExecuteContext$.$anonfun$scoped$3(ExecuteContext.scala:47)
E               	at is.hail.utils.package$.using(package.scala:627)
E               	at is.hail.expr.ir.ExecuteContext$.$anonfun$scoped$2(ExecuteContext.scala:47)
E               	at is.hail.utils.package$.using(package.scala:627)
E               	at is.hail.annotations.RegionPool$.scoped(RegionPool.scala:13)
E               	at is.hail.expr.ir.ExecuteContext$.scoped(ExecuteContext.scala:46)
E               	at is.hail.backend.local.LocalBackend.withExecuteContext(LocalBackend.scala:69)
E               	at is.hail.backend.local.LocalBackend.execute(LocalBackend.scala:128)
E               	at is.hail.backend.local.LocalBackend.$anonfun$executeJSON$1(LocalBackend.scala:145)
E               	at is.hail.utils.ExecutionTimer$.time(ExecutionTimer.scala:52)
E               	at is.hail.backend.local.LocalBackend.executeJSON(LocalBackend.scala:143)
E               	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
E               	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E               	at java.lang.reflect.Method.invoke(Method.java:498)
E               	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E               	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
E               	at py4j.Gateway.invoke(Gateway.java:282)
E               	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E               	at py4j.commands.CallCommand.execute(CallCommand.java:79)
E               	at py4j.GatewayConnection.run(GatewayConnection.java:238)
E               	at java.lang.Thread.run(Thread.java:748)
```

cc: @cseed , I'm not sure I got the changes to fs right.