### PR TITLE
[query] test utils needs to use binary I/O for binary data

### DIFF
--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -46,12 +46,12 @@ class Tests(unittest.TestCase):
 
         self.assertEqual(data, data4)
 
-        with hadoop_open(resource('randomBytes'), buffer_size=100) as f:
-            with hadoop_open('/tmp/randomBytesOut', 'w', buffer_size=150) as out:
+        with hadoop_open(resource('randomBytes'), mode='rb', buffer_size=100) as f:
+            with hadoop_open('/tmp/randomBytesOut', mode='wb', buffer_size=150) as out:
                 b = f.read()
                 out.write(b)
 
-        with hadoop_open('/tmp/randomBytesOut', buffer_size=199) as f:
+        with hadoop_open('/tmp/randomBytesOut', mode='rb', buffer_size=199) as f:
             b2 = f.read()
 
         self.assertEqual(b, b2)

--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -13,8 +13,6 @@ tearDownModule = stopTestHailContext
 
 class Tests(unittest.TestCase):
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_hadoop_methods(self):
         data = ['foo', 'bar', 'baz']
         data.extend(map(str, range(100)))


### PR DESCRIPTION
I have no idea how this ever worked. It should have triggered UTF-8 decoding errors.