### PR TITLE
[query] Enable NDArray based PCA to run on local and service backend

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -94,8 +94,6 @@ class Tests(unittest.TestCase):
         _, aucs = hl.experimental.plot_roc_curve(ht, ['score1', 'score2', 'score3'])
 
     @pytest.mark.unchecked_allocator
-    @fails_service_backend()
-    @fails_local_backend()
     def test_ld_score_regression(self):
 
         ht_scores = hl.import_table(

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -69,7 +69,6 @@ def test_pca_against_numpy():
     np.testing.assert_allclose(hail_loadings, np_loadings, rtol=1e-5)
 
 @fails_service_backend()
-@fails_local_backend()
 def test_blanczos_against_numpy():
 
     def concatToNumpy(field, horizontal=True):

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -884,18 +884,20 @@ object LowerTableIR {
                 ),
                 partition = { (partitionRef: Ref) =>
                   bindIRs(GetField(partitionRef, "oldContext"), GetField(partitionRef, "scanState")) { case Seq(oldContext, scanState) =>
-                    RunAggScan(
-                      lc.partition(oldContext),
-                      "row",
-                      Begin(aggs.aggs.zipWithIndex.map { case (agg, i) =>
-                        InitFromSerializedValue(i, GetTupleElement(scanState, i), agg.state)
-                      }),
-                      aggs.seqPerElt,
-                      Let(
-                        resultUID,
-                        ResultOp(0, aggs.aggs),
-                        aggs.postAggIR),
-                      aggs.states
+                    Let("global", lc.globals,
+                      RunAggScan(
+                        lc.partition(oldContext),
+                        "row",
+                        Begin(aggs.aggs.zipWithIndex.map { case (agg, i) =>
+                          InitFromSerializedValue(i, GetTupleElement(scanState, i), agg.state)
+                        }),
+                        aggs.seqPerElt,
+                        Let(
+                          resultUID,
+                          ResultOp(0, aggs.aggs),
+                          aggs.postAggIR),
+                        aggs.states
+                      )
                     )
                   }
                 }


### PR DESCRIPTION
Had to fix a bug where we were not binding global when lowering scans.