### PR TITLE
[query-service] concurrently use multiple Hail Query JAR versions 

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -46,5 +46,4 @@ COPY batch/setup.py batch/MANIFEST.in /batch/
 COPY batch/batch /batch/batch/
 RUN hail-pip-install --no-deps /batch && rm -rf /batch
 
-COPY batch/hail.jar /
 COPY query/log4j.properties /

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -28,9 +28,6 @@ build-batch: build-prereqs
 
 .PHONY: build-worker
 build-worker: build-prereqs
-	$(MAKE) -C ../hail shadowJar
-# janky
-	cp ../hail/build/libs/hail-all-spark.jar ./hail.jar
 	-docker pull $(BATCH_WORKER_LATEST)
 	python3 ../ci/jinja2_render.py '{"global":{"docker_prefix":"$(DOCKER_PREFIX)"}}' Dockerfile.worker Dockerfile.worker.out
 	docker build -t batch-worker -f Dockerfile.worker.out --cache-from batch-worker,$(BATCH_WORKER_LATEST),service-base ..

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -235,7 +235,7 @@ class Timings:
 
 class ContainerStepManager:
     def __init__(self, timing: Dict[str, float], is_deleted: Callable[[], bool]):
-        self.timing: Dict[str, float] = dict()
+        self.timing: Dict[str, float] = timing
         self.is_deleted = is_deleted
 
     def __enter__(self):

--- a/build.yaml
+++ b/build.yaml
@@ -2439,7 +2439,7 @@ steps:
       gcloud -q auth activate-service-account --key-file=/query-gsa-key/key.json
 
       {% if deploy %}
-      destination=gs://$(cat /global-config/hail_query_bucket)/jars/
+      destination=$(cat /global-config/hail_query_gcs_path)/jars/
       {% else %}
       destination=gs://hail-test-dmk9z/{{ token }}/jars/
       {% endif %}

--- a/build.yaml
+++ b/build.yaml
@@ -366,6 +366,7 @@ steps:
       kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "batch-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
       kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "benchmark-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
       kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "ci-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
+      kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "query-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
       kubectl -n {{ default_ns.name }} get -o json secret test-gsa-key | jq '{apiVersion, kind, type, data, metadata: {name: "test-dev-gsa-key"}}' | kubectl -n {{ default_ns.name }} apply -f -
     scopes:
       - test
@@ -781,12 +782,9 @@ steps:
     inputs:
       - from: /repo
         to: /io/repo
-      - from: /just-jar/hail.jar
-        to: /io/repo/batch/hail.jar
       - from: /hail_version
         to: /io/repo/hail_version
     dependsOn:
-      - build_hail_jar_only
       - merge_code
   - kind: buildImage2
     name: service_java_run_base_image
@@ -2432,6 +2430,40 @@ steps:
       - deploy_address_sa
       - address_image
       - create_certs
+  - kind: runImage
+    name: upload_query_jar
+    image:
+      valueFrom: base_image.image
+    script: |
+      set -ex
+      gcloud -q auth activate-service-account --key-file=/query-gsa-key/key.json
+
+      {% if deploy %}
+      destination=gs://$(cat /global-config/hail_query_bucket)/jars/
+      {% else %}
+      destination=gs://hail-test-dmk9z/{{ token }}/jars/
+      {% endif %}
+
+      gsutil -m cp /io/hail.jar ${destination}$(cat /io/git_version).jar
+    secrets:
+      - name: query-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /query-gsa-key
+      - name: global-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /global-config
+    inputs:
+      - from: /just-jar/hail.jar
+        to: /io/hail.jar
+      - from: /git_version
+        to: /io/git_version
+    dependsOn:
+      - default_ns
+      - base_image
+      - build_hail_jar_only
+      - merge_code
   - kind: deploy
     name: deploy_query
     namespace:
@@ -2447,6 +2479,7 @@ steps:
       - deploy_shuffler
       - query_image
       - deploy_query_sa
+      - upload_query_jar
       - deploy_address
       - create_certs
   - kind: deploy
@@ -2463,6 +2496,156 @@ steps:
       - memory_image
       - deploy_memory_sa
       - create_certs
+  - kind: runImage
+    name: test_hail_python_service_backend_0
+    image:
+      valueFrom: hail_run_image.image
+    script: |
+      set -ex
+      cd /io
+      tar xzf test.tar.gz
+      tar xvf wheel-container.tar
+      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+      export PYTEST_SPLITS=3
+      export PYTEST_SPLIT_INDEX=0
+      export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+      export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+      export HAIL_QUERY_BACKEND=service
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      hailctl config set batch/billing_project test
+      hailctl config set batch/bucket hail-test-dmk9z
+      python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+    inputs:
+      - from: /wheel-container.tar
+        to: /io/wheel-container.tar
+      - from: /test.tar.gz
+        to: /io/test.tar.gz
+    secrets:
+      - name: gce-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+      - name: ssl-config-query-tests
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /ssl-config
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    timeout: 3600
+    dependsOn:
+      - default_ns
+      - upload_test_resources_to_gcs
+      - deploy_query
+      - deploy_memory
+      - deploy_shuffler
+      - hail_run_image
+      - build_hail
+  - kind: runImage
+    name: test_hail_python_service_backend_1
+    image:
+      valueFrom: hail_run_image.image
+    script: |
+      set -ex
+      cd /io
+      tar xzf test.tar.gz
+      tar xvf wheel-container.tar
+      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+      export PYTEST_SPLITS=3
+      export PYTEST_SPLIT_INDEX=1
+      export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+      export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+      export HAIL_QUERY_BACKEND=service
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      hailctl config set batch/billing_project test
+      hailctl config set batch/bucket hail-test-dmk9z
+      python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+    inputs:
+      - from: /wheel-container.tar
+        to: /io/wheel-container.tar
+      - from: /test.tar.gz
+        to: /io/test.tar.gz
+    secrets:
+      - name: gce-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+      - name: ssl-config-query-tests
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /ssl-config
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    timeout: 3600
+    dependsOn:
+      - default_ns
+      - upload_test_resources_to_gcs
+      - deploy_query
+      - deploy_memory
+      - deploy_shuffler
+      - hail_run_image
+      - build_hail
+  - kind: runImage
+    name: test_hail_python_service_backend_2
+    image:
+      valueFrom: hail_run_image.image
+    script: |
+      set -ex
+      cd /io
+      tar xzf test.tar.gz
+      tar xvf wheel-container.tar
+      python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
+      export PYTEST_SPLITS=3
+      export PYTEST_SPLIT_INDEX=2
+      export HAIL_TEST_RESOURCES_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/test/resources
+      export HAIL_DOCTEST_DATA_DIR=gs://hail-test-dmk9z/{{ upload_test_resources_to_gcs.token }}/doctest/data
+      export HAIL_QUERY_BACKEND=service
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      hailctl config set batch/billing_project test
+      hailctl config set batch/bucket hail-test-dmk9z
+      python3 -m pytest -n 8 --ignore=test/hailtop/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
+    inputs:
+      - from: /wheel-container.tar
+        to: /io/wheel-container.tar
+      - from: /test.tar.gz
+        to: /io/test.tar.gz
+    secrets:
+      - name: gce-deploy-config
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /deploy-config
+      - name: test-tokens
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /user-tokens
+      - name: ssl-config-query-tests
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /ssl-config
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    timeout: 3600
+    dependsOn:
+      - default_ns
+      - upload_test_resources_to_gcs
+      - deploy_query
+      - deploy_memory
+      - deploy_shuffler
+      - hail_run_image
+      - build_hail
   - kind: runImage
     name: test_lsm
     image:
@@ -3793,6 +3976,9 @@ steps:
       - test_hailtop_batch_2
       - test_hailtop_batch_3
       - test_hailtop_batch_4
+      - test_hail_python_service_backend_0
+      - test_hail_python_service_backend_1
+      - test_hail_python_service_backend_2
   - kind: runImage
     name: delete_batch_instances
     image:
@@ -3835,6 +4021,9 @@ steps:
       - test_hailtop_batch_2
       - test_hailtop_batch_3
       - test_hailtop_batch_4
+      - test_hail_python_service_backend_0
+      - test_hail_python_service_backend_1
+      - test_hail_python_service_backend_2
   - kind: runImage
     name: delete_atgu_tables
     image:

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -54,7 +54,8 @@ async def main():
         ('benchmark', None, 0, 1),
         ('ci', None, 0, 1),
         ('test', None, 0, 0),
-        ('test-dev', None, 1, 0)
+        ('test-dev', None, 1, 0),
+        ('query', None, 0, 1),
     ]
 
     app = {}

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -3,11 +3,11 @@ import datetime
 import humanize
 
 
-def time_msecs():
+def time_msecs() -> int:
     return int(time.time() * 1000 + 0.5)
 
 
-def time_msecs_str(t):
+def time_msecs_str(t) -> str:
     return datetime.datetime.utcfromtimestamp(t / 1000).strftime(
         '%Y-%m-%dT%H:%M:%SZ')
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -575,7 +575,7 @@ def is_transient_error(e):
         return True
     if isinstance(e, socket.gaierror):
         # socket.EAI_AGAIN: [Errno -3] Temporary failure in name resolution
-        return e.args[0] == socket.EAI_AGAIN
+        return e.errno == socket.EAI_AGAIN
     if isinstance(e, ConnectionResetError):
         return True
     if isinstance(e, google.auth.exceptions.TransportError):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -573,6 +573,9 @@ def is_transient_error(e):
         return True
     if isinstance(e, socket.timeout):
         return True
+    if isinstance(e, socket.gaierror):
+        # socket.EAI_AGAIN: [Errno -3] Temporary failure in name resolution
+        return e.args[0] == socket.EAI_AGAIN
     if isinstance(e, ConnectionResetError):
         return True
     if isinstance(e, google.auth.exceptions.TransportError):

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -26,5 +26,5 @@ def ensure_event_loop_is_initialized_in_test_thread():
     try:
         asyncio.get_event_loop()
     except RuntimeError as err:
-        assert err.args[0] == "There is no current event loop in thread 'Dummy-1'"
+        assert err.args[0] == "There is no current event loop in thread 'Dummy-1'."
         asyncio.set_event_loop(asyncio.new_event_loop())

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -94,6 +94,7 @@ class Tests(unittest.TestCase):
         _, aucs = hl.experimental.plot_roc_curve(ht, ['score1', 'score2', 'score3'])
 
     @pytest.mark.unchecked_allocator
+    @fails_service_backend(reason='''fails this assertion in ShuffleWrite assert(keyPType == shuffleType.keyDecodedPType)''')
     def test_ld_score_regression(self):
 
         ht_scores = hl.import_table(
@@ -291,7 +292,6 @@ class Tests(unittest.TestCase):
         ht = hl.experimental.pc_project(mt_to_project.GT, loadings_ht.loadings, loadings_ht.af)
         assert ht._force_count() == 100
 
-    @fails_service_backend()
     def test_mt_full_outer_join(self):
         mt1 = hl.utils.range_matrix_table(10, 10)
         mt1 = mt1.annotate_cols(c1=hl.rand_unif(0, 1))
@@ -313,7 +313,6 @@ class Tests(unittest.TestCase):
 
         assert(mtj.count() == (15, 15))
 
-    @fails_service_backend()
     def test_mt_full_outer_join_self(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         jmt = hl.experimental.full_outer_join_mt(mt, mt)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -18,7 +18,6 @@ class Tests(unittest.TestCase):
     def collect_unindexed_expression(self):
         self.assertEqual(hl.array([4,1,2,3]).collect(), [4,1,2,3])
 
-    @fails_service_backend()
     def test_key_by_random(self):
         ht = hl.utils.range_table(10, 4)
         ht = ht.annotate(new_key=hl.rand_unif(0, 1))
@@ -80,7 +79,6 @@ class Tests(unittest.TestCase):
             self.assertEqual(set(s1.idx.collect()), expected)
             self.assertEqual(set(s2.idx.collect()), expected)
 
-    @fails_service_backend()
     def test_order_by_head_optimization_with_randomness(self):
         ht = hl.utils.range_table(10, 6).annotate(x=hl.rand_unif(0, 1))
         expected = sorted(ht.collect(), key=lambda x: x['x'])[:5]
@@ -398,7 +396,6 @@ class Tests(unittest.TestCase):
         table = hl.utils.range_table(10).annotate(foo=hl.missing(tint))
         table.aggregate(hl.agg.approx_quantiles(table.foo, qs=[0.5]))
 
-    @fails_service_backend()
     def test_approx_cdf_col_aggregate(self):
         mt = hl.utils.range_matrix_table(10, 10)
         mt = mt.annotate_entries(foo=mt.row_idx + mt.col_idx)
@@ -829,7 +826,6 @@ class Tests(unittest.TestCase):
         assert t.annotate(x=hl.bind(lambda i: hl.scan.sum(t.idx + i), 1, _ctx='scan')).x.collect() == [0, 1, 3, 6, 10]
         assert t.aggregate(hl.bind(lambda i: hl.agg.collect(i), t.idx * t.idx, _ctx='agg')) == [0, 1, 4, 9, 16]
 
-    @fails_service_backend()
     def test_scan(self):
         table = hl.utils.range_table(10)
 
@@ -877,7 +873,6 @@ class Tests(unittest.TestCase):
         for aggregation, expected in tests:
             self.assertEqual(aggregation.collect(), expected)
 
-    @fails_service_backend()
     def test_scan_explode(self):
         t = hl.utils.range_table(5)
         tests = [
@@ -909,7 +904,6 @@ class Tests(unittest.TestCase):
         for aggregation, expected in tests:
             self.assertEqual(aggregation.collect(), expected)
 
-    @fails_service_backend()
     def test_scan_group_by(self):
         t = hl.utils.range_table(5)
         tests = [
@@ -992,7 +986,6 @@ class Tests(unittest.TestCase):
         assert r.n_smaller == 0
         assert r.n_larger == 0
 
-    @fails_service_backend()
     def test_aggregator_cse(self):
         ht = hl.utils.range_table(10)
         x = hl.agg.count()
@@ -1113,7 +1106,6 @@ class Tests(unittest.TestCase):
         r = ht.aggregate(hl.agg.downsample(ht.idx, ht.y, n_divisions=10))
         self.assertTrue(len(r) == 0)
 
-    @fails_service_backend()
     def test_downsample_in_array_agg(self):
         mt = hl.utils.range_matrix_table(50, 50)
         mt = mt.annotate_rows(y = hl.rand_unif(0, 1))
@@ -2850,7 +2842,6 @@ class Tests(unittest.TestCase):
             hl.eval(hl.contig_length('chr5', 'GRCh37'))
 
 
-    @fails_service_backend()
     def test_initop(self):
         t = (hl.utils.range_table(5, 3)
              .annotate(GT=hl.call(0, 1))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -685,6 +685,7 @@ def test_ndarray_diagonal():
     assert "2 dimensional" in str(exc.value)
 
 
+@fails_service_backend()
 def test_ndarray_solve():
     a = hl.nd.array([[1, 2], [3, 5]])
     b = hl.nd.array([1, 2])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -685,7 +685,6 @@ def test_ndarray_diagonal():
     assert "2 dimensional" in str(exc.value)
 
 
-@fails_service_backend()
 def test_ndarray_solve():
     a = hl.nd.array([[1, 2], [3, 5]])
     b = hl.nd.array([1, 2])

--- a/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_grouped_matrix_table.py
@@ -90,7 +90,6 @@ class Tests(unittest.TestCase):
         d = mt.group_cols_by(group5=(mt['group4']['a'] + 1)).aggregate_cols(x=hl.agg.count())
         self.assertRaises(ExpressionException, d.aggregate_cols, x=hl.agg.count()) # duplicate field
 
-    @fails_service_backend()
     def test_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(mt['group1']).aggregate(c=hl.agg.sum(mt['c']))
@@ -101,7 +100,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(b.count_cols(), 6)
         self.assertTrue('group3' in b.col_key)
 
-    @fails_service_backend()
     def test_nested_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(mt['group2']['a']).aggregate(c=hl.agg.sum(mt['c']))
@@ -112,7 +110,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(b.count_cols(), 6)
         self.assertTrue('a' in b.col_key)
 
-    @fails_service_backend()
     def test_named_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(group5=(mt['group2']['a'] + 1)).aggregate(c=hl.agg.sum(mt['c']))

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -73,7 +73,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(f(hl.eval(mt.annotate_globals(foo=hl.literal(x, t)).foo), x), f"{x}, {t}")
             self.assertTrue(f(hl.eval(ht.annotate_globals(foo=hl.literal(x, t)).foo), x), f"{x}, {t}")
 
-    @fails_service_backend()
     def test_head(self):
         # no empty partitions
         mt1 = hl.utils.range_matrix_table(10, 10)
@@ -100,7 +99,6 @@ class Tests(unittest.TestCase):
         assert mt1.head(1, None).count() == (1, 10)
         assert mt1.head(None, 1).count() == (10, 1)
 
-    @fails_service_backend()
     def test_tail(self):
         # no empty partitions
         mt1 = hl.utils.range_matrix_table(10, 10)
@@ -279,7 +277,6 @@ class Tests(unittest.TestCase):
         self.assertTrue('GT' not in mt2.entry)
         mt2._force_count_rows()
 
-    @fails_service_backend()
     def test_explode_rows(self):
         mt = hl.utils.range_matrix_table(4, 4)
         mt = mt.annotate_entries(e=mt.row_idx * 10 + mt.col_idx)
@@ -292,7 +289,6 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_rows(x=hl.struct(y=hl.range(0, mt.row_idx)))
         self.assertEqual(mt.explode_rows(mt.x.y).count_rows(), 6)
 
-    @fails_service_backend()
     def test_explode_cols(self):
         mt = hl.utils.range_matrix_table(4, 4)
         mt = mt.annotate_entries(e=mt.row_idx * 10 + mt.col_idx)
@@ -310,7 +306,6 @@ class Tests(unittest.TestCase):
         with self.assertRaises(ValueError):
             mt.explode_rows('b')
 
-    @fails_service_backend()
     def test_group_by_field_lifetimes(self):
         mt = hl.utils.range_matrix_table(3, 3)
         mt2 = (mt.group_rows_by(row_idx='100')
@@ -321,7 +316,6 @@ class Tests(unittest.TestCase):
                .aggregate(x=hl.agg.collect_as_set(mt.col_idx + 5)))
         assert mt3.aggregate_entries(hl.agg.all(mt3.x == hl.set({5, 6, 7})))
 
-    @fails_service_backend()
     def test_aggregate_cols_by(self):
         mt = hl.utils.range_matrix_table(2, 4)
         mt = (mt.annotate_cols(group=mt.col_idx < 2)
@@ -351,7 +345,6 @@ class Tests(unittest.TestCase):
             mt.aggregate_cols(hl.agg.filter(False, hl.agg.sum(mt.GT.is_non_ref())))
         assert "scope violation" in str(exc.value)
 
-    @fails_service_backend()
     def test_aggregate_rows_by(self):
         mt = hl.utils.range_matrix_table(4, 2)
         mt = (mt.annotate_rows(group=mt.row_idx < 2)
@@ -479,14 +472,16 @@ class Tests(unittest.TestCase):
         with self.assertRaisesRegex(hl.expr.ExpressionException, "MatrixTable col key: *<<<empty key>>>"):
             mt.key_cols_by().index_cols(mt.col_idx)
 
-    @fails_service_backend()
     def test_table_join(self):
         ds = self.get_mt()
         # test different row schemas
         self.assertTrue(ds.union_cols(ds.drop(ds.info))
                         .count_rows(), 346)
 
-    @fails_service_backend()
+    @skip_when_service_backend('''The Service and Shuffler have no way of knowing the order in which rows appear in the original
+dataset, as such it is impossible to guarantee the ordering in `matches`.
+
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/235425714''')
     def test_table_product_join(self):
         left = hl.utils.range_matrix_table(5, 1)
         right = hl.utils.range_table(5)
@@ -532,7 +527,6 @@ class Tests(unittest.TestCase):
          .aggregate(bar=hl.agg.collect(mt.globals == lit))
          ._force_count_rows())
 
-    @fails_service_backend()
     def test_unions(self):
         dataset = hl.import_vcf(resource('sample2.vcf'))
 
@@ -554,7 +548,6 @@ class Tests(unittest.TestCase):
         for s, count in ds.aggregate_cols(agg.counter(ds.s)).items():
             self.assertEqual(count, 3)
 
-    @fails_service_backend()
     def test_union_cols_example(self):
         joined = hl.import_vcf(resource('joined.vcf'))
 
@@ -563,13 +556,11 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(left.union_cols(right)._same(joined))
 
-    @fails_service_backend()
     def test_union_cols_distinct(self):
         mt = hl.utils.range_matrix_table(10, 10)
         mt = mt.key_rows_by(x = mt.row_idx // 2)
         assert mt.union_cols(mt).count_rows() == 5
 
-    @fails_service_backend()
     def test_union_cols_outer(self):
         r, c = 10, 10
         mt = hl.utils.range_matrix_table(2*r, c)
@@ -617,7 +608,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(ds.choose_cols(list(range(10))).s.collect(),
                          old_order[:10])
 
-    @fails_service_backend()
     def test_choose_cols_vs_explode(self):
         ds = self.get_mt()
 
@@ -625,7 +615,6 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(ds.choose_cols(sorted(list(range(ds.count_cols())) * 2))._same(ds2))
 
-    @fails_service_backend()
     def test_distinct_by_row(self):
         orig_mt = hl.utils.range_matrix_table(10, 10)
         mt = orig_mt.key_rows_by(row_idx=orig_mt.row_idx // 2)
@@ -633,7 +622,6 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(orig_mt.union_rows(orig_mt).distinct_by_row()._same(orig_mt))
 
-    @fails_service_backend()
     def test_distinct_by_col(self):
         orig_mt = hl.utils.range_matrix_table(10, 10)
         mt = orig_mt.key_cols_by(col_idx=orig_mt.col_idx // 2)
@@ -810,7 +798,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(
             ds.filter_rows(ds.alleles.length() == 2).count_rows(), 0)
 
-    @fails_service_backend()
     def test_field_groups(self):
         ds = self.get_mt()
 
@@ -840,7 +827,6 @@ class Tests(unittest.TestCase):
                 ds._filter_partitions([0, 3, 7]),
                 ds._filter_partitions([0, 3, 7], keep=False))))
 
-    @fails_service_backend()
     def test_from_rows_table(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         mt = mt.annotate_globals(foo='bar')
@@ -863,7 +849,6 @@ class Tests(unittest.TestCase):
         t = hl.read_table(f + '/cols')
         self.assertTrue(ds.cols()._same(t))
 
-    @fails_service_backend()
     def test_read_stored_rows(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x='foo')
@@ -872,7 +857,6 @@ class Tests(unittest.TestCase):
         t = hl.read_table(f + '/rows')
         self.assertTrue(ds.rows()._same(t))
 
-    @fails_service_backend()
     def test_read_stored_globals(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x=5, baz='foo')
@@ -1051,7 +1035,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(ht.order_by(hl.asc('idx')).idx.collect(), list(range(10)))
         self.assertEqual(ht.order_by(hl.desc('idx')).idx.collect(), list(range(10))[::-1])
 
-    @fails_service_backend()
     def test_order_by_complex_exprs(self):
         ht = hl.utils.range_table(10)
         assert ht.order_by(-ht.idx).idx.collect() == list(range(10))[::-1]
@@ -1094,7 +1077,6 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_entries(x=mt.row_idx * mt.col_idx)
         self.assertEqual(mt.x.collect(), [])
 
-    @fails_service_backend()
     def test_make_table(self):
         mt = hl.utils.range_matrix_table(3, 2)
         mt = mt.select_entries(x=mt.row_idx * mt.col_idx)
@@ -1130,7 +1112,6 @@ class Tests(unittest.TestCase):
         t = mt.make_table(separator='__')
         assert list(t.row) == ['row_idx', '0__x', '1__x']
 
-    @fails_service_backend()
     def test_make_table_row_equivalence(self):
         mt = hl.utils.range_matrix_table(3, 3)
         mt = mt.annotate_rows(r1 = hl.rand_norm(), r2 = hl.rand_norm())
@@ -1506,7 +1487,6 @@ class Tests(unittest.TestCase):
                                                  fraction_filtered=hl.float32(0.0))})
         assert mt.aggregate_cols(hl.agg.all(mt.entry_stats_col == col_expected[mt.col_idx % 4 == 0]))
 
-    @fails_service_backend()
     def test_annotate_col_agg_lowering(self):
         mt = hl.utils.range_matrix_table(10, 10, 2)
         mt = mt.annotate_cols(c1=[mt.col_idx, mt.col_idx * 2])
@@ -1518,7 +1498,6 @@ class Tests(unittest.TestCase):
                               grouped=hl.agg.group_by(mt.e1 % 5, hl.agg.sum(mt.e1) + common_ref))
         mt.cols()._force_count()
 
-    @fails_service_backend()
     def test_annotate_rows_scan_lowering(self):
         mt = hl.utils.range_matrix_table(10, 10, 2)
         mt = mt.annotate_rows(r1=[mt.row_idx, mt.row_idx * 2])
@@ -1549,7 +1528,6 @@ class Tests(unittest.TestCase):
         actual = mt.show(handler=str)
         assert actual == expected
 
-    @fails_service_backend()
     def test_partitioned_write(self):
         mt = hl.utils.range_matrix_table(40, 3, 5)
 
@@ -1589,7 +1567,6 @@ class Tests(unittest.TestCase):
         ],
                    mt.filter_rows((mt.row_idx >= 5) & (mt.row_idx < 35)))
 
-    @fails_service_backend()
     def test_partitioned_write_coerce(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         parts = [
@@ -1616,12 +1593,10 @@ class Tests(unittest.TestCase):
         with pytest.raises(hl.utils.FatalError, match='metadata does not contain file version'):
             hl.read_matrix_table(resource('0.1-1fd5cc7.vds'))
 
-    @fails_service_backend()
     def test_legacy_files_with_required_globals(self):
         hl.read_table(resource('required_globals.ht'))._force_count()
         hl.read_matrix_table(resource('required_globals.mt'))._force_count_rows()
 
-    @fails_service_backend()
     def test_matrix_native_write_range(self):
         mt = hl.utils.range_matrix_table(11, 3, n_partitions=3)
         f = new_temp_file()
@@ -1646,7 +1621,6 @@ class Tests(unittest.TestCase):
         mt = mt.add_col_index()
         mt.show()
 
-    @fails_service_backend()
     def test_filtered_entries_group_rows_by(self):
         mt = hl.utils.range_matrix_table(1, 1)
         mt = mt.filter_entries(False)
@@ -1672,7 +1646,6 @@ class Tests(unittest.TestCase):
             mt.annotate_entries(x = mt2.af)
 
 
-@fails_service_backend()
 def test_read_write_all_types():
     mt = create_all_values_matrix_table()
     tmp_file = new_temp_file()

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -527,6 +527,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
          .aggregate(bar=hl.agg.collect(mt.globals == lit))
          ._force_count_rows())
 
+    @skip_when_service_backend('ShuffleRead non-deterministically causes segfaults')
     def test_unions(self):
         dataset = hl.import_vcf(resource('sample2.vcf'))
 
@@ -1222,6 +1223,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         mt2 = hl.read_matrix_table(f)
         self.assertTrue(mt._same(mt2))
 
+    @skip_when_service_backend('ShuffleRead non-deterministically causes segfaults')
     def test_write_checkpoint_file(self):
         mt = self.get_mt()
         f = new_temp_file(extension='mt')

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -549,7 +549,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         for s, count in ds.aggregate_cols(agg.counter(ds.s)).items():
             self.assertEqual(count, 3)
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_union_cols_example(self):
         joined = hl.import_vcf(resource('joined.vcf'))
 
@@ -610,7 +610,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertEqual(ds.choose_cols(list(range(10))).s.collect(),
                          old_order[:10])
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_choose_cols_vs_explode(self):
         ds = self.get_mt()
 
@@ -830,7 +830,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
                 ds._filter_partitions([0, 3, 7]),
                 ds._filter_partitions([0, 3, 7], keep=False))))
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_from_rows_table(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         mt = mt.annotate_globals(foo='bar')
@@ -853,7 +853,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         t = hl.read_table(f + '/cols')
         self.assertTrue(ds.cols()._same(t))
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_read_stored_rows(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x='foo')
@@ -1573,7 +1573,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         ],
                    mt.filter_rows((mt.row_idx >= 5) & (mt.row_idx < 35)))
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_partitioned_write_coerce(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         parts = [

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -548,6 +548,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         for s, count in ds.aggregate_cols(agg.counter(ds.s)).items():
             self.assertEqual(count, 3)
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_union_cols_example(self):
         joined = hl.import_vcf(resource('joined.vcf'))
 
@@ -608,6 +609,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertEqual(ds.choose_cols(list(range(10))).s.collect(),
                          old_order[:10])
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_choose_cols_vs_explode(self):
         ds = self.get_mt()
 
@@ -827,6 +829,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
                 ds._filter_partitions([0, 3, 7]),
                 ds._filter_partitions([0, 3, 7], keep=False))))
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_from_rows_table(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         mt = mt.annotate_globals(foo='bar')
@@ -849,6 +852,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         t = hl.read_table(f + '/cols')
         self.assertTrue(ds.cols()._same(t))
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_read_stored_rows(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x='foo')
@@ -1567,6 +1571,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         ],
                    mt.filter_rows((mt.row_idx >= 5) & (mt.row_idx < 35)))
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_partitioned_write_coerce(self):
         mt = hl.import_vcf(resource('sample.vcf'))
         parts = [

--- a/hail/python/test/hail/methods/test_family_methods.py
+++ b/hail/python/test/hail/methods/test_family_methods.py
@@ -95,7 +95,6 @@ class Tests(unittest.TestCase):
         tt = hl.trio_matrix(mt, ped, complete_trios=True)
         self.assertEqual(tt.count_cols(), 0)
 
-    @fails_service_backend()
     def test_trio_matrix_incomplete_trios(self):
         ped = hl.Pedigree.read(resource('triomatrix.fam'))
         mt = hl.import_vcf(resource('triomatrix.vcf'))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -58,6 +58,7 @@ class VCFTests(unittest.TestCase):
         for f in _FLOAT_ARRAY_INFO_FIELDS:
             self.assertEqual(mt['info'][f].dtype, hl.tarray(hl.tfloat64))
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_glob(self):
         full = hl.import_vcf(resource('sample.vcf'))
         parts = hl.import_vcf(resource('samplepart*.vcf'))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -58,7 +58,6 @@ class VCFTests(unittest.TestCase):
         for f in _FLOAT_ARRAY_INFO_FIELDS:
             self.assertEqual(mt['info'][f].dtype, hl.tarray(hl.tfloat64))
 
-    @fails_service_backend()
     def test_glob(self):
         full = hl.import_vcf(resource('sample.vcf'))
         parts = hl.import_vcf(resource('samplepart*.vcf'))
@@ -142,7 +141,6 @@ class VCFTests(unittest.TestCase):
         entries = entries.select('GT', 'GTA', 'GTZ')
         self.assertTrue(entries._same(expected))
 
-    @fails_service_backend()
     def test_import_vcf(self):
         vcf = hl.split_multi_hts(
             hl.import_vcf(resource('sample2.vcf'),
@@ -188,7 +186,6 @@ class VCFTests(unittest.TestCase):
                                              hl.agg.all(mt.negative_int_array == [-1, -2]) &
                                              hl.agg.all(mt.negative_float_array == [-0.5, -1.5])))
 
-    @fails_service_backend()
     def test_import_vcf_missing_info_field_elements(self):
         mt = hl.import_vcf(resource('missingInfoArray.vcf'), reference_genome='GRCh37', array_elements_required=False)
         mt = mt.select_rows(FOO=mt.info.FOO, BAR=mt.info.BAR)
@@ -233,7 +230,6 @@ class VCFTests(unittest.TestCase):
         mt = hl.import_vcf(resource('test_set_field_missing.vcf'))
         mt.aggregate_entries(hl.agg.sum(mt.DP))
 
-    @fails_service_backend()
     def test_import_vcf_dosages_as_doubles_or_floats(self):
         mt = hl.import_vcf(resource('small-ds.vcf'))
         self.assertEqual(hl.expr.expressions.typed_expressions.Float64Expression, type(mt.entry.DS))
@@ -459,6 +455,7 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(len(parts), comb.n_partitions())
         comb._force_count_rows()
 
+    @fails_service_backend(reason='register_ir_function')
     def test_haploid_combiner_ok(self):
         from hail.experimental.vcf_combiner.vcf_combiner import transform_gvcf
         # make a combiner table
@@ -2004,7 +2001,6 @@ class ImportTableTests(unittest.TestCase):
                        ht.source.endswith('variantAnnotations.split.2.tsv'))))
 
 
-    @fails_service_backend()
     def test_read_write_identity(self):
         ht = self.small_dataset_1()
         f = new_temp_file(extension='ht')
@@ -2018,7 +2014,6 @@ class ImportTableTests(unittest.TestCase):
         ht.write(f)
         assert ht._same(hl.read_table(f))
 
-    @fails_service_backend()
     def test_import_same(self):
         ht = hl.import_table(resource('sampleAnnotations.tsv'))
         ht2 = hl.import_table(resource('sampleAnnotations.tsv'))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -58,7 +58,7 @@ class VCFTests(unittest.TestCase):
         for f in _FLOAT_ARRAY_INFO_FIELDS:
             self.assertEqual(mt['info'][f].dtype, hl.tarray(hl.tfloat64))
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_glob(self):
         full = hl.import_vcf(resource('sample.vcf'))
         parts = hl.import_vcf(resource('samplepart*.vcf'))

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -69,6 +69,7 @@ def test_pca_against_numpy():
     np.testing.assert_allclose(hail_loadings, np_loadings, rtol=1e-5)
 
 
+@fails_service_backend(reason='persist_ir')
 def test_blanczos_against_numpy():
 
     def concatToNumpy(field, horizontal=True):
@@ -128,6 +129,7 @@ def test_blanczos_against_numpy():
     assert bound(np_loadings, loadings) > 0.9
 
 
+@fails_service_backend(reason='persist_ir')
 def test_spectra():
     def make_spectral_matrix(index_func, k, m, n):
         sigma_dim = min(m, n)

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -51,7 +51,6 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(r[0].sqc.r_het_hom_var, 0.3333333333)
         self.assertAlmostEqual(r[0].sqc.r_insertion_deletion, None)
 
-    @fails_service_backend()
     def test_variant_qc(self):
         data = [
             {'v': '1:1:A:T', 's': '1', 'GT': hl.Call([0, 0]), 'GQ': 10, 'DP': 0},

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -57,6 +57,7 @@ class Tests(unittest.TestCase):
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
     linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -1149,6 +1150,7 @@ class Tests(unittest.TestCase):
             hl.ld_matrix(mt.GT.n_alt_alleles(), mt.locus, radius=1.0, coord_expr=mt.cm).to_numpy(),
             [[1., -0.85280287, 0.], [-0.85280287, 1., 0.], [0., 0., 1.]]))
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_split_multi_hts(self):
         ds1 = hl.import_vcf(resource('split_test.vcf'))
         ds1 = hl.split_multi_hts(ds1)
@@ -1313,6 +1315,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(glob.bn.pop_dist), [1, 2])
         self.assertEqual(hl.eval(glob.bn.fst), [.02, .06])
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_balding_nichols_model_same_results(self):
         for mixture in [True, False]:
             hl.set_global_seed(1)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -9,7 +9,8 @@ import hail.utils as utils
 from hail.linalg import BlockMatrix
 from hail.utils import FatalError
 from ..helpers import (startTestHailContext, stopTestHailContext, resource,
-                       skip_unless_spark_backend, fails_local_backend, fails_service_backend)
+                       skip_unless_spark_backend, fails_local_backend, fails_service_backend,
+                       skip_when_service_backend)
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -137,6 +137,7 @@ class Tests(unittest.TestCase):
                 linreg_function([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
                                 pass_through=[mt.filters.length()])
 
+    @skip_when_service_backend('ShuffleRead non-deterministically causes segfaults')
     def test_linreg_chained(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -58,7 +58,7 @@ class Tests(unittest.TestCase):
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
     linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -1152,7 +1152,7 @@ class Tests(unittest.TestCase):
             hl.ld_matrix(mt.GT.n_alt_alleles(), mt.locus, radius=1.0, coord_expr=mt.cm).to_numpy(),
             [[1., -0.85280287, 0.], [-0.85280287, 1., 0.], [0., 0., 1.]]))
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_split_multi_hts(self):
         ds1 = hl.import_vcf(resource('split_test.vcf'))
         ds1 = hl.split_multi_hts(ds1)
@@ -1317,7 +1317,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(glob.bn.pop_dist), [1, 2])
         self.assertEqual(hl.eval(glob.bn.fst), [.02, .06])
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_balding_nichols_model_same_results(self):
         for mixture in [True, False]:
             hl.set_global_seed(1)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -57,7 +57,6 @@ class Tests(unittest.TestCase):
     backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
     linreg_functions = [hl.linear_regression_rows, hl._linear_regression_rows_nd] if backend_name == "spark" else [hl._linear_regression_rows_nd]
 
-    @fails_service_backend()
     def test_linreg_basic(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -93,7 +92,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(t1._same(t4a))
             self.assertTrue(t1._same(t4b))
 
-    @fails_service_backend()
     def test_linreg_pass_through(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -137,7 +135,6 @@ class Tests(unittest.TestCase):
                 linreg_function([[phenos[mt.s].Pheno]], mt.GT.n_alt_alleles(), [1.0],
                                 pass_through=[mt.filters.length()])
 
-    @fails_service_backend()
     def test_linreg_chained(self):
         phenos = hl.import_table(resource('regressionLinear.pheno'),
                                  types={'Pheno': hl.tfloat64},
@@ -352,7 +349,6 @@ class Tests(unittest.TestCase):
             self.assertAlmostEqual(results[3].p_value, 0.2533675, places=6)
             self.assertTrue(np.isnan(results[6].standard_error))
 
-    @fails_service_backend()
     def test_linear_regression_equivalence_between_ds_and_gt(self):
         """Test that linear regressions on data converted from dosage to genotype returns the same results"""
         ds_mt = hl.import_vcf(resource('small-ds.vcf'))
@@ -433,7 +429,6 @@ class Tests(unittest.TestCase):
             self.assertTrue(np.isnan(results[9].standard_error))
             self.assertTrue(np.isnan(results[10].standard_error))
 
-    @fails_service_backend()
     def test_linear_regression_multi_pheno_same(self):
         covariates = hl.import_table(resource('regressionLinear.cov'),
                                      key='Sample',
@@ -1154,7 +1149,6 @@ class Tests(unittest.TestCase):
             hl.ld_matrix(mt.GT.n_alt_alleles(), mt.locus, radius=1.0, coord_expr=mt.cm).to_numpy(),
             [[1., -0.85280287, 0.], [-0.85280287, 1., 0.], [0., 0., 1.]]))
 
-    @fails_service_backend()
     def test_split_multi_hts(self):
         ds1 = hl.import_vcf(resource('split_test.vcf'))
         ds1 = hl.split_multi_hts(ds1)
@@ -1319,7 +1313,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(glob.bn.pop_dist), [1, 2])
         self.assertEqual(hl.eval(glob.bn.fst), [.02, .06])
 
-    @fails_service_backend()
     def test_balding_nichols_model_same_results(self):
         for mixture in [True, False]:
             hl.set_global_seed(1)

--- a/hail/python/test/hail/table/test_grouped_table.py
+++ b/hail/python/test/hail/table/test_grouped_table.py
@@ -8,7 +8,6 @@ tearDownModule = stopTestHailContext
 
 
 class GroupedTableTests(unittest.TestCase):
-    @fails_service_backend()
     def test_aggregate_by(self):
         ht = hl.utils.range_table(4)
         ht = ht.annotate(foo=0, group=ht.idx < 2, bar='hello').annotate_globals(glob=5)
@@ -49,7 +48,6 @@ class GroupedTableTests(unittest.TestCase):
 
         self.assertTrue(result._same(expected))
 
-    @fails_service_backend()
     def test_issue_2446_takeby(self):
         t = hl.utils.range_table(10)
         result = t.group_by(foo=5).aggregate(x=hl.agg.take(t.idx, 3, ordering=t.idx))

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -198,7 +198,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         r = kt.aggregate(agg.filter(kt.idx % 2 != 0, agg.sum(kt.idx + 2)) + kt.g1)
         self.assertEqual(r, 40)
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_to_matrix_table(self):
         N, M = 50, 50
         mt = hl.utils.range_matrix_table(N, M)
@@ -1012,7 +1012,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
-    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
+    @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_null_joins_2(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -834,6 +834,32 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/missing.20logs.3
         self.assertEqual(t2.n_partitions(), 3)
         self.assertTrue(t.filter((t.idx >= 150) & (t.idx < 500))._same(t2))
 
+    @skip_when_service_backend('''Flaky test. Type does not parse correctly on worker.
+
+2021-05-03 15:43:33 INFO  WorkerTimer$:41 - readInputs took 2634.286074 ms.
+2021-05-03 15:43:35 INFO  Hail:28 - Running Hail version 0.2.65-11b564f90eb6
+2021-05-03 15:43:36 INFO  root:17 - RegionPool: initialized for thread 1: main
+Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
+	at is.hail.expr.ir.SortOrder$.parse(AbstractTableSpec.scala:23)
+	at is.hail.expr.ir.IRParser$.sort_field(Parser.scala:565)
+	at is.hail.expr.ir.IRParser$.$anonfun$sort_fields$1(Parser.scala:560)
+	at is.hail.expr.ir.IRParser$.repUntilNonStackSafe(Parser.scala:322)
+	at is.hail.expr.ir.IRParser$.base_seq_parser(Parser.scala:329)
+	at is.hail.expr.ir.IRParser$.sort_fields(Parser.scala:560)
+	at is.hail.expr.ir.IRParser$.type_expr(Parser.scala:546)
+	at is.hail.expr.ir.IRParser$.$anonfun$parseType$1(Parser.scala:1972)
+	at is.hail.expr.ir.IRParser$.parse(Parser.scala:1951)
+	at is.hail.expr.ir.IRParser$.parseType(Parser.scala:1972)
+	at is.hail.expr.ir.IRParser$.parseType(Parser.scala:1986)
+	at __C1477collect_distributed_array.__m1495setup_null(Unknown Source)
+	at __C1477collect_distributed_array.apply(Unknown Source)
+	at __C1477collect_distributed_array.apply(Unknown Source)
+	at is.hail.backend.BackendUtils.$anonfun$collectDArray$2(BackendUtils.scala:31)
+	at is.hail.utils.package$.using(package.scala:627)
+	at is.hail.annotations.RegionPool.scopedRegion(RegionPool.scala:141)
+	at is.hail.backend.BackendUtils.$anonfun$collectDArray$1(BackendUtils.scala:30)
+	at is.hail.backend.service.Worker$.main(Worker.scala:105)
+	at is.hail.backend.service.Worker.main(Worker.scala)''')
     def test_order_by_parsing(self):
         hl.utils.range_table(1).annotate(**{'a b c' : 5}).order_by('a b c')._force_count()
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -17,7 +17,7 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
-    @fails_service_backend()
+    @skip_when_service_backend('flaky, not sure why yet')
     def test_annotate(self):
         schema = hl.tstruct(a=hl.tint32, b=hl.tint32, c=hl.tint32, d=hl.tint32, e=hl.tstr, f=hl.tarray(hl.tint32))
 
@@ -130,7 +130,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(set(results.q4), {"hello", "cat"})
         self.assertAlmostEqual(results.q5, 4)
 
-    @fails_service_backend()
+    @skip_when_service_backend('''The Service and Shuffler have no way of knowing the order in which rows appear in the original
+dataset, as such it is impossible to guarantee the ordering in x2.
+
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/235425714''')
     def test_aggregate2(self):
         schema = hl.tstruct(status=hl.tint32, GT=hl.tcall, qPheno=hl.tint32)
 
@@ -195,7 +198,6 @@ class Tests(unittest.TestCase):
         r = kt.aggregate(agg.filter(kt.idx % 2 != 0, agg.sum(kt.idx + 2)) + kt.g1)
         self.assertEqual(r, 40)
 
-    @fails_service_backend()
     def test_to_matrix_table(self):
         N, M = 50, 50
         mt = hl.utils.range_matrix_table(N, M)
@@ -210,7 +212,6 @@ class Tests(unittest.TestCase):
 
         assert re_mt.choose_cols(mapping).drop('col_idx')._same(mt.drop('col_idx'))
 
-    @fails_service_backend()
     def test_to_matrix_table_row_major(self):
         t = hl.utils.range_table(10)
         t = t.annotate(foo=t.idx, bar=2 * t.idx, baz=3 * t.idx)
@@ -236,14 +237,12 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: t.to_matrix_table_row_major(['d'], entry_field_name='c'))
         self.assertRaises(ValueError, lambda: t.to_matrix_table_row_major([]))
 
-    @fails_service_backend()
     def test_group_by_field_lifetimes(self):
         ht = hl.utils.range_table(3)
         ht2 = (ht.group_by(idx='100')
                .aggregate(x=hl.agg.collect_as_set(ht.idx + 5)))
         assert (ht2.all(ht2.x == hl.set({5, 6, 7})))
 
-    @fails_service_backend()
     def test_group_aggregate_by_key(self):
         ht = hl.utils.range_table(100, n_partitions=10)
 
@@ -252,7 +251,6 @@ class Tests(unittest.TestCase):
         assert r1.all(r1.n == 20)
         assert r2.all(r2.n == 20)
 
-    @fails_service_backend()
     def test_aggregate_by_key_partitioning(self):
         ht1 = hl.Table.parallelize([
             {'k': 'foo', 'b': 1},
@@ -533,7 +531,6 @@ class Tests(unittest.TestCase):
         joined = hl.Table.multi_way_zip_join([t1, t2, t3], '__data', '__globals')
         self.assertEqual(hl.eval(joined.globals), hl.eval(expected))
 
-    @fails_service_backend()
     def test_multi_way_zip_join_key_downcast(self):
         mt = hl.import_vcf(resource('sample.vcf.bgz'))
         mt = mt.key_rows_by('locus')
@@ -541,7 +538,8 @@ class Tests(unittest.TestCase):
         j = hl.Table.multi_way_zip_join([ht, ht], 'd', 'g')
         j._force_count()
 
-    @fails_service_backend()
+    @skip_when_service_backend('''This blew memory once; seems flaky in the service.
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_multi_way_zip_join_key_downcast2.20blew.20memory.20in.20a.20test/near/236602960''')
     def test_multi_way_zip_join_key_downcast2(self):
         vcf2 = hl.import_vcf(resource('gvcfs/HG00268.g.vcf.gz'), force_bgz=True, reference_genome='GRCh38')
         vcf1 = hl.import_vcf(resource('gvcfs/HG00096.g.vcf.gz'), force_bgz=True, reference_genome='GRCh38')
@@ -574,12 +572,15 @@ class Tests(unittest.TestCase):
         with self.assertRaisesRegex(hl.expr.ExpressionException, "Table key: *<<<empty key>>>"):
             t[t.idx]
 
-    @fails_service_backend()
     def test_aggregation_with_no_aggregators(self):
         ht = hl.utils.range_table(3)
         self.assertEqual(ht.group_by(ht.idx).aggregate().count(), 3)
 
-    @fails_service_backend()
+    @skip_when_service_backend('''The Shuffler does not guarantee the ordering of records that share a key. It can't really do that
+unless we send some preferred ordering of the values (like global index). I don't undrestand how
+this test passes in the Spark backend.
+
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/235399459''')
     def test_drop(self):
         kt = hl.utils.range_table(10)
         kt = kt.annotate(sq=kt.idx ** 2, foo='foo', bar='bar').key_by('foo')
@@ -669,7 +670,6 @@ class Tests(unittest.TestCase):
         with self.assertRaises(LookupError):
             kt.rename({'hello': 'a'})
 
-    @fails_service_backend()
     def test_distinct(self):
         t1 = hl.Table.parallelize([
             {'a': 'foo', 'b': 1},
@@ -692,7 +692,10 @@ class Tests(unittest.TestCase):
         self.assertTrue(dist.all(hl.len(dist.values) == 1))
         self.assertEqual(dist.count(), len(t1.aggregate(hl.agg.collect_as_set(t1.a))))
 
-    @fails_service_backend()
+    @skip_when_service_backend('''The Service and Shuffler have no way of knowing the order in which rows appear in the original
+dataset, as such it is impossible to guarantee the ordering in `matches`.
+
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/235425714''')
     def test_group_by_key(self):
         t1 = hl.Table.parallelize([
             {'a': 'foo', 'b': 1},
@@ -807,7 +810,6 @@ class Tests(unittest.TestCase):
         t_read_back = hl.import_table(tmp_file, types=dict(t.row.dtype)).key_by('idx')
         self.assertTrue(t.select_globals()._same(t_read_back, tolerance=1e-4, absolute=True))
 
-    @fails_service_backend()
     def test_indexed_read(self):
         t = hl.utils.range_table(2000, 10)
         f = new_temp_file(extension='ht')
@@ -854,7 +856,6 @@ class Tests(unittest.TestCase):
             ht._filter_partitions([0, 7]).idx.collect(),
             [0, 1, 2, 21, 22])
 
-    @fails_service_backend()
     def test_localize_entries(self):
         ref_schema = hl.tstruct(row_idx=hl.tint32,
                                 __entries=hl.tarray(hl.tstruct(v=hl.tint32)))
@@ -867,7 +868,6 @@ class Tests(unittest.TestCase):
         t = mt._localize_entries('__entries', '__cols')
         self.assertTrue(t._same(ref_tab))
 
-    @fails_service_backend()
     def test_localize_self_join(self):
         ref_schema = hl.tstruct(row_idx=hl.tint32,
                                 __entries=hl.tarray(hl.tstruct(v=hl.tint32)))
@@ -946,7 +946,6 @@ class Tests(unittest.TestCase):
             self.assertEqual(table.head(0).count(), 0)
             self.assertEqual(table.head(0)._force_count(), 0)
 
-    @fails_service_backend()
     def test_table_order_by_head_rewrite(self):
         rt = hl.utils.range_table(10, 2)
         rt = rt.annotate(x = 10 - rt.idx)
@@ -1012,7 +1011,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
-    @fails_service_backend()
     def test_null_joins_2(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),
@@ -1053,7 +1051,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
-    @fails_service_backend()
     def test_joins_one_null(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=tr.idx)
@@ -1128,7 +1125,6 @@ class Tests(unittest.TestCase):
         assert j.globals.dtype == hl.tstruct(glob1=hl.tint32, glob1_1=hl.tint32)
         j._force_count()
 
-    @fails_service_backend()
     def test_join_with_filter_intervals(self):
         ht = hl.utils.range_table(100, 5)
         ht = ht.key_by(idx2=ht.idx // 2)
@@ -1145,7 +1141,6 @@ class Tests(unittest.TestCase):
         ht3 = ht1.join(ht2)
         assert ht3.filter(ht3.idx2 == 10).count() == 4
 
-    @fails_service_backend()
     def test_key_by_aggregate_rewriting(self):
         ht = hl.utils.range_table(10)
         ht = ht.group_by(x=ht.idx % 5).aggregate(aggr = hl.agg.count())
@@ -1182,7 +1177,6 @@ class Tests(unittest.TestCase):
         ht = hl.utils.range_table(10)
         assert hl.eval(ht.idx.collect(_localize=False)) == ht.idx.collect()
 
-    @fails_service_backend()
     def test_expr_collect(self):
         t = hl.utils.range_table(3)
 
@@ -1220,12 +1214,10 @@ class Tests(unittest.TestCase):
     def test_no_row_fields_show(self):
         hl.utils.range_table(5).key_by().select().show()
 
-    @fails_service_backend()
     def test_same_equal(self):
         t1 = hl.utils.range_table(1)
         self.assertTrue(t1._same(t1))
 
-    @fails_service_backend()
     def test_same_within_tolerance(self):
         t = hl.utils.range_table(1)
         t1 = t.annotate(x = 1.0)
@@ -1250,7 +1242,6 @@ class Tests(unittest.TestCase):
         t2 = t1.annotate_globals(x = 8)
         self.assertFalse(t1._same(t2))
 
-    @fails_service_backend()
     def test_same_different_rows(self):
         t1 = (hl.utils.range_table(2)
               .annotate(x = 7))
@@ -1261,7 +1252,6 @@ class Tests(unittest.TestCase):
         t3 = t1.filter(t1.idx == 0)
         self.assertFalse(t1._same(t3))
 
-    @fails_service_backend()
     def test_rvd_key_write(self):
         with hl.TemporaryDirectory(suffix='.ht', ensure_exists=False) as tempfile:
             ht1 = hl.utils.range_table(1).key_by(foo='a', bar='b')
@@ -1338,7 +1328,6 @@ class Tests(unittest.TestCase):
         ht = ht.annotate(fd=hl.sorted(a))
         assert ht.fd.collect()[0] == ["e", "é"]
 
-    @fails_service_backend()
     def test_physical_key_truncation(self):
         path = new_temp_file(extension='ht')
         hl.import_vcf(resource('sample.vcf')).rows().key_by('locus').write(path)
@@ -1362,22 +1351,20 @@ class Tests(unittest.TestCase):
             ht.write(path)
         assert "both an input and output source" in str(exc.value)
 
-@fails_service_backend()
-def test_large_number_of_fields(tmpdir):
+def test_large_number_of_fields():
     ht = hl.utils.range_table(100)
     ht = ht.annotate(**{
         str(k): k for k in range(1000)
     })
-    f = tmpdir.join("foo.ht")
-    assert_time(lambda: ht.count(), 5)
-    assert_time(lambda: ht.write(str(f)), 5)
-    ht = assert_time(lambda: hl.read_table(str(f)), 5)
-    assert_time(lambda: ht.count(), 5)
+    with hl.TemporaryDirectory(ensure_exists=False) as f:
+        assert_time(lambda: ht.count(), 5)
+        assert_time(lambda: ht.write(str(f)), 5)
+        ht = assert_time(lambda: hl.read_table(str(f)), 5)
+        assert_time(lambda: ht.count(), 5)
 
 def test_import_many_fields():
     assert_time(lambda: hl.import_table(resource('many_cols.txt')), 5)
 
-@fails_service_backend()
 def test_segfault():
     t = hl.utils.range_table(1)
     t2 = hl.utils.range_table(3)
@@ -1388,7 +1375,6 @@ def test_segfault():
     assert joined.collect() == []
 
 
-@fails_service_backend()
 def test_maybe_flexindex_table_by_expr_direct_match():
     t1 = hl.utils.range_table(1)
     t2 = hl.utils.range_table(1)
@@ -1408,7 +1394,6 @@ def test_maybe_flexindex_table_by_expr_direct_match():
     assert t1._maybe_flexindex_table_by_expr(hl.str(mt1.row_key)) is None
 
 
-@fails_service_backend()
 def test_maybe_flexindex_table_by_expr_prefix_match():
     t1 = hl.utils.range_table(1)
     t2 = hl.utils.range_table(1)
@@ -1475,7 +1460,6 @@ def test_maybe_flexindex_table_by_expr_prefix_interval_match():
 widths = [256, 512, 1024, 2048, 4096]
 
 
-@fails_service_backend()
 def test_can_process_wide_tables():
     for w in widths:
         print(f'working on width {w}')
@@ -1535,7 +1519,6 @@ def test_join_distinct_preserves_count():
     assert n_defined_2 == 0
     assert keys_2 == left_pos
 
-@fails_service_backend()
 def test_write_table_containing_ndarray():
     t = hl.utils.range_table(5)
     t = t.annotate(n = hl.nd.arange(t.idx))
@@ -1594,7 +1577,6 @@ def test_range_annotate_range():
     ht2 = hl.utils.range_table(5).annotate(x = 1)
     ht1.annotate(x = ht2[ht1.idx].x)._force_count()
 
-@fails_service_backend()
 def test_read_write_all_types():
     ht = create_all_values_table()
     tmp_file = new_temp_file()
@@ -1615,7 +1597,6 @@ def test_map_partitions_errors():
     with pytest.raises(ValueError, match='must preserve key fields'):
         ht._map_partitions(lambda rows: rows.map(lambda r: r.drop('idx')))
 
-@fails_service_backend()
 def test_map_partitions_indexed():
     tmp_file = new_temp_file()
     hl.utils.range_table(100, 8).write(tmp_file)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -830,7 +830,6 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertEqual(t2.n_partitions(), 3)
         self.assertTrue(t.filter((t.idx >= 150) & (t.idx < 500))._same(t2))
 
-    @fails_service_backend()
     def test_order_by_parsing(self):
         hl.utils.range_table(1).annotate(**{'a b c' : 5}).order_by('a b c')._force_count()
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -198,6 +198,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         r = kt.aggregate(agg.filter(kt.idx % 2 != 0, agg.sum(kt.idx + 2)) + kt.g1)
         self.assertEqual(r, 40)
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_to_matrix_table(self):
         N, M = 50, 50
         mt = hl.utils.range_matrix_table(N, M)
@@ -1011,6 +1012,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
+    @skip_when_service_backend('Shuffler is encoding/decoding is broken.')
     def test_null_joins_2(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=hl.if_else((tr.idx == 3) | (tr.idx == 5),

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -811,6 +811,10 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         t_read_back = hl.import_table(tmp_file, types=dict(t.row.dtype)).key_by('idx')
         self.assertTrue(t.select_globals()._same(t_read_back, tolerance=1e-4, absolute=True))
 
+    @skip_when_service_backend('''Mysteriously fails the first _same check but nothing is written to stdout. I cannot
+replicate on my laptop.
+
+https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/missing.20logs.3F''')
     def test_indexed_read(self):
         t = hl.utils.range_table(2000, 10)
         f = new_temp_file(extension='ht')

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -55,7 +55,7 @@ class User(
   val fs: GoogleStorageFS)
 
 class ServiceBackend(
-  private[this] val queryGCSPath: String
+  private[this] val queryGCSJarPath: String
 ) extends Backend {
   import ServiceBackend.log
 
@@ -128,7 +128,7 @@ class ServiceBackend(
             "command" -> JArray(List(
               JString("is.hail.backend.service.Worker"),
               JString(HAIL_REVISION),
-              JString(queryGCSPath + HAIL_REVISION + ".jar"),
+              JString(queryGCSJarPath + HAIL_REVISION + ".jar"),
               JString(root),
               JString(s"$i"))),
             "type" -> JString("jvm")),
@@ -644,15 +644,10 @@ object ServiceBackendMain {
     assert(argv.length == 1, argv.toFastIndexedSeq)
     val udsAddress = argv(0)
     val queryGCSPathEnvVar = System.getenv("HAIL_QUERY_GCS_PATH")
-    val queryGCSBucketEnvVar = System.getenv("HAIL_QUERY_GCS_BUCKET")
-    val queryGCSPath = if (queryGCSPathEnvVar != null) {
-      assert(queryGCSBucketEnvVar == null, queryGCSBucketEnvVar)
-      queryGCSPathEnvVar
-    } else {
-      s"gs://${queryGCSBucketEnvVar}/jars/"
-    }
+    assert(queryGCSPathEnvVar != null)
+    val queryGCSJarPath = queryGCSPathEnvVar + "/jars/"
     val executor = Executors.newCachedThreadPool()
-    val backend = new ServiceBackend(queryGCSPath)
+    val backend = new ServiceBackend(queryGCSJarPath)
     HailContext(backend, "hail.log", false, false, 50, skipLoggingConfiguration = true, 3)
 
     val ss = AFUNIXServerSocket.newInstance()

--- a/hail/src/main/scala/is/hail/backend/service/Worker.scala
+++ b/hail/src/main/scala/is/hail/backend/service/Worker.scala
@@ -99,6 +99,7 @@ object Worker {
     timer.start("executeFunction")
 
     val hailContext = HailContext(
+      // FIXME: workers should not have backends, but some things do need hail contexts
       new ServiceBackend(null), skipLoggingConfiguration = true, quiet = true)
     val htc = new ServiceTaskContext(i)
     val result = f(context, htc, fs)

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -98,7 +98,7 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
   def getOwner: String = null
 }
 
-class GoogleStorageFS(var serviceAccountKey: String) extends FS {
+class GoogleStorageFS(val serviceAccountKey: String) extends FS {
   import GoogleStorageFS._
 
   @transient private lazy val storage: Storage = {

--- a/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/GoogleStorageFS.scala
@@ -41,7 +41,7 @@ object GoogleStorageFS {
     val uri = new URI(filename).normalize()
 
     val scheme = uri.getScheme
-    assert(scheme != null && scheme == "gs", uri.getScheme)
+    assert(scheme != null && scheme == "gs", (uri.getScheme, filename))
 
     val bucket = uri.getHost
     assert(bucket != null)
@@ -98,7 +98,7 @@ class GoogleStorageFileStatus(path: String, modificationTime: java.lang.Long, si
   def getOwner: String = null
 }
 
-class GoogleStorageFS(serviceAccountKey: String) extends FS {
+class GoogleStorageFS(var serviceAccountKey: String) extends FS {
   import GoogleStorageFS._
 
   @transient private lazy val storage: Storage = {
@@ -161,7 +161,7 @@ class GoogleStorageFS(serviceAccountKey: String) extends FS {
         }
 
         pos += 1
-        bb.get()
+        bb.get().toInt & 0xff
       }
 
       override def read(bytes: Array[Byte], off: Int, len: Int): Int = {

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -1,6 +1,7 @@
 package is.hail.linalg
 
 import java.lang.reflect.Method
+import java.util.function._
 
 import com.sun.jna.{FunctionMapper, Library, Native, NativeLibrary}
 import com.sun.jna.ptr.IntByReference
@@ -17,26 +18,28 @@ class UnderscoreFunctionMapper extends FunctionMapper {
 // ALL LAPACK C function args must be passed by address, not value
 // see: https://software.intel.com/content/www/us/en/develop/documentation/mkl-linux-developer-guide/top/language-specific-usage-options/mixed-language-programming-with-the-intel-math-kernel-library/calling-lapack-blas-and-cblas-routines-from-c-c-language-environments.html
 object LAPACK {
-  lazy val libraryInstance = {
-    val standard = Native.loadLibrary("lapack", classOf[LAPACKLibrary]).asInstanceOf[LAPACKLibrary]
+  private[this] val libraryInstance = ThreadLocal.withInitial(new Supplier[LAPACKLibrary]() {
+    def get() = {
+      val standard = Native.loadLibrary("lapack", classOf[LAPACKLibrary]).asInstanceOf[LAPACKLibrary]
 
-    versionTest(standard) match {
-      case Success(version) =>
-        log.info(s"Imported LAPACK version ${version} with standard names")
-        standard
-      case Failure(exception) =>
-        val underscoreAfterMap = new java.util.HashMap[String, FunctionMapper]()
-        underscoreAfterMap.put(Library.OPTION_FUNCTION_MAPPER, new UnderscoreFunctionMapper)
-        val underscoreAfter = Native.loadLibrary("lapack", classOf[LAPACKLibrary], underscoreAfterMap).asInstanceOf[LAPACKLibrary]
-        versionTest(underscoreAfter) match {
-          case Success(version) =>
-            log.info(s"Imported LAPACK version ${version} with underscore names")
-            underscoreAfter
-          case Failure(exception) =>
-            throw exception
-        }
+      versionTest(standard) match {
+        case Success(version) =>
+          log.info(s"Imported LAPACK version ${version} with standard names")
+          standard
+        case Failure(exception) =>
+          val underscoreAfterMap = new java.util.HashMap[String, FunctionMapper]()
+          underscoreAfterMap.put(Library.OPTION_FUNCTION_MAPPER, new UnderscoreFunctionMapper)
+          val underscoreAfter = Native.loadLibrary("lapack", classOf[LAPACKLibrary], underscoreAfterMap).asInstanceOf[LAPACKLibrary]
+          versionTest(underscoreAfter) match {
+            case Success(version) =>
+              log.info(s"Imported LAPACK version ${version} with underscore names")
+              underscoreAfter
+            case Failure(exception) =>
+              throw exception
+          }
+      }
     }
-  }
+  })
 
   def dgeqrf(M: Int, N: Int, A: Long, LDA: Int, TAU: Long, WORK: Long, LWORK: Int): Int = {
     val mInt = new IntByReference(M)
@@ -44,7 +47,7 @@ object LAPACK {
     val LDAInt = new IntByReference(LDA)
     val LWORKInt = new IntByReference(LWORK)
     val infoInt = new IntByReference(1)
-    libraryInstance.dgeqrf(mInt, nInt, A, LDAInt, TAU, WORK, LWORKInt, infoInt)
+    libraryInstance.get.dgeqrf(mInt, nInt, A, LDAInt, TAU, WORK, LWORKInt, infoInt)
     infoInt.getValue()
   }
 
@@ -55,7 +58,7 @@ object LAPACK {
     val LDAInt = new IntByReference(LDA)
     val LWORKInt = new IntByReference(LWORK)
     val infoInt = new IntByReference(1)
-    libraryInstance.dorgqr(mInt, nInt, kInt, A, LDAInt, TAU, WORK, LWORKInt, infoInt)
+    libraryInstance.get.dorgqr(mInt, nInt, kInt, A, LDAInt, TAU, WORK, LWORKInt, infoInt)
     infoInt.getValue()
   }
 
@@ -65,7 +68,7 @@ object LAPACK {
     val LDAref = new IntByReference(LDA)
     val INFOref = new IntByReference(1)
 
-    libraryInstance.dgetrf(Mref, Nref, A, LDAref, IPIV, INFOref)
+    libraryInstance.get.dgetrf(Mref, Nref, A, LDAref, IPIV, INFOref)
     INFOref.getValue()
   }
 
@@ -75,7 +78,7 @@ object LAPACK {
     val LWORKref = new IntByReference(LWORK)
     val INFOref = new IntByReference(1)
 
-    libraryInstance.dgetri(Nref, A, LDAref, IPIV, WORK, LWORKref, INFOref)
+    libraryInstance.get.dgetri(Nref, A, LDAref, IPIV, WORK, LWORKref, INFOref)
     INFOref.getValue()
   }
 
@@ -89,7 +92,7 @@ object LAPACK {
     val LWORKRef = new IntByReference(LWORK)
     val INFOref = new IntByReference(1)
 
-    libraryInstance.dgesdd(JOBZ, Mref, Nref, A, LDAref, S, U, LDUref, VT, LDVTref, WORK, LWORKRef, IWORK, INFOref)
+    libraryInstance.get.dgesdd(JOBZ, Mref, Nref, A, LDAref, S, U, LDUref, VT, LDVTref, WORK, LWORKRef, IWORK, INFOref)
 
     INFOref.getValue()
   }
@@ -101,7 +104,7 @@ object LAPACK {
     val LDBref = new IntByReference(LDB)
     val INFOref = new IntByReference(1)
 
-    libraryInstance.dgesv(Nref, NHRSref, A, LDAref, IPIV, B, LDBref, INFOref)
+    libraryInstance.get.dgesv(Nref, NHRSref, A, LDAref, IPIV, B, LDBref, INFOref)
 
     INFOref.getValue()
   }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -133,8 +133,8 @@ object AbstractRVDSpec {
 
     val reader = PartitionZippedNativeReader(specLeft.typedCodecSpec, specRight.typedCodecSpec, indexSpecLeft, indexSpecRight, requestedKey)
 
-    val absPathLeft = uriPath(pathLeft)
-    val absPathRight = uriPath(pathRight)
+    val absPathLeft = removeFileProtocol(pathLeft)
+    val absPathRight = removeFileProtocol(pathRight)
     val partsAndIntervals: IndexedSeq[(String, Interval)] = if (specLeft.key.isEmpty) {
       specLeft.partFiles.map { p => (p, null) }
     } else {
@@ -501,7 +501,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
       val rSpec = typedCodecSpec
       val reader = ir.PartitionNativeReaderIndexed(rSpec, indexSpec, partitioner.kType.fieldNames)
 
-      val absPath = uriPath(path)
+      val absPath = removeFileProtocol(path)
       val partPaths = tmpPartitioner.rangeBounds.map { b => partFiles(partitioner.lowerBoundInterval(b)) }
 
 

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -264,6 +264,7 @@ object EType {
     case TFloat64 => EFloat64(r.required)
     case TBoolean => EBoolean(r.required)
     case TBinary => EBinary(r.required)
+    case _: TShuffle => EShuffle(r.required)
     case TString => EBinary(r.required)
     case TLocus(_) =>
       EBaseStruct(Array(

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -16,6 +16,7 @@ package object physical {
     case _: PBoolean => typeInfo[Boolean]
     case PVoid => typeInfo[Unit]
     case _: PBinary => typeInfo[Long]
+    case _: PShuffle => typeInfo[Long]
     case _: PStream => classInfo[StreamArgType]
     case _: PBaseStruct => typeInfo[Long]
     case _: PNDArray => typeInfo[Long]

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -310,6 +310,15 @@ package object utils extends Logging
 
   def uriPath(uri: String): String = new URI(uri).getPath
 
+  def removeFileProtocol(uriString: String): String = {
+    val uri = new URI(uriString)
+    if (uri.getScheme == "file") {
+      uri.getPath
+    } else {
+      uri.toString
+    }
+  }
+
   // NB: can't use Nothing here because it is not a super type of Null
   private object flattenOrNullInstance extends FlattenOrNull[Array]
 

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -216,6 +216,28 @@ trait FSSuite {
   @Test def testStripCodecExtension(): Unit = {
     assert(fs.stripCodecExtension("foo.vcf.bgz") == "foo.vcf")
   }
+
+  @Test def testReadWriteBytes(): Unit = {
+    val f = t()
+
+    using(fs.create(f)) { os =>
+      os.write(1)
+      os.write(127)
+      os.write(255)
+    }
+
+    assert(fs.exists(f))
+
+    using(fs.open(f)) { is =>
+      assert(is.read() == 1)
+      assert(is.read() == 127)
+      assert(is.read() == 255)
+    }
+
+    fs.delete(f, false)
+
+    assert(!fs.exists(f))
+  }
 }
 
 class HadoopFSSuite extends HailSuite with FSSuite {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -16,6 +16,8 @@ variable "batch_gcp_regions" {}
 variable "gcp_project" {}
 variable "batch_logs_bucket_location" {}
 variable "batch_logs_bucket_storage_class" {}
+variable "hail_query_bucket_location" {}
+variable "hail_query_bucket_storage_class" {}
 variable "gcp_region" {}
 variable "gcp_zone" {}
 variable "domain" {}
@@ -227,6 +229,7 @@ resource "kubernetes_secret" "global_config" {
   data = {
     batch_gcp_regions = var.batch_gcp_regions
     batch_logs_bucket = google_storage_bucket.batch_logs.name
+    hail_query_bucket = google_storage_bucket.hail_query.name
     default_namespace = "default"
     docker_root_image = local.docker_root_image
     domain = var.domain
@@ -532,6 +535,34 @@ resource "google_project_iam_member" "batch_storage_admin" {
   member = "serviceAccount:${google_service_account.batch.email}"
 }
 
+resource "random_id" "query_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_service_account" "query" {
+  account_id = "query-${random_id.query_name_suffix.hex}"
+}
+
+resource "google_service_account_key" "query_key" {
+  service_account_id = google_service_account.query.name
+}
+
+resource "kubernetes_secret" "query_gsa_key" {
+  metadata {
+    name = "query-gsa-key"
+  }
+
+  data = {
+    "key.json" = base64decode(google_service_account_key.query_key.private_key)
+  }
+}
+
+resource "google_storage_bucket_iam_member" "query_hail_query_bucket_storage_admin" {
+  bucket = google_storage_bucket.hail_query.name
+  role = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.query.email}"
+}
+
 resource "google_service_account" "benchmark" {
   account_id = "benchmark"
 }
@@ -742,6 +773,17 @@ resource "google_storage_bucket" "batch_logs" {
   location = var.batch_logs_bucket_location
   force_destroy = true
   storage_class = var.batch_logs_bucket_storage_class
+}
+
+resource "random_id" "hail_query_bucket_name_suffix" {
+  byte_length = 2
+}
+
+resource "google_storage_bucket" "hail_query" {
+  name = "hail-query-${random_id.hail_query_bucket_name_suffix.hex}"
+  location = var.hail_query_bucket_location
+  force_destroy = true
+  storage_class = var.hail_query_bucket_storage_class
 }
 
 resource "google_dns_managed_zone" "dns_zone" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -21,7 +21,7 @@ variable "hail_query_bucket_storage_class" {}
 variable "gcp_region" {}
 variable "gcp_zone" {}
 variable "domain" {}
-variable "use_artifact_registry" { 
+variable "use_artifact_registry" {
   type = bool
   description = "pull the ubuntu image from Artifact Registry. Otherwise, GCR"
 }
@@ -29,7 +29,7 @@ variable "use_artifact_registry" {
 locals {
   docker_prefix = (
     var.use_artifact_registry ?
-    "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/hail" : 
+    "${var.gcp_region}-docker.pkg.dev/${var.gcp_project}/hail" :
     "gcr.io/${var.gcp_project}"
   )
   docker_root_image = "${local.docker_prefix}/ubuntu:18.04"
@@ -161,9 +161,9 @@ resource "random_id" "db_name_suffix" {
 }
 
 # Without this, I get:
-# Error: Error, failed to create instance because the network doesn't have at least 
-# 1 private services connection. Please see 
-# https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements 
+# Error: Error, failed to create instance because the network doesn't have at least
+# 1 private services connection. Please see
+# https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements
 # for how to create this connection.
 resource "google_compute_global_address" "google_managed_services_default" {
   name = "google-managed-services-default"
@@ -229,7 +229,7 @@ resource "kubernetes_secret" "global_config" {
   data = {
     batch_gcp_regions = var.batch_gcp_regions
     batch_logs_bucket = google_storage_bucket.batch_logs.name
-    hail_query_bucket = google_storage_bucket.hail_query.name
+    hail_query_gcs_path = "gs://${google_storage_bucket.hail_query.name}"
     default_namespace = "default"
     docker_root_image = local.docker_root_image
     domain = var.domain

--- a/query/Makefile
+++ b/query/Makefile
@@ -28,9 +28,13 @@ push: build
 	docker tag query $(QUERY_IMAGE)
 	docker push $(QUERY_IMAGE)
 
+UPLOAD_QUERY_JAR_TOKEN := $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+HAIL_REVISION := $(shell git rev-parse HEAD)
+
 .PHONY: deploy
 deploy: push
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
 	kubectl -n $(NAMESPACE) apply -f service-account.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"}}' deployment.yaml deployment.yaml.out
+	gsutil cp ./hail.jar gs://hail-test-dmk9z/$(UPLOAD_QUERY_JAR_TOKEN)/jars/$(HAIL_REVISION).jar
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"query_image":{"image":"$(QUERY_IMAGE)"},"global":{"project":"$(PROJECT)","domain":"$(DOMAIN)"},"upload_query_jar":{"token":"$(UPLOAD_QUERY_JAR_TOKEN)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -17,7 +17,9 @@ spec:
         hail.is/sha: "{{ code.sha }}"
         grafanak8sapp: "true"
     spec:
-      terminationGracePeriodSeconds: 28800  # 8 hours
+      # This does not actually work. Java dies immediately and python gets stuck waiting for java
+      # to come back
+      # terminationGracePeriodSeconds: 28800  # 8 hours
       serviceAccountName: query
 {% if deploy %}
       priorityClassName: production
@@ -62,8 +64,7 @@ spec:
               cpu: "300m"
               memory: "1G"
             limits:
-              cpu: "1"
-              memory: "2.5G"
+              memory: "7.5G"
           readinessProbe:
             tcpSocket:
               port: 5000
@@ -94,6 +95,16 @@ spec:
              value: "{{ code.sha }}"
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
+{% if deploy %}
+           - name: HAIL_QUERY_GCS_BUCKET
+             valueFrom:
+             secretKeyRef:
+               name: global-config
+               key: hail_query_bucket
+{% else %}
+           - name: HAIL_QUERY_GCS_PATH
+             value: gs://hail-test-dmk9z/{{ upload_query_jar.token }}/jars/
+{% endif %}
           ports:
            - containerPort: 5000
           volumeMounts:
@@ -128,35 +139,6 @@ spec:
          secret:
            optional: false
            secretName: ssl-config-query
-{% if not deploy %}
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: query
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: query
-  minReplicas: 3
-  maxReplicas: 32
-  metrics:
-   - type: Resource
-     resource:
-       name: cpu
-       targetAverageUtilization: 80
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: query
-spec:
-  minAvailable: 2
-  selector:
-    matchLabels:
-      app: query
-{% endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -96,14 +96,14 @@ spec:
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
 {% if deploy %}
-           - name: HAIL_QUERY_GCS_BUCKET
+           - name: HAIL_QUERY_GCS_PATH
              valueFrom:
              secretKeyRef:
                name: global-config
-               key: hail_query_bucket
+               key: hail_query_gcs_path
 {% else %}
            - name: HAIL_QUERY_GCS_PATH
-             value: gs://hail-test-dmk9z/{{ upload_query_jar.token }}/jars/
+             value: gs://hail-test-dmk9z/{{ upload_query_jar.token }}
 {% endif %}
           ports:
            - containerPort: 5000


### PR DESCRIPTION
The high-level problem:

The Hail Query Service is redeployed with each commit to `main`. Each deployment has a new JAR file
whose ABI is backwards-incompatible.

The high-level solution:

Hail Batch Workers can load the JAR for a given Hail version on-demand. Although not a long-term
solution, we currently start a fresh JVM for each job. As a result, we can simply start the JVM with
the correct JAR on its classpath. We cache jars on the local filesystem.

I had to abandon the old approach for two reasons:

1. Multiple JVMs race to download the JAR. In the new approach, the python worker process uses a
   lock to ensure at most one coroutine is downloading a given version of a JAR at the same time.

2. The JVM assumes that a child ClassLoader does not redefine a class from the parent
   ClassLoader. That's why ClassLoaders always prefer to load a class from the parent ClassLoader's
   classes.

When we decide to re-use JVMs or use a single multi-threaded JVM, we'll need to ensure the top-level
ClassLoader *does not have Hail on its classpath*. I looked briefly at this approach and found it
more work than the current approach.

---

My apologies for eliminating JVMProcess in this PR. It's an unrelated change which facilitated my
understanding worker.py. I essentially inlined JVMProcess into JVMJob and eliminated any duplicative
code.

---

After making this change I restored the tests. Some tests had bitrotted. In the process of fixing
those tests, I found a few other bugs. Fixing these lower-level bugs unlocked a number of new
tests.

A couple tests (which were added since the service tests were removed) had to be marked as
failing.

Here are the bugs I fixed:

1. Correct the error message raised when tests are run in a non-main thread (we look for this
   message and start an event loop for Hail's async code because asyncio refuses to start an event
   loop in a non-main thread).

2. Use a `SafeRow` to copy the globals data out of a Region and into durable, GC'ed objects.

3. Re-enable serialization of GoogleStorageFS (including its private key, which we really shouldn't
   do; Tim is working on it), which was broken (presumably) when we changed Scala versions. The
   `var` modifier ensures the name is compiled as a JVM field.

4. Correctly convert from a `Byte` to an `Int`. By default `Byte` to `Int` conversion (which is done
   automatically when you return a `Byte` from a function whose return type is `Int`) is
   sign-preserving. That means that the byte `0000 1111` is converted to the `Int` 15 and the byte
   `1000 1111` is converted to the `Int` -113. The contract of
   [`InputStream.read`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read--)
   is to return the unsigned integeral value of the next `Byte` or `-1` if we've reached the end of
   the stream. `DataInputStream` treats any negative value as EOS which lead to perplexing EOSes
   when reading data from GCS.

5. Retain the `gs://` protocol when reading MTs and Ts. `uriPath` strips *all* protocols. Before the
   Query Service, these code paths were only used by the LocalBackend. In the LocalBackend, the only
   URIs generated are `file://`. However, UNIX/JVM file system operations do not support URIs, they
   want bare paths.

6. Implement missing cases for EShuffle and PShuffle.

7. BLAS and LAPACK need to be thread-local.

8. The LSM-tree used by the Shuffler needs to permit multiple values for the same key. There was
   some subtlety here around fine-grained locking. Unfortunately, the LSM doesn't expose the right
   operations (putIfAbsent) to make this easy, so I had to use a concurrent hash map of locks.

---

I've already updated the cluster with the new bucket and the corresponding change to the
`global-config` secret. We'll should notify Leo et al. about the Terraform changes.

---

Small changes and fixes:

- Rename `key.json` to `/worker-key.json` for clarity, this is the worker's own GCP service account
  key.

- Create a test query-gsa-key in test and dev namespaces.

- Add terraform rules for the query service account. It already existed, but it was missing from the
  Terraform file. You can verify the permissions grant by inspecting `gsutil iam get
  gs://hail-query`.

- The `query` user was missing from bootstrap-create-accounts.

- Remove the auto-scaling and remove the k8s grace period. Neither of these really works right. We
  will live without the auto-scaling for now. I have to fix the grace period thing before we let
  users run real pipelines.
