### PR TITLE
[ci] all builds share the same cache repo

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -481,6 +481,7 @@ class BuildImage2Step(Step):
             create_inline_dockerfile_if_present = ''
         dockerfile_in_context = os.path.join(context, 'Dockerfile.' + self.token)
 
+        cache_repo = DOCKER_PREFIX + '/cache'
         script = f'''
 set -ex
 
@@ -500,7 +501,7 @@ set +e
 /busybox/sh /convert-google-application-credentials-to-kaniko-auth-config
 set -e
 
-/kaniko/executor --dockerfile={shq(dockerfile_in_context)} --context=dir://{shq(context)} --destination={shq(self.image)} --cache=true --snapshotMode=redo --use-new-run'''
+/kaniko/executor --dockerfile={shq(dockerfile_in_context)} --context=dir://{shq(context)} --destination={shq(self.image)} --cache=true --cache-repo={shq(cache_repo)} --snapshotMode=redo --use-new-run'''
 
         log.info(f'step {self.name}, script:\n{script}')
 


### PR DESCRIPTION
Without `--cache-repo`, Kaniko uses `{image_name}/cache` (e.g. `gcr.io/hail-vdc/batch-worker/cache`). That works particularly poorly for all the test images which are `gcr.io/hail-vdc/ci-intermediate` and therefore don't share a cache with the default images.