### PR TITLE
[ci] allow kaniko to build the kaniko image

### DIFF
--- a/ci/kaniko/Dockerfile
+++ b/ci/kaniko/Dockerfile
@@ -1,7 +1,29 @@
 FROM python:3.7-slim-stretch
 RUN pip3 install jinja2
-COPY jinja2_render.py /jinja2_render.py
 
 FROM gcr.io/kaniko-project/executor:debug
-COPY --from=0 / /python3.7-slim-stretch
+
+COPY --from=0 /bin/ /python3.7-slim-stretch/bin
+# boot is empty
+# cannot copy dev in kaniko
+# etc is too big in kaniko, ld is necessary for python to dynamically link
+COPY --from=0 /etc/ld.so.cache /python3.7-slim-stretch/etc/ld.so.cache
+COPY --from=0 /etc/ld.so.conf /python3.7-slim-stretch/etc/ld.so.conf
+# home is empty
+COPY --from=0 /lib/ /python3.7-slim-stretch/lib
+COPY --from=0 /lib64/ /python3.7-slim-stretch/lib64
+# media is empty
+# mnt is empty
+# opt is empty
+# cannot copy proc in kaniko
+COPY --from=0 /root/ /python3.7-slim-stretch/root
+COPY --from=0 /run/ /python3.7-slim-stretch/run
+COPY --from=0 /sbin/ /python3.7-slim-stretch/sbin
+# srv is empty
+# cannot copy sys in kaniko
+# ignore tmp
+COPY --from=0 /usr/ /python3.7-slim-stretch/usr
+COPY --from=0 /var/ /python3.7-slim-stretch/var
+
+COPY jinja2_render.py /python3.7-slim-stretch/jinja2_render.py
 COPY kaniko/convert-google-application-credentials-to-kaniko-auth-config /convert-google-application-credentials-to-kaniko-auth-config


### PR DESCRIPTION
I do not know why but /etc triggers errors about:
```
archive/tar: write too long
```
Even though /etc is not very large (1.4MB). I suspect there is some symlink
or other nonsense which is breaking Kaniko.

The solution, after much trial and error, was simple: copy over directories that do not
cause issues and copy only the necessary files out of etc. A mix of speculation and
binary search lead me to the conclusion that /etc/ld.so.* are the only files necessary
from /etc for python to run correctly. These files tell the kernel how to link python3.7
to the various libraries on which it depends (which live in lib and lib64).

Anyway, I've tested that this image can build itself, so it should be good enough for
our purposes.