### PR TITLE
[ci] remove Kaniko resource requirements

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -626,9 +626,6 @@ steps:
     dockerFile: /io/repo/ci/kaniko/Dockerfile
     contextPath: /io/repo/ci
     publishAs: hail-kaniko
-    resources:
-      memory: highmem
-      storage: 10Gi
     inputs:
       - from: /repo/ci
         to: /io/repo/ci

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -137,9 +137,6 @@ steps:
     dockerFile: /io/repo/ci/kaniko/Dockerfile
     contextPath: /io/repo/ci
     publishAs: hail-kaniko
-    resources:
-      memory: highmem
-      storage: 10Gi
     inputs:
       - from: /repo/ci
         to: /io/repo/ci


### PR DESCRIPTION
I think this was a red-herring caused by Kaniko blowing disk
trying to copy special files.

If this PR passes, then Kaniko is able to build itself with normal workers
and no extra disk, so there is no risk of another firedrill wherein
Kaniko is broken