### PR TITLE
[query] Fix user function cleanup

### DIFF
--- a/hail/python/test/hail/test_context.py
+++ b/hail/python/test/hail/test_context.py
@@ -12,6 +12,12 @@ class Tests(unittest.TestCase):
     def test_init_hail_context_twice(self):
         hl.init(idempotent=True)  # Should be no error
         hl.stop()
+
+        hl.init(idempotent=True)
+        hl.experimental.define_function(lambda x: x + 2, hl.tint32)
+        # ensure functions are cleaned up without error
+        hl.stop()
+
         hl.init(idempotent=True)  # Should be no error
         hl.init(hl.spark_context(), idempotent=True)  # Should be no error
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -25,7 +25,7 @@ object IRFunctionRegistry {
 
   def clearUserFunctions() {
     userAddedFunctions.foreach { case (name, (rt, typeParameters, valueParameterTypes)) =>
-      removeJVMFunction(name, rt, typeParameters, valueParameterTypes) }
+      removeIRFunction(name, rt, typeParameters, valueParameterTypes) }
     userAddedFunctions.clear()
   }
 
@@ -82,16 +82,14 @@ object IRFunctionRegistry {
       })
   }
 
-  def removeJVMFunction(
+  def removeIRFunction(
     name: String,
     returnType: Type,
     typeParameters: Seq[Type],
     valueParameterTypes: Seq[Type]
   ): Unit = {
-    val functions = jvmRegistry(name)
-    val toRemove = functions.filter(_.unify(typeParameters, valueParameterTypes, returnType)).toArray
-    assert(toRemove.length == 1)
-    jvmRegistry.removeBinding(name, toRemove.head)
+    val m = irRegistry(name)
+    m.remove((typeParameters, valueParameterTypes, returnType, false))
   }
 
   def lookupFunction(


### PR DESCRIPTION
They're IR functions, not JVM functions