### PR TITLE
[benchmark] Add memory tracking to benchmarks

### DIFF
--- a/benchmark/python/benchmark_hail/combine/combine.py
+++ b/benchmark/python/benchmark_hail/combine/combine.py
@@ -32,7 +32,7 @@ def combine(output, files):
     logging.info(f'{len(files)} files to merge')
 
     config = None
-    benchmark_data = collections.defaultdict(lambda: {'failed': False, 'trials': []})
+    benchmark_data = collections.defaultdict(lambda: {'failed': False, 'trials': [], 'peak_task_memory': []})
 
     for file in files:
         with open(file, 'r') as f:
@@ -44,6 +44,8 @@ def combine(output, files):
                 bm_data['failed'] = True
             else:
                 bm_data['trials'].append(bm['times'])
+                if 'peak_task_memory' in bm:
+                    bm_data['peak_task_memory'].append(bm['peak_task_memory'])
 
     import numpy as np
     import scipy.stats as stats
@@ -57,6 +59,10 @@ def combine(output, files):
             data['median'] = np.median(flat_times)
             data['mean'] = np.mean(flat_times)
             data['stdev'] = np.std(flat_times)
+            flat_peak_memory = [m for memory_list in data['peak_task_memory'] for m in memory_list]
+            data['peak_task_memory'] = flat_peak_memory
+            if len(flat_peak_memory) > 0:
+                data['max_memory'] = max(flat_peak_memory)
             if len(data['trials']) > 1:
                 f_stat, p_value = stats.f_oneway(*data['trials'])
                 data['f-stat'] = f_stat

--- a/benchmark/python/benchmark_hail/run/cli.py
+++ b/benchmark/python/benchmark_hail/run/cli.py
@@ -6,7 +6,8 @@ import sys
 
 import hail as hl
 
-from .utils import run_all, run_pattern, run_list, RunConfig, init_logging
+from .utils import run_all, run_pattern, run_list, RunConfig
+from .. import init_logging
 
 
 def main(args_):


### PR DESCRIPTION
This works by parsing log files for the message produced by TaskContext cleanup added in #10392.

A bit hacky, but it works!

```
                                        Benchmark Name      Ratio     Time 1     Time 2   Mem Ratio   Mem 1 (MB)   Mem 2 (MB)
                                        --------------      -----     ------     ------   ---------   ----------   ----------
                                     union_p1000_p1000     116.0%     28.394     32.935      100.0%            1            1
                                        union_p10_p100     114.8%     33.685     38.683      100.0%            1            1
                                      compile_2k_merge     112.1%    253.023    283.740      100.0%            7            7
                        ndarray_matmul_int64_benchmark     110.1%      8.165      8.992      100.0%            1            1
                 shuffle_key_by_aggregate_bad_locality     108.9%    414.396    451.457      100.0%            4            4
                              shuffle_order_by_10m_int     108.7%     95.688    103.993      100.0%            1            1
                             import_and_transform_gvcf     107.0%    109.282    116.941      100.0%            1            1
                             matrix_table_entries_show     106.8%      1.318      1.408      100.0%            2            2
                                             sample_qc     106.7%     31.869     34.002      100.0%            2            2
                          matrix_table_scan_count_rows     105.3%    129.907    136.832      100.0%            1            1
                                shuffle_key_rows_by_mt     104.9%     25.313     26.553      100.0%            3            3
                     matrix_table_entries_table_no_key     104.9%     47.893     50.225      100.0%            1            1
                 table_aggregate_downsample_worst_case     104.7%     33.056     34.625      100.0%            1            1
                             python_only_10k_transform     104.6%     69.072     72.271      100.0%            1            1
                shuffle_key_by_aggregate_good_locality     104.4%     10.776     11.250      100.0%           24           24
                       table_aggregate_take_by_strings     104.3%      7.718      8.049      100.0%            1            1
                                  kyle_sex_specific_qc     104.2%      9.326      9.715      100.0%            1            1
                                       union_p100_p100     104.1%     24.184     25.174      100.0%            1            1
                              table_scan_prev_non_null     103.6%    111.901    115.887      100.0%            1            1
                         write_range_matrix_table_p100     103.3%      6.568      6.786      100.0%            1            1
                                  read_force_count_p10     103.2%      3.644      3.760      100.0%            1            1
           variant_and_sample_qc_nested_with_filters_4     103.1%     33.173     34.204      100.0%            2            2
                                           concordance     102.8%     34.514     35.475      100.0%            3            3
               table_foreign_key_join_same_cardinality     102.4%     17.859     18.279      100.0%            2            2
                       gnomad_coverage_stats_optimized     102.3%     27.443     28.087      100.0%            1            1
                       table_group_by_aggregate_sorted     101.6%      7.337      7.458      100.0%            4            4
                               write_range_table_p1000     101.0%     43.753     44.186      100.0%            1            1
                                     table_range_means     100.9%      9.722      9.810      100.0%            1            1
                 matrix_table_decode_and_count_just_gt     100.7%      5.026      5.063      100.0%            1            1
                               import_gvcf_force_count     100.6%     94.292     94.818      100.0%            1            1
                                import_bgen_info_score     100.3%    208.245    208.972      100.0%            4            4
                              import_bgen_filter_count     100.2%    156.366    156.717      100.0%            6            6
   hwe_normalized_pca_blanczos_small_data_0_iterations     100.1%     22.247     22.265      100.0%           24           24
                          block_matrix_nested_multiply     100.0%   1800.000   1800.000      100.0%            1            1
                                table_range_join_1b_1b     100.0%   1800.000   1800.000          NA            0            0
                                linear_regression_rows     100.0%     61.691     61.675      100.0%            3            3
                         matrix_table_array_arithmetic      99.9%     10.360     10.344      100.0%            1            1
                                write_range_table_p100      99.7%     15.340     15.301      100.0%            1            1
                                        join_p100_p100      99.4%     59.651     59.288      100.0%            1            1
                          table_scan_sum_1k_partitions      99.3%      5.550      5.509      100.0%            1            1
                             table_aggregate_array_sum      99.2%      5.961      5.914      100.0%            1            1
                            table_aggregate_approx_cdf      99.0%     54.704     54.158      100.0%            1            1
                              table_annotate_many_flat      99.0%      1.333      1.320      100.0%            1            1
                                      write_profile_mt      98.9%     48.628     48.103      100.0%            2            2
                             table_aggregate_int_stats      98.9%     10.969     10.848      100.0%            1            1
                                   ld_prune_profile_25      98.7%    583.669    576.246      100.0%           94           94
                     shuffle_key_rows_by_65k_byte_rows      98.6%     14.874     14.670      100.0%            2            2
        table_foreign_key_join_left_higher_cardinality      98.4%     16.905     16.635      100.0%            2            2
                      test_head_and_tail_region_memory      98.3%      8.256      8.118      100.0%          382          382
                               table_aggregate_counter      98.3%     21.611     21.250      100.0%            2            2
                      ndarray_matmul_float64_benchmark      98.2%      4.642      4.558      100.0%            1            1
                                         join_p10_p100      97.9%     72.497     70.961      100.0%            1            1
                        table_read_force_count_strings      97.7%      4.994      4.878      100.0%            1            1
                           table_read_force_count_ints      97.6%      9.507      9.282      100.0%            1            1
                                 read_force_count_p100      97.6%      4.162      4.062      100.0%            1            1
            export_range_matrix_table_entry_field_p100      97.5%     11.272     10.986      100.0%            1            1
       table_annotate_many_nested_dependence_constants      97.3%      7.007      6.819      100.0%            1            1
                          test_left_join_region_memory      97.3%     17.402     16.930      100.0%          764          764

...
```