### PR TITLE
[utils] make sleep_and_backoff a bit more predictable

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,4 +1,5 @@
 import random
+import datetime
 import math
 import collections
 import os
@@ -801,12 +802,12 @@ def test_job_private_instance_cancel(client):
     start = time.time()
     while True:
         status = j.status()
-        if time.time() - start > 60:
-            assert False, f'timed out waiting for creating state: {status}'
         if status['state'] == 'Creating':
             break
+        now = time.time()
+        if now + delay > 60:
+            assert False, f'timed out waiting for creating state: {status} {datetime.datetime.fromtimestamp(now)}'
         delay = sync_sleep_and_backoff(delay)
-
     b.cancel()
     status = j.wait()
     assert status['state'] == 'Cancelled', str(status)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -805,7 +805,7 @@ def test_job_private_instance_cancel(client):
         if status['state'] == 'Creating':
             break
         now = time.time()
-        if now + delay > 60:
+        if now + delay - start > 60:
             assert False, f'timed out waiting for creating state: {status} {datetime.datetime.fromtimestamp(now)}'
         delay = sync_sleep_and_backoff(delay)
     b.cancel()

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -319,7 +319,7 @@ set +e
 /busybox/sh /convert-google-application-credentials-to-kaniko-auth-config
 set -e
 
-/kaniko/executor --dockerfile={shq(dockerfile_in_context)} --context=dir://{shq(context)} --destination={shq(self.image)} --cache=true --cache-repo={shq(cache_repo)} --snapshotMode=redo --use-new-run'''
+exec /kaniko/executor --dockerfile={shq(dockerfile_in_context)} --context=dir://{shq(context)} --destination={shq(self.image)} --cache=true --cache-repo={shq(cache_repo)} --snapshotMode=redo --use-new-run'''
 
         log.info(f'step {self.name}, script:\n{script}')
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -588,16 +588,16 @@ def is_transient_error(e):
 
 async def sleep_and_backoff(delay):
     # exponentially back off, up to (expected) max of 30s
-    t = delay * random.random()
+    t = delay * random.uniform(0.9, 1.1)
     await asyncio.sleep(t)
-    return min(delay * 2, 60.0)
+    return min(delay * 2, 30.0)
 
 
 def sync_sleep_and_backoff(delay):
     # exponentially back off, up to (expected) max of 30s
-    t = delay * random.random()
+    t = delay * random.uniform(0.9, 1.1)
     time.sleep(t)
-    return min(delay * 2, 60.0)
+    return min(delay * 2, 30.0)
 
 
 def retry_all_errors(msg=None, error_logging_interval=10):


### PR DESCRIPTION
Multiplying by random number from 0 to 1 uniformly seems a bit too aggressive and harder for us, as
the programmers, to understand.

Consider that, one in a hundred uses of this function, we will get a sequence of random draws with
each number less than 0.1:

    0.1, ..., 0.05, ..., 0.09

For that same sequence of draws, the sequence of delays, if started at 0.1, is this:

    0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2

The next delay will be 60. Suppose the next draw is 1.0. We will have waited no more than ~5 seconds
[1], but our next delay is 60 seconds!

This PR proposes using

    t = delay * random.uniform(0.9, 1.1)

which ensures that each delay is at least 90% of the expected delay. In the worst case scenario, by
the 11th attempt we have waited, in total, at least ~45 seconds.

I think this is better because whatever code we run between the delays is highly likely to follow an
exponential back-off up to 30s rather. Currently, there is a one-in-one-hundred chance that we have
ten delays of <2.5 seconds followed by something relatively large like 30s.