### PR TITLE
[batch] update GPG key before apt-get update on build-worker instance

### DIFF
--- a/batch/build-batch-worker-image-startup.sh
+++ b/batch/build-batch-worker-image-startup.sh
@@ -5,6 +5,10 @@ set -ex
 curl --silent --show-error --remote-name --fail https://dl.google.com/cloudagents/add-logging-agent-repo.sh
 bash add-logging-agent-repo.sh
 
+
+# Get the lates GPG key as it might not always be up to date
+# https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 apt-get update
 
 apt-get install -y \

--- a/batch/build-batch-worker-image-startup.sh
+++ b/batch/build-batch-worker-image-startup.sh
@@ -6,7 +6,7 @@ curl --silent --show-error --remote-name --fail https://dl.google.com/cloudagent
 bash add-logging-agent-repo.sh
 
 
-# Get the lates GPG key as it might not always be up to date
+# Get the latest GPG key as it might not always be up to date
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 apt-get update


### PR DESCRIPTION
Tested this manually to make sure that the build-worker instance ran to completion (it fails on `apt-get update` currently)