### PR TITLE
[docs] rework layout template logic

### DIFF
--- a/hail/python/hail/docs/_templates/layout.html
+++ b/hail/python/hail/docs/_templates/layout.html
@@ -91,26 +91,26 @@
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
-          {% if logo and theme_logo_only %}
-            <a href="{{ pathto(master_doc) }}">
-          {% else %}
-            <a href="{{ pathto(master_doc) }}"><span class="icon icon-home"></span> {{ project }} Docs
-            {% if theme_display_version %}
+          <a href="{{ pathto(master_doc) }}">
+            {% if not logo or not theme_logo_only %}
+              <span class="icon icon-home"></span> {{ project }} Docs
+              {% if theme_display_version %}
                 {%- set nav_version = version %}
                 {% if READTHEDOCS and current_version %}
                   {%- set nav_version = current_version %}
                 {% endif %}
                 {% if nav_version %}
-                    ({{ nav_version }})
+                  ({{ nav_version }})
                 {% endif %}
+              {% endif %}
             {% endif %}
-          {% endif %}
 
-          {% if logo %}
-            {# Not strictly valid HTML, but it's the only way to display/scale it properly, without weird scripting or heaps of work #}
-            <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" />
-          {% endif %}
+            {% if logo %}
+              {# Not strictly valid HTML, but it's the only way to display/scale it properly, without weird scripting or heaps of work #}
+              <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" />
+            {% endif %}
           </a>
+
           {% block menu %}
             {% set toctree = toctree(maxdepth=4, collapse=theme_collapse_navigation, includehidden=True) %}
             {% if toctree %}


### PR DESCRIPTION
`curlylint` doesn't like logical blocks that produce incomplete html tags. This is the only instance in our codebase where we do that though. In either path of the if/else block we produce an open `a` tag and then close it out outside of the block. I reorganized it to avoid this and think it's actually more clear, and that creating open tags like this is a footgun to avoid since it's super easy not to close them (which we have had a lot).