### PR TITLE
[datasets] add 1000 Genomes NYGC 30x on GRCh38

### DIFF
--- a/datasets/extract/extract_1000_Genomes_30x_GRCh38_samples.sh
+++ b/datasets/extract/extract_1000_Genomes_30x_GRCh38_samples.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget -c -O - "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/20130606_g1k_3202_samples_ped_population.txt" |
+bgzip -c |
+gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_samples_ped_population.txt.bgz

--- a/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
+++ b/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
@@ -5,7 +5,7 @@ phased_url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/" \
 gt_url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/" \
               "1000G_2504_high_coverage/working/20201028_3202_raw_GT_with_annot"
 
-backend = hb.ServiceBackend()
+backend = hb.ServiceBackend(billing_project="hail-datasets-api")
 batch = hb.Batch(backend=backend, name="1kg-highcov")
 for i in [str(x) for x in range(1,23)]:
     j = batch.new_job(name=i)

--- a/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
+++ b/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
@@ -1,0 +1,23 @@
+import hailtop.batch as hb
+
+url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/working/20201028_3202_phased"
+chr_i = [str(x) for x in range(1,23)]
+
+backend = hb.ServiceBackend()
+batch = hb.Batch(backend=backend, name="1kg-highcov")
+for i in chr_i:
+    j = batch.new_job(name=i)
+    j.image("gcr.io/broad-ctsa/datasets:041421")
+    j.command(f"wget -c -O - {url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.shapeit2-duohmm-phased.vcf.gz | "
+              f"zcat | "
+              f"bgzip -c | "
+              f"gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_phased_chr{i}_GRCh38.vcf.bgz")
+for i in ["X"]:
+    j = batch.new_job(name=i)
+    j.image("gcr.io/broad-ctsa/datasets:041421")
+    j.command(f"wget -c -O - {url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.eagle2-phased.vcf.gz | "
+              f"zcat | "
+              f"bgzip -c | "
+              f"gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_phased_chr{i}_GRCh38.vcf.bgz")
+batch.run(open=True, wait=False)
+backend.close()

--- a/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
+++ b/datasets/extract/extract_1000_Genomes_NYGC_30x_GRCh38.py
@@ -1,23 +1,32 @@
 import hailtop.batch as hb
 
-url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/working/20201028_3202_phased"
-chr_i = [str(x) for x in range(1,23)]
+phased_url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/" \
+                  "1000G_2504_high_coverage/working/20201028_3202_phased"
+gt_url_root = "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/" \
+              "1000G_2504_high_coverage/working/20201028_3202_raw_GT_with_annot"
 
 backend = hb.ServiceBackend()
 batch = hb.Batch(backend=backend, name="1kg-highcov")
-for i in chr_i:
+for i in [str(x) for x in range(1,23)]:
     j = batch.new_job(name=i)
     j.image("gcr.io/broad-ctsa/datasets:041421")
-    j.command(f"wget -c -O - {url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.shapeit2-duohmm-phased.vcf.gz | "
+    j.command(f"wget -c -O - {phased_url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.shapeit2-duohmm-phased.vcf.gz | "
               f"zcat | "
               f"bgzip -c | "
               f"gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_phased_chr{i}_GRCh38.vcf.bgz")
 for i in ["X"]:
     j = batch.new_job(name=i)
     j.image("gcr.io/broad-ctsa/datasets:041421")
-    j.command(f"wget -c -O - {url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.eagle2-phased.vcf.gz | "
+    j.command(f"wget -c -O - {phased_url_root}/CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.filtered.eagle2-phased.vcf.gz | "
               f"zcat | "
               f"bgzip -c | "
               f"gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_phased_chr{i}_GRCh38.vcf.bgz")
+for i in ["Y"]:
+    j = batch.new_job(name=i)
+    j.image("gcr.io/broad-ctsa/datasets:041421")
+    j.command(f"wget -c -O - {gt_url_root}/20201028_CCDG_14151_B01_GRM_WGS_2020-08-05_chr{i}.recalibrated_variants.vcf.gz | "
+              f"zcat | "
+              f"bgzip -c | "
+              f"gsutil cp - gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_chr{i}_GRCh38.vcf.bgz")
 batch.run(open=True, wait=False)
 backend.close()

--- a/datasets/load/load_1000_Genomes_NYGC_30x_HighCov_samples.py
+++ b/datasets/load/load_1000_Genomes_NYGC_30x_HighCov_samples.py
@@ -1,0 +1,31 @@
+import hail as hl
+
+ht_samples = hl.import_table(
+        "gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_samples_ped_population.txt.bgz",
+        delimiter="\s+",
+        impute=True)
+
+ht_samples = ht_samples.annotate(FatherID=hl.if_else(ht_samples.FatherID == "0",
+                                                     hl.missing(hl.tstr),
+                                                     ht_samples.FatherID),
+                                 MotherID=hl.if_else(ht_samples.MotherID == "0",
+                                                     hl.missing(hl.tstr),
+                                                     ht_samples.MotherID),
+                                 Sex=hl.if_else(ht_samples.Sex == 1, "male", "female"))
+ht_samples = ht_samples.key_by("SampleID")
+
+n_rows = ht_samples.count()
+n_partitions = ht_samples.n_partitions()
+
+ht_samples = ht_samples.annotate_globals(
+        metadata=hl.struct(
+                name="1000_Genomes_HighCov_samples",
+                n_rows=n_rows,
+                n_partitions=n_partitions
+        )
+)
+
+ht_samples.write("gs://hail-datasets-us/1000_Genomes_NYGC_30x_HighCov_samples.ht", overwrite=True)
+
+ht_samples = hl.read_table("gs://hail-datasets-us/1000_Genomes_NYGC_30x_HighCov_samples.ht")
+ht_samples.describe()

--- a/datasets/load/load_1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.py
+++ b/datasets/load/load_1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.py
@@ -1,0 +1,31 @@
+import hail as hl
+
+ht_samples = hl.read_table("gs://hail-datasets-us/1000_Genomes_NYGC_30x_HighCov_samples.ht")
+
+mt = hl.import_vcf(
+        ("gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_"
+         "phased_chr{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22}_"
+         "GRCh38.vcf.bgz"),
+        reference_genome="GRCh38")
+
+n_rows, n_cols = mt.count()
+n_partitions = mt.n_partitions()
+
+mt = mt.annotate_globals(
+        metadata=hl.struct(
+                name="1000_Genomes_HighCov_autosomes",
+                reference_genome="GRCh38",
+                n_rows=n_rows,
+                n_cols=n_cols,
+                n_partitions=n_partitions
+        )
+)
+
+mt = mt.annotate_cols(**ht_samples[mt.s])
+mt = hl.sample_qc(mt)
+mt = hl.variant_qc(mt)
+
+mt.write("gs://hail-datasets-us/1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.mt", overwrite=False)
+
+mt = hl.read_matrix_table("gs://hail-datasets-us/1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.mt")
+mt.describe()

--- a/datasets/load/load_1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.py
+++ b/datasets/load/load_1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.py
@@ -1,0 +1,29 @@
+import hail as hl
+
+ht_samples = hl.read_table("gs://hail-datasets-us/1000_Genomes_NYGC_30x_HighCov_samples.ht")
+
+mt = hl.import_vcf(
+        "gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_phased_chrX_GRCh38.vcf.bgz",
+        reference_genome="GRCh38")
+
+n_rows, n_cols = mt.count()
+n_partitions = mt.n_partitions()
+
+mt = mt.annotate_globals(
+        metadata=hl.struct(
+                name="1000_Genomes_HighCov_chrX",
+                reference_genome="GRCh38",
+                n_rows=n_rows,
+                n_cols=n_cols,
+                n_partitions=n_partitions
+        )
+)
+
+mt = mt.annotate_cols(**ht_samples[mt.s])
+mt = hl.sample_qc(mt)
+mt = hl.variant_qc(mt)
+
+mt.write("gs://hail-datasets-us/1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.mt", overwrite=True)
+
+mt = hl.read_matrix_table("gs://hail-datasets-us/1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.mt")
+mt.describe()

--- a/datasets/load/load_1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.py
+++ b/datasets/load/load_1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.py
@@ -1,0 +1,29 @@
+import hail as hl
+
+ht_samples = hl.read_table("gs://hail-datasets-us/1000_Genomes_NYGC_30x_HighCov_samples.ht")
+
+mt = hl.import_vcf(
+        "gs://hail-datasets-tmp/1000_Genomes_NYGC_30x/1000_Genomes_NYGC_30x_chrY_GRCh38.vcf.bgz",
+        reference_genome="GRCh38")
+
+n_rows, n_cols = mt.count()
+n_partitions = mt.n_partitions()
+
+mt = mt.annotate_globals(
+        metadata=hl.struct(
+                name="1000_Genomes_HighCov_chrY",
+                reference_genome="GRCh38",
+                n_rows=n_rows,
+                n_cols=n_cols,
+                n_partitions=n_partitions
+        )
+)
+
+mt = mt.annotate_cols(**ht_samples[mt.s])
+mt = hl.sample_qc(mt)
+mt = hl.variant_qc(mt)
+
+mt.write("gs://hail-datasets-us/1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.mt", overwrite=True)
+
+mt = hl.read_matrix_table("gs://hail-datasets-us/1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.mt")
+mt.describe()

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_autosomes.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_autosomes.rst
@@ -1,0 +1,171 @@
+.. _1000_Genomes_HighCov_autosomes:
+
+1000_Genomes_HighCov_autosomes
+==============================
+
+*  **Versions:** NYGC_30x
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (NYGC_30x, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'FamilyID': str
+        'FatherID': str
+        'MotherID': str
+        'Sex': str
+        'Population': str
+        'Superpopulation': str
+        'sample_qc': struct {
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            AC: array<int32>,
+            AC_AFR: array<int32>,
+            AC_AMR: array<int32>,
+            AC_EAS: array<int32>,
+            AC_EUR: array<int32>,
+            AC_Het: array<int32>,
+            AC_Het_AFR: array<int32>,
+            AC_Het_AMR: array<int32>,
+            AC_Het_EAS: array<int32>,
+            AC_Het_EUR: array<int32>,
+            AC_Het_SAS: array<int32>,
+            AC_Hom: array<int32>,
+            AC_Hom_AFR: array<int32>,
+            AC_Hom_AMR: array<int32>,
+            AC_Hom_EAS: array<int32>,
+            AC_Hom_EUR: array<int32>,
+            AC_Hom_SAS: array<int32>,
+            AC_SAS: array<int32>,
+            AF: array<float64>,
+            AF_AFR: array<float64>,
+            AF_AMR: array<float64>,
+            AF_EAS: array<float64>,
+            AF_EUR: array<float64>,
+            AF_SAS: array<float64>,
+            AN: int32,
+            AN_AFR: int32,
+            AN_AMR: int32,
+            AN_EAS: int32,
+            AN_EUR: int32,
+            AN_SAS: int32,
+            BaseQRankSum: float64,
+            ClippingRankSum: float64,
+            DP: int32,
+            DS: bool,
+            END: int32,
+            FS: float64,
+            HWE: array<float64>,
+            HWE_AFR: array<float64>,
+            HWE_AMR: array<float64>,
+            HWE_EAS: array<float64>,
+            HWE_EUR: array<float64>,
+            HWE_SAS: array<float64>,
+            HaplotypeScore: float64,
+            InbreedingCoeff: float64,
+            MLEAC: array<int32>,
+            MLEAF: array<float64>,
+            MQ: float64,
+            MQ0: int32,
+            MQRankSum: float64,
+            NEGATIVE_TRAIN_SITE: bool,
+            POSITIVE_TRAIN_SITE: bool,
+            QD: float64,
+            RAW_MQ: float64,
+            ReadPosRankSum: float64,
+            SOR: float64,
+            VQSLOD: float64,
+            VariantType: str,
+            culprit: str,
+            AN_EUR_unrel: int32,
+            AN_EAS_unrel: int32,
+            AN_AMR_unrel: int32,
+            AN_SAS_unrel: int32,
+            AN_AFR_unrel: int32,
+            AC_EUR_unrel: array<int32>,
+            AC_EAS_unrel: array<int32>,
+            AC_AMR_unrel: array<int32>,
+            AC_SAS_unrel: array<int32>,
+            AC_AFR_unrel: array<int32>,
+            AC_Hom_EUR_unrel: array<int32>,
+            AC_Hom_EAS_unrel: array<int32>,
+            AC_Hom_AMR_unrel: array<int32>,
+            AC_Hom_SAS_unrel: array<int32>,
+            AC_Hom_AFR_unrel: array<int32>,
+            AC_Het_EUR_unrel: array<int32>,
+            AC_Het_EAS_unrel: array<int32>,
+            AC_Het_AMR_unrel: array<int32>,
+            AC_Het_SAS_unrel: array<int32>,
+            AC_Het_AFR_unrel: array<int32>,
+            AF_EUR_unrel: array<float64>,
+            AF_EAS_unrel: array<float64>,
+            AF_AMR_unrel: array<float64>,
+            AF_SAS_unrel: array<float64>,
+            AF_AFR_unrel: array<float64>,
+            ExcHet_EAS: array<float64>,
+            ExcHet_AMR: array<float64>,
+            ExcHet_EUR: array<float64>,
+            ExcHet_AFR: array<float64>,
+            ExcHet_SAS: array<float64>,
+            ExcHet: array<float64>
+        }
+        'variant_qc': struct {
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'GT': call
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_chrX.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_chrX.rst
@@ -1,0 +1,206 @@
+.. _1000_Genomes_HighCov_chrX:
+
+1000_Genomes_HighCov_chrX
+=========================
+
+*  **Versions:** NYGC_30x
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (NYGC_30x, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'FamilyID': str
+        'FatherID': str
+        'MotherID': str
+        'Sex': str
+        'Population': str
+        'Superpopulation': str
+        'sample_qc': struct {
+            dp_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            gq_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            AC: array<int32>,
+            AC_AFR: array<int32>,
+            AC_AMR: array<int32>,
+            AC_EAS: array<int32>,
+            AC_EUR: array<int32>,
+            AC_Het: array<int32>,
+            AC_Het_AFR: array<int32>,
+            AC_Het_AMR: array<int32>,
+            AC_Het_EAS: array<int32>,
+            AC_Het_EUR: array<int32>,
+            AC_Het_SAS: array<int32>,
+            AC_Hom: array<int32>,
+            AC_Hom_AFR: array<int32>,
+            AC_Hom_AMR: array<int32>,
+            AC_Hom_EAS: array<int32>,
+            AC_Hom_EUR: array<int32>,
+            AC_Hom_SAS: array<int32>,
+            AC_SAS: array<int32>,
+            AF: array<float64>,
+            AF_AFR: array<float64>,
+            AF_AMR: array<float64>,
+            AF_EAS: array<float64>,
+            AF_EUR: array<float64>,
+            AF_SAS: array<float64>,
+            AN: int32,
+            AN_AFR: int32,
+            AN_AMR: int32,
+            AN_EAS: int32,
+            AN_EUR: int32,
+            AN_SAS: int32,
+            BaseQRankSum: float64,
+            ClippingRankSum: float64,
+            DP: int32,
+            DS: bool,
+            END: int32,
+            FS: float64,
+            HWE: array<float64>,
+            HWE_AFR: array<float64>,
+            HWE_AMR: array<float64>,
+            HWE_EAS: array<float64>,
+            HWE_EUR: array<float64>,
+            HWE_SAS: array<float64>,
+            HaplotypeScore: float64,
+            InbreedingCoeff: float64,
+            MLEAC: array<int32>,
+            MLEAF: array<float64>,
+            MQ: float64,
+            MQ0: int32,
+            MQRankSum: float64,
+            NEGATIVE_TRAIN_SITE: bool,
+            POSITIVE_TRAIN_SITE: bool,
+            QD: float64,
+            RAW_MQ: float64,
+            ReadPosRankSum: float64,
+            SOR: float64,
+            VQSLOD: float64,
+            VariantType: str,
+            culprit: str,
+            AN_EUR_unrel: int32,
+            AN_EAS_unrel: int32,
+            AN_AMR_unrel: int32,
+            AN_SAS_unrel: int32,
+            AN_AFR_unrel: int32,
+            AC_EUR_unrel: array<int32>,
+            AC_EAS_unrel: array<int32>,
+            AC_AMR_unrel: array<int32>,
+            AC_SAS_unrel: array<int32>,
+            AC_AFR_unrel: array<int32>,
+            AC_Hom_EUR_unrel: array<int32>,
+            AC_Hom_EAS_unrel: array<int32>,
+            AC_Hom_AMR_unrel: array<int32>,
+            AC_Hom_SAS_unrel: array<int32>,
+            AC_Hom_AFR_unrel: array<int32>,
+            AC_Het_EUR_unrel: array<int32>,
+            AC_Het_EAS_unrel: array<int32>,
+            AC_Het_AMR_unrel: array<int32>,
+            AC_Het_SAS_unrel: array<int32>,
+            AC_Het_AFR_unrel: array<int32>,
+            AF_EUR_unrel: array<float64>,
+            AF_EAS_unrel: array<float64>,
+            AF_AMR_unrel: array<float64>,
+            AF_SAS_unrel: array<float64>,
+            AF_AFR_unrel: array<float64>,
+            ExcHet_EAS: array<float64>,
+            ExcHet_AMR: array<float64>,
+            ExcHet_EUR: array<float64>,
+            ExcHet_AFR: array<float64>,
+            ExcHet_SAS: array<float64>,
+            ExcHet: array<float64>
+        }
+        'variant_qc': struct {
+            dp_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            gq_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'AB': float64
+        'AD': array<int32>
+        'DP': int32
+        'GQ': int32
+        'GT': call
+        'MIN_DP': int32
+        'MQ0': int32
+        'PGT': call
+        'PID': str
+        'PL': array<int32>
+        'RGQ': int32
+        'SB': array<int32>
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_chrY.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_HighCov_chrY.rst
@@ -1,0 +1,173 @@
+.. _1000_Genomes_HighCov_chrY:
+
+1000_Genomes_HighCov_chrY
+=========================
+
+*  **Versions:** NYGC_30x
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (NYGC_30x, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'FamilyID': str
+        'FatherID': str
+        'MotherID': str
+        'Sex': str
+        'Population': str
+        'Superpopulation': str
+        'sample_qc': struct {
+            dp_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            gq_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            BaseQRankSum: float64,
+            ClippingRankSum: float64,
+            DP: int32,
+            DS: bool,
+            END: int32,
+            ExcessHet: float64,
+            FS: float64,
+            HaplotypeScore: float64,
+            InbreedingCoeff: float64,
+            MLEAC: array<int32>,
+            MLEAF: array<float64>,
+            MQ: float64,
+            MQ0: int32,
+            MQRankSum: float64,
+            NEGATIVE_TRAIN_SITE: bool,
+            POSITIVE_TRAIN_SITE: bool,
+            QD: float64,
+            RAW_MQ: float64,
+            ReadPosRankSum: float64,
+            SOR: float64,
+            VQSLOD: float64,
+            VariantType: str,
+            culprit: str,
+            AN_EAS: int32,
+            AN_AMR: int32,
+            AN_EUR: int32,
+            AN_AFR: int32,
+            AN_SAS: int32,
+            AN_EUR_unrel: int32,
+            AN_EAS_unrel: int32,
+            AN_AMR_unrel: int32,
+            AN_SAS_unrel: int32,
+            AN_AFR_unrel: int32,
+            AC_EAS: array<int32>,
+            AC_AMR: array<int32>,
+            AC_EUR: array<int32>,
+            AC_AFR: array<int32>,
+            AC_SAS: array<int32>,
+            AC_EUR_unrel: array<int32>,
+            AC_EAS_unrel: array<int32>,
+            AC_AMR_unrel: array<int32>,
+            AC_SAS_unrel: array<int32>,
+            AC_AFR_unrel: array<int32>,
+            AF_EAS: array<float64>,
+            AF_AMR: array<float64>,
+            AF_EUR: array<float64>,
+            AF_AFR: array<float64>,
+            AF_SAS: array<float64>,
+            AF_EUR_unrel: array<float64>,
+            AF_EAS_unrel: array<float64>,
+            AF_AMR_unrel: array<float64>,
+            AF_SAS_unrel: array<float64>,
+            AF_AFR_unrel: array<float64>
+        }
+        'variant_qc': struct {
+            dp_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            gq_stats: struct {
+                mean: float64,
+                stdev: float64,
+                min: float64,
+                max: float64
+            },
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_filtered: int64,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'AB': float64
+        'AD': array<int32>
+        'DP': int32
+        'GQ': int32
+        'GT': call
+        'MIN_DP': int32
+        'MQ0': int32
+        'PGT': call
+        'PID': str
+        'PL': array<int32>
+        'RGQ': int32
+        'SB': array<int32>
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_autosomes.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_autosomes.rst
@@ -1,0 +1,128 @@
+.. _1000_Genomes_Retracted_autosomes:
+
+1000_Genomes_Retracted_autosomes
+================================
+
+*  **Versions:** phase_3
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (phase_3, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'population': str
+        'super_population': str
+        'is_female': bool
+        'family_id': str
+        'relationship_role': str
+        'maternal_id': str
+        'paternal_id': str
+        'children_ids': array<str>
+        'sibling_ids': array<str>
+        'second_order_relationship_ids': array<str>
+        'third_order_relationship_ids': array<str>
+        'sample_qc': struct {
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            CIEND: int32,
+            CIPOS: int32,
+            CS: str,
+            END: int32,
+            IMPRECISE: bool,
+            MC: array<str>,
+            MEINFO: array<str>,
+            MEND: int32,
+            MLEN: int32,
+            MSTART: int32,
+            SVLEN: array<int32>,
+            SVTYPE: str,
+            TSD: str,
+            AC: int32,
+            AF: float64,
+            NS: int32,
+            AN: int32,
+            EAS_AF: float64,
+            EUR_AF: float64,
+            AFR_AF: float64,
+            AMR_AF: float64,
+            SAS_AF: float64,
+            DP: int32,
+            AA: str,
+            VT: str,
+            EX_TARGET: bool,
+            MULTI_ALLELIC: bool,
+            STRAND_FLIP: bool,
+            REF_SWITCH: bool,
+            DEPRECATED_RSID: array<str>,
+            RSID_REMOVED: array<str>,
+            GRCH37_38_REF_STRING_MATCH: bool,
+            NOT_ALL_RSIDS_STRAND_CHANGE_OR_REF_SWITCH: bool,
+            GRCH37_POS: int32,
+            GRCH37_REF: str,
+            ALLELE_TRANSFORM: bool,
+            REF_NEW_ALLELE: bool,
+            CHROM_CHANGE_BETWEEN_ASSEMBLIES: str
+        }
+        'a_index': int32
+        'was_split': bool
+        'old_locus': locus<GRCh38>
+        'old_alleles': array<str>
+        'variant_qc': struct {
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            n_called: int64,
+            n_not_called: int64,
+            call_rate: float32,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'GT': call
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_chrX.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_chrX.rst
@@ -1,0 +1,128 @@
+.. _1000_Genomes_Retracted_chrX:
+
+1000_Genomes_Retracted_chrX
+===========================
+
+*  **Versions:** phase_3
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (phase_3, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'population': str
+        'super_population': str
+        'is_female': bool
+        'family_id': str
+        'relationship_role': str
+        'maternal_id': str
+        'paternal_id': str
+        'children_ids': array<str>
+        'sibling_ids': array<str>
+        'second_order_relationship_ids': array<str>
+        'third_order_relationship_ids': array<str>
+        'sample_qc': struct {
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            CIEND: int32,
+            CIPOS: int32,
+            CS: str,
+            END: int32,
+            IMPRECISE: bool,
+            MC: array<str>,
+            MEINFO: array<str>,
+            MEND: int32,
+            MLEN: int32,
+            MSTART: int32,
+            SVLEN: array<int32>,
+            SVTYPE: str,
+            TSD: str,
+            AC: int32,
+            AF: float64,
+            NS: int32,
+            AN: int32,
+            EAS_AF: float64,
+            EUR_AF: float64,
+            AFR_AF: float64,
+            AMR_AF: float64,
+            SAS_AF: float64,
+            DP: int32,
+            AA: str,
+            VT: str,
+            EX_TARGET: bool,
+            MULTI_ALLELIC: bool,
+            STRAND_FLIP: bool,
+            REF_SWITCH: bool,
+            DEPRECATED_RSID: array<str>,
+            RSID_REMOVED: array<str>,
+            GRCH37_38_REF_STRING_MATCH: bool,
+            NOT_ALL_RSIDS_STRAND_CHANGE_OR_REF_SWITCH: bool,
+            GRCH37_POS: int32,
+            GRCH37_REF: str,
+            ALLELE_TRANSFORM: bool,
+            REF_NEW_ALLELE: bool,
+            CHROM_CHANGE_BETWEEN_ASSEMBLIES: str
+        }
+        'a_index': int32
+        'was_split': bool
+        'old_locus': locus<GRCh38>
+        'old_alleles': array<str>
+        'variant_qc': struct {
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            n_called: int64,
+            n_not_called: int64,
+            call_rate: float32,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'GT': call
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_chrY.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_Retracted_chrY.rst
@@ -1,0 +1,117 @@
+.. _1000_Genomes_Retracted_chrY:
+
+1000_Genomes_Retracted_chrY
+===========================
+
+*  **Versions:** phase_3
+*  **Reference genome builds:** GRCh38
+*  **Type:** :class:`hail.MatrixTable`
+
+Schema (phase_3, GRCh38)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    ----------------------------------------
+    Global fields:
+        'metadata': struct {
+            name: str,
+            version: str,
+            reference_genome: str,
+            n_rows: int32,
+            n_cols: int32,
+            n_partitions: int32
+        }
+    ----------------------------------------
+    Column fields:
+        's': str
+        'population': str
+        'super_population': str
+        'is_female': bool
+        'family_id': str
+        'relationship_role': str
+        'maternal_id': str
+        'paternal_id': str
+        'children_ids': array<str>
+        'sibling_ids': array<str>
+        'second_order_relationship_ids': array<str>
+        'third_order_relationship_ids': array<str>
+        'sample_qc': struct {
+            call_rate: float64,
+            n_called: int64,
+            n_not_called: int64,
+            n_hom_ref: int64,
+            n_het: int64,
+            n_hom_var: int64,
+            n_non_ref: int64,
+            n_singleton: int64,
+            n_snp: int64,
+            n_insertion: int64,
+            n_deletion: int64,
+            n_transition: int64,
+            n_transversion: int64,
+            n_star: int64,
+            r_ti_tv: float64,
+            r_het_hom_var: float64,
+            r_insertion_deletion: float64
+        }
+    ----------------------------------------
+    Row fields:
+        'locus': locus<GRCh38>
+        'alleles': array<str>
+        'rsid': str
+        'qual': float64
+        'filters': set<str>
+        'info': struct {
+            DP: int32,
+            END: int32,
+            SVTYPE: str,
+            AA: str,
+            AC: int32,
+            AF: float64,
+            NS: int32,
+            AN: int32,
+            EAS_AF: float64,
+            EUR_AF: float64,
+            AFR_AF: float64,
+            AMR_AF: float64,
+            SAS_AF: float64,
+            VT: str,
+            EX_TARGET: bool,
+            MULTI_ALLELIC: bool,
+            STRAND_FLIP: bool,
+            REF_SWITCH: bool,
+            DEPRECATED_RSID: str,
+            RSID_REMOVED: str,
+            GRCH37_38_REF_STRING_MATCH: bool,
+            NOT_ALL_RSIDS_STRAND_CHANGE_OR_REF_SWITCH: bool,
+            GRCH37_POS: int32,
+            GRCH37_REF: str,
+            ALLELE_TRANSFORM: bool,
+            REF_NEW_ALLELE: bool,
+            CHROM_CHANGE_BETWEEN_ASSEMBLIES: str
+        }
+        'a_index': int32
+        'was_split': bool
+        'old_locus': locus<GRCh38>
+        'old_alleles': array<str>
+        'variant_qc': struct {
+            AC: array<int32>,
+            AF: array<float64>,
+            AN: int32,
+            homozygote_count: array<int32>,
+            n_called: int64,
+            n_not_called: int64,
+            call_rate: float32,
+            n_het: int64,
+            n_non_ref: int64,
+            het_freq_hwe: float64,
+            p_value_hwe: float64
+        }
+    ----------------------------------------
+    Entry fields:
+        'GT': call
+    ----------------------------------------
+    Column key: ['s']
+    Row key: ['locus', 'alleles']
+    ----------------------------------------

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_autosomes.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_autosomes.rst
@@ -4,7 +4,7 @@
 ======================
 
 *  **Versions:** phase_3
-*  **Reference genome builds:** GRCh37, GRCh38
+*  **Reference genome builds:** GRCh37
 *  **Type:** :class:`hail.MatrixTable`
 
 Schema (phase_3, GRCh37)
@@ -115,4 +115,3 @@ Schema (phase_3, GRCh37)
     Column key: ['s']
     Row key: ['locus', 'alleles']
     ----------------------------------------
-

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_chrX.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_chrX.rst
@@ -4,7 +4,7 @@
 =================
 
 *  **Versions:** phase_3
-*  **Reference genome builds:** GRCh37, GRCh38
+*  **Reference genome builds:** GRCh37
 *  **Type:** :class:`hail.MatrixTable`
 
 Schema (phase_3, GRCh37)
@@ -115,4 +115,3 @@ Schema (phase_3, GRCh37)
     Column key: ['s']
     Row key: ['locus', 'alleles']
     ----------------------------------------
-

--- a/hail/python/hail/docs/datasets/schemas/1000_Genomes_chrY.rst
+++ b/hail/python/hail/docs/datasets/schemas/1000_Genomes_chrY.rst
@@ -4,7 +4,7 @@
 =================
 
 *  **Versions:** phase_3
-*  **Reference genome builds:** GRCh37, GRCh38
+*  **Reference genome builds:** GRCh37
 *  **Type:** :class:`hail.MatrixTable`
 
 Schema (phase_3, GRCh37)
@@ -104,4 +104,3 @@ Schema (phase_3, GRCh37)
     Column key: ['s']
     Row key: ['locus', 'alleles']
     ----------------------------------------
-

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -1,6 +1,108 @@
 {
+  "1000_Genomes_HighCov_autosomes": {
+    "description": "1000 Genomes Project: The New York Genome Center (NYGC), funded by NHGRI, has sequenced 3202 samples from the 1000 Genomes Project sample collection to 30x coverage. Initially, the 2504 unrelated samples from the phase three panel from the 1000 Genomes Project were sequenced. Thereafter, an additional 698 samples, related to samples in the 2504 panel, were also sequenced. This dataset contains phased calls.",
+    "url": "https://www.internationalgenome.org/data-portal/data-collection/30x-grch38",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_autosomes_NYGC_30x_HighCov_GRCh38.mt"
+          }
+        },
+        "version": "NYGC_30x"
+      }
+    ]
+  },
+  "1000_Genomes_HighCov_chrX": {
+    "description": "1000 Genomes Project: The New York Genome Center (NYGC), funded by NHGRI, has sequenced 3202 samples from the 1000 Genomes Project sample collection to 30x coverage. Initially, the 2504 unrelated samples from the phase three panel from the 1000 Genomes Project were sequenced. Thereafter, an additional 698 samples, related to samples in the 2504 panel, were also sequenced. This dataset contains phased calls.",
+    "url": "https://www.internationalgenome.org/data-portal/data-collection/30x-grch38",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrX_NYGC_30x_HighCov_GRCh38.mt"
+          }
+        },
+        "version": "NYGC_30x"
+      }
+    ]
+  },
+  "1000_Genomes_HighCov_chrY": {
+    "description": "1000 Genomes Project: The New York Genome Center (NYGC), funded by NHGRI, has sequenced 3202 samples from the 1000 Genomes Project sample collection to 30x coverage. Initially, the 2504 unrelated samples from the phase three panel from the 1000 Genomes Project were sequenced. Thereafter, an additional 698 samples, related to samples in the 2504 panel, were also sequenced.",
+    "url": "https://www.internationalgenome.org/data-portal/data-collection/30x-grch38",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrY_NYGC_30x_HighCov_GRCh38.mt"
+          }
+        },
+        "version": "NYGC_30x"
+      }
+    ]
+  },
+  "1000_Genomes_Retracted": {
+    "description": "1000 Genomes Project: These datasets have been retracted due to a number of known issues on GRCh38, see link for more details.",
+    "url": "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/supporting/GRCh38_positions/README_GRCh38_liftover_20170504.txt",
+    "versions": [
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_autosomes.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh38.mt"
+          }
+        },
+        "version": "phase_3_autosomes"
+      },
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrX.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh38.mt"
+          }
+        },
+        "version": "phase_3_chrX"
+      },
+      {
+        "reference_genome": "GRCh38",
+        "url": {
+          "aws": {
+            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrY.phase_3.GRCh38.mt"
+          },
+          "gcp": {
+            "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh38.mt",
+            "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh38.mt"
+          }
+        },
+        "version": "phase_3_chrY"
+      }
+    ]
+  },
   "1000_Genomes_autosomes": {
-    "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_autosomes version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage autosomes phased dataset is available as 1000_Genomes_HighCov_autosomes.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -15,24 +117,11 @@
           }
         },
         "version": "phase_3"
-      },
-      {
-        "reference_genome": "GRCh38",
-        "url": {
-          "aws": {
-            "us": "s3://hail-datasets-us-east-1/1000_Genomes_autosomes.phase_3.GRCh38.mt"
-          },
-          "gcp": {
-            "eu": "gs://hail-datasets-eu/1000_Genomes_autosomes.phase_3.GRCh38.mt",
-            "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh38.mt"
-          }
-        },
-        "version": "phase_3"
       }
     ]
   },
   "1000_Genomes_chrMT": {
-    "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
+    "description": "1000 Genomes Project: Mitochondrial chromosome variants.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -51,7 +140,7 @@
     ]
   },
   "1000_Genomes_chrX": {
-    "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_chrX version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage chrX phased dataset is available as 1000_Genomes_HighCov_chrX.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -66,24 +155,11 @@
           }
         },
         "version": "phase_3"
-      },
-      {
-        "reference_genome": "GRCh38",
-        "url": {
-          "aws": {
-            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrX.phase_3.GRCh38.mt"
-          },
-          "gcp": {
-            "eu": "gs://hail-datasets-eu/1000_Genomes_chrX.phase_3.GRCh38.mt",
-            "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh38.mt"
-          }
-        },
-        "version": "phase_3"
       }
     ]
   },
   "1000_Genomes_chrY": {
-    "description": "1000 Genomes Project: the largest public catalogue of human variation and genotype data.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_chrY version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage chrY dataset is available as 1000_Genomes_HighCov_chrY.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -95,19 +171,6 @@
           "gcp": {
             "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh37.mt",
             "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh37.mt"
-          }
-        },
-        "version": "phase_3"
-      },
-      {
-        "reference_genome": "GRCh38",
-        "url": {
-          "aws": {
-            "us": "s3://hail-datasets-us-east-1/1000_Genomes_chrY.phase_3.GRCh38.mt"
-          },
-          "gcp": {
-            "eu": "gs://hail-datasets-eu/1000_Genomes_chrY.phase_3.GRCh38.mt",
-            "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh38.mt"
           }
         },
         "version": "phase_3"

--- a/hail/python/hail/experimental/datasets.json
+++ b/hail/python/hail/experimental/datasets.json
@@ -56,7 +56,7 @@
       }
     ]
   },
-  "1000_Genomes_Retracted": {
+  "1000_Genomes_Retracted_autosomes": {
     "description": "1000 Genomes Project: These datasets have been retracted due to a number of known issues on GRCh38, see link for more details.",
     "url": "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/supporting/GRCh38_positions/README_GRCh38_liftover_20170504.txt",
     "versions": [
@@ -71,8 +71,14 @@
             "us": "gs://hail-datasets-us/1000_Genomes_autosomes.phase_3.GRCh38.mt"
           }
         },
-        "version": "phase_3_autosomes"
-      },
+        "version": "phase_3"
+      }
+    ]
+  },
+  "1000_Genomes_Retracted_chrX": {
+    "description": "1000 Genomes Project: These datasets have been retracted due to a number of known issues on GRCh38, see link for more details.",
+    "url": "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/supporting/GRCh38_positions/README_GRCh38_liftover_20170504.txt",
+    "versions": [
       {
         "reference_genome": "GRCh38",
         "url": {
@@ -84,8 +90,14 @@
             "us": "gs://hail-datasets-us/1000_Genomes_chrX.phase_3.GRCh38.mt"
           }
         },
-        "version": "phase_3_chrX"
-      },
+        "version": "phase_3"
+      }
+    ]
+  },
+  "1000_Genomes_Retracted_chrY": {
+    "description": "1000 Genomes Project: These datasets have been retracted due to a number of known issues on GRCh38, see link for more details.",
+    "url": "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/supporting/GRCh38_positions/README_GRCh38_liftover_20170504.txt",
+    "versions": [
       {
         "reference_genome": "GRCh38",
         "url": {
@@ -97,12 +109,12 @@
             "us": "gs://hail-datasets-us/1000_Genomes_chrY.phase_3.GRCh38.mt"
           }
         },
-        "version": "phase_3_chrY"
+        "version": "phase_3"
       }
     ]
   },
   "1000_Genomes_autosomes": {
-    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_autosomes version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage autosomes phased dataset is available as 1000_Genomes_HighCov_autosomes.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see the 1000_Genomes_Retracted_autosomes dataset). For GRCh38, the NYGC 30x coverage autosomes phased dataset is available as 1000_Genomes_HighCov_autosomes.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -140,7 +152,7 @@
     ]
   },
   "1000_Genomes_chrX": {
-    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_chrX version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage chrX phased dataset is available as 1000_Genomes_HighCov_chrX.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see the 1000_Genomes_Retracted_chrX dataset). For GRCh38, the NYGC 30x coverage chrX phased dataset is available as 1000_Genomes_HighCov_chrX.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {
@@ -159,7 +171,7 @@
     ]
   },
   "1000_Genomes_chrY": {
-    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see phase_3_chrY version of the 1000_Genomes_Retracted dataset). For GRCh38, the NYGC 30x coverage chrY dataset is available as 1000_Genomes_HighCov_chrY.",
+    "description": "1000 Genomes Project: The GRCh38 phase_3 version has been retracted, but is still available (see the 1000_Genomes_Retracted_chrY dataset). For GRCh38, the NYGC 30x coverage chrY dataset is available as 1000_Genomes_HighCov_chrY.",
     "url": "https://www.internationalgenome.org/home",
     "versions": [
       {


### PR DESCRIPTION
Adds the [1000 Genomes NYGC 30x on GRCh38](https://www.internationalgenome.org/data-portal/data-collection/30x-grch38) autosomes, chrX, and chrY MatrixTables as `1000_Genomes_HighCov_autosomes`, `1000_Genomes_HighCov_chrX`, and `1000_Genomes_HighCov_chrY`. 

The `1000_Genomes_HighCov_autosomes` and `1000_Genomes_HighCov_chrX` datasets have phased calls. 

[Due to multiple issues](http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/supporting/GRCh38_positions/README_GRCh38_liftover_20170504.txt), the phase 3 GRCh38 versions of the current `1000_Genomes_autosomes`, `1000_Genomes_chrX`, and `1000_Genomes_chrY` datasets have been retracted. They have been renamed to `1000_Genomes_Retracted_autosomes`, `1000_Genomes_Retracted_chrX`,  and `1000_Genomes_Retracted_chrY`, respectively. The phase 3 GRCh37 versions of `1000_Genomes_autosomes`, `1000_Genomes_chrX`, and `1000_Genomes_chrY` are not affected and are still accessible as before. 