### PR TITLE
[ci] fix make_pip_versioned_docs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1780,6 +1780,8 @@ steps:
       # 0.2.63 was the last old-style docs
       if [[ "$(cat hail/python/hail/hail_pip_version)" != "0.2.63" ]]
       then
+          # downloading files from GCS changes permissions, so we reset all of that first
+          git reset --hard HEAD
           # if the tag doesn't exist, this commit is the release
           git checkout $(cat hail/python/hail/hail_pip_version) || true
       fi


### PR DESCRIPTION
When we download files from GCS, they lose their permissions. Git complains and then the checkout fails.