### PR TITLE
[query] test_spectra was too slow

### DIFF
--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -128,27 +128,52 @@ def test_blanczos_against_numpy():
     np.testing.assert_allclose(eigens, np_eigenvalues, rtol=0.05)
     assert bound(np_loadings, loadings) > 0.9
 
+def make_spectral_matrix(index_func, k, m, n):
+    sigma_dim = min(m, n)
+    answer = np.zeros((m, n))
+    for j in range(sigma_dim):
+        answer[j, j] = index_func(j + 1, k)
+    return answer
+
+def matrix_table_from_numpy(np_mat):
+    rows, cols = np_mat.shape
+    mt = hl.utils.range_matrix_table(rows, cols)
+    mt = mt.annotate_globals(entries_global = np_mat)
+    mt = mt.annotate_entries(ent = mt.entries_global[mt.row_idx, mt.col_idx])
+    return mt
+
+# k, m, n
+dim_triplets = [(10, 1000, 1000), (20, 1000, 1000), (10, 100, 200)]
+
+def spectra_helper(spec_func):
+
+    for triplet in dim_triplets:
+        k, m, n = triplet
+        sigma = make_spectral_matrix(spec_func, k, m, n)
+        seed = 1025
+        np.random.seed(seed)
+        U = np.linalg.qr(np.random.normal(0, 1, (m, m)))[0]
+        V = np.linalg.qr(np.random.normal(0, 1, (n, n)))[0]
+        A = U @ sigma @ V
+        mt_A = matrix_table_from_numpy(A)
+
+        eigenvalues, scores, loadings = hl._blanczos_pca(mt_A.ent, k=k, oversampling_param=k, compute_loadings=True, q_iterations=4)
+        singulars = np.sqrt(eigenvalues)
+        hail_V = (np.array(scores.scores.collect()) / singulars).T
+        hail_U = np.array(loadings.loadings.collect())
+        approx_A = hail_U @ np.diag(singulars) @ hail_V
+        norm_of_diff = np.linalg.norm(A - approx_A, 2)
+        np.testing.assert_allclose(norm_of_diff, spec_func(k + 1, k), rtol=1e-02, err_msg=f"Norm test failed on triplet {triplet} ")
+        np.testing.assert_allclose(singulars, np.diag(sigma)[:k], rtol=1e-01, err_msg=f"Failed on triplet {triplet}")
 
 @fails_service_backend(reason='persist_ir')
-def test_spectra():
-    def make_spectral_matrix(index_func, k, m, n):
-        sigma_dim = min(m, n)
-        answer = np.zeros((m, n))
-        for j in range(sigma_dim):
-            answer[j, j] = index_func(j + 1, k)
-        return answer
-
-    def matrix_table_from_numpy(np_mat):
-        rows, cols = np_mat.shape
-        mt = hl.utils.range_matrix_table(rows, cols)
-        mt = mt.annotate_globals(entries_global = np_mat)
-        mt = mt.annotate_entries(ent = mt.entries_global[mt.row_idx, mt.col_idx])
-        return mt
-
-    # Defined for j >= 1
+def test_spectra_1():
     def spec1(j, k):
         return 1/j
+    spectra_helper(spec1)
 
+@fails_service_backend(reason='persist_ir')
+def test_spectra_2():
     def spec2(j, k):
         if j == 1:
             return 1
@@ -156,13 +181,19 @@ def test_spectra():
             return 2 * 10**-5
         else:
             return (10**-5) * (k + 1)/j
+    spectra_helper(spec2)
 
+@fails_service_backend(reason='persist_ir')
+def test_spectra_3():
     def spec3(j, k):
         if j <= k:
             return 10**(-5*(j-1)/(k-1))
         else:
             return (10**-5)*(k+1)/j
+    spectra_helper(spec3)
 
+@fails_service_backend(reason='persist_ir')
+def test_spectra_4():
     def spec4(j, k):
         if j <= k:
             return 10**(-5*(j-1)/(k-1))
@@ -170,35 +201,13 @@ def test_spectra():
             return 10**-5
         else:
             return 0
+    spectra_helper(spec4)
 
+@fails_service_backend(reason='persist_ir')
+def test_spectra_5():
     def spec5(j, k):
         if j <= k:
             return 10**-5 + (1 - 10**-5)*(k - j)/(k - 1)
         else:
             return 10**-5 * math.sqrt((k + 1)/j)
-
-    spectral_functions = [spec1, spec2, spec3, spec4, spec5]
-
-    # k, m, n
-    dim_triplets = [(10, 1000, 1000), (20, 1000, 1000), (10, 100, 200)]
-
-    for triplet in dim_triplets:
-        k, m, n = triplet
-        for idx, spec_func in enumerate(spectral_functions):
-            sigma = make_spectral_matrix(spec_func, k, m, n)
-            seed = 1025
-            np.random.seed(seed)
-            U = np.linalg.qr(np.random.normal(0, 1, (m, m)))[0]
-            V = np.linalg.qr(np.random.normal(0, 1, (n, n)))[0]
-            A = U @ sigma @ V
-            mt_A = matrix_table_from_numpy(A)
-
-            eigenvalues, scores, loadings = hl._blanczos_pca(mt_A.ent, k=k, oversampling_param=k, compute_loadings=True, q_iterations=4)
-            singulars = np.sqrt(eigenvalues)
-            hail_V = (np.array(scores.scores.collect()) / singulars).T
-            hail_U = np.array(loadings.loadings.collect())
-            approx_A = hail_U @ np.diag(singulars) @ hail_V
-            norm_of_diff = np.linalg.norm(A - approx_A, 2)
-            np.testing.assert_allclose(norm_of_diff, spec_func(k + 1, k), rtol=1e-02, err_msg=f"Norm test failed on triplet {triplet} on spec{idx + 1}")
-            np.testing.assert_allclose(singulars, np.diag(sigma)[:k], rtol=1e-01, err_msg=f"Failed on triplet {triplet} on spec{idx + 1}")
-
+    spectra_helper(spec5)

--- a/hail/python/test/hail/methods/test_pca.py
+++ b/hail/python/test/hail/methods/test_pca.py
@@ -143,7 +143,7 @@ def matrix_table_from_numpy(np_mat):
     return mt
 
 # k, m, n
-dim_triplets = [(10, 1000, 1000), (20, 1000, 1000), (10, 100, 200)]
+dim_triplets = [(20, 1000, 1000), (10, 100, 200)]
 
 def spectra_helper(spec_func):
 


### PR DESCRIPTION
I split it up into 5 separate tests, and I took away one of the 3 data sizes we test on, so it's faster and more easily split now. Let me know if you think there's other things we can remove/change without losing information.