### PR TITLE
[batch] enable command-click on job id cell

### DIFF
--- a/batch/batch/front_end/templates/batch.html
+++ b/batch/batch/front_end/templates/batch.html
@@ -85,8 +85,8 @@
       <tbody>
         {% for job in batch['jobs'] %}
         <tr>
-          <td class="numeric-cell" onClick="document.location.href='{{ base_path }}/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}';">
-            <a href="{{ base_path }}/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}">{{ job['job_id'] }}</a>
+          <td class="numeric-cell">
+            <a class="fill-td" href="{{ base_path }}/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}">{{ job['job_id'] }}</a>
           </td>
           <td>
             {% if 'name' in job and job['name'] is not none %}

--- a/batch/batch/front_end/templates/batches.html
+++ b/batch/batch/front_end/templates/batches.html
@@ -70,8 +70,8 @@
 	<tbody>
 	  {% for batch in batches %}
 	  <tr>
-	    <td class="numeric-cell" onClick="document.location.href='{{ base_path }}/batches/{{ batch['id'] }}';">
-              <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
+	    <td class="numeric-cell">
+        <a class="fill-td" href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
 	    </td>
 	    <td>{{ batch['user'] }}</td>
 	    <td>{{ batch['billing_project'] }}</td>

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -430,3 +430,9 @@ pre {
   word-wrap: normal;
   white-space: pre;
 }
+
+td a.fill-td {
+  display: block;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
An onclick handler does not correctly handle command+click. Instead, we
convert the anchor to a block element (allowing it to have width and
height independent of its contents) and set the width and height to
100% of its container.