### PR TITLE
[query] Lower BlockMatrix.fill

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -41,7 +41,7 @@ class Tests(unittest.TestCase):
     @staticmethod
     def _np_matrix(a):
         if isinstance(a, BlockMatrix):
-            return np.array(a.to_numpy())
+            return hl.eval(a.to_ndarray())
         else:
             return np.array(a)
 
@@ -530,8 +530,6 @@ class Tests(unittest.TestCase):
                 self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_sixty_by_twenty_five, splits=split_size), fifty_by_sixty @ sixty_by_twenty_five)
 
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_fill(self):
         nd = np.ones((3, 5))
         bm = BlockMatrix.fill(3, 5, 1.0)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -223,11 +223,10 @@ object LowerBlockMatrixIR {
         new BlockMatrixStage(Array(elt.name -> eltValue), TTuple(TInt64, TInt64)) {
           def blockContext(idx: (Int, Int)): IR = {
             val (i, j) = x.typ.blockShape(idx._1, idx._2)
-            // Block size in block matrix type is an int, so it's safe to cast.
-            MakeTuple.ordered(FastSeq(I32(i.toInt), I32(j.toInt)))
+            MakeTuple.ordered(FastSeq(I64(i.toInt), I64(j.toInt)))
           }
           def blockBody(ctxRef: Ref): IR =
-            MakeNDArray(ToArray(mapIR(rangeIR(GetTupleElement(ctxRef, 0) * GetTupleElement(ctxRef, 1)))(_ => elt)),
+            MakeNDArray(ToArray(mapIR(rangeIR( invoke("toInt32", TInt32, GetTupleElement(ctxRef, 0) * GetTupleElement(ctxRef, 1))) )(_ => elt)),
               ctxRef, True(), ErrorIDs.NO_ERROR)
         }
       case x@BlockMatrixBroadcast(child, IndexedSeq(axis), _, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -226,7 +226,7 @@ object LowerBlockMatrixIR {
             MakeTuple.ordered(FastSeq(I64(i.toInt), I64(j.toInt)))
           }
           def blockBody(ctxRef: Ref): IR =
-            MakeNDArray(ToArray(mapIR(rangeIR( invoke("toInt32", TInt32, GetTupleElement(ctxRef, 0) * GetTupleElement(ctxRef, 1))) )(_ => elt)),
+            MakeNDArray(ToArray(mapIR(rangeIR(Cast(GetTupleElement(ctxRef, 0) * GetTupleElement(ctxRef, 1), TInt32)))(_ => elt)),
               ctxRef, True(), ErrorIDs.NO_ERROR)
         }
       case x@BlockMatrixBroadcast(child, IndexedSeq(axis), _, _) =>

--- a/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/types/BlockMatrixType.scala
@@ -138,7 +138,7 @@ case class BlockMatrixType(
 
   def blockShape(i: Int, j: Int): (Long, Long) = {
     val r = if (i == nRowBlocks - 1) nRows - (i * blockSize) else blockSize
-    val c = if (i == nColBlocks - 1) nCols - (i * blockSize) else blockSize
+    val c = if (j == nColBlocks - 1) nCols - (j * blockSize) else blockSize
     r -> c
   }
 


### PR DESCRIPTION
This was an easy one, since  we already  had `BlockMatrixBroadcast` lowered. All  `ValueToBlockMatrix` does is make a tiny 1x1 BlockMatrix that can later be broadcast. I kind  of think this is a weird  IR design and that we should actually have a  `BlockMatrixBroadcast`  that takes a value `IR` child instead of a `BlockMatrixIR`, but I'll experiment with that refactoring later. Trying to just get the current thing lowered. 