### PR TITLE
[query] remove some registerCode/wrapArg calls

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -124,7 +124,7 @@ object LocusFunctions extends RegistryFunctions {
         val variantTuple = Code.invokeScalaObject2[Locus, IndexedSeq[String], (Locus, IndexedSeq[String])](
           VariantMethods.getClass, "minRep",
           locus.getLocusObj(cb),
-          Code.checkcast[IndexedSeq[String]](wrapArg(r, alleles.pt)(alleles.code).asInstanceOf[Code[AnyRef]]))
+          Code.checkcast[IndexedSeq[String]](scodeToJavaValue(cb, r.region, alleles)))
 
         emitVariant(cb, r.region, variantTuple, rt)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -157,10 +157,10 @@ object UtilFunctions extends RegistryFunctions {
       ("Float32", TFloat32, PFloat32(), implicitly[ClassTag[Float]])
     )) {
       val ctString: ClassTag[String] = implicitly
-      registerCode1(s"to$name", TString, t, (_: Type, _: PType) => rpt) {
-        case (r, rt, (xT: PString, x: Code[Long])) =>
-          val s = asm4s.coerce[String](wrapArg(r, xT)(x))
-          Code.invokeScalaObject1(thisClass, s"parse$name", s)(ctString, ct)
+      registerPCode1(s"to$name", TString, t, (_: Type, _: PType) => rpt) {
+        case (r, cb, rt, x: PStringCode) =>
+          val s = x.loadString()
+          PCode(rt, Code.invokeScalaObject1(thisClass, s"parse$name", s)(ctString, ct))
       }
       registerIEmitCode1(s"to${name}OrMissing", TString, t, (_: Type, xPT: PType) => rpt.setRequired(xPT.required)) {
         case (cb, r, rt, x) =>


### PR DESCRIPTION
now that `tcode` is gone/will be gone soon, we can also work on getting rid of `PCode.code`