### PR TITLE
[query] Renovate StagedArrayBuilder and sorting IR code generators

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1051,6 +1051,25 @@ class CodeArray[T](val lhs: Code[Array[T]])(implicit tti: TypeInfo[T]) {
     Code(lhs, lir.insn1(ARRAYLENGTH))
 }
 
+class UntypedCodeArray(val lhs: Code[_], tti: TypeInfo[_]) {
+  def apply(i: Code[Int]): Code[_] =
+    Code(lhs, i, lir.insn2(tti.aloadOp))
+
+  def update(i: Code[Int], x: Code[_]): Code[Unit] = {
+    lhs.start.append(lir.goto(i.end))
+    i.start.append(lir.goto(x.start))
+    x.end.append(lir.stmtOp(tti.astoreOp, lhs.v, i.v, x.v))
+    val newC = new VCode(lhs.start, x.end, null)
+    lhs.clear()
+    i.clear()
+    x.clear()
+    newC
+  }
+
+  def length(): Code[Int] =
+    Code(lhs, lir.insn1(ARRAYLENGTH))
+}
+
 object CodeLabel {
   def apply(): CodeLabel = {
     val L = new lir.Block()

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -105,8 +105,8 @@ package object asm4s {
     val desc = "Z"
     val loadOp = ILOAD
     val storeOp = ISTORE
-    val aloadOp = IALOAD
-    val astoreOp = IASTORE
+    val aloadOp = BALOAD
+    val astoreOp = BASTORE
     val returnOp = IRETURN
     val newarrayOp = NEWARRAY
 

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -6,6 +6,8 @@ import is.hail.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, P
 import is.hail.types.virtual.{TArray, TDict, TSet, Type}
 import is.hail.utils.FastIndexedSeq
 
+import scala.language.existentials
+
 class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   val ti: TypeInfo[_] = array.elt.ti
   val mb: EmitMethodBuilder[_] = r.mb

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -3,74 +3,147 @@ package is.hail.expr.ir
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, PCode, PIndexableCode, PType, typeToTypeInfo}
+import is.hail.types.virtual.{TArray, TDict, TSet, Type}
+import is.hail.utils.FastIndexedSeq
 
 class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
-  val typ: PType = array.elt
-  val ti: TypeInfo[_] = typeToTypeInfo(typ)
+  val ti: TypeInfo[_] = array.elt.ti
   val mb: EmitMethodBuilder[_] = r.mb
 
-  def sort(sorter: DependentEmitFunctionBuilder[_]): Code[Unit] = {
-    val localF = ti match {
-      case BooleanInfo => mb.genFieldThisRef[AsmFunction2[Boolean, Boolean, Boolean]]()
-      case IntInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
-      case LongInfo => mb.genFieldThisRef[AsmFunction2[Int, Int, Boolean]]()
-      case FloatInfo => mb.genFieldThisRef[AsmFunction2[Long, Long, Boolean]]()
-      case DoubleInfo => mb.genFieldThisRef[AsmFunction2[Double, Double, Boolean]]()
-    }
-    Code(localF.storeAny(Code.checkcast(sorter.newInstance(mb))(localF.ti)), array.sort(localF))
-  }
+  def sort(cb: EmitCodeBuilder, region: Value[Region], comparesLessThan: (EmitCodeBuilder, Value[Region], Code[_], Code[_]) => Code[Boolean]): Unit = {
 
-  def toRegion(cb: EmitCodeBuilder, t: PType): PIndexableCode = {
-    t match {
-      case pca: PCanonicalArray =>
-        val len = cb.newLocal[Int]("arraysorter_to_region_len", array.size)
-        pca.constructFromElements(cb, r.region, len, deepCopy = false) { (cb, idx) =>
-          IEmitCode(cb, array.isMissing(idx), PCode(typ, array(idx)))
+    val sortMB = cb.emb.ecb.newEmitMethod("arraySorter_outer", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
+    sortMB.voidWithBuilder { cb =>
+
+      val newEnd = cb.newLocal[Int]("newEnd", 0)
+      val i = cb.newLocal[Int]("i", 0)
+      val size = cb.newLocal[Int]("size", array.size)
+
+      cb.whileLoop(i < size, {
+        cb.ifx(!array.isMissing(i), {
+          cb.ifx(newEnd.cne(i), cb += array.update(newEnd, array.apply(i)))
+          cb.assign(newEnd, newEnd + 1)
+        })
+        cb.assign(i, i + 1)
+      })
+      cb.assign(i, newEnd)
+      cb.whileLoop(i < size, {
+        cb += array.setMissing(i, true)
+        cb.assign(i, i + 1)
+      })
+
+      // sort elements in [0, newEnd]
+
+      val quickSortMB = cb.emb.ecb.newEmitMethod("arraySorter_quicksort", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo), UnitInfo)
+      quickSortMB.voidWithBuilder { cb =>
+        val r = quickSortMB.getCodeParam[Region](1)
+        val low = quickSortMB.getCodeParam[Int](2)
+        val n = quickSortMB.getCodeParam[Int](3)
+
+        def swap(i: Value[Int], j: Value[Int]) {
+          val tmp = cb.newLocalAny("tmp", array(i))(ti)
+          cb += array.update(i, array(j))
+          cb += array.update(j, tmp)
         }
-      case td: PCanonicalDict =>
-        td.construct(toRegion(cb, td.arrayRep))
-      case ts: PCanonicalSet =>
-        ts.construct(toRegion(cb, ts.arrayRep))
+
+        cb.ifx(n > 1, {
+          val pivotIdx = cb.newLocal[Int]("pivotIdx", low + (n / 2))
+          val pivot = cb.newLocalAny("pivot", array(pivotIdx))(ti)
+
+          val left = cb.newLocal[Int]("left", low)
+          val right = cb.newLocal[Int]("right", low + n - 1)
+          swap(pivotIdx, right)
+
+          cb.whileLoop(left < right, {
+            cb.ifx(!comparesLessThan(cb, r, array(left), pivot),
+              cb.assign(left, left + 1),
+              cb.ifx(comparesLessThan(cb, r, array(right - 1), pivot),
+                cb.assign(right, right - 1),
+                {
+                  swap(left, cb.newLocal[Int]("rightMinusOne", right - 1))
+                  cb.assign(left, left + 1)
+                  cb.assign(right, right - 1)
+                },
+              ))
+          })
+
+          swap(left, cb.newLocal("newEnd", low + n - 1))
+
+          cb.invokeVoid(quickSortMB, r, low, left - low)
+          cb.invokeVoid(quickSortMB, r, left + 1, n - (left - low - 1))
+        })
+      }
+
+      cb.invokeCode(quickSortMB, sortMB.getCodeParam[Region](1), const(0), newEnd)
+    }
+    cb.invokeVoid(sortMB, region)
+  }
+
+  def toRegion(cb: EmitCodeBuilder, t: Type): PIndexableCode = {
+    t match {
+      case pca: TArray =>
+        val len = cb.newLocal[Int]("arraysorter_to_region_len", array.size)
+        // fixme element requiredness should be set here
+        val arrayType = PCanonicalArray(array.elt.loadedSType.canonicalPType())
+
+        arrayType.constructFromElements(cb, r.region, len, deepCopy = false) { (cb, idx) =>
+          array.loadFromIndex(cb, r.region, idx)
+        }
+      case td: TDict =>
+        PCanonicalDict.coerceArrayCode(toRegion(cb, TArray(td.elementType)))
+      case ts: TSet =>
+        PCanonicalSet.coerceArrayCode(toRegion(cb, TArray(ts.elementType)))
     }
   }
 
-  def pruneMissing: Code[Unit] = {
-    val i = mb.newLocal[Int]()
-    val n = mb.newLocal[Int]()
-
-    Code(
-      n := 0,
-      i := 0,
-      Code.whileLoop(i < array.size,
-        Code(
-          array.isMissing(i).mux(
-            Code._empty,
-            i.ceq(n).mux(
-              n += 1,
-              Code(array.setMissing(n, false), array.update(n, array(i)), n += 1))),
-          i += 1)),
-      array.setSize(n))
+  def pruneMissing(cb: EmitCodeBuilder): Unit = {
+    val i = cb.newLocal[Int]("i", 0)
+    val n = cb.newLocal[Int]("n", 0)
+    val size = cb.newLocal[Int]("size", array.size)
+    cb.whileLoop(i < size, {
+      cb.ifx(!array.isMissing(i), {
+        cb.ifx(i.cne(n),
+          cb += array.update(n, array(i)))
+        cb.assign(n, n + 1)
+      })
+      cb.assign(i, i + 1)
+    })
+    cb += array.setSize(n)
   }
 
-  def distinctFromSorted(discardNext: (Code[Region], Code[_], Code[Boolean], Code[_], Code[Boolean]) => Code[Boolean]): Code[Unit] = {
-    val i = mb.newLocal[Int]()
-    val n = mb.newLocal[Int]()
+  def distinctFromSorted(cb: EmitCodeBuilder, region: Value[Region], discardNext: (EmitCodeBuilder, Value[Region], EmitCode, EmitCode) => Code[Boolean]): Unit = {
 
-    Code(
-      i := 0,
-      n := 0,
-      Code.whileLoop(i < array.size,
-        i += 1,
-        Code.whileLoop(i < array.size && discardNext(r.region, array(n), array.isMissing(n), array(i), array.isMissing(i)),
-          i += 1),
-        n += 1,
-        (i < array.size && i.cne(n)).mux(
-          Code(
-            array.setMissing(n, array.isMissing(i)),
-            array.isMissing(n).mux(
-              Code._empty,
-              array.update(n, array(i)))),
-          Code._empty)),
-      array.setSize(n))
+    val distinctMB = cb.emb.newEmitMethod("distinctFromSorted", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
+    distinctMB.voidWithBuilder { cb =>
+      val region = distinctMB.getCodeParam[Region](1)
+      val i = cb.newLocal[Int]("i", 0)
+      val n = cb.newLocal[Int]("n", 0)
+      val size = cb.newLocal[Int]("size", array.size)
+      cb.whileLoop(i < size, {
+        cb.assign(i, i + 1)
+
+        val LskipLoopBegin = CodeLabel()
+        val LskipLoopEnd = CodeLabel()
+        cb.define(LskipLoopBegin)
+        cb.ifx(i >= size, cb.goto(LskipLoopEnd))
+        cb.ifx(!discardNext(cb, region,
+          EmitCode.fromI(distinctMB)(cb => array.loadFromIndex(cb, region, n)),
+          EmitCode.fromI(distinctMB)(cb => array.loadFromIndex(cb, region, i))),
+          cb.goto(LskipLoopEnd))
+        cb.assign(i, i + 1)
+        cb.goto(LskipLoopBegin)
+
+        cb.define(LskipLoopEnd)
+
+        cb.assign(n, n + 1)
+        cb.ifx(i < size && i.cne(n), {
+          cb += array.setMissing(n, array.isMissing(i))
+          cb.ifx(!array.isMissing(n), cb += array.update(n, array(i)))
+        })
+
+      })
+      cb += array.setSize(n)
+    }
+    cb.invokeVoid(distinctMB, region)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -2,13 +2,21 @@ package is.hail.expr.ir
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, PCode, PIndexableCode, PType, typeToTypeInfo}
+import is.hail.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet, PIndexableCode}
 import is.hail.types.virtual.{TArray, TDict, TSet, Type}
 import is.hail.utils.FastIndexedSeq
 
 class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   val ti: TypeInfo[_] = array.elt.ti
   val mb: EmitMethodBuilder[_] = r.mb
+
+  private[this] var prunedMissing: Boolean = false
+
+  private[this] val workingArrayInfo = arrayInfo(array.ti)
+  private[this] val workingArray1 = mb.genFieldThisRef("sorter_working_array")(workingArrayInfo)
+  private[this] val workingArray2 = mb.genFieldThisRef("sorter_working_array")(workingArrayInfo)
+
+  private[this] def arrayRef(workingArray: Code[Array[_]]): UntypedCodeArray = new UntypedCodeArray(workingArray, array.ti)
 
   def sort(cb: EmitCodeBuilder, region: Value[Region], comparesLessThan: (EmitCodeBuilder, Value[Region], Code[_], Code[_]) => Code[Boolean]): Unit = {
 
@@ -34,49 +42,94 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
 
       // sort elements in [0, newEnd]
 
-      val quickSortMB = cb.emb.ecb.newEmitMethod("arraySorter_quicksort", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo), UnitInfo)
-      quickSortMB.voidWithBuilder { cb =>
-        val r = quickSortMB.getCodeParam[Region](1)
-        val low = quickSortMB.getCodeParam[Int](2)
-        val n = quickSortMB.getCodeParam[Int](3)
+      // merging into B
+      val mergeMB = cb.emb.ecb.newEmitMethod("arraySorter_merge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
+      mergeMB.voidWithBuilder { cb =>
+        val r = mergeMB.getCodeParam[Region](1)
+        val begin = mergeMB.getCodeParam[Int](2)
+        val mid = mergeMB.getCodeParam[Int](3)
+        val end = mergeMB.getCodeParam[Int](4)
 
-        def swap(i: Value[Int], j: Value[Int]) {
-          val tmp = cb.newLocalAny("tmp", array(i))(ti)
-          cb += array.update(i, array(j))
-          cb += array.update(j, tmp)
-        }
+        def arrayA = new UntypedCodeArray(mergeMB.getCodeParam(5)(workingArrayInfo), array.ti)
 
-        cb.ifx(n > 1, {
-          val pivotIdx = cb.newLocal[Int]("pivotIdx", low + (n / 2))
-          val pivot = cb.newLocalAny("pivot", array(pivotIdx))(ti)
+        def arrayB = new UntypedCodeArray(mergeMB.getCodeParam(6)(workingArrayInfo), array.ti)
 
-          val left = cb.newLocal[Int]("left", low)
-          val right = cb.newLocal[Int]("right", low + n - 1)
-          swap(pivotIdx, right)
+        val i = cb.newLocal[Int]("mergemb_i", begin)
+        val j = cb.newLocal[Int]("mergemb_j", mid)
 
-          cb.whileLoop(left < right, {
-            cb.ifx(!comparesLessThan(cb, r, array(left), pivot),
-              cb.assign(left, left + 1),
-              cb.ifx(comparesLessThan(cb, r, array(right - 1), pivot),
-                cb.assign(right, right - 1),
-                {
-                  swap(left, cb.newLocal[Int]("rightMinusOne", right - 1))
-                  cb.assign(left, left + 1)
-                  cb.assign(right, right - 1)
-                },
-              ))
-          })
+        val k = cb.newLocal[Int]("mergemb_k", i)
+        cb.whileLoop(k < end, {
 
-          swap(left, cb.newLocal("newEnd", low + n - 1))
+          val LtakeFromLeft = CodeLabel()
+          val LtakeFromRight = CodeLabel()
+          val Ldone = CodeLabel()
 
-          cb.invokeVoid(quickSortMB, r, low, left - low)
-          cb.invokeVoid(quickSortMB, r, left + 1, n - (left - low - 1))
+          cb.ifx(j < end, {
+            cb.ifx(i >= mid, cb.goto(LtakeFromRight))
+            cb.ifx(comparesLessThan(cb, r, arrayA(j), arrayA(i)), cb.goto(LtakeFromRight), cb.goto(LtakeFromLeft))
+          }, cb.goto(LtakeFromLeft))
+
+          cb.define(LtakeFromLeft)
+          cb += arrayB.update(k, arrayA(i))
+          cb.assign(i, i + 1)
+          cb.goto(Ldone)
+
+          cb.define(LtakeFromRight)
+          cb += arrayB.update(k, arrayA(j))
+          cb.assign(j, j + 1)
+          cb.goto(Ldone)
+
+          cb.define(Ldone)
+          cb.assign(k, k + 1)
         })
       }
 
-      cb.invokeCode(quickSortMB, sortMB.getCodeParam[Region](1), const(0), newEnd)
+      val splitMergeMB = cb.emb.ecb.newEmitMethod("arraySorter_splitMerge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
+      splitMergeMB.voidWithBuilder { cb =>
+        val r = splitMergeMB.getCodeParam[Region](1)
+        val begin = splitMergeMB.getCodeParam[Int](2)
+        val end = splitMergeMB.getCodeParam[Int](3)
+
+        val arrayB = splitMergeMB.getCodeParam(4)(workingArrayInfo)
+        val arrayA = splitMergeMB.getCodeParam(5)(workingArrayInfo)
+
+        cb.ifx(end - begin > 1, {
+          val mid = cb.newLocal[Int]("splitMerge_mid", (begin + end) / 2)
+
+          cb.invokeVoid(splitMergeMB, r, begin, mid, arrayA, arrayB)
+          cb.invokeVoid(splitMergeMB, r, mid, end, arrayA, arrayB)
+
+          // result goes in A
+          cb.invokeVoid(mergeMB, r, begin, mid, end, arrayB, arrayA)
+        })
+      }
+
+      // these arrays should be allocated once and reused
+      cb.ifx(workingArray1.isNull || arrayRef(workingArray1).length() < newEnd, {
+        cb.assignAny(workingArray1, Code.newArray(newEnd)(array.ti))
+        cb.assignAny(workingArray2, Code.newArray(newEnd)(array.ti))
+      })
+
+      cb.assign(i, 0)
+      cb.whileLoop(i < newEnd, {
+        cb += arrayRef(workingArray1).update(i, array(i))
+        cb += arrayRef(workingArray2).update(i, array(i))
+        cb.assign(i, i + 1)
+      })
+
+      // elements are sorted in workingArray2 after calling splitMergeMB
+      cb.invokeVoid(splitMergeMB, sortMB.getCodeParam[Region](1), const(0), newEnd, workingArray1, workingArray2)
+
+      cb.assign(i, 0)
+      cb.whileLoop(i < newEnd, {
+        cb += array.update(i, arrayRef(workingArray2)(i))
+        cb.assign(i, i + 1)
+      })
+
     }
     cb.invokeVoid(sortMB, region)
+
+
   }
 
   def toRegion(cb: EmitCodeBuilder, t: Type): PIndexableCode = {
@@ -84,7 +137,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       case pca: TArray =>
         val len = cb.newLocal[Int]("arraysorter_to_region_len", array.size)
         // fixme element requiredness should be set here
-        val arrayType = PCanonicalArray(array.elt.loadedSType.canonicalPType())
+        val arrayType = PCanonicalArray(array.elt.loadedSType.canonicalPType().setRequired(this.prunedMissing || array.eltRequired))
 
         arrayType.constructFromElements(cb, r.region, len, deepCopy = false) { (cb, idx) =>
           array.loadFromIndex(cb, r.region, idx)
@@ -97,6 +150,8 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   }
 
   def pruneMissing(cb: EmitCodeBuilder): Unit = {
+    this.prunedMissing = true
+
     val i = cb.newLocal[Int]("i", 0)
     val n = cb.newLocal[Int]("n", 0)
     val size = cb.newLocal[Int]("size", array.size)
@@ -136,6 +191,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         cb.define(LskipLoopEnd)
 
         cb.assign(n, n + 1)
+
         cb.ifx(i < size && i.cne(n), {
           cb += array.setMissing(n, array.isMissing(i))
           cb.ifx(!array.isMissing(n), cb += array.update(n, array(i)))
@@ -144,6 +200,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       })
       cb += array.setSize(n)
     }
+
     cb.invokeVoid(distinctMB, region)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -22,7 +22,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
 
   def sort(cb: EmitCodeBuilder, region: Value[Region], comparesLessThan: (EmitCodeBuilder, Value[Region], Code[_], Code[_]) => Code[Boolean]): Unit = {
 
-    val sortMB = cb.emb.ecb.newEmitMethod("arraySorter_outer", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
+    val sortMB = cb.emb.ecb.genEmitMethod("arraySorter_outer", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
     sortMB.voidWithBuilder { cb =>
 
       val newEnd = cb.newLocal[Int]("newEnd", 0)
@@ -45,7 +45,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
       // sort elements in [0, newEnd]
 
       // merging into B
-      val mergeMB = cb.emb.ecb.newEmitMethod("arraySorter_merge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
+      val mergeMB = cb.emb.ecb.genEmitMethod("arraySorter_merge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
       mergeMB.voidWithBuilder { cb =>
         val r = mergeMB.getCodeParam[Region](1)
         val begin = mergeMB.getCodeParam[Int](2)
@@ -86,7 +86,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
         })
       }
 
-      val splitMergeMB = cb.emb.ecb.newEmitMethod("arraySorter_splitMerge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
+      val splitMergeMB = cb.emb.ecb.genEmitMethod("arraySorter_splitMerge", FastIndexedSeq[ParamType](classInfo[Region], IntInfo, IntInfo, workingArrayInfo, workingArrayInfo), UnitInfo)
       splitMergeMB.voidWithBuilder { cb =>
         val r = splitMergeMB.getCodeParam[Region](1)
         val begin = splitMergeMB.getCodeParam[Int](2)
@@ -170,7 +170,7 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
 
   def distinctFromSorted(cb: EmitCodeBuilder, region: Value[Region], discardNext: (EmitCodeBuilder, Value[Region], EmitCode, EmitCode) => Code[Boolean]): Unit = {
 
-    val distinctMB = cb.emb.newEmitMethod("distinctFromSorted", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
+    val distinctMB = cb.emb.genEmitMethod("distinctFromSorted", FastIndexedSeq[ParamType](classInfo[Region]), UnitInfo)
     distinctMB.voidWithBuilder { cb =>
       val region = distinctMB.getCodeParam[Region](1)
       val i = cb.newLocal[Int]("i", 0)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -994,68 +994,155 @@ class Emit[C](
           PCode(pt, bs.getClosestIndex(arr.code.asInstanceOf[Code[Long]], e.m, e.v))
         }
 
+      case x@ArraySort(a, left, right, lessThan) =>
+        emitStream(a, cb, region).map(cb) { case stream: SStreamCode =>
+          val producer = stream.producer
+
+          val sct = SingleCodeType.fromSType(producer.element.st)
+
+          val vab = new StagedArrayBuilder(sct, mb, 0)
+          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          val sorter = new ArraySorter(EmitRegion(mb, region), vab)
+          sorter.sort(cb, region, makeDependentSortingFunction(cb, sct, lessThan, env, Array(left, right)))
+          sorter.toRegion(cb, x.typ)
+        }
+
+      case x@ToSet(a) =>
+        emitStream(a, cb, region).map(cb) { case stream: SStreamCode =>
+          val producer = stream.producer
+
+          val sct = SingleCodeType.fromSType(producer.element.st)
+
+          val vab = new StagedArrayBuilder(sct, mb, 0)
+          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          val sorter = new ArraySorter(EmitRegion(mb, region), vab)
+
+          def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Code[_], r: Code[_]): Code[Boolean] = {
+            cb.emb.ecb.getOrdering(sct.loadedSType, sct.loadedSType)
+              .ltNonnull(cb, sct.loadToPCode(cb, region, l), sct.loadToPCode(cb, region, r))
+          }
+          sorter.sort(cb, region, lessThan)
+
+          def skipNext(cb: EmitCodeBuilder, region: Value[Region], l: EmitCode, r: EmitCode): Code[Boolean] = {
+            cb.emb.ecb.getOrdering(l.st, r.st)
+              .equiv(cb, l, r, missingEqual = true)
+          }
+          sorter.distinctFromSorted(cb, region, skipNext)
+          sorter.toRegion(cb, x.typ)
+        }
+
+      case x@ToDict(a) =>
+        emitStream(a, cb, region).map(cb) { case stream: SStreamCode =>
+          val producer = stream.producer
+
+          val sct = SingleCodeType.fromSType(producer.element.st)
+
+          val vab = new StagedArrayBuilder(sct, mb, 0)
+          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
+          val sorter = new ArraySorter(EmitRegion(mb, region), vab)
+
+          def lessThan(cb: EmitCodeBuilder, region: Value[Region], l: Code[_], r: Code[_]): Code[Boolean] = {
+            val lk = EmitCode.fromI(cb.emb)(cb => sct.loadToPCode(cb, region, l)
+              .asBaseStruct.memoize(cb, "lt_l")
+              .loadField(cb, "key")
+              .typecast[PCode])
+
+            val rk = EmitCode.fromI(cb.emb)(cb => sct.loadToPCode(cb, region, r)
+              .asBaseStruct.memoize(cb, "lt_r")
+              .loadField(cb, "key")
+              .typecast[PCode])
+
+            cb.emb.ecb.getOrdering(lk.st, rk.st)
+              .lt(cb, lk, rk, missingEqual = true)
+          }
+
+          sorter.sort(cb, region, lessThan)
+
+          def skipNext(cb: EmitCodeBuilder, region: Value[Region], l: EmitCode, r: EmitCode): Code[Boolean] = {
+
+            val lk = EmitCode.fromI(cb.emb) { cb =>
+              l.toI(cb).flatMap(cb) { x =>
+                x.asBaseStruct.memoize(cb, "lt_l")
+                  .loadField(cb, "key")
+                  .typecast[PCode]
+              }
+            }
+
+            val rk = EmitCode.fromI(cb.emb) { cb =>
+              r.toI(cb).flatMap(cb) { x =>
+                x.asBaseStruct.memoize(cb, "lt_r")
+                  .loadField(cb, "key")
+                  .typecast[PCode]
+              }
+            }
+
+            cb.emb.ecb.getOrdering(lk.st, rk.st)
+              .equiv(cb, lk, rk, missingEqual = true)
+          }
+
+          sorter.distinctFromSorted(cb, region, skipNext)
+          sorter.toRegion(cb, x.typ)
+        }
+
       case GroupByKey(collection) =>
-        // sort collection by group
-        val collectionTyp = coerce[PStream](collection.pType)
-        val keyValTyp = coerce[PBaseStruct](collectionTyp.elementType)
-        val keyTyp = keyValTyp.types(0)
-        val valTyp = keyValTyp.types(1)
-        val dictTyp = coerce[PCanonicalDict](ir.pType)
-        val groupTyp = dictTyp.elementType
-        val arrayTyp = PCanonicalArray(groupTyp, required = true)
-
-        val sortedElts = new StagedArrayBuilder(keyValTyp, mb, 16)
-        val sorter = new ArraySorter(EmitRegion(mb, region), sortedElts)
-
-        val (k1, k2) = keyValTyp match {
-          case t: PStruct => GetField(In(0, PCodeEmitParamType(t)), "key") -> GetField(In(1, PCodeEmitParamType(t)), "key")
-          case t: PTuple =>
-            assert(t.fields(0).index == 0)
-            GetTupleElement(In(0, PCodeEmitParamType(t)), 0) -> GetTupleElement(In(1, PCodeEmitParamType(t)), 0)
-        }
-
-        val compare = ApplyComparisonOp(Compare(keyValTyp.types(0).virtualType), k1, k2) < 0
-        InferPType(compare)
-        val leftRightComparatorNames = Array.empty[String]
-        val sortF = sortedElts.ti match {
-          case BooleanInfo => makeDependentSortingFunction[Boolean](region, keyValTyp, compare, env, leftRightComparatorNames)
-          case IntInfo => makeDependentSortingFunction[Int](region, keyValTyp, compare, env, leftRightComparatorNames)
-          case LongInfo => makeDependentSortingFunction[Long](region, keyValTyp, compare, env, leftRightComparatorNames)
-          case FloatInfo => makeDependentSortingFunction[Float](region, keyValTyp, compare, env, leftRightComparatorNames)
-          case DoubleInfo => makeDependentSortingFunction[Double](region, keyValTyp, compare, env, leftRightComparatorNames)
-        }
-
-        val groupSizes = new StagedArrayBuilder(PInt32(), mb, 0)
-
-        val (lastKey, currKey) = (keyValTyp.virtualType: @unchecked) match {
-          case ts: TStruct =>
-            GetField(In(0, PCodeEmitParamType(keyValTyp)), ts.fieldNames(0)) -> GetField(In(1, PCodeEmitParamType(keyValTyp)), ts.fieldNames(0))
-          case tt: TTuple =>
-            GetTupleElement(In(0, PCodeEmitParamType(keyValTyp)), tt.fields(0).index) -> GetTupleElement(In(1, PCodeEmitParamType(keyValTyp)), tt.fields(0).index)
-        }
-        val compare2 = ApplyComparisonOp(EQWithNA(keyTyp.virtualType), lastKey, currKey)
-        InferPType(compare2)
-        val isSame = mb.genEmitMethod("isSame",
-          FastIndexedSeq(typeInfo[Region], PCodeEmitParamType(keyValTyp), PCodeEmitParamType(keyValTyp)),
-          BooleanInfo)
-        isSame.emitWithBuilder { cb =>
-          emitInMethod(cb, compare2).consumeCode[Boolean](cb, true, _.asBoolean.boolCode(cb))
-        }
-
-        val eltIdx = mb.newLocal[Int]("groupByKey_eltIdx")
-        val grpIdx = mb.newLocal[Int]("groupByKey_grpIdx")
-        val withinGrpIdx = mb.newLocal[Int]("groupByKey_withinGrpIdx")
-        val outerSize = mb.newLocal[Int]("groupByKey_outerSize")
-        val groupSize = mb.newLocal[Int]("groupByKey_groupSize")
-
         emitStream(collection, cb, region).map(cb) { case stream: SStreamCode =>
 
+          val sct = SingleCodeType.fromSType(stream.producer.element.st)
+          val sortedElts = new StagedArrayBuilder(sct, mb, 16)
           StreamUtils.writeToArrayBuilder(cb, stream.producer, sortedElts, region)
-          cb += sorter.sort(sortF)
-          cb += sorter.pruneMissing
+          val sorter = new ArraySorter(EmitRegion(mb, region), sortedElts)
+
+          def lt(cb: EmitCodeBuilder, region: Value[Region], l: Code[_], r: Code[_]): Code[Boolean] = {
+            val lk = EmitCode.fromI(cb.emb)(cb => sct.loadToPCode(cb, region, l)
+              .asBaseStruct.memoize(cb, "lt_l")
+              .loadField(cb, 0)
+              .typecast[PCode])
+
+            val rk = EmitCode.fromI(cb.emb)(cb => sct.loadToPCode(cb, region, r)
+              .asBaseStruct.memoize(cb, "lt_r")
+              .loadField(cb, 0)
+              .typecast[PCode])
+
+            cb.emb.ecb.getOrdering(lk.st, rk.st)
+              .lt(cb, lk, rk, missingEqual = true)
+          }
+
+          sorter.sort(cb, region, lt)
+          sorter.pruneMissing(cb)
+
+          val groupSizes = new StagedArrayBuilder(Int32SingleCodeType, mb, 0)
+
+          val eltIdx = mb.newLocal[Int]("groupByKey_eltIdx")
+          val grpIdx = mb.newLocal[Int]("groupByKey_grpIdx")
+          val withinGrpIdx = mb.newLocal[Int]("groupByKey_withinGrpIdx")
+          val outerSize = mb.newLocal[Int]("groupByKey_outerSize")
+          val groupSize = mb.newLocal[Int]("groupByKey_groupSize")
+
+
           cb += groupSizes.clear
           cb.assign(eltIdx, 0)
           cb.assign(groupSize, 0)
+
+          def sameKeyAtIndices(cb: EmitCodeBuilder, region: Value[Region], idx1: Code[Int], idx2: Code[Int]): Code[Boolean] = {
+            val lk = EmitCode.fromI(cb.emb) { cb =>
+              sortedElts.loadFromIndex(cb, region, idx1).flatMap(cb) { x =>
+                x.asBaseStruct.memoize(cb, "lt_l")
+                  .loadField(cb, 0)
+                  .typecast[PCode]
+              }
+            }
+
+            val rk = EmitCode.fromI(cb.emb) { cb =>
+              sortedElts.loadFromIndex(cb, region, idx2).flatMap(cb) { x =>
+                x.asBaseStruct.memoize(cb, "lt_r")
+                  .loadField(cb, 0)
+                  .typecast[PCode]
+              }
+            }
+
+            cb.emb.ecb.getOrdering(lk.st, rk.st)
+              .equiv(cb, lk, rk, missingEqual = true)
+          }
 
           cb.whileLoop(eltIdx < sortedElts.size, {
             val bottomOfLoop = CodeLabel()
@@ -1065,7 +1152,7 @@ class Emit[C](
             cb.ifx(eltIdx.ceq(sortedElts.size - 1), {
               cb.goto(newGroup)
             }, {
-              cb.ifx(cb.invokeCode[Boolean](isSame, region, sortedElts.applyEV(mb, eltIdx), sortedElts.applyEV(mb, eltIdx + 1)), {
+              cb.ifx(sameKeyAtIndices(cb, region, eltIdx, eltIdx + 1), {
                 cb.goto(bottomOfLoop)
               }, {
                 cb.goto(newGroup)
@@ -1080,6 +1167,11 @@ class Emit[C](
           })
 
           cb.assign(outerSize, groupSizes.size)
+          val innerType = PCanonicalArray(sct.loadedSType.canonicalPType(), true)
+          val arrayTyp = PCanonicalArray(innerType, false)
+          val kt = sct.loadedSType.canonicalPType().asInstanceOf[PStruct].types(0)
+          val groupType = PCanonicalStruct(true, ("key", kt), ("value", innerType))
+          val dictType = PCanonicalDict(kt, innerType, false)
           val (addGroup, finishOuter) = arrayTyp.constructFromFunctions(cb, region, outerSize, deepCopy = false)
 
           cb.assign(eltIdx, 0)
@@ -1088,25 +1180,25 @@ class Emit[C](
           cb.whileLoop(grpIdx < outerSize, {
             cb.assign(groupSize, coerce[Int](groupSizes(grpIdx)))
             cb.assign(withinGrpIdx, 0)
-            val firstStruct = sortedElts.applyEV(mb, eltIdx).get(cb).asBaseStruct.memoize(cb, "GroupByKey_firstStruct")
+            val firstStruct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct.memoize(cb, "GroupByKey_firstStruct")
             val key = EmitCode.fromI(mb) { cb => firstStruct.loadField(cb, 0).typecast[PCode] }
             val group = EmitCode.fromI(mb) { cb =>
-              val (addElt, finishInner) = PCanonicalArray(valTyp, required = true)
+              val (addElt, finishInner) = innerType
                 .constructFromFunctions(cb, region, groupSize, deepCopy = false)
               cb.whileLoop(withinGrpIdx < groupSize, {
-                val struct = sortedElts.applyEV(mb, eltIdx).get(cb).asBaseStruct.memoize(cb, "GroupByKey_struct")
+                val struct = sortedElts.loadFromIndex(cb, region, eltIdx).get(cb).asBaseStruct.memoize(cb, "GroupByKey_struct")
                 addElt(cb, struct.loadField(cb, 1).typecast[PCode])
                 cb.assign(eltIdx, eltIdx + 1)
                 cb.assign(withinGrpIdx, withinGrpIdx + 1)
               })
               IEmitCode.present(cb, finishInner(cb))
             }
-            val elt = groupTyp.constructFromFields(cb, region, FastIndexedSeq(key, group), deepCopy = false)
+            val elt = groupType.constructFromFields(cb, region, FastIndexedSeq(key, group), deepCopy = false)
             addGroup(cb, IEmitCode.present(cb, elt))
             cb.assign(grpIdx, grpIdx + 1)
           })
 
-          dictTyp.construct(finishOuter(cb))
+          dictType.construct(finishOuter(cb))
         }
 
       case x@StreamLen(a) =>
@@ -2276,80 +2368,6 @@ class Emit[C](
           throw new RuntimeException(s"PValue type did not match inferred ptype:\n name: $name\n  pv: ${ ev.pt }\n  ir: $pt")
         ev.load
 
-      case x@(_: ArraySort | _: ToSet | _: ToDict) =>
-        val resultTypeAsIterable = coerce[PIterable](x.pType)
-        val eltType = x.children(0).asInstanceOf[IR].pType.asInstanceOf[PIterable].elementType
-        val eltVType = eltType.virtualType
-
-        val vab = new StagedArrayBuilder(resultTypeAsIterable.elementType, mb, 0)
-        val sorter = new ArraySorter(EmitRegion(mb, region), vab)
-
-        val (array, lessThan, distinct, leftRightComparatorNames: Array[String]) = (x: @unchecked) match {
-          case ArraySort(a, l, r, lessThan) => (a, lessThan, Code._empty, Array(l, r))
-          case ToSet(a) =>
-            val discardNext = mb.genEmitMethod("discardNext",
-              FastIndexedSeq[ParamType](typeInfo[Region], PCodeEmitParamType(eltType), PCodeEmitParamType(eltType)),
-              typeInfo[Boolean])
-            val cmp2 = ApplyComparisonOp(EQWithNA(eltVType), In(0, PCodeEmitParamType(eltType)), In(1, PCodeEmitParamType(eltType)))
-            InferPType(cmp2)
-            val EmitCode(m, pv) = emitInMethod(cmp2, discardNext)
-            discardNext.emitWithBuilder { cb =>
-              m || pv.asBoolean.boolCode(cb)
-            }
-            val lessThan = ApplyComparisonOp(Compare(eltVType), In(0, PCodeEmitParamType(eltType)), In(1, PCodeEmitParamType(eltType))) < 0
-            InferPType(lessThan)
-            (a, lessThan, sorter.distinctFromSorted { (r, v1, m1, v2, m2) =>
-              EmitCodeBuilder.scopedCode[Boolean](mb) { cb =>
-                cb.invokeCode[Boolean](discardNext, r,
-                  EmitCode(Code._empty, m1, PCode(eltType, v1)),
-                  EmitCode(Code._empty, m2, PCode(eltType, v2)))
-              }
-            }, Array.empty[String])
-          case ToDict(a) =>
-            val (k0, k1, keyType) = eltType match {
-              case t: PStruct => (GetField(In(0, PCodeEmitParamType(eltType)), "key"), GetField(In(1, PCodeEmitParamType(eltType)), "key"), t.fieldType("key"))
-              case t: PTuple => (GetTupleElement(In(0, PCodeEmitParamType(eltType)), 0), GetTupleElement(In(1, PCodeEmitParamType(eltType)), 0), t.types(0))
-            }
-            val discardNext = mb.genEmitMethod("discardNext",
-              FastIndexedSeq[ParamType](typeInfo[Region], PCodeEmitParamType(eltType), PCodeEmitParamType(eltType)),
-              typeInfo[Boolean])
-
-            val cmp2 = ApplyComparisonOp(EQWithNA(keyType.virtualType), k0, k1).deepCopy()
-            InferPType(cmp2)
-            val EmitCode(m, pv) = emitInMethod(cmp2, discardNext)
-            discardNext.emitWithBuilder { cb =>
-              m || pv.asBoolean.boolCode(cb)
-            }
-            val lessThan = (ApplyComparisonOp(Compare(keyType.virtualType), k0, k1) < 0).deepCopy()
-            InferPType(lessThan)
-            (a, lessThan, Code(sorter.pruneMissing, sorter.distinctFromSorted { (r, v1, m1, v2, m2) =>
-              EmitCodeBuilder.scopedCode[Boolean](mb) { cb =>
-                cb.invokeCode[Boolean](discardNext, r,
-                  EmitCode(Code._empty, m1, PCode(eltType, v1)),
-                  EmitCode(Code._empty, m2, PCode(eltType, v2)))
-              }
-            }), Array.empty[String])
-        }
-
-        val sort = vab.ti match {
-          case BooleanInfo => sorter.sort(makeDependentSortingFunction[Boolean](
-            region, eltType, lessThan, env, leftRightComparatorNames))
-          case IntInfo => sorter.sort(makeDependentSortingFunction[Int](region, eltType, lessThan, env, leftRightComparatorNames))
-          case LongInfo => sorter.sort(makeDependentSortingFunction[Long](
-            region, eltType, lessThan, env, leftRightComparatorNames))
-          case FloatInfo => sorter.sort(makeDependentSortingFunction[Float](
-            region, eltType, lessThan, env, leftRightComparatorNames))
-          case DoubleInfo => sorter.sort(makeDependentSortingFunction[Double](
-            region, eltType, lessThan, env, leftRightComparatorNames))
-        }
-
-        val optStream = emitStream(array, region)
-        EmitCode.fromI(mb)(cb => optStream.toI(cb).map(cb) { case stream: SStreamCode =>
-          StreamUtils.writeToArrayBuilder(cb, stream.producer, vab, region)
-          cb += sort
-          cb += distinct
-          sorter.toRegion(cb, x.pType)
-        })
 
       case In(i, expectedPType) =>
         // this, Code[Region], ...
@@ -2427,7 +2445,7 @@ class Emit[C](
     } else result
   }
 
-  private def capturedReferences(ir: IR): (IR, (Emit.E, DependentEmitFunctionBuilder[_]) => Emit.E) = {
+  private def capturedReferences(ir: IR, cb: EmitCodeBuilder, env: Emit.E): Emit.E = {
     var ids = Set[String]()
 
     VisitIR(ir) {
@@ -2436,42 +2454,40 @@ class Emit[C](
       case _ =>
     }
 
-    (ir, { (env: Emit.E, f: DependentEmitFunctionBuilder[_]) =>
-      Env[EmitValue](ids.toFastSeq.flatMap { id =>
-         env.lookupOption(id).map { e =>
-           (id, f.newDepEmitField(e.load))
-        }
-      }: _*)
+    Env.fromSeq[EmitValue](ids.toFastSeq.flatMap { id =>
+      env.lookupOption(id).map { e =>
+        (id, cb.memoizeField(e.load, id))
+      }
     })
   }
 
-  private def makeDependentSortingFunction[T: TypeInfo](
-    region: Code[Region],
-    elemPType: PType, ir: IR, env: Emit.E, leftRightComparatorNames: Array[String]): DependentEmitFunctionBuilder[AsmFunction2[T, T, Boolean]] = {
-    val (newIR, getEnv) = capturedReferences(ir)
-    val f = cb.genDependentFunction[T, T, Boolean](baseName = "sort_compare")
-    val fregion = f.newDepField[Region](region)
-    var newEnv = getEnv(env, f)
+  private def makeDependentSortingFunction(
+    cb: EmitCodeBuilder,
+    elemSCT: SingleCodeType, ir: IR, env: Emit.E, leftRightComparatorNames: Array[String]): (EmitCodeBuilder, Value[Region], Code[_], Code[_]) => Code[Boolean] = {
+    val fb = cb.emb.ecb
+    var newEnv = capturedReferences(ir, cb, env)
 
-    val leftEC = EmitCode(Code._empty, false, PCode(elemPType, f.getCodeParam[T](1)))
-    val rightEC = EmitCode(Code._empty, false, PCode(elemPType, f.getCodeParam[T](2)))
-    val sort = f.genEmitMethod("sort",
-      FastIndexedSeq(typeInfo[Region], leftEC.emitParamType, rightEC.emitParamType),
+    val sort = fb.genEmitMethod("sort",
+      FastIndexedSeq(typeInfo[Region], CodeParamType(elemSCT.ti), CodeParamType(elemSCT.ti)),
       BooleanInfo)
 
-    if (leftRightComparatorNames.nonEmpty) {
-      assert(leftRightComparatorNames.length == 2)
-      newEnv = newEnv.bindIterable(
-        IndexedSeq(
-          (leftRightComparatorNames(0), sort.getEmitParam(2, fregion)),
-          (leftRightComparatorNames(1), sort.getEmitParam(3, fregion))))
+    sort.emitWithBuilder[Boolean] { cb =>
+      val region = sort.getCodeParam[Region](1)
+      val leftEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToPCode(cb, region, sort.getCodeParam(2)(elemSCT.ti))), "sort_leftEC")
+      val rightEC = cb.memoize(EmitCode.present(sort, elemSCT.loadToPCode(cb, region, sort.getCodeParam(3)(elemSCT.ti))), "sort_rightEC")
+
+      if (leftRightComparatorNames.nonEmpty) {
+        assert(leftRightComparatorNames.length == 2)
+        newEnv = newEnv.bindIterable(
+          IndexedSeq(
+            (leftRightComparatorNames(0), leftEC),
+            (leftRightComparatorNames(1), rightEC)))
+      }
+
+      val iec = new Emit(ctx, fb).emitI(ir, cb, newEnv, None)
+      iec.get(cb, "Result of sorting function cannot be missing").asBoolean.boolCode(cb)
     }
-
-    val EmitCode(m, v) = new Emit(ctx, f.ecb).emit(newIR, sort, newEnv, None)
-
-    sort.emit(m.mux(Code._fatal[Boolean]("Result of sorting function cannot be missing."), v.code))
-    f.apply_method.emitWithBuilder(cb => cb.invokeCode[Boolean](sort, fregion, leftEC, rightEC))
-    f
+    (cb: EmitCodeBuilder, region: Value[Region], l: Code[_], r: Code[_]) => cb.invokeCode[Boolean](sort, region, l, r)
   }
 
   private def present(pv: PCode): EmitCode = EmitCode(Code._empty, false, pv)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -139,10 +139,11 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
           if (c.ti != cpt.ti)
             throw new RuntimeException(s"invoke ${ callee.mb.methodName }: arg $i: type mismatch:" +
               s"\n  got ${ c.ti }" +
-              s"\n  expected ${ cpt.ti }")
+              s"\n  expected ${ cpt.ti }" +
+              s"\n  all param types: ${expectedArgs}-")
           FastIndexedSeq(c)
         case (PCodeParam(pc), pcpt: PCodeParamType) =>
-          if (pc.pt != pcpt.pt)
+          if (!pc.pt.equalModuloRequired(pcpt.pt))
             throw new RuntimeException(s"invoke ${ callee.mb.methodName }: arg $i: type mismatch:" +
               s"\n  got ${ pc.pt }" +
               s"\n  expected ${ pcpt.pt }")
@@ -216,6 +217,12 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   def strValue(sc: SCode): Code[String] = {
     val x = sc.asPCode
     strValue(x.pt, x.code)
+  }
+
+  def strValue(ec: EmitCode): Code[String] = {
+    val s = newLocal[String]("s")
+    ec.toI(this).consume(this, assign(s, "NA"), sc => assign(s, strValue(sc)))
+    s
   }
 
   // for debugging

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -8,7 +8,7 @@ import is.hail.utils.BoxedArrayBuilder
 
 import scala.reflect.ClassTag
 
-class StagedArrayBuilder(val elt: SingleCodeType, mb: EmitMethodBuilder[_], len: Code[Int]) {
+class StagedArrayBuilder(val elt: SingleCodeType, val eltRequired: Boolean, mb: EmitMethodBuilder[_], len: Code[Int]) {
 
   val ti: TypeInfo[_] = elt.ti
 
@@ -43,26 +43,6 @@ class StagedArrayBuilder(val elt: SingleCodeType, mb: EmitMethodBuilder[_], len:
     case LongInfo => coerce[LongMissingArrayBuilder](ref).invoke[Int, Long, Unit]("update", i, coerce[Long](x))
     case FloatInfo => coerce[FloatMissingArrayBuilder](ref).invoke[Int, Float, Unit]("update", i, coerce[Float](x))
     case DoubleInfo => coerce[DoubleMissingArrayBuilder](ref).invoke[Int, Double, Unit]("update", i, coerce[Double](x))
-  }
-
-  def sort(compare: Code[AsmFunction2[_, _, _]]): Code[Unit] = {
-    ti match {
-      case BooleanInfo =>
-        type F = AsmFunction2[Boolean, Boolean, Boolean]
-        coerce[BooleanMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
-      case IntInfo =>
-        type F = AsmFunction2[Int, Int, Boolean]
-        coerce[IntMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
-      case LongInfo =>
-        type F = AsmFunction2[Long, Long, Boolean]
-        coerce[LongMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
-      case FloatInfo =>
-        type F = AsmFunction2[Float, Float, Boolean]
-        coerce[FloatMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
-      case DoubleInfo =>
-        type F = AsmFunction2[Double, Double, Boolean]
-        coerce[DoubleMissingArrayBuilder](ref).invoke[F, Unit]("sort", coerce[F](compare))
-    }
   }
 
   def addMissing(): Code[Unit] =

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -104,7 +104,7 @@ abstract class CodeOrdering {
     if (!arg2.st.equalsExceptTopLevelRequiredness(type2))
       throw new RuntimeException(s"CodeOrdering: $context: type mismatch (right)\n  generated: $type2\n  argument:  ${ arg2.st }")
 
-    val cacheKey = ("ordering", reversed, type1, type2, context, missingEqual)
+    val cacheKey = ("ordering", reversed, arg1.emitType, arg2.emitType, context, missingEqual)
     val mb = cb.emb.ecb.getOrGenEmitMethod(s"ord_$context", cacheKey,
       FastIndexedSeq(arg1.emitParamType, arg2.emitParamType), ti) { mb =>
 

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -22,7 +22,7 @@ object StreamUtils {
     val aTyp = PCanonicalArray(stream.element.st.canonicalPType(), true)
     stream.length match {
       case None =>
-        val vab = new StagedArrayBuilder(SingleCodeType.fromSType(stream.element.st), mb, 0)
+        val vab = new StagedArrayBuilder(SingleCodeType.fromSType(stream.element.st), stream.element.required, mb, 0)
         writeToArrayBuilder(cb, stream, vab, destRegion)
         cb.assign(xLen, vab.size)
 

--- a/hail/src/main/scala/is/hail/lir/X.scala
+++ b/hail/src/main/scala/is/hail/lir/X.scala
@@ -831,6 +831,7 @@ class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends Valu
       case L2I => IntInfo
       case F2I => IntInfo
       case D2I => IntInfo
+      case IALOAD => IntInfo
       // Long
       case LNEG => LongInfo
       case LADD => LongInfo
@@ -847,6 +848,7 @@ class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends Valu
       case I2L => LongInfo
       case F2L => LongInfo
       case D2L => LongInfo
+      case LALOAD => LongInfo
       // Float
       case FNEG => FloatInfo
       case FADD => FloatInfo
@@ -857,6 +859,8 @@ class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends Valu
       case I2F => FloatInfo
       case L2F => FloatInfo
       case D2F => FloatInfo
+      case FALOAD => FloatInfo
+
       // Double
       case DNEG => DoubleInfo
       case DADD => DoubleInfo
@@ -867,8 +871,10 @@ class InsnX(val op: Int, _ti: TypeInfo[_], var lineNumber: Int = 0) extends Valu
       case I2D => DoubleInfo
       case L2D => DoubleInfo
       case F2D => DoubleInfo
+      case DALOAD => DoubleInfo
       // Boolean
       case I2B => BooleanInfo
+      case BALOAD => BooleanInfo
     }
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -5,6 +5,16 @@ import is.hail.types.virtual.{TDict, Type}
 import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode}
 import org.apache.spark.sql.Row
 
+object PCanonicalDict {
+  def coerceArrayCode(contents: PIndexableCode): PIndexableCode = {
+    contents.pt match {
+      case PCanonicalArray(ps: PCanonicalStruct, r) =>
+        PCanonicalDict(ps.fieldType("key"), ps.fieldType("value"), r)
+          .construct(contents)
+    }
+  }
+}
+
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
   val elementType = PCanonicalStruct(required = true, "key" -> keyType, "value" -> valueType)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
@@ -5,6 +5,15 @@ import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePoin
 import is.hail.types.virtual.{TSet, Type}
 import is.hail.utils._
 
+object PCanonicalSet {
+  def coerceArrayCode(contents: PIndexableCode): PIndexableCode = {
+    contents.pt match {
+      case PCanonicalArray(elt, r) =>
+        PCanonicalSet(elt, r).construct(contents)
+    }
+  }
+}
+
 final case class PCanonicalSet(elementType: PType,  required: Boolean = false) extends PSet with PArrayBackedContainer {
   val arrayRep = PCanonicalArray(elementType, required)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -58,10 +58,14 @@ sealed trait SingleCodeType {
   def virtualType: Type
 
   def coercePCode(cb: EmitCodeBuilder, pc: PCode, region: Value[Region], deepCopy: Boolean): SingleCodePCode
+
+  def loadedSType: SType
 }
 
 case object Int32SingleCodeType extends SingleCodeType {
   def ti: TypeInfo[_] = IntInfo
+
+  override def loadedSType: SType = SInt32(false)
 
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = new SInt32Code(true, coerce[Int](c))
 
@@ -73,6 +77,8 @@ case object Int32SingleCodeType extends SingleCodeType {
 case object Int64SingleCodeType extends SingleCodeType {
   def ti: TypeInfo[_] = LongInfo
 
+  override def loadedSType: SType = SInt64(false)
+
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = new SInt64Code(true, coerce[Long](c))
 
   def virtualType: Type = TInt64
@@ -82,6 +88,8 @@ case object Int64SingleCodeType extends SingleCodeType {
 
 case object Float32SingleCodeType extends SingleCodeType {
   def ti: TypeInfo[_] = FloatInfo
+
+  override def loadedSType: SType = SFloat32(false)
 
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = new SFloat32Code(true, coerce[Float](c))
 
@@ -93,6 +101,8 @@ case object Float32SingleCodeType extends SingleCodeType {
 case object Float64SingleCodeType extends SingleCodeType {
   def ti: TypeInfo[_] = DoubleInfo
 
+  override def loadedSType: SType = SFloat64(false)
+
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = new SFloat64Code(true, coerce[Double](c))
 
   def virtualType: Type = TFloat64
@@ -103,6 +113,8 @@ case object Float64SingleCodeType extends SingleCodeType {
 case object BooleanSingleCodeType extends SingleCodeType {
   def ti: TypeInfo[_] = BooleanInfo
 
+  override def loadedSType: SType = SBoolean(false)
+
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = new SBooleanCode(true, coerce[Boolean](c))
 
   def virtualType: Type = TBoolean
@@ -111,6 +123,8 @@ case object BooleanSingleCodeType extends SingleCodeType {
 }
 
 case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, eltType: PType) extends SingleCodeType { self =>
+
+  override def loadedSType: SType = SStream(eltType.sType, false)
 
   def virtualType: Type = TStream(eltType.virtualType)
 
@@ -153,6 +167,8 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
 
 case class PTypeReferenceSingleCodeType(pt: PType) extends SingleCodeType {
   def ti: TypeInfo[_] = LongInfo
+
+  override def loadedSType: SType = pt.sType
 
   def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): PCode = pt.loadCheapPCode(cb, coerce[Long](c))
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -41,6 +41,8 @@ trait SType {
 
 case class EmitType(st: SType, required: Boolean) {
   def virtualType: Type = st.virtualType
-  def paramType: EmitParamType = PCodeEmitParamType(st.pType.setRequired(required))
+
+  def paramType: PCodeEmitParamType = PCodeEmitParamType(st.pType.setRequired(required))
+
   def canonicalPType: PType = st.canonicalPType().setRequired(required)
 }

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -131,7 +131,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
 
-    val sab = new StagedArrayBuilder(PInt64(), fb.apply_method, 16)
+    val sab = new StagedArrayBuilder(Int64SingleCodeType, fb.apply_method, 16)
     val idx = fb.newLocal[Int]()
     val returnArray = fb.newLocal[Array[java.lang.Long]]()
 

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -131,7 +131,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
     val key = new TestBTreeKey(fb.apply_method)
     val btree = new AppendOnlyBTree(cb, key, r, root, maxElements = n)
 
-    val sab = new StagedArrayBuilder(Int64SingleCodeType, fb.apply_method, 16)
+    val sab = new StagedArrayBuilder(Int64SingleCodeType, true, fb.apply_method, 16)
     val idx = fb.newLocal[Int]()
     val returnArray = fb.newLocal[Array[java.lang.Long]]()
 


### PR DESCRIPTION
* push SingleCodeType through StagedArrayBuilder
* what was makeDependentSortingFunction, let's not do that anymore
* generate a staged quicksort instead of pass a virtual function
  as a param and copying everything many times
* Break apart emitters for different IRs. They don't share that much.

Non-randomly assigning Chris because we talked about this design in the past.