### PR TITLE
[query] Add compile-time constant bool analysis to generate requiredness

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -321,7 +321,9 @@ package object asm4s {
 
   implicit def const(s: String): Value[String] = _const(s, classInfo[String])
 
-  implicit def const(b: Boolean): Value[Boolean] = _const(if (b) 1 else 0, BooleanInfo)
+  implicit def const(b: Boolean): Value[Boolean] = new Value[Boolean] {
+    def get: Code[Boolean] = new ConstCodeBoolean(b)
+  }
 
   implicit def const(i: Int): Value[Int] = _const(i, IntInfo)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -416,7 +416,7 @@ class EmitCode(private val start: CodeLabel, private val iec: IEmitCode) {
 
   def setup: Code[Unit] = Code._empty
 
-  val m: Code[Boolean] = if (iec.required) const(false) else new CCode(start.L, iec.Lmissing.L, iec.Lpresent.L)
+  val m: Code[Boolean] = new CCode(start.L, iec.Lmissing.L, iec.Lpresent.L)
 
   def pt: PType = pv.pt
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -212,12 +212,16 @@ class EmitUnrealizableValue(private val ec: EmitCode) extends EmitValue {
  */
 object IEmitCode {
   def apply[A](cb: EmitCodeBuilder, m: Code[Boolean], value: => A): IEmitCodeGen[A] = {
-    val Lmissing = CodeLabel()
-    val Lpresent = CodeLabel()
-    cb.ifx(m, { cb.goto(Lmissing) })
-    val res: A = value
-    cb.goto(Lpresent)
-    IEmitCodeGen(Lmissing, Lpresent, res, false)
+    Code.constBoolValue(m) match {
+      case Some(false) => present(cb, value)
+      case _ =>
+        val Lmissing = CodeLabel()
+        val Lpresent = CodeLabel()
+        cb.ifx(m, cb.goto(Lmissing))
+        val res: A = value
+        cb.goto(Lpresent)
+        IEmitCodeGen(Lmissing, Lpresent, res, false)
+    }
   }
 
   def apply[A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, required: Boolean): IEmitCodeGen[A] =

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -416,7 +416,7 @@ class EmitCode(private val start: CodeLabel, private val iec: IEmitCode) {
 
   def setup: Code[Unit] = Code._empty
 
-  val m: Code[Boolean] = new CCode(start.L, iec.Lmissing.L, iec.Lpresent.L)
+  val m: Code[Boolean] = if (iec.required) const(false) else new CCode(start.L, iec.Lmissing.L, iec.Lpresent.L)
 
   def pt: PType = pv.pt
 

--- a/hail/src/test/scala/is/hail/lir/CompileTimeRequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/lir/CompileTimeRequirednessSuite.scala
@@ -1,0 +1,19 @@
+package is.hail.lir
+
+import is.hail.HailSuite
+import is.hail.asm4s._
+import is.hail.utils._
+import org.testng.annotations.Test
+
+class CompileTimeRequirednessSuite extends HailSuite {
+  @Test def testCodeBooleanFolding(): Unit = {
+    val cFalse = const(false)
+    val cTrue = const(true)
+
+    assert(Code.constBoolValue(cFalse).contains(false))
+    assert(Code.constBoolValue(cTrue).contains(true))
+    assert(Code.constBoolValue(!cFalse).contains(true))
+    assert(Code.constBoolValue(!cTrue).contains(false))
+    assert(Code.constBoolValue(const(1) < 2).isEmpty)
+  }
+}


### PR DESCRIPTION
We need the negation folding as well due to the structure of how requiredness
is used in stypes/ptypes.