### PR TITLE
[black] Add pyproject.toml and run black on services code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        files: 'ci/.*'
-        args: ['--line-length=120', '--skip-string-normalization']
   - repo: https://github.com/thibaudcolas/curlylint
     rev: v0.12.0
     hooks:

--- a/address/address/__main__.py
+++ b/address/address/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/address/setup.py
+++ b/address/setup.py
@@ -8,5 +8,5 @@ setup(
     author_email='hail@broadinstitute.org',
     description='Convert names to IP addresses',
     packages=find_packages(),
-    include_package_data=True
+    include_package_data=True,
 )

--- a/address/test/test_address.py
+++ b/address/test/test_address.py
@@ -14,21 +14,22 @@ deploy_config = get_deploy_config()
 async def test_connect_to_address_on_pod_ip():
     ssl_config = _get_ssl_config()
     client_ssl_context = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH,
-        cafile=ssl_config['outgoing_trust'])
+        purpose=ssl.Purpose.SERVER_AUTH, cafile=ssl_config['outgoing_trust']
+    )
     client_ssl_context.load_default_certs()
-    client_ssl_context.load_cert_chain(ssl_config['cert'],
-                                       keyfile=ssl_config['key'],
-                                       password=None)
+    client_ssl_context.load_cert_chain(ssl_config['cert'], keyfile=ssl_config['key'], password=None)
     client_ssl_context.verify_mode = ssl.CERT_REQUIRED
     client_ssl_context.check_hostname = False
 
     async with aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(ssl=client_ssl_context),
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=5),
-            headers=service_auth_headers(deploy_config, 'address')) as session:
+        connector=aiohttp.TCPConnector(ssl=client_ssl_context),
+        raise_for_status=True,
+        timeout=aiohttp.ClientTimeout(total=5),
+        headers=service_auth_headers(deploy_config, 'address'),
+    ) as session:
+
         async def get():
             address, port = await deploy_config.address('address')
             session.get(f'https://{address}:{port}{deploy_config.base_path("address")}/api/address')
+
         await retry_transient_errors(get)

--- a/atgu/atgu/__main__.py
+++ b/atgu/atgu/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/atgu/setup.py
+++ b/atgu/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'atgu',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'ATGU intranet',
-    packages = find_packages(),
-    include_package_data=True
+    name='atgu',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='ATGU intranet',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/auth/auth/__main__.py
+++ b/auth/auth/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/auth/auth/driver/__main__.py
+++ b/auth/auth/driver/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/auth/setup.py
+++ b/auth/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'auth',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Authentication service',
-    packages = find_packages(),
-    include_package_data=True
+    name='auth',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Authentication service',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/batch/batch/batch_format_version.py
+++ b/batch/batch/batch_format_version.py
@@ -25,9 +25,10 @@ class BatchFormatVersion:
 
         secrets = spec.get('secrets')
         if secrets:
-            secrets = [[secret['namespace'], secret['name'],
-                        secret['mount_path'], int(secret.get('mount_in_copy', False))]
-                       for secret in secrets]
+            secrets = [
+                [secret['namespace'], secret['name'], secret['mount_path'], int(secret.get('mount_in_copy', False))]
+                for secret in secrets
+            ]
 
         service_account = spec.get('service_account')
         if service_account:
@@ -46,7 +47,7 @@ class BatchFormatVersion:
                 secrets,
                 service_account,
                 int(len(spec.get('input_files', [])) > 0),
-                int(len(spec.get('output_files', [])) > 0)
+                int(len(spec.get('output_files', [])) > 0),
             ]
 
         return [
@@ -54,7 +55,7 @@ class BatchFormatVersion:
             service_account,
             int(len(spec.get('input_files', [])) > 0),
             int(len(spec.get('output_files', [])) > 0),
-            machine_spec
+            machine_spec,
         ]
 
     def get_spec_secrets(self, spec):
@@ -62,10 +63,10 @@ class BatchFormatVersion:
             return spec.get('secrets')
         secrets = spec[0]
         if secrets:
-            return [{'namespace': secret[0],
-                     'name': secret[1],
-                     'mount_path': secret[2],
-                     'mount_in_copy': bool(secret[3])} for secret in secrets]
+            return [
+                {'namespace': secret[0], 'name': secret[1], 'mount_path': secret[2], 'mount_in_copy': bool(secret[3])}
+                for secret in secrets
+            ]
         return None
 
     def get_spec_service_account(self, spec):
@@ -73,8 +74,7 @@ class BatchFormatVersion:
             return spec.get('service_account')
         service_account = spec[1]
         if service_account:
-            return {'namespace': service_account[0],
-                    'name': service_account[1]}
+            return {'namespace': service_account[0], 'name': service_account[1]}
         return None
 
     def get_spec_has_input_files(self, spec):
@@ -92,9 +92,11 @@ class BatchFormatVersion:
             return None
         machine_type_spec = spec[4]
         if machine_type_spec:
-            return {'machine_type': machine_type_spec[0],
-                    'preemptible': bool(machine_type_spec[1]),
-                    'storage_gib': machine_type_spec[2]}
+            return {
+                'machine_type': machine_type_spec[0],
+                'preemptible': bool(machine_type_spec[1]),
+                'storage_gib': machine_type_spec[2],
+            }
         return None
 
     def db_status(self, status):

--- a/batch/batch/copy/__main__.py
+++ b/batch/batch/copy/__main__.py
@@ -13,8 +13,7 @@ async def copy(requester_pays_project: Optional[str], transfer: Union[Transfer, 
     else:
         params = None
     with ThreadPoolExecutor() as thread_pool:
-        async with RouterAsyncFS(
-                'file', [LocalAsyncFS(thread_pool), GoogleStorageAsyncFS(params=params)]) as fs:
+        async with RouterAsyncFS('file', [LocalAsyncFS(thread_pool), GoogleStorageAsyncFS(params=params)]) as fs:
             sema = asyncio.Semaphore(50)
             async with sema:
                 copy_report = await fs.copy(sema, transfer)
@@ -26,9 +25,9 @@ async def main() -> None:
     requster_pays_project = json.loads(sys.argv[1])
     files = json.loads(sys.argv[2])
 
-    await copy(requster_pays_project, [
-        Transfer(f['from'], f['to'], treat_dest_as=Transfer.DEST_IS_TARGET)
-        for f in files])
+    await copy(
+        requster_pays_project, [Transfer(f['from'], f['to'], treat_dest_as=Transfer.DEST_IS_TARGET) for f in files]
+    )
 
 
 if __name__ == '__main__':

--- a/batch/batch/driver/__main__.py
+++ b/batch/batch/driver/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/batch/batch/driver/instance_collection_manager.py
+++ b/batch/batch/driver/instance_collection_manager.py
@@ -35,8 +35,7 @@ class InstanceCollectionManager:
             self.name_pool[pool_name] = pool
             self.name_inst_coll[pool_name] = pool
 
-        await asyncio.gather(*[inst_coll.async_init()
-                               for inst_coll in self.name_inst_coll.values()])
+        await asyncio.gather(*[inst_coll.async_init() for inst_coll in self.name_inst_coll.values()])
 
         log.info('finished initializing instance collections')
 
@@ -65,8 +64,7 @@ class InstanceCollectionManager:
 
     @property
     def global_n_instances_by_state(self):
-        counters = [collections.Counter(inst_coll.n_instances_by_state)
-                    for inst_coll in self.name_inst_coll.values()]
+        counters = [collections.Counter(inst_coll.n_instances_by_state) for inst_coll in self.name_inst_coll.values()]
         result = collections.Counter({})
         for counter in counters:
             result += counter

--- a/batch/batch/driver/k8s_cache.py
+++ b/batch/batch/driver/k8s_cache.py
@@ -12,13 +12,11 @@ class K8sCache:
         self.max_size = max_size
 
         self.secrets = {}
-        self.secret_ids = sortedcontainers.SortedSet(
-            key=lambda id: self.secrets[id][1])
+        self.secret_ids = sortedcontainers.SortedSet(key=lambda id: self.secrets[id][1])
         self.secret_locks = {}
 
         self.service_accounts = {}
-        self.service_account_ids = sortedcontainers.SortedSet(
-            key=lambda id: self.service_accounts[id][1])
+        self.service_account_ids = sortedcontainers.SortedSet(key=lambda id: self.service_accounts[id][1])
         self.service_account_locks = {}
 
     async def read_secret(self, name, namespace, timeout):
@@ -39,10 +37,8 @@ class K8sCache:
                 del self.secrets[head_id]
 
             secret = await retry_transient_errors(
-                self.client.read_namespaced_secret,
-                name,
-                namespace,
-                _request_timeout=timeout)
+                self.client.read_namespaced_secret, name, namespace, _request_timeout=timeout
+            )
 
             self.secrets[id] = (secret, time.time())
             self.secret_ids.add(id)
@@ -68,10 +64,8 @@ class K8sCache:
                 del self.service_accounts[head_id]
 
             sa = await retry_transient_errors(
-                self.client.read_namespaced_service_account,
-                name,
-                namespace,
-                _request_timeout=timeout)
+                self.client.read_namespaced_service_account, name, namespace, _request_timeout=timeout
+            )
 
             self.service_accounts[id] = (sa, time.time())
             self.service_account_ids.add(id)

--- a/batch/batch/driver/zone_monitor.py
+++ b/batch/batch/driver/zone_monitor.py
@@ -69,8 +69,7 @@ class ZoneMonitor:
         if self.app['inst_coll_manager'].global_live_total_cores_mcpu // 1000 < 1_000:
             zone = GCP_ZONE
         else:
-            zone_weights = self.zone_weights(worker_cores, worker_local_ssd_data_disk,
-                                             worker_pd_ssd_data_disk_size_gb)
+            zone_weights = self.zone_weights(worker_cores, worker_local_ssd_data_disk, worker_pd_ssd_data_disk_size_gb)
 
             if not zone_weights:
                 return None
@@ -78,8 +77,8 @@ class ZoneMonitor:
             zones = [zw.zone for zw in zone_weights]
 
             zone_prob_weights = [
-                min(zw.weight, 10) * self.zone_success_rate.zone_success_rate(zw.zone)
-                for zw in zone_weights]
+                min(zw.weight, 10) * self.zone_success_rate.zone_success_rate(zw.zone) for zw in zone_weights
+            ]
 
             log.info(f'zone_success_rate {self.zone_success_rate}')
             log.info(f'zone_prob_weights {zone_prob_weights}')
@@ -93,10 +92,7 @@ class ZoneMonitor:
 
         _zone_weights = []
         for r in self.region_info.values():
-            quota_remaining = {
-                q['metric']: q['limit'] - q['usage']
-                for q in r['quotas']
-            }
+            quota_remaining = {q['metric']: q['limit'] - q['usage'] for q in r['quotas']}
 
             remaining = quota_remaining['PREEMPTIBLE_CPUS'] / worker_cores
             if worker_local_ssd_data_disk:
@@ -113,14 +109,9 @@ class ZoneMonitor:
         return _zone_weights
 
     async def update_region_quotas(self):
-        self.region_info = {
-            name: await self.compute_client.get(f'/regions/{name}')
-            for name in BATCH_GCP_REGIONS
-        }
+        self.region_info = {name: await self.compute_client.get(f'/regions/{name}') for name in BATCH_GCP_REGIONS}
 
-        self.zones = [url_basename(z)
-                      for r in self.region_info.values()
-                      for z in r['zones']]
+        self.zones = [url_basename(z) for r in self.region_info.values() for z in r['zones']]
 
         log.info('updated region quotas')
 

--- a/batch/batch/front_end/__main__.py
+++ b/batch/batch/front_end/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -17,37 +17,58 @@ import google.oauth2.service_account
 import google.api_core.exceptions
 import humanize
 from prometheus_async.aio.web import server_stats  # type: ignore
-from hailtop.utils import (time_msecs, time_msecs_str, humanize_timedelta_msecs,
-                           request_retry_transient_errors, run_if_changed,
-                           retry_long_running, LoggingTimer, cost_str, dump_all_stacktraces)
-from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes)
+from hailtop.utils import (
+    time_msecs,
+    time_msecs_str,
+    humanize_timedelta_msecs,
+    request_retry_transient_errors,
+    run_if_changed,
+    retry_long_running,
+    LoggingTimer,
+    cost_str,
+    dump_all_stacktraces,
+)
+from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.httpx import client_session
 from hailtop.hail_logging import AccessLogger
 from hailtop import aiotools, dictfix
-from gear import (Database, setup_aiohttp_session,
-                  rest_authenticated_users_only,
-                  web_authenticated_users_only,
-                  web_authenticated_developers_only,
-                  check_csrf_token, transaction,
-                  monitor_endpoint)
-from web_common import (setup_aiohttp_jinja2, setup_common_static_routes,
-                        render_template, set_message)
+from gear import (
+    Database,
+    setup_aiohttp_session,
+    rest_authenticated_users_only,
+    web_authenticated_users_only,
+    web_authenticated_developers_only,
+    check_csrf_token,
+    transaction,
+    monitor_endpoint,
+)
+from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
 
 # import uvloop
 
-from ..utils import (coalesce, query_billing_projects, is_valid_cores_mcpu, cost_from_msec_mcpu,
-                     cores_mcpu_to_memory_bytes, batch_only)
+from ..utils import (
+    coalesce,
+    query_billing_projects,
+    is_valid_cores_mcpu,
+    cost_from_msec_mcpu,
+    cores_mcpu_to_memory_bytes,
+    batch_only,
+)
 from ..batch import batch_record_to_dict, job_record_to_dict, cancel_batch_in_db
-from ..exceptions import (BatchUserError, NonExistentBillingProjectError,
-                          ClosedBillingProjectError, InvalidBillingLimitError,
-                          BatchOperationAlreadyCompletedError)
+from ..exceptions import (
+    BatchUserError,
+    NonExistentBillingProjectError,
+    ClosedBillingProjectError,
+    InvalidBillingLimitError,
+    BatchOperationAlreadyCompletedError,
+)
 from ..inst_coll_config import InstanceCollectionConfigs
 from ..log_store import LogStore
 from ..database import CallError, check_call_procedure
-from ..batch_configuration import (BATCH_BUCKET_NAME, DEFAULT_NAMESPACE)
-from ..globals import (HTTP_CLIENT_MAX_SIZE, BATCH_FORMAT_VERSION, memory_to_worker_type)
+from ..batch_configuration import BATCH_BUCKET_NAME, DEFAULT_NAMESPACE
+from ..globals import HTTP_CLIENT_MAX_SIZE, BATCH_FORMAT_VERSION, memory_to_worker_type
 from ..spec_writer import SpecWriter
 from ..batch_format_version import BatchFormatVersion
 
@@ -74,6 +95,7 @@ def rest_authenticated_developers_or_auth_only(fun):
         if userdata['is_developer'] == 1 or userdata['username'] == 'auth':
             return await fun(request, userdata, *args, **kwargs)
         raise web.HTTPUnauthorized()
+
     return wrapped
 
 
@@ -85,7 +107,8 @@ FROM batches
 LEFT JOIN billing_project_users ON batches.billing_project = billing_project_users.billing_project
 WHERE id = %s AND billing_project_users.`user` = %s;
 ''',
-        (batch_id, user))
+        (batch_id, user),
+    )
 
     return record is not None
 
@@ -101,6 +124,7 @@ def rest_billing_project_users_only(fun):
         if not permitted_user:
             raise web.HTTPNotFound()
         return await fun(request, userdata, batch_id, *args, **kwargs)
+
     return wrapped
 
 
@@ -116,7 +140,9 @@ def web_billing_project_users_only(redirect=True):
             if not permitted_user:
                 raise web.HTTPNotFound()
             return await fun(request, userdata, batch_id, *args, **kwargs)
+
         return wrapped
+
     return wrap
 
 
@@ -163,15 +189,13 @@ async def _query_batch_jobs(request, batch_id):
         'failed': ['Failed'],
         'bad': ['Error', 'Failed'],
         'success': ['Success'],
-        'done': ['Cancelled', 'Error', 'Failed', 'Success']
+        'done': ['Cancelled', 'Error', 'Failed', 'Success'],
     }
 
     db = request.app['db']
 
     # batch has already been validated
-    where_conditions = [
-        '(jobs.batch_id = %s)'
-    ]
+    where_conditions = ['(jobs.batch_id = %s)']
     where_args = [batch_id]
 
     last_job_id = request.query.get('last_job_id')
@@ -207,8 +231,7 @@ async def _query_batch_jobs(request, batch_id):
             args = [k]
         elif t in state_query_values:
             values = state_query_values[t]
-            condition = ' OR '.join([
-                '(jobs.state = %s)' for v in values])
+            condition = ' OR '.join(['(jobs.state = %s)' for v in values])
             condition = f'({condition})'
             args = values
         else:
@@ -243,9 +266,7 @@ LIMIT 50;
 '''
     sql_args = where_args
 
-    jobs = [job_record_to_dict(record, record['name'])
-            async for record
-            in db.select_and_fetchall(sql, sql_args)]
+    jobs = [job_record_to_dict(record, record['name']) async for record in db.select_and_fetchall(sql, sql_args)]
 
     if len(jobs) == 50:
         last_job_id = jobs[-1]['job_id']
@@ -264,14 +285,14 @@ async def get_jobs(request, userdata, batch_id):  # pylint: disable=unused-argum
         '''
 SELECT * FROM batches
 WHERE id = %s AND NOT deleted;
-''', (batch_id,))
+''',
+        (batch_id,),
+    )
     if not record:
         raise web.HTTPNotFound()
 
     jobs, last_job_id = await _query_batch_jobs(request, batch_id)
-    resp = {
-        'jobs': jobs
-    }
+    resp = {'jobs': jobs}
     if last_job_id is not None:
         resp['last_job_id'] = last_job_id
     return web.json_response(resp)
@@ -281,12 +302,9 @@ async def _get_job_log_from_record(app, batch_id, job_id, record):
     state = record['state']
     ip_address = record['ip_address']
     if state == 'Running':
-        async with aiohttp.ClientSession(
-                raise_for_status=True,
-                timeout=aiohttp.ClientTimeout(total=5)) as session:
+        async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
             try:
-                url = (f'http://{ip_address}:5000'
-                       f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
+                url = f'http://{ip_address}:5000' f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log'
                 resp = await request_retry_transient_errors(session, 'GET', url)
                 return await resp.json()
             except aiohttp.ClientResponseError as e:
@@ -328,7 +346,8 @@ async def _get_job_log_from_record(app, batch_id, job_id, record):
 async def _get_job_log(app, batch_id, job_id):
     db: Database = app['db']
 
-    record = await db.select_and_fetchone('''
+    record = await db.select_and_fetchone(
+        '''
 SELECT jobs.state, jobs.spec, ip_address, format_version, jobs.attempt_id
 FROM jobs
 INNER JOIN batches
@@ -339,7 +358,8 @@ LEFT JOIN instances
   ON attempts.instance_name = instances.name
 WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 ''',
-                                          (batch_id, job_id))
+        (batch_id, job_id),
+    )
     if not record:
         raise web.HTTPNotFound()
     return await _get_job_log_from_record(app, batch_id, job_id, record)
@@ -356,12 +376,14 @@ async def _get_attributes(app, record):
         spec = json.loads(record['spec'])
         return spec.get('attributes')
 
-    records = db.select_and_fetchall('''
+    records = db.select_and_fetchall(
+        '''
 SELECT `key`, `value`
 FROM job_attributes
 WHERE batch_id = %s AND job_id = %s;
 ''',
-                                     (batch_id, job_id))
+        (batch_id, job_id),
+    )
     return {record['key']: record['value'] async for record in records}
 
 
@@ -415,12 +437,9 @@ async def _get_full_job_status(app, record):
     assert record['status'] is None
 
     ip_address = record['ip_address']
-    async with aiohttp.ClientSession(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=5)) as session:
+    async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         try:
-            url = (f'http://{ip_address}:5000'
-                   f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/status')
+            url = f'http://{ip_address}:5000' f'/api/v1alpha/batches/{batch_id}/jobs/{job_id}/status'
             resp = await request_retry_transient_errors(session, 'GET', url)
             return await resp.json()
         except aiohttp.ClientResponseError as e:
@@ -441,7 +460,10 @@ async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-ar
 async def _query_batches(request, user, q):
     db = request.app['db']
 
-    where_conditions = ['EXISTS (SELECT * FROM billing_project_users WHERE billing_project_users.`user` = %s AND billing_project_users.billing_project = batches.billing_project)', 'NOT deleted']
+    where_conditions = [
+        'EXISTS (SELECT * FROM billing_project_users WHERE billing_project_users.`user` = %s AND billing_project_users.billing_project = batches.billing_project)',
+        'NOT deleted',
+    ]
     where_args = [user]
 
     last_batch_id = request.query.get('last_batch_id')
@@ -533,9 +555,7 @@ LIMIT 51;
 '''
     sql_args = where_args
 
-    batches = [batch_record_to_dict(batch)
-               async for batch
-               in db.select_and_fetchall(sql, sql_args)]
+    batches = [batch_record_to_dict(batch) async for batch in db.select_and_fetchall(sql, sql_args)]
 
     if len(batches) == 51:
         batches.pop()
@@ -553,9 +573,7 @@ async def get_batches(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
     q = request.query.get('q', f'user:{user}')
     batches, last_batch_id = await _query_batches(request, user, q)
-    body = {
-        'batches': batches
-    }
+    body = {'batches': batches}
     if last_batch_id is not None:
         body['last_batch_id'] = last_batch_id
     return web.json_response(body)
@@ -565,9 +583,8 @@ def check_service_account_permissions(user, sa):
     if sa is None:
         return
     if user == 'ci':
-        if sa['name'] in ('ci-agent', 'admin'):
-            if DEFAULT_NAMESPACE == 'default' or sa['namespace'] == DEFAULT_NAMESPACE:  # pylint: disable=consider-using-in
-                return
+        if sa['name'] in ('ci-agent', 'admin') and DEFAULT_NAMESPACE in ('default', sa['namespace']):
+            return
     elif user == 'test':
         if sa['namespace'] == DEFAULT_NAMESPACE and sa['name'] == 'test-batch-sa':
             return
@@ -591,7 +608,7 @@ async def create_jobs(request, userdata):
     userdata = {
         'username': user,
         'gsa_key_secret_name': userdata['gsa_key_secret_name'],
-        'tokens_secret_name': userdata['tokens_secret_name']
+        'tokens_secret_name': userdata['tokens_secret_name'],
     }
 
     async with LoggingTimer(f'batch {batch_id} create jobs') as timer:
@@ -601,7 +618,8 @@ async def create_jobs(request, userdata):
 SELECT `state`, format_version FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
-                (user, batch_id))
+                (user, batch_id),
+            )
 
         if not record:
             raise web.HTTPNotFound()
@@ -625,13 +643,15 @@ WHERE user = %s AND id = %s AND NOT deleted;
             job_parents_args = []
             job_attributes_args = []
 
-            inst_coll_resources = collections.defaultdict(lambda: {
-                'n_jobs': 0,
-                'n_ready_jobs': 0,
-                'ready_cores_mcpu': 0,
-                'n_ready_cancellable_jobs': 0,
-                'ready_cancellable_cores_mcpu': 0
-            })
+            inst_coll_resources = collections.defaultdict(
+                lambda: {
+                    'n_jobs': 0,
+                    'n_ready_jobs': 0,
+                    'ready_cores_mcpu': 0,
+                    'n_ready_cancellable_jobs': 0,
+                    'ready_cancellable_cores_mcpu': 0,
+                }
+            )
 
             prev_job_idx = None
             start_job_id = None
@@ -654,7 +674,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if batch_format_version.has_full_spec_in_gcs() and prev_job_idx:
                     if job_id != prev_job_idx + 1:
                         raise web.HTTPBadRequest(
-                            reason=f'noncontiguous job ids found in the spec: {prev_job_idx} -> {job_id}')
+                            reason=f'noncontiguous job ids found in the spec: {prev_job_idx} -> {job_id}'
+                        )
                 prev_job_idx = job_id
 
                 resources = spec.get('resources')
@@ -667,8 +688,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 preemptible = resources.get('preemptible', BATCH_JOB_DEFAULT_PREEMPTIBLE)
 
                 if machine_type and ('cpu' in resources or 'memory' in resources):
-                    raise web.HTTPBadRequest(
-                        reason='cannot specify cpu and memory with machine_type')
+                    raise web.HTTPBadRequest(reason='cannot specify cpu and memory with machine_type')
 
                 if machine_type is None:
                     if 'cpu' not in resources:
@@ -681,7 +701,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         raise web.HTTPBadRequest(
                             reason=f'bad resource request for job {id}: '
                             f'cpu must be a power of two with a min of 0.25; '
-                            f'found {resources["req_cpu"]}.')
+                            f'found {resources["req_cpu"]}.'
+                        )
 
                     if 'memory' not in resources:
                         resources['memory'] = BATCH_JOB_DEFAULT_MEMORY
@@ -712,9 +733,9 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 inst_coll_configs: InstanceCollectionConfigs = app['inst_coll_configs']
 
-                result, exc = inst_coll_configs.select_inst_coll(machine_type, preemptible,
-                                                                 worker_type, req_cores_mcpu,
-                                                                 req_memory_bytes, req_storage_bytes)
+                result, exc = inst_coll_configs.select_inst_coll(
+                    machine_type, preemptible, worker_type, req_cores_mcpu, req_memory_bytes, req_storage_bytes
+                )
 
                 if exc:
                     raise web.HTTPBadRequest(reason=exc.message)
@@ -726,7 +747,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         f'memory={resources["req_memory"]}, '
                         f'storage={resources["req_storage"]}, '
                         f'preemptible={preemptible}, '
-                        f'machine_type={machine_type}')
+                        f'machine_type={machine_type}'
+                    )
 
                 inst_coll_name, cores_mcpu, memory_bytes, storage_gib = result
                 resources['cores_mcpu'] = cores_mcpu
@@ -747,12 +769,14 @@ WHERE user = %s AND id = %s AND NOT deleted;
                         raise web.HTTPBadRequest(reason=f'unauthorized secret {(secret["namespace"], secret["name"])}')
 
                 spec['secrets'] = secrets
-                secrets.append({
-                    'namespace': DEFAULT_NAMESPACE,
-                    'name': userdata['gsa_key_secret_name'],
-                    'mount_path': '/gsa-key',
-                    'mount_in_copy': True
-                })
+                secrets.append(
+                    {
+                        'namespace': DEFAULT_NAMESPACE,
+                        'name': userdata['gsa_key_secret_name'],
+                        'mount_path': '/gsa-key',
+                        'mount_in_copy': True,
+                    }
+                )
 
                 env = spec.get('env')
                 if not env:
@@ -761,28 +785,33 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 assert isinstance(spec['env'], list)
 
                 if all(envvar['name'] != 'GOOGLE_APPLICATION_CREDENTIALS' for envvar in spec['env']):
-                    spec['env'].append(
-                        {'name': 'GOOGLE_APPLICATION_CREDENTIALS', 'value': '/gsa-key/key.json'})
+                    spec['env'].append({'name': 'GOOGLE_APPLICATION_CREDENTIALS', 'value': '/gsa-key/key.json'})
 
                 if spec.get('mount_tokens', False):
-                    secrets.append({
-                        'namespace': DEFAULT_NAMESPACE,
-                        'name': userdata['tokens_secret_name'],
-                        'mount_path': '/user-tokens',
-                        'mount_in_copy': False
-                    })
-                    secrets.append({
-                        'namespace': DEFAULT_NAMESPACE,
-                        'name': 'gce-deploy-config',
-                        'mount_path': '/deploy-config',
-                        'mount_in_copy': False
-                    })
-                    secrets.append({
-                        'namespace': DEFAULT_NAMESPACE,
-                        'name': 'ssl-config-batch-user-code',
-                        'mount_path': '/ssl-config',
-                        'mount_in_copy': False
-                    })
+                    secrets.append(
+                        {
+                            'namespace': DEFAULT_NAMESPACE,
+                            'name': userdata['tokens_secret_name'],
+                            'mount_path': '/user-tokens',
+                            'mount_in_copy': False,
+                        }
+                    )
+                    secrets.append(
+                        {
+                            'namespace': DEFAULT_NAMESPACE,
+                            'name': 'gce-deploy-config',
+                            'mount_path': '/deploy-config',
+                            'mount_in_copy': False,
+                        }
+                    )
+                    secrets.append(
+                        {
+                            'namespace': DEFAULT_NAMESPACE,
+                            'name': 'ssl-config-batch-user-code',
+                            'mount_path': '/ssl-config',
+                            'mount_in_copy': False,
+                        }
+                    )
 
                 sa = spec.get('service_account')
                 check_service_account_permissions(user, sa)
@@ -807,17 +836,24 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 db_spec = batch_format_version.db_spec(spec)
 
                 jobs_args.append(
-                    (batch_id, job_id, state, json.dumps(db_spec),
-                     always_run, cores_mcpu, len(parent_ids), inst_coll_name))
+                    (
+                        batch_id,
+                        job_id,
+                        state,
+                        json.dumps(db_spec),
+                        always_run,
+                        cores_mcpu,
+                        len(parent_ids),
+                        inst_coll_name,
+                    )
+                )
 
                 for parent_id in parent_ids:
-                    job_parents_args.append(
-                        (batch_id, job_id, parent_id))
+                    job_parents_args.append((batch_id, job_id, parent_id))
 
                 if attributes:
                     for k, v in attributes.items():
-                        job_attributes_args.append(
-                            (batch_id, job_id, k, v))
+                        job_attributes_args.append((batch_id, job_id, k, v))
 
         if batch_format_version.has_full_spec_in_gcs():
             async with timer.step('write spec to gcs'):
@@ -826,14 +862,17 @@ WHERE user = %s AND id = %s AND NOT deleted;
         rand_token = random.randint(0, app['n_tokens'] - 1)
 
         async with timer.step('insert jobs'):
+
             @transaction(db)
             async def insert(tx):
                 try:
-                    await tx.execute_many('''
+                    await tx.execute_many(
+                        '''
 INSERT INTO jobs (batch_id, job_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
 ''',
-                                          jobs_args)
+                        jobs_args,
+                    )
                 except pymysql.err.IntegrityError as err:
                     # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
                     if err.args[0] == 1062:
@@ -841,22 +880,25 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
                         return
                     raise
                 try:
-                    await tx.execute_many('''
+                    await tx.execute_many(
+                        '''
 INSERT INTO `job_parents` (batch_id, job_id, parent_id)
 VALUES (%s, %s, %s);
 ''',
-                                          job_parents_args)
+                        job_parents_args,
+                    )
                 except pymysql.err.IntegrityError as err:
                     # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
                     if err.args[0] == 1062:
-                        raise web.HTTPBadRequest(
-                            text=f'bunch contains job with duplicated parents ({err})')
+                        raise web.HTTPBadRequest(text=f'bunch contains job with duplicated parents ({err})')
                     raise
-                await tx.execute_many('''
+                await tx.execute_many(
+                    '''
 INSERT INTO `job_attributes` (batch_id, job_id, `key`, `value`)
 VALUES (%s, %s, %s, %s);
 ''',
-                                      job_attributes_args)
+                    job_attributes_args,
+                )
 
                 for inst_coll, resources in inst_coll_resources.items():
                     n_jobs = resources['n_jobs']
@@ -865,7 +907,8 @@ VALUES (%s, %s, %s, %s);
                     n_ready_cancellable_jobs = resources['n_ready_cancellable_jobs']
                     ready_cancellable_cores_mcpu = resources['ready_cancellable_cores_mcpu']
 
-                    await tx.execute_update('''
+                    await tx.execute_update(
+                        '''
 INSERT INTO batches_inst_coll_staging (batch_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
 VALUES (%s, %s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
@@ -873,35 +916,56 @@ ON DUPLICATE KEY UPDATE
   n_ready_jobs = n_ready_jobs + %s,
   ready_cores_mcpu = ready_cores_mcpu + %s;
 ''',
-                                            (batch_id, inst_coll, rand_token,
-                                             n_jobs, n_ready_jobs, ready_cores_mcpu,
-                                             n_jobs, n_ready_jobs, ready_cores_mcpu))
-                    await tx.execute_update('''
+                        (
+                            batch_id,
+                            inst_coll,
+                            rand_token,
+                            n_jobs,
+                            n_ready_jobs,
+                            ready_cores_mcpu,
+                            n_jobs,
+                            n_ready_jobs,
+                            ready_cores_mcpu,
+                        ),
+                    )
+                    await tx.execute_update(
+                        '''
 INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
 VALUES (%s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
   n_ready_cancellable_jobs = n_ready_cancellable_jobs + %s,
   ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + %s;
 ''',
-                                            (batch_id, inst_coll, rand_token,
-                                             n_ready_cancellable_jobs, ready_cancellable_cores_mcpu,
-                                             n_ready_cancellable_jobs, ready_cancellable_cores_mcpu))
+                        (
+                            batch_id,
+                            inst_coll,
+                            rand_token,
+                            n_ready_cancellable_jobs,
+                            ready_cancellable_cores_mcpu,
+                            n_ready_cancellable_jobs,
+                            ready_cancellable_cores_mcpu,
+                        ),
+                    )
 
                 if batch_format_version.has_full_spec_in_gcs():
-                    await tx.execute_update('''
+                    await tx.execute_update(
+                        '''
 INSERT INTO batch_bunches (batch_id, token, start_job_id)
 VALUES (%s, %s, %s);
 ''',
-                                            (batch_id, spec_writer.token, start_job_id))
+                        (batch_id, spec_writer.token, start_job_id),
+                    )
 
             try:
                 await insert()  # pylint: disable=no-value-for-parameter
             except aiohttp.web.HTTPException:
                 raise
             except Exception as err:
-                raise ValueError(f'encountered exception while inserting a bunch'
-                                 f'jobs_args={json.dumps(jobs_args)}'
-                                 f'job_parents_args={json.dumps(job_parents_args)}') from err
+                raise ValueError(
+                    f'encountered exception while inserting a bunch'
+                    f'jobs_args={json.dumps(jobs_args)}'
+                    f'job_parents_args={json.dumps(job_parents_args)}'
+                ) from err
     return web.Response()
 
 
@@ -926,7 +990,7 @@ async def create_batch(request, userdata):
     userdata = {
         'username': user,
         'gsa_key_secret_name': userdata['gsa_key_secret_name'],
-        'tokens_secret_name': userdata['tokens_secret_name']
+        'tokens_secret_name': userdata['tokens_secret_name'],
     }
 
     billing_project = batch_spec['billing_project']
@@ -949,14 +1013,17 @@ async def create_batch(request, userdata):
         limit = bp['limit']
         accrued_cost = bp['accrued_cost']
         if limit is not None and accrued_cost >= limit:
-            raise web.HTTPForbidden(reason=f'billing project {billing_project} has exceeded the budget; accrued={cost_str(accrued_cost)} limit={cost_str(limit)}')
+            raise web.HTTPForbidden(
+                reason=f'billing project {billing_project} has exceeded the budget; accrued={cost_str(accrued_cost)} limit={cost_str(limit)}'
+            )
 
         maybe_batch = await tx.execute_and_fetchone(
             '''
 SELECT * FROM batches
 WHERE token = %s AND user = %s FOR UPDATE;
 ''',
-            (token, user))
+            (token, user),
+        )
 
         if maybe_batch is not None:
             return maybe_batch['id']
@@ -967,9 +1034,20 @@ WHERE token = %s AND user = %s FOR UPDATE;
 INSERT INTO batches (userdata, user, billing_project, attributes, callback, n_jobs, time_created, token, state, format_version, cancel_after_n_failures)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 ''',
-            (json.dumps(userdata), user, billing_project, json.dumps(attributes),
-             batch_spec.get('callback'), batch_spec['n_jobs'],
-             now, token, 'open', BATCH_FORMAT_VERSION, batch_spec.get('cancel_after_n_failures')))
+            (
+                json.dumps(userdata),
+                user,
+                billing_project,
+                json.dumps(attributes),
+                batch_spec.get('callback'),
+                batch_spec['n_jobs'],
+                now,
+                token,
+                'open',
+                BATCH_FORMAT_VERSION,
+                batch_spec.get('cancel_after_n_failures'),
+            ),
+        )
 
         if attributes:
             await tx.execute_many(
@@ -977,8 +1055,10 @@ VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
 INSERT INTO `batch_attributes` (batch_id, `key`, `value`)
 VALUES (%s, %s, %s)
 ''',
-                [(id, k, v) for k, v in attributes.items()])
+                [(id, k, v) for k, v in attributes.items()],
+            )
         return id
+
     id = await insert()  # pylint: disable=no-value-for-parameter
     return web.json_response({'id': id})
 
@@ -986,7 +1066,8 @@ VALUES (%s, %s, %s)
 async def _get_batch(app, batch_id):
     db: Database = app['db']
 
-    record = await db.select_and_fetchone('''
+    record = await db.select_and_fetchone(
+        '''
 SELECT batches.*, SUM(`usage` * rate) AS cost FROM batches
 LEFT JOIN aggregated_batch_resources
        ON batches.id = aggregated_batch_resources.batch_id
@@ -994,7 +1075,9 @@ LEFT JOIN resources
        ON aggregated_batch_resources.resource = resources.resource
 WHERE id = %s AND NOT deleted
 GROUP BY batches.id;
-''', (batch_id))
+''',
+        (batch_id),
+    )
     if not record:
         raise web.HTTPNotFound()
 
@@ -1015,14 +1098,13 @@ async def _delete_batch(app, batch_id):
 SELECT `state` FROM batches
 WHERE id = %s AND NOT deleted;
 ''',
-        (batch_id,))
+        (batch_id,),
+    )
     if not record:
         raise web.HTTPNotFound()
 
-    await db.just_execute(
-        'CALL cancel_batch(%s);', (batch_id,))
-    await db.execute_update(
-        'UPDATE batches SET deleted = 1 WHERE id = %s;', (batch_id,))
+    await db.just_execute('CALL cancel_batch(%s);', (batch_id,))
+    await db.execute_update('UPDATE batches SET deleted = 1 WHERE id = %s;', (batch_id,))
 
     if record['state'] == 'running':
         app['delete_batch_state_changed'].set()
@@ -1058,28 +1140,29 @@ async def close_batch(request, userdata):
 SELECT 1 FROM batches
 WHERE user = %s AND id = %s AND NOT deleted;
 ''',
-        (user, batch_id))
+        (user, batch_id),
+    )
     if not record:
         raise web.HTTPNotFound()
 
     try:
         now = time_msecs()
-        await check_call_procedure(
-            db, 'CALL close_batch(%s, %s);', (batch_id, now))
+        await check_call_procedure(db, 'CALL close_batch(%s, %s);', (batch_id, now))
     except CallError as e:
         # 2: wrong number of jobs
         if e.rv['rc'] == 2:
             expected_n_jobs = e.rv['expected_n_jobs']
             actual_n_jobs = e.rv['actual_n_jobs']
-            raise web.HTTPBadRequest(
-                reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
+            raise web.HTTPBadRequest(reason=f'wrong number of jobs: expected {expected_n_jobs}, actual {actual_n_jobs}')
         raise
 
     async with client_session() as session:
         await request_retry_transient_errors(
-            session, 'PATCH',
+            session,
+            'PATCH',
             deploy_config.url('batch-driver', f'/api/v1alpha/batches/{user}/{batch_id}/close'),
-            headers=app['batch_headers'])
+            headers=app['batch_headers'],
+        )
 
     return web.Response()
 
@@ -1107,11 +1190,7 @@ async def ui_batch(request, userdata, batch_id):
 
     batch['cost'] = cost_str(batch['cost'])
 
-    page_context = {
-        'batch': batch,
-        'q': request.query.get('q'),
-        'last_job_id': last_job_id
-    }
+    page_context = {'batch': batch, 'q': request.query.get('q'), 'last_job_id': last_job_id}
     return await render_template('batch', request, userdata, 'batch.html', page_context)
 
 
@@ -1159,18 +1238,15 @@ async def ui_batches(request, userdata):
     batches, last_batch_id = await _query_batches(request, user, q)
     for batch in batches:
         batch['cost'] = cost_str(batch['cost'])
-    page_context = {
-        'batches': batches,
-        'q': q,
-        'last_batch_id': last_batch_id
-    }
+    page_context = {'batches': batches, 'q': q, 'last_batch_id': last_batch_id}
     return await render_template('batch', request, userdata, 'batches.html', page_context)
 
 
 async def _get_job(app, batch_id, job_id):
     db: Database = app['db']
 
-    record = await db.select_and_fetchone('''
+    record = await db.select_and_fetchone(
+        '''
 SELECT jobs.*, user, billing_project, ip_address, format_version, SUM(`usage` * rate) AS cost
 FROM jobs
 INNER JOIN batches
@@ -1187,14 +1263,13 @@ LEFT JOIN resources
 WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s
 GROUP BY jobs.batch_id, jobs.job_id;
 ''',
-                                          (batch_id, job_id))
+        (batch_id, job_id),
+    )
     if not record:
         raise web.HTTPNotFound()
 
     full_status, full_spec, attributes = await asyncio.gather(
-        _get_full_job_status(app, record),
-        _get_full_job_spec(app, record),
-        _get_attributes(app, record)
+        _get_full_job_status(app, record), _get_full_job_spec(app, record), _get_attributes(app, record)
     )
 
     job = job_record_to_dict(record, attributes.get('name'))
@@ -1208,14 +1283,16 @@ GROUP BY jobs.batch_id, jobs.job_id;
 async def _get_attempts(app, batch_id, job_id):
     db: Database = app['db']
 
-    attempts = db.select_and_fetchall('''
+    attempts = db.select_and_fetchall(
+        '''
 SELECT attempts.*
 FROM jobs
 INNER JOIN batches ON jobs.batch_id = batches.id
 LEFT JOIN attempts ON jobs.batch_id = attempts.batch_id and jobs.job_id = attempts.job_id
 WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 ''',
-                                      (batch_id, job_id))
+        (batch_id, job_id),
+    )
 
     attempts = [attempt async for attempt in attempts]
     if len(attempts) == 0:
@@ -1273,30 +1350,36 @@ async def ui_get_job(request, userdata, batch_id):
     app = request.app
     job_id = int(request.match_info['job_id'])
 
-    job, attempts, job_log = await asyncio.gather(_get_job(app, batch_id, job_id),
-                                                  _get_attempts(app, batch_id, job_id),
-                                                  _get_job_log(app, batch_id, job_id))
+    job, attempts, job_log = await asyncio.gather(
+        _get_job(app, batch_id, job_id), _get_attempts(app, batch_id, job_id), _get_job_log(app, batch_id, job_id)
+    )
 
     job['duration'] = humanize_timedelta_msecs(job['duration'])
     job['cost'] = cost_str(job['cost'])
 
     job_status = job['status']
-    container_status_spec = dictfix.NoneOr({
-        'name': str,
-        'timing': {'pulling': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)}),
-                   'running': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)})},
-        'short_error': dictfix.NoneOr(str),
-        'container_status': {'out_of_memory': dictfix.NoneOr(bool)},
-        'state': str})
+    container_status_spec = dictfix.NoneOr(
+        {
+            'name': str,
+            'timing': {
+                'pulling': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)}),
+                'running': dictfix.NoneOr({'duration': dictfix.NoneOr(Number)}),
+            },
+            'short_error': dictfix.NoneOr(str),
+            'container_status': {'out_of_memory': dictfix.NoneOr(bool)},
+            'state': str,
+        }
+    )
     job_status_spec = {
-        'container_statuses': {'input': container_status_spec,
-                               'main': container_status_spec,
-                               'output': container_status_spec}}
+        'container_statuses': {
+            'input': container_status_spec,
+            'main': container_status_spec,
+            'output': container_status_spec,
+        }
+    }
     job_status = dictfix.dictfix(job_status, job_status_spec)
     container_statuses = job_status['container_statuses']
-    step_statuses = [container_statuses['input'],
-                     container_statuses['main'],
-                     container_statuses['output']]
+    step_statuses = [container_statuses['input'], container_statuses['main'], container_statuses['output']]
 
     for status in step_statuses:
         # backwards compatibility
@@ -1311,18 +1394,16 @@ async def ui_get_job(request, userdata, batch_id):
             assert process_specification['type'] in {'docker', 'jvm'}
             job_specification['image'] = process_specification['image'] if process_type == 'docker' else '[jvm]'
             job_specification['command'] = process_specification['command']
-        job_specification = dictfix.dictfix(job_specification,
-                                            dictfix.NoneOr({'image': str,
-                                                            'command': list,
-                                                            'resources': dict(),
-                                                            'env': list}))
+        job_specification = dictfix.dictfix(
+            job_specification, dictfix.NoneOr({'image': str, 'command': list, 'resources': dict(), 'env': list})
+        )
 
     resources = job_specification['resources']
     if 'memory_bytes' in resources:
         resources['actual_memory'] = humanize.naturalsize(resources['memory_bytes'], binary=True)
         del resources['memory_bytes']
     if 'storage_gib' in resources:
-        resources['actual_storage'] = humanize.naturalsize(resources['storage_gib'] * 1024**3, binary=True)
+        resources['actual_storage'] = humanize.naturalsize(resources['storage_gib'] * 1024 ** 3, binary=True)
         del resources['storage_gib']
     if 'cores_mcpu' in resources:
         resources['actual_cpu'] = resources['cores_mcpu'] / 1000
@@ -1336,7 +1417,7 @@ async def ui_get_job(request, userdata, batch_id):
         'attempts': attempts,
         'step_statuses': step_statuses,
         'job_specification': job_specification,
-        'job_status_str': json.dumps(job, indent=2)
+        'job_status_str': json.dumps(job, indent=2),
     }
     return await render_template('batch', request, userdata, 'job.html', page_context)
 
@@ -1355,10 +1436,7 @@ async def ui_get_billing_limits(request, userdata):
 
     billing_projects = await query_billing_projects(db, user=user)
 
-    page_context = {
-        'billing_projects': billing_projects,
-        'is_developer': userdata['is_developer']
-    }
+    page_context = {'billing_projects': billing_projects, 'is_developer': userdata['is_developer']}
     return await render_template('batch', request, userdata, 'billing_limits.html', page_context)
 
 
@@ -1387,7 +1465,8 @@ FROM billing_projects
 WHERE billing_projects.name = %s AND billing_projects.`status` != 'deleted'
 FOR UPDATE;
         ''',
-            (billing_project,))
+            (billing_project,),
+        )
         if row is None:
             raise NonExistentBillingProjectError(billing_project)
 
@@ -1398,7 +1477,9 @@ FOR UPDATE;
             '''
 UPDATE billing_projects SET `limit` = %s WHERE name = %s;
 ''',
-            (limit, billing_project))
+            (limit, billing_project),
+        )
+
     await insert()  # pylint: disable=no-value-for-parameter
 
 
@@ -1491,9 +1572,7 @@ GROUP BY billing_project, `user`;
         del record['msec_mcpu']
         return record
 
-    billing = [billing_record_to_dict(record)
-               async for record
-               in db.select_and_fetchall(sql, sql_args)]
+    billing = [billing_record_to_dict(record) async for record in db.select_and_fetchall(sql, sql_args)]
 
     return (billing, start_query, end_query)
 
@@ -1513,20 +1592,19 @@ async def ui_get_billing(request, userdata):
         billing_by_user[user] = billing_by_user.get(user, 0) + cost
         billing_by_project[billing_project] = billing_by_project.get(billing_project, 0) + cost
 
-    billing_by_project = [{'billing_project': billing_project,
-                           'cost': cost_str(cost)}
-                          for billing_project, cost in billing_by_project.items()]
+    billing_by_project = [
+        {'billing_project': billing_project, 'cost': cost_str(cost)}
+        for billing_project, cost in billing_by_project.items()
+    ]
     billing_by_project.sort(key=lambda record: record['billing_project'])
 
-    billing_by_user = [{'user': user,
-                        'cost': cost_str(cost)}
-                       for user, cost in billing_by_user.items()]
+    billing_by_user = [{'user': user, 'cost': cost_str(cost)} for user, cost in billing_by_user.items()]
     billing_by_user.sort(key=lambda record: record['user'])
 
-    billing_by_project_user = [{'billing_project': record['billing_project'],
-                                'user': record['user'],
-                                'cost': cost_str(record['cost'])}
-                               for record in billing]
+    billing_by_project_user = [
+        {'billing_project': record['billing_project'], 'user': record['user'], 'cost': cost_str(record['cost'])}
+        for record in billing
+    ]
     billing_by_project_user.sort(key=lambda record: (record['billing_project'], record['user']))
 
     page_context = {
@@ -1534,7 +1612,7 @@ async def ui_get_billing(request, userdata):
         'billing_by_user': billing_by_user,
         'billing_by_project_user': billing_by_project_user,
         'start': start,
-        'end': end
+        'end': end,
     }
     return await render_template('batch', request, userdata, 'billing.html', page_context)
 
@@ -1547,7 +1625,7 @@ async def ui_get_billing_projects(request, userdata):
     billing_projects = await query_billing_projects(db)
     page_context = {
         'billing_projects': [{**p, 'size': len(p['users'])} for p in billing_projects if p['status'] == 'open'],
-        'closed_projects': [p for p in billing_projects if p['status'] == 'closed']
+        'closed_projects': [p for p in billing_projects if p['status'] == 'closed'],
     }
     return await render_template('batch', request, userdata, 'billing_projects.html', page_context)
 
@@ -1602,23 +1680,30 @@ LEFT JOIN (SELECT * FROM billing_project_users
   ON billing_projects.name = t.billing_project
 WHERE billing_projects.name = %s;
 ''',
-            (billing_project, user, billing_project))
+            (billing_project, user, billing_project),
+        )
         if not row:
             raise NonExistentBillingProjectError(billing_project)
         assert row['billing_project'] == billing_project
 
         if row['status'] in {'closed', 'deleted'}:
-            raise BatchUserError(f'Billing project {billing_project} has been closed or deleted and cannot be modified.', 'error')
+            raise BatchUserError(
+                f'Billing project {billing_project} has been closed or deleted and cannot be modified.', 'error'
+            )
 
         if row['user'] is None:
-            raise BatchOperationAlreadyCompletedError(f'User {user} is not in billing project {billing_project}.', 'info')
+            raise BatchOperationAlreadyCompletedError(
+                f'User {user} is not in billing project {billing_project}.', 'info'
+            )
 
         await tx.just_execute(
             '''
 DELETE FROM billing_project_users
 WHERE billing_project = %s AND user = %s;
 ''',
-            (billing_project, user))
+            (billing_project, user),
+        )
+
     await delete()  # pylint: disable=no-value-for-parameter
 
 
@@ -1663,7 +1748,8 @@ WHERE billing_project = %s AND user = %s FOR UPDATE) AS t
 ON billing_projects.name = t.billing_project
 WHERE billing_projects.name = %s AND billing_projects.`status` != 'deleted' LOCK IN SHARE MODE;
         ''',
-            (billing_project, user, billing_project))
+            (billing_project, user, billing_project),
+        )
         if row is None:
             raise NonExistentBillingProjectError(billing_project)
 
@@ -1671,13 +1757,17 @@ WHERE billing_projects.name = %s AND billing_projects.`status` != 'deleted' LOCK
             raise ClosedBillingProjectError(billing_project)
 
         if row['user'] is not None:
-            raise BatchOperationAlreadyCompletedError(f'User {user} is already member of billing project {billing_project}.', 'info')
+            raise BatchOperationAlreadyCompletedError(
+                f'User {user} is already member of billing project {billing_project}.', 'info'
+            )
         await tx.execute_insertone(
             '''
 INSERT INTO billing_project_users(billing_project, user)
 VALUES (%s, %s);
         ''',
-            (billing_project, user))
+            (billing_project, user),
+        )
+
     await insert()  # pylint: disable=no-value-for-parameter
 
 
@@ -1720,7 +1810,8 @@ SELECT `status` FROM billing_projects
 WHERE name = %s
 FOR UPDATE;
 ''',
-            (billing_project))
+            (billing_project),
+        )
         if row is not None:
             raise BatchOperationAlreadyCompletedError(f'Billing project {billing_project} already exists.', 'info')
 
@@ -1729,7 +1820,9 @@ FOR UPDATE;
 INSERT INTO billing_projects(name)
 VALUES (%s);
 ''',
-            (billing_project,))
+            (billing_project,),
+        )
+
     await insert()  # pylint: disable=no-value-for-parameter
 
 
@@ -1772,18 +1865,20 @@ ON billing_projects.name = batches.billing_project
 AND billing_projects.`status` != 'deleted' AND batches.time_completed IS NULL
 WHERE name = %s LIMIT 1 FOR UPDATE;
     ''',
-            (billing_project,))
+            (billing_project,),
+        )
         if not row:
             raise NonExistentBillingProjectError(billing_project)
         assert row['name'] == billing_project
         if row['status'] == 'closed':
-            raise BatchOperationAlreadyCompletedError(f'Billing project {billing_project} is already closed or deleted.', 'info')
+            raise BatchOperationAlreadyCompletedError(
+                f'Billing project {billing_project} is already closed or deleted.', 'info'
+            )
         if row['batch_id'] is not None:
             raise BatchUserError(f'Billing project {billing_project} has open or running batches.', 'error')
 
-        await tx.execute_update(
-            "UPDATE billing_projects SET `status` = 'closed' WHERE name = %s;",
-            (billing_project, ))
+        await tx.execute_update("UPDATE billing_projects SET `status` = 'closed' WHERE name = %s;", (billing_project,))
+
     await close_project()  # pylint: disable=no-value-for-parameter
 
 
@@ -1817,8 +1912,8 @@ async def _reopen_billing_project(db, billing_project):
     @transaction(db)
     async def open_project(tx):
         row = await tx.execute_and_fetchone(
-            "SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;",
-            (billing_project,))
+            "SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;", (billing_project,)
+        )
         if not row:
             raise NonExistentBillingProjectError(billing_project)
         assert row['name'] == billing_project
@@ -1827,9 +1922,8 @@ async def _reopen_billing_project(db, billing_project):
         if row['status'] == 'open':
             raise BatchOperationAlreadyCompletedError(f'Billing project {billing_project} is already open.', 'info')
 
-        await tx.execute_update(
-            "UPDATE billing_projects SET `status` = 'open' WHERE name = %s;",
-            (billing_project, ))
+        await tx.execute_update("UPDATE billing_projects SET `status` = 'open' WHERE name = %s;", (billing_project,))
+
     await open_project()  # pylint: disable=no-value-for-parameter
 
 
@@ -1862,8 +1956,8 @@ async def _delete_billing_project(db, billing_project):
     @transaction(db)
     async def delete_project(tx):
         row = await tx.execute_and_fetchone(
-            'SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;',
-            (billing_project,))
+            'SELECT name, `status` FROM billing_projects WHERE name = %s FOR UPDATE;', (billing_project,)
+        )
         if not row:
             raise NonExistentBillingProjectError(billing_project)
         assert row['name'] == billing_project
@@ -1872,9 +1966,8 @@ async def _delete_billing_project(db, billing_project):
         if row['status'] == 'open':
             raise BatchUserError(f'Billing project {billing_project} is open and cannot be deleted.', 'error')
 
-        await tx.execute_update(
-            "UPDATE billing_projects SET `status` = 'deleted' WHERE name = %s;",
-            (billing_project, ))
+        await tx.execute_update("UPDATE billing_projects SET `status` = 'deleted' WHERE name = %s;", (billing_project,))
+
     await delete_project()  # pylint: disable=no-value-for-parameter
 
 
@@ -1908,9 +2001,11 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 async def cancel_batch_loop_body(app):
     async with client_session() as session:
         await request_retry_transient_errors(
-            session, 'POST',
+            session,
+            'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/cancel'),
-            headers=app['batch_headers'])
+            headers=app['batch_headers'],
+        )
 
     should_wait = True
     return should_wait
@@ -1919,9 +2014,11 @@ async def cancel_batch_loop_body(app):
 async def delete_batch_loop_body(app):
     async with client_session() as session:
         await request_retry_transient_errors(
-            session, 'POST',
+            session,
+            'POST',
             deploy_config.url('batch-driver', '/api/v1alpha/batches/delete'),
-            headers=app['batch_headers'])
+            headers=app['batch_headers'],
+        )
 
     should_wait = True
     return should_wait
@@ -1939,7 +2036,8 @@ async def on_startup(app):
     row = await db.select_and_fetchone(
         '''
 SELECT instance_id, internal_token, n_tokens FROM globals;
-''')
+'''
+    )
 
     app['n_tokens'] = row['n_tokens']
 
@@ -1949,12 +2047,9 @@ SELECT instance_id, internal_token, n_tokens FROM globals;
 
     app['internal_token'] = row['internal_token']
 
-    app['batch_headers'] = {
-        'Authorization': f'Bearer {row["internal_token"]}'
-    }
+    app['batch_headers'] = {'Authorization': f'Bearer {row["internal_token"]}'}
 
-    credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-        '/gsa-key/key.json')
+    credentials = google.oauth2.service_account.Credentials.from_service_account_file('/gsa-key/key.json')
     app['log_store'] = LogStore(BATCH_BUCKET_NAME, instance_id, pool, credentials=credentials)
 
     inst_coll_configs = InstanceCollectionConfigs(app)
@@ -1964,16 +2059,16 @@ SELECT instance_id, internal_token, n_tokens FROM globals;
     cancel_batch_state_changed = asyncio.Event()
     app['cancel_batch_state_changed'] = cancel_batch_state_changed
 
-    app['task_manager'].ensure_future(retry_long_running(
-        'cancel_batch_loop',
-        run_if_changed, cancel_batch_state_changed, cancel_batch_loop_body, app))
+    app['task_manager'].ensure_future(
+        retry_long_running('cancel_batch_loop', run_if_changed, cancel_batch_state_changed, cancel_batch_loop_body, app)
+    )
 
     delete_batch_state_changed = asyncio.Event()
     app['delete_batch_state_changed'] = delete_batch_state_changed
 
-    app['task_manager'].ensure_future(retry_long_running(
-        'delete_batch_loop',
-        run_if_changed, delete_batch_state_changed, delete_batch_loop_body, app))
+    app['task_manager'].ensure_future(
+        retry_long_running('delete_batch_loop', run_if_changed, delete_batch_state_changed, delete_batch_loop_body, app)
+    )
 
 
 async def on_cleanup(app):
@@ -1997,10 +2092,10 @@ def run():
 
     asyncio.get_event_loop().add_signal_handler(signal.SIGUSR1, dump_all_stacktraces)
 
-    web.run_app(deploy_config.prefix_application(app,
-                                                 'batch',
-                                                 client_max_size=HTTP_CLIENT_MAX_SIZE),
-                host='0.0.0.0',
-                port=5000,
-                access_log_class=AccessLogger,
-                ssl_context=internal_server_ssl_context())
+    web.run_app(
+        deploy_config.prefix_application(app, 'batch', client_max_size=HTTP_CLIENT_MAX_SIZE),
+        host='0.0.0.0',
+        port=5000,
+        access_log_class=AccessLogger,
+        ssl_context=internal_server_ssl_context(),
+    )

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -1,9 +1,28 @@
-from hailtop.batch_client.parse import (MEMORY_REGEX, MEMORY_REGEXPAT,
-                                        CPU_REGEX, CPU_REGEXPAT,
-                                        STORAGE_REGEX, STORAGE_REGEXPAT)
+from hailtop.batch_client.parse import (
+    MEMORY_REGEX,
+    MEMORY_REGEXPAT,
+    CPU_REGEX,
+    CPU_REGEXPAT,
+    STORAGE_REGEX,
+    STORAGE_REGEXPAT,
+)
 
-from hailtop.utils.validate import anyof, bool_type, dictof, keyed, listof, int_type, nullable, \
-    numeric, oneof, regex, required, str_type, switch, ValidationError
+from hailtop.utils.validate import (
+    anyof,
+    bool_type,
+    dictof,
+    keyed,
+    listof,
+    int_type,
+    nullable,
+    numeric,
+    oneof,
+    regex,
+    required,
+    str_type,
+    switch,
+    ValidationError,
+)
 
 from ..globals import valid_machine_types, memory_to_worker_type
 
@@ -21,70 +40,66 @@ image_str = str_type
 # pvc_size -> resources/storage
 
 
-job_validator = keyed({
-    'always_run': bool_type,
-    'attributes': dictof(str_type),
-    'env': listof(keyed({
-        'name': str_type,
-        'value': str_type
-    })),
-    'gcsfuse': listof(keyed({
-        required('bucket'): str_type,
-        required('mount_path'): str_type,
-        required('read_only'): bool_type,
-    })),
-    'input_files': listof(keyed({
-        required('from'): str_type,
-        required('to'): str_type
-    })),
-    required('job_id'): int_type,
-    'mount_tokens': bool_type,
-    'network': oneof('public', 'private'),
-    'output_files': listof(keyed({
-        required('from'): str_type,
-        required('to'): str_type
-    })),
-    required('parent_ids'): listof(int_type),
-    'port': int_type,
-    required('process'): switch('type', {
-        'docker': {
-            required('command'): listof(str_type),
-            required('image'): image_str,
-            required('mount_docker_socket'): bool_type
-        },
-        'jvm': {
-            required('command'): listof(str_type)
-        }
-    }),
-    'requester_pays_project': str_type,
-    'resources': keyed({
-        'memory': anyof(regex(MEMORY_REGEXPAT, MEMORY_REGEX),
-                        oneof(*memory_to_worker_type.keys())),
-        'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
-        'storage': regex(STORAGE_REGEXPAT, STORAGE_REGEX),
-        'machine_type': oneof(*valid_machine_types),
-        'preemptible': bool_type
-    }),
-    'secrets': listof(keyed({
-        required('namespace'): k8s_str,
-        required('name'): k8s_str,
-        required('mount_path'): str_type
-    })),
-    'service_account': keyed({
-        required('namespace'): k8s_str,
-        required('name'): k8s_str
-    }),
-    'timeout': numeric(**{"x > 0": lambda x: x > 0})
-})
+job_validator = keyed(
+    {
+        'always_run': bool_type,
+        'attributes': dictof(str_type),
+        'env': listof(keyed({'name': str_type, 'value': str_type})),
+        'gcsfuse': listof(
+            keyed(
+                {
+                    required('bucket'): str_type,
+                    required('mount_path'): str_type,
+                    required('read_only'): bool_type,
+                }
+            )
+        ),
+        'input_files': listof(keyed({required('from'): str_type, required('to'): str_type})),
+        required('job_id'): int_type,
+        'mount_tokens': bool_type,
+        'network': oneof('public', 'private'),
+        'output_files': listof(keyed({required('from'): str_type, required('to'): str_type})),
+        required('parent_ids'): listof(int_type),
+        'port': int_type,
+        required('process'): switch(
+            'type',
+            {
+                'docker': {
+                    required('command'): listof(str_type),
+                    required('image'): image_str,
+                    required('mount_docker_socket'): bool_type,
+                },
+                'jvm': {required('command'): listof(str_type)},
+            },
+        ),
+        'requester_pays_project': str_type,
+        'resources': keyed(
+            {
+                'memory': anyof(regex(MEMORY_REGEXPAT, MEMORY_REGEX), oneof(*memory_to_worker_type.keys())),
+                'cpu': regex(CPU_REGEXPAT, CPU_REGEX),
+                'storage': regex(STORAGE_REGEXPAT, STORAGE_REGEX),
+                'machine_type': oneof(*valid_machine_types),
+                'preemptible': bool_type,
+            }
+        ),
+        'secrets': listof(
+            keyed({required('namespace'): k8s_str, required('name'): k8s_str, required('mount_path'): str_type})
+        ),
+        'service_account': keyed({required('namespace'): k8s_str, required('name'): k8s_str}),
+        'timeout': numeric(**{"x > 0": lambda x: x > 0}),
+    }
+)
 
-batch_validator = keyed({
-    'attributes': nullable(dictof(str_type)),
-    required('billing_project'): str_type,
-    'callback': nullable(str_type),
-    required('n_jobs'): int_type,
-    required('token'): str_type,
-    'cancel_after_n_failures': nullable(numeric(**{"x > 0": lambda x: isinstance(x, int) and x > 0}))
-})
+batch_validator = keyed(
+    {
+        'attributes': nullable(dictof(str_type)),
+        required('billing_project'): str_type,
+        'callback': nullable(str_type),
+        required('n_jobs'): int_type,
+        required('token'): str_type,
+        'cancel_after_n_failures': nullable(numeric(**{"x > 0": lambda x: isinstance(x, int) and x > 0})),
+    }
+)
 
 
 def validate_and_clean_jobs(jobs):
@@ -98,14 +113,14 @@ def validate_and_clean_jobs(jobs):
 def handle_deprecated_job_keys(i, job):
     if 'pvc_size' in job:
         if 'resources' in job and 'storage' in job['resources']:
-            raise ValidationError(f"jobs[{i}].resources.storage is already defined, but "
-                                  f"deprecated key 'pvc_size' is also present.")
+            raise ValidationError(
+                f"jobs[{i}].resources.storage is already defined, but " f"deprecated key 'pvc_size' is also present."
+            )
         pvc_size = job['pvc_size']
         try:
             job_validator['resources']['storage'].validate(f"jobs[{i}].pvc_size", job['pvc_size'])
         except ValidationError as e:
-            raise ValidationError(f"[pvc_size key is DEPRECATED. Use "
-                                  f"resources.storage] {e.reason}") from e
+            raise ValidationError(f"[pvc_size key is DEPRECATED. Use " f"resources.storage] {e.reason}") from e
         resources = job.get('resources')
         if resources is None:
             resources = {}
@@ -116,9 +131,11 @@ def handle_deprecated_job_keys(i, job):
     if 'process' not in job:
         process_keys = ['command', 'image', 'mount_docker_socket']
         if 'command' not in job or 'image' not in job or 'mount_docker_socket' not in job:
-            raise ValidationError(f'jobs[{i}].process is not defined, but '
-                                  f'deprecated keys {[k for k in process_keys if k not in job]} '
-                                  f'are not in jobs[{i}]')
+            raise ValidationError(
+                f'jobs[{i}].process is not defined, but '
+                f'deprecated keys {[k for k in process_keys if k not in job]} '
+                f'are not in jobs[{i}]'
+            )
         command = job['command']
         image = job['image']
         mount_docker_socket = job['mount_docker_socket']
@@ -126,24 +143,30 @@ def handle_deprecated_job_keys(i, job):
             for k in process_keys:
                 job_validator['process']['docker'][k].validate(f"jobs[{i}].{k}", job[k])
         except ValidationError as e:
-            raise ValidationError(f"[command, image, mount_docker_socket keys are "
-                                  f"DEPRECATED. Use process.command, process.image, "
-                                  f"process.mount_docker_socket with process.type = 'docker'.] "
-                                  f"{e.reason}") from e
+            raise ValidationError(
+                f"[command, image, mount_docker_socket keys are "
+                f"DEPRECATED. Use process.command, process.image, "
+                f"process.mount_docker_socket with process.type = 'docker'.] "
+                f"{e.reason}"
+            ) from e
 
-        job['process'] = {'command': command,
-                          'image': image,
-                          'mount_docker_socket': mount_docker_socket,
-                          'type': 'docker'}
+        job['process'] = {
+            'command': command,
+            'image': image,
+            'mount_docker_socket': mount_docker_socket,
+            'type': 'docker',
+        }
         del job['command']
         del job['image']
         del job['mount_docker_socket']
     else:
         if 'command' in job or 'image' in job or 'mount_docker_socket' in job:
-            raise ValidationError(f"jobs[{i}].process is already defined, but "
-                                  f"deprecated keys 'command', 'image', "
-                                  f"'mount_docker_socket' are also present. "
-                                  f"Please remove deprecated keys.")
+            raise ValidationError(
+                f"jobs[{i}].process is already defined, but "
+                f"deprecated keys 'command', 'image', "
+                f"'mount_docker_socket' are also present. "
+                f"Please remove deprecated keys."
+            )
 
 
 def validate_batch(batch):

--- a/batch/batch/globals.py
+++ b/batch/batch/globals.py
@@ -24,11 +24,7 @@ for typ in ('highcpu', 'standard', 'highmem'):
     for cores in possible_cores:
         valid_machine_types.append(f'n1-{typ}-{cores}')
 
-memory_to_worker_type = {
-    'lowmem': 'highcpu',
-    'standard': 'standard',
-    'highmem': 'highmem'
-}
+memory_to_worker_type = {'lowmem': 'highcpu', 'standard': 'standard', 'highmem': 'highmem'}
 
 HTTP_CLIENT_MAX_SIZE = 8 * 1024 * 1024
 

--- a/batch/batch/log_store.py
+++ b/batch/batch/log_store.py
@@ -39,8 +39,7 @@ class LogStore:
         return await self.gcs.write_gs_file_from_string(path, data)
 
     async def delete_batch_logs(self, batch_id):
-        await self.gcs.delete_gs_files(
-            self.batch_log_dir(batch_id))
+        await self.gcs.delete_gs_files(self.batch_log_dir(batch_id))
 
     def status_path(self, batch_id, job_id, attempt_id):
         return f'{self.batch_log_dir(batch_id)}/{job_id}/{attempt_id}/status.json'
@@ -77,8 +76,7 @@ class LogStore:
 
     async def write_spec_file(self, batch_id, token, data_bytes, offsets_bytes):
         idx_path = self.specs_index_path(batch_id, token)
-        write1 = self.gcs.write_gs_file_from_string(idx_path, offsets_bytes,
-                                                    content_type='application/octet-stream')
+        write1 = self.gcs.write_gs_file_from_string(idx_path, offsets_bytes, content_type='application/octet-stream')
 
         specs_path = self.specs_path(batch_id, token)
         write2 = self.gcs.write_gs_file_from_string(specs_path, data_bytes)

--- a/batch/batch/spec_writer.py
+++ b/batch/batch/spec_writer.py
@@ -14,7 +14,9 @@ class SpecWriter:
     def get_index_file_offsets(job_id, start_job_id):
         assert job_id >= start_job_id
         idx_start = SpecWriter.bytes_per_offset * (job_id - start_job_id)
-        idx_end = (idx_start + 2 * SpecWriter.bytes_per_offset) - 1  # `end` parameter in gcs is inclusive of last byte to return
+        idx_end = (
+            idx_start + 2 * SpecWriter.bytes_per_offset
+        ) - 1  # `end` parameter in gcs is inclusive of last byte to return
         return (idx_start, idx_end)
 
     @staticmethod
@@ -33,7 +35,8 @@ WHERE batch_id = %s AND start_job_id <= %s
 ORDER BY start_job_id DESC
 LIMIT 1;
 ''',
-            (batch_id, job_id))
+            (batch_id, job_id),
+        )
         token = bunch_record['token']
         start_job_id = bunch_record['start_job_id']
         return (token, start_job_id)
@@ -60,6 +63,7 @@ LIMIT 1;
         end = len(self._data_bytes)
         self._offsets_bytes.extend(end.to_bytes(8, byteorder=SpecWriter.byteorder, signed=SpecWriter.signed))
 
-        await self.log_store.write_spec_file(self.batch_id, self.token,
-                                             bytes(self._data_bytes), bytes(self._offsets_bytes))
+        await self.log_store.write_spec_file(
+            self.batch_id, self.token, bytes(self._data_bytes), bytes(self._offsets_bytes)
+        )
         return self.token

--- a/batch/batch/worker/disk.py
+++ b/batch/batch/worker/disk.py
@@ -56,27 +56,28 @@ class Disk:
                 'name': self.name,
                 'sizeGb': f'{self.size_in_gb}',
                 'type': f'zones/{self.zone}/diskTypes/pd-ssd',
-                'labels': labels
+                'labels': labels,
             }
 
-            await self.compute_client.create_disk(f'/zones/{self.zone}/disks',
-                                                  json=config)
+            await self.compute_client.create_disk(f'/zones/{self.zone}/disks', json=config)
 
     async def _attach(self):
         async with LoggingTimer(f'attaching disk {self.name} to {self.instance_name}'):
             config = {
                 'source': f'/compute/v1/projects/{self.project}/zones/{self.zone}/disks/{self.name}',
                 'autoDelete': True,
-                'deviceName': self.name
+                'deviceName': self.name,
             }
 
-            await self.compute_client.attach_disk(f'/zones/{self.zone}/instances/{self.instance_name}/attachDisk',
-                                                  json=config)
+            await self.compute_client.attach_disk(
+                f'/zones/{self.zone}/instances/{self.instance_name}/attachDisk', json=config
+            )
 
     async def _detach(self):
         async with LoggingTimer(f'detaching disk {self.name} from {self.instance_name}'):
-            await self.compute_client.detach_disk(f'/zones/{self.zone}/instances/{self.instance_name}/detachDisk',
-                                                  params={'deviceName': self.name})
+            await self.compute_client.detach_disk(
+                f'/zones/{self.zone}/instances/{self.instance_name}/detachDisk', params={'deviceName': self.name}
+            )
 
     async def _delete(self):
         async with LoggingTimer(f'deleting disk {self.name}'):

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -20,12 +20,22 @@ import aiodocker
 from collections import defaultdict
 from aiodocker.exceptions import DockerError
 import google.oauth2.service_account
-from hailtop.utils import (time_msecs, request_retry_transient_errors, sleep_and_backoff,
-                           retry_all_errors, check_shell, CalledProcessError, check_shell_output,
-                           is_google_registry_domain, find_spark_home, dump_all_stacktraces,
-                           parse_docker_image_reference, blocking_to_async)
+from hailtop.utils import (
+    time_msecs,
+    request_retry_transient_errors,
+    sleep_and_backoff,
+    retry_all_errors,
+    check_shell,
+    CalledProcessError,
+    check_shell_output,
+    is_google_registry_domain,
+    find_spark_home,
+    dump_all_stacktraces,
+    parse_docker_image_reference,
+    blocking_to_async,
+)
 from hailtop.httpx import client_session
-from hailtop.batch_client.parse import (parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes)
+from hailtop.batch_client.parse import parse_cpu_in_mcpu, parse_memory_in_bytes, parse_storage_in_bytes
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 from hailtop import aiotools
 from hailtop.aiotools.fs import RouterAsyncFS, LocalAsyncFS
@@ -36,13 +46,22 @@ import hailtop.aiogoogle as aiogoogle
 from hailtop.config import DeployConfig
 from hailtop.hail_logging import configure_logging
 
-from ..utils import (adjust_cores_for_memory_request, cores_mcpu_to_memory_bytes,
-                     adjust_cores_for_packability, adjust_cores_for_storage_request,
-                     round_storage_bytes_to_gib, cores_mcpu_to_storage_bytes)
+from ..utils import (
+    adjust_cores_for_memory_request,
+    cores_mcpu_to_memory_bytes,
+    adjust_cores_for_packability,
+    adjust_cores_for_storage_request,
+    round_storage_bytes_to_gib,
+    cores_mcpu_to_storage_bytes,
+)
 from ..semaphore import FIFOWeightedSemaphore
 from ..log_store import LogStore
-from ..globals import (HTTP_CLIENT_MAX_SIZE, STATUS_FORMAT_VERSION, RESERVED_STORAGE_GB_PER_CORE,
-                       MAX_PERSISTENT_SSD_SIZE_GIB)
+from ..globals import (
+    HTTP_CLIENT_MAX_SIZE,
+    STATUS_FORMAT_VERSION,
+    RESERVED_STORAGE_GB_PER_CORE,
+    MAX_PERSISTENT_SSD_SIZE_GIB,
+)
 from ..batch_format_version import BatchFormatVersion
 from ..worker_config import WorkerConfig
 from ..publicly_available_images import publicly_available_images
@@ -132,15 +151,18 @@ def docker_call_retry(timeout, name):
                 # DockerError(500, 'Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
                 # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
                 # DockerError(500, 'Get https://gcr.io/v2/: dial tcp: lookup gcr.io: Temporary failure in name resolution')
-                elif e.status == 500 and ("request canceled while waiting for connection" in e.message
-                                          or re.match("error creating overlay mount.*device or resource busy", e.message)
-                                          or "Temporary failure in name resolution" in e.message):
+                elif e.status == 500 and (
+                    "request canceled while waiting for connection" in e.message
+                    or re.match("error creating overlay mount.*device or resource busy", e.message)
+                    or "Temporary failure in name resolution" in e.message
+                ):
                     log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
                 else:
                     raise
             except (aiohttp.client_exceptions.ServerDisconnectedError, asyncio.TimeoutError):
                 log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
                 delay = await sleep_and_backoff(delay)
+
     return wrapper
 
 
@@ -303,11 +325,7 @@ class Container:
 
     def container_config(self):
         weight = worker_fraction_in_1024ths(self.spec['cpu'])
-        host_config = {
-            'CpuShares': weight,
-            'Memory': self.spec['memory'],
-            'BlkioWeight': min(weight, 1000)
-        }
+        host_config = {'CpuShares': weight, 'Memory': self.spec['memory'], 'BlkioWeight': min(weight, 1000)}
 
         config = {
             "AttachStdin": False,
@@ -317,22 +335,15 @@ class Container:
             'OpenStdin': False,
             'Cmd': self.spec['command'],
             'Image': self.image_ref_str,
-            'Entrypoint': ''
+            'Entrypoint': '',
         }
 
         env = self.spec.get('env', [])
 
         if self.port is not None:
             assert self.host_port is not None
-            config['ExposedPorts'] = {
-                f'{self.port}/tcp': {}
-            }
-            host_config['PortBindings'] = {
-                f'{self.port}/tcp': [{
-                    'HostIp': '',
-                    'HostPort': str(self.host_port)
-                }]
-            }
+            config['ExposedPorts'] = {f'{self.port}/tcp': {}}
+            host_config['PortBindings'] = {f'{self.port}/tcp': [{'HostIp': '', 'HostPort': str(self.host_port)}]}
             env = list(env)
             env.append(f'HAIL_BATCH_WORKER_PORT={self.host_port}')
             env.append(f'HAIL_BATCH_WORKER_IP={IP_ADDRESS}')
@@ -375,7 +386,7 @@ class Container:
             'state': cstate['Status'],
             'started_at': cstate['StartedAt'],
             'finished_at': cstate['FinishedAt'],
-            'out_of_memory': cstate['OOMKilled']
+            'out_of_memory': cstate['OOMKilled'],
         }
         cerror = cstate['Error']
         if cerror:
@@ -387,12 +398,12 @@ class Container:
 
     async def ensure_image_is_pulled(self, auth=None):
         try:
-            await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                docker.images.get, self.image_ref_str)
+            await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(docker.images.get, self.image_ref_str)
         except DockerError as e:
             if e.status == 404:
                 await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                    docker.images.pull, self.image_ref_str, auth=auth)
+                    docker.images.pull, self.image_ref_str, auth=auth
+                )
 
     def current_user_access_token(self):
         key = base64.b64decode(self.job.gsa_key['key.json']).decode()
@@ -401,9 +412,11 @@ class Container:
     async def batch_worker_access_token(self):
         async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
             async with await request_retry_transient_errors(
-                    session, 'POST',
-                    'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token',
-                    headers={'Metadata-Flavor': 'Google'}) as resp:
+                session,
+                'POST',
+                'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token',
+                headers={'Metadata-Flavor': 'Google'},
+            ) as resp:
                 access_token = (await resp.json())['access_token']
                 return {'username': 'oauth2accesstoken', 'password': access_token}
 
@@ -426,7 +439,8 @@ class Container:
                         # per-user image cache.
                         auth = self.current_user_access_token()
                         await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                            docker.images.pull, self.image_ref_str, auth=auth)
+                            docker.images.pull, self.image_ref_str, auth=auth
+                        )
                 except DockerError as e:
                     if e.status == 404 and 'pull access denied' in e.message:
                         self.short_error = 'image cannot be pulled'
@@ -440,7 +454,8 @@ class Container:
                 config = self.container_config()
                 log.info(f'starting {self}')
                 self.container = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    create_container, config, name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}')
+                    create_container, config, name=f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}'
+                )
 
             c = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(self.container.show)
 
@@ -453,11 +468,12 @@ class Container:
                 with open('/xfsquota/projects', 'a') as f:
                     f.write(f'{self.job.project_id}:{self.overlay_path}\n')
 
-            await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.job.project_name}" /host/')
+            await check_shell_output(
+                f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.job.project_name}" /host/'
+            )
 
             with self.step('starting'):
-                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    start_container, self.container)
+                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(start_container, self.container)
 
             timed_out = False
             with self.step('running'):
@@ -471,9 +487,13 @@ class Container:
 
             with self.step('uploading_log'):
                 await worker.log_store.write_log_file(
-                    self.job.format_version, self.job.batch_id,
-                    self.job.job_id, self.job.attempt_id, self.name,
-                    await self.get_container_log())
+                    self.job.format_version,
+                    self.job.batch_id,
+                    self.job.job_id,
+                    self.job.attempt_id,
+                    self.name,
+                    await self.get_container_log(),
+                )
 
             with self.step('deleting'):
                 await self.delete_container()
@@ -504,7 +524,8 @@ class Container:
 
     async def get_container_log(self):
         logs = await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-            self.container.log, stderr=True, stdout=True)
+            self.container.log, stderr=True, stdout=True
+        )
         self.log = "".join(logs)
         return self.log
 
@@ -523,11 +544,11 @@ class Container:
         if self.container:
             try:
                 log.info(f'{self}: deleting container')
-                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    stop_container, self.container)
+                await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(stop_container, self.container)
                 # v=True deletes anonymous volumes created by the container
                 await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(
-                    delete_container, self.container, v=True)
+                    delete_container, self.container, v=True
+                )
                 self.container = None
             except asyncio.CancelledError:
                 raise
@@ -560,11 +581,7 @@ class Container:
     async def status(self, state=None):
         if not state:
             state = self.state
-        status = {
-            'name': self.name,
-            'state': state,
-            'timing': self.timings.to_dict()
-        }
+        status = {'name': self.name, 'state': state, 'timing': self.timings.to_dict()}
         if self.error:
             status['error'] = self.error
         if self.short_error:
@@ -598,7 +615,8 @@ async def add_gcsfuse_bucket(mount_path, bucket, key_file, read_only):
     error = 0
     while True:
         try:
-            return await check_shell(f'''
+            return await check_shell(
+                f'''
 /usr/bin/gcsfuse \
     -o {",".join(options)} \
     --file-mode 770 \
@@ -606,7 +624,8 @@ async def add_gcsfuse_bucket(mount_path, bucket, key_file, read_only):
     --implicit-dirs \
     --key-file {key_file} \
     {bucket} {mount_path}
-''')
+'''
+            )
         except CalledProcessError:
             error += 1
             if error == 5:
@@ -625,12 +644,12 @@ def copy_container(job, name, files, volume_mounts, cpu, memory, requester_pays_
             '-m',
             'batch.copy',
             json.dumps(requester_pays_project),
-            json.dumps(files)
+            json.dumps(files),
         ],
         'env': ['GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json'],
         'cpu': cpu,
         'memory': memory,
-        'volume_mounts': volume_mounts
+        'volume_mounts': volume_mounts,
     }
     return Container(job, name, copy_spec)
 
@@ -665,14 +684,16 @@ class Job:
         assert type == 'jvm'
         return JVMJob(batch_id, user, gsa_key, job_spec, format_version, task_manager, pool)
 
-    def __init__(self,
-                 batch_id: int,
-                 user: str,
-                 gsa_key,
-                 job_spec,
-                 format_version: BatchFormatVersion,
-                 task_manager: aiotools.BackgroundTaskManager,
-                 pool: concurrent.futures.ThreadPoolExecutor):
+    def __init__(
+        self,
+        batch_id: int,
+        user: str,
+        gsa_key,
+        job_spec,
+        format_version: BatchFormatVersion,
+        task_manager: aiotools.BackgroundTaskManager,
+        pool: concurrent.futures.ThreadPoolExecutor,
+    ):
         self.batch_id = batch_id
         self.user = user
         self.gsa_key = gsa_key
@@ -696,19 +717,26 @@ class Job:
             req_memory_in_bytes = parse_memory_in_bytes(job_spec['resources']['memory'])
             req_storage_in_bytes = parse_storage_in_bytes(job_spec['resources']['storage'])
 
-            cpu_in_mcpu = adjust_cores_for_memory_request(req_cpu_in_mcpu, req_memory_in_bytes, worker_config.instance_type)
+            cpu_in_mcpu = adjust_cores_for_memory_request(
+                req_cpu_in_mcpu, req_memory_in_bytes, worker_config.instance_type
+            )
             # still need to adjust cpu for storage request as that is how it was computed in the front_end
-            cpu_in_mcpu = adjust_cores_for_storage_request(cpu_in_mcpu, req_storage_in_bytes, CORES, worker_config.local_ssd_data_disk, worker_config.data_disk_size_gb)
+            cpu_in_mcpu = adjust_cores_for_storage_request(
+                cpu_in_mcpu,
+                req_storage_in_bytes,
+                CORES,
+                worker_config.local_ssd_data_disk,
+                worker_config.data_disk_size_gb,
+            )
             cpu_in_mcpu = adjust_cores_for_packability(cpu_in_mcpu)
 
             self.cpu_in_mcpu = cpu_in_mcpu
             self.memory_in_bytes = cores_mcpu_to_memory_bytes(cpu_in_mcpu, worker_config.instance_type)
 
             self.external_storage_in_gib = 0
-            data_disk_storage_in_bytes = cores_mcpu_to_storage_bytes(cpu_in_mcpu,
-                                                                     CORES,
-                                                                     worker_config.local_ssd_data_disk,
-                                                                     worker_config.data_disk_size_gb)
+            data_disk_storage_in_bytes = cores_mcpu_to_storage_bytes(
+                cpu_in_mcpu, CORES, worker_config.local_ssd_data_disk, worker_config.data_disk_size_gb
+            )
             self.data_disk_storage_in_gib = round_storage_bytes_to_gib(data_disk_storage_in_bytes)
         else:
             self.cpu_in_mcpu = job_spec['resources']['cores_mcpu']
@@ -725,7 +753,9 @@ class Job:
                 # maximum number of simultaneous jobs on a worker is 64 which
                 # basically fills the disk not allowing for caches etc. Most jobs
                 # would need an external disk in that case.
-                self.data_disk_storage_in_gib = min(RESERVED_STORAGE_GB_PER_CORE, self.cpu_in_mcpu / 1000 * RESERVED_STORAGE_GB_PER_CORE)
+                self.data_disk_storage_in_gib = min(
+                    RESERVED_STORAGE_GB_PER_CORE, self.cpu_in_mcpu / 1000 * RESERVED_STORAGE_GB_PER_CORE
+                )
 
         self.resources = worker_config.resources(self.cpu_in_mcpu, self.memory_in_bytes, self.external_storage_in_gib)
 
@@ -801,7 +831,7 @@ class Job:
             'user': self.user,
             'state': self.state,
             'format_version': self.format_version.format_version,
-            'resources': self.resources
+            'resources': self.resources,
         }
         if self.error:
             status['error'] = self.error
@@ -816,14 +846,16 @@ class Job:
 
 
 class DockerJob(Job):
-    def __init__(self,
-                 batch_id: int,
-                 user: str,
-                 gsa_key,
-                 job_spec,
-                 format_version,
-                 task_manager: aiotools.BackgroundTaskManager,
-                 pool: concurrent.futures.ThreadPoolExecutor):
+    def __init__(
+        self,
+        batch_id: int,
+        user: str,
+        gsa_key,
+        job_spec,
+        format_version,
+        task_manager: aiotools.BackgroundTaskManager,
+        pool: concurrent.futures.ThreadPoolExecutor,
+    ):
         super().__init__(batch_id, user, gsa_key, job_spec, format_version, task_manager, pool)
         input_files = job_spec.get('input_files')
         output_files = job_spec.get('output_files')
@@ -847,8 +879,14 @@ class DockerJob(Job):
 
         if input_files:
             containers['input'] = copy_container(
-                self, 'input', input_files, self.input_volume_mounts,
-                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays_project)
+                self,
+                'input',
+                input_files,
+                self.input_volume_mounts,
+                self.cpu_in_mcpu,
+                self.memory_in_bytes,
+                requester_pays_project,
+            )
 
         # main container
         main_spec = {
@@ -858,7 +896,7 @@ class DockerJob(Job):
             'env': [f'{var["name"]}={var["value"]}' for var in self.env],
             'cpu': self.cpu_in_mcpu,
             'memory': self.memory_in_bytes,
-            'volume_mounts': self.main_volume_mounts
+            'volume_mounts': self.main_volume_mounts,
         }
         port = job_spec.get('port')
         if port:
@@ -874,39 +912,46 @@ class DockerJob(Job):
 
         if output_files:
             containers['output'] = copy_container(
-                self, 'output', output_files, self.output_volume_mounts,
-                self.cpu_in_mcpu, self.memory_in_bytes, requester_pays_project)
+                self,
+                'output',
+                output_files,
+                self.output_volume_mounts,
+                self.cpu_in_mcpu,
+                self.memory_in_bytes,
+                requester_pays_project,
+            )
 
         self.containers = containers
 
     async def setup_io(self):
         if not worker_config.job_private:
             if worker.data_disk_space_remaining.value < self.external_storage_in_gib:
-                log.info(f'worker data disk storage is full: {self.external_storage_in_gib}Gi requested and {worker.data_disk_space_remaining}Gi remaining')
+                log.info(
+                    f'worker data disk storage is full: {self.external_storage_in_gib}Gi requested and {worker.data_disk_space_remaining}Gi remaining'
+                )
 
                 # disk name must be 63 characters or less
                 # https://cloud.google.com/compute/docs/reference/rest/v1/disks#resource:-disk
                 # under the information for the name field
                 uid = self.token[:20]
-                self.disk = Disk(zone=ZONE,
-                                 project=PROJECT,
-                                 instance_name=NAME,
-                                 name=f'batch-disk-{uid}',
-                                 compute_client=worker.compute_client,
-                                 size_in_gb=self.external_storage_in_gib,
-                                 mount_path=self.io_host_path())
-                labels = {
-                    'namespace': NAMESPACE,
-                    'batch': '1',
-                    'instance-name': NAME,
-                    'uid': uid
-                }
+                self.disk = Disk(
+                    zone=ZONE,
+                    project=PROJECT,
+                    instance_name=NAME,
+                    name=f'batch-disk-{uid}',
+                    compute_client=worker.compute_client,
+                    size_in_gb=self.external_storage_in_gib,
+                    mount_path=self.io_host_path(),
+                )
+                labels = {'namespace': NAMESPACE, 'batch': '1', 'instance-name': NAME, 'uid': uid}
                 await self.disk.create(labels=labels)
                 log.info(f'created disk {self.disk.name} for job {self.id}')
                 return
 
             worker.data_disk_space_remaining.value -= self.external_storage_in_gib
-            log.info(f'acquired {self.external_storage_in_gib}Gi from worker data disk storage with {worker.data_disk_space_remaining}Gi remaining')
+            log.info(
+                f'acquired {self.external_storage_in_gib}Gi from worker data disk storage with {worker.data_disk_space_remaining}Gi remaining'
+            )
 
         assert self.disk is None, self.disk
         os.makedirs(self.io_host_path())
@@ -933,12 +978,18 @@ class DockerJob(Job):
                     async with Flock('/xfsquota/projects', pool=worker.pool):
                         with open('/xfsquota/projects', 'a') as f:
                             f.write(f'{self.project_id}:{self.scratch}\n')
-                    data_disk_storage_in_bytes = storage_gib_to_bytes(self.external_storage_in_gib + self.data_disk_storage_in_gib)
+                    data_disk_storage_in_bytes = storage_gib_to_bytes(
+                        self.external_storage_in_gib + self.data_disk_storage_in_gib
+                    )
                 else:
                     data_disk_storage_in_bytes = storage_gib_to_bytes(self.data_disk_storage_in_gib)
 
-                await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.project_name}" /host/')
-                await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft={data_disk_storage_in_bytes} bhard={data_disk_storage_in_bytes} {self.project_name}" /host/')
+                await check_shell_output(
+                    f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.project_name}" /host/'
+                )
+                await check_shell_output(
+                    f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft={data_disk_storage_in_bytes} bhard={data_disk_storage_in_bytes} {self.project_name}" /host/'
+                )
 
                 if self.secrets:
                     for secret in self.secrets:
@@ -948,10 +999,12 @@ class DockerJob(Job):
                     populate_secret_host_path(self.gsa_key_file_path(), self.gsa_key)
                     for b in self.gcsfuse:
                         bucket = b['bucket']
-                        await add_gcsfuse_bucket(mount_path=self.gcsfuse_path(bucket),
-                                                 bucket=bucket,
-                                                 key_file=f'{self.gsa_key_file_path()}/key.json',
-                                                 read_only=b['read_only'])
+                        await add_gcsfuse_bucket(
+                            mount_path=self.gcsfuse_path(bucket),
+                            bucket=bucket,
+                            key_file=f'{self.gsa_key_file_path()}/key.json',
+                            read_only=b['read_only'],
+                        )
 
                 self.state = 'running'
 
@@ -1019,7 +1072,9 @@ class DockerJob(Job):
                     await check_shell(f'fusermount -u {mount_path}')
                     log.info(f'unmounted gcsfuse bucket {bucket} from {mount_path}')
 
-            await check_shell(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host')
+            await check_shell(
+                f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host'
+            )
 
             async with Flock('/xfsquota/projid', pool=worker.pool):
                 await check_shell(f"sed -i '/{self.project_name}:{self.project_id}/d' /xfsquota/projid")
@@ -1043,9 +1098,7 @@ class DockerJob(Job):
 
     async def status(self):
         status = await super().status()
-        cstatuses = {
-            name: await c.status() for name, c in self.containers.items()
-        }
+        cstatuses = {name: await c.status() for name, c in self.containers.items()}
         status['container_statuses'] = cstatuses
 
         return status
@@ -1060,14 +1113,16 @@ class JVMJob(Job):
     def secret_host_path(self, secret):
         return f'{self.scratch}/secrets{secret["mount_path"]}'
 
-    def __init__(self,
-                 batch_id: int,
-                 user: str,
-                 gsa_key,
-                 job_spec,
-                 format_version,
-                 task_manager: aiotools.BackgroundTaskManager,
-                 pool: concurrent.futures.ThreadPoolExecutor):
+    def __init__(
+        self,
+        batch_id: int,
+        user: str,
+        gsa_key,
+        job_spec,
+        format_version,
+        task_manager: aiotools.BackgroundTaskManager,
+        pool: concurrent.futures.ThreadPoolExecutor,
+    ):
         super().__init__(batch_id, user, gsa_key, job_spec, format_version, task_manager, pool)
         assert job_spec['process']['type'] == 'jvm'
 
@@ -1077,18 +1132,20 @@ class JVMJob(Job):
             raise Exception("i/o not supported")
 
         for envvar in self.env:
-            assert envvar['name'] not in {'HAIL_DEPLOY_CONFIG_FILE', 'HAIL_TOKENS_FILE',
-                                          'HAIL_SSL_CONFIG_DIR', 'HAIL_GSA_KEY_FILE',
-                                          'HAIL_WORKER_SCRATCH_DIR'}, envvar
+            assert envvar['name'] not in {
+                'HAIL_DEPLOY_CONFIG_FILE',
+                'HAIL_TOKENS_FILE',
+                'HAIL_SSL_CONFIG_DIR',
+                'HAIL_GSA_KEY_FILE',
+                'HAIL_WORKER_SCRATCH_DIR',
+            }, envvar
 
-        self.env.append({'name': 'HAIL_DEPLOY_CONFIG_FILE',
-                         'value': f'{self.scratch}/secrets/deploy-config/deploy-config.json'})
-        self.env.append({'name': 'HAIL_TOKENS_FILE',
-                         'value': f'{self.scratch}/secrets/user-tokens/tokens.json'})
-        self.env.append({'name': 'HAIL_SSL_CONFIG_DIR',
-                         'value': f'{self.scratch}/secrets/ssl-config'})
-        self.env.append({'name': 'HAIL_GSA_KEY_FILE',
-                         'value': f'{self.scratch}/secrets/gsa-key/key.json'})
+        self.env.append(
+            {'name': 'HAIL_DEPLOY_CONFIG_FILE', 'value': f'{self.scratch}/secrets/deploy-config/deploy-config.json'}
+        )
+        self.env.append({'name': 'HAIL_TOKENS_FILE', 'value': f'{self.scratch}/secrets/user-tokens/tokens.json'})
+        self.env.append({'name': 'HAIL_SSL_CONFIG_DIR', 'value': f'{self.scratch}/secrets/ssl-config'})
+        self.env.append({'name': 'HAIL_GSA_KEY_FILE', 'value': f'{self.scratch}/secrets/gsa-key/key.json'})
         self.env.append({'name': 'HAIL_WORKER_SCRATCH_DIR', 'value': self.scratch})
 
         # main container
@@ -1110,10 +1167,12 @@ class JVMJob(Job):
 
         self.command_string = [
             'java',
-            '-classpath', classpath,
+            '-classpath',
+            classpath,
             f'-Xmx{self.heap_size}',
             f'-Xss{self.stack_size}',
-            *user_command_string]
+            *user_command_string,
+        ]
 
         self.process = None
         self.deleted = False
@@ -1148,8 +1207,12 @@ class JVMJob(Job):
                     with open('/xfsquota/projects', 'a') as f:
                         f.write(f'{self.project_id}:{self.scratch}\n')
 
-                await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.project_name}" /host/')
-                await check_shell_output(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft={self.data_disk_storage_in_gib} bhard={self.data_disk_storage_in_gib} {self.project_name}" /host/')
+                await check_shell_output(
+                    f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "project -s {self.project_name}" /host/'
+                )
+                await check_shell_output(
+                    f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft={self.data_disk_storage_in_gib} bhard={self.data_disk_storage_in_gib} {self.project_name}" /host/'
+                )
 
                 if self.secrets:
                     for secret in self.secrets:
@@ -1165,9 +1228,15 @@ class JVMJob(Job):
                         if not os.path.isfile(local_jar_location):
                             user_fs = RouterAsyncFS(
                                 'file',
-                                [LocalAsyncFS(worker.pool),
-                                 aiogoogle.GoogleStorageAsyncFS(credentials=aiogoogle.Credentials.from_file(
-                                     f'{self.scratch}/secrets/gsa-key/key.json'))])
+                                [
+                                    LocalAsyncFS(worker.pool),
+                                    aiogoogle.GoogleStorageAsyncFS(
+                                        credentials=aiogoogle.Credentials.from_file(
+                                            f'{self.scratch}/secrets/gsa-key/key.json'
+                                        )
+                                    ),
+                                ],
+                            )
                             async with await user_fs.open(self.jar_url) as jar_data:
                                 await user_fs.makedirs('/hail-jars/', exist_ok=True)
                                 async with await user_fs.create(local_jar_location) as local_file:
@@ -1184,18 +1253,17 @@ class JVMJob(Job):
                         *self.command_string,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
-                        env={envvar['name']: envvar['value'] for envvar in self.env})
+                        env={envvar['name']: envvar['value'] for envvar in self.env},
+                    )
 
-                    await asyncio.gather(self.pipe_to_log(self.process.stdout),
-                                         self.pipe_to_log(self.process.stderr))
+                    await asyncio.gather(self.pipe_to_log(self.process.stdout), self.pipe_to_log(self.process.stderr))
                     await self.process.wait()
 
                 log.info(f'finished {self} with return code {self.process.returncode}')
 
                 await worker.log_store.write_log_file(
-                    self.format_version, self.batch_id,
-                    self.job_id, self.attempt_id, 'main',
-                    self.logbuffer.decode())
+                    self.format_version, self.batch_id, self.job_id, self.attempt_id, 'main', self.logbuffer.decode()
+                )
 
                 if self.process.returncode == 0:
                     self.state = 'succeeded'
@@ -1221,7 +1289,9 @@ class JVMJob(Job):
 
         log.info(f'{self}: cleaning up')
         try:
-            await check_shell(f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host')
+            await check_shell(
+                f'xfs_quota -x -D /xfsquota/projects -P /xfsquota/projid -c "limit -p bsoft=0 bhard=0 {self.project_name}" /host'
+            )
 
             async with Flock('/xfsquota/projid', pool=worker.pool):
                 await check_shell(f"sed -i '/{self.project_name}:{self.project_id}/d' /xfsquota/projid")
@@ -1262,11 +1332,7 @@ class JVMJob(Job):
     async def status(self):
         status = await super().status()
         status['container_statuses'] = dict()
-        status['container_statuses']['main'] = {
-            'name': 'main',
-            'state': self.state,
-            'timing': self.timings.to_dict()
-        }
+        status['container_statuses']['main'] = {'name': 'main', 'state': self.state, 'timing': self.timings.to_dict()}
         if self.process is not None and self.process.returncode is not None:
             status['container_statuses']['main']['exit_code'] = self.process.returncode
         return status
@@ -1339,7 +1405,9 @@ class Worker:
         if id in self.jobs:
             return web.HTTPForbidden()
 
-        job = Job.create(batch_id, body['user'], body['gsa_key'], job_spec, format_version, self.task_manager, self.pool)
+        job = Job.create(
+            batch_id, body['user'], body['gsa_key'], job_spec, format_version, self.task_manager, self.pool
+        )
 
         log.info(f'created {job}, adding to jobs')
 
@@ -1396,14 +1464,16 @@ class Worker:
 
     async def run(self):
         app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE)
-        app.add_routes([
-            web.post('/api/v1alpha/kill', self.kill),
-            web.post('/api/v1alpha/batches/jobs/create', self.create_job),
-            web.delete('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/delete', self.delete_job),
-            web.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log', self.get_job_log),
-            web.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/status', self.get_job_status),
-            web.get('/healthcheck', self.healthcheck)
-        ])
+        app.add_routes(
+            [
+                web.post('/api/v1alpha/kill', self.kill),
+                web.post('/api/v1alpha/batches/jobs/create', self.create_job),
+                web.delete('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/delete', self.delete_job),
+                web.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log', self.get_job_log),
+                web.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/status', self.get_job_status),
+                web.get('/healthcheck', self.healthcheck),
+            ]
+        )
         try:
             await asyncio.wait_for(self.activate(), MAX_IDLE_TIME_MSECS / 1000)
         except asyncio.TimeoutError:
@@ -1426,8 +1496,10 @@ class Worker:
                     if not self.jobs and idle_duration >= MAX_IDLE_TIME_MSECS:
                         log.info(f'idle {idle_duration} ms, exiting')
                         break
-                    log.info(f'n_jobs {len(self.jobs)} free_cores {self.cpu_sem.value / 1000} idle {idle_duration} '
-                             f'free worker data disk storage {self.data_disk_space_remaining.value}Gi')
+                    log.info(
+                        f'n_jobs {len(self.jobs)} free_cores {self.cpu_sem.value / 1000} idle {idle_duration} '
+                        f'free worker data disk storage {self.data_disk_space_remaining.value}Gi'
+                    )
         finally:
             log.info('shutting down')
             await site.stop()
@@ -1444,8 +1516,8 @@ class Worker:
             # gone (e.g. testing a PR), this would go into an
             # infinite loop and the instance won't be deleted.
             await session.post(
-                deploy_config.url('batch-driver', '/api/v1alpha/instances/deactivate'),
-                headers=self.headers)
+                deploy_config.url('batch-driver', '/api/v1alpha/instances/deactivate'), headers=self.headers
+            )
 
     async def kill_1(self, request):  # pylint: disable=unused-argument
         log.info('killed')
@@ -1461,11 +1533,8 @@ class Worker:
 
         if job.format_version.has_full_status_in_gcs():
             await retry_all_errors(f'error while writing status file to gcs for {job}')(
-                self.log_store.write_status_file,
-                job.batch_id,
-                job.job_id,
-                job.attempt_id,
-                json.dumps(full_status))
+                self.log_store.write_status_file, job.batch_id, job.job_id, job.attempt_id, json.dumps(full_status)
+            )
 
         db_status = job.format_version.db_status(full_status)
 
@@ -1478,12 +1547,10 @@ class Worker:
             'start_time': full_status['start_time'],
             'end_time': full_status['end_time'],
             'resources': full_status['resources'],
-            'status': db_status
+            'status': db_status,
         }
 
-        body = {
-            'status': status
-        }
+        body = {'status': status}
 
         start_time = time_msecs()
         delay_secs = 0.1
@@ -1492,27 +1559,26 @@ class Worker:
                 async with client_session() as session:
                     await session.post(
                         deploy_config.url('batch-driver', '/api/v1alpha/instances/job_complete'),
-                        json=body, headers=self.headers)
+                        json=body,
+                        headers=self.headers,
+                    )
                     return
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception as e:
-                if isinstance(e, aiohttp.ClientResponseError) and e.status == 404:   # pylint: disable=no-member
+                if isinstance(e, aiohttp.ClientResponseError) and e.status == 404:  # pylint: disable=no-member
                     raise
                 log.warning(f'failed to mark {job} complete, retrying', exc_info=True)
 
             # unlist job after 3m or half the run duration
             now = time_msecs()
             elapsed = now - start_time
-            if (job.id in self.jobs
-                    and elapsed > 180 * 1000
-                    and elapsed > run_duration / 2):
+            if job.id in self.jobs and elapsed > 180 * 1000 and elapsed > run_duration / 2:
                 log.info(f'too much time elapsed marking {job} complete, removing from jobs, will keep retrying')
                 del self.jobs[job.id]
                 self.last_updated = time_msecs()
 
-            await asyncio.sleep(
-                delay_secs * random.uniform(0.7, 1.3))
+            await asyncio.sleep(delay_secs * random.uniform(0.7, 1.3))
             # exponentially back off, up to (expected) max of 2m
             delay_secs = min(delay_secs * 2, 2 * 60.0)
 
@@ -1538,18 +1604,19 @@ class Worker:
             'job_id': full_status['job_id'],
             'attempt_id': full_status['attempt_id'],
             'start_time': full_status['start_time'],
-            'resources': full_status['resources']
+            'resources': full_status['resources'],
         }
 
-        body = {
-            'status': status
-        }
+        body = {'status': status}
 
         async with client_session() as session:
             await request_retry_transient_errors(
-                session, 'POST',
+                session,
+                'POST',
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/job_started'),
-                json=body, headers=self.headers)
+                json=body,
+                headers=self.headers,
+            )
 
     async def post_job_started(self, job):
         try:
@@ -1562,39 +1629,34 @@ class Worker:
     async def activate(self):
         async with client_session() as session:
             resp = await request_retry_transient_errors(
-                session, 'GET',
+                session,
+                'GET',
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/gsa_key'),
-                headers={
-                    'X-Hail-Instance-Name': NAME,
-                    'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
-                })
+                headers={'X-Hail-Instance-Name': NAME, 'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'},
+            )
             resp_json = await resp.json()
 
             with open('/worker-key.json', 'w') as f:
                 f.write(json.dumps(resp_json['key']))
 
-            credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                '/worker-key.json')
-            self.log_store = LogStore(BATCH_LOGS_BUCKET_NAME, INSTANCE_ID, self.pool,
-                                      project=PROJECT, credentials=credentials)
+            credentials = google.oauth2.service_account.Credentials.from_service_account_file('/worker-key.json')
+            self.log_store = LogStore(
+                BATCH_LOGS_BUCKET_NAME, INSTANCE_ID, self.pool, project=PROJECT, credentials=credentials
+            )
 
             credentials = aiogoogle.Credentials.from_file('/worker-key.json')
             self.compute_client = aiogoogle.ComputeClient(PROJECT, credentials=credentials)
 
             resp = await request_retry_transient_errors(
-                session, 'POST',
+                session,
+                'POST',
                 deploy_config.url('batch-driver', '/api/v1alpha/instances/activate'),
                 json={'ip_address': os.environ['IP_ADDRESS']},
-                headers={
-                    'X-Hail-Instance-Name': NAME,
-                    'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'
-                })
+                headers={'X-Hail-Instance-Name': NAME, 'Authorization': f'Bearer {os.environ["ACTIVATION_TOKEN"]}'},
+            )
             resp_json = await resp.json()
 
-            self.headers = {
-                'X-Hail-Instance-Name': NAME,
-                'Authorization': f'Bearer {resp_json["token"]}'
-            }
+            self.headers = {'X-Hail-Instance-Name': NAME, 'Authorization': f'Bearer {resp_json["token"]}'}
 
 
 async def async_main():

--- a/batch/download-gcs-connector.py
+++ b/batch/download-gcs-connector.py
@@ -1,6 +1,7 @@
 import os
 import urllib.request
 import shutil
+
 # Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
 with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar") as input:
     with open(os.environ['SPARK_HOME'] + "/jars/gcs-connector-hadoop2-2.0.1.jar", 'wb') as output:

--- a/batch/setup.py
+++ b/batch/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'batch',
-    version = '0.0.2',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Job manager',
-    packages = find_packages(),
-    include_package_data=True
+    name='batch',
+    version='0.0.2',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Job manager',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -20,12 +20,9 @@ class FailureInjectingClientSession:
             raise aiohttp.ClientResponseError(
                 status=503,
                 message='Service Unavailable from FailureInjectingClientSession',
-                request_info=aiohttp.RequestInfo(
-                    url=path,
-                    method=method,
-                    headers=headers,
-                    real_url=path),
-                history=())
+                request_info=aiohttp.RequestInfo(url=path, method=method, headers=headers, real_url=path),
+                history=(),
+            )
 
     async def request(self, method, path, *args, **kwargs):
         self.maybe_fail(method, path, kwargs.get('headers', {}))

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -5,8 +5,7 @@ import requests
 from werkzeug.serving import make_server
 from flask import Response
 
-from hailtop.utils import (retry_response_returning_functions,
-                           external_requests_client_session)
+from hailtop.utils import retry_response_returning_functions, external_requests_client_session
 
 
 class ServerThread(threading.Thread):
@@ -34,8 +33,7 @@ class ServerThread(threading.Thread):
         session = external_requests_client_session()
         while not up:
             try:
-                retry_response_returning_functions(
-                    session.get, ping_url)
+                retry_response_returning_functions(session.get, ping_url)
                 up = True
             except requests.exceptions.ConnectionError:
                 time.sleep(0.01)

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -14,6 +14,7 @@ DOCKER_ROOT_IMAGE = os.environ.get('DOCKER_ROOT_IMAGE', 'gcr.io/hail-vdc/ubuntu:
 @pytest.fixture
 async def make_client():
     _bcs = []
+
     async def factory(project=None):
         bc = BatchClient(project, token_file=os.environ['HAIL_TEST_TOKEN_FILE'])
         _bcs.append(bc)
@@ -54,10 +55,12 @@ def get_billing_project_name():
     billing_project_prefix = get_billing_project_prefix()
     attempt_prefix = f'{billing_project_prefix}_{secret_alnum_string(5)}'
     projects = []
+
     def get_name():
         name = f'{attempt_prefix}_{len(projects)}'
         projects.append(name)
         return name
+
     return get_name
 
 
@@ -172,7 +175,9 @@ async def test_close_reopen_billing_project(dev_client, new_billing_project):
     # test idempotent
     await dev_client.reopen_billing_project(project)
     r = await dev_client.list_billing_projects()
-    assert [bp['billing_project'] for bp in r if bp['billing_project'] == project and bp['status'] == 'open'] == [project], r
+    assert [bp['billing_project'] for bp in r if bp['billing_project'] == project and bp['status'] == 'open'] == [
+        project
+    ], r
 
 
 async def test_close_billing_project_with_open_batch_errors(dev_client, make_client, new_billing_project):
@@ -430,7 +435,9 @@ async def search_batches(client, expected_batch_id, q):
     return found, [b.id for b in batches]
 
 
-async def test_user_can_access_batch_made_by_other_user_in_shared_billing_project(make_client, dev_client, new_billing_project):
+async def test_user_can_access_batch_made_by_other_user_in_shared_billing_project(
+    make_client, dev_client, new_billing_project
+):
     project = new_billing_project
 
     r = await dev_client.add_user("test", project)
@@ -501,7 +508,9 @@ async def test_user_can_access_batch_made_by_other_user_in_shared_billing_projec
     assert not found, str((b.id, batches))
 
 
-async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(make_client, dev_client, new_billing_project):
+async def test_batch_cannot_be_accessed_by_users_outside_the_billing_project(
+    make_client, dev_client, new_billing_project
+):
     project = new_billing_project
 
     r = await dev_client.add_user("test", project)

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -20,8 +20,7 @@ async def test_invariants():
     headers = service_auth_headers(deploy_config, 'batch-driver')
     async with client_session() as session:
 
-        resp = await utils.request_retry_transient_errors(
-            session, 'GET', url, headers=headers)
+        resp = await utils.request_retry_transient_errors(session, 'GET', url, headers=headers)
         data = await resp.json()
 
         assert data['check_incremental_error'] is None, data

--- a/batch/test/test_scale.py
+++ b/batch/test/test_scale.py
@@ -2,8 +2,7 @@ import random
 import pytest
 from hailtop.batch_client.client import BatchClient
 
-from .utils import batch_status_job_counter, \
-    legacy_batch_status
+from .utils import batch_status_job_counter, legacy_batch_status
 
 
 @pytest.fixture

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -1,4 +1,3 @@
-
 def batch_status_job_counter(batch_status, job_state):
     return len([j for j in batch_status['jobs'] if j['state'] == job_state])
 

--- a/batch/utils/stress.py
+++ b/batch/utils/stress.py
@@ -10,14 +10,10 @@ def flip(p):
 
 
 def stress():
-    b = hb.Batch(
-        name='stress',
-        backend=hb.ServiceBackend(billing_project='hail'),
-        default_image=DOCKER_ROOT_IMAGE)
+    b = hb.Batch(name='stress', backend=hb.ServiceBackend(billing_project='hail'), default_image=DOCKER_ROOT_IMAGE)
 
     for i in range(100):
-        j = (b
-             .new_job(name=f'parent_{i}'))
+        j = b.new_job(name=f'parent_{i}')
         d = random.choice(range(4))
         if flip(0.2):
             j.command(f'sleep {d}; exit 1')
@@ -26,9 +22,7 @@ def stress():
 
         for k in range(10):
             d = random.choice(range(4))
-            c = (b
-                 .new_job(name=f'child_{i}_{k}')
-                 .command(f'sleep {d}; echo child {i} {k}'))
+            c = b.new_job(name=f'child_{i}_{k}').command(f'sleep {d}; echo child {i} {k}')
             c.depends_on(j)
             if flip(0.1):
                 c._always_run = True

--- a/benchmark-service/benchmark/__main__.py
+++ b/benchmark-service/benchmark/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/benchmark-service/benchmark/submit.py
+++ b/benchmark-service/benchmark/submit.py
@@ -82,11 +82,7 @@ git checkout {self.sha}
 '''
 
 
-def submit(hail_code: Commit,
-           benchmark_code: Commit,
-           test_names: Set[str],
-           n_replicates: int,
-           n_iters: int):
+def submit(hail_code: Commit, benchmark_code: Commit, test_names: Set[str], n_replicates: int, n_iters: int):
 
     sync_check_shell(benchmark_code.checkout_script())
 
@@ -98,19 +94,24 @@ def submit(hail_code: Commit,
 
     output_file = f'gs://hail-benchmarks-2/benchmark/{hail_code.sha}-{benchmark_code.sha}.json'
 
-    b = hb.Batch(name=f'benchmark-{hail_code.sha}',
-                 backend=hb.ServiceBackend(billing_project='hail'),
-                 default_image=BENCHMARK_IMAGE,
-                 default_cpu='2',
-                 attributes={'output_file': output_file,
-                             'n_replicates': str(n_replicates),
-                             'n_iters': str(n_iters),
-                             'image': str(BENCHMARK_IMAGE),
-                             'hail_code': str(hail_code),
-                             'benchmark_code': str(benchmark_code)})
+    b = hb.Batch(
+        name=f'benchmark-{hail_code.sha}',
+        backend=hb.ServiceBackend(billing_project='hail'),
+        default_image=BENCHMARK_IMAGE,
+        default_cpu='2',
+        attributes={
+            'output_file': output_file,
+            'n_replicates': str(n_replicates),
+            'n_iters': str(n_iters),
+            'image': str(BENCHMARK_IMAGE),
+            'hail_code': str(hail_code),
+            'benchmark_code': str(benchmark_code),
+        },
+    )
 
     build_hail = b.new_job('build_hail_wheel')
-    build_hail.command(f'''
+    build_hail.command(
+        f'''
  set -ex
  { hail_code.checkout_script() }
  cd hail
@@ -119,10 +120,12 @@ def submit(hail_code: Commit,
  time (cd python && zip -r hail.zip hail hailtop)
  (cd build/deploy/dist/ && tar -cvf wheel-container.tar hail-*-py3-none-any.whl)
  cp build/deploy/dist/hail-*-py3-none-any.whl {build_hail.wheel}
-''')
+'''
+    )
 
     build_benchmark = b.new_job('build_benchmark_wheel')
-    build_benchmark.command(f'''
+    build_benchmark.command(
+        f'''
  set -ex
  {benchmark_code.checkout_script()}
  make -C hail python/hail/hail_pip_version
@@ -131,7 +134,8 @@ def submit(hail_code: Commit,
  cd benchmark/python/ && python3 setup.py -q bdist_wheel
  python3 -m pip -q install dist/benchmark_hail-$HAIL_VERSION-py3-none-any.whl
  cp dist/benchmark_hail-$HAIL_VERSION-py3-none-any.whl {build_benchmark.wheel}
-''')
+'''
+    )
     resource_jobs = {}
     for r in all_resources:
         j = b.new_job(f'create_resource_{r.name()}').cpu(4)
@@ -158,7 +162,9 @@ def submit(hail_code: Commit,
             for replicate in range(n_replicates):
                 job_fs.append((benchmark.name, replicate, benchmark.groups))
 
-    log.info(f'generating {n_passed_filter} * {n_replicates} = {n_passed_filter * n_replicates} individual benchmark jobs')
+    log.info(
+        f'generating {n_passed_filter} * {n_replicates} = {n_passed_filter * n_replicates} individual benchmark jobs'
+    )
 
     random.shuffle(job_fs)
     for name, replicate, groups in job_fs:
@@ -172,12 +178,14 @@ def submit(hail_code: Commit,
             resource_job = resource_jobs[resource_group]
             j.command(f'mv {resource_job.ofile} benchmark-resources/{resource_group.name()}.tar')
             j.command(f'time tar -xf benchmark-resources/{resource_group.name()}.tar')
-        j.command(f'MKL_NUM_THREADS=1'
-                  f'OPENBLAS_NUM_THREADS=1'
-                  f'OMP_NUM_THREADS=1'
-                  f'VECLIB_MAXIMUM_THREADS=1'
-                  f'PYSPARK_SUBMIT_ARGS="--driver-memory 6G pyspark-shell" '
-                  f'hail-bench run -o {j.ofile} -n {n_iters} --data-dir benchmark-resources -t {name}')
+        j.command(
+            f'MKL_NUM_THREADS=1'
+            f'OPENBLAS_NUM_THREADS=1'
+            f'OMP_NUM_THREADS=1'
+            f'VECLIB_MAXIMUM_THREADS=1'
+            f'PYSPARK_SUBMIT_ARGS="--driver-memory 6G pyspark-shell" '
+            f'hail-bench run -o {j.ofile} -n {n_iters} --data-dir benchmark-resources -t {name}'
+        )
         all_output.append(j.ofile)
 
     combine_branch_factor = int(os.environ.get('BENCHMARK_BRANCH_FACTOR', 32))
@@ -194,7 +202,8 @@ def submit(hail_code: Commit,
             combine.command(f'mv {build_benchmark.wheel} benchmark_hail--py3-none-any.whl')
             combine.command('pip install benchmark_hail--py3-none-any.whl')
             combine.command(
-                f'hail-bench combine -o {combine.ofile} ' + ' '.join(all_output[i:i + combine_branch_factor]))
+                f'hail-bench combine -o {combine.ofile} ' + ' '.join(all_output[i : i + combine_branch_factor])
+            )
             new_output.append(combine.ofile)
             i += combine_branch_factor
             job_i += 1
@@ -218,26 +227,21 @@ def submit(hail_code: Commit,
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--hail-source',
-                        type=str,
-                        help='owner/name:sha for where the Hail code should be checked out from.',
-                        required=True)
-    parser.add_argument('--benchmark-source',
-                        type=str,
-                        help='owner/name:sha for where the Benchmark code should be checked out from.',
-                        required=True)
-    parser.add_argument('--replicates',
-                        type=int,
-                        default=1,
-                        help='Number of replicates.')
-    parser.add_argument('--iters',
-                        type=int,
-                        default=1,
-                        help='Number of iterations.')
-    parser.add_argument('--tests',
-                        type=str,
-                        help='Benchmark tests to run.',
-                        required=True)
+    parser.add_argument(
+        '--hail-source',
+        type=str,
+        help='owner/name:sha for where the Hail code should be checked out from.',
+        required=True,
+    )
+    parser.add_argument(
+        '--benchmark-source',
+        type=str,
+        help='owner/name:sha for where the Benchmark code should be checked out from.',
+        required=True,
+    )
+    parser.add_argument('--replicates', type=int, default=1, help='Number of replicates.')
+    parser.add_argument('--iters', type=int, default=1, help='Number of iterations.')
+    parser.add_argument('--tests', type=str, help='Benchmark tests to run.', required=True)
 
     args = parser.parse_args()
 
@@ -245,8 +249,10 @@ if __name__ == '__main__':
     benchmark_code = Commit.from_str(args.benchmark_source)
     tests = set(args.tests.split(','))
 
-    submit(hail_code=hail_code,
-           benchmark_code=benchmark_code,
-           test_names=tests,
-           n_replicates=args.replicates,
-           n_iters=args.iters)
+    submit(
+        hail_code=hail_code,
+        benchmark_code=benchmark_code,
+        test_names=tests,
+        n_replicates=args.replicates,
+        n_iters=args.iters,
+    )

--- a/benchmark-service/benchmark/utils.py
+++ b/benchmark-service/benchmark/utils.py
@@ -36,11 +36,7 @@ def enumerate_list_of_trials(list_of_trials):
         within_group_idx.extend([f'{j+1}' for j in range(len(trial))])
         temp = [count] * len(trial)
         trial_indices.extend(temp)
-    res_dict = {
-        'trial_indices': trial_indices,
-        'wall_times': wall_times,
-        'within_group_index': within_group_idx
-    }
+    res_dict = {'trial_indices': trial_indices, 'wall_times': wall_times, 'within_group_index': within_group_idx}
     return res_dict
 
 
@@ -55,11 +51,13 @@ async def submit_test_batch(batch_client, sha):
     batch = batch_client.create_batch(attributes={'sha': sha})
     known_file_path = 'gs://hail-benchmarks-2/tpoterba/0.2.21-f6f337d1e9bb.json'
     dest_file_path = f'{BENCHMARK_RESULTS_PATH}/0-{sha}.json'
-    job = batch.create_job(image='ubuntu:18.04',
-                           command=['/bin/bash', '-c', 'touch /io/test; sleep 5'],
-                           resources={'cpu': '0.25'},
-                           input_files=[(known_file_path, '/io/test')],
-                           output_files=[('/io/test', dest_file_path)])
+    job = batch.create_job(
+        image='ubuntu:18.04',
+        command=['/bin/bash', '-c', 'touch /io/test; sleep 5'],
+        resources={'cpu': '0.25'},
+        input_files=[(known_file_path, '/io/test')],
+        output_files=[('/io/test', dest_file_path)],
+    )
     await batch.submit(disable_progress_bar=True)
     log.info(f'submitting batch for commit {sha}')
     return job.batch_id

--- a/benchmark-service/setup.py
+++ b/benchmark-service/setup.py
@@ -8,5 +8,5 @@ setup(
     author_email='hail@broadinstitute.org',
     description='Benchmark service',
     packages=find_packages(),
-    include_package_data=True
+    include_package_data=True,
 )

--- a/benchmark-service/test/test_update_commits.py
+++ b/benchmark-service/test/test_update_commits.py
@@ -23,7 +23,8 @@ async def test_update_commits():
 
     async def request(method):
         return await utils.request_retry_transient_errors(
-            session, method, f'{commit_benchmark_url}', headers=headers, json={'sha': sha})
+            session, method, f'{commit_benchmark_url}', headers=headers, json={'sha': sha}
+        )
 
     async with client_session() as session:
         await request('DELETE')

--- a/benchmark/python/setup.py
+++ b/benchmark/python/setup.py
@@ -20,7 +20,5 @@ setup(
     install_requires=[
         'hail>=0.2',
     ],
-    entry_points={
-        'console_scripts': ['hail-bench = benchmark_hail.__main__:main']
-    },
+    entry_points={'console_scripts': ['hail-bench = benchmark_hail.__main__:main']},
 )

--- a/benchmark/scripts/benchmark_in_batch.py
+++ b/benchmark/scripts/benchmark_in_batch.py
@@ -23,15 +23,19 @@ if __name__ == '__main__':
     output_file = os.path.join(BUCKET_BASE, f'{labeled_sha}.json')
     permissions_test_file = os.path.join(BUCKET_BASE, f'permissions-test')
 
-    b = hb.Batch(name=f'benchmark-{labeled_sha}',
-                 backend=hb.ServiceBackend(billing_project='hail'),
-                 default_image=BENCHMARK_IMAGE,
-                 default_cpu='2',
-                 default_storage='30G',
-                 attributes={'output_file': output_file,
-                             'n_replicates': str(N_REPLICATES),
-                             'n_iters': str(N_ITERS),
-                             'image': str(BENCHMARK_IMAGE)})
+    b = hb.Batch(
+        name=f'benchmark-{labeled_sha}',
+        backend=hb.ServiceBackend(billing_project='hail'),
+        default_image=BENCHMARK_IMAGE,
+        default_cpu='2',
+        default_storage='30G',
+        attributes={
+            'output_file': output_file,
+            'n_replicates': str(N_REPLICATES),
+            'n_iters': str(N_ITERS),
+            'image': str(BENCHMARK_IMAGE),
+        },
+    )
 
     test_permissions = b.new_job(f'test permissions')
     test_permissions.command(f'echo hello world > {test_permissions.permissions_test_file}')
@@ -52,7 +56,6 @@ if __name__ == '__main__':
 
     all_output = []
 
-
     task_filter_regex_include = os.environ.get('BENCHMARK_REGEX_INCLUDE')
     task_filter_regex_exclude = os.environ.get('BENCHMARK_REGEX_EXCLUDE')
 
@@ -66,7 +69,6 @@ if __name__ == '__main__':
     else:
         exclude = lambda t: False
 
-
     n_passed_filter = 0
     task_fs = []
     for benchmark in all_benchmarks:
@@ -76,7 +78,9 @@ if __name__ == '__main__':
                 for replicate in range(N_REPLICATES):
                     task_fs.append((benchmark.name, replicate, benchmark.groups))
 
-    print(f'generating {n_passed_filter} * {N_REPLICATES} = {n_passed_filter * N_REPLICATES} individual benchmark tasks')
+    print(
+        f'generating {n_passed_filter} * {N_REPLICATES} = {n_passed_filter * N_REPLICATES} individual benchmark tasks'
+    )
 
     random.shuffle(task_fs)
 
@@ -93,13 +97,15 @@ if __name__ == '__main__':
             resource_task = resource_tasks[resource_group]
             j.command(f'mv {resource_task.ofile} benchmark-resources/{resource_group.name()}.tar')
             j.command(f'time tar -xf benchmark-resources/{resource_group.name()}.tar')
-        j.command(f'MKL_NUM_THREADS=1'
-                  f'OPENBLAS_NUM_THREADS=1'
-                  f'OMP_NUM_THREADS=1'
-                  f'VECLIB_MAXIMUM_THREADS=1'
-                  f'{benchmark_lower_env_var}'
-                  f'PYSPARK_SUBMIT_ARGS="--driver-memory 6G pyspark-shell" '
-                  f'hail-bench run -o {j.ofile} -n {N_ITERS} --data-dir benchmark-resources -t {name}')
+        j.command(
+            f'MKL_NUM_THREADS=1'
+            f'OPENBLAS_NUM_THREADS=1'
+            f'OMP_NUM_THREADS=1'
+            f'VECLIB_MAXIMUM_THREADS=1'
+            f'{benchmark_lower_env_var}'
+            f'PYSPARK_SUBMIT_ARGS="--driver-memory 6G pyspark-shell" '
+            f'hail-bench run -o {j.ofile} -n {N_ITERS} --data-dir benchmark-resources -t {name}'
+        )
         all_output.append(j.ofile)
 
     combine_branch_factor = int(os.environ.get('BENCHMARK_BRANCH_FACTOR', 32))
@@ -113,7 +119,8 @@ if __name__ == '__main__':
         while i < len(all_output):
             combine = b.new_job(f'combine_output_phase{phase_i}_job{job_i}')
             combine.command(
-                f'hail-bench combine -o {combine.ofile} ' + ' '.join(all_output[i:i + combine_branch_factor]))
+                f'hail-bench combine -o {combine.ofile} ' + ' '.join(all_output[i : i + combine_branch_factor])
+            )
             new_output.append(combine.ofile)
             i += combine_branch_factor
             job_i += 1

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -42,7 +42,17 @@ async def insert_user_if_not_exists(app, username, email, is_developer, is_servi
     INSERT INTO users (state, username, email, is_developer, is_service_account, gsa_email, gsa_key_secret_name, namespace_name)
     VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
     ''',
-            ('creating', username, email, is_developer, is_service_account, gsa_email, gsa_key_secret_name, namespace_name))
+            (
+                'creating',
+                username,
+                email,
+                is_developer,
+                is_service_account,
+                gsa_email,
+                gsa_key_secret_name,
+                namespace_name,
+            ),
+        )
 
     return await insert()
 
@@ -74,7 +84,8 @@ async def main():
     app['k8s_client'] = k8s_client
 
     app['iam_client'] = aiogoogle.IAmClient(
-        PROJECT, credentials=aiogoogle.Credentials.from_file('/auth-gsa-key/key.json'))
+        PROJECT, credentials=aiogoogle.Credentials.from_file('/auth-gsa-key/key.json')
+    )
 
     for username, email, is_developer, is_service_account in users:
         user_id = await insert_user_if_not_exists(app, username, email, is_developer, is_service_account)

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -18,7 +18,8 @@ async def insert_user_if_not_exists(db, username, email):
     INSERT INTO users (state, username, email, is_developer, is_service_account)
     VALUES (%s, %s, %s, %s, %s);
     ''',
-            ('creating', username, email, 1, 0))
+            ('creating', username, email, 1, 0),
+        )
 
     return await insert(db)
 
@@ -26,10 +27,8 @@ async def insert_user_if_not_exists(db, username, email):
 async def main():
     parser = argparse.ArgumentParser(description='Create initial Hail as a service account.')
 
-    parser.add_argument('username',
-                        help='The username of the initial user.')
-    parser.add_argument('email',
-                        help='The email of the initial user.')
+    parser.add_argument('username', help='The username of the initial user.')
+    parser.add_argument('email', help='The email of the initial user.')
 
     args = parser.parse_args()
 

--- a/devbin/sync.py
+++ b/devbin/sync.py
@@ -38,9 +38,12 @@ class Sync:
     async def sync_and_restart_pod(self, pod, namespace):
         log.info(f'reloading {pod}@{namespace}')
         try:
-            await asyncio.gather(*[
-                check_shell(f'{DEVBIN}/krsync.sh {RSYNC_ARGS} {local} {pod}@{namespace}:{remote}')
-                for local, remote in self.paths])
+            await asyncio.gather(
+                *[
+                    check_shell(f'{DEVBIN}/krsync.sh {RSYNC_ARGS} {local} {pod}@{namespace}:{remote}')
+                    for local, remote in self.paths
+                ]
+            )
             await check_shell(f'kubectl exec {pod} --namespace {namespace} -- kill -2 1')
         except CalledProcessError:
             log.warning(f'could not synchronize {namespace}/{pod}, removing from active pods', exc_info=True)
@@ -51,9 +54,12 @@ class Sync:
     async def initialize_pod(self, pod, namespace):
         log.info(f'initializing {pod}@{namespace}')
         try:
-            await asyncio.gather(*[
-                check_shell(f'{DEVBIN}/krsync.sh {RSYNC_ARGS} {local} {pod}@{namespace}:{remote}')
-                for local, remote in self.paths])
+            await asyncio.gather(
+                *[
+                    check_shell(f'{DEVBIN}/krsync.sh {RSYNC_ARGS} {local} {pod}@{namespace}:{remote}')
+                    for local, remote in self.paths
+                ]
+            )
             await check_shell(f'kubectl exec {pod} --namespace {namespace} -- kill -2 1')
         except CalledProcessError:
             log.warning(f'could not initialize {namespace}/{pod}', exc_info=True)
@@ -67,30 +73,28 @@ class Sync:
         while True:
             log.info('monitor_pods: start loop')
             updated_pods = await retry_transient_errors(
-                k8s.list_namespaced_pod,
-                namespace,
-                label_selector=f'app in ({",".join(apps)})')
-            updated_pods = [x for x in updated_pods.items
-                            if x.status.phase == 'Running'
-                            if all(s.ready for s in x.status.container_statuses)]
+                k8s.list_namespaced_pod, namespace, label_selector=f'app in ({",".join(apps)})'
+            )
+            updated_pods = [
+                x
+                for x in updated_pods.items
+                if x.status.phase == 'Running'
+                if all(s.ready for s in x.status.container_statuses)
+            ]
             updated_pods = {(pod.metadata.name, namespace) for pod in updated_pods}
             fresh_pods = updated_pods - self.pods
             dead_pods = self.pods - updated_pods
             log.info(f'monitor_pods: fresh_pods: {fresh_pods}')
             log.info(f'monitor_pods: dead_pods: {dead_pods}')
             self.pods = self.pods - dead_pods
-            await asyncio.gather(*[
-                self.initialize_pod(name, namespace)
-                for name, namespace in fresh_pods])
+            await asyncio.gather(*[self.initialize_pod(name, namespace) for name, namespace in fresh_pods])
             await asyncio.sleep(5)
 
     async def update_loop(self):
         while True:
             await self.should_sync_event.wait()
             self.should_sync_event.clear()
-            await asyncio.gather(*[
-                self.sync_and_restart_pod(pod, namespace)
-                for pod, namespace in self.pods])
+            await asyncio.gather(*[self.sync_and_restart_pod(pod, namespace) for pod, namespace in self.pods])
 
     async def should_sync(self):
         self.should_sync_event.set()
@@ -100,29 +104,24 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog='sync.py',
         description='Develop locally, deploy cloudly.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        '--app',
-        action='append',
-        type=str,
-        help='An app label to watch.')
-    parser.add_argument(
-        '--namespace',
-        required=False,
-        type=str,
-        help='The namespace in which to watch.')
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument('--app', action='append', type=str, help='An app label to watch.')
+    parser.add_argument('--namespace', required=False, type=str, help='The namespace in which to watch.')
     parser.add_argument(
         '--path',
         action='append',
         nargs='+',
         metavar=('local', 'remote'),
-        help='The local path will be kept in sync with the remote path.')
+        help='The local path will be kept in sync with the remote path.',
+    )
     parser.add_argument(
         '--ignore',
         required=False,
         type=str,
         default='flycheck_.*|.*~|\.#.*',
-        help='A regular expression indicating in which files to ignore changes.')
+        help='A regular expression indicating in which files to ignore changes.',
+    )
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -144,9 +143,7 @@ if __name__ == '__main__':
             monitor.set_callback(callback)
 
             signal.signal(signal.SIGINT, monitor._handle_signal)
-            thread = Thread(target=libfswatch.fsw_start_monitor,
-                            args=(monitor.handle,),
-                            daemon=True)
+            thread = Thread(target=libfswatch.fsw_start_monitor, args=(monitor.handle,), daemon=True)
             thread.start()
             loop.run_until_complete(sync.monitor_pods(args.app, args.namespace))
         finally:

--- a/etc/pdf-split-shuffle-partition/doit.py
+++ b/etc/pdf-split-shuffle-partition/doit.py
@@ -11,11 +11,15 @@ apps = [x for x in range(1, int(sys.argv[1]) + 1)]
 shuffle(apps)
 for idx, line in enumerate(numpy.array_split(apps, len(reviewers))):
     pdfs = [f'build/split.d/{x}.pdf' for x in line]
-    sp.run(['gs',
+    sp.run(
+        [
+            'gs',
             '-q',
             '-dNOPAUSE',
             '-dBATCH',
             '-sDEVICE=pdfwrite',
             f'-sOutputFile=build/packets.d/{reviewers[idx]}.pdf',
-            *pdfs],
-           check=True)
+            *pdfs,
+        ],
+        check=True,
+    )

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,8 +1,15 @@
 from .database import create_database_pool, Database, transaction
 from .session import setup_aiohttp_session
-from .auth import userdata_from_web_request, userdata_from_rest_request, \
-    web_authenticated_users_only, web_maybe_authenticated_user, rest_authenticated_users_only, \
-    web_authenticated_developers_only, rest_authenticated_developers_only, maybe_parse_bearer_header
+from .auth import (
+    userdata_from_web_request,
+    userdata_from_rest_request,
+    web_authenticated_users_only,
+    web_maybe_authenticated_user,
+    rest_authenticated_users_only,
+    web_authenticated_developers_only,
+    rest_authenticated_developers_only,
+    maybe_parse_bearer_header,
+)
 from .csrf import new_csrf_token, check_csrf_token
 from .auth_utils import insert_user, create_session
 from .metrics import monitor_endpoint
@@ -24,5 +31,5 @@ __all__ = [
     'create_session',
     'transaction',
     'maybe_parse_bearer_header',
-    'monitor_endpoint'
+    'monitor_endpoint',
 ]

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -17,7 +17,7 @@ BEARER = 'Bearer '
 
 def maybe_parse_bearer_header(value: str) -> Optional[str]:
     if value.startswith(BEARER):
-        return value[len(BEARER):]
+        return value[len(BEARER) :]
     return None
 
 
@@ -58,6 +58,7 @@ def rest_authenticated_users_only(fun):
                 return web.HTTPUnauthorized(reason="provided web auth to REST endpoint")
             raise web.HTTPUnauthorized()
         return await fun(request, userdata, *args, **kwargs)
+
     return wrapped
 
 
@@ -90,7 +91,9 @@ def web_authenticated_users_only(redirect=True):
                     return web.HTTPUnauthorized(reason="provided REST auth to web endpoint")
                 raise _web_unauthorized(request, redirect)
             return await fun(request, userdata, *args, **kwargs)
+
         return wrapped
+
     return wrap
 
 
@@ -98,6 +101,7 @@ def web_maybe_authenticated_user(fun):
     @wraps(fun)
     async def wrapped(request, *args, **kwargs):
         return await fun(request, await userdata_from_web_request(request), *args, **kwargs)
+
     return wrapped
 
 
@@ -109,7 +113,9 @@ def web_authenticated_developers_only(redirect=True):
             if userdata['is_developer'] == 1:
                 return await fun(request, userdata, *args, **kwargs)
             raise _web_unauthorized(request, redirect)
+
         return wrapped
+
     return wrap
 
 
@@ -120,4 +126,5 @@ def rest_authenticated_developers_only(fun):
         if userdata['is_developer'] == 1:
             return await fun(request, userdata, *args, **kwargs)
         raise web.HTTPUnauthorized()
+
     return wrapped

--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -10,12 +10,15 @@ async def insert_user(db, spec):
 INSERT INTO users ({', '.join(spec.keys())})
 VALUES ({', '.join([f'%({k})s' for k in spec.keys()])})
 ''',
-        spec)
+        spec,
+    )
 
 
 # 2592000s = 30d
 async def create_session(db, user_id, max_age_secs=2592000):
     session_id = session_id_encode_to_str(secrets.token_bytes(32))
-    await db.just_execute('INSERT INTO sessions (session_id, user_id, max_age_secs) VALUES (%s, %s, %s);',
-                          (session_id, user_id, max_age_secs))
+    await db.just_execute(
+        'INSERT INTO sessions (session_id, user_id, max_age_secs) VALUES (%s, %s, %s);',
+        (session_id, user_id, max_age_secs),
+    )
     return session_id

--- a/gear/gear/csrf.py
+++ b/gear/gear/csrf.py
@@ -20,4 +20,5 @@ def check_csrf_token(fun):
             return await fun(request, *args, **kwargs)
         log.info('request made with invalid csrf tokens')
         raise web.HTTPUnauthorized()
+
     return wrapped

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -30,11 +30,15 @@ def retry_transient_mysql_errors(f):
                 return await f(*args, **kwargs)
             except pymysql.err.OperationalError as e:
                 if e.args[0] in retry_codes:
-                    log.warning(f'encountered pymysql error, retrying {e}', exc_info=True,
-                                extra={'full_stacktrace' : '\n'.join(traceback.format_stack())})
+                    log.warning(
+                        f'encountered pymysql error, retrying {e}',
+                        exc_info=True,
+                        extra={'full_stacktrace': '\n'.join(traceback.format_stack())},
+                    )
                 else:
                     raise
             delay = await sleep_and_backoff(delay)
+
     return wrapper
 
 
@@ -45,7 +49,9 @@ def transaction(db, **transaction_kwargs):
         async def wrapper(*args, **kwargs):
             async with db.start(**transaction_kwargs) as tx:
                 return await fun(tx, *args, **kwargs)
+
         return wrapper
+
     return transformer
 
 
@@ -59,8 +65,7 @@ async def aexit(acontext_manager, exc_type=None, exc_val=None, exc_tb=None):
 
 def get_sql_config(maybe_config_file: Optional[str] = None) -> SQLConfig:
     if maybe_config_file is None:
-        config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE',
-                                     '/sql-config/sql-config.json')
+        config_file = os.environ.get('HAIL_DATABASE_CONFIG_FILE', '/sql-config/sql-config.json')
     else:
         config_file = maybe_config_file
     with open(config_file, 'r') as f:
@@ -78,11 +83,8 @@ def get_database_ssl_context(sql_config: Optional[SQLConfig] = None) -> ssl.SSLC
     if database_ssl_context is None:
         if sql_config is None:
             sql_config = get_sql_config()
-        database_ssl_context = ssl.create_default_context(
-            cafile=sql_config.ssl_ca)
-        database_ssl_context.load_cert_chain(sql_config.ssl_cert,
-                                             keyfile=sql_config.ssl_key,
-                                             password=None)
+        database_ssl_context = ssl.create_default_context(cafile=sql_config.ssl_ca)
+        database_ssl_context.load_cert_chain(sql_config.ssl_cert, keyfile=sql_config.ssl_key, password=None)
         database_ssl_context.verify_mode = ssl.CERT_REQUIRED
         database_ssl_context.check_hostname = False
     return database_ssl_context
@@ -96,9 +98,16 @@ async def create_database_pool(config_file: str = None, autocommit: bool = True,
     return await aiomysql.create_pool(
         maxsize=maxsize,
         # connection args
-        host=sql_config.host, user=sql_config.user, password=sql_config.password,
-        db=sql_config.db, port=sql_config.port, charset='utf8',
-        ssl=ssl_context, cursorclass=aiomysql.cursors.DictCursor, autocommit=autocommit)
+        host=sql_config.host,
+        user=sql_config.user,
+        password=sql_config.password,
+        db=sql_config.db,
+        port=sql_config.port,
+        charset='utf8',
+        ssl=ssl_context,
+        cursorclass=aiomysql.cursors.DictCursor,
+        autocommit=autocommit,
+    )
 
 
 class TransactionAsyncContextManager:

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -12,7 +12,10 @@ def monitor_endpoint(handler):
         # Use the path template given to @route.<METHOD>, not the fully resolved one
         endpoint = request.match_info.route.resource.canonical
         verb = request.method
-        response = await prom_async_time(REQUEST_TIME.labels(endpoint=endpoint, verb=verb), handler(request, *args, **kwargs))
+        response = await prom_async_time(
+            REQUEST_TIME.labels(endpoint=endpoint, verb=verb), handler(request, *args, **kwargs)
+        )
         REQUEST_COUNT.labels(endpoint=endpoint, verb=verb, status=response.status).inc()
         return response
+
     return wrapped

--- a/gear/gear/session.py
+++ b/gear/gear/session.py
@@ -7,11 +7,15 @@ from hailtop.config import get_deploy_config
 def setup_aiohttp_session(app):
     deploy_config = get_deploy_config()
     with open('/session-secret-key/session-secret-key', 'rb') as f:
-        aiohttp_session.setup(app, aiohttp_session.cookie_storage.EncryptedCookieStorage(
-            f.read(),
-            cookie_name=deploy_config.auth_session_cookie_name(),
-            secure=True,
-            httponly=True,
-            domain=os.environ['HAIL_DOMAIN'],
-            # 2592000s = 30d
-            max_age=2592000))
+        aiohttp_session.setup(
+            app,
+            aiohttp_session.cookie_storage.EncryptedCookieStorage(
+                f.read(),
+                cookie_name=deploy_config.auth_session_cookie_name(),
+                secure=True,
+                httponly=True,
+                domain=os.environ['HAIL_DOMAIN'],
+                # 2592000s = 30d
+                max_age=2592000,
+            ),
+        )

--- a/gear/setup.py
+++ b/gear/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'gear',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Utils for building services',
+    name='gear',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Utils for building services',
     package_data={"gear": ["py.typed"]},
-    packages = find_packages(),
-    include_package_data=True
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/memory/memory/__main__.py
+++ b/memory/memory/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -1,4 +1,3 @@
-
 import aiohttp
 import concurrent
 
@@ -10,8 +9,7 @@ from hailtop.utils import request_retry_transient_errors
 
 
 class MemoryClient:
-    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None,
-                 headers=None, _token=None):
+    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None, _token=None):
         if not deploy_config:
             self._deploy_config = get_deploy_config()
         else:
@@ -38,10 +36,9 @@ class MemoryClient:
     async def _get_file_if_exists(self, filename):
         params = {'q': filename}
         try:
-            async with await request_retry_transient_errors(self._session,
-                                                            'get', self.objects_url,
-                                                            params=params,
-                                                            headers=self._headers) as response:
+            async with await request_retry_transient_errors(
+                self._session, 'get', self.objects_url, params=params, headers=self._headers
+            ) as response:
                 return await response.read()
         except aiohttp.ClientResponseError as e:
             if e.status == 404:
@@ -56,11 +53,9 @@ class MemoryClient:
 
     async def write_file(self, filename, data):
         params = {'q': filename}
-        async with await request_retry_transient_errors(self._session,
-                                                        'post', self.objects_url,
-                                                        params=params,
-                                                        headers=self._headers,
-                                                        data=data) as response:
+        async with await request_retry_transient_errors(
+            self._session, 'post', self.objects_url, params=params, headers=self._headers, data=data
+        ) as response:
             assert response.status == 200
 
     async def close(self):

--- a/memory/setup.py
+++ b/memory/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'memory',
-    version = '0.0.2',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Caching service',
-    packages = find_packages(),
-    include_package_data=True)
+    name='memory',
+    version='0.0.2',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Caching service',
+    packages=find_packages(),
+    include_package_data=True,
+)

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -10,8 +10,7 @@ from hailtop.utils import async_to_blocking
 
 
 class BlockingMemoryClient:
-    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None,
-                 headers=None, _token=None):
+    def __init__(self, gcs_project=None, fs=None, deploy_config=None, session=None, headers=None, _token=None):
         self._client = MemoryClient(gcs_project, fs, deploy_config, session, headers, _token)
         async_to_blocking(self._client.async_init())
 

--- a/monitoring/monitoring/__main__.py
+++ b/monitoring/monitoring/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -8,5 +8,5 @@ setup(
     author_email='hail@broadinstitute.org',
     description='Monitoring service',
     packages=find_packages(),
-    include_package_data=True
+    include_package_data=True,
 )

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -23,7 +23,8 @@ async def test_billing_monitoring():
             data = None
             while data is None:
                 resp = await utils.request_retry_transient_errors(
-                    session, 'GET', f'{monitoring_deploy_config_url}', headers=headers)
+                    session, 'GET', f'{monitoring_deploy_config_url}', headers=headers
+                )
                 data = await resp.json()
                 await asyncio.sleep(5)
             return data

--- a/notebook/notebook/__main__.py
+++ b/notebook/notebook/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 configure_logging()
 
 from .notebook import run  # noqa: E402 pylint: disable=wrong-import-position

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -15,12 +15,16 @@ from prometheus_async.aio.web import server_stats  # type: ignore
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from gear import (setup_aiohttp_session, create_database_pool,
-                  web_authenticated_users_only, web_maybe_authenticated_user,
-                  web_authenticated_developers_only, check_csrf_token,
-                  monitor_endpoint)
-from web_common import (sass_compile, setup_aiohttp_jinja2,
-                        setup_common_static_routes, set_message, render_template)
+from gear import (
+    setup_aiohttp_session,
+    create_database_pool,
+    web_authenticated_users_only,
+    web_maybe_authenticated_user,
+    web_authenticated_developers_only,
+    check_csrf_token,
+    monitor_endpoint,
+)
+from web_common import sass_compile, setup_aiohttp_jinja2, setup_common_static_routes, set_message, render_template
 
 log = logging.getLogger('notebook')
 
@@ -54,8 +58,8 @@ async def workshop_userdata_from_web_request(request):
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
             await cursor.execute(
-                'SELECT * FROM workshops WHERE name = %s AND token = %s AND active = 1;',
-                (name, token))
+                'SELECT * FROM workshops WHERE name = %s AND token = %s AND active = 1;', (name, token)
+            )
             workshops = await cursor.fetchall()
 
             if len(workshops) != 1:
@@ -64,16 +68,14 @@ async def workshop_userdata_from_web_request(request):
                 return None
             workshop = workshops[0]
 
-    return {
-        'id': workshop_session['id'],
-        'workshop': workshop
-    }
+    return {'id': workshop_session['id'], 'workshop': workshop}
 
 
 def web_maybe_authenticated_workshop_guest(fun):
     @wraps(fun)
     async def wrapped(request, *args, **kwargs):
         return await fun(request, await workshop_userdata_from_web_request(request), *args, **kwargs)
+
     return wrapped
 
 
@@ -87,7 +89,9 @@ def web_authenticated_workshop_guest_only(redirect=True):
                     return web.HTTPFound(deploy_config.external_url('workshop', '/login'))
                 raise web.HTTPUnauthorized()
             return await fun(request, userdata, *args, **kwargs)
+
         return wrapped
+
     return wrap
 
 
@@ -99,7 +103,10 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
         'notebook',
         f'--NotebookApp.token={jupyter_token}',
         f'--NotebookApp.base_url={service_base_path}/instance/{notebook_token}/',
-        "--ip", "0.0.0.0", "--no-browser", "--allow-root"
+        "--ip",
+        "0.0.0.0",
+        "--no-browser",
+        "--allow-root",
     ]
 
     if service == 'notebook':
@@ -110,41 +117,27 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
 
         image = DEFAULT_WORKER_IMAGE
 
-        env = [kube.client.V1EnvVar(name='HAIL_DEPLOY_CONFIG_FILE',
-                                    value='/deploy-config/deploy-config.json')]
+        env = [kube.client.V1EnvVar(name='HAIL_DEPLOY_CONFIG_FILE', value='/deploy-config/deploy-config.json')]
 
         tokens_secret_name = userdata['tokens_secret_name']
         gsa_key_secret_name = userdata['gsa_key_secret_name']
         volumes = [
             kube.client.V1Volume(
-                name='deploy-config',
-                secret=kube.client.V1SecretVolumeSource(
-                    secret_name='deploy-config')),
+                name='deploy-config', secret=kube.client.V1SecretVolumeSource(secret_name='deploy-config')
+            ),
             kube.client.V1Volume(
-                name='gsa-key',
-                secret=kube.client.V1SecretVolumeSource(
-                    secret_name=gsa_key_secret_name)),
+                name='gsa-key', secret=kube.client.V1SecretVolumeSource(secret_name=gsa_key_secret_name)
+            ),
             kube.client.V1Volume(
-                name='user-tokens',
-                secret=kube.client.V1SecretVolumeSource(
-                    secret_name=tokens_secret_name))
+                name='user-tokens', secret=kube.client.V1SecretVolumeSource(secret_name=tokens_secret_name)
+            ),
         ]
         volume_mounts = [
-            kube.client.V1VolumeMount(
-                mount_path='/deploy-config',
-                name='deploy-config',
-                read_only=True),
-            kube.client.V1VolumeMount(
-                mount_path='/gsa-key',
-                name='gsa-key',
-                read_only=True),
-            kube.client.V1VolumeMount(
-                mount_path='/user-tokens',
-                name='user-tokens',
-                read_only=True)
+            kube.client.V1VolumeMount(mount_path='/deploy-config', name='deploy-config', read_only=True),
+            kube.client.V1VolumeMount(mount_path='/gsa-key', name='gsa-key', read_only=True),
+            kube.client.V1VolumeMount(mount_path='/user-tokens', name='user-tokens', read_only=True),
         ]
-        resources = kube.client.V1ResourceRequirements(
-            requests={'cpu': '1.601', 'memory': '1.601G'})
+        resources = kube.client.V1ResourceRequirements(requests={'cpu': '1.601', 'memory': '1.601G'})
     else:
         workshop = userdata['workshop']
 
@@ -157,8 +150,8 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
         cpu = workshop['cpu']
         memory = workshop['memory']
         resources = kube.client.V1ResourceRequirements(
-            requests={'cpu': cpu, 'memory': memory},
-            limits={'cpu': cpu, 'memory': memory})
+            requests={'cpu': cpu, 'memory': memory}, limits={'cpu': cpu, 'memory': memory}
+        )
 
     pod_spec = kube.client.V1PodSpec(
         node_selector={'preemptible': 'false'},
@@ -171,23 +164,22 @@ async def start_pod(k8s, service, userdata, notebook_token, jupyter_token):
                 env=env,
                 ports=[kube.client.V1ContainerPort(container_port=POD_PORT)],
                 resources=resources,
-                volume_mounts=volume_mounts)
+                volume_mounts=volume_mounts,
+            )
         ],
-        volumes=volumes)
+        volumes=volumes,
+    )
 
     user_id = str(userdata['id'])
     pod_template = kube.client.V1Pod(
         metadata=kube.client.V1ObjectMeta(
-            generate_name='notebook-worker-',
-            labels={
-                'app': 'notebook-worker',
-                'user_id': user_id
-            }),
-        spec=pod_spec)
+            generate_name='notebook-worker-', labels={'app': 'notebook-worker', 'user_id': user_id}
+        ),
+        spec=pod_spec,
+    )
     pod = await k8s.create_namespaced_pod(
-        NOTEBOOK_NAMESPACE,
-        pod_template,
-        _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+        NOTEBOOK_NAMESPACE, pod_template, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+    )
 
     return pod
 
@@ -202,10 +194,7 @@ def notebook_status_from_pod(pod):
             for c in pod.status.conditions:
                 if c.type == 'Ready' and c.status == 'True':
                     state = 'Initializing'
-    return {
-        'pod_ip': pod_ip,
-        'state': state
-    }
+    return {'pod_ip': pod_ip, 'state': state}
 
 
 async def k8s_notebook_status_from_notebook(k8s, notebook):
@@ -214,9 +203,8 @@ async def k8s_notebook_status_from_notebook(k8s, notebook):
 
     try:
         pod = await k8s.read_namespaced_pod(
-            name=notebook['pod_name'],
-            namespace=NOTEBOOK_NAMESPACE,
-            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+            name=notebook['pod_name'], namespace=NOTEBOOK_NAMESPACE, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+        )
         return notebook_status_from_pod(pod)
     except kube.client.rest.ApiException as e:
         if e.status == 404:
@@ -238,13 +226,12 @@ async def notebook_status_from_notebook(k8s, service, headers, cookies, notebook
 
             # don't have dev credentials to connect through internal.hail.is
             ready_url = deploy_config.external_url(
-                service,
-                f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}')
+                service, f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}'
+            )
             try:
                 async with aiohttp.ClientSession(
-                        timeout=aiohttp.ClientTimeout(total=1),
-                        headers=headers,
-                        cookies=cookies) as session:
+                    timeout=aiohttp.ClientTimeout(total=1), headers=headers, cookies=cookies
+                ) as session:
                     async with session.get(ready_url) as resp:
                         if resp.status >= 200 and resp.status < 300:
                             log.info(f'GET on jupyter pod {pod_name} succeeded: {resp}')
@@ -261,16 +248,15 @@ async def update_notebook_return_changed(dbpool, user_id, notebook, new_status):
     if not new_status:
         async with dbpool.acquire() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(
-                    'DELETE FROM notebooks WHERE user_id = %s;',
-                    user_id)
+                await cursor.execute('DELETE FROM notebooks WHERE user_id = %s;', user_id)
                 return True
     if new_status['state'] != notebook['state']:
         async with dbpool.acquire() as conn:
             async with conn.cursor() as cursor:
                 await cursor.execute(
                     'UPDATE notebooks SET state = %s, pod_ip = %s WHERE user_id = %s;',
-                    (new_status['state'], new_status['pod_ip'], user_id))
+                    (new_status['state'], new_status['pod_ip'], user_id),
+                )
         return True
     return False
 
@@ -289,10 +275,7 @@ async def get_user_notebook(dbpool, user_id):
 
 async def delete_worker_pod(k8s, pod_name):
     try:
-        await k8s.delete_namespaced_pod(
-            pod_name,
-            NOTEBOOK_NAMESPACE,
-            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+        await k8s.delete_namespaced_pod(pod_name, NOTEBOOK_NAMESPACE, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
     except kube.client.rest.ApiException as e:
         log.info(f'pod {pod_name} already deleted {e}')
 
@@ -312,10 +295,7 @@ async def index(request, userdata):  # pylint: disable=unused-argument
 async def _get_notebook(service, request, userdata):
     app = request.app
     dbpool = app['dbpool']
-    page_context = {
-        'notebook': await get_user_notebook(dbpool, str(userdata['id'])),
-        'notebook_service': service
-    }
+    page_context = {'notebook': await get_user_notebook(dbpool, str(userdata['id'])), 'notebook_service': service}
     return await render_template(service, request, userdata, 'notebook.html', page_context)
 
 
@@ -341,10 +321,10 @@ async def _post_notebook(service, request, userdata):
 DELETE FROM notebooks WHERE user_id = %s;
 INSERT INTO notebooks (user_id, notebook_token, pod_name, state, pod_ip, jupyter_token) VALUES (%s, %s, %s, %s, %s, %s);
 ''',
-                (user_id, user_id, notebook_token, pod.metadata.name, state, pod.status.pod_ip, jupyter_token))
+                (user_id, user_id, notebook_token, pod.metadata.name, state, pod.status.pod_ip, jupyter_token),
+            )
 
-    return web.HTTPFound(
-        location=deploy_config.external_url(service, '/notebook'))
+    return web.HTTPFound(location=deploy_config.external_url(service, '/notebook'))
 
 
 async def _delete_notebook(service, request, userdata):
@@ -357,8 +337,7 @@ async def _delete_notebook(service, request, userdata):
         await delete_worker_pod(k8s, notebook['pod_name'])
         async with dbpool.acquire() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(
-                    'DELETE FROM notebooks WHERE user_id = %s;', user_id)
+                await cursor.execute('DELETE FROM notebooks WHERE user_id = %s;', user_id)
 
     return web.HTTPFound(location=deploy_config.external_url(service, '/notebook'))
 
@@ -388,7 +367,7 @@ async def _wait_websocket(service, request, userdata):
     if 'sesh' in request.cookies:
         cookies['sesh'] = request.cookies['sesh']
 
-    ready = (notebook['state'] == 'Ready')
+    ready = notebook['state'] == 'Ready'
     count = 0
     while count < 10:
         try:
@@ -428,16 +407,18 @@ async def _get_error(service, request, userdata):
     session = await aiohttp_session.get_session(request)
     if notebook:
         if new_status['state'] == 'Ready':
-            return web.HTTPFound(deploy_config.external_url(
-                service,
-                f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}'))
-        set_message(session,
-                    'Could not connect to Jupyter instance.  Please wait for Jupyter to be ready and try again.',
-                    'error')
+            return web.HTTPFound(
+                deploy_config.external_url(
+                    service, f'/instance/{notebook["notebook_token"]}/?token={notebook["jupyter_token"]}'
+                )
+            )
+        set_message(
+            session,
+            'Could not connect to Jupyter instance.  Please wait for Jupyter to be ready and try again.',
+            'error',
+        )
     else:
-        set_message(session,
-                    'Jupyter instance not found.  Please launch a new instance.',
-                    'error')
+        set_message(session, 'Jupyter instance not found.  Please launch a new instance.', 'error')
     return web.HTTPFound(deploy_config.external_url(service, '/notebook'))
 
 
@@ -450,9 +431,7 @@ async def _get_auth(request, userdata):
     if notebook and notebook['notebook_token'] == requested_notebook_token:
         pod_ip = notebook['pod_ip']
         if pod_ip:
-            return web.Response(headers={
-                'pod_ip': f'{pod_ip}:{POD_PORT}'
-            })
+            return web.Response(headers={'pod_ip': f'{pod_ip}:{POD_PORT}'})
 
     return web.HTTPForbidden()
 
@@ -521,9 +500,7 @@ async def workshop_admin(request, userdata):
             await cursor.execute('SELECT * FROM workshops')
             workshops = await cursor.fetchall()
 
-    page_context = {
-        'workshops': workshops
-    }
+    page_context = {'workshops': workshops}
     return await render_template('notebook', request, userdata, 'workshop-admin.html', page_context)
 
 
@@ -540,27 +517,21 @@ async def create_workshop(request, userdata):  # pylint: disable=unused-argument
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
             try:
-                active = (post.get('active') == 'on')
+                active = post.get('active') == 'on'
                 if active:
                     token = secrets.token_urlsafe(32)
                 else:
                     token = None
-                await cursor.execute('''
+                await cursor.execute(
+                    '''
 INSERT INTO workshops (name, image, cpu, memory, password, active, token) VALUES (%s, %s, %s, %s, %s, %s, %s);
 ''',
-                                     (name,
-                                      post['image'],
-                                      post['cpu'],
-                                      post['memory'],
-                                      post['password'],
-                                      active,
-                                      token))
+                    (name, post['image'], post['cpu'], post['memory'], post['password'], active, token),
+                )
                 set_message(session, f'Created workshop {name}.', 'info')
             except pymysql.err.IntegrityError as e:
                 if e.args[0] == 1062:  # duplicate error
-                    set_message(session,
-                                f'Cannot create workshop {name}: duplicate name.',
-                                'error')
+                    set_message(session, f'Cannot create workshop {name}: duplicate name.', 'error')
                 else:
                     raise
 
@@ -581,27 +552,20 @@ async def update_workshop(request, userdata):  # pylint: disable=unused-argument
     session = await aiohttp_session.get_session(request)
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
-            active = (post.get('active') == 'on')
+            active = post.get('active') == 'on'
             # FIXME don't set token unless re-activating
             if active:
                 token = secrets.token_urlsafe(32)
             else:
                 token = None
-            n = await cursor.execute('''
+            n = await cursor.execute(
+                '''
 UPDATE workshops SET name = %s, image = %s, cpu = %s, memory = %s, password = %s, active = %s, token = %s WHERE id = %s;
 ''',
-                                     (name,
-                                      post['image'],
-                                      post['cpu'],
-                                      post['memory'],
-                                      post['password'],
-                                      active,
-                                      token,
-                                      id))
+                (name, post['image'], post['cpu'], post['memory'], post['password'], active, token, id),
+            )
             if n == 0:
-                set_message(session,
-                            f'Internal error: cannot update workshop: workshop ID {id} not found.',
-                            'error')
+                set_message(session, f'Internal error: cannot update workshop: workshop ID {id} not found.', 'error')
             else:
                 set_message(session, f'Updated workshop {name}.', 'info')
 
@@ -620,9 +584,12 @@ async def delete_workshop(request, userdata):  # pylint: disable=unused-argument
     name = post['name']
     async with dbpool.acquire() as conn:
         async with conn.cursor() as cursor:
-            n = await cursor.execute('''
+            n = await cursor.execute(
+                '''
 DELETE FROM workshops WHERE name = %s;
-''', name)
+''',
+                name,
+            )
 
     session = await aiohttp_session.get_session(request)
     if n == 1:
@@ -641,9 +608,7 @@ workshop_routes = web.RouteTableDef()
 @monitor_endpoint
 @web_maybe_authenticated_workshop_guest
 async def workshop_get_index(request, userdata):
-    page_context = {
-        'notebook_service': 'workshop'
-    }
+    page_context = {'notebook_service': 'workshop'}
     return await render_template('workshop', request, userdata, 'workshop/index.html', page_context)
 
 
@@ -654,9 +619,7 @@ async def workshop_get_login(request, userdata):
     if userdata:
         return web.HTTPFound(location=deploy_config.external_url('workshop', '/notebook'))
 
-    page_context = {
-        'notebook_service': 'workshop'
-    }
+    page_context = {'notebook_service': 'workshop'}
     return await render_template('workshop', request, userdata, 'workshop/login.html', page_context)
 
 
@@ -678,25 +641,19 @@ async def workshop_post_login(request):
 SELECT * FROM workshops
 WHERE name = %s AND password = %s AND active = 1;
 ''',
-                (name, password))
+                (name, password),
+            )
             workshops = await cursor.fetchall()
 
             if len(workshops) != 1:
                 assert len(workshops) == 0
-                set_message(
-                    session,
-                    'Workshop Inactive!',
-                    'error')
+                set_message(session, 'Workshop Inactive!', 'error')
                 return web.HTTPFound(location=deploy_config.external_url('workshop', '/login'))
             workshop = workshops[0]
 
     # use hex since K8s labels can't start or end with _ or -
     user_id = secrets.token_hex(16)
-    session['workshop_session'] = {
-        'workshop_name': name,
-        'workshop_token': workshop['token'],
-        'id': user_id
-    }
+    session['workshop_session'] = {'workshop_name': name, 'workshop_token': workshop['token'], 'id': user_id}
 
     set_message(session, f'Welcome to the {name} workshop!', 'info')
 
@@ -719,8 +676,7 @@ async def workshop_post_logout(request, userdata):
         await delete_worker_pod(k8s, notebook['pod_name'])
         async with dbpool.acquire() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(
-                    'DELETE FROM notebooks WHERE user_id = %s;', user_id)
+                await cursor.execute('DELETE FROM notebooks WHERE user_id = %s;', user_id)
 
     session = await aiohttp_session.get_session(request)
     if 'workshop_session' in session:
@@ -733,9 +689,7 @@ async def workshop_post_logout(request, userdata):
 @monitor_endpoint
 @web_maybe_authenticated_workshop_guest
 async def workshop_get_faq(request, userdata):
-    page_context = {
-        'notebook_service': 'workshop'
-    }
+    page_context = {'notebook_service': 'workshop'}
     return await render_template('workshop', request, userdata, 'workshop/resources.html', page_context)
 
 
@@ -821,13 +775,9 @@ def run():
     workshop_app = init_app(workshop_routes)
 
     root_app = web.Application()
-    root_app.add_domain('notebook*',
-                        deploy_config.prefix_application(notebook_app, 'notebook'))
-    root_app.add_domain('workshop*',
-                        deploy_config.prefix_application(workshop_app, 'workshop'))
+    root_app.add_domain('notebook*', deploy_config.prefix_application(notebook_app, 'notebook'))
+    root_app.add_domain('workshop*', deploy_config.prefix_application(workshop_app, 'workshop'))
     root_app.router.add_get("/metrics", server_stats)
-    web.run_app(root_app,
-                host='0.0.0.0',
-                port=5000,
-                access_log_class=AccessLogger,
-                ssl_context=internal_server_ssl_context())
+    web.run_app(
+        root_app, host='0.0.0.0', port=5000, access_log_class=AccessLogger, ssl_context=internal_server_ssl_context()
+    )

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -28,45 +28,33 @@ async def run(args, i):
 
     async with client_session() as session:
         # make sure notebook is up
-        async with session.get(
-                deploy_config.url('workshop', ''),
-                headers=headers) as resp:
+        async with session.get(deploy_config.url('workshop', ''), headers=headers) as resp:
             await resp.text()
 
         log.info(f'{i} loaded notebook home page')
 
         # log in as workshop guest
         # get csrf token
-        async with session.get(
-                deploy_config.url('workshop', '/login'),
-                headers=headers) as resp:
+        async with session.get(deploy_config.url('workshop', '/login'), headers=headers) as resp:
             pass
 
         data = aiohttp.FormData()
         data.add_field(name='name', value=args.workshop)
         data.add_field(name='password', value=args.password)
         data.add_field(name='_csrf', value=get_cookie(session, '_csrf'))
-        async with session.post(
-                deploy_config.url('workshop', '/login'),
-                data=data,
-                headers=headers) as resp:
+        async with session.post(deploy_config.url('workshop', '/login'), data=data, headers=headers) as resp:
             pass
 
         log.info(f'{i} logged in')
 
         # create notebook
         # get csrf token
-        async with session.get(
-                deploy_config.url('workshop', '/notebook'),
-                headers=headers) as resp:
+        async with session.get(deploy_config.url('workshop', '/notebook'), headers=headers) as resp:
             pass
 
         data = aiohttp.FormData()
         data.add_field(name='_csrf', value=get_cookie(session, '_csrf'))
-        async with session.post(
-                deploy_config.url('workshop', '/notebook'),
-                data=data,
-                headers=headers) as resp:
+        async with session.post(deploy_config.url('workshop', '/notebook'), data=data, headers=headers) as resp:
             pass
 
         log.info(f'{i} created notebook')
@@ -79,8 +67,8 @@ async def run(args, i):
         # 5 attempts overkill, should only take 2: Scheduling => Running => Ready
         while not ready and attempt < 5:
             async with session.ws_connect(
-                    deploy_config.url('workshop', '/notebook/wait', base_scheme='ws'),
-                    headers=headers) as ws:
+                deploy_config.url('workshop', '/notebook/wait', base_scheme='ws'), headers=headers
+            ) as ws:
                 async for msg in ws:
                     if msg.data == '1':
                         ready = True
@@ -93,17 +81,12 @@ async def run(args, i):
 
         # delete notebook
         # get csrf token
-        async with session.get(
-                deploy_config.url('workshop', '/notebook'),
-                headers=headers) as resp:
+        async with session.get(deploy_config.url('workshop', '/notebook'), headers=headers) as resp:
             pass
 
         data = aiohttp.FormData()
         data.add_field(name='_csrf', value=get_cookie(session, '_csrf'))
-        async with session.post(
-                deploy_config.url('workshop', '/notebook/delete'),
-                data=data,
-                headers=headers) as resp:
+        async with session.post(deploy_config.url('workshop', '/notebook/delete'), data=data, headers=headers) as resp:
             pass
 
         log.info(f'{i} notebook delete, done.')
@@ -112,8 +95,7 @@ async def run(args, i):
 
 
 async def main():
-    parser = argparse.ArgumentParser(
-        description='Notebook scale test.')
+    parser = argparse.ArgumentParser(description='Notebook scale test.')
     parser.add_argument('n', type=int, help='number of notebooks to start')
     parser.add_argument('workshop', type=str, help='workshop name')
     parser.add_argument('password', type=str, help='workshop password')
@@ -121,8 +103,7 @@ async def main():
 
     n = args.n
     d = int(math.log10(n)) + 1
-    outcomes = await asyncio.gather(
-        *[run(args, str(i).zfill(d)) for i in range(n)])
+    outcomes = await asyncio.gather(*[run(args, str(i).zfill(d)) for i in range(n)])
 
     times = []
     for duration, ready in outcomes:

--- a/notebook/setup.py
+++ b/notebook/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'notebook',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Notebook service',
-    packages = find_packages(),
-    include_package_data=True
+    name='notebook',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Notebook service',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+exclude = 'hail|datasets|sql|\.mypy'

--- a/query/query/__main__.py
+++ b/query/query/__main__.py
@@ -1,4 +1,5 @@
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -16,7 +16,12 @@ from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
 from hailtop import version
-from gear import setup_aiohttp_session, rest_authenticated_users_only, rest_authenticated_developers_only, monitor_endpoint
+from gear import (
+    setup_aiohttp_session,
+    rest_authenticated_users_only,
+    rest_authenticated_developers_only,
+    monitor_endpoint,
+)
 
 from .sockets import connect_to_java
 
@@ -35,10 +40,8 @@ async def add_user(app, userdata):
 
     k8s_client = app['k8s_client']
     gsa_key_secret = await retry_transient_errors(
-        k8s_client.read_namespaced_secret,
-        userdata['gsa_key_secret_name'],
-        DEFAULT_NAMESPACE,
-        _request_timeout=5.0)
+        k8s_client.read_namespaced_secret, userdata['gsa_key_secret_name'], DEFAULT_NAMESPACE, _request_timeout=5.0
+    )
 
     if username in users:
         return
@@ -57,13 +60,20 @@ def blocking_execute(userdata, body):
     with connect_to_java() as java:
         log.info(f'executing {body["token"]}')
         return java.execute(
-            userdata['username'], userdata['session_id'], body['billing_project'], body['bucket'], body['code'], body['token'])
+            userdata['username'],
+            userdata['session_id'],
+            body['billing_project'],
+            body['bucket'],
+            body['code'],
+            body['token'],
+        )
 
 
 def blocking_load_references_from_dataset(userdata, body):
     with connect_to_java() as java:
         return java.load_references_from_dataset(
-            userdata['username'], body['billing_project'], body['bucket'], body['path'])
+            userdata['username'], body['billing_project'], body['bucket'], body['path']
+        )
 
 
 def blocking_value_type(userdata, body):
@@ -86,7 +96,7 @@ def blocking_blockmatrix_type(userdata, body):
         return java.block_matrix_type(userdata['username'], body['code'])
 
 
-def blocking_get_reference(userdata, body):   # pylint: disable=unused-argument
+def blocking_get_reference(userdata, body):  # pylint: disable=unused-argument
     with connect_to_java() as java:
         return java.reference_genome(userdata['username'], body['name'])
 
@@ -102,12 +112,13 @@ async def handle_ws_response(request, userdata, endpoint, f):
     query = user_queries.get(body['token'])
     if query is None:
         await add_user(app, userdata)
-        query = asyncio.ensure_future(
-            retry_transient_errors(blocking_to_async, app['thread_pool'], f, userdata, body))
+        query = asyncio.ensure_future(retry_transient_errors(blocking_to_async, app['thread_pool'], f, userdata, body))
         user_queries[body['token']] = query
 
     try:
-        receive = asyncio.ensure_future(ws.receive_str())  # receive automatically ping-pongs which keeps the socket alive
+        receive = asyncio.ensure_future(
+            ws.receive_str()
+        )  # receive automatically ping-pongs which keeps the socket alive
         await asyncio.wait([receive, query], return_when=asyncio.FIRST_COMPLETED)
         if receive.done():
             # we expect no messages from the client
@@ -141,7 +152,9 @@ async def execute(request, userdata):
 @monitor_endpoint
 @rest_authenticated_users_only
 async def load_references_from_dataset(request, userdata):
-    return await handle_ws_response(request, userdata, 'load_references_from_dataset', blocking_load_references_from_dataset)
+    return await handle_ws_response(
+        request, userdata, 'load_references_from_dataset', blocking_load_references_from_dataset
+    )
 
 
 @routes.get('/api/v1alpha/type/value')
@@ -267,5 +280,5 @@ def run():
         host='0.0.0.0',
         port=5000,
         access_log_class=AccessLogger,
-        ssl_context=internal_server_ssl_context()
+        ssl_context=internal_server_ssl_context(),
     )

--- a/query/query/sockets.py
+++ b/query/query/sockets.py
@@ -38,9 +38,7 @@ class ServiceBackendSocketConnection:
 
     def __enter__(self) -> 'ServiceBackendSocketConnection':
         self._conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # pylint: disable=attribute-defined-outside-init
-        sync_retry_transient_errors(
-            self._conn.connect,
-            ServiceBackendSocketConnection.FNAME)
+        sync_retry_transient_errors(self._conn.connect, ServiceBackendSocketConnection.FNAME)
         return self
 
     def __exit__(self, type, value, traceback):

--- a/query/setup.py
+++ b/query/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'query',
-    version = '0.0.2',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Query service',
-    packages = find_packages(),
-    include_package_data=True)
+    name='query',
+    version='0.0.2',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Query service',
+    packages=find_packages(),
+    include_package_data=True,
+)

--- a/web_common/setup.py
+++ b/web_common/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'web_common',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'Shared web support',
+    name='web_common',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='Shared web support',
     package_data={"web_common": ["py.typed"]},
-    packages = find_packages(),
-    include_package_data=True
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/web_common/web_common/__init__.py
+++ b/web_common/web_common/__init__.py
@@ -1,5 +1,11 @@
-from .web_common import sass_compile, setup_aiohttp_jinja2, setup_common_static_routes, \
-    set_message, base_context, render_template
+from .web_common import (
+    sass_compile,
+    setup_aiohttp_jinja2,
+    setup_common_static_routes,
+    set_message,
+    base_context,
+    render_template,
+)
 
 __all__ = [
     'sass_compile',
@@ -7,5 +13,5 @@ __all__ = [
     'setup_common_static_routes',
     'set_message',
     'base_context',
-    'render_template'
+    'render_template',
 ]

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -22,18 +22,14 @@ def sass_compile(module_name):
     os.makedirs(scss_path, exist_ok=True)
     os.makedirs(css_path, exist_ok=True)
 
-    sass.compile(
-        dirname=(scss_path, css_path), output_style='compressed',
-        include_paths=[f'{WEB_COMMON_ROOT}/styles'])
+    sass.compile(dirname=(scss_path, css_path), output_style='compressed', include_paths=[f'{WEB_COMMON_ROOT}/styles'])
 
 
 def setup_aiohttp_jinja2(app: aiohttp.web.Application, module: str, *extra_loaders: jinja2.BaseLoader):
     aiohttp_jinja2.setup(
-        app, loader=jinja2.ChoiceLoader([
-            jinja2.PackageLoader('web_common'),
-            jinja2.PackageLoader(module),
-            *extra_loaders
-        ]))
+        app,
+        loader=jinja2.ChoiceLoader([jinja2.PackageLoader('web_common'), jinja2.PackageLoader(module), *extra_loaders]),
+    )
 
 
 _compiled = False
@@ -50,10 +46,7 @@ def setup_common_static_routes(routes):
 
 def set_message(session, text, type):
     assert type in ('info', 'error')
-    session['message'] = {
-        'text': text,
-        'type': type
-    }
+    session['message'] = {'text': text, 'type': type}
 
 
 def base_context(session, userdata, service):
@@ -71,7 +64,7 @@ def base_context(session, userdata, service):
         'monitoring_base_url': deploy_config.external_url('monitoring', ''),
         'benchmark_base_url': deploy_config.external_url('benchmark', ''),
         'blog_base_url': deploy_config.external_url('blog', ''),
-        'userdata': userdata
+        'userdata': userdata,
     }
     if 'message' in session:
         context['message'] = session.pop('message')

--- a/website/setup.py
+++ b/website/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(
-    name = 'website',
-    version = '0.0.1',
-    url = 'https://github.com/hail-is/hail.git',
-    author = 'Hail Team',
-    author_email = 'hail@broadinstitute.org',
-    description = 'website',
-    packages = find_packages(),
-    include_package_data=True
+    name='website',
+    version='0.0.1',
+    url='https://github.com/hail-is/hail.git',
+    author='Hail Team',
+    author_email='hail@broadinstitute.org',
+    description='website',
+    packages=find_packages(),
+    include_package_data=True,
 )

--- a/website/website/__main__.py
+++ b/website/website/__main__.py
@@ -1,14 +1,15 @@
 import sys
 from hailtop.hail_logging import configure_logging
+
 # configure logging before importing anything else
 configure_logging()
 
 from .website import run  # noqa: E402 pylint: disable=wrong-import-position
 
-local_mode=False
+local_mode = False
 
 if len(sys.argv) > 1:
     assert len(sys.argv) == 2 and sys.argv[1] == 'local', sys.argv
-    local_mode=True
+    local_mode = True
 
 run(local_mode=local_mode)


### PR DESCRIPTION
Black only supports the `pyproject.toml` configuration file. Between all our tools (mypy, flake8, black, pylint…), there's no single config file they all seem to support. I moved the black config from `.pre-commit-config.yaml` to `pyproject.toml` so black can pick up the configuration whenever it's run, so editor plugins to activate autoformatting can work by default now.