### PR TITLE
[query] Push through requiredness on EmitCodes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -86,21 +86,21 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
 
   def memoize(v: EmitCode, name: String): EmitValue = {
     require(v.pt.isRealizable)
-    val l = emb.newEmitLocal(name, v.pt)
+    val l = emb.newEmitLocal(name, v.emitType)
     assign(l, v)
     l
   }
 
   def memoize(v: IEmitCode, name: String): EmitValue = {
     require(v.pt.isRealizable)
-    val l = emb.newEmitLocal(name, v.pt)
+    val l = emb.newEmitLocal(name, v.emitType)
     assign(l, v)
     l
   }
 
   def memoizeField[T](ec: EmitCode, name: String): EmitValue = {
     require(ec.pt.isRealizable)
-    val l = emb.newEmitField(name, ec.pt)
+    val l = emb.newEmitField(name, ec.emitType)
     l.store(this, ec)
     l
   }
@@ -120,7 +120,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
 
   def memoizeField(v: IEmitCode, name: String): EmitValue = {
     require(v.pt.isRealizable)
-    val l = emb.newEmitField(name, v.pt)
+    val l = emb.newEmitField(name, v.emitType)
     assign(l, v)
     l
   }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -428,20 +428,23 @@ final case class NDArrayWrite(nd: IR, path: IR) extends IR
 final case class NDArrayMatMul(l: IR, r: IR) extends NDArrayIR
 
 object NDArrayQR {
-  val pTypes: Map[String, PType] = Map(
-    "r" -> PCanonicalNDArray(PFloat64Required, 2),
-    "raw" -> PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 1)),
-    "reduced" -> PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 2)),
-    "complete" -> PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 2)))
+  def pType(mode: String, req: Boolean): PType = {
+    mode match {
+      case "r" => PCanonicalNDArray(PFloat64Required, 2, req)
+      case "raw" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 1, true))
+      case "reduced" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 2, true))
+      case "complete" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 2, true)))
+    }
+  }
 }
 
 object NDArraySVD {
-  def pTypes(computeUV: Boolean): PType = {
+  def pTypes(computeUV: Boolean, req: Boolean): PType = {
     if (computeUV) {
-      PCanonicalTuple(false, PCanonicalNDArray(PFloat64Required, 2), PCanonicalNDArray(PFloat64Required, 1), PCanonicalNDArray(PFloat64Required, 2))
+      PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 1, true), PCanonicalNDArray(PFloat64Required, 2, true))
     }
     else {
-      PCanonicalNDArray(PFloat64Required, 1)
+      PCanonicalNDArray(PFloat64Required, 1, req)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -433,7 +433,7 @@ object NDArrayQR {
       case "r" => PCanonicalNDArray(PFloat64Required, 2, req)
       case "raw" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 1, true))
       case "reduced" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 2, true))
-      case "complete" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 2, true)))
+      case "complete" => PCanonicalTuple(req, PCanonicalNDArray(PFloat64Required, 2, true), PCanonicalNDArray(PFloat64Required, 2, true))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -249,8 +249,8 @@ object InferPType {
         val lTyp = coerce[PNDArray](l.pType)
         val rTyp = coerce[PNDArray](r.pType)
         PCanonicalNDArray(lTyp.elementType, TNDArray.matMulNDims(lTyp.nDims, rTyp.nDims), requiredness(node).required)
-      case NDArrayQR(_, mode) => NDArrayQR.pTypes(mode)
-      case NDArraySVD(_, _, computeUV) => NDArraySVD.pTypes(computeUV)
+      case NDArrayQR(child, mode) => NDArrayQR.pType(mode, child.pType.required)
+      case NDArraySVD(child, _, computeUV) => NDArraySVD.pTypes(computeUV, child.pType.required)
       case NDArrayInv(_) => NDArrayInv.pType
       case MakeStruct(fields) =>
         PCanonicalStruct(requiredness(node).required,

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -599,8 +599,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case NDArrayMatMul(l, r) =>
         requiredness.unionFrom(lookup(l))
         requiredness.union(lookup(r).required)
-      case NDArrayQR(_, mode) => requiredness.fromPType(NDArrayQR.pTypes(mode))
-      case NDArraySVD(_, _, computeUV) => requiredness.fromPType(NDArraySVD.pTypes(computeUV))
+      case NDArrayQR(child, mode) => requiredness.fromPType(NDArrayQR.pType(mode, lookup(child).required))
+      case NDArraySVD(child, _, computeUV) => requiredness.fromPType(NDArraySVD.pTypes(computeUV, lookup(child).required))
       case NDArrayInv(child) => requiredness.unionFrom(lookup(child))
       case MakeStruct(fields) =>
         fields.foreach { case (n, f) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -24,6 +24,7 @@ object Requiredness {
 
 case class RequirednessAnalysis(r: Memo[BaseTypeWithRequiredness], states: Memo[IndexedSeq[TypeWithRequiredness]]) {
   def lookup(node: BaseIR): BaseTypeWithRequiredness = r.lookup(node)
+  def lookupOpt(node: BaseIR): Option[BaseTypeWithRequiredness] = r.get(node)
   def apply(node: IR): TypeWithRequiredness = coerce[TypeWithRequiredness](lookup(node))
   def getState(node: IR): IndexedSeq[TypeWithRequiredness] = states(node)
 }
@@ -600,7 +601,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(lookup(r).required)
       case NDArrayQR(_, mode) => requiredness.fromPType(NDArrayQR.pTypes(mode))
       case NDArraySVD(_, _, computeUV) => requiredness.fromPType(NDArraySVD.pTypes(computeUV))
-      case NDArrayInv(_) => requiredness.fromPType(NDArrayInv.pType)
+      case NDArrayInv(child) => requiredness.unionFrom(lookup(child))
       case MakeStruct(fields) =>
         fields.foreach { case (n, f) =>
           coerce[RStruct](requiredness).field(n).unionFrom(lookup(f))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -165,12 +165,12 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
 }
 
 class PrimitiveRVAState(val vtypes: Array[VirtualTypeWithReq], val kb: EmitClassBuilder[_]) extends AggregatorState {
-  private[this] val ptypes = vtypes.map(_.canonicalPType)
-  assert(ptypes.forall(_.isPrimitive))
+  private[this] val emitTypes = vtypes.map(_.canonicalEmitType)
+  assert(emitTypes.forall(_.st.pType.isPrimitive))
 
-  val nFields: Int = ptypes.length
-  val fields: Array[EmitSettable] = Array.tabulate(nFields) { i => kb.newEmitField(s"primitiveRVA_${ i }_v", ptypes(i)) }
-  val storageType = PCanonicalTuple(true, ptypes: _*)
+  val nFields: Int = emitTypes.length
+  val fields: Array[EmitSettable] = Array.tabulate(nFields) { i => kb.newEmitField(s"primitiveRVA_${ i }_v", emitTypes(i)) }
+  val storageType = PCanonicalTuple(true, emitTypes.map(_.canonicalPType): _*)
   val sStorageType = SBaseStructPointer(storageType)
 
   def foreachField(f: (Int, EmitSettable) => Unit): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -36,7 +36,8 @@ object GenotypeFunctions extends RegistryFunctions {
       PCode(rt, code)
     }
 
-    registerIEmitCode1("dosage", TArray(tv("N", "float64")), TFloat64,  (_: Type, _: PType) => PFloat64()
+    registerIEmitCode1("dosage", TArray(tv("N", "float64")), TFloat64,
+      (_: Type, arrayType: PType) => PFloat64(arrayType.required && arrayType.asInstanceOf[PArray].elementType.required)
     ) { case (cb, r, rt, gp) =>
       gp.toI(cb).flatMap(cb) { case (gpc: PIndexableCode) =>
         val gpv = gpc.memoize(cb, "dosage_gp")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -288,7 +288,10 @@ object UtilFunctions extends RegistryFunctions {
             )
           })
 
-        IEmitCode(cb, ((M >> w) & 1).cne(0), PCode(rt, w.ceq(10)))
+        val Lpresent = CodeLabel()
+        val Lmissing = CodeLabel()
+        cb.ifx(((M >> w) & 1).cne(0), cb.goto(Lmissing), cb.goto(Lpresent))
+        IEmitCode(Lmissing, Lpresent, PCode(rt, w.ceq(10)), l.required && r.required)
     }
 
     registerIEmitCode2("lor", TBoolean, TBoolean, TBoolean, (_: Type, tl: PType, tr: PType) => PBoolean(tl.required && tr.required)) {
@@ -315,7 +318,10 @@ object UtilFunctions extends RegistryFunctions {
             )
           })
 
-        IEmitCode(cb, ((M >> w) & 1).cne(0), PCode(rt, w.cne(0)))
+        val Lpresent = CodeLabel()
+        val Lmissing = CodeLabel()
+        cb.ifx(((M >> w) & 1).cne(0), cb.goto(Lmissing), cb.goto(Lpresent))
+        IEmitCode(Lmissing, Lpresent, PCode(rt, w.cne(0)), l.required && r.required)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -230,27 +230,27 @@ object UtilFunctions extends RegistryFunctions {
         IEmitCode(Lmissing, Ldefined, PCode(rt, value.load()), v1.required || v2.required)
       }
 
-      registerIEmitCode2(ignoreMissingName, TInt32, TInt32, TInt32, (_: Type, t1: PType, t2: PType) => PInt32(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreMissingName, TInt32, TInt32, TInt32, (_: Type, t1: PType, t2: PType) => PInt32(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Int](cb, rt, v1, v2, name, Code.invokeStatic2[Math, Int, Int, Int](name, _, _))
       }
 
-      registerIEmitCode2(ignoreMissingName, TInt64, TInt64, TInt64, (_: Type, t1: PType, t2: PType) => PInt64(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreMissingName, TInt64, TInt64, TInt64, (_: Type, t1: PType, t2: PType) => PInt64(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Long](cb, rt, v1, v2, name, Code.invokeStatic2[Math, Long, Long, Long](name, _, _))
       }
 
-      registerIEmitCode2(ignoreMissingName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreMissingName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Float](cb, rt, v1, v2, name, Code.invokeStatic2[Math, Float, Float, Float](name, _, _))
       }
 
-      registerIEmitCode2(ignoreMissingName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreMissingName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Double](cb, rt, v1, v2, name, Code.invokeStatic2[Math, Double, Double, Double](name, _, _))
       }
 
-      registerIEmitCode2(ignoreBothName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreBothName, TFloat32, TFloat32, TFloat32, (_: Type, t1: PType, t2: PType) => PFloat32(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Float](cb, rt, v1, v2, ignoreNanName, Code.invokeScalaObject2[Float, Float, Float](thisClass, ignoreNanName, _, _))
       }
 
-      registerIEmitCode2(ignoreBothName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required && t2.required)) {
+      registerIEmitCode2(ignoreBothName, TFloat64, TFloat64, TFloat64, (_: Type, t1: PType, t2: PType) => PFloat64(t1.required || t2.required)) {
         case (cb, r, rt, v1, v2) => ignoreMissingTriplet[Double](cb, rt, v1, v2, ignoreNanName, Code.invokeScalaObject2[Double, Double, Double](thisClass, ignoreNanName, _, _))
       }
     }

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -2,7 +2,7 @@ package is.hail.types
 
 import is.hail.annotations.{Annotation, NDArray}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.SType
+import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval}
 import org.apache.spark.sql.Row
@@ -154,6 +154,10 @@ object VirtualTypeWithReq {
 
 case class VirtualTypeWithReq(t: Type, r: TypeWithRequiredness) {
   lazy val canonicalPType: PType = r.canonicalPType(t)
+  lazy val canonicalEmitType: EmitType = {
+    val pt = r.canonicalPType(t)
+    EmitType(pt.sType, pt.required)
+  }
 
   def setRequired(newReq: Boolean): VirtualTypeWithReq = {
     val newR = r.copy(r.children).asInstanceOf[TypeWithRequiredness]
@@ -186,6 +190,10 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
     _unionPType(pType)
   }
   def canonicalPType(t: Type): PType
+  def canonicalEmitType(t: Type): EmitType = {
+    val pt = canonicalPType(t)
+    EmitType(pt.sType, pt.required)
+  }
   def matchesPType(pt: PType): Boolean = pt.required == required && _matchesPType(pt)
   def _toString: String
   override def toString: String = if (required) "+" + _toString else _toString

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -42,4 +42,5 @@ trait SType {
 case class EmitType(st: SType, required: Boolean) {
   def virtualType: Type = st.virtualType
   def paramType: EmitParamType = PCodeEmitParamType(st.pType.setRequired(required))
+  def canonicalPType: PType = st.canonicalPType().setRequired(required)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -4,13 +4,15 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.stypes.interfaces.SContainer
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.{EmitType, SCode, SType}
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalDict, PCanonicalSet, PCode, PContainer, PIndexableCode, PIndexableValue, PSettable, PType}
 import is.hail.utils.FastIndexedSeq
 
 
 case class SIndexablePointer(pType: PContainer) extends SContainer {
   override def elementType: SType = pType.elementType.sType
+
+  def elementEmitType: EmitType = EmitType(elementType, pType.elementType.required)
 
   def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SIndexablePointerCode(this, pType.store(cb, region, value, deepCopy))

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -2,13 +2,16 @@ package is.hail.types.physical.stypes.interfaces
 
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitSCode}
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
 
 trait SContainer extends SType {
   def elementType: SType
+  def elementEmitType: EmitType
 }
 
 trait SIndexableValue extends SValue {
+  def st: SContainer
+
   def loadLength(): Value[Int]
 
   def isElementMissing(i: Code[Int]): Code[Boolean]

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -414,10 +414,10 @@ class EmitStreamSuite extends HailSuite {
   }
 
   @Test def testEmitFromIterator() {
-    val intsPType = PCanonicalStream(PInt32())
+    val intsPType = PCanonicalStream(PInt32(true))
 
     val f1 = compileStreamWithIter(
-      StreamScan(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32()))),
+      StreamScan(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(true, PInt32(true)))),
         zero = 0,
         "a", "x", Ref("a", TInt32) + Ref("x", TInt32) * Ref("x", TInt32)
       ), false, intsPType)
@@ -426,13 +426,13 @@ class EmitStreamSuite extends HailSuite {
 
     val f2 = compileStreamWithIter(
       StreamFlatMap(
-        In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32()))),
+        In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true)))),
         "n", StreamRange(0, Ref("n", TInt32), 1)
       ), false, intsPType)
     assert(f2(Seq(1, 5, 2, 9).iterator) == IndexedSeq(1, 5, 2, 9).flatMap(0 until _))
 
     val f3 = compileStreamWithIter(
-      StreamRange(0, StreamLen(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32())))), 1), false, intsPType)
+      StreamRange(0, StreamLen(In(0, SingleCodeEmitParamType(true, StreamSingleCodeType(false, PInt32(true))))), 1), false, intsPType)
     assert(f3(Seq(1, 5, 2, 9).iterator) == IndexedSeq(0, 1, 2, 3))
     assert(f3(Seq().iterator) == IndexedSeq())
   }

--- a/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
@@ -1,14 +1,13 @@
 package is.hail.expr.ir
 
-import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.types.virtual.TFloat64
 import is.hail.utils.FastIndexedSeq
+import is.hail.{ExecStrategy, HailSuite}
 import org.testng.annotations.{DataProvider, Test}
-import org.scalatest.testng.TestNGSuite
 
-class GenotypeFunctionsSuite extends TestNGSuite {
+class GenotypeFunctionsSuite extends HailSuite {
 
   implicit val execStrats = ExecStrategy.javaOnly
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -70,12 +70,12 @@ object IRSuite {
       }
 
     def registerAll() {
-      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, null) { case (cb, mb, rt,  _, l) =>
+      registerSeededWithMissingness("incr_s", TBoolean, TBoolean, { (ret: Type, pt: PType) => pt }) { case (cb, mb, rt, _, l) =>
         cb += Code.invokeScalaObject0[Unit](outer.getClass, "incr")
         l.toI(cb)
       }
 
-      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, null) { case (cb, mb, rt, _, l) =>
+      registerSeededWithMissingness("incr_v", TBoolean, TBoolean, { (ret: Type, pt: PType) => pt }) { case (cb, mb, rt, _, l) =>
         l.toI(cb).map(cb) { pc =>
           cb += Code.invokeScalaObject0[Unit](outer.getClass, "incr")
           pc


### PR DESCRIPTION
EmitCodes and their EmitTypes, not ptypes, are to be the authoritative
source of requiredness information in the code generator.

This is the next step toward removing top-level requiredness from ptypes.