### PR TITLE
[query] Create BlockMatrix from NDArray + Actually Running Lowering Tests

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -508,6 +508,12 @@ class BlockMatrix(object):
 
         return BlockMatrix(ValueToBlockMatrix(hl.literal(data)._ir, [n_rows, n_cols], block_size))
 
+    @classmethod
+    def from_ndarray(cls, ndarray_expression, block_size=4096):
+        """Create a BlockMatrix from an ndarray"""
+        shape = hl.eval(ndarray_expression.shape)
+        return BlockMatrix(ValueToBlockMatrix(ndarray_expression._ir, shape, block_size))
+
     @staticmethod
     def default_block_size():
         """Default block side length."""

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -512,6 +512,8 @@ class BlockMatrix(object):
     def from_ndarray(cls, ndarray_expression, block_size=4096):
         """Create a BlockMatrix from an ndarray"""
         shape = hl.eval(ndarray_expression.shape)
+        if shape is None:
+            raise ValueError("Cannot make a BlockMatrix from a missing NDArray")
         return BlockMatrix(ValueToBlockMatrix(ndarray_expression._ir, shape, block_size))
 
     @staticmethod

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -9,7 +9,7 @@ import scipy.linalg as spla
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr import construct_expr, construct_variable
-from hail.expr.expressions import (expr_float64, matrix_table_source,
+from hail.expr.expressions import (expr_float64, matrix_table_source, expr_ndarray,
                                    check_entry_indexed, expr_tuple, expr_array, expr_int32, expr_int64)
 from hail.ir import (BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, F64,
                      BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix,
@@ -509,9 +509,14 @@ class BlockMatrix(object):
         return BlockMatrix(ValueToBlockMatrix(hl.literal(data)._ir, [n_rows, n_cols], block_size))
 
     @classmethod
+    @typecheck_method(ndarray_expression=expr_ndarray(), block_size=int)
     def from_ndarray(cls, ndarray_expression, block_size=4096):
         """Create a BlockMatrix from an ndarray"""
+        if ndarray_expression.dtype.element_type != hl.tfloat64:
+            raise ValueError("BlockMatrix.from_ndarray expects an ndarray of type float64")
+
         shape = hl.eval(ndarray_expression.shape)
+
         if shape is None:
             raise ValueError("Cannot make a BlockMatrix from a missing NDArray")
         return BlockMatrix(ValueToBlockMatrix(ndarray_expression._ir, shape, block_size))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -486,8 +486,8 @@ class Tests(unittest.TestCase):
         self._assert_eq((m @ m.T).diagonal(), np.array([[14.0, 77.0]]))
 
 
-    @fails_service_backend
-    @fails_local_backend
+    @fails_service_backend()
+    @fails_local_backend()
     def test_matrix_sums(self):
         self._assert_eq(m.sum(axis=0).T, np.array([[5.0], [7.0], [9.0]]))
         self._assert_eq(m.sum(axis=1).T, np.array([[6.0, 15.0]]))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -46,6 +46,9 @@ class Tests(unittest.TestCase):
             return np.array(a)
 
     def _assert_eq(self, a, b):
+        test_val = np.array_equal(self._np_matrix(a), self._np_matrix(b))
+        if test_val is False:
+            import pdb; pdb.set_trace()
         self.assertTrue(np.array_equal(self._np_matrix(a), self._np_matrix(b)))
 
     def _assert_close(self, a, b):
@@ -145,12 +148,10 @@ class Tests(unittest.TestCase):
             BlockMatrix.write_from_entry_expr(mt.x + 2, path, overwrite=True)
             self._assert_eq(BlockMatrix.read(path), bm + 2)
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_random_uniform(self):
         uniform = BlockMatrix.random(10, 10, gaussian=False)
 
-        nuniform = uniform.to_numpy()
+        nuniform = hl.eval(uniform.to_ndarray())
         for row in nuniform:
             for entry in row:
                 assert entry > 0
@@ -461,12 +462,12 @@ class Tests(unittest.TestCase):
     @fails_local_backend()
     def test_matrix_ops(self):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        m = BlockMatrix.from_numpy(nm, block_size=2)
+        m = BlockMatrix.from_ndarray(hl.nd.array(nm), block_size=2)
         nsquare = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
-        square = BlockMatrix.from_numpy(nsquare, block_size=2)
+        square = BlockMatrix.from_ndarray(hl.nd.array(nsquare), block_size=2)
 
         nrow = np.array([[7.0, 8.0, 9.0]])
-        row = BlockMatrix.from_numpy(nrow, block_size=2)
+        row = BlockMatrix.from_ndarray(hl.nd.array(nrow), block_size=2)
 
         self._assert_eq(m.T, nm.T)
         self._assert_eq(m.T, nm.T)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -860,16 +860,16 @@ class Tests(unittest.TestCase):
             self._assert_eq(expected, BlockMatrix.rectangles_to_numpy(rect_uri))
             self._assert_eq(expected, BlockMatrix.rectangles_to_numpy(rect_bytes_uri, binary=True))
 
-    @fails_service_backend
-    @fails_local_backend
+    @fails_service_backend()
+    @fails_local_backend()
     def test_to_ndarray(self):
-        np_mat = np.arange(12).reshape((4, 3))
-        mat = BlockMatrix.from_numpy(np_mat).to_ndarray()
+        np_mat = np.arange(12).reshape((4, 3)).astype(np.float64)
+        mat = BlockMatrix.from_ndarray(hl.nd.array(np_mat)).to_ndarray()
         self.assertTrue(np.array_equal(np_mat, hl.eval(mat)))
 
         blocks_to_sparsify = [1, 4, 7, 12, 20, 42, 48]
         sparsed_numpy = sparsify_numpy(np.arange(25*25).reshape((25, 25)), 4,  blocks_to_sparsify)
-        sparsed = BlockMatrix.from_numpy(sparsed_numpy, block_size=4)._sparsify_blocks(blocks_to_sparsify).to_ndarray()
+        sparsed = BlockMatrix.from_ndarray(hl.nd.array(sparsed_numpy), block_size=4)._sparsify_blocks(blocks_to_sparsify).to_ndarray()
         self.assertTrue(np.array_equal(sparsed_numpy, hl.eval(sparsed)))
 
     @fails_service_backend()

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -489,6 +489,14 @@ class Tests(unittest.TestCase):
     @fails_service_backend()
     @fails_local_backend()
     def test_matrix_sums(self):
+        nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        m = BlockMatrix.from_ndarray(hl.nd.array(nm), block_size=2)
+        nsquare = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        square = BlockMatrix.from_ndarray(hl.nd.array(nsquare), block_size=2)
+
+        nrow = np.array([[7.0, 8.0, 9.0]])
+        row = BlockMatrix.from_ndarray(hl.nd.array(nrow), block_size=2)
+
         self._assert_eq(m.sum(axis=0).T, np.array([[5.0], [7.0], [9.0]]))
         self._assert_eq(m.sum(axis=1).T, np.array([[6.0, 15.0]]))
         self._assert_eq(m.sum(axis=0).T + row, np.array([[12.0, 13.0, 14.0],

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -445,11 +445,9 @@ class Tests(unittest.TestCase):
         self._assert_close(m / nr, m / r)
         self._assert_close(m / nm, m / m)
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_special_elementwise_ops(self):
         nm = np.array([[1.0, 2.0, 3.0, 3.14], [4.0, 5.0, 6.0, 12.12]])
-        m = BlockMatrix.from_numpy(nm)
+        m = BlockMatrix.from_ndarray(hl.nd.array(nm))
 
         self._assert_close(m ** 3, nm ** 3)
         self._assert_close(m.sqrt(), np.sqrt(nm))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -46,10 +46,9 @@ class Tests(unittest.TestCase):
             return np.array(a)
 
     def _assert_eq(self, a, b):
-        test_val = np.array_equal(self._np_matrix(a), self._np_matrix(b))
-        if test_val is False:
-            import pdb; pdb.set_trace()
-        self.assertTrue(np.array_equal(self._np_matrix(a), self._np_matrix(b)))
+        anp = self._np_matrix(a)
+        bnp = self._np_matrix(b)
+        np.testing.assert_equal(anp, bnp)
 
     def _assert_close(self, a, b):
         self.assertTrue(np.allclose(self._np_matrix(a), self._np_matrix(b)))
@@ -456,8 +455,6 @@ class Tests(unittest.TestCase):
         self._assert_close(m.log(), np.log(nm))
         self._assert_close((m - 4).abs(), np.abs(nm - 4))
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_matrix_ops(self):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_ndarray(hl.nd.array(nm), block_size=2)
@@ -488,6 +485,10 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.T.diagonal(), np.array([[1.0, 5.0]]))
         self._assert_eq((m @ m.T).diagonal(), np.array([[14.0, 77.0]]))
 
+
+    @fails_service_backend
+    @fails_local_backend
+    def test_matrix_sums(self):
         self._assert_eq(m.sum(axis=0).T, np.array([[5.0], [7.0], [9.0]]))
         self._assert_eq(m.sum(axis=1).T, np.array([[6.0, 15.0]]))
         self._assert_eq(m.sum(axis=0).T + row, np.array([[12.0, 13.0, 14.0],

--- a/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RefEquality.scala
@@ -52,6 +52,8 @@ class Memo[T] private(val m: mutable.HashMap[RefEquality[BaseIR], T]) {
 
   def delete(ir: BaseIR): Unit = delete(RefEquality(ir))
   def delete(ir: RefEquality[BaseIR]): Unit = m -= ir
+
+  override def toString: String = s"Memo(${m})"
 }
 
 

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -235,6 +235,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case CollectDistributedArray(ctxs, globs, c, g, body, _) =>
         addElementBinding(c, ctxs)
         addBinding(g, globs)
+      case BlockMatrixMap(child, eltName, f, _) => addBinding(eltName, f)
       case TableAggregate(c, q) =>
         addTableBinding(c)
       case TableFilter(child, pred) =>
@@ -698,7 +699,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
 
   def analyzeBlockMatrix(node: BlockMatrixIR): Boolean = {
     val requiredness = lookup(node)
-    // What do I do here? BlockMatrix is always required.
+    // BlockMatrix is always required, so I don't change anything.
+
     requiredness.probeChangedAndReset()
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -16,7 +16,7 @@ object BlockMatrixStage {
     new BlockMatrixStage(Array(v.name -> vector), TStruct("start" -> TInt32, "shape" -> TTuple(TInt32, TInt32))) {
       def blockContext(idx: (Int, Int)): IR = {
         val (i, j) = typ.blockShape(idx._1, idx._2)
-        val start = (if (asRowVector) idx._1 else idx._2) * typ.blockSize
+        val start = (if (asRowVector) idx._2 else idx._1) * typ.blockSize
         makestruct("start" -> start, "shape" -> MakeTuple.ordered(FastSeq[IR](i.toInt, j.toInt)))
       }
 
@@ -236,12 +236,17 @@ object LowerBlockMatrixIR {
 
       case x@BlockMatrixBroadcast(child, IndexedSeq(axis, axis2), _, _) if (axis == axis2) => // diagonal as row/col vector
         val nBlocks = java.lang.Math.min(child.typ.nRowBlocks, child.typ.nColBlocks)
-        val idxs = Array.tabulate(nBlocks) { i => i -> i }
+        val idxs = Array.tabulate(nBlocks) { i => (i, i) }
         val getDiagonal = { (ctx: IR, block: IR) =>
-          bindIR(block)(b => ToArray(mapIR(rangeIR(GetField(ctx, "new")))(i => NDArrayRef(b, FastIndexedSeq(i, i), -1))))
+          bindIR(block)(b => ToArray(mapIR(rangeIR(GetField(ctx, "new")))(i => NDArrayRef(b, FastIndexedSeq(Cast(i, TInt64), Cast(i, TInt64)), ErrorIDs.NO_ERROR))))
         }
 
-        val vector = bindIR(lower(child).collectBlocks(relationalLetsAbove)(getDiagonal, idxs.filter(child.typ.hasBlock))) { existing =>
+        val loweredWithContext = lower(child).addContext(TInt32){ case (i, j) => {
+          val (rows, cols) = x.typ.blockShape(i, j)
+          I32(math.max(rows.toInt, cols.toInt))
+        } }
+
+        val vector = bindIR(loweredWithContext.collectBlocks(relationalLetsAbove)(getDiagonal, idxs.filter(child.typ.hasBlock))) { existing =>
           var i = -1
           val vectorBlocks = idxs.map { idx =>
             if (child.typ.hasBlock(idx)) {
@@ -249,13 +254,13 @@ object LowerBlockMatrixIR {
               ArrayRef(existing, i)
             } else {
               val (i, j) = child.typ.blockShape(idx._1, idx._2)
-              mapIR(rangeIR(java.lang.Math.min(i, j)))(_ => zero(x.typ.elementType))
+              ToArray(mapIR(rangeIR(java.lang.Math.min(i, j)))(_ => zero(x.typ.elementType)))
             }
           }
-          MakeNDArray(ToArray(flatten(MakeStream(vectorBlocks, TStream(TStream(x.typ.elementType))))),
+          MakeNDArray(ToArray(flatten(MakeStream(vectorBlocks, TStream(TArray(x.typ.elementType))))),
             MakeTuple.ordered(FastSeq(I64(java.lang.Math.min(child.typ.nRows, child.typ.nCols)))), true, ErrorIDs.NO_ERROR)
         }
-        BlockMatrixStage.broadcastVector(vector, x.typ, asRowVector = axis == 1)
+        BlockMatrixStage.broadcastVector(vector, x.typ, asRowVector = axis == 0)
 
       case BlockMatrixBroadcast(child, IndexedSeq(1, 0), _, _) => //transpose
         val lowered = lower(child)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -327,8 +327,8 @@ object LowerBlockMatrixIR {
       }
       case x@ValueToBlockMatrix(child, _, blockSize) =>
         val nd = child.typ match {
-          case _: TArray => MakeNDArray(child, MakeTuple.ordered(FastSeq(I64(x.typ.nRows), I64(x.typ.nCols))), True(), ErrorIDs.NO_ERROR)
-          case _: TNDArray => child
+          case _: TArray => MakeNDArray(lowerIR(child), MakeTuple.ordered(FastSeq(I64(x.typ.nRows), I64(x.typ.nCols))), True(), ErrorIDs.NO_ERROR)
+          case _: TNDArray => lowerIR(child)
         }
         val v = Ref(genUID(), nd.typ)
         new BlockMatrixStage(

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
@@ -11,6 +11,7 @@ import org.apache.spark.sql.Row
 object LowerToCDA {
 
   def apply(ir: IR, typesToLower: DArrayLowering.Type, ctx: ExecuteContext): IR = {
+    TypeCheck(ir)
     val r = Requiredness(ir, ctx)
 
     lower(ir, typesToLower, ctx, r, Map())

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
@@ -11,7 +11,6 @@ import org.apache.spark.sql.Row
 object LowerToCDA {
 
   def apply(ir: IR, typesToLower: DArrayLowering.Type, ctx: ExecuteContext): IR = {
-    TypeCheck(ir)
     val r = Requiredness(ir, ctx)
 
     lower(ir, typesToLower, ctx, r, Map())

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -14,6 +14,7 @@ object BaseTypeWithRequiredness {
       t.rowType.fields.map(f => f.name -> TypeWithRequiredness(f.typ)),
       t.globalType.fields.map(f => f.name -> TypeWithRequiredness(f.typ)),
       t.key)
+    case t: BlockMatrixType => RBlockMatrix(TypeWithRequiredness(t.elementType))
   }
 
   def check(r: BaseTypeWithRequiredness, typ: BaseType): Unit = {
@@ -451,4 +452,12 @@ case class RTable(rowFields: Seq[(String, TypeWithRequiredness)], globalFields: 
 
 case class RMatrix(rowType: RStruct, entryType: RStruct, colType: RStruct, globalType: RStruct) {
   val entriesRVType: RStruct = RStruct(Seq(MatrixType.entriesIdentifier -> RIterable(entryType)))
+}
+
+case class RBlockMatrix(val elementType: TypeWithRequiredness) extends BaseTypeWithRequiredness {
+  override def children: Seq[BaseTypeWithRequiredness] = Seq()
+
+  override def copy(newChildren: Seq[BaseTypeWithRequiredness]): BaseTypeWithRequiredness = RBlockMatrix(elementType)
+
+  override def toString: String = s"RBlockMatrix(${elementType})"
 }

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -455,9 +455,9 @@ case class RMatrix(rowType: RStruct, entryType: RStruct, colType: RStruct, globa
 }
 
 case class RBlockMatrix(val elementType: TypeWithRequiredness) extends BaseTypeWithRequiredness {
-  override def children: Seq[BaseTypeWithRequiredness] = Seq()
+  override def children: Seq[BaseTypeWithRequiredness] = Seq(elementType)
 
-  override def copy(newChildren: Seq[BaseTypeWithRequiredness]): BaseTypeWithRequiredness = RBlockMatrix(elementType)
+  override def copy(newChildren: Seq[BaseTypeWithRequiredness]): BaseTypeWithRequiredness = RBlockMatrix(newChildren(0).asInstanceOf[TypeWithRequiredness])
 
   override def toString: String = s"RBlockMatrix(${elementType})"
 }


### PR DESCRIPTION
In this PR:

- I add `BlockMatrix.from_ndarray`. The implementation isn't great, it just basically just evals the ndarray and adds NDArray support to `ValueToBlockMatrix`. A better version wouldn't cross the Python / Java boundary at all, but I want something that works on all backends, so for now this will have to suffice. Any solution will at least need to communicate the shape of the ndarray back to python, since it's tracked in the block matrix type. 
- With this new method, I can now get many tests in `test_linalg.py` to run on the local / service backends. Most BM lowering was apparently untested before, so some bug fixes were necessary, including:
    - Support requiredness analysis on BlockMatrix, even though the answer is always required. 
    - Use `CompileAndEvaluate`  rather than `Interpret` to evaluate the child node in `ValueToBlockMatrix`. 
    - Casting between Int32 and Int64 in various places in lowering. Almost always the culprit was a bad interaction between ndarray shapes (which are Int64) and `StreamRange` argument (which is an Int32). This is sort of a pervasive ndarray problem  that will need to be systematically addressed at some point. I don't anticipate anyone making a BlockMatrix with blocks big enough to blow 32 bits though. 
    - Lots of fixes to the `BlockMatrixBroadcast` rule for getting diagonal of a BlockMatrix, as it was clearly never run. It had `MakeStream(StreamIR)` which was not allowed, it didn't update the context appropriately,  and it used the wrong axis to determine if something was a row vector. 