### PR TITLE
[query] Address tests with many calls to `hl.eval`

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1466,11 +1466,8 @@ class Tests(unittest.TestCase):
         self.assertFalse(hl.eval(s_whitespace.endswith('a')))
 
     def test_str_parsing(self):
-        for x in ('true', 'True', 'TRUE'):
-            self.assertTrue(hl.eval(hl.bool(x)))
-
-        for x in ('false', 'False', 'FALSE'):
-            self.assertFalse(hl.eval(hl.bool(x)))
+        assert_all_eval_to(*[(hl.bool(x), True) for x in ('true', 'True', 'TRUE')])
+        assert_all_eval_to(*[(hl.bool(x), False) for x in ('false', 'False', 'FALSE')])
 
         for x in ('nan', 'Nan', 'naN', 'NaN'):
             for f in (hl.float, hl.float32, hl.float64, hl.parse_float32, hl.parse_float64):
@@ -1486,20 +1483,15 @@ class Tests(unittest.TestCase):
                 self.assertTrue(hl.eval(f('-' + x) < 0.0))
 
         for x in ('0', '1', '-5', '12382421'):
-            for f in (hl.int32, hl.int64, hl.parse_int32, hl.parse_int64):
-                self.assertEqual(hl.eval(f(hl.literal(x))), int(x))
-            for f in (hl.float32, hl.float64, hl.parse_float32, hl.parse_float64):
-                self.assertEqual(hl.eval(f(hl.literal(x))), float(x))
+            assert_all_eval_to(*[(f(hl.literal(x)), int(x)) for f in (hl.int32, hl.int64, hl.parse_int32, hl.parse_int64)])
+            assert_all_eval_to(*[(f(hl.literal(x)), float(x)) for f in (hl.float32, hl.float64, hl.parse_float32, hl.parse_float64)])
 
         for x in ('-1.5', '0.0', '2.5'):
-            for f in (hl.float32, hl.float64, hl.parse_float32, hl.parse_float64):
-                self.assertEqual(hl.eval(f(hl.literal(x))), float(x))
-            for f in (hl.parse_int32, hl.parse_int64):
-                self.assertEqual(hl.eval(f(hl.literal(x))), None)
+            assert_all_eval_to(*[(f(hl.literal(x)), float(x)) for f in (hl.float32, hl.float64, hl.parse_float32, hl.parse_float64)])
+            assert_all_eval_to(*[(f(hl.literal(x)), None) for f in (hl.parse_int32, hl.parse_int64)])
 
         for x in ('abc', '1abc', ''):
-            for f in (hl.parse_float32, hl.parse_float64, hl.parse_int32, hl.parse_int64):
-                self.assertEqual(hl.eval(f(hl.literal(x))), None)
+            assert_all_eval_to(*[(f(hl.literal(x)), None) for f in (hl.parse_float32, hl.parse_float64, hl.parse_int32, hl.parse_int64)])
 
     def test_str_missingness(self):
         self.assertEqual(hl.eval(hl.str(1)), '1')

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1471,16 +1471,19 @@ class Tests(unittest.TestCase):
 
         for x in ('nan', 'Nan', 'naN', 'NaN'):
             for f in (hl.float, hl.float32, hl.float64, hl.parse_float32, hl.parse_float64):
-                self.assertTrue(hl.eval(hl.is_nan(f(x))))
-                self.assertTrue(hl.eval(hl.is_nan(f('+' + x))))
-                self.assertTrue(hl.eval(hl.is_nan(f('-' + x))))
-
+                assert_all_eval_to(
+                    (hl.is_nan(f(x)), True),
+                    (hl.is_nan(f('+' + x)), True),
+                    (hl.is_nan(f('-' + x)), True)
+                )
         for x in ('inf', 'Inf', 'iNf', 'InF', 'infinity', 'InfiNitY', 'INFINITY'):
             for f in (hl.float, hl.float32, hl.float64, hl.parse_float32, hl.parse_float64):
-                self.assertTrue(hl.eval(hl.is_infinite(f(x))))
-                self.assertTrue(hl.eval(hl.is_infinite(f('+' + x))))
-                self.assertTrue(hl.eval(hl.is_infinite(f('-' + x))))
-                self.assertTrue(hl.eval(f('-' + x) < 0.0))
+                assert_all_eval_to(
+                    (hl.is_infinite(f(x)), True),
+                    (hl.is_infinite(f('+' + x)), True),
+                    (hl.is_infinite(f('-' + x)), True),
+                    (f('-' + x) < 0.0, True)
+                )
 
         for x in ('0', '1', '-5', '12382421'):
             assert_all_eval_to(*[(f(hl.literal(x)), int(x)) for f in (hl.int32, hl.int64, hl.parse_int32, hl.parse_int64)])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -1046,13 +1046,11 @@ def test_hstack():
 
 def test_eye():
     for i in range(13):
-        for y in range(13):
-            assert(np.array_equal(hl.eval(hl.nd.eye(i, y)), np.eye(i, y)))
+        assert_ndarrays_eq(*[(hl.nd.eye(i, y), np.eye(i, y)) for y in range(13)])
 
 
 def test_identity():
-    for i in range(13):
-        assert(np.array_equal(hl.eval(hl.nd.identity(i)), np.identity(i)))
+    assert_ndarrays_eq(*[(hl.nd.identity(i), np.identity(i)) for i in range(13)])
 
 
 def test_agg_ndarray_sum():


### PR DESCRIPTION
Service tests have high latency to the JVM. Let's not separately call `hl.eval` so many times when we don't need to. 