### PR TITLE
[query] Remove EmitCode.get

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -453,9 +453,6 @@ class EmitCode(private val start: CodeLabel, private val iec: IEmitCode) {
       eci
     }
 
-  def get(): PCode =
-    PCode(pv.pt, Code(setup, m.orEmpty(Code._fatal[Unit]("expected non-missing")), pv.code))
-
   def asVoid(): Code[Unit] = {
     require(pv.pt == PVoid)
     Code(setup, Code.toUnit(m))

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -949,9 +949,7 @@ class EmitMethodBuilder[C](
 
           override def load: EmitCode = emitCode
 
-          override def get(cb: EmitCodeBuilder): PCode = {
-            emitCode.get()
-          }
+          override def get(cb: EmitCodeBuilder): PCode = emitCode.toI(cb).get(cb)
         }
 
       case PCodeEmitParamType(_pt) =>

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1399,7 +1399,7 @@ object EmitStream {
           }
 
           mb.implementLabel(childProducer.LproduceElementDone) { cb =>
-            cb.assign(xCurElt, childProducer.element.get())
+            cb.assign(xCurElt, childProducer.element.toI(cb).get(cb))
             cb.assign(curKey, subsetCode)
             cb.ifx(inOuter, cb.goto(LchildProduceDoneOuter), cb.goto(LchildProduceDoneInner))
           }
@@ -2265,4 +2265,3 @@ object EmitStream {
     }
   }
 }
-


### PR DESCRIPTION
replace usages with toI.get instead