### PR TITLE
[query] Fix bad memory leak triggered by set contains IR function

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -146,10 +146,10 @@ trait PArrayBackedContainer extends PContainer {
 
   def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): PCode = new SIndexablePointerCode(SIndexablePointer(this), addr)
 
-  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value, deepCopy)
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value.asIndexable.castToArray(cb), deepCopy)
 
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit =
-    arrayRep.storeAtAddress(cb, addr, region, value, deepCopy)
+    arrayRep.storeAtAddress(cb, addr, region, value.asIndexable.castToArray(cb), deepCopy)
 
   def loadFromNested(addr: Code[Long]): Code[Long] = arrayRep.loadFromNested(addr)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -417,6 +417,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
   }
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
+    assert(value.st.virtualType.isInstanceOf[TArray])
     value.st match {
       case SIndexablePointer(PCanonicalArray(otherElementType, _)) if otherElementType == elementType && !deepCopy =>
         value.asInstanceOf[SIndexablePointerCode].a
@@ -424,7 +425,6 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         val newAddr = cb.newLocal[Long]("pcarray_store_newaddr")
         val pcInd = value.asIndexable.memoize(cb, "pcarray_store_src_sametype").asInstanceOf[SIndexablePointerSettable]
         cb.assign(newAddr, allocate(region, pcInd.loadLength()))
-
         storeContentsAtAddress(cb, newAddr, region, pcInd, deepCopy)
         newAddr
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -2,11 +2,10 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.stypes.interfaces.SContainer
-import is.hail.types.physical.{PCanonicalArray, PCode, PContainer, PIndexableCode, PIndexableValue, PSettable, PType}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalDict, PCanonicalSet, PCode, PContainer, PIndexableCode, PIndexableValue, PSettable, PType}
 import is.hail.utils.FastIndexedSeq
 
 
@@ -62,6 +61,14 @@ class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extend
   def memoize(cb: EmitCodeBuilder, name: String): PIndexableValue = memoize(cb, name, cb.localBuilder)
 
   def memoizeField(cb: EmitCodeBuilder, name: String): PIndexableValue = memoize(cb, name, cb.fieldBuilder)
+
+  def castToArray(cb: EmitCodeBuilder): PIndexableCode = {
+    pt match {
+      case t: PArray => this
+      case t: PCanonicalDict => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), a)
+      case t: PCanonicalSet => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), a)
+    }
+  }
 }
 
 object SIndexablePointerSettable {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -42,5 +42,7 @@ trait SIndexableCode extends SCode {
   def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SIndexableValue
+
+  def castToArray(cb: EmitCodeBuilder): SIndexableCode
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
@@ -1,0 +1,36 @@
+package is.hail.expr.ir
+
+import is.hail.HailSuite
+import is.hail.TestUtils.eval
+import is.hail.expr.ir
+import is.hail.types.virtual.{TArray, TBoolean, TSet, TString}
+import is.hail.utils._
+import org.testng.annotations.Test
+
+class MemoryLeakSuite extends HailSuite {
+  @Test def testLiteralSetContains(): Unit = {
+
+    val litSize = 32000
+
+   def run(size: Int): Long = {
+      val lit = Literal(TSet(TString), (0 until litSize).map(_.toString).toSet)
+      val queries = Literal(TArray(TString), (0 until size).map(_.toString).toFastIndexedSeq)
+      ExecuteContext.scoped() { ctx =>
+        val r = eval(
+          ToArray(
+            mapIR(ToStream(queries)) { r => ir.invoke("contains", TBoolean, lit, r) }
+          ), Env.empty, FastIndexedSeq(), None, None, false, ctx)
+        ctx.r.pool.getHighestTotalUsage
+      }
+    }
+
+    val size1 = 10
+    val size2 = 100
+    val mem1 = run(size1)
+    val mem2 = run(size2)
+    if (mem2 > (mem1 * 1.1))
+      throw new AssertionError(s"literal set contains is scaling with number of queries!" +
+        s"\n  Memory used with size1=$size1: ${formatSpace(mem1)}" +
+        s"\n  Memory used with size1=$size2: ${formatSpace(mem2)}")
+  }
+}


### PR DESCRIPTION
CHANGELOG: Fixed a memory leak triggered by `hl.literal(...).contains(...)

This bug is present elsewhere in the code generator, but the set
contains function is probably the worst place for it to happen.
This leads to a full copy of the set where the binary search
is executed.

The core problem was a bug in PArrayBackedContainer not casting
its codes properly, leading to the no-op coerce logic in PCanonicalArray
being bypassed in favor of the generic copy-the-world implementation of
`store`. The test I have added catches the memory leak, but now fails at
compile time at the assertion to `PCanonicalArray.store` instead.