### PR TITLE
[query] NDArrayMatMul Emit Handles Row Major matrices without copying

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1244,7 +1244,7 @@ class Emit[C](
               val N = rShape(rPType.nDims - 1)
               val K = lShape(lPType.nDims - 1)
 
-              def LDA = leftIsColumnMajor.mux(M, K)
+              val LDA = leftIsColumnMajor.mux(M, K)
               val LDB = rightIsColumnMajor.mux(K, N)
               val LDC = M
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -708,6 +708,15 @@ class Emit[C](
       }
     }
 
+    // Returns an IEmitCode along with a Boolean that is true if the returned value is column major. If false it's row
+    // major instead.
+    def emitNDArrayStandardStriding(ir: IR): IEmitCodeGen[(PNDArrayValue, Value[Boolean])] = {
+      emitI(ir).map(cb){case pNDCode: PNDArrayCode =>
+        val pNDValue = pNDCode.memoize(cb, "ndarray_standard_striding_check")
+        LinalgCodeUtils.checkStandardStriding(pNDValue, cb, region)
+      }
+    }
+
     val pt = ir.pType
 
     if (pt == PVoid) {
@@ -1210,13 +1219,10 @@ class Emit[C](
         }
 
       case NDArrayMatMul(lChild, rChild) =>
-        emitNDArrayColumnMajorStrides(lChild).flatMap(cb) { case leftPCode: PNDArrayCode =>
-          emitNDArrayColumnMajorStrides(rChild).map(cb) { case rightPCode: PNDArrayCode =>
-            val lPType = leftPCode.pt
-            val rPType = rightPCode.pt
-
-            val leftPVal = leftPCode.memoize(cb, "left_ndarray_matmul")
-            val rightPVal = rightPCode.memoize(cb, "right_ndarray_matmul")
+        emitNDArrayStandardStriding(lChild).flatMap(cb) { case (leftPVal: PNDArrayValue, leftIsColumnMajor: Value[Boolean]) =>
+          emitNDArrayStandardStriding(rChild).map(cb) { case (rightPVal: PNDArrayValue, rightIsColumnMajor: Value[Boolean]) =>
+            val lPType = leftPVal.pt
+            val rPType = rightPVal.pt
 
             val lShape = leftPVal.shapes(cb)
             val rShape = rightPVal.shapes(cb)
@@ -1238,9 +1244,12 @@ class Emit[C](
               val N = rShape(rPType.nDims - 1)
               val K = lShape(lPType.nDims - 1)
 
-              val LDA = M
-              val LDB = K
+              def LDA = leftIsColumnMajor.mux(M, K)
+              val LDB = rightIsColumnMajor.mux(K, N)
               val LDC = M
+
+              val TRANSA: Code[String] = leftIsColumnMajor.mux("N", "T")
+              val TRANSB: Code[String] = rightIsColumnMajor.mux("N", "T")
 
               val (answerFirstElementAddr, answerFinisher) = outputPType.constructDataFunction(
                 IndexedSeq(M, N),
@@ -1252,8 +1261,8 @@ class Emit[C](
                 cb.append(lPType.elementType match {
                   case PFloat32(_) =>
                     Code.invokeScalaObject13[String, String, Int, Int, Int, Float, Long, Int, Long, Int, Float, Long, Int, Unit](BLAS.getClass, method = "sgemm",
-                      "N",
-                      "N",
+                      TRANSA,
+                      TRANSB,
                       M.toI,
                       N.toI,
                       K.toI,
@@ -1268,8 +1277,8 @@ class Emit[C](
                     )
                   case PFloat64(_) =>
                     Code.invokeScalaObject13[String, String, Int, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, method = "dgemm",
-                      "N",
-                      "N",
+                      TRANSA,
+                      TRANSB,
                       M.toI,
                       N.toI,
                       K.toI,

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -18,15 +18,11 @@ object LinalgCodeUtils {
     val nDims = pndv.pt.nDims
 
     cb.assign(answer, true)
-    cb.append(Code(
-      runningProduct := elementType.byteSize,
-      Code.foreach(0 until nDims){ index =>
-        Code(
-          answer := answer & (strides(index) ceq runningProduct),
-          runningProduct := runningProduct * (shapes(index) > 0L).mux(shapes(index), 1L)
-        )
-      }
-    ))
+    cb.assign(runningProduct, elementType.byteSize)
+    (0 until nDims).foreach{ index =>
+      cb.assign(answer, answer & (strides(index) ceq runningProduct))
+      cb.assign(runningProduct, runningProduct * (shapes(index) > 0L).mux(shapes(index), 1L))
+    }
     answer
   }
 


### PR DESCRIPTION
BLAS's DGEMM has an option for transposing input matrix, which is effectively just transposing. I've added support for this. It should save time and memory to not have to copy into column major format. 

Didn't end up making my linear regression benchmark much faster, maybe 3%. It's using a bit less memory too. 