### PR TITLE
[black] force-exclude excluded files to work with pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-exclude = 'hail|datasets|sql|\.mypy'
+force-exclude = 'hail|datasets|sql|\.mypy'


### PR DESCRIPTION
`pre-commit` passes changed files as arguments to `black`, which overrides its `exclude` flag. `force-exclude` excludes files even if they are passed explicitly as arguments.