### PR TITLE
[query] Lower BlockMatrix.entries

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -881,8 +881,6 @@ class Tests(unittest.TestCase):
         sparsed = BlockMatrix.from_ndarray(hl.nd.array(sparsed_numpy), block_size=4)._sparsify_blocks(blocks_to_sparsify).to_ndarray()
         self.assertTrue(np.array_equal(sparsed_numpy, hl.eval(sparsed)))
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3
         rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(n_rows) for j in range(n_cols)]
@@ -894,7 +892,7 @@ class Tests(unittest.TestCase):
         ndarray = np.reshape(list(map(lambda row: row['entry'], rows)), (n_rows, n_cols))
 
         for block_size in [1, 2, 1024]:
-            block_matrix = BlockMatrix.from_numpy(ndarray, block_size)
+            block_matrix = BlockMatrix.from_ndarray(hl.literal(ndarray), block_size)
             entries_table = block_matrix.entries()
             self.assertEqual(entries_table.count(), n_cols * n_rows)
             self.assertEqual(len(entries_table.row), 3)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -262,9 +262,7 @@ object ArraySort {
 final case class ArraySort(a: IR, left: String, right: String, lessThan: IR) extends IR
 final case class ToSet(a: IR) extends IR
 final case class ToDict(a: IR) extends IR
-final case class ToArray(a: IR) extends IR {
-  val st = Thread.currentThread().getStackTrace.mkString("\n")
-}
+final case class ToArray(a: IR) extends IR
 final case class CastToArray(a: IR) extends IR
 final case class ToStream(a: IR, requiresMemoryManagementPerElement: Boolean = false) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -262,7 +262,9 @@ object ArraySort {
 final case class ArraySort(a: IR, left: String, right: String, lessThan: IR) extends IR
 final case class ToSet(a: IR) extends IR
 final case class ToDict(a: IR) extends IR
-final case class ToArray(a: IR) extends IR
+final case class ToArray(a: IR) extends IR {
+  val st = Thread.currentThread().getStackTrace.mkString("\n")
+}
 final case class CastToArray(a: IR) extends IR
 final case class ToStream(a: IR, requiresMemoryManagementPerElement: Boolean = false) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -90,7 +90,8 @@ object InferType {
       case ToDict(a) =>
         val elt = coerce[TBaseStruct](coerce[TStream](a.typ).elementType)
         TDict(elt.types(0), elt.types(1))
-      case ToArray(a) =>
+      case ta@ToArray(a) =>
+        assert(a.typ.isInstanceOf[TStream], s"Expected TStream, ${a.typ}. ToArray made at \n ${ta.st}")
         val elt = coerce[TStream](a.typ).elementType
         TArray(elt)
       case CastToArray(a) =>
@@ -223,6 +224,7 @@ object InferType {
       case MakeTuple(values) =>
         TTuple(values.map { case (i, value) => TupleField(i, value.typ) }.toFastIndexedSeq)
       case GetTupleElement(o, idx) =>
+        assert(o.typ.isInstanceOf[TTuple], s"${o.typ}")
         val t = coerce[TTuple](o.typ)
         val fd = t.fields(t.fieldIndex(idx)).typ
         fd

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -91,7 +91,6 @@ object InferType {
         val elt = coerce[TBaseStruct](coerce[TStream](a.typ).elementType)
         TDict(elt.types(0), elt.types(1))
       case ta@ToArray(a) =>
-        assert(a.typ.isInstanceOf[TStream], s"Expected TStream, ${a.typ}. ToArray made at \n ${ta.st}")
         val elt = coerce[TStream](a.typ).elementType
         TArray(elt)
       case CastToArray(a) =>
@@ -224,7 +223,6 @@ object InferType {
       case MakeTuple(values) =>
         TTuple(values.map { case (i, value) => TupleField(i, value.typ) }.toFastIndexedSeq)
       case GetTupleElement(o, idx) =>
-        assert(o.typ.isInstanceOf[TTuple], s"${o.typ}")
         val t = coerce[TTuple](o.typ)
         val fd = t.fields(t.fieldIndex(idx)).typ
         fd

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1102,7 +1102,7 @@ object LowerTableIR {
 
         case bmtt@BlockMatrixToTable(bmir) =>
           val bmStage = LowerBlockMatrixIR.lower(bmir, typesToLower, ctx, r, relationalLetsAbove)
-          val ts = BlockMatrixStage.blockMatrixStageToEntriesTableStage(bmStage, bmir.typ)
+          val ts = LowerBlockMatrixIR.lowerToTableStage(bmir, typesToLower, ctx, r, relationalLetsAbove)
           // I now have an unkeyed table of (blockRow, blockCol, block).
           val entriesUnkeyed = ts.mapPartitionWithContext { (partition, ctxRef) =>
             flatMapIR(partition)(singleRowRef =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -85,8 +85,6 @@ class TableStage(
 
   assert(key.forall(f => rowType.hasField(f)))
   assert(kType.fields.forall(f => rowType.field(f.name).typ == f.typ))
-  println(broadcastVals)
-  println(globals)
   assert(broadcastVals.exists { case (name, value) => name == globals.name && value == globals})
 
   def copy(
@@ -1102,12 +1100,29 @@ object LowerTableIR {
         case TableLiteral(typ, rvd, enc, encodedGlobals) =>
           RVDToTableStage(rvd, EncodedLiteral(enc, encodedGlobals))
 
-        case BlockMatrixToTable(bmir) =>
+        case bmtt@BlockMatrixToTable(bmir) =>
           val bmStage = LowerBlockMatrixIR.lower(bmir, typesToLower, ctx, r, relationalLetsAbove)
           val ts = BlockMatrixStage.blockMatrixStageToEntriesTableStage(bmStage, bmir.typ)
-          val compiledTemp = CompileAndEvaluate[Any](ctx, ts.collectWithGlobals(relationalLetsAbove))
-          println(compiledTemp)
-          ???
+          // I now have an unkeyed table of (blockRow, blockCol, block).
+          val entriesUnkeyed = ts.mapPartitionWithContext { (partition, ctxRef) =>
+            flatMapIR(partition)(singleRowRef =>
+              bindIR(GetField(singleRowRef, "block")) { singleNDRef =>
+                bindIR(NDArrayShape(singleNDRef)) { shapeTupleRef =>
+                  flatMapIR(rangeIR(Cast(GetTupleElement(shapeTupleRef, 0), TInt32))) { withinNDRowIdx =>
+                    mapIR(rangeIR(Cast(GetTupleElement(shapeTupleRef, 1), TInt32))) { withinNDColIdx =>
+                      val entry = NDArrayRef(singleNDRef, IndexedSeq(Cast(withinNDRowIdx, TInt64), Cast(withinNDColIdx, TInt64)), ErrorIDs.NO_ERROR)
+                      val blockStartRow = GetField(singleRowRef, "blockRow") * bmir.typ.blockSize
+                      val blockStartCol = GetField(singleRowRef, "blockCol") * bmir.typ.blockSize
+                      makestruct("i" -> Cast(withinNDRowIdx + blockStartRow, TInt64), "j" -> Cast(withinNDColIdx + blockStartCol, TInt64), "entry" -> entry)
+                    }
+                  }
+                }
+              }
+            )
+          }
+
+          val rowR = r.lookup(bmtt).asInstanceOf[RTable].rowType
+          ctx.backend.lowerDistributedSort(ctx, entriesUnkeyed, IndexedSeq(SortField("i", Ascending), SortField("j", Ascending)), relationalLetsAbove, rowR)
 
         case node =>
           throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -85,6 +85,8 @@ class TableStage(
 
   assert(key.forall(f => rowType.hasField(f)))
   assert(kType.fields.forall(f => rowType.field(f.name).typ == f.typ))
+  println(broadcastVals)
+  println(globals)
   assert(broadcastVals.exists { case (name, value) => name == globals.name && value == globals})
 
   def copy(
@@ -1101,7 +1103,10 @@ object LowerTableIR {
           RVDToTableStage(rvd, EncodedLiteral(enc, encodedGlobals))
 
         case BlockMatrixToTable(bmir) =>
-          val bmStage = LowerBlockMatrixIR.lower(bmir, typesToLower, ctx, ???, relationalLetsAbove)
+          val bmStage = LowerBlockMatrixIR.lower(bmir, typesToLower, ctx, r, relationalLetsAbove)
+          val ts = BlockMatrixStage.blockMatrixStageToEntriesTableStage(bmStage, bmir.typ)
+          val compiledTemp = CompileAndEvaluate[Any](ctx, ts.collectWithGlobals(relationalLetsAbove))
+          println(compiledTemp)
           ???
 
         case node =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1100,6 +1100,10 @@ object LowerTableIR {
         case TableLiteral(typ, rvd, enc, encodedGlobals) =>
           RVDToTableStage(rvd, EncodedLiteral(enc, encodedGlobals))
 
+        case BlockMatrixToTable(bmir) =>
+          val bmStage = LowerBlockMatrixIR.lower(bmir, typesToLower, ctx, ???, relationalLetsAbove)
+          ???
+
         case node =>
           throw new LowererUnsupportedOperation(s"undefined: \n${ Pretty(node) }")
       }


### PR DESCRIPTION
This PR lowers `BlockMatrixToTable`, which is the implementation of Hail's `BlockMatrix.entries`. It turns a `BlockMatrix` to a table of `(i, j, entry)` triplets. 