### PR TITLE
[query] Fixed BlockMatrixToValueApply simplify rule

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -257,7 +257,10 @@ class Tests(unittest.TestCase):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
         e = 2.0
-        x = BlockMatrix.from_ndarray(hl.literal(nx), block_size=8)
+        # BlockMatrixMap requires very simple IRs on the SparkBackend. If I use
+        # `from_ndarray` here, it generates an `NDArrayRef` expression that it can't handle.
+        # Will be fixed by improving FoldConstants handling of ndarrays or fully lowering BlockMatrix.
+        x = BlockMatrix._create(1, 1, [2.0], block_size=8)
         c = BlockMatrix.from_ndarray(hl.literal(nc), block_size=8)
         r = BlockMatrix.from_ndarray(hl.literal(nr), block_size=8)
         m = BlockMatrix.from_ndarray(hl.literal(nm), block_size=8)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -250,19 +250,17 @@ class Tests(unittest.TestCase):
         mt_round_trip = BlockMatrix.from_entry_expr(mt.element).to_matrix_table_row_major()
         assert mt._same(mt_round_trip)
 
-    @fails_service_backend()
-    @fails_local_backend()
-    def test_elementwise_ops(self):
+    def test_paired_elementwise_ops(self):
         nx = np.array([[2.0]])
         nc = np.array([[1.0], [2.0]])
         nr = np.array([[1.0, 2.0, 3.0]])
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
         e = 2.0
-        x = BlockMatrix.from_numpy(nx, block_size=8)
-        c = BlockMatrix.from_numpy(nc, block_size=8)
-        r = BlockMatrix.from_numpy(nr, block_size=8)
-        m = BlockMatrix.from_numpy(nm, block_size=8)
+        x = BlockMatrix.from_ndarray(hl.literal(nx), block_size=8)
+        c = BlockMatrix.from_ndarray(hl.literal(nc), block_size=8)
+        r = BlockMatrix.from_ndarray(hl.literal(nr), block_size=8)
+        m = BlockMatrix.from_ndarray(hl.literal(nm), block_size=8)
 
         self.assertRaises(TypeError,
                           lambda: x + np.array(['one'], dtype=str))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -421,6 +421,11 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
       case ValueToBlockMatrix(child, _, _) =>
         Interpret[Any](ctx, child) match {
           case vector: IndexedSeq[_] => vector.asInstanceOf[IndexedSeq[Double]].toArray
+          case vector: NDArray => {
+            val IndexedSeq(numRows, numCols) = vector.shape
+            assert(numRows == 1L || numCols == 1L)
+            vector.getRowMajorElements().asInstanceOf[IndexedSeq[Double]].toArray
+          }
         }
       case _ => ir.execute(ctx).toBreezeMatrix().data
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -565,9 +565,11 @@ object Simplify {
       canBeLifted(query)
     } => query
 
-    case BlockMatrixToValueApply(ValueToBlockMatrix(child, IndexedSeq(nrows, ncols), _), functions.GetElement(Seq(i, j))) =>
-      if (child.typ.isInstanceOf[TArray]) ArrayRef(child, I32((i * ncols + j).toInt)) else child
-
+    case BlockMatrixToValueApply(ValueToBlockMatrix(child, IndexedSeq(nrows, ncols), _), functions.GetElement(Seq(i, j))) => child.typ match {
+      case TArray(_) => ArrayRef(child, I32((i * ncols + j).toInt))
+      case TNDArray(_, _) => NDArrayRef(child, IndexedSeq(i, j), ErrorIDs.NO_ERROR)
+      case TFloat64 => child
+    }
     case LiftMeOut(child) if IsConstant(child) => child
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -427,6 +427,8 @@ object TypeCheck {
       case BlockMatrixCollect(_) =>
       case BlockMatrixWrite(_, _) =>
       case BlockMatrixMultiWrite(_, _) =>
+      case ValueToBlockMatrix(child, _, _) =>
+        assert(child.typ.isInstanceOf[TArray] || child.typ.isInstanceOf[TNDArray] ||  child.typ == TFloat64)
       case CollectDistributedArray(ctxs, globals, cname, gname, body, _) =>
         assert(ctxs.typ.isInstanceOf[TStream])
       case x@ReadPartition(context, rowType, reader) =>


### PR DESCRIPTION
Before ndarrays, the two choices for children of `ValueToBlockMatrix` were array or float. This simplify rule hadn't been updated to reflect that ndarrays were now an option, so it was falling through to the float case when it saw an ndarray. 

By fixing this, I've gotten `test_paired_elementwise_ops` to work on lowered backends. 