### PR TITLE
[compiler] Remove PCode.code and EmitCode.v

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -430,8 +430,6 @@ class EmitCode(private val start: CodeLabel, private val iec: IEmitCode) {
 
   val m: Code[Boolean] = new CCode(start.L, iec.Lmissing.L, iec.Lpresent.L)
 
-  def v: Code[_] = pv.code
-
   def toI(cb: EmitCodeBuilder): IEmitCode = {
     cb.goto(start)
     iec

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -992,7 +992,8 @@ class EmitMethodBuilder[C](
     // FIXME: this should optionally construct a tuple to support multiple-code SCodes
     emit(EmitCodeBuilder.scopedCode(this) { cb =>
       val res = f(cb)
-      res.code
+      require(res.st.nCodes == 1)
+      res.codeTuple().head
     })
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -65,10 +65,11 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     ev1: EmitSettable,
     ev2: EmitValue
   ): Unit = {
+    val combined = primitive(monoid.typ, monoid(ev1.pv.asPrimitive.primitiveCode, ev2.pv.asPrimitive.primitiveCode))
     cb.ifx(ev1.m,
       cb.ifx(!ev2.m, cb.assign(ev1, ev2)),
       cb.ifx(!ev2.m,
-        cb.assign(ev1, EmitCode.present(cb.emb, primitive(ev1.st.virtualType, monoid(ev1.v, ev2.v))))))
+        cb.assign(ev1, EmitCode.present(cb.emb, combined))))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -269,7 +269,7 @@ abstract class RegistryFunctions {
       case SFloat32 => Code.boxFloat(sc.asFloat32.floatCode(cb))
       case SFloat64 => Code.boxDouble(sc.asFloat64.doubleCode(cb))
       case SBoolean => Code.boxBoolean(sc.asBoolean.boolCode(cb))
-      case _: SCall => Code.boxInt(coerce[Int](sc.asPCode.code))
+      case _: SCall => Code.boxInt(sc.asCall.loadCanonicalRepresentation(cb))
       case _: SString => sc.asString.loadString()
       case _: SLocus => sc.asLocus.getLocusObj(cb)
       case t =>

--- a/hail/src/main/scala/is/hail/types/physical/PCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCode.scala
@@ -192,8 +192,6 @@ abstract class PCode extends SCode {
 
   def st: SType
 
-  def code: Code[_]
-
   def codeTuple(): IndexedSeq[Code[_]]
 
   override def asBoolean: SBooleanCode = asInstanceOf[SBooleanCode]

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -129,8 +129,6 @@ class SNDArrayPointerSettable(
 class SNDArrayPointerCode(val st: SNDArrayPointer, val a: Code[Long]) extends PNDArrayCode {
   val pt: PCanonicalNDArray = st.pType
 
-  override def code: Code[_] = a
-
   override def codeTuple(): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
   def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): PNDArrayValue = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -82,9 +82,6 @@ class SSubsetStructSettable(val st: SSubsetStruct, prev: PStructSettable) extend
 }
 
 class SSubsetStructCode(val st: SSubsetStruct, val prev: PBaseStructCode) extends PBaseStructCode {
-
-  def code: Code[_] = prev.code
-
   def codeTuple(): IndexedSeq[Code[_]] = prev.codeTuple()
 
   def memoize(cb: EmitCodeBuilder, name: String): PBaseStructValue = {

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -143,7 +143,7 @@ class BTreeBackedSet(ctx: ExecuteContext, region: Region, n: Int) {
         cb += Code.memoize(koff, "koff") { koff =>
           val ec = key.loadCompKey(cb, koff)
           ec.m.mux(sab.addMissing(),
-            sab.add(ec.v))
+            sab.add(ec.pv.asInt64.longCode(cb)))
         }
       }
       cb += (returnArray := Code.newArray[java.lang.Long](sab.size))


### PR DESCRIPTION
There was basically nothing to do here after the latest changes.