### PR TITLE
[query] Correctly lowered BlockMatrixSlice

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -596,14 +596,17 @@ class Tests(unittest.TestCase):
             self._assert_eq(bm[indices] - bm, nd[indices] - nd)
             self._assert_eq(bm - bm[indices], nd - nd[indices])
 
-        for indices in [(slice(0, 8), slice(0, 10)),
-                        (slice(0, 8, 2), slice(0, 10, 2)),
-                        (slice(2, 4), slice(5, 7)),
-                        (slice(-8, -1), slice(-10, -1)),
-                        (slice(-8, -1, 2), slice(-10, -1, 2)),
-                        (slice(None, 4, 1), slice(None, 4, 1)),
-                        (slice(4, None), slice(4, None)),
-                        (slice(None, None), slice(None, None))]:
+        for indices in [
+            (slice(0, 8), slice(0, 10)),
+            (slice(0, 8, 2), slice(0, 10, 2)),
+            (slice(2, 4), slice(5, 7)),
+            (slice(-8, -1), slice(-10, -1)),
+            (slice(-8, -1, 2), slice(-10, -1, 2)),
+            (slice(None, 4, 1), slice(None, 4, 1)),
+            (slice(4, None), slice(4, None)),
+            (slice(None, None), slice(None, None))
+        ]:
+            print(f"Trying slice {indices}")
             self._assert_eq(bm[indices], nd[indices])
             self._assert_eq(bm[indices][:, :2], nd[indices][:, :2])
             self._assert_eq(bm[indices][:2, :], nd[indices][:2, :])

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -572,7 +572,6 @@ class Tests(unittest.TestCase):
         self.assert_sums_agree(bm3, nd)
         self.assert_sums_agree(bm4, nd4)
 
-    @fails_service_backend()
     def test_slicing(self):
         nd = np.array(np.arange(0, 80, dtype=float)).reshape(8, 10)
         bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -606,7 +606,6 @@ class Tests(unittest.TestCase):
             (slice(4, None), slice(4, None)),
             (slice(None, None), slice(None, None))
         ]:
-            print(f"Trying slice {indices}")
             self._assert_eq(bm[indices], nd[indices])
             self._assert_eq(bm[indices][:, :2], nd[indices][:, :2])
             self._assert_eq(bm[indices][:2, :], nd[indices][:2, :])

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -573,10 +573,9 @@ class Tests(unittest.TestCase):
         self.assert_sums_agree(bm4, nd4)
 
     @fails_service_backend()
-    @fails_local_backend()
     def test_slicing(self):
         nd = np.array(np.arange(0, 80, dtype=float)).reshape(8, 10)
-        bm = BlockMatrix.from_numpy(nd, block_size=3)
+        bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)
 
         for indices in [(0, 0), (5, 7), (-3, 9), (-8, -10)]:
             self._assert_eq(bm[indices], nd[indices])

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2823,7 +2823,7 @@ class Emit[C](
                   }
                   else {
                     cb.ifx(dimLength.cne(localDim),
-                      cb._fatal(const(s"NDArrayConcat: mismatched dimensions of input NDArrays along axis ").concat(loopIdx.toS).concat(": expected ")
+                      cb._fatal(const(s"NDArrayConcat: mismatched dimensions of input NDArrays along axis ").concat(axis.toString).concat(": expected ")
                         .concat(localDim.toS).concat(", got ")
                         .concat(dimLength.toS))
                     )

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -293,6 +293,8 @@ object Pretty {
       single(prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats)))
     case MatrixToValueApply(_, function) =>
       single(prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats)))
+    case BlockMatrixToValueApply(_, function) =>
+      single(prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats)))
     case BlockMatrixToTableApply(_, _, function) =>
       single(prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats)))
     case TableRename(_, rowMap, globalMap) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -943,12 +943,12 @@ object Simplify {
     case BlockMatrixSlice(BlockMatrixMap2(l, r, ln, rn, f, sparsityStrategy), slices) =>
       BlockMatrixMap2(BlockMatrixSlice(l, slices), BlockMatrixSlice(r, slices), ln, rn, f, sparsityStrategy)
     case BlockMatrixMap2(BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), right, leftName, rightName, f, sparsityStrategy) =>
-      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
+      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(IndexedSeq(0, 0)))
       val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = true, rightBlock = false)
       val maybeDense = if (needsDense) BlockMatrixDensify(right) else right
       BlockMatrixMap(maybeDense, rightName, Subst(f, BindingEnv.eval(leftName -> getElement)), needsDense)
     case BlockMatrixMap2(left, BlockMatrixBroadcast(scalarBM, IndexedSeq(), _, _), leftName, rightName, f, sparsityStrategy) =>
-      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(Seq(0, 0)))
+      val getElement = BlockMatrixToValueApply(scalarBM, functions.GetElement(IndexedSeq(0, 0)))
       val needsDense = sparsityStrategy == NeedsDense || sparsityStrategy.exists(leftBlock = false, rightBlock = true)
       val maybeDense = if (needsDense) BlockMatrixDensify(left) else left
       BlockMatrixMap(maybeDense, leftName, Subst(f, BindingEnv.eval(rightName -> getElement)), needsDense)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
@@ -5,7 +5,7 @@ import is.hail.types.BlockMatrixType
 import is.hail.types.virtual.Type
 import is.hail.linalg.BlockMatrix
 
-case class GetElement(index: Seq[Long]) extends BlockMatrixToValueFunction {
+case class GetElement(index: IndexedSeq[Long]) extends BlockMatrixToValueFunction {
   assert(index.length == 2)
 
   override def typ(childType: BlockMatrixType): Type = childType.elementType

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -364,29 +364,32 @@ object LowerBlockMatrixIR {
         val rowDependents = x.rowBlockDependents
         val colDependents = x.colBlockDependents
 
-        println(s"Trying to lower ${x}")
-        println(s"rowDependents = ${rowDependents.map(_.toIndexedSeq).toIndexedSeq}")
-        println(s"colDependents = ${colDependents.map(_.toIndexedSeq).toIndexedSeq}")
-
         val condensed = lower(child).condenseBlocks(child.typ, rowDependents, colDependents)
           .addContext(TTuple(TTuple(TInt64, TInt64, TInt64), TTuple(TInt64, TInt64, TInt64))) { idx =>
-            val i = idx._1
-            val j = idx._2
-            val rowStartIdx = rowDependents(i).head.toLong * x.typ.blockSize
-            val colStartIdx = colDependents(j).head.toLong * x.typ.blockSize
+            val (i, j) = idx
 
-            val rowEndIdx = java.lang.Math.min(child.typ.nRows, (rowDependents(i).last + 1L) * x.typ.blockSize)
-            val colEndIdx = java.lang.Math.min(child.typ.nCols, (colDependents(j).last + 1L) * x.typ.blockSize)
+            // Aligned with the edges of blocks in child BM.
+            val blockAlignedRowStartIdx = rowDependents(i).head.toLong * x.typ.blockSize
+            val blockAlignedColStartIdx = colDependents(j).head.toLong * x.typ.blockSize
+            val blockAlignedRowEndIdx = math.min(child.typ.nRows, (rowDependents(i).last + 1L) * x.typ.blockSize * rStep)
+            val blockAlignedColEndIdx = math.min(child.typ.nCols, (colDependents(j).last + 1L) * x.typ.blockSize * cStep)
+
+            val rStartPlusSeenAlready = rStart + i * x.typ.blockSize * rStep
+            val cStartPlusSeenAlready = cStart + j * x.typ.blockSize * cStep
+
+            val rowTrueStart = rStartPlusSeenAlready - blockAlignedRowStartIdx
+            val rowTrueEnd = math.min(math.min(rEnd, blockAlignedRowEndIdx) - blockAlignedRowStartIdx, rowTrueStart + x.typ.blockSize * rStep)
             val rows = MakeTuple.ordered(FastSeq[IR](
-              if (rStart >= rowStartIdx) rStart - rowStartIdx else (rowStartIdx - rStart) % rStep,
-              java.lang.Math.min(rEnd, rowEndIdx) - rowStartIdx,
+              rowTrueStart,
+              rowTrueEnd,
               rStep))
+
+            val colTrueStart = cStartPlusSeenAlready - blockAlignedColStartIdx
+            val colTrueEnd = math.min(java.lang.Math.min(cEnd, blockAlignedColEndIdx) - blockAlignedColStartIdx, colTrueStart + x.typ.blockSize * cStep)
             val cols = MakeTuple.ordered(FastSeq[IR](
-              if (cStart >= colStartIdx) cStart - colStartIdx else (colStartIdx - cStart) % cStep,
-              java.lang.Math.min(cEnd, colEndIdx) - colStartIdx,
+              colTrueStart,
+              colTrueEnd,
               cStep))
-            //println(s"${idx} colStartIdx = ${colStartIdx}, colEndIdx = ${colEndIdx}, cStart = ${cStart}, cEnd = ${cEnd}")
-            //println(s"${idx} maps to slices of ${FastSeq(rows, cols)}")
             MakeTuple.ordered(FastSeq(rows, cols))
           }
 


### PR DESCRIPTION
We had a lowering defined for `BlockMatrixSlice`, but it was barely tested and not correct. In this PR I rewrote it to be correct and enabled the python tests in `test_linalg` that check slicing behavior. 