### PR TITLE
Quieter rsync on make install

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -192,7 +192,7 @@ copy-py-files: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES) 
 	mkdir -p build/deploy
 	mkdir -p build/deploy/src
 	cp ../README.md build/deploy/
-	rsync -rv \
+	rsync -r \
 	    --exclude '.eggs/' \
 	    --exclude '.pytest_cache/' \
 	    --exclude '__pycache__/' \


### PR DESCRIPTION
rsync -v prints every file that's being copied, which is way too much terminal noise. I feel like it didn't used to do this? Maybe mac update changed it. 