### PR TITLE
[query] Replace Matrix / Vector multiplies with DGEMV

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -672,6 +672,22 @@ def test_ndarray_matmul():
         hl.eval(hl.nd.array([1, 2]) @ hl.nd.array([1, 2, 3]))
     assert "Matrix dimensions incompatible" in str(exc.value)
 
+def test_ndarray_matmul_dgemv():
+    np_mat_3_4 = np.arange(12, dtype=np.float64).reshape((3, 4))
+    np_mat_4_3 = np.arange(12, dtype=np.float64).reshape((4, 3))
+    np_vec_3 = np.array([4, 2, 7], dtype=np.float64)
+    np_vec_4 = np.array([9, 17, 3, 1], dtype=np.float64)
+
+    mat_3_4 = hl.nd.array(np_mat_3_4)
+    mat_4_3 = hl.nd.array(np_mat_4_3)
+    vec_3 = hl.nd.array(np_vec_3)
+    vec_4 = hl.nd.array(np_vec_4)
+
+    assert_ndarrays_eq(
+        (mat_3_4 @ vec_4, np_mat_3_4 @ np_vec_4),
+        (mat_4_3 @ vec_3, np_mat_4_3 @ np_vec_3),
+        (mat_3_4.T @ vec_3, np_mat_3_4.T @ np_vec_3)
+    )
 
 def test_ndarray_big():
     assert hl.eval(hl.nd.array(hl.range(100_000))).size == 100_000

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -731,7 +731,6 @@ class Tests(unittest.TestCase):
             self.assertAlmostEqual(multi_results[1001].logistic_regression[0].p_value,single_results[1001].p_value, places=6)
             #TODO test handling of missingness
 
-
     def test_logistic_regression_wald_test_pl(self):
         covariates = hl.import_table(resource('regressionLogistic.cov'),
                                      key='Sample',

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -277,6 +277,20 @@ object Code {
       cls, method, Array[Class[_]](
         a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass, a7ct.runtimeClass, a8ct.runtimeClass), Array(a1, a2, a3, a4, a5, a6, a7, a8))
 
+  def invokeScalaObject11[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, S](
+    cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6], a7: Code[A7], a8: Code[A8],
+    a9: Code[A9], a10: Code[A10], a11: Code[A11])(
+    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], a7ct: ClassTag[A7],
+    a8ct: ClassTag[A8], a9ct: ClassTag[A9], a10ct: ClassTag[A10], a11ct: ClassTag[A11], sct: ClassTag[S]
+  ): Code[S] =
+    invokeScalaObject[S](
+      cls, method,
+      Array[Class[_]](
+        a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass, a7ct.runtimeClass, a8ct.runtimeClass,
+        a9ct.runtimeClass, a10ct.runtimeClass, a11ct.runtimeClass),
+      Array(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+    )
+
   def invokeScalaObject13[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, S](
     cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6], a7: Code[A7], a8: Code[A8],
     a9: Code[A9], a10: Code[A10], a11: Code[A11], a12: Code[A12], a13: Code[A13])(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1443,9 +1443,11 @@ class Emit[C](
               val leftDataAddress = leftPVal.firstDataAddress(cb)
               val rightDataAddress = rightPVal.firstDataAddress(cb)
 
-              val M = lShape(lSType.nDims - 2)
-              val N = lShape(lSType.nDims - 1)
-              val outputSize = cb.newLocal[Long]("output_size", M)
+              val numRows = lShape(lSType.nDims - 2)
+              val numCols = lShape(lSType.nDims - 1)
+              val M = cb.newLocal[Long]("dgemv_m", leftIsColumnMajor.mux(numRows, numCols))
+              val N = cb.newLocal[Long]("dgemv_n", leftIsColumnMajor.mux(numCols, numRows))
+              val outputSize = cb.newLocal[Long]("output_size", numRows)
 
               val alpha = 1.0
               val beta = 0.0
@@ -1474,13 +1476,7 @@ class Emit[C](
               ))
 
 
-              val res = answerFinisher(cb).memoize(cb, "foo")
-              cb.println(const("M = ").concat(M.toS))
-              cb.println(const("N = ").concat(N.toS))
-              cb.println(const("left: ") concat cb.strValue(leftPVal))
-              cb.println(const("right: ") concat cb.strValue(rightPVal))
-              cb.println(const("ans: ") concat cb.strValue(res))
-              res
+              answerFinisher(cb)
             }  else {
               val numericElementType = coerce[PNumeric](lSType.elementType.canonicalPType())
               val eVti = typeToTypeInfo(numericElementType)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1451,8 +1451,8 @@ class Emit[C](
               val LDA = M
 
               val (answerFirstElementAddr, answerFinisher) = outputPType.constructDataFunction(
-                IndexedSeq(N),
-                outputPType.makeColumnMajorStrides(IndexedSeq(N), region, cb),
+                IndexedSeq(M),
+                outputPType.makeColumnMajorStrides(IndexedSeq(M), region, cb),
                 cb,
                 region)
               

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1449,6 +1449,7 @@ class Emit[C](
               val beta = 0.0
 
               val LDA = M
+              val TRANS: Code[String] = leftIsColumnMajor.mux("N", "T")
 
               val (answerFirstElementAddr, answerFinisher) = outputPType.constructDataFunction(
                 IndexedSeq(M),
@@ -1457,7 +1458,7 @@ class Emit[C](
                 region)
               
               cb.append(Code.invokeScalaObject11[String, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, method="dgemv",
-                "N",
+                TRANS,
                 M.toI,
                 N.toI,
                 alpha,

--- a/hail/src/main/scala/is/hail/linalg/BLAS.scala
+++ b/hail/src/main/scala/is/hail/linalg/BLAS.scala
@@ -68,9 +68,22 @@ object BLAS {
 
     libraryInstance.get.dgemm(TRANSA, TRANSB, mInt, nInt, kInt, alphaDouble, A, LDAInt, B, LDBInt, betaDouble, C, LDCInt)
   }
+
+  def dgemv(TRANS: String, M: Int, N: Int, ALPHA: Double, A: Long, LDA: Int, X: Long, INCX: Int, BETA: Double, Y: Long, INCY: Int): Unit = {
+    val mInt = new IntByReference(M)
+    val nInt = new IntByReference(N)
+    val alphaDouble = new DoubleByReference(ALPHA)
+    val LDAInt = new IntByReference(LDA)
+    val betaDouble = new DoubleByReference(BETA)
+    val incxInt = new IntByReference(INCX)
+    val incyInt = new IntByReference(INCY)
+
+    libraryInstance.dgemv(TRANS, mInt, nInt, alphaDouble, A, LDAInt, X, incxInt, betaDouble, Y, incyInt)
+  }
 }
 
 trait BLASLibrary extends Library {
+  def dgemv(TRANS: String, M: IntByReference, N: IntByReference, ALPHA: DoubleByReference, A: Long, LDA: IntByReference, X: Long, INCX: IntByReference, BETA: DoubleByReference, Y: Long, INCY: IntByReference)
   def dgemm(TRANSA: String, TRANSB: String, M: IntByReference, N: IntByReference, K: IntByReference,
     ALPHA: DoubleByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference,
     BETA: DoubleByReference, C: Long, LDC: IntByReference)

--- a/hail/src/main/scala/is/hail/linalg/BLAS.scala
+++ b/hail/src/main/scala/is/hail/linalg/BLAS.scala
@@ -78,7 +78,7 @@ object BLAS {
     val incxInt = new IntByReference(INCX)
     val incyInt = new IntByReference(INCY)
 
-    libraryInstance.dgemv(TRANS, mInt, nInt, alphaDouble, A, LDAInt, X, incxInt, betaDouble, Y, incyInt)
+    libraryInstance.get.dgemv(TRANS, mInt, nInt, alphaDouble, A, LDAInt, X, incxInt, betaDouble, Y, incyInt)
   }
 }
 


### PR DESCRIPTION
Need to use dgemv when doing matrix vector multiplies. 

Makes `logistic_regression_rows_nd` ~12% faster