### PR TITLE
[hailtop/fs] add S3AsyncFS

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -48,6 +48,7 @@ steps:
       - gcr-push-service-account-key
       - hail-ci-0-1-github-oauth-token
       - test-gsa-key
+      - test-aws-key
       - auth-oauth2-client-secret
       - zulip-config
       - benchmark-gsa-key
@@ -1252,8 +1253,10 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=0
@@ -1272,6 +1275,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_tests_image
@@ -1293,8 +1300,10 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=1
@@ -1313,6 +1322,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_tests_image
@@ -1334,8 +1347,10 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=2
@@ -1354,6 +1369,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_tests_image
@@ -1375,8 +1394,10 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=3
@@ -1395,6 +1416,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_tests_image
@@ -1416,8 +1441,10 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=4
@@ -1436,6 +1463,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_tests_image
@@ -1453,8 +1484,10 @@ steps:
       tar xzf test.tar.gz
       tar xvf debug-wheel-container.tar
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+      export HAIL_TEST_S3_BUCKET=hail-test-dy5rg
+      export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
       python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 -n 10 test/hailtop/aiotools/test_copy.py
     inputs:
       - from: /debug-wheel-container.tar
@@ -1466,6 +1499,10 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-gsa-key
+      - name: test-aws-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-aws-key
     dependsOn:
       - default_ns
       - hail_run_image
@@ -1487,7 +1524,7 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       python3 -m pytest -m unchecked_allocator --ignore=test/hailtop/batch/ --log-cli-level=INFO -s -vv --instafail --durations=50 test
@@ -1604,7 +1641,7 @@ steps:
       python3 -m pip install --no-dependencies hail-*-py3-none-any.whl
       export HAIL_TEST_RESOURCES_DIR=./resources
       export HAIL_DOCTEST_DATA_DIR=./data
-      export HAIL_TEST_BUCKET=hail-test-dmk9z
+      export HAIL_TEST_GCS_BUCKET=hail-test-dmk9z
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=2
       export HAIL_QUERY_BACKEND=local

--- a/hail/python/hailtop/aiotools/fs.py
+++ b/hail/python/hailtop/aiotools/fs.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List, Type, BinaryIO, cast, Set, AsyncIterator, Union, Dict
+from typing import Any, AsyncContextManager, Optional, List, Type, BinaryIO, cast, Set, AsyncIterator, Union, Dict
 from types import TracebackType
 import abc
 import os
@@ -12,7 +12,7 @@ import urllib.parse
 import humanize
 from hailtop.utils import (
     retry_transient_errors, blocking_to_async, url_basename, url_join, bounded_gather2,
-    time_msecs, humanize_timedelta_msecs)
+    time_msecs, humanize_timedelta_msecs, OnlineBoundedGather2)
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 
 
@@ -54,7 +54,7 @@ class FileListEntry(abc.ABC):
 
 class MultiPartCreate(abc.ABC):
     @abc.abstractmethod
-    async def create_part(self, number: int, start: int, *, retry_writes: bool = True):
+    async def create_part(self, number: int, start: int) -> AsyncContextManager[WritableStream]:
         pass
 
     @abc.abstractmethod
@@ -86,7 +86,7 @@ class AsyncFS(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create(self, url: str, *, retry_writes: bool = True) -> WritableStream:
+    async def create(self, url: str, *, retry_writes: bool = True) -> AsyncContextManager[WritableStream]:
         pass
 
     @abc.abstractmethod
@@ -117,6 +117,33 @@ class AsyncFS(abc.ABC):
     async def staturl(self, url: str) -> str:
         pass
 
+    async def _staturl_parallel_isfile_isdir(self, url: str) -> str:
+        assert not url.endswith('/')
+
+        async def with_exception(f, *args, **kwargs):
+            try:
+                return (await f(*args, **kwargs)), None
+            except Exception as e:
+                return None, e
+
+        [(is_file, isfile_exc), (is_dir, isdir_exc)] = await asyncio.gather(
+            with_exception(self.isfile, url), with_exception(self.isdir, url + '/'))
+        # raise exception deterministically
+        if isfile_exc:
+            raise isfile_exc
+        if isdir_exc:
+            raise isdir_exc
+
+        if is_file:
+            if is_dir:
+                raise FileAndDirectoryError(url)
+            return AsyncFS.FILE
+
+        if is_dir:
+            return AsyncFS.DIR
+
+        raise FileNotFoundError(url)
+
     @abc.abstractmethod
     async def isfile(self, url: str) -> bool:
         pass
@@ -129,9 +156,24 @@ class AsyncFS(abc.ABC):
     async def remove(self, url: str) -> None:
         pass
 
+    async def _remove_doesnt_exist_ok(self, url):
+        try:
+            await self.remove(url)
+        except FileNotFoundError:
+            pass
+
     @abc.abstractmethod
     async def rmtree(self, sema: Optional[asyncio.Semaphore], url: str) -> None:
         pass
+
+    async def _rmtree_with_recursive_listfiles(self, sema: asyncio.Semaphore, url: str) -> None:
+        async with OnlineBoundedGather2(sema) as pool:
+            try:
+                it = await self.listfiles(url, recursive=True)
+            except FileNotFoundError:
+                return
+            async for entry in it:
+                await pool.call(self._remove_doesnt_exist_ok, await entry.url())
 
     async def touch(self, url: str) -> None:
         async with await self.create(url):
@@ -221,7 +263,7 @@ class LocalMultiPartCreate(MultiPartCreate):
         self._path = path
         self._num_parts = num_parts
 
-    async def create_part(self, number: int, start: int, *, retry_writes: bool = True):  # pylint: disable=unused-argument
+    async def create_part(self, number: int, start: int):  # pylint: disable=unused-argument
         assert 0 <= number < self._num_parts
         f = await blocking_to_async(self._fs._thread_pool, open, self._path, 'r+b')
         f.seek(start)
@@ -514,12 +556,12 @@ class SourceCopier:
 
         async with await self.router_fs.open(srcfile) as srcf:
             try:
-                destf = await self.router_fs.create(destfile, retry_writes=False)
+                dest_cm = await self.router_fs.create(destfile, retry_writes=False)
             except FileNotFoundError:
                 await self.router_fs.makedirs(os.path.dirname(destfile), exist_ok=True)
-                destf = await self.router_fs.create(destfile)
+                dest_cm = await self.router_fs.create(destfile)
 
-            async with destf:
+            async with dest_cm as destf:
                 while True:
                     b = await srcf.read(Copier.BUFFER_SIZE)
                     if not b:
@@ -530,7 +572,7 @@ class SourceCopier:
     async def _copy_part(self, source_report, srcfile, part_number, part_creator, return_exceptions):
         try:
             async with await self.router_fs.open_from(srcfile, part_number * self.PART_SIZE) as srcf:
-                async with await part_creator.create_part(part_number, part_number * self.PART_SIZE, retry_writes=False) as destf:
+                async with await part_creator.create_part(part_number, part_number * self.PART_SIZE) as destf:
                     n = self.PART_SIZE
                     while n > 0:
                         b = await srcf.read(min(Copier.BUFFER_SIZE, n))

--- a/hail/python/hailtop/aiotools/s3asyncfs.py
+++ b/hail/python/hailtop/aiotools/s3asyncfs.py
@@ -1,0 +1,413 @@
+from typing import Any, AsyncIterator, BinaryIO, cast, AsyncContextManager, Dict, List, Optional, Set, Tuple, Type
+from types import TracebackType
+from concurrent.futures import ThreadPoolExecutor
+import os.path
+import urllib
+import asyncio
+import botocore.exceptions
+import boto3
+from hailtop.utils import blocking_to_async
+from hailtop.aiotools import (
+    FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
+    MultiPartCreate)
+from .stream import (
+    AsyncQueueWritableStream,
+    async_writable_blocking_readable_stream_pair,
+    blocking_readable_stream_to_async)
+
+
+class PageIterator:
+    def __init__(self, fs: 'S3AsyncFS', bucket: str, prefix: str, delimiter: Optional[str] = None):
+        self._fs = fs
+        self._bucket = bucket
+        self._prefix = prefix
+        self._kwargs = {}
+        if delimiter is not None:
+            self._kwargs['Delimiter'] = delimiter
+        self._page = None
+
+    def __aiter__(self) -> 'PageIterator':
+        return self
+
+    async def __anext__(self):
+        if self._page is None:
+            self._page = await blocking_to_async(self._fs._thread_pool, self._fs._s3.list_objects_v2,
+                                                 Bucket=self._bucket,
+                                                 Prefix=self._prefix,
+                                                 **self._kwargs)
+            return self._page
+
+        next_continuation_token = self._page.get('NextContinuationToken')
+        if next_continuation_token is not None:
+            self._page = await blocking_to_async(self._fs._thread_pool, self._fs._s3.list_objects_v2,
+                                                 Bucket=self._bucket,
+                                                 Prefix=self._prefix,
+                                                 ContinuationToken=next_continuation_token,
+                                                 **self._kwargs)
+            return self._page
+
+        raise StopAsyncIteration
+
+
+class S3HeadObjectFileStatus(FileStatus):
+    def __init__(self, head_object_resp):
+        self.head_object_resp = head_object_resp
+
+    async def size(self) -> int:
+        return self.head_object_resp['ContentLength']
+
+    async def __getitem__(self, key: str) -> Any:
+        return self.head_object_resp[key]
+
+
+class S3ListFilesFileStatus(FileStatus):
+    def __init__(self, item: Dict[str, Any]):
+        self._item = item
+
+    async def size(self) -> int:
+        return self._item['Size']
+
+    async def __getitem__(self, key: str) -> Any:
+        return self._item.get(key)
+
+
+class S3CreateManager(AsyncContextManager[WritableStream]):
+    def __init__(self, fs, bucket, name):
+        self.fs = fs
+        self.bucket = bucket
+        self.name = name
+        self.async_writable = None
+        self.put_task = None
+        self._value = None
+
+    async def __aenter__(self) -> WritableStream:
+        async_writable, blocking_readable = async_writable_blocking_readable_stream_pair()
+        self.async_writable = async_writable
+        self.put_task = asyncio.create_task(
+            blocking_to_async(self.fs._thread_pool, self.fs._s3.upload_fileobj,
+                              blocking_readable,
+                              Bucket=self.bucket,
+                              Key=self.name))
+        return async_writable
+
+    async def __aexit__(
+            self, exc_type: Optional[Type[BaseException]] = None,
+            exc_value: Optional[BaseException] = None,
+            exc_traceback: Optional[TracebackType] = None) -> None:
+        await self.async_writable.wait_closed()
+        self._value = await self.put_task
+
+
+class S3FileListEntry(FileListEntry):
+    def __init__(self, bucket: str, key: str, item: Optional[Dict[str, Any]]):
+        assert key.endswith('/') == (item is None)
+        self._bucket = bucket
+        self._key = key
+        self._item = item
+        self._status: Optional[S3ListFilesFileStatus] = None
+
+    def name(self) -> str:
+        return os.path.basename(self._key)
+
+    async def url(self) -> str:
+        return f's3://{self._bucket}/{self._key}'
+
+    def url_maybe_trailing_slash(self) -> str:
+        return f's3://{self._bucket}/{self._key}'
+
+    async def is_file(self) -> bool:
+        return self._item is not None
+
+    async def is_dir(self) -> bool:
+        return self._item is None
+
+    async def status(self) -> FileStatus:
+        if self._status is None:
+            if self._item is None:
+                raise IsADirectoryError(f's3://{self._bucket}/{self._key}')
+            self._status = S3ListFilesFileStatus(self._item)
+        return self._status
+
+
+def _upload_part(s3, bucket, key, number, f, upload_id):
+    b = f.read()
+    resp = s3.upload_part(
+        Bucket=bucket,
+        Key=key,
+        PartNumber=number + 1,
+        UploadId=upload_id,
+        Body=b)
+    return resp['ETag']
+
+
+class S3CreatePartManager(AsyncContextManager[WritableStream]):
+    def __init__(self, mpc, number: int):
+        self._mpc = mpc
+        self._number = number
+        self._async_writable: Optional[AsyncQueueWritableStream] = None
+        self._put_task: Optional[asyncio.Task] = None
+
+    async def __aenter__(self) -> WritableStream:
+        async_writable, blocking_readable = async_writable_blocking_readable_stream_pair()
+        self._async_writable = async_writable
+        self._put_task = asyncio.create_task(
+            blocking_to_async(self._mpc._fs._thread_pool, _upload_part,
+                              self._mpc._fs._s3,
+                              self._mpc._bucket,
+                              self._mpc._name,
+                              self._number,
+                              blocking_readable,
+                              self._mpc._upload_id))
+        return async_writable
+
+    async def __aexit__(
+            self, exc_type: Optional[Type[BaseException]] = None,
+            exc_value: Optional[BaseException] = None,
+            exc_traceback: Optional[TracebackType] = None) -> None:
+        assert self._async_writable is not None
+        assert self._put_task is not None
+        try:
+            await self._async_writable.wait_closed()
+        finally:
+            self._mpc._etags[self._number] = await self._put_task
+
+
+class S3MultiPartCreate(MultiPartCreate):
+    def __init__(self, sema: asyncio.Semaphore, fs: 'S3AsyncFS', bucket: str, name: str, num_parts: int):
+        self._sema = sema
+        self._fs = fs
+        self._bucket = bucket
+        self._name = name
+        self._num_parts = num_parts
+        self._upload_id = None
+        self._etags: List[Optional[str]] = [None] * num_parts
+
+    async def __aenter__(self) -> 'S3MultiPartCreate':
+        resp = await blocking_to_async(self._fs._thread_pool, self._fs._s3.create_multipart_upload,
+                                       Bucket=self._bucket,
+                                       Key=self._name)
+        self._upload_id = resp['UploadId']
+        return self
+
+    async def __aexit__(
+            self, exc_type: Optional[Type[BaseException]] = None,
+            exc_value: Optional[BaseException] = None,
+            exc_traceback: Optional[TracebackType] = None) -> None:
+        if exc_value is not None:
+            await blocking_to_async(self._fs._thread_pool, self._fs._s3.abort_multipart_upload,
+                                    Bucket=self._bucket,
+                                    Key=self._name,
+                                    UploadId=self._upload_id)
+            return
+
+        parts = []
+        part_number = 1
+        for etag in self._etags:
+            assert etag is not None
+            parts.append({
+                'ETag': etag,
+                'PartNumber': part_number
+            })
+            part_number += 1
+
+        await blocking_to_async(self._fs._thread_pool, self._fs._s3.complete_multipart_upload,
+                                Bucket=self._bucket,
+                                Key=self._name,
+                                MultipartUpload={'Parts': parts},
+                                UploadId=self._upload_id)
+
+    async def create_part(self, number: int, start: int) -> S3CreatePartManager:  # pylint: disable=unused-argument
+        return S3CreatePartManager(self, number)
+
+
+class S3AsyncFS(AsyncFS):
+    def __init__(self, thread_pool: ThreadPoolExecutor, max_workers=None):
+        if not thread_pool:
+            thread_pool = ThreadPoolExecutor(max_workers=max_workers)
+        self._thread_pool = thread_pool
+        self._s3 = boto3.client('s3')
+
+    def schemes(self) -> Set[str]:
+        return {'s3'}
+
+    @staticmethod
+    def _get_bucket_name(url: str) -> Tuple[str, str]:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != 's3':
+            raise ValueError(f"invalid scheme, expected s3: {parsed.scheme}")
+
+        name = parsed.path
+        if name:
+            assert name[0] == '/'
+            name = name[1:]
+
+        return (parsed.netloc, name)
+
+    async def open(self, url: str) -> ReadableStream:
+        bucket, name = self._get_bucket_name(url)
+        resp = await blocking_to_async(self._thread_pool, self._s3.get_object,
+                                       Bucket=bucket,
+                                       Key=name)
+        return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, resp['Body']))
+
+    async def open_from(self, url: str, start: int) -> ReadableStream:
+        bucket, name = self._get_bucket_name(url)
+        resp = await blocking_to_async(self._thread_pool, self._s3.get_object,
+                                       Bucket=bucket,
+                                       Key=name,
+                                       Range=f'bytes={start}-')
+        return blocking_readable_stream_to_async(self._thread_pool, cast(BinaryIO, resp['Body']))
+
+    async def create(self, url: str, *, retry_writes: bool = True) -> S3CreateManager:  # pylint: disable=unused-argument
+        # It may be possible to write a more efficient version of this
+        # that takes advantage of retry_writes=False.  Here's the
+        # background information:
+        #
+        # There are essentially three options for implementing writes.
+        # The first two handle retries:
+        #
+        #  1. Use some form of multipart uploads (which, in the case
+        #     of GCS, we implement by writing temporary objects and
+        #     then calling compose).
+        #
+        #  2. Use resumable uploads.  This is what the GCS backend
+        #     does, although the performance is must worse than
+        #     non-resumable uploads so in fact it may always be better
+        #     to always use multipart uploads (1).
+        #
+        # The third does not handle failures:
+        #
+        #  3. Don't be failure/retry safe.  Just write the object, and
+        #  if the API call fails, fail.  This is useful when you can
+        #  retry at a higher level (this is what the copy code does).
+        #
+        # Unfortunately, I don't see how to do (3) with boto3, since
+        # AWS APIs require a header that includes a hash of the
+        # request body, and that needs to be computed up front.  In
+        # terms of the boto3 interface, this contraint translates into
+        # calls like `put_object` require bytes or a seekable stream
+        # (so it can make two passes over the data, one to compute the
+        # checksome, and the other to send the data).
+        #
+        # Here, we use S3CreateManager, which in turn uses boto3
+        # `upload_fileobj` which is implemented in terms of multipart
+        # uploads.
+        #
+        # Another possibility is to make an alternate `create` call
+        # that takes bytes instead of returning a file-like object,
+        # and then using `put_object`, and make copy use that
+        # interface.  This has the disadvantage that the read must
+        # complete before the write can begin (unlike the current
+        # code, that copies 128MB parts in 256KB chunks).
+        bucket, name = self._get_bucket_name(url)
+        return S3CreateManager(self, bucket, name)
+
+    async def multi_part_create(
+            self,
+            sema: asyncio.Semaphore,
+            url: str,
+            num_parts: int) -> MultiPartCreate:
+        bucket, name = self._get_bucket_name(url)
+        return S3MultiPartCreate(sema, self, bucket, name, num_parts)
+
+    async def mkdir(self, url: str) -> None:
+        pass
+
+    async def makedirs(self, url: str, exist_ok: bool = False) -> None:
+        pass
+
+    async def statfile(self, url: str) -> FileStatus:
+        bucket, name = self._get_bucket_name(url)
+        try:
+            resp = await blocking_to_async(self._thread_pool, self._s3.head_object,
+                                           Bucket=bucket,
+                                           Key=name)
+            return S3HeadObjectFileStatus(resp)
+        except botocore.exceptions.ClientError as e:
+            if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                raise FileNotFoundError(url) from e
+            raise e
+
+    async def _listfiles_recursive(self, bucket: str, name: str) -> AsyncIterator[FileListEntry]:
+        assert not name or name.endswith('/')
+        async for page in PageIterator(self, bucket, name):
+            assert 'CommonPrefixes' not in page
+            contents = page.get('Contents')
+            if contents:
+                for item in contents:
+                    yield S3FileListEntry(bucket, item['Key'], item)
+
+    async def _listfiles_flat(self, bucket: str, name: str) -> AsyncIterator[FileListEntry]:
+        assert not name or name.endswith('/')
+        async for page in PageIterator(self, bucket, name, delimiter='/'):
+            prefixes = page.get('CommonPrefixes')
+            if prefixes is not None:
+                for prefix in prefixes:
+                    yield S3FileListEntry(bucket, prefix['Prefix'], None)
+            contents = page.get('Contents')
+            if contents:
+                for item in contents:
+                    yield S3FileListEntry(bucket, item['Key'], item)
+
+    async def listfiles(self, url: str, recursive: bool = False) -> AsyncIterator[FileListEntry]:
+        bucket, name = self._get_bucket_name(url)
+        if name and not name.endswith('/'):
+            name = name + '/'
+        if recursive:
+            it = self._listfiles_recursive(bucket, name)
+        else:
+            it = self._listfiles_flat(bucket, name)
+
+        it = it.__aiter__()
+        try:
+            first_entry = await it.__anext__()
+        except StopAsyncIteration:
+            raise FileNotFoundError(url)  # pylint: disable=raise-missing-from
+
+        async def cons(first_entry, it):
+            yield first_entry
+            try:
+                while True:
+                    yield await it.__anext__()
+            except StopAsyncIteration:
+                pass
+
+        return cons(first_entry, it)
+
+    async def staturl(self, url: str) -> str:
+        return await self._staturl_parallel_isfile_isdir(url)
+
+    async def isfile(self, url: str) -> bool:
+        try:
+            bucket, name = self._get_bucket_name(url)
+            await blocking_to_async(self._thread_pool, self._s3.head_object,
+                                    Bucket=bucket,
+                                    Key=name)
+            return True
+        except botocore.exceptions.ClientError as e:
+            if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                return False
+            raise e
+
+    async def isdir(self, url: str) -> bool:
+        try:
+            async for _ in await self.listfiles(url, recursive=True):
+                return True
+            assert False  # unreachable
+        except FileNotFoundError:
+            return False
+
+    async def remove(self, url: str) -> None:
+        try:
+            bucket, name = self._get_bucket_name(url)
+            await blocking_to_async(self._thread_pool, self._s3.delete_object,
+                                    Bucket=bucket,
+                                    Key=name)
+        except self._s3.exceptions.NoSuchKey as e:
+            raise FileNotFoundError(url) from e
+
+    async def rmtree(self, sema: asyncio.Semaphore, url: str) -> None:
+        await self._rmtree_with_recursive_listfiles(sema, url)
+
+    async def close(self) -> None:
+        pass

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -1,7 +1,9 @@
-from typing import Optional, Type, BinaryIO
+from typing import BinaryIO, Optional, Tuple, Type
 from types import TracebackType
 import abc
+import io
 from concurrent.futures import ThreadPoolExecutor
+import janus
 from hailtop.utils import blocking_to_async
 
 
@@ -92,6 +94,8 @@ class _ReadableStreamFromBlocking(ReadableStream):
         self._f = f
 
     async def read(self, n: int = -1) -> bytes:
+        if n == -1:
+            return await blocking_to_async(self._thread_pool, self._f.read)
         return await blocking_to_async(self._thread_pool, self._f.read, n)
 
     async def _wait_closed(self) -> None:
@@ -125,3 +129,73 @@ def blocking_readable_stream_to_async(thread_pool: ThreadPoolExecutor, f: Binary
 
 def blocking_writable_stream_to_async(thread_pool: ThreadPoolExecutor, f: BinaryIO) -> _WritableStreamFromBlocking:
     return _WritableStreamFromBlocking(thread_pool, f)
+
+
+class BlockingQueueReadableStream(io.RawIOBase):
+    # self.closed and self.close() must be multithread safe, because
+    # they can be accessed by both the stream reader and writer which
+    # are in different threads.
+    def __init__(self, q: janus.Queue):
+        super().__init__()
+        self._q = q
+        self._saw_eos = False
+        self._closed = False
+        self._unread = b''
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, b: bytearray) -> int:
+        if self._closed:
+            raise ValueError('read on closed stream')
+        if self._saw_eos:
+            return 0
+
+        while not self._unread:
+            c = self._q.sync_q.get()
+            if c is None:
+                self._saw_eos = True
+                return 0
+            self._unread = c
+
+        n = min(len(self._unread), len(b))
+        b[:n] = self._unread[:n]
+        self._unread = self._unread[n:]
+        return n
+
+    def close(self):
+        self._closed = True
+        # drain the q so the writer doesn't deadlock
+        while not self._saw_eos:
+            c = self._q.sync_q.get()
+            if c is None:
+                self._saw_eos = True
+
+
+class AsyncQueueWritableStream(WritableStream):
+    def __init__(self, q: janus.Queue, blocking_readable: BlockingQueueReadableStream):
+        super().__init__()
+        self._sent_eos = False
+        self._q = q
+        self._blocking_readable = blocking_readable
+
+    async def write(self, b: bytes) -> int:
+        if self._blocking_readable._closed:
+            if not self._sent_eos:
+                await self._q.async_q.put(None)
+                self._sent_eos = True
+            raise ValueError('reader closed')
+        await self._q.async_q.put(b)
+        return len(b)
+
+    async def _wait_closed(self) -> None:
+        if not self._sent_eos:
+            await self._q.async_q.put(None)
+            self._sent_eos = True
+
+
+def async_writable_blocking_readable_stream_pair() -> Tuple[AsyncQueueWritableStream, BlockingQueueReadableStream]:
+    q: janus.Queue = janus.Queue(maxsize=1)
+    blocking_readable = BlockingQueueReadableStream(q)
+    async_writable = AsyncQueueWritableStream(q, blocking_readable)
+    return async_writable, blocking_readable

--- a/hail/python/hailtop/aiotools/stream.py
+++ b/hail/python/hailtop/aiotools/stream.py
@@ -153,7 +153,7 @@ class BlockingQueueReadableStream(io.RawIOBase):
 
         if not self._unread:
             self._unread = self._q.sync_q.get()
-            if self._unead is None:
+            if self._unread is None:
                 self._saw_eos = True
                 return 0
         assert self._unread

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import os
 import secrets
 import shutil
@@ -6,30 +7,27 @@ from concurrent.futures import ThreadPoolExecutor
 import asyncio
 import pytest
 import concurrent
+import urllib.parse
 from hailtop.utils import secret_alnum_string, bounded_gather2
 from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS
 from hailtop.aiogoogle import StorageClient, GoogleStorageAsyncFS
 
 
-@pytest.fixture(params=['file', 'gs', 'router/file', 'router/gs'])
-async def filesystem(request):
+@pytest.fixture(params=['gs', 'router/gs'])
+async def gs_filesystem(request):
     token = secret_alnum_string()
 
     with ThreadPoolExecutor() as thread_pool:
         if request.param.startswith('router/'):
             fs = RouterAsyncFS(
-                'file', [LocalAsyncFS(thread_pool), GoogleStorageAsyncFS()])
-        elif request.param == 'file':
-            fs = LocalAsyncFS(thread_pool)
+                'file', [LocalAsyncFS(thread_pool),
+                         GoogleStorageAsyncFS()])
         else:
+            assert request.param.endswith('gs')
             fs = GoogleStorageAsyncFS()
         async with fs:
-            if request.param.endswith('file'):
-                base = f'/tmp/{token}/'
-            else:
-                assert request.param.endswith('gs')
-                bucket = os.environ['HAIL_TEST_BUCKET']
-                base = f'gs://{bucket}/tmp/{token}/'
+            bucket = os.environ['HAIL_TEST_GCS_BUCKET']
+            base = f'gs://{bucket}/tmp/{token}/'
 
             await fs.mkdir(base)
             sema = asyncio.Semaphore(50)
@@ -37,181 +35,11 @@ async def filesystem(request):
                 yield (sema, fs, base)
                 await fs.rmtree(sema, base)
             assert not await fs.isdir(base)
-
-
-@pytest.fixture
-async def local_filesystem(request):
-    token = secret_alnum_string()
-
-    with ThreadPoolExecutor() as thread_pool:
-        async with LocalAsyncFS(thread_pool) as fs:
-            base = f'/tmp/{token}/'
-            await fs.mkdir(base)
-            sema = asyncio.Semaphore(50)
-            async with sema:
-                yield (sema, fs, base)
-                await fs.rmtree(sema, base)
-            assert not await fs.isdir(base)
-
-
-@pytest.fixture(params=['small', 'multipart', 'large'])
-async def file_data(request):
-    if request.param == 'small':
-        return [b'foo']
-    elif request.param == 'multipart':
-        return [b'foo', b'bar', b'baz']
-    else:
-        assert request.param == 'large'
-        return [secrets.token_bytes(1_000_000)]
-
-
-@pytest.mark.asyncio
-async def test_write_read(filesystem, file_data):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    async with await fs.create(file) as f:
-        for b in file_data:
-            await f.write(b)
-
-    expected = b''.join(file_data)
-    async with await fs.open(file) as f:
-        actual = await f.read()
-
-    assert expected == actual
-
-
-@pytest.mark.asyncio
-async def test_open_from(filesystem):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    async with await fs.create(file) as f:
-        await f.write(b'abcde')
-
-    async with await fs.open_from(file, 2) as f:
-        r = await f.read()
-        assert r == b'cde'
-
-
-@pytest.mark.asyncio
-async def test_read_from(filesystem):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    await fs.write(file, b'abcde')
-    r = await fs.read_from(file, 2)
-    assert r == b'cde'
-
-
-@pytest.mark.asyncio
-async def test_read_range(filesystem):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    await fs.write(file, b'abcde')
-
-    r = await fs.read_range(file, 2, 2)
-    assert r == b'c'
-
-    r = await fs.read_range(file, 2, 4)
-    assert r == b'cde'
-
-    r = await fs.read_range(file, 2, 10)
-    assert r == b'cde'
-
-
-@pytest.mark.asyncio
-async def test_isfile(filesystem):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    # doesn't exist yet
-    assert not await fs.isfile(file)
-
-    await fs.touch(file)
-
-    assert await fs.isfile(file)
-
-
-@pytest.mark.asyncio
-async def test_isdir(filesystem):
-    sema, fs, base = filesystem
-
-    # mkdir with trailing slash
-    dir = f'{base}dir/'
-    await fs.mkdir(dir)
-
-    await fs.touch(f'{dir}foo')
-
-    # can't test this until after creating foo
-    assert await fs.isdir(dir)
-
-    # mkdir without trailing slash
-    dir2 = f'{base}dir2'
-    await fs.mkdir(dir2)
-
-    await fs.touch(f'{dir2}/foo')
-
-    assert await fs.isdir(dir)
-
-
-@pytest.mark.asyncio
-async def test_isdir_subdir_only(filesystem):
-    sema, fs, base = filesystem
-
-    dir = f'{base}dir/'
-    await fs.mkdir(dir)
-
-    subdir = f'{dir}subdir/'
-    await fs.mkdir(subdir)
-
-    await fs.touch(f'{subdir}foo')
-
-    # can't test this until after creating foo
-    assert await fs.isdir(dir)
-    assert await fs.isdir(subdir)
-
-
-@pytest.mark.asyncio
-async def test_remove(filesystem):
-    sema, fs, base = filesystem
-
-    file = f'{base}foo'
-
-    await fs.touch(file)
-    assert await fs.isfile(file)
-
-    await fs.remove(file)
-
-    assert not await fs.isfile(file)
-
-
-@pytest.mark.asyncio
-async def test_rmtree(filesystem):
-    sema, fs, base = filesystem
-
-    dir = f'{base}foo/'
-
-    await fs.mkdir(dir)
-    await fs.touch(f'{dir}a')
-    await fs.touch(f'{dir}b')
-
-    assert await fs.isdir(dir)
-
-    await fs.rmtree(sema, dir)
-
-    assert not await fs.isdir(dir)
 
 
 @pytest.mark.asyncio
 async def test_get_object_metadata():
-    bucket = os.environ['HAIL_TEST_BUCKET']
+    bucket = os.environ['HAIL_TEST_GCS_BUCKET']
     file = secrets.token_hex(16)
 
     async with StorageClient() as client:
@@ -226,7 +54,7 @@ async def test_get_object_metadata():
 
 @pytest.mark.asyncio
 async def test_get_object_headers():
-    bucket = os.environ['HAIL_TEST_BUCKET']
+    bucket = os.environ['HAIL_TEST_GCS_BUCKET']
     file = secrets.token_hex(16)
 
     async with StorageClient() as client:
@@ -241,7 +69,7 @@ async def test_get_object_headers():
 
 @pytest.mark.asyncio
 async def test_compose():
-    bucket = os.environ['HAIL_TEST_BUCKET']
+    bucket = os.environ['HAIL_TEST_GCS_BUCKET']
     token = secret_alnum_string()
 
     part_data = [b'a', b'bb', b'ccc']
@@ -259,123 +87,16 @@ async def test_compose():
 
 
 @pytest.mark.asyncio
-async def test_statfile_nonexistent_file(filesystem):
-    sema, fs, base = filesystem
-
-    with pytest.raises(FileNotFoundError):
-        await fs.statfile(f'{base}foo')
-
-
-@pytest.mark.asyncio
-async def test_statfile_directory(filesystem):
-    sema, fs, base = filesystem
-
-    await fs.mkdir(f'{base}dir/')
-    await fs.touch(f'{base}dir/foo')
-
-    with pytest.raises(FileNotFoundError):
-        # statfile raises FileNotFound on directories
-        await fs.statfile(f'{base}dir')
-
-
-@pytest.mark.asyncio
-async def test_statfile(filesystem):
-    sema, fs, base = filesystem
-
-    n = 37
-    file = f'{base}bar'
-    await fs.write(file, secrets.token_bytes(n))
-    status = await fs.statfile(file)
-    assert await status.size() == n
-
-@pytest.mark.asyncio
-async def test_listfiles(filesystem):
-    sema, fs, base = filesystem
-
-    with pytest.raises(FileNotFoundError):
-        await fs.listfiles(f'{base}does/not/exist')
-
-    with pytest.raises(FileNotFoundError):
-        await fs.listfiles(f'{base}does/not/exist', recursive=True)
-
-    # create the following directory structure in base:
-    # foobar
-    # foo/a
-    # foo/b/c
-    a = f'{base}foo/a'
-    b = f'{base}foo/b/'
-    c = f'{base}foo/b/c'
-    await fs.touch(f'{base}foobar')
-    await fs.mkdir(f'{base}foo/')
-    await fs.touch(a)
-    await fs.mkdir(b)
-    await fs.touch(c)
-
-    async def listfiles(dir, recursive):
-        return {(await entry.url(), await entry.is_file()) async for entry in await fs.listfiles(dir, recursive)}
-
-    assert await listfiles(f'{base}foo/', recursive=True) == {(a, True), (c, True)}
-    assert await listfiles(f'{base}foo/', recursive=False) == {(a, True), (b, False)}
-
-    # without trailing slash
-    assert await listfiles(f'{base}foo', recursive=True) == {(a, True), (c, True)}
-    assert await listfiles(f'{base}foo', recursive=False) == {(a, True), (b, False)}
-
-    # test FileListEntry.status raises on directory
-    async for entry in await fs.listfiles(f'{base}foo/', recursive=False):
-        if await entry.is_dir():
-            with pytest.raises(IsADirectoryError):
-                await entry.status()
-        else:
-            stat = await entry.status()
-            assert await stat.size() == 0
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("permutation", [
-    None,
-    [0, 1, 2],
-    [0, 2, 1],
-    [1, 2, 0],
-    [2, 1, 0]
-])
-async def test_multi_part_create(filesystem, permutation):
-    sema, fs, base = filesystem
-
-    part_data = [secrets.token_bytes(s) for s in [8192, 600, 20000]]
-
-    s = 0
-    part_start = []
-    for b in part_data:
-        part_start.append(s)
-        s += len(b)
-
-    path = f'{base}a'
-    async with await fs.multi_part_create(sema, path, len(part_data)) as c:
-        async def create_part(i):
-            async with await c.create_part(i, part_start[i]) as f:
-                await f.write(part_data[i])
-
-        if permutation:
-            # do it in a fixed order
-            for i in permutation:
-                await create_part(i)
-        else:
-            # do in parallel
-            await asyncio.gather(*[
-                create_part(i) for i in range(len(part_data))])
-
-    expected = b''.join(part_data)
-    actual = await fs.read(path)
-    assert expected == actual
-
-
-@pytest.mark.asyncio
-async def test_multi_part_create_many(filesystem):
+async def test_multi_part_create_many_two_level_merge(gs_filesystem):
+    # This is a white-box test.  compose has a maximum of 32 inputs,
+    # so if we're composing more than 32 parts, the
+    # GoogleStorageAsyncFS does a multi-level hierarhical merge.
     try:
-        sema, fs, base = filesystem
+        sema, fs, base = gs_filesystem
 
-        # > 32 so we perform at least 2 layers of merging
-        part_data = [secrets.token_bytes(100) for _ in range(80)]
+        # > 32 so we perform at least 2 levels of merging
+        part_data_size = [100 for _ in range(40)]
+        part_data = [secrets.token_bytes(s) for s in part_data_size]
 
         s = 0
         part_start = []

--- a/hail/python/test/hailtop/test_fs.py
+++ b/hail/python/test/hailtop/test_fs.py
@@ -1,0 +1,338 @@
+from typing import Optional
+import os
+import secrets
+import shutil
+from itertools import accumulate
+from concurrent.futures import ThreadPoolExecutor
+import asyncio
+import pytest
+import concurrent
+import urllib.parse
+from hailtop.utils import secret_alnum_string, bounded_gather2
+from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS
+from hailtop.aiotools.s3asyncfs import S3AsyncFS
+from hailtop.aiogoogle import GoogleStorageAsyncFS
+
+
+@pytest.fixture(params=['file', 'gs', 's3', 'router/file', 'router/gs', 'router/s3'])
+async def filesystem(request):
+    token = secret_alnum_string()
+
+    with ThreadPoolExecutor() as thread_pool:
+        if request.param.startswith('router/'):
+            fs = RouterAsyncFS(
+                'file', [LocalAsyncFS(thread_pool),
+                         GoogleStorageAsyncFS(),
+                         S3AsyncFS(thread_pool)])
+        elif request.param == 'file':
+            fs = LocalAsyncFS(thread_pool)
+        elif request.param.endswith('gs'):
+            fs = GoogleStorageAsyncFS()
+        else:
+            assert request.param.endswith('s3')
+            fs = S3AsyncFS(thread_pool)
+        async with fs:
+            if request.param.endswith('file'):
+                base = f'/tmp/{token}/'
+            elif request.param.endswith('gs'):
+                bucket = os.environ['HAIL_TEST_GCS_BUCKET']
+                base = f'gs://{bucket}/tmp/{token}/'
+            else:
+                assert request.param.endswith('s3')
+                bucket = os.environ['HAIL_TEST_S3_BUCKET']
+                base = f's3://{bucket}/tmp/{token}/'
+
+            await fs.mkdir(base)
+            sema = asyncio.Semaphore(50)
+            async with sema:
+                yield (sema, fs, base)
+                await fs.rmtree(sema, base)
+            assert not await fs.isdir(base)
+
+
+@pytest.fixture
+async def local_filesystem(request):
+    token = secret_alnum_string()
+
+    with ThreadPoolExecutor() as thread_pool:
+        async with LocalAsyncFS(thread_pool) as fs:
+            base = f'/tmp/{token}/'
+            await fs.mkdir(base)
+            sema = asyncio.Semaphore(50)
+            async with sema:
+                yield (sema, fs, base)
+                await fs.rmtree(sema, base)
+            assert not await fs.isdir(base)
+
+
+@pytest.fixture(params=['small', 'multipart', 'large'])
+async def file_data(request):
+    if request.param == 'small':
+        return [b'foo']
+    elif request.param == 'multipart':
+        return [b'foo', b'bar', b'baz']
+    else:
+        assert request.param == 'large'
+        return [secrets.token_bytes(1_000_000)]
+
+
+@pytest.mark.asyncio
+async def test_write_read(filesystem, file_data):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    async with await fs.create(file) as f:
+        for b in file_data:
+            await f.write(b)
+
+    expected = b''.join(file_data)
+    async with await fs.open(file) as f:
+        actual = await f.read()
+
+    assert expected == actual
+
+
+@pytest.mark.asyncio
+async def test_open_from(filesystem):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    async with await fs.create(file) as f:
+        await f.write(b'abcde')
+
+    async with await fs.open_from(file, 2) as f:
+        r = await f.read()
+        assert r == b'cde'
+
+
+@pytest.mark.asyncio
+async def test_read_from(filesystem):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.write(file, b'abcde')
+    r = await fs.read_from(file, 2)
+    assert r == b'cde'
+
+
+@pytest.mark.asyncio
+async def test_read_range(filesystem):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.write(file, b'abcde')
+
+    r = await fs.read_range(file, 2, 2)
+    assert r == b'c'
+
+    r = await fs.read_range(file, 2, 4)
+    assert r == b'cde'
+
+    r = await fs.read_range(file, 2, 10)
+    assert r == b'cde'
+
+
+@pytest.mark.asyncio
+async def test_isfile(filesystem):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    # doesn't exist yet
+    assert not await fs.isfile(file)
+
+    await fs.touch(file)
+
+    assert await fs.isfile(file)
+
+
+@pytest.mark.asyncio
+async def test_isdir(filesystem):
+    sema, fs, base = filesystem
+
+    # mkdir with trailing slash
+    dir = f'{base}dir/'
+    await fs.mkdir(dir)
+
+    await fs.touch(f'{dir}foo')
+
+    # can't test this until after creating foo
+    assert await fs.isdir(dir)
+
+    # mkdir without trailing slash
+    dir2 = f'{base}dir2'
+    await fs.mkdir(dir2)
+
+    await fs.touch(f'{dir2}/foo')
+
+    assert await fs.isdir(dir)
+
+
+@pytest.mark.asyncio
+async def test_isdir_subdir_only(filesystem):
+    sema, fs, base = filesystem
+
+    dir = f'{base}dir/'
+    await fs.mkdir(dir)
+
+    subdir = f'{dir}subdir/'
+    await fs.mkdir(subdir)
+
+    await fs.touch(f'{subdir}foo')
+
+    # can't test this until after creating foo
+    assert await fs.isdir(dir)
+    assert await fs.isdir(subdir)
+
+
+@pytest.mark.asyncio
+async def test_remove(filesystem):
+    sema, fs, base = filesystem
+
+    file = f'{base}foo'
+
+    await fs.touch(file)
+    assert await fs.isfile(file)
+
+    await fs.remove(file)
+
+    assert not await fs.isfile(file)
+
+
+@pytest.mark.asyncio
+async def test_rmtree(filesystem):
+    sema, fs, base = filesystem
+
+    dir = f'{base}foo/'
+
+    await fs.mkdir(dir)
+    await fs.touch(f'{dir}a')
+    await fs.touch(f'{dir}b')
+
+    assert await fs.isdir(dir)
+
+    await fs.rmtree(sema, dir)
+
+    assert not await fs.isdir(dir)
+
+
+@pytest.mark.asyncio
+async def test_statfile_nonexistent_file(filesystem):
+    sema, fs, base = filesystem
+
+    with pytest.raises(FileNotFoundError):
+        await fs.statfile(f'{base}foo')
+
+
+@pytest.mark.asyncio
+async def test_statfile_directory(filesystem):
+    sema, fs, base = filesystem
+
+    await fs.mkdir(f'{base}dir/')
+    await fs.touch(f'{base}dir/foo')
+
+    with pytest.raises(FileNotFoundError):
+        # statfile raises FileNotFound on directories
+        await fs.statfile(f'{base}dir')
+
+
+@pytest.mark.asyncio
+async def test_statfile(filesystem):
+    sema, fs, base = filesystem
+
+    n = 37
+    file = f'{base}bar'
+    await fs.write(file, secrets.token_bytes(n))
+    status = await fs.statfile(file)
+    assert await status.size() == n
+
+@pytest.mark.asyncio
+async def test_listfiles(filesystem):
+    sema, fs, base = filesystem
+
+    with pytest.raises(FileNotFoundError):
+        await fs.listfiles(f'{base}does/not/exist')
+
+    with pytest.raises(FileNotFoundError):
+        await fs.listfiles(f'{base}does/not/exist', recursive=True)
+
+    # create the following directory structure in base:
+    # foobar
+    # foo/a
+    # foo/b/c
+    a = f'{base}foo/a'
+    b = f'{base}foo/b/'
+    c = f'{base}foo/b/c'
+    await fs.touch(f'{base}foobar')
+    await fs.mkdir(f'{base}foo/')
+    await fs.touch(a)
+    await fs.mkdir(b)
+    await fs.touch(c)
+
+    async def listfiles(dir, recursive):
+        return {(await entry.url(), await entry.is_file()) async for entry in await fs.listfiles(dir, recursive)}
+
+    assert await listfiles(f'{base}foo/', recursive=True) == {(a, True), (c, True)}
+    assert await listfiles(f'{base}foo/', recursive=False) == {(a, True), (b, False)}
+
+    # without trailing slash
+    assert await listfiles(f'{base}foo', recursive=True) == {(a, True), (c, True)}
+    assert await listfiles(f'{base}foo', recursive=False) == {(a, True), (b, False)}
+
+    # test FileListEntry.status raises on directory
+    async for entry in await fs.listfiles(f'{base}foo/', recursive=False):
+        if await entry.is_dir():
+            with pytest.raises(IsADirectoryError):
+                await entry.status()
+        else:
+            stat = await entry.status()
+            assert await stat.size() == 0
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permutation", [
+    None,
+    [0, 1, 2],
+    [0, 2, 1],
+    [1, 2, 0],
+    [2, 1, 0]
+])
+async def test_multi_part_create(filesystem, permutation):
+    sema, fs, base = filesystem
+
+    # S3 has a minimum part size (except for the last part) of 5GiB
+    if base.startswith('s3'):
+        min_part_size = 5 * 1024 * 1024
+        part_data_size = [min_part_size, min_part_size, min_part_size]
+    else:
+        part_data_size = [8192, 600, 20000]
+    part_data = [secrets.token_bytes(s) for s in part_data_size]
+
+    s = 0
+    part_start = []
+    for b in part_data:
+        part_start.append(s)
+        s += len(b)
+
+    path = f'{base}a'
+    async with await fs.multi_part_create(sema, path, len(part_data)) as c:
+        async def create_part(i):
+            async with await c.create_part(i, part_start[i]) as f:
+                await f.write(part_data[i])
+
+        if permutation:
+            # do it in a fixed order
+            for i in permutation:
+                await create_part(i)
+        else:
+            # do in parallel
+            await asyncio.gather(*[
+                create_part(i) for i in range(len(part_data))])
+
+    expected = b''.join(part_data)
+    async with await fs.open(path) as f:
+        actual = await f.read()
+    assert expected == actual


### PR DESCRIPTION
Summary of changes:
 - Add S3AsyncFS which is implemented in terms of the AWS Python client library, boto3.  boto3 is sync (there is an in-progress async version but I decided not to use it to start).  The operations are nearly identical to GCS, except S3 supports explicit API requests for multi-part uploads (unlike GCS, where we implement it in terms of compose).
 - The only tricky bit is `create`, which needs an async stream writer, but a synchronous stream reader that is passed to boto3.
 - I split up test_aiogoogle.py.  The GCS specific tests stay there, and AsyncFS tests move to test_fs.py.
 - Add S3 to the AsyncFS and copy tests.  I created an S3 bucket (hail-test-dy5rg) and test user credentials (added to K8s as test-aws-key).  I'm still trying to figure out how to give the rest of the services team admin access to the AWS project, I might have to go through BITS.