### PR TITLE
Fixed arbitrary maps on BlockMatrix, added test

### DIFF
--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -154,8 +154,8 @@ fails_service_backend = pytest.mark.xfail(
     strict=True)
 
 def check_spark():
-    from hail.backend.spark_backend import SparkBackend
-    return isinstance(hl.utils.java.Env.backend(), SparkBackend)
+    backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
+    return backend_name == 'spark'
 
 fails_spark_backend = pytest.mark.xfail(
     check_spark(),

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -130,6 +130,17 @@ def skip_unless_spark_backend():
 
     return wrapper
 
+def skip_when_spark_backend():
+    from hail.backend.spark_backend import SparkBackend
+    @decorator
+    def wrapper(func, *args, **kwargs):
+        if isinstance(hl.utils.java.Env.backend(), SparkBackend):
+            raise unittest.SkipTest('Does not support Spark')
+        else:
+            return func(*args, **kwargs)
+
+    return wrapper
+
 
 def skip_when_service_backend(message='does not work on ServiceBackend'):
     from hail.backend.service_backend import ServiceBackend

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -153,9 +153,12 @@ fails_service_backend = pytest.mark.xfail(
     reason="doesn't yet work on service backend",
     strict=True)
 
+def check_spark():
+    from hail.backend.spark_backend import SparkBackend
+    return isinstance(hl.utils.java.Env.backend(), SparkBackend)
 
 fails_spark_backend = pytest.mark.xfail(
-    os.environ.get('HAIL_QUERY_BACKEND') == 'spark',
+    check_spark(),
     reason="doesn't yet work on spark backend",
     strict=True)
 

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -130,18 +130,6 @@ def skip_unless_spark_backend():
 
     return wrapper
 
-def skip_when_spark_backend():
-    from hail.backend.spark_backend import SparkBackend
-    @decorator
-    def wrapper(func, *args, **kwargs):
-        if isinstance(hl.utils.java.Env.backend(), SparkBackend):
-            raise unittest.SkipTest('Does not support Spark')
-        else:
-            return func(*args, **kwargs)
-
-    return wrapper
-
-
 def skip_when_service_backend(message='does not work on ServiceBackend'):
     from hail.backend.service_backend import ServiceBackend
     @decorator
@@ -163,6 +151,12 @@ fails_local_backend = pytest.mark.xfail(
 fails_service_backend = pytest.mark.xfail(
     os.environ.get('HAIL_QUERY_BACKEND') == 'service',
     reason="doesn't yet work on service backend",
+    strict=True)
+
+
+fails_spark_backend = pytest.mark.xfail(
+    os.environ.get('HAIL_QUERY_BACKEND') == 'spark',
+    reason="doesn't yet work on spark backend",
     strict=True)
 
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1194,7 +1194,7 @@ class Tests(unittest.TestCase):
         assert f.to_numpy().shape == (10, 1)
 
 
-    @skip_when_spark_backend()
+    @fails_spark_backend()
     def test_map(self):
         np_mat = np.arange(20, dtype=np.float64).reshape((4, 5))
         bm = BlockMatrix.from_ndarray(hl.nd.array(np_mat))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -1192,3 +1192,17 @@ class Tests(unittest.TestCase):
         # Summing horizontally along a column vector to make sure nothing changes
         f = col.sum(axis=1)
         assert f.to_numpy().shape == (10, 1)
+
+
+    @skip_when_spark_backend()
+    def test_map(self):
+        np_mat = np.arange(20, dtype=np.float64).reshape((4, 5))
+        bm = BlockMatrix.from_ndarray(hl.nd.array(np_mat))
+        bm_mapped_arith = bm._map_dense(lambda x: (x * x) + 5)
+        self._assert_eq(bm_mapped_arith, np_mat * np_mat + 5)
+
+        bm_mapped_if = bm._map_dense(lambda x: hl.if_else(x >= 1, x, -8.0))
+        np_if = np_mat.copy()
+        np_if[0, 0] = -8.0
+        self._assert_eq(bm_mapped_if, np_if)
+

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -243,8 +243,6 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
 }
 
 case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDense: Boolean) extends BlockMatrixIR {
-  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply] || f.isInstanceOf[ApplyBinaryPrimOp])
-
   override lazy val typ: BlockMatrixType = child.typ
   assert(!needsDense || !typ.isSparse)
 
@@ -268,6 +266,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, eltName: String, f: IR, needsDen
     f(_, scalar)
 
   override protected[ir] def execute(ctx: ExecuteContext): BlockMatrix = {
+    assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply] || f.isInstanceOf[ApplyBinaryPrimOp])
     val prev = child.execute(ctx)
 
     val functionArgs = f match {
@@ -359,7 +358,6 @@ case object NeedsDense extends SparsityStrategy {
 }
 
 case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: String, rightName: String, f: IR, sparsityStrategy: SparsityStrategy) extends BlockMatrixIR {
-  assert(f.isInstanceOf[ApplyBinaryPrimOp] || f.isInstanceOf[Apply])
   assert(
     left.typ.nRows == right.typ.nRows &&
     left.typ.nCols == right.typ.nCols &&
@@ -382,6 +380,8 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, leftName: 
   }
 
   override protected[ir] def execute(ctx: ExecuteContext): BlockMatrix = {
+    assert(f.isInstanceOf[ApplyBinaryPrimOp] || f.isInstanceOf[Apply])
+
     left match {
       case BlockMatrixBroadcast(vectorIR: BlockMatrixIR, IndexedSeq(x), _, _) =>
         val vector = coerceToVector(ctx , vectorIR)


### PR DESCRIPTION
We had an old   assert  that only  applies  to Spark, moved it  into the execute method. 