### PR TITLE
[compiler] Fix bad performance in parseFloat{32, 64}

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -22,53 +22,60 @@ object UtilFunctions extends RegistryFunctions {
 
   def parseInt64(s: String): Long = s.toLong
 
-  private val NAN = 1
-  private val POS_INF = 2
-  private val NEG_INF = 3
-
-  def parseSpecialNum(s: String): Int = s.length match {
-    case 3 if s equalsCI "nan" => NAN
-    case 4 if (s equalsCI "+nan") || (s equalsCI "-nan") => NAN
-    case 3 if s equalsCI "inf" => POS_INF
-    case 4 if s equalsCI "+inf" => POS_INF
-    case 4 if s equalsCI "-inf" => NEG_INF
-    case 8 if s equalsCI "infinity" => POS_INF
-    case 9 if s equalsCI "+infinity" => POS_INF
-    case 9 if s equalsCI "-infinity" => NEG_INF
-    case _ => 0
+  def parseSpecialNum32(s: String): Float = {
+    s.length match {
+      case 3 =>
+        if (s.equalsCaseInsensitive("nan")) return Float.NaN
+        if (s.equalsCaseInsensitive("inf")) return Float.PositiveInfinity
+      case 4 =>
+        if ((s equalsCaseInsensitive "+nan") || (s.equalsCaseInsensitive("-nan"))) return Float.NaN
+        if (s.equalsCaseInsensitive("+inf")) return Float.PositiveInfinity
+        if (s.equalsCaseInsensitive("-inf")) return Float.NegativeInfinity
+      case 8 =>
+        if (s.equalsCaseInsensitive("infinity")) return Float.PositiveInfinity
+      case 9 =>
+        if (s.equalsCaseInsensitive("+infinity")) return Float.PositiveInfinity
+        if (s.equalsCaseInsensitive("-infinity")) return Float.NegativeInfinity
+      case _ =>
+    }
+    throw new NumberFormatException(s"cannot parse float32 from $s")
   }
 
-  def parseFloat32(s: String): Float = parseSpecialNum(s) match {
-    case NAN => Float.NaN
-    case POS_INF => Float.PositiveInfinity
-    case NEG_INF => Float.NegativeInfinity
-    case _ => s.toFloat
+  def parseSpecialNum64(s: String): Double = {
+    s.length match {
+      case 3 =>
+        if (s.equalsCaseInsensitive("nan")) return Double.NaN
+        if (s.equalsCaseInsensitive("inf")) return Double.PositiveInfinity
+      case 4 =>
+        if ((s equalsCaseInsensitive "+nan") || (s.equalsCaseInsensitive("-nan"))) return Double.NaN
+        if (s.equalsCaseInsensitive("+inf")) return Double.PositiveInfinity
+        if (s.equalsCaseInsensitive("-inf")) return Double.NegativeInfinity
+      case 8 =>
+        if (s.equalsCaseInsensitive("infinity")) return Double.PositiveInfinity
+      case 9 =>
+        if (s.equalsCaseInsensitive("+infinity")) return Double.PositiveInfinity
+        if (s.equalsCaseInsensitive("-infinity")) return Double.NegativeInfinity
+      case _ =>
+    }
+    throw new NumberFormatException(s"cannot parse float64 from $s")
   }
 
-  def parseFloat64(s: String): Double = parseSpecialNum(s) match {
-    case NAN => Double.NaN
-    case POS_INF => Double.PositiveInfinity
-    case NEG_INF => Double.NegativeInfinity
-    case _ => s.toDouble
+  def parseFloat32(s: String): Float = {
+    try {
+      s.toFloat
+    } catch {
+      case _: NumberFormatException =>
+        parseSpecialNum32(s)
+    }
   }
 
-  def isValidBoolean(s: String): Boolean =
-    (s equalsCI "true") || (s equalsCI "false")
-
-  def isValidInt32(s: String): Boolean =
-    try { s.toInt; true } catch { case _: NumberFormatException => false }
-
-  def isValidInt64(s: String): Boolean =
-    try { s.toLong; true } catch { case _: NumberFormatException => false }
-
-  def isValidFloat32(s: String): Boolean = parseSpecialNum(s) match {
-    case 0 => try { s.toFloat; true } catch { case _: NumberFormatException => false }
-    case _ => true
-  }
-
-  def isValidFloat64(s: String): Boolean = parseSpecialNum(s) match {
-    case 0 => try { s.toDouble; true } catch { case _: NumberFormatException => false }
-    case _ => true
+  def parseFloat64(s: String): Double = {
+    try {
+      s.toDouble
+    } catch {
+      case _: NumberFormatException =>
+        parseSpecialNum64(s)
+    }
   }
 
   def min_ignore_missing(l: Int, lMissing: Boolean, r: Int, rMissing: Boolean): Int =

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -28,7 +28,7 @@ object UtilFunctions extends RegistryFunctions {
         if (s.equalsCaseInsensitive("nan")) return Float.NaN
         if (s.equalsCaseInsensitive("inf")) return Float.PositiveInfinity
       case 4 =>
-        if ((s equalsCaseInsensitive "+nan") || (s.equalsCaseInsensitive("-nan"))) return Float.NaN
+        if (s.equalsCaseInsensitive("+nan") || s.equalsCaseInsensitive("-nan")) return Float.NaN
         if (s.equalsCaseInsensitive("+inf")) return Float.PositiveInfinity
         if (s.equalsCaseInsensitive("-inf")) return Float.NegativeInfinity
       case 8 =>
@@ -47,7 +47,7 @@ object UtilFunctions extends RegistryFunctions {
         if (s.equalsCaseInsensitive("nan")) return Double.NaN
         if (s.equalsCaseInsensitive("inf")) return Double.PositiveInfinity
       case 4 =>
-        if ((s equalsCaseInsensitive "+nan") || (s.equalsCaseInsensitive("-nan"))) return Double.NaN
+        if (s.equalsCaseInsensitive("+nan") || s.equalsCaseInsensitive("-nan")) return Double.NaN
         if (s.equalsCaseInsensitive("+inf")) return Double.PositiveInfinity
         if (s.equalsCaseInsensitive("-inf")) return Double.NegativeInfinity
       case 8 =>
@@ -76,6 +76,37 @@ object UtilFunctions extends RegistryFunctions {
       case _: NumberFormatException =>
         parseSpecialNum64(s)
     }
+  }
+
+  def isValidBoolean(s: String): Boolean =
+    (s.equalsCaseInsensitive("true") || s.equalsCaseInsensitive("false"))
+
+  def isValidInt32(s: String): Boolean =
+    try {
+      s.toInt; true
+    } catch {
+      case _: NumberFormatException => false
+    }
+
+  def isValidInt64(s: String): Boolean =
+    try {
+      s.toLong; true
+    } catch {
+      case _: NumberFormatException => false
+    }
+
+  def isValidFloat32(s: String): Boolean = try {
+    parseFloat32(s)
+    true
+  } catch {
+    case _: NumberFormatException => false
+  }
+
+  def isValidFloat64(s: String): Boolean = try {
+    parseFloat64(s)
+    true
+  } catch {
+    case _: NumberFormatException => false
   }
 
   def min_ignore_missing(l: Int, lMissing: Boolean, r: Int, rMissing: Boolean): Int =

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichString.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichString.scala
@@ -9,13 +9,14 @@ class RichString(val str: String) extends AnyVal {
     def strings: (String, String) = (truncate, str)
   }
 
-  def equalsCI(other: String): Boolean =
+  def equalsCaseInsensitive(other: String): Boolean =
     if (str.length == other.length) {
-      for (i <- 0 until str.length)
+      var i = 0
+      while (i < str.length) {
         if ((str charAt i).toLower != (other charAt i).toLower)
           return false
+        i += 1
+      }
       true
-    }
-    else
-      false
+    } else false
 }


### PR DESCRIPTION
Exceptional control flow is not great, but that's the rare
case here. This is faster than matching on the first few characters
instead of using exceptions.