### PR TITLE
[batch] Avoid CI deadlocks based on zone

### DIFF
--- a/batch/batch/driver/instance_collection.py
+++ b/batch/batch/driver/instance_collection.py
@@ -26,6 +26,7 @@ class InstanceCollection:
         self.is_pool = is_pool
 
         self.name_instance: Dict[str, Instance] = {}
+        self.live_free_cores_mcpu_by_zone: Dict[str, int] = {}
 
         self.instances_by_last_updated = sortedcontainers.SortedSet(key=lambda instance: instance.last_updated)
 
@@ -70,6 +71,7 @@ class InstanceCollection:
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu -= max(0, instance.free_cores_mcpu)
             self.live_total_cores_mcpu -= instance.cores_mcpu
+            self.live_free_cores_mcpu_by_zone[instance.zone] -= max(0, instance.free_cores_mcpu)
 
     async def remove_instance(self, instance, reason, timestamp=None):
         await instance.deactivate(reason, timestamp)
@@ -88,6 +90,7 @@ class InstanceCollection:
         if instance.state in ('pending', 'active'):
             self.live_free_cores_mcpu += max(0, instance.free_cores_mcpu)
             self.live_total_cores_mcpu += instance.cores_mcpu
+            self.live_free_cores_mcpu_by_zone[instance.zone] += max(0, instance.free_cores_mcpu)
 
     def add_instance(self, instance):
         assert instance.name not in self.name_instance

--- a/batch/batch/driver/instance_collection.py
+++ b/batch/batch/driver/instance_collection.py
@@ -2,6 +2,7 @@ import aiohttp
 import sortedcontainers
 import logging
 import dateutil.parser
+import collections
 from typing import Dict
 
 from hailtop.utils import time_msecs, secret_alnum_string, periodically_call
@@ -26,7 +27,7 @@ class InstanceCollection:
         self.is_pool = is_pool
 
         self.name_instance: Dict[str, Instance] = {}
-        self.live_free_cores_mcpu_by_zone: Dict[str, int] = {}
+        self.live_free_cores_mcpu_by_zone: Dict[str, int] = collections.defaultdict(int)
 
         self.instances_by_last_updated = sortedcontainers.SortedSet(key=lambda instance: instance.last_updated)
 

--- a/batch/batch/driver/pool.py
+++ b/batch/batch/driver/pool.py
@@ -229,7 +229,7 @@ GROUP BY user;
         n_live_instances = self.n_instances_by_state['pending'] + self.n_instances_by_state['active']
 
         instances_needed = (ready_cores_mcpu - self.live_free_cores_mcpu + (self.worker_cores * 1000) - 1) // (
-                self.worker_cores * 1000
+            self.worker_cores * 1000
         )
         instances_needed = min(
             instances_needed,

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -248,7 +248,7 @@ class ExceededSharesCounter:
         self._global_counter = WindowFractionCounter(10)
 
     def push(self, success: bool):
-        self._global_counter.push('exceeded_shares', success)
+        self._global_counter.push(secrets.token_urlsafe(6), success)
 
     def rate(self) -> float:
         return self._global_counter.fraction()

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -7,6 +7,7 @@ from functools import wraps
 from collections import deque
 
 from gear import maybe_parse_bearer_header
+from hailtop.utils import secret_alnum_string
 
 from .globals import RESERVED_STORAGE_GB_PER_CORE
 
@@ -248,7 +249,8 @@ class ExceededSharesCounter:
         self._global_counter = WindowFractionCounter(10)
 
     def push(self, success: bool):
-        self._global_counter.push(secrets.token_urlsafe(6), success)
+        token = secret_alnum_string(6)
+        self._global_counter.push(token, success)
 
     def rate(self) -> float:
         return self._global_counter.fraction()

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -593,7 +593,7 @@ def is_transient_error(e):
     #
     # OSError: [Errno 51] Connect call failed ('35.188.91.25', 443)
     # https://hail.zulipchat.com/#narrow/stream/223457-Batch-support/topic/ssl.20error
-    if isinstance(e, aiohttp.ClientResponseError) and (
+    if isinstance(e, (aiohttp.ClientResponseError, aiohttp.client_exceptions.ClientResponseError)) and (
             e.status in RETRYABLE_HTTP_STATUS_CODES):
         # nginx returns 502 if it cannot connect to the upstream server
         # 408 request timeout, 500 internal server error, 502 bad gateway

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -593,7 +593,7 @@ def is_transient_error(e):
     #
     # OSError: [Errno 51] Connect call failed ('35.188.91.25', 443)
     # https://hail.zulipchat.com/#narrow/stream/223457-Batch-support/topic/ssl.20error
-    if isinstance(e, (aiohttp.ClientResponseError, aiohttp.client_exceptions.ClientResponseError)) and (
+    if isinstance(e, aiohttp.ClientResponseError) and (
             e.status in RETRYABLE_HTTP_STATUS_CODES):
         # nginx returns 502 if it cannot connect to the upstream server
         # 408 request timeout, 500 internal server error, 502 bad gateway


### PR DESCRIPTION
This PR fixes the problem where there were 3 free cores on an instance not in us-central. ci can not schedule jobs in other zones so ci could not progress.