### PR TITLE
Fix documentation for hl.experimental.haplotype_freq_em

### DIFF
--- a/hail/python/hail/experimental/haplotype_freq_em.py
+++ b/hail/python/hail/experimental/haplotype_freq_em.py
@@ -14,7 +14,7 @@ def haplotype_freq_em(gt_counts) -> ArrayExpression:
     [AABB, AABb, AAbb, AaBB, AaBb, Aabb, aaBB, aaBb, aabb]
 
     The estimated haplotype counts are returned in an array in the following order:
-    [AB, Ab, aB, ab]
+    [AB, aB, Ab, ab]
 
     Where _A_ and _a_ are the reference and non-reference alleles for the first variant, resp.
     And _B_ and _b_ are the reference and non-reference alleles for the second variant, resp.


### PR DESCRIPTION
`hl.experimental.haplotype_freq_em` documents the order of input and output arrays in terms of A/a and B/b for reference and non-reference alleles for two variants.

https://github.com/hail-is/hail/blob/ff10ed660b3655c70204589b96e440115ed9063b/hail/python/hail/experimental/haplotype_freq_em.py#L13-L20

However, the underlying Scala code swaps A and B.

For example, the Python function's documentation says index 2 should represent AAbb but the Scala code treats index 2 as aaBB.

https://github.com/hail-is/hail/blob/1a861505c1fc2ea3c9d7b32a47be7af10d13907c/hail/src/main/scala/is/hail/experimental/package.scala#L50-L62

The currently documented order of outputs from the Python function seems to be based on the Scala code and thus does not match with the documented inputs.

@lfrancioli 