### PR TITLE
[compiler] Add SUnreachable SType for NA / Die

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -845,7 +845,7 @@ class Emit[C](
         emitI(v)
           .map(cb)(pc => pc.st.castRename(_typ).fromCodes(pc.makeCodeTuple(cb)))
       case NA(typ) =>
-        IEmitCode(cb, const(true), typeWithReq.canonicalEmitType.st.defaultValue)
+        IEmitCode.missing(cb, SUnreachable.fromVirtualType(typ).defaultValue)
       case IsNA(v) =>
         val m = emitI(v).consumeCode(cb, true, _ => false)
         presentPC(primitive(m))
@@ -1022,7 +1022,7 @@ class Emit[C](
 
       case ArrayLen(a) =>
         emitI(a).map(cb) { (ac) =>
-          primitive(ac.asIndexable.loadLength())
+          primitive(ac.asIndexable.codeLoadLength())
         }
 
       case GetField(o, name) =>
@@ -2075,7 +2075,7 @@ class Emit[C](
           { sc => cb.assign(msg, sc.asString.loadString()) })
         cb._throw[HailException](Code.newInstance[HailException, String, Int](msg, errorId))
 
-        IEmitCode.present(cb, typeWithReq.canonicalEmitType.st.defaultValue)
+        IEmitCode.present(cb, SUnreachable.fromVirtualType(typ).defaultValue)
 
       case CastToArray(a) =>
         emitI(a).map(cb) { ind => ind.asIndexable.castToArray(cb) }
@@ -2677,7 +2677,7 @@ abstract class NDArrayEmitter(val outputShape: IndexedSeq[Value[Long]], val elem
 
     SNDArray.forEachIndexColMajor(cb, shapeArray, "ndarrayemitter_emitloops") { case (cb, idxVars) =>
       val element = IEmitCode.present(cb, outputElement(cb, idxVars)).consume(cb, {
-        cb._fatal("NDArray elements cannot  be missing")
+        cb._fatal("NDArray elements cannot be missing")
       }, { elementPc =>
         targetType.elementType.storeAtAddress(cb, firstElementAddress + (idx.toL * targetType.elementType.byteSize), region, elementPc, true)
       })

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1376,9 +1376,7 @@ class Emit[C](
             val outputPType = PCanonicalNDArray(lSType.elementType.canonicalPType().setRequired(true),
               TNDArray.matMulNDims(lSType.nDims, rSType.nDims))
 
-            if ((lSType.elementType.isInstanceOf[PFloat64] || lSType.elementType.isInstanceOf[PFloat32]) && lSType.nDims == 2 && rSType.nDims == 2) {
-              val leftPValAddr = SingleCodeSCode.fromSCode(cb, leftPVal, region)
-              val rightPValAddr = SingleCodeSCode.fromSCode(cb, rightPVal, region)
+            if ((lSType.elementType.virtualType == TFloat64 || lSType.elementType.virtualType == TFloat32) && lSType.nDims == 2 && rSType.nDims == 2) {
               val leftDataAddress = leftPVal.firstDataAddress(cb)
               val rightDataAddress = rightPVal.firstDataAddress(cb)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -56,13 +56,13 @@ object IntervalFunctions extends RegistryFunctions {
     registerSCode1("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
-      case (r, cb, rt, interval: SIntervalCode) => primitive(interval.includesStart())
+      case (r, cb, rt, interval: SIntervalCode) => primitive(interval.codeIncludesStart())
     }
 
     registerSCode1("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
-      case (r, cb, rt, interval: SIntervalCode) => primitive(interval.includesEnd())
+      case (r, cb, rt, interval: SIntervalCode) => primitive(interval.codeIncludesEnd())
     }
 
     registerIEmitCode2("contains", TInterval(tv("T")), tv("T"), TBoolean, {

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/StringOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/StringOrdering.scala
@@ -22,6 +22,17 @@ object StringOrdering {
             ord.compareNonnull(cb, x.asString.asBytes(), y.asString.asBytes())
           }
         }
+
+      case (_, _) =>
+        new CodeOrderingCompareConsistentWithOthers {
+
+          val type1: SString = t1
+          val type2: SString = t2
+
+          def _compareNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Int] = {
+            x.asString.loadString().invoke[String, Int]("compareTo", y.asString.loadString())
+          }
+        }
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.orderings.StructOrdering
 import is.hail.services.shuffler.CompileTimeShuffleClient
 import is.hail.types.{TypeWithRequiredness, VirtualTypeWithReq}
 import is.hail.types.physical.stypes.{EmitType, SType}
-import is.hail.types.physical.stypes.concrete.SCanonicalShufflePointerSettable
+import is.hail.types.physical.stypes.concrete.{SCanonicalShufflePointerSettable, SUnreachable}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code}
 import is.hail.types.physical.{PCanonicalArray, PCanonicalStream, PCanonicalStruct, PInterval, PStruct, PType}
@@ -168,8 +168,8 @@ object EmitStream {
 
     streamIR match {
 
-      case x@NA(_typ) =>
-        val st = typeWithReq.canonicalEmitType.st.asInstanceOf[SStream]
+      case x@NA(_typ: TStream) =>
+        val st = SStream(EmitType(SUnreachable.fromVirtualType(_typ.elementType), true))
         val region = mb.genFieldThisRef[Region]("na_region")
         val producer = new StreamProducer {
           override def initialize(cb: EmitCodeBuilder): Unit = {}

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -14,12 +14,11 @@ object LinalgCodeUtils {
     val strides = pndv.strides(cb)
     val runningProduct = cb.newLocal[Long]("check_column_major_running_product")
 
-    val pt = pndv.st.asInstanceOf[SNDArrayPointer].pType
-    val elementType = pt.elementType
+    val st = pndv.st
     val nDims = pndv.st.nDims
 
     cb.assign(answer, true)
-    cb.assign(runningProduct, elementType.byteSize)
+    cb.assign(runningProduct, st.elementByteSize)
     (0 until nDims).foreach{ index =>
       cb.assign(answer, answer & (strides(index) ceq runningProduct))
       cb.assign(runningProduct, runningProduct * (shapes(index) > 0L).mux(shapes(index), 1L))
@@ -33,12 +32,11 @@ object LinalgCodeUtils {
     val strides = pndv.strides(cb)
     val runningProduct = cb.newLocal[Long]("check_column_major_running_product")
 
-    val pt = pndv.st.asInstanceOf[SNDArrayPointer].pType
-    val elementType = pt.elementType
-    val nDims = pt.nDims
+    val st = pndv.st
+    val nDims = st.nDims
 
     cb.assign(answer, true)
-    cb.assign(runningProduct, elementType.byteSize)
+    cb.assign(runningProduct, st.elementByteSize)
     ((nDims - 1) to 0 by -1).foreach { index =>
       cb.assign(answer, answer & (strides(index) ceq runningProduct))
       cb.assign(runningProduct, runningProduct * (shapes(index) > 0L).mux(shapes(index), 1L))

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -3,7 +3,7 @@ package is.hail.linalg
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.concrete.SNDArrayPointer
+import is.hail.types.physical.PCanonicalNDArray
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArraySettable, SNDArrayValue}
 import is.hail.utils.FastIndexedSeq
 
@@ -46,7 +46,7 @@ object LinalgCodeUtils {
 
   def createColumnMajorCode(pndv: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): SNDArrayCode = {
     val shape = pndv.shapes(cb)
-    val pt = pndv.st.asInstanceOf[SNDArrayPointer].pType
+    val pt = PCanonicalNDArray(pndv.st.elementType.canonicalPType().setRequired(true), pndv.st.nDims, false)
     val strides = pt.makeColumnMajorStrides(shape, region, cb)
 
     val (dataFirstElementAddress, dataFinisher) = pt.constructDataFunction(shape, strides, cb, region)

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.physical.PCanonicalNDArray
+import is.hail.types.physical.stypes.concrete.SUnreachableNDArray
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArraySettable, SNDArrayValue}
 import is.hail.utils.FastIndexedSeq
 
@@ -68,6 +69,9 @@ object LinalgCodeUtils {
   }
 
   def checkStandardStriding(aInput: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): (SNDArrayValue, Value[Boolean]) = {
+    if (aInput.st.isInstanceOf[SUnreachableNDArray])
+      return (aInput, const(true))
+
     val aIsColumnMajor = LinalgCodeUtils.checkColumnMajor(aInput, cb)
     val a = cb.emb.newPField("ndarray_output_standardized", aInput.st).asInstanceOf[SNDArraySettable]
     cb.ifx(aIsColumnMajor, {cb.assign(a, aInput)}, {

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -2,9 +2,9 @@ package is.hail.linalg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.physical.stypes.concrete.{SNDArrayPointer, SNDArrayPointerSettable}
-import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.physical.stypes.concrete.SNDArrayPointer
+import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArraySettable, SNDArrayValue}
 import is.hail.utils.FastIndexedSeq
 
 object LinalgCodeUtils {
@@ -59,7 +59,7 @@ object LinalgCodeUtils {
 
   def checkColMajorAndCopyIfNeeded(aInput: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): SNDArrayValue = {
     val aIsColumnMajor = LinalgCodeUtils.checkColumnMajor(aInput, cb)
-    val aColMajor = cb.emb.newPField("ndarray_output_column_major", aInput.st).asInstanceOf[SNDArrayPointerSettable]
+    val aColMajor = cb.emb.newPField("ndarray_output_column_major", aInput.st).asInstanceOf[SNDArraySettable]
     cb.ifx(aIsColumnMajor, {cb.assign(aColMajor, aInput)},
       {
         cb.assign(aColMajor, LinalgCodeUtils.createColumnMajorCode(aInput, cb, region))
@@ -69,7 +69,7 @@ object LinalgCodeUtils {
 
   def checkStandardStriding(aInput: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): (SNDArrayValue, Value[Boolean]) = {
     val aIsColumnMajor = LinalgCodeUtils.checkColumnMajor(aInput, cb)
-    val a = cb.emb.newPField("ndarray_output_standardized", aInput.st).asInstanceOf[SNDArrayPointerSettable]
+    val a = cb.emb.newPField("ndarray_output_standardized", aInput.st).asInstanceOf[SNDArraySettable]
     cb.ifx(aIsColumnMajor, {cb.assign(a, aInput)}, {
       val isRowMajor = LinalgCodeUtils.checkRowMajor(aInput, cb)
       cb.ifx(isRowMajor, {cb.assign(a, aInput)}, {

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -8,7 +8,7 @@ import is.hail.types.BaseStruct
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.physical.stypes.concrete._
-import is.hail.types.physical.stypes.interfaces.SBaseStructValue
+import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SLocus, SLocusValue}
 import is.hail.types.virtual._
 import is.hail.utils._
 
@@ -75,10 +75,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       case SIntervalPointer(t: PCanonicalInterval) => new SBaseStructPointerSettable(
         SBaseStructPointer(t.representation),
         v.asInstanceOf[SIntervalPointerSettable].a)
-      case SCanonicalLocusPointer(t) =>
-        new SBaseStructPointerSettable(
-          SBaseStructPointer(t.representation),
-          v.asInstanceOf[SCanonicalLocusPointerSettable].a)
+      case _: SLocus => v.asInstanceOf[SLocusValue].structRepr(cb)
       case _ => v.asInstanceOf[SBaseStructValue]
     }
     // write missing bytes

--- a/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
@@ -9,7 +9,7 @@ import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerCode, SBinaryPointerSettable, SStringPointer, SStringPointerCode, SStringPointerSettable}
-import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue}
+import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue, SString}
 import is.hail.utils._
 
 case object EBinaryOptional extends EBinary(false)
@@ -21,6 +21,7 @@ class EBinary(override val required: Boolean) extends EType {
     val bin = v.st match {
       case _: SBinary => v.asInstanceOf[SBinaryValue]
       case SStringPointer(t) => new SBinaryPointerSettable(SBinaryPointer(t.binaryRepresentation), v.asInstanceOf[SStringPointerSettable].a)
+      case _: SString => v.asString.asBytes().memoize(cb, "encoder_sstring")
     }
 
     val len = cb.newLocal[Int]("len", bin.loadLength())

--- a/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
@@ -9,7 +9,7 @@ import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerCode, SBinaryPointerSettable, SStringPointer, SStringPointerCode, SStringPointerSettable}
-import is.hail.types.physical.stypes.interfaces.SBinaryValue
+import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue}
 import is.hail.utils._
 
 case object EBinaryOptional extends EBinary(false)
@@ -19,7 +19,7 @@ class EBinary(override val required: Boolean) extends EType {
 
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val bin = v.st match {
-      case SBinaryPointer(t) => v.asInstanceOf[SBinaryValue]
+      case _: SBinary => v.asInstanceOf[SBinaryValue]
       case SStringPointer(t) => new SBinaryPointerSettable(SBinaryPointer(t.binaryRepresentation), v.asInstanceOf[SStringPointerSettable].a)
     }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EInt32.scala
@@ -7,7 +7,7 @@ import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
 import is.hail.types.physical.stypes.concrete.{SCanonicalCall, SCanonicalCallCode}
-import is.hail.types.physical.stypes.interfaces.SCallValue
+import is.hail.types.physical.stypes.interfaces.{SCall, SCallValue}
 import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code}
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -19,7 +19,7 @@ case object EInt32Required extends EInt32(true)
 class EInt32(override val required: Boolean) extends EType {
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val x = v.st match {
-      case SCanonicalCall => v.asInstanceOf[SCallValue].canonicalCall(cb)
+      case _: SCall => v.asInstanceOf[SCallValue].canonicalCall(cb)
       case SInt32 => v.asInt32.intCode(cb)
     }
     cb += out.writeInt(x)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -422,9 +422,9 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
         value.asInstanceOf[SIndexablePointerCode].a
       case _ =>
         val newAddr = cb.newLocal[Long]("pcarray_store_newaddr")
-        val pcInd = value.asIndexable.memoize(cb, "pcarray_store_src_sametype").asInstanceOf[SIndexablePointerSettable]
-        cb.assign(newAddr, allocate(region, pcInd.loadLength()))
-        storeContentsAtAddress(cb, newAddr, region, pcInd, deepCopy)
+        val valueMemo = value.asIndexable.memoize(cb, "pcarray_store_src_difftype")
+        cb.assign(newAddr, allocate(region, valueMemo.loadLength()))
+        storeContentsAtAddress(cb, newAddr, region, valueMemo, deepCopy)
         newAddr
     }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -52,7 +52,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
   }
 
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeInt(addr, value.asCall.loadCanonicalRepresentation(cb)
+    cb += Region.storeInt(addr, value.asCall.loadCanonicalRepresentation(cb))
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -52,7 +52,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
   }
 
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeInt(addr, value.asInstanceOf[SCanonicalCallCode].call)
+    cb += Region.storeInt(addr, value.asCall.loadCanonicalRepresentation(cb)
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -359,7 +359,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
           cb.append(region.trackNDArray(storedAddress))
         }
         storedAddress
-      case SNDArrayPointer(t) =>
+      case _ =>
         val oldND = value.asNDArray.memoize(cb, "pcanonical_ndarray_store_old")
         val shape = oldND.shapes(cb)
         val newStrides = makeColumnMajorStrides(shape, region, cb)

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -110,7 +110,7 @@ object PType {
 
   implicit def arbType = Arbitrary(genArb)
 
-  def canonical(t: Type, required: Boolean): PType = {
+  def canonical(t: Type, required: Boolean, innerRequired: Boolean): PType = {
     t match {
       case TInt32 => PInt32(required)
       case TInt64 => PInt64(required)
@@ -122,19 +122,21 @@ object PType {
       case TString => PCanonicalString(required)
       case TCall => PCanonicalCall(required)
       case t: TLocus => PCanonicalLocus(t.rg, required)
-      case t: TInterval => PCanonicalInterval(canonical(t.pointType), required)
-      case t: TStream => PCanonicalStream(canonical(t.elementType), required = required)
-      case t: TArray => PCanonicalArray(canonical(t.elementType), required)
-      case t: TSet => PCanonicalSet(canonical(t.elementType), required)
-      case t: TDict => PCanonicalDict(canonical(t.keyType), canonical(t.valueType), required)
-      case t: TTuple => PCanonicalTuple(t._types.map(tf => PTupleField(tf.index, canonical(tf.typ))), required)
-      case t: TStruct => PCanonicalStruct(t.fields.map(f => PField(f.name, canonical(f.typ), f.index)), required)
-      case t: TNDArray => PCanonicalNDArray(canonical(t.elementType).setRequired(true), t.nDims, required)
+      case t: TInterval => PCanonicalInterval(canonical(t.pointType, innerRequired, innerRequired), required)
+      case t: TStream => PCanonicalStream(canonical(t.elementType, innerRequired, innerRequired), required = required)
+      case t: TArray => PCanonicalArray(canonical(t.elementType, innerRequired, innerRequired), required)
+      case t: TSet => PCanonicalSet(canonical(t.elementType, innerRequired, innerRequired), required)
+      case t: TDict => PCanonicalDict(canonical(t.keyType, innerRequired, innerRequired), canonical(t.valueType, innerRequired, innerRequired), required)
+      case t: TTuple => PCanonicalTuple(t._types.map(tf => PTupleField(tf.index, canonical(tf.typ, innerRequired, innerRequired))), required)
+      case t: TStruct => PCanonicalStruct(t.fields.map(f => PField(f.name, canonical(f.typ, innerRequired, innerRequired), f.index)), required)
+      case t: TNDArray => PCanonicalNDArray(canonical(t.elementType, innerRequired, innerRequired).setRequired(true), t.nDims, required)
       case TVoid => PVoid
     }
   }
 
-  def canonical(t: Type): PType = canonical(t, false)
+  def canonical(t: Type, required: Boolean): PType = canonical(t, required, false)
+
+  def canonical(t: Type): PType = canonical(t, false, false)
 
   // currently identity
   def canonical(t: PType): PType = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitSettable, SCodeEmitParamType, SCodeParamType}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.PType
+import is.hail.types.physical.stypes.concrete.SUnreachable
 import is.hail.types.physical.stypes.interfaces.SStream
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
@@ -12,10 +13,15 @@ import is.hail.types.virtual._
 
 object SType {
   def chooseCompatibleType(req: VirtualTypeWithReq, stypes: SType*): SType = {
-    if (stypes.toSet.size == 1)
-      stypes.head
+    val reachable = stypes.filter(t => !t.isInstanceOf[SUnreachable]).toSet
+
+    // all unreachable
+    if (reachable.isEmpty)
+      SUnreachable.fromVirtualType(req.t)
+    else if (reachable.size == 1) // only one reachable stype
+      reachable.head
     else
-      req.canonicalEmitType.st
+      req.canonicalEmitType.st // fall back to canonical emit type from requiredness
   }
 
   def canonical(virt: Type): SType = {
@@ -36,7 +42,14 @@ object SType {
 trait SType {
   def virtualType: Type
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode
+  final def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+    value.st match {
+      case _: SUnreachable => this.defaultValue
+      case _ => _coerceOrCopy(cb, region, value, deepCopy)
+    }
+  }
+
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]]
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -49,7 +49,7 @@ trait SType {
     }
   }
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode
+  protected[stypes] def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]]
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -21,7 +21,7 @@ case class SBaseStructPointer(pType: PBaseStruct) extends SBaseStruct {
 
   override def fieldIdx(fieldName: String): Int = pType.fieldIdx(fieldName)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SBaseStructPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -15,7 +15,7 @@ case class SBinaryPointer(pType: PBinary) extends SBinary {
   require(!pType.required)
 
   lazy val virtualType: Type = pType.virtualType
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SBinaryPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -13,7 +13,7 @@ import is.hail.variant.Genotype
 
 
 case object SCanonicalCall extends SCall {
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SCanonicalCall => value
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SLocus, SLocusCode, SLocusValue, SString, SStringCode}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue, SLocus, SLocusCode, SLocusValue, SString, SStringCode}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType}
 import is.hail.types.physical.{PCanonicalLocus, PType}
 import is.hail.types.virtual.Type
@@ -81,6 +81,9 @@ class SCanonicalLocusPointerSettable(
   }
 
   def position(cb: EmitCodeBuilder): Code[Int] = _position
+
+  override def structRepr(cb: EmitCodeBuilder): SBaseStructValue = new SBaseStructPointerSettable(
+    SBaseStructPointer(st.pType.representation), a)
 }
 
 class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Long]) extends SLocusCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.stypes.interfaces.{SLocus, SLocusCode, SLocusValue, SString, SStringCode}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SLocus, SLocusCode, SLocusValue, SString, SStringCode}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType}
 import is.hail.types.physical.{PCanonicalLocus, PType}
 import is.hail.types.virtual.Type
@@ -110,4 +110,6 @@ class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Lon
   def memoizeField(cb: EmitCodeBuilder, name: String): SCanonicalLocusPointerSettable = memoize(cb, name, cb.fieldBuilder)
 
   def store(mb: EmitMethodBuilder[_], r: Value[Region], dst: Code[Long]): Code[Unit] = Region.storeAddress(dst, a)
+
+  def structRepr(cb: EmitCodeBuilder): SBaseStructCode = new SBaseStructPointerCode(SBaseStructPointer(st.pType.representation), a)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -23,7 +23,7 @@ case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
 
   override def rg: ReferenceGenome = pType.rg
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SCanonicalLocusPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
@@ -20,7 +20,7 @@ case class SCanonicalShufflePointer(pType: PCanonicalShuffle) extends SShuffle {
 
   lazy val binarySType = SBinaryPointer(pType.representation)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SCanonicalShufflePointerCode(this, pType.representation.loadCheapSCode(cb, pType.store(cb, region, value, deepCopy)))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -21,7 +21,7 @@ case class SIndexablePointer(pType: PContainer) extends SContainer {
 
   def elementEmitType: EmitType = EmitType(elementType, pType.elementType.required)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SIndexablePointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
@@ -54,7 +54,7 @@ class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extend
 
   def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
-  def loadLength(): Code[Int] = pt.loadLength(a)
+  def codeLoadLength(): Code[Int] = pt.loadLength(a)
 
   def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIndexableValue = {
     val s = SIndexablePointerSettable(sb, st, name)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
@@ -63,7 +63,7 @@ case class SInsertFieldsStruct(virtualType: TStruct, parent: SBaseStruct, insert
     })
   }
 
-    override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value match {
       case ss: SInsertFieldsStructCode if ss.st == this => value
       case _ => throw new RuntimeException(s"copy insertfields struct")

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
@@ -63,7 +63,7 @@ case class SInsertFieldsStruct(virtualType: TStruct, parent: SBaseStruct, insert
     })
   }
 
-  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+    override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value match {
       case ss: SInsertFieldsStructCode if ss.st == this => value
       case _ => throw new RuntimeException(s"copy insertfields struct")

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -14,7 +14,7 @@ import is.hail.utils.FastIndexedSeq
 case class SIntervalPointer(pType: PInterval) extends SInterval {
   require(!pType.required)
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SIntervalPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
@@ -111,9 +111,9 @@ class SIntervalPointerCode(val st: SIntervalPointer, val a: Code[Long]) extends 
 
   def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
-  def includesStart(): Code[Boolean] = pt.includesStart(a)
+  def codeIncludesStart(): Code[Boolean] = pt.includesStart(a)
 
-  def includesEnd(): Code[Boolean] = pt.includesEnd(a)
+  def codeIncludesEnd(): Code[Boolean] = pt.includesEnd(a)
 
   def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIntervalValue = {
     val s = SIntervalPointerSettable(sb, st, name)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -14,6 +14,8 @@ case class SNDArrayPointer(pType: PCanonicalNDArray) extends SNDArray {
 
   def nDims: Int = pType.nDims
 
+  override def elementByteSize: Long = pType.elementType.byteSize
+
   override def elementType: SType = pType.elementType.sType
 
   override def elementPType: PType = pType.elementType

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -4,6 +4,10 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SNDArray, SNDArrayCode, SNDArrayValue}
+import is.hail.asm4s.{Code, IntInfo, LongInfo, Settable, SettableBuilder, TypeInfo, Value, const}
+import is.hail.expr.ir.orderings.CodeOrdering
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SNDArray, SNDArrayCode, SNDArraySettable, SNDArrayValue}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalNDArray, PType}
 import is.hail.types.virtual.Type
@@ -66,7 +70,7 @@ class SNDArrayPointerSettable(
    val shape: IndexedSeq[Settable[Long]],
    val strides: IndexedSeq[Settable[Long]],
    val dataFirstElement: Settable[Long]
- ) extends SNDArrayValue with SSettable {
+ ) extends SNDArraySettable {
   val pt: PCanonicalNDArray = st.pType
 
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -22,7 +22,7 @@ case class SNDArrayPointer(pType: PCanonicalNDArray) extends SNDArray {
 
   override def castRename(t: Type): SType = SNDArrayPointer(pType.deepRename(t))
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SNDArrayPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -68,7 +68,7 @@ case class SStackStruct(virtualType: TBaseStruct, fieldEmitTypes: IndexedSeq[Emi
     })
   }
 
-  override def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value match {
       case ss: SStackStructCode =>
         if (ss.st == this && !deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -18,7 +18,7 @@ case class SStringPointer(pType: PString) extends SString {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SStringPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -43,7 +43,7 @@ case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) ex
     newType
   }
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     if (deepCopy)
       throw new NotImplementedError("Deep copy on subset struct")
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -247,7 +247,7 @@ case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with 
   override def elementByteSize: Long = 0L
 }
 
-class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachableValue with SNDArrayValue with SNDArrayCode {
+class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachableValue with SNDArraySettable with SNDArrayCode {
   override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
 
   def shape(cb: EmitCodeBuilder): SBaseStructCode = SUnreachableStruct(TTuple((0 until st.nDims).map(_ => TInt64): _*)).defaultValue.asBaseStruct

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -66,7 +66,7 @@ case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable wit
   val fieldTypes: IndexedSeq[SType] = virtualType.types.map(SUnreachable.fromVirtualType)
   val fieldEmitTypes: IndexedSeq[EmitType] = fieldTypes.map(f => EmitType(f, true))
 
-  def fieldIdx(fieldName: String): Int = virtualType.asInstanceOf[TStruct].fieldIdx(fieldName)
+  def fieldIdx(fieldName: String): Int = virtualType.fieldIdx(fieldName)
 
   val sv = new SUnreachableStructValue(this)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -60,7 +60,6 @@ abstract class SUnreachableValue extends SCode with SSettable {
 }
 
 case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable with SBaseStruct {
-
   override def size: Int = virtualType.size
 
   val fieldTypes: IndexedSeq[SType] = virtualType.types.map(SUnreachable.fromVirtualType)
@@ -279,7 +278,6 @@ class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachable
 
   override def get: SUnreachableNDArrayValue = this
 }
-
 
 case class SUnreachableContainer(virtualType: TContainer) extends SUnreachable with SContainer {
   val sv = new SUnreachableContainerValue(this)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -178,7 +178,7 @@ class SUnreachableLocusValue(val st: SUnreachableLocus) extends SUnreachableValu
 
   override def contig(cb: EmitCodeBuilder): SStringCode = new SUnreachableStringValue
 
-  override def structRepr(cb: EmitCodeBuilder): SBaseStructCode = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asBaseStruct
+  override def structRepr(cb: EmitCodeBuilder): SBaseStructValue = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asBaseStruct
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -277,6 +277,9 @@ class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachable
   override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
 
   override def get: SUnreachableNDArrayValue = this
+
+  override def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], deepCopy: Boolean, indexVars: IndexedSeq[String],
+    destIndices: IndexedSeq[Int], arrays: (SNDArrayCode, IndexedSeq[Int], String)*)(body: IndexedSeq[SCode] => SCode): Unit = ()
 }
 
 case class SUnreachableContainer(virtualType: TContainer) extends SUnreachable with SContainer {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -251,7 +251,7 @@ case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with 
 
   override def elementPType: PType = elementType.canonicalPType()
 
-  override def pType: PNDArray = PCanonicalNDArray(elementPType, nDims, false)
+  override def pType: PNDArray = PCanonicalNDArray(elementPType.setRequired(true), nDims, false)
 
   override def elementByteSize: Long = 0L
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -177,6 +177,8 @@ class SUnreachableLocusValue(val st: SUnreachableLocus) extends SUnreachableValu
   override def position(cb: EmitCodeBuilder): Code[Int] = const(0)
 
   override def contig(cb: EmitCodeBuilder): SStringCode = new SUnreachableStringValue
+
+  override def structRepr(cb: EmitCodeBuilder): SBaseStructCode = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asBaseStruct
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -1,0 +1,295 @@
+package is.hail.types.physical.stypes.concrete
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
+import is.hail.types.physical.PType
+import is.hail.types.physical.stypes.interfaces._
+import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType}
+import is.hail.types.virtual._
+import is.hail.utils.FastIndexedSeq
+import is.hail.variant.ReferenceGenome
+
+object SUnreachable {
+  def fromVirtualType(t: Type): SType = {
+    require(t.isRealizable)
+    t match {
+      case t if t.isPrimitive => SType.canonical(t)
+      case ts: TBaseStruct => SUnreachableStruct(ts)
+      case tc: TContainer => SUnreachableContainer(tc)
+      case tnd: TNDArray => SUnreachableNDArray(tnd)
+      case tl: TLocus => SUnreachableLocus(tl)
+      case ti: TInterval => SUnreachableInterval(ti)
+      case ts: TShuffle => SUnreachableShuffle(ts)
+      case TCall => SUnreachableCall
+      case TBinary => SUnreachableBinary
+      case TString => SUnreachableString
+      case TVoid => SVoid
+    }
+  }
+}
+
+abstract class SUnreachable extends SType {
+  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
+
+  override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
+
+  def canonicalPType(): PType = PType.canonical(virtualType).deepInnerRequired(true).setRequired(false)
+
+  override def asIdent: String = s"s_unreachable"
+
+  def castRename(t: Type): SType = SUnreachable.fromVirtualType(t)
+
+  val sv: SUnreachableValue
+
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = sv
+
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SUnreachableValue = sv
+
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = sv
+}
+
+abstract class SUnreachableValue extends SCode with SSettable {
+  def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq()
+
+  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq()
+
+  def store(cb: EmitCodeBuilder, v: SCode): Unit = {}
+
+  override def get: SCode = this
+}
+
+case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable with SBaseStruct {
+
+  override def size: Int = virtualType.size
+
+  val fieldTypes: IndexedSeq[SType] = virtualType.types.map(SUnreachable.fromVirtualType)
+  val fieldEmitTypes: IndexedSeq[EmitType] = fieldTypes.map(f => EmitType(f, true))
+
+  def fieldIdx(fieldName: String): Int = virtualType.asInstanceOf[TStruct].fieldIdx(fieldName)
+
+  val sv = new SUnreachableStructValue(this)
+
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SUnreachableStructValue = sv
+}
+
+class SUnreachableStructValue(val st: SUnreachableStruct) extends SUnreachableValue with SBaseStructValue with SBaseStructCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue = this
+
+  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = IEmitCode.present(cb, SUnreachable.fromVirtualType(st.virtualType.types(fieldIdx)).defaultValue)
+
+  override def isFieldMissing(fieldIdx: Int): Code[Boolean] = false
+
+  override def loadSingleField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = loadField(cb, fieldIdx)
+
+  override def subset(fieldNames: String*): SBaseStructCode = {
+    val oldType = st.virtualType.asInstanceOf[TStruct]
+    val newType = TStruct(fieldNames.map(f => (f, oldType.fieldType(f))): _*)
+    new SUnreachableStructValue(SUnreachableStruct(newType))
+  }
+
+  override def baseInsert(cb: EmitCodeBuilder, region: Value[Region], newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode =
+    new SUnreachableStructValue(SUnreachableStruct(newType))
+}
+
+case object SUnreachableBinary extends SUnreachable with SBinary {
+  override def virtualType: Type = TBinary
+
+  val sv = new SUnreachableBinaryValue
+}
+
+class SUnreachableBinaryValue extends SUnreachableValue with SBinaryValue with SBinaryCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableBinaryValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableBinaryValue = this
+
+  override def loadByte(i: Code[Int]): Code[Byte] = const(0.toByte)
+
+  override def bytesAddress(): Code[Long] = const(0L)
+
+  override def loadBytes(): Code[Array[Byte]] = Code._null
+
+  override def loadLength(): Code[Int] = const(0)
+
+  def st: SUnreachableBinary.type = SUnreachableBinary
+
+  override def get: SUnreachableBinaryValue = this
+}
+
+case object SUnreachableString extends SUnreachable with SString {
+  override def virtualType: Type = TString
+
+  val sv = new SUnreachableStringValue
+
+  override def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringCode = sv
+}
+
+class SUnreachableStringValue extends SUnreachableValue with SStringValue with SStringCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableStringValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableStringValue = this
+
+  override def loadLength(): Code[Int] = const(0)
+
+  def st: SUnreachableString.type = SUnreachableString
+
+  override def loadString(): Code[String] = Code._null
+
+  override def asBytes(): SBinaryCode = new SUnreachableBinaryValue
+
+  override def get: SUnreachableStringValue = this
+}
+
+case class SUnreachableShuffle(virtualType: TShuffle) extends SUnreachable with SShuffle {
+  val sv = new SUnreachableShuffleValue(this)
+}
+
+class SUnreachableShuffleValue(val st: SUnreachableShuffle) extends SUnreachableValue with SShuffleValue with SShuffleCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableShuffleValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableShuffleValue = this
+
+  override def loadBytes(): Code[Array[Byte]] = Code._null
+
+  override def loadLength(): Code[Int] = const(0)
+
+  override def get: SUnreachableShuffleValue = this
+}
+
+case class SUnreachableLocus(virtualType: TLocus) extends SUnreachable with SLocus {
+  val sv = new SUnreachableLocusValue(this)
+
+  override def contigType: SString = SUnreachableString
+
+  override def rg: ReferenceGenome = virtualType.rg
+}
+
+class SUnreachableLocusValue(val st: SUnreachableLocus) extends SUnreachableValue with SLocusValue with SLocusCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableLocusValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableLocusValue = this
+
+  override def position(cb: EmitCodeBuilder): Code[Int] = const(0)
+
+  override def contig(cb: EmitCodeBuilder): SStringCode = new SUnreachableStringValue
+}
+
+
+case object SUnreachableCall extends SUnreachable with SCall {
+  override def virtualType: Type = TCall
+
+  val sv = new SUnreachableCallValue
+}
+
+class SUnreachableCallValue extends SUnreachableValue with SCallValue with SCallCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableCallValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableCallValue = this
+
+  override def loadCanonicalRepresentation(cb: EmitCodeBuilder): Code[Int] = const(0)
+
+  override def forEachAllele(cb: EmitCodeBuilder)(alleleCode: Value[Int] => Unit): Unit = {}
+
+  override def isPhased(): Code[Boolean] = const(false)
+
+  override def ploidy(): Code[Int] = const(0)
+
+  override def canonicalCall(cb: EmitCodeBuilder): Code[Int] = const(0)
+
+  def st: SUnreachableCall.type = SUnreachableCall
+
+  override def get: SUnreachableCallValue = this
+}
+
+
+case class SUnreachableInterval(virtualType: TInterval) extends SUnreachable with SInterval {
+  val sv = new SUnreachableIntervalValue(this)
+
+  override def pointType: SType = SUnreachable.fromVirtualType(virtualType.pointType)
+
+  override def pointEmitType: EmitType = EmitType(pointType, true)
+}
+
+class SUnreachableIntervalValue(val st: SUnreachableInterval) extends SUnreachableValue with SIntervalValue with SIntervalCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableIntervalValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableIntervalValue = this
+
+  def includesStart(): Value[Boolean] = const(false)
+
+  def includesEnd(): Value[Boolean] = const(false)
+
+  def codeIncludesStart(): Code[Boolean] = const(false)
+
+  def codeIncludesEnd(): Code[Boolean] = const(false)
+
+  def loadStart(cb: EmitCodeBuilder): IEmitCode = IEmitCode.present(cb, SUnreachable.fromVirtualType(st.virtualType.pointType).defaultValue)
+
+  def startDefined(cb: EmitCodeBuilder): Code[Boolean] = const(false)
+
+  def loadEnd(cb: EmitCodeBuilder): IEmitCode = IEmitCode.present(cb, SUnreachable.fromVirtualType(st.virtualType.pointType).defaultValue)
+
+  def endDefined(cb: EmitCodeBuilder): Code[Boolean] = const(false)
+
+  def isEmpty(cb: EmitCodeBuilder): Code[Boolean] = const(false)
+}
+
+
+case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with SNDArray {
+  val sv = new SUnreachableNDArrayValue(this)
+
+  override def nDims: Int = virtualType.nDims
+
+  lazy val elementType: SType = SUnreachable.fromVirtualType(virtualType.elementType)
+}
+
+class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachableValue with SNDArrayValue with SNDArrayCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
+
+  def shape(cb: EmitCodeBuilder): SBaseStructCode = SUnreachableStruct(TTuple((0 until st.nDims).map(_ => TInt64): _*)).defaultValue.asBaseStruct
+
+  def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode = SUnreachable.fromVirtualType(st.virtualType.elementType).defaultValue
+
+  def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = (0 until st.nDims).map(_ => const(0L))
+
+  def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = (0 until st.nDims).map(_ => const(0L))
+
+  def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean] = const(false)
+
+  def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int = -1): Code[Unit] = Code._empty
+
+  def sameShape(other: SNDArrayValue, cb: EmitCodeBuilder): Code[Boolean] = const(false)
+
+  def firstDataAddress(cb: EmitCodeBuilder): Value[Long] = const(0L)
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
+}
+
+
+case class SUnreachableContainer(virtualType: TContainer) extends SUnreachable with SContainer {
+  val sv = new SUnreachableContainerValue(this)
+
+  lazy val elementType: SType = SUnreachable.fromVirtualType(virtualType.elementType)
+
+  lazy val elementEmitType: EmitType = EmitType(elementType, true)
+}
+
+class SUnreachableContainerValue(val st: SUnreachableContainer) extends SUnreachableValue with SIndexableValue with SIndexableCode {
+  override def memoizeField(cb: EmitCodeBuilder, name: String): SUnreachableContainerValue = this
+
+  override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableContainerValue = this
+
+  def loadLength(): Value[Int] = const(0)
+
+  override def codeLoadLength(): Code[Int] = const(0)
+
+  def isElementMissing(i: Code[Int]): Code[Boolean] = const(false)
+
+  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode = IEmitCode.present(cb, SUnreachable.fromVirtualType(st.virtualType.elementType).defaultValue)
+
+  def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean] = const(false)
+
+  def castToArray(cb: EmitCodeBuilder): SIndexableCode = SUnreachable.fromVirtualType(st.virtualType.arrayElementsRepr).defaultValue.asIndexable
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -178,7 +178,7 @@ class SUnreachableLocusValue(val st: SUnreachableLocus) extends SUnreachableValu
 
   override def contig(cb: EmitCodeBuilder): SStringCode = new SUnreachableStringValue
 
-  override def structRepr(cb: EmitCodeBuilder): SBaseStructValue = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asBaseStruct
+  override def structRepr(cb: EmitCodeBuilder): SBaseStructValue = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asInstanceOf[SUnreachableStructValue]
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -34,7 +34,7 @@ abstract class SUnreachable extends SType {
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
 
-  def canonicalPType(): PType = PType.canonical(virtualType).deepInnerRequired(true).setRequired(false)
+  def canonicalPType(): PType = PType.canonical(virtualType, required = false, innerRequired = true)
 
   override def asIdent: String = s"s_unreachable"
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -90,7 +90,10 @@ class SUnreachableStructValue(val st: SUnreachableStruct) extends SUnreachableVa
     new SUnreachableStructValue(SUnreachableStruct(newType))
   }
 
-  override def baseInsert(cb: EmitCodeBuilder, region: Value[Region], newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode =
+  override def insert(cb: EmitCodeBuilder, region: Value[Region], newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode =
+    new SUnreachableStructValue(SUnreachableStruct(newType))
+
+  override def _insert(newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode =
     new SUnreachableStructValue(SUnreachableStruct(newType))
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -243,6 +243,8 @@ case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with 
   override def nDims: Int = virtualType.nDims
 
   lazy val elementType: SType = SUnreachable.fromVirtualType(virtualType.elementType)
+
+  override def elementByteSize: Long = 0L
 }
 
 class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachableValue with SNDArrayValue with SNDArrayCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.PType
+import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType}
 import is.hail.types.virtual._
@@ -249,6 +249,10 @@ case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with 
 
   lazy val elementType: SType = SUnreachable.fromVirtualType(virtualType.elementType)
 
+  override def elementPType: PType = elementType.canonicalPType()
+
+  override def pType: PNDArray = PCanonicalNDArray(elementPType, nDims, false)
+
   override def elementByteSize: Long = 0L
 }
 
@@ -272,6 +276,8 @@ class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachable
   def firstDataAddress(cb: EmitCodeBuilder): Value[Long] = const(0L)
 
   override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
+
+  override def get: SUnreachableNDArrayValue = this
 }
 
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -64,7 +64,7 @@ trait SBaseStructCode extends SCode {
     )
   }
 
-  final def insert(cb: EmitCodeBuilder, region: Value[Region], newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode = {
+  def insert(cb: EmitCodeBuilder, region: Value[Region], newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode = {
     if (newType.size < 64 || fields.length < 16)
       return _insert(newType, fields: _*)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -40,7 +40,7 @@ trait SIndexableValue extends SValue {
 trait SIndexableCode extends SCode {
   def st: SContainer
 
-  def loadLength(): Code[Int]
+  def codeLoadLength(): Code[Int]
 
   def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -31,9 +31,9 @@ trait SIntervalValue extends SValue {
 trait SIntervalCode extends SCode {
   def st: SInterval
 
-  def includesStart(): Code[Boolean]
+  def codeIncludesStart(): Code[Boolean]
 
-  def includesEnd(): Code[Boolean]
+  def codeIncludesEnd(): Code[Boolean]
 
   def memoize(cb: EmitCodeBuilder, name: String): SIntervalValue
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -31,4 +31,6 @@ trait SLocusCode extends SCode {
   def memoize(cb: EmitCodeBuilder, name: String): SLocusValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SLocusValue
+
+  def structRepr(cb: EmitCodeBuilder): SBaseStructCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -17,6 +17,8 @@ trait SLocusValue extends SValue {
 
   def getLocusObj(cb: EmitCodeBuilder): Code[Locus] = Code.invokeStatic2[Locus, String, Int, Locus]("apply",
     contig(cb).loadString(), position(cb))
+
+  def structRepr(cb: EmitCodeBuilder): SBaseStructValue
 }
 
 trait SLocusCode extends SCode {
@@ -31,6 +33,4 @@ trait SLocusCode extends SCode {
   def memoize(cb: EmitCodeBuilder, name: String): SLocusValue
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SLocusValue
-
-  def structRepr(cb: EmitCodeBuilder): SBaseStructCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -3,8 +3,8 @@ package is.hail.types.physical.stypes.interfaces
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.{PNDArray, PType}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
+import is.hail.types.physical.{PNDArray, PType}
 import is.hail.utils.{FastIndexedSeq, toRichIterable}
 
 object SNDArray {
@@ -284,6 +284,8 @@ trait SNDArrayValue extends SValue {
   )(body: IndexedSeq[SCode] => SCode
   ): Unit
 }
+
+trait SNDArraySettable extends SNDArrayValue with SSettable
 
 trait SNDArrayCode extends SCode {
   def st: SNDArray

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -233,6 +233,8 @@ trait SNDArray extends SType {
 
   def elementType: SType
   def elementPType: PType
+
+  def elementByteSize: Long
 }
 
 trait SNDArrayValue extends SValue {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -11,7 +11,7 @@ import is.hail.types.virtual.{TStream, Type}
 case class SStream(elementEmitType: EmitType) extends SType {
   def elementType: SType = elementEmitType.st
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     if (deepCopy) throw new UnsupportedOperationException
 
     assert(value.st == this)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -14,7 +14,7 @@ case object SVoid extends SType {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = value
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = value
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = IndexedSeq()
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -16,7 +16,7 @@ case object SBoolean extends SPrimitive {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SBoolean =>
         value

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -16,7 +16,7 @@ case object SFloat32 extends SPrimitive {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SFloat32 => value
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -16,7 +16,7 @@ case object SFloat64 extends SPrimitive {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SFloat64 => value
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -16,7 +16,7 @@ case object SInt32 extends SPrimitive {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SInt32 => value
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -15,7 +15,7 @@ case object SInt64 extends SPrimitive {
 
   override def castRename(t: Type): SType = this
 
-  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SInt64 => value
     }

--- a/hail/src/main/scala/is/hail/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TArray.scala
@@ -66,4 +66,6 @@ final case class TArray(elementType: Type) extends TContainer {
     val subsetElem = elementType.valueSubsetter(subtype.asInstanceOf[TArray].elementType)
     (a: Any) => a.asInstanceOf[IndexedSeq[Any]].map(subsetElem)
   }
+
+  override def arrayElementsRepr: TArray = this
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
@@ -27,7 +27,7 @@ abstract class TBaseStruct extends Type {
 
   def fields: IndexedSeq[Field]
 
-  lazy val fieldIdx: Map[String, Int] = fields.map(f => (f.name, f.index)).toMap
+  lazy val fieldIdx: collection.Map[String, Int] = toMapFast(fields)(_.name, _.index)
 
   override def children: Seq[Type] = types
 

--- a/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TBaseStruct.scala
@@ -27,6 +27,8 @@ abstract class TBaseStruct extends Type {
 
   def fields: IndexedSeq[Field]
 
+  lazy val fieldIdx: Map[String, Int] = fields.map(f => (f.name, f.index)).toMap
+
   override def children: Seq[Type] = types
 
   def size: Int

--- a/hail/src/main/scala/is/hail/types/virtual/TContainer.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TContainer.scala
@@ -9,4 +9,6 @@ abstract class TContainer extends TIterable {
       && (a1.asInstanceOf[Iterable[_]].size == a2.asInstanceOf[Iterable[_]].size)
       && a1.asInstanceOf[Iterable[_]].zip(a2.asInstanceOf[Iterable[_]])
       .forall { case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance, absolute) })
+
+  def arrayElementsRepr: TArray
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TDict.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TDict.scala
@@ -86,4 +86,6 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
     val subsetValue = valueType.valueSubsetter(subdict.valueType)
     (a: Any) => a.asInstanceOf[Map[Any, Any]].mapValues(subsetValue)
   }
+
+  override def arrayElementsRepr: TArray = TArray(elementType)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TSet.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TSet.scala
@@ -61,4 +61,6 @@ final case class TSet(elementType: Type) extends TContainer {
     assert(elementType == subtype.asInstanceOf[TSet].elementType)
     identity
   }
+
+  override def arrayElementsRepr: TArray = TArray(elementType)
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -39,8 +39,6 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
   lazy val types: Array[Type] = fields.map(_.typ).toArray
 
-  lazy val fieldIdx: collection.Map[String, Int] = toMapFast(fields)(_.name, _.index)
-
   lazy val fieldNames: Array[String] = fields.map(_.name).toArray
 
   def size: Int = fields.length


### PR DESCRIPTION
While only used in a few places, this helps us generate
much better code in the case where we emit error-checking
IRs as below:

```
If
  <error_condition>
  Die err_msg
  <value we want>
```

The code generator for the `If` node uses `SType.canonical` to
choose its result type, and casts both consequent and alternate
values to that type. We want the stype of the result here to be
the type of the alternate `<value we want>`, which we can achieve
by adding unreachable types/codes for the `SType.canonical` logic.  