### PR TITLE
[query] Make ndarray from stream

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4354,7 +4354,7 @@ def empty_array(t: Union[HailType, builtins.str]) -> ArrayExpression:
     return construct_expr(a, array_t)
 
 
-def _ndarray(collection, row_major=None, dtype=None):
+def _ndarray(collection, known_shape=None, row_major=None, dtype=None):
     """Construct a Hail ndarray from either a flat Hail array, a `NumPy` ndarray or python value/nested lists.
 
     Parameters
@@ -4403,6 +4403,8 @@ def _ndarray(collection, row_major=None, dtype=None):
     if isinstance(collection, Expression):
         if isinstance(collection, ArrayNumericExpression):
             data_expr = collection
+            if known_shape is not None:
+                shape_expr = known_shape
             shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ttuple(tint64))
             ndim = 1
         elif isinstance(collection, NumericExpression):

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4354,7 +4354,7 @@ def empty_array(t: Union[HailType, builtins.str]) -> ArrayExpression:
     return construct_expr(a, array_t)
 
 
-def _ndarray(collection, known_shape=None, row_major=None, dtype=None):
+def _ndarray(collection, row_major=None, dtype=None):
     """Construct a Hail ndarray from either a flat Hail array, a `NumPy` ndarray or python value/nested lists.
 
     Parameters
@@ -4403,10 +4403,7 @@ def _ndarray(collection, known_shape=None, row_major=None, dtype=None):
     if isinstance(collection, Expression):
         if isinstance(collection, ArrayNumericExpression):
             data_expr = collection
-            if known_shape is not None:
-                shape_expr = known_shape
-            else:
-                shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ttuple(tint64))
+            shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ttuple(tint64))
             ndim = 1
         elif isinstance(collection, NumericExpression):
             data_expr = array([collection])

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4405,7 +4405,8 @@ def _ndarray(collection, known_shape=None, row_major=None, dtype=None):
             data_expr = collection
             if known_shape is not None:
                 shape_expr = known_shape
-            shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ttuple(tint64))
+            else:
+                shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ttuple(tint64))
             ndim = 1
         elif isinstance(collection, NumericExpression):
             data_expr = array([collection])

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -93,7 +93,11 @@ def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
     :class:`.NDArrayNumericExpression`
         A 1-dimensional ndarray from `start` to `stop` by `step`.
     """
-    return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple(stop-start))
+    # if stop is not None:
+    #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple(hl.int64(stop-start)))
+    # else:
+    #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple([hl.int64(start)]))
+    return _ndarray(hl.range(start, stop, step)
 
 
 @typecheck(shape=shape_type, value=expr_any, dtype=nullable(HailType))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -97,7 +97,7 @@ def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
     #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple(hl.int64(stop-start)))
     # else:
     #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple([hl.int64(start)]))
-    return _ndarray(hl.range(start, stop, step)
+    return _ndarray(hl.range(start, stop, step))
 
 
 @typecheck(shape=shape_type, value=expr_any, dtype=nullable(HailType))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -93,7 +93,7 @@ def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
     :class:`.NDArrayNumericExpression`
         A 1-dimensional ndarray from `start` to `stop` by `step`.
     """
-    return array(hl.range(start, stop, step))
+    return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple(stop-start))
 
 
 @typecheck(shape=shape_type, value=expr_any, dtype=nullable(HailType))

--- a/hail/python/hail/nd/nd.py
+++ b/hail/python/hail/nd/nd.py
@@ -93,10 +93,6 @@ def arange(start, stop=None, step=1) -> NDArrayNumericExpression:
     :class:`.NDArrayNumericExpression`
         A 1-dimensional ndarray from `start` to `stop` by `step`.
     """
-    # if stop is not None:
-    #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple(hl.int64(stop-start)))
-    # else:
-    #     return _ndarray(hl.range(start, stop, step), known_shape=hl.tuple([hl.int64(start)]))
     return _ndarray(hl.range(start, stop, step))
 
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1293,7 +1293,6 @@ class Emit[C](
                   xP.constructByCopyingArray(shapeValues, stridesSettables, memoData.asIndexable, cb, region)
                 }
               case _: TStream =>
-                cb.println("STREAM PATH")
                 EmitStream.produce(this, dataIR, cb, region, env, container)
                   .map(cb) {
                     case stream: SStreamCode => {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1246,51 +1246,88 @@ class Emit[C](
           }
         }
 
-      case x@MakeNDArray(dataIR, shapeIR, rowMajorIR, errorID) =>
+
+      case x@MakeNDArray(dataIR, shapeIR, rowMajorIR, errorId) =>
+        val nDims = x.typ.nDims
+        val xP = PCanonicalNDArray(dataCode.st.elementType.canonicalPType().setRequired(true), nDims)
 
         emitI(rowMajorIR).flatMap(cb) { isRowMajorCode =>
           emitI(shapeIR).flatMap(cb) { case shapeTupleCode: SBaseStructCode =>
-            emitI(dataIR).map(cb) { case dataCode: SIndexableCode =>
+            dataIR.typ match {
+              case _: TArray =>
+                emitI(dataIR).map(cb) { case dataCode: SIndexableCode =>
+                  val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
+                  val memoData = dataCode.memoize(cb, "make_nd_array_memoized_data")
 
-              val shapeSType = shapeTupleCode.st
-              val nDims = shapeSType.size
-              val xP = PCanonicalNDArray(dataCode.st.elementType.canonicalPType().setRequired(true), nDims)
+                  cb.ifx(memoData.hasMissingValues(cb), {
+                    cb._throw(Code.newInstance[HailException, String, Int](
+                      "Cannot construct an ndarray with missing values.", errorId
+                    ))
+                  })
 
-              val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
-              val memoData = dataCode.memoize(cb, "make_nd_array_memoized_data")
+                  (0 until nDims).foreach { index =>
+                    cb.ifx(shapeTupleValue.isFieldMissing(index),
+                      cb._fatalWithError(errorId, "shape missing at index $index")))
+                  }
 
-              cb.ifx(memoData.hasMissingValues(cb), {
-                cb._throw(Code.newInstance[HailException, String, Int](
-                  "Cannot construct an ndarray with missing values.", errorID
-                ))
-              })
+                  val stridesSettables = (0 until nDims).map(i => cb.newLocal[Long](s"make_ndarray_stride_$i"))
 
-              (0 until nDims).foreach { index =>
-                cb.ifx(shapeTupleValue.isFieldMissing(index),
-                  cb.append(Code._fatalWithID[Unit](s"shape missing at index $index", errorID)))
-              }
+                  val shapeValues = (0 until nDims).map { i =>
+                    val shape = SingleCodeSCode.fromSCode(cb, shapeTupleValue.loadField(cb, i).get(cb), region)
+                    cb.newLocalAny[Long](s"make_ndarray_shape_${ i }", shape.code)
+                  }
 
-              val stridesSettables = (0 until nDims).map(i => cb.newLocal[Long](s"make_ndarray_stride_$i"))
+                  cb.ifx(isRowMajorCode.asBoolean.boolCode(cb), {
+                    val strides = xP.makeRowMajorStrides(shapeValues, region, cb)
 
-              val shapeValues = (0 until nDims).map { i =>
-                val shape = SingleCodeSCode.fromSCode(cb, shapeTupleValue.loadField(cb, i).get(cb), region)
-                cb.newLocalAny[Long](s"make_ndarray_shape_${ i }", shape.code)
-              }
+                    stridesSettables.zip(strides).foreach { case (settable, stride) =>
+                      cb.assign(settable, stride)
+                    }
+                  }, {
+                    val strides = xP.makeColumnMajorStrides(shapeValues, region, cb)
+                    stridesSettables.zip(strides).foreach { case (settable, stride) =>
+                      cb.assign(settable, stride)
+                    }
+                  })
 
-              cb.ifx(isRowMajorCode.asBoolean.boolCode(cb), {
-                val strides = xP.makeRowMajorStrides(shapeValues, region, cb)
-
-                stridesSettables.zip(strides).foreach { case (settable, stride) =>
-                  cb.assign(settable, stride)
+                  xP.constructByCopyingArray(shapeValues, stridesSettables, memoData.asIndexable, cb, region)
                 }
-              }, {
-                val strides = xP.makeColumnMajorStrides(shapeValues, region, cb)
-                stridesSettables.zip(strides).foreach { case (settable, stride) =>
-                  cb.assign(settable, stride)
-                }
-              })
+              case _: TStream =>
+                cb.println("STREAM PATH")
+                EmitStream.produce(this, dataIR, cb, region, env, container)
+                  .map(cb) {
+                    case stream: SStreamCode => {
+                      val shapeTupleValue = shapeTupleCode.memoize(cb, "make_ndarray_shape")
+                      (0 until nDims).foreach { index =>
+                        cb.ifx(shapeTupleValue.isFieldMissing(index),
+                          cb.append(Code._fatal[Unit](s"shape missing at index $index")))
+                      }
 
-              xP.constructByCopyingArray(shapeValues, stridesSettables, memoData.sc.asIndexable, cb, region)
+                      val stridesSettables = (0 until nDims).map(i => cb.newLocal[Long](s"make_ndarray_stride_$i"))
+
+                      val shapeValues = (0 until nDims).map { i =>
+                        shapeTupleValue.loadField(cb, i).get(cb).memoize(cb, s"make_ndarray_shape_${i}").asPValue.value.asInstanceOf[Value[Long]]
+                      }
+
+                      cb.ifx(isRowMajorCode.asBoolean.boolCode(cb), {
+                        val strides = xP.makeRowMajorStrides(shapeValues, region, cb)
+
+
+                        stridesSettables.zip(strides).foreach { case (settable, stride) =>
+                          cb.assign(settable, stride)
+                        }
+                      }, {
+                        val strides = xP.makeColumnMajorStrides(shapeValues, region, cb)
+                        stridesSettables.zip(strides).foreach { case (settable, stride) =>
+                          cb.assign(settable, stride)
+                        }
+                      })
+
+                      val (firstElementAddress, finisher) = xP.constructDataFunction(shapeValues, stridesSettables, cb, region)
+                      StreamUtils.storeNDArrayElementsAtAddress(cb, stream.producer, region, firstElementAddress, errorId)
+                      finisher(cb)
+                    }
+                  }
             }
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1267,7 +1267,7 @@ class Emit[C](
 
                   (0 until nDims).foreach { index =>
                     cb.ifx(shapeTupleValue.isFieldMissing(index),
-                      cb._fatalWithError(errorId, "shape missing at index $index")))
+                      cb._fatalWithError(errorId, s"shape missing at index $index"))
                   }
 
                   val stridesSettables = (0 until nDims).map(i => cb.newLocal[Long](s"make_ndarray_stride_$i"))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -31,7 +31,7 @@ object InferType {
       case MakeArray(_, t) => t
       case MakeStream(_, t, _) => t
       case MakeNDArray(data, shape, _, _) =>
-        TNDArray(coerce[TArray](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
+        TNDArray(coerce[TIterable](data.typ).elementType, Nat(shape.typ.asInstanceOf[TTuple].size))
       case _: ArrayLen => TInt32
       case _: StreamRange => TStream(TInt32)
       case _: ArrayZeros => TArray(TInt32)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1125,7 +1125,7 @@ object PruneDeadFields {
       case MakeNDArray(data, shape, rowMajor, errorId) =>
         val elementType = requestedType.asInstanceOf[TNDArray].elementType
         unifyEnvs(
-          memoizeValueIR(data, TArray(elementType), memo),
+          memoizeValueIR(data, data.typ, memo),
           memoizeValueIR(shape, shape.typ, memo),
           memoizeValueIR(rowMajor, rowMajor.typ, memo)
         )

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1124,8 +1124,9 @@ object PruneDeadFields {
         )
       case MakeNDArray(data, shape, rowMajor, errorId) =>
         val elementType = requestedType.asInstanceOf[TNDArray].elementType
+        val dataType = if (data.typ.isInstanceOf[TArray]) TArray(elementType) else TStream(elementType)
         unifyEnvs(
-          memoizeValueIR(data, data.typ, memo),
+          memoizeValueIR(data, dataType, memo),
           memoizeValueIR(shape, shape.typ, memo),
           memoizeValueIR(rowMajor, rowMajor.typ, memo)
         )

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -242,6 +242,7 @@ object Simplify {
       Let(name, value, x)
 
     case MakeNDArray(ToArray(someStream), shape, rowMajor, errorId) => MakeNDArray(someStream, shape, rowMajor, errorId)
+    case MakeNDArray(ToStream(someArray, _), shape, rowMajor, errorId) => MakeNDArray(someArray, shape, rowMajor, errorId)
     case NDArrayShape(MakeNDArray(data, shape, _, _)) => {
       If(IsNA(data), NA(shape.typ), shape)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -241,6 +241,7 @@ object Simplify {
     case ToStream(Let(name, value, ToArray(x)), _) if x.typ.isInstanceOf[TStream] =>
       Let(name, value, x)
 
+    case MakeNDArray(ToArray(someStream), shape, rowMajor, errorId) => MakeNDArray(someStream, shape, rowMajor, errorId)
     case NDArrayShape(MakeNDArray(data, shape, _, _)) => {
       If(IsNA(data), NA(shape.typ), shape)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -149,7 +149,7 @@ object TypeCheck {
       case x@ArrayZeros(length) =>
         assert(length.typ == TInt32)
       case x@MakeNDArray(data, shape, rowMajor, _) =>
-        assert(data.typ.isInstanceOf[TArray])
+        assert(data.typ.isInstanceOf[TArray] || data.typ.isInstanceOf[TStream])
         assert(shape.typ.asInstanceOf[TTuple].types.forall(t => t == TInt64))
         assert(rowMajor.typ == TBoolean)
       case x@NDArrayShape(nd) =>

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -3,14 +3,10 @@ package is.hail.expr.ir.streams
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode, IR, NDArrayMap, NDArrayMap2, Ref, RunAggScan, StagedArrayBuilder, StreamFilter, StreamFlatMap, StreamFold, StreamFold2, StreamFor, StreamJoinRightDistinct, StreamMap, StreamScan, StreamZip, StreamZipJoin}
-<<<<<<< HEAD
 import is.hail.types.physical.stypes.interfaces.SIndexableCode
-import is.hail.types.physical.PCanonicalArray
 import is.hail.types.physical.stypes.SingleCodeType
-=======
-import is.hail.types.physical.{PCanonicalArray, PCode, PIndexableCode, SingleCodePCode}
+import is.hail.types.physical.{PCanonicalArray}
 import is.hail.utils.HailException
->>>>>>> 83ee57981 (WIP)
 
 trait StreamArgType {
   def apply(outerRegion: Region, eltRegion: Region): Iterator[java.lang.Long]

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -3,15 +3,50 @@ package is.hail.expr.ir.streams
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode, IR, NDArrayMap, NDArrayMap2, Ref, RunAggScan, StagedArrayBuilder, StreamFilter, StreamFlatMap, StreamFold, StreamFold2, StreamFor, StreamJoinRightDistinct, StreamMap, StreamScan, StreamZip, StreamZipJoin}
+<<<<<<< HEAD
 import is.hail.types.physical.stypes.interfaces.SIndexableCode
 import is.hail.types.physical.PCanonicalArray
 import is.hail.types.physical.stypes.SingleCodeType
+=======
+import is.hail.types.physical.{PCanonicalArray, PCode, PIndexableCode, SingleCodePCode}
+import is.hail.utils.HailException
+>>>>>>> 83ee57981 (WIP)
 
 trait StreamArgType {
   def apply(outerRegion: Region, eltRegion: Region): Iterator[java.lang.Long]
 }
 
 object StreamUtils {
+
+  def storeNDArrayElementsAtAddress(
+    cb: EmitCodeBuilder,
+    stream: StreamProducer,
+    destRegion: Value[Region],
+    addr: Value[Long],
+    errorId: Int
+  ): Unit = {
+    val currentElementIndex = cb.newLocal[Long]("store_ndarray_elements_stream_current_index", 0)
+    val currentElementAddress = cb.newLocal[Long]("store_ndarray_elements_stream_current_addr", addr)
+    val elementType = stream.element.st.canonicalPType()
+    val elementByteSize = elementType.byteSize
+
+    var push: (EmitCodeBuilder, IEmitCode) => Unit = null
+    stream.memoryManagedConsume(destRegion, cb, setup = { cb =>
+      push = { case (cb, iec) =>
+        iec.consume(cb,
+          cb._throw(Code.newInstance[HailException, String, Int](
+            "Cannot construct an ndarray with missing values.", errorId
+          )),
+          { sc =>
+            elementType.storeAtAddress(cb, currentElementAddress, destRegion, sc, deepCopy = true)
+          })
+        cb.assign(currentElementIndex, currentElementIndex + 1)
+        cb.assign(currentElementAddress, currentElementAddress + elementByteSize)
+      }
+    }) { cb =>
+      push(cb, stream.element.toI(cb))
+    }
+  }
 
   def toArray(
     cb: EmitCodeBuilder,


### PR DESCRIPTION
Previously, we always made the stream into an array, then copied the array into the ndarray. Now we just insert the stream directly into the ndarray. This saves memory (~7% on the linear regression rows benchmark), and had no noticeable effect on speed in my experiments. 