### PR TITLE
Add hl.hadoop_scheme_supported function

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -59,7 +59,7 @@ from . import nd  # noqa: E402
 from hail.expr import aggregators as agg  # noqa: E402
 from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  # noqa: E402
                         hadoop_stat, hadoop_exists, hadoop_is_file,
-                        hadoop_is_dir, copy_log)
+                        hadoop_is_dir, hadoop_scheme_supported, copy_log)
 
 from .context import (init, init_local, stop, spark_context, tmp_dir, default_reference,  # noqa: E402
                       get_reference, set_global_seed, _set_flags, _get_flags, current_backend,
@@ -94,6 +94,7 @@ __all__ = [
     'hadoop_stat',
     'hadoop_exists',
     'hadoop_ls',
+    'hadoop_scheme_supported',
     'copy_log',
     'Struct',
     'Interval',

--- a/hail/python/hail/docs/utils/index.rst
+++ b/hail/python/hail/docs/utils/index.rst
@@ -15,6 +15,7 @@ utils
     hadoop_is_dir
     hadoop_stat
     hadoop_ls
+    hadoop_scheme_supported
     copy_log
     range_table
     range_matrix_table
@@ -31,6 +32,7 @@ utils
 .. autofunction:: hadoop_is_dir
 .. autofunction:: hadoop_stat
 .. autofunction:: hadoop_ls
+.. autofunction:: hadoop_scheme_supported
 .. autofunction:: copy_log
 .. autofunction:: range_table
 .. autofunction:: range_matrix_table

--- a/hail/python/hail/fs/fs.py
+++ b/hail/python/hail/fs/fs.py
@@ -57,6 +57,10 @@ class FS(abc.ABC):
     def rmtree(self, path: str):
         pass
 
+    @abc.abstractmethod
+    def supports_scheme(self, scheme: str) -> bool:
+        pass
+
     def copy_log(self, path: str) -> None:
         log = Env.hc()._log
         try:

--- a/hail/python/hail/fs/google_fs.py
+++ b/hail/python/hail/fs/google_fs.py
@@ -139,3 +139,6 @@ class GoogleCloudStorageFS(FS):
         if self._is_local(path):
             rmtree(path)
         self.client.rm(path, recursive=True)
+
+    def supports_scheme(self, scheme: str) -> bool:
+        return scheme in ("gs", "")

--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -50,6 +50,9 @@ class HadoopFS(FS):
     def rmtree(self, path: str):
         return self._jfs.rmtree(path)
 
+    def supports_scheme(self, scheme: str) -> bool:
+        return self._jfs.supportsScheme(scheme)
+
 
 class HadoopReader(io.RawIOBase):
     def __init__(self, hfs, path, buffer_size):

--- a/hail/python/hail/fs/local_fs.py
+++ b/hail/python/hail/fs/local_fs.py
@@ -68,3 +68,6 @@ class LocalFS(FS):
 
     def rmtree(self, path: str):
         rmtree(path)
+
+    def supports_scheme(self, scheme: str) -> bool:
+        return scheme == ""

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -15,7 +15,7 @@ __all__ = ['hadoop_open',
            'hadoop_is_file',
            'hadoop_stat',
            'hadoop_ls',
-           'hadoop_scheme_supported'
+           'hadoop_scheme_supported',
            'copy_log',
            'wrap_to_list',
            'new_local_temp_dir',

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -1,5 +1,5 @@
 from .misc import wrap_to_list, get_env_or_default, uri_path, local_path_uri, new_temp_file, new_local_temp_dir, new_local_temp_file, with_local_temp_file, storage_level, range_matrix_table, range_table, run_command, HailSeedGenerator, timestamp_path, _dumps_partitions, default_handler
-from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file, hadoop_ls, hadoop_stat, copy_log
+from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file, hadoop_ls, hadoop_scheme_supported, hadoop_stat, copy_log
 from .struct import Struct
 from .linkedlist import LinkedList
 from .interval import Interval
@@ -15,6 +15,7 @@ __all__ = ['hadoop_open',
            'hadoop_is_file',
            'hadoop_stat',
            'hadoop_ls',
+           'hadoop_scheme_supported'
            'copy_log',
            'wrap_to_list',
            'new_local_temp_dir',

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -214,6 +214,26 @@ def hadoop_ls(path: str) -> List[Dict]:
     return Env.fs().ls(path)
 
 
+def hadoop_scheme_supported(scheme: str) -> bool:
+    """Returns ``True`` if the Hadoop filesystem supports URLs with the given
+    scheme.
+
+    Examples
+    --------
+
+    >>> hadoop_scheme_supported('gs') # doctest: +SKIP
+
+    Parameters
+    ----------
+    scheme : :class:`str`
+
+    Returns
+    -------
+    :obj:`.bool`
+    """
+    return Env.fs().supports_scheme(scheme)
+
+
 def copy_log(path: str) -> None:
     """Attempt to copy the session log to a hadoop-API-compatible location.
 

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -175,4 +175,18 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
     val pathFS = ppath.getFileSystem(conf.value)
     pathFS.deleteOnExit(ppath)
   }
+
+  def supportsScheme(scheme: String): Boolean = {
+    if (scheme == "") {
+      true
+    } else {
+      try {
+        hadoop.fs.FileSystem.getFileSystemClass(scheme, conf.value)
+        true
+      } catch {
+        case e: hadoop.fs.UnsupportedFileSystemException => false
+        case e: Exception => throw e
+      }
+    }
+  }
 }


### PR DESCRIPTION
Currently, the only way to check if Hail can read URLs with a given scheme (`gs`, `s3`, etc) is to attempt to read a URL with that scheme. However, the same exception type is thrown whether the scheme is not supported or the file doesn't exist or something else went wrong and the error message is the only way to determine what went wrong.

This adds a `hl.hadoop_scheme_supported` function, which returns a boolean indicating whether or not a URL scheme is supported.

Discussed on Zulip: https://hail.zulipchat.com/#narrow/stream/123010-Hail-0.2E2.20support/topic/Get.20supported.20URL.20schemes

@johnc1231 