### PR TITLE
[query] Fix table type of MT cols subfolder

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -852,7 +852,7 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         f = new_temp_file(extension='mt')
         ds.write(f)
         t = hl.read_table(f + '/cols')
-        self.assertTrue(ds.cols()._same(t))
+        self.assertTrue(ds.cols().key_by()._same(t))
 
     @skip_when_service_backend('Shuffler encoding/decoding is broken.')
     def test_read_stored_rows(self):

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -845,7 +845,6 @@ https://hail.zulipchat.com/#narrow/stream/123011-Hail-Dev/topic/test_drop/near/2
         self.assertTrue(ds_small.count_rows() < ds.count_rows())
 
     @fails_service_backend()
-    @fails_local_backend()
     def test_read_stored_cols(self):
         ds = self.get_mt()
         ds = ds.annotate_globals(x='foo')

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -96,7 +96,7 @@ case class MatrixValue(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
       "../references",
-      typ.colsTableType,
+      typ.colsTableType.copy(key = FastIndexedSeq[String]()),
       Map("globals" -> RVDComponentSpec("../globals/rows"),
         "rows" -> RVDComponentSpec("rows"),
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -117,7 +117,7 @@ case class MatrixNativeWriter(
         Str(partFile(1, 0)), globalWriter)
 
       val globalTableWriter = TableSpecWriter(s"$path/globals", TableType(tm.globalType, FastIndexedSeq(), TStruct.empty), "rows", "globals", "../references", log = false)
-      val colTableWriter = TableSpecWriter(s"$path/cols", tm.colsTableType, "rows", "../globals/rows", "../references", log = false)
+      val colTableWriter = TableSpecWriter(s"$path/cols", tm.colsTableType.copy(key = FastIndexedSeq[String]()), "rows", "../globals/rows", "../references", log = false)
       val rowTableWriter = TableSpecWriter(s"$path/rows", tm.rowsTableType, "rows", "../globals/rows", "../references", log = false)
       val entriesTableWriter = TableSpecWriter(s"$path/entries", TableType(tm.entriesRVType, FastIndexedSeq(), tm.globalType), "rows", "../globals/rows", "../references", log = false)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -924,7 +924,7 @@ class TableNativeReader(
     else
       params.options.map(opts => new RVDPartitioner(specPart.kType, opts.intervals))
 
-    spec.rowsSpec.readTableStage(ctx, spec.rowsComponent.absolutePath(params.path), requestedType.rowType, partitioner, filterIntervals).apply(globals)
+    spec.rowsSpec.readTableStage(ctx, spec.rowsComponent.absolutePath(params.path), requestedType, partitioner, filterIntervals).apply(globals)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1130,7 +1130,7 @@ object LowerTableIR {
 
       assert(tir.typ.globalType == lowered.globalType, s"\n  ir global: ${tir.typ.globalType}\n  lowered global: ${lowered.globalType}")
       assert(tir.typ.rowType == lowered.rowType, s"\n  ir row: ${tir.typ.rowType}\n  lowered row: ${lowered.rowType}")
-      assert(lowered.key startsWith tir.typ.keyType.fieldNames, s"\n  ir key: ${tir.typ.keyType.fieldNames}\n  lowered key: ${lowered.key}")
+      assert(lowered.key startsWith tir.typ.keyType.fieldNames, s"\n  ir key: ${tir.typ.keyType.fieldNames.toSeq}\n  lowered key: ${lowered.key}")
 
       lowered
     }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -8,6 +8,7 @@ import is.hail.expr.ir.{ExecuteContext, IR, PartitionZippedNativeReader}
 import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.io.index.{InternalNodeBuilder, LeafNodeBuilder}
+import is.hail.types.TableType
 import is.hail.types.encoded.ETypeSerializer
 import is.hail.types.physical.{PCanonicalStruct, PInt64Optional, PStruct, PType, PTypeSerializer}
 import is.hail.types.virtual.{TStructSerializer, _}
@@ -260,24 +261,28 @@ abstract class AbstractRVDSpec {
   def readTableStage(
     ctx: ExecuteContext,
     path: String,
-    requestedType: TStruct,
+    requestedType: TableType,
     newPartitioner: Option[RVDPartitioner] = None,
     filterIntervals: Boolean = false
   ): IR => TableStage = newPartitioner match {
     case Some(_) => fatal("attempted to read unindexed data as indexed")
     case None =>
+      if (!partitioner.kType.fieldNames.startsWith(requestedType.key))
+        fatal(s"cannot generate whole-stage code for legacy table: " +
+          s"table key = [${ requestedType.key.mkString(", ") }], " +
+          s"key on disk: [${ partitioner.kType.fieldNames.mkString(", ") }]")
 
       val rSpec = typedCodecSpec
 
       val ctxType = TStruct("path" -> TString)
       val contexts = ir.ToStream(ir.Literal(TArray(ctxType), absolutePartPaths(path).map(x => Row(x)).toFastIndexedSeq))
 
-      val body = (ctx: IR) => ir.ReadPartition(ir.GetField(ctx, "path"), requestedType, ir.PartitionNativeReader(rSpec))
+      val body = (ctx: IR) => ir.ReadPartition(ir.GetField(ctx, "path"), requestedType.rowType, ir.PartitionNativeReader(rSpec))
 
       (globals: IR) =>
         TableStage(
           globals,
-          partitioner,
+          partitioner.coarsen(partitioner.kType.fieldNames.takeWhile(requestedType.rowType.hasField).length),
           TableStageDependency.none,
           contexts,
           body)
@@ -487,7 +492,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
   override def readTableStage(
     ctx: ExecuteContext,
     path: String,
-    requestedType: TStruct,
+    requestedType: TableType,
     newPartitioner: Option[RVDPartitioner] = None,
     filterIntervals: Boolean = false
   ): IR => TableStage = newPartitioner match {
@@ -519,7 +524,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
 
       val contexts = ir.ToStream(ir.Literal(TArray(reader.contextType), contextsValues))
 
-      val body = (ctx: IR) => ir.ReadPartition(ctx, requestedType, reader)
+      val body = (ctx: IR) => ir.ReadPartition(ctx, requestedType.rowType, reader)
 
       { (globals: IR) =>
         val ts = TableStage(


### PR DESCRIPTION
This change makes the `test_read_stored_cols` work via lowering.
I'm still unsure if we should support the cols/rows/entries subfolders
of a MT being valid tables themselves, but certainly it's incorrect
to describe the written cols table as having the same key as the MT
columns when it's unordered.

This change strips the col key off the tabletype generated in the
file, to reflect the ordering status.