### PR TITLE
[hailtop.batch] parallelize the upload of serialized functions

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3120,6 +3120,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=0
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
@@ -3172,6 +3173,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=1
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
@@ -3224,6 +3226,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=2
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
@@ -3276,6 +3279,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=3
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
@@ -3328,6 +3332,7 @@ steps:
       cd /io/hailtop
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=4
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
@@ -3379,6 +3384,7 @@ steps:
     script: |
       set -ex
       export HAIL_GSA_KEY_FILE=/test-gsa-key/key.json
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       cd /io/hailtop/batch
       hailctl config set batch/billing_project test
       hailctl config set batch/bucket hail-test-dmk9z

--- a/hail/python/hailtop/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiogoogle/client/storage_client.py
@@ -546,8 +546,13 @@ class GoogleStorageMultiPartCreate(MultiPartCreate):
 class GoogleStorageAsyncFS(AsyncFS):
     def __init__(self, *,
                  storage_client: Optional[StorageClient] = None,
+                 project: Optional[str] = None,
                  **kwargs):
         if not storage_client:
+            if project is not None:
+                if 'params' not in kwargs:
+                    kwargs['params'] = {}
+                kwargs['params']['userProject'] = project
             storage_client = StorageClient(**kwargs)
         self._storage_client = storage_client
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -26,6 +26,11 @@ from .exceptions import BatchException
 
 
 RunningBatchType = TypeVar('RunningBatchType')
+"""
+The type of value returned by :py:meth:`.Backend._run`. The value returned by some backends
+enables the user to monitor the asynchronous execution of a Batch.
+"""
+
 SelfType = TypeVar('SelfType')
 
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -5,17 +5,21 @@ import os
 import subprocess as sp
 import uuid
 import time
+import functools
 import copy
 from shlex import quote as shq
 import webbrowser
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
 from hailtop.config import get_deploy_config, get_user_config
-from hailtop.utils import is_google_registry_domain, parse_docker_image_reference
+from hailtop.utils import is_google_registry_domain, parse_docker_image_reference, async_to_blocking, bounded_gather, tqdm
 from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 from hailtop.batch_client.parse import parse_cpu_in_mcpu
 import hailtop.batch_client.client as bc
 from hailtop.batch_client.client import BatchClient
+from hailtop.aiotools import RouterAsyncFS, LocalAsyncFS, AsyncFS
+from hailtop.aiogoogle import GoogleStorageAsyncFS
 
 from . import resource, batch, job as _job  # pylint: disable=unused-import
 from .exceptions import BatchException
@@ -37,6 +41,11 @@ class Backend(abc.ABC):
         This method should not be called directly. Instead, use :meth:`.batch.Batch.run`.
         """
         return
+
+    @property
+    @abc.abstractmethod
+    def _fs(self) -> AsyncFS:
+        raise NotImplementedError()
 
     # pylint: disable=R0201
     def close(self):
@@ -95,6 +104,11 @@ class LocalBackend(Backend):
             flags += f' -v {gsa_key_file}:/gsa-key/key.json'
 
         self._extra_docker_run_flags = flags
+        self.__fs: AsyncFS = LocalAsyncFS(ThreadPoolExecutor())
+
+    @property
+    def _fs(self):
+        return self.__fs
 
     def _run(self,
              batch: 'batch.Batch',
@@ -214,7 +228,7 @@ class LocalBackend(Backend):
 
             for job in batch._jobs:
                 if isinstance(job, _job.PythonJob):
-                    job._compile(tmpdir, tmpdir)
+                    async_to_blocking(job._compile(tmpdir, tmpdir))
 
                 os.makedirs(f'{tmpdir}/{job._job_id}/', exist_ok=True)
 
@@ -288,6 +302,9 @@ class LocalBackend(Backend):
 
         return _get_random_name()
 
+    def close(self):
+        async_to_blocking(self._fs.close())
+
 
 class ServiceBackend(Backend):
     """Backend that executes batches on Hail's Batch Service on Google Cloud.
@@ -328,6 +345,10 @@ class ServiceBackend(Backend):
     remote_tmpdir:
         Temporary data will be stored in this google cloud storage folder. Cannot be used with
         bucket.
+    google_project:
+        If specified, the project to use when authenticating with Google
+        Storage. Google Storage is used to transfer serialized values between
+        this computer and the cloud machines that execute Python jobs.
 
     """
 
@@ -335,7 +356,8 @@ class ServiceBackend(Backend):
                  *args,
                  billing_project: Optional[str] = None,
                  bucket: Optional[str] = None,
-                 remote_tmpdir: Optional[str] = None
+                 remote_tmpdir: Optional[str] = None,
+                 google_project: Optional[str] = None
                  ):
         if len(args) > 2:
             raise TypeError(f'ServiceBackend() takes 2 positional arguments but {len(args)} were given')
@@ -361,6 +383,8 @@ class ServiceBackend(Backend):
                 'or run `hailctl config set batch/billing_project '
                 'MY_BILLING_PROJECT`')
         self._batch_client = BatchClient(billing_project)
+        self.__fs: AsyncFS = RouterAsyncFS('file', [LocalAsyncFS(ThreadPoolExecutor()),
+                                                    GoogleStorageAsyncFS(project=google_project)])
 
         if remote_tmpdir is None:
             if bucket is None:
@@ -382,6 +406,10 @@ class ServiceBackend(Backend):
             remote_tmpdir += '/'
         self.remote_tmpdir = remote_tmpdir
 
+    @property
+    def _fs(self):
+        return self.__fs
+
     def close(self):
         """
         Close the connection with the Batch Service.
@@ -392,6 +420,7 @@ class ServiceBackend(Backend):
         end of your script.
         """
         self._batch_client.close()
+        async_to_blocking(self._fs.close())
 
     def _run(self,
              batch: 'batch.Batch',
@@ -433,7 +462,20 @@ class ServiceBackend(Backend):
         token:
             If not `None`, a string used for idempotency of batch submission.
         """
+        return async_to_blocking(
+            self._async_run(batch, dry_run, verbose, delete_scratch_on_exit, wait, open, disable_progress_bar, callback, token, **backend_kwargs))
 
+    async def _async_run(self,
+                         batch: 'batch.Batch',
+                         dry_run: bool,
+                         verbose: bool,
+                         delete_scratch_on_exit: bool,
+                         wait: bool = True,
+                         open: bool = False,
+                         disable_progress_bar: bool = False,
+                         callback: Optional[str] = None,
+                         token: Optional[str] = None,
+                         **backend_kwargs):  # pylint: disable-msg=too-many-statements
         if backend_kwargs:
             raise ValueError(f'ServiceBackend does not support any of these keywords: {backend_kwargs}')
 
@@ -509,16 +551,22 @@ class ServiceBackend(Backend):
                 jobs_to_command[j] = write_cmd
                 n_jobs_submitted += 1
 
-        for job in batch._jobs:
-            if isinstance(job, _job.PythonJob):
-                if job._image is None:
-                    version = sys.version_info
-                    if version.major != 3 or version.minor not in (6, 7, 8):
-                        raise BatchException(
-                            f"You must specify 'image' for Python jobs if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})")
-                    job._image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
-                job._compile(local_tmpdir, batch_remote_tmpdir)
+        pyjobs = [j for j in batch._jobs if isinstance(j, _job.PythonJob)]
+        for job in pyjobs:
+            if job._image is None:
+                version = sys.version_info
+                if version.major != 3 or version.minor not in (6, 7, 8):
+                    raise BatchException(
+                        f"You must specify 'image' for Python jobs if you are using a Python version other than 3.6, 3.7, or 3.8 (you are using {version})")
+                job._image = f'hailgenetics/python-dill:{version.major}.{version.minor}-slim'
 
+        with tqdm(total=len(pyjobs), desc='upload python functions', disable=disable_progress_bar) as pbar:
+            async def compile_job(job):
+                await job._compile(local_tmpdir, batch_remote_tmpdir)
+                pbar.update(1)
+            await bounded_gather(*[functools.partial(compile_job, j) for j in pyjobs], parallelism=150)
+
+        for job in tqdm(batch._jobs, desc='create job objects', disable=disable_progress_bar):
             inputs = [x for r in job._inputs for x in copy_input(r)]
 
             outputs = [x for r in job._internal_outputs for x in copy_internal_output(r)]

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -79,10 +79,10 @@ class Batch:
         `dill` pre-installed will automatically be used if the current Python version is
         3.6, 3.7, or 3.8.
     project:
-         DEPRECATED: please specify `google_project` on the ServiceBackend instead. If specified,
-         the project to use when authenticating with Google Storage. Google Storage is used to
-         transfer serialized values between this computer and the cloud machines that execute Python
-         jobs.
+        DEPRECATED: please specify `google_project` on the ServiceBackend instead. If specified,
+        the project to use when authenticating with Google Storage. Google Storage is used to
+        transfer serialized values between this computer and the cloud machines that execute Python
+        jobs.
     cancel_after_n_failures:
         Automatically cancel the batch after N failures have occurred. The default
         behavior is there is no limit on the number of failures. Only
@@ -566,6 +566,7 @@ class Batch:
         if self._DEPRECATED_fs is not None:
             # best effort only because this is deprecated
             self._DEPRECATED_fs.close()
+            self._DEPRECATED_fs = None
         return run_result
 
     def __str__(self):

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -562,7 +562,7 @@ class Batch:
                     raise BatchException("cycle detected in dependency graph")
 
         self._jobs = ordered_jobs
-        run_result = self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)
+        run_result = self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)  # pylint: disable=assignment-from-no-return
         if self._DEPRECATED_fs is not None:
             # best effort only because this is deprecated
             self._DEPRECATED_fs.close()

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -154,7 +154,7 @@ class Batch:
         if self._DEPRECATED_project is not None:
             if self._DEPRECATED_fs is None:
                 self._DEPRECATED_fs = RouterAsyncFS('file', [LocalAsyncFS(ThreadPoolExecutor()),
-                                                            GoogleStorageAsyncFS(project=self._DEPRECATED_project)])
+                                                             GoogleStorageAsyncFS(project=self._DEPRECATED_project)])
             return self._DEPRECATED_fs
         return self._backend._fs
 

--- a/hail/python/hailtop/batch/docs/api.rst
+++ b/hail/python/hailtop/batch/docs/api.rst
@@ -96,6 +96,7 @@ at `<https://batch.hail.is>`__.
     :nosignatures:
     :template: class.rst
 
+    backend.RunningBatchType
     backend.Backend
     backend.LocalBackend
     backend.ServiceBackend

--- a/hail/python/hailtop/batch/docs/conf.py
+++ b/hail/python/hailtop/batch/docs/conf.py
@@ -29,6 +29,7 @@ version = ''
 # The full version, including alpha/beta/rc tags
 release = ''
 nitpicky = True
+nitpick_ignore = [('py:class', 'hailtop.batch_client.client.Batch')]
 
 # -- General configuration ---------------------------------------------------
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -5,8 +5,6 @@ import functools
 from io import BytesIO
 from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast
 
-from hailtop.utils import async_to_blocking
-
 from . import backend, resource as _resource, batch  # pylint: disable=cyclic-import
 from .exceptions import BatchException
 

--- a/pylintrc
+++ b/pylintrc
@@ -11,7 +11,7 @@
 # C1801 Do not use len(SEQUENCE) as condition value
 # W0221 Parameters differ from overridden method
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,too-many-public-methods,broad-except,too-many-return-statements,bare-except
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221,line-too-long,too-few-public-methods,fixme,too-many-function-args,too-many-branches,too-many-lines,too-many-boolean-expressions,too-many-statements,too-many-nested-blocks,wrong-import-order,logging-not-lazy,unnecessary-lambda,too-many-public-methods,broad-except,too-many-return-statements,bare-except,invalid-name,unsubscriptable-object
 
 
 [FORMAT]


### PR DESCRIPTION
KC was experiencing extremely long batch creation times.

This change allows hailtop.batch to upload serialized python jobs 150-way parallel into GCS. I found that above 150-way parallelism, I didn't receive any further benefits. I can now upload KC's batch's jobs at about ~330 jobs per second. For 400k jobs, that will take ~20 minutes. I think the total batch submission should take less than an hour.

I lifted a few changes from the #10331. I had to put the AsyncFS on the backend though because the backend is the only object which has a close method.