### PR TITLE
[hailtop] bounded_gather2 takes partial functions

### DIFF
--- a/hail/python/test/hailtop/aiotools/test_copy.py
+++ b/hail/python/test/hailtop/aiotools/test_copy.py
@@ -63,9 +63,9 @@ async def router_filesystem(request):
             async with sema:
                 yield (sema, fs, bases)
                 await bounded_gather2(sema,
-                                      fs.rmtree(sema, file_base),
-                                      fs.rmtree(sema, gs_base),
-                                      fs.rmtree(sema, s3_base))
+                                      functools.partial(fs.rmtree, sema, file_base),
+                                      functools.partial(fs.rmtree, sema, gs_base)),
+                                      functools.partial(fs.rmtree, sema, s3_base)))
 
             assert not await fs.isdir(file_base)
             assert not await fs.isdir(gs_base)

--- a/hail/python/test/hailtop/aiotools/test_copy.py
+++ b/hail/python/test/hailtop/aiotools/test_copy.py
@@ -2,6 +2,7 @@ import os
 import secrets
 from concurrent.futures import ThreadPoolExecutor
 import asyncio
+import functools
 import pytest
 from hailtop.utils import url_scheme, bounded_gather2
 from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS, Transfer, FileAndDirectoryError

--- a/hail/python/test/hailtop/aiotools/test_copy.py
+++ b/hail/python/test/hailtop/aiotools/test_copy.py
@@ -64,8 +64,8 @@ async def router_filesystem(request):
                 yield (sema, fs, bases)
                 await bounded_gather2(sema,
                                       functools.partial(fs.rmtree, sema, file_base),
-                                      functools.partial(fs.rmtree, sema, gs_base)),
-                                      functools.partial(fs.rmtree, sema, s3_base)))
+                                      functools.partial(fs.rmtree, sema, gs_base),
+                                      functools.partial(fs.rmtree, sema, s3_base))
 
             assert not await fs.isdir(file_base)
             assert not await fs.isdir(gs_base)

--- a/hail/python/test/hailtop/test_aiogoogle.py
+++ b/hail/python/test/hailtop/test_aiogoogle.py
@@ -8,6 +8,7 @@ import asyncio
 import pytest
 import concurrent
 import urllib.parse
+import functools
 from hailtop.utils import secret_alnum_string, bounded_gather2
 from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS
 from hailtop.aiogoogle import StorageClient, GoogleStorageAsyncFS
@@ -112,7 +113,7 @@ async def test_multi_part_create_many_two_level_merge(gs_filesystem):
 
             # do in parallel
             await bounded_gather2(sema, *[
-                create_part(i) for i in range(len(part_data))])
+                functools.partial(create_part, i) for i in range(len(part_data))])
 
         expected = b''.join(part_data)
         actual = await fs.read(path)

--- a/hail/python/test/hailtop/test_fs.py
+++ b/hail/python/test/hailtop/test_fs.py
@@ -8,7 +8,7 @@ import asyncio
 import pytest
 import concurrent
 import urllib.parse
-from hailtop.utils import secret_alnum_string, bounded_gather2
+from hailtop.utils import secret_alnum_string
 from hailtop.aiotools import LocalAsyncFS, RouterAsyncFS
 from hailtop.aiotools.s3asyncfs import S3AsyncFS
 from hailtop.aiogoogle import GoogleStorageAsyncFS


### PR DESCRIPTION
This supresses "coroutines not awaited" messages in the case that a
bounded gather is cancelled before all subtasks have had a chance to
start.
