### PR TITLE
[hail] remove repo.spring.io, which we was added to support hortonworks spark

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -23,7 +23,6 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
-    maven { url "https://repo.spring.io/plugins-release/" }
 }
 
 sourceSets.main.scala.srcDir "src/main/java"


### PR DESCRIPTION
See [discussion](https://hail.zulipchat.com/#narrow/stream/127527-team/topic/CI.20Deploy.20Failure/near/241944633). spring.io no
longer supports [direct, unauthenticated access to its repository](https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020).