### PR TITLE
[compiler] New Array PType

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArray.scala
@@ -2,8 +2,6 @@ package is.hail.types.physical
 
 import is.hail.annotations.Annotation
 import is.hail.check.Gen
-import is.hail.expr.ir.EmitMethodBuilder
-import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.types.virtual.TArray
 
 trait PArrayIterator {

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -52,6 +52,8 @@ abstract class PContainer extends PIterable {
 
   def elementOffset(aoff: Code[Long], i: Code[Int]): Code[Long]
 
+  final def elementOffsetFromBase(elementBase: Code[Long], i: Code[Int]): Code[Long] = elementBase + i.toL * elementByteSize
+
   def firstElementOffset(aoff: Code[Long], length: Code[Int]): Code[Long]
 
   def firstElementOffset(aoff: Code[Long]): Code[Long]

--- a/hail/src/main/scala/is/hail/types/physical/PNewArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNewArray.scala
@@ -175,7 +175,7 @@ final case class PNewArray(elementType: PType, required: Boolean = false) extend
 
   def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = ???
 
-  def setRequired(required: Boolean): PType = ???
+  def setRequired(required: Boolean): PType = PNewArray(elementType, required)
 
   protected[physical] def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = ???
 

--- a/hail/src/main/scala/is/hail/types/physical/PNewArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNewArray.scala
@@ -1,0 +1,197 @@
+package is.hail.types.physical
+import is.hail.annotations.{Annotation, Region, UnsafeOrdering, UnsafeUtils}
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.utils._
+
+final case class PNewArray(elementType: PType, required: Boolean = false) extends PArray {
+  // A C-struct for arrays with the following structure:
+  // struct {
+  //    int length;
+  //    T *elements;
+  //    char *missing; // if !required
+  // }
+  override val alignment: Long = 8
+  val byteSize: Long = if (required) 16 else 24
+  val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)
+  val contentsAlignment: Long = elementType.alignment
+  private val elementsOffset: Long = 8
+  private val missingOffset: Long = 16
+  private def elements(addr: Long): Long = Region.loadLong(addr + elementsOffset)
+  private def elements(addr: Code[Long]): Code[Long] = Region.loadAddress(addr + elementsOffset)
+  private def missing(addr: Long): Long = Region.loadLong(addr + missingOffset)
+  private def missing(addr: Code[Long]): Code[Long] = Region.loadAddress(addr + missingOffset)
+  def nMissingBytes(len: Int): Int = UnsafeUtils.packBitsToBytes(len)
+  def nMissingBytes(len: Code[Int]): Code[Int] = UnsafeUtils.packBitsToBytes(len)
+
+  def elementIterator(addr: Long, length: Int): PArrayIterator = ???
+
+  def loadLength(addr: Long): Int = Region.loadInt(addr)
+
+  def loadLength(addr: Code[Long]): Code[Int] = Region.loadInt(addr)
+
+  def storeLength(addr: Code[Long], length: Code[Int]): Code[Unit] = Region.storeInt(addr, length)
+
+  def lengthHeaderBytes: Long = 0
+
+  def elementsOffset(length: Int): Long = 0
+
+  def elementsOffset(length: Code[Int]): Code[Long] = 0
+
+  def isElementMissing(addr: Long, i: Int): Boolean = Region.loadBit(missing(addr), i)
+
+  def isElementDefined(addr: Long, i: Int): Boolean = !isElementMissing(addr, i)
+
+  def isElementMissing(addr: Code[Long], i: Code[Int]): Code[Boolean] = Region.loadBit(missing(addr), i.toL)
+
+  def isElementDefined(addr: Code[Long], i: Code[Int]): Code[Boolean] = !isElementMissing(addr, i)
+
+  def setElementMissing(addr: Long, i: Int): Unit =
+    if (!elementRequired) {
+      Region.setBit(missing(addr), i)
+    }
+
+  def setElementMissing(addr: Code[Long], i: Code[Int]): Code[Unit] =
+    if (!elementRequired)
+      Region.setBit(missing(addr), i.toL)
+    else
+      Code._fatal[Unit](s"Required element cannot be missing")
+
+  def setElementPresent(addr: Long, i: Int) {
+    if (!elementRequired)
+      Region.clearBit(missing(addr), i)
+  }
+
+  def setElementPresent(addr: Code[Long], i: Code[Int]): Code[Unit] =
+    if (!elementRequired)
+      Region.clearBit(missing(addr), i.toL)
+    else
+      Code._empty
+
+  def firstElementOffset(addr: Long, length: Int): Long = elements(addr)
+
+  def firstElementOffset(addr: Code[Long], length: Code[Int]): Code[Long] = firstElementOffset(addr)
+
+  def firstElementOffset(addr: Code[Long]): Code[Long] = elements(addr)
+
+  def elementOffset(addr: Long, length: Int, i: Int): Long = elementOffset(addr, i)
+
+  def elementOffset(addr: Long, i: Int): Long = elements(addr) + i * elementByteSize
+
+  def elementOffset(addr: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = elementOffset(addr, i)
+
+  def elementOffset(addr: Code[Long], i: Code[Int]): Code[Long] = firstElementOffset(addr) + i.toL * elementByteSize
+
+  def loadElement(addr: Long, length: Int, i: Int): Long = loadElement(addr, i)
+
+  def loadElement(addr: Long, i: Int): Long = elementType.unstagedLoadFromNested(elementOffset(addr, i))
+
+  def loadElement(addr: Code[Long], i: Code[Int]): Code[Long] = elementType.loadFromNested(elementOffset(addr, i))
+
+  def loadElement(addr: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = loadElement(addr, i)
+
+  def allocate(region: Region, length: Int): Long = {
+    val a = region.allocate(alignment, byteSize)
+    val e = region.allocate(contentsAlignment, elementByteSize * length)
+    Region.storeInt(a, length)
+    Region.storeAddress(elements(a), e)
+    if (!elementRequired) {
+      val m = region.allocate(4, nMissingBytes(length))
+      Region.storeAddress(missing(a), m)
+    }
+    a
+  }
+
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long] =
+    Code.memoize(region, "new_array_region", length, "new_array_length") { (r, len) =>
+      Code.memoize(r.allocate(alignment, byteSize), "new_array_a") { a =>
+        val e = r.allocate(contentsAlignment, elementByteSize * len)
+        Code(
+          Region.storeAddress(elements(a), e),
+          if (elementRequired)
+            Code._empty
+          else {
+            val m = r.allocate(4L, nMissingBytes(len))
+            Region.storeAddress(missing(a), m)
+          },
+          a
+        )
+      }
+    }
+
+  private def writeMissingness(addr: Long, length: Int, value: Byte) {
+    Region.setMemory(missing(addr), nMissingBytes(length), value)
+  }
+
+  def setAllMissingBits(addr: Long, length: Int): Unit =
+    if (!elementRequired) {
+      writeMissingness(addr, length, -1)
+    }
+
+  def clearMissingBits(addr: Long, length: Int): Unit =
+    if (!elementRequired) {
+      writeMissingness(addr, length, 0)
+    }
+
+  def initialize(addr: Long, length: Int, setMissing: Boolean): Unit = {
+    storeLength(addr, length)
+    if (setMissing)
+      setAllMissingBits(addr, length)
+    else
+      clearMissingBits(addr, length)
+  }
+
+  def stagedInitialize(addr: Code[Long], length: Code[Int], setMissing: Boolean): Code[Unit] =
+    if (elementRequired) {
+      storeLength(addr, length)
+    } else {
+      Code.memoize(addr, "staged_init_addr",
+        length, "staged_init_length") { (addr, length) =>
+        Code(
+          Region.storeInt(addr, length),
+          Region.setMemory(missing(addr), nMissingBytes(length).toL, const(if (setMissing) (-1).toByte else 0.toByte)))
+
+      }
+    }
+
+  def zeroes(region: Region, length: Int): Long = ???
+
+  def zeroes(mb: EmitMethodBuilder[_], region: Value[Region], length: Code[Int]): Code[Long] = ???
+
+  def forEach(mb: EmitMethodBuilder[_], addr: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] = ???
+
+  def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean] = ???
+
+  def nextElementAddress(currentOffset: Long): Long = ???
+
+  def nextElementAddress(currentOffset: Code[Long]): Code[Long] = ???
+
+  def sType: SType = ???
+
+  def unsafeOrdering(): UnsafeOrdering = ???
+
+  def _asIdent: String = ???
+
+  def _pretty(sb: StringBuilder, indent: Int, compact: Boolean): Unit = ???
+
+  def setRequired(required: Boolean): PType = ???
+
+  protected[physical] def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = ???
+
+  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = ???
+
+  def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = ???
+
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = ???
+
+  def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = ???
+
+  def loadFromNested(addr: Code[Long]): Code[Long] = ???
+
+  def unstagedLoadFromNested(addr: Long): Long = ???
+
+  def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = ???
+
+  def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = ???
+}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackArray.scala
@@ -1,0 +1,83 @@
+package is.hail.types.physical.stypes.concrete
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
+import is.hail.types.physical.{PNewArray, PType}
+import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType}
+import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableCode, SIndexableValue}
+import is.hail.types.virtual.Type
+import is.hail.utils.FastIndexedSeq
+
+case class SStackArray(pType: PNewArray) extends SContainer {
+  lazy val elementType: SType = pType.elementType.sType
+
+  lazy val elementEmitType: EmitType = EmitType(elementType, pType.elementRequired)
+
+  lazy val virtualType: Type = pType.virtualType
+
+  def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = ???
+
+  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = if (elementEmitType.required) {
+    FastIndexedSeq(IntInfo, LongInfo)
+  } else {
+    FastIndexedSeq(IntInfo, LongInfo, LongInfo)
+  }
+
+  def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = settables match {
+    case IndexedSeq(length, elements, missing) => new SStackArraySettable(this, coerce(length), coerce(elements), Some(coerce(missing)))
+    case IndexedSeq(length, elements) => new SStackArraySettable(this, coerce(length), coerce(elements), None)
+  }
+
+  def fromCodes(codes: IndexedSeq[Code[_]]): SCode = codes match {
+    case IndexedSeq(length, elements, missing) => new SStackArrayCode(this, coerce(length), coerce(elements), Some(coerce(missing)))
+    case IndexedSeq(length, elements) => new SStackArrayCode(this, coerce(length), coerce(elements), None)
+  }
+
+  def canonicalPType(): PType = pType
+
+  def castRename(t: Type): SType = SStackArray(pType.deepRename(t).asInstanceOf)
+}
+
+class SStackArrayCode(val st: SStackArray,
+  length: Code[Int],
+  elements: Code[Long],
+  missing: Option[Code[Long]]) extends SIndexableCode {
+  require(missing.isEmpty == st.elementEmitType.required)
+
+  def loadLength(): Code[Int] = length
+
+  def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue = ???
+
+  def memoizeField(cb: EmitCodeBuilder, name: String): SIndexableValue = ???
+
+  def castToArray(cb: EmitCodeBuilder): SIndexableCode = ???
+
+  def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(length, elements) ++ missing
+}
+
+class SStackArraySettable(val st: SStackArray,
+  length: Settable[Int],
+  elements: Settable[Long],
+  missing: Option[Settable[Long]]
+) extends SIndexableValue with SSettable {
+  require(missing.isEmpty == st.elementEmitType.required)
+  val pt = st.pType
+
+  def loadLength(): Value[Int] = length
+
+  def isElementMissing(i: Code[Int]): Code[Boolean] = missing.map(m => Region.loadBit(m, i.toL)).getOrElse(true)
+
+  def loadElement(cb: EmitCodeBuilder, i: Code[Int]): IEmitCode = {
+    val iv = cb.newLocal("stack_array_load_element_i", i)
+    IEmitCode(cb, isElementMissing(iv), pt.elementType.loadCheapPCode(cb, pt.elementOffsetFromBase(elements, iv)))
+  }
+
+  def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean] = missing.map(m => Region.containsNonZeroBits(m, length.toL)).getOrElse(false)
+
+  def store(cb: EmitCodeBuilder, v: SCode): Unit = ???
+
+  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(length, elements) ++ missing
+
+  def get: SCode = new SStackArrayCode(st, length, elements, missing.map(_.get))
+}


### PR DESCRIPTION
The purpose of this series is to create a new PArray type that will
eventually replace PCanonicalArray. It is represented as a C struct with
the following layout (T is the element type):

```
struct {
    int length;
    T *elements;
    char *missing; // present only if T is optional
}
```

This puts the PType used for arrays more in line with
the values in SIndexablePointerValue.