### PR TITLE
[hailctl dataproc] Use an env variable for log dir, set on dataproc

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -35,7 +35,10 @@ def _get_local_tmpdir(local_tmpdir):
 def _get_log(log):
     if log is None:
         py_version = version()
-        log = hail.utils.timestamp_path(os.path.join(os.getcwd(), 'hail'),
+        log_dir = os.environ.get('HAIL_LOG_DIR')
+        if log_dir is None:
+            log_dir = os.getcwd()
+        log = hail.utils.timestamp_path(os.path.join(log_dir, 'hail'),
                                         suffix=f'-{py_version}.log')
     return log
 

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -82,6 +82,7 @@ if role == 'Master':
         'SPARK_HOME': '/usr/lib/spark/',
         'PYSPARK_PYTHON': '/opt/conda/default/bin/python',
         'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',
+        'HAIL_LOG_DIR': '/home/hail',
     }
 
     # VEP ENV


### PR DESCRIPTION
This means that logs from submitted gcloud jobs won't go into
the void by default.