### PR TITLE
[compiler] Relegate PType.deepInnerRequired to tests

### DIFF
--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -403,23 +403,6 @@ abstract class PType extends Serializable with Requiredness {
     }
   }
 
-  def deepInnerRequired(required: Boolean): PType =
-    this match {
-      case t: PArray => PCanonicalArray(t.elementType.deepInnerRequired(true), required)
-      case t: PSet => PCanonicalSet(t.elementType.deepInnerRequired(true), required)
-      case t: PDict => PCanonicalDict(t.keyType.deepInnerRequired(true), t.valueType.deepInnerRequired(true), required)
-      case t: PStruct =>
-        PCanonicalStruct(t.fields.map(f => PField(f.name, f.typ.deepInnerRequired(true), f.index)), required)
-      case t: PCanonicalTuple =>
-        PCanonicalTuple(t._types.map { f => f.copy(typ = f.typ.deepInnerRequired(true)) }, required)
-      case t: PInterval =>
-        PCanonicalInterval(t.pointType.deepInnerRequired(true), required)
-      case t: PStream =>
-        PCanonicalStream(t.elementType.deepInnerRequired(true), required = required)
-      case t =>
-        t.setRequired(required)
-    }
-
   protected[physical] def _copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long
 
   def copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long = {

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -3,7 +3,7 @@ package is.hail.annotations
 import is.hail.HailSuite
 import is.hail.asm4s._
 import is.hail.check.{Gen, Prop}
-import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode}
+import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, RequirednessSuite}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete.SStringPointer
 import is.hail.types.physical.stypes.interfaces._
@@ -462,7 +462,7 @@ class StagedConstructorSuite extends HailSuite {
       "x3" -> PCanonicalArray(PInt32(true), required = true),
       "x4" -> PCanonicalSet(PCanonicalStruct(true, "y" -> PCanonicalString(true)), required = false)
     ), required = false)
-    val t2 = t1.deepInnerRequired(false)
+    val t2 = RequirednessSuite.deepInnerRequired(t1, false)
 
     val value = IndexedSeq(
       Row(1, IndexedSeq(1,2,3), IndexedSeq(0, -1), Set(Row("asdasdasd"), Row(""))),
@@ -490,7 +490,7 @@ class StagedConstructorSuite extends HailSuite {
       "x3" -> PCanonicalArray(PInt32(true), required = true),
       "x4" -> PCanonicalSet(PCanonicalStruct(true, "y" -> PCanonicalString(true)), required = false)
     ), required = false))
-    val t2 = t1.deepInnerRequired(false).asInstanceOf[PCanonicalStruct]
+    val t2 = RequirednessSuite.deepInnerRequired(t1, false).asInstanceOf[PCanonicalStruct]
 
     val value = IndexedSeq(
       Row(1, IndexedSeq(1,2,3), IndexedSeq(0, -1), Set(Row("asdasdasd"), Row(""))),


### PR DESCRIPTION
It's only used in tests, and is not something we wish to maintain as part of the ptype interface.