### PR TITLE
[compiler] Rework SIndexablePointer to be a multi-code SCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -146,9 +146,9 @@ class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
           array.loadFromIndex(cb, r.region, idx)
         }
       case td: TDict =>
-        PCanonicalDict.coerceArrayCode(toRegion(cb, TArray(td.elementType)))
+        PCanonicalDict.coerceArrayCode(cb, toRegion(cb, TArray(td.elementType)))
       case ts: TSet =>
-        PCanonicalSet.coerceArrayCode(toRegion(cb, TArray(ts.elementType)))
+        PCanonicalSet.coerceArrayCode(cb, toRegion(cb, TArray(ts.elementType)))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1231,7 +1231,7 @@ class Emit[C](
             cb.assign(grpIdx, grpIdx + 1)
           })
 
-          dictType.construct(finishOuter(cb))
+          dictType.sType.fromCodes(finishOuter(cb).makeCodeTuple(cb))
         }
 
       case x@StreamLen(a) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -232,9 +232,9 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
   }
 
   private def appendShallow(cb: EmitCodeBuilder, r: Code[Region], aCode: SCode): Unit = {
-    val buff = cb.memoize(aCode, "sbll_append_shallow_a").asInstanceOf[SIndexablePointerSettable]
+    val buff = cb.memoize(aCode, "sbll_append_shallow_list").asInstanceOf[SIndexablePointerSettable]
     val newNode = cb.newLocal[Long]("sbll_append_shallow_newnode", nodeType.allocate(r))
-    cb += initNode(newNode, buf = buff.a, count = buff.length)
+    cb += initNode(newNode, buf = buff.baseAddress(), count = buff.length)
     cb += setNext(lastNode, newNode)
     cb.assign(lastNode, newNode)
     cb.assign(totalCount, totalCount + buff.length)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -510,7 +510,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       mb.invokeCode(_, _, _)
     }
 
-    mb.emitWithBuilder[Long] { cb =>
+    mb.emitPCode { cb =>
       val r = mb.getCodeParam[Region](1)
 
       val indicesToSort = cb.newLocal[Long]("indices_to_sort",
@@ -533,9 +533,9 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           .flatMap(cb) { case pct: SBaseStructPointerCode =>
             pct.memoize(cb, "takeby_result_tuple").loadField(cb, 1)
           }
-      }.a
+      }
     }
-    resultType.loadCheapPCode(cb, cb.invokeCode[Long](mb, _r))
+    cb.invokePCode(mb, _r).asInstanceOf[SIndexablePointerCode]
   }
 }
 

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -49,8 +49,8 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
   def loadFrom(cb: EmitCodeBuilder, ib: StagedIndexWriterUtils, idx: Value[Int]): Unit = {
     cb.assign(region, ib.getRegion(idx))
     cb.assign(node.a, ib.getArrayOffset(idx))
-    val aoff = node.loadField(cb, 0).get(cb).asInstanceOf[SIndexablePointerCode].a
-    ab.loadFrom(cb, aoff, ib.getLength(idx))
+    val value = node.loadField(cb, 0).get(cb).asInstanceOf[SIndexablePointerCode]
+    ab.loadFrom(cb, value, ib.getLength(idx))
   }
 
   def store(cb: EmitCodeBuilder, ib: StagedIndexWriterUtils, idx: Value[Int]): Unit =

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -144,7 +144,8 @@ trait PArrayBackedContainer extends PContainer {
 
   def sType: SIndexablePointer = SIndexablePointer(setRequired(false).asInstanceOf[PArrayBackedContainer])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SIndexablePointerCode(sType, addr)
+  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode =
+    sType.fromCodes(arrayRep.loadCheapPCode(cb, addr).makeCodeTuple(cb))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value.asIndexable.castToArray(cb), deepCopy)
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -9,8 +9,11 @@ abstract class PContainer extends PIterable {
   override def containsPointers: Boolean = true
 
   def elementByteSize: Long
-
   def contentsAlignment: Long
+
+  override def setRequired(required: Boolean): PContainer
+
+  final def elementOffsetFromBase(baseAddress: Code[Long], i: Code[Int]): Code[Long] = baseAddress + const(elementByteSize) * i.toL
 
   def loadLength(aoff: Long): Int
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -9,7 +9,6 @@ import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalDict, PCanonic
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
-
 case class SIndexablePointer(pType: PContainer) extends SContainer {
   require(!pType.required)
 
@@ -22,7 +21,12 @@ case class SIndexablePointer(pType: PContainer) extends SContainer {
   def elementEmitType: EmitType = EmitType(elementType, pType.elementType.required)
 
   def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
-    new SIndexablePointerCode(this, pType.store(cb, region, value, deepCopy))
+    value match {
+      case value: SIndexablePointerCode if !deepCopy => new SIndexablePointerCode(this, value.length, value.elements, value.missing)
+      case _ =>
+        val addr = pType.store(cb, region, value, deepCopy)
+        pType.loadCheapPCode(cb, addr)
+    }
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
@@ -30,31 +34,46 @@ case class SIndexablePointer(pType: PContainer) extends SContainer {
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo, IntInfo, LongInfo)
 
   def fromSettables(settables: IndexedSeq[Settable[_]]): SIndexablePointerSettable = {
-    val IndexedSeq(a: Settable[Long@unchecked], length: Settable[Int@unchecked], elementsAddress: Settable[Long@unchecked]) = settables
-    assert(a.ti == LongInfo)
+    val (length, elements, missing) = settables match {
+      case IndexedSeq(length: Settable[Int@unchecked], elements: Settable[Long@unchecked], missing: Settable[Long@unchecked]) =>
+        (length, elements, Some(missing))
+      case IndexedSeq(length: Settable[Int@unchecked], elements: Settable[Long@unchecked]) =>
+        (length, elements, None)
+    }
     assert(length.ti == IntInfo)
-    assert(elementsAddress.ti == LongInfo)
-    new SIndexablePointerSettable(this, a, length, elementsAddress)
+    assert(elements.ti == LongInfo)
+    missing.foreach(m => assert(m.ti == LongInfo))
+    new SIndexablePointerSettable(this, length, elements, missing)
   }
 
   def fromCodes(codes: IndexedSeq[Code[_]]): SIndexablePointerCode = {
-    val IndexedSeq(a: Code[Long@unchecked]) = codes
-    assert(a.ti == LongInfo)
-    new SIndexablePointerCode(this, a)
+    val (length, elements, missing) = codes match {
+      case IndexedSeq(length: Code[Int@unchecked], elements: Code[Long@unchecked], missing: Code[Long@unchecked]) =>
+        (length, elements, Some(missing))
+      case IndexedSeq(length: Code[Int@unchecked], elements: Code[Long@unchecked]) =>
+        (length, elements, None)
+    }
+    assert(length.ti == IntInfo)
+    assert(elements.ti == LongInfo)
+    missing.foreach(m => assert(m.ti == LongInfo))
+    new SIndexablePointerCode(this, length, elements, missing)
   }
 
   def canonicalPType(): PType = pType
 }
 
 
-class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extends SIndexableCode {
+class SIndexablePointerCode(val st: SIndexablePointer,
+  val length: Code[Int],
+  val elements: Code[Long],
+  val missing: Option[Code[Long]]
+) extends SIndexableCode {
   val pt: PContainer = st.pType
+  require(missing.isEmpty == pt.elementType.required)
 
-  def code: Code[_] = a
+  def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(length, elements) ++ missing
 
-  def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(a)
-
-  def loadLength(): Code[Int] = pt.loadLength(a)
+  def loadLength(): Code[Int] = length
 
   def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIndexableValue = {
     val s = SIndexablePointerSettable(sb, st, name)
@@ -68,9 +87,9 @@ class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extend
 
   def castToArray(cb: EmitCodeBuilder): SIndexableCode = {
     pt match {
-      case t: PArray => this
-      case t: PCanonicalDict => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), a)
-      case t: PCanonicalSet => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), a)
+      case t: PCanonicalDict => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), length, elements, missing)
+      case t: PCanonicalSet => new SIndexablePointerCode(SIndexablePointer(t.arrayRep), length, elements, missing)
+      case _: PArray => this
     }
   }
 }
@@ -78,23 +97,24 @@ class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extend
 object SIndexablePointerSettable {
   def apply(sb: SettableBuilder, st: SIndexablePointer, name: String): SIndexablePointerSettable = {
     new SIndexablePointerSettable(st,
-      sb.newSettable[Long](s"${ name }_a"),
       sb.newSettable[Int](s"${ name }_length"),
-      sb.newSettable[Long](s"${ name }_elems_addr"))
+      sb.newSettable[Long](s"${ name }_elements"),
+      if (st.pType.elementType.required) None else Some(sb.newSettable[Long](s"${ name }_missing")))
   }
 }
 
 class SIndexablePointerSettable(
   val st: SIndexablePointer,
-  val a: Settable[Long],
   val length: Settable[Int],
-  val elementsAddress: Settable[Long]
+  val elements: Settable[Long],
+  val missing: Option[Settable[Long]]
 ) extends SIndexableValue with SSettable {
   val pt: PContainer = st.pType
+  require(missing.isEmpty == pt.elementType.required)
 
-  def get: SIndexableCode = new SIndexablePointerCode(st, a)
+  def get: SIndexableCode = new SIndexablePointerCode(st, length, elements, missing.map(_.get))
 
-  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, length, elementsAddress)
+  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(length, elements) ++ missing
 
   def loadLength(): Value[Int] = length
 
@@ -102,24 +122,27 @@ class SIndexablePointerSettable(
     val iv = cb.newLocal("pcindval_i", i)
     IEmitCode(cb,
       isElementMissing(iv),
-      pt.elementType.loadCheapPCode(cb, pt.loadElement(a, length, iv))) // FIXME loadElement should take elementsAddress
+      pt.elementType.loadCheapPCode(cb, pt.elementOffsetFromBase(elements, iv))) // FIXME loadElement should take elementsAddress
   }
 
-  def isElementMissing(i: Code[Int]): Code[Boolean] = pt.isElementMissing(a, i)
+  def isElementMissing(i: Code[Int]): Code[Boolean] =
+    missing.map(m => Region.loadBit(m, i.toL)).getOrElse(false)
 
-  def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(a, pc.asInstanceOf[SIndexablePointerCode].a)
-    cb.assign(length, pt.loadLength(a))
-    cb.assign(elementsAddress, pt.firstElementOffset(a, length))
+  def store(cb: EmitCodeBuilder, sc: SCode): Unit = sc match {
+    case sc: SIndexablePointerCode =>
+      cb.assign(length, sc.length)
+      cb.assign(elements, sc.elements)
+      missing.foreach(missing => cb.assign(missing, sc.missing.get))
   }
 
-  override def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean] = pt.hasMissingValues(a)
+  override def hasMissingValues(cb: EmitCodeBuilder): Code[Boolean] =
+    missing.map(m => Region.containsNonZeroBits(m, length.toL)).getOrElse(false)
 
   override def forEachDefined(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SCode) => Unit) {
     st.pType match {
       case pca: PCanonicalArray =>
         val idx = cb.newLocal[Int]("foreach_pca_idx", 0)
-        val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elementsAddress)
+        val elementPtr = cb.newLocal[Long]("foreach_pca_elt_ptr", elements)
         val et = pca.elementType
         cb.whileLoop(idx < length, {
           cb.ifx(isElementMissing(idx),
@@ -133,5 +156,17 @@ class SIndexablePointerSettable(
         })
       case _ => super.forEachDefined(cb)(f)
     }
+  }
+
+  /**
+    * If this SVector was created from a canonical [[PContainer]]
+    * (one of [[PCanonicalArray]], [[PCanonicalDict]], [[PCanonicalSet]])
+    * then get the base address that corresponds to the pointer that would
+    * be passed to [[PType.loadCheapPCode]]
+    * @return [[Code]]
+    */
+  def baseAddress(): Code[Long] = pt match {
+    case _: PCanonicalSet | _: PCanonicalDict | _: PCanonicalArray =>
+      elements - pt.elementsOffset(length)
   }
 }

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.check.{Gen, Prop}
 import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, RequirednessSuite}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.concrete.SStringPointer
+import is.hail.types.physical.stypes.concrete.{SStringPointer, SIndexablePointerSettable}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.SInt32Code
 import is.hail.types.virtual._
@@ -100,7 +100,7 @@ class StagedConstructorSuite extends HailSuite {
       val elt = fb.getCodeParam[Int](2)
       rt.constructFromElements(cb, region, const(1), false) { (cb, idx) =>
         IEmitCode.present(cb, primitive(elt))
-      }.a
+      }.memoize(cb, "result").asInstanceOf[SIndexablePointerSettable].baseAddress()
     }
 
     val region = Region(pool=pool)
@@ -188,7 +188,7 @@ class StagedConstructorSuite extends HailSuite {
           EmitCode.fromI(cb.emb)(cb => IEmitCode.present(cb, primitive(idx + 1))),
           EmitCode.fromI(cb.emb)(cb => IEmitCode.present(cb, st.constructFromString(cb, region, fb.getCodeParam[String](2))))
         ), deepCopy = false))
-      }.a
+      }.memoize(cb, "result").asInstanceOf[SIndexablePointerSettable].baseAddress()
     }
 
     val region = Region(pool=pool)
@@ -363,7 +363,7 @@ class StagedConstructorSuite extends HailSuite {
       val region = fb.emb.getCodeParam[Region](1)
       rt.constructFromElements(cb, region, const(2), deepCopy = false) { (cb, idx) =>
         IEmitCode(cb, idx > 0, new SInt32Code(fb.getCodeParam[Int](2)))
-      }.a
+      }.memoize(cb, "result").asInstanceOf[SIndexablePointerSettable].baseAddress()
     }
 
     val region = Region(pool=pool)

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -5,6 +5,7 @@ import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
 import is.hail.asm4s.Code
 import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.concrete.SIndexablePointerSettable
 import is.hail.utils._
 import org.testng.Assert._
 import org.testng.annotations.Test
@@ -93,7 +94,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
       fb.emitWithBuilder { cb =>
         cb.assign(rField, rArg)
         sbll.load(cb, ptr)
-        sbll.resultArray(cb, rArg, arrayPType).a
+        sbll.resultArray(cb, rArg, arrayPType).memoize(cb, "result").asInstanceOf[SIndexablePointerSettable].baseAddress()
       }
 
       val f = fb.result()()


### PR DESCRIPTION
The new implementation is comprised of three (two if the element type is required) codes:
```
length: Code[Int]
elements: Code[Long]
missing: Option[Code[Long]] // if None if element is required
```
