### PR TITLE
[compiler] Use AsmTuple for multi-code SType return values

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -76,6 +76,8 @@ class ClassesBytes(classesBytes: Array[(String, Array[Byte])]) extends Serializa
 }
 
 class AsmTuple[C](val cb: ClassBuilder[C], val fields: IndexedSeq[Field[_]], val ctor: MethodBuilder[C]) {
+  val ti: TypeInfo[_] = cb.ti
+
   def newTuple(elems: IndexedSeq[Code[_]]): Code[C] = Code.newInstance(cb, ctor, elems)
 
   def loadElementsAny(t: Value[_]): IndexedSeq[Code[_]] = fields.map(_.get(coerce[C](t) ))
@@ -108,7 +110,7 @@ class ModuleBuilder() {
 
   def tupleClass(fieldTypes: IndexedSeq[TypeInfo[_]]): AsmTuple[_] = {
     tuples.getOrElseUpdate(fieldTypes, {
-      val cb = genClass[AnyRef]("Tuple")
+      val cb = genClass[AnyRef](s"Tuple${fieldTypes.length}")
       val fields = fieldTypes.zipWithIndex.map { case (ti, i) =>
         cb.newField(s"_$i")(ti)
       }

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -110,18 +110,29 @@ class ModuleBuilder() {
 
   def tupleClass(fieldTypes: IndexedSeq[TypeInfo[_]]): AsmTuple[_] = {
     tuples.getOrElseUpdate(fieldTypes, {
-      val cb = genClass[Unit](s"Tuple${fieldTypes.length}")
+      val kb = genClass[Unit](s"Tuple${fieldTypes.length}")
       val fields = fieldTypes.zipWithIndex.map { case (ti, i) =>
-        cb.newField(s"_$i")(ti)
+        kb.newField(s"_$i")(ti)
       }
-      val ctor = cb.newMethod("<init>", fieldTypes, UnitInfo)
+      val ctor = kb.newMethod("<init>", fieldTypes, UnitInfo)
       ctor.emitWithBuilder { cb =>
+        // FIXME, maybe a more elegant way to do this?
+        val L = new lir.Block()
+        L.append(
+          lir.methodStmt(INVOKESPECIAL,
+            "java/lang/Object",
+            "<init>",
+            "()V",
+            false,
+            UnitInfo,
+            FastIndexedSeq(lir.load(ctor._this.asInstanceOf[LocalRef[_]].l))))
+        cb += new VCode(L, L, null)
         fields.zipWithIndex.foreach { case (f, i) =>
             cb += f.putAny(ctor._this, ctor.getArg(i + 1)(f.ti).get)
         }
         Code._empty
       }
-      new AsmTuple(cb, fields, ctor)
+      new AsmTuple(kb, fields, ctor)
     })
   }
 

--- a/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/ClassBuilder.scala
@@ -110,7 +110,7 @@ class ModuleBuilder() {
 
   def tupleClass(fieldTypes: IndexedSeq[TypeInfo[_]]): AsmTuple[_] = {
     tuples.getOrElseUpdate(fieldTypes, {
-      val cb = genClass[AnyRef](s"Tuple${fieldTypes.length}")
+      val cb = genClass[Unit](s"Tuple${fieldTypes.length}")
       val fields = fieldTypes.zipWithIndex.map { case (ti, i) =>
         cb.newField(s"_$i")(ti)
       }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -963,7 +963,6 @@ class EmitMethodBuilder[C](
   def voidWithBuilder(f: (EmitCodeBuilder) => Unit): Unit = emit(EmitCodeBuilder.scopedVoid(this)(f))
 
   def emitPCode(f: (EmitCodeBuilder) => SCode): Unit = {
-    // FIXME: this should optionally construct a tuple to support multiple-code SCodes
     emit(EmitCodeBuilder.scopedCode(this) { cb =>
       val res = f(cb)
       if (res.st.nCodes == 1)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -184,8 +184,12 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
   // FIXME: this should be invokeSCode and should allocate/destructure a tuple when more than one code is present
   def invokePCode(callee: EmitMethodBuilder[_], args: Param*): SCode = {
     val st = callee.emitReturnType.asInstanceOf[PCodeParamType].st
-    assert(st.nCodes == 1, st)
-    st.fromCodes(FastIndexedSeq(_invoke(callee, args: _*))).asInstanceOf[SCode]
+    if (st.nCodes == 1)
+      st.fromCodes(FastIndexedSeq(_invoke(callee, args: _*)))
+    else {
+      val tup = newLocal("invokepcode_tuple", _invoke(callee, args: _*))(callee.asmTuple.ti)
+      st.fromCodes(callee.asmTuple.loadElementsAny(tup))
+    }
   }
 
   // for debugging

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -181,7 +181,7 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     _invoke[T](callee, args: _*)
   }
 
-  // FIXME: this should be invokeSCode and should allocate/destructure a tuple when more than one code is present
+  // FIXME: this should be invokeSCode
   def invokePCode(callee: EmitMethodBuilder[_], args: Param*): SCode = {
     val st = callee.emitReturnType.asInstanceOf[PCodeParamType].st
     if (st.nCodes == 1)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -88,7 +88,6 @@ class SIntervalPointerSettable(
     cb.assign(includesEnd, pt.includesEnd(a.load()))
   }
 
-  // FIXME orderings should take emitcodes/iemitcodes
   def isEmpty(cb: EmitCodeBuilder): Code[Boolean] = {
     val gt = cb.emb.ecb.getOrderingFunction(st.pointType, CodeOrdering.Gt())
     val gteq = cb.emb.ecb.getOrderingFunction(st.pointType, CodeOrdering.Gteq())


### PR DESCRIPTION
This removes the single code requirement (st.nCodes == 1) for methods
returning SCodes.