### PR TITLE
[compiler] Rename almost every reference from PCode to SCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -57,7 +57,7 @@ class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltTy
 
   // Returns smallest i, 0 <= i < n, for which a(i) >= key, or returns n if a(i) < key for all i
   findElt.emitWithBuilder[Int] { cb =>
-    val indexable = findElt.getPCodeParam(1).asIndexable.memoize(cb, "findElt_indexable")
+    val indexable = findElt.getSCodeParam(1).asIndexable.memoize(cb, "findElt_indexable")
 
     val elt = findElt.getEmitParam(2, null) // no streams
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -137,13 +137,13 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
               s"\n  expected ${ cpt.ti }" +
               s"\n  all param types: ${expectedArgs}-")
           FastIndexedSeq(c)
-        case (PCodeParam(pc), pcpt: PCodeParamType) =>
+        case (SCodeParam(pc), pcpt: SCodeParamType) =>
           if (pc.st != pcpt.st)
             throw new RuntimeException(s"invoke ${ callee.mb.methodName }: arg $i: type mismatch:" +
               s"\n  got ${ pc.st }" +
               s"\n  expected ${ pcpt.st }")
           pc.makeCodeTuple(this)
-        case (EmitParam(ec), PCodeEmitParamType(et)) =>
+        case (EmitParam(ec), SCodeEmitParamType(et)) =>
           if (!ec.emitType.equalModuloRequired(et)) {
             throw new RuntimeException(s"invoke ${callee.mb.methodName}: arg $i: type mismatch:" +
               s"\n  got ${ec.st}" +
@@ -181,9 +181,8 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     _invoke[T](callee, args: _*)
   }
 
-  // FIXME: this should be invokeSCode
-  def invokePCode(callee: EmitMethodBuilder[_], args: Param*): SCode = {
-    val st = callee.emitReturnType.asInstanceOf[PCodeParamType].st
+  def invokeSCode(callee: EmitMethodBuilder[_], args: Param*): SCode = {
+    val st = callee.emitReturnType.asInstanceOf[SCodeParamType].st
     if (st.nCodes == 1)
       st.fromCodes(FastIndexedSeq(_invoke(callee, args: _*)))
     else {

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -60,7 +60,7 @@ class PartitionIteratorLongReader(
 
           cb.goto(LproduceElementDone)
         }
-        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltPType.loadCheapPCode(cb, rv)))
+        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltPType.loadCheapSCode(cb, rv)))
 
         override def close(cb: EmitCodeBuilder): Unit = {}
       }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -261,7 +261,7 @@ case class SplitPartitionNativeWriter(
       cb += os2.invoke[Unit]("close")
       filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, pctx, false)
       cb += Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)
-      pResultType.loadCheapPCode(cb, result.get)
+      pResultType.loadCheapSCode(cb, result.get)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Param.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Param.scala
@@ -17,10 +17,10 @@ case class CodeParamType(ti: TypeInfo[_]) extends ParamType {
   override def toString: String = s"CodeParam($ti)"
 }
 
-case class PCodeParamType(st: SType) extends ParamType {
+case class SCodeParamType(st: SType) extends ParamType {
   def nCodes: Int = st.nCodes
 
-  override def toString: String = s"PCodeParam($st, $nCodes)"
+  override def toString: String = s"SCodeParam($st, $nCodes)"
 }
 
 trait EmitParamType extends ParamType {
@@ -49,7 +49,7 @@ case class SingleCodeEmitParamType(required: Boolean, sct: SingleCodeType) exten
   override def toString: String = s"SingleCodeEmitParamType($required, $sct)"
 }
 
-case class PCodeEmitParamType(et: EmitType) extends EmitParamType {
+case class SCodeEmitParamType(et: EmitType) extends EmitParamType {
   def required: Boolean = et.required
 
   def virtualType: Type = et.st.virtualType
@@ -61,4 +61,4 @@ sealed trait Param
 
 case class CodeParam(c: Code[_]) extends Param
 case class EmitParam(ec: EmitCode) extends Param
-case class PCodeParam(pc: SCode) extends Param
+case class SCodeParam(sc: SCode) extends Param

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -684,7 +684,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         requiredness.union(lookup(path).required)
         requiredness.fromPType(spec.encodedType.decodedPType(rt))
       case In(_, t) => t match {
-        case PCodeEmitParamType(et) => requiredness.fromPType(et.canonicalPType)
+        case SCodeEmitParamType(et) => requiredness.fromPType(et.canonicalPType)
         case SingleCodeEmitParamType(required, StreamSingleCodeType(_, eltType)) => requiredness.fromPType(PCanonicalStream(eltType, required)) // fixme hacky
         case SingleCodeEmitParamType(required, PTypeReferenceSingleCodeType(pt)) => requiredness.fromPType(pt.setRequired(required))
         case SingleCodeEmitParamType(required, _) => requiredness.union(required)

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -65,7 +65,7 @@ class StagedArrayBuilder(val elt: SingleCodeType, val eltRequired: Boolean, mb: 
 
   def loadFromIndex(cb: EmitCodeBuilder, r: Value[Region], i: Code[Int]): IEmitCode = {
     val idx = cb.newLocal[Int]("loadFromIndex_idx", i)
-    IEmitCode(cb, isMissing(idx), elt.loadToPCode(cb, r, apply(idx)))
+    IEmitCode(cb, isMissing(idx), elt.loadToSCode(cb, r, apply(idx)))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -511,7 +511,7 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
           cb.assign(next, upcastF.invoke[Region, Long, Long]("apply", region, Code.longValue(iterator.invoke[java.lang.Long]("next"))))
           cb.goto(LproduceElementDone)
         }
-        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, upcastPType.loadCheapPCode(cb, next)))
+        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, upcastPType.loadCheapSCode(cb, next)))
 
         override def close(cb: EmitCodeBuilder): Unit = {}
       }
@@ -662,7 +662,7 @@ case class PartitionNativeReaderIndexed(spec: AbstractTypedCodecSpec, indexSpec:
           cb.goto(LproduceElementDone)
 
         }
-        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapPCode(cb, next)))
+        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapSCode(cb, next)))
 
         override def close(cb: EmitCodeBuilder): Unit = cb += it.invoke[Unit]("close")
       }
@@ -839,7 +839,7 @@ case class PartitionZippedNativeReader(specLeft: AbstractTypedCodecSpec, specRig
           cb.assign(next, it.invoke[Long]("_next"))
           cb.goto(LproduceElementDone)
         }
-        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapPCode(cb, next)))
+        override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapSCode(cb, next)))
 
         override def close(cb: EmitCodeBuilder): Unit = cb += it.invoke[Unit]("close")
       }

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -194,7 +194,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
                   deepCopy = false))
             },
               ob.invoke[Long]("indexOffset"),
-              IEmitCode.present(cb, PCanonicalStruct().loadCheapPCode(cb, 0L)))
+              IEmitCode.present(cb, PCanonicalStruct().loadCheapSCode(cb, 0L)))
           }
         cb += ob.writeByte(1.asInstanceOf[Byte])
 
@@ -228,7 +228,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
       cb += os.invoke[Unit]("close")
       filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, pctx, false)
       cb += Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)
-      pResultType.loadCheapPCode(cb, result.get)
+      pResultType.loadCheapSCode(cb, result.get)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -52,7 +52,7 @@ trait AggregatorState {
     cb += t.storeLength(addr, lazyBuffer.invoke[Int]("length"))
     cb += lazyBuffer.invoke[Long, Unit]("copyToAddress", t.bytesAddress(addr))
 
-    t.loadCheapPCode(cb, addr)
+    t.loadCheapSCode(cb, addr)
   }
 }
 
@@ -142,18 +142,18 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
   }
 
   def get(cb: EmitCodeBuilder): IEmitCode = {
-    IEmitCode(cb, storageType.isFieldMissing(off, 0), ptype.loadCheapPCode(cb, storageType.loadField(off, 0)))
+    IEmitCode(cb, storageType.isFieldMissing(off, 0), ptype.loadCheapSCode(cb, storageType.loadField(off, 0)))
   }
 
   def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
     newState(cb, off)
-    storageType.storeAtAddress(cb, off, region, storageType.loadCheapPCode(cb, src), deepCopy = true)
+    storageType.storeAtAddress(cb, off, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
     val codecSpec = TypedCodecSpec(storageType, codec)
     val enc = codecSpec.encodedType.buildEncoder(storageType.sType, kb)
-    (cb, ob: Value[OutputBuffer]) => enc(cb, storageType.loadCheapPCode(cb, off), ob)
+    (cb, ob: Value[OutputBuffer]) => enc(cb, storageType.loadCheapSCode(cb, off), ob)
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -43,7 +43,7 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   }
 
   def result(cb: EmitCodeBuilder, region: Value[Region]): SBaseStructPointerCode = {
-    QuantilesAggregator.resultType.loadCheapPCode(cb, aggr.invoke[Region, Long]("rvResult", region))
+    QuantilesAggregator.resultType.loadCheapSCode(cb, aggr.invoke[Region, Long]("rvResult", region))
   }
 
   def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -257,7 +257,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
           cb.assign(i, i + 1)
         })
         // don't need to deep copy because that's done in nested aggregators
-        pt.storeAtAddress(cb, addr, region, resultType.loadCheapPCode(cb, resultAddr), deepCopy = false)
+        pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr), deepCopy = false)
 
       }
     )

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -77,7 +77,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = { (cb, ob) =>
     val codecSpec = TypedCodecSpec(CallStatsState.stateType, codec)
     codecSpec.encodedType.buildEncoder(CallStatsState.stateType.sType, kb)
-      .apply(cb, CallStatsState.stateType.loadCheapPCode(cb, off), ob)
+      .apply(cb, CallStatsState.stateType.loadCheapSCode(cb, off), ob)
   }
 
   def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = {
@@ -92,7 +92,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
   }
 
   def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
-    cb.assign(off, CallStatsState.stateType.store(cb, region, CallStatsState.stateType.loadCheapPCode(cb, src), deepCopy = true))
+    cb.assign(off, CallStatsState.stateType.store(cb, region, CallStatsState.stateType.loadCheapSCode(cb, src), deepCopy = true))
     loadNAlleles(cb)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -19,7 +19,7 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
   def isKeyMissing(src: Code[Long]): Code[Boolean] = storageType.isFieldMissing(src, 0)
 
   def loadKey(cb: EmitCodeBuilder, src: Code[Long]): SCode = {
-    typ.loadCheapPCode(cb, storageType.loadField(src, 0))
+    typ.loadCheapSCode(cb, storageType.loadField(src, 0))
   }
 
   def isEmpty(cb: EmitCodeBuilder, off: Code[Long]): Code[Boolean] = storageType.isFieldMissing(off, 1)
@@ -46,7 +46,7 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
     cb += Region.copyFrom(src, dest, storageType.byteSize)
 
   def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], src: Code[Long]): Unit = {
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapPCode(cb, src), deepCopy = true)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
   }
 
   def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -57,7 +57,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
     val codecSpec = TypedCodecSpec(arrayStorageType, codec)
     (cb: EmitCodeBuilder, ob: Value[OutputBuffer]) => {
 
-      val arrayCode = arrayStorageType.loadCheapPCode(cb, arrayAddr)
+      val arrayCode = arrayStorageType.loadCheapSCode(cb, arrayAddr)
       codecSpec.encodedType.buildEncoder(arrayCode.st, kb)
         .apply(cb, arrayCode, ob)
       cb += ob.writeInt(const(DensifyAggregator.END_SERIALIZATION))
@@ -88,7 +88,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
   private def gc(cb: EmitCodeBuilder): Unit = {
     cb.ifx(region.totalManagedBytes() > maxRegionSize, {
       val newRegion = cb.newLocal[Region]("densify_gc", Region.stagedCreate(regionSize, kb.pool()))
-      cb.assign(arrayAddr, arrayStorageType.store(cb, newRegion, arrayStorageType.loadCheapPCode(cb, arrayAddr), deepCopy = true))
+      cb.assign(arrayAddr, arrayStorageType.store(cb, newRegion, arrayStorageType.loadCheapSCode(cb, arrayAddr), deepCopy = true))
       cb += region.invalidate()
       cb.assign(r, newRegion)
 
@@ -113,7 +113,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
 
   def combine(cb: EmitCodeBuilder, other: DensifyState): Unit = {
     assert(other.arrayStorageType == this.arrayStorageType)
-    val arr = arrayStorageType.loadCheapPCode(cb, other.arrayAddr).memoize(cb, "densify_comb_other")
+    val arr = arrayStorageType.loadCheapSCode(cb, other.arrayAddr).memoize(cb, "densify_comb_other")
     arr.asInstanceOf[SIndexableValue].forEachDefined(cb) { case (cb, idx, element) =>
       cb += arrayStorageType.setElementPresent(arrayAddr, idx)
       eltType.storeAtAddress(cb, arrayStorageType.elementOffset(arrayAddr, length, idx), region, element, deepCopy = true)
@@ -122,14 +122,14 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
   }
 
   def result(cb: EmitCodeBuilder, region: Value[Region]): SIndexablePointerCode = {
-    arrayStorageType.loadCheapPCode(cb, arrayAddr)
+    arrayStorageType.loadCheapSCode(cb, arrayAddr)
   }
 
   def copyFrom(cb: EmitCodeBuilder, srcCode: Code[Long]): Unit = {
     cb.assign(arrayAddr,
       arrayStorageType.store(cb,
         region,
-        arrayStorageType.loadCheapPCode(cb, arrayStorageType.loadFromNested(srcCode)),
+        arrayStorageType.loadCheapSCode(cb, arrayStorageType.loadFromNested(srcCode)),
         deepCopy = true))
     cb.assign(length, arrayStorageType.loadLength(arrayAddr))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -43,7 +43,7 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
     storageType.isFieldMissing(off, 0)
 
   def loadKey(cb: EmitCodeBuilder, off: Code[Long]): SCode = {
-    kt.loadCheapPCode(cb, storageType.loadField(off, 0))
+    kt.loadCheapSCode(cb, storageType.loadField(off, 0))
   }
 
   def initValue(cb: EmitCodeBuilder, destc: Code[Long], k: EmitCode, rIdx: Code[Int]): Unit = {
@@ -82,11 +82,11 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
     cb += Region.storeInt(storageType.fieldOffset(off, 1), -1)
 
   def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapPCode(cb, src), deepCopy = false)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = false)
 
   def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], srcCode: Code[Long]): Unit = {
     val src = cb.newLocal("ga_deep_copy_src", srcCode)
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapPCode(cb, src), deepCopy = true)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
     container.copyFrom(cb, containerOffset(src))
     container.store(cb)
   }
@@ -313,6 +313,6 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
     }
 
     // don't need to deep copy because that's done in nested aggregators
-    pt.storeAtAddress(cb, addr, region, resultType.loadCheapPCode(cb, resultAddr), deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -273,6 +273,6 @@ class LinearRegressionAggregator() extends StagedAggregator {
       stateType.loadField(state.off, 0),
       stateType.loadField(state.off, 1),
       Region.loadInt(stateType.loadField(state.off, 2))))
-    pt.storeAtAddress(cb, addr, region, LinearRegressionAggregator.resultType.loadCheapPCode(cb, resAddr), deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, LinearRegressionAggregator.resultType.loadCheapSCode(cb, resAddr), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, PCodeEmitParamType}
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, SCodeEmitParamType}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.stypes.SCode
 import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable
@@ -40,7 +40,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
       val nextNDInput = seqOpMethod.getEmitParam(1, null) // no streams here
       nextNDInput.toI(cb).consume(cb, {}, { case nextNDArrayPCode: SNDArrayCode =>
         val nextNDPV = nextNDArrayPCode.memoize(cb, "ndarray_sum_seqop_next")
-        val statePV = state.storageType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_seq_op_state")
+        val statePV = state.storageType.loadCheapSCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_seq_op_state")
         statePV.loadField(cb, ndarrayFieldNumber).consume(cb,
           {
             cb += (state.region.getNewRegion(Region.TINY))
@@ -61,11 +61,11 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
     val combOpMethod = cb.emb.genEmitMethod[Unit]("ndarray_sum_aggregator_comb_op")
 
     combOpMethod.voidWithBuilder { cb =>
-      val rightPV = other.storageType.loadCheapPCode(cb, other.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_right")
+      val rightPV = other.storageType.loadCheapSCode(cb, other.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_right")
       rightPV.loadField(cb, ndarrayFieldNumber).consume(cb, {},
         { rightNDPC =>
           val rightNdValue = rightNDPC.asNDArray.memoize(cb, "right_ndarray_sum_agg")
-          val leftPV = state.storageType.loadCheapPCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_left")
+          val leftPV = state.storageType.loadCheapSCode(cb, state.off).asBaseStruct.memoize(cb, "ndarray_sum_comb_op_left")
           leftPV.loadField(cb, ndarrayFieldNumber).consume(cb,
             {
               state.storeNonmissing(cb, rightNdValue)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -37,11 +37,11 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
     cb.assign(tmpOff, src)
     cb.assign(size, Region.loadInt(currentSizeOffset(tmpOff)))
     cb.assign(capacity, Region.loadInt(capacityOffset(tmpOff)))
-    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapPCode(cb, Region.loadAddress(dataOffset(tmpOff))), deepCopy = true))
+    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapSCode(cb, Region.loadAddress(dataOffset(tmpOff))), deepCopy = true))
   }
 
   def reallocateData(cb: EmitCodeBuilder): Unit = {
-    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapPCode(cb, data), deepCopy = true))
+    cb.assign(data, eltArray.store(cb, region, eltArray.loadCheapSCode(cb, data), deepCopy = true))
   }
 
   def storeTo(cb: EmitCodeBuilder, dest: Code[Long]): Unit = {
@@ -58,7 +58,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
       cb += ob.writeInt(size)
       cb += ob.writeInt(capacity)
       codecSpec.encodedType.buildEncoder(eltArray.sType, kb)
-        .apply(cb, eltArray.loadCheapPCode(cb, data), ob)
+        .apply(cb, eltArray.loadCheapSCode(cb, data), ob)
       cb += ob.writeInt(const(StagedArrayBuilder.END_SERIALIZATION))
     }
   }
@@ -112,7 +112,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
 
   def loadElement(cb: EmitCodeBuilder, idx: Value[Int]): EmitCode = {
     val m = eltArray.isElementMissing(data, idx)
-    EmitCode(Code._empty, m, eltType.loadCheapPCode(cb, eltArray.loadElement(data, capacity, idx)))
+    EmitCode(Code._empty, m, eltType.loadCheapSCode(cb, eltArray.loadElement(data, capacity, idx)))
   }
 
   private def resize(cb: EmitCodeBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -142,7 +142,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
       cb.whileLoop(i < count(n),
         {
           f(cb, EmitCode(Code._empty, bufferType.isElementMissing(buffer(n), i),
-            elemType.loadCheapPCode(cb, bufferType.loadElement(buffer(n), capacity(n), i))))
+            elemType.loadCheapSCode(cb, bufferType.loadElement(buffer(n), capacity(n), i))))
           cb.assign(i, i + 1)
         })
     }
@@ -209,7 +209,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
       foreachNode(cb, n) { cb =>
         cb += ob.writeBoolean(true)
         cb.assign(b, buffer(n))
-        bufferEType.buildPrefixEncoder(cb, bufferType.loadCheapPCode(cb, b).memoize(cb, "sbll_serialize_v"), ob, count(n))
+        bufferEType.buildPrefixEncoder(cb, bufferType.loadCheapSCode(cb, b).memoize(cb, "sbll_serialize_v"), ob, count(n))
       }
       cb += ob.writeBoolean(false)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -199,7 +199,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
   private def keyIsMissing(offset: Code[Long]): Code[Boolean] = indexedKeyType.isFieldMissing(offset, 0)
 
-  private def loadKeyValue(cb: EmitCodeBuilder, offset: Code[Long]): SCode = keyType.loadCheapPCode(cb, indexedKeyType.loadField(offset, 0))
+  private def loadKeyValue(cb: EmitCodeBuilder, offset: Code[Long]): SCode = keyType.loadCheapSCode(cb, indexedKeyType.loadField(offset, 0))
 
   private def loadKey(cb: EmitCodeBuilder, offset: Value[Long]): EmitCode =
     EmitCode(Code._empty, keyIsMissing(offset), loadKeyValue(cb, offset))
@@ -210,8 +210,8 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     val j = mb.getCodeParam[Long](2)
 
     mb.emitWithBuilder(cb => compareIndexedKey(cb,
-      indexedKeyType.loadCheapPCode(cb, eltTuple.fieldOffset(i, 0)),
-      indexedKeyType.loadCheapPCode(cb, eltTuple.fieldOffset(j, 0))))
+      indexedKeyType.loadCheapSCode(cb, eltTuple.fieldOffset(i, 0)),
+      indexedKeyType.loadCheapSCode(cb, eltTuple.fieldOffset(j, 0))))
 
     mb.invokeCode(_, _)
   }
@@ -329,7 +329,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     indexedKeyType.storeAtAddress(cb,
       eltTuple.fieldOffset(staging, 0),
       region,
-      indexedKeyType.loadCheapPCode(cb, indexedKey),
+      indexedKeyType.loadCheapSCode(cb, indexedKey),
       deepCopy = false)
     value.toI(cb)
       .consume(cb,
@@ -343,12 +343,12 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   }
 
   private def swapStaging(cb: EmitCodeBuilder): Unit = {
-    eltTuple.storeAtAddress(cb, ab.elementOffset(0), region, eltTuple.loadCheapPCode(cb, staging), true)
+    eltTuple.storeAtAddress(cb, ab.elementOffset(0), region, eltTuple.loadCheapSCode(cb, staging), true)
     rebalanceDown(cb, 0)
   }
 
   private def enqueueStaging(cb: EmitCodeBuilder): Unit = {
-    ab.append(cb, eltTuple.loadCheapPCode(cb, staging))
+    ab.append(cb, eltTuple.loadCheapSCode(cb, staging))
     rebalanceUp(cb, ab.size - 1)
   }
 
@@ -383,8 +383,8 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
   // for tests
   def seqOp(cb: EmitCodeBuilder, vm: Code[Boolean], v: Code[_], km: Code[Boolean], k: Code[_]): Unit = {
-    val vec = EmitCode(Code._empty, vm, if (valueType.isPrimitive) primitive(valueType.virtualType, v) else valueType.loadCheapPCode(cb, coerce[Long](v)))
-    val kec = EmitCode(Code._empty, km, if (keyType.isPrimitive) primitive(keyType.virtualType, k) else keyType.loadCheapPCode(cb, coerce[Long](k)))
+    val vec = EmitCode(Code._empty, vm, if (valueType.isPrimitive) primitive(valueType.virtualType, v) else valueType.loadCheapSCode(cb, coerce[Long](v)))
+    val kec = EmitCode(Code._empty, km, if (keyType.isPrimitive) primitive(keyType.virtualType, k) else keyType.loadCheapSCode(cb, coerce[Long](k)))
     seqOp(cb, vec, kec)
   }
 
@@ -535,7 +535,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           }
       }.a
     }
-    resultType.loadCheapPCode(cb, cb.invokeCode[Long](mb, _r))
+    resultType.loadCheapSCode(cb, cb.invokeCode[Long](mb, _r))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -15,29 +15,29 @@ object CallFunctions extends RegistryFunctions {
   def registerAll() {
     registerWrappedScalaFunction1("Call", TString, TCall, (rt: Type, st: SType) => SCanonicalCall)(Call.getClass, "parse")
 
-    registerPCode1("callFromRepr", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
+    registerSCode1("callFromRepr", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
       case (er, cb, rt, repr) => SCanonicalCall.constructFromIntRepr(repr.asInt.intCode(cb))
     }
 
-    registerPCode1("Call", TBoolean, TCall, (rt: Type, _: SType) => SCanonicalCall) {
+    registerSCode1("Call", TBoolean, TCall, (rt: Type, _: SType) => SCanonicalCall) {
       case (er, cb, rt, phased) =>
         SCanonicalCall.constructFromIntRepr(Code.invokeScalaObject[Int](
           Call0.getClass, "apply", Array(classTag[Boolean].runtimeClass), Array(phased.asBoolean.boolCode(cb))))
     }
 
-    registerPCode2("Call", TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
+    registerSCode2("Call", TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, a1, phased) =>
         SCanonicalCall.constructFromIntRepr(Code.invokeScalaObject[Int](
           Call1.getClass, "apply", Array(classTag[Int].runtimeClass, classTag[Boolean].runtimeClass), Array(a1.asInt.intCode(cb), phased.asBoolean.boolCode(cb))))
     }
 
-    registerPCode3("Call", TInt32, TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType, _: SType) => SCanonicalCall) {
+    registerSCode3("Call", TInt32, TInt32, TBoolean, TCall, (rt: Type, _: SType, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, a1, a2, phased) =>
         SCanonicalCall.constructFromIntRepr(Code.invokeScalaObject[Int](
           Call2.getClass, "apply", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass, classTag[Boolean].runtimeClass), Array(a1.asInt.intCode(cb), a2.asInt.intCode(cb), phased.asBoolean.boolCode(cb))))
     }
 
-    registerPCode1("UnphasedDiploidGtIndexCall", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
+    registerSCode1("UnphasedDiploidGtIndexCall", TInt32, TCall, (rt: Type, _: SType) => SCanonicalCall) {
       case (er, cb, rt, x) =>
         SCanonicalCall.constructFromIntRepr(Code.invokeScalaObject[Int](
           Call2.getClass, "fromUnphasedDiploidGtIndex", Array(classTag[Int].runtimeClass), Array(x.asInt.intCode(cb))))
@@ -51,39 +51,39 @@ object CallFunctions extends RegistryFunctions {
     val qualities = Array("isPhased", "isHomRef", "isHet",
       "isHomVar", "isNonRef", "isHetNonRef", "isHetRef")
     for (q <- qualities) {
-      registerPCode1(q, TCall, TBoolean, (rt: Type, _: SType) => SBoolean) {
+      registerSCode1(q, TCall, TBoolean, (rt: Type, _: SType) => SBoolean) {
         case (er, cb, rt, call) =>
           primitive(Code.invokeScalaObject[Boolean](
             Call.getClass, q, Array(classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb))))
       }
     }
 
-    registerPCode1("ploidy", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
+    registerSCode1("ploidy", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
       case (er, cb, rt, call) =>
         primitive(Code.invokeScalaObject[Int](
           Call.getClass, "ploidy", Array(classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb))))
     }
 
-    registerPCode1("nNonRefAlleles", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
+    registerSCode1("nNonRefAlleles", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
       case (er, cb, rt, call) =>
         primitive(Code.invokeScalaObject[Int](
           Call.getClass, "nNonRefAlleles", Array(classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb))))
     }
 
-    registerPCode1("unphasedDiploidGtIndex", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
+    registerSCode1("unphasedDiploidGtIndex", TCall, TInt32, (rt: Type, _: SType) => SInt32) {
       case (er, cb, rt, call) =>
         primitive(Code.invokeScalaObject[Int](
           Call.getClass, "unphasedDiploidGtIndex", Array(classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb))))
     }
 
-    registerPCode2("index", TCall, TInt32, TInt32, (rt: Type, _: SType, _: SType) => SInt32) {
+    registerSCode2("index", TCall, TInt32, TInt32, (rt: Type, _: SType, _: SType) => SInt32) {
       case (er, cb, rt, call, idx) =>
         primitive(Code.invokeScalaObject[Int](
           Call.getClass, "alleleByIndex", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb), idx.asInt.intCode(cb))))
     }
 
 
-    registerPCode2("downcode", TCall, TInt32, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
+    registerSCode2("downcode", TCall, TInt32, TCall, (rt: Type, _: SType, _: SType) => SCanonicalCall) {
       case (er, cb, rt, call, downcodedAllele) =>
         SCanonicalCall.constructFromIntRepr(Code.invokeScalaObject[Int](
           Call.getClass, "downcode", Array(classTag[Int].runtimeClass, classTag[Int].runtimeClass), Array(call.asCall.loadCanonicalRepresentation(cb), downcodedAllele.asInt.intCode(cb))))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -334,7 +334,7 @@ abstract class RegistryFunctions {
       new SBaseStructPointerCode(SBaseStructPointer(pt.setRequired(false).asInstanceOf[PBaseStruct]), addr)
   }
 
-  def registerPCode(
+  def registerSCode(
     name: String,
     valueParameterTypes: Array[Type],
     returnType: Type,
@@ -422,7 +422,7 @@ abstract class RegistryFunctions {
     cls: Class[_],
     method: String
   ) {
-    registerPCode(name, valueParameterTypes, returnType, calculateReturnType) { case (r, cb, _, rt, args) =>
+    registerSCode(name, valueParameterTypes, returnType, calculateReturnType) { case (r, cb, _, rt, args) =>
       val cts = valueParameterTypes.map(PrimitiveTypeToIRIntermediateClassTag(_).runtimeClass)
       rt.fromCodes(FastIndexedSeq(
         Code.invokeScalaObject(cls, method, cts, args.map { a => SType.extractPrimCode(cb, a) })(PrimitiveTypeToIRIntermediateClassTag(returnType))
@@ -456,7 +456,7 @@ abstract class RegistryFunctions {
       case _ => scodeToJavaValue(cb, r, code)
     }
 
-    registerPCode(name, valueParameterTypes, returnType, calculateReturnType) { case (r, cb, _, rt, args) =>
+    registerSCode(name, valueParameterTypes, returnType, calculateReturnType) { case (r, cb, _, rt, args) =>
       val cts = valueParameterTypes.map(ct(_).runtimeClass)
       unwrapReturn(cb, r.region, rt,
         Code.invokeScalaObject(cls, method, cts, args.map { a => wrap(cb, r.region, a) })(ct(returnType)))
@@ -483,51 +483,51 @@ abstract class RegistryFunctions {
   def registerIR(name: String, valueParameterTypes: Array[Type], returnType: Type, inline: Boolean = false, typeParameters: Array[Type] = Array.empty)(f: (Seq[Type], Seq[IR]) => IR): Unit =
     IRFunctionRegistry.addIR(name, typeParameters, valueParameterTypes, returnType, inline, f)
 
-  def registerPCode1(name: String, mt1: Type, rt: Type, pt: (Type, SType) => SType)(impl: (EmitRegion, EmitCodeBuilder, SType, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1), rt, unwrappedApply(pt)) {
+  def registerSCode1(name: String, mt1: Type, rt: Type, pt: (Type, SType) => SType)(impl: (EmitRegion, EmitCodeBuilder, SType, SCode) => SCode): Unit =
+    registerSCode(name, Array(mt1), rt, unwrappedApply(pt)) {
       case (r, cb, _, rt, Array(a1)) => impl(r, cb, rt, a1)
     }
 
-  def registerPCode1t(name: String, typeParams: Array[Type], mt1: Type, rt: Type, pt: (Type, SType) => SType)(impl: (EmitRegion, EmitCodeBuilder, Seq[Type], SType, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1), rt, unwrappedApply(pt), typeParameters = typeParams) {
+  def registerSCode1t(name: String, typeParams: Array[Type], mt1: Type, rt: Type, pt: (Type, SType) => SType)(impl: (EmitRegion, EmitCodeBuilder, Seq[Type], SType, SCode) => SCode): Unit =
+    registerSCode(name, Array(mt1), rt, unwrappedApply(pt), typeParameters = typeParams) {
       case (r, cb, typeParams, rt, Array(a1)) => impl(r, cb, typeParams, rt, a1)
     }
 
-  def registerPCode2(name: String, mt1: Type, mt2: Type, rt: Type, pt: (Type, SType, SType) => SType)
+  def registerSCode2(name: String, mt1: Type, mt2: Type, rt: Type, pt: (Type, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, SType, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2), rt, unwrappedApply(pt)) {
+    registerSCode(name, Array(mt1, mt2), rt, unwrappedApply(pt)) {
       case (r, cb, _, rt, Array(a1, a2)) => impl(r, cb, rt, a1, a2)
     }
 
-  def registerPCode2t(name: String, typeParams: Array[Type], mt1: Type, mt2: Type, rt: Type, pt: (Type, SType, SType) => SType)
+  def registerSCode2t(name: String, typeParams: Array[Type], mt1: Type, mt2: Type, rt: Type, pt: (Type, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, Seq[Type], SType, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2), rt, unwrappedApply(pt), typeParameters = typeParams) {
+    registerSCode(name, Array(mt1, mt2), rt, unwrappedApply(pt), typeParameters = typeParams) {
       case (r, cb, typeParams, rt, Array(a1, a2)) => impl(r, cb, typeParams, rt, a1, a2)
     }
 
-  def registerPCode3(name: String, mt1: Type, mt2: Type, mt3: Type, rt: Type, pt: (Type, SType, SType, SType) => SType)
+  def registerSCode3(name: String, mt1: Type, mt2: Type, mt3: Type, rt: Type, pt: (Type, SType, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, SType, SCode, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2, mt3), rt, unwrappedApply(pt)) {
+    registerSCode(name, Array(mt1, mt2, mt3), rt, unwrappedApply(pt)) {
       case (r, cb, _, rt, Array(a1, a2, a3)) => impl(r, cb, rt, a1, a2, a3)
     }
 
-  def registerPCode4(name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type, pt: (Type, SType, SType, SType, SType) => SType)
+  def registerSCode4(name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type, pt: (Type, SType, SType, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, SType, SCode, SCode, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt)) {
+    registerSCode(name, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt)) {
       case (r, cb, _, rt, Array(a1, a2, a3, a4)) => impl(r, cb, rt, a1, a2, a3, a4)
     }
 
-  def registerPCode4t(name: String, typeParams: Array[Type], mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type,
+  def registerSCode4t(name: String, typeParams: Array[Type], mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type,
     pt: (Type, SType, SType, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, Seq[Type], SType, SCode, SCode, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt), typeParams) {
+    registerSCode(name, Array(mt1, mt2, mt3, mt4), rt, unwrappedApply(pt), typeParams) {
       case (r, cb, typeParams, rt, Array(a1, a2, a3, a4)) => impl(r, cb, typeParams, rt, a1, a2, a3, a4)
     }
 
 
-  def registerPCode5(name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, rt: Type, pt: (Type, SType, SType, SType, SType, SType) => SType)
+  def registerSCode5(name: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, rt: Type, pt: (Type, SType, SType, SType, SType, SType) => SType)
     (impl: (EmitRegion, EmitCodeBuilder, SType, SCode, SCode, SCode, SCode, SCode) => SCode): Unit =
-    registerPCode(name, Array(mt1, mt2, mt3, mt4, mt5), rt, unwrappedApply(pt)) {
+    registerSCode(name, Array(mt1, mt2, mt3, mt4, mt5), rt, unwrappedApply(pt)) {
       case (r, cb, _, rt, Array(a1, a2, a3, a4, a5)) => impl(r, cb, rt, a1, a2, a3, a4, a5)
     }
 
@@ -690,11 +690,11 @@ abstract class UnseededMissingnessObliviousJVMFunction (
     val unified = unify(typeParameters, args.map(_.virtualType), rpt.virtualType)
     assert(unified)
     val methodbuilder = cb.genEmitMethod(name, FastIndexedSeq[ParamType](typeInfo[Region]) ++ args.map(_.paramType), rpt.paramType)
-    methodbuilder.emitPCode(cb => apply(EmitRegion.default(methodbuilder),
+    methodbuilder.emitSCode(cb => apply(EmitRegion.default(methodbuilder),
       cb,
       rpt,
       typeParameters,
-      (0 until args.length).map(i => methodbuilder.getPCodeParam(i + 2)): _*))
+      (0 until args.length).map(i => methodbuilder.getSCodeParam(i + 2)): _*))
     methodbuilder
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -12,7 +12,7 @@ import is.hail.types.virtual.{TArray, TFloat64, TInt32, Type}
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerPCode1("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: SType) => SInt32)
+    registerSCode1("gqFromPL", TArray(tv("N", "int32")), TInt32, (_: Type, _: SType) => SInt32)
     { case (r, cb, rt, _pl: SIndexableCode) =>
       val code = EmitCodeBuilder.scopedCode(r.mb) { cb =>
         val pl = _pl.memoize(cb, "plv")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -53,13 +53,13 @@ object IntervalFunctions extends RegistryFunctions {
         }
     }
 
-    registerPCode1("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
+    registerSCode1("includesStart", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
       case (r, cb, rt, interval: SIntervalCode) => primitive(interval.includesStart())
     }
 
-    registerPCode1("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
+    registerSCode1("includesEnd", TInterval(tv("T")), TBoolean, (_: Type, x: SType) =>
       SBoolean
     ) {
       case (r, cb, rt, interval: SIntervalCode) => primitive(interval.includesEnd())
@@ -87,7 +87,7 @@ object IntervalFunctions extends RegistryFunctions {
         }
     }
 
-    registerPCode1("isEmpty", TInterval(tv("T")), TBoolean, (_: Type, pt: SType) => SBoolean) {
+    registerSCode1("isEmpty", TInterval(tv("T")), TBoolean, (_: Type, pt: SType) => SBoolean) {
       case (r, cb, rt, interval: SIntervalCode) =>
         val empty = EmitCodeBuilder.scopedCode(r.mb) { cb =>
           val intv = interval.memoize(cb, "interval")
@@ -96,7 +96,7 @@ object IntervalFunctions extends RegistryFunctions {
         primitive(empty)
     }
 
-    registerPCode2("overlaps", TInterval(tv("T")), TInterval(tv("T")), TBoolean, (_: Type, i1t: SType, i2t: SType) => SBoolean) {
+    registerSCode2("overlaps", TInterval(tv("T")), TInterval(tv("T")), TBoolean, (_: Type, i1t: SType, i2t: SType) => SBoolean) {
       case (r, cb, rt, int1: SIntervalCode, int2: SIntervalCode) =>
         val overlap = EmitCodeBuilder.scopedCode(r.mb) { cb =>
           val interval1 = int1.memoize(cb, "interval1")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -94,13 +94,13 @@ object LocusFunctions extends RegistryFunctions {
   def registerAll() {
     val locusClass = Locus.getClass
 
-    registerPCode1("contig", tlocus("T"), TString,
+    registerSCode1("contig", tlocus("T"), TString,
       (_: Type, x: SType) => x.asInstanceOf[SLocus].contigType) {
       case (r, cb, rt, locus: SLocusCode) =>
         locus.contig(cb)
     }
 
-    registerPCode1("position", tlocus("T"), TInt32, (_: Type, x: SType) => SInt32) {
+    registerSCode1("position", tlocus("T"), TInt32, (_: Type, x: SType) => SInt32) {
       case (r, cb, rt, pc: SLocusCode) =>
         val locus = pc.memoize(cb, "locus_position_locus")
         primitive(locus.position(cb))
@@ -115,7 +115,7 @@ object LocusFunctions extends RegistryFunctions {
     registerLocusCode("inXNonPar") { locus => inX(locus) && !inPar(locus) }
     registerLocusCode("inYNonPar") { locus => inY(locus) && !inPar(locus) }
 
-    registerPCode2("min_rep", tlocus("T"), TArray(TString), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString)), {
+    registerSCode2("min_rep", tlocus("T"), TArray(TString), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString)), {
       (returnType: Type, _: SType, _: SType) => {
         val locusPT = PCanonicalLocus(returnType.asInstanceOf[TStruct].field("locus").typ.asInstanceOf[TLocus].rg, true)
         PCanonicalStruct("locus" -> locusPT, "alleles" -> PCanonicalArray(PCanonicalString(true), true)).sType
@@ -130,7 +130,7 @@ object LocusFunctions extends RegistryFunctions {
         emitVariant(cb, r.region, variantTuple, rt)
     }
 
-    registerPCode2("locus_windows_per_contig", TArray(TArray(TFloat64)), TFloat64, TTuple(TArray(TInt32), TArray(TInt32)), {
+    registerSCode2("locus_windows_per_contig", TArray(TArray(TFloat64)), TFloat64, TTuple(TArray(TInt32), TArray(TInt32)), {
       (_: Type, _: SType, _: SType) =>
         PCanonicalTuple(false, PCanonicalArray(PInt32(true), true), PCanonicalArray(PInt32(true), true)).sType
     }) {
@@ -230,7 +230,7 @@ object LocusFunctions extends RegistryFunctions {
           ), deepCopy = false)
     }
 
-    registerPCode1("Locus", TString, tlocus("T"), {
+    registerSCode1("Locus", TString, tlocus("T"), {
       (returnType: Type, _: SType) => PCanonicalLocus(returnType.asInstanceOf[TLocus].rg).sType
     }) {
       case (r, cb, SCanonicalLocusPointer(rt: PCanonicalLocus), str: SStringCode) =>
@@ -241,7 +241,7 @@ object LocusFunctions extends RegistryFunctions {
           rt)
     }
 
-    registerPCode2("Locus", TString, TInt32, tlocus("T"), {
+    registerSCode2("Locus", TString, TInt32, tlocus("T"), {
       (returnType: Type, _: SType, _: SType) => PCanonicalLocus(returnType.asInstanceOf[TLocus].rg).sType
     }) {
       case (r, cb, SCanonicalLocusPointer(rt: PCanonicalLocus), contig, pos) =>
@@ -251,7 +251,7 @@ object LocusFunctions extends RegistryFunctions {
         rt.constructFromPositionAndString(cb, r.region, contigMemo.asString.loadString(), posMemo.asInt.intCode(cb))
     }
 
-    registerPCode1("LocusAlleles", TString, tvariant("T"), {
+    registerSCode1("LocusAlleles", TString, tvariant("T"), {
       (returnType: Type, _: SType) => {
         val lTyp = returnType.asInstanceOf[TStruct].field("locus").typ.asInstanceOf[TLocus]
         PCanonicalStruct("locus" -> PCanonicalLocus(lTyp.rg, true), "alleles" -> PCanonicalArray(PCanonicalString(true), true)).sType
@@ -348,7 +348,7 @@ object LocusFunctions extends RegistryFunctions {
         }
     }
 
-    registerPCode1("globalPosToLocus", TInt64, tlocus("T"), {
+    registerSCode1("globalPosToLocus", TInt64, tlocus("T"), {
       (returnType: Type, _: SType) =>
         PCanonicalLocus(returnType.asInstanceOf[TLocus].rg).sType
     }) {
@@ -358,7 +358,7 @@ object LocusFunctions extends RegistryFunctions {
         rt.constructFromPositionAndString(cb, r.region, locus.invoke[String]("contig"), locus.invoke[Int]("position"))
     }
 
-    registerPCode1("locusToGlobalPos", tlocus("T"), TInt64, (_: Type, _: SType) => SInt64) {
+    registerSCode1("locusToGlobalPos", tlocus("T"), TInt64, (_: Type, _: SType) => SInt64) {
       case (r, cb, rt, locus: SLocusCode) =>
         val locusObject = locus.memoize(cb, "locus_to_global_pos")
           .getLocusObj(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -169,7 +169,7 @@ object MathFunctions extends RegistryFunctions {
 
     registerWrappedScalaFunction1("entropy", TString, TFloat64, null)(thisClass, "irentropy")
 
-    registerPCode4("fisher_exact_test", TInt32, TInt32, TInt32, TInt32, fetStruct.virtualType,
+    registerSCode4("fisher_exact_test", TInt32, TInt32, TInt32, TInt32, fetStruct.virtualType,
       (_, _, _, _, _) => fetStruct.sType
     ) { case (r, cb, rt, a: SInt32Code, b: SInt32Code, c: SInt32Code, d: SInt32Code) =>
       val res = cb.newLocal[Array[Double]]("fisher_exact_test_res",
@@ -187,7 +187,7 @@ object MathFunctions extends RegistryFunctions {
       ), deepCopy = false)
     }
 
-    registerPCode4("chi_squared_test", TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
+    registerSCode4("chi_squared_test", TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
       (_, _, _, _, _) => chisqStruct.sType
     ) { case (r, cb, rt, a: SInt32Code, b: SInt32Code, c: SInt32Code, d: SInt32Code) =>
       val res = cb.newLocal[Array[Double]]("chi_squared_test_res",
@@ -203,7 +203,7 @@ object MathFunctions extends RegistryFunctions {
       ), deepCopy = false)
     }
 
-    registerPCode5("contingency_table_test", TInt32, TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
+    registerSCode5("contingency_table_test", TInt32, TInt32, TInt32, TInt32, TInt32, chisqStruct.virtualType,
       (_, _, _, _, _, _) => chisqStruct.sType
     ) { case (r, cb, rt, a: SInt32Code, b: SInt32Code, c: SInt32Code, d: SInt32Code, mcc: SInt32Code) =>
       val res = cb.newLocal[Array[Double]]("contingency_table_test_res",
@@ -220,7 +220,7 @@ object MathFunctions extends RegistryFunctions {
       ), deepCopy = false)
     }
 
-    registerPCode3("hardy_weinberg_test", TInt32, TInt32, TInt32, hweStruct.virtualType,
+    registerSCode3("hardy_weinberg_test", TInt32, TInt32, TInt32, hweStruct.virtualType,
       (_, _, _, _) => hweStruct.sType
     ) { case (r, cb, rt, nHomRef: SInt32Code, nHet: SInt32Code, nHomVar: SInt32Code) =>
       val res = cb.newLocal[Array[Double]]("hardy_weinberg_test_res",

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -99,7 +99,7 @@ object NDArrayFunctions extends RegistryFunctions {
         }
     }
 
-    registerPCode2("linear_solve", TNDArray(TFloat64, Nat(2)), TNDArray(TFloat64, Nat(2)), TNDArray(TFloat64, Nat(2)),
+    registerSCode2("linear_solve", TNDArray(TFloat64, Nat(2)), TNDArray(TFloat64, Nat(2)), TNDArray(TFloat64, Nat(2)),
       { (t, p1, p2) => PCanonicalNDArray(PFloat64Required, 2, true).sType }) {
       case (er, cb, SNDArrayPointer(pt), apc, bpc) =>
         val (resPCode, info) = linear_solve(apc.asNDArray, bpc.asNDArray, pt, cb, er.region)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -15,19 +15,19 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
   def rgCode(mb: EmitMethodBuilder[_], rg: ReferenceGenome): Code[ReferenceGenome] = mb.getReferenceGenome(rg)
 
   def registerAll() {
-    registerPCode1t("isValidContig", Array(LocusFunctions.tlocus("R")), TString, TBoolean, (_: Type, _: SType) => SBoolean) {
+    registerSCode1t("isValidContig", Array(LocusFunctions.tlocus("R")), TString, TBoolean, (_: Type, _: SType) => SBoolean) {
       case (r, cb, Seq(tlocus: TLocus), _, contig) =>
         val scontig = contig.asString.loadString()
         primitive(rgCode(r.mb, tlocus.asInstanceOf[TLocus].rg).invoke[String, Boolean]("isValidContig", scontig))
     }
 
-    registerPCode2t("isValidLocus", Array(LocusFunctions.tlocus("R")), TString, TInt32, TBoolean, (_: Type, _: SType, _: SType) => SBoolean) {
+    registerSCode2t("isValidLocus", Array(LocusFunctions.tlocus("R")), TString, TInt32, TBoolean, (_: Type, _: SType, _: SType) => SBoolean) {
       case (r, cb, Seq(tlocus: TLocus), _, contig, pos) =>
         val scontig = contig.asString.loadString()
         primitive(rgCode(r.mb, tlocus.rg).invoke[String, Int, Boolean]("isValidLocus", scontig, pos.asInt.intCode(cb)))
     }
 
-    registerPCode4t("getReferenceSequenceFromValidLocus",
+    registerSCode4t("getReferenceSequenceFromValidLocus",
       Array(LocusFunctions.tlocus("R")),
       TString, TInt32, TInt32, TInt32, TString,
       (_: Type, _: SType, _: SType, _: SType, _: SType) => SStringPointer(PCanonicalString())) {
@@ -41,7 +41,7 @@ object ReferenceGenomeFunctions extends RegistryFunctions {
             after.asInt.intCode(cb)))
     }
 
-    registerPCode1t("contigLength", Array(LocusFunctions.tlocus("R")), TString, TInt32, (_: Type, _: SType) => SInt32) {
+    registerSCode1t("contigLength", Array(LocusFunctions.tlocus("R")), TString, TInt32, (_: Type, _: SType) => SInt32) {
       case (r, cb, Seq(tlocus: TLocus), _, contig) =>
         val scontig = contig.asString.loadString()
         primitive(rgCode(r.mb, tlocus.rg).invoke[String, Int]("contigLength", scontig))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -100,11 +100,11 @@ object StringFunctions extends RegistryFunctions {
   def registerAll(): Unit = {
     val thisClass = getClass
 
-    registerPCode1("length", TString, TInt32, (_: Type, _: SType) => SInt32) { case (r: EmitRegion, cb, _, s: SStringCode) =>
+    registerSCode1("length", TString, TInt32, (_: Type, _: SType) => SInt32) { case (r: EmitRegion, cb, _, s: SStringCode) =>
       primitive(s.loadString().invoke[Int]("length"))
     }
 
-    registerPCode3("substring", TString, TInt32, TInt32, TString, {
+    registerSCode3("substring", TString, TInt32, TInt32, TString, {
       (_: Type, _: SType, _: SType, _: SType) => SStringPointer(PCanonicalString())
     }) {
       case (r: EmitRegion, cb, st: SString, s, start, end) =>
@@ -141,7 +141,7 @@ object StringFunctions extends RegistryFunctions {
     registerIR2("sliceRight", TString, TInt32, TString) { (_, s, start) => invoke("slice", TString, s, start, invoke("length", TInt32, s)) }
     registerIR2("sliceLeft", TString, TInt32, TString) { (_, s, end) => invoke("slice", TString, s, I32(0), end) }
 
-    registerPCode1("str", tv("T"), TString, (_: Type, _: SType) => SStringPointer(PCanonicalString())) { case (r, cb, st: SString, a) =>
+    registerSCode1("str", tv("T"), TString, (_: Type, _: SType) => SStringPointer(PCanonicalString())) { case (r, cb, st: SString, a) =>
       val annotation = scodeToJavaValue(cb, r.region, a)
       val str = cb.emb.getType(a.st.virtualType).invoke[Any, String]("str", annotation)
       st.constructFromString(cb, r.region, str)
@@ -292,7 +292,7 @@ object StringFunctions extends RegistryFunctions {
       case (_: Type, _: SType, _: SType, _: SType) => SInt64
     })(thisClass, "strptime")
 
-    registerPCode("parse_json", Array(TString), TTuple(tv("T")),
+    registerSCode("parse_json", Array(TString), TTuple(tv("T")),
       (rType: Type, _: Seq[SType]) => SType.canonical(rType), typeParameters = Array(tv("T"))
     ) { case (er, cb, _, resultType, Array(s: SStringCode)) =>
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -167,7 +167,7 @@ object UtilFunctions extends RegistryFunctions {
   def registerAll() {
     val thisClass = getClass
 
-    registerPCode4("valuesSimilar", tv("T"), tv("U"), TFloat64, TBoolean, TBoolean, {
+    registerSCode4("valuesSimilar", tv("T"), tv("U"), TFloat64, TBoolean, TBoolean, {
       case (_: Type, _: SType, _: SType, _: SType, _: SType) => SBoolean
     }) {
       case (er, cb, rt, l, r, tol, abs) =>
@@ -182,10 +182,10 @@ object UtilFunctions extends RegistryFunctions {
       (n * (n + 1)) / 2
     }
 
-    registerPCode1("toInt32", TBoolean, TInt32, (_: Type, _: SType) => SInt32) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI) }
-    registerPCode1("toInt64", TBoolean, TInt64, (_: Type, _: SType) => SInt64) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toL) }
-    registerPCode1("toFloat32", TBoolean, TFloat32, (_: Type, _: SType) => SFloat32) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toF) }
-    registerPCode1("toFloat64", TBoolean, TFloat64, (_: Type, _: SType) => SFloat64) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toD) }
+    registerSCode1("toInt32", TBoolean, TInt32, (_: Type, _: SType) => SInt32) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI) }
+    registerSCode1("toInt64", TBoolean, TInt64, (_: Type, _: SType) => SInt64) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toL) }
+    registerSCode1("toFloat32", TBoolean, TFloat32, (_: Type, _: SType) => SFloat32) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toF) }
+    registerSCode1("toFloat64", TBoolean, TFloat64, (_: Type, _: SType) => SFloat64) { case (_, cb, _, x) => primitive(x.asBoolean.boolCode(cb).toI.toD) }
 
     for ((name, t, rpt, ct) <- Seq[(String, Type, SType, ClassTag[_])](
       ("Boolean", TBoolean, SBoolean, implicitly[ClassTag[Boolean]]),
@@ -195,7 +195,7 @@ object UtilFunctions extends RegistryFunctions {
       ("Float32", TFloat32, SFloat32, implicitly[ClassTag[Float]])
     )) {
       val ctString: ClassTag[String] = implicitly[ClassTag[String]]
-      registerPCode1(s"to$name", TString, t, (_: Type, _: SType) => rpt) {
+      registerSCode1(s"to$name", TString, t, (_: Type, _: SType) => rpt) {
         case (r, cb, rt, x: SStringCode) =>
           val s = x.loadString()
           primitive(rt.virtualType, Code.invokeScalaObject1(thisClass, s"parse$name", s)(ctString, ct))
@@ -293,7 +293,7 @@ object UtilFunctions extends RegistryFunctions {
       }
     }
 
-    registerPCode2("format", TString, tv("T", "tuple"), TString, (_: Type, _: SType, _: SType) => PCanonicalString().sType) {
+    registerSCode2("format", TString, tv("T", "tuple"), TString, (_: Type, _: SType, _: SType) => PCanonicalString().sType) {
       case (r, cb, SStringPointer(rt: PCanonicalString), format, args) =>
         val javaObjArgs = Code.checkcast[Row](scodeToJavaValue(cb, r.region, args))
         val formatted = Code.invokeScalaObject2[String, Row, String](thisClass, "format", format.asString.loadString(), javaObjArgs)

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -77,7 +77,7 @@ abstract class CodeOrdering {
 
   def reversed: Boolean = false
 
-  final def checkedPCode[T](cb: EmitCodeBuilder, arg1: SCode, arg2: SCode, context: String,
+  final def checkedSCode[T](cb: EmitCodeBuilder, arg1: SCode, arg2: SCode, context: String,
     f: (EmitCodeBuilder, SCode, SCode) => Code[T])(implicit ti: TypeInfo[T]): Code[T] = {
     if (arg1.st != type1)
       throw new RuntimeException(s"CodeOrdering: $context: type mismatch (left)\n  generated: $type1\n  argument:  ${ arg1.st }")
@@ -89,8 +89,8 @@ abstract class CodeOrdering {
       FastIndexedSeq(arg1.st.paramType, arg2.st.paramType), ti) { mb =>
 
       mb.emitWithBuilder[T] { cb =>
-        val arg1 = mb.getPCodeParam(1)
-        val arg2 = mb.getPCodeParam(2)
+        val arg1 = mb.getSCodeParam(1)
+        val arg2 = mb.getSCodeParam(2)
         f(cb, arg1, arg2)
       }
     }
@@ -119,27 +119,27 @@ abstract class CodeOrdering {
 
 
   final def compareNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Int] = {
-    checkedPCode(cb, x, y, "compareNonnull", _compareNonnull)
+    checkedSCode(cb, x, y, "compareNonnull", _compareNonnull)
   }
 
   final def ltNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Boolean] = {
-    checkedPCode(cb, x, y, "ltNonnull", _ltNonnull)
+    checkedSCode(cb, x, y, "ltNonnull", _ltNonnull)
   }
 
   final def lteqNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Boolean] = {
-    checkedPCode(cb, x, y, "lteqNonnull", _lteqNonnull)
+    checkedSCode(cb, x, y, "lteqNonnull", _lteqNonnull)
   }
 
   final def gtNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Boolean] = {
-    checkedPCode(cb, x, y, "gtNonnull", _gtNonnull)
+    checkedSCode(cb, x, y, "gtNonnull", _gtNonnull)
   }
 
   final def gteqNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Boolean] = {
-    checkedPCode(cb, x, y, "gteqNonnull", _gteqNonnull)
+    checkedSCode(cb, x, y, "gteqNonnull", _gteqNonnull)
   }
 
   final def equivNonnull(cb: EmitCodeBuilder, x: SCode, y: SCode): Code[Boolean] = {
-    checkedPCode(cb, x, y, "equivNonnull", _equivNonnull)
+    checkedSCode(cb, x, y, "equivNonnull", _equivNonnull)
   }
 
   final def lt(cb: EmitCodeBuilder, x: EmitCode, y: EmitCode, missingEqual: Boolean): Code[Boolean] = {

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -189,9 +189,9 @@ package object ir {
 
   implicit def valueToCodeParam(v: Value[_]): CodeParam = CodeParam(v)
 
-  implicit def toPCodeParam(pc: SCode): PCodeParam = PCodeParam(pc)
+  implicit def sCodeToSCodeParam(sc: SCode): SCodeParam = SCodeParam(sc)
 
-  implicit def pValueToPCodeParam(pv: SValue): PCodeParam = PCodeParam(pv)
+  implicit def sValueToSCodeParam(sv: SValue): SCodeParam = SCodeParam(sv)
 
   implicit def toEmitParam(ec: EmitCode): EmitParam = EmitParam(ec)
 

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1870,7 +1870,7 @@ object EmitStream {
               cb.define(Lpush)
               cb.assign(xKey, EmitCode.present(cb.emb, curKey))
               cb.assign(xElts, EmitCode.present(cb.emb, curValsType.constructFromElements(cb, elementRegion, k, false) { (cb, i) =>
-                IEmitCode(cb, result(i).ceq(0L), eltType.loadCheapPCode(cb, result(i)))
+                IEmitCode(cb, result(i).ceq(0L), eltType.loadCheapSCode(cb, result(i)))
               }))
               cb.goto(LproduceElementDone)
 
@@ -1878,7 +1878,7 @@ object EmitStream {
               cb.forLoop(cb.assign(i, 0), i < k, cb.assign(i, i + 1), {
                 cb += (result(i) = 0L)
               })
-              cb.assign(curKey, eltType.loadCheapPCode(cb, heads(winner)).subset(key: _*)
+              cb.assign(curKey, eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                 .castTo(cb, elementRegion, curKey.st, true))
               cb.goto(LaddToResult)
 
@@ -1909,8 +1909,8 @@ object EmitStream {
 
                 cb.ifx(winner.ceq(k), cb.goto(LchallengerWins))
 
-                val left = eltType.loadCheapPCode(cb, heads(challenger)).subset(key: _*)
-                val right = eltType.loadCheapPCode(cb, heads(winner)).subset(key: _*)
+                val left = eltType.loadCheapSCode(cb, heads(challenger)).subset(key: _*)
+                val right = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                 val ord = StructOrdering.make(left.st, right.st, cb.emb.ecb, missingFieldsEqual = false)
                 cb.ifx(ord.lteqNonnull(cb, left, right),
                   cb.goto(LchallengerWins),
@@ -1938,7 +1938,7 @@ object EmitStream {
                     })
                 }, {
                   cb.ifx(!winner.cne(k), cb.goto(Lpush))
-                  val left = eltType.loadCheapPCode(cb, heads(winner)).subset(key: _*)
+                  val left = eltType.loadCheapSCode(cb, heads(winner)).subset(key: _*)
                   val right = curKey
                   val ord = StructOrdering.make(left.st, right.st.asInstanceOf[SBaseStruct],
                     cb.emb.ecb, missingFieldsEqual = false)
@@ -2058,8 +2058,8 @@ object EmitStream {
             * left when key fields are missing.
             */
           def comp(cb: EmitCodeBuilder, li: Code[Int], lv: Code[Long], ri: Code[Int], rv: Code[Long]): Code[Boolean] = {
-            val l = unifiedType.loadCheapPCode(cb, lv).asBaseStruct.subset(key: _*).memoize(cb, "stream_merge_l")
-            val r = unifiedType.loadCheapPCode(cb, rv).asBaseStruct.subset(key: _*).memoize(cb, "stream_merge_r")
+            val l = unifiedType.loadCheapSCode(cb, lv).asBaseStruct.subset(key: _*).memoize(cb, "stream_merge_l")
+            val r = unifiedType.loadCheapSCode(cb, rv).asBaseStruct.subset(key: _*).memoize(cb, "stream_merge_r")
             val ord1 = StructOrdering.make(l.asBaseStruct.st, r.asBaseStruct.st, cb.emb.ecb, missingFieldsEqual = false)
             val ord2 = StructOrdering.make(r.asBaseStruct.st, l.asBaseStruct.st, cb.emb.ecb, missingFieldsEqual = false)
             val b = cb.newLocal[Boolean]("stream_merge_comp_result")
@@ -2168,7 +2168,7 @@ object EmitStream {
               }
             }
 
-            override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, unifiedType.loadCheapPCode(cb, heads(winner))))
+            override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, unifiedType.loadCheapSCode(cb, heads(winner))))
 
             override def close(cb: EmitCodeBuilder): Unit = {
               producers.foreach { p =>

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -517,7 +517,7 @@ object CompileDecoder {
             val dataOffset = cb.newLocal[Int]("bgen_add_entries_offset", const(settings.nSamples + 10) + i * 2)
             val d0 = data(dataOffset) & 0xff
             val d1 = data(dataOffset + 1) & 0xff
-            val pc = entryType.loadCheapPCode(cb, memoTyp.loadElement(memoizedEntryData, settings.nSamples, (d0 << 8) | d1))
+            val pc = entryType.loadCheapSCode(cb, memoTyp.loadElement(memoizedEntryData, settings.nSamples, (d0 << 8) | d1))
             cb.goto(Lpresent)
             val iec = IEmitCode(Lmissing, Lpresent, pc, false)
             pushElement(cb, iec)

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -116,7 +116,7 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
   def create(cb: EmitCodeBuilder, dest: Code[Long]): Unit = {
     cb.assign(aoff, arrayType.allocate(region, maxSize))
     cb += arrayType.stagedInitialize(aoff, maxSize)
-    arrayType.storeAtAddress(cb, dest, region, arrayType.loadCheapPCode(cb, aoff), deepCopy = false)
+    arrayType.storeAtAddress(cb, dest, region, arrayType.loadCheapSCode(cb, aoff), deepCopy = false)
     cb.assign(len, 0)
   }
 
@@ -136,7 +136,7 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
     loadChild(cb, len)
     cb.assign(len, len + 1)
   }
-  def loadChild(cb: EmitCodeBuilder, idx: Code[Int]): Unit = elt.store(cb, eltType.loadCheapPCode(cb, arrayType.loadElement(aoff, idx)))
+  def loadChild(cb: EmitCodeBuilder, idx: Code[Int]): Unit = elt.store(cb, eltType.loadCheapSCode(cb, arrayType.loadElement(aoff, idx)))
   def getLoadedChild: SBaseStructValue = elt
 }
 
@@ -244,9 +244,9 @@ object StagedIndexWriter {
       .voidWithBuilder(cb => siw.init(cb, cb.emb.getCodeParam[String](1)))
     fb.emb.voidWithBuilder { cb =>
       siw.add(cb,
-        IEmitCode(cb, false, keyType.loadCheapPCode(cb, fb.getCodeParam[Long](1))),
+        IEmitCode(cb, false, keyType.loadCheapSCode(cb, fb.getCodeParam[Long](1))),
         fb.getCodeParam[Long](2),
-        IEmitCode(cb, false, annotationType.loadCheapPCode(cb, fb.getCodeParam[Long](3))))
+        IEmitCode(cb, false, annotationType.loadCheapSCode(cb, fb.getCodeParam[Long](3))))
     }
     cb.newEmitMethod("close", FastIndexedSeq[ParamType](), typeInfo[Unit])
       .voidWithBuilder(siw.close)

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -62,7 +62,7 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
   }
 
   def allocate(cb: EmitCodeBuilder): Unit = {
-    node.store(cb, pType.loadCheapPCode(cb, pType.allocate(region)))
+    node.store(cb, pType.loadCheapSCode(cb, pType.allocate(region)))
     ab.create(cb, pType.fieldOffset(node.a, "children"))
   }
 

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -49,14 +49,14 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
 
   def reset(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
     cb += region.invoke[Unit]("clear")
-    node.store(cb, pType.loadCheapPCode(cb, pType.allocate(region)))
+    node.store(cb, pType.loadCheapSCode(cb, pType.allocate(region)))
     idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(firstIdx))
     ab.create(cb, pType.fieldOffset(node.a, "keys"))
   }
 
   def create(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
     cb.assign(region, Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
-    node.store(cb, pType.loadCheapPCode(cb, pType.allocate(region)))
+    node.store(cb, pType.loadCheapSCode(cb, pType.allocate(region)))
     idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(firstIdx))
     ab.create(cb, pType.fieldOffset(node.a, "keys"))
   }
@@ -78,5 +78,5 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
 
   def loadChild(cb: EmitCodeBuilder, idx: Code[Int]): Unit = ab.loadChild(cb, idx)
   def getLoadedChild: SBaseStructValue = ab.getLoadedChild
-  def firstIdx(cb: EmitCodeBuilder): SCode = idxType.loadCheapPCode(cb, pType.fieldOffset(node.a, "first_idx"))
+  def firstIdx(cb: EmitCodeBuilder): SCode = idxType.loadCheapSCode(cb, pType.fieldOffset(node.a, "first_idx"))
 }

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -132,7 +132,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
     val pt = decodedPType(t)
     val addr = cb.newLocal[Long]("base_struct_dec_addr", region.allocate(pt.alignment, pt.byteSize))
     _buildInplaceDecoder(cb, pt, region, addr, in)
-    pt.loadCheapPCode(cb, addr)
+    pt.loadCheapSCode(cb, addr)
   }
 
   override def _buildInplaceDecoder(cb: EmitCodeBuilder, pt: PType, region: Value[Region], addr: Value[Long], in: Value[InputBuffer]): Unit = {

--- a/hail/src/main/scala/is/hail/types/encoded/EShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EShuffle.scala
@@ -32,7 +32,7 @@ class EShuffle(override val required: Boolean) extends EType {
     val barray = cb.newLocal[Long]("barray", bT.allocate(region, len))
     cb += bT.storeLength(barray, len)
     cb += in.readBytes(region, bT.bytesAddress(barray), len)
-    new SCanonicalShufflePointerCode(SCanonicalShufflePointer(shuffleType), bT.loadCheapPCode(cb, barray))
+    new SCanonicalShufflePointerCode(SCanonicalShufflePointer(shuffleType), bT.loadCheapSCode(cb, barray))
   }
 
   def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit = {

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -54,7 +54,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
       UnitInfo) { mb =>
 
       mb.voidWithBuilder { cb =>
-        val arg = mb.getPCodeParam(1)
+        val arg = mb.getSCodeParam(1)
           .memoize(cb, "encoder_method_arg")
         val out = mb.getCodeParam[OutputBuffer](2)
         _buildEncoder(cb, arg, out)
@@ -65,7 +65,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
   final def buildDecoder(t: Type, kb: EmitClassBuilder[_]): StagedDecoder = {
     val mb = buildDecoderMethod(t: Type, kb);
     { (cb: EmitCodeBuilder, r: Code[Region], ib: Code[InputBuffer]) =>
-      cb.invokePCode(mb, r, ib)
+      cb.invokeSCode(mb, r, ib)
     }
   }
 
@@ -76,7 +76,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
       FastIndexedSeq[ParamType](typeInfo[Region], classInfo[InputBuffer]),
       st.paramType) { mb =>
 
-      mb.emitPCode { cb =>
+      mb.emitSCode { cb =>
         val region: Value[Region] = mb.getCodeParam[Region](1)
         val in: Value[InputBuffer] = mb.getCodeParam[InputBuffer](2)
         val sc = _buildDecoder(cb, t, region, in)
@@ -204,7 +204,7 @@ object EType {
       mb.voidWithBuilder { cb =>
         val addr: Code[Long] = mb.getCodeParam[Long](1)
         val out: Code[OutputBuffer] = mb.getCodeParam[OutputBuffer](2)
-        val pc = pt.loadCheapPCode(cb, addr)
+        val pc = pt.loadCheapSCode(cb, addr)
         val f = et.buildEncoder(pc.st, mb.ecb)
         f(cb, pc, out)
       }

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -144,7 +144,7 @@ trait PArrayBackedContainer extends PContainer {
 
   def sType: SIndexablePointer = SIndexablePointer(setRequired(false).asInstanceOf[PArrayBackedContainer])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SIndexablePointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SIndexablePointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = arrayRep.store(cb, region, value.asIndexable.castToArray(cb), deepCopy)
 

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -33,7 +33,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
     cb += Region.storeBoolean(addr, value.asBoolean.boolCode(cb))
   }
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanCode = new SBooleanCode(Region.loadBoolean(addr))
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanCode = new SBooleanCode(Region.loadBoolean(addr))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeByte(addr, annotation.asInstanceOf[Boolean].toByte)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -323,7 +323,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       cb.ifx(isElementDefined(dstAddress, currentIdx),
         {
           cb.assign(currentElementAddress, elementOffset(dstAddress, len, currentIdx))
-          this.elementType.storeAtAddress(cb, currentElementAddress, region, this.elementType.loadCheapPCode(cb, this.elementType.loadFromNested(currentElementAddress)), true)
+          this.elementType.storeAtAddress(cb, currentElementAddress, region, this.elementType.loadCheapSCode(cb, this.elementType.loadFromNested(currentElementAddress)), true)
         }))
   }
 
@@ -379,7 +379,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def sType: SIndexablePointer = SIndexablePointer(setRequired(false).asInstanceOf[PCanonicalArray])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerCode = new SIndexablePointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerCode = new SIndexablePointerCode(sType, addr)
 
   def storeContentsAtAddress(cb: EmitCodeBuilder, addr: Value[Long], region: Value[Region], indexable: SIndexableValue, deepCopy: Boolean): Unit = {
     val length = indexable.loadLength()

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -105,7 +105,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
         cb.ifx(isFieldDefined(dstAddr, f.index),
           {
             val fieldAddr = cb.newLocal[Long]("pcbs_dpcopy_field", fieldOffset(dstAddr, f.index))
-            dstFieldType.storeAtAddress(cb, fieldAddr, region, dstFieldType.loadCheapPCode(cb, dstFieldType.loadFromNested(fieldAddr)), deepCopy = true)
+            dstFieldType.storeAtAddress(cb, fieldAddr, region, dstFieldType.loadCheapSCode(cb, dstFieldType.loadFromNested(fieldAddr)), deepCopy = true)
           })
       }
     }
@@ -156,7 +156,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
 
   def sType: SBaseStructPointer = SBaseStructPointer(setRequired(false).asInstanceOf[PCanonicalBaseStruct])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructPointerCode = new SBaseStructPointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructPointerCode = new SBaseStructPointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -131,7 +131,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 
   def sType: SBinaryPointer = SBinaryPointer(setRequired(false).asInstanceOf[PCanonicalBinary])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerCode = new SBinaryPointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerCode = new SBinaryPointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -40,7 +40,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
 
   def sType: SCall = SCanonicalCall
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalCallCode(Region.loadInt(addr))
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalCallCode(Region.loadInt(addr))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -70,19 +70,19 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   def sType: SIntervalPointer = SIntervalPointer(setRequired(false).asInstanceOf[PCanonicalInterval])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SIntervalPointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SIntervalPointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SIntervalPointer(t: PCanonicalInterval) =>
-        representation.store(cb, region, t.representation.loadCheapPCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)
+        representation.store(cb, region, t.representation.loadCheapSCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)
     }
   }
 
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SIntervalPointer(t: PCanonicalInterval) =>
-        representation.storeAtAddress(cb, addr, region, t.representation.loadCheapPCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)
+        representation.storeAtAddress(cb, addr, region, t.representation.loadCheapSCode(cb, value.asInstanceOf[SIntervalPointerCode].a), deepCopy)
     }
   }
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -93,19 +93,19 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def sType: SCanonicalLocusPointer = SCanonicalLocusPointer(setRequired(false).asInstanceOf[PCanonicalLocus])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalLocusPointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalLocusPointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {
       case SCanonicalLocusPointer(pt) =>
-        representation.store(cb, region, pt.representation.loadCheapPCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)
+        representation.store(cb, region, pt.representation.loadCheapSCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)
     }
   }
 
   def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
     value.st match {
       case SCanonicalLocusPointer(pt) =>
-        representation.storeAtAddress(cb, addr, region, pt.representation.loadCheapPCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)
+        representation.storeAtAddress(cb, addr, region, pt.representation.loadCheapSCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a), deepCopy)
     }
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalShuffle.scala
@@ -44,11 +44,11 @@ final case class PCanonicalShuffle(
   override def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long =
     this.representation.unstagedStoreJavaObject(annotation, region)
 
-  def loadBinary(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerCode = representation.loadCheapPCode(cb, addr).asInstanceOf[SBinaryPointerCode]
+  def loadBinary(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerCode = representation.loadCheapSCode(cb, addr).asInstanceOf[SBinaryPointerCode]
 
   def sType: SCanonicalShufflePointer = SCanonicalShufflePointer(setRequired(false).asInstanceOf[PCanonicalShuffle])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalShufflePointerCode(sType, representation.loadCheapPCode(cb, addr))
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SCanonicalShufflePointerCode(sType, representation.loadCheapSCode(cb, addr))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -60,7 +60,7 @@ class PCanonicalString(val required: Boolean) extends PString {
 
   def sType: SStringPointer = SStringPointer(setRequired(false).asInstanceOf[PCanonicalString])
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SStringPointerCode(sType, addr)
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SStringPointerCode(sType, addr)
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -43,7 +43,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeFloat(addr, value.asFloat.floatCode(cb)))
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SFloat32Code(Region.loadFloat(addr))
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SFloat32Code(Region.loadFloat(addr))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeFloat(addr, annotation.asInstanceOf[Float])

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -44,7 +44,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeDouble(addr, value.asDouble.doubleCode(cb)))
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SFloat64Code(Region.loadDouble(addr))
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SFloat64Code(Region.loadDouble(addr))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeDouble(addr, annotation.asInstanceOf[Double])

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -40,7 +40,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeInt(addr, value.asInt.intCode(cb)))
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SInt32Code(Region.loadInt(addr))
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SInt32Code(Region.loadInt(addr))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeInt(addr, annotation.asInstanceOf[Int])

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -41,7 +41,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
   def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
     cb.append(Region.storeLong(addr, value.asLong.longCode(cb)))
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SInt64Code(Region.loadLong(addr))
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = new SInt64Code(Region.loadLong(addr))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeLong(addr, annotation.asInstanceOf[Long])

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -54,5 +54,5 @@ trait PStruct extends PBaseStruct {
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PStruct
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructCode
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -123,7 +123,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
     throw new UnsupportedOperationException
   }
 
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructCode = throw new UnsupportedOperationException
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructCode = throw new UnsupportedOperationException
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {
     throw new UnsupportedOperationException

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -416,8 +416,8 @@ abstract class PType extends Serializable with Requiredness {
     _copyFromAddress(region, srcPType, srcAddress, deepCopy)
   }
 
-  // return a PCode that can cheaply operate on the region representation. Generally a pointer type, but not necessarily (e.g. primitives).
-  def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode
+  // return a SCode that can cheaply operate on the region representation. Generally a pointer type, but not necessarily (e.g. primitives).
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode
 
   // stores a stack value as a region value of this type
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long]

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -32,7 +32,7 @@ trait PUnrealizable extends PType {
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit =
     unsupported
 
-  override def loadCheapPCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = unsupported
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCode = unsupported
 
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): Code[Long] = unsupported
 

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -7,7 +7,7 @@ import is.hail.types.physical.stypes.{SCode, SValue}
 import scala.language.implicitConversions
 
 package object physical {
-  implicit def pvalueToPCode(pv: SValue): SCode = pv.get
+  implicit def sValueToSCode(sv: SValue): SCode = sv.get
 
   def typeToTypeInfo(t: PType): TypeInfo[_] = t match {
     case _: PInt32 => typeInfo[Int]

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -2,7 +2,7 @@ package is.hail.types.physical.stypes
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitSettable, PCodeEmitParamType, PCodeParamType}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitSettable, SCodeEmitParamType, SCodeParamType}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.PType
 import is.hail.types.physical.stypes.interfaces.SStream
@@ -52,7 +52,7 @@ trait SType {
 
   def canonicalPType(): PType
 
-  def paramType: PCodeParamType = PCodeParamType(this)
+  def paramType: SCodeParamType = SCodeParamType(this)
 
   def asIdent: String = canonicalPType().asIdent
 
@@ -73,7 +73,7 @@ trait SType {
 case class EmitType(st: SType, required: Boolean) {
   def virtualType: Type = st.virtualType
 
-  def paramType: PCodeEmitParamType = PCodeEmitParamType(this)
+  def paramType: SCodeEmitParamType = SCodeEmitParamType(this)
 
   def canonicalPType: PType = st.canonicalPType().setRequired(required)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -35,7 +35,7 @@ object SingleCodeType {
 sealed trait SingleCodeType {
   def ti: TypeInfo[_]
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode
 
   def virtualType: Type
 
@@ -49,7 +49,7 @@ case object Int32SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SInt32
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SInt32Code(coerce[Int](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SInt32Code(coerce[Int](c))
 
   def virtualType: Type = TInt32
 
@@ -61,7 +61,7 @@ case object Int64SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SInt64
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SInt64Code(coerce[Long](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SInt64Code(coerce[Long](c))
 
   def virtualType: Type = TInt64
 
@@ -73,7 +73,7 @@ case object Float32SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SFloat32
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SFloat32Code(coerce[Float](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SFloat32Code(coerce[Float](c))
 
   def virtualType: Type = TFloat32
 
@@ -85,7 +85,7 @@ case object Float64SingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SFloat64
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SFloat64Code(coerce[Double](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SFloat64Code(coerce[Double](c))
 
   def virtualType: Type = TFloat64
 
@@ -97,7 +97,7 @@ case object BooleanSingleCodeType extends SingleCodeType {
 
   override def loadedSType: SType = SBoolean
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SBooleanCode(coerce[Boolean](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = new SBooleanCode(coerce[Boolean](c))
 
   def virtualType: Type = TBoolean
 
@@ -113,7 +113,7 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
 
   def ti: TypeInfo[_] = classInfo[StreamArgType]
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = {
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = {
     val mb = cb.emb
     val xIter = mb.genFieldThisRef[Iterator[java.lang.Long]]("streamInIterator")
 
@@ -140,7 +140,7 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
         cb.goto(LproduceElementDone)
       }
 
-      override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapPCode(cb, rvAddr)))
+      override val element: EmitCode = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapSCode(cb, rvAddr)))
 
       override def close(cb: EmitCodeBuilder): Unit = {}
     }
@@ -155,7 +155,7 @@ case class PTypeReferenceSingleCodeType(pt: PType) extends SingleCodeType {
 
   override def loadedSType: SType = pt.sType
 
-  def loadToPCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = pt.loadCheapPCode(cb, coerce[Long](c))
+  def loadToSCode(cb: EmitCodeBuilder, r: Value[Region], c: Code[_]): SCode = pt.loadCheapSCode(cb, coerce[Long](c))
 
   def virtualType: Type = pt.virtualType
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -65,7 +65,7 @@ class SBaseStructPointerSettable(
   def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     IEmitCode(cb,
       pt.isFieldMissing(a, fieldIdx),
-      pt.fields(fieldIdx).typ.loadCheapPCode(cb, pt.loadField(a, fieldIdx)))
+      pt.fields(fieldIdx).typ.loadCheapSCode(cb, pt.loadField(a, fieldIdx)))
   }
 
   def store(cb: EmitCodeBuilder, pv: SCode): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -25,7 +25,7 @@ case class SBinaryPointer(pType: PBinary) extends SBinary {
     if (pt == this.pType)
       new SBinaryPointerCode(this, addr)
     else
-      coerceOrCopy(cb, region, pt.loadCheapPCode(cb, addr), deepCopy = false)
+      coerceOrCopy(cb, region, pt.loadCheapSCode(cb, addr), deepCopy = false)
   }
 
   def fromSettables(settables: IndexedSeq[Settable[_]]): SBinaryPointerSettable = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -77,7 +77,7 @@ class SCanonicalLocusPointerSettable(
   }
 
   def contig(cb: EmitCodeBuilder): SStringCode = {
-    pt.contigType.loadCheapPCode(cb, _contig).asString
+    pt.contigType.loadCheapSCode(cb, _contig).asString
   }
 
   def position(cb: EmitCodeBuilder): Code[Int] = _position
@@ -90,7 +90,7 @@ class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Lon
 
   def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = FastIndexedSeq(a)
 
-  def contig(cb: EmitCodeBuilder): SStringCode = pt.contigType.loadCheapPCode(cb, pt.contigAddr(a)).asString
+  def contig(cb: EmitCodeBuilder): SStringCode = pt.contigType.loadCheapSCode(cb, pt.contigAddr(a)).asString
 
   def position(cb: EmitCodeBuilder): Code[Int] = pt.position(a)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalShufflePointer.scala
@@ -21,7 +21,7 @@ case class SCanonicalShufflePointer(pType: PCanonicalShuffle) extends SShuffle {
   lazy val binarySType = SBinaryPointer(pType.representation)
 
   def coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
-    new SCanonicalShufflePointerCode(this, pType.representation.loadCheapPCode(cb, pType.store(cb, region, value, deepCopy)))
+    new SCanonicalShufflePointerCode(this, pType.representation.loadCheapSCode(cb, pType.store(cb, region, value, deepCopy)))
   }
 
   def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
@@ -46,7 +46,7 @@ object SCanonicalShufflePointerSettable {
       "PCanonicalShuffleSettableOff",
       pt.representation.allocate(region, Wire.ID_SIZE))
     cb.append(pt.representation.store(off, bytes))
-    pt.loadCheapPCode(cb, off).memoize(cb, "scanonicalshuffle_fromarraybytes").asInstanceOf[SCanonicalShufflePointerSettable]
+    pt.loadCheapSCode(cb, off).memoize(cb, "scanonicalshuffle_fromarraybytes").asInstanceOf[SCanonicalShufflePointerSettable]
   }
 }
 
@@ -66,7 +66,7 @@ class SCanonicalShufflePointerSettable(val st: SCanonicalShufflePointer, val shu
   def storeFromBytes(cb: EmitCodeBuilder, region: Value[Region], bytes: Value[Array[Byte]]): Unit = {
     val addr = cb.newLocal[Long]("bytesAddr", st.pType.representation.allocate(region, bytes.length()))
     cb += st.pType.representation.store(addr, bytes)
-    shuffle.store(cb, st.pType.representation.loadCheapPCode(cb, addr))
+    shuffle.store(cb, st.pType.representation.loadCheapSCode(cb, addr))
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -102,7 +102,7 @@ class SIndexablePointerSettable(
     val iv = cb.newLocal("pcindval_i", i)
     IEmitCode(cb,
       isElementMissing(iv),
-      pt.elementType.loadCheapPCode(cb, pt.loadElement(a, length, iv))) // FIXME loadElement should take elementsAddress
+      pt.elementType.loadCheapSCode(cb, pt.loadElement(a, length, iv))) // FIXME loadElement should take elementsAddress
   }
 
   def isElementMissing(i: Code[Int]): Code[Boolean] = pt.isElementMissing(a, i)
@@ -125,7 +125,7 @@ class SIndexablePointerSettable(
           cb.ifx(isElementMissing(idx),
             {}, // do nothing,
             {
-              val elt = et.loadCheapPCode(cb, et.loadFromNested(elementPtr))
+              val elt = et.loadCheapSCode(cb, et.loadFromNested(elementPtr))
               f(cb, idx, elt)
             })
           cb.assign(idx, idx + 1)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -71,14 +71,14 @@ class SIntervalPointerSettable(
   def loadStart(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.startDefined(a)),
-      pt.pointType.loadCheapPCode(cb, pt.loadStart(a)))
+      pt.pointType.loadCheapSCode(cb, pt.loadStart(a)))
 
   def startDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.startDefined(a)
 
   def loadEnd(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.endDefined(a)),
-      pt.pointType.loadCheapPCode(cb, pt.loadEnd(a)))
+      pt.pointType.loadCheapSCode(cb, pt.loadEnd(a)))
 
   def endDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.endDefined(a)
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -68,7 +68,7 @@ class SNDArrayPointerSettable(
 
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode = {
     assert(indices.size == pt.nDims)
-    pt.elementType.loadCheapPCode(cb, pt.loadElementFromDataAndStrides(cb, indices, dataFirstElement, strides))
+    pt.elementType.loadCheapSCode(cb, pt.loadElementFromDataAndStrides(cb, indices, dataFirstElement, strides))
   }
 
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a) ++ shape ++ strides ++ FastIndexedSeq(dataFirstElement)
@@ -134,5 +134,5 @@ class SNDArrayPointerCode(val st: SNDArrayPointer, val a: Code[Long]) extends SN
 
   override def memoizeField(cb: EmitCodeBuilder, name: String): SValue = memoize(cb, name, cb.fieldBuilder)
 
-  override def shape(cb: EmitCodeBuilder): SBaseStructCode = pt.shapeType.loadCheapPCode(cb, pt.representation.loadField(a, "shape"))
+  override def shape(cb: EmitCodeBuilder): SBaseStructCode = pt.shapeType.loadCheapSCode(cb, pt.representation.loadField(a, "shape"))
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -99,7 +99,7 @@ object SNDArray {
         val pt: PType = array.st.pType.elementType
 
         // FIXME: need to use `pos` of smallest index var
-        def get: SCode = pt.loadCheapPCode(cb, pt.loadFromNested(pos(0)))
+        def get: SCode = pt.loadCheapSCode(cb, pt.loadFromNested(pos(0)))
         def store(cb: EmitCodeBuilder, v: SCode): Unit = pt.storeAtAddress(cb, pos(0), region, v, deepCopy)
         def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(pos.last)
       }

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -436,7 +436,7 @@ class StagedConstructorSuite extends HailSuite {
           val fb = EmitFunctionBuilder[Region, Long, Long](ctx, "deep_copy")
           fb.emitWithBuilder[Long](cb => t.store(cb,
             fb.apply_method.getCodeParam[Region](1),
-            t.loadCheapPCode(cb, fb.apply_method.getCodeParam[Long](2)),
+            t.loadCheapSCode(cb, fb.apply_method.getCodeParam[Long](2)),
               deepCopy = true))
           val copyF = fb.resultWithIndex()(ctx.fs, 0, region)
           val newOff = copyF(region, src)
@@ -505,7 +505,7 @@ class StagedConstructorSuite extends HailSuite {
       val f1 = EmitFunctionBuilder[Long](ctx, "stagedCopy1")
       f1.emitWithBuilder { cb =>
         val region = f1.partitionRegion
-        t2.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapPCode(cb, v1))), deepCopy = false).a
+        t2.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapSCode(cb, v1))), deepCopy = false).a
       }
       val cp1 = f1.resultWithIndex()(ctx.fs, 0, r)()
       assert(SafeRow.read(t2, cp1) == Row(value))
@@ -513,7 +513,7 @@ class StagedConstructorSuite extends HailSuite {
       val f2 = EmitFunctionBuilder[Long](ctx, "stagedCopy2")
       f2.emitWithBuilder { cb =>
         val region = f2.partitionRegion
-        t1.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapPCode(cb, v1))), deepCopy = false).a
+        t1.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, t2.types(0).loadCheapSCode(cb, v1))), deepCopy = false).a
       }
       val cp2 = f2.resultWithIndex()(ctx.fs, 0, r)()
       assert(SafeRow.read(t1, cp2) == Row(value))

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -67,7 +67,7 @@ class ETypeSuite extends HailSuite {
     val ibArg = fb2.apply_method.getCodeParam[InputBuffer](2)
     val dec = eType.buildDecoderMethod(outPType.virtualType, fb2.apply_method.ecb)
     fb2.emitWithBuilder[Long] { cb =>
-      val decoded = cb.invokePCode(dec, regArg, ibArg)
+      val decoded = cb.invokeSCode(dec, regArg, ibArg)
       outPType.store(cb, regArg, decoded, deepCopy = false)
     }
 

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -32,10 +32,10 @@ object TestRegisterFunctions extends RegistryFunctions {
     registerJavaStaticFunction("compare", Array(TInt32, TInt32), TInt32, null)(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", Array(), TInt32, null)(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", Array(), TInt32, null)(ScalaTestCompanion.getClass, "testFunction")
-    registerPCode2("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x"), null) {
+    registerSCode2("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x"), null) {
       case (_, cb, rt, a, b) => primitive(a.asInt.intCode(cb) + b.asInt.intCode(cb))
     }
-    registerPCode1("testCodeUnification2", tv("x"), tv("x"), null) { case (_, cb, rt, a) => a }
+    registerSCode1("testCodeUnification2", tv("x"), tv("x"), null) { case (_, cb, rt, a) => a }
   }
 }
 

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -39,8 +39,8 @@ class OrderingSuite extends HailSuite {
     implicit val x = op.rtti
     val fb = EmitFunctionBuilder[Region, Long, Long, op.ReturnType](ctx, "lifted")
     fb.emitWithBuilder { cb =>
-      val cv1 = t.loadCheapPCode(cb, fb.getCodeParam[Long](2))
-      val cv2 = t.loadCheapPCode(cb, fb.getCodeParam[Long](3))
+      val cv1 = t.loadCheapSCode(cb, fb.getCodeParam[Long](2))
+      val cv2 = t.loadCheapSCode(cb, fb.getCodeParam[Long](3))
       fb.ecb.getOrderingFunction(cv1.st, cv2.st, op)
           .apply(cb, EmitCode.present(cb.emb, cv1), EmitCode.present(cb.emb, cv2))
     }
@@ -58,9 +58,9 @@ class OrderingSuite extends HailSuite {
       val fb = EmitFunctionBuilder[Region, Boolean, Long, Boolean, Long, op.ReturnType](ctx, "lifted")
       fb.emitWithBuilder { cb =>
         val m1 = fb.getCodeParam[Boolean](2)
-        val cv1 = t.loadCheapPCode(cb, fb.getCodeParam[Long](3))
+        val cv1 = t.loadCheapSCode(cb, fb.getCodeParam[Long](3))
         val m2 = fb.getCodeParam[Boolean](4)
-        val cv2 = t.loadCheapPCode(cb, fb.getCodeParam[Long](5))
+        val cv2 = t.loadCheapSCode(cb, fb.getCodeParam[Long](5))
         val ev1 = EmitCode(Code._empty, m1, cv1)
         val ev2 = EmitCode(Code._empty, m2, cv2)
         fb.ecb.getOrderingFunction(ev1.st, ev2.st, op)
@@ -460,8 +460,8 @@ class OrderingSuite extends HailSuite {
 
         val bs = new BinarySearch(fb.apply_method, pset.sType, EmitType(pset.elementType.sType, true), keyOnly = false)
         fb.emitWithBuilder(cb =>
-          bs.getClosestIndex(cb, pset.loadCheapPCode(cb, cset),
-            EmitCode.fromI(fb.apply_method)(cb => IEmitCode.present(cb, pt.loadCheapPCode(cb, pTuple.loadField(cetuple, 0))))))
+          bs.getClosestIndex(cb, pset.loadCheapSCode(cb, cset),
+            EmitCode.fromI(fb.apply_method)(cb => IEmitCode.present(cb, pt.loadCheapSCode(cb, pTuple.loadField(cetuple, 0))))))
 
         val asArray = SafeIndexedSeq(pArray, soff)
 
@@ -500,8 +500,8 @@ class OrderingSuite extends HailSuite {
 
         val m = ptuple.isFieldMissing(cktuple, 0)
         fb.emitWithBuilder(cb =>
-          bs.getClosestIndex(cb, pDict.loadCheapPCode(cb, cdict),
-            EmitCode.fromI(fb.apply_method)(cb => IEmitCode.present(cb, pDict.keyType.loadCheapPCode(cb, ptuple.loadField(cktuple, 0))))))
+          bs.getClosestIndex(cb, pDict.loadCheapSCode(cb, cdict),
+            EmitCode.fromI(fb.apply_method)(cb => IEmitCode.present(cb, pDict.keyType.loadCheapSCode(cb, ptuple.loadField(cktuple, 0))))))
 
         val asArray = SafeIndexedSeq(PCanonicalArray(pDict.elementType), soff)
 

--- a/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/StagedBlockLinkedListSuite.scala
@@ -47,7 +47,7 @@ class StagedBlockLinkedListSuite extends HailSuite {
         sbll.load(cb, ptr)
         sbll.push(cb, r, EmitCode(Code._empty,
           eltOff.get.ceq(0L),
-          elemPType.loadCheapPCode(cb, eltOff)))
+          elemPType.loadCheapSCode(cb, eltOff)))
         sbll.store(cb, ptr)
         Code._empty
       }

--- a/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
+++ b/hail/src/test/scala/is/hail/types/physical/PhysicalTestUtils.scala
@@ -54,7 +54,7 @@ abstract class PhysicalTestUtils extends HailSuite {
     val value = fb.getCodeParam[Long](2)
 
     try {
-      fb.emitWithBuilder(cb => destType.store(cb, codeRegion, sourceType.loadCheapPCode(cb, value), deepCopy = deepCopy))
+      fb.emitWithBuilder(cb => destType.store(cb, codeRegion, sourceType.loadCheapSCode(cb, value), deepCopy = deepCopy))
       compileSuccess = true
     } catch {
       case e: Throwable =>


### PR DESCRIPTION
There may be a few varables with the name `pc` or `pv` around, but with
this, PCode should be history (for now).