### PR TITLE
[query] tensor index expression code generator

### DIFF
--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -19,11 +19,11 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     val shapes = ndarray.shapes(cb)
     shapes.foreach(s => cb += out.writeLong(s))
 
-    SNDArray.forEachIndex(cb, shapes, "ndarray_encoder") { case (cb, idxVars) =>
-      val elt = ndarray.loadElement(idxVars, cb)
-      elementType.buildEncoder(elt.st, cb.emb.ecb)
-        .apply(cb, elt, out)
-    }
+    SNDArray.coiterate(cb, null, FastIndexedSeq((ndarray.get, "A")), {
+      case Seq(elt) =>
+        elementType.buildEncoder(elt.st, cb.emb.ecb)
+          .apply(cb, elt, out)
+    })
   }
 
   override def _buildDecoder(cb: EmitCodeBuilder, t: Type, region: Value[Region], in: Value[InputBuffer]): SCode = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -80,7 +80,7 @@ class SNDArrayPointerSettable(
     cb.assign(dataFirstElement, pt.dataFirstElementPointer(a))
   }
 
-  override def get: SCode = new SNDArrayPointerCode(st, a)
+  override def get: SNDArrayPointerCode = new SNDArrayPointerCode(st, a)
 
   override def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean] = {
     val shape = this.shapes(cb)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -92,7 +92,7 @@ object SNDArray {
         }
       }
       val strides = array.strides(cb)
-      val pos = Array.tabulate(array.st.nDims) { i => cb.newLocal[Long](s"$name$i") }
+      val pos = Array.tabulate(array.st.nDims + 1) { i => cb.newLocal[Long](s"$name$i") }
       val elt = new SSettable {
         def st: SType = array.st.elementType
         val pt: PType = array.st.pType.elementType
@@ -117,7 +117,7 @@ object SNDArray {
             if (info(n).indexToDim.contains(idx)) {
               val i = info(n).indexToDim(idx)
               // FIXME: assumes array's indices in ascending order
-              cb.assign(info(n).pos(i), if (i == info(n).array.st.nDims - 1) info(n).array.firstDataAddress(cb) else info(n).pos(i+1))
+              cb.assign(info(n).pos(i), info(n).pos(i+1))
             }
           }
         }
@@ -135,6 +135,9 @@ object SNDArray {
       }
     }
 
+    for (n <- arrays.indices) {
+      cb.assign(info(n).pos(info(n).array.st.nDims), info(n).array.firstDataAddress(cb))
+    }
     recurLoopBuilder(indexVars.length - 1)
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -72,7 +72,8 @@ object SNDArray {
       strides: IndexedSeq[Value[Long]],
       pos: IndexedSeq[Settable[Long]],
       elt: SSettable,
-      indexToDim: Map[Int, Int])
+      indexToDim: Map[Int, Int],
+      name: String)
 
     val info = arrays.map { case (_array, indices, name) =>
       for (idx <- indices) assert(idx < indexVars.length && idx >= 0)
@@ -99,11 +100,11 @@ object SNDArray {
 
         // FIXME: need to use `pos` of smallest index var
         def get: SCode = pt.loadCheapPCode(cb, pt.loadFromNested(pos(0)))
-        def store(cb: EmitCodeBuilder, v: SCode): Unit = pt.storeAtAddress(cb, pos.last, region, v, deepCopy)
+        def store(cb: EmitCodeBuilder, v: SCode): Unit = pt.storeAtAddress(cb, pos(0), region, v, deepCopy)
         def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(pos.last)
       }
       val indexToDim = Map(indices.indices.map(i => indices(i) -> i): _*)
-      ArrayInfo(array, strides, pos, elt, indexToDim)
+      ArrayInfo(array, strides, pos, elt, indexToDim, name)
     }
 
     def recurLoopBuilder(idx: Int): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -1,8 +1,11 @@
 package is.hail.types.physical.stypes.interfaces
 
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.physical.{PNDArray, PType}
+import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
+import is.hail.utils.{FastIndexedSeq, toRichIterable}
 
 object SNDArray {
   def numElements(shape: IndexedSeq[Value[Long]]): Code[Long] = {
@@ -41,6 +44,97 @@ object SNDArray {
     recurLoopBuilder(0, body)
   }
 
+  def coiterate(cb: EmitCodeBuilder, region: Value[Region], arrays: IndexedSeq[(SNDArrayCode, String)], body: IndexedSeq[SSettable] => Unit): Unit =
+    coiterate(cb, region, arrays, body, deepCopy=false)
+
+  def coiterate(cb: EmitCodeBuilder, region: Value[Region], arrays: IndexedSeq[(SNDArrayCode, String)], body: IndexedSeq[SSettable] => Unit, deepCopy: Boolean): Unit = {
+    if (arrays.isEmpty) return
+    val indexVars = Array.tabulate(arrays(0)._1.st.nDims)(i => s"i$i").toFastIndexedSeq
+    val indices = Array.range(0, arrays(0)._1.st.nDims).toFastIndexedSeq
+    coiterate(cb, region, indexVars, arrays.map { case (array, name) => (array, indices, name) }, body, deepCopy)
+  }
+
+  def coiterate(cb: EmitCodeBuilder, region: Value[Region], indexVars: IndexedSeq[String], arrays: IndexedSeq[(SNDArrayCode, IndexedSeq[Int], String)], body: IndexedSeq[SSettable] => Unit): Unit =
+    coiterate(cb, region, indexVars, arrays, body, deepCopy=false)
+
+  // Note: to iterate through an array in column major order, make sure the indices are in ascending order. E.g.
+  // coiterate(cb, region, IndexedSeq("i", "j"), IndexedSeq((A, IndexedSeq(0, 1), "A"), (B, IndexedSeq(0, 1), "B")), {
+  //   case Seq(a, b) => cb.assign(a, SCode.add(cb, a, b))
+  // })
+  // computes A += B.
+  def coiterate(cb: EmitCodeBuilder, region: Value[Region], indexVars: IndexedSeq[String], arrays: IndexedSeq[(SNDArrayCode, IndexedSeq[Int], String)], body: IndexedSeq[SSettable] => Unit, deepCopy: Boolean): Unit = {
+
+    val indexSizes = new Array[Settable[Int]](indexVars.length)
+    val indexCoords = Array.tabulate(indexVars.length) { i => cb.newLocal[Int](indexVars(i)) }
+
+    case class ArrayInfo(
+      array: SNDArrayValue,
+      strides: IndexedSeq[Value[Long]],
+      pos: IndexedSeq[Settable[Long]],
+      elt: SSettable,
+      indexToDim: Map[Int, Int])
+
+    val info = arrays.map { case (_array, indices, name) =>
+      for (idx <- indices) assert(idx < indexVars.length && idx >= 0)
+      for (i <- 0 until indices.length - 1) assert(indices(i) < indices(i+1))
+      assert(indices.length == _array.st.nDims)
+
+      val array = _array.memoize(cb, s"${name}_copy")
+      val shape = array.shapes(cb)
+      for (i <- indices.indices) {
+        val idx = indices(i)
+        if (indexSizes(idx) == null) {
+          indexSizes(idx) = cb.newLocal[Int](s"${indexVars(idx)}_max")
+          cb.assign(indexSizes(idx), shape(i).toI)
+        } else {
+          cb.ifx(indexSizes(idx).cne(shape(i).toI), s"${indexVars(idx)} indexes incompatible dimensions")
+        }
+      }
+      val strides = array.strides(cb)
+      val pos = Array.tabulate(array.st.nDims) { i => cb.newLocal[Long](s"$name$i") }
+      val elt = new SSettable {
+        def st: SType = array.st.elementType
+        val pt: PType = array.st.pType.elementType
+
+        def get: SCode = pt.loadCheapPCode(cb, pt.loadFromNested(pos.last))
+        def store(cb: EmitCodeBuilder, v: SCode): Unit = pt.storeAtAddress(cb, pos.last, region, v, deepCopy)
+        def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(pos.last)
+      }
+      val indexToDim = Map(indices.indices.map(i => indices(i) -> i): _*)
+      ArrayInfo(array, strides, pos, elt, indexToDim)
+    }
+
+    def recurLoopBuilder(idx: Int): Unit = {
+      if (idx < 0) {
+        body(info.map(_.elt))
+      } else {
+        val coord = indexCoords(idx)
+        def init(): Unit = {
+          cb.assign(coord, 0)
+          for (n <- arrays.indices) {
+            if (info(n).indexToDim.contains(idx)) {
+              val i = info(n).indexToDim(idx)
+              cb.assign(info(n).pos(i), if (i == 0) info(n).array.firstDataAddress(cb) else info(n).pos(i-1))
+            }
+          }
+        }
+        def increment(): Unit = {
+          cb.assign(coord, coord + 1)
+          for (n <- arrays.indices) {
+            if (info(n).indexToDim.contains(idx)) {
+              val i = info(n).indexToDim(idx)
+              cb.assign(info(n).pos(i), info(n).pos(i) + info(n).strides(i))
+            }
+          }
+        }
+
+        cb.forLoop(init(), coord < indexSizes(idx), increment(), recurLoopBuilder(idx - 1))
+      }
+    }
+
+    recurLoopBuilder(indexVars.length - 1)
+  }
+
   // Column major order
   def unstagedForEachIndex(shape: IndexedSeq[Long])
                           (f: IndexedSeq[Long] => Unit): Unit = {
@@ -72,6 +166,8 @@ object SNDArray {
 
 
 trait SNDArray extends SType {
+  def pType: PNDArray
+
   def nDims: Int
 
   def elementType: SType
@@ -79,6 +175,8 @@ trait SNDArray extends SType {
 
 trait SNDArrayValue extends SValue {
   def st: SNDArray
+
+  override def get: SNDArrayCode
 
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -103,7 +103,7 @@ object SNDArray {
         def store(cb: EmitCodeBuilder, v: SCode): Unit = pt.storeAtAddress(cb, pos(0), region, v, deepCopy)
         def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(pos.last)
       }
-      val indexToDim = Map(indices.indices.map(i => indices(i) -> i): _*)
+      val indexToDim = indices.zipWithIndex.toMap
       ArrayInfo(array, strides, pos, elt, indexToDim, name)
     }
 


### PR DESCRIPTION
Add a codegen method `SNDArray.coiterate`, with signature
```
def coiterate(cb: EmitCodeBuilder, region: Value[Region], indexVars: IndexedSeq[String], arrays: IndexedSeq[(SNDArrayCode, IndexedSeq[Int], String)], body: IndexedSeq[SSettable] => Unit, deepCopy: Boolean): Unit
```
For example, the index expression `A[i, j] += B[j]` would be written
```
coiterate(cb, region, Seq("i", "j"), Seq((A, Seq(0, 1), "A"), (B, Seq(1), "B")), {
  case Seq(a, b) => cb.assign(a, SCode.add(cb, a, b))
})
```
This generates a loop nest, with one loop per variable in `indexVars`. The inner loop is `indexVars(0)`, so that column major traversal is when index variables are increasing, as in `(A, Seq(0, 1), "A")`. Each index variable iterates over a dimension, with the size of the dimension inferred from its use. In the inner loop, each index variable `i0, i1, ...` has a value; `body` is run, with each of the `SSettable`s bound to an element of the corresponding input in `arrays`. For example, if the first element of `arrays` is `(A, IndexedSeq(1, 3), "A")`, then the `SSettable` will be the element of `A` at index `(i1, i3)`. However, it avoids computing the address of each element from the indices from scratch in the inner loop.

This was motivated by the need to generate operations on ndarrays in the local whitening aggregator. I replaced a few uses of `forEachIndex` with `coiterate`, which may give a performance boost since it avoids index math in the inner loop.