### PR TITLE
[batch] use correct quota for preemptible local ssd

### DIFF
--- a/batch/batch/driver/zone_monitor.py
+++ b/batch/batch/driver/zone_monitor.py
@@ -96,7 +96,7 @@ class ZoneMonitor:
 
             remaining = quota_remaining['PREEMPTIBLE_CPUS'] / worker_cores
             if worker_local_ssd_data_disk:
-                remaining = min(remaining, quota_remaining['LOCAL_SSD_TOTAL_GB'] / 375)
+                remaining = min(remaining, quota_remaining['PREEMPTIBLE_LOCAL_SSD_GB'] / 375)
             else:
                 remaining = min(remaining, quota_remaining['SSD_TOTAL_GB'] / worker_pd_ssd_data_disk_size_gb)
 


### PR DESCRIPTION
The LOCAL_SSD_TOTAL_GB has nothing to do with *preemptible* local ssds.