### PR TITLE
[batch] Don't create jobs while shutting down the worker

### DIFF
--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -428,6 +428,8 @@ async def schedule_job(app, record, instance):
             await instance.mark_healthy()
             if e.status == 403:
                 log.info(f'attempt already exists for job {id} on {instance}, aborting')
+            if e.status == 503:
+                log.info(f'job {id} cannot be scheduled because {instance} is shutting down, aborting')
             raise e
         except Exception:
             await instance.incr_failed_request_count()

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -23,7 +23,7 @@ class BackgroundTaskManager:
 
     def shutdown(self):
         for task in self.tasks:
-            if not task.done():
+            try:
                 task.cancel()
-        if self.tasks:
-            await asyncio.wait(self.tasks)
+            except Exception:
+                log.warning(f'encountered an exception while cancelling background task: {task}', exc_info=True)

--- a/hail/python/hailtop/aiotools/tasks.py
+++ b/hail/python/hailtop/aiotools/tasks.py
@@ -23,7 +23,7 @@ class BackgroundTaskManager:
 
     def shutdown(self):
         for task in self.tasks:
-            try:
+            if not task.done():
                 task.cancel()
-            except Exception:
-                log.warning(f'encountered an exception while cancelling background task: {task}', exc_info=True)
+        if self.tasks:
+            await asyncio.wait(self.tasks)


### PR DESCRIPTION
Konrad ran into a problem where we started shutting down the worker because it was idle, but in between checking if there were any jobs still running and shutting down the site, a create job request came in. MJS was sent to the driver, but MJC was never sent because the worker shut down. The driver thought the job failed to schedule because the deactivate request was sent in before create job could return. The end result was Konrad's job still ran, but the database was left with an attempt that has a start time but no end time.