### PR TITLE
[prometheus] make middleware function instead of per-route decorator

### DIFF
--- a/atgu/atgu/atgu.py
+++ b/atgu/atgu/atgu.py
@@ -19,7 +19,7 @@ from gear import (
     web_authenticated_developers_only,
     check_csrf_token,
     new_csrf_token,
-    monitor_endpoint,
+    monitor_endpoints_middleware,
 )
 
 
@@ -71,7 +71,6 @@ def resource_record_to_dict(record):
 @routes.get('')
 @routes.get('/')
 @routes.get('/resources')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @render_template('resources.html')
 async def get_resources(request, userdata):  # pylint: disable=unused-argument
@@ -89,7 +88,6 @@ ORDER BY time_created DESC;
 
 
 @routes.get('/resources/create')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @render_template('create_resource.html')
 async def get_create_resource(request, userdata):  # pylint: disable=unused-argument
@@ -99,7 +97,6 @@ async def get_create_resource(request, userdata):  # pylint: disable=unused-argu
 @routes.post('/resources/create')
 # this method has special content handling, can't call `request.post()`
 # @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only(redirect=False)
 async def post_create_resource(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -156,7 +153,6 @@ VALUES (%s, %s, %s, %s, %s, %s, %s);
 
 
 @routes.get('/resources/{id}')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @render_template('resource.html')
 async def get_resource(request, userdata):  # pylint: disable=unused-argument
@@ -175,7 +171,6 @@ WHERE id = %s;
 
 
 @routes.get('/resources/{id}/edit')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @render_template('edit_resource.html')
 async def get_edit_resource(request, userdata):  # pylint: disable=unused-argument
@@ -196,7 +191,6 @@ WHERE id = %s;
 @routes.post('/resources/{id}/edit')
 # this method has special content handling, can't call `request.post()`
 # @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only(redirect=False)
 async def post_edit_resource(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -274,7 +268,6 @@ WHERE id = %s
 
 @routes.post('/resources/{id}/delete')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only(redirect=False)
 async def post_delete_resource(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -312,7 +305,6 @@ WHERE id = %s;
 
 
 @routes.get('/resources/{resource_id}/attachments/{attachment_id}')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_attachment(request, userdata):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -370,7 +362,7 @@ async def on_cleanup(app):
 
 
 def run():
-    app = web.Application()
+    app = web.Application(middlewares=[monitor_endpoints_middleware])
 
     setup_aiohttp_session(app)
 

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -24,7 +24,7 @@ from gear import (
     transaction,
     Database,
     maybe_parse_bearer_header,
-    monitor_endpoint,
+    monitor_endpoints_middleware,
 )
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, set_message, render_template
 
@@ -80,13 +80,11 @@ async def get_healthcheck(request):  # pylint: disable=W0613
 
 @routes.get('')
 @routes.get('/')
-@monitor_endpoint
 async def get_index(request):  # pylint: disable=unused-argument
     return aiohttp.web.HTTPFound(deploy_config.external_url('auth', '/login'))
 
 
 @routes.get('/creating')
-@monitor_endpoint
 @web_maybe_authenticated_user
 async def creating_account(request, userdata):
     db = request.app['db']
@@ -125,7 +123,6 @@ async def creating_account(request, userdata):
 
 
 @routes.get('/creating/wait')
-@monitor_endpoint
 async def creating_account_wait(request):
     session = await aiohttp_session.get_session(request)
     if 'pending' not in session:
@@ -170,7 +167,6 @@ async def _wait_websocket(request, email):
 
 
 @routes.get('/signup')
-@monitor_endpoint
 async def signup(request):
     next_page = request.query.get('next', deploy_config.external_url('notebook', ''))
 
@@ -188,7 +184,6 @@ async def signup(request):
 
 
 @routes.get('/login')
-@monitor_endpoint
 async def login(request):
     next_page = request.query.get('next', deploy_config.external_url('notebook', ''))
 
@@ -207,7 +202,6 @@ async def login(request):
 
 
 @routes.get('/oauth2callback')
-@monitor_endpoint
 async def callback(request):
     session = await aiohttp_session.get_session(request)
     if 'state' not in session:
@@ -285,7 +279,6 @@ async def callback(request):
 
 
 @routes.get('/user')
-@monitor_endpoint
 @web_authenticated_users_only()
 async def user_page(request, userdata):
     return await render_template('auth', request, userdata, 'user.html', {})
@@ -302,7 +295,6 @@ async def create_copy_paste_token(db, session_id, max_age_secs=300):
 
 @routes.post('/copy-paste-token')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_users_only()
 async def get_copy_paste_token(request, userdata):
     session = await aiohttp_session.get_session(request)
@@ -314,7 +306,6 @@ async def get_copy_paste_token(request, userdata):
 
 
 @routes.post('/api/v1alpha/copy-paste-token')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_copy_paste_token_api(request, userdata):
     session_id = userdata['session_id']
@@ -325,7 +316,6 @@ async def get_copy_paste_token_api(request, userdata):
 
 @routes.post('/logout')
 @check_csrf_token
-@monitor_endpoint
 @web_maybe_authenticated_user
 async def logout(request, userdata):
     if not userdata:
@@ -342,7 +332,6 @@ async def logout(request, userdata):
 
 
 @routes.get('/api/v1alpha/login')
-@monitor_endpoint
 async def rest_login(request):
     callback_port = request.query['callback_port']
 
@@ -353,7 +342,6 @@ async def rest_login(request):
 
 
 @routes.get('/roles')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_roles(request, userdata):
     db = request.app['db']
@@ -364,7 +352,6 @@ async def get_roles(request, userdata):
 
 @routes.post('/roles')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def post_create_role(request, userdata):  # pylint: disable=unused-argument
     session = await aiohttp_session.get_session(request)
@@ -386,7 +373,6 @@ VALUES (%s);
 
 
 @routes.get('/users')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_users(request, userdata):
     db = request.app['db']
@@ -397,7 +383,6 @@ async def get_users(request, userdata):
 
 @routes.post('/users')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def post_create_user(request, userdata):  # pylint: disable=unused-argument
     session = await aiohttp_session.get_session(request)
@@ -433,7 +418,6 @@ VALUES (%s, %s, %s, %s, %s);
 
 @routes.post('/users/delete')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def delete_user(request, userdata):  # pylint: disable=unused-argument
     session = await aiohttp_session.get_session(request)
@@ -460,7 +444,6 @@ WHERE id = %s AND username = %s;
 
 
 @routes.get('/api/v1alpha/oauth2callback')
-@monitor_endpoint
 async def rest_callback(request):
     state = request.query['state']
     code = request.query['code']
@@ -492,7 +475,6 @@ async def rest_callback(request):
 
 
 @routes.post('/api/v1alpha/copy-paste-login')
-@monitor_endpoint
 async def rest_copy_paste_login(request):
     copy_paste_token = request.query['copy_paste_token']
     db = request.app['db']
@@ -519,7 +501,6 @@ WHERE copy_paste_tokens.id = %s
 
 
 @routes.post('/api/v1alpha/logout')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def rest_logout(request, userdata):
     session_id = userdata['session_id']
@@ -555,7 +536,6 @@ WHERE users.state = 'active' AND (sessions.session_id = %s) AND (ISNULL(sessions
 
 
 @routes.get('/api/v1alpha/userinfo')
-@monitor_endpoint
 async def userinfo(request):
     if 'Authorization' not in request.headers:
         log.info('Authorization not in request.headers')
@@ -582,7 +562,6 @@ async def get_session_id(request):
 
 
 @routes.get('/api/v1alpha/verify_dev_credentials')
-@monitor_endpoint
 async def verify_dev_credentials(request):
     session_id = await get_session_id(request)
     if not session_id:
@@ -605,7 +584,7 @@ async def on_cleanup(app):
 
 
 def run():
-    app = web.Application()
+    app = web.Application(middlewares=[monitor_endpoints_middleware])
 
     setup_aiohttp_jinja2(app, 'auth')
     setup_aiohttp_session(app)

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -18,7 +18,7 @@ from gear import (
     web_authenticated_developers_only,
     check_csrf_token,
     transaction,
-    monitor_endpoint,
+    monitor_endpoints_middleware,
 )
 from hailtop.hail_logging import AccessLogger
 from hailtop.config import get_deploy_config
@@ -160,7 +160,6 @@ async def get_healthcheck(request):  # pylint: disable=W0613
 
 
 @routes.get('/check_invariants')
-@monitor_endpoint
 @rest_authenticated_developers_only
 async def get_check_invariants(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -172,7 +171,6 @@ async def get_check_invariants(request, userdata):  # pylint: disable=unused-arg
 
 
 @routes.patch('/api/v1alpha/batches/{user}/{batch_id}/close')
-@monitor_endpoint
 @batch_only
 async def close_batch(request):
     db = request.app['db']
@@ -201,7 +199,6 @@ def set_cancel_state_changed(app):
 
 
 @routes.post('/api/v1alpha/batches/cancel')
-@monitor_endpoint
 @batch_only
 async def cancel_batch(request):
     set_cancel_state_changed(request.app)
@@ -209,7 +206,6 @@ async def cancel_batch(request):
 
 
 @routes.post('/api/v1alpha/batches/delete')
-@monitor_endpoint
 @batch_only
 async def delete_batch(request):
     set_cancel_state_changed(request.app)
@@ -236,14 +232,12 @@ async def activate_instance_1(request, instance):
 
 
 @routes.get('/api/v1alpha/instances/gsa_key')
-@monitor_endpoint
 @activating_instances_only
 async def get_gsa_key(request, instance):  # pylint: disable=unused-argument
     return await asyncio.shield(get_gsa_key_1(instance))
 
 
 @routes.post('/api/v1alpha/instances/activate')
-@monitor_endpoint
 @activating_instances_only
 async def activate_instance(request, instance):
     return await asyncio.shield(activate_instance_1(request, instance))
@@ -257,7 +251,6 @@ async def deactivate_instance_1(instance):
 
 
 @routes.post('/api/v1alpha/instances/deactivate')
-@monitor_endpoint
 @active_instances_only
 async def deactivate_instance(request, instance):  # pylint: disable=unused-argument
     return await asyncio.shield(deactivate_instance_1(instance))
@@ -305,7 +298,6 @@ async def job_complete_1(request, instance):
 
 
 @routes.post('/api/v1alpha/instances/job_complete')
-@monitor_endpoint
 @active_instances_only
 async def job_complete(request, instance):
     return await asyncio.shield(job_complete_1(request, instance))
@@ -329,7 +321,6 @@ async def job_started_1(request, instance):
 
 
 @routes.post('/api/v1alpha/instances/job_started')
-@monitor_endpoint
 @active_instances_only
 async def job_started(request, instance):
     return await asyncio.shield(job_started_1(request, instance))
@@ -337,7 +328,6 @@ async def job_started(request, instance):
 
 @routes.get('/')
 @routes.get('')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_index(request, userdata):
     app = request.app
@@ -393,7 +383,6 @@ async def refresh_inst_colls_on_front_end(app):
 
 @routes.post('/config-update/pool/{pool}')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def pool_config_update(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -502,7 +491,6 @@ async def pool_config_update(request, userdata):  # pylint: disable=unused-argum
 
 @routes.post('/config-update/jpim')
 @check_csrf_token
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def job_private_config_update(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -542,7 +530,6 @@ async def job_private_config_update(request, userdata):  # pylint: disable=unuse
 
 
 @routes.get('/inst_coll/pool/{pool}')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_pool(request, userdata):
     app = request.app
@@ -577,7 +564,6 @@ async def get_pool(request, userdata):
 
 
 @routes.get('/inst_coll/jpim')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_job_private_inst_manager(request, userdata):
     app = request.app
@@ -609,7 +595,6 @@ async def get_job_private_inst_manager(request, userdata):
 
 
 @routes.get('/user_resources')
-@monitor_endpoint
 @web_authenticated_developers_only()
 async def get_user_resources(request, userdata):
     app = request.app
@@ -1042,7 +1027,7 @@ def run():
             verbose=3,
         )
 
-    app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE)
+    app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE, middlewares=[monitor_endpoints_middleware])
     setup_aiohttp_session(app)
 
     setup_aiohttp_jinja2(app, 'batch.driver')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -43,7 +43,7 @@ from gear import (
     web_authenticated_developers_only,
     check_csrf_token,
     transaction,
-    monitor_endpoint,
+    monitor_endpoints_middleware,
 )
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
 
@@ -112,6 +112,7 @@ def catch_ui_error_in_dev(fun):
                 log.exception('error while populating ui page')
                 raise web.HTTPInternalServerError(text=traceback.format_exc()) from e
             raise
+
     return wrapped
 
 
@@ -296,7 +297,6 @@ LIMIT 50;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def get_jobs(request, userdata, batch_id):  # pylint: disable=unused-argument
     db = request.app['db']
@@ -468,7 +468,6 @@ async def _get_full_job_status(app, record):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def get_job_log(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -586,7 +585,6 @@ LIMIT 51;
 
 
 @routes.get('/api/v1alpha/batches')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_batches(request, userdata):  # pylint: disable=unused-argument
     user = userdata['username']
@@ -611,7 +609,6 @@ def check_service_account_permissions(user, sa):
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def create_jobs(request, userdata):
     app = request.app
@@ -993,7 +990,6 @@ VALUES (%s, %s, %s);
 
 
 @routes.post('/api/v1alpha/batches/create')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def create_batch(request, userdata):
     app = request.app
@@ -1134,14 +1130,12 @@ WHERE id = %s AND NOT deleted;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def get_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     return web.json_response(await _get_batch(request.app, batch_id))
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _handle_api_error(_cancel_batch, request.app, batch_id)
@@ -1149,7 +1143,6 @@ async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
@@ -1191,7 +1184,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
 
 @routes.delete('/api/v1alpha/batches/{batch_id}')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-argument
     await _delete_batch(request.app, batch_id)
@@ -1199,7 +1191,6 @@ async def delete_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.get('/batches/{batch_id}')
-@monitor_endpoint
 @web_billing_project_users_only()
 @catch_ui_error_in_dev
 async def ui_batch(request, userdata, batch_id):
@@ -1219,7 +1210,6 @@ async def ui_batch(request, userdata, batch_id):
 
 
 @routes.post('/batches/{batch_id}/cancel')
-@monitor_endpoint
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1238,7 +1228,6 @@ async def ui_cancel_batch(request, userdata, batch_id):  # pylint: disable=unuse
 
 
 @routes.post('/batches/{batch_id}/delete')
-@monitor_endpoint
 @check_csrf_token
 @web_billing_project_users_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1256,7 +1245,6 @@ async def ui_delete_batch(request, userdata, batch_id):  # pylint: disable=unuse
 
 
 @routes.get('/batches', name='batches')
-@monitor_endpoint
 @web_authenticated_users_only()
 @catch_ui_error_in_dev
 async def ui_batches(request, userdata):
@@ -1353,7 +1341,6 @@ WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/attempts')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -1362,7 +1349,6 @@ async def get_attempts(request, userdata, batch_id):  # pylint: disable=unused-a
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
-@monitor_endpoint
 @rest_billing_project_users_only
 async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argument
     job_id = int(request.match_info['job_id'])
@@ -1371,7 +1357,6 @@ async def get_job(request, userdata, batch_id):  # pylint: disable=unused-argume
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}')
-@monitor_endpoint
 @web_billing_project_users_only()
 @catch_ui_error_in_dev
 async def ui_get_job(request, userdata, batch_id):
@@ -1449,13 +1434,12 @@ async def ui_get_job(request, userdata, batch_id):
         'job_specification': job_specification,
         'job_status_str': json.dumps(job, indent=2),
         'step_errors': step_errors,
-        'error': job_status.get('error')
+        'error': job_status.get('error'),
     }
     return await render_template('batch', request, userdata, 'job.html', page_context)
 
 
 @routes.get('/billing_limits')
-@monitor_endpoint
 @web_authenticated_users_only()
 @catch_ui_error_in_dev
 async def ui_get_billing_limits(request, userdata):
@@ -1517,7 +1501,6 @@ UPDATE billing_projects SET `limit` = %s WHERE name = %s;
 
 
 @routes.post('/api/v1alpha/billing_limits/{billing_project}/edit')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1529,7 +1512,6 @@ async def post_edit_billing_limits(request, userdata):  # pylint: disable=unused
 
 
 @routes.post('/billing_limits/{billing_project}/edit')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1612,7 +1594,6 @@ GROUP BY billing_project, `user`;
 
 
 @routes.get('/billing')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @catch_ui_error_in_dev
 async def ui_get_billing(request, userdata):
@@ -1653,7 +1634,6 @@ async def ui_get_billing(request, userdata):
 
 
 @routes.get('/billing_projects')
-@monitor_endpoint
 @web_authenticated_developers_only()
 @catch_ui_error_in_dev
 async def ui_get_billing_projects(request, userdata):
@@ -1667,7 +1647,6 @@ async def ui_get_billing_projects(request, userdata):
 
 
 @routes.get('/api/v1alpha/billing_projects')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_billing_projects(request, userdata):
     db: Database = request.app['db']
@@ -1683,7 +1662,6 @@ async def get_billing_projects(request, userdata):
 
 
 @routes.get('/api/v1alpha/billing_projects/{billing_project}')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_billing_project(request, userdata):
     db: Database = request.app['db']
@@ -1744,7 +1722,6 @@ WHERE billing_project = %s AND user = %s;
 
 
 @routes.post('/billing_projects/{billing_project}/users/{user}/remove')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1761,7 +1738,6 @@ async def post_billing_projects_remove_user(request, userdata):  # pylint: disab
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/remove')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_get_billing_projects_remove_user(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1809,7 +1785,6 @@ VALUES (%s, %s);
 
 
 @routes.post('/billing_projects/{billing_project}/users/add')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1828,7 +1803,6 @@ async def post_billing_projects_add_user(request, userdata):  # pylint: disable=
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/users/{user}/add')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_billing_projects_add_user(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1865,7 +1839,6 @@ VALUES (%s);
 
 
 @routes.post('/billing_projects/create')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1883,7 +1856,6 @@ async def post_create_billing_projects(request, userdata):  # pylint: disable=un
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/create')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_get_create_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1926,7 +1898,6 @@ FOR UPDATE;
 
 
 @routes.post('/billing_projects/{billing_project}/close')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1942,7 +1913,6 @@ async def post_close_billing_projects(request, userdata):  # pylint: disable=unu
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/close')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_close_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -1972,7 +1942,6 @@ async def _reopen_billing_project(db, billing_project):
 
 
 @routes.post('/billing_projects/{billing_project}/reopen')
-@monitor_endpoint
 @check_csrf_token
 @web_authenticated_developers_only(redirect=False)
 @catch_ui_error_in_dev
@@ -1988,7 +1957,6 @@ async def post_reopen_billing_projects(request, userdata):  # pylint: disable=un
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/reopen')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_reopen_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -2017,7 +1985,6 @@ async def _delete_billing_project(db, billing_project):
 
 
 @routes.post('/api/v1alpha/billing_projects/{billing_project}/delete')
-@monitor_endpoint
 @rest_authenticated_developers_or_auth_only
 async def api_delete_billing_projects(request, userdata):  # pylint: disable=unused-argument
     db: Database = request.app['db']
@@ -2125,7 +2092,7 @@ async def on_cleanup(app):
 
 
 def run():
-    app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE)
+    app = web.Application(client_max_size=HTTP_CLIENT_MAX_SIZE, middlewares=[monitor_endpoints_middleware])
     setup_aiohttp_session(app)
 
     setup_aiohttp_jinja2(app, 'batch.front_end')

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -12,7 +12,7 @@ from .auth import (
 )
 from .csrf import new_csrf_token, check_csrf_token
 from .auth_utils import insert_user, create_session
-from .metrics import monitor_endpoint
+from .metrics import monitor_endpoints_middleware
 
 __all__ = [
     'create_database_pool',
@@ -31,5 +31,5 @@ __all__ = [
     'create_session',
     'transaction',
     'maybe_parse_bearer_header',
-    'monitor_endpoint',
+    'monitor_endpoints_middleware',
 ]

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -1,21 +1,24 @@
-from functools import wraps
+from aiohttp import web
 import prometheus_client as pc  # type: ignore
 from prometheus_async.aio import time as prom_async_time  # type: ignore
 
 REQUEST_TIME = pc.Summary('http_request_latency_seconds', 'Endpoint latency in seconds', ['endpoint', 'verb'])
 REQUEST_COUNT = pc.Counter('http_request_count', 'Number of HTTP requests', ['endpoint', 'verb', 'status'])
+CONCURRENT_REQUESTS = pc.Gauge('http_concurrent_requests', 'Number of in progress HTTP requests', ['endpoint', 'verb'])
 
 
-def monitor_endpoint(handler):
-    @wraps(handler)
-    async def wrapped(request, *args, **kwargs):
-        # Use the path template given to @route.<METHOD>, not the fully resolved one
-        endpoint = request.match_info.route.resource.canonical
-        verb = request.method
-        response = await prom_async_time(
-            REQUEST_TIME.labels(endpoint=endpoint, verb=verb), handler(request, *args, **kwargs)
-        )
+@web.middleware
+async def monitor_endpoints_middleware(request, handler):
+    # Use the path template given to @route.<METHOD>, not the fully resolved one
+    endpoint = request.match_info.route.resource.canonical
+    verb = request.method
+    CONCURRENT_REQUESTS.labels(endpoint=endpoint, verb=verb).inc()
+    try:
+        response = await prom_async_time(REQUEST_TIME.labels(endpoint=endpoint, verb=verb), handler(request))
         REQUEST_COUNT.labels(endpoint=endpoint, verb=verb, status=response.status).inc()
         return response
-
-    return wrapped
+    except web.HTTPException as e:
+        REQUEST_COUNT.labels(endpoint=endpoint, verb=verb, status=e.status).inc()
+        raise e
+    finally:
+        CONCURRENT_REQUESTS.labels(endpoint=endpoint, verb=verb).dec()

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -17,7 +17,7 @@ from hailtop.google_storage import GCS
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors, dump_all_stacktraces
-from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_endpoint
+from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_endpoints_middleware
 
 uvloop.install()
 
@@ -34,7 +34,6 @@ async def healthcheck(request):  # pylint: disable=unused-argument
 
 
 @routes.get('/api/v1alpha/objects')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_object(request, userdata):
     filepath = request.query.get('q')
@@ -48,7 +47,6 @@ async def get_object(request, userdata):
 
 
 @routes.post('/api/v1alpha/objects')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def write_object(request, userdata):
     filepath = request.query.get('q')
@@ -159,7 +157,7 @@ async def on_cleanup(app):
 
 
 def run():
-    app = web.Application()
+    app = web.Application(middlewares=[monitor_endpoints_middleware])
 
     setup_aiohttp_session(app)
     app.add_routes(routes)

--- a/query/query/query.py
+++ b/query/query/query.py
@@ -20,7 +20,7 @@ from gear import (
     setup_aiohttp_session,
     rest_authenticated_users_only,
     rest_authenticated_developers_only,
-    monitor_endpoint,
+    monitor_endpoints_middleware,
 )
 
 from .sockets import connect_to_java
@@ -142,14 +142,12 @@ async def handle_ws_response(request, userdata, endpoint, f):
 
 
 @routes.get('/api/v1alpha/execute')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def execute(request, userdata):
     return await handle_ws_response(request, userdata, 'execute', blocking_execute)
 
 
 @routes.get('/api/v1alpha/load_references_from_dataset')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def load_references_from_dataset(request, userdata):
     return await handle_ws_response(
@@ -158,42 +156,36 @@ async def load_references_from_dataset(request, userdata):
 
 
 @routes.get('/api/v1alpha/type/value')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def value_type(request, userdata):
     return await handle_ws_response(request, userdata, 'type/value', blocking_value_type)
 
 
 @routes.get('/api/v1alpha/type/table')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def table_type(request, userdata):
     return await handle_ws_response(request, userdata, 'type/table', blocking_table_type)
 
 
 @routes.get('/api/v1alpha/type/matrix')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def matrix_type(request, userdata):
     return await handle_ws_response(request, userdata, 'type/matrix', blocking_matrix_type)
 
 
 @routes.get('/api/v1alpha/type/blockmatrix')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def blockmatrix_type(request, userdata):
     return await handle_ws_response(request, userdata, 'type/blockmatrix', blocking_blockmatrix_type)
 
 
 @routes.get('/api/v1alpha/references/get')
-@monitor_endpoint
 @rest_authenticated_users_only
 async def get_reference(request, userdata):  # pylint: disable=unused-argument
     return await handle_ws_response(request, userdata, 'references/get', blocking_get_reference)
 
 
 @routes.get('/api/v1alpha/flags/get')
-@monitor_endpoint
 @rest_authenticated_developers_only
 async def get_flags(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -203,7 +195,6 @@ async def get_flags(request, userdata):  # pylint: disable=unused-argument
 
 
 @routes.get('/api/v1alpha/flags/get/{flag}')
-@monitor_endpoint
 @rest_authenticated_developers_only
 async def get_flag(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -214,7 +205,6 @@ async def get_flag(request, userdata):  # pylint: disable=unused-argument
 
 
 @routes.get('/api/v1alpha/flags/set/{flag}')
-@monitor_endpoint
 @rest_authenticated_developers_only
 async def set_flag(request, userdata):  # pylint: disable=unused-argument
     app = request.app
@@ -261,7 +251,7 @@ async def on_shutdown(_):
 
 
 def run():
-    app = web.Application()
+    app = web.Application(middlewares=[monitor_endpoints_middleware])
 
     setup_aiohttp_session(app)
 

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -9,7 +9,7 @@ from prometheus_async.aio.web import server_stats  # type: ignore
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
 from hailtop.hail_logging import AccessLogger
-from gear import setup_aiohttp_session, web_maybe_authenticated_user, monitor_endpoint
+from gear import setup_aiohttp_session, web_maybe_authenticated_user, monitor_endpoints_middleware
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, sass_compile
 
 
@@ -63,7 +63,6 @@ docs_pages = set(
 
 
 @routes.get('/docs/{tail:.*}')
-@monitor_endpoint
 @web_maybe_authenticated_user
 async def serve_docs(request, userdata):
     tail = request.match_info['tail']
@@ -91,7 +90,7 @@ for fname in os.listdir(f'{MODULE_PATH}/pages'):
 
 
 def run(local_mode):
-    app = web.Application()
+    app = web.Application(middlewares=[monitor_endpoints_middleware])
 
     if local_mode:
         log.error('running in local mode with bogus cookie storage key')


### PR DESCRIPTION
We currently have a `@monitor_endpoint` decorator that we use to wrap aiohttp endpoints and produce prometheus metrics, but the same result can be achieved with fewer lines of code by using essentially the same wrapper as an aiohttp middleware. 

Separately, I fixed the wrapper to correctly catch and report on endpoints that raise exceptions, as well as keeping track of the number of concurrent connections.