### PR TITLE
[query] Fix the branches in logreg sigmoid

### DIFF
--- a/hail/python/hail/docs/functions/index.rst
+++ b/hail/python/hail/docs/functions/index.rst
@@ -99,11 +99,13 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     bit_rshift
     bit_not
     exp
+    expit
     is_nan
     is_finite
     is_infinite
     log
     log10
+    logit
     sign
     sqrt
     int

--- a/hail/python/hail/docs/functions/numeric.rst
+++ b/hail/python/hail/docs/functions/numeric.rst
@@ -15,11 +15,13 @@ Numeric functions
     bit_rshift
     bit_not
     exp
+    expit
     is_nan
     is_finite
     is_infinite
     log
     log10
+    logit
     sign
     sqrt
     int
@@ -59,11 +61,13 @@ Numeric functions
 .. autofunction:: bit_rshift
 .. autofunction:: bit_not
 .. autofunction:: exp
+.. autofunction:: expit
 .. autofunction:: is_nan
 .. autofunction:: is_finite
 .. autofunction:: is_infinite
 .. autofunction:: log
 .. autofunction:: log10
+.. autofunction:: logit
 .. autofunction:: floor
 .. autofunction:: ceil
 .. autofunction:: sqrt

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -44,7 +44,7 @@ from .functions import literal, chi_squared_test, if_else, cond, switch, case, \
     parse_int32, parse_int64, bool, get_sequence, reverse_complement, \
     is_valid_contig, is_valid_locus, contig_length, liftover, min_rep, \
     uniroot, format, approx_equal, reversed, bit_and, bit_or, bit_xor, \
-    bit_lshift, bit_rshift, bit_not, binary_search, \
+    bit_lshift, bit_rshift, bit_not, binary_search, logit, expit, \
     _values_similar, _showstr, _sort_by, _compare, _locus_windows_per_contig, \
     shuffle
 
@@ -126,6 +126,8 @@ __all__ = ['HailType',
            'parse_json',
            'log',
            'log10',
+           'logit',
+           'expit',
            'null',
            'missing',
            'or_else',

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1695,6 +1695,52 @@ def log10(x) -> Float64Expression:
     return _func("log10", tfloat64, x)
 
 
+@typecheck(x=expr_float64)
+def logit(x) -> Float64Expression:
+    """The logistic function.
+
+    Examples
+    --------
+    >>> hl.eval(hl.logit(.01))
+    -4.59511985013459
+    >>> hl.eval(hl.logit(.5))
+    0.0
+
+    Parameters
+    ----------
+    x : float or :class:`.Expression` of type :py:data:`.tfloat64`
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tfloat64`
+    """
+    return hl.log(x / (1 - x))
+
+
+@typecheck(x=expr_float64)
+def expit(x) -> Float64Expression:
+    """The logistic sigmoid function.
+
+    Examples
+    --------
+    >>> hl.eval(hl.logit(.01))
+    0.7310585786300049
+    >>> hl.eval(hl.logit(0.0))
+    0.5
+
+
+    Parameters
+    ----------
+    x : float or :class:`.Expression` of type :py:data:`.tfloat64`
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tfloat64`
+    """
+    return hl.if_else(x >= 0,  1 / (1 + hl.exp(-x)), hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1)))
+
+
+
 @typecheck(args=expr_any)
 def coalesce(*args):
     """Returns the first non-missing value of `args`.

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1723,9 +1723,9 @@ def expit(x) -> Float64Expression:
 
     Examples
     --------
-    >>> hl.eval(hl.logit(.01))
-    0.7310585786300049
-    >>> hl.eval(hl.logit(0.0))
+    >>> hl.eval(hl.expit(.01))
+    0.5024999791668749
+    >>> hl.eval(hl.expit(0.0))
     0.5
 
 
@@ -1737,8 +1737,7 @@ def expit(x) -> Float64Expression:
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return hl.if_else(x >= 0,  1 / (1 + hl.exp(-x)), hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1)))
-
+    return hl.if_else(x >= 0, 1 / (1 + hl.exp(-x)), hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1)))
 
 
 @typecheck(args=expr_any)

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -866,7 +866,7 @@ def mean_impute(hl_array):
 
 
 def sigmoid(hl_nd):
-    return hl_nd.map(lambda x: hl.if_else(x >= 0,  1 / (1 + hl.exp(-x)), hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1))))
+    return hl_nd.map(lambda x: hl.expit(x))
 
 
 def nd_max(hl_nd):

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -866,7 +866,7 @@ def mean_impute(hl_array):
 
 
 def sigmoid(hl_nd):
-    return hl_nd.map(lambda x: hl.if_else(x > 0, hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1)), 1 / (1 + hl.exp(-x))))
+    return hl_nd.map(lambda x: hl.if_else(x >= 0,  1 / (1 + hl.exp(-x)), hl.rbind(hl.exp(x), lambda exped: exped / (exped + 1))))
 
 
 def nd_max(hl_nd):

--- a/hail/python/test/hail/expr/test_math.py
+++ b/hail/python/test/hail/expr/test_math.py
@@ -1,0 +1,15 @@
+import hail as hl
+import scipy.special as scsp
+import pytest
+
+def test_logit():
+    assert hl.eval(hl.logit(.5)) == 0.0
+    assert hl.eval(hl.is_infinite(hl.logit(1.0)))
+    assert hl.eval(hl.is_nan(hl.logit(1.01)))
+    assert hl.eval(hl.logit(.27)) == scsp.logit(.27)
+
+def test_expit():
+    assert hl.eval(hl.expit(0.0)) == 0.5
+    assert hl.eval(hl.expit(800)) == 1.0
+    assert hl.eval(hl.expit(-920)) == 0.0
+    assert hl.eval(hl.expit(.75)) == scsp.expit(.75)


### PR DESCRIPTION
A user reviewing the code pointed out that the branches of this function were backwards. Is there any easy way to construct a test that would catch this? Is `sigmoid` worth wrapping up into like `hl.math.sigmoid` or something? It seems like the name `sigmoid` refers to many things, maybe it should be `expit` like it apparently is in R and scipy?