### PR TITLE
[query] Fix magic collection struct errors

### DIFF
--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -262,9 +262,9 @@ def get_obj_metadata(obj):
     elif isinstance(obj, StructExpression):
         return 'StructExpression', StructExpression, struct_error(obj), True
     elif isinstance(obj, ArrayStructExpression):
-        return 'ArrayStructExpression', StructExpression, struct_error(obj), True
+        return 'ArrayStructExpression', ArrayStructExpression, struct_error(obj), True
     elif isinstance(obj, SetStructExpression):
-        return 'SetStructExpression', StructExpression, struct_error(obj), True
+        return 'SetStructExpression', SetStructExpression, struct_error(obj), True
     else:
         raise NotImplementedError(obj)
 


### PR DESCRIPTION
Now get:
```
E           AttributeError: ArrayStructExpression instance has no field, method, or property 'select'
E               Did you mean:
E                   ArrayStructExpression inherited method: 'collect'
```

instead of

```
AttributeError: ArrayStructExpression instance has no field, method, or property 'select'
    Did you mean:
        ArrayStructExpression method: 'select'
        ArrayStructExpression inherited method: 'collect'

```