### PR TITLE
[query] Allow hl.sorted to sort sets and dicts

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4510,7 +4510,7 @@ def _sort_by(collection, less_than):
         collection._aggregations)
 
 
-@typecheck(collection=expr_array(),
+@typecheck(collection=expr_oneof(expr_array(), expr_dict(), expr_set()),
            key=nullable(func_spec(1, expr_any)),
            reverse=expr_bool)
 def sorted(collection,
@@ -4538,8 +4538,8 @@ def sorted(collection,
 
     Parameters
     ----------
-    collection : :class:`.ArrayExpression`
-        Array to sort.
+    collection : :class:`.ArrayExpression` or :class:`.SetExpression` or :class:`.DictExpression`
+        Collection to sort.
     key: function ( (arg) -> :class:`.Expression`), optional
         Function to evaluate for each element to compute sort key.
     reverse : :class:`.BooleanExpression`
@@ -4550,6 +4550,9 @@ def sorted(collection,
     :class:`.ArrayExpression`
         Sorted array.
     """
+
+    if not isinstance(collection, ArrayExpression):
+        collection = hl.array(collection)
 
     def comp(left, right):
         return (hl.case()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2470,6 +2470,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.sorted([0, 1, 4, hl.missing(tint), 3, 2], lambda x: x, reverse=True).collect()[0], [4, 3, 2, 1, 0, None])
         self.assertEqual(hl.eval(hl.sorted([0, 1, 4, hl.missing(tint), 3, 2], lambda x: x, reverse=True)), [4, 3, 2, 1, 0, None])
 
+        self.assertEqual(hl.eval(hl.sorted({0, 1, 4, 3, 2})), [0, 1, 2, 3, 4])
+
+        self.assertEqual(hl.eval(hl.sorted({"foo": 1, "bar": 2})), [("bar", 2), ("foo", 1)])
+
     def test_sort_by(self):
         self.assertEqual(hl.eval(hl._sort_by(["c", "aaa", "bb", hl.missing(hl.tstr)], lambda l, r: hl.len(l) < hl.len(r))), ["c", "bb", "aaa", None])
         self.assertEqual(hl.eval(hl._sort_by([hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5]], lambda l, r: l.x < r.x)),


### PR DESCRIPTION
Currently, `hl.sorted` only accepts an array expression. If we want to sort a set or dict, we have to convert it to an array first.

```python
hl.eval(hl.sorted({1, 2, 3}))
# TypeError: sorted: parameter 'collection': expected expression of type array<any>, found set: {1, 2, 3}

hl.eval(hl.sorted(hl.array({1, 2, 3})))
# [1, 2, 3]
```

Hail supports converting set and dict expressions to array expressions through [`hl.array`](https://hail.is/docs/0.2/functions/constructors.html#hail.expr.functions.array). This changes `hl.sorted` to also accept set and dict expressions and automatically convert them to array expressions.