### PR TITLE
[query] Impute Hail type for frozensets

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -4,7 +4,7 @@ import numpy as np
 import hail
 import hail as hl
 from hail.expr import expressions
-from hail.expr.types import HailType, is_numeric, is_compound, tint32, \
+from hail.expr.types import HailType, is_numeric, is_compound, is_setlike, tint32, \
     tint64, tfloat32, tfloat64, tstr, tbool, tarray, \
     tndarray, tset, tdict, tstruct, ttuple, tinterval, \
     tlocus, tcall, from_numpy
@@ -162,7 +162,7 @@ def impute_type(x):
             raise ExpressionException("Hail does not support heterogeneous arrays: "
                                       "found list with elements of types {} ".format(list(ts)))
         return tarray(unified_type)
-    elif isinstance(x, set):
+    elif is_setlike(x):
         if len(x) == 0:
             raise ExpressionException("Cannot impute type of empty set. Use 'hl.empty_set' to create an empty set.")
         ts = {impute_type(element) for element in x}

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3060,6 +3060,7 @@ class Tests(unittest.TestCase):
         t = hl.set([3, 8])
 
         self.assert_evals_to(s, set([1, 3, 7]))
+        self.assert_evals_to(hl.set(frozenset([1, 2, 3])), set([1, 2, 3]))
 
         self.assert_evals_to(s.add(3), set([1, 3, 7]))
         self.assert_evals_to(s.add(4), set([1, 3, 4, 7]))


### PR DESCRIPTION
Currently, Hail cannot impute a Hail type for frozenset objects.

```python
hl.literal(frozenset(["foo"]))
# ExpressionException: Hail cannot automatically impute type of <class 'frozenset'>: frozenset({'foo'})
```

This is an issue because frozenset is Hail's Python counterpart to SetExpression. Since Hail outputs frozensets from functions like `eval` and `collect`, users are likely to expect that Hail can also accept them as input.

```python
hl.eval(hl.set([1,2,3]))
# frozenset({1, 2, 3})

hl.set([1,2,3]).collect()
# [frozenset({1, 2, 3})]
```

One example use case where this issue pops up is annotating a table with all possible values of some field. Currently, the output of aggregating using `hl.agg.collect_as_set` cannot be directly used to annotate a table, it must be explicitly cast to a set.

```python
values = ds.aggregate(hl.agg.collect_as_set(ds.field))
ds.annotate_globals(values=values)
# TypeError: annotate_globals: keyword argument 'values': expected expression of type any, found frozenset: frozenset({0, 1, 2})

ds.annotate_globals(values=set(values))
```