### PR TITLE
[hailtop.batch] Fix exit code for Python jobs

### DIFF
--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -965,4 +965,5 @@ with open(os.environ[\\"{result}\\"], \\"wb\\") as dill_out:
     except Exception as e:
         traceback.print_exc()
         dill.dump((e, traceback.format_exception(type(e), e, e.__traceback__)), dill_out, recurse=True)
+        raise e
 "''')

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -794,7 +794,7 @@ class ServiceTests(unittest.TestCase):
 
     def test_python_job_w_non_zero_ec(self):
         b = self.batch(default_python_image='gcr.io/hail-vdc/python-dill:3.7-slim')
-        j = b.new_job()
+        j = b.new_python_job()
 
         def error():
             raise Exception("this should fail")

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -792,6 +792,17 @@ class ServiceTests(unittest.TestCase):
         assert res.status()['state'] == 'success', debug_info(res)
         assert res.get_job_log(3)['main'] == "15\n", debug_info(res)
 
+    def test_python_job_w_non_zero_ec(self):
+        b = self.batch(default_python_image='gcr.io/hail-vdc/python-dill:3.7-slim')
+        j = b.new_job()
+
+        def error():
+            raise Exception("this should fail")
+
+        j.call(error)
+        res = b.run()
+        assert res.status()['state'] == 'failure', debug_info(res)
+
     def test_fail_fast(self):
         b = self.batch(cancel_after_n_failures=1)
 


### PR DESCRIPTION
CHANGELOG: Made failed Python Jobs have non-zero exit codes.