### PR TITLE
[query] fix _quantile_from_cdf bug

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -59,10 +59,7 @@ def _quantile_from_cdf(cdf, q):
     def compute(cdf):
         n = cdf.ranks[cdf.ranks.length() - 1]
         pos = hl.int64(q * n) + 1
-        idx = (hl.switch(q)
-                 .when(0.0, 0)
-                 .when(1.0, cdf.values.length() - 1)
-                 .default(_lower_bound(cdf.ranks, pos) - 1))
+        idx = hl.max(0, hl.min(cdf.values.length() - 1, _lower_bound(cdf.ranks, pos) - 1))
         res = hl.if_else(n == 0,
                          hl.missing(cdf.values.dtype.element_type),
                          cdf.values[idx])


### PR DESCRIPTION
A user was getting an index out-of-bounds error on `cdf.values[idx]`. I can't reproduce it, but this should guarantee the index is in bounds, and is a simplification besides.