### PR TITLE
[grafana] Configure datasources in ConfigMap

### DIFF
--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -14,5 +14,5 @@ build:
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"project": "$(PROJECT)"},"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -23,6 +23,11 @@ spec:
         - name: grafana-configmap-volume
           configMap:
             name: grafana-config
+            items:
+            - key: grafana.ini
+              path: grafana.ini
+            - key: datasources.yaml
+              path: provisioning/datasources/datasources.yaml
         - name: ssl-config-grafana
           secret:
             optional: false
@@ -100,6 +105,21 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
+    [paths]
+    provisioning = /etc/grafana/provisioning
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Google Cloud Monitoring
+        type: stackdriver
+        access: proxy
+        jsonData:
+          authenticationType: gce
+          defaultProject: {{ global.project }}
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.default.svc.cluster.local:9090
 ---
 apiVersion: v1
 kind: Service

--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -230,8 +230,13 @@ metadata:
   name: prometheus
 spec:
   ports:
-   - port: 443
+   - name: https
+     port: 443
      protocol: TCP
      targetPort: 443
+   - name: http
+     port: 9090
+     protocol: TCP
+     targetPort: 9090
   selector:
     app: prometheus


### PR DESCRIPTION
This adds the Google Cloud Monitoring and Prometheus datasources to the grafana configuration. I had done this initially by hand in the UI but this is the first step toward reproducible monitoring, and I'll eventually follow up with dashboards as code.

The one "change" I made is I exposed the prometheus port sitting behind nginx so that grafana can talk directly to prometheus. Currently, there's an nginx sitting in front of prometheus so that the prometheus UI can be exposed at prometheus.hail.is with https and dev authentication. This hasn't changed. Currently though, grafana is piggybacking on this flow by forwarding the user's session (which I set up in the UI), but I couldn't figure out an easy way to set that in the config and it seemed unnecessarily complicated. I ended up going the simpler route of just letting grafana talk to prometheus directly and not go through nginx. The 9090 endpoint is not reachable outside of the cluster.

I considered namespacing the prometheus domain (`{{ default_ns.name }}` instead of `default`), but I pretty much never find it useful to spin up my own prometheus. In the rare case I run my own grafana I just point it to the data from default.