### PR TITLE
[batch] close compute and logging clients on shutdown

### DIFF
--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1009,10 +1009,16 @@ async def on_cleanup(app):
                             try:
                                 app['task_manager'].shutdown()
                             finally:
-                                del app['k8s_cache'].client
-                                await asyncio.gather(
-                                    *(t for t in asyncio.all_tasks() if t is not asyncio.current_task())
-                                )
+                                try:
+                                    await app['logging_client'].close()
+                                finally:
+                                    try:
+                                        await app['compute_client'].close()
+                                    finally:
+                                        del app['k8s_cache'].client
+                                        await asyncio.gather(
+                                            *(t for t in asyncio.all_tasks() if t is not asyncio.current_task())
+                                        )
 
 
 def run():

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1323,8 +1323,10 @@ class Worker:
         self.headers = None
         self.compute_client = None
 
-    def shutdown(self):
+    async def shutdown(self):
         self.task_manager.shutdown()
+        if self.compute_client:
+            await self.compute_client.close()
 
     async def run_job(self, job):
         try:
@@ -1641,7 +1643,7 @@ async def async_main():
         await worker.run()
     finally:
         try:
-            worker.shutdown()
+            await worker.shutdown()
             log.info('worker shutdown')
         finally:
             await docker.close()


### PR DESCRIPTION
Whenever the batch driver shuts down we have some errors due to unclosed aiohttp `ClientSession`s. Deploying the driver in asyncio debug mode revealed that these sessions were in the `ComputeClient` and `LoggingClient`, which we don't call `close` on (and we don't use them as context managers). After this change I was able to delete my driver pod without any unclosed client session errors (though plenty of cancelled errors, which is a separate issue.