### PR TITLE
[batch] add ability to fetch access tokens from instance metadata server

### DIFF
--- a/hail/python/hailtop/aiogoogle/auth/credentials.py
+++ b/hail/python/hailtop/aiogoogle/auth/credentials.py
@@ -40,9 +40,8 @@ class Credentials(abc.ABC):
 
         log.warning('unable to locate Google Cloud credentials file, will attempt to '
                     'use instance metadata server instead')
-        
-        return InstanceMetadataCredentials()
 
+        return InstanceMetadataCredentials()
 
     async def get_access_token(self, session):
         pass
@@ -100,6 +99,7 @@ class ServiceAccountCredentials(Credentials):
                     'assertion': encoded_assertion
                 })) as resp:
             return await resp.json()
+
 
 # https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#applications
 class InstanceMetadataCredentials():


### PR DESCRIPTION
This makes Hail Batch usable from a VM that's run under a service account, without requiring a JSON key.

#assign services