### PR TITLE
[batch] Increase timeout for disk wait operation

### DIFF
--- a/hail/python/hailtop/aiogoogle/client/compute_client.py
+++ b/hail/python/hailtop/aiogoogle/client/compute_client.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Mapping, Any, Optional, MutableMapping, List, Dict
 import logging
+import aiohttp
 
 from .base_client import BaseClient
 from hailtop.utils import retry_transient_errors, sleep_and_backoff
@@ -98,7 +99,8 @@ class ComputeClient(BaseClient):
 
             delay = 2
             while True:
-                result = await self.post(f'/zones/{zone}/operations/{operation_id}/wait')
+                result = await self.post(f'/zones/{zone}/operations/{operation_id}/wait',
+                                         timeout=aiohttp.ClientTimeout(total=150))
                 if result['status'] == 'DONE':
                     error = result.get('error')
                     if error:


### PR DESCRIPTION
I think our default timeout of 5 seconds is why the disk operations are slow. The `wait` endpoint returns within 2 minutes. https://cloud.google.com/compute/docs/api/how-tos/api-requests-responses#handling_api_responses