### PR TITLE
[ci] Dont rebuild a failed source SHA

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -189,6 +189,7 @@ class PR(Code):
         self.sha = None
         self.batch = None
         self.source_sha_failed = None
+        self.merge_conflict = False
 
         # 'error', 'success', 'failure', None
         self.build_state = None
@@ -274,6 +275,7 @@ class PR(Code):
             self.sha = None
             self.batch = None
             self.source_sha_failed = None
+            self.merge_conflict = False
             self.set_build_state(None)
             self.target_branch.batch_changed = True
             self.target_branch.state_changed = True
@@ -478,6 +480,7 @@ mkdir -p {shq(repo_dir)}
             )
             self.set_build_state('error')
             self.source_sha_failed = True
+            self.merge_conflict = True
             self.target_branch.state_changed = True
         finally:
             if batch and not self.batch:


### PR DESCRIPTION
If you sort the GitHub PRs by `is:pr is:open sort:updated-desc`, you'll see that some PRs which have merge conflicts are continuously tested by CI. Really old PRs that are stuck in this state reach a GitHub quota for status updates to a PR for a given SHA. It seems to me that we shouldn't retest any PR that is `source_sha_failed`, and I think this should resolve that particular issue, but am not sure if this is necessarily the best place to insert this logic.