### PR TITLE
[query] Add items method to DictExpression

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1505,6 +1505,22 @@ class DictExpression(Expression):
         """
         return self._method("values", tarray(self.dtype.value_type))
 
+    def items(self):
+        """Returns an array of tuples containing key/value pairs in the dictionary.
+
+        Examples
+        --------
+
+        >>> hl.eval(d.items())  # doctest: +SKIP_OUTPUT_CHECK
+        [('Alice', 430), ('Bob', 330), ('Charles', 440)]
+
+        Returns
+        -------
+        :class:`.ArrayExpression`
+            All key/value pairs in the dictionary.
+        """
+        return hl.array(self)
+
     def _extra_summary_fields(self, agg_result):
         return {
             'Min Size': agg_result[0],

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -209,12 +209,14 @@ class Tests(unittest.TestCase):
             x6=kt.a.keys(),
             x7=kt.a.values(),
             x8=kt.a.size(),
-            x9=kt.a.map_values(lambda v: v * 2.0)
+            x9=kt.a.map_values(lambda v: v * 2.0),
+            x10=kt.a.items(),
         ).take(1)[0])
 
         expected = {'a': {'cat': 3, 'dog': 7}, 'x': 2.0, 'x1': 3, 'x2': 7, 'x3': False,
                     'x4': False, 'x5': {'cat', 'dog'}, 'x6': ['cat', 'dog'],
-                    'x7': [3, 7], 'x8': 2, 'x9': {'cat': 6.0, 'dog': 14.0}}
+                    'x7': [3, 7], 'x8': 2, 'x9': {'cat': 6.0, 'dog': 14.0},
+                    'x10': [('cat', 3), ('dog', 7)]}
 
         self.assertDictEqual(result, expected)
 


### PR DESCRIPTION
It's possible to get a list of (key, value) tuples from DictExpression by casting it to an array.

```python
hl.eval(hl.array(hl.literal({"foo": 1, "bar": 2})))
# [('bar', 2), ('foo', 1)]
```

This adds an `items` method to DictExpression that returns the same thing. This aligns with the `items` method of Python dicts and may be more intuitive/discoverable than casting to an array.

#assign compiler