### PR TITLE
[hailtop.batch] Write out large commands to GCS for BashJobs

### DIFF
--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -161,6 +161,12 @@
       <td>image</td>
       <td>{{ job_specification['image'] }}</td>
     </tr>
+    {% if 'user_code' in job_specification %}
+    <tr>
+      <td>user code</td>
+      <td><pre style="max-height: 10em; max-width: 80em;">{{ job_specification['user_code'] }}</pre></td>
+    </tr>
+    {% endif %}
     <tr>
       <td>command</td>
       <td><pre style="max-height: 10em; max-width: 80em;">{{ "'" + (job_specification['command'] | join("' '")) + "'" }}</pre></td>

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -89,6 +89,7 @@ job_validator = keyed(
         ),
         'service_account': keyed({required('namespace'): k8s_str, required('name'): k8s_str}),
         'timeout': numeric(**{"x > 0": lambda x: x > 0}),
+        'user_code': str_type,
     }
 )
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -236,8 +236,7 @@ class LocalBackend(Backend[None]):
                 run_code(code)
 
             for job in batch._jobs:
-                if isinstance(job, _job.PythonJob):
-                    async_to_blocking(job._compile(tmpdir, tmpdir))
+                async_to_blocking(job._compile(tmpdir, tmpdir))
 
                 os.makedirs(f'{tmpdir}/{job._job_id}/', exist_ok=True)
 

--- a/hail/python/hailtop/batch/globals.py
+++ b/hail/python/hailtop/batch/globals.py
@@ -9,3 +9,6 @@ def arg_max():
     if __ARG_MAX is None:
         __ARG_MAX = int(sp.check_output(['getconf', 'ARG_MAX']))
     return __ARG_MAX
+
+
+DEFAULT_SHELL = '/bin/bash'

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -662,6 +662,9 @@ class BashJob(Job):
         return self
 
     async def _compile(self, local_tmpdir, remote_tmpdir):
+        if len(self._command) == 0:
+            return False
+
         job_shell = self._shell if self._shell else DEFAULT_SHELL
 
         job_command = [cmd.strip() for cmd in self._command]

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -3,7 +3,7 @@ import dill
 import os
 import functools
 import inspect
-from io import StringIO, BytesIO
+from io import BytesIO
 from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast
 
 from . import backend, resource as _resource, batch  # pylint: disable=cyclic-import
@@ -673,7 +673,9 @@ class BashJob(Job):
 {job_command}
 '''
 
-        if len(bytes(job_command)) <= 10 * 1024:
+        job_command_bytes = job_command.encode()
+
+        if len(job_command_bytes) <= 10 * 1024:
             self._wrapper_code.append(job_command)
             return False
 
@@ -684,7 +686,7 @@ class BashJob(Job):
         code_path = f'{job_path}/code.sh'
 
         await self._batch._fs.makedirs(os.path.dirname(code_path), exist_ok=True)
-        await self._batch._fs.write(code_path, job_command.encode())
+        await self._batch._fs.write(code_path, job_command_bytes)
         code = self._batch.read_input(code_path)
 
         wrapper_command = f'''

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -426,7 +426,7 @@ class BatchBuilder:
                    input_files=None, output_files=None, always_run=False,
                    timeout=None, gcsfuse=None, requester_pays_project=None,
                    mount_tokens=False, network: Optional[str] = None,
-                   unconfined: bool = False):
+                   unconfined: bool = False, user_code: Optional[str] = None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
 
@@ -502,6 +502,8 @@ class BatchBuilder:
             job_spec['network'] = network
         if unconfined:
             job_spec['unconfined'] = unconfined
+        if user_code:
+            job_spec['user_code'] = user_code
 
         self._job_specs.append(job_spec)
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -203,7 +203,7 @@ class BatchBuilder:
                    input_files=None, output_files=None, always_run=False,
                    timeout=None, gcsfuse=None, requester_pays_project=None,
                    mount_tokens=False, network: Optional[str] = None,
-                   unconfined: bool = False) -> Job:
+                   unconfined: bool = False, user_code: Optional[str] = None) -> Job:
         if parents:
             parents = [parent._async_job for parent in parents]
 
@@ -215,7 +215,7 @@ class BatchBuilder:
             input_files=input_files, output_files=output_files, always_run=always_run,
             timeout=timeout, gcsfuse=gcsfuse,
             requester_pays_project=requester_pays_project, mount_tokens=mount_tokens,
-            network=network, unconfined=unconfined)
+            network=network, unconfined=unconfined, user_code=user_code)
 
         return Job.from_async_job(async_job)
 


### PR DESCRIPTION
I made any command that is larger than 10KB is written to a file instead and is downloaded as an input file to be run (same as what we do for Python jobs). I also added a new field `user_code` that represents the user's code that they want to run versus the command we have Docker run. I formatted the `user_code` for Python jobs to show the actual function definition and the arguments used to call the function. It's probably not perfect (i.e. JobResourceFile), but better than nothing.