### PR TITLE
[query] Generate better code in lowering rule for MatrixAggregate

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.expr.ir.functions.{WrappedMatrixToTableFunction, WrappedMatrixToValueFunction}
+import is.hail.expr.ir._
 import is.hail.types._
 import is.hail.types.virtual.{TArray, TBaseStruct, TDict, TInt32, TInterval, TStruct}
 import is.hail.utils._
@@ -812,17 +813,15 @@ object LowerMatrixIR {
       case MatrixAggregate(child, query) =>
         val lc = lower(child, ab)
         val idx = Symbol(genUID())
-        lc
-          .aggregate(
-            aggLet(
-              __entries_field = 'row (entriesField),
-              __cols_field = 'global (colsField)) {
-              irRange(0, '__entries_field.len)
-                .filter(idx ~> !'__entries_field (idx).isNA)
-                .aggExplode(idx ~> aggLet(sa = '__cols_field (idx), g = '__entries_field (idx)) {
-                  subst(query, matrixSubstEnv(child))
-                })
-            })
+        TableAggregate(lc,
+          aggExplodeIR(filterIR(zip2(GetField(Ref("row", lc.typ.rowType), entriesFieldName),
+            GetField(Ref("global", lc.typ.globalType), colsFieldName),
+            ArrayZipBehavior.AssertSameLength
+          ) { case (e, c) =>
+            MakeTuple.ordered(FastSeq(e, c))
+          }) { tuple => ApplyUnaryPrimOp(Bang(), IsNA(GetTupleElement(tuple, 0))) }) { tuple =>
+            Let("g", GetTupleElement(tuple, 0), Let("sa", GetTupleElement(tuple, 1), Subst(query, matrixSubstEnvIR(child, lc))))
+          })
       case _ => lowerChildren(ir, ab).asInstanceOf[IR]
     }
     assertTypeUnchanged(ir, lowered)

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -184,6 +184,16 @@ package object ir {
   def makestruct(fields: (String, IR)*): MakeStruct = MakeStruct(fields)
   def maketuple(fields: IR*): MakeTuple = MakeTuple(fields.zipWithIndex.map{ case (field, idx) => (idx, field)})
 
+  def aggBindIR(v: IR, isScan: Boolean = false)(body: Ref => IR): IR = {
+    val ref = Ref(genUID(), v.typ)
+    AggLet(ref.name, v, body(ref), isScan = isScan)
+  }
+
+  def aggExplodeIR(v: IR, isScan: Boolean = false)(body: Ref => IR): AggExplode = {
+    val r = Ref(genUID(), v.typ.asInstanceOf[TIterable].elementType)
+    AggExplode(v, r.name, body(r), isScan)
+  }
+
   implicit def toRichIndexedSeqEmitSettable(s: IndexedSeq[EmitSettable]): RichIndexedSeqEmitSettable = new RichIndexedSeqEmitSettable(s)
 
   implicit def emitValueToCode(ev: EmitValue): EmitCode = ev.load


### PR DESCRIPTION
With StackStruct, now we don't allocate in the `MakeTuple` here.
Should deforest better, and be faster in general.