### PR TITLE
Fix formatting for metadata parameter type in export_vcf docs

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -488,7 +488,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
         ``'separate_header'``, return a separate VCF header file and a set of
         VCF files (one per partition) without the header. If ``None``,
         concatenate the header and all partitions into one VCF file.
-    metadata : :obj:`dict` [:obj:`str`, :obj:`dict` [:obj:`str`, :obj:`dict` [obj:`str`, obj:`str`]]]`, optional
+    metadata : :obj:`dict` [:obj:`str`, :obj:`dict` [:obj:`str`, :obj:`dict` [:obj:`str`, :obj:`str`]]], optional
         Dictionary with information to fill in the VCF header. See
         :func:`get_vcf_metadata` for how this
         dictionary should be structured.


### PR DESCRIPTION
Before

![Screen Shot 2021-07-15 at 4 40 48 PM](https://user-images.githubusercontent.com/1156625/125855239-76b10b75-3602-442e-bb62-f6125eb5d5e5.png)

https://hail.is/docs/0.2/methods/impex.html#hail.methods.export_vcf

After

![Screen Shot 2021-07-15 at 4 45 01 PM](https://user-images.githubusercontent.com/1156625/125855230-b59131a6-f346-4391-b658-5e160dbbee20.png)

#assign compiler