### PR TITLE
[batch] Only one pull image task should extract the root filesystem

### DIFF
--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -244,7 +244,7 @@ sudo service google-fluentd restart
 docker pull $BATCH_WORKER_IMAGE || \
 (echo 'pull failed, retrying' && sleep 15 && docker pull $BATCH_WORKER_IMAGE)
 
-BATCH_WORKER_IMAGE_ID=$(docker inspect $BATCH_WORKER_IMAGE --format='{{.Id}}' | cut -d':' -f2)
+BATCH_WORKER_IMAGE_ID=$(docker inspect $BATCH_WORKER_IMAGE --format='{{{{.Id}}}}' | cut -d':' -f2)
 
 # So here I go it's my shot.
 docker run \


### PR DESCRIPTION
I dev deployed all *_image steps on a single worker running `main` and saw many fail with corrupted filesystems. I imagine this is because multiple jobs were extracting the same filesystem into the same place. The previous change to using a r/w lock for pulling and deleting images is correct, but we must lock on the image id when *extracting* the actual filesystem. With this change everything passed in my dev. The `BATCH_WORKER_IMAGE_ID` fix from before didn't actually work because of not properly escaping the `{` in the f-string.

I also moved the `docker rmi` step to be first in the image cleanup process because I imagine if docker refuses to remove an image we shouldn't remove it from our own cache either.