### PR TITLE
[batch] Prefix job hostnames with hostname_

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -156,7 +156,7 @@ class NetworkNamespace:
         self.private = private
         self.internet_interface = internet_interface
         self.network_ns_name = uuid.uuid4().hex[:5]
-        self.hostname = uuid.uuid4().hex[:10]
+        self.hostname = 'hostname-' + uuid.uuid4().hex[:10]
         self.veth_host = self.network_ns_name + '-host'
         self.veth_job = self.network_ns_name + '-job'
 


### PR DESCRIPTION
Random hex strings, while valid, are a little dangerous to use as hostnames because some tools (Spark) could attempt to interpret an entirely numeric name as an IP address. This just avoids that danger entirely.