### PR TITLE
[batch] Write job logs to disk in user's XFS project

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -474,6 +474,14 @@ def test_log_after_failing_job(client):
     assert j.is_complete()
 
 
+def test_long_log_line(client):
+    b = client.create_batch()
+    j = b.create_job(DOCKER_ROOT_IMAGE, ['/bin/sh', '-c', 'for _ in {0..70000}; do echo -n a; done'])
+    b.submit()
+    status = j.wait()
+    assert status['state'] == 'Success'
+
+
 def test_authorized_users_only():
     session = external_requests_client_session()
     endpoints = [


### PR DESCRIPTION
The current implementation of piping into the worker's process and calling `readline` fails on log lines that are greater than 64KiB. This directs the container's stdout/stderr to a log file in their XFS project, so a job cannot blow up the worker with excessive logging. It then just calls `read` on the entire log file when requested, so there still is some issue of loading the log into memory, but no more so than currently exists.

The added test currently fails in default.