### PR TITLE
[query] Fix Array Encode

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -68,7 +68,7 @@ compileScala {
         "-target:jvm-1.8",
         "-feature",
         "-Xno-patmat-analysis",
- //       "-Xfatal-warnings",
+        "-Xfatal-warnings",
         "-Xlint:_",
         "-deprecation",
         "-unchecked",

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -68,7 +68,7 @@ compileScala {
         "-target:jvm-1.8",
         "-feature",
         "-Xno-patmat-analysis",
-        "-Xfatal-warnings",
+ //       "-Xfatal-warnings",
         "-Xlint:_",
         "-deprecation",
         "-unchecked",

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -61,7 +61,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
           cb.ifx(value.isElementMissing(i), cb.assign(b, b | (const(1) << shift)))
           cb.assign(shift, shift + 1)
           cb.assign(i, i + 1)
-          cb.ifx(shift.ceq(7), {
+          cb.ifx(shift.ceq(8), {
             cb.assign(shift, 0)
             cb += out.writeByte(b.toB)
             cb.assign(b, 0)

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -32,7 +32,7 @@ trait PStruct extends PBaseStruct {
 
   def rename(m: Map[String, String]): PStruct
 
-  def identBase: String = "tuple"
+  def identBase: String = "struct"
 
   final def selectFields(names: Seq[String]): PCanonicalStruct = PCanonicalStruct(required, names.map(f => f -> field(f).typ): _*)
 

--- a/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ETypeSuite.scala
@@ -156,4 +156,14 @@ class ETypeSuite extends HailSuite {
     assert(encodeDecode(pStructContainingNDArray, eStructContainingNDArray, pOnlyReadB, dataStruct) ==
       Row(3))
   }
+
+  @Test def testArrayOfString(): Unit = {
+    val etype = EArray(EBinary(false), false)
+    val toEncode = PCanonicalArray(PCanonicalStringRequired, false)
+    val toDecode = PCanonicalArray(PCanonicalStringOptional, false)
+    val longListOfStrings = (0 until 36).map(idx => s"foo_name_sample_${idx}")
+    val data = longListOfStrings
+
+    assert(encodeDecode(toEncode, etype, toDecode, data) == data)
+  }
 }


### PR DESCRIPTION
The main change here is changing a 7 to an 8. I'm not sure how any lowered array anything ever worked. We should release after this goes in. 