### PR TITLE
[docker] Make steps should fail if building an image fails

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 CONTEXT="$(cd $1 && pwd)"
 DOCKERFILE="$CONTEXT/$2"
 REMOTE_IMAGE_NAME=$3


### PR DESCRIPTION
Right now if a `make ... deploy` step fails to build one of its images it continues (because the building now happens in `docker-build.sh`), which can result in running a service that expects an image not in GCR.