### PR TITLE
[batch] Replace docker on the worker with podman

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -8,6 +8,7 @@ RUN chmod 755 /bin/retry && \
 RUN hail-apt-get-install \
     iproute2 \
     iptables \
+    wget \
     openjdk-8-jre-headless \
     liblapack3
 
@@ -32,23 +33,13 @@ RUN echo "APT::Acquire::Retries \"5\";" > /etc/apt/apt.conf.d/80-retries && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     hail-apt-get-install fuse gcsfuse
 
-# Install crun runtime dependencies
-RUN hail-apt-get-install libyajl-dev
+# pycairo, libcairo2-dev and pkg-config needed for a podman dependency. Without them `pip check` fails
+RUN . /etc/os-release && \
+    sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' >/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list" && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | apt-key add - && \
+    hail-apt-get-install libcairo2-dev pkg-config podman && \
+    hail-pip-install pycairo
 
-# Build crun in separate build step
-FROM base AS crun_builder
-RUN hail-apt-get-install make git gcc build-essential pkgconf libtool \
-   libsystemd-dev libcap-dev libseccomp-dev \
-   go-md2man libtool autoconf automake
-RUN git clone --depth 1 --branch 0.19.1 https://github.com/containers/crun.git && \
-   cd crun && \
-   ./autogen.sh && \
-   ./configure && \
-   make && \
-   make install
-
-FROM base
-COPY --from=crun_builder /usr/local/bin/crun /usr/local/bin/crun
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 
 COPY hail/python/setup-hailtop.py /hailtop/setup.py

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -43,11 +43,11 @@ deploy: build
 .PHONY: create-build-worker-image-instance
 create-build-worker-image-instance:
 	-gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch-worker-image
-	python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"$(DOCKER_ROOT_IMAGE)"}}' build-batch-worker-image-startup.sh build-batch-worker-image-startup.sh.out
+	python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"$(DOCKER_ROOT_IMAGE)", "docker_prefix": "$(DOCKER_PREFIX)"}}' build-batch-worker-image-startup.sh build-batch-worker-image-startup.sh.out
 	gcloud -q compute --project $(PROJECT) instances create --zone=$(ZONE) build-batch-worker-image --machine-type=n1-standard-1 --network=default --network-tier=PREMIUM --metadata-from-file startup-script=build-batch-worker-image-startup.sh.out --no-restart-on-failure --maintenance-policy=MIGRATE --scopes=https://www.googleapis.com/auth/cloud-platform --image=$$(gcloud compute images list --standard-images --filter 'family="ubuntu-minimal-2004-lts"' --format='value(name)') --image-project=ubuntu-os-cloud --boot-disk-size=10GB --boot-disk-type=pd-ssd
 
 .PHONY: create-worker-image
 create-worker-image:
-	-gcloud -q compute --project $(PROJECT) images delete batch-worker-12
-	gcloud -q compute --project $(PROJECT) images create batch-worker-12 --source-disk=build-batch-worker-image --source-disk-zone=$(ZONE)
+	-gcloud -q compute --project $(PROJECT) images delete batch-worker-13
+	gcloud -q compute --project $(PROJECT) images create batch-worker-13 --source-disk=build-batch-worker-image --source-disk-zone=$(ZONE)
 	gcloud -q compute --project $(PROJECT) instances delete --zone=$(ZONE) build-batch-worker-image

--- a/batch/batch/driver/create_instance.py
+++ b/batch/batch/driver/create_instance.py
@@ -72,7 +72,7 @@ def create_instance_config(
                 'boot': True,
                 'autoDelete': True,
                 'initializeParams': {
-                    'sourceImage': f'projects/{PROJECT}/global/images/batch-worker-12',
+                    'sourceImage': f'projects/{PROJECT}/global/images/batch-worker-13',
                     'diskType': f'projects/{PROJECT}/zones/{zone}/diskTypes/pd-ssd',
                     'diskSizeGb': str(boot_disk_size_gb),
                 },
@@ -136,11 +136,9 @@ sudo mount -o prjquota /dev/$WORKER_DATA_DISK_NAME /mnt/disks/$WORKER_DATA_DISK_
 sudo chmod a+w /mnt/disks/$WORKER_DATA_DISK_NAME
 XFS_DEVICE=$(xfs_info /mnt/disks/$WORKER_DATA_DISK_NAME | head -n 1 | awk '{{ print $1 }}' | awk  'BEGIN {{ FS = "=" }}; {{ print $2 }}')
 
-# reconfigure docker to use local SSD
-sudo service docker stop
-sudo mv /var/lib/docker /mnt/disks/$WORKER_DATA_DISK_NAME/docker
-sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/docker /var/lib/docker
-sudo service docker start
+# reconfigure podman to use local SSD
+sudo mv /var/lib/containers /mnt/disks/$WORKER_DATA_DISK_NAME/containers
+sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/containers /var/lib/containers
 
 # reconfigure /batch and /logs and /gcsfuse to use local SSD
 sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/batch/
@@ -153,6 +151,13 @@ sudo mkdir -p /mnt/disks/$WORKER_DATA_DISK_NAME/gcsfuse/
 sudo ln -s /mnt/disks/$WORKER_DATA_DISK_NAME/gcsfuse /gcsfuse
 
 sudo mkdir -p /etc/netns
+sudo mkdir -p /var/run/netns
+sudo mkdir -p /run/crun
+
+sysctl net.ipv4.ip_forward=1
+
+# By default drop traffic
+iptables --policy FORWARD DROP
 
 CORES=$(nproc)
 NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")
@@ -251,14 +256,11 @@ rm /etc/google-fluentd/google-fluentd.conf.bak
 
 sudo service google-fluentd restart
 
-# retry once
-docker pull $BATCH_WORKER_IMAGE || \
-(echo 'pull failed, retrying' && sleep 15 && docker pull $BATCH_WORKER_IMAGE)
-
-BATCH_WORKER_IMAGE_ID=$(docker inspect $BATCH_WORKER_IMAGE --format='{{{{.Id}}}}' | cut -d':' -f2)
+gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin $DOCKER_PREFIX
+BATCH_WORKER_IMAGE_ID=$(podman pull $BATCH_WORKER_IMAGE)
 
 # So here I go it's my shot.
-docker run \
+podman run \
 -e CORES=$CORES \
 -e NAME=$NAME \
 -e NAMESPACE=$NAMESPACE \
@@ -277,15 +279,14 @@ docker run \
 -e BATCH_WORKER_IMAGE_ID=$BATCH_WORKER_IMAGE_ID \
 -e UNRESERVED_WORKER_DATA_DISK_SIZE_GB=$UNRESERVED_WORKER_DATA_DISK_SIZE_GB \
 -e INTERNAL_GATEWAY_IP=$INTERNAL_GATEWAY_IP \
--v /var/run/docker.sock:/var/run/docker.sock \
 -v /var/run/netns:/var/run/netns:shared \
--v /usr/bin/docker:/usr/bin/docker \
+-v /var/lib/containers:/var/lib/containers \
+-v /run/crun:/run/crun \
 -v /usr/sbin/xfs_quota:/usr/sbin/xfs_quota \
 -v /batch:/batch:shared \
 -v /logs:/logs \
 -v /gcsfuse:/gcsfuse:shared \
 -v /etc/netns:/etc/netns \
--v /sys/fs/cgroup:/sys/fs/cgroup \
 --mount type=bind,source=/mnt/disks/$WORKER_DATA_DISK_NAME,target=/host \
 --mount type=bind,source=/dev,target=/dev,bind-propagation=rshared \
 -p 5000:5000 \
@@ -293,9 +294,11 @@ docker run \
 --device $XFS_DEVICE \
 --device /dev \
 --privileged \
---cap-add SYS_ADMIN \
---security-opt apparmor:unconfined \
+--security-opt apparmor=unconfined \
 --network host \
+--pid host \
+--cgroupns host \
+--name worker \
 $BATCH_WORKER_IMAGE \
 python3 -u -m batch.worker.worker >worker.log 2>&1
 
@@ -314,8 +317,6 @@ set -x
 
 INSTANCE_ID=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance_id")
 NAME=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
-
-journalctl -u docker.service > dockerd.log
 ''',
                 },
                 {'key': 'activation_token', 'value': activation_token},

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -2,7 +2,6 @@ from typing import Optional, Dict, Callable, Tuple, Awaitable, Any
 import os
 import json
 import sys
-import re
 import logging
 import asyncio
 import random
@@ -16,11 +15,9 @@ import aiohttp.client_exceptions
 from aiohttp import web
 import async_timeout
 import concurrent
-import aiodocker  # type: ignore
 import aiorwlock
 from collections import defaultdict
 import psutil
-from aiodocker.exceptions import DockerError  # type: ignore
 import google.oauth2.service_account  # type: ignore
 from hailtop.utils import (
     time_msecs,
@@ -45,8 +42,6 @@ from hailtop.batch.hail_genetics_images import HAIL_GENETICS_IMAGES
 from hailtop import aiotools
 from hailtop.aiotools.fs import RouterAsyncFS, LocalAsyncFS
 import hailtop.aiogoogle as aiogoogle
-
-# import uvloop
 
 from hailtop.config import DeployConfig
 from hailtop.hail_logging import configure_logging
@@ -73,8 +68,6 @@ from ..publicly_available_images import publicly_available_images
 from ..utils import storage_gib_to_bytes, Box
 
 from .disk import Disk
-
-# uvloop.install()
 
 configure_logging()
 log = logging.getLogger('batch-worker')
@@ -125,8 +118,6 @@ worker_config = WorkerConfig(WORKER_CONFIG)
 assert worker_config.cores == CORES
 
 deploy_config = DeployConfig('gce', NAMESPACE, {})
-
-docker: Optional[aiodocker.Docker] = None
 
 port_allocator: Optional['PortAllocator'] = None
 network_allocator: Optional['NetworkAllocator'] = None
@@ -284,34 +275,6 @@ class NetworkAllocator:
             self.public_networks.put_nowait(netns)
 
 
-def docker_call_retry(timeout, name):
-    async def wrapper(f, *args, **kwargs):
-        delay = 0.1
-        while True:
-            try:
-                return await asyncio.wait_for(f(*args, **kwargs), timeout)
-            except DockerError as e:
-                # 408 request timeout, 503 service unavailable
-                if e.status == 408 or e.status == 503:
-                    log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                # DockerError(500, 'Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
-                # DockerError(500, 'error creating overlay mount to /var/lib/docker/overlay2/545a1337742e0292d9ed197b06fe900146c85ab06e468843cd0461c3f34df50d/merged: device or resource busy'
-                # DockerError(500, 'Get https://gcr.io/v2/: dial tcp: lookup gcr.io: Temporary failure in name resolution')
-                elif e.status == 500 and (
-                    "request canceled while waiting for connection" in e.message
-                    or re.match("error creating overlay mount.*device or resource busy", e.message)
-                    or "Temporary failure in name resolution" in e.message
-                ):
-                    log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                else:
-                    raise
-            except (aiohttp.client_exceptions.ServerDisconnectedError, asyncio.TimeoutError):
-                log.warning(f'in docker call to {f.__name__} for {name}, retrying', stack_info=True, exc_info=True)
-                delay = await sleep_and_backoff(delay)
-
-    return wrapper
-
-
 class JobDeletedError(Exception):
     pass
 
@@ -357,20 +320,16 @@ def worker_fraction_in_1024ths(cpu_in_mcpu):
 
 
 def user_error(e):
-    if isinstance(e, DockerError):
-        if e.status == 404 and 'pull access denied' in e.message:
-            return True
-        if e.status == 404 and ('not found: manifest unknown' in e.message or 'no such image' in e.message):
-            return True
-        if e.status == 400 and 'executable file not found' in e.message:
-            return True
-    if isinstance(e, CalledProcessError):
+    user_error_messages = [
         # Opening GCS connection...\n', b'daemonize.Run: readFromProcess: sub-process: mountWithArgs: mountWithConn:
         # fs.NewServer: create file system: SetUpBucket: OpenBucket: Bad credentials for bucket "BUCKET". Check the
         # bucket name and your credentials.\n')
-        if 'Bad credentials for bucket' in e.outerr:
-            return True
-    return False
+        'Bad credentials for bucket',
+        'Error reading manifest',
+        'manifest unknown',
+        'executable file not found',
+    ]
+    return isinstance(e, CalledProcessError) and any(msg in e.outerr[1].decode() for msg in user_error_messages)
 
 
 class Container:
@@ -440,7 +399,7 @@ class Container:
                     # that a user has access to a cached image without pulling.
                     await self.pull_image()
                     self.image_config = image_configs[self.image_ref_str]
-                    self.image_id = self.image_config['Id'].split(":")[1]
+                    self.image_id = self.image_config['Id']
                     worker.image_data[self.image_id] += 1
 
                     self.rootfs_path = f'/host/rootfs/{self.image_id}'
@@ -521,37 +480,37 @@ class Container:
 
         try:
             if not is_google_image:
-                await self.ensure_image_is_pulled()
-            elif is_public_image:
-                auth = await self.batch_worker_access_token()
-                await self.ensure_image_is_pulled(auth=auth)
+                # Explicitly default to dockerhub
+                if self.image_ref.domain is None:
+                    self.image_ref.domain = 'docker.io'
+                    self.image_ref_str = str(self.image_ref)
+                await check_exec_output('podman', 'pull', self.image_ref_str)
             else:
-                # Pull to verify this user has access to this
-                # image.
-                # FIXME improve the performance of this with a
-                # per-user image cache.
-                auth = self.current_user_access_token()
-                await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                    docker.images.pull, self.image_ref_str, auth=auth
-                )
-        except DockerError as e:
-            if e.status == 404 and 'pull access denied' in e.message:
+                if is_public_image:
+                    auth = await self.batch_worker_access_token()
+                else:
+                    # Pull to verify this user has access to this
+                    # image.
+                    # FIXME improve the performance of this with a
+                    # per-user image cache.
+                    auth = self.current_user_access_token()
+                os.makedirs(self.container_scratch, exist_ok=True)
+                authfile_name = f'{self.container_scratch}/podman_auth.json'
+                with open(authfile_name, 'w+') as authfile:
+                    creds = base64.b64encode(f'{auth["username"]}:{auth["password"]}'.encode())
+                    auth_json = {'auths': {'gcr.io': {'auth': creds.decode()}}}
+                    authfile.write(json.dumps(auth_json))
+                await check_exec_output('podman', 'pull', f'--authfile={authfile_name}', self.image_ref_str)
+        except CalledProcessError as e:
+            error = e.outerr[1].decode()
+            if 'unauthorized' in error:
                 self.short_error = 'image cannot be pulled'
-            elif 'not found: manifest unknown' in e.message:
+            elif 'manifest unknown' in error:
                 self.short_error = 'image not found'
             raise
 
-        image_config, _ = await check_exec_output('docker', 'inspect', self.image_ref_str)
+        image_config, _ = await check_exec_output('podman', 'inspect', self.image_ref_str)
         image_configs[self.image_ref_str] = json.loads(image_config)[0]
-
-    async def ensure_image_is_pulled(self, auth=None):
-        try:
-            await docker_call_retry(MAX_DOCKER_OTHER_OPERATION_SECS, f'{self}')(docker.images.get, self.image_ref_str)
-        except DockerError as e:
-            if e.status == 404:
-                await docker_call_retry(MAX_DOCKER_IMAGE_PULL_SECS, f'{self}')(
-                    docker.images.pull, self.image_ref_str, auth=auth
-                )
 
     async def batch_worker_access_token(self):
         async with aiohttp.ClientSession(raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
@@ -572,7 +531,7 @@ class Container:
         assert self.rootfs_path
         os.makedirs(self.rootfs_path)
         await check_shell(
-            f'id=$(docker create {self.image_id}) && docker export $id | tar -C {self.rootfs_path} -xf - && docker rm $id'
+            f'id=$(podman create {self.image_id}) && podman export $id | tar -C {self.rootfs_path} -xf - && podman rm $id'
         )
         log.info(f'Extracted rootfs for image {self.image_ref_str}')
 
@@ -635,8 +594,10 @@ class Container:
     async def container_config(self):
         uid, gid = await self._get_in_container_user()
         weight = worker_fraction_in_1024ths(self.spec['cpu'])
-        workdir = self.image_config['Config']['WorkingDir']
-        default_docker_capabilities = [
+        workdir = self.image_config['Config'].get('WorkingDir')
+        if not workdir:
+            workdir = '/'
+        default_capabilities = [
             'CAP_CHOWN',
             'CAP_DAC_OVERRIDE',
             'CAP_FSETID',
@@ -669,11 +630,12 @@ class Container:
                 'env': self._env(),
                 'cwd': workdir if workdir != "" else "/",
                 'capabilities': {
-                    'bounding': default_docker_capabilities,
-                    'effective': default_docker_capabilities,
-                    'inheritable': default_docker_capabilities,
-                    'permitted': default_docker_capabilities,
+                    'bounding': default_capabilities,
+                    'effective': default_capabilities,
+                    'inheritable': default_capabilities,
+                    'permitted': default_capabilities,
                 },
+                'oomScoreAdj': 1,
             },
             'linux': {
                 'namespaces': [
@@ -728,7 +690,7 @@ class Container:
         return config
 
     async def _get_in_container_user(self):
-        user = self.image_config['Config']['User']
+        user = self.image_config['User']
         if not user:
             uid, gid = 0, 0
         elif ":" in user:
@@ -748,7 +710,7 @@ class Container:
     def _mounts(self, uid, gid):
         # Only supports empty volumes
         external_volumes = []
-        volumes = self.image_config['Config']['Volumes']
+        volumes = self.image_config['Config'].get('Volumes')
         if volumes:
             for v_container_path in volumes:
                 if not v_container_path.startswith('/'):
@@ -2056,7 +2018,7 @@ class Worker:
                     if image_data.ref_count == 0 and (now - image_data.last_accessed) > 10 * 60 * 1000:
                         assert image_id != BATCH_WORKER_IMAGE_ID
                         log.info(f'Found an unused image with ID {image_id}')
-                        await check_shell(f'docker rmi -f {image_id}')
+                        await check_exec_output('podman', 'rmi', '-f', image_id)
                         image_path = f'/host/rootfs/{image_id}'
                         await blocking_to_async(self.pool, shutil.rmtree, image_path)
                         del self.image_data[image_id]
@@ -2068,9 +2030,7 @@ class Worker:
 
 
 async def async_main():
-    global port_allocator, network_allocator, worker, docker
-
-    docker = aiodocker.Docker()
+    global port_allocator, network_allocator, worker
 
     port_allocator = PortAllocator()
     network_allocator = NetworkAllocator()
@@ -2084,10 +2044,7 @@ async def async_main():
             await worker.shutdown()
             log.info('worker shutdown')
         finally:
-            await docker.close()
-            log.info('docker closed')
             asyncio.get_event_loop().set_debug(True)
-            log.debug('Tasks immediately after docker close')
             dump_all_stacktraces()
             other_tasks = [t for t in asyncio.all_tasks() if t != asyncio.current_task()]
             if other_tasks:

--- a/batch/build-batch-worker-image-startup.sh
+++ b/batch/build-batch-worker-image-startup.sh
@@ -5,10 +5,12 @@ set -ex
 curl --silent --show-error --remote-name --fail https://dl.google.com/cloudagents/add-logging-agent-repo.sh
 bash add-logging-agent-repo.sh
 
-
 # Get the latest GPG key as it might not always be up to date
 # https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+source /etc/os-release
+sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
 apt-get update
 
 apt-get install -y \
@@ -18,37 +20,19 @@ apt-get install -y \
     google-fluentd \
     google-fluentd-catch-all-config-structured \
     jq \
-    software-properties-common
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-
-add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-
-apt-get install -y docker-ce
+    software-properties-common \
+    podman
 
 rm -rf /var/lib/apt/lists/*
-
-[ -f /etc/docker/daemon.json ] || echo "{}" > /etc/docker/daemon.json
 
 VERSION=2.0.4
 OS=linux
 ARCH=amd64
 
-curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_${OS}_${ARCH}-${VERSION}.tar.gz" \
-  | tar xz --to-stdout ./docker-credential-gcr \
-	> /usr/bin/docker-credential-gcr && chmod +x /usr/bin/docker-credential-gcr
-
 # avoid "unable to get current user home directory: os/user lookup failed"
 export HOME=/root
 
-docker-credential-gcr configure-docker --include-artifact-registry
-docker pull {{ global.docker_root_image }}
-
-# add docker daemon debug logging
-jq '.debug = true' /etc/docker/daemon.json > daemon.json.tmp
-mv daemon.json.tmp /etc/docker/daemon.json
+gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin {{ global.docker_prefix }}
+podman pull {{ global.docker_root_image }}
 
 shutdown -h now

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,5 +1,4 @@
 aiodns==2.0.0
-aiodocker==0.17.0
 aiohttp-jinja2==1.1.1
 aiohttp-session==2.7.0
 aiohttp==3.7.4


### PR DESCRIPTION
This introduces a new version of the batch worker instance: one without `docker`. Instead we bring in `podman` to cover the functions of pulling images, extracting expanding filesystems from those images, and running the worker container. `podman` by default uses `crun` as its low-level runtime so we can get rid of the independent `crun` installation in the worker image. `podman` is daemonless and can be run rootless. For the most part you can't tell the difference, except this makes `podman` easy to run under multiple users with different caches per user. So if you ssh into a worker, be sure to `sudo` before any `podman` (or `crun`) command or else you might think nothing is running when in fact the worker is running under root's podman configuration. The podman/crun state directories are now shared between the host and the worker so `sudo crun list` on the worker should reveal the running job containers without having to exec into the worker first.

For the most part, `podman` is a drop-in replacement for `docker`, but there are a handful of inconsistencies that comprise most of this PR. One notable change is that we no longer persist any GCR credentials in the worker VM image so we authenticate again on start up.

cc: @jigold 