### PR TITLE
[query] Fix loop memory management

### DIFF
--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -444,3 +444,8 @@ class Tests(unittest.TestCase):
 
         initial_struct = hl.struct(s1="a", s2="gfedcb")
         assert hl.eval(hl.experimental.loop(loop_func, hl.tstruct(s1=hl.tstr, s2=hl.tstr), initial_struct)) == hl.Struct(s1="abcd", s2="gfe")
+
+    def test_loop_memory(self):
+        def foo(recur, arr, idx): return hl.if_else(idx > 10, arr, recur(arr.append(hl.str(idx)), idx+1))
+
+        assert hl.eval(hl.experimental.loop(foo, hl.tarray(hl.tstr), hl.literal(['foo']), 1)) == ['foo', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2207,7 +2207,7 @@ class Emit[C](
 
         cb.define(loopStartLabel)
 
-        val result = emitI(body, env = argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRef))).map(cb) { pc =>
+        val result = emitI(body, region=loopRef.r1, env = argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRef))).map(cb) { pc =>
           val answerInRightRegion = pc.copyToRegion(cb, region, pc.st)
           cb.append(loopRef.r1.clearRegion())
           cb.append(loopRef.r2.clearRegion())
@@ -2219,9 +2219,9 @@ class Emit[C](
       case Recur(name, args, _) =>
         val loopRef = loopEnv.get.lookup(name)
 
-        // Need to emit into region 2, clear region 1, then swap them.
+        // Need to emit into region 1, copy to region 2, then clear region 1, then swap them.
         (loopRef.tmpLoopArgs, loopRef.loopTypes, args).zipped.map { case (tmpLoopArg, et, arg) =>
-          tmpLoopArg.store(cb, emitI(arg, loopEnv = None, region = loopRef.r2).map(cb)(_.castTo(cb, loopRef.r2, et.st)))
+          tmpLoopArg.store(cb, emitI(arg, loopEnv = None, region = loopRef.r1).map(cb)(_.copyToRegion(cb, loopRef.r2, et.st)))
         }
 
         cb.append(loopRef.r1.clearRegion())


### PR DESCRIPTION
Recur needs to emit its args into region 1, then copy them into region 2. Also the `emitI` result needs to emit into `loopRef.r1` before being copied into the main `region`. 