### PR TITLE
[hailtop.batch] Fix BatchPoolExecutor to cancel batches on errors

### DIFF
--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -250,6 +250,7 @@ class BatchPoolExecutor:
             for task in tasks:
                 if not task.done():
                     task.cancel()
+
             if tasks:
                 await asyncio.wait(tasks)
 
@@ -259,9 +260,9 @@ class BatchPoolExecutor:
                 if not task.cancelled() and not task.exception():
                     bp_future = task.result()
                     bp_futures.append(bp_future)
+
             if bp_futures:
                 await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
-            raise
 
         async def async_result_or_cancel_all(future):
             try:

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -537,7 +537,7 @@ class BatchPoolFuture:
         try:
             return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
         except asyncio.TimeoutError:
-            await self.batch.cancel()
+            await self.async_cancel()
             raise
 
     async def _async_fetch_result(self):

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -246,23 +246,25 @@ class BatchPoolExecutor:
 
         try:
             bp_futures: List[BatchPoolFuture] = await asyncio.gather(*tasks)
-        except Exception:
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
+        finally:
+            _, exc, _ = sys.exc_info()
+            if exc is not None:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
 
-            if tasks:
-                await asyncio.wait(tasks)
+                if tasks:
+                    await asyncio.wait(tasks)
 
-            bp_futures = []
-            for task in tasks:
-                assert task.done()
-                if not task.cancelled() and not task.exception():
-                    bp_future = task.result()
-                    bp_futures.append(bp_future)
+                bp_futures = []
+                for task in tasks:
+                    assert task.done()
+                    if not task.cancelled() and not task.exception():
+                        bp_future = task.result()
+                        bp_futures.append(bp_future)
 
-            if bp_futures:
-                await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
+                if bp_futures:
+                    await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
 
         async def async_result_or_cancel_all(future):
             try:
@@ -535,7 +537,7 @@ class BatchPoolFuture:
         try:
             return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
         except asyncio.TimeoutError:
-            await self.async_cancel()
+            await self.batch.cancel()
             raise
 
     async def _async_fetch_result(self):

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -250,7 +250,6 @@ class BatchPoolExecutor:
             for task in tasks:
                 if not task.done():
                     task.cancel()
-
             if tasks:
                 await asyncio.wait(tasks)
 
@@ -260,9 +259,9 @@ class BatchPoolExecutor:
                 if not task.cancelled() and not task.exception():
                     bp_future = task.result()
                     bp_futures.append(bp_future)
-
             if bp_futures:
                 await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
+            raise
 
         async def async_result_or_cancel_all(future):
             try:

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -240,23 +240,47 @@ class BatchPoolExecutor:
                 chunk for chunk in iterables_chunks if len(chunk) > 0]
             fn = chunk(fn)
             iterables = iterables_chunks
-        submissions = [self.async_submit(fn, *arguments)
-                       for arguments in zip(*iterables)]
-        futures: List[BatchPoolFuture] = await asyncio.gather(*submissions)
+
+        tasks = [asyncio.create_task(self.async_submit(fn, *arguments))
+                 for arguments in zip(*iterables)]
+
+        try:
+            bp_futures: List[BatchPoolFuture] = await asyncio.gather(*tasks)
+        finally:
+            _, exc, _ = sys.exc_info()
+            if exc is not None:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+
+                if tasks:
+                    await asyncio.wait(tasks)
+
+                bp_futures = []
+                for task in tasks:
+                    assert task.done()
+                    if not task.cancelled() and not task.exception():
+                        bp_future = task.result()
+                        bp_futures.append(bp_future)
+
+                if bp_futures:
+                    await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
 
         async def async_result_or_cancel_all(future):
             try:
                 return await future.async_result(timeout=timeout)
             except Exception as err:
-                for fut in futures:
-                    fut.cancel()
+                if bp_futures:
+                    await asyncio.wait([bp_fut.async_cancel() for bp_fut in bp_futures])
                 raise err
+
         if chunksize > 1:
             return (val
-                    for future in futures
+                    for future in bp_futures
                     for val in await async_result_or_cancel_all(future))
+
         return (await async_result_or_cancel_all(future)
-                for future in futures)
+                for future in bp_futures)
 
     def submit(self,
                fn: Callable,
@@ -324,7 +348,6 @@ class BatchPoolExecutor:
                            **kwargs: Any
                            ) -> 'BatchPoolFuture':
         """Aysncio compatible version of :meth:`BatchPoolExecutor.submit`."""
-
         if self._shutdown:
             raise RuntimeError('BatchPoolExecutor has already been shutdown.')
 
@@ -511,7 +534,11 @@ class BatchPoolFuture:
         """
         if self.cancelled():
             raise concurrent.futures.CancelledError()
-        return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
+        try:
+            return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
+        except asyncio.TimeoutError:
+            await self.batch.cancel()
+            raise
 
     async def _async_fetch_result(self):
         try:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -484,7 +484,6 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel
         if tasks:
             async with WithoutSemaphore(sema):
                 await asyncio.wait(tasks)
-        raise
 
 
 async def bounded_gather2(sema: asyncio.Semaphore, *pfs, return_exceptions: bool = False, cancel_on_error: bool = False):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -477,15 +477,13 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel
     try:
         async with WithoutSemaphore(sema):
             return await asyncio.gather(*tasks)
-    finally:
-        _, exc, _ = sys.exc_info()
-        if exc is not None:
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
-            if tasks:
-                async with WithoutSemaphore(sema):
-                    await asyncio.wait(tasks)
+    except Exception:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            async with WithoutSemaphore(sema):
+                await asyncio.wait(tasks)
 
 
 async def bounded_gather2(sema: asyncio.Semaphore, *pfs, return_exceptions: bool = False, cancel_on_error: bool = False):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -484,6 +484,7 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel
         if tasks:
             async with WithoutSemaphore(sema):
                 await asyncio.wait(tasks)
+        raise
 
 
 async def bounded_gather2(sema: asyncio.Semaphore, *pfs, return_exceptions: bool = False, cancel_on_error: bool = False):

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -477,13 +477,15 @@ async def bounded_gather2_raise_exceptions(sema: asyncio.Semaphore, *pfs, cancel
     try:
         async with WithoutSemaphore(sema):
             return await asyncio.gather(*tasks)
-    except Exception:
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        if tasks:
-            async with WithoutSemaphore(sema):
-                await asyncio.wait(tasks)
+    finally:
+        _, exc, _ = sys.exc_info()
+        if exc is not None:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                async with WithoutSemaphore(sema):
+                    await asyncio.wait(tasks)
 
 
 async def bounded_gather2(sema: asyncio.Semaphore, *pfs, return_exceptions: bool = False, cancel_on_error: bool = False):


### PR DESCRIPTION
First error was we were not cancelling the batch on TimeoutErrors. I kept the interface to timeout on the client side rather than passing the timeout to the service spec. We can revisit this design at another point.

I also added another layer of tasks to make sure we were cancelling batches in the case that a submit failed. Some coroutines may have already succeeded and created a BatchPoolFuture, which we need to cancel. We need to use tasks instead of coroutines as the input to `gather` because on at least one failure we need to know if the submit task was completed successfully to extract the BatchPoolFuture to cancel it.