### PR TITLE
[svcr] add VariantDataset class and add functions to vds submodule

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -46,6 +46,7 @@ from .matrixtable import MatrixTable, GroupedMatrixTable  # noqa: E402
 from .expr import *  # noqa: F401,F403,E402
 from .genetics import *  # noqa: F401,F403,E402
 from .methods import *  # noqa: F401,F403,E402
+from .vds import *  # noqa: F401,F403,E402
 from . import expr  # noqa: E402
 from . import genetics  # noqa: E402
 from . import methods  # noqa: E402
@@ -119,6 +120,7 @@ __all__ = [
 
 __all__.extend(genetics.__all__)
 __all__.extend(methods.__all__)
+__all__.extend(vds.__all__)
 
 # don't overwrite builtins in `from hail import *`
 import builtins  # noqa: E402

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -46,7 +46,6 @@ from .matrixtable import MatrixTable, GroupedMatrixTable  # noqa: E402
 from .expr import *  # noqa: F401,F403,E402
 from .genetics import *  # noqa: F401,F403,E402
 from .methods import *  # noqa: F401,F403,E402
-from .vds import *  # noqa: F401,F403,E402
 from . import expr  # noqa: E402
 from . import genetics  # noqa: E402
 from . import methods  # noqa: E402
@@ -57,6 +56,7 @@ from . import experimental  # noqa: E402
 from . import ir  # noqa: E402
 from . import backend  # noqa: E402
 from . import nd  # noqa: E402
+from . import vds  # noqa: E402
 from hail.expr import aggregators as agg  # noqa: E402
 from hail.utils import (Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls,  # noqa: E402
                         hadoop_stat, hadoop_exists, hadoop_is_file,
@@ -109,6 +109,7 @@ __all__ = [
     'plot',
     'experimental',
     'ir',
+    'vds',
     'backend',
     'current_backend',
     'debug_info',
@@ -120,7 +121,6 @@ __all__ = [
 
 __all__.extend(genetics.__all__)
 __all__.extend(methods.__all__)
-__all__.extend(vds.__all__)
 
 # don't overwrite builtins in `from hail import *`
 import builtins  # noqa: E402

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -1,23 +1,18 @@
-import os
-from collections import Counter
-from typing import List, Tuple, Union
-
 import hail as hl
-from hail.ir import TableToTableApply
-from hail.matrixtable import MatrixTable
-from hail.table import Table
-from hail.typecheck import anytype, nullable, oneof, typecheck
+from collections import Counter
+import os
+from typing import Tuple, List, Union
+from hail.typecheck import typecheck, oneof, anytype, nullable
 from hail.utils.java import Env, info
 from hail.utils.misc import divide_null
-from hail.vds import VariantDataset
+from hail.matrixtable import MatrixTable
+from hail.table import Table
+from hail.ir import TableToTableApply
+from .misc import require_biallelic, require_row_key_variant, require_col_key_str, require_table_key_variant
 
-from .misc import (require_biallelic, require_col_key_str,
-                   require_first_key_field_locus, require_row_key_variant,
-                   require_table_key_variant)
 
-
-@typecheck(mt=oneof(MatrixTable, VariantDataset), name=str)
-def sample_qc(mt, name='sample_qc') -> Union[MatrixTable, Table]:
+@typecheck(mt=MatrixTable, name=str)
+def sample_qc(mt, name='sample_qc') -> MatrixTable:
     """Compute per-sample metrics useful for quality control.
 
     .. include:: ../_templates/req_tvariant.rst
@@ -86,11 +81,7 @@ def sample_qc(mt, name='sample_qc') -> Union[MatrixTable, Table]:
         Dataset with a new column-indexed field `name`.
     """
 
-    if type(mt) is VariantDataset:
-        require_first_key_field_locus(mt.reference_data, 'sample_qc')
-        require_first_key_field_locus(mt.variant_data, 'sample_qc')
-    else:
-        require_row_key_variant(mt, 'sample_qc')
+    require_row_key_variant(mt, 'sample_qc')
 
     from hail.expr.functions import _num_allele_type, _allele_types
 
@@ -109,142 +100,75 @@ def sample_qc(mt, name='sample_qc') -> Union[MatrixTable, Table]:
 
     variant_ac = Env.get_uid()
     variant_atypes = Env.get_uid()
+    mt = mt.annotate_rows(**{variant_ac: hl.agg.call_stats(mt.GT, mt.alleles).AC,
+                             variant_atypes: mt.alleles[1:].map(lambda alt: allele_type(mt.alleles[0], alt))})
 
-    if type(mt) is VariantDataset:
-        gq_bins = (0, 20, 60)
-        vmt = mt.variant_data
-        if 'GT' not in vmt.entry:
-            vmt = vmt.annotate_entries(GT=hl.experimental.lgt_to_gt(vmt.LGT, vmt.LA))
+    bound_exprs = {}
+    gq_dp_exprs = {}
 
-        vmt = vmt.annotate_rows(**{variant_ac: hl.agg.call_stats(vmt.GT, vmt.alleles).AC,
-                                   variant_atypes: vmt.alleles[1:].map(lambda alt: allele_type(vmt.alleles[0], alt))})
+    def has_field_of_type(name, dtype):
+        return name in mt.entry and mt[name].dtype == dtype
 
-        bound_exprs = {}
+    if has_field_of_type('DP', hl.tint32):
+        gq_dp_exprs['dp_stats'] = hl.agg.stats(mt.DP).select('mean', 'stdev', 'min', 'max')
 
-        bound_exprs['n_het'] = hl.agg.count_where(vmt['GT'].is_het())
-        bound_exprs['n_hom_var'] = hl.agg.count_where(vmt['GT'].is_hom_var())
-        bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, vmt['GT'].ploidy).map(lambda i: vmt[variant_ac][vmt['GT'][i]] == 1)))
+    if has_field_of_type('GQ', hl.tint32):
+        gq_dp_exprs['gq_stats'] = hl.agg.stats(mt.GQ).select('mean', 'stdev', 'min', 'max')
 
-        def get_allele_type(allele_idx):
-            return hl.if_else(allele_idx > 0, vmt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
+    if not has_field_of_type('GT', hl.tcall):
+        raise ValueError("'sample_qc': expect an entry field 'GT' of type 'call'")
 
-        bound_exprs['allele_type_counts'] = hl.agg.explode(
-            lambda elt: hl.agg.counter(elt),
-            hl.range(0, vmt['GT'].ploidy).map(lambda i: get_allele_type(vmt['GT'][i])))
+    bound_exprs['n_called'] = hl.agg.count_where(hl.is_defined(mt['GT']))
+    bound_exprs['n_not_called'] = hl.agg.count_where(hl.is_missing(mt['GT']))
 
-        zero = hl.int64(0)
+    n_rows_ref = hl.expr.construct_expr(hl.ir.Ref('n_rows'), hl.tint64, mt._col_indices,
+                                        hl.utils.LinkedList(hl.expr.expressions.Aggregation))
+    bound_exprs['n_filtered'] = n_rows_ref - hl.agg.count()
+    bound_exprs['n_hom_ref'] = hl.agg.count_where(mt['GT'].is_hom_ref())
+    bound_exprs['n_het'] = hl.agg.count_where(mt['GT'].is_het())
+    bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, mt['GT'].ploidy).map(lambda i: mt[variant_ac][mt['GT'][i]] == 1)))
 
-        gq_exprs = hl.agg.filter(hl.is_defined(vmt.GT),
-                                 hl.struct(**{f'gq_over_{x}': hl.agg.count_where(vmt.GQ > x)
-                                              for x in gq_bins}))
+    def get_allele_type(allele_idx):
+        return hl.if_else(allele_idx > 0, mt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
 
-        result_struct = hl.rbind(
-            hl.struct(**bound_exprs),
-            lambda x: hl.rbind(
-                hl.struct(**{
-                    'gq_exprs': gq_exprs,
-                    'n_het': x.n_het,
-                    'n_hom_var': x.n_hom_var,
-                    'n_non_ref': x.n_het + x.n_hom_var,
-                    'n_singleton': x.n_singleton,
-                    'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
-                              + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
-                    'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
-                    'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
-                    'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
-                    'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
-                    'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
-                }),
-                lambda s: s.annotate(
-                    r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
-                    r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
-                    r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
-                )))
-        variant_results = vmt.select_cols(**result_struct).cols()
+    bound_exprs['allele_type_counts'] = hl.agg.explode(
+        lambda elt: hl.agg.counter(elt),
+        hl.range(0, mt['GT'].ploidy).map(lambda i: get_allele_type(mt['GT'][i])))
 
-        rmt = mt.reference_data
-        ref_results = rmt.select_cols(gq_exprs=hl.struct(**{
-            f'gq_over_{x}': hl.agg.filter(rmt.GQ > x, hl.agg.sum(1 + rmt.END - rmt.locus.position))
-            for x in gq_bins
-        })).cols()
+    zero = hl.int64(0)
 
-        joined = ref_results[variant_results.key].gq_exprs
-        joined_results = variant_results.transmute(**{
-            f'gq_over_{x}': variant_results.gq_exprs[f'gq_over_{x}'] + joined[f'gq_over_{x}']
-            for x in gq_bins
-        })
-        return joined_results
+    result_struct = hl.rbind(
+        hl.struct(**bound_exprs),
+        lambda x: hl.rbind(
+            hl.struct(**{
+                **gq_dp_exprs,
+                'call_rate': hl.float64(x.n_called) / (x.n_called + x.n_not_called + x.n_filtered),
+                'n_called': x.n_called,
+                'n_not_called': x.n_not_called,
+                'n_filtered': x.n_filtered,
+                'n_hom_ref': x.n_hom_ref,
+                'n_het': x.n_het,
+                'n_hom_var': x.n_called - x.n_hom_ref - x.n_het,
+                'n_non_ref': x.n_called - x.n_hom_ref,
+                'n_singleton': x.n_singleton,
+                'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
+                          + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
+                'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
+                'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
+                'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
+                'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
+                'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
+            }),
+            lambda s: s.annotate(
+                r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
+                r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
+                r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
+            )))
 
+    mt = mt.annotate_cols(**{name: result_struct})
+    mt = mt.drop(variant_ac, variant_atypes)
 
-    else:
-        mt = mt.annotate_rows(**{variant_ac: hl.agg.call_stats(mt.GT, mt.alleles).AC,
-                                 variant_atypes: mt.alleles[1:].map(lambda alt: allele_type(mt.alleles[0], alt))})
-
-        bound_exprs = {}
-        gq_dp_exprs = {}
-
-        def has_field_of_type(name, dtype):
-            return name in mt.entry and mt[name].dtype == dtype
-
-        if has_field_of_type('DP', hl.tint32):
-            gq_dp_exprs['dp_stats'] = hl.agg.stats(mt.DP).select('mean', 'stdev', 'min', 'max')
-
-        if has_field_of_type('GQ', hl.tint32):
-            gq_dp_exprs['gq_stats'] = hl.agg.stats(mt.GQ).select('mean', 'stdev', 'min', 'max')
-
-        if not has_field_of_type('GT', hl.tcall):
-            raise ValueError("'sample_qc': expect an entry field 'GT' of type 'call'")
-
-        bound_exprs['n_called'] = hl.agg.count_where(hl.is_defined(mt['GT']))
-        bound_exprs['n_not_called'] = hl.agg.count_where(hl.is_missing(mt['GT']))
-
-        n_rows_ref = hl.expr.construct_expr(hl.ir.Ref('n_rows'), hl.tint64, mt._col_indices,
-                                            hl.utils.LinkedList(hl.expr.expressions.Aggregation))
-        bound_exprs['n_filtered'] = n_rows_ref - hl.agg.count()
-        bound_exprs['n_hom_ref'] = hl.agg.count_where(mt['GT'].is_hom_ref())
-        bound_exprs['n_het'] = hl.agg.count_where(mt['GT'].is_het())
-        bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, mt['GT'].ploidy).map(lambda i: mt[variant_ac][mt['GT'][i]] == 1)))
-
-        def get_allele_type(allele_idx):
-            return hl.if_else(allele_idx > 0, mt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
-
-        bound_exprs['allele_type_counts'] = hl.agg.explode(
-            lambda elt: hl.agg.counter(elt),
-            hl.range(0, mt['GT'].ploidy).map(lambda i: get_allele_type(mt['GT'][i])))
-
-        zero = hl.int64(0)
-
-        result_struct = hl.rbind(
-            hl.struct(**bound_exprs),
-            lambda x: hl.rbind(
-                hl.struct(**{
-                    **gq_dp_exprs,
-                    'call_rate': hl.float64(x.n_called) / (x.n_called + x.n_not_called + x.n_filtered),
-                    'n_called': x.n_called,
-                    'n_not_called': x.n_not_called,
-                    'n_filtered': x.n_filtered,
-                    'n_hom_ref': x.n_hom_ref,
-                    'n_het': x.n_het,
-                    'n_hom_var': x.n_called - x.n_hom_ref - x.n_het,
-                    'n_non_ref': x.n_called - x.n_hom_ref,
-                    'n_singleton': x.n_singleton,
-                    'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
-                              + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
-                    'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
-                    'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
-                    'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
-                    'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
-                    'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
-                }),
-                lambda s: s.annotate(
-                    r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
-                    r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
-                    r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
-                )))
-
-        mt = mt.annotate_cols(**{name: result_struct})
-        mt = mt.drop(variant_ac, variant_atypes)
-        return mt
+    return mt
 
 
 @typecheck(mt=MatrixTable, name=str)
@@ -533,8 +457,8 @@ def concordance(left, right, *, _localize_global_statistics=True) -> Tuple[List[
     def n_discordant(counter):
         return hl.sum(
             hl.array(counter)
-                .filter(lambda tup: hl.literal(discordant_indices).contains(tup[0]))
-                .map(lambda tup: tup[1]))
+            .filter(lambda tup: hl.literal(discordant_indices).contains(tup[0]))
+            .map(lambda tup: tup[1]))
 
     glob = joined.aggregate_entries(concordance_array(aggr), _localize=_localize_global_statistics)
     if _localize_global_statistics:

--- a/hail/python/hail/vds/__init__.py
+++ b/hail/python/hail/vds/__init__.py
@@ -1,6 +1,8 @@
 from .variant_dataset import VariantDataset, read_vds
+from .methods import sample_qc
 
 __all__ = [
     'VariantDataset',
-    'read_vds'
+    'read_vds',
+    'sample_qc'
 ]

--- a/hail/python/hail/vds/__init__.py
+++ b/hail/python/hail/vds/__init__.py
@@ -1,0 +1,6 @@
+from .variant_dataset import VariantDataset, read_vds
+
+__all__ = [
+    'VariantDataset',
+    'read_vds'
+]

--- a/hail/python/hail/vds/__init__.py
+++ b/hail/python/hail/vds/__init__.py
@@ -1,8 +1,14 @@
+from .methods import filter_intervals, filter_samples, filter_variants, sample_qc, split_multi, to_dense_mt, to_merged_sparse_mt
 from .variant_dataset import VariantDataset, read_vds
-from .methods import sample_qc
 
 __all__ = [
     'VariantDataset',
     'read_vds',
-    'sample_qc'
+    'filter_intervals',
+    'filter_samples',
+    'filter_variants',
+    'sample_qc',
+    'split_multi',
+    'to_dense_mt',
+    'to_merged_sparse_mt'
 ]

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -1,0 +1,113 @@
+from typing import Sequence
+
+import hail as hl
+from hail.methods.misc import require_first_key_field_locus
+from hail.table import Table
+from hail.typecheck import sequenceof, typecheck
+from hail.utils.java import Env
+from hail.utils.misc import divide_null
+from hail.vds import VariantDataset
+
+
+@typecheck(vds=VariantDataset, name=str, gq_bins=sequenceof(int))
+def sample_qc(vds, *, name='sample_qc', gq_bins: 'Sequence[int]' = (0, 20, 60)) -> 'Table':
+    """Run sample_qc on dataset in the sparse :class:`.VariantDataset` representation.
+
+    Parameters
+    ----------
+    vds : :class:`.VariantDataset`
+        Dataset in sparse variant dataset representation.
+    name : :obj:`str`
+        Name for resulting field.
+    gq_bins : :class:`tup` of :obj:`int`
+        Tuple containing cutoffs for genotype quality (GQ) scores.
+
+    Returns
+    -------
+    :class:`.Table`
+        Hail Table of results, keyed by sample.
+    """
+
+    require_first_key_field_locus(vds.reference_data, 'sample_qc')
+    require_first_key_field_locus(vds.variant_data, 'sample_qc')
+
+    from hail.expr.functions import _num_allele_type, _allele_types
+
+    allele_types = _allele_types[:]
+    allele_types.extend(['Transition', 'Transversion'])
+    allele_enum = {i: v for i, v in enumerate(allele_types)}
+    allele_ints = {v: k for k, v in allele_enum.items()}
+
+    def allele_type(ref, alt):
+        return hl.bind(lambda at: hl.if_else(at == allele_ints['SNP'],
+                                             hl.if_else(hl.is_transition(ref, alt),
+                                                        allele_ints['Transition'],
+                                                        allele_ints['Transversion']),
+                                             at),
+                       _num_allele_type(ref, alt))
+
+    variant_ac = Env.get_uid()
+    variant_atypes = Env.get_uid()
+
+    vmt = vds.variant_data
+    if 'GT' not in vmt.entry:
+        vmt = vmt.annotate_entries(GT=hl.experimental.lgt_to_gt(vmt.LGT, vmt.LA))
+
+    vmt = vmt.annotate_rows(**{variant_ac: hl.agg.call_stats(vmt.GT, vmt.alleles).AC,
+                               variant_atypes: vmt.alleles[1:].map(lambda alt: allele_type(vmt.alleles[0], alt))})
+
+    bound_exprs = {}
+
+    bound_exprs['n_het'] = hl.agg.count_where(vmt['GT'].is_het())
+    bound_exprs['n_hom_var'] = hl.agg.count_where(vmt['GT'].is_hom_var())
+    bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, vmt['GT'].ploidy).map(lambda i: vmt[variant_ac][vmt['GT'][i]] == 1)))
+
+    def get_allele_type(allele_idx):
+        return hl.if_else(allele_idx > 0, vmt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
+
+    bound_exprs['allele_type_counts'] = hl.agg.explode(
+        lambda elt: hl.agg.counter(elt),
+        hl.range(0, vmt['GT'].ploidy).map(lambda i: get_allele_type(vmt['GT'][i])))
+
+    zero = hl.int64(0)
+
+    gq_exprs = hl.agg.filter(hl.is_defined(vmt.GT),
+                             hl.struct(**{f'gq_over_{x}': hl.agg.count_where(vmt.GQ > x)
+                                          for x in gq_bins}))
+
+    result_struct = hl.rbind(
+        hl.struct(**bound_exprs),
+        lambda x: hl.rbind(
+            hl.struct(**{
+                'gq_exprs': gq_exprs,
+                'n_het': x.n_het,
+                'n_hom_var': x.n_hom_var,
+                'n_non_ref': x.n_het + x.n_hom_var,
+                'n_singleton': x.n_singleton,
+                'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
+                          + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
+                'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
+                'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
+                'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
+                'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
+                'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
+            }),
+            lambda s: s.annotate(
+                r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
+                r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
+                r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
+            )))
+    variant_results = vmt.select_cols(**result_struct).cols()
+
+    rmt = vds.reference_data
+    ref_results = rmt.select_cols(gq_exprs=hl.struct(**{
+        f'gq_over_{x}': hl.agg.filter(rmt.GQ > x, hl.agg.sum(1 + rmt.END - rmt.locus.position))
+        for x in gq_bins
+    })).cols()
+
+    joined = ref_results[variant_results.key].gq_exprs
+    joined_results = variant_results.transmute(**{
+        f'gq_over_{x}': variant_results.gq_exprs[f'gq_over_{x}'] + joined[f'gq_over_{x}']
+        for x in gq_bins
+    })
+    return joined_results

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -8,7 +8,7 @@ from hail.table import Table
 from hail.typecheck import sequenceof, typecheck
 from hail.utils.java import Env
 from hail.utils.misc import divide_null
-from hail.vds import VariantDataset
+from hail.vds.variant_dataset import VariantDataset
 
 
 @typecheck(vds=VariantDataset)

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -1,0 +1,222 @@
+import hail as hl
+import os
+
+from hail.utils.java import Env
+from hail.utils.misc import divide_null
+from typing import Sequence
+
+
+def read_vds(path):
+    """
+
+    Parameters
+    ----------
+    path: :obj:`str`
+
+    Returns
+    -------
+    :class:`.VariantDataset`
+    """
+    reference_data = hl.read_matrix_table(VariantDataset._reference_path(path))
+    variant_data = hl.read_matrix_table(VariantDataset._variants_path(path))
+
+    return VariantDataset(reference_data, variant_data)
+
+class VariantDataset(object):
+    """
+    Class for representing cohort-level genomic data.
+    """
+
+    @staticmethod
+    def _reference_path(base: str) -> str:
+        return os.path.join(base, 'reference_data')
+
+    @staticmethod
+    def _variants_path(base: str) -> str:
+        return os.path.join(base, 'variant_data')
+
+
+    @staticmethod
+    def from_merged_representation(mt, ref_block_fields = ('GQ', 'DP', 'MIN_DP')):
+        gt_field = 'LGT' if 'LGT' in mt.entry else 'GT'
+        rmt = mt.filter_entries(mt[gt_field].is_hom_ref())
+        rmt = rmt.select_entries(*(x for x in ref_block_fields if x in rmt.entry), 'END')
+        rmt = rmt.filter_rows(hl.agg.count() > 0)
+
+        # drop other alleles
+        rmt = rmt.key_rows_by(rmt.locus)
+        rmt = rmt.annotate_rows(alleles=rmt.alleles[:1])
+
+        vmt = mt.filter_entries(mt[gt_field].is_non_ref() | hl.is_missing(mt[gt_field]))
+        vmt = vmt.filter_rows(hl.agg.count() > 0)
+
+        return VariantDataset(rmt, vmt)
+
+    def __init__(self, reference_data: 'hl.MatrixTable', variant_data: 'hl.MatrixTable'):
+        self.reference_data: 'hl.MatrixTable' = reference_data
+        self.variant_data: 'hl.MatrixTable' = variant_data
+
+    def write(self, path, **kwargs):
+        self.reference_data.write(VariantDataset._reference_path(path), **kwargs)
+        self.variant_data.write(VariantDataset._variants_path(path), **kwargs)
+
+    def checkpoint(self, path, **kwargs):
+        self.write(path, **kwargs)
+        return hl.read_vds(path)
+
+    def filter_intervals(self, intervals, *, keep=False):
+        # for now, don't touch reference data.
+        # should remove large regions and scan forward ref blocks to the start of the next kept region
+        self.variant_data = hl.filter_intervals(self.variant_data, intervals, keep)
+
+    def merged_sparse_mt(self):
+        rht = self.reference_data \
+            .localize_entries('ref_entries', 'ref_cols')
+        vht = self.variant_data.localize_entries('var_entries', 'var_cols').rename({'alleles': 'var_alleles'})
+
+        merged_schema = {}
+        for e in self.reference_data.entry:
+            merged_schema[e] = self.reference_data[e].dtype
+        for e in self.variant_data.entry:
+            if e in merged_schema:
+                if not merged_schema[e] == self.variant_data[e].dtype:
+                    raise TypeError(f"cannot unify field {e!r}: {merged_schema[e]}, {self.variant_data[e].dtype}")
+            else:
+                merged_schema[e] = self.variant_data[e].dtype
+
+        ht = rht.join(vht, how='outer').drop('ref_cols')
+
+        def merge_arrays(r_array, v_array):
+
+            def rewrite_ref(r):
+                ref_block_selector = {}
+                for k, t in merged_schema.items():
+                    if k == 'LA':
+                        ref_block_selector[k] = hl.literal([0])
+                    elif k in ('LGT', 'GT'):
+                        ref_block_selector[k] = hl.call(0, 0)
+                    else:
+                        ref_block_selector[k] = r[k] if k in r else hl.missing(t)
+                return r.select(**ref_block_selector)
+
+            def rewrite_var(v):
+                return v.select(**{
+                    k: v[k] if k in v else hl.missing(t)
+                    for k, t in merged_schema.items()
+                })
+
+            return hl.case() \
+                .when(hl.is_missing(r_array), v_array.map(rewrite_var)) \
+                .when(hl.is_missing(v_array), r_array.map(rewrite_ref)) \
+                .default(hl.zip(r_array, v_array).map(lambda t: hl.coalesce(rewrite_ref(t[0]), rewrite_var(t[1]))))
+
+        ht = ht.select(alleles=hl.coalesce(ht['var_alleles'], ht['alleles']),
+                       **{k: ht[k] for k in self.variant_data.row_value if k != 'alleles'}, # handle cases where vmt is not keyed by alleles
+                       entries=merge_arrays(ht['ref_entries'], ht['var_entries']))
+        return ht._unlocalize_entries('entries', 'var_cols', list(self.variant_data.col_key))
+
+
+    def dense_mt(self):
+        # we can do something more efficient here!
+        return hl.experimental.densify(self.merged_sparse_mt())
+
+    def split_multi(self, *, filter_changed_loci: bool = False):
+        self.variant_data = hl.experimental.sparse_split_multi(self.variant_data, filter_changed_loci=filter_changed_loci)
+
+    def sample_qc(self, *, name='sample_qc', gq_bins: 'Sequence[int]' = (0, 20, 60)) -> 'hl.Table':
+
+        from hail.expr.functions import _num_allele_type, _allele_types
+
+        allele_types = _allele_types[:]
+        allele_types.extend(['Transition', 'Transversion'])
+        allele_enum = {i: v for i, v in enumerate(allele_types)}
+        allele_ints = {v: k for k, v in allele_enum.items()}
+
+        def allele_type(ref, alt):
+            return hl.bind(lambda at: hl.if_else(at == allele_ints['SNP'],
+                                                 hl.if_else(hl.is_transition(ref, alt),
+                                                            allele_ints['Transition'],
+                                                            allele_ints['Transversion']),
+                                                 at),
+                           _num_allele_type(ref, alt))
+
+        variant_ac = Env.get_uid()
+        variant_atypes = Env.get_uid()
+
+        vmt = self.variant_data
+        if not 'GT' in vmt.entry:
+            vmt = vmt.annotate_entries(GT=hl.experimental.lgt_to_gt(vmt.LGT, vmt.LA))
+
+
+        vmt = vmt.annotate_rows(**{variant_ac: hl.agg.call_stats(vmt.GT, vmt.alleles).AC,
+                                 variant_atypes: vmt.alleles[1:].map(lambda alt: allele_type(vmt.alleles[0], alt))})
+
+        bound_exprs = {}
+
+        bound_exprs['n_het'] = hl.agg.count_where(vmt['GT'].is_het())
+        bound_exprs['n_hom_var'] = hl.agg.count_where(vmt['GT'].is_hom_var())
+        bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, vmt['GT'].ploidy).map(lambda i: vmt[variant_ac][vmt['GT'][i]] == 1)))
+
+        def get_allele_type(allele_idx):
+            return hl.if_else(allele_idx > 0, vmt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
+
+        bound_exprs['allele_type_counts'] = hl.agg.explode(
+            lambda elt: hl.agg.counter(elt),
+            hl.range(0, vmt['GT'].ploidy).map(lambda i: get_allele_type(vmt['GT'][i])))
+
+        zero = hl.int64(0)
+
+        gq_exprs = hl.agg.filter(hl.is_defined(vmt.GT),
+                                 hl.struct(**{f'gq_over_{x}': hl.agg.count_where(vmt.GQ > x)
+                                              for x in gq_bins}))
+
+        result_struct = hl.rbind(
+            hl.struct(**bound_exprs),
+            lambda x: hl.rbind(
+                hl.struct(**{
+                    'gq_exprs': gq_exprs,
+                    'n_het': x.n_het,
+                    'n_hom_var': x.n_hom_var,
+                    'n_non_ref': x.n_het + x.n_hom_var,
+                    'n_singleton': x.n_singleton,
+                    'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
+                              + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
+                    'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
+                    'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
+                    'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
+                    'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
+                    'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
+                }),
+                lambda s: s.annotate(
+                    r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
+                    r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
+                    r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
+                )))
+        variant_results = vmt.select_cols(**result_struct).cols()
+
+        rmt = self.reference_data
+        ref_results = rmt.select_cols(gq_exprs=hl.struct(**{
+            f'gq_over_{x}': hl.agg.filter(rmt.GQ > x, hl.agg.sum(1 + rmt.END - rmt.locus.position))
+            for x in gq_bins
+        })).cols()
+
+        joined = ref_results[variant_results.key].gq_exprs
+        return variant_results.transmute(**{
+            f'gq_over_{x}': variant_results.gq_exprs[f'gq_over_{x}'] + joined[f'gq_over_{x}']
+                for x in gq_bins
+        })
+
+    def filter_samples(self, samples_table: 'hl.Table', *, keep: bool = True):
+        if not list(samples_table[x].dtype for x in samples_table.key) == [hl.tstr]:
+            raise TypeError(f'invalid key: {samples_table.key.dtype}')
+        samples_to_keep = samples_table.aggregate(hl.agg.collect_as_set(samples_table.key[0]), _localize=False)._persist()
+        self.reference_data = self.reference_data.filter_cols(samples_to_keep.contains(self.reference_data.key[0]), keep=keep)
+        self.variant_data = self.variant_data.filter_cols(samples_to_keep.contains(self.variant_data.key[0]), keep=keep)
+
+    def filter_variants(self, variants_table: 'hl.Table', *, keep: bool = True):
+        # don't remove reference data
+        if keep:
+            self.variant_data = self.variant_data.semi_join_rows(variants_table)
+        else:
+            self.variant_data = self.variant_data.anti_join_rows(variants_table)
+

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -1,13 +1,11 @@
 import os
-from typing import Sequence
 
 import hail as hl
-from hail.utils.java import Env
-from hail.utils.misc import divide_null
+from hail.matrixtable import MatrixTable
 
 
 def read_vds(path):
-    """
+    """Read in a :class:`.VariantDataset` written with :meth:`.VariantDataset.write`.
 
     Parameters
     ----------
@@ -23,9 +21,19 @@ def read_vds(path):
     return VariantDataset(reference_data, variant_data)
 
 
-class VariantDataset(object):
-    """
-    Class for representing cohort-level genomic data.
+class VariantDataset:
+    """Class for representing cohort-level genomic data.
+
+    This class facilitates a sparse, split representation of genomic data in
+    which reference block data and variant data are contained in separate
+    :class:`.MatrixTable` objects.
+
+    Parameters
+    ----------
+    reference_data : :class:`.MatrixTable`
+        MatrixTable containing only reference block data.
+    variant_data : :class:`.MatrixTable`
+        MatrixTable containing only variant data.
     """
 
     @staticmethod
@@ -52,9 +60,9 @@ class VariantDataset(object):
 
         return VariantDataset(rmt, vmt)
 
-    def __init__(self, reference_data: 'hl.MatrixTable', variant_data: 'hl.MatrixTable'):
-        self.reference_data: 'hl.MatrixTable' = reference_data
-        self.variant_data: 'hl.MatrixTable' = variant_data
+    def __init__(self, reference_data: 'MatrixTable', variant_data: 'MatrixTable'):
+        self.reference_data: 'MatrixTable' = reference_data
+        self.variant_data: 'MatrixTable' = variant_data
 
     def write(self, path, **kwargs):
         self.reference_data.write(VariantDataset._reference_path(path), **kwargs)
@@ -63,182 +71,3 @@ class VariantDataset(object):
     def checkpoint(self, path, **kwargs):
         self.write(path, **kwargs)
         return hl.read_vds(path)
-
-    def filter_intervals(self, intervals, *, keep=False):
-        # for now, don't touch reference data.
-        # should remove large regions and scan forward ref blocks to the start of the next kept region
-        self.variant_data = hl.filter_intervals(self.variant_data, intervals, keep)
-
-    def merged_sparse_mt(self):
-        rht = self.reference_data \
-            .localize_entries('ref_entries', 'ref_cols')
-        vht = self.variant_data.localize_entries('var_entries', 'var_cols').rename({'alleles': 'var_alleles'})
-
-        merged_schema = {}
-        for e in self.reference_data.entry:
-            merged_schema[e] = self.reference_data[e].dtype
-        for e in self.variant_data.entry:
-            if e in merged_schema:
-                if not merged_schema[e] == self.variant_data[e].dtype:
-                    raise TypeError(f"cannot unify field {e!r}: {merged_schema[e]}, {self.variant_data[e].dtype}")
-            else:
-                merged_schema[e] = self.variant_data[e].dtype
-
-        ht = rht.join(vht, how='outer').drop('ref_cols')
-
-        def merge_arrays(r_array, v_array):
-
-            def rewrite_ref(r):
-                ref_block_selector = {}
-                for k, t in merged_schema.items():
-                    if k == 'LA':
-                        ref_block_selector[k] = hl.literal([0])
-                    elif k in ('LGT', 'GT'):
-                        ref_block_selector[k] = hl.call(0, 0)
-                    else:
-                        ref_block_selector[k] = r[k] if k in r else hl.missing(t)
-                return r.select(**ref_block_selector)
-
-            def rewrite_var(v):
-                return v.select(**{
-                    k: v[k] if k in v else hl.missing(t)
-                    for k, t in merged_schema.items()
-                })
-
-            return hl.case() \
-                .when(hl.is_missing(r_array), v_array.map(rewrite_var)) \
-                .when(hl.is_missing(v_array), r_array.map(rewrite_ref)) \
-                .default(hl.zip(r_array, v_array).map(lambda t: hl.coalesce(rewrite_ref(t[0]), rewrite_var(t[1]))))
-
-        ht = ht.select(alleles=hl.coalesce(ht['var_alleles'], ht['alleles']),
-                       **{k: ht[k] for k in self.variant_data.row_value if k != 'alleles'},  # handle cases where vmt is not keyed by alleles
-                       entries=merge_arrays(ht['ref_entries'], ht['var_entries']))
-        return ht._unlocalize_entries('entries', 'var_cols', list(self.variant_data.col_key))
-
-    def dense_mt(self):
-        ref = self.reference_data
-        ref = ref.drop(*(x for x in ('alleles', 'rsid') if x in ref.row))
-        var = self.variant_data
-        refl = ref.localize_entries('_ref_entries')
-        varl = var.localize_entries('_var_entries', '_var_cols')
-        varl = varl.annotate(_variant_defined=True)
-        joined = refl.join(varl.key_by('locus'), how='outer')
-        dr = joined.annotate(dense_ref=hl.or_missing(joined._variant_defined, hl.scan._densify(hl.len(joined._var_cols), joined._ref_entries)))
-        dr = dr.filter(dr._variant_defined)
-
-        def coalesce_join(ref, var):
-
-            call_field = 'GT' if 'GT' in var else 'LGT'
-            assert call_field in var, var.dtype
-
-            merged_fields = {}
-            merged_fields[call_field] = hl.coalesce(var[call_field], hl.call(0, 0))
-            for field in ref.dtype:
-                if field in var:
-                    merged_fields[field] = hl.coalesce(var[field], ref[field])
-
-            return hl.struct(**merged_fields).annotate(**{f: var[f] for f in var if f not in merged_fields})
-
-        dr = dr.annotate(_dense=hl.zip(dr._var_entries, dr.dense_ref).map(lambda tuple: coalesce_join(hl.or_missing(tuple[1].END <= dr.locus.position, tuple[1]), tuple[0])))
-        dr = dr._key_by_assert_sorted('locus', 'alleles')
-        dr = dr.drop('_var_entries', '_ref_entries', 'dense_ref', '_variant_defined')
-        return dr._unlocalize_entries('_dense', '_var_cols', list(var.col_key))
-
-    def split_multi(self, *, filter_changed_loci: bool = False):
-        self.variant_data = hl.experimental.sparse_split_multi(self.variant_data, filter_changed_loci=filter_changed_loci)
-
-    def sample_qc(self, *, name='sample_qc', gq_bins: 'Sequence[int]' = (0, 20, 60)) -> 'hl.Table':
-
-        from hail.expr.functions import _num_allele_type, _allele_types
-
-        allele_types = _allele_types[:]
-        allele_types.extend(['Transition', 'Transversion'])
-        allele_enum = {i: v for i, v in enumerate(allele_types)}
-        allele_ints = {v: k for k, v in allele_enum.items()}
-
-        def allele_type(ref, alt):
-            return hl.bind(lambda at: hl.if_else(at == allele_ints['SNP'],
-                                                 hl.if_else(hl.is_transition(ref, alt),
-                                                            allele_ints['Transition'],
-                                                            allele_ints['Transversion']),
-                                                 at),
-                           _num_allele_type(ref, alt))
-
-        variant_ac = Env.get_uid()
-        variant_atypes = Env.get_uid()
-
-        vmt = self.variant_data
-        if not 'GT' in vmt.entry:
-            vmt = vmt.annotate_entries(GT=hl.experimental.lgt_to_gt(vmt.LGT, vmt.LA))
-
-        vmt = vmt.annotate_rows(**{variant_ac: hl.agg.call_stats(vmt.GT, vmt.alleles).AC,
-                                   variant_atypes: vmt.alleles[1:].map(lambda alt: allele_type(vmt.alleles[0], alt))})
-
-        bound_exprs = {}
-
-        bound_exprs['n_het'] = hl.agg.count_where(vmt['GT'].is_het())
-        bound_exprs['n_hom_var'] = hl.agg.count_where(vmt['GT'].is_hom_var())
-        bound_exprs['n_singleton'] = hl.agg.sum(hl.sum(hl.range(0, vmt['GT'].ploidy).map(lambda i: vmt[variant_ac][vmt['GT'][i]] == 1)))
-
-        def get_allele_type(allele_idx):
-            return hl.if_else(allele_idx > 0, vmt[variant_atypes][allele_idx - 1], hl.missing(hl.tint32))
-
-        bound_exprs['allele_type_counts'] = hl.agg.explode(
-            lambda elt: hl.agg.counter(elt),
-            hl.range(0, vmt['GT'].ploidy).map(lambda i: get_allele_type(vmt['GT'][i])))
-
-        zero = hl.int64(0)
-
-        gq_exprs = hl.agg.filter(hl.is_defined(vmt.GT),
-                                 hl.struct(**{f'gq_over_{x}': hl.agg.count_where(vmt.GQ > x)
-                                              for x in gq_bins}))
-
-        result_struct = hl.rbind(
-            hl.struct(**bound_exprs),
-            lambda x: hl.rbind(
-                hl.struct(**{
-                    'gq_exprs': gq_exprs,
-                    'n_het': x.n_het,
-                    'n_hom_var': x.n_hom_var,
-                    'n_non_ref': x.n_het + x.n_hom_var,
-                    'n_singleton': x.n_singleton,
-                    'n_snp': (x.allele_type_counts.get(allele_ints["Transition"], zero)
-                              + x.allele_type_counts.get(allele_ints["Transversion"], zero)),
-                    'n_insertion': x.allele_type_counts.get(allele_ints["Insertion"], zero),
-                    'n_deletion': x.allele_type_counts.get(allele_ints["Deletion"], zero),
-                    'n_transition': x.allele_type_counts.get(allele_ints["Transition"], zero),
-                    'n_transversion': x.allele_type_counts.get(allele_ints["Transversion"], zero),
-                    'n_star': x.allele_type_counts.get(allele_ints["Star"], zero)
-                }),
-                lambda s: s.annotate(
-                    r_ti_tv=divide_null(hl.float64(s.n_transition), s.n_transversion),
-                    r_het_hom_var=divide_null(hl.float64(s.n_het), s.n_hom_var),
-                    r_insertion_deletion=divide_null(hl.float64(s.n_insertion), s.n_deletion)
-                )))
-        variant_results = vmt.select_cols(**result_struct).cols()
-
-        rmt = self.reference_data
-        ref_results = rmt.select_cols(gq_exprs=hl.struct(**{
-            f'gq_over_{x}': hl.agg.filter(rmt.GQ > x, hl.agg.sum(1 + rmt.END - rmt.locus.position))
-            for x in gq_bins
-        })).cols()
-
-        joined = ref_results[variant_results.key].gq_exprs
-        return variant_results.transmute(**{
-            f'gq_over_{x}': variant_results.gq_exprs[f'gq_over_{x}'] + joined[f'gq_over_{x}']
-            for x in gq_bins
-        })
-
-    def filter_samples(self, samples_table: 'hl.Table', *, keep: bool = True):
-        if not list(samples_table[x].dtype for x in samples_table.key) == [hl.tstr]:
-            raise TypeError(f'invalid key: {samples_table.key.dtype}')
-        samples_to_keep = samples_table.aggregate(hl.agg.collect_as_set(samples_table.key[0]), _localize=False)._persist()
-        self.reference_data = self.reference_data.filter_cols(samples_to_keep.contains(self.reference_data.key[0]), keep=keep)
-        self.variant_data = self.variant_data.filter_cols(samples_to_keep.contains(self.variant_data.key[0]), keep=keep)
-
-    def filter_variants(self, variants_table: 'hl.Table', *, keep: bool = True):
-        # don't remove reference data
-        if keep:
-            self.variant_data = self.variant_data.semi_join_rows(variants_table)
-        else:
-            self.variant_data = self.variant_data.anti_join_rows(variants_table)


### PR DESCRIPTION
Adds the split `VariantDataset` representation, where reference block data and variant data are contained in separate `MatrixTable` objects. Functions are accessible via the `hail.vds` submodule, e.g. `hl.vds.sample_qc(vds)`.