### PR TITLE
[query] Fix memory management of tree aggregation intermediates

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1212,7 +1212,7 @@ object LowerTableIR {
                       InitFromSerializedValue(i, GetTupleElement(serializedTuple, i), sig.state)
                     })
                 },
-                forIR(StreamRange(1, ArrayLen(partArrayRef), 1)) { fileIdx =>
+                forIR(StreamRange(1, ArrayLen(partArrayRef), 1, requiresMemoryManagementPerElement = true)) { fileIdx =>
 
                   bindIR(ReadValue(ArrayRef(partArrayRef, fileIdx), codecSpec, codecSpec.encodedVirtualType)) { serializedTuple =>
                     Begin(


### PR DESCRIPTION
Before this change, all agg states for each intermediate aggregation phase are left in memory for the duration of the task.