### PR TITLE
[docker] bump nest_asyncio version to fix transient error

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -39,7 +39,7 @@ keyrings.alt>=3.1
 kubernetes-asyncio==9.1.0
 libsass==0.19.2
 mypy==0.780
-nest_asyncio==1.0.0
+nest_asyncio==1.5.1
 parsimonious==0.8.1
 prometheus_async==19.2.0
 prometheus_client==0.11.0

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -486,6 +486,7 @@ class BatchPoolFuture:
             return False
         await self.batch.cancel()
         self.fetch_coro.cancel()
+        await asyncio.wait([self.fetch_coro])
         return True
 
     def cancelled(self):


### PR DESCRIPTION
See https://github.com/erdewit/nest_asyncio/issues/11

Original error was this:

```
_________________ ServiceTests.test_single_task_resource_group _________________

self = <test.hailtop.batch.test_batch.ServiceTests testMethod=test_single_task_resource_group>

    def test_single_task_resource_group(self):
        b = self.batch()
        j = b.new_job()
        j.declare_resource_group(output={'foo': '{root}.foo'})
        j.command(f'echo "hello" > {j.output.foo}')
>       res = b.run()

../test/hailtop/batch/test_batch.py:484: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
batch/batch.py:565: in run
    run_result = self._backend._run(self, dry_run, verbose, delete_scratch_on_exit, **backend_kwargs)  # pylint: disable=assignment-from-no-return
batch/backend.py:475: in _run
    self._async_run(batch, dry_run, verbose, delete_scratch_on_exit, wait, open, disable_progress_bar, callback, token, **backend_kwargs))
utils/utils.py:127: in async_to_blocking
    return asyncio.get_event_loop().run_until_complete(coro)
/usr/local/lib/python3.7/dist-packages/nest_asyncio.py:63: in run_until_complete
    return self._run_until_complete_orig(future)
/usr/lib/python3.7/asyncio/base_events.py:574: in run_until_complete
    self.run_forever()
/usr/lib/python3.7/asyncio/base_events.py:541: in run_forever
    self._run_once()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>

    def _run_once(self):
        """Run one full iteration of the event loop.
    
        This calls all currently ready callbacks, polls for I/O,
        schedules the resulting callbacks, and finally schedules
        'call_later' callbacks.
        """
    
        sched_count = len(self._scheduled)
        if (sched_count > _MIN_SCHEDULED_TIMER_HANDLES and
            self._timer_cancelled_count / sched_count >
                _MIN_CANCELLED_TIMER_HANDLES_FRACTION):
            # Remove delayed calls that were cancelled if their number
            # is too high
            new_scheduled = []
            for handle in self._scheduled:
                if handle._cancelled:
                    handle._scheduled = False
                else:
                    new_scheduled.append(handle)
    
            heapq.heapify(new_scheduled)
            self._scheduled = new_scheduled
            self._timer_cancelled_count = 0
        else:
            # Remove delayed calls that were cancelled from head of queue.
            while self._scheduled and self._scheduled[0]._cancelled:
                self._timer_cancelled_count -= 1
                handle = heapq.heappop(self._scheduled)
                handle._scheduled = False
    
        timeout = None
        if self._ready or self._stopping:
            timeout = 0
        elif self._scheduled:
            # Compute the desired timeout.
            when = self._scheduled[0]._when
            timeout = min(max(0, when - self.time()), MAXIMUM_SELECT_TIMEOUT)
    
        if self._debug and timeout != 0:
            t0 = self.time()
            event_list = self._selector.select(timeout)
            dt = self.time() - t0
            if dt >= 1.0:
                level = logging.INFO
            else:
                level = logging.DEBUG
            nevent = len(event_list)
            if timeout is None:
                logger.log(level, 'poll took %.3f ms: %s events',
                           dt * 1e3, nevent)
            elif nevent:
                logger.log(level,
                           'poll %.3f ms took %.3f ms: %s events',
                           timeout * 1e3, dt * 1e3, nevent)
            elif dt >= 1.0:
                logger.log(level,
                           'poll %.3f ms took %.3f ms: timeout',
                           timeout * 1e3, dt * 1e3)
        else:
            event_list = self._selector.select(timeout)
        self._process_events(event_list)
    
        # Handle 'later' callbacks that are ready.
        end_time = self.time() + self._clock_resolution
        while self._scheduled:
            handle = self._scheduled[0]
            if handle._when >= end_time:
                break
            handle = heapq.heappop(self._scheduled)
            handle._scheduled = False
            self._ready.append(handle)
    
        # This is the only place where callbacks are actually *called*.
        # All other places just add them to ready.
        # Note: We run all currently scheduled callbacks, but not any
        # callbacks scheduled by callbacks run this time around --
        # they will be run the next time (after another I/O poll).
        # Use an idiom that is thread-safe without using locks.
        ntodo = len(self._ready)
        for i in range(ntodo):
>           handle = self._ready.popleft()
E           IndexError: pop from an empty deque
```