### PR TITLE
[batch] Shield extracting the rootfs of an image

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -441,7 +441,7 @@ class Container:
                     self.rootfs_path = f'/host/rootfs/{self.image_id}'
                     async with worker.rootfs_locks[self.image_id]:
                         if not os.path.exists(self.rootfs_path):
-                            await self.extract_rootfs()
+                            await asyncio.shield(self.extract_rootfs())
                             log.info(f'Added expanded image to cache: {self.image_ref_str}, ID: {self.image_id}')
 
             with self.step('pulling'):


### PR DESCRIPTION
Follow-up on this zulip thread https://hail.zulipchat.com/#narrow/stream/219455-ServicesDev/topic/unexpected.20image.20cleanup.20err/near/247270652

If `extract_rootfs` creates the `rootfs_path` and then is cancelled while it's extracting the filesystem, following jobs will assume the rootfs is already extracted and run without a filesystem.. which isn't good.