### PR TITLE
[query] Increase test parallelism

### DIFF
--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -17,7 +17,7 @@ def startTestHailContext():
     if not _initialized:
         backend_name = os.environ.get('HAIL_QUERY_BACKEND', 'spark')
         if backend_name == 'spark':
-            hl.init(master='local[1]', min_block_size=0, quiet=True)
+            hl.init(master='local[2]', min_block_size=0, quiet=True)
         else:
             Env.hc()  # force initialization
         _initialized = True


### PR DESCRIPTION
I changed this from 2=>1 in April of last year unintentionally while debugging
(it's easy to get interleaved prints/logs with 2 concurrent worker threads).

https://github.com/hail-is/hail/pull/8535/files#diff-bf51d09b286fddaa730b426824ccb12dac8b9032e0c88bde81882f3cb1423df8R14