### PR TITLE
[query] Lower BlockMatrixAgg

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -155,10 +155,10 @@ class BlockMatrixAgg(BlockMatrixIR):
             shape = []
         elif self.out_index_expr == [0]:
             is_row_vector = True
-            shape = [1, child_matrix_shape[1]]
+            shape = [child_matrix_shape[1]]
         elif self.out_index_expr == [1]:
             is_row_vector = False
-            shape = [child_matrix_shape[0], 1]
+            shape = [child_matrix_shape[0]]
         else:
             raise ValueError("Invalid out_index_expr")
 

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -149,8 +149,19 @@ class BlockMatrixAgg(BlockMatrixIR):
         return self.out_index_expr == other.out_index_expr
 
     def _compute_type(self):
-        shape = [tensor_shape_to_matrix_shape(self.child)[i] for i in self.out_index_expr]
-        is_row_vector = self.out_index_expr == [1]
+        child_matrix_shape = tensor_shape_to_matrix_shape(self.child)
+        if self.out_index_expr == [0, 1]:
+            is_row_vector = False
+            shape = []
+        elif self.out_index_expr == [0]:
+            is_row_vector = True
+            shape = [1, child_matrix_shape[1]]
+        elif self.out_index_expr == [1]:
+            is_row_vector = False
+            shape = [child_matrix_shape[0], 1]
+        else:
+            raise ValueError("Invalid out_index_expr")
+
         self._type = tblockmatrix(self.child.typ.element_type,
                                   shape,
                                   is_row_vector,

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1662,10 +1662,10 @@ class BlockMatrix(object):
             If ``1``, returns a block matrix with a single column.
         """
         if axis is None:
-            bmir = BlockMatrixAgg(self._bmir, [])
+            bmir = BlockMatrixAgg(self._bmir, [0, 1])
             return BlockMatrix(bmir)[0, 0]
         elif axis == 0 or axis == 1:
-            out_index_expr = [dim for dim in range(len(self.shape)) if dim != axis]
+            out_index_expr = [axis]
 
             bmir = BlockMatrixAgg(self._bmir, out_index_expr)
             return BlockMatrix(bmir)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -68,8 +68,8 @@ class Tests(unittest.TestCase):
 
     def assert_sums_agree(self, bm, nd):
         self.assertAlmostEqual(bm.sum(), np.sum(nd))
-        self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
-        self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
+        #self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
+        #self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
 
     def test_from_entry_expr_simple(self):
         mt = get_dataset()
@@ -544,10 +544,9 @@ class Tests(unittest.TestCase):
         self._assert_eq(bm2, nd)
 
     @fails_service_backend()
-    @fails_local_backend()
     def test_sum(self):
         nd = np.random.normal(size=(11, 13))
-        bm = BlockMatrix.from_numpy(nd, block_size=3)
+        bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)
 
         self.assert_sums_agree(bm, nd)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -545,7 +545,7 @@ class Tests(unittest.TestCase):
 
     @fails_service_backend()
     def test_sum(self):
-        nd = np.random.normal(size=(11, 13))
+        nd = np.arange(11 * 13, dtype=np.float64).reshape((11, 13))#np.random.normal(size=(11, 13))
         bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)
 
         self.assert_sums_agree(bm, nd)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -68,7 +68,7 @@ class Tests(unittest.TestCase):
 
     def assert_sums_agree(self, bm, nd):
         self.assertAlmostEqual(bm.sum(), np.sum(nd))
-        #self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
+        self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
         #self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
 
     def test_from_entry_expr_simple(self):
@@ -545,7 +545,7 @@ class Tests(unittest.TestCase):
 
     @fails_service_backend()
     def test_sum(self):
-        nd = np.arange(11 * 13, dtype=np.float64).reshape((11, 13))#np.random.normal(size=(11, 13))
+        nd = np.arange(11 * 13, dtype=np.float64).reshape((11, 13))
         bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)
 
         self.assert_sums_agree(bm, nd)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -481,8 +481,6 @@ class Tests(unittest.TestCase):
         self._assert_eq((m @ m.T).diagonal(), np.array([[14.0, 77.0]]))
 
 
-    @fails_service_backend()
-    @fails_local_backend()
     def test_matrix_sums(self):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_ndarray(hl.nd.array(nm), block_size=2)
@@ -532,7 +530,6 @@ class Tests(unittest.TestCase):
                 self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_fifty_by_sixty.T, splits=split_size), fifty_by_sixty @ fifty_by_sixty.T)
                 self._assert_eq(bm_fifty_by_sixty.tree_matmul(bm_sixty_by_twenty_five, splits=split_size), fifty_by_sixty @ sixty_by_twenty_five)
 
-
     def test_fill(self):
         nd = np.ones((3, 5))
         bm = BlockMatrix.fill(3, 5, 1.0)
@@ -550,7 +547,7 @@ class Tests(unittest.TestCase):
 
         self.assert_sums_agree(bm, nd)
 
-    @skip_unless_spark_backend()
+    @fails_local_backend
     def test_sum_with_sparsify(self):
         nd = np.zeros(shape=(5, 7))
         nd[2, 4] = 1.0

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -69,7 +69,7 @@ class Tests(unittest.TestCase):
     def assert_sums_agree(self, bm, nd):
         self.assertAlmostEqual(bm.sum(), np.sum(nd))
         self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
-        #self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
+        self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
 
     def test_from_entry_expr_simple(self):
         mt = get_dataset()

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -480,7 +480,6 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.T.diagonal(), np.array([[1.0, 5.0]]))
         self._assert_eq((m @ m.T).diagonal(), np.array([[14.0, 77.0]]))
 
-
     def test_matrix_sums(self):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_ndarray(hl.nd.array(nm), block_size=2)
@@ -540,7 +539,6 @@ class Tests(unittest.TestCase):
         self._assert_eq(bm, nd)
         self._assert_eq(bm2, nd)
 
-    @fails_service_backend()
     def test_sum(self):
         nd = np.arange(11 * 13, dtype=np.float64).reshape((11, 13))
         bm = BlockMatrix.from_ndarray(hl.literal(nd), block_size=3)
@@ -554,11 +552,13 @@ class Tests(unittest.TestCase):
         nd[2, 5] = 2.0
         nd[3, 4] = 3.0
         nd[3, 5] = 4.0
-        bm = BlockMatrix.from_numpy(nd, block_size=2).sparsify_rectangles([[2, 4, 4, 6]])
 
-        bm2 = BlockMatrix.from_numpy(nd, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 5, 0, 1]])
+        hnd = hl.nd.array(nd)
+        bm = BlockMatrix.from_ndarray(hnd, block_size=2).sparsify_rectangles([[2, 4, 4, 6]])
 
-        bm3 = BlockMatrix.from_numpy(nd, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 1, 0, 7]])
+        bm2 = BlockMatrix.from_ndarray(hnd, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 5, 0, 1]])
+
+        bm3 = BlockMatrix.from_ndarray(hnd, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 1, 0, 7]])
 
         nd4 = np.zeros(shape=(5, 7))
         bm4 = BlockMatrix.fill(5, 7, value=0.0, block_size=2).sparsify_rectangles([])

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -622,8 +622,8 @@ case class BlockMatrixAgg(
   override lazy val typ: BlockMatrixType = {
     val matrixShape = BlockMatrixIR.tensorShapeToMatrixShape(child)
     val matrixShapeArr = Array[Long](matrixShape._1, matrixShape._2)
-    val shape = axesToSumOut.map({ i: Int => matrixShapeArr(i) }).toFastIndexedSeq
-    val isRowVector = axesToSumOut == FastIndexedSeq(1)
+    val shape = IndexedSeq(0, 1).filter(i => !axesToSumOut.contains(i)).map({ i: Int => matrixShapeArr(i) }).toFastIndexedSeq
+    val isRowVector = axesToSumOut == FastIndexedSeq(0)
 
     val sparsity = if (child.typ.isSparse) {
       axesToSumOut match {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -85,7 +85,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
 
   private def addValues(cb: EmitCodeBuilder, region: Value[Region], leftNdValue: SNDArrayValue, rightNdValue: SNDArrayValue): Unit = {
     cb.ifx(!leftNdValue.sameShape(rightNdValue, cb),
-      cb += Code._fatal[Unit](const("Can't sum ndarrays of different shapes")))
+      cb += Code._fatal[Unit]("Can't sum ndarrays of different shapes."))
 
     leftNdValue.coiterateMutate(cb, region, (rightNdValue.get, "right")) {
       case Seq(l, r) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -84,9 +84,8 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
   }
 
   private def addValues(cb: EmitCodeBuilder, region: Value[Region], leftNdValue: SNDArrayValue, rightNdValue: SNDArrayValue): Unit = {
-
     cb.ifx(!leftNdValue.sameShape(rightNdValue, cb),
-      cb += Code._fatal[Unit]("Can't sum ndarrays of different shapes."))
+      cb += Code._fatal[Unit](const("Can't sum ndarrays of different shapes")))
 
     leftNdValue.coiterateMutate(cb, region, (rightNdValue.get, "right")) {
       case Seq(l, r) =>

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -356,7 +356,7 @@ object LowerBlockMatrixIR {
               override def blockContext(idx: (Int, Int)): IR = makestruct()
               override def blockBody(ctxRef: Ref): IR = NDArrayReshape(res, MakeTuple.ordered(Seq(I64(1L), I64(1L))), ErrorIDs.NO_ERROR)
             }
-          case IndexedSeq(1) => {
+          case IndexedSeq(0) => {
             new BlockMatrixStage(loweredChild.globalVals, TArray(loweredChild.ctxType)) {
               // Idea. Make an array of all child contexts in the row as the context.
               // Then use each one to look up child.
@@ -378,7 +378,7 @@ object LowerBlockMatrixIR {
               }
             }
           }//childBm.rowSum()
-          case IndexedSeq(0) => unimplemented(a)//childBm.colSum()
+          case IndexedSeq(1) => unimplemented(a)//childBm.colSum()
         }
 
       case x@BlockMatrixFilter(child, keep) =>


### PR DESCRIPTION
`BlockMatrixAgg` is the IR node that sums along an axis. This PR lowers `BlockMatrixAgg`. It confusingly took different arguments from `NDArrayAgg`, in that it requested a list of axes you wanted to keep around, instead of a list of axes you want to sum out. Since the `sum` function in numpy, on hail ndarrays, and on hail `BlockMatrix` takes in a list of axes you want to sum out, I decided it would be better to make things consistent and changed the arguments to be consistent. 