### PR TITLE
[batch] Don't use group by with a JSON array value

### DIFF
--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -294,7 +294,7 @@ LEFT JOIN aggregated_billing_project_resources
 LEFT JOIN resources
   ON resources.resource = aggregated_billing_project_resources.resource
 {where_condition}
-GROUP BY billing_projects.name, billing_projects.status, users, msec_mcpu, `limit`
+GROUP BY billing_projects.name, billing_projects.status, msec_mcpu, `limit`
 LOCK IN SHARE MODE;
 '''
 


### PR DESCRIPTION
This PR eliminates this warning message:

```
This version of MySQL doesn't yet support 'sorting of non-scalar JSON values'
```

I tested this change in the SQL Fiddle and still got the correct answer. We could remove all non-varying fields from the group by, but decided to leave the other sortable fields as that is the SQL standard.