### PR TITLE
[batch] Make Container.delete only set deleted_event

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -862,7 +862,6 @@ class Container:
     async def delete(self):
         log.info(f'deleting {self}')
         self.deleted_event.set()
-        await self.delete_container()
 
     # {
     #   name: str,


### PR DESCRIPTION
The current implementation of `Container.delete`,
```python
    async def delete(self):
        log.info(f'deleting {self}')
        self.deleted_event.set()
        await self.delete_container()
```

provokes a race between the `run` task and the `delete` task. The former sees the `deleted_event`, raises and jumps to `delete_container`, so both tasks might be trying to delete the container at the same time. This races here,
```python
        if self.container_is_running():
            try:
                log.info(f'{self} container is still running, killing crun process')
                self.process.terminate()
                self.process = None
                await check_exec_output('crun', 'kill', '--all', self.container_name, 'SIGTERM')
            except asyncio.CancelledError:
                raise
            except Exception:
                log.exception('while deleting container', exc_info=True)

```
where we might queue two `crun kill` calls, the second of which fails because it cannot find any such container. Calling `delete_container` from within the `delete` method is a remnant from an older implementation of deletion, before we used `deleted_event` to explicitly signal to the `run` task that it's time to wrap things up. This is no longer necessary. The simplified way to think about deletion now is:

- Calling `Container.delete` just sets an `asyncio.Event` that the container has been deleted.
- Anything in the `run` task of the container that can be interrupted by a deletion waits on that event and short circuits the run process if it is set.
- The `run` task is the only task that calls `delete_container`, and always calls it when it is done.