### PR TITLE
[hailtop.batch] Fix compile code and directly use resource paths in code

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -254,6 +254,7 @@ class LocalBackend(Backend[None]):
                 code += [x for r in job._mentioned for x in symlink_input_resource_group(r)]
 
                 env = {**job._env, 'BATCH_TMPDIR': tmpdir}
+                env = [f'export {k}={v}' for k, v in env.items()]
                 joined_env = '; '.join(env) + '; ' if env else ''
 
                 job_shell = job._shell if job._shell else DEFAULT_SHELL

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -245,7 +245,7 @@ class LocalBackend(Backend[None]):
                 code.append(f"# {job._job_id}: {job.name if job.name else ''}")
 
                 if job._user_code:
-                    code.append(f'# USER CODE')
+                    code.append('# USER CODE')
                     user_code = [f'# {line}' for cmd in job._user_code for line in cmd.split('\n')]
                     code.append('\n'.join(user_code))
 
@@ -603,10 +603,7 @@ class ServiceBackend(Backend[bc.Batch]):
 {" && ".join(prepared_job_command)}
 '''
 
-            if job._user_code:
-                user_code = '\n\n'.join(job._user_code)
-            else:
-                user_code = None
+            user_code = '\n\n'.join(job._user_code) if job._user_code else None
 
             if dry_run:
                 formatted_command = f'''

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -254,8 +254,8 @@ class LocalBackend(Backend[None]):
                 code += [x for r in job._mentioned for x in symlink_input_resource_group(r)]
 
                 env = {**job._env, 'BATCH_TMPDIR': tmpdir}
-                env = [f'export {k}={v}' for k, v in env.items()]
-                joined_env = '; '.join(env) + '; ' if env else ''
+                env_declarations = [f'export {k}={v}' for k, v in env.items()]
+                joined_env = '; '.join(env_declarations) + '; ' if env else ''
 
                 job_shell = job._shell if job._shell else DEFAULT_SHELL
 

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -254,7 +254,6 @@ class LocalBackend(Backend[None]):
                 code += [x for r in job._mentioned for x in symlink_input_resource_group(r)]
 
                 env = {**job._env, 'BATCH_TMPDIR': tmpdir}
-                env = [f'export {k}={v}' for k, v in env.items()]
                 joined_env = '; '.join(env) + '; ' if env else ''
 
                 job_shell = job._shell if job._shell else DEFAULT_SHELL

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -87,7 +87,6 @@ class Batch:
         Automatically cancel the batch after N failures have occurred. The default
         behavior is there is no limit on the number of failures. Only
         applicable for the :class:`.ServiceBackend`. Must be greater than 0.
-
     """
 
     _counter = 0

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -488,6 +488,10 @@ class Batch:
                                  f"Hint: resources must be bound as a result "
                                  f"using the PythonJob 'call' method")
 
+        if isinstance(self._backend, _backend.LocalBackend):
+            if not dest.startswith('gs://'):
+                dest = os.path.abspath(dest)
+
         resource._add_output_path(dest)
 
     def select_jobs(self, pattern: str) -> List[job.Job]:

--- a/hail/python/hailtop/batch/batch.py
+++ b/hail/python/hailtop/batch/batch.py
@@ -490,7 +490,7 @@ class Batch:
 
         if isinstance(self._backend, _backend.LocalBackend):
             if not dest.startswith('gs://'):
-                dest = os.path.abspath(dest)
+                dest = os.path.abspath(os.path.expanduser(dest))
 
         resource._add_output_path(dest)
 

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -98,7 +98,7 @@ class Job:
         def safe_str(s):
             new_s = ''
             for c in s:
-                if c.isalnum():
+                if c.isalnum() or c == '-':
                     new_s += c
                 else:
                     new_s += '_'

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -95,7 +95,15 @@ class Job:
         self._valid: Set[_resource.Resource] = set()  # resources declared in the appropriate place
         self._dependencies: Set[Job] = set()
 
-        self._dirname = name.replace(' ', '_') + f'-{self._token}' if name else self._token
+        def safe_str(s):
+            new_s = ''
+            for c in s:
+                if c.isalnum():
+                    new_s += c
+                else:
+                    new_s += '_'
+
+        self._dirname = f'{safe_str(name)}-{self._token}' if name else self._token
 
     def _get_resource(self, item: str) -> '_resource.Resource':
         raise NotImplementedError

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -96,12 +96,13 @@ class Job:
         self._dependencies: Set[Job] = set()
 
         def safe_str(s):
-            new_s = ''
+            new_s = []
             for c in s:
                 if c.isalnum() or c == '-':
-                    new_s += c
+                    new_s.append(c)
                 else:
-                    new_s += '_'
+                    new_s.append('_')
+            return ''.join(new_s)
 
         self._dirname = f'{safe_str(name)}-{self._token}' if name else self._token
 
@@ -420,19 +421,6 @@ class Job:
 
     async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):
         raise NotImplementedError
-
-    def _process_command(self, command, handler):  # pylint: disable=no-self-use
-        regexes = [_resource.ResourceFile._regex_pattern,
-                   _resource.ResourceGroup._regex_pattern,
-                   _resource.PythonResult._regex_pattern,
-                   Job._regex_pattern,
-                   batch.Batch._regex_pattern]
-
-        subst_command = re.sub('(' + ')|('.join(regexes) + ')',
-                               handler,
-                               command)
-
-        return subst_command
 
     def _interpolate_command(self, command, allow_python_results=False):
         def handler(match_obj):

--- a/hail/python/hailtop/batch/job.py
+++ b/hail/python/hailtop/batch/job.py
@@ -3,6 +3,8 @@ import dill
 import os
 import functools
 import inspect
+import textwrap
+from shlex import quote as shq
 from io import BytesIO
 from typing import Union, Optional, Dict, List, Set, Tuple, Callable, Any, cast
 
@@ -404,6 +406,72 @@ class Job:
     async def _compile(self, local_tmpdir, remote_tmpdir, *, dry_run=False):
         raise NotImplementedError
 
+    def _process_command(self, command, handler):  # pylint: disable=no-self-use
+        regexes = [_resource.ResourceFile._regex_pattern,
+                   _resource.ResourceGroup._regex_pattern,
+                   _resource.PythonResult._regex_pattern,
+                   Job._regex_pattern,
+                   batch.Batch._regex_pattern]
+
+        subst_command = re.sub('(' + ')|('.join(regexes) + ')',
+                               handler,
+                               command)
+
+        return subst_command
+
+    def _interpolate_command_handler(self, command, allow_python_results):
+        def handler(match_obj):
+            groups = match_obj.groupdict()
+
+            if groups['JOB']:
+                raise BatchException(f"found a reference to a Job object in command '{command}'.")
+            if groups['BATCH']:
+                raise BatchException(f"found a reference to a Batch object in command '{command}'.")
+            if groups['PYTHON_RESULT'] and not allow_python_results:
+                raise BatchException(f"found a reference to a PythonResult object. hint: Use one of the methods `as_str`, `as_json` or `as_repr` on a PythonResult. command: '{command}'")
+
+            assert groups['RESOURCE_FILE'] or groups['RESOURCE_GROUP'] or groups['PYTHON_RESULT']
+            r_uid = match_obj.group()
+            r = self._batch._resource_map.get(r_uid)
+
+            if r is None:
+                raise BatchException(f"undefined resource '{r_uid}' in command '{command}'.\n"
+                                     f"Hint: resources must be from the same batch as the current job.")
+
+            if r._source != self:
+                self._add_inputs(r)
+                if r._source is not None:
+                    if r not in r._source._valid:
+                        name = r._source._resources_inverse[r]
+                        raise BatchException(f"undefined resource '{name}'\n"
+                                             f"Hint: resources must be defined within "
+                                             f"the job methods 'command' or 'declare_resource_group'")
+                    self._dependencies.add(r._source)
+                    r._source._add_internal_outputs(r)
+            else:
+                _add_resource_to_set(self._valid, r)
+
+            self._mentioned.add(r)
+            return f'{r_uid}'
+        return handler
+
+    def _interpolate_command(self, command, allow_python_results=False):
+        handler = self._interpolate_command_handler(command, allow_python_results)
+        return self._process_command(command, handler)
+
+    def _subst_resource_path_handler(self, local_tmpdir):
+        def handler(match_obj):
+            groups = match_obj.groupdict()
+            assert groups['RESOURCE_FILE'] or groups['RESOURCE_GROUP'] or groups['PYTHON_RESULT']
+            r_uid = match_obj.group()
+            r = self._batch._resource_map.get(r_uid)
+            return shq(r._get_path(local_tmpdir))
+        return handler
+
+    def _subst_resource_path(self, command, local_tmpdir):
+        handler = self._subst_resource_path_handler(local_tmpdir)
+        return self._process_command(command, handler)
+
     def _pretty(self):
         s = f"Job '{self._uid}'" \
             f"\tName:\t'{self.name}'" \
@@ -540,72 +608,6 @@ class BashJob(Job):
 
         self._image = image
         return self
-
-    def _process_command(self, command, handler):
-        regexes = [_resource.ResourceFile._regex_pattern,
-                   _resource.ResourceGroup._regex_pattern,
-                   _resource.PythonResult._regex_pattern,
-                   Job._regex_pattern,
-                   batch.Batch._regex_pattern]
-
-        subst_command = re.sub('(' + ')|('.join(regexes) + ')',
-                               handler,
-                               command)
-
-        return subst_command
-
-    def _subst_resource_path_handler(self, local_tmpdir):
-        def handler(match_obj):
-            groups = match_obj.groupdict()
-            assert groups['RESOURCE_FILE'] or groups['RESOURCE_GROUP']
-            r_uid = match_obj.group()
-            r = self._batch._resource_map.get(r_uid)
-            return r._get_path(local_tmpdir)
-        return handler
-
-    def _subst_resource_path(self, command, local_tmpdir):
-        handler = self._subst_resource_path_handler(local_tmpdir)
-        return self._process_command(command, handler)
-
-    def _interpolate_command_handler(self, command):
-        def handler(match_obj):
-            groups = match_obj.groupdict()
-
-            if groups['JOB']:
-                raise BatchException(f"found a reference to a Job object in command '{command}'.")
-            if groups['BATCH']:
-                raise BatchException(f"found a reference to a Batch object in command '{command}'.")
-            if groups['PYTHON_RESULT']:
-                raise BatchException(f"found a reference to a PythonResult object. hint: Use one of the methods `as_str`, `as_json` or `as_repr` on a PythonResult. command: '{command}'")
-
-            assert groups['RESOURCE_FILE'] or groups['RESOURCE_GROUP']
-            r_uid = match_obj.group()
-            r = self._batch._resource_map.get(r_uid)
-
-            if r is None:
-                raise BatchException(f"undefined resource '{r_uid}' in command '{command}'.\n"
-                                     f"Hint: resources must be from the same batch as the current job.")
-
-            if r._source != self:
-                self._add_inputs(r)
-                if r._source is not None:
-                    if r not in r._source._valid:
-                        name = r._source._resources_inverse[r]
-                        raise BatchException(f"undefined resource '{name}'\n"
-                                             f"Hint: resources must be defined within "
-                                             f"the job methods 'command' or 'declare_resource_group'")
-                    self._dependencies.add(r._source)
-                    r._source._add_internal_outputs(r)
-            else:
-                _add_resource_to_set(self._valid, r)
-
-            self._mentioned.add(r)
-            return f'{r_uid}'
-        return handler
-
-    def _interpolate_command(self, command):
-        handler = self._interpolate_command_handler(command)
-        return self._process_command(command, handler)
 
     def command(self, command: str) -> 'BashJob':
         """Set the job's command to execute.
@@ -1015,34 +1017,29 @@ class PythonJob(Job):
                 await self._batch._fs.write(code_path, pipe.getvalue())
 
             code = self._batch.read_input(code_path)
-            self._add_inputs(code)
-            self._mentioned.add(code)
 
             json_write = ''
             if result._json:
-                self._mentioned.add(result._json)
                 json_write = f'''
-            with open(os.environ[\\"{result._json}\\"], \\"w\\") as out:
+            with open(\\"{result._json}\\", \\"w\\") as out:
                 out.write(json.dumps(result) + \\"\\n\\")
 '''
 
             str_write = ''
             if result._str:
-                self._mentioned.add(result._str)
                 str_write = f'''
-            with open(os.environ[\\"{result._str}\\"], \\"w\\") as out:
+            with open(\\"{result._str}\\", \\"w\\") as out:
                 out.write(str(result) + \\"\\n\\")
 '''
 
             repr_write = ''
             if result._repr:
-                self._mentioned.add(result._repr)
                 repr_write = f'''
-            with open(os.environ[\\"{result._repr}\\"], \\"w\\") as out:
+            with open(\\"{result._repr}\\", \\"w\\") as out:
                 out.write(repr(result) + \\"\\n\\")
 '''
 
-            self._wrapper_code.append(f'''python3 -c "
+            wrapper_code = f'''python3 -c "
 import os
 import base64
 import dill
@@ -1050,9 +1047,9 @@ import traceback
 import json
 import sys
 
-with open(os.environ[\\"{result}\\"], \\"wb\\") as dill_out:
+with open(\\"{result}\\", \\"wb\\") as dill_out:
     try:
-        with open(os.environ[\\"{code}\\"], \\"rb\\") as f:
+        with open(\\"{code}\\", \\"rb\\") as f:
             result = dill.load(f)()
             dill.dump(result, dill_out, recurse=True)
             {json_write}
@@ -1062,12 +1059,17 @@ with open(os.environ[\\"{result}\\"], \\"wb\\") as dill_out:
         traceback.print_exc()
         dill.dump((e, traceback.format_exception(type(e), e, e.__traceback__)), dill_out, recurse=True)
         raise e
-"''')
+"'''
 
-            self._user_code.append(inspect.getsource(unapplied))
+            wrapper_code = self._interpolate_command(wrapper_code, allow_python_results=True)
+            wrapper_code = self._subst_resource_path(wrapper_code, local_tmpdir)
+            self._wrapper_code.append(wrapper_code)
+
+            self._user_code.append(textwrap.dedent(inspect.getsource(unapplied)))
             args = ', '.join([f'{arg!r}' for _, arg in args])
             kwargs = ', '.join([f'{k}={v!r}' for k, (_, v) in kwargs.items()])
             separator = ', ' if args and kwargs else ''
-            self._user_code.append(f'{unapplied.__name__}({args}{separator}{kwargs})')
+            func_call = f'{unapplied.__name__}({args}{separator}{kwargs})'
+            self._user_code.append(self._subst_resource_path(func_call, local_tmpdir))
 
         return True

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -22,9 +22,6 @@ class Resource:
     def _add_output_path(self, path: str) -> None:
         pass
 
-    def _declare(self, directory: str) -> str:
-        return f"export {self._uid}={shq(self._get_path(directory))}"  # pylint: disable=no-member
-
 
 class ResourceFile(Resource, str):
     """
@@ -73,7 +70,7 @@ class ResourceFile(Resource, str):
         return self._resource_group
 
     def __str__(self):
-        return f'"{self._uid}"'  # pylint: disable=no-member
+        return f'{self._uid}'  # pylint: disable=no-member
 
     def __repr__(self):
         return self._uid  # pylint: disable=no-member
@@ -269,7 +266,7 @@ class ResourceGroup(Resource):
         return other + str(self._uid)
 
     def __str__(self):
-        return f'"{self._uid}"'
+        return f'{self._uid}'
 
 
 class PythonResult(Resource, str):
@@ -448,7 +445,7 @@ class PythonResult(Resource, str):
         return cast(JobResourceFile, self._repr)
 
     def __str__(self):
-        return f'"{self._uid}"'  # pylint: disable=no-member
+        return f'{self._uid}'  # pylint: disable=no-member
 
     def __repr__(self):
         return self._uid  # pylint: disable=no-member

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -132,7 +132,7 @@ class JobResourceFile(ResourceFile):
     def _get_path(self, directory: str) -> str:
         assert self._source is not None
         assert self._value is not None
-        return f'{directory}/{self._source._job_id}/{self._value}'
+        return f'{directory}/{self._source._dirname}/{self._value}'
 
     def add_extension(self, extension: str) -> 'JobResourceFile':
         """
@@ -237,7 +237,7 @@ class ResourceGroup(Resource):
             resource_file._add_resource_group(self)
 
     def _get_path(self, directory: str) -> str:
-        subdir = str(self._source._job_id) if self._source else 'inputs'
+        subdir = str(self._source._dirname) if self._source else 'inputs'
         return directory + '/' + subdir + '/' + self._root
 
     def _add_output_path(self, path: str) -> None:
@@ -329,7 +329,7 @@ class PythonResult(Resource, str):
     def _get_path(self, directory: str) -> str:
         assert self._source is not None
         assert self._value is not None
-        return f'{directory}/{self._source._job_id}/{self._value}'
+        return f'{directory}/{self._source._dirname}/{self._value}'
 
     def _add_converted_resource(self, value):
         jrf = self._source._batch._new_job_resource_file(self._source, value)

--- a/hail/python/hailtop/batch/resource.py
+++ b/hail/python/hailtop/batch/resource.py
@@ -1,5 +1,4 @@
 import abc
-from shlex import quote as shq
 from typing import Optional, Set, cast
 
 from . import job  # pylint: disable=cyclic-import

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -1,3 +1,4 @@
+import secrets
 import unittest
 import os
 import subprocess as sp
@@ -841,4 +842,12 @@ class ServiceTests(unittest.TestCase):
         j1.command(f'echo hello > {j1.ofile}')
         j2 = b.new_job()
         j2.command(f'cat {j1.ofile}')
+        b.run()
+
+    def test_large_command(self):
+        backend = ServiceBackend(remote_tmpdir='gs://hail-test-dmk9z/temporary-files')
+        b = Batch(backend=backend)
+        j1 = b.new_job()
+        long_str = secrets.token_urlsafe(15 * 1024)
+        j1.command(f'echo "{long_str}"')
         b.run()


### PR DESCRIPTION
CHANGELOG: Fixes writing large commands to GCS

I made a couple of changes here:
1. Try and format a readable version of the code (including the user code) for the dry run mode
2. Fix `interpolate_command` was not idempotent. Thus large commands with resource files would fail.
3. Use paths directly in paths by doing a double interpolation. I'm worried about the speed of having to doubling parse the command with the regex, but I think the improvement in readability is a big win.