### PR TITLE
[query] Better lowering for TableHead

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -990,13 +990,13 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
         # test TableRange and TableParallelize rewrite rules
         tables = [rt, par, rt.cache(), chkpt]
         for table in tables:
-            self.assertEqual(table.tail(10).count(), 10)
-            self.assertEqual(table.tail(10)._force_count(), 10)
-            self.assertEqual(table.tail(9).count(), 9)
-            self.assertEqual(table.tail(9)._force_count(), 9)
-            self.assertEqual(table.tail(11).count(), 10)
-            self.assertEqual(table.tail(11)._force_count(), 10)
-            self.assertEqual(table.tail(0).count(), 0)
+            # self.assertEqual(table.tail(10).count(), 10)
+            # self.assertEqual(table.tail(10)._force_count(), 10)
+            # self.assertEqual(table.tail(9).count(), 9)
+            # self.assertEqual(table.tail(9)._force_count(), 9)
+            # self.assertEqual(table.tail(11).count(), 10)
+            # self.assertEqual(table.tail(11)._force_count(), 10)
+            # self.assertEqual(table.tail(0).count(), 0)
             self.assertEqual(table.tail(0)._force_count(), 0)
 
     def test_table_order_by_head_rewrite(self):

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -990,13 +990,13 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
         # test TableRange and TableParallelize rewrite rules
         tables = [rt, par, rt.cache(), chkpt]
         for table in tables:
-            # self.assertEqual(table.tail(10).count(), 10)
-            # self.assertEqual(table.tail(10)._force_count(), 10)
-            # self.assertEqual(table.tail(9).count(), 9)
-            # self.assertEqual(table.tail(9)._force_count(), 9)
-            # self.assertEqual(table.tail(11).count(), 10)
-            # self.assertEqual(table.tail(11)._force_count(), 10)
-            # self.assertEqual(table.tail(0).count(), 0)
+            self.assertEqual(table.tail(10).count(), 10)
+            self.assertEqual(table.tail(10)._force_count(), 10)
+            self.assertEqual(table.tail(9).count(), 9)
+            self.assertEqual(table.tail(9)._force_count(), 9)
+            self.assertEqual(table.tail(11).count(), 10)
+            self.assertEqual(table.tail(11)._force_count(), 10)
+            self.assertEqual(table.tail(0).count(), 0)
             self.assertEqual(table.tail(0)._force_count(), 0)
 
     def test_table_order_by_head_rewrite(self):

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -966,9 +966,11 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
     def test_table_head_returns_right_number(self):
         rt = hl.utils.range_table(10, 11)
         par = hl.Table.parallelize([hl.Struct(x=x) for x in range(10)], schema='struct{x: int32}', n_partitions=11)
+        f = new_temp_file(extension='ht')
+        chkpt = rt.checkpoint(f)
 
         # test TableRange and TableParallelize rewrite rules
-        tables = [rt, par, rt.cache()]
+        tables = [rt, par, rt.cache(), chkpt]
         for table in tables:
             self.assertEqual(table.head(10).count(), 10)
             self.assertEqual(table.head(10)._force_count(), 10)
@@ -978,6 +980,24 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
             self.assertEqual(table.head(11)._force_count(), 10)
             self.assertEqual(table.head(0).count(), 0)
             self.assertEqual(table.head(0)._force_count(), 0)
+
+    def test_table_tail_returns_right_number(self):
+        rt = hl.utils.range_table(10, 11)
+        par = hl.Table.parallelize([hl.Struct(x=x) for x in range(10)], schema='struct{x: int32}', n_partitions=11)
+        f = new_temp_file(extension='ht')
+        chkpt = rt.checkpoint(f)
+
+        # test TableRange and TableParallelize rewrite rules
+        tables = [rt, par, rt.cache(), chkpt]
+        for table in tables:
+            self.assertEqual(table.tail(10).count(), 10)
+            self.assertEqual(table.tail(10)._force_count(), 10)
+            self.assertEqual(table.tail(9).count(), 9)
+            self.assertEqual(table.tail(9)._force_count(), 9)
+            self.assertEqual(table.tail(11).count(), 10)
+            self.assertEqual(table.tail(11)._force_count(), 10)
+            self.assertEqual(table.tail(0).count(), 0)
+                self.assertEqual(table.tail(0)._force_count(), 0)
 
     def test_table_order_by_head_rewrite(self):
         rt = hl.utils.range_table(10, 2)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -997,7 +997,7 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
             self.assertEqual(table.tail(11).count(), 10)
             self.assertEqual(table.tail(11)._force_count(), 10)
             self.assertEqual(table.tail(0).count(), 0)
-                self.assertEqual(table.tail(0)._force_count(), 0)
+            self.assertEqual(table.tail(0)._force_count(), 0)
 
     def test_table_order_by_head_rewrite(self):
         rt = hl.utils.range_table(10, 2)

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -674,7 +674,7 @@ object LowerTableIR {
                   sumSoFar += partCounts(idx)
                   idx += 1
                 }
-                val partsToKeep = partCounts.slice(0, 0)
+                val partsToKeep = partCounts.slice(0, idx)
                 MakeArray.apply(partsToKeep.map(partSize => I32(partSize.toInt)), TArray(TInt32))
               case None =>
                 val partitionSizeArrayFunc = genUID()
@@ -752,7 +752,16 @@ object LowerTableIR {
             val howManyPartsToTry = Ref(genUID(), TInt32)
 
             ir.partitionCounts match {
-              case Some(partCounts) => ???
+              case Some(partCounts) =>
+                var idx = partCounts.size - 1
+                var sumSoFar = 0L
+                while (idx >= 0 && sumSoFar < targetNumRows) {
+                  sumSoFar += partCounts(idx)
+                  idx -= 1
+                }
+                val partsToKeep = partCounts.slice(idx, partCounts.size)
+                println(s"Part counts was ${partCounts}, Parts to keep was ${partsToKeep}, idx was ${idx}, target was ${targetNumRows}")
+                MakeArray.apply(partsToKeep.map(partSize => I32(partSize.toInt)), TArray(TInt32))
               case None =>
                 TailLoop(
                   partitionSizeArrayFunc,

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -744,7 +744,7 @@ object LowerTableIR {
               loweredChild.partition(GetField(ctxRef, "old")),
               GetField(ctxRef, "numberToTake")))
 
-        case ir@TableTail(child, targetNumRows) =>
+        case TableTail(child, targetNumRows) =>
           val loweredChild = lower(child)
 
           def partitionSizeArray(childContexts: Ref, totalNumPartitions: Ref): IR = {
@@ -755,7 +755,7 @@ object LowerTableIR {
               FastIndexedSeq(howManyPartsToTry.name -> 4),
               bindIR(
                 loweredChild
-                  .mapContexts(_ => StreamDrop(ToStream(childContexts), maxIR(totalNumPartitions - howManyPartsToTry, 0))) { ctx: IR => ctx }
+                  .mapContexts(_ => StreamDrop(ToStream(childContexts), maxIR(totalNumPartitions - howManyPartsToTry, 0))){ ctx: IR => ctx }
                   .mapCollect(relationalLetsAbove)(StreamLen)
               ) { counts =>
                 If((Cast(streamSumIR(ToStream(counts)), TInt64) >= targetNumRows) || (totalNumPartitions <= ArrayLen(counts)),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -750,6 +750,7 @@ object LowerTableIR {
           def partitionSizeArray(childContexts: Ref, totalNumPartitions: Ref): IR = {
             val partitionSizeArrayFunc = genUID()
             val howManyPartsToTry = Ref(genUID(), TInt32)
+
             TailLoop(
               partitionSizeArrayFunc,
               FastIndexedSeq(howManyPartsToTry.name -> 4),

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -806,7 +806,7 @@ object LowerTableIR {
             bindIR(ArrayLen(childContexts)) { totalNumPartitions =>
               bindIR(partitionSizeArray(childContexts, totalNumPartitions)) { partitionSizeArrayRef =>
                 bindIR(answerTuple(partitionSizeArrayRef)) { answerTupleRef =>
-                  val numPartsToDropFromPartitionSizeArray = GetTupleElement(answerTupleRef, 0)
+                  val numPartsToDropFromPartitionSizeArray = ConsoleLog(Apply("str", IndexedSeq(), IndexedSeq(answerTupleRef), TString, -1), GetTupleElement(answerTupleRef, 0))
                   val numElementsFromFirstPart = GetTupleElement(answerTupleRef, 1)
                   val numPartsToDropFromTotal = numPartsToDropFromPartitionSizeArray + (totalNumPartitions - ArrayLen(partitionSizeArrayRef))
                   val onlyNeededPartitions = StreamDrop(ToStream(childContexts), numPartsToDropFromTotal)


### PR DESCRIPTION
This will make `TableHead` ~and `TableTail`~ lowered implementation performant enough to actually use.

EDIT: I was doing something wrong with `TableTail`, decided to just leave it for a follow up PR instead of having this sit. 