### PR TITLE
[query] Fixed ArrayRef interpret rule

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -228,7 +228,7 @@ object Interpret {
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
       case MakeStream(elements, _, _) => elements.map(interpret(_, env, args)).toFastIndexedSeq
-      case x@ArrayRef(a, i, s) =>
+      case x@ArrayRef(a, i, errorId) =>
         val aValue = interpret(a, env, args)
         val iValue = interpret(i, env, args)
         if (aValue == null || iValue == null)
@@ -238,14 +238,7 @@ object Interpret {
           val i = iValue.asInstanceOf[Int]
 
           if (i < 0 || i >= a.length) {
-            val msg = interpret(s, env, args)
-            val prettied = Pretty(x)
-            val irString =
-              if (prettied.size > 100) prettied.take(100) + " ..."
-              else prettied
-            val toAdd = if (msg == "") "" else s"\n----------\nPython traceback:\n${ msg }"
-            fatal(s"array index out of bounds: index=$i, length=${ a.length }" +
-              s"\n----------\nIR:\n${ irString }$s" + toAdd)
+            fatal(s"array index out of bounds: index=$i, length=${ a.length }", errorId = errorId)
           } else
             a.apply(i)
         }


### PR DESCRIPTION
It still thought it had `s`, an error message to print as a python traceback, rather than an error id like it has now.