### PR TITLE
[hailctl dataproc] Add OmitStackTraceInFastThrow to debug mode options

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -231,8 +231,8 @@ def main(args, pass_through_args):
 
     if args.debug_mode:
         conf.extend_flag('properties', {
-            "spark:spark.driver.extraJavaOptions": "-Xss4M -XX:+HeapDumpOnOutOfMemoryError",
-            "spark:spark.executor.extraJavaOptions": "-Xss4M -XX:+HeapDumpOnOutOfMemoryError",
+            "spark:spark.driver.extraJavaOptions": "-Xss4M -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow",
+            "spark:spark.executor.extraJavaOptions": "-Xss4M -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow",
         })
 
     # default to highmem machines if using VEP


### PR DESCRIPTION
This should hopefully preserve stack traces for more exceptions during
execution.

See https://stackoverflow.com/questions/2411487/nullpointerexception-in-java-with-no-stacktrace
for more detail