### PR TITLE
[compiler] Remove Type.fundamentalType

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PrimitiveTypeToIRIntermediateClassTag.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PrimitiveTypeToIRIntermediateClassTag.scala
@@ -6,7 +6,7 @@ import is.hail.types.virtual._
 import scala.reflect.{ClassTag, classTag}
 
 object PrimitiveTypeToIRIntermediateClassTag {
-  def apply(t: Type): ClassTag[_] = t.fundamentalType match {
+  def apply(t: Type): ClassTag[_] = t match {
     case TBoolean => classTag[Boolean]
     case TInt32 => classTag[Int]
     case TInt64 => classTag[Long]

--- a/hail/src/main/scala/is/hail/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TArray.scala
@@ -12,12 +12,6 @@ final case class TArray(elementType: Type) extends TContainer {
     elementType.pyString(sb)
     sb.append('>')
   }
-  override val fundamentalType: TArray = {
-    if (elementType == elementType.fundamentalType)
-      this
-    else
-      this.copy(elementType = elementType.fundamentalType)
-  }
 
   def _toPretty = s"Array[$elementType]"
 

--- a/hail/src/main/scala/is/hail/types/virtual/TCall.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TCall.scala
@@ -16,8 +16,6 @@ case object TCall extends Type {
   }
   val representation: Type = TInt32
 
-  override def fundamentalType: Type = representation.fundamentalType
-
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]
 
   override def genNonmissingValue: Gen[Annotation] = Call.genNonmissingValue

--- a/hail/src/main/scala/is/hail/types/virtual/TDict.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TDict.scala
@@ -11,8 +11,6 @@ import scala.reflect.{ClassTag, classTag}
 final case class TDict(keyType: Type, valueType: Type) extends TContainer {
   lazy val elementType: TBaseStruct = (TStruct("key" -> keyType, "value" -> valueType)).asInstanceOf[TBaseStruct]
 
-  override val fundamentalType: TArray = TArray(elementType.fundamentalType)
-
   override def canCompare(other: Type): Boolean = other match {
     case TDict(okt, ovt) => keyType.canCompare(okt) && valueType.canCompare(ovt)
     case _ => false

--- a/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TInterval.scala
@@ -10,8 +10,6 @@ import scala.reflect.{ClassTag, classTag}
 
 case class TInterval(pointType: Type) extends Type {
 
-  override def fundamentalType: Type = representation.fundamentalType
-
   override def children = FastSeq(pointType)
 
   def _toPretty = s"""Interval[$pointType]"""

--- a/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TLocus.scala
@@ -27,8 +27,6 @@ object TLocus {
 
 case class TLocus(rgBc: BroadcastRG) extends Type {
 
-  override def fundamentalType: Type = representation.fundamentalType
-
   def rg: ReferenceGenome = rgBc.value
 
   def _toPretty = s"Locus($rg)"

--- a/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TNDArray.scala
@@ -24,8 +24,6 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
     nDimsBase.asInstanceOf[Nat].n
   }
 
-  override def fundamentalType: Type = representation.fundamentalType
-
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean = {
     if (a1 == null || a2 == null) {
       a1 == a2

--- a/hail/src/main/scala/is/hail/types/virtual/TSet.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TSet.scala
@@ -9,8 +9,6 @@ import org.json4s.jackson.JsonMethods
 import scala.reflect.{ClassTag, classTag}
 
 final case class TSet(elementType: Type) extends TContainer {
-  override lazy val fundamentalType: TArray = TArray(elementType.fundamentalType)
-
   def _toPretty = s"Set[$elementType]"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/types/virtual/TStream.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStream.scala
@@ -12,12 +12,6 @@ final case class TStream(elementType: Type) extends TIterable {
     elementType.pyString(sb)
     sb.append('>')
   }
-  override val fundamentalType: TStream = {
-    if (elementType == elementType.fundamentalType)
-      this
-    else
-      this.copy(elementType = elementType.fundamentalType)
-  }
 
   def _toPretty = s"Stream[$elementType]"
 

--- a/hail/src/main/scala/is/hail/types/virtual/TString.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TString.scala
@@ -27,6 +27,4 @@ case object TString extends Type {
 
   override def mkOrdering(missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[String]], missingEqual)
-
-  override def fundamentalType: Type = TBinary
 }

--- a/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TStruct.scala
@@ -369,17 +369,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
   def typeAfterSelect(keep: IndexedSeq[Int]): TStruct =
     TStruct(keep.map(i => fieldNames(i) -> types(i)): _*)
 
-  override lazy val fundamentalType: TStruct = {
-    val fundamentalFieldTypes = fields.map(f => f.typ.fundamentalType)
-    if ((fields, fundamentalFieldTypes).zipped
-      .forall { case (f, ft) => f.typ == ft })
-      this
-    else
-      TStruct((fields, fundamentalFieldTypes).zipped.map { case (f, ft) => (f.name, ft) }: _*)
-  }
-
   def toEnv: Env[Type] = Env(fields.map(f => (f.name, f.typ)): _*)
-
 
   override def valueSubsetter(subtype: Type): Any => Any = {
     if (this == subtype)

--- a/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TTuple.scala
@@ -78,16 +78,6 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
     sb.append(')')
   }
 
-
-  override lazy val fundamentalType: TTuple = {
-    val fundamentalFieldTypes = _types.map(tf => tf.copy(typ = tf.typ.fundamentalType))
-    if ((_types, fundamentalFieldTypes).zipped
-      .forall { case (t, ft) => t == ft })
-      this
-    else
-      TTuple(fundamentalFieldTypes)
-  }
-
   override def valueSubsetter(subtype: Type): Any => Any = {
     if (this == subtype)
       return identity

--- a/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/TUnion.scala
@@ -121,15 +121,6 @@ final case class TUnion(cases: IndexedSeq[Case]) extends Type {
     }
   }
 
-  override lazy val fundamentalType: TUnion = {
-    val fundamentalCaseTypes = cases.map(f => f.typ.fundamentalType)
-    if ((cases, fundamentalCaseTypes).zipped
-      .forall { case (f, ft) => f.typ == ft })
-      this
-    else
-      TUnion((cases, fundamentalCaseTypes).zipped.map { case (f, ft) => (f.name, ft) }: _*)
-  }
-
   override def scalaClassTag: ClassTag[AnyRef] = ???
 
   def mkOrdering(missingEqual: Boolean): ExtendedOrdering = ???

--- a/hail/src/main/scala/is/hail/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/types/virtual/Type.scala
@@ -209,10 +209,6 @@ abstract class Type extends BaseType with Serializable {
     def toJSON(pk: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(pk, self)
   }
 
-  /*  Fundamental types are types that can be handled natively by RegionValueBuilder: primitive
-      types, Array and Struct. */
-  def fundamentalType: Type = this
-
   def _typeCheck(a: Any): Boolean
 
   final def typeCheck(a: Any): Boolean = a == null || _typeCheck(a)


### PR DESCRIPTION
This was unused, but was a performance nightmare -- the reconstruction of a single type triggered a full reallocation of the nested structure.

![image](https://user-images.githubusercontent.com/10562794/127706520-a3202b3f-b478-407d-b64f-496a4f08f68b.png)
