### PR TITLE
[compiler] Stop calling `Thread.getStackTrace` in `cb.fatal`

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -354,9 +354,10 @@ object Code {
   }
 
   private def getEmitLineNum: Int = {
-    val st = Thread.currentThread().getStackTrace
-    val i = st.indexWhere(ste => ste.getFileName == "Emit.scala")
-    if (i == -1) 0 else st(i).getLineNumber
+//    val st = Thread.currentThread().getStackTrace
+//    val i = st.indexWhere(ste => ste.getFileName == "Emit.scala")
+//    if (i == -1) 0 else st(i).getLineNumber
+    0
   }
 
   def _throw[T <: java.lang.Throwable, U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] =


### PR DESCRIPTION
Leave old code commented out for debugging

![image](https://user-images.githubusercontent.com/10562794/127707159-f6a4051c-d110-4184-ba47-a63689121636.png)
