### PR TITLE
[hailtop.batch] More batch pool executor fixes

### DIFF
--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -487,7 +487,6 @@ class BatchPoolFuture:
             self.fetch_coro.result()
             return False
 
-        await self.batch.cancel()
         self.fetch_coro.cancel()
         await asyncio.wait([self.fetch_coro])
         return True
@@ -545,7 +544,7 @@ class BatchPoolFuture:
         if self.cancelled():
             raise concurrent.futures.CancelledError()
         try:
-            return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
+            return await asyncio.wait_for(asyncio.shield(self.fetch_coro), timeout=timeout)
         except asyncio.TimeoutError as e:
             raise concurrent.futures.TimeoutError() from e
 

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -548,8 +548,6 @@ class BatchPoolFuture:
             return await asyncio.wait_for(self.fetch_coro, timeout=timeout)
         except asyncio.TimeoutError as e:
             raise concurrent.futures.TimeoutError() from e
-        finally:
-            await self.batch.cancel()
 
     async def _async_fetch_result(self):
         try:
@@ -567,6 +565,7 @@ class BatchPoolFuture:
             traceback = ''.join(traceback)
             raise ValueError(f'submitted job failed:\n{traceback}')
         finally:
+            await self.batch.cancel()
             self.executor._finish_future()
 
     def exception(self, timeout: Optional[Union[float, int]] = None):

--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -495,7 +495,7 @@ class BatchPoolFuture:
     def cancelled(self):
         """Returns ``True`` if :meth:`.cancel` was called before a value was produced.
         """
-        return self.fetch_coro.cancelled() and self._cancelled_batch
+        return self.fetch_coro.cancelled()
 
     def running(self):  # pylint: disable=no-self-use
         """Always returns False.

--- a/hail/python/test/hailtop/batch/test_batch_pool_executor.py
+++ b/hail/python/test/hailtop/batch/test_batch_pool_executor.py
@@ -129,7 +129,7 @@ def test_map_chunksize(backend):
         0,  4,  8, 12, 16]
 
 
-def test_map_timeout_foo(backend):
+def test_map_timeout(backend):
     with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         def sleep_forever():
             while True:

--- a/hail/python/test/hailtop/batch/test_batch_pool_executor.py
+++ b/hail/python/test/hailtop/batch/test_batch_pool_executor.py
@@ -1,25 +1,62 @@
 import asyncio
+import concurrent.futures
 import time
 import os
-from hailtop.batch import BatchPoolExecutor
+
+import hailtop.batch_client.client
+import pytest
+
+from hailtop.batch import BatchPoolExecutor, ServiceBackend
+from hailtop.config import get_user_config
+from hailtop.utils import sync_sleep_and_backoff
 
 PYTHON_DILL_IMAGE = os.environ['PYTHON_DILL_IMAGE']
 
 
-def test_simple_map():
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+submitted_batch_ids = []
+
+
+class RecordingServiceBackend(ServiceBackend):
+    def _run(self, *args, **kwargs):
+        b = super()._run(*args, **kwargs)
+        submitted_batch_ids.append(b.id)
+        return b
+
+
+@pytest.fixture
+def backend():
+    return RecordingServiceBackend()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def check_for_running_batches():
+    yield
+    billing_project = get_user_config().get('batch', 'billing_project', fallback=None)
+    with hailtop.batch_client.client.BatchClient(billing_project=billing_project) as bc:
+        for id in submitted_batch_ids:
+            b = bc.get_batch(id)
+            delay = 0.1
+            while True:
+                if b.status()['state'] != 'running':
+                    break
+                print(f'batch {b.id} is still running')
+                delay = sync_sleep_and_backoff(delay)
+
+
+def test_simple_map(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         actual = list(bpe.map(lambda x: x * 3, range(4)))
     assert [0, 3, 6, 9] == actual
 
 
-def test_simple_submit_result():
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+def test_simple_submit_result(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         future_twenty_one = bpe.submit(lambda: 7 * 3)
     assert 21 == future_twenty_one.result()
 
 
-def test_cancel_future():
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+def test_cancel_future(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         def sleep_forever():
             while True:
                 time.sleep(3600)
@@ -30,8 +67,8 @@ def test_cancel_future():
     assert future.cancelled()
 
 
-def test_cancel_future_after_shutdown_no_wait():
-    bpe = BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE)
+def test_cancel_future_after_shutdown_no_wait(backend):
+    bpe = BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE)
     def sleep_forever():
         while True:
             time.sleep(3600)
@@ -43,8 +80,8 @@ def test_cancel_future_after_shutdown_no_wait():
     assert future.cancelled()
 
 
-def test_cancel_future_after_exit_no_wait_on_exit():
-    with BatchPoolExecutor(project='hail-vdc', wait_on_exit=False, image=PYTHON_DILL_IMAGE) as bpe:
+def test_cancel_future_after_exit_no_wait_on_exit(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', wait_on_exit=False, image=PYTHON_DILL_IMAGE) as bpe:
         def sleep_forever():
             while True:
                 time.sleep(3600)
@@ -55,8 +92,8 @@ def test_cancel_future_after_exit_no_wait_on_exit():
     assert future.cancelled()
 
 
-def test_result_with_timeout():
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+def test_result_with_timeout(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         def sleep_forever():
             while True:
                 time.sleep(3600)
@@ -72,14 +109,14 @@ def test_result_with_timeout():
             future.cancel()
 
 
-def test_map_chunksize():
+def test_map_chunksize(backend):
     row_args = [x
                 for row in range(5)
                 for x in [row, row, row, row, row]]
     col_args = [x
                 for row in range(5)
                 for x in list(range(5))]
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         multiplication_table = list(bpe.map(lambda x, y: x * y,
                                             row_args,
                                             col_args,
@@ -92,28 +129,28 @@ def test_map_chunksize():
         0,  4,  8, 12, 16]
 
 
-def test_map_timeout():
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+def test_map_timeout_foo(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         def sleep_forever():
             while True:
                 time.sleep(3600)
         try:
             list(bpe.map(lambda _: sleep_forever(), range(5), timeout=2))
-        except asyncio.TimeoutError:
+        except concurrent.futures.TimeoutError:
             pass
         else:
             assert False
 
 
-def test_map_error_without_wait_no_error():
-    with BatchPoolExecutor(project='hail-vdc', wait_on_exit=False, image=PYTHON_DILL_IMAGE) as bpe:
+def test_map_error_without_wait_no_error(backend):
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', wait_on_exit=False, image=PYTHON_DILL_IMAGE) as bpe:
         bpe.map(lambda _: time.sleep(10), range(5), timeout=2)
 
 
-def test_exception_in_map():
+def test_exception_in_map(backend):
     def raise_value_error():
         raise ValueError('dead')
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         try:
             gen = bpe.map(lambda _: raise_value_error(), range(5))
             next(gen)
@@ -123,10 +160,10 @@ def test_exception_in_map():
             assert False
 
 
-def test_exception_in_result():
+def test_exception_in_result(backend):
     def raise_value_error():
         raise ValueError('dead')
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         try:
             future = bpe.submit(raise_value_error)
             future.result()
@@ -136,10 +173,10 @@ def test_exception_in_result():
             assert False
 
 
-def test_exception_in_exception():
+def test_exception_in_exception(backend):
     def raise_value_error():
         raise ValueError('dead')
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         try:
             future = bpe.submit(raise_value_error)
             future.exception()
@@ -149,10 +186,10 @@ def test_exception_in_exception():
             assert False
 
 
-def test_no_exception_when_exiting_context():
+def test_no_exception_when_exiting_context(backend):
     def raise_value_error():
         raise ValueError('dead')
-    with BatchPoolExecutor(project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
+    with BatchPoolExecutor(backend=backend, project='hail-vdc', image=PYTHON_DILL_IMAGE) as bpe:
         future = bpe.submit(raise_value_error)
     try:
         future.exception()
@@ -162,9 +199,11 @@ def test_no_exception_when_exiting_context():
         assert False
 
 
-def test_bad_image_gives_good_error():
-    with BatchPoolExecutor(project='hail-vdc',
-                           image='hailgenetics/not-a-valid-image:123abc') as bpe:
+def test_bad_image_gives_good_error(backend):
+    with BatchPoolExecutor(
+            backend=backend,
+            project='hail-vdc',
+            image='hailgenetics/not-a-valid-image:123abc') as bpe:
         future = bpe.submit(lambda: 3)
     try:
         future.exception()


### PR DESCRIPTION
A couple of fixes to batch pool executor to both get rid of orphaned running forever jobs and exception not retrieved errors:

- `asyncio.wait` does not retrieve results. I had to change waits to gathers with return_exceptions=True to get the behavior we want.
- A timeout error with `asyncio.wait_for` cancels the task automatically. Therefore, the previous code would never cancel the batch because the task was already "cancelled".
- I made `asyncio_cancel` idempotent and made sure we cancel the batch if the task has been cancelled to address the issue above. I added a check to see if the batch is running before cancelling. I'm ambivalent on whether this change is necessary.
- I added an explicit test now to make sure all batches are terminated. I think this is a good change, but the downstream consequences could be if this runs forever on a deploy (relies on an explicit timeout). Although, `test_hailtop_batch_*` has explicit timeouts. So I think we're good.