### PR TITLE
[query] Partition reader no ptype

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -8,7 +8,7 @@ import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
-import is.hail.types.TableType
+import is.hail.types.{TableType, TypeWithRequiredness}
 import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode}
 import is.hail.types.physical.{PStruct, PType}
 import is.hail.types.virtual.{TArray, TStruct, Type}
@@ -25,7 +25,11 @@ class PartitionIteratorLongReader(
   bodyPType: Type => PType,
   body: Type => (Region, Any) => Iterator[Long]) extends PartitionReader {
 
-  def rowPType(requestedType: Type): PType = bodyPType(requestedType.asInstanceOf[TStruct])
+  def rowRequiredness(requestedType: Type): TypeWithRequiredness = {
+    val tr = TypeWithRequiredness.apply(requestedType)
+    tr.fromPType(bodyPType(requestedType.asInstanceOf[TStruct]))
+    tr
+  }
 
   def emitStream(
     ctx: ExecuteContext,

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -9,6 +9,7 @@ import is.hail.expr.ir.lowering.TableStageDependency
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, TypedCodecSpec}
 import is.hail.rvd.RVDSpecMaker
+import is.hail.types.TypeWithRequiredness
 import is.hail.types.encoded._
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{BooleanSingleCodeType, Float32SingleCodeType, Float64SingleCodeType, Int32SingleCodeType, Int64SingleCodeType, PTypeReferenceSingleCodeType, SType}
@@ -676,7 +677,7 @@ abstract class PartitionReader {
 
   def fullRowType: Type
 
-  def rowPType(requestedType: Type): PType
+  def rowRequiredness(requestedType: Type): TypeWithRequiredness
 
   def emitStream(
     ctx: ExecuteContext,

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -684,7 +684,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         coerce[RIterable](requiredness).elementType.unionFrom(lookup(body))
       case ReadPartition(context, rowType, reader) =>
         requiredness.union(lookup(context).required)
-        coerce[RIterable](requiredness).elementType.fromPType(reader.rowPType(rowType))
+        coerce[RIterable](requiredness).elementType.unionFrom(reader.rowRequiredness(rowType))
       case WritePartition(value, writeCtx, writer) =>
         val sType = coerce[PStream](lookup(value).canonicalPType(value.typ))
         val ctxType = lookup(writeCtx).canonicalPType(writeCtx.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -526,7 +526,11 @@ case class PartitionRVDReader(rvd: RVD) extends PartitionReader {
 trait AbstractNativeReader extends PartitionReader {
   def spec: AbstractTypedCodecSpec
 
-  def rowRequiredness(requestedType: Type): PType = spec.decodedPType(requestedType)
+  override def rowRequiredness(requestedType: Type): TypeWithRequiredness = {
+    val tr = TypeWithRequiredness(requestedType)
+    tr.fromPType(spec.decodedPType(requestedType))
+    tr
+  }
 
   def fullRowType: Type = spec.encodedVirtualType
 }


### PR DESCRIPTION
We want to make a `PartitionReader` that reads in lines of text, no notion of `PType` makes sense for this.

@tpoterba, does this make sense? I find the `Requiredness` stuff confusing, but I think this should do the same thing the old code did 