### PR TITLE
Added parens to address Scala warning

### DIFF
--- a/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
@@ -253,25 +253,25 @@ class RegionSuite extends TestNGSuite {
       }
       val chunkCache = new ChunkCache(allocate, free)
       val ab = new LongArrayBuilder()
-      var i = 0
+
       ab += chunkCache.getChunk(pool, 400L)._1
       chunkCache.freeChunkToCache(ab.pop())
       ab += chunkCache.getChunk(pool, 50L)._1
-      assert(operations(0)==("allocate", 512))
+      assert(operations(0) == (("allocate", 512)))
       //512 size chunk freed from cache to not exceed peak memory
-      assert(operations(1)==("free", 0L))
-      assert(operations(2)==("allocate", 64))
+      assert(operations(1) == (("free", 0L)))
+      assert(operations(2) == (("allocate", 64)))
       chunkCache.freeChunkToCache(ab.pop())
       //No additional allocate should be made as uses cache
       ab += chunkCache.getChunk(pool, 50L)._1
       assert(operations.length == 3)
       ab += chunkCache.getChunk(pool, 40L)._1
       chunkCache.freeChunksToCache(ab)
-      assert(operations(3) == ("allocate", 64))
+      assert(operations(3) == (("allocate", 64)))
       assert(operations.length == 4)
       chunkCache.freeAll(pool)
-      assert(operations(4)==("free", 0L))
-      assert(operations(5)==("free", 0L))
+      assert(operations(4) == (("free", 0L)))
+      assert(operations(5) == (("free", 0L)))
       assert(operations.length == 6)
 
     }


### PR DESCRIPTION
I don't know if this happens to you guys, but when I try to compile `RegionSuite.scala` I get Scala compiler warnings about how it's not cool to do `operations(3) == ("allocate", 64)`, since Scala can't tell if we mean:

`operations(3).==("allocate", 64)`

or 

`operations(3).==(("allocate", 64))`.

It was annoying me, so I added the extra parens so it would stop.