### PR TITLE
Better warning about accidentally using Expression as a bool.

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -650,6 +650,9 @@ class Expression(object):
         """
         return self._type
 
+    def __bool__(self):
+        raise TypeError("'Expression' objects cannot be converted to a 'bool'. Use 'hl.if_else' instead of Python if statements.")
+
     def __len__(self):
         raise TypeError("'Expression' objects have no static length: use 'hl.len' for the length of collections")
 

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1619,6 +1619,9 @@ class StructExpression(Mapping[str, Expression], Expression):
     def __len__(self):
         return len(self._fields)
 
+    def __bool__(self):
+        return bool(len(self))
+
     @typecheck_method(item=oneof(str, int, slice))
     def __getitem__(self, item):
         """Access a field of the struct by name or index.
@@ -1948,6 +1951,9 @@ class TupleExpression(Expression, Sequence):
         :obj:`int`
         """
         return len(self.dtype.types)
+
+    def __bool__(self):
+        return bool(len(self))
 
     def __iter__(self):
         for i in range(len(self)):


### PR DESCRIPTION
Previously, if you did:

```
x = hl.bool(True)
if x:
    ....
```

You'd get a message like: "Expressions do not have a static length", because in Python, truthiness is resolved by first checking if `__bool__` is defined, then checking if `__len__` is nonzero. This PR gives a better message suggesting that the user has in some way tried to coerce an `Expression` into a bool, and only shows the other error if someone does something that specifically needs the length.