### PR TITLE
[compiler] Fix bug in streamJoinLeftDistinct with multiple key repeats.

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1120,6 +1120,27 @@ Exception in thread "main" java.lang.RuntimeException: invalid sort order: b
         self.assertEqual(inner_join.collect(), inner_join_expected)
         self.assertEqual(outer_join.collect(), outer_join_expected)
 
+    def test_join_types(self):
+        ht1 = hl.utils.range_table(3, 3)
+        ht1 = ht1.key_by(idx=ht1.idx + 1)
+        ht1 = ht1.annotate(L_DUP=hl.range(ht1.idx)).explode('L_DUP')
+        assert ht1.idx.collect() == [1, *([2] * 2), *([3] * 3)]
+
+        ht2 = hl.utils.range_table(3, 3)
+        ht2 = ht2.key_by(idx=ht2.idx + 2)
+        ht2 = ht2.annotate(R_DUP=hl.range(ht2.idx)).explode('R_DUP')
+        assert ht2.idx.collect() == [*([2] * 2), *([3] * 3), *([4] * 4)]
+
+        left = ht1.join(ht2, 'left')
+        right = ht1.join(ht2, 'right')
+        inner = ht1.join(ht2, 'inner')
+        outer = ht1.join(ht2, 'outer')
+
+        assert left.idx.collect() == [1, *([2] * 4), *([3] * 9)]
+        assert right.idx.collect() == [*([2] * 4), *([3] * 9), *([4] * 4)]
+        assert inner.idx.collect() == [*([2] * 4), *([3] * 9)]
+        assert outer.idx.collect() == [1, *([2] * 4), *([3] * 9), *([4] * 4)]
+
     @fails_service_backend()
     @fails_local_backend()
     def test_partitioning_rewrite(self):

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1185,7 +1185,7 @@ object EmitStream {
                           cb.assign(leftEOS, true)
                           cb.assign(lOutMissing, true)
                           cb.assign(rOutMissing, false)
-                          cb.ifx(pulledRight && c.cne(0),
+                          cb.ifx(pulledRight && !pushedRight,
                             {
                               if (rightProducer.requiresMemoryManagementPerElement) {
                                 cb += elementRegion.trackAndIncrementReferenceCountOf(rightProducer.elementRegion)

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -1092,6 +1092,7 @@ object EmitStream {
                     cb.define(LpullRight)
                     if (rightProducer.requiresMemoryManagementPerElement)
                       cb += rightProducer.elementRegion.clearRegion()
+                    cb.assign(pulledRight, true)
                     cb.goto(rightProducer.LproduceElement)
 
                     cb.define(LpullLeft)
@@ -1113,10 +1114,8 @@ object EmitStream {
                             }
                             cb.goto(Lpush)
                           },
-                            {
-                              cb.assign(pulledRight, true)
-                              cb.goto(LpullRight)
-                            })
+                            cb.goto(LpullRight)
+                          )
                         },
                         {
                           cb.ifx(c < 0,
@@ -1175,10 +1174,8 @@ object EmitStream {
                             cb.goto(Lcompare)
                           }
                         ),
-                        {
-                          cb.assign(pulledRight, true)
-                          cb.goto(LpullRight)
-                        })
+                        cb.goto(LpullRight)
+                      )
                     }
 
                     mb.implementLabel(leftProducer.LendOfStream) { cb =>
@@ -1196,8 +1193,6 @@ object EmitStream {
                               cb.goto(Lpush)
                             },
                             {
-                              cb.assign(pulledRight, true)
-
                               if (rightProducer.requiresMemoryManagementPerElement) {
                                 cb += rightProducer.elementRegion.clearRegion()
                               }


### PR DESCRIPTION
The new tests in scala and python both catch this.