### PR TITLE
More complete instructions for building hail on spark clusters

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -252,18 +252,18 @@ upload-artifacts: $(WHEEL)
 .PHONY: install-editable
 install-editable: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
 install-editable: python/README.md $(PYTHON_JAR)
-	-$(PIP) uninstall -y hail
+	-$(PIP) uninstall -y hail || true
 	cd python && $(PIP) install -e .
 
 .PHONY: install
 install: $(WHEEL)
-	-$(PIP) uninstall -y hail
+	-$(PIP) uninstall -y hail || true
 	$(PIP) install $(WHEEL)
 
 .PHONY: install-on-cluster
 install-on-cluster: $(WHEEL)
 	sed '/^pyspark/d' python/requirements.txt | grep -v '^#' | xargs $(PIP) install -U
-	-$(PIP) uninstall -y hail
+	-$(PIP) uninstall -y hail || true
 	$(PIP) install $(WHEEL) --no-deps
 
 .PHONY: install-hailctl

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -252,18 +252,18 @@ upload-artifacts: $(WHEEL)
 .PHONY: install-editable
 install-editable: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
 install-editable: python/README.md $(PYTHON_JAR)
-	-$(PIP) uninstall -y hail || true
+	-$(PIP) uninstall -y hail
 	cd python && $(PIP) install -e .
 
 .PHONY: install
 install: $(WHEEL)
-	-$(PIP) uninstall -y hail || true
+	-$(PIP) uninstall -y hail
 	$(PIP) install $(WHEEL)
 
 .PHONY: install-on-cluster
 install-on-cluster: $(WHEEL)
 	sed '/^pyspark/d' python/requirements.txt | grep -v '^#' | xargs $(PIP) install -U
-	-$(PIP) uninstall -y hail || true
+	-$(PIP) uninstall -y hail
 	$(PIP) install $(WHEEL) --no-deps
 
 .PHONY: install-hailctl

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -14,17 +14,21 @@ requires:
 - Python 3.6+.
 - A recent C and a C++ compiler, GCC 5.0, LLVM 3.4, or later versions of either
   suffice.
+- The LZ4 library.
 - BLAS and LAPACK.
 
 On a Debian-like system, the following should suffice:
 
 .. code-block:: sh
 
+   apt-get update
    apt-get install \
        openjdk-8-jdk-headless \
        g++ \
        python3 python3-pip \
-       libopenblas-dev liblapack-dev
+       libopenblas-dev liblapack-dev \
+       liblz4-dev
+
 
 The next block of commands downloads, builds, and installs Hail from source.
 

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -36,7 +36,7 @@ The next block of commands downloads, builds, and installs Hail from source.
 
     git clone https://github.com/hail-is/hail.git
     cd hail/hail
-    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.5
+    make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.12.13 SPARK_VERSION=3.1.1
 
 If you forget to install any of the requirements before running `make install-on-cluster`, it's possible
 to get into a bad state where `make` insists you don't have a requirement that you have in fact installed.

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -38,6 +38,10 @@ The next block of commands downloads, builds, and installs Hail from source.
     cd hail/hail
     make install-on-cluster HAIL_COMPILE_NATIVES=1 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.5
 
+If you forget to install any of the requirements before running `make install-on-cluster`, it's possible
+to get into a bad state where `make` insists you don't have a requirement that you have in fact installed.
+Try doing `make clean` and then a fresh invocation of the `make install-on-cluster` line if this happens.
+
 On every worker node of the cluster, you must install a BLAS and LAPACK library
 such as the Intel MKL or OpenBLAS. On a Debian-like system you might try the
 following on every worker node.


### PR DESCRIPTION
Resolves #10747

I sshed into a VM and tried to do a clean install based on the issue raised above. As noted there, lz4 was missing from our cluster install docs. I also noticed `pip` returns a nonzero exit code if it tries to install something but doesn't find it, so I added some `|| true` to prevent a confusing error message. I also updated our examples to use Spark 3 by default.