### PR TITLE
[batch] ensure we cancel batches after BPE tests

### DIFF
--- a/hail/python/test/hailtop/batch/test_batch_pool_executor.py
+++ b/hail/python/test/hailtop/batch/test_batch_pool_executor.py
@@ -103,11 +103,16 @@ def test_map_timeout():
             pass
         else:
             assert False
+        finally:
+            for f in bpe.futures:
+                f.cancel()
 
 
 def test_map_error_without_wait_no_error():
     with BatchPoolExecutor(project='hail-vdc', wait_on_exit=False, image=PYTHON_DILL_IMAGE) as bpe:
         bpe.map(lambda _: time.sleep(10), range(5), timeout=2)
+    for f in bpe.futures:
+        f.cancel()
 
 
 def test_exception_in_map():


### PR DESCRIPTION
BPE tests with timeouts need to explicitly cancel their jobs.