### PR TITLE
[query] Broadcast with array of array byte streams

### DIFF
--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -13,7 +13,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
   buf += new ByteArrayOutputStream(initialBufferCapacity)
 
   protected var bytesInCurrentArray = 0
-  protected var currentArray = 0
+  protected var currentArray = buf(0)
 
   /**
     * Creates a new byte array output stream. The buffer capacity is
@@ -27,7 +27,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
     if (bytesInCurrentArray == MAX_ARRAY_SIZE) {
       buf.ensureCapacity(buf.length + 1)
       buf += new ByteArrayOutputStream(initialBufferCapacity)
-      currentArray += 1
+      currentArray = buf.last
       bytesInCurrentArray = 0
     }
   }
@@ -35,7 +35,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
   override def write(b: Int): Unit = {
     ensureNextByte()
 
-    buf(buf.length - 1).write(b)
+    currentArray.write(b)
     bytesInCurrentArray += 1
   }
 
@@ -46,7 +46,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
       ensureNextByte()
       val remainingBytesAllowed = MAX_ARRAY_SIZE - bytesInCurrentArray
       val bytesToWrite = math.min(remainingBytesAllowed, len - bytesWritten)
-      buf(buf.length - 1).write(b, off + bytesWritten, bytesToWrite)
+      currentArray.write(b, off + bytesWritten, bytesToWrite)
       bytesWritten += bytesToWrite
     }
   }

--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -1,6 +1,6 @@
 package is.hail.utils
 
-import java.io.OutputStream
+import java.io.{ByteArrayOutputStream, OutputStream}
 
 class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStream {
 
@@ -9,8 +9,8 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
   /**
     * The buffer where data is stored.
     */
-  protected var buf: Array[Array[Byte]] = new Array[Array[Byte]](1)
-  buf(0) = new Array[Byte](initialBufferCapacity)
+  protected var buf = new BoxedArrayBuilder[ByteArrayOutputStream](1)
+  buf ++= new ByteArrayOutputStream(initialBufferCapacity)
 
   protected var bytesInCurrentArray = 0
   protected var currentArray = 0
@@ -25,14 +25,21 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
 
   def ensureNextByte(): Unit = {
     if (bytesInCurrentArray == MAX_ARRAY_SIZE) {
-      
+      buf.ensureCapacity(buf.length + 1)
+      buf ++= new ByteArrayOutputStream(initialBufferCapacity)
+      currentArray += 1
+      bytesInCurrentArray = 0
     }
   }
 
   override def write(b: Int): Unit = {
     ensureNextByte()
 
-    buf(currentArray)(bytesInCurrentArray)
+    buf(buf.length - 1).write(b)
     bytesInCurrentArray += 1
+  }
+
+  def toByteArrays(): Unit = {
+    buf.result().map(_.toByteArray)
   }
 }

--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -39,6 +39,18 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
     bytesInCurrentArray += 1
   }
 
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+    var bytesWritten = 0
+
+    while (bytesWritten < len) {
+      ensureNextByte()
+      val remainingBytesAllowed = MAX_ARRAY_SIZE - bytesInCurrentArray
+      val bytesToWrite = math.min(remainingBytesAllowed, len - bytesWritten)
+      buf(buf.length - 1).write(b, off + bytesWritten, bytesToWrite)
+      bytesWritten += bytesToWrite
+    }
+  }
+
   def toByteArrays(): Array[Array[Byte]] = {
     buf.result().map(_.toByteArray)
   }

--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -3,16 +3,17 @@ package is.hail.utils
 import java.io.OutputStream
 
 class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStream {
+
+  val MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
   /**
     * The buffer where data is stored.
     */
   protected var buf: Array[Array[Byte]] = new Array[Array[Byte]](1)
   buf(0) = new Array[Byte](initialBufferCapacity)
 
-  /**
-    * The number of valid bytes in the buffer.
-    */
-  protected var count = 0L
+  protected var bytesInCurrentArray = 0
+  protected var currentArray = 0
 
   /**
     * Creates a new byte array output stream. The buffer capacity is
@@ -22,9 +23,16 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
     this(32)
   }
 
+  def ensureNextByte(): Unit = {
+    if (bytesInCurrentArray == MAX_ARRAY_SIZE) {
+      
+    }
+  }
 
   override def write(b: Int): Unit = {
-    ???
-    count += b
+    ensureNextByte()
+
+    buf(currentArray)(bytesInCurrentArray)
+    bytesInCurrentArray += 1
   }
 }

--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -1,0 +1,30 @@
+package is.hail.utils
+
+import java.io.OutputStream
+
+class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStream {
+  /**
+    * The buffer where data is stored.
+    */
+  protected var buf: Array[Array[Byte]] = new Array[Array[Byte]](1)
+  buf(0) = new Array[Byte](initialBufferCapacity)
+
+  /**
+    * The number of valid bytes in the buffer.
+    */
+  protected var count = 0L
+
+  /**
+    * Creates a new byte array output stream. The buffer capacity is
+    * initially 32 bytes, though its size increases if necessary.
+    */
+  def this() {
+    this(32)
+  }
+
+
+  override def write(b: Int): Unit = {
+    ???
+    count += b
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ArrayOfByteArrayOutputStream.scala
@@ -10,7 +10,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
     * The buffer where data is stored.
     */
   protected var buf = new BoxedArrayBuilder[ByteArrayOutputStream](1)
-  buf ++= new ByteArrayOutputStream(initialBufferCapacity)
+  buf += new ByteArrayOutputStream(initialBufferCapacity)
 
   protected var bytesInCurrentArray = 0
   protected var currentArray = 0
@@ -26,7 +26,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
   def ensureNextByte(): Unit = {
     if (bytesInCurrentArray == MAX_ARRAY_SIZE) {
       buf.ensureCapacity(buf.length + 1)
-      buf ++= new ByteArrayOutputStream(initialBufferCapacity)
+      buf += new ByteArrayOutputStream(initialBufferCapacity)
       currentArray += 1
       bytesInCurrentArray = 0
     }
@@ -39,7 +39,7 @@ class ArrayOfByteArrayOutputStream(initialBufferCapacity: Int) extends OutputStr
     bytesInCurrentArray += 1
   }
 
-  def toByteArrays(): Unit = {
+  def toByteArrays(): Array[Array[Byte]] = {
     buf.result().map(_.toByteArray)
   }
 }

--- a/hail/src/main/scala/is/hail/utils/prettyPrint/ArrayOfByteArrayInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/prettyPrint/ArrayOfByteArrayInputStream.scala
@@ -1,0 +1,29 @@
+package is.hail.utils.prettyPrint
+
+import java.io.{ByteArrayInputStream, InputStream}
+
+class ArrayOfByteArrayInputStream(bytes: Array[Array[Byte]]) extends InputStream {
+
+  val byteInputStreams = bytes.map(new ByteArrayInputStream(_))
+  var currentInputStreamIdx = 0
+
+  override def read(): Int = {
+    var foundByte = false
+    var byteToReturn = -1
+    while (!foundByte) {
+      if (currentInputStreamIdx == bytes.length) {
+        foundByte = true
+      } else {
+        val readByte = byteInputStreams(currentInputStreamIdx).read()
+        if (readByte == -1) {
+          currentInputStreamIdx += 1
+        }
+        else {
+          foundByte = true
+          byteToReturn = readByte
+        }
+      }
+    }
+    byteToReturn
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/prettyPrint/ArrayOfByteArrayInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/prettyPrint/ArrayOfByteArrayInputStream.scala
@@ -11,7 +11,7 @@ class ArrayOfByteArrayInputStream(bytes: Array[Array[Byte]]) extends InputStream
     var foundByte = false
     var byteToReturn = -1
     while (!foundByte) {
-      if (currentInputStreamIdx == bytes.length) {
+      if (currentInputStreamIdx == byteInputStreams.length) {
         foundByte = true
       } else {
         val readByte = byteInputStreams(currentInputStreamIdx).read()
@@ -25,5 +25,25 @@ class ArrayOfByteArrayInputStream(bytes: Array[Array[Byte]]) extends InputStream
       }
     }
     byteToReturn
+  }
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = {
+    var numBytesRead = 0
+    var moreToRead = true
+
+    while(numBytesRead < len && moreToRead) {
+      if (currentInputStreamIdx == byteInputStreams.length) {
+        moreToRead = false
+      } else {
+        val bytesReadInOneCall = byteInputStreams(currentInputStreamIdx).read(b, off + numBytesRead, len - numBytesRead)
+        if (bytesReadInOneCall == -1) {
+          currentInputStreamIdx += 1
+        } else {
+          numBytesRead += bytesReadInOneCall
+        }
+      }
+    }
+
+    numBytesRead
   }
 }


### PR DESCRIPTION
I ran into issues when broadcasting a very large struct of ndarrays for a huge linear regression, where the the total size was more than `MAX_INT` bytes. To solve this, I've changed `SerializableRegionValue` to use `ArrayOfByteArrayOutputStream` and `ArrayOfByteInputStream`, which create nested arrays of bytes instead of just one array, removing any maximum length issues. 

PRing now for tests, also running benchmarks.