### PR TITLE
[ci] Dont try to assign reviewers with empty PR body

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -352,7 +352,7 @@ class PR(Code):
             log.exception(f'{self.short_str()}: Unexpected exception in post to github: {data}')
 
     async def assign_gh_reviewer_if_requested(self, gh_client):
-        if len(self.assignees) == 0 and len(self.reviewers) == 0:
+        if len(self.assignees) == 0 and len(self.reviewers) == 0 and self.body is not None:
             assignees = set()
             if ASSIGN_SERVICES in self.body:
                 assignees.add(select_random_teammate(SERVICES_TEAM).gh_username)


### PR DESCRIPTION
There's a small CI feature where you can randomly assign someone from services and/or compiler team to review a PR by including a directive in the github PR body, e.g. #assign compiler. There's a slight bug where if the PR body is left blank, GitHub will report it as `None` instead of what I assumed would be "", which breaks the lines like `if ASSIGN_SERVICES in self.body` with the error that `None` is not iterable. This just inserts a guard against that.