### PR TITLE
[query] String multiplying

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -2477,6 +2477,20 @@ class Int32Expression(NumericExpression):
     def _summary_aggs(self):
         return hl.agg.stats(self)
 
+    def __mul__(self, other):
+        other = to_expr(other)
+        if other.dtype == tstr:
+            return other * self
+        else:
+            return NumericExpression.__mul__(self, other)
+
+    def __rmul__(self, other):
+        other = to_expr(other)
+        if other.dtype == tstr:
+            return other * self
+        else:
+            return NumericExpression.__mul__(self, other)
+
 
 class Int64Expression(NumericExpression):
     """Expression of type :py:data:`.tint64`."""
@@ -2562,6 +2576,16 @@ class StringExpression(Expression):
         if not other.dtype == tstr:
             raise NotImplementedError("'{}' + '{}'".format(other.dtype, self.dtype))
         return self._bin_op_reverse("concat", other, self.dtype)
+
+    def __mul__(self, other):
+        other = to_expr(other)
+        if not other.dtype == tint32:
+            raise NotImplementedError("'{}' + '{}'".format(self.dtype, other.dtype))
+        return hl.delimit(hl.range(other).map(lambda x: self), delimiter='')
+
+    def __rmul__(self, other):
+        other = to_expr(other)
+        return other * self
 
     def _slice(self, start=None, stop=None, step=None):
         if step is not None:

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -147,6 +147,7 @@ class Tests(unittest.TestCase):
             x51=[1.0, 2.0, 3.0] <= kt.f,
             x52=[1.0, 2.0, 3.0] >= kt.f,
             x53=hl.tuple([True, 1.0]) < (1.0, 0.0),
+            x54=kt.e * kt.a,
         ).take(1)[0])
 
         expected = {'a': 4, 'b': 1, 'c': 3, 'd': 5, 'e': "hello", 'f': [1, 2, 3],
@@ -166,7 +167,8 @@ class Tests(unittest.TestCase):
                     'x42': False, 'x43': True, 'x44': True,
                     'x45': True, 'x46': True, 'x47': True,
                     'x48': True, 'x49': False, 'x50': False,
-                    'x51': True, 'x52': True, 'x53': False}
+                    'x51': True, 'x52': True, 'x53': False,
+                    'x54': "hellohellohellohello"}
 
         for k, v in expected.items():
             if isinstance(v, float):
@@ -347,6 +349,14 @@ class Tests(unittest.TestCase):
 
         with pytest.raises(TypeError, match="Expected str collection, int32 found"):
             hl.eval(hl.str(",").join([1, 2, 3]))
+
+    def test_string_multiply(self):
+        # Want to make sure all implict conversions work.
+        ps = "cat"
+        pn = 3
+        s = hl.str(ps)
+        n = hl.int32(pn)
+        assert all([x == "catcatcat" for x in hl.eval(hl.array([ps * n, n * ps, s * pn, pn * s]))])
 
     def test_cond(self):
         self.assertEqual(hl.eval('A' + hl.if_else(True, 'A', 'B')), 'AA')


### PR DESCRIPTION
In python, `"hail" * 3` evaluates to `"hailhailhail"`. I've added support for this syntax to hail expressions by overriding `StringExpression.__mul__`, `StringExpression.__rmul__`, `Int32Expression.__mul__`, and `Int32Expression.__rmul__`. It was necessary to do all 4 in order to make sure all possible combinations of python values and hail expressions work. 