### PR TITLE
[query] refactor PCNDArray constructors

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -925,6 +925,12 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 
   def >=(rhs: Code[Long]): Code[Boolean] = compare(rhs) >= 0
 
+  def max(rhs: Code[Long]): Code[Long] =
+    Code.invokeStatic2[Math, Long, Long, Long]("max", lhs, rhs)
+
+  def min(rhs: Code[Long]): Code[Long] =
+    Code.invokeStatic2[Math, Long, Long, Long]("min", lhs, rhs)
+
   def ceq(rhs: Code[Long]): Code[Boolean] = compare(rhs) ceq 0
 
   def cne(rhs: Code[Long]): Code[Boolean] = compare(rhs) cne 0

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1701,7 +1701,7 @@ class Emit[C](
           else {
             val outputPType = retPTypeUncast.asInstanceOf[PCanonicalNDArray]
 
-            def noOp(cb: EmitCodeBuilder): SNDArrayCode = {
+            def noOp(cb: EmitCodeBuilder): SNDArrayValue = {
               throw new IllegalStateException("Can't happen")
             }
 
@@ -1771,7 +1771,7 @@ class Emit[C](
             val outputPType = NDArraySVD.pTypes(true, false).asInstanceOf[PCanonicalTuple]
             outputPType.constructFromFields(cb, region, FastIndexedSeq(EmitCode.present(cb.emb, u), EmitCode.present(cb.emb, s), EmitCode.present(cb.emb, vt)), deepCopy = false)
           } else {
-            s
+            s.get
           }
           IEmitCode(cb, false, resultPCode)
 
@@ -1851,14 +1851,13 @@ class Emit[C](
           cb.append(infoDGEQRFErrorTest("Failed to compute H and Tau."))
 
           val h = hFinisher(cb)
-          val hMemo = h.memoize(cb, "ndarray_qr_h_memo")
 
           val result: SCode = if (mode == "raw") {
             val resultType = resultPType.asInstanceOf[PCanonicalBaseStruct]
             val tau = tauFinisher(cb)
 
             resultType.constructFromFields(cb, region, FastIndexedSeq(
-              EmitCode.present(cb.emb, hMemo),
+              EmitCode.present(cb.emb, h),
               EmitCode.present(cb.emb, tau)
             ), deepCopy = false)
 
@@ -1900,7 +1899,7 @@ class Emit[C](
                 cb.append(Region.storeDouble(
                   curWriteAddress,
                   (currCol >= currRow).mux(
-                    hMemo.loadElement(IndexedSeq(currCol, currRow), cb).asDouble.doubleCode(cb),
+                    h.loadElement(IndexedSeq(currCol, currRow), cb).asDouble.doubleCode(cb),
                     0.0
                   )
                 ))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -56,7 +56,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       val infoDTRTRSResult = cb.newLocal[Int]("dtrtrs_result")
 
       val outputPType = coerce[PCanonicalNDArray](outputPt)
-      val output = outputPType.constructByActuallyCopyingData(ndDepColMajor, cb, region).memoize(cb, "triangular_solve_output")
+      val output = outputPType.constructByActuallyCopyingData(ndDepColMajor, cb, region)
 
       cb.assign(infoDTRTRSResult, Code.invokeScalaObject9[String, String, String, Int, Int, Long, Int, Long, Int, Int](LAPACK.getClass, "dtrtrs",
         uplo,
@@ -73,7 +73,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       (output.get, infoDTRTRSResult)
     }
 
-    def linear_solve(a: SNDArrayCode, b: SNDArrayCode, outputPt: PType, cb: EmitCodeBuilder, region: Value[Region], errorID: Value[Int]): (SNDArrayCode, Value[Int]) = {
+    def linear_solve(a: SNDArrayCode, b: SNDArrayCode, outputPt: PType, cb: EmitCodeBuilder, region: Value[Region], errorID: Value[Int]): (SNDArrayValue, Value[Int]) = {
       val aInput = a.asNDArray.memoize(cb, "A")
       val bInput = b.asNDArray.memoize(cb, "B")
 

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -42,7 +42,7 @@ abstract class NDArrayProducer {
     }
   }
 
-  def toSCode(cb: EmitCodeBuilder, targetType: PCanonicalNDArray, region: Value[Region], rowMajor: Boolean = false): SNDArrayCode =  {
+  def toSCode(cb: EmitCodeBuilder, targetType: PCanonicalNDArray, region: Value[Region], rowMajor: Boolean = false): SNDArrayValue =  {
     val (firstElementAddress, finish) = targetType.constructDataFunction(
       shape,
       targetType.makeColumnMajorStrides(shape, region, cb),
@@ -265,7 +265,7 @@ object EmitNDArray {
                 }
 
                 val childPType = childND.st.storageType().asInstanceOf[PCanonicalNDArray]
-                val rowMajor = fromSValue(childMemo, cb).toSCode(cb, childPType, region, true).memoize(cb, "ndarray_reshape_row_major_layout")
+                val rowMajor = fromSValue(childMemo, cb).toSCode(cb, childPType, region, true)
                 // The canonical row major thing is now in the order we want. We just need to read this with the row major striding that
                 // would be generated for something of the new shape.
                 val outputPType = PCanonicalNDArray(rowMajor.st.elementPType.setRequired(true), x.typ.nDims, true) // TODO Should it be required?

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -52,7 +52,7 @@ object LinalgCodeUtils {
 
     val (dataFirstElementAddress, dataFinisher) = pt.constructDataFunction(shape, strides, cb, region)
     // construct an SNDArrayCode with undefined contents
-    val result = dataFinisher(cb).memoize(cb, "col_major_result")
+    val result = dataFinisher(cb)
 
     result.coiterateMutate(cb, region, (pndv.get, "pndv")) { case Seq(l, r) => r }
     result.get

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -6,7 +6,7 @@ import is.hail.expr.Nat
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.physical.stypes.SCode
-import is.hail.types.physical.stypes.concrete.SNDArrayPointerCode
+import is.hail.types.physical.stypes.concrete.{SNDArrayPointerCode, SNDArrayPointerValue}
 import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SNDArrayCode, SNDArrayValue}
 import is.hail.types.virtual.TNDArray
 
@@ -55,5 +55,5 @@ abstract class PNDArray extends PType {
     strides: IndexedSeq[Value[Long]],
     cb: EmitCodeBuilder,
     region: Value[Region]
-  ): (Value[Long], EmitCodeBuilder =>  SNDArrayPointerCode)
+  ): (Value[Long], EmitCodeBuilder => SNDArrayPointerValue)
 }


### PR DESCRIPTION
This adds a `constructUninitialized` constructor to `PCanonicalNDArray`. Now that we have interface methods that mutate an ndarray, there's no reason to force initialization of the data to happen inside the constructor. And there are plenty of uses, like out parameters for lapack methods, that just want an uninitialized ndarray.

Also, it seemed silly to be forced to memoize the new uninitialized ndarray before filling its data, when the constructor already had everything in locals, so I changed the ndarray constructors to return `SNDArrayValue`s.