### PR TITLE
[query] more lapack bindings, support using mkl

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -478,8 +478,7 @@ object HailFeatureFlags {
     ("log_service_timing", ("HAIL_DEV_LOG_SERVICE_TIMING" -> null)),
     ("cache_service_input", ("HAIL_DEV_CACHE_SERVICE_INPUT" -> null)),
     ("write_ir_files", ("HAIL_WRITE_IR_FILES" -> null)),
-    ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16")),
-    ("mkl_path", ("MKL_PATH" -> null))
+    ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16"))
   )
 }
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -478,7 +478,8 @@ object HailFeatureFlags {
     ("log_service_timing", ("HAIL_DEV_LOG_SERVICE_TIMING" -> null)),
     ("cache_service_input", ("HAIL_DEV_CACHE_SERVICE_INPUT" -> null)),
     ("write_ir_files", ("HAIL_WRITE_IR_FILES" -> null)),
-    ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16"))
+    ("method_split_ir_limit", ("HAIL_DEV_METHOD_SPLIT_LIMIT" -> "16")),
+    ("mkl_path", ("MKL_PATH" -> null))
   )
 }
 

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -312,6 +312,19 @@ object Code {
       Array(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
     )
 
+  def invokeScalaObject16[A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, S](
+    cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6], a7: Code[A7], a8: Code[A8],
+    a9: Code[A9], a10: Code[A10], a11: Code[A11], a12: Code[A12], a13: Code[A13], a14: Code[A14], a15: Code[A15], a16: Code[A16])(
+    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], a7ct: ClassTag[A7],
+    a8ct: ClassTag[A8], a9ct: ClassTag[A9], a10ct: ClassTag[A10], a11ct: ClassTag[A11], a12ct: ClassTag[A12], a13ct: ClassTag[A13], a14ct: ClassTag[A14],
+    a15ct: ClassTag[A15], a16ct: ClassTag[A16], sct: ClassTag[S]): Code[S] =
+    invokeScalaObject[S](
+      cls, method,
+      Array[Class[_]](
+        a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass, a7ct.runtimeClass, a8ct.runtimeClass,
+        a9ct.runtimeClass, a10ct.runtimeClass, a11ct.runtimeClass, a12ct.runtimeClass, a13ct.runtimeClass, a14ct.runtimeClass, a15ct.runtimeClass, a16ct.runtimeClass),
+      Array(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+
   def invokeStatic[S](cls: Class[_], method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit sct: ClassTag[S]): Code[S] = {
     val m = Invokeable.lookupMethod(cls, method, parameterTypes)(sct)
     assert(m.isStatic)

--- a/hail/src/main/scala/is/hail/linalg/BLAS.scala
+++ b/hail/src/main/scala/is/hail/linalg/BLAS.scala
@@ -43,6 +43,34 @@ object BLAS {
     }
   }
 
+  def dcopy(n: Int, X: Long, incX: Int, Y: Long, incY: Int): Unit = {
+    val nInt = new IntByReference(n)
+    val incXInt = new IntByReference(incX)
+    val incYInt = new IntByReference(incY)
+
+    libraryInstance.get.dcopy(nInt, X, incXInt, Y, incYInt)
+  }
+
+  def dscal(n: Int, alpha: Double, X: Long, incX: Int): Unit = {
+    val nInt = new IntByReference(n)
+    val alphaDouble = new DoubleByReference(alpha)
+    val incXInt = new IntByReference(incX)
+
+    libraryInstance.get.dscal(nInt, alphaDouble, X, incXInt)
+  }
+
+  def dgemv(TRANS: String, M: Int, N: Int, ALPHA: Double, A: Long, LDA: Int, X: Long, INCX: Int, BETA: Double, Y: Long, INCY: Int): Unit = {
+    val mInt = new IntByReference(M)
+    val nInt = new IntByReference(N)
+    val alphaDouble = new DoubleByReference(ALPHA)
+    val LDAInt = new IntByReference(LDA)
+    val betaDouble = new DoubleByReference(BETA)
+    val incxInt = new IntByReference(INCX)
+    val incyInt = new IntByReference(INCY)
+
+    libraryInstance.get.dgemv(TRANS, mInt, nInt, alphaDouble, A, LDAInt, X, incxInt, betaDouble, Y, incyInt)
+  }
+
   def sgemm(TRANSA: String, TRANSB: String, M: Int, N: Int, K: Int, ALPHA: Float, A: Long, LDA: Int, B: Long, LDB: Int, BETA: Float, C: Long, LDC: Int) = {
     val mInt = new IntByReference(M)
     val nInt = new IntByReference(N)
@@ -69,26 +97,28 @@ object BLAS {
     libraryInstance.get.dgemm(TRANSA, TRANSB, mInt, nInt, kInt, alphaDouble, A, LDAInt, B, LDBInt, betaDouble, C, LDCInt)
   }
 
-  def dgemv(TRANS: String, M: Int, N: Int, ALPHA: Double, A: Long, LDA: Int, X: Long, INCX: Int, BETA: Double, Y: Long, INCY: Int): Unit = {
-    val mInt = new IntByReference(M)
-    val nInt = new IntByReference(N)
-    val alphaDouble = new DoubleByReference(ALPHA)
-    val LDAInt = new IntByReference(LDA)
-    val betaDouble = new DoubleByReference(BETA)
-    val incxInt = new IntByReference(INCX)
-    val incyInt = new IntByReference(INCY)
+  def dtrmm(side: String, uplo: String, transA: String, diag: String, m: Int, n: Int, alpha: Double, A: Long, ldA: Int, B: Long, ldB: Int) = {
+    val mInt = new IntByReference(m)
+    val nInt = new IntByReference(n)
+    val alphaDouble = new DoubleByReference(alpha)
+    val ldAInt = new IntByReference(ldA)
+    val ldBInt = new IntByReference(ldB)
 
-    libraryInstance.get.dgemv(TRANS, mInt, nInt, alphaDouble, A, LDAInt, X, incxInt, betaDouble, Y, incyInt)
+    libraryInstance.get.dtrmm(side, uplo, transA, diag, mInt, nInt, alphaDouble, A, ldAInt, B, ldBInt)
   }
 }
 
 trait BLASLibrary extends Library {
+  def dcopy(n: IntByReference, X: Long, incX: IntByReference, Y: Long, incY: IntByReference)
+  def dscal(n: IntByReference, alpha: DoubleByReference, X: Long, incX: IntByReference)
   def dgemv(TRANS: String, M: IntByReference, N: IntByReference, ALPHA: DoubleByReference, A: Long, LDA: IntByReference, X: Long, INCX: IntByReference, BETA: DoubleByReference, Y: Long, INCY: IntByReference)
-  def dgemm(TRANSA: String, TRANSB: String, M: IntByReference, N: IntByReference, K: IntByReference,
-    ALPHA: DoubleByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference,
-    BETA: DoubleByReference, C: Long, LDC: IntByReference)
   def sgemm(TRANSA: String, TRANSB: String, M: IntByReference, N: IntByReference, K: IntByReference,
     ALPHA: FloatByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference,
     BETA: FloatByReference, C: Long, LDC: IntByReference)
+  def dgemm(TRANSA: String, TRANSB: String, M: IntByReference, N: IntByReference, K: IntByReference,
+    ALPHA: DoubleByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference,
+    BETA: DoubleByReference, C: Long, LDC: IntByReference)
+  def dtrmm(side: String, uplo: String, transA: String, diag: String, m: IntByReference, n: IntByReference,
+    alpha: DoubleByReference, A: Long, ldA: IntByReference, B: Long, ldB: IntByReference)
   def dnrm2(N: IntByReference, X: Array[Double], INCX: IntByReference): Double
 }

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -5,6 +5,7 @@ import java.util.function._
 
 import com.sun.jna.{FunctionMapper, Library, Native, NativeLibrary}
 import com.sun.jna.ptr.IntByReference
+import is.hail.HailContext
 
 import scala.util.{Failure, Success, Try}
 import is.hail.utils._
@@ -20,19 +21,25 @@ class UnderscoreFunctionMapper extends FunctionMapper {
 object LAPACK {
   private[this] val libraryInstance = ThreadLocal.withInitial(new Supplier[LAPACKLibrary]() {
     def get() = {
-      val standard = Native.loadLibrary("lapack", classOf[LAPACKLibrary]).asInstanceOf[LAPACKLibrary]
+      val library_name = if (HailContext.isInitialized && HailContext.getFlag("mkl_path") != null) {
+        NativeLibrary.addSearchPath("mkl_rt", "/Users/pschulz/opt/miniconda3/envs/hail/lib")
+        "mkl_rt"
+      } else {
+        "lapack"
+      }
+      val standard = Native.loadLibrary(library_name, classOf[LAPACKLibrary]).asInstanceOf[LAPACKLibrary]
 
       versionTest(standard) match {
         case Success(version) =>
-          log.info(s"Imported LAPACK version ${version} with standard names")
+          log.info(s"Imported LAPACK library ${library_name}, version ${version}, with standard names")
           standard
         case Failure(exception) =>
           val underscoreAfterMap = new java.util.HashMap[String, FunctionMapper]()
           underscoreAfterMap.put(Library.OPTION_FUNCTION_MAPPER, new UnderscoreFunctionMapper)
-          val underscoreAfter = Native.loadLibrary("lapack", classOf[LAPACKLibrary], underscoreAfterMap).asInstanceOf[LAPACKLibrary]
+          val underscoreAfter = Native.loadLibrary(library_name, classOf[LAPACKLibrary], underscoreAfterMap).asInstanceOf[LAPACKLibrary]
           versionTest(underscoreAfter) match {
             case Success(version) =>
-              log.info(s"Imported LAPACK version ${version} with underscore names")
+              log.info(s"Imported LAPACK library ${library_name}, version ${version}, with underscore names")
               underscoreAfter
             case Failure(exception) =>
               throw exception
@@ -59,6 +66,58 @@ object LAPACK {
     val LWORKInt = new IntByReference(LWORK)
     val infoInt = new IntByReference(1)
     libraryInstance.get.dorgqr(mInt, nInt, kInt, A, LDAInt, TAU, WORK, LWORKInt, infoInt)
+    infoInt.getValue()
+  }
+
+  def dgeqrt(m: Int, n: Int, nb: Int, A: Long, ldA: Int, T: Long, ldT: Int, work: Long): Int = {
+    val mInt = new IntByReference(m)
+    val nInt = new IntByReference(n)
+    val nbInt = new IntByReference(nb)
+    val ldAInt = new IntByReference(ldA)
+    val ldTInt = new IntByReference(ldT)
+    val infoInt = new IntByReference(1)
+    libraryInstance.get.dgeqrt(mInt, nInt, nbInt, A, ldAInt, T, ldTInt, work, infoInt)
+    infoInt.getValue()
+  }
+
+  def dgemqrt(side: String, trans: String, m: Int, n: Int, k: Int, nb: Int, V: Long, ldV: Int, T: Long, ldT: Int, C: Long, ldC: Int, work: Long): Int = {
+    val mInt = new IntByReference(m)
+    val nInt = new IntByReference(n)
+    val kInt = new IntByReference(k)
+    val nbInt = new IntByReference(nb)
+    val ldVInt = new IntByReference(ldV)
+    val ldTInt = new IntByReference(ldT)
+    val ldCInt = new IntByReference(ldC)
+    val infoInt = new IntByReference(1)
+    libraryInstance.get.dgemqrt(side, trans, mInt, nInt, kInt, nbInt, V, ldVInt, T, ldTInt, C, ldCInt, work, infoInt)
+    infoInt.getValue()
+  }
+
+  def dtpqrt(m: Int, n: Int, l: Int, nb: Int, A: Long, ldA: Int, B: Long, ldB: Int, T: Long, ldT: Int, work: Long): Int = {
+    val mInt = new IntByReference(m)
+    val nInt = new IntByReference(n)
+    val lInt = new IntByReference(l)
+    val nbInt = new IntByReference(nb)
+    val ldAInt = new IntByReference(ldA)
+    val ldBInt = new IntByReference(ldB)
+    val ldTInt = new IntByReference(ldT)
+    val infoInt = new IntByReference(1)
+    libraryInstance.get.dtpqrt(mInt, nInt, lInt, nbInt, A, ldAInt, B, ldBInt, T, ldTInt, work, infoInt)
+    infoInt.getValue()
+  }
+
+  def dtpmqrt(side: String, trans: String, m: Int, n: Int, k: Int, l: Int, nb: Int, V: Long, ldV: Int, T: Long, ldT: Int, A: Long, ldA: Int, B: Long, ldB: Int, work: Long): Int = {
+    val mInt = new IntByReference(m)
+    val nInt = new IntByReference(n)
+    val kInt = new IntByReference(k)
+    val lInt = new IntByReference(l)
+    val nbInt = new IntByReference(nb)
+    val ldVInt = new IntByReference(ldV)
+    val ldTInt = new IntByReference(ldT)
+    val ldAInt = new IntByReference(ldA)
+    val ldBInt = new IntByReference(ldB)
+    val infoInt = new IntByReference(1)
+    libraryInstance.get.dtpmqrt(side, trans, mInt, nInt, kInt, lInt, nbInt, V, ldVInt, T, ldTInt, A, ldAInt, B, ldBInt, work, infoInt)
     infoInt.getValue()
   }
 
@@ -120,6 +179,16 @@ object LAPACK {
     INFOref.getValue()
   }
 
+  def ilaenv(ispec: Int, name: String, opts: String, n1: Int, n2: Int, n3: Int, n4: Int): Int = {
+    val ispecref = new IntByReference(ispec)
+    val n1ref = new IntByReference(n1)
+    val n2ref = new IntByReference(n2)
+    val n3ref = new IntByReference(n3)
+    val n4ref = new IntByReference(n4)
+
+    libraryInstance.get.ilaenv(ispecref, name, opts, n1ref, n2ref, n3ref, n4ref)
+  }
+
   private def versionTest(libInstance: LAPACKLibrary): Try[String] = {
     val major = new IntByReference()
     val minor = new IntByReference()
@@ -136,9 +205,14 @@ trait LAPACKLibrary extends Library {
   def dgesv(N: IntByReference, NHRS: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, B: Long, LDB: IntByReference, INFO: IntByReference)
   def dgeqrf(M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, TAU: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dorgqr(M: IntByReference, N: IntByReference, K: IntByReference, A: Long, LDA: IntByReference, TAU: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
+  def dgeqrt(m: IntByReference, n: IntByReference, nb: IntByReference, A: Long, ldA: IntByReference, T: Long, ldT: IntByReference, work: Long, info: IntByReference)
+  def dgemqrt(side: String, trans: String, m: IntByReference, n: IntByReference, k: IntByReference, nb: IntByReference, V: Long, ldV: IntByReference, T: Long, ldT: IntByReference, C: Long, ldC: IntByReference, work: Long, info: IntByReference)
+  def dtpqrt(M: IntByReference, N: IntByReference, L: IntByReference, NB: IntByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference, T: Long, LDT: IntByReference, WORK: Long, INFO: IntByReference)
+  def dtpmqrt(side: String, trans: String, M: IntByReference, N: IntByReference, K: IntByReference, L: IntByReference, NB: IntByReference, V: Long, LDV: IntByReference, T: Long, LDT: IntByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference, WORK: Long, INFO: IntByReference)
   def dgetrf(M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, INFO: IntByReference)
   def dgetri(N: IntByReference, A: Long, LDA: IntByReference, IPIV: Long, WORK: Long, LWORK: IntByReference, INFO: IntByReference)
   def dgesdd(JOBZ: String, M: IntByReference, N: IntByReference, A: Long, LDA: IntByReference, S: Long, U: Long, LDU: IntByReference, VT: Long, LDVT: IntByReference, WORK: Long, LWORK: IntByReference, IWORK: Long, INFO: IntByReference)
   def ilaver(MAJOR: IntByReference, MINOR: IntByReference, PATCH: IntByReference)
+  def ilaenv(ispec: IntByReference, name: String, opts: String, n1: IntByReference, n2: IntByReference, n3: IntByReference, n4: IntByReference): Int
   def dtrtrs(UPLO: String, TRANS: String, DIAG: String, N: IntByReference, NRHS: IntByReference, A: Long, LDA: IntByReference, B: Long, LDB: IntByReference, INFO:IntByReference)
 }

--- a/hail/src/main/scala/is/hail/linalg/LAPACK.scala
+++ b/hail/src/main/scala/is/hail/linalg/LAPACK.scala
@@ -22,7 +22,7 @@ object LAPACK {
   private[this] val libraryInstance = ThreadLocal.withInitial(new Supplier[LAPACKLibrary]() {
     def get() = {
       val library_name = if (HailContext.isInitialized && HailContext.getFlag("mkl_path") != null) {
-        NativeLibrary.addSearchPath("mkl_rt", "/Users/pschulz/opt/miniconda3/envs/hail/lib")
+        NativeLibrary.addSearchPath("mkl_rt", HailContext.getFlag("mkl_path"))
         "mkl_rt"
       } else {
         "lapack"


### PR DESCRIPTION
Adds support for using mkl, which is needed for some of the added lapack methods.

To use, install mkl, then set the environment variable `HAIL_MKL_PATH` to the directory containing the mkl dylib files. In particular, it should contain `libmkl_rt.dylib`.

On my laptop, I installed mkl through conda with `conda install -c intel mkl`, then set `HAIL_MKL_PATH=~/opt/miniconda3/envs/hail/lib/`.