### PR TITLE
[grafana] Add grafana authorization token to prometheus requests

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -573,6 +573,18 @@ async def verify_dev_credentials(request):
     return web.Response(status=200)
 
 
+@routes.get('/api/v1alpha/verify_dev_or_sa_credentials')
+async def verify_dev_credentials(request):
+    session_id = await get_session_id(request)
+    if not session_id:
+        raise web.HTTPUnauthorized()
+    userdata = await get_userinfo(request, session_id)
+    is_developer_or_sa = userdata is not None and (userdata['is_developer'] == 1 or userdata['is_service_account'] == 1)
+    if not is_developer_or_sa:
+        raise web.HTTPUnauthorized()
+    return web.Response(status=200)
+
+
 async def on_startup(app):
     db = Database()
     await db.async_init(maxsize=50)

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -66,6 +66,7 @@ async def main():
         ('test', None, 0, 0),
         ('test-dev', None, 1, 0),
         ('query', None, 0, 1),
+        ('grafana', None, 0, 1),
     ]
 
     app = {}

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -8,11 +8,12 @@ GRAFANA_NGINX_IMAGE := $(DOCKER_PREFIX)/grafana_nginx:$(TOKEN)
 
 build:
 	$(MAKE) -C ../docker hail-ubuntu
+	$(MAKE) -C ../docker base
 	python3 ../ci/jinja2_render.py '{"hail_ubuntu_image":{"image":"'$$(cat ../docker/hail-ubuntu-image-ref)'"}}' Dockerfile.nginx Dockerfile.nginx.out
 	python3 ../ci/jinja2_render.py '{"deploy": $(DEPLOY), "default_ns": {"name": "$(NAMESPACE)"}}' nginx.conf nginx.conf.out
 	../docker-build.sh . Dockerfile.nginx.out $(GRAFANA_NGINX_IMAGE)
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}, "base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -23,10 +23,28 @@ spec:
         - name: grafana-configmap-volume
           configMap:
             name: grafana-config
+        - name: grafana-datasources-configmap-volume
+          configMap:
+            name: grafana-datasources-config
         - name: ssl-config-grafana
           secret:
             optional: false
             secretName: ssl-config-grafana
+        - name: grafana-tokens
+          secret:
+            secretName: grafana-tokens
+        - name: grafana-shared
+          emptyDir: {}
+      initContainers:
+       - name: setup-tokens
+         image: {{ base_image.image }}
+         command: ["/bin/bash"]
+         args: ["-c", "jq -r '.{{ default_ns.name }}' /grafana-tokens/tokens.json > /grafana-shared/token"]
+         volumeMounts:
+           - mountPath: /grafana-tokens
+             name: grafana-tokens
+           - mountPath: /grafana-shared
+             name: grafana-shared
       containers:
        - name: grafana
          image: grafana/grafana:8.0.2
@@ -47,6 +65,12 @@ spec:
             name: grafana-storage
           - mountPath: /etc/grafana
             name: grafana-configmap-volume
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafana-datasources-configmap-volume
+          - mountPath: /grafana-tokens
+            name: grafana-tokens
+          - mountPath: /grafana-shared
+            name: grafana-shared
          resources:
            requests:
              cpu: "100m"
@@ -100,6 +124,21 @@ data:
     root_url = %(protocol)s://%(domain)/{{ default_ns.name }}/grafana/
     serve_from_sub_path = true
 {% endif %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources-config
+data:
+  prometheus.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: prometheus
+        type: prometheus
+        jsonData:
+          httpHeaderName1: 'Authorization'
+        secureJsonData:
+          httpHeaderValue1: 'Bearer $__file{/grafana-shared/token}'
 ---
 apiVersion: v1
 kind: Service

--- a/prometheus/nginx.conf
+++ b/prometheus/nginx.conf
@@ -58,9 +58,9 @@ http {
     location = /auth {
         internal;
 {% if deploy %}
-        proxy_pass https://auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://auth/api/v1alpha/verify_dev_or_sa_credentials;
 {% else %}
-        proxy_pass https://auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_credentials;
+        proxy_pass https://auth/{{ default_ns.name }}/auth/api/v1alpha/verify_dev_or_sa_credentials;
 {% endif %}
         include /ssl-config/ssl-config-proxy.conf;
     }


### PR DESCRIPTION
I finally figured out how to get the authorization bearer token for the Grafana robot into Grafana automatically. The problem I'm running into right now is when we load a datasource from a configuration file, we can not edit any of the settings in the UI. We'd want to make sure all the prometheus settings we want are inside the new config file. I also don't want to accidentally overwrite any of the existing configuration.