### PR TITLE
[query] Prevent to_matrix_table_row_major IR from being linear in sample size

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1802,7 +1802,7 @@ class BlockMatrix(object):
         """
         t = self.to_table_row_major(n_partitions, maximum_cache_memory_in_bytes)
         t = t.transmute(entries=t.entries.map(lambda i: hl.struct(element=i)))
-        t = t.annotate_globals(cols=hl.array([hl.struct(col_idx=hl.int64(i)) for i in range(self.n_cols)]))
+        t = t.annotate_globals(cols=hl.range(self.n_cols).map(lambda i: hl.struct(col_idx=hl.int64(i))))
         return t._unlocalize_entries('entries', 'cols', ['col_idx'])
 
     @staticmethod

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3101,7 +3101,7 @@ class Table(ExprContainer):
             entries = hl.array([hl.struct(**{entry_field_name: field}) for field in fields])
 
         t = self.transmute(entries=entries)
-        t = t.annotate_globals(cols=hl.array([hl.struct(**{col_field_name: col}) for col in columns]))
+        t = t.annotate_globals(cols=hl.array(columns).map(lambda col: hl.struct(**{col_field_name: col})))
         return t._unlocalize_entries('entries', 'cols', [col_field_name])
 
     @property


### PR DESCRIPTION
Generate less code in to_matrix_table_row_major methods of table and BlockMatrix by using hl.map instead of python list comprehensions