### PR TITLE
[batch] Close service backend connections on deletion

### DIFF
--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -430,6 +430,9 @@ class ServiceBackend(Backend[bc.Batch]):
         self._batch_client.close()
         async_to_blocking(self._fs.close())
 
+    def __del__(self):
+        self.close()
+
     def _run(self,
              batch: 'batch.Batch',
              dry_run: bool,


### PR DESCRIPTION
Not sure if this is unidiomatic but I always write little scripts that don't close the service backend and end with errors about unclosed sessions. This auto-closes a `ServiceBackend`.