### PR TITLE
[query] Fixed example in split_multi_hts warning

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2147,7 +2147,7 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False, vep_root='vep', *, 
     non-split variants.
 
     >>> bi = mt.filter_rows(hl.len(mt.alleles) == 2)
-    >>> bi = bi.annotate_rows(was_split=False)
+    >>> bi = bi.annotate_rows(a_index=1, was_split=False)
     >>> multi = mt.filter_rows(hl.len(mt.alleles) > 2)
     >>> split = hl.split_multi_hts(multi)
     >>> mt = split.union_rows(bi)


### PR DESCRIPTION
#10676 correctly points out a documentation error, which I am addressing. 