### PR TITLE
[query] Preserve static NDArray shape information

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1430,14 +1430,14 @@ class Emit[C](
         childEC.map(cb) { case sndCode: SNDArrayPointerCode =>
           val childPType = sndCode.st.pType
           val sndVal = sndCode.memoize(cb, "ndarray_reindex_child")
-          val childShape = sndVal.shapes(cb)
-          val childStrides = sndVal.strides(cb)
+          val childShape = sndVal.shapes
+          val childStrides = sndVal.strides
 
           val pndAddr = SingleCodeSCode.fromSCode(cb, sndVal, region)
-          val dataPtr = sndVal.firstDataAddress(cb)
+          val dataPtr = sndVal.firstDataAddress
 
           val newShape = indexMap.map { childIndex =>
-            if (childIndex < childPType.nDims) childShape(childIndex) else const(1L)
+            if (childIndex < childPType.nDims) childShape(childIndex) else SizeValueStatic(1L)
           }
           val newStrides = indexMap.map { childIndex =>
             if (childIndex < childPType.nDims) childStrides(childIndex) else const(0L)
@@ -1475,8 +1475,8 @@ class Emit[C](
             val lSType = leftPVal.st
             val rSType = rightPVal.st
 
-            val lShape = leftPVal.shapes(cb)
-            val rShape = rightPVal.shapes(cb)
+            val lShape = leftPVal.shapes
+            val rShape = rightPVal.shapes
 
             val unifiedShape = NDArrayEmitter.matmulShape(cb, lShape, rShape, errorID)
 
@@ -1487,8 +1487,8 @@ class Emit[C](
               TNDArray.matMulNDims(lSType.nDims, rSType.nDims))
 
             if ((lSType.elementType.virtualType == TFloat64 || lSType.elementType.virtualType == TFloat32) && lSType.nDims == 2 && rSType.nDims == 2) {
-              val leftDataAddress = leftPVal.firstDataAddress(cb)
-              val rightDataAddress = rightPVal.firstDataAddress(cb)
+              val leftDataAddress = leftPVal.firstDataAddress
+              val rightDataAddress = rightPVal.firstDataAddress
 
               val M = lShape(lSType.nDims - 2)
               val N = rShape(rSType.nDims - 1)
@@ -1507,7 +1507,7 @@ class Emit[C](
                 cb,
                 region)
 
-              cb.ifx((M cne 0L) && (N cne 0L) && (K cne 0L), {
+              cb.ifx((M.get cne 0L) && (N.get cne 0L) && (K.get cne 0L), {
                 cb.append(lSType.elementType.virtualType match {
                   case TFloat32 =>
                     Code.invokeScalaObject13[String, String, Int, Int, Int, Float, Long, Int, Long, Int, Float, Long, Int, Unit](BLAS.getClass, method = "sgemm",
@@ -1550,8 +1550,8 @@ class Emit[C](
 
               answerFinisher(cb)
             } else if (lSType.elementType.virtualType == TFloat64 && lSType.nDims == 2 && rSType.nDims == 1) {
-              val leftDataAddress = leftPVal.firstDataAddress(cb)
-              val rightDataAddress = rightPVal.firstDataAddress(cb)
+              val leftDataAddress = leftPVal.firstDataAddress
+              val rightDataAddress = rightPVal.firstDataAddress
 
               val numRows = lShape(lSType.nDims - 2)
               val numCols = lShape(lSType.nDims - 1)
@@ -1646,7 +1646,7 @@ class Emit[C](
           val pndVal = pNDCode.memoize(cb, "ndarray_inverse_nd")
           val ndPT = pndVal.st.asInstanceOf[SNDArrayPointer].pType
 
-          val shapeArray = pndVal.shapes(cb)
+          val shapeArray = pndVal.shapes
           val stridesArray = ndPT.makeColumnMajorStrides(shapeArray, region, cb)
 
 
@@ -1656,7 +1656,7 @@ class Emit[C](
           val N = shapeArray(1)
           val LDA = M
 
-          val dataFirstAddress = pndVal.firstDataAddress(cb)
+          val dataFirstAddress = pndVal.firstDataAddress
 
           val IPIVptype = PCanonicalArray(PInt32Required, true)
           val IPIVaddr = mb.genFieldThisRef[Long]()
@@ -1711,7 +1711,7 @@ class Emit[C](
             .orEmpty(Code._fatalWithID[Unit](const(s"LAPACK error DGESDD. $extraErrorMsg Error code = ").concat(infoDGESDDResult.toS), errorID))
 
           val LWORKAddress = mb.newLocal[Long]("svd_lwork_address")
-          val shapes = ndPVal.shapes(cb)
+          val shapes = ndPVal.shapes
           val M = shapes(0)
           val N = shapes(1)
           val K = cb.newLocal[Long]("nd_svd_K")
@@ -1722,7 +1722,7 @@ class Emit[C](
           val LDVT = if (full_matrices) N else K
           val IWORK = cb.newLocal[Long]("dgesdd_IWORK_address")
           val A = cb.newLocal[Long]("dgesdd_A_address")
-          val firstElementDataAddress = ndPVal.firstDataAddress(cb)
+          val firstElementDataAddress = ndPVal.firstDataAddress
 
           cb.assign(LWORKAddress, Code.invokeStatic1[Memory, Long, Long]("malloc", 8L))
 
@@ -1830,7 +1830,7 @@ class Emit[C](
           // the PCanonicalNDArray representation.
           val pType = pndValue.st.asInstanceOf[SNDArrayPointer].pType
 
-          val shapeArray = pndValue.shapes(cb)
+          val shapeArray = pndValue.shapes
 
           val LWORKAddress = cb.newLocal[Long]("dgeqrf_lwork_address")
 
@@ -1846,7 +1846,7 @@ class Emit[C](
           def LWORK = (Region.loadDouble(LWORKAddress).toI > 0).mux(Region.loadDouble(LWORKAddress).toI, 1)
 
           val ndPT = pType
-          val dataFirstElementAddress = pndValue.firstDataAddress(cb)
+          val dataFirstElementAddress = pndValue.firstDataAddress
 
           val hPType = ndPT
           val hShapeArray = FastIndexedSeq[Value[Long]](N, M)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -84,7 +84,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
   }
 
   private def addValues(cb: EmitCodeBuilder, region: Value[Region], leftNdValue: SNDArrayValue, rightNdValue: SNDArrayValue): Unit = {
-    cb.ifx(!leftNdValue.sameShape(rightNdValue, cb),
+    cb.ifx(!leftNdValue.sameShape(cb, rightNdValue),
       cb += Code._fatal[Unit]("Can't sum ndarrays of different shapes."))
 
     leftNdValue.coiterateMutate(cb, region, (rightNdValue.get, "right")) {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -44,10 +44,10 @@ object  NDArrayFunctions extends RegistryFunctions {
       val ndCoefColMajor = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(ndCoefInput, cb, region)
       val ndDepColMajor = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(ndDepInput, cb, region)
 
-      val IndexedSeq(ndCoefRow, ndCoefCol) = ndCoefColMajor.shapes(cb)
+      val IndexedSeq(ndCoefRow, ndCoefCol) = ndCoefColMajor.shapes
       cb.ifx(ndCoefRow cne ndCoefCol, cb._fatalWithError(errorID, "hail.nd.solve_triangular: matrix a must be square."))
 
-      val IndexedSeq(ndDepRow, ndDepCol) = ndDepColMajor.shapes(cb)
+      val IndexedSeq(ndDepRow, ndDepCol) = ndDepColMajor.shapes
       cb.ifx(ndCoefRow  cne ndDepRow, cb._fatalWithError(errorID,"hail.nd.solve_triangular: Solve dimensions incompatible"))
 
       val uplo = cb.newLocal[String]("dtrtrs_uplo")
@@ -64,9 +64,9 @@ object  NDArrayFunctions extends RegistryFunctions {
         const("N"),
         ndDepRow.toI,
         ndDepCol.toI,
-        ndCoefColMajor.firstDataAddress(cb),
+        ndCoefColMajor.firstDataAddress,
         ndDepRow.toI,
-        output.firstDataAddress(cb),
+        output.firstDataAddress,
         ndDepRow.toI
       ))
 
@@ -80,11 +80,11 @@ object  NDArrayFunctions extends RegistryFunctions {
       val aColMajor = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(aInput, cb, region)
       val bColMajor = LinalgCodeUtils.checkColMajorAndCopyIfNeeded(bInput, cb, region)
 
-      val IndexedSeq(n0, n1) = aColMajor.shapes(cb)
+      val IndexedSeq(n0, n1) = aColMajor.shapes
 
       cb.ifx(n0 cne n1, cb._fatalWithError(errorID, "hail.nd.solve: matrix a must be square."))
 
-      val IndexedSeq(n, nrhs) = bColMajor.shapes(cb)
+      val IndexedSeq(n, nrhs) = bColMajor.shapes
 
       cb.ifx(n0 cne n, cb._fatalWithError(errorID, "hail.nd.solve: Solve dimensions incompatible"))
 
@@ -97,7 +97,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       def aNumBytes = n * n * 8L
 
       cb.assign(aCopy, Code.invokeStatic1[Memory, Long, Long]("malloc", aNumBytes))
-      val aColMajorFirstElement = aColMajor.firstDataAddress(cb)
+      val aColMajorFirstElement = aColMajor.firstDataAddress
 
       cb.append(Region.copyFrom(aColMajorFirstElement, aCopy, aNumBytes))
 
@@ -105,7 +105,7 @@ object  NDArrayFunctions extends RegistryFunctions {
       val outputShape = IndexedSeq(n, nrhs)
       val (outputAddress, outputFinisher) = outputPType.constructDataFunction(outputShape, outputPType.makeColumnMajorStrides(outputShape, region, cb), cb, region)
 
-      cb.append(Region.copyFrom(bColMajor.firstDataAddress(cb), outputAddress, n * nrhs * 8L))
+      cb.append(Region.copyFrom(bColMajor.firstDataAddress, outputAddress, n * nrhs * 8L))
 
       cb.assign(infoDGESVResult, Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgesv",
         n.toI,

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -208,7 +208,7 @@ object EmitNDArray {
               // Plan: Run through the child row major, make an array. Then jump around it as needed.
               val childMemo = childND.memoize(cb, "ndarray_reshape_child")
 
-              val childShapeValues = childMemo.shapes(cb)
+              val childShapeValues = childMemo.shapes
               val outputNDims = x.typ.nDims
 
               val requestedShapeValues = Array.tabulate(outputNDims)(i => cb.newLocal[Long](s"ndarray_reindex_request_shape_$i")).toIndexedSeq
@@ -270,7 +270,7 @@ object EmitNDArray {
                 // would be generated for something of the new shape.
                 val outputPType = PCanonicalNDArray(rowMajor.st.elementPType.setRequired(true), x.typ.nDims, true) // TODO Should it be required?
                 val rowMajorStriding = outputPType.makeRowMajorStrides(requestedShapeValues, region, cb)
-                fromShapeStridesFirstAddress(rowMajor.st.elementPType, requestedShapeValues, rowMajorStriding, rowMajor.firstDataAddress(cb), cb)
+                fromShapeStridesFirstAddress(rowMajor.st.elementPType, requestedShapeValues, rowMajorStriding, rowMajor.firstDataAddress, cb)
               }
             }
 
@@ -306,7 +306,7 @@ object EmitNDArray {
 
                 val newShape = (0 until x.typ.nDims).map { dimIdx =>
                   val localDim = cb.newLocal[Long](s"ndarray_concat_output_shape_element_${dimIdx}")
-                  val ndShape = firstND.shapes(cb)
+                  val ndShape = firstND.shapes
                   cb.assign(localDim, ndShape(dimIdx))
                   if (dimIdx == axis) {
                     pushElement(cb, EmitCode(Code._empty, false, primitive(localDim)).toI(cb))
@@ -601,10 +601,10 @@ object EmitNDArray {
   }
 
   def fromSValue(ndSv: SNDArrayValue, cb: EmitCodeBuilder): NDArrayProducer = {
-    val ndSvShape = ndSv.shapes(cb)
-    val strides = ndSv.strides(cb)
+    val ndSvShape = ndSv.shapes
+    val strides = ndSv.strides
 
-    fromShapeStridesFirstAddress(ndSv.st.elementPType, ndSvShape, strides, ndSv.firstDataAddress(cb), cb)
+    fromShapeStridesFirstAddress(ndSv.st.elementPType, ndSvShape, strides, ndSv.firstDataAddress, cb)
   }
 
   def fromShapeStridesFirstAddress(newElementType: PType, ndSvShape: IndexedSeq[Value[Long]], strides: IndexedSeq[Value[Long]], firstDataAddress: Value[Long], cb: EmitCodeBuilder): NDArrayProducer = {

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -11,8 +11,8 @@ import is.hail.utils.FastIndexedSeq
 object LinalgCodeUtils {
   def checkColumnMajor(pndv: SNDArrayValue, cb: EmitCodeBuilder): Value[Boolean] = {
     val answer = cb.newField[Boolean]("checkColumnMajorResult")
-    val shapes = pndv.shapes(cb)
-    val strides = pndv.strides(cb)
+    val shapes = pndv.shapes
+    val strides = pndv.strides
     val runningProduct = cb.newLocal[Long]("check_column_major_running_product")
 
     val st = pndv.st
@@ -29,8 +29,8 @@ object LinalgCodeUtils {
 
   def checkRowMajor(pndv: SNDArrayValue, cb: EmitCodeBuilder): Value[Boolean] = {
     val answer = cb.newField[Boolean]("checkColumnMajorResult")
-    val shapes = pndv.shapes(cb)
-    val strides = pndv.strides(cb)
+    val shapes = pndv.shapes
+    val strides = pndv.strides
     val runningProduct = cb.newLocal[Long]("check_column_major_running_product")
 
     val st = pndv.st
@@ -46,7 +46,7 @@ object LinalgCodeUtils {
   }
 
   def createColumnMajorCode(pndv: SNDArrayValue, cb: EmitCodeBuilder, region: Value[Region]): SNDArrayCode = {
-    val shape = pndv.shapes(cb)
+    val shape = pndv.shapes
     val pt = PCanonicalNDArray(pndv.st.elementType.storageType().setRequired(true), pndv.st.nDims, false)
     val strides = pt.makeColumnMajorStrides(shape, region, cb)
 

--- a/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBlockMatrixNDArray.scala
@@ -23,7 +23,7 @@ final case class EBlockMatrixNDArray(elementType: EType, encodeRowMajor: Boolean
 
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val ndarray = v.asInstanceOf[SNDArrayValue]
-    val shapes = ndarray.shapes(cb)
+    val shapes = ndarray.shapes
     val r = cb.newLocal[Long]("r", shapes(0))
     val c = cb.newLocal[Long]("c", shapes(1))
     val i = cb.newLocal[Long]("i")

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -16,7 +16,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val ndarray = v.asInstanceOf[SNDArrayValue]
 
-    val shapes = ndarray.shapes(cb)
+    val shapes = ndarray.shapes
     shapes.foreach(s => cb += out.writeLong(s))
 
     SNDArray.coiterate(cb, (ndarray.get, "A")){

--- a/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PNDArray.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.physical.stypes.SCode
 import is.hail.types.physical.stypes.concrete.{SNDArrayPointerCode, SNDArrayPointerValue}
-import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SNDArrayCode, SNDArrayValue}
+import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SNDArrayCode, SNDArrayValue, SizeValue, SizeValueDyn}
 import is.hail.types.virtual.TNDArray
 
 abstract class PNDArray extends PType {
@@ -48,7 +48,7 @@ abstract class PNDArray extends PType {
     data: SIndexableCode,
     cb: EmitCodeBuilder,
     region: Value[Region]
-  ): SNDArrayCode
+  ): SNDArrayValue
 
   def constructDataFunction(
     shape: IndexedSeq[Value[Long]],

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PNumeric, PPrimitive, PType}
 import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType, SValue}
-import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SNDArray, SNDArrayCode, SNDArrayValue, primitive}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SNDArray, SNDArrayCode, SNDArrayValue, SizeValue, SizeValueDyn, primitive}
 import is.hail.types.physical.stypes.primitives.SInt64
 import is.hail.types.virtual.{TInt64, TNDArray, TTuple, Type}
 import is.hail.utils.{FastIndexedSeq, toRichIterable}
@@ -57,35 +57,34 @@ final case class SNDArraySlice(pType: PCanonicalNDArray) extends SNDArray {
     val shape = settables.slice(0, nDims).asInstanceOf[IndexedSeq[Value[Long@unchecked]]]
     val strides = settables.slice(nDims, 2 * nDims).asInstanceOf[IndexedSeq[Value[Long@unchecked]]]
     val dataFirstElementPointer = settables.last.asInstanceOf[Value[Long]]
-    new SNDArraySliceValue(this, shape, strides, dataFirstElementPointer)
+    new SNDArraySliceValue(this, shape.map(SizeValueDyn.apply), strides, dataFirstElementPointer)
   }
 
   override def containsPointers: Boolean = true
 }
 
 class SNDArraySliceValue(
-  val st: SNDArraySlice,
-  val shape: IndexedSeq[Value[Long]],
-  val strides: IndexedSeq[Value[Long]],
-  val dataFirstElement: Value[Long]
+  override val st: SNDArraySlice,
+  override val shapes: IndexedSeq[SizeValue],
+  override val strides: IndexedSeq[Value[Long]],
+  override val firstDataAddress: Value[Long]
 ) extends SNDArrayValue {
   val pt: PCanonicalNDArray = st.pType
 
   override def loadElementAddress(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Long] = {
     assert(indices.size == pt.nDims)
-    pt.loadElementFromDataAndStrides(cb, indices, dataFirstElement, strides)
+    pt.loadElementFromDataAndStrides(cb, indices, firstDataAddress, strides)
   }
 
   override def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SCode =
     pt.elementType.loadCheapSCode(cb, loadElementAddress(indices, cb))
 
-  override def get: SNDArraySliceCode = new SNDArraySliceCode(st, shape, strides, dataFirstElement)
+  override def get: SNDArraySliceCode = new SNDArraySliceCode(st, shapes, strides, firstDataAddress)
 
-  override def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = shape
-
-  override def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = strides
-
-  override def firstDataAddress(cb: EmitCodeBuilder): Value[Long] = dataFirstElement
+  def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = {
+    cb.ifx(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
+    new SNDArraySliceValue(st, otherShape, strides, firstDataAddress)
+  }
 
   override def coiterateMutate(
     cb: EmitCodeBuilder,
@@ -118,17 +117,17 @@ object SNDArraySliceSettable {
 
 final class SNDArraySliceSettable(
   st: SNDArraySlice,
-  override val shape: IndexedSeq[Settable[Long]],
+  shape: IndexedSeq[Settable[Long]],
   override val strides: IndexedSeq[Settable[Long]],
-  override val dataFirstElement: Settable[Long]
-) extends SNDArraySliceValue(st, shape, strides, dataFirstElement) with SSettable {
-  override def settableTuple(): IndexedSeq[Settable[_]] = shape ++ strides :+ dataFirstElement
+  override val firstDataAddress: Settable[Long]
+) extends SNDArraySliceValue(st, shape.map(SizeValueDyn.apply), strides, firstDataAddress) with SSettable {
+  override def settableTuple(): IndexedSeq[Settable[_]] = shape ++ strides :+ firstDataAddress
 
   override def store(cb: EmitCodeBuilder, v: SCode): Unit = {
     val vSlice = v.asInstanceOf[SNDArraySliceCode]
     shape.zip(vSlice.shape).foreach { case (x, s) => cb.assign(x, s) }
     strides.zip(vSlice.strides).foreach { case (x, s) => cb.assign(x, s) }
-    cb.assign(dataFirstElement, vSlice.dataFirstElement)
+    cb.assign(firstDataAddress, vSlice.dataFirstElement)
   }
 }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -255,17 +255,19 @@ class SUnreachableNDArrayValue(val st: SUnreachableNDArray) extends SUnreachable
 
   def loadElementAddress(indices: IndexedSeq[is.hail.asm4s.Value[Long]],cb: is.hail.expr.ir.EmitCodeBuilder): is.hail.asm4s.Code[Long] = const(0L)
 
-  def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = (0 until st.nDims).map(_ => const(0L))
+  def shapes: IndexedSeq[SizeValue] = (0 until st.nDims).map(_ => SizeValueStatic(0L))
 
-  def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]] = (0 until st.nDims).map(_ => const(0L))
+  def strides: IndexedSeq[Value[Long]] = (0 until st.nDims).map(_ => const(0L))
 
   override def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean] = const(false)
 
   override def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int = -1): Unit = {}
 
-  override def sameShape(other: SNDArrayValue, cb: EmitCodeBuilder): Code[Boolean] = const(false)
+  override def sameShape(cb: EmitCodeBuilder, other: SNDArrayValue): Code[Boolean] = const(false)
 
-  def firstDataAddress(cb: EmitCodeBuilder): Value[Long] = const(0L)
+  override def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = this
+
+  def firstDataAddress: Value[Long] = const(0L)
 
   override def memoize(cb: EmitCodeBuilder, name: String): SUnreachableNDArrayValue = this
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -5,12 +5,12 @@ import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.{RNDArray, TypeWithRequiredness}
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
-import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceCode}
+import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceCode, SNDArraySliceValue}
 import is.hail.linalg.{BLAS, LAPACK}
 import is.hail.types.physical.stypes.primitives.SFloat64Code
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
-import is.hail.utils.{toRichIterable, valueToRichCodeRegion}
+import is.hail.utils.{FastIndexedSeq, toRichIterable, valueToRichCodeRegion}
 
 import scala.collection.mutable
 
@@ -75,7 +75,7 @@ object SNDArray {
       assert(indices.length == _array.st.nDims)
 
       val array = _array.memoize(cb, s"${name}_copy")
-      val shape = array.shapes(cb)
+      val shape = array.shapes
       for (i <- indices.indices) {
         val idx = indices(i)
         if (indexSizes(idx) == null) {
@@ -85,7 +85,7 @@ object SNDArray {
           cb.ifx(indexSizes(idx).cne(shape(i).toI), s"${indexVars(idx)} indexes incompatible dimensions")
         }
       }
-      val strides = array.strides(cb)
+      val strides = array.strides
       val pos = Array.tabulate(array.st.nDims + 1) { i => cb.newLocal[Long](s"$name$i") }
       val indexToDim = indices.zipWithIndex.toMap
       ArrayInfo(array, strides, pos, indexToDim, name)
@@ -122,7 +122,7 @@ object SNDArray {
     }
 
     for (n <- arrays.indices) {
-      cb.assign(info(n).pos(info(n).array.st.nDims), info(n).array.firstDataAddress(cb))
+      cb.assign(info(n).pos(info(n).array.st.nDims), info(n).array.firstDataAddress)
     }
     recurLoopBuilder(indexVars.length - 1)
   }
@@ -241,23 +241,22 @@ object SNDArray {
 
   def assertColMajor(cb: EmitCodeBuilder, nds: SNDArrayValue*): Unit = {
     for (nd <- nds) {
-      cb.ifx(nd.strides(cb)(0).cne(nd.st.pType.elementType.byteSize), cb._fatal("Require column major: found row stride ", nd.strides(cb)(0).toS, ", expected ", nd.st.pType.elementType.byteSize.toString))
+      cb.ifx(nd.strides(0).cne(nd.st.pType.elementType.byteSize), cb._fatal("Require column major: found row stride ", nd.strides(0).toS, ", expected ", nd.st.pType.elementType.byteSize.toString))
     }
   }
 
   def copyVector(cb: EmitCodeBuilder, _X: SNDArrayCode, _Y: SNDArrayCode): Unit = {
     val X = _X.memoize(cb, "copy_X")
     val Y = _Y.memoize(cb, "copy_Y")
-    assertVector(X, Y)
-    val n = X.shapes(cb)(0)
-    cb.ifx(Y.shapes(cb)(0).cne(n), cb._fatal("copy: vectors have different sizes: ", Y.shapes(cb)(0).toS, ", ", n.toS))
+    val Seq(n) = X.shapes
 
-    val ldX = X.eltStride(cb, 0).max(1)
-    val ldY = Y.eltStride(cb, 0).max(1)
+    Y.assertHasShape(cb, FastIndexedSeq(n), "copy: vectors have different sizes: ", Y.shapes(0).toS, ", ", n.toS)
+    val ldX = X.eltStride(0).max(1)
+    val ldY = Y.eltStride(0).max(1)
     cb += Code.invokeScalaObject5[Int, Long, Int, Long, Int, Unit](BLAS.getClass, "dcopy",
       n.toI,
-      X.firstDataAddress(cb), ldX,
-      Y.firstDataAddress(cb), ldY)
+      X.firstDataAddress, ldX,
+      Y.firstDataAddress, ldY)
   }
 
   def scale(cb: EmitCodeBuilder, alpha: SCode, X: SNDArrayCode): Unit =
@@ -265,12 +264,10 @@ object SNDArray {
 
   def scale(cb: EmitCodeBuilder, alpha: Code[Double], _X: SNDArrayCode): Unit = {
     val X = _X.memoize(cb, "scale_X")
-    assertVector(X)
-    val n = X.shapes(cb)(0)
-
-    val ldX = X.eltStride(cb, 0).max(1)
+    val Seq(n) = X.shapes
+    val ldX = X.eltStride(0).max(1)
     cb += Code.invokeScalaObject4[Int, Double, Long, Int, Unit](BLAS.getClass, "dscal",
-      n.toI, alpha, X.firstDataAddress(cb), ldX)
+      n.toI, alpha, X.firstDataAddress, ldX)
   }
 
   def gemv(cb: EmitCodeBuilder, trans: String, A: SNDArrayCode, X: SNDArrayCode, Y: SNDArrayCode): Unit = {
@@ -283,25 +280,27 @@ object SNDArray {
     val Y = _Y.memoize(cb, "gemv_Y")
 
     assertMatrix(A)
+    val Seq(m, n) = A.shapes
+    val errMsg = "gemv: incompatible dimensions"
+    if (trans == "N") {
+      X.assertHasShape(cb, FastIndexedSeq(n), errMsg)
+      Y.assertHasShape(cb, FastIndexedSeq(m), errMsg)
+    } else {
+      X.assertHasShape(cb, FastIndexedSeq(m), errMsg)
+      Y.assertHasShape(cb, FastIndexedSeq(n), errMsg)
+    }
     assertColMajor(cb, A)
-    assertVector(X, Y)
 
-    val Seq(m, n) = A.shapes(cb)
-    if (trans == "N")
-      cb.ifx(X.shapes(cb)(0).cne(n) || Y.shapes(cb)(0).cne(m), cb._fatal("gemv: incompatible dimensions"))
-    else
-      cb.ifx(X.shapes(cb)(0).cne(m) || Y.shapes(cb)(0).cne(n), cb._fatal("gemv: incompatible dimensions"))
-
-    val ldA = A.eltStride(cb, 1).max(1)
-    val ldX = X.eltStride(cb, 0).max(1)
-    val ldY = Y.eltStride(cb, 0).max(1)
+    val ldA = A.eltStride(1).max(1)
+    val ldX = X.eltStride(0).max(1)
+    val ldY = Y.eltStride(0).max(1)
     cb += Code.invokeScalaObject11[String, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, "dgemv",
       trans, m.toI, n.toI,
       alpha,
-      A.firstDataAddress(cb), ldA,
-      X.firstDataAddress(cb), ldX,
+      A.firstDataAddress, ldA,
+      X.firstDataAddress, ldX,
       beta,
-      Y.firstDataAddress(cb), ldY)
+      Y.firstDataAddress, ldY)
   }
 
   def gemm(cb: EmitCodeBuilder, tA: String, tB: String, A: SNDArrayCode, B: SNDArrayCode, C: SNDArrayCode): Unit =
@@ -311,26 +310,32 @@ object SNDArray {
     val A = _A.memoize(cb, "gemm_A")
     val B = _B.memoize(cb, "gemm_B")
     val C = _C.memoize(cb, "gemm_C")
+
     assertMatrix(A, B, C)
+    val Seq(m, n) = C.shapes
+    val k = if (tA == "N") A.shapes(1) else A.shapes(0)
+
+    val errMsg = "gemm: incompatible matrix dimensions"
+    if (tA == "N")
+      A.assertHasShape(cb, FastIndexedSeq(m, k), errMsg)
+    else
+      A.assertHasShape(cb, FastIndexedSeq(k, m), errMsg)
+    if (tB == "N")
+      B.assertHasShape(cb, FastIndexedSeq(k, n), errMsg)
+    else
+      B.assertHasShape(cb, FastIndexedSeq(n, k), errMsg)
     assertColMajor(cb, A, B, C)
 
-    val Seq(a0, a1) = A.shapes(cb)
-    val (m, ka) = if (tA == "N") (a0, a1) else (a1, a0)
-    val Seq(b0, b1) = B.shapes(cb)
-    val (kb, n) = if (tB == "N") (b0, b1) else (b1, b0)
-    val Seq(c0, c1) = C.shapes(cb)
-    cb.ifx(ka.cne(kb) || c0.cne(m) || c1.cne(n), cb._fatal("gemm: incompatible matrix dimensions"))
-
-    val ldA = A.eltStride(cb, 1).max(1)
-    val ldB = B.eltStride(cb, 1).max(1)
-    val ldC = C.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
+    val ldB = B.eltStride(1).max(1)
+    val ldC = C.eltStride(1).max(1)
     cb += Code.invokeScalaObject13[String, String, Int, Int, Int, Double, Long, Int, Long, Int, Double, Long, Int, Unit](BLAS.getClass, "dgemm",
-      tA, tB, m.toI, n.toI, ka.toI,
+      tA, tB, m.toI, n.toI, k.toI,
       alpha,
-      A.firstDataAddress(cb), ldA,
-      B.firstDataAddress(cb), ldB,
+      A.firstDataAddress, ldA,
+      B.firstDataAddress, ldB,
       beta,
-      C.firstDataAddress(cb), ldC)
+      C.firstDataAddress, ldC)
   }
 
   def trmm(cb: EmitCodeBuilder, side: String, uplo: String, transA: String, diag: String,
@@ -340,19 +345,20 @@ object SNDArray {
     assertMatrix(A, B)
     assertColMajor(cb, A, B)
 
-    val Seq(m, n) = B.shapes(cb)
-    val Seq(a0, a1) = A.shapes(cb)
+    val Seq(m, n) = B.shapes
+    val Seq(a0, a1) = A.shapes
     cb.ifx(a1.cne(if (side == "left") m else n), cb._fatal("trmm: incompatible matrix dimensions"))
-    cb.ifx(a0 < a1, cb._fatal("trmm: A has fewer rows than cols: ", a0.toS, ", ", a1.toS))
+    // Elide check in the common case that we statically know A is square
+    if (a0 != a1) cb.ifx(a0 < a1, cb._fatal("trmm: A has fewer rows than cols: ", a0.toS, ", ", a1.toS))
 
-    val ldA = A.eltStride(cb, 1).max(1)
-    val ldB = B.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
+    val ldB = B.eltStride(1).max(1)
     cb += Code.invokeScalaObject11[String, String, String, String, Int, Int, Double, Long, Int, Long, Int, Unit](BLAS.getClass, "dtrmm",
       side, uplo, transA, diag,
       m.toI, n.toI,
       alpha,
-      A.firstDataAddress(cb), ldA,
-      B.firstDataAddress(cb), ldB)
+      A.firstDataAddress, ldA,
+      B.firstDataAddress, ldB)
   }
 
   def geqrt(_A: SNDArrayCode, _T: SNDArrayCode, _work: SNDArrayCode, blocksize: Value[Long], cb: EmitCodeBuilder): Unit = {
@@ -363,19 +369,19 @@ object SNDArray {
     assertColMajor(cb, A)
     assertVector(work, T)
 
-    val Seq(m, n) = A.shapes(cb)
+    val Seq(m, n) = A.shapes
     val nb = blocksize
     cb.ifx(nb > m.min(n) || nb < 1, cb._fatal("invalid block size"))
-    cb.ifx(T.shapes(cb)(0) < nb*(m.min(n)), cb._fatal("T too small"))
-    cb.ifx(work.shapes(cb)(0) < nb * n, cb._fatal("work array too small"))
+    cb.ifx(T.shapes(0) < nb*(m.min(n)), cb._fatal("T too small"))
+    cb.ifx(work.shapes(0) < nb * n, cb._fatal("work array too small"))
 
     val error = cb.mb.newLocal[Int]()
-    val ldA = A.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
     cb.assign(error, Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dgeqrt",
       m.toI, n.toI, nb.toI,
-      A.firstDataAddress(cb), ldA,
-      T.firstDataAddress(cb), nb.toI.max(1),
-      work.firstDataAddress(cb)))
+      A.firstDataAddress, ldA,
+      T.firstDataAddress, nb.toI.max(1),
+      work.firstDataAddress))
     cb.ifx(error.cne(0), cb._fatal("LAPACK error dtpqrt. Error code = ", error.toS))
   }
 
@@ -390,28 +396,28 @@ object SNDArray {
 
     assert(side == "L" || side == "R")
     assert(trans == "T" || trans == "N")
-    val Seq(l, k) = V.shapes(cb)
-    val Seq(m, n) = C.shapes(cb)
+    val Seq(l, k) = V.shapes
+    val Seq(m, n) = C.shapes
     val nb = blocksize
     cb.ifx(nb > k || nb < 1, cb._fatal("invalid block size"))
-    cb.ifx(T.shapes(cb)(0) < nb*k, cb._fatal("invalid T size"))
+    cb.ifx(T.shapes(0) < nb*k, cb._fatal("invalid T size"))
     if (side == "L") {
       cb.ifx(l.cne(m), cb._fatal("invalid dimensions"))
-      cb.ifx(work.shapes(cb)(0) < nb * n, cb._fatal("work array too small"))
+      cb.ifx(work.shapes(0) < nb * n, cb._fatal("work array too small"))
     } else {
       cb.ifx(l.cne(n), cb._fatal("invalid dimensions"))
-      cb.ifx(work.shapes(cb)(0) < nb * m, cb._fatal("work array too small"))
+      cb.ifx(work.shapes(0) < nb * m, cb._fatal("work array too small"))
     }
 
     val error = cb.mb.newLocal[Int]()
-    val ldV = V.eltStride(cb, 1).max(1)
-    val ldC = C.eltStride(cb, 1).max(1)
+    val ldV = V.eltStride(1).max(1)
+    val ldC = C.eltStride(1).max(1)
     cb.assign(error, Code.invokeScalaObject13[String, String, Int, Int, Int, Int, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dgemqrt",
       side, trans, m.toI, n.toI, k.toI, nb.toI,
-      V.firstDataAddress(cb), ldV,
-      T.firstDataAddress(cb), nb.toI.max(1),
-      C.firstDataAddress(cb), ldC,
-      work.firstDataAddress(cb)))
+      V.firstDataAddress, ldV,
+      T.firstDataAddress, nb.toI.max(1),
+      C.firstDataAddress, ldC,
+      work.firstDataAddress))
     cb.ifx(error.cne(0), cb._fatal("LAPACK error dtpqrt. Error code = ", error.toS))
   }
 
@@ -424,23 +430,22 @@ object SNDArray {
     assertColMajor(cb, A, B)
     assertVector(work, T)
 
-    val Seq(m, n) = B.shapes(cb)
+    val Seq(m, n) = B.shapes
     val nb = blocksize
     cb.ifx(nb > n || nb < 1, cb._fatal("invalid block size"))
-    cb.ifx(T.shapes(cb)(0) < nb*n, cb._fatal("T too small"))
-    val Seq(a1, a2) = A.shapes(cb)
-    cb.ifx(a1.cne(n) || a2.cne(n), cb._fatal("invalid A size"))
-    cb.ifx(work.shapes(cb)(0) < nb * n, cb._fatal("work array too small"))
+    cb.ifx(T.shapes(0) < nb*n, cb._fatal("T too small"))
+    A.assertHasShape(cb, FastIndexedSeq(n, n))
+    cb.ifx(work.shapes(0) < nb * n, cb._fatal("work array too small"))
 
     val error = cb.mb.newLocal[Int]()
-    val ldA = A.eltStride(cb, 1).max(1)
-    val ldB = B.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
+    val ldB = B.eltStride(1).max(1)
     cb.assign(error, Code.invokeScalaObject11[Int, Int, Int, Int, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dtpqrt",
       m.toI, n.toI, 0, nb.toI,
-      A.firstDataAddress(cb), ldA,
-      B.firstDataAddress(cb), ldB,
-      T.firstDataAddress(cb), nb.toI.max(1),
-      work.firstDataAddress(cb)))
+      A.firstDataAddress, ldA,
+      B.firstDataAddress, ldB,
+      T.firstDataAddress, nb.toI.max(1),
+      work.firstDataAddress))
     cb.ifx(error.cne(0), cb._fatal("LAPACK error dtpqrt. Error code = ", error.toS))
   }
 
@@ -456,33 +461,32 @@ object SNDArray {
 
     assert(side == "L" || side == "R")
     assert(trans == "T" || trans == "N")
-    val Seq(l, k) = V.shapes(cb)
-    val Seq(m, n) = B.shapes(cb)
+    val Seq(l, k) = V.shapes
+    val Seq(m, n) = B.shapes
     val nb = blocksize
     cb.ifx(nb > k || nb < 1, cb._fatal("invalid block size"))
-    cb.ifx(T.shapes(cb)(0) < nb*k, cb._fatal("T too small"))
-    val Seq(a1, a2) = A.shapes(cb)
+    cb.ifx(T.shapes(0) < nb*k, cb._fatal("T too small"))
     if (side == "L") {
       cb.ifx(l.cne(m), cb._fatal("invalid dimensions"))
-      cb.ifx(work.shapes(cb)(0) < nb * n, cb._fatal("work array too small"))
-      cb.ifx(a1.cne(k) || a2.cne(n), cb._fatal("A has wrong dimensions"))
+      cb.ifx(work.shapes(0) < nb * n, cb._fatal("work array too small"))
+      A.assertHasShape(cb, FastIndexedSeq(k, n))
     } else {
       cb.ifx(l.cne(n), cb._fatal("invalid dimensions"))
-      cb.ifx(work.shapes(cb)(0) < nb * m, cb._fatal("work array too small"))
-      cb.ifx(a1.cne(m) || a2.cne(k), cb._fatal("A has wrong dimensions"))
+      cb.ifx(work.shapes(0) < nb * m, cb._fatal("work array too small"))
+      A.assertHasShape(cb, FastIndexedSeq(m, k))
     }
 
     val error = cb.mb.newLocal[Int]()
-    val ldV = V.eltStride(cb, 1).max(1)
-    val ldA = A.eltStride(cb, 1).max(1)
-    val ldB = B.eltStride(cb, 1).max(1)
+    val ldV = V.eltStride(1).max(1)
+    val ldA = A.eltStride(1).max(1)
+    val ldB = B.eltStride(1).max(1)
     cb.assign(error, Code.invokeScalaObject16[String, String, Int, Int, Int, Int, Int, Long, Int, Long, Int, Long, Int, Long, Int, Long, Int](LAPACK.getClass, "dtpmqrt",
       side, trans, m.toI, n.toI, k.toI, 0, nb.toI,
-      V.firstDataAddress(cb), ldV,
-      T.firstDataAddress(cb), nb.toI.max(1),
-      A.firstDataAddress(cb), ldA,
-      B.firstDataAddress(cb), ldB,
-      work.firstDataAddress(cb)))
+      V.firstDataAddress, ldV,
+      T.firstDataAddress, nb.toI.max(1),
+      A.firstDataAddress, ldA,
+      B.firstDataAddress, ldB,
+      work.firstDataAddress))
     cb.ifx(error.cne(0), cb._fatal("LAPACK error dtpqrt. Error code = ", error.toS))
   }
 
@@ -510,18 +514,18 @@ object SNDArray {
     assertColMajor(cb, A)
     assertVector(T, work)
 
-    val Seq(m, n) = A.shapes(cb)
-    cb.ifx(T.shapes(cb)(0).cne(m.min(n)), cb._fatal("geqrf: T has wrong size"))
-    val lwork = work.shapes(cb)(0)
+    val Seq(m, n) = A.shapes
+    cb.ifx(T.shapes(0).cne(m.min(n)), cb._fatal("geqrf: T has wrong size"))
+    val lwork = work.shapes(0)
     cb.ifx(lwork < n.max(1L), cb._fatal("geqrf: work has wrong size"))
 
-    val ldA = A.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
     val info = cb.newLocal[Int]("dgeqrf_info")
     cb.assign(info, Code.invokeScalaObject7[Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dgeqrf",
       m.toI, n.toI,
-      A.firstDataAddress(cb), ldA,
-      T.firstDataAddress(cb),
-      work.firstDataAddress(cb), lwork.toI))
+      A.firstDataAddress, ldA,
+      T.firstDataAddress,
+      work.firstDataAddress, lwork.toI))
     cb.ifx(info.cne(0), cb._fatal(s"LAPACK error DGEQRF. Error code = ", info.toS))
   }
 
@@ -534,19 +538,19 @@ object SNDArray {
     assertColMajor(cb, A)
     assertVector(T, work)
 
-    val Seq(m, n) = A.shapes(cb)
+    val Seq(m, n) = A.shapes
     cb.ifx(k < 0 || k > n.toI, cb._fatal("orgqr: invalid k"))
-    cb.ifx(T.shapes(cb)(0).cne(m.min(n)), cb._fatal("orgqr: T has wrong size"))
-    val lwork = work.shapes(cb)(0)
+    cb.ifx(T.shapes(0).cne(m.min(n)), cb._fatal("orgqr: T has wrong size"))
+    val lwork = work.shapes(0)
     cb.ifx(lwork < n.max(1L), cb._fatal("orgqr: work has wrong size"))
 
-    val ldA = A.eltStride(cb, 1).max(1)
+    val ldA = A.eltStride(1).max(1)
     val info = cb.newLocal[Int]("dgeqrf_info")
     cb.assign(info, Code.invokeScalaObject8[Int, Int, Int, Long, Int, Long, Long, Int, Int](LAPACK.getClass, "dorgqr",
       m.toI, n.toI, k.toI,
-      A.firstDataAddress(cb), ldA,
-      T.firstDataAddress(cb),
-      work.firstDataAddress(cb), lwork.toI))
+      A.firstDataAddress, ldA,
+      T.firstDataAddress,
+      work.firstDataAddress, lwork.toI))
     cb.ifx(info.cne(0), cb._fatal(s"LAPACK error DGEQRF. Error code = ", info.toS))
   }
 }
@@ -568,7 +572,49 @@ trait SNDArray extends SType {
 sealed abstract class NDArrayIndex
 case class ScalarIndex(i: Value[Long]) extends NDArrayIndex
 case class SliceIndex(begin: Option[Value[Long]], end: Option[Value[Long]]) extends NDArrayIndex
+case class SliceSize(begin: Option[Value[Long]], size: SizeValue) extends NDArrayIndex
 case object ColonIndex extends NDArrayIndex
+
+// Used to preserve static information about dimension sizes.
+// If `l == r`, then we know statically that the sizes are equal, even if
+// the size itself is dynamic (e.g. they share the same storage location)
+// `l.ceq(r)` compares the sizes dynamically, but takes advantage of static
+// knowledge to elide the comparison when possible.
+sealed abstract class SizeValue extends Value[Long] {
+  def ceq(other: SizeValue): Code[Boolean] = (this, other) match {
+    case (SizeValueStatic(l), SizeValueStatic(r)) => const(l == r)
+    case (l, r) => if (l == r) const(true) else l.get.ceq(r.get)
+  }
+  def cne(other: SizeValue): Code[Boolean] = (this, other) match {
+    case (SizeValueStatic(l), SizeValueStatic(r)) => const(l != r)
+    case (l, r) => if (l == r) const(false) else l.get.cne(r.get)
+  }
+}
+object SizeValueDyn {
+  def apply(v: Value[Long]): SizeValueDyn = new SizeValueDyn(v)
+  def unapply(size: SizeValueDyn): Some[Value[Long]] = Some(size.v)
+}
+object SizeValueStatic {
+  def apply(v: Long): SizeValueStatic = {
+    assert(v >= 0)
+    new SizeValueStatic(v)
+  }
+  def unapply(size: SizeValueStatic): Some[Long] = Some(size.v)
+}
+final class SizeValueDyn(val v: Value[Long]) extends SizeValue {
+  def get: Code[Long] = v.get
+  override def equals(other: Any): Boolean = other match {
+    case SizeValueDyn(v2) => v eq v2
+    case _ => false
+  }
+}
+final class SizeValueStatic(val v: Long) extends SizeValue {
+  def get: Code[Long] = const(v)
+  override def equals(other: Any): Boolean = other match {
+    case SizeValueStatic(v2) => v == v2
+    case _ => false
+  }
+}
 
 trait SNDArrayValue extends SValue {
   def st: SNDArray
@@ -579,20 +625,20 @@ trait SNDArrayValue extends SValue {
 
   def loadElementAddress(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Long]
 
-  def shapes(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
+  def shapes: IndexedSeq[SizeValue]
 
-  def strides(cb: EmitCodeBuilder): IndexedSeq[Value[Long]]
+  def strides: IndexedSeq[Value[Long]]
 
-  def eltStride(cb: EmitCodeBuilder, i: Int): Code[Int] = st.elementByteSize match {
-    case 4 => strides(cb)(i).toI >> 2
-    case 8 => strides(cb)(i).toI >> 3
-    case eltSize => strides(cb)(i).toI / eltSize.toInt
+  def eltStride(i: Int): Code[Int] = st.elementByteSize match {
+    case 4 => strides(i).toI >> 2
+    case 8 => strides(i).toI >> 3
+    case eltSize => strides(i).toI / eltSize.toInt
   }
 
-  def firstDataAddress(cb: EmitCodeBuilder): Value[Long]
+  def firstDataAddress: Value[Long]
 
   def outOfBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): Code[Boolean] = {
-    val shape = this.shapes(cb)
+    val shape = this.shapes
     val outOfBounds = cb.newLocal[Boolean]("sndarray_out_of_bounds", false)
 
     (0 until st.nDims).foreach { dimIndex =>
@@ -602,7 +648,7 @@ trait SNDArrayValue extends SValue {
   }
 
   def assertInBounds(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder, errorId: Int): Unit = {
-    val shape = this.shapes(cb)
+    val shape = this.shapes
     for (dimIndex <- 0 until st.nDims) {
       cb.ifx(indices(dimIndex) >= shape(dimIndex), {
         cb._fatalWithError(errorId,
@@ -612,6 +658,32 @@ trait SNDArrayValue extends SValue {
       })
     }
   }
+
+  def sameShape(cb: EmitCodeBuilder, other: SNDArrayValue): Code[Boolean] =
+    hasShape(cb, other.shapes)
+
+  def hasShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): Code[Boolean] = {
+    var b: Code[Boolean] = const(true)
+    val shape = this.shapes
+    assert(shape.length == otherShape.length)
+
+    (shape, otherShape).zipped.foreach { (s1, s2) =>
+      b = s1.ceq(s2)
+    }
+    b
+  }
+
+  def assertHasShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue], msg: Code[String]*) =
+    if (!hasShapeStatic(otherShape))
+      cb.ifx(!hasShape(cb, otherShape), cb._fatal(msg: _*))
+
+  // True IFF shape can be proven equal to otherShape statically
+  def hasShapeStatic(otherShape: IndexedSeq[SizeValue]): Boolean =
+    shapes == otherShape
+
+  // ensure coerceToShape(cb, otherShape).hasShapeStatic(otherShape)
+  // Inserts any necessary dynamic assertions
+  def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue
 
   def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], arrays: (SNDArrayCode, String)*)(body: IndexedSeq[SCode] => SCode): Unit =
     coiterateMutate(cb, region, false, arrays: _*)(body)
@@ -641,41 +713,40 @@ trait SNDArrayValue extends SValue {
   )(body: IndexedSeq[SCode] => SCode
   ): Unit
 
-  def sameShape(other: SNDArrayValue, cb: EmitCodeBuilder): Code[Boolean] = {
-    val otherShapes = other.shapes(cb)
-    val b = cb.newLocal[Boolean]("sameShape_b", true)
-    val shape = this.shapes(cb)
-    assert(shape.length == otherShapes.length)
-    shape.zip(otherShapes).foreach { case (s1, s2) =>
-      cb.assign(b, b && s1.ceq(s2))
-    }
-    b
-  }
-
-  def slice(cb: EmitCodeBuilder, indices: IndexedSeq[NDArrayIndex]): SNDArraySliceCode = {
-    val shapeX = shapes(cb)
-    val stridesX = strides(cb)
-    val shapeBuilder = mutable.ArrayBuilder.make[Code[Long]]
-    val stridesBuilder = mutable.ArrayBuilder.make[Code[Long]]
+  def slice(cb: EmitCodeBuilder, indices: IndexedSeq[NDArrayIndex]): SNDArraySliceValue = {
+    val shapeX = shapes
+    val stridesX = strides
+    val shapeBuilder = mutable.ArrayBuilder.make[SizeValue]
+    val stridesBuilder = mutable.ArrayBuilder.make[Value[Long]]
 
     for (i <- indices.indices) indices(i) match {
       case ScalarIndex(j) =>
         cb.ifx(j < 0 || j >= shapeX(i), cb._fatal("Index out of bounds"))
       case SliceIndex(Some(begin), Some(end)) =>
         cb.ifx(begin < 0 || end > shapeX(i) || begin > end, cb._fatal("Index out of bounds"))
-        shapeBuilder += end - begin
+        val s = cb.newLocal[Long]("slice_size", end - begin)
+        shapeBuilder += SizeValueDyn(s)
         stridesBuilder += stridesX(i)
       case SliceIndex(None, Some(end)) =>
         cb.ifx(end >= shapeX(i) || end < 0, cb._fatal("Index out of bounds"))
-        shapeBuilder += end
+        shapeBuilder += SizeValueDyn(end)
         stridesBuilder += stridesX(i)
       case SliceIndex(Some(begin), None) =>
         val end = shapeX(i)
         cb.ifx(begin < 0 || begin > end, cb._fatal("Index out of bounds"))
-        shapeBuilder += end - begin
+        val s = cb.newLocal[Long]("slice_size", end - begin)
+        shapeBuilder += SizeValueDyn(s)
         stridesBuilder += stridesX(i)
       case SliceIndex(None, None) =>
         shapeBuilder += shapeX(i)
+        stridesBuilder += stridesX(i)
+      case SliceSize(None, size) =>
+        cb.ifx(size >= shapeX(i), cb._fatal("Index out of bounds") )
+        shapeBuilder += size
+        stridesBuilder += stridesX(i)
+      case SliceSize(Some(begin), size) =>
+        cb.ifx(begin < 0 || begin + size > shapeX(i), cb._fatal("Index out of bounds") )
+        shapeBuilder += size
         stridesBuilder += stridesX(i)
       case ColonIndex =>
         shapeBuilder += shapeX(i)
@@ -691,11 +762,11 @@ trait SNDArrayValue extends SValue {
       case ColonIndex => const(0L)
     }
 
-    val newFirstDataAddress = loadElementAddress(firstElementIndices, cb)
+    val newFirstDataAddress = cb.newLocal[Long]("slice_ptr", loadElementAddress(firstElementIndices, cb))
 
     val newSType = SNDArraySlice(PCanonicalNDArray(st.pType.elementType, newShape.size, st.pType.required))
 
-    new SNDArraySliceCode(newSType, newShape, newStrides, newFirstDataAddress)
+    new SNDArraySliceValue(newSType, newShape, newStrides, newFirstDataAddress)
   }
 }
 


### PR DESCRIPTION
~Stacked on #10770~
~Stacked on #10791~

This PR attempts to allow linear algebra codegen methods, like the LAPACK wrappers and the local whitening methods I'm working on, to defensively assert shape compatibility preconditions, without generating redundant runtime checks. (I always hate when we're pushed to avoid using code generation abstractions (in this case, just factoring code into smaller functions), because they generate worse code.)

The method is pretty simple. SNDArray shapes are now arrays of `SizeValue`, which is a sum type with cases `SizeValueDyn(Value[Long])` and `SizeValueStatic(Long)`. I don't think static sizes occur very often, but it was a simple addition.

`SizeValue`s can be compared statically with `==`, or at runtime with `ceq`: the former is true only if we can prove statically that the two sizes must be equal, while the latter emits code to check equality at runtime, using static knowledge to elide dynamic checks where possible.

The way we encode static knowledge that two sizes are equal is by using the same local variable to store both. The primary interface to introduce that static knowledge (other than using the same set of sizes to construct multiple SNDArrays), is the method `coerceToShape(cb: CodeBuilder, newShape: Seq[SizeValue]): SNDArrayValue`, which emits code to dynamically assert that `this.shape` agrees with `newShape`, then returns `this` with shape replaced by `newShape`. Thus, `a.coerceToShape(cb, newShape).shape == newShape` will always be true, preserving the static knowledge about the shape of `a`.

As a simple example, `gemm` verifies its inputs with (simplifying to the case with no transposes)
```
    val Seq(m, n) = C.shapes
    val k = A.shapes(1)
    A.assertHasShape(cb, FastIndexedSeq(m, k), errMsg)
    B.assertHasShape(cb, FastIndexedSeq(k, n), errMsg)
```
If we call this with
```
val m, n, k = \\ compute expected dim sizes

\\ emit dynamic size checks once
val A_ = A.coerceToShape(cb, IndexedSeq(m, k))
val B_ = B.coerceToShape(cb, IndexedSeq(k, n))
val C_ = C.coerceToShape(cb, IndexedSeq(m, n))

\\ this generates no new dynamic shape checks
SNDArray.gemm(cb, A, B, C)
```
then we can emit one set of runtime shape assertions, and further calls to methods with shape preconditions generate no new runtime assertions.