### PR TITLE
[terraform] Use a module for gsa and secret creation

### DIFF
--- a/infra/gsa_k8s_secret/main.tf
+++ b/infra/gsa_k8s_secret/main.tf
@@ -1,0 +1,28 @@
+resource "random_id" "name_suffix" {
+  byte_length = 2
+}
+
+resource "google_service_account" "service_account" {
+  account_id = "${var.name}-${random_id.name_suffix.hex}"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "kubernetes_secret" "k8s_key" {
+  metadata {
+    name = "${var.name}-gsa-key"
+  }
+
+  data = {
+    "key.json" = base64decode(google_service_account_key.service_account_key.private_key)
+  }
+}
+
+resource "google_project_iam_member" "iam_member" {
+  for_each = toset(var.iam_roles)
+
+  role = "roles/${each.key}"
+  member = "serviceAccount:${google_service_account.service_account.email}"
+}

--- a/infra/gsa_k8s_secret/outputs.tf
+++ b/infra/gsa_k8s_secret/outputs.tf
@@ -1,0 +1,3 @@
+output "email" {
+  value = google_service_account.service_account.email
+}

--- a/infra/gsa_k8s_secret/variables.tf
+++ b/infra/gsa_k8s_secret/variables.tf
@@ -1,0 +1,8 @@
+variable "name" {
+  type = string
+}
+
+variable "iam_roles" {
+  type = list(string)
+  default = []
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -446,7 +446,7 @@ module "auth_gsa_secret" {
   iam_roles = [
     "iam.serviceAccountAdmin",
     "iam.serviceAccountKeyAdmin",
-    "storage.admin",
+    # "storage.admin",
   ]
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -352,7 +352,7 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.reader"
-  member = "serviceAccount:${google_service_account.ci.email}"
+  member = "serviceAccount:${module.ci_gsa_secret.email}"
 }
 
 resource "google_storage_bucket_iam_member" "gcr_push_admin" {
@@ -435,165 +435,57 @@ resource "kubernetes_service" "ukbb_rb_static" {
   }
 }
 
-resource "random_id" "atgu_name_suffix" {
-  byte_length = 2
+module "atgu_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "atgu"
 }
 
-resource "google_service_account" "atgu" {
-  account_id = "atgu-${random_id.atgu_name_suffix.hex}"
+module "auth_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "auth"
+  iam_roles = [
+    "iam.serviceAccountAdmin",
+    "iam.serviceAccountKeyAdmin",
+    "storage.admin",
+  ]
 }
 
-resource "google_service_account_key" "atgu_key" {
-  service_account_id = google_service_account.atgu.name
+module "batch_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "batch"
+  iam_roles = [
+    "compute.instanceAdmin.v1",
+    "iam.serviceAccountUser",
+    "logging.viewer",
+    "storage.admin",
+  ]
 }
 
-resource "kubernetes_secret" "atgu_gsa_key" {
-  metadata {
-    name = "atgu-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.atgu_key.private_key)
-  }
-}
-
-resource "random_id" "auth_name_suffix" {
-  byte_length = 2
-}
-
-resource "google_service_account" "auth" {
-  account_id = "auth-${random_id.auth_name_suffix.hex}"
-}
-
-resource "google_service_account_key" "auth_key" {
-  service_account_id = google_service_account.auth.name
-}
-
-resource "google_project_iam_member" "auth_service_account_admin" {
-  role = "roles/iam.serviceAccountAdmin"
-  member = "serviceAccount:${google_service_account.auth.email}"
-}
-
-resource "google_project_iam_member" "auth_service_account_key_admin" {
-  role = "roles/iam.serviceAccountKeyAdmin"
-  member = "serviceAccount:${google_service_account.auth.email}"
-}
-
-resource "google_project_iam_member" "auth_storage_admin" {
-  role = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.auth.email}"
-}
-
-resource "kubernetes_secret" "auth_gsa_key" {
-  metadata {
-    name = "auth-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.auth_key.private_key)
-  }
-}
-
-resource "random_id" "batch_name_suffix" {
-  byte_length = 2
-}
-
-resource "google_service_account" "batch" {
-  account_id = "batch-${random_id.batch_name_suffix.hex}"
-}
-
-resource "google_service_account_key" "batch_key" {
-  service_account_id = google_service_account.batch.name
-}
-
-resource "kubernetes_secret" "batch_gsa_key" {
-  metadata {
-    name = "batch-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.batch_key.private_key)
-  }
-}
-
-resource "google_project_iam_member" "batch_compute_instance_admin" {
-  role = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.batch.email}"
-}
-
-resource "google_project_iam_member" "batch_service_account_user" {
-  role = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${google_service_account.batch.email}"
-}
-
-resource "google_project_iam_member" "batch_logging_viewer" {
-  role = "roles/logging.viewer"
-  member = "serviceAccount:${google_service_account.batch.email}"
-}
-
-resource "google_project_iam_member" "batch_storage_admin" {
-  role = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.batch.email}"
-}
-
-resource "random_id" "query_name_suffix" {
-  byte_length = 2
-}
-
-resource "google_service_account" "query" {
-  account_id = "query-${random_id.query_name_suffix.hex}"
-}
-
-resource "google_service_account_key" "query_key" {
-  service_account_id = google_service_account.query.name
-}
-
-resource "kubernetes_secret" "query_gsa_key" {
-  metadata {
-    name = "query-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.query_key.private_key)
-  }
+module "query_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "query"
 }
 
 resource "google_storage_bucket_iam_member" "query_hail_query_bucket_storage_admin" {
   bucket = google_storage_bucket.hail_query.name
   role = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.query.email}"
+  member = "serviceAccount:${module.query_gsa_secret.email}"
 }
 
 resource "google_storage_bucket_iam_member" "batch_hail_query_bucket_storage_viewer" {
   bucket = google_storage_bucket.hail_query.name
   role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.batch.email}"
+  member = "serviceAccount:${module.batch_gsa_secret.email}"
 }
 
-resource "google_service_account" "benchmark" {
-  account_id = "benchmark"
+module "benchmark_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "benchmark"
 }
 
-resource "google_service_account_key" "benchmark_key" {
-  service_account_id = google_service_account.benchmark.name
-}
-
-resource "kubernetes_secret" "benchmark_gsa_key" {
-  metadata {
-    name = "benchmark-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.benchmark_key.private_key)
-  }
-}
-
-resource "random_id" "ci_name_suffix" {
-  byte_length = 2
-}
-
-resource "google_service_account" "ci" {
-  account_id = "ci-${random_id.ci_name_suffix.hex}"
+module "ci_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "ci"
 }
 
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_viewer" {
@@ -601,127 +493,44 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_vie
   repository = google_artifact_registry_repository.repository.name
   location = var.gcp_location
   role = "roles/artifactregistry.reader"
-  member = "serviceAccount:${google_service_account.ci.email}"
+  member = "serviceAccount:${module.ci_gsa_secret.email}"
 }
 
-resource "google_service_account_key" "ci_key" {
-  service_account_id = google_service_account.ci.name
+module "monitoring_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "monitoring"
 }
 
-resource "kubernetes_secret" "ci_gsa_key" {
-  metadata {
-    name = "ci-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.ci_key.private_key)
-  }
+module "test_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "test"
+  iam_roles = [
+    "compute.instanceAdmin.v1",
+    "iam.serviceAccountUser",
+    "logging.viewer",
+    "serviceusage.serviceUsageConsumer",
+  ]
 }
 
-resource "google_service_account" "monitoring" {
-  account_id = "monitoring"
-}
-
-resource "google_service_account_key" "monitoring_key" {
-  service_account_id = google_service_account.monitoring.name
-}
-
-resource "kubernetes_secret" "monitoring_gsa_key" {
-  metadata {
-    name = "monitoring-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.monitoring_key.private_key)
-  }
-}
-
-resource "random_id" "test_name_suffix" {
-  byte_length = 2
-}
-
-resource "google_service_account" "test" {
-  account_id = "test-${random_id.test_name_suffix.hex}"
-}
-
-resource "google_service_account_key" "test_key" {
-  service_account_id = google_service_account.test.name
-}
-
-resource "kubernetes_secret" "test_gsa_key" {
-  metadata {
-    name = "test-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.test_key.private_key)
-  }
-}
-
-resource "google_project_iam_member" "test_compute_instance_admin" {
-  role = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.test.email}"
-}
-
-resource "google_project_iam_member" "test_service_account_user" {
-  role = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${google_service_account.test.email}"
-}
-
-resource "google_project_iam_member" "test_logging_viewer" {
-  role = "roles/logging.viewer"
-  member = "serviceAccount:${google_service_account.test.email}"
-}
-
-resource "google_project_iam_member" "test_service_usage_consumer" {
-  role = "roles/serviceusage.serviceUsageConsumer"
-  member = "serviceAccount:${google_service_account.test.email}"
-}
-
-resource "google_service_account" "test_dev" {
-  account_id = "test-dev"
-}
-
-resource "google_service_account_key" "test_dev_key" {
-  service_account_id = google_service_account.test_dev.name
-}
-
-resource "kubernetes_secret" "test_dev_gsa_key" {
-  metadata {
-    name = "test-dev-gsa-key"
-  }
-
-  data = {
-    "key.json" = base64decode(google_service_account_key.test_dev_key.private_key)
-  }
+module "test_dev_gsa_secret" {
+  source = "./gsa_k8s_secret"
+  name = "test-dev"
 }
 
 resource "google_service_account" "batch_agent" {
   account_id = "batch2-agent"
 }
 
-resource "google_project_iam_member" "batch_agent_compute_instance_admin" {
-  role = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.batch_agent.email}"
-}
+resource "google_project_iam_member" "batch_agent_iam_member" {
+  for_each = toset([
+    "compute.instanceAdmin.v1",
+    "iam.serviceAccountUser",
+    "logging.logWriter",
+    "storage.objectCreator",
+    "storage.objectViewer",
+  ])
 
-resource "google_project_iam_member" "batch_agent_service_account_user" {
-  role = "roles/iam.serviceAccountUser"
-  member = "serviceAccount:${google_service_account.batch_agent.email}"
-}
-
-resource "google_project_iam_member" "batch_agent_log_writer" {
-  role = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.batch_agent.email}"
-}
-
-resource "google_project_iam_member" "batch_agent_object_creator" {
-  role = "roles/storage.objectCreator"
-  member = "serviceAccount:${google_service_account.batch_agent.email}"
-}
-
-resource "google_project_iam_member" "batch_agent_object_viewer" {
-  role = "roles/storage.objectViewer"
+  role = "roles/${each.key}"
   member = "serviceAccount:${google_service_account.batch_agent.email}"
 }
 


### PR DESCRIPTION
This is an attempt to modularize / refactor our terraform code regarding google service accounts and kubernetes secrets. This doesn't add any new functionality.

Currently, our use of terraform is one flat file `main.tf` where we declare every `resource` in GCP that should exist. Examples of such resources are `google_service_account`, `google_service_account_key` and `kubernetes_secret`. For each of the accounts we create for various services, we end up creating these three resources (and sometimes IAM roles) in the same way. To abstract this, we can create a custom `module`, which is just a collection of resources, a set of inputs called `variables`, and a set of outputs. A module can then be "instantiated" using a `module` block in `main.tf`, providing it the source path of the module and values for its declared variables.

Tested by hand in my own GCP project.