### PR TITLE
[query] defaultValue is a value

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1240,7 +1240,7 @@ object FieldRef {
 }
 
 object Value {
-  def fromLIR[T](v: lir.ValueX): Value[T] = new Value[T] {
+  def fromLIR[T](v: => lir.ValueX): Value[T] = new Value[T] {
     def get: Code[T] = Code(v)
   }
 }

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -349,10 +349,10 @@ object Code {
   def invokeStatic5[T, A1, A2, A3, A4, A5, S](method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5])(implicit tct: ClassTag[T], sct: ClassTag[S], a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5]): Code[S] =
     invokeStatic[S](tct.runtimeClass, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4, a5))(sct)
 
-  def _null[T >: Null](implicit tti: TypeInfo[T]): Code[T] = Code(lir.insn0(ACONST_NULL, tti))
-  def _uncheckednull(tti: TypeInfo[_]): Code[_] = Code(lir.insn0(ACONST_NULL, tti))
+  def _null[T >: Null](implicit tti: TypeInfo[T]): Value[T] = Value.fromLIR[T](lir.insn0(ACONST_NULL, tti))
+  def _uncheckednull[T](tti: TypeInfo[T]): Value[T] = Value.fromLIR[T](lir.insn0(ACONST_NULL, tti))
 
-  def _empty: Code[Unit] = Code[Unit](null: lir.ValueX)
+  def _empty: Value[Unit] = Value.fromLIR[Unit](null: lir.ValueX)
 
   def _throwAny[T <: java.lang.Throwable]: Thrower[T] = new Thrower[T] {
     def apply[U](cerr: Code[T])(implicit uti: TypeInfo[U]): Code[U] = {
@@ -1236,6 +1236,12 @@ object FieldRef {
       s"when getting field ${ tct.runtimeClass.getName }.$field: ${ f.getType.getName }: wrong type ${ sct.runtimeClass.getName } ")
 
     new FieldRef(f)
+  }
+}
+
+object Value {
+  def fromLIR[T](v: lir.ValueX): Value[T] = new Value[T] {
+    def get: Code[T] = Code(v)
   }
 }
 

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -29,7 +29,7 @@ package asm4s {
 
     override def toString: String = desc
 
-    def uninitializedValue: Code[_]
+    def uninitializedValue: Value[_]
   }
 
   class ClassInfo[C](className: String) extends TypeInfo[C] {
@@ -43,7 +43,7 @@ package asm4s {
 
     def newArray(): AbstractInsnNode = new TypeInsnNode(ANEWARRAY, iname)
 
-    override def uninitializedValue: Code[_] = Code._uncheckednull(this)
+    override def uninitializedValue: Value[_] = Code._uncheckednull(this)
   }
 
   class ArrayInfo[T](implicit val tti: TypeInfo[T]) extends TypeInfo[Array[T]] {
@@ -57,7 +57,7 @@ package asm4s {
 
     def newArray() = new TypeInsnNode(ANEWARRAY, iname)
 
-    override def uninitializedValue: Code[_] = Code._null[Array[T]](this)
+    override def uninitializedValue: Value[_] = Code._null[Array[T]](this)
   }
 }
 
@@ -118,7 +118,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_BOOLEAN)
 
-    override def uninitializedValue: Code[_] = const(false)
+    override def uninitializedValue: Value[_] = const(false)
   }
 
   implicit object ByteInfo extends TypeInfo[Byte] {
@@ -132,7 +132,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_BYTE)
 
-    override def uninitializedValue: Code[_] = const(0.toByte)
+    override def uninitializedValue: Value[_] = const(0.toByte)
   }
 
   implicit object ShortInfo extends TypeInfo[Short] {
@@ -146,7 +146,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_SHORT)
 
-    override def uninitializedValue: Code[_] = const(0.toShort)
+    override def uninitializedValue: Value[_] = const(0.toShort)
   }
 
   implicit object IntInfo extends TypeInfo[Int] {
@@ -159,7 +159,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_INT)
 
-    override def uninitializedValue: Code[_] = const(0)
+    override def uninitializedValue: Value[_] = const(0)
   }
 
   implicit object LongInfo extends TypeInfo[Long] {
@@ -173,7 +173,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_LONG)
 
-    override def uninitializedValue: Code[_] = const(0L)
+    override def uninitializedValue: Value[_] = const(0L)
   }
 
   implicit object FloatInfo extends TypeInfo[Float] {
@@ -187,7 +187,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_FLOAT)
 
-    override def uninitializedValue: Code[_] = const(0f)
+    override def uninitializedValue: Value[_] = const(0f)
   }
 
   implicit object DoubleInfo extends TypeInfo[Double] {
@@ -201,7 +201,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_DOUBLE)
 
-    override def uninitializedValue: Code[_] = const(0d)
+    override def uninitializedValue: Value[_] = const(0d)
   }
 
   implicit object CharInfo extends TypeInfo[Char] {
@@ -215,7 +215,7 @@ package object asm4s {
 
     def newArray() = new IntInsnNode(NEWARRAY, T_CHAR)
 
-    override def uninitializedValue: Code[_] = const(0.toChar)
+    override def uninitializedValue: Value[_] = const(0.toChar)
   }
 
   implicit object UnitInfo extends TypeInfo[Unit] {
@@ -229,7 +229,7 @@ package object asm4s {
 
     def newArray() = ???
 
-    override def uninitializedValue: Code[_] = Code._empty
+    override def uninitializedValue: Value[_] = Code._empty
   }
 
   def classInfoFromClass[C](c: Class[C]): ClassInfo[C] = {
@@ -339,9 +339,7 @@ package object asm4s {
   implicit def toLocalRefInt(f: LocalRef[Int]): LocalRefInt = new LocalRefInt(f)
 
   def _const[T](a: Any, ti: TypeInfo[T]): Value[T] =
-    new Value[T] {
-      def get: Code[T] = Code(lir.ldcInsn(a, ti))
-    }
+    Value.fromLIR[T](lir.ldcInsn(a, ti))
 
   implicit def const(s: String): Value[String] = _const(s, classInfo[String])
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -159,7 +159,10 @@ case class EmitRegion(mb: EmitMethodBuilder[_], region: Value[Region]) {
 
 object EmitValue {
   def apply(missing: Option[Value[Boolean]], v: SValue): EmitValue = new EmitValue {
-    lazy val required: Boolean = missing.isEmpty
+    lazy val required: Boolean = missing match {
+      case None => true
+      case Some(m) => Code.constBoolValue(m).contains(false)
+    }
 
     override lazy val emitType: EmitType = EmitType(v.st, required)
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -401,7 +401,7 @@ class EmitClassBuilder[C](
 
   def freeSerializedAgg(i: Int): Code[Unit] = {
     assert(i < _nSerialized)
-    _aggSerialized.load().update(i, Code._null)
+    _aggSerialized.load().update(i, Code._null[Array[Byte]])
   }
 
   def runMethodWithHailExceptionHandler(mname: String): Code[(String, java.lang.Integer)] = {

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -432,9 +432,9 @@ class CompiledLineParser(
 
   fb.cb.emitInit(Code(
     pos := 0,
-    filename := Code._null,
+    filename := Code._null[String],
     lineNumber := 0L,
-    line := Code._null))
+    line := Code._null[String]))
 
 
   @transient private[this] val parseStringMb = fb.genEmitMethod[Region, String]("parseString")

--- a/hail/src/main/scala/is/hail/types/physical/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/package.scala
@@ -36,7 +36,7 @@ package object physical {
     case LongInfo => 0L
     case FloatInfo => 0.0f
     case DoubleInfo => 0.0
-    case _: ClassInfo[_] => Code._null
+    case _: ClassInfo[_] => Code._null[String]
     case ti => throw new RuntimeException(s"unsupported type found: $ti")
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SType.scala
@@ -72,7 +72,7 @@ trait SType {
   def asIdent: String = getClass.getSimpleName
 
   def defaultValue: SValue =
-    fromValues(codeTupleTypes().map(ti => ti.uninitializedValue))
+    fromValues(settableTupleTypes().map(ti => ti.uninitializedValue))
 
   def isPrimitive: Boolean = this match {
     case SInt32 | SInt64 | SFloat32 | SFloat64 | SBoolean => true

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -85,7 +85,7 @@ object SBaseStructPointerSettable {
 final class SBaseStructPointerSettable(
   st: SBaseStructPointer,
   override val a: Settable[Long]
-) extends SBaseStructPointerValue(st, a) with SSettable {
+) extends SBaseStructPointerValue(st, a) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
   override def store(cb: EmitCodeBuilder, pv: SCode): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SInsertFieldsStruct.scala
@@ -172,7 +172,7 @@ final class SInsertFieldsStructSettable(
   st: SInsertFieldsStruct,
   parent: SBaseStructSettable,
   newFields: IndexedSeq[EmitSettable]
-) extends SInsertFieldsStructValue(st, parent, newFields) with SSettable {
+) extends SInsertFieldsStructValue(st, parent, newFields) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = parent.settableTuple() ++ newFields.flatMap(_.settableTuple())
 
   override def store(cb: EmitCodeBuilder, pv: SCode): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -11,22 +11,22 @@ import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
 
-case class SIntervalPointer(pType: PInterval) extends SInterval {
+final case class SIntervalPointer(pType: PInterval) extends SInterval {
   require(!pType.required)
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SIntervalPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
   override def castRename(t: Type): SType = SIntervalPointer(pType.deepRename(t).asInstanceOf[PInterval])
 
-  lazy val virtualType: Type = pType.virtualType
+  override lazy val virtualType: Type = pType.virtualType
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo, BooleanInfo, BooleanInfo)
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SIntervalPointerSettable = {
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SIntervalPointerSettable = {
     val IndexedSeq(a: Settable[Long@unchecked], includesStart: Settable[Boolean@unchecked], includesEnd: Settable[Boolean@unchecked]) = settables
     assert(a.ti == LongInfo)
     assert(includesStart.ti == BooleanInfo)
@@ -34,65 +34,55 @@ case class SIntervalPointer(pType: PInterval) extends SInterval {
     new SIntervalPointerSettable(this, a, includesStart, includesEnd)
   }
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SIntervalPointerCode = {
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SIntervalPointerCode = {
     val IndexedSeq(a: Code[Long@unchecked]) = codes
     assert(a.ti == LongInfo)
     new SIntervalPointerCode(this, a)
   }
 
+  override def fromValues(values: IndexedSeq[Value[_]]): SIntervalPointerValue = {
+    val IndexedSeq(a: Value[Long@unchecked], includesStart: Value[Boolean@unchecked], includesEnd: Value[Boolean@unchecked]) = values
+    assert(a.ti == LongInfo)
+    assert(includesStart.ti == BooleanInfo)
+    assert(includesEnd.ti == BooleanInfo)
+    new SIntervalPointerValue(this, a, includesStart, includesEnd)
+  }
+
   override def pointType: SType = pType.pointType.sType
   override def pointEmitType: EmitType = EmitType(pType.pointType.sType, pType.pointType.required)
 
-  def storageType(): PType = pType
+  override def storageType(): PType = pType
 
-  def copiedType: SType = SIntervalPointer(pType.copiedType.asInstanceOf[PInterval])
+  override def copiedType: SType = SIntervalPointer(pType.copiedType.asInstanceOf[PInterval])
 
-  def containsPointers: Boolean = pType.containsPointers
+  override def containsPointers: Boolean = pType.containsPointers
 }
 
-
-object SIntervalPointerSettable {
-  def apply(sb: SettableBuilder, st: SIntervalPointer, name: String): SIntervalPointerSettable = {
-    new SIntervalPointerSettable(st,
-      sb.newSettable[Long](s"${ name }_a"),
-      sb.newSettable[Boolean](s"${ name }_includes_start"),
-      sb.newSettable[Boolean](s"${ name }_includes_end"))
-  }
-}
-
-class SIntervalPointerSettable(
+class SIntervalPointerValue(
   val st: SIntervalPointer,
-  val a: Settable[Long],
-  val includesStart: Settable[Boolean],
-  val includesEnd: Settable[Boolean]
-) extends SIntervalValue with SSettable {
-  def get: SIntervalCode = new SIntervalPointerCode(st, a)
+  val a: Value[Long],
+  val includesStart: Value[Boolean],
+  val includesEnd: Value[Boolean]
+) extends SIntervalValue {
+  override def get: SIntervalCode = new SIntervalPointerCode(st, a)
 
   val pt: PInterval = st.pType
 
-  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, includesStart, includesEnd)
-
-  def loadStart(cb: EmitCodeBuilder): IEmitCode =
+  override def loadStart(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.startDefined(a)),
       pt.pointType.loadCheapSCode(cb, pt.loadStart(a)))
 
-  def startDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.startDefined(a)
+  override def startDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.startDefined(a)
 
-  def loadEnd(cb: EmitCodeBuilder): IEmitCode =
+  override def loadEnd(cb: EmitCodeBuilder): IEmitCode =
     IEmitCode(cb,
       !(pt.endDefined(a)),
       pt.pointType.loadCheapSCode(cb, pt.loadEnd(a)))
 
-  def endDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.endDefined(a)
+  override def endDefined(cb: EmitCodeBuilder): Code[Boolean] = pt.endDefined(a)
 
-  def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(a, pc.asInstanceOf[SIntervalPointerCode].a)
-    cb.assign(includesStart, pt.includesStart(a.load()))
-    cb.assign(includesEnd, pt.includesEnd(a.load()))
-  }
-
-  def isEmpty(cb: EmitCodeBuilder): Code[Boolean] = {
+  override def isEmpty(cb: EmitCodeBuilder): Code[Boolean] = {
     val gt = cb.emb.ecb.getOrderingFunction(st.pointType, CodeOrdering.Gt())
     val gteq = cb.emb.ecb.getOrderingFunction(st.pointType, CodeOrdering.Gteq())
 
@@ -105,7 +95,30 @@ class SIntervalPointerSettable(
         cb.assign(empty, gteq(cb, start, end))))
     empty
   }
+}
 
+object SIntervalPointerSettable {
+  def apply(sb: SettableBuilder, st: SIntervalPointer, name: String): SIntervalPointerSettable = {
+    new SIntervalPointerSettable(st,
+      sb.newSettable[Long](s"${ name }_a"),
+      sb.newSettable[Boolean](s"${ name }_includes_start"),
+      sb.newSettable[Boolean](s"${ name }_includes_end"))
+  }
+}
+
+final class SIntervalPointerSettable(
+  st: SIntervalPointer,
+  override val a: Settable[Long],
+  override val includesStart: Settable[Boolean],
+  override val includesEnd: Settable[Boolean]
+) extends SIntervalPointerValue(st, a, includesStart, includesEnd) with SSettable {
+  override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, includesStart, includesEnd)
+
+  override def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
+    cb.assign(a, pc.asInstanceOf[SIntervalPointerCode].a)
+    cb.assign(includesStart, pt.includesStart(a.load()))
+    cb.assign(includesEnd, pt.includesEnd(a.load()))
+  }
 }
 
 class SIntervalPointerCode(val st: SIntervalPointer, val a: Code[Long]) extends SIntervalCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -48,7 +48,7 @@ final case class SNDArrayPointer(pType: PCanonicalNDArray) extends SNDArray {
   }
 
   override def fromValues(values: IndexedSeq[Value[_]]): SNDArrayPointerValue = {
-    val a = values(0).asInstanceOf[Settable[Long@unchecked]]
+    val a = values(0).asInstanceOf[Value[Long@unchecked]]
     val shape = values.slice(1, 1 + pType.nDims).asInstanceOf[IndexedSeq[Value[Long@unchecked]]]
     val strides = values.slice(1 + pType.nDims, 1 + 2 * pType.nDims).asInstanceOf[IndexedSeq[Value[Long@unchecked]]]
     val dataFirstElementPointer = values.last.asInstanceOf[Value[Long]]

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -135,7 +135,7 @@ class SStackStructValue(val st: SStackStruct, settables: IndexedSeq[EmitValue]) 
 final class SStackStructSettable(
   st: SStackStruct,
   settables: IndexedSeq[EmitSettable]
-) extends SStackStructValue(st, settables) with SSettable {
+) extends SStackStructValue(st, settables) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = settables.flatMap(_.settableTuple())
 
   override def store(cb: EmitCodeBuilder, pv: SCode): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -11,32 +11,38 @@ import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
 
-case class SStringPointer(pType: PString) extends SString {
+final case class SStringPointer(pType: PString) extends SString {
   require(!pType.required)
 
-  lazy val virtualType: Type = pType.virtualType
+  override lazy val virtualType: Type = pType.virtualType
 
   override def castRename(t: Type): SType = this
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     new SStringPointerCode(this, pType.store(cb, region, value, deepCopy))
   }
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SStringPointerSettable = {
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SStringPointerSettable = {
     val IndexedSeq(a: Settable[Long@unchecked]) = settables
     assert(a.ti == LongInfo)
     new SStringPointerSettable(this, a)
   }
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SStringPointerCode = {
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SStringPointerCode = {
     val IndexedSeq(a: Code[Long@unchecked]) = codes
     assert(a.ti == LongInfo)
     new SStringPointerCode(this, a)
   }
 
-  def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringPointerCode = {
+  override def fromValues(values: IndexedSeq[Value[_]]): SStringPointerValue = {
+    val IndexedSeq(a: Value[Long@unchecked]) = values
+    assert(a.ti == LongInfo)
+    new SStringPointerValue(this, a)
+  }
+
+  override def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringPointerCode = {
     new SStringPointerCode(this, pType.allocateAndStoreString(cb.emb, r, s))
   }
 
@@ -44,7 +50,7 @@ case class SStringPointer(pType: PString) extends SString {
 
   override def copiedType: SType = SStringPointer(pType.copiedType.asInstanceOf[PString])
 
-  def containsPointers: Boolean = pType.containsPointers
+  override def containsPointers: Boolean = pType.containsPointers
 }
 
 
@@ -72,6 +78,12 @@ class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends SStr
   def binaryRepr: SBinaryPointerCode = new SBinaryPointerCode(SBinaryPointer(st.pType.binaryRepresentation), a)
 }
 
+class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SStringValue {
+  override def get: SStringPointerCode = new SStringPointerCode(st, a)
+
+  def binaryRepr(): SBinaryPointerValue = new SBinaryPointerValue(SBinaryPointer(st.pType.binaryRepresentation), a)
+}
+
 object SStringPointerSettable {
   def apply(sb: SettableBuilder, st: SStringPointer, name: String): SStringPointerSettable = {
     new SStringPointerSettable(st,
@@ -79,14 +91,12 @@ object SStringPointerSettable {
   }
 }
 
-class SStringPointerSettable(val st: SStringPointer, val a: Settable[Long]) extends SStringValue with SSettable {
-  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
+final class SStringPointerSettable(st: SStringPointer, override val a: Settable[Long]) extends SStringPointerValue(st, a) with SSettable {
+  override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  def get: SStringPointerCode = new SStringPointerCode(st, a.load())
-
-  def store(cb: EmitCodeBuilder, v: SCode): Unit = {
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = {
     cb.assign(a, v.asInstanceOf[SStringPointerCode].a)
   }
 
-  def binaryRepr(): SBinaryPointerSettable = new SBinaryPointerSettable(SBinaryPointer(st.pType.binaryRepresentation), a)
+  override def binaryRepr(): SBinaryPointerSettable = new SBinaryPointerSettable(SBinaryPointer(st.pType.binaryRepresentation), a)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -101,7 +101,7 @@ class SSubsetStructValue(val st: SSubsetStruct, prev: SBaseStructValue) extends 
     prev.isFieldMissing(st.newToOldFieldMapping(fieldIdx))
 }
 
-final class SSubsetStructSettable(st: SSubsetStruct, prev: SBaseStructSettable) extends SSubsetStructValue(st, prev) with SSettable {
+final class SSubsetStructSettable(st: SSubsetStruct, prev: SBaseStructSettable) extends SSubsetStructValue(st, prev) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = prev.settableTuple()
 
   override def store(cb: EmitCodeBuilder, pv: SCode): Unit = prev.store(cb, pv.asInstanceOf[SSubsetStructCode].prev)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -4,23 +4,23 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{Code, LongInfo, Settable, TypeInfo, Value}
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
-import is.hail.types.physical.stypes.{EmitType, SCode, SType}
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructValue, SStructSettable}
+import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructSettable, SBaseStructValue}
 import is.hail.types.physical.{PCanonicalStruct, PType, StoredSTypePType}
 import is.hail.types.virtual.{TStruct, Type}
 
-case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) extends SBaseStruct {
+final case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) extends SBaseStruct {
 
-  val size: Int = fieldNames.size
+  override val size: Int = fieldNames.size
 
   val _fieldIdx: Map[String, Int] = fieldNames.zipWithIndex.toMap
   val newToOldFieldMapping: Map[Int, Int] = _fieldIdx
     .map { case (f, i) => (i, parent.virtualType.asInstanceOf[TStruct].fieldIdx(f)) }
 
-  val fieldTypes: IndexedSeq[SType] = Array.tabulate(size)(i => parent.fieldTypes(newToOldFieldMapping(i)))
-  val fieldEmitTypes: IndexedSeq[EmitType] = Array.tabulate(size)(i => parent.fieldEmitTypes(newToOldFieldMapping(i)))
+  override val fieldTypes: IndexedSeq[SType] = Array.tabulate(size)(i => parent.fieldTypes(newToOldFieldMapping(i)))
+  override val fieldEmitTypes: IndexedSeq[EmitType] = Array.tabulate(size)(i => parent.fieldEmitTypes(newToOldFieldMapping(i)))
 
-  lazy val virtualType: TStruct = {
+  override lazy val virtualType: TStruct = {
     val vparent = parent.virtualType.asInstanceOf[TStruct]
     TStruct(fieldNames.map(f => (f, vparent.field(f).typ)): _*)
   }
@@ -43,7 +43,7 @@ case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) ex
     newType
   }
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     if (deepCopy)
       throw new NotImplementedError("Deep copy on subset struct")
     value.st match {
@@ -52,16 +52,20 @@ case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) ex
     }
   }
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = parent.codeTupleTypes()
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = parent.codeTupleTypes()
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = parent.settableTupleTypes()
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SSubsetStructSettable = {
-    new SSubsetStructSettable(this, parent.fromSettables(settables).asInstanceOf[SStructSettable])
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSubsetStructSettable = {
+    new SSubsetStructSettable(this, parent.fromSettables(settables).asInstanceOf[SBaseStructSettable])
   }
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SSubsetStructCode = {
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SSubsetStructCode = {
     new SSubsetStructCode(this, parent.fromCodes(codes))
+  }
+
+  override def fromValues(values: IndexedSeq[Value[_]]): SSubsetStructValue = {
+    new SSubsetStructValue(this, parent.fromValues(values).asInstanceOf[SBaseStructValue])
   }
 
   override def copiedType: SType = {
@@ -83,32 +87,34 @@ case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[String]) ex
 //  aspirational implementation
 //  def storageType(): PType = StoredSTypePType(this, false)
 
-  def containsPointers: Boolean = parent.containsPointers
+  override def containsPointers: Boolean = parent.containsPointers
 }
 
-class SSubsetStructSettable(val st: SSubsetStruct, prev: SStructSettable) extends SStructSettable {
-  def get: SSubsetStructCode = new SSubsetStructCode(st, prev.load().asBaseStruct)
+class SSubsetStructValue(val st: SSubsetStruct, prev: SBaseStructValue) extends SBaseStructValue {
+  override def get: SSubsetStructCode = new SSubsetStructCode(st, prev.asBaseStruct)
 
-  def settableTuple(): IndexedSeq[Settable[_]] = prev.settableTuple()
-
-  def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
+  override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     prev.loadField(cb, st.newToOldFieldMapping(fieldIdx))
   }
 
-  def isFieldMissing(fieldIdx: Int): Code[Boolean] =
+  override def isFieldMissing(fieldIdx: Int): Code[Boolean] =
     prev.isFieldMissing(st.newToOldFieldMapping(fieldIdx))
+}
 
-  def store(cb: EmitCodeBuilder, pv: SCode): Unit = prev.store(cb, pv.asInstanceOf[SSubsetStructCode].prev)
+final class SSubsetStructSettable(st: SSubsetStruct, prev: SBaseStructSettable) extends SSubsetStructValue(st, prev) with SSettable {
+  override def settableTuple(): IndexedSeq[Settable[_]] = prev.settableTuple()
+
+  override def store(cb: EmitCodeBuilder, pv: SCode): Unit = prev.store(cb, pv.asInstanceOf[SSubsetStructCode].prev)
 }
 
 class SSubsetStructCode(val st: SSubsetStruct, val prev: SBaseStructCode) extends SBaseStructCode {
   def makeCodeTuple(cb: EmitCodeBuilder): IndexedSeq[Code[_]] = prev.makeCodeTuple(cb)
 
   def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue = {
-    new SSubsetStructSettable(st, prev.memoize(cb, name).asInstanceOf[SStructSettable])
+    new SSubsetStructSettable(st, prev.memoize(cb, name).asInstanceOf[SBaseStructSettable])
   }
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue = {
-    new SSubsetStructSettable(st, prev.memoizeField(cb, name).asInstanceOf[SStructSettable])
+    new SSubsetStructSettable(st, prev.memoizeField(cb, name).asInstanceOf[SBaseStructSettable])
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -29,15 +29,15 @@ object SUnreachable {
 }
 
 abstract class SUnreachable extends SType {
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq()
 
-  def storageType(): PType = PType.canonical(virtualType, required = false, innerRequired = true)
+  override def storageType(): PType = PType.canonical(virtualType, required = false, innerRequired = true)
 
   override def asIdent: String = s"s_unreachable"
 
-  def castRename(t: Type): SType = SUnreachable.fromVirtualType(t)
+  override def castRename(t: Type): SType = SUnreachable.fromVirtualType(t)
 
   val sv: SUnreachableValue
 
@@ -45,11 +45,13 @@ abstract class SUnreachable extends SType {
 
   override def fromCodes(codes: IndexedSeq[Code[_]]): SUnreachableValue = sv
 
+  override def fromValues(values: IndexedSeq[Value[_]]): SUnreachableValue = sv
+
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = sv
 
-  def copiedType: SType = this
+  override def copiedType: SType = this
 
-  def containsPointers: Boolean = false
+  override def containsPointers: Boolean = false
 }
 
 abstract class SUnreachableValue extends SCode with SSettable {
@@ -97,6 +99,8 @@ class SUnreachableStructValue(val st: SUnreachableStruct) extends SUnreachableVa
 
   override def _insert(newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode =
     new SUnreachableStructValue(SUnreachableStruct(newType))
+
+  override def get: SBaseStructCode = this
 }
 
 case object SUnreachableBinary extends SUnreachable with SBinary {
@@ -112,7 +116,7 @@ class SUnreachableBinaryValue extends SUnreachableValue with SBinaryValue with S
 
   override def loadByte(i: Code[Int]): Code[Byte] = const(0.toByte)
 
-  override def loadBytes(): Code[Array[Byte]] = Code._null
+  override def loadBytes(): Code[Array[Byte]] = Code._null[Array[Byte]]
 
   override def loadLength(): Code[Int] = const(0)
 
@@ -138,7 +142,7 @@ class SUnreachableStringValue extends SUnreachableValue with SStringValue with S
 
   def st: SUnreachableString.type = SUnreachableString
 
-  override def loadString(): Code[String] = Code._null
+  override def loadString(): Code[String] = Code._null[String]
 
   override def toBytes(): SBinaryCode = new SUnreachableBinaryValue
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -31,10 +31,12 @@ trait SBaseStruct extends SType {
   }
 }
 
-trait SStructSettable extends SBaseStructValue with SSettable
+trait SBaseStructSettable extends SBaseStructValue with SSettable
 
 trait SBaseStructValue extends SValue {
   def st: SBaseStruct
+
+  override def get: SBaseStructCode
 
   def isFieldMissing(fieldIdx: Int): Code[Boolean]
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -9,25 +9,27 @@ import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType, SUnreal
 import is.hail.types.physical.PType
 import is.hail.types.virtual.{TStream, Type}
 
-case class SStream(elementEmitType: EmitType) extends SType {
+final case class SStream(elementEmitType: EmitType) extends SType {
   def elementType: SType = elementEmitType.st
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     if (deepCopy) throw new NotImplementedError()
 
     assert(value.st == this)
     value
   }
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = throw new NotImplementedError()
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = throw new NotImplementedError()
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new NotImplementedError()
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new NotImplementedError()
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new NotImplementedError()
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new NotImplementedError()
 
-  def storageType(): PType = throw new NotImplementedError()
+  override def fromValues(values: IndexedSeq[Value[_]]): SValue = throw new NotImplementedError()
 
-  def copiedType: SType = throw new NotImplementedError()
+  override def storageType(): PType = throw new NotImplementedError()
+
+  override def copiedType: SType = throw new NotImplementedError()
 
   override def containsPointers: Boolean = throw new NotImplementedError()
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -15,21 +15,23 @@ case object SVoid extends SType {
 
   override def castRename(t: Type): SType = this
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = value
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = value
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = IndexedSeq()
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = IndexedSeq()
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new UnsupportedOperationException
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SCode = throw new UnsupportedOperationException
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new UnsupportedOperationException
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = throw new UnsupportedOperationException
 
-  def storageType(): PType = throw new UnsupportedOperationException
+  override def fromValues(values: IndexedSeq[Value[_]]): SValue = throw new UnsupportedOperationException
+
+  override def storageType(): PType = throw new UnsupportedOperationException
 
   override def copiedType: SType = this
 
   override def _typeWithRequiredness: TypeWithRequiredness = throw new UnsupportedOperationException
 
-  def containsPointers: Boolean = false
+  override def containsPointers: Boolean = false
 }
 
 case object SVoidCode extends SCode with SUnrealizableCode {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -10,40 +10,39 @@ import is.hail.types.virtual.{TInt64, Type}
 import is.hail.utils.FastIndexedSeq
 
 case object SInt64 extends SPrimitive {
-  def ti: TypeInfo[_] = LongInfo
+  override def ti: TypeInfo[_] = LongInfo
 
-  lazy val virtualType: Type = TInt64
+  override lazy val virtualType: Type = TInt64
 
   override def castRename(t: Type): SType = this
 
-  def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
+  override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SCode, deepCopy: Boolean): SCode = {
     value.st match {
       case SInt64 => value
     }
   }
 
-  def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
+  override def codeTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo)
 
-  def fromSettables(settables: IndexedSeq[Settable[_]]): SInt64Settable = {
+  override def fromSettables(settables: IndexedSeq[Settable[_]]): SInt64Settable = {
     val IndexedSeq(x: Settable[Long@unchecked]) = settables
     assert(x.ti == LongInfo)
     new SInt64Settable(x)
   }
 
-  def fromCodes(codes: IndexedSeq[Code[_]]): SInt64Code = {
+  override def fromCodes(codes: IndexedSeq[Code[_]]): SInt64Code = {
     val IndexedSeq(x: Code[Long@unchecked]) = codes
     assert(x.ti == LongInfo)
     new SInt64Code(x)
   }
 
-  def storageType(): PType = PInt64()
-}
-
-trait SInt64Value extends SValue {
-  def longCode(cb: EmitCodeBuilder): Code[Long]
-  override def hash(cb: EmitCodeBuilder): SInt32Code = {
-   new SInt32Code(invokeStatic1[java.lang.Long, Long, Int]("hashCode", longCode(cb)))
+  override def fromValues(settables: IndexedSeq[Value[_]]): SInt64Value = {
+    val IndexedSeq(x: Value[Long@unchecked]) = settables
+    assert(x.ti == LongInfo)
+    new SInt64Value(x)
   }
+
+  override def storageType(): PType = PInt64()
 }
 
 class SInt64Code(val code: Code[Long]) extends SCode with SPrimitiveCode {
@@ -66,22 +65,24 @@ class SInt64Code(val code: Code[Long]) extends SCode with SPrimitiveCode {
   def longCode(cb: EmitCodeBuilder): Code[Long] = code
 }
 
+class SInt64Value(x: Value[Long]) extends SValue {
+  val pt: PInt64 = PInt64(false)
+
+  override def st: SInt64.type = SInt64
+
+  override def get: SCode = new SInt64Code(x)
+
+  def longCode(cb: EmitCodeBuilder): Code[Long] = x
+}
+
 object SInt64Settable {
   def apply(sb: SettableBuilder, name: String): SInt64Settable = {
     new SInt64Settable(sb.newSettable[Long](name))
   }
 }
 
-class SInt64Settable(x: Settable[Long]) extends SInt64Value with SSettable {
-  val pt: PInt64 = PInt64(false)
+final class SInt64Settable(x: Settable[Long]) extends SInt64Value(x) with SSettable {
+  override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  def st: SInt64.type = SInt64
-
-  def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asLong.longCode(cb))
-
-  def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
-
-  def get: SCode = new SInt64Code(x)
-
-  def longCode(cb: EmitCodeBuilder): Code[Long] = x
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asLong.longCode(cb))
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -73,6 +73,9 @@ class SInt64Value(x: Value[Long]) extends SValue {
   override def get: SCode = new SInt64Code(x)
 
   def longCode(cb: EmitCodeBuilder): Code[Long] = x
+
+  override def hash(cb: EmitCodeBuilder): SInt32Code =
+    new SInt32Code(invokeStatic1[java.lang.Long, Long, Int]("hashCode", longCode(cb)))
 }
 
 object SInt64Settable {


### PR DESCRIPTION
Makes `SCode.defaultValue` return an `SValue`. To support that, I added `SCode.fromValues`, which required adding concrete `SValue` subclasses for every SType. I also did some tidying up, adding `final` and `override` keywords more consistently.