### PR TITLE
[compiler] TableIR.execute returns TableExecuteIntermediate

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -4,12 +4,13 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.backend.BroadcastValue
 import is.hail.expr.TableAnnotationImpex
+import is.hail.expr.ir.lowering.{RVDToTableStage, TableStage, TableStageToRVD}
 import is.hail.io.fs.FS
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PStruct}
 import is.hail.types.virtual.{Field, TArray, TStruct}
 import is.hail.types.{MatrixType, TableType}
 import is.hail.io.{BufferSpec, TypedCodecSpec, exportTypes}
-import is.hail.rvd.{AbstractRVDSpec, RVD, RVDContext, RVDType}
+import is.hail.rvd.{AbstractRVDSpec, RVD, RVDContext, RVDPartitioner, RVDType}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
@@ -19,6 +20,42 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.storage.StorageLevel
 import org.json4s.jackson.JsonMethods
+
+object TableExecuteIntermediate {
+  def apply(tv: TableValue): TableExecuteIntermediate = new TableValueIntermediate(tv)
+
+  def apply(ts: TableStage): TableExecuteIntermediate = new TableStageIntermediate(ts)
+}
+
+sealed trait TableExecuteIntermediate {
+  def asTableStage(ctx: ExecuteContext): TableStage
+
+  def asTableValue(ctx: ExecuteContext): TableValue
+
+  def partitioner: RVDPartitioner
+}
+
+class TableValueIntermediate(tv: TableValue) extends TableExecuteIntermediate {
+  def asTableStage(ctx: ExecuteContext): TableStage = {
+    RVDToTableStage(tv.rvd, tv.globals.toEncodedLiteral())
+  }
+
+  def asTableValue(ctx: ExecuteContext): TableValue = tv
+
+  def partitioner: RVDPartitioner = tv.rvd.partitioner
+}
+
+class TableStageIntermediate(ts: TableStage) extends TableExecuteIntermediate {
+  def asTableStage(ctx: ExecuteContext): TableStage = ts
+
+  def asTableValue(ctx: ExecuteContext): TableValue = {
+    val (globals, rvd) = TableStageToRVD(ctx, ts, Map.empty)
+    TableValue(ctx, TableType(ts.rowType, ts.key, ts.globalType), globals, rvd)
+  }
+
+  def partitioner: RVDPartitioner = ts.partitioner
+}
+
 
 object TableValue {
   def apply(ctx: ExecuteContext, rowType: PStruct, key: IndexedSeq[String], rdd: ContextRDD[Long]): TableValue = {

--- a/hail/src/test/scala/is/hail/expr/ir/LiftLiteralsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LiftLiteralsSuite.scala
@@ -11,7 +11,7 @@ class LiftLiteralsSuite extends HailSuite {
   implicit val execStrats = ExecStrategy.interpretOnly
 
   @Test def testNestedGlobalsRewrite() {
-    val tab = TableLiteral(TableRange(10, 1).execute(ctx))
+    val tab = TableLiteral(TableRange(10, 1).execute(ctx).asTableValue(ctx))
     val ir = TableGetGlobals(
       TableMapGlobals(
         tab,

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -98,7 +98,7 @@ class PruneSuite extends HailSuite {
         Row(FastIndexedSeq(Row("hi", FastIndexedSeq(Row(1)), "bye", Row(2, FastIndexedSeq(Row("bar"))), "foo")), Row(5, 10))),
       None),
     FastIndexedSeq("3"),
-    false).execute(ctx))
+    false).execute(ctx).asTableValue(ctx))
 
   lazy val tr = TableRead(tab.typ, false, new TableReader {
     override def renderShort(): String = ???

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -753,7 +753,7 @@ class TableIRSuite extends HailSuite {
     val table = TableRange(5, 4)
     val path = ctx.createTmpPath("test-table-write", "ht")
     Interpret[Unit](ctx, TableWrite(table, TableNativeWriter(path)))
-    val before = table.execute(ctx)
+    val before = table.execute(ctx).asTableValue(ctx)
     val after = Interpret(TableIR.read(fs, path), ctx, false)
     assert(before.globals.javaValue == after.globals.javaValue)
     assert(before.rdd.collect().toFastIndexedSeq == after.rdd.collect().toFastIndexedSeq)


### PR DESCRIPTION
This is a trivial (non-semantic) refactor.