### PR TITLE
[batch] Only umount a container's overlay if it was successfully created

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -420,6 +420,8 @@ class Container:
         self.config_path = f'{self.container_scratch}/config'
         self.log_path = f'{self.container_scratch}/container.log'
 
+        self.overlay_mounted = False
+
         self.fs = LocalAsyncFS(worker.pool)
 
         self.container_name = f'batch-{self.job.batch_id}-job-{self.job.job_id}-{self.name}'
@@ -582,6 +584,7 @@ class Container:
         await check_shell(
             f'mount -t overlay overlay -o lowerdir={lower_dir},upperdir={upper_dir},workdir={work_dir} {merged_dir}'
         )
+        self.overlay_mounted = True
 
     async def setup_network_namespace(self):
         network = self.spec.get('network')
@@ -844,12 +847,14 @@ class Container:
             except Exception:
                 log.exception('while deleting container', exc_info=True)
 
-        try:
-            await check_shell(f'umount -l {self.container_overlay_path}/merged')
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            log.exception('while unmounting overlay', exc_info=True)
+        if self.overlay_mounted:
+            try:
+                await check_shell(f'umount -l {self.container_overlay_path}/merged')
+                self.overlay_mounted = False
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception('while unmounting overlay', exc_info=True)
 
         if self.host_port is not None:
             port_allocator.free(self.host_port)

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -845,7 +845,7 @@ class Container:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                log.exception('while deleting container', exc_info=True)
+                log.exception(f'while deleting container {self}', exc_info=True)
 
         if self.overlay_mounted:
             try:
@@ -854,7 +854,7 @@ class Container:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                log.exception('while unmounting overlay', exc_info=True)
+                log.exception(f'while unmounting overlay in {self}', exc_info=True)
 
         if self.host_port is not None:
             port_allocator.free(self.host_port)


### PR DESCRIPTION
Scenario: A job is cancelled while its image is being pulled. The container overlay will never be made, so we should not try to unmount it in `delete_container`. This adds a flag to prevent that scenario.