### PR TITLE
[batch] Use separate ComputeClient per disk

### DIFF
--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1310,7 +1310,9 @@ class DockerJob(Job):
                     project=PROJECT,
                     instance_name=NAME,
                     name=f'batch-disk-{uid}',
-                    compute_client=worker.compute_client,
+                    compute_client=aiogoogle.ComputeClient(
+                        PROJECT, credentials=aiogoogle.Credentials.from_file('/worker-key.json')
+                    ),
                     size_in_gb=self.external_storage_in_gib,
                     mount_path=self.io_host_path(),
                 )

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1310,9 +1310,6 @@ class DockerJob(Job):
                     project=PROJECT,
                     instance_name=NAME,
                     name=f'batch-disk-{uid}',
-                    compute_client=aiogoogle.ComputeClient(
-                        PROJECT, credentials=aiogoogle.Credentials.from_file('/worker-key.json')
-                    ),
                     size_in_gb=self.external_storage_in_gib,
                     mount_path=self.io_host_path(),
                 )
@@ -1422,6 +1419,8 @@ class DockerJob(Job):
                             log.info(f'deleted disk {self.disk.name} for {self.id}')
                         except Exception:
                             log.exception(f'while detaching and deleting disk {self.disk.name} for {self.id}')
+                        finally:
+                            await self.disk.close()
                     else:
                         worker.data_disk_space_remaining.value += self.external_storage_in_gib
 


### PR DESCRIPTION
Sharing the worker's compute client can lead to prematurely closing the client session shared by the worker and disks. Just use compute clients instead.