### PR TITLE
[query/compiler] Harmonize FS.open behavior in python

### DIFF
--- a/hail/python/hail/fs/hadoop_fs.py
+++ b/hail/python/hail/fs/hadoop_fs.py
@@ -11,12 +11,19 @@ class HadoopFS(FS):
         self._jfs = jfs
 
     def open(self, path: str, mode: str = 'r', buffer_size: int = 8192):
+        return self._open(path, mode, buffer_size, use_codec=False)
+
+    def legacy_open(self, path: str, mode: str = 'r', buffer_size: int = 8192):
+        # this method for combatibility with hadoop_open in 0.2
+        return self._open(path, mode, buffer_size, use_codec=True)
+
+    def _open(self, path: str, mode: str = 'r', buffer_size: int = 8192, use_codec: bool = False):
         if 'r' in mode:
-            handle = io.BufferedReader(HadoopReader(self, path, buffer_size), buffer_size=buffer_size)
+            handle = io.BufferedReader(HadoopReader(self, path, buffer_size, use_codec=use_codec), buffer_size=buffer_size)
         elif 'w' in mode:
-            handle = io.BufferedWriter(HadoopWriter(self, path), buffer_size=buffer_size)
+            handle = io.BufferedWriter(HadoopWriter(self, path, use_codec=use_codec), buffer_size=buffer_size)
         elif 'x' in mode:
-            handle = io.BufferedWriter(HadoopWriter(self, path, exclusive=True), buffer_size=buffer_size)
+            handle = io.BufferedWriter(HadoopWriter(self, path, exclusive=True, use_codec=use_codec), buffer_size=buffer_size)
 
         if 'b' in mode:
             return handle
@@ -55,15 +62,27 @@ class HadoopFS(FS):
 
 
 class HadoopReader(io.RawIOBase):
-    def __init__(self, hfs, path, buffer_size):
+    def __init__(self, hfs, path, buffer_size, use_codec=False):
         super(HadoopReader, self).__init__()
-        self._jfile = hfs._utils_package_object.readFile(hfs._jfs, path, buffer_size)
+        self._seekable = not use_codec
+        if use_codec:
+            self._jfile = hfs._utils_package_object.readFileCodec(hfs._jfs, path, buffer_size)
+        else:
+            self._jfile = hfs._utils_package_object.readFile(hfs._jfs, path, buffer_size)
 
     def close(self):
         self._jfile.close()
 
     def readable(self):
         return True
+
+    def seekable(self):
+        return self._seekable
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if whence != io.SEEK_SET:
+            raise io.UnsupportedOperation('only SEEK_SET is supported')
+        self._jfile.seek(offset)
 
     def readinto(self, b):
         b_from_java = self._jfile.read(len(b))
@@ -73,9 +92,12 @@ class HadoopReader(io.RawIOBase):
 
 
 class HadoopWriter(io.RawIOBase):
-    def __init__(self, hfs, path, exclusive=False):
-        self._jfile = hfs._utils_package_object.writeFile(hfs._jfs, path, exclusive)
+    def __init__(self, hfs, path, exclusive=False, use_codec=False):
         super(HadoopWriter, self).__init__()
+        if use_codec:
+            self._jfile = hfs._utils_package_object.writeFileCodec(hfs._jfs, path, exclusive)
+        else:
+            self._jfile = hfs._utils_package_object.writeFile(hfs._jfs, path, exclusive)
 
     def writable(self):
         return True

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -1,6 +1,7 @@
+from typing import Dict, List
+from hail.fs.hadoop_fs import HadoopFS
 from hail.utils.java import Env
 from hail.typecheck import typecheck, enumeration
-from typing import Dict, List
 
 
 @typecheck(path=str,
@@ -76,7 +77,11 @@ def hadoop_open(path: str, mode: str = 'r', buffer_size: int = 8192):
     -------
         Readable or writable file handle.
     """
-    return Env.fs().open(path, mode, buffer_size)
+    # legacy hack
+    fs = Env.fs()
+    if isinstance(fs, HadoopFS):
+        return fs.legacy_open(path, mode, buffer_size)
+    return fs.open(path, mode, buffer_size)
 
 
 @typecheck(src=str,

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -5,7 +5,7 @@ import java.io.{InputStream, OutputStream}
 import is.hail.HailContext
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.types.virtual.Type
-import is.hail.io.fs.{FS, FileStatus}
+import is.hail.io.fs.{FS, FileStatus, SeekableDataInputStream}
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
 
@@ -101,10 +101,19 @@ trait Py4jUtils {
     (n / factor.toDouble).formatted("%.1f")
   }
 
-  def readFile(fs: FS, path: String, buffSize: Int): HadoopPyReader =
+  def readFile(fs: FS, path: String, buffSize: Int): HadoopSeekablePyReader =
+    new HadoopSeekablePyReader(fs.openNoCompression(path), buffSize)
+
+  def readFileCodec(fs: FS, path: String, buffSize: Int): HadoopPyReader =
     new HadoopPyReader(fs.open(path), buffSize)
 
   def writeFile(fs: FS, path: String, exclusive: Boolean): HadoopPyWriter = {
+    if (exclusive && fs.exists(path))
+      fatal(s"a file already exists at '$path'")
+    new HadoopPyWriter(fs.createNoCompression(path))
+  }
+
+  def writeFileCodec(fs: FS, path: String, exclusive: Boolean): HadoopPyWriter = {
     if (exclusive && fs.exists(path))
       fatal(s"a file already exists at '$path'")
     new HadoopPyWriter(fs.create(path))
@@ -151,6 +160,10 @@ class HadoopPyReader(in: InputStream, buffSize: Int) {
   def close() {
     in.close()
   }
+}
+
+class HadoopSeekablePyReader(in: SeekableDataInputStream, buffSize: Int) extends HadoopPyReader(in, buffSize) {
+  def seek(pos: Long) = in.seek(pos)
 }
 
 class HadoopPyWriter(out: OutputStream) {


### PR DESCRIPTION
hadoop_open has a somewhat strange behavior, when the global fs is
HadoopFS, BGzip and Gzip files are handled transparently by file
extension, so python reads and writes uncompressed data. This is not the
case if the global fs is LocalFS or GoogleCloudStorageFS. We'd
eventually like to move away from this behavior for HadoopFS altogether,
but we cannot change the behavior of hadoop_open without breaking user
code.

To that end, rewrite HadoopFS.open to ignore codecs, and add legacy_open
to preserve the old behavior.

As a result of this, we also implement the seekable interface in python
for HadoopFS openend files.