### PR TITLE
[compiler] catch bad format exception

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -165,7 +165,7 @@ object UtilFunctions extends RegistryFunctions {
     String.format(f, args.toSeq.map(_.asInstanceOf[java.lang.Object]): _*)
   } catch {
     case e: IllegalFormatConversionException =>
-      fatal(s"Encountered invalid type for format string $f: format specifier ${e.getConversion} does not accept type ${e.getArgumentClass.getCanonicalName}", e)
+      fatal(s"Encountered invalid type for format string $f: format specifier ${e.getConversion} does not accept type ${e.getArgumentClass.getCanonicalName}")
   }
 
   def registerAll() {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,5 +1,7 @@
 package is.hail.expr.ir.functions
 
+import java.util.IllegalFormatConversionException
+
 import is.hail.asm4s.{coerce => _, _}
 import is.hail.expr.ir._
 import is.hail.types.physical.stypes._
@@ -159,8 +161,12 @@ object UtilFunctions extends RegistryFunctions {
 
   def intMax(a: IR, b: IR): IR = If(ApplyComparisonOp(GT(a.typ), a, b), a, b)
 
-  def format(f: String, args: Row): String =
+  def format(f: String, args: Row): String = try {
     String.format(f, args.toSeq.map(_.asInstanceOf[java.lang.Object]): _*)
+  } catch {
+    case e: IllegalFormatConversionException =>
+      fatal(s"Encountered invalid type for format string $f: format specifier ${e.getConversion} does not accept type ${e.getArgumentClass.getCanonicalName}", e)
+  }
 
   def registerAll() {
     val thisClass = getClass


### PR DESCRIPTION
When I test this, I get
```
FatalError: IllegalFormatConversionException: d != java.lang.String

Java stack trace:
is.hail.utils.HailException: Encountered invalid type for format string %d: format specifier d does not accept type java.lang.String
	at is.hail.utils.ErrorHandling.fatal(ErrorHandling.scala:15)
	at is.hail.utils.ErrorHandling.fatal$(ErrorHandling.scala:15)
	at is.hail.utils.package$.fatal(package.scala:78)
	at is.hail.expr.ir.functions.UtilFunctions$.format(UtilFunctions.scala:168)
	at __C12Compiled.__m15format(Emit.scala)
...

java.util.IllegalFormatConversionException: d != java.lang.String
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4302)
	at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2793)
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:2747)
	at java.util.Formatter.format(Formatter.java:2520)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at is.hail.expr.ir.functions.UtilFunctions$.format(UtilFunctions.scala:165)
	at __C12Compiled.__m15format(Emit.scala)
...




Hail version: 0.2.74-4d495f1c5e01
Error summary: IllegalFormatConversionException: d != java.lang.String
```

Why is the summary not the `HailException` string?