### PR TITLE
[query] Escaping field names that don't start with a letter

### DIFF
--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -138,7 +138,7 @@ def jiterable_to_list(it):
         return None
 
 
-_parsable_str = re.compile(r'[\w_]+')
+_parsable_str = re.compile(r'[a-zA-Z][\w_]+')
 
 
 def escape_parsable(s):

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -138,7 +138,7 @@ def jiterable_to_list(it):
         return None
 
 
-_parsable_str = re.compile(r'[a-zA-Z][\w_]+')
+_parsable_str = re.compile(r'[a-zA-Z][\w_]*')
 
 
 def escape_parsable(s):

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -138,7 +138,7 @@ def jiterable_to_list(it):
         return None
 
 
-_parsable_str = re.compile(r'[a-zA-Z][\w_]*')
+_parsable_str = re.compile(r'[_a-zA-Z][\w_]*')
 
 
 def escape_parsable(s):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1543,6 +1543,8 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(hl.str(1)), '1')
         self.assertEqual(hl.eval(hl.str(hl.missing('int32'))), None)
 
+    def test_missing_with_field_starting_with_number(self):
+        assert hl.eval(hl.missing(hl.tstruct(**{"1kg": hl.tint32}))) is None
 
     def check_expr(self, expr, expected, expected_type):
         self.assertEqual(expected_type, expr.dtype)


### PR DESCRIPTION
My understanding of this now is that we have to backtick-escape any identifiers that aren't going to be valid java/python identifiers. That means we have to change the regex that identifies those to only accept things that start with a letter.