### PR TITLE
[query] Removed Code[Unit] from several PTypes

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2155,8 +2155,8 @@ class Emit[C](
           cb.assign(tv, EmitCode.missing(cb.emb, errTuple))
           cb.assign(maybeMissingEV, ev)
         }, {
-          val str = EmitCode.fromI(mb)(cb => IEmitCode.present(cb, sst.constructFromString(cb, region, maybeException.invoke[String]("_1"))))
-          val errorId = EmitCode.fromI(mb)(cb =>
+          val str = EmitCode.fromI(cb.emb)(cb => IEmitCode.present(cb, sst.constructFromString(cb, region, maybeException.invoke[String]("_1"))))
+          val errorId = EmitCode.fromI(cb.emb)(cb =>
             IEmitCode.present(cb, primitive(maybeException.invoke[java.lang.Integer]("_2").invoke[Int]("intValue"))))
           cb.assign(tv, IEmitCode.present(cb, SStackStruct.constructFromArgs(cb, region, errTupleType, str, errorId)))
           cb.assign(maybeMissingEV, EmitCode.missing(cb.emb, ev.st))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2006,7 +2006,7 @@ class Emit[C](
           val rvAgg = agg.Extract.getAgg(sig(j))
           val fieldAddr = cb.newLocal(s"resultop_field_addr_$j", pt.fieldOffset(addr, j))
           rvAgg.storeResult(cb, sc.states(idx), pt.types(j), fieldAddr, region,
-            (cb: EmitCodeBuilder) => cb += pt.setFieldMissing(addr, j))
+            (cb: EmitCodeBuilder) => pt.setFieldMissing(cb, addr, j))
         }
 
         presentPC(pt.loadCheapSCode(cb, addr))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -952,7 +952,7 @@ class Emit[C](
           val elementSize = outputPType.elementByteSize
           val numElements = cb.newLocal[Int]("n_elements", n.intCode(cb))
           val arrayAddress = cb.newLocal[Long]("array_addr", outputPType.allocate(region, numElements))
-          cb += outputPType.stagedInitialize(arrayAddress, numElements)
+          outputPType.stagedInitialize(cb, arrayAddress, numElements)
           cb += Region.setMemory(outputPType.firstElementOffset(arrayAddress), numElements.toL * elementSize, 0.toByte)
           outputPType.loadCheapSCode(cb, arrayAddress)
         }
@@ -1625,7 +1625,7 @@ class Emit[C](
           cb.assign(An, (M * N).toI)
 
           cb.assign(IPIVaddr, IPIVptype.allocate(region, N.toI))
-          cb.append(IPIVptype.stagedInitialize(IPIVaddr, N.toI))
+          IPIVptype.stagedInitialize(cb, IPIVaddr, N.toI)
 
           val (aAadrFirstElement, finish) = ndPT.constructDataFunction(shapeArray, stridesArray, cb, region)
           cb.append(Region.copyFrom(dataFirstAddress,

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -803,7 +803,7 @@ class Emit[C](
       case x@UUID4(_) =>
         val pt = PCanonicalString()
         presentPC(pt.loadCheapSCode(cb, pt.
-          allocateAndStoreString(mb, region, Code.invokeScalaObject0[String](
+          allocateAndStoreString(cb, region, Code.invokeScalaObject0[String](
             Class.forName("is.hail.expr.ir.package$"), "uuid4"))))
       case x@Literal(t, v) =>
         presentPC(mb.addLiteral(v, typeWithReq))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1999,7 +1999,7 @@ class Emit[C](
         val pt = PCanonicalTuple(false, sig.map(_.pResultType): _*)
 
         val addr = cb.newLocal("resultop_tuple_addr", pt.allocate(region))
-        cb += pt.stagedInitialize(addr, setMissing = false)
+        pt.stagedInitialize(cb, addr, setMissing = false)
 
         (0 until aggs.length).foreach { j =>
           val idx = start + j

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -79,8 +79,8 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     f
   }
 
-  def memoize[T: TypeInfo](v: Code[T]): Value[T] = {
-    newLocal[T]("memoize", v)
+  def memoize[T: TypeInfo](v: Code[T], optionalName: String = ""): Value[T] = {
+    newLocal[T]("memoize" + optionalName, v)
   }
 
   def memoizeField[T: TypeInfo](v: Code[T]): Value[T] = {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStreamDistribute.scala
@@ -53,11 +53,11 @@ object EmitStreamDistribute {
       val splittersWasDuplicatedPType = PCanonicalArray(PBooleanRequired)
 
       val paddedSplittersAddr = cb.newLocal[Long]("stream_dist_splitters_addr", paddedSplittersPType.allocate(region, paddedSplittersSize))
-      cb += paddedSplittersPType.stagedInitialize(paddedSplittersAddr, paddedSplittersSize)
+      paddedSplittersPType.stagedInitialize(cb, paddedSplittersAddr, paddedSplittersSize)
 
       val splittersWasDuplicatedLength = paddedSplittersSize
       val splittersWasDuplicatedAddr = cb.newLocal[Long]("stream_dist_dupe_splitters_addr", splittersWasDuplicatedPType.allocate(region, splittersWasDuplicatedLength))
-      cb += splittersWasDuplicatedPType.stagedInitialize(splittersWasDuplicatedAddr, splittersWasDuplicatedLength)
+      splittersWasDuplicatedPType.stagedInitialize(cb, splittersWasDuplicatedAddr, splittersWasDuplicatedLength)
       val splitters: SIndexableValue = new SIndexablePointerCode(SIndexablePointer(paddedSplittersPType), paddedSplittersAddr).memoize(cb, "stream_distribute_splitters_deduplicated") // last element is duplicated, otherwise this is sorted without duplicates.
 
       val requestedSplittersIdx = cb.newLocal[Int]("stream_distribute_splitters_index")
@@ -95,7 +95,7 @@ object EmitStreamDistribute {
 
     def buildTree(paddedSplitters: SIndexableValue, treePType: PCanonicalArray): SIndexableValue = {
       val treeAddr = cb.newLocal[Long]("stream_dist_tree_addr", treePType.allocate(region, paddedSplittersSize))
-      cb += treePType.stagedInitialize(treeAddr, paddedSplittersSize)
+      treePType.stagedInitialize(cb, treeAddr, paddedSplittersSize)
 
       /*
       Walk through the array one level of the tree at a time, filling in the tree as you go to get a breadth
@@ -122,7 +122,7 @@ object EmitStreamDistribute {
       // in splitters list. Since We don't want many empty files, we need to make an array mapping output buckets to files.
       val fileMappingType = PCanonicalArray(PInt32Required)
       val fileMappingAddr = cb.newLocal("stream_dist_file_map_addr", fileMappingType.allocate(region, numberOfBuckets))
-      cb += fileMappingType.stagedInitialize(fileMappingAddr, numberOfBuckets)
+      fileMappingType.stagedInitialize(cb, fileMappingAddr, numberOfBuckets)
 
       val bucketIdx = cb.newLocal[Int]("stream_dist_bucket_idx")
       val currentFileToMapTo = cb.newLocal[Int]("stream_dist_mapping_cur_storage", 0)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -49,7 +49,7 @@ trait AggregatorState {
     val ob = cb.newLocal("aggstate_ser_to_region_ob", lazyBuffer.invoke[OutputBuffer]("buffer"))
     serialize(BufferSpec.defaultUncompressed)(cb, ob)
     cb.assign(addr, t.allocate(r, lazyBuffer.invoke[Int]("length")))
-    cb += t.storeLength(addr, lazyBuffer.invoke[Int]("length"))
+    t.storeLength(cb, addr, lazyBuffer.invoke[Int]("length"))
     cb += lazyBuffer.invoke[Long, Unit]("copyToAddress", t.bytesAddress(addr))
 
     t.loadCheapSCode(cb, addr)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -132,12 +132,12 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
   }
 
   def storeMissing(cb: EmitCodeBuilder): Unit = {
-    cb += storageType.setFieldMissing(off, 0)
+    storageType.setFieldMissing(cb, off, 0)
   }
 
   def storeNonmissing(cb: EmitCodeBuilder, sc: SCode): Unit = {
     cb += region.getNewRegion(const(regionSize))
-    cb += storageType.setFieldPresent(off, 0)
+    storageType.setFieldPresent(cb, off, 0)
     ptype.storeAtAddress(cb, storageType.fieldOffset(off, 0), region, sc, deepCopy = true)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -47,8 +47,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
   private def createNode(cb: EmitCodeBuilder, nodeBucket: Settable[Long]): Unit = {
     cb.assign(nodeBucket, region.allocate(storageType.alignment, storageType.byteSize))
-    cb += storageType.stagedInitialize(nodeBucket, true)
-    cb += elementsType.stagedInitialize(elements(nodeBucket), true)
+    storageType.stagedInitialize(cb, nodeBucket, true)
+    elementsType.stagedInitialize(cb, elements(nodeBucket), true)
   }
 
   private def isRoot(node: Code[Long]): Code[Boolean] = storageType.isFieldMissing(node, 0)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -62,11 +62,11 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
   private def hasKey(node: Code[Long], i: Int): Code[Boolean] = elementsType.isFieldDefined(elements(node), i)
 
   private def setKeyPresent(cb: EmitCodeBuilder, node: Code[Long], i: Int): Unit = {
-    cb += elementsType.setFieldPresent(elements(node), i)
+    elementsType.setFieldPresent(cb, elements(node), i)
   }
 
   private def setKeyMissing(cb: EmitCodeBuilder, node: Code[Long], i: Int): Unit = {
-    cb += elementsType.setFieldMissing(elements(node), i)
+    elementsType.setFieldMissing(cb, elements(node), i)
   }
 
   private def isFull(node: Code[Long]): Code[Boolean] = hasKey(node, maxElements - 1)
@@ -89,9 +89,9 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     val child = cb.newLocal[Long]("aobt_set_child_child", childC)
 
     if (i == -1)
-      cb += storageType.setFieldPresent(parent, 1)
+      storageType.setFieldPresent(cb, parent, 1)
     cb += Region.storeAddress(childOffset(parent, i), child)
-    cb += storageType.setFieldPresent(child, 0)
+    storageType.setFieldPresent(cb, child, 0)
     cb += Region.storeAddress(storageType.fieldOffset(child, 0), parent)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -54,7 +54,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
     cb.assign(aoff, arrayType.allocate(region, lenRef))
     cb += Region.storeAddress(typ.fieldOffset(off, 1), aoff)
     arrayType.stagedInitialize(cb, aoff, lenRef)
-    cb += typ.setFieldPresent(off, 1)
+    typ.setFieldPresent(cb, off, 1)
   }
 
   def seq(cb: EmitCodeBuilder, init: => Unit, initPerElt: => Unit, seqOp: => Unit): Unit = {
@@ -90,7 +90,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
     initOp(cb)
     initContainer.store(cb)
     if (initLen) {
-      cb += typ.setFieldMissing(off, 1)
+      typ.setFieldMissing(cb, off, 1)
     }
   }
 
@@ -137,7 +137,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
         initLen = false)
       cb.assign(lenRef, ib.readInt())
       cb.ifx(lenRef < 0, {
-        cb += typ.setFieldMissing(off, 1)
+        typ.setFieldMissing(cb, off, 1)
       }, {
         seq(cb, {
           nested.toCodeWithArgs(cb,
@@ -158,7 +158,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
 
     init(cb, cb => initContainer.copyFrom(cb, initOffset), initLen = false)
     cb.ifx(typ.isFieldMissing(srcOff, 1), {
-      cb += typ.setFieldMissing(off, 1)
+      typ.setFieldMissing(cb, off, 1)
       cb.assign(lenRef, -1)
     }, {
       cb.assign(lenRef, arrayType.loadLength(typ.loadField(srcOff, 1)))
@@ -251,7 +251,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
           state.nested.toCode { case (nestedIdx, nestedState) =>
             val nestedAddr = cb.newLocal[Long](s"arrayagg_result_nested_addr_$nestedIdx", resultEltType.fieldOffset(addrAtI, nestedIdx))
             nestedAggs(nestedIdx).storeResult(cb, nestedState, resultEltType.types(nestedIdx), nestedAddr, region,
-              (cb: EmitCodeBuilder) => cb += resultEltType.setFieldMissing(addrAtI, nestedIdx))
+              (cb: EmitCodeBuilder) => resultEltType.setFieldMissing(cb, addrAtI, nestedIdx))
           }
           state.store(cb)
           cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -53,7 +53,7 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
     cb += region.setNumParents((lenRef + 1) * nStates)
     cb.assign(aoff, arrayType.allocate(region, lenRef))
     cb += Region.storeAddress(typ.fieldOffset(off, 1), aoff)
-    cb += arrayType.stagedInitialize(aoff, lenRef)
+    arrayType.stagedInitialize(cb, aoff, lenRef)
     cb += typ.setFieldPresent(off, 1)
   }
 
@@ -240,7 +240,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
       ifMissing(cb),
       {
         val resultAddr = cb.newLocal[Long]("arrayagg_result_addr", resultType.allocate(region, len))
-        cb += resultType.stagedInitialize(resultAddr, len, setMissing = false)
+        resultType.stagedInitialize(cb, resultAddr, len, setMissing = false)
         val i = cb.newLocal[Int]("arrayagg_result_i", 0)
 
         cb.whileLoop(i < len, {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -245,7 +245,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
 
         cb.whileLoop(i < len, {
           val addrAtI = cb.newLocal[Long]("arrayagg_result_addr_at_i", resultType.elementOffset(resultAddr, len, i))
-          cb += resultEltType.stagedInitialize(addrAtI, setMissing = false)
+          resultEltType.stagedInitialize(cb, addrAtI, setMissing = false)
           cb.assign(state.idx, i)
           state.load(cb)
           state.nested.toCode { case (nestedIdx, nestedState) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -120,10 +120,10 @@ class CallStatsAggregator extends StagedAggregator {
           cb.assign(state.nAlleles, n)
           cb.assign(state.off, state.region.allocate(CallStatsState.stateType.alignment, CallStatsState.stateType.byteSize))
           cb.assign(addr, CallStatsState.callStatsInternalArrayType.allocate(state.region, n))
-          cb += CallStatsState.callStatsInternalArrayType.stagedInitialize(addr, n)
+          CallStatsState.callStatsInternalArrayType.stagedInitialize(cb, addr, n)
           cb += Region.storeAddress(state.alleleCountsOffset, addr)
           cb.assign(addr, CallStatsState.callStatsInternalArrayType.allocate(state.region, n))
-          cb += CallStatsState.callStatsInternalArrayType.stagedInitialize(addr, n)
+          CallStatsState.callStatsInternalArrayType.stagedInitialize(cb, addr, n)
           cb += Region.storeAddress(state.homCountsOffset, addr)
           cb.assign(i, 0)
           cb.whileLoop(i < n,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -195,7 +195,7 @@ class CallStatsAggregator extends StagedAggregator {
     acType.storeAtAddress(cb, rt.fieldOffset(addr, "AC"), region, ac, deepCopy = false)
 
     cb.ifx(alleleNumber.ceq(0),
-      cb += rt.setFieldMissing(addr, "AF"),
+      rt.setFieldMissing(cb, addr, "AF"),
       {
         val afType = resultType.fieldType("AF").asInstanceOf[PCanonicalArray]
         val af = afType.constructFromElements(cb, region, state.nAlleles, deepCopy = true) { (cb, i) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -180,7 +180,7 @@ class CallStatsAggregator extends StagedAggregator {
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     val rt = CallStatsState.resultType
     assert(pt == rt)
-    cb += rt.stagedInitialize(addr, setMissing = false)
+    rt.stagedInitialize(cb, addr, setMissing = false)
     val alleleNumber = cb.newLocal[Int]("callstats_result_alleleNumber", 0)
 
     val acType = resultType.fieldType("AC").asInstanceOf[PCanonicalArray]

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -25,19 +25,19 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
   def isEmpty(cb: EmitCodeBuilder, off: Code[Long]): Code[Boolean] = storageType.isFieldMissing(off, 1)
 
   def initializeEmpty(cb: EmitCodeBuilder, off: Code[Long]): Unit =
-    cb += storageType.setFieldMissing(off, 1)
+    storageType.setFieldMissing(cb, off, 1)
 
   def store(cb: EmitCodeBuilder, destc: Code[Long], k: EmitCode): Unit = {
     val dest = cb.newLocal("casa_store_dest", destc)
 
-    cb += storageType.setFieldPresent(dest, 1)
+    storageType.setFieldPresent(cb, dest, 1)
     k.toI(cb)
       .consume(cb,
         {
-          cb += storageType.setFieldMissing(dest, 0)
+          storageType.setFieldMissing(cb, dest, 0)
         },
         { sc =>
-          cb += storageType.setFieldPresent(dest, 0)
+          storageType.setFieldPresent(cb, dest, 0)
           typ.storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)
         })
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -82,7 +82,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
   def init(cb: EmitCodeBuilder, _maxSize: Code[Int]): Unit = {
     cb.assign(length, _maxSize)
     cb.assign(arrayAddr, arrayStorageType.allocate(region, length))
-    cb += arrayStorageType.stagedInitialize(arrayAddr, length, setMissing = true)
+    arrayStorageType.stagedInitialize(cb, arrayAddr, length, setMissing = true)
   }
 
   private def gc(cb: EmitCodeBuilder): Unit = {
@@ -104,7 +104,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
         { sc =>
           val arr = sc.memoize(cb, "densify_seq_arr")
           arr.asInstanceOf[SIndexableValue].forEachDefined(cb) { case (cb, idx, element) =>
-            cb += arrayStorageType.setElementPresent(arrayAddr, idx)
+            arrayStorageType.setElementPresent(cb, arrayAddr, idx)
             eltType.storeAtAddress(cb, arrayStorageType.elementOffset(arrayAddr, length, idx), region, element, deepCopy = true)
           }
         })
@@ -115,7 +115,7 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
     assert(other.arrayStorageType == this.arrayStorageType)
     val arr = arrayStorageType.loadCheapSCode(cb, other.arrayAddr).memoize(cb, "densify_comb_other")
     arr.asInstanceOf[SIndexableValue].forEachDefined(cb) { case (cb, idx, element) =>
-      cb += arrayStorageType.setElementPresent(arrayAddr, idx)
+      arrayStorageType.setElementPresent(cb, arrayAddr, idx)
       eltType.storeAtAddress(cb, arrayStorageType.elementOffset(arrayAddr, length, idx), region, element, deepCopy = true)
     }
     gc(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -464,9 +464,9 @@ class DownsampleState(val kb: EmitClassBuilder[_], labelType: VirtualTypeWithReq
         pointType.fieldType("y").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "y"), region, y, deepCopy = true)
         l.toI(cb)
           .consume(cb,
-            cb += pointType.setFieldMissing(pointStaging, "label"),
+            pointType.setFieldMissing(cb, pointStaging, "label"),
             { sc =>
-              cb += pointType.setFieldPresent(pointStaging, "label")
+              pointType.setFieldPresent(cb, pointStaging, "label")
               pointType.fieldType("label").storeAtAddress(cb, pointType.fieldOffset(pointStaging, "label"), region, sc, deepCopy = true)
             }
           )

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -51,10 +51,10 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
     k.toI(cb)
       .consume(cb,
         {
-          cb += storageType.setFieldMissing(dest, 0)
+          storageType.setFieldMissing(cb, dest, 0)
         },
         { sc =>
-          cb += storageType.setFieldPresent(dest, 0)
+          storageType.setFieldPresent(cb, dest, 0)
           storageType.fieldType("kt")
             .storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)
         })
@@ -295,7 +295,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
       val addrAtI = cb.newLocal[Long]("groupedagg_result_addr_at_i", arrayRep.elementOffset(resultAddr, len, i))
       cb += dictElt.stagedInitialize(addrAtI, setMissing = false)
       k.toI(cb).consume(cb,
-        cb += dictElt.setFieldMissing(addrAtI, "key"),
+        dictElt.setFieldMissing(cb, addrAtI, "key"),
         { sc =>
           dictElt.fieldType("key").storeAtAddress(cb, dictElt.fieldOffset(addrAtI, "key"), region, sc, deepCopy = true)
         })
@@ -305,7 +305,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
       state.nested.toCode { case (nestedIdx, nestedState) =>
         val nestedAddr = cb.newLocal[Long](s"groupedagg_result_nested_addr_$nestedIdx", resultEltType.fieldOffset(valueAddr, nestedIdx))
         nestedAggs(nestedIdx).storeResult(cb, nestedState, resultEltType.types(nestedIdx), nestedAddr, region,
-          (cb: EmitCodeBuilder) => cb += resultEltType.setFieldMissing(valueAddr, nestedIdx))
+          (cb: EmitCodeBuilder) => resultEltType.setFieldMissing(cb, valueAddr, nestedIdx))
 
       }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -288,7 +288,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
 
     val len = state.size
     val resultAddr = cb.newLocal[Long]("groupedagg_result_addr", resultType.allocate(region, len))
-    cb += arrayRep.stagedInitialize(resultAddr, len, setMissing = false)
+    arrayRep.stagedInitialize(cb, resultAddr, len, setMissing = false)
     val i = cb.newLocal[Int]("groupedagg_result_i", 0)
 
     state.foreach(cb) { (cb, k) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -293,7 +293,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
 
     state.foreach(cb) { (cb, k) =>
       val addrAtI = cb.newLocal[Long]("groupedagg_result_addr_at_i", arrayRep.elementOffset(resultAddr, len, i))
-      cb += dictElt.stagedInitialize(addrAtI, setMissing = false)
+      dictElt.stagedInitialize(cb, addrAtI, setMissing = false)
       k.toI(cb).consume(cb,
         dictElt.setFieldMissing(cb, addrAtI, "key"),
         { sc =>
@@ -301,7 +301,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
         })
 
       val valueAddr = cb.newLocal[Long]("groupedagg_value_addr", dictElt.fieldOffset(addrAtI, "value"))
-      cb += resultEltType.stagedInitialize(valueAddr, setMissing = false)
+      resultEltType.stagedInitialize(cb, valueAddr, setMissing = false)
       state.nested.toCode { case (nestedIdx, nestedState) =>
         val nestedAddr = cb.newLocal[Long](s"groupedagg_result_nested_addr_$nestedIdx", resultEltType.fieldOffset(valueAddr, nestedIdx))
         nestedAggs(nestedIdx).storeResult(cb, nestedState, resultEltType.types(nestedIdx), nestedAddr, region,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -147,7 +147,7 @@ class ImputeTypeAggregator() extends StagedAggregator {
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     val rt = ImputeTypeState.resultType
     assert(pt == rt)
-    cb += rt.stagedInitialize(addr, setMissing = false)
+    rt.stagedInitialize(cb, addr, setMissing = false)
     Array(state.getAnyNonMissing, state.getAllDefined, state.getSupportsBool,
       state.getSupportsI32, state.getSupportsI64, state.getSupportsF64)
       .zipWithIndex.foreach { case (b, idx) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -107,8 +107,8 @@ class LinearRegressionAggregator() extends StagedAggregator {
         .concat(") of covariates, inclusive"))
     )
     cb.assign(state.off, stateType.allocate(state.region))
-    cb += Region.storeAddress(stateType.fieldOffset(state.off, 0), vector.zeroes(cb.emb, state.region, k))
-    cb += Region.storeAddress(stateType.fieldOffset(state.off, 1), vector.zeroes(cb.emb, state.region, k * k))
+    cb += Region.storeAddress(stateType.fieldOffset(state.off, 0), vector.zeroes(cb, state.region, k))
+    cb += Region.storeAddress(stateType.fieldOffset(state.off, 1), vector.zeroes(cb, state.region, k * k))
     cb += Region.storeInt(stateType.loadField(state.off, 2), k0)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -44,7 +44,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
         statePV.loadField(cb, ndarrayFieldNumber).consume(cb,
           {
             cb += state.region.getNewRegion(Region.TINY)
-            cb += state.storageType.setFieldPresent(state.off, ndarrayFieldNumber)
+            state.storageType.setFieldPresent(cb, state.off, ndarrayFieldNumber)
             val tempRegionForCreation = cb.newLocal[Region]("ndarray_sum_agg_temp_region", Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
             val fullyCopiedNDArray = ndTyp.constructByActuallyCopyingData(nextNDPV, cb, tempRegionForCreation).memoize(cb, "ndarray_sum_seq_op_full_copy")
             state.storeNonmissing(cb, fullyCopiedNDArray)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -89,7 +89,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
 
 
   def append(cb: EmitCodeBuilder, elt: SCode, deepCopy: Boolean = true): Unit = {
-    cb += eltArray.setElementPresent(data, size)
+    eltArray.setElementPresent(cb, data, size)
     eltType.storeAtAddress(cb, eltArray.elementOffset(data, capacity, size), region, elt, deepCopy)
     incrementSize(cb)
   }
@@ -99,12 +99,10 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
   def initialize(cb: EmitCodeBuilder): Unit = initialize(cb, const(0), const(initialCapacity))
 
   private def initialize(cb: EmitCodeBuilder, _size: Code[Int], _capacity: Code[Int]): Unit = {
-    cb += Code(
-      size := _size,
-      capacity := _capacity,
-      data := eltArray.allocate(region, capacity),
-      eltArray.stagedInitialize(data, capacity, setMissing = true)
-    )
+    cb.assign(size, _size)
+    cb.assign(capacity, _capacity)
+    cb.assign(data, eltArray.allocate(region, capacity))
+    eltArray.stagedInitialize(cb, data, capacity, setMissing = true)
   }
 
   def elementOffset(idx: Value[Int]): Code[Long] = eltArray.elementOffset(data, capacity, idx)
@@ -121,7 +119,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
       {
         cb.assign(capacity, capacity * 2)
         cb.assign(newDataOffset, eltArray.allocate(region, capacity))
-        cb += eltArray.stagedInitialize(newDataOffset, capacity, setMissing = true)
+        eltArray.stagedInitialize(cb, newDataOffset, capacity, setMissing = true)
         cb += Region.copyFrom(data + eltArray.lengthHeaderBytes, newDataOffset + eltArray.lengthHeaderBytes, eltArray.nMissingBytes(size).toL)
         cb += Region.copyFrom(data + eltArray.elementsOffset(size),
           newDataOffset + eltArray.elementsOffset(capacity.load()),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -111,7 +111,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     initWithCapacity(cb, r, defaultBlockCap)
 
   private def pushNewBlockNode(cb: EmitCodeBuilder, r: Value[Region], cap: Code[Int]): Unit = {
-    val newNode = cb.emb.newLocal[Long]()
+    val newNode = cb.newLocal[Long]("sbll_push_new_block_node")
     allocateNode(cb, newNode)(r, cap)
     setNext(cb, lastNode, newNode)
     cb.assign(lastNode, newNode)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -90,7 +90,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
   }
 
   private def pushMissing(cb: EmitCodeBuilder, n: Node): Unit = {
-    bufferType.setElementMissing(cb, count(n), buffer(n))
+    bufferType.setElementMissing(cb, buffer(n), count(n))
     incrCount(cb, n)
   }
 
@@ -254,7 +254,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
       other.foreach(cb) { (cb, elt) =>
         elt.toI(cb)
           .consume(cb,
-            bufferType.setElementMissing(cb, i, buf),
+            bufferType.setElementMissing(cb, buf, i),
             { sc =>
               bufferType.setElementPresent(cb, buf, i)
               elemType.storeAtAddress(cb, bufferType.elementOffset(buf, i), r, sc, deepCopy = true)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -311,10 +311,10 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     k.toI(cb)
       .consume(cb,
         {
-          cb += indexedKeyType.setFieldMissing(keyStage, 0)
+          indexedKeyType.setFieldMissing(cb, keyStage, 0)
         },
         { sc =>
-          cb += indexedKeyType.setFieldPresent(keyStage, 0)
+          indexedKeyType.setFieldPresent(cb, keyStage, 0)
           keyType.storeAtAddress(cb, indexedKeyType.fieldOffset(keyStage, 0), region, sc, deepCopy = false)
         }
       )
@@ -334,10 +334,10 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     value.toI(cb)
       .consume(cb,
         {
-          cb += eltTuple.setFieldMissing(staging, 1)
+          eltTuple.setFieldMissing(cb, staging, 1)
         },
         { v =>
-          cb += eltTuple.setFieldPresent(staging, 1)
+          eltTuple.setFieldPresent(cb, staging, 1)
           valueType.storeAtAddress(cb, eltTuple.fieldOffset(staging, 1), region, v, deepCopy = false)
         })
   }

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -120,7 +120,7 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
     cb.assign(len, 0)
   }
 
-  def storeLength(cb: EmitCodeBuilder): Unit = arrayType.storeLength(cb, length, aoff)
+  def storeLength(cb: EmitCodeBuilder): Unit = arrayType.storeLength(cb, aoff, length)
 
   def setFieldValue(cb: EmitCodeBuilder, name: String, field: SCode): Unit = {
     cb += eltType.setFieldPresent(elt.a, name)

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -123,13 +123,13 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
   def storeLength(cb: EmitCodeBuilder): Unit = arrayType.storeLength(cb, aoff, length)
 
   def setFieldValue(cb: EmitCodeBuilder, name: String, field: SCode): Unit = {
-    cb += eltType.setFieldPresent(elt.a, name)
+    eltType.setFieldPresent(cb, elt.a, name)
     eltType.fieldType(name).storeAtAddress(cb, eltType.fieldOffset(elt.a, name), region, field, deepCopy = true)
   }
 
   def setField(cb: EmitCodeBuilder, name: String, v: => IEmitCode): Unit =
     v.consume(cb,
-      cb += eltType.setFieldMissing(elt.a, name),
+      eltType.setFieldMissing(cb, elt.a, name),
       setFieldValue(cb, name, _))
 
   def addChild(cb: EmitCodeBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -115,12 +115,12 @@ class IndexWriterArrayBuilder(name: String, maxSize: Int, sb: SettableBuilder, r
 
   def create(cb: EmitCodeBuilder, dest: Code[Long]): Unit = {
     cb.assign(aoff, arrayType.allocate(region, maxSize))
-    cb += arrayType.stagedInitialize(aoff, maxSize)
+    arrayType.stagedInitialize(cb, aoff, maxSize)
     arrayType.storeAtAddress(cb, dest, region, arrayType.loadCheapSCode(cb, aoff), deepCopy = false)
     cb.assign(len, 0)
   }
 
-  def storeLength(cb: EmitCodeBuilder): Unit = cb += arrayType.storeLength(aoff, length)
+  def storeLength(cb: EmitCodeBuilder): Unit = arrayType.storeLength(cb, length, aoff)
 
   def setFieldValue(cb: EmitCodeBuilder, name: String, field: SCode): Unit = {
     cb += eltType.setFieldPresent(elt.a, name)

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -97,7 +97,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
 
     val len = cb.newLocal[Int]("len", in.readInt())
     val array = cb.newLocal[Long]("array", arrayType.allocate(region, len))
-    cb += arrayType.storeLength(array, len)
+    arrayType.storeLength(cb, len, array)
 
     val i = cb.newLocal[Int]("i")
     val readElemF = elementType.buildInplaceDecoder(arrayType.elementType, cb.emb.ecb)

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -97,7 +97,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
 
     val len = cb.newLocal[Int]("len", in.readInt())
     val array = cb.newLocal[Long]("array", arrayType.allocate(region, len))
-    arrayType.storeLength(cb, len, array)
+    arrayType.storeLength(cb, array, len)
 
     val i = cb.newLocal[Int]("i")
     val readElemF = elementType.buildInplaceDecoder(arrayType.elementType, cb.emb.ecb)

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -149,12 +149,12 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
         if (f.typ.required) {
           readElemF(cb, region, rFieldAddr, in)
           if (!rf.typ.required)
-            cb += structType.setFieldPresent(addr, rf.index)
+            structType.setFieldPresent(cb, addr, rf.index)
         } else {
           cb.ifx(Region.loadBit(mbytes, const(missingIdx(f.index).toLong)), {
-            cb += structType.setFieldMissing(addr, rf.index)
+            structType.setFieldMissing(cb, addr, rf.index)
           }, {
-            cb += structType.setFieldPresent(addr, rf.index)
+            structType.setFieldPresent(cb, addr, rf.index)
             readElemF(cb, region, rFieldAddr, in)
           })
         }

--- a/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
@@ -47,10 +47,10 @@ class EBinary(override val required: Boolean) extends EType {
       case SBinaryPointer(t) => t
     }
 
-    val bT = pt.asInstanceOf[PBinary]
+    val bT = pt
     val len = cb.newLocal[Int]("len", in.readInt())
     val barray = cb.newLocal[Long]("barray", bT.allocate(region, len))
-    cb += bT.storeLength(barray, len)
+    bT.storeLength(cb, barray, len)
     cb += in.readBytes(region, bT.bytesAddress(barray), len)
     t1 match {
       case t: SStringPointer => new SStringPointerCode(t, barray)

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -118,9 +118,6 @@ trait PArrayBackedContainer extends PContainer {
   override def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long] =
     arrayRep.zeroes(cb, region, length)
 
-  override def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] =
-    arrayRep.forEach(mb, aoff, body)
-
   override def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean] =
     arrayRep.hasMissingValues(sourceOffset)
 

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -24,8 +24,8 @@ trait PArrayBackedContainer extends PContainer {
   override def loadLength(aoff: Code[Long]): Code[Int] =
     arrayRep.loadLength(aoff)
 
-  override def storeLength(aoff: Code[Long], length: Code[Int]): Code[Unit] =
-    arrayRep.storeLength(aoff, length)
+  override def storeLength(cb: EmitCodeBuilder, length: Code[Int], aoff: Code[Long]): Unit =
+    arrayRep.storeLength(cb, length, aoff)
 
   override def nMissingBytes(len: Code[Int]): Code[Int] =
     arrayRep.nMissingBytes(len)
@@ -51,15 +51,15 @@ trait PArrayBackedContainer extends PContainer {
   override def setElementMissing(aoff: Long, i: Int) =
     arrayRep.setElementMissing(aoff, i)
 
-  override def setElementMissing(aoff: Code[Long], i: Code[Int]): Code[Unit] =
-    arrayRep.setElementMissing(aoff, i)
+  override def setElementMissing(cb: EmitCodeBuilder, i: Code[Int], aoff: Code[Long]): Unit =
+    arrayRep.setElementMissing(cb, i, aoff)
 
   override def setElementPresent(aoff: Long, i: Int) {
       arrayRep.setElementPresent(aoff, i)
   }
 
-  override def setElementPresent(aoff: Code[Long], i: Code[Int]): Code[Unit] =
-    arrayRep.setElementPresent(aoff, i)
+  override def setElementPresent(cb: EmitCodeBuilder, aoff: Code[Long], i: Code[Int]): Unit =
+    arrayRep.setElementPresent(cb, aoff, i)
 
   override def firstElementOffset(aoff: Long, length: Int): Long =
     arrayRep.firstElementOffset(aoff, length)
@@ -109,14 +109,14 @@ trait PArrayBackedContainer extends PContainer {
   override def initialize(aoff: Long, length: Int, setMissing: Boolean = false) =
     arrayRep.initialize(aoff, length, setMissing)
 
-  override def stagedInitialize(aoff: Code[Long], length: Code[Int], setMissing: Boolean = false): Code[Unit] =
-    arrayRep.stagedInitialize(aoff, length, setMissing)
+  override def stagedInitialize(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int], setMissing: Boolean = false): Unit =
+    arrayRep.stagedInitialize(cb, aoff, length, setMissing)
 
   override def zeroes(region: Region, length: Int): Long =
     arrayRep.zeroes(region, length)
 
-  override def zeroes(mb: EmitMethodBuilder[_], region: Value[Region], length: Code[Int]): Code[Long] =
-    arrayRep.zeroes(mb, region, length)
+  override def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long] =
+    arrayRep.zeroes(cb, region, length)
 
   override def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] =
     arrayRep.forEach(mb, aoff, body)

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -24,8 +24,8 @@ trait PArrayBackedContainer extends PContainer {
   override def loadLength(aoff: Code[Long]): Code[Int] =
     arrayRep.loadLength(aoff)
 
-  override def storeLength(cb: EmitCodeBuilder, length: Code[Int], aoff: Code[Long]): Unit =
-    arrayRep.storeLength(cb, length, aoff)
+  override def storeLength(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int]): Unit =
+    arrayRep.storeLength(cb, aoff, length)
 
   override def nMissingBytes(len: Code[Int]): Code[Int] =
     arrayRep.nMissingBytes(len)
@@ -51,8 +51,8 @@ trait PArrayBackedContainer extends PContainer {
   override def setElementMissing(aoff: Long, i: Int) =
     arrayRep.setElementMissing(aoff, i)
 
-  override def setElementMissing(cb: EmitCodeBuilder, i: Code[Int], aoff: Code[Long]): Unit =
-    arrayRep.setElementMissing(cb, i, aoff)
+  override def setElementMissing(cb: EmitCodeBuilder, aoff: Code[Long], i: Code[Int]): Unit =
+    arrayRep.setElementMissing(cb, aoff, i)
 
   override def setElementPresent(aoff: Long, i: Int) {
       arrayRep.setElementPresent(aoff, i)

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -117,7 +117,7 @@ abstract class PBaseStruct extends PType {
 
   def initialize(structAddress: Long, setMissing: Boolean = false): Unit
 
-  def stagedInitialize(structAddress: Code[Long], setMissing: Boolean = false): Code[Unit]
+  def stagedInitialize(cb: EmitCodeBuilder, structAddress: Code[Long], setMissing: Boolean = false): Unit
 
   def isFieldDefined(offset: Long, fieldIdx: Int): Boolean
 

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -130,11 +130,11 @@ abstract class PBaseStruct extends PType {
 
   def setFieldMissing(offset: Long, fieldIdx: Int): Unit
 
-  def setFieldMissing(offset: Code[Long], fieldIdx: Int): Code[Unit]
+  def setFieldMissing(cb: EmitCodeBuilder, offset: Code[Long], fieldIdx: Int): Unit
 
   def setFieldPresent(offset: Long, fieldIdx: Int): Unit
 
-  def setFieldPresent(offset: Code[Long], fieldIdx: Int): Code[Unit]
+  def setFieldPresent(cb: EmitCodeBuilder, offset: Code[Long], fieldIdx: Int): Unit
 
   def fieldOffset(structAddress: Long, fieldIdx: Int): Long
 

--- a/hail/src/main/scala/is/hail/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBinary.scala
@@ -61,7 +61,7 @@ abstract class PBinary extends PType {
 
   def storeLength(boff: Long, len: Int): Unit
 
-  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit]
+  def storeLength(cb: EmitCodeBuilder, boff: Code[Long], len: Code[Int]): Unit
 
   def bytesAddress(boff: Long): Long
 
@@ -69,5 +69,5 @@ abstract class PBinary extends PType {
 
   def store(addr: Long, bytes: Array[Byte]): Unit
 
-  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit]
+  def store(cb: EmitCodeBuilder, addr: Code[Long], bytes: Code[Array[Byte]]): Unit
 }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -246,19 +246,6 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     aoff
   }
 
-  def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit] = {
-    val i = mb.newLocal[Int]()
-    val n = mb.newLocal[Int]()
-    Code(
-      n := loadLength(aoff),
-      i := 0,
-      Code.whileLoop(i < n,
-        isElementDefined(aoff, i).mux(
-          body(loadElement(aoff, n, i)),
-          Code._empty
-        )))
-  }
-
   override def unsafeOrdering(): UnsafeOrdering =
     unsafeOrdering(this)
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -103,9 +103,9 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     loadCheapSCode(cb, addr).get
   }
 
-  def constructAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] = {
+  def constructAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Unit = {
     val srcBinary = srcPType.asInstanceOf[PBinary]
-    Region.storeAddress(addr, constructOrCopy(cb, region, srcBinary, srcAddress, deepCopy))
+    cb += Region.storeAddress(addr, constructOrCopy(cb, region, srcBinary, srcAddress, deepCopy))
   }
 
   private def constructOrCopy(cb: EmitCodeBuilder, region: Value[Region], srcBinary: PBinary, srcAddress: Code[Long], deepCopy: Boolean): Code[Long] = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -89,8 +89,8 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
   }
 
   override def store(cb: EmitCodeBuilder, _addr: Code[Long], _bytes: Code[Array[Byte]]): Unit = {
-    val addr = cb.memoize(_addr)
-    val bytes = cb.memoize(_bytes)
+    val addr = cb.memoize(_addr, "pcanonical_binary_store_addr")
+    val bytes = cb.memoize(_bytes, "pcanonical_binary_store_bytes")
     cb += Region.storeInt(addr, bytes.length())
     cb += Region.storeBytes(bytesAddress(addr), bytes)
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -77,7 +77,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
 
   def storeLength(boff: Long, len: Int): Unit = Region.storeInt(boff, len)
 
-  def storeLength(boff: Code[Long], len: Code[Int]): Code[Unit] = Region.storeInt(boff, len)
+  def storeLength(cb: EmitCodeBuilder, boff: Code[Long], len: Code[Int]): Unit = cb += Region.storeInt(boff, len)
 
   def bytesAddress(boff: Long): Long = boff + lengthHeaderBytes
 
@@ -88,54 +88,49 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     Region.storeBytes(bytesAddress(addr), bytes)
   }
 
-  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] =
-    Code.memoize(addr, "pcbin_store_addr") { addr =>
-      Code.memoize(bytes, "pcbin_store_bytes") { bytes =>
-        Code(
-          Region.storeInt(addr, bytes.length),
-          Region.storeBytes(bytesAddress(addr), bytes))
-      }
-    }
+  override def store(cb: EmitCodeBuilder, _addr: Code[Long], _bytes: Code[Array[Byte]]): Unit = {
+    val addr = cb.memoize(_addr)
+    val bytes = cb.memoize(_bytes)
+    cb += Region.storeInt(addr, bytes.length())
+    cb += Region.storeBytes(bytesAddress(addr), bytes)
+  }
 
   def constructFromByteArray(cb: EmitCodeBuilder, region: Value[Region], bytes: Code[Array[Byte]]): SBinaryPointerCode = {
     val ba = cb.newLocal[Array[Byte]]("pcbin_ba", bytes)
     val len = cb.newLocal[Int]("pcbin_len", ba.length())
     val addr = cb.newLocal[Long]("pcbin_addr", allocate(region, len))
-    cb += store(addr, ba)
+    store(cb, addr, ba)
     loadCheapSCode(cb, addr).get
   }
 
-  def constructAtAddress(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] = {
+  def constructAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] = {
     val srcBinary = srcPType.asInstanceOf[PBinary]
-    Region.storeAddress(addr, constructOrCopy(mb, region, srcBinary, srcAddress, deepCopy))
+    Region.storeAddress(addr, constructOrCopy(cb, region, srcBinary, srcAddress, deepCopy))
   }
 
-  private def constructOrCopy(mb: EmitMethodBuilder[_], region: Value[Region], srcBinary: PBinary, srcAddress: Code[Long], deepCopy: Boolean): Code[Long] = {
+  private def constructOrCopy(cb: EmitCodeBuilder, region: Value[Region], srcBinary: PBinary, srcAddress: Code[Long], deepCopy: Boolean): Code[Long] = {
     if (srcBinary == this) {
       if (deepCopy) {
-        val srcAddrVar = mb.newLocal[Long]()
-        val len = mb.newLocal[Int]()
-        val newAddr = mb.newLocal[Long]()
-        Code(
-          srcAddrVar := srcAddress,
-          len := srcBinary.loadLength(srcAddrVar),
-          newAddr := allocate(region, len),
-          Region.copyFrom(srcAddrVar, newAddr, contentByteSize(len)),
-          newAddr)
+        val srcAddrVar = cb.newLocal[Long]("pcanonical_binary_construct_or_copy_src_addr")
+        val len = cb.newLocal[Int]("pcanonical_binary_construct_or_copy_len")
+        val newAddr = cb.newLocal[Long]("pcanonical_binary_construct_or_copy_new_addr")
+        cb.assign(srcAddrVar, srcAddress)
+        cb.assign(len, srcBinary.loadLength(srcAddrVar))
+        cb.assign(newAddr, allocate(region, len))
+        cb += Region.copyFrom(srcAddrVar, newAddr, contentByteSize(len))
+        newAddr
       } else
         srcAddress
     } else {
-      val srcAddrVar = mb.newLocal[Long]()
-      val len = mb.newLocal[Int]()
-      val newAddr = mb.newLocal[Long]()
-      Code(
-        srcAddrVar := srcAddress,
-        len := srcBinary.loadLength(srcAddrVar),
-        newAddr := allocate(region, len),
-        storeLength(newAddr, len),
-        Region.copyFrom(srcAddrVar + srcBinary.lengthHeaderBytes, newAddr + lengthHeaderBytes, len.toL),
-        newAddr
-      )
+      val srcAddrVar = cb.newLocal[Long]("pcanonical_binary_construct_or_copy_src_addr")
+      val len = cb.newLocal[Int]("pcanonical_binary_construct_or_copy_len")
+      val newAddr = cb.newLocal[Long]("pcanonical_binary_construct_or_copy_new_addr")
+      cb.assign(srcAddrVar, srcAddress)
+      cb.assign(len, srcBinary.loadLength(srcAddrVar))
+      cb.assign(newAddr, allocate(region, len))
+      storeLength(cb, newAddr, len)
+      cb += Region.copyFrom(srcAddrVar + srcBinary.lengthHeaderBytes, newAddr + lengthHeaderBytes, len.toL)
+      newAddr
     }
   }
 
@@ -154,7 +149,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
           val bv = value.asInstanceOf[SBinaryPointerCode].memoize(cb, "pcbin_store")
           val len = cb.newLocal[Int]("pcbinary_store_len", bv.loadLength())
           val newAddr = cb.newLocal[Long]("pcbinary_store_newaddr", allocate(region, len))
-          cb += storeLength(newAddr, len)
+          storeLength(cb, newAddr, len)
           cb += Region.copyFrom(bytesAddress(bv.a), bytesAddress(newAddr), len.toL)
           newAddr
         } else
@@ -163,7 +158,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
         val bv = value.asBinary.memoize(cb, "pcbin_store")
         val len = cb.newLocal[Int]("pcbinary_store_len", bv.loadLength())
         val newAddr = cb.newLocal[Long]("pcbinary_store_newaddr", allocate(region, len))
-        cb += storeLength(newAddr, len)
+        storeLength(cb, newAddr, len)
         cb += Region.storeBytes(bytesAddress(newAddr), bv.loadBytes())
         newAddr
     }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -45,14 +45,13 @@ class PCanonicalString(val required: Boolean) extends PString {
     dstAddrss
   }
 
-  def allocateAndStoreString(mb: EmitMethodBuilder[_], region: Value[Region], str: Code[String]): Code[Long] = {
-    val dstAddress = mb.genFieldThisRef[Long]()
-    val byteRep = mb.genFieldThisRef[Array[Byte]]()
-    Code(
-      byteRep := str.invoke[Array[Byte]]("getBytes"),
-      dstAddress := binaryRepresentation.allocate(region, byteRep.length),
-      binaryRepresentation.store(dstAddress, byteRep),
-      dstAddress)
+  def allocateAndStoreString(cb: EmitCodeBuilder, region: Value[Region], str: Code[String]): Code[Long] = {
+    val dstAddress = cb.newField[Long]("pcanonical_string_alloc_dst_address")
+    val byteRep = cb.newField[Array[Byte]]("pcanonical_string_alloc_byte_rep")
+    cb.assign(byteRep, str.invoke[Array[Byte]]("getBytes"))
+    cb.assign(dstAddress, binaryRepresentation.allocate(region, byteRep.length))
+    binaryRepresentation.store(cb, dstAddress, byteRep)
+    dstAddress
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
@@ -1,6 +1,7 @@
 package is.hail.types.physical
 
 import is.hail.asm4s.Code
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.{TStruct, Type}
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -85,11 +86,11 @@ final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean 
   def fieldOffset(offset: Code[Long], fieldName: String): Code[Long] =
     fieldOffset(offset, fieldIdx(fieldName))
 
-  def setFieldPresent(offset: Code[Long], field: String): Code[Unit] =
-    setFieldPresent(offset, fieldIdx(field))
+  def setFieldPresent(cb: EmitCodeBuilder, offset: Code[Long], field: String): Unit =
+    setFieldPresent(cb, offset, fieldIdx(field))
 
-  def setFieldMissing(offset: Code[Long], field: String): Code[Unit] =
-    setFieldMissing(offset, fieldIdx(field))
+  def setFieldMissing(cb: EmitCodeBuilder, offset: Code[Long], field: String): Unit =
+    setFieldMissing(cb, offset, fieldIdx(field))
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PStruct = {
     val ab = new BoxedArrayBuilder[PField](fields.length)

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -16,7 +16,7 @@ abstract class PContainer extends PIterable {
 
   def loadLength(aoff: Code[Long]): Code[Int]
 
-  def storeLength(cb: EmitCodeBuilder, length: Code[Int], aoff: Code[Long]): Unit
+  def storeLength(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int]): Unit
 
   def nMissingBytes(len: Code[Int]): Code[Int]
 
@@ -36,7 +36,7 @@ abstract class PContainer extends PIterable {
 
   def setElementMissing(aoff: Long, i: Int)
 
-  def setElementMissing(cb: EmitCodeBuilder, i: Code[Int], aoff: Code[Long]): Unit
+  def setElementMissing(cb: EmitCodeBuilder, aoff: Code[Long], i: Code[Int]): Unit
 
   def setElementPresent(aoff: Long, i: Int)
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -16,7 +16,7 @@ abstract class PContainer extends PIterable {
 
   def loadLength(aoff: Code[Long]): Code[Int]
 
-  def storeLength(aoff: Code[Long], length: Code[Int]): Code[Unit]
+  def storeLength(cb: EmitCodeBuilder, length: Code[Int], aoff: Code[Long]): Unit
 
   def nMissingBytes(len: Code[Int]): Code[Int]
 
@@ -36,11 +36,11 @@ abstract class PContainer extends PIterable {
 
   def setElementMissing(aoff: Long, i: Int)
 
-  def setElementMissing(aoff: Code[Long], i: Code[Int]): Code[Unit]
+  def setElementMissing(cb: EmitCodeBuilder, i: Code[Int], aoff: Code[Long]): Unit
 
   def setElementPresent(aoff: Long, i: Int)
 
-  def setElementPresent(aoff: Code[Long], i: Code[Int]): Code[Unit]
+  def setElementPresent(cb: EmitCodeBuilder, aoff: Code[Long], i: Code[Int]): Unit
 
   def firstElementOffset(aoff: Long, length: Int): Long
 
@@ -74,11 +74,11 @@ abstract class PContainer extends PIterable {
 
   def initialize(aoff: Long, length: Int, setMissing: Boolean = false)
 
-  def stagedInitialize(aoff: Code[Long], length: Code[Int], setMissing: Boolean = false): Code[Unit]
+  def stagedInitialize(cb: EmitCodeBuilder, aoff: Code[Long], length: Code[Int], setMissing: Boolean = false): Unit
 
   def zeroes(region: Region, length: Int): Long
 
-  def zeroes(mb: EmitMethodBuilder[_], region: Value[Region], length: Code[Int]): Code[Long]
+  def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long]
 
   def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit]
 

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -80,8 +80,6 @@ abstract class PContainer extends PIterable {
 
   def zeroes(cb: EmitCodeBuilder, region: Value[Region], length: Code[Int]): Code[Long]
 
-  def forEach(mb: EmitMethodBuilder[_], aoff: Code[Long], body: Code[Long] => Code[Unit]): Code[Unit]
-
   def hasMissingValues(sourceOffset: Code[Long]): Code[Boolean]
 
   def nextElementAddress(currentOffset: Long): Long

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -24,5 +24,5 @@ abstract class PString extends PType {
 
   def allocateAndStoreString(region: Region, str: String): Long
 
-  def allocateAndStoreString(mb: EmitMethodBuilder[_], region: Value[Region], str: Code[String]): Code[Long]
+  def allocateAndStoreString(cb: EmitCodeBuilder, region: Value[Region], str: Code[String]): Code[Long]
 }

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -48,9 +48,9 @@ trait PStruct extends PBaseStruct {
 
   def fieldOffset(offset: Code[Long], fieldName: String): Code[Long]
 
-  def setFieldPresent(offset: Code[Long], fieldName: String): Code[Unit]
+  def setFieldPresent(cb: EmitCodeBuilder, offset: Code[Long], fieldName: String): Unit
 
-  def setFieldMissing(offset: Code[Long], fieldName: String): Code[Unit]
+  def setFieldMissing(cb: EmitCodeBuilder, offset: Code[Long], fieldName: String): Unit
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PStruct
 

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -97,8 +97,8 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   override def initialize(structAddress: Long, setMissing: Boolean): Unit =
     ps.initialize(structAddress, setMissing)
 
-  override def stagedInitialize(structAddress: Code[Long], setMissing: Boolean): Code[Unit] =
-    ps.stagedInitialize(structAddress, setMissing)
+  override def stagedInitialize(cb: EmitCodeBuilder, structAddress: Code[Long], setMissing: Boolean): Unit =
+    ps.stagedInitialize(cb, structAddress, setMissing)
 
   def allocate(region: Region): Long =
     ps.allocate(region)

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -80,17 +80,17 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   override def loadField(structAddress: Code[Long], fieldIdx: Int): Code[Long] =
     ps.loadField(structAddress, idxMap(fieldIdx))
 
-  override def setFieldPresent(structAddress: Code[Long], fieldName: String): Code[Unit] = ???
+  override def setFieldPresent(cb: EmitCodeBuilder, structAddress: Code[Long], fieldName: String): Unit = ???
 
-  override def setFieldMissing(structAddress: Code[Long], fieldName: String): Code[Unit] = ???
+  override def setFieldMissing(cb: EmitCodeBuilder, structAddress: Code[Long], fieldName: String): Unit = ???
 
   override def setFieldMissing(structAddress: Long, fieldIdx: Int): Unit = ???
 
-  override def setFieldMissing(structAddress: Code[Long], fieldIdx: Int): Code[Unit] = ???
+  override def setFieldMissing(cb: EmitCodeBuilder, structAddress: Code[Long], fieldIdx: Int): Unit = ???
 
   override def setFieldPresent(structAddress: Long, fieldIdx: Int): Unit = ???
 
-  override def setFieldPresent(structAddress: Code[Long], fieldIdx: Int): Code[Unit] = ???
+  override def setFieldPresent(cb: EmitCodeBuilder, structAddress: Code[Long], fieldIdx: Int): Unit = ???
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PSubsetStruct = ???
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -20,9 +20,6 @@ trait PUnrealizable extends PType {
   override def copyFromAddress(region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Long =
     unsupported
 
-  def constructAtAddress(mb: EmitMethodBuilder[_], addr: Code[Long], region: Value[Region], srcPType: PType, srcAddress: Code[Long], deepCopy: Boolean): Code[Unit] =
-    unsupported
-
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit =
     unsupported
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -102,10 +102,4 @@ class SBinaryPointerCode(val st: SBinaryPointer, val a: Code[Long]) extends SBin
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SBinaryPointerValue =
     memoize(cb, cb.fieldBuilder, name)
-
-  def store(mb: EmitMethodBuilder[_], r: Value[Region], dst: Code[Long]): Code[Unit] = {
-    EmitCodeBuilder.scopedVoid(mb) { cb =>
-      pt.storeAtAddress(cb, dst, r, this, false)
-    }
-  }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -162,7 +162,5 @@ class SCanonicalCallCode(val call: Code[Int]) extends SCallCode {
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SCanonicalCallValue = memoize(cb, name, cb.fieldBuilder)
 
-  def store(mb: EmitMethodBuilder[_], r: Value[Region], dst: Code[Long]): Code[Unit] = Region.storeInt(dst, call)
-
   def loadCanonicalRepresentation(cb: EmitCodeBuilder): Code[Int] = call
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -125,7 +125,5 @@ class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Lon
 
   def memoizeField(cb: EmitCodeBuilder, name: String): SCanonicalLocusPointerSettable = memoize(cb, name, cb.fieldBuilder)
 
-  def store(mb: EmitMethodBuilder[_], r: Value[Region], dst: Code[Long]): Code[Unit] = Region.storeAddress(dst, a)
-
   def structRepr(cb: EmitCodeBuilder): SBaseStructCode = new SBaseStructPointerCode(SBaseStructPointer(st.pType.representation), a)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -37,7 +37,7 @@ final case class SStringPointer(pType: PString) extends SString {
   }
 
   override def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringPointerCode = {
-    new SStringPointerCode(this, pType.allocateAndStoreString(cb.emb, r, s))
+    new SStringPointerCode(this, pType.allocateAndStoreString(cb, r, s))
   }
 
   override def storageType(): PType = pType

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -23,16 +23,16 @@ class TestBTreeKey(mb: EmitMethodBuilder[_]) extends BTreeKey {
   def isEmpty(cb: EmitCodeBuilder, off: Code[Long]): Code[Boolean] =
     storageType.isFieldMissing(off, 1)
   def initializeEmpty(cb: EmitCodeBuilder, off: Code[Long]): Unit =
-    cb += storageType.setFieldMissing(off, 1)
+    storageType.setFieldMissing(cb, off, 1)
 
-  def storeKey(cb: EmitCodeBuilder, off: Code[Long], m: Code[Boolean], v: Code[Long]): Unit =
-    cb += Code.memoize(off, "off") { off =>
-      Code(
-        storageType.stagedInitialize(off),
-        m.mux(
-          storageType.setFieldMissing(off, 0),
-          Region.storeLong(storageType.fieldOffset(off, 0), v)))
-    }
+  def storeKey(cb: EmitCodeBuilder, _off: Code[Long], m: Code[Boolean], v: Code[Long]): Unit = {
+    val off = cb.memoize[Long](_off)
+    cb += storageType.stagedInitialize(off)
+    cb.ifx(m,
+      storageType.setFieldMissing(cb, off, 0),
+      cb += Region.storeLong(storageType.fieldOffset(off, 0), v)
+    )
+  }
 
   def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
     cb += Region.copyFrom(src, dest, storageType.byteSize)

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -27,7 +27,7 @@ class TestBTreeKey(mb: EmitMethodBuilder[_]) extends BTreeKey {
 
   def storeKey(cb: EmitCodeBuilder, _off: Code[Long], m: Code[Boolean], v: Code[Long]): Unit = {
     val off = cb.memoize[Long](_off)
-    cb += storageType.stagedInitialize(off)
+    storageType.stagedInitialize(cb, off)
     cb.ifx(m,
       storageType.setFieldMissing(cb, off, 0),
       cb += Region.storeLong(storageType.fieldOffset(off, 0), v)

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -30,7 +30,7 @@ class TakeByAggregatorSuite extends HailSuite {
           cb += (i := 0L)
           cb.whileLoop(i < n.toLong, {
             cb += argR.invoke[Unit]("clear")
-            cb += (off := stringPT.allocateAndStoreString(fb.apply_method, argR, const("str").concat(i.toS)))
+            cb.assign(off, stringPT.allocateAndStoreString(cb, argR, const("str").concat(i.toS)))
             tba.seqOp(cb, false, off, false, -i)
             cb += (i := i + 1L)
           })


### PR DESCRIPTION
Starting to remove `Code[Unit]` from `PType` methods in `PContainer`, `PBinary`, `PString`, `PBaseStruct`