### PR TITLE
[compiler] Use a UUID prefix instead of a suffix for partfiles

### DIFF
--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -595,13 +595,11 @@ package object utils extends Logging
     "part-" + StringUtils.leftPad(is, numDigits, "0")
   }
 
-  def partSuffix(ctx: TaskContext): String = {
-    val rng = new java.security.SecureRandom()
-    val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-    s"${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
-  }
+  def partSuffix(ctx: TaskContext): String =
+    s"${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }"
 
-  def partFile(d: Int, i: Int, ctx: TaskContext): String = s"${ partFile(d, i) }-${ partSuffix(ctx) }"
+  def partFile(d: Int, i: Int, ctx: TaskContext): String =
+    s"${ java.util.UUID.randomUUID() }-${ partFile(d, i) }-${ partSuffix(ctx) }"
 
   def mangle(strs: Array[String], formatter: Int => String = "_%d".format(_)): (Array[String], Array[(String, String)]) = {
     val b = new BoxedArrayBuilder[String]


### PR DESCRIPTION
Google Cloud Storage documentation and [best practices] for object names
recommends avoiding sequential names like 'part-0nnnn'. We already use
UUIDs for randomness to avoid two tasks writing to the exact same
object, but by using the UUID as a prefix rather than a suffix we
(to a degree) uniformly distribute part file names over a range,
(hopefully) improving throughput.

[best practices]: https://cloud.google.com/storage/docs/best-practices#naming