### PR TITLE
[infra] Add tf resources for gateways and container registry

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -105,7 +105,7 @@ You can now install Hail:
   ssh forwarding rule to the default network.
 
 - Standardize file permissions.  This is for docker, which considers
-  permissions for caching.  Run `echo 'umask 022' > ~/.profile`.  You
+  permissions for caching.  Run `echo 'umask 022' >> ~/.profile`.  You
   will need to log out/in or run `umask 022`.
 
 - Clone the Hail Github repository:

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -35,7 +35,7 @@ and client secret credentials from another developer who has them, or reset
 them. Either to create the service principal or reset it, run the following
 
 ```
-az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/${ARM_SUBSCRIPTION_ID}" --name="terraform-principal" > terraform_principal.json
+az ad sp create-for-rbac --role="Owner" --scopes="/subscriptions/${ARM_SUBSCRIPTION_ID}" --name="terraform-principal" > terraform_principal.json
 ```
 
 Note: Your developer Azure account must be an owner of the terraform service principal.
@@ -109,12 +109,14 @@ Next, create a `global.tfvars` file from the following template and replace in t
 
 ```
 az_resource_group_name = "<resource_group_name>"
+acr_name               = "<azure_container_registry_name>"
 ```
 
-Run `terraform apply -var-file=global.tfvars`. To sync the kubernetes config, run
+Run `terraform apply -var-file=global.tfvars`. To sync the kubernetes config and login with docker, run
 
 ```
 az aks get-credentials --name vdc --resource-group $AZ_RESOURCE_GROUP_NAME
+az acr login --name <aczure_container_registry_name>
 ```
 
 you can now use `kubectl` to communicate with AKS cluster.

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -109,14 +109,16 @@ Next, create a `global.tfvars` file from the following template and replace in t
 
 ```
 az_resource_group_name = "<resource_group_name>"
+# Omit this field to have the container registry name default to the resource group name
 acr_name               = "<azure_container_registry_name>"
 ```
 
-Run `terraform apply -var-file=global.tfvars`. To sync the kubernetes config and login with docker, run
+Run `terraform apply -var-file=global.tfvars`. To sync the kubernetes config and authenticate
+docker with the container registry, run
 
 ```
 az aks get-credentials --name vdc --resource-group $AZ_RESOURCE_GROUP_NAME
-az acr login --name <aczure_container_registry_name>
+az acr login --name <azure_container_registry_name>
 ```
 
 you can now use `kubectl` to communicate with AKS cluster.

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.70.0"
+      version = "=2.74.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -21,10 +21,10 @@ data "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_virtual_network" "default" {
-  name = "default"
+  name                = "default"
   resource_group_name = data.azurerm_resource_group.rg.name
-  address_space = ["10.0.0.0/8"]
-  location = data.azurerm_resource_group.rg.location
+  address_space       = ["10.0.0.0/8"]
+  location            = data.azurerm_resource_group.rg.location
 }
 
 resource "azurerm_subnet" "k8s_subnet" {
@@ -32,6 +32,8 @@ resource "azurerm_subnet" "k8s_subnet" {
   address_prefixes     = ["10.240.0.0/16"]
   resource_group_name  = data.azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.default.name
+
+  enforce_private_link_endpoint_network_policies = true
 }
 
 resource "azurerm_subnet" "batch_worker_subnet" {
@@ -48,9 +50,9 @@ resource "azurerm_kubernetes_cluster" "vdc" {
   dns_prefix          = "example"
 
   default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_D2_v2"
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D2_v2"
     vnet_subnet_id = azurerm_subnet.k8s_subnet.id
   }
 
@@ -60,16 +62,48 @@ resource "azurerm_kubernetes_cluster" "vdc" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "vdc_pool" {
-  name = "pool"
+  name                  = "pool"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.vdc.id
-  vm_size = "Standard_D2_v2"
-  vnet_subnet_id = azurerm_subnet.k8s_subnet.id
+  vm_size               = "Standard_D2_v2"
+  vnet_subnet_id        = azurerm_subnet.k8s_subnet.id
 
   enable_auto_scaling = true
 
-  node_count = 1
   min_count = 0
   max_count = 200
+}
+
+resource "azurerm_public_ip" "gateway_ip" {
+  name                = "gateway-ip"
+  resource_group_name = azurerm_kubernetes_cluster.vdc.node_resource_group
+  location            = data.azurerm_resource_group.rg.location
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_container_registry" "acr" {
+  name                = var.acr_name
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
+  sku                 = var.acr_sku
+}
+
+resource "azurerm_role_assignment" "vdc_to_acr" {
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_kubernetes_cluster.vdc.kubelet_identity[0].object_id
+}
+
+resource "azurerm_role_assignment" "vdc_batch_worker_subnet" {
+  scope                = azurerm_subnet.batch_worker_subnet.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_kubernetes_cluster.vdc.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "vdc_k8s_subnet" {
+  scope                = azurerm_subnet.k8s_subnet.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_kubernetes_cluster.vdc.identity[0].principal_id
 }
 
 resource "random_id" "db_name_suffix" {
@@ -94,4 +128,18 @@ resource "azurerm_mysql_server" "db" {
 
   ssl_enforcement_enabled       = true
   public_network_access_enabled = false
+}
+
+resource "azurerm_private_endpoint" "db_endpoint" {
+  name                = "${azurerm_mysql_server.db.name}-endpoint"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.rg.location
+  subnet_id           = azurerm_subnet.k8s_subnet.id
+
+  private_service_connection {
+    name                           = "${azurerm_mysql_server.db.name}-endpoint"
+    private_connection_resource_id = azurerm_mysql_server.db.id
+    subresource_names              = [ "mysqlServer" ]
+    is_manual_connection           = false
+  }
 }

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -16,6 +16,10 @@ provider "azurerm" {
   features {}
 }
 
+locals {
+  acr_name = var.acr_name == "" ? var.az_resource_group_name : var.acr_name
+}
+
 data "azurerm_resource_group" "rg" {
   name = var.az_resource_group_name
 }
@@ -82,7 +86,7 @@ resource "azurerm_public_ip" "gateway_ip" {
 }
 
 resource "azurerm_container_registry" "acr" {
-  name                = var.acr_name
+  name                = local.acr_name
   resource_group_name = data.azurerm_resource_group.rg.name
   location            = data.azurerm_resource_group.rg.location
   sku                 = var.acr_sku

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -4,6 +4,7 @@ variable az_resource_group_name {
 
 variable acr_name {
   type = string
+  default = ""
 }
 
 variable acr_sku {

--- a/infra/azure/variables.tf
+++ b/infra/azure/variables.tf
@@ -1,3 +1,12 @@
 variable az_resource_group_name {
   type = string
 }
+
+variable acr_name {
+  type = string
+}
+
+variable acr_sku {
+  type = string
+  default = "Basic"
+}


### PR DESCRIPTION
This adds the following terraform capabilities:
- A reserved public IP for the k8s gateway
- A container registry and pull access for the k8s cluster
- A [private link](https://azure.microsoft.com/en-us/services/private-link/) for the mysql database that makes it accessible on the k8s subnet. I haven't set up the config to use the database yet but ensured that the hostname for the database was resolvable from a pod on the cluster

I think this covers most of the azure specific resources that we need. Most of the rest of our terraform for gcp creating k8s secrets for the database config and various service accounts. I'd like to approach that in a single chunk to find out how best to abstract those into modules.