### PR TITLE
[benchmark] Upgrade setuptools to allow avro dependency

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -24,8 +24,9 @@ RUN apt-get update && \
 
 COPY requirements.txt .
 RUN python3 -m pip install --upgrade --no-cache-dir --upgrade pip && \
-  python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir -r requirements.txt && \
-  python3 -m pip install --use-feature=2020-resolver --upgrade --no-cache-dir aiomysql && \
+  python3 -m pip install --upgrade --no-cache-dir setuptools && \
+  python3 -m pip install --upgrade --no-cache-dir -r requirements.txt && \
+  python3 -m pip install --upgrade --no-cache-dir aiomysql && \
   python3 -m pip check
 
 ARG HAIL_WHEEL


### PR DESCRIPTION
Also, removed deprecated 2020-resolver arguments. This was necessary to resolve `avro` dependencies as per: https://stackoverflow.com/questions/65233583/pip-install-cannot-resolve-the-version-from-artifactory