### PR TITLE
[terraform] Create modules for gcs_bucket and ukbb k8s resources

### DIFF
--- a/infra/gcs_bucket/main.tf
+++ b/infra/gcs_bucket/main.tf
@@ -1,0 +1,10 @@
+resource "random_id" "bucket_prefix" {
+  byte_length = 5
+}
+
+resource "google_storage_bucket" "bucket" {
+  name = "${var.short_name}-${random_id.bucket_prefix.hex}"
+  location = var.location
+  force_destroy = true
+  storage_class = var.storage_class
+}

--- a/infra/gcs_bucket/outputs.tf
+++ b/infra/gcs_bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = google_storage_bucket.bucket.name
+}

--- a/infra/gcs_bucket/variables.tf
+++ b/infra/gcs_bucket/variables.tf
@@ -1,0 +1,11 @@
+variable "short_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "storage_class" {
+  type = string
+}

--- a/infra/ukbb/main.tf
+++ b/infra/ukbb/main.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_namespace" "ukbb_rg" {
+  metadata {
+    name = "ukbb-rg"
+  }
+}
+
+resource "kubernetes_service" "ukbb_rb_browser" {
+  metadata {
+    name = "ukbb-rg-browser"
+    namespace = kubernetes_namespace.ukbb_rg.metadata[0].name
+    labels = {
+      app = "ukbb-rg-browser"
+    }
+  }
+  spec {
+    port {
+      port = 80
+      protocol = "TCP"
+      target_port = 80
+    }
+    selector = {
+      app = "ukbb-rg-browser"
+    }
+  }
+}
+
+resource "kubernetes_service" "ukbb_rb_static" {
+  metadata {
+    name = "ukbb-rg-static"
+    namespace = kubernetes_namespace.ukbb_rg.metadata[0].name
+    labels = {
+      app = "ukbb-rg-static"
+    }
+  }
+  spec {
+    port {
+      port = 80
+      protocol = "TCP"
+      target_port = 80
+    }
+    selector = {
+      app = "ukbb-rg-static"
+    }
+  }
+}


### PR DESCRIPTION
Yet Another Terraform Refactoring PR, this creates two simple modules:
- A gcs_bucket module to remove the redundancy of resources that we have across the batch-logs, query and test bucket
- A ukbb module which sets up the ukbb k8s resources. While this technically would allow us to reuse this, say in azure, it's more an attempt to tease it apart from the google-specific infrastructure so that we wouldn't have to. In short, it would be nice to organize things such that deploying hail with or without the ukbb site is as simple as choosing to include or omit a terraform module.