### PR TITLE
[gateway] Include server block for ukbb if it is listed as subdomain

### DIFF
--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -73,38 +73,7 @@ server {
 }
 
 {% for service in subdomains %}
-{% if service != 'ukbb-rg' %}
-server {
-    server_name {% if service == 'www' %}{{ domain }}{% endif %} {{ service }}.{{ domain }};
-    client_max_body_size 8m;
-
-    location / {
-        resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass https://{{ service }}.default.svc.cluster.local;
-
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
-
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        include /ssl-config/ssl-config-proxy.conf;
-    }
-
-    listen [::]:443 ssl;
-    listen 443 ssl;
-    ssl_certificate /etc/letsencrypt/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-}
-
-{% endif %}
-{% endfor %}
-
+{% if service == 'ukbb-rg' %}
 server {
     server_name ukbb-rg.{{ domain }};
 
@@ -139,3 +108,33 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
+{% else %}
+server {
+    server_name {% if service == 'www' %}{{ domain }}{% endif %} {{ service }}.{{ domain }};
+    client_max_body_size 8m;
+
+    location / {
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass https://{{ service }}.default.svc.cluster.local;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        include /ssl-config/ssl-config-proxy.conf;
+    }
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
This is a pretty simple change, though the diff is a little bizarre. I don't want running a ukbb server to be a requirement of running a hail instance. Since the ukbb app is a special case in the way we deploy apps in k8s, we would render the gateway configuration server blocks with the logic:

- For each service, if it's not ukbb, render it the usual way
- Render the ukbb block

This is a very simple change to instead make the logic

- For each service, if it's ukbb render it the ukbb way, else render it the usual way

Together with the separation of the ukbb terraform into its own module in #10842, it should be easier to deploy hail without the ukbb app and simplify the bootstrap process.

This is currently running in hail-vdc.