### PR TITLE
[query] Add a check that file exists before checking if it's a directory

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -27,11 +27,13 @@ object RelationalSpec {
     new MatrixTypeSerializer
 
   def readMetadata(fs: FS, path: String): JValue = {
-    if (!fs.exists(path)) {
-      fatal(s"No file or directory found at ${path}")
+    if (!fs.isDir(path)) {
+      if (!fs.exists(path)) {
+        fatal(s"No file or directory found at ${path}")
+      } else {
+        fatal(s"MatrixTable and Table files are directories; path '$path' is not a directory")
+      }
     }
-    if (!fs.isDir(path))
-      fatal(s"MatrixTable and Table files are directories; path '$path' is not a directory")
     val metadataFile = path + "/metadata.json.gz"
     val jv = using(fs.open(metadataFile)) { in => parse(in) }
 

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -27,6 +27,9 @@ object RelationalSpec {
     new MatrixTypeSerializer
 
   def readMetadata(fs: FS, path: String): JValue = {
+    if (!fs.exists(path)) {
+      fatal(s"No file or directory found at ${path}")
+    }
     if (!fs.isDir(path))
       fatal(s"MatrixTable and Table files are directories; path '$path' is not a directory")
     val metadataFile = path + "/metadata.json.gz"


### PR DESCRIPTION
Resolves #10843 

Now you'll see:

```
Hail version: 0.2.74-467a12fcbef9
Error summary: HailException: No file or directory found at gs://hail-datasets-us/annotations/THIS_PATH_DOES_NOT_EXIST
```

instead of the error about it not being a directory.