### PR TITLE
[memory] substantially reduce cpu requests

### DIFF
--- a/memory/deployment.yaml
+++ b/memory/deployment.yaml
@@ -41,7 +41,7 @@ spec:
              mountPath: /redis
           resources:
             requests:
-              cpu: "600m"
+              cpu: "50m"
               memory: "2G"
             limits:
               cpu: "1"
@@ -90,7 +90,7 @@ spec:
           resources:
             requests:
               memory: "1.25G"
-              cpu: "400m"
+              cpu: "100m"
             limits:
               memory: "3.75G"
               cpu: "1"


### PR DESCRIPTION
See [the metrics explorer](https://console.cloud.google.com/monitoring/metrics-explorer?project=hail-vdc&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fcpu%2Frequest_utilization%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metadata.user_labels.%5C%22app%5C%22%3D%5C%22memory%5C%22%22,%22minAlignmentPeriod%22:%2260s%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22resource.label.%5C%22container_name%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22groupByFields%22:%5B%5D%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%226w%22%7D%7D). There is very little CPU use by redis and only bursty use of CPU use by python when I run query experiments.

<img width="1391" alt="Screen Shot 2021-09-10 at 7 34 24 PM" src="https://user-images.githubusercontent.com/106194/132927815-2cdbff0b-4697-42f3-b836-44e20d63e2dd.png">
