### PR TITLE
[memory] safe to evict

### DIFF
--- a/memory/deployment.yaml
+++ b/memory/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         app: memory
         hail.is/sha: "{{ code.sha }}"
         grafanak8sapp: "true"
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       serviceAccountName: memory
 {% if deploy %}


### PR DESCRIPTION
Memory's local storage is a simple cache, so it is safe for k8s to
evict it from the node if the node is underutilized.

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node