### PR TITLE
[internal-gateway] reduce request for internal-gateway

### DIFF
--- a/internal-gateway/deployment.yaml
+++ b/internal-gateway/deployment.yaml
@@ -37,7 +37,7 @@ spec:
          image: "{{ internal_gateway_image.image }}"
          resources:
            requests:
-             cpu: "100m"
+             cpu: "20m"
              memory: "200M"
            limits:
              cpu: "1"


### PR DESCRIPTION
It never uses more than 3% of its request.

https://console.cloud.google.com/monitoring/metrics-explorer?project=hail-vdc&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fcpu%2Frequest_utilization%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metadata.user_labels.%5C%22app%5C%22%3D%5C%22internal-gateway%5C%22%22,%22minAlignmentPeriod%22:%2260s%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22metadata.user_labels.%5C%22app%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22groupByFields%22:%5B%5D%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%22custom%22,%22start%22:%222021-07-02T15:10:00.000Z%22,%22end%22:%222021-09-13T15:10:41.820Z%22%7D%7D