### PR TITLE
[k8s] Remove unused hail-vdc-sa-key

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -43,7 +43,6 @@ steps:
     namespaceName: default
     public: true
     secrets:
-      - hail-vdc-sa-key
       - gcr-pull-key
       - gcr-push-service-account-key
       - hail-ci-0-1-github-oauth-token


### PR DESCRIPTION
I don't see any other mentions of this secret in the codebase.