### PR TITLE
[compiler] More SCode -> SValue

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -57,7 +57,7 @@ class BinarySearch[C](mb: EmitMethodBuilder[C], containerType: SContainer, eltTy
 
   // Returns smallest i, 0 <= i < n, for which a(i) >= key, or returns n if a(i) < key for all i
   findElt.emitWithBuilder[Int] { cb =>
-    val indexable = findElt.getSCodeParam(1).asIndexable.memoize(cb, "findElt_indexable")
+    val indexable = findElt.getSCodeParam(1).asIndexable
 
     val elt = findElt.getEmitParam(cb, 2, null) // no streams
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2724,7 +2724,7 @@ abstract class NDArrayEmitter(val outputShape: IndexedSeq[Value[Long]], val elem
       region)
 
     SNDArray.forEachIndexColMajor(cb, shapeArray, "ndarrayemitter_emitloops") { case (cb, idxVars) =>
-      val element = IEmitCode.present(cb, outputElement(cb, idxVars)).consume(cb, {
+      val element = IEmitCode.present(cb, outputElement(cb, idxVars).memoize(cb, "NDArray_emit")).consume(cb, {
         cb._fatal("NDArray elements cannot be missing")
       }, { elementPc =>
         targetType.elementType.storeAtAddress(cb, firstElementAddress + (idx.toL * targetType.elementType.byteSize), region, elementPc, true)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -879,7 +879,7 @@ class EmitMethodBuilder[C](
     }
   }
 
-  def getSCodeParam(emitIndex: Int): SCode = {
+  def getSCodeParam(emitIndex: Int): SValue = {
     assert(mb.isStatic || emitIndex != 0)
     val static = (!mb.isStatic).toInt
     val _st = emitParamTypes(emitIndex - static).asInstanceOf[SCodeParamType].st
@@ -890,7 +890,7 @@ class EmitMethodBuilder[C](
 
     _st.fromValues(ts.zipWithIndex.map { case (t, i) =>
       mb.getArg(codeIndex + i)(t)
-    }).get
+    })
   }
 
   def storeEmitParam(emitIndex: Int, cb: EmitCodeBuilder): Value[Region] => EmitValue = {

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -267,7 +267,7 @@ case class SplitPartitionNativeWriter(
       cb += ob2.flush()
       cb += os1.invoke[Unit]("close")
       cb += os2.invoke[Unit]("close")
-      filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, pctx.get, false)
+      filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, pctx, false)
       cb += Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)
       pResultType.loadCheapSCode(cb, result.get)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -238,7 +238,7 @@ case class PartitionNativeWriter(spec: AbstractTypedCodecSpec, partPrefix: Strin
         indexWriter.close(cb)
       cb += ob.flush()
       cb += os.invoke[Unit]("close")
-      filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, ctx.get, false)
+      filenameType.storeAtAddress(cb, pResultType.fieldOffset(result, "filePath"), region, ctx, false)
       cb += Region.storeLong(pResultType.fieldOffset(result, "partitionCounts"), n)
       pResultType.loadCheapSCode(cb, result.get)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -6,9 +6,9 @@ import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.SCode
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerCode, SStackStruct}
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointerCode, SStackStruct}
 import is.hail.types.physical.stypes.interfaces.SBinaryCode
+import is.hail.types.physical.stypes.{SCode, SValue}
 import is.hail.utils._
 
 trait AggregatorState {
@@ -135,7 +135,7 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
     storageType.setFieldMissing(cb, off, 0)
   }
 
-  def storeNonmissing(cb: EmitCodeBuilder, sc: SCode): Unit = {
+  def storeNonmissing(cb: EmitCodeBuilder, sc: SValue): Unit = {
     cb += region.getNewRegion(const(regionSize))
     storageType.setFieldPresent(cb, off, 0)
     ptype.storeAtAddress(cb, storageType.fieldOffset(off, 0), region, sc, deepCopy = true)
@@ -147,7 +147,7 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
 
   def copyFrom(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
     newState(cb, off)
-    storageType.storeAtAddress(cb, off, region, storageType.loadCheapSCode(cb, src).get, deepCopy = true)
+    storageType.storeAtAddress(cb, off, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {
@@ -161,7 +161,7 @@ abstract class AbstractTypedRegionBackedAggState(val ptype: PType) extends Regio
 
     val dec = codecSpec.encodedType.buildDecoder(storageType.virtualType, kb)
     ((cb: EmitCodeBuilder, ib: Value[InputBuffer]) =>
-      storageType.storeAtAddress(cb, off, region, dec(cb, region, ib), deepCopy = false))
+      storageType.storeAtAddress(cb, off, region, dec(cb, region, ib).memoize(cb, "deserialize"), deepCopy = false))
   }
 }
 
@@ -200,7 +200,7 @@ class PrimitiveRVAState(val vtypes: Array[VirtualTypeWithReq], val kb: EmitClass
     storageType.storeAtAddress(cb,
       dest,
       null,
-      SStackStruct.constructFromArgs(cb, null, storageType.virtualType, fields.map(_.load): _*).get,
+      SStackStruct.constructFromArgs(cb, null, storageType.virtualType, fields.map(_.load): _*),
       false)
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -4,8 +4,8 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
-import is.hail.types.physical.stypes.concrete.SBaseStructPointerCode
-import is.hail.types.physical.{PBooleanRequired, PCanonicalStruct, PInt32Required, PStruct, PType}
+import is.hail.types.physical.stypes.concrete.SBaseStructPointerValue
+import is.hail.types.physical._
 import is.hail.types.virtual.{TFloat64, TInt32, Type}
 import is.hail.utils._
 
@@ -42,8 +42,8 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
     cb += aggr.invoke[ApproxCDFStateManager, Unit]("combOp", other.aggr)
   }
 
-  def result(cb: EmitCodeBuilder, region: Value[Region]): SBaseStructPointerCode = {
-    QuantilesAggregator.resultType.loadCheapSCode(cb, aggr.invoke[Region, Long]("rvResult", region)).get
+  def result(cb: EmitCodeBuilder, region: Value[Region]): SBaseStructPointerValue = {
+    QuantilesAggregator.resultType.loadCheapSCode(cb, aggr.invoke[Region, Long]("rvResult", region))
   }
 
   def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -257,7 +257,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
           cb.assign(i, i + 1)
         })
         // don't need to deep copy because that's done in nested aggregators
-        pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr).get, deepCopy = false)
+        pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr), deepCopy = false)
 
       }
     )

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -191,7 +191,7 @@ class CallStatsAggregator extends StagedAggregator {
       IEmitCode.present(cb, primitive(acAtIndex))
     }
 
-    acType.storeAtAddress(cb, rt.fieldOffset(addr, "AC"), region, ac.get, deepCopy = false)
+    acType.storeAtAddress(cb, rt.fieldOffset(addr, "AC"), region, ac, deepCopy = false)
 
     cb.ifx(alleleNumber.ceq(0),
       rt.setFieldMissing(cb, addr, "AF"),
@@ -201,12 +201,12 @@ class CallStatsAggregator extends StagedAggregator {
           val acAtIndex = cb.newLocal[Int]("callstats_result_acAtIndex", state.alleleCountAtIndex(i, state.nAlleles))
           IEmitCode.present(cb, primitive(cb.memoize(acAtIndex.toD / alleleNumber.toD)))
         }
-        afType.storeAtAddress(cb, rt.fieldOffset(addr, "AF"), region, af.get, deepCopy = false)
+        afType.storeAtAddress(cb, rt.fieldOffset(addr, "AF"), region, af, deepCopy = false)
       })
 
     val anType = resultType.fieldType("AN")
     val an = primitive(alleleNumber)
-    anType.storeAtAddress(cb, rt.fieldOffset(addr, "AN"), region, an.get, deepCopy = false)
+    anType.storeAtAddress(cb, rt.fieldOffset(addr, "AN"), region, an, deepCopy = false)
 
 
     val homCountType = resultType.fieldType("homozygote_count").asInstanceOf[PCanonicalArray]
@@ -215,6 +215,6 @@ class CallStatsAggregator extends StagedAggregator {
       IEmitCode.present(cb, primitive(homCountAtIndex))
     }
 
-    homCountType.storeAtAddress(cb, rt.fieldOffset(addr, "homozygote_count"), region, homCount.get, deepCopy = false)
+    homCountType.storeAtAddress(cb, rt.fieldOffset(addr, "homozygote_count"), region, homCount, deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -82,6 +82,6 @@ class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregat
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     assert(pt == resultType)
     // deepCopy is handled by the blocked linked list
-    pt.storeAtAddress(cb, addr, region, state.bll.resultArray(cb, region, resultType).get, deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, state.bll.resultArray(cb, region, resultType), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -38,7 +38,7 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
         },
         { sc =>
           storageType.setFieldPresent(cb, dest, 0)
-          typ.storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc.get, deepCopy = true)
+          typ.storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)
         })
   }
 
@@ -46,7 +46,7 @@ class TypedKey(typ: PType, kb: EmitClassBuilder[_], region: Value[Region]) exten
     cb += Region.copyFrom(src, dest, storageType.byteSize)
 
   def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], src: Code[Long]): Unit = {
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src).get, deepCopy = true)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
   }
 
   def compKeys(cb: EmitCodeBuilder, k1: EmitCode, k2: EmitCode): Code[Int] = {
@@ -177,6 +177,6 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
       pushElement(cb, elt.toI(cb))
     }
     // deepCopy is handled by `storeElement` above
-    resultType.storeAtAddress(cb, addr, region, finish(cb).get, deepCopy = false)
+    resultType.storeAtAddress(cb, addr, region, finish(cb), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -38,6 +38,6 @@ object CountAggregator extends StagedAggregator {
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
-    pt.storeAtAddress(cb, addr, region, ev.pv.get, deepCopy = true)
+    pt.storeAtAddress(cb, addr, region, ev.pv, deepCopy = true)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -6,7 +6,7 @@ import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.concrete.SIndexablePointerCode
+import is.hail.types.physical.stypes.concrete.SIndexablePointerValue
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
@@ -120,8 +120,8 @@ class DensifyState(val arrayVType: VirtualTypeWithReq, val kb: EmitClassBuilder[
     gc(cb)
   }
 
-  def result(cb: EmitCodeBuilder, region: Value[Region]): SIndexablePointerCode = {
-    arrayStorageType.loadCheapSCode(cb, arrayAddr).get
+  def result(cb: EmitCodeBuilder, region: Value[Region]): SIndexablePointerValue = {
+    arrayStorageType.loadCheapSCode(cb, arrayAddr)
   }
 
   def copyFrom(cb: EmitCodeBuilder, srcCode: Code[Long]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -56,7 +56,7 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
         { sc =>
           storageType.setFieldPresent(cb, dest, 0)
           storageType.fieldType("kt")
-            .storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc.get, deepCopy = true)
+            .storeAtAddress(cb, storageType.fieldOffset(dest, 0), region, sc, deepCopy = true)
         })
     storeRegionIdx(cb, dest, rIdx)
     container.newState(cb)
@@ -82,11 +82,11 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
     cb += Region.storeInt(storageType.fieldOffset(off, 1), -1)
 
   def copy(cb: EmitCodeBuilder, src: Code[Long], dest: Code[Long]): Unit =
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src).get, deepCopy = false)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = false)
 
   def deepCopy(cb: EmitCodeBuilder, er: EmitRegion, dest: Code[Long], srcCode: Code[Long]): Unit = {
     val src = cb.newLocal("ga_deep_copy_src", srcCode)
-    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src).get, deepCopy = true)
+    storageType.storeAtAddress(cb, dest, region, storageType.loadCheapSCode(cb, src), deepCopy = true)
     container.copyFrom(cb, containerOffset(src))
     container.store(cb)
   }
@@ -297,7 +297,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
       k.toI(cb).consume(cb,
         dictElt.setFieldMissing(cb, addrAtI, "key"),
         { sc =>
-          dictElt.fieldType("key").storeAtAddress(cb, dictElt.fieldOffset(addrAtI, "key"), region, sc.get, deepCopy = true)
+          dictElt.fieldType("key").storeAtAddress(cb, dictElt.fieldOffset(addrAtI, "key"), region, sc, deepCopy = true)
         })
 
       val valueAddr = cb.newLocal[Long]("groupedagg_value_addr", dictElt.fieldOffset(addrAtI, "value"))
@@ -313,6 +313,6 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
     }
 
     // don't need to deep copy because that's done in nested aggregators
-    pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr).get, deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, resultType.loadCheapSCode(cb, resultAddr), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -151,7 +151,7 @@ class ImputeTypeAggregator() extends StagedAggregator {
     Array(state.getAnyNonMissing, state.getAllDefined, state.getSupportsBool,
       state.getSupportsI32, state.getSupportsI64, state.getSupportsF64)
       .zipWithIndex.foreach { case (b, idx) =>
-      rt.types(idx).storeAtAddress(cb, rt.fieldOffset(addr, idx), region, primitive(b), deepCopy = true)
+      rt.types(idx).storeAtAddress(cb, rt.fieldOffset(addr, idx), region, primitive(cb.memoize(b)), deepCopy = true)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -273,6 +273,6 @@ class LinearRegressionAggregator() extends StagedAggregator {
       stateType.loadField(state.off, 0),
       stateType.loadField(state.off, 1),
       Region.loadInt(stateType.loadField(state.off, 2))))
-    pt.storeAtAddress(cb, addr, region, LinearRegressionAggregator.resultType.loadCheapSCode(cb, resAddr).get, deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, LinearRegressionAggregator.resultType.loadCheapSCode(cb, resAddr), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -57,7 +57,7 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     state.fields(0).toI(cb).consume(cb,
       ifMissing(cb),
-      sc => pt.storeAtAddress(cb, addr, region, sc.get, deepCopy = true))
+      sc => pt.storeAtAddress(cb, addr, region, sc, deepCopy = true))
   }
 
   private def combine(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -50,7 +50,7 @@ class NDArrayMultiplyAddAggregator(nDVTyp: VirtualTypeWithReq) extends StagedAgg
               state.storageType.setFieldPresent(cb, state.off.get, ndarrayFieldNumber)
               val shape = IndexedSeq(NDArrayA.shapes(0), NDArrayB.shapes(1))
               val uninitializedNDArray = ndTyp.constructUnintialized(shape, ndTyp.makeColumnMajorStrides(shape, tempRegionForCreation, cb), cb, tempRegionForCreation)
-              state.storeNonmissing(cb, uninitializedNDArray.get)
+              state.storeNonmissing(cb, uninitializedNDArray)
               SNDArray.gemm(cb, "N", "N", const(1.0), NDArrayA.get, NDArrayB.get, const(0.0), uninitializedNDArray.get)
             },
             { currentNDPValue =>
@@ -74,7 +74,7 @@ class NDArrayMultiplyAddAggregator(nDVTyp: VirtualTypeWithReq) extends StagedAgg
           val leftPV = state.storageType.loadCheapSCode(cb, state.off).asBaseStruct
           leftPV.loadField(cb, ndarrayFieldNumber).consume(cb,
             {
-              state.storeNonmissing(cb, rightNdValue.get)
+              state.storeNonmissing(cb, rightNdValue)
             },
             { case leftNdValue: SNDArrayValue =>
               NDArraySumAggregator.addValues(cb, state.region, leftNdValue, rightNdValue)
@@ -88,6 +88,6 @@ class NDArrayMultiplyAddAggregator(nDVTyp: VirtualTypeWithReq) extends StagedAgg
   override protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     state.get(cb).consume(cb,
       ifMissing(cb),
-      { sc => pt.storeAtAddress(cb, addr, region, sc.asNDArray.get, deepCopy = true) })
+      { sc => pt.storeAtAddress(cb, addr, region, sc.asNDArray, deepCopy = true) })
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -24,7 +24,7 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
     elt.toI(cb)
       .consume(cb,
         { /* do nothing if missing */ },
-        sc => state.storeNonmissing(cb, sc.get)
+        sc => state.storeNonmissing(cb, sc)
       )
   }
 
@@ -32,13 +32,13 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
     other.get(cb)
       .consume(cb,
         { /* do nothing if missing */ },
-        sc => state.storeNonmissing(cb, sc.get)
+        sc => state.storeNonmissing(cb, sc)
       )
   }
 
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     state.get(cb).consume(cb,
       ifMissing(cb),
-      { sc => pt.storeAtAddress(cb, addr, region, sc.get, deepCopy = true) })
+      { sc => pt.storeAtAddress(cb, addr, region, sc, deepCopy = true) })
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.SValue
 import is.hail.utils._
 
 object StagedArrayBuilder {
@@ -88,7 +88,7 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
   def setMissing(cb: EmitCodeBuilder): Unit = incrementSize(cb) // all elements set to missing on initialization
 
 
-  def append(cb: EmitCodeBuilder, elt: SCode, deepCopy: Boolean = true): Unit = {
+  def append(cb: EmitCodeBuilder, elt: SValue, deepCopy: Boolean = true): Unit = {
     eltArray.setElementPresent(cb, data, size)
     eltType.storeAtAddress(cb, eltArray.elementOffset(data, capacity, size), region, elt, deepCopy)
     incrementSize(cb)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -155,7 +155,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
         pushMissing(cb, lastNode),
         { sc =>
           pushPresent(cb, lastNode) { (cb, addr) =>
-            elemType.storeAtAddress(cb, addr, r, sc.get, deepCopy = true)
+            elemType.storeAtAddress(cb, addr, r, sc, deepCopy = true)
           }
         })
 
@@ -257,7 +257,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
             bufferType.setElementMissing(cb, buf, i),
             { sc =>
               bufferType.setElementPresent(cb, buf, i)
-              elemType.storeAtAddress(cb, bufferType.elementOffset(buf, i), r, sc.get, deepCopy = true)
+              elemType.storeAtAddress(cb, bufferType.elementOffset(buf, i), r, sc, deepCopy = true)
             })
         incrCount(cb, firstNode)
         cb.assign(i, i + 1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -71,7 +71,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
       elt.toI(cb)
         .consume(cb,
           builder.setMissing(cb),
-          sc => builder.append(cb, sc.get)))
+          sc => builder.append(cb, sc)))
   }
 
   def combine(cb: EmitCodeBuilder, other: TakeRVAS): Unit = {
@@ -82,7 +82,7 @@ class TakeRVAS(val eltType: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) ext
         other.builder.loadElement(cb, j).toI(cb)
           .consume(cb,
             builder.setMissing(cb),
-            sc => builder.append(cb, sc.get))
+            sc => builder.append(cb, sc))
         cb.assign(j, j + 1)
       })
   }
@@ -128,6 +128,6 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
     assert(pt == resultType)
     // deepCopy is handled by state.resultArray
-    pt.storeAtAddress(cb, addr, region, state.resultArray(cb, region, resultType).get, deepCopy = false)
+    pt.storeAtAddress(cb, addr, region, state.resultArray(cb, region, resultType), deepCopy = false)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -460,7 +460,7 @@ abstract class RegistryFunctions {
           val sv = code.asIndexable.memoize(cb, "scode_array_string")
           val arr = cb.newLocal[Array[String]]("scode_array_string", Code.newArray[String](sv.loadLength()))
           sv.forEachDefined(cb) { case (cb, idx, elt) =>
-            cb += (arr(idx) = elt.asString.loadString())
+            cb += (arr(idx) = elt.asString.loadString(cb))
           }
           arr
       }
@@ -710,7 +710,7 @@ abstract class UnseededMissingnessObliviousJVMFunction (
       rpt,
       typeParameters,
       methodbuilder.getCodeParam[Int](2),
-      (0 until args.length).map(i => methodbuilder.getSCodeParam(i + 3)): _*))
+      (0 until args.length).map(i => methodbuilder.getSCodeParam(i + 3).get): _*))
     methodbuilder
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -55,7 +55,7 @@ abstract class NDArrayProducer {
     initAll(cb)
     val idxGenerator = if (rowMajor) SNDArray.forEachIndexWithInitAndIncRowMajor _ else SNDArray.forEachIndexWithInitAndIncColMajor _
     idxGenerator(cb, shape, initAxis, stepAxis.map(stepper => (cb: EmitCodeBuilder) => stepper(cb, 1L)), "ndarray_producer_toSCode"){ (cb, indices) =>
-      targetType.elementType.storeAtAddress(cb, currentWriteAddr, region, loadElementAtCurrentAddr(cb).get, true)
+      targetType.elementType.storeAtAddress(cb, currentWriteAddr, region, loadElementAtCurrentAddr(cb), true)
       cb.assign(currentWriteAddr, currentWriteAddr + targetType.elementType.byteSize)
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/orderings/CodeOrdering.scala
@@ -90,7 +90,7 @@ abstract class CodeOrdering {
       mb.emitWithBuilder[T] { cb =>
         val arg1 = mb.getSCodeParam(1)
         val arg2 = mb.getSCodeParam(2)
-        f(cb, arg1, arg2)
+        f(cb, arg1.get, arg2.get)
       }
     }
     cb.invokeCode[T](mb, arg1, arg2)

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -34,7 +34,7 @@ object StreamUtils {
             "Cannot construct an ndarray with missing values.", errorId
           )),
           { sc =>
-            elementType.storeAtAddress(cb, currentElementAddress, destRegion, sc.get, deepCopy = true)
+            elementType.storeAtAddress(cb, currentElementAddress, destRegion, sc, deepCopy = true)
           })
         cb.assign(currentElementIndex, currentElementIndex + 1)
         cb.assign(currentElementAddress, currentElementAddress + elementByteSize)

--- a/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -81,8 +81,8 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
 
   def add(cb: EmitCodeBuilder, indexFileOffset: Code[Long], firstIndex: Code[Long], firstChild: SBaseStructValue): Unit = {
     ab.addChild(cb)
-    ab.setFieldValue(cb, "index_file_offset", primitive(indexFileOffset))
-    ab.setFieldValue(cb, "first_idx", primitive(firstIndex))
+    ab.setFieldValue(cb, "index_file_offset", primitive(cb.memoize(indexFileOffset)))
+    ab.setFieldValue(cb, "first_idx", primitive(cb.memoize(firstIndex)))
     ab.setField(cb, "first_key", firstChild.loadField(cb, "key"))
     ab.setField(cb, "first_record_offset", firstChild.loadField(cb, "offset"))
     ab.setField(cb, "first_annotation", firstChild.loadField(cb, "annotation"))
@@ -90,7 +90,7 @@ class StagedInternalNodeBuilder(maxSize: Int, keyType: PType, annotationType: PT
 
   def add(cb: EmitCodeBuilder, indexFileOffset: Code[Long], firstChild: SBaseStructValue): Unit = {
     ab.addChild(cb)
-    ab.setFieldValue(cb, "index_file_offset", primitive(indexFileOffset))
+    ab.setFieldValue(cb, "index_file_offset", primitive(cb.memoize(indexFileOffset)))
     ab.setField(cb, "first_idx", firstChild.loadField(cb, "first_idx"))
     ab.setField(cb, "first_key", firstChild.loadField(cb, "first_key"))
     ab.setField(cb, "first_record_offset", firstChild.loadField(cb, "first_record_offset"))

--- a/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -50,14 +50,14 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
   def reset(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
     cb += region.invoke[Unit]("clear")
     node.store(cb, pType.loadCheapSCode(cb, pType.allocate(region)).get)
-    idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(firstIdx))
+    idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(cb.memoize(firstIdx)))
     ab.create(cb, pType.fieldOffset(node.a, "keys"))
   }
 
   def create(cb: EmitCodeBuilder, firstIdx: Code[Long]): Unit = {
     cb.assign(region, Region.stagedCreate(Region.REGULAR, cb.emb.ecb.pool()))
     node.store(cb, pType.loadCheapSCode(cb, pType.allocate(region)).get)
-    idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(firstIdx))
+    idxType.storePrimitiveAtAddress(cb, pType.fieldOffset(node.a, "first_idx"), primitive(cb.memoize(firstIdx)))
     ab.create(cb, pType.fieldOffset(node.a, "keys"))
   }
 
@@ -72,7 +72,7 @@ class StagedLeafNodeBuilder(maxSize: Int, keyType: PType, annotationType: PType,
   def add(cb: EmitCodeBuilder, key: => IEmitCode, offset: Code[Long], annotation: => IEmitCode): Unit = {
     ab.addChild(cb)
     ab.setField(cb, "key", key)
-    ab.setFieldValue(cb, "offset", primitive(offset))
+    ab.setFieldValue(cb, "offset", primitive(cb.memoize(offset)))
     ab.setField(cb, "annotation", annotation)
   }
 

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -54,7 +54,7 @@ object LinalgCodeUtils {
     // construct an SNDArrayCode with undefined contents
     val result = dataFinisher(cb)
 
-    result.coiterateMutate(cb, region, (pndv.get, "pndv")) { case Seq(l, r) => r }
+    result.coiterateMutate(cb, region, (pndv, "pndv")) { case Seq(l, r) => r }
     result.get
   }
 

--- a/hail/src/main/scala/is/hail/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EArray.scala
@@ -3,13 +3,12 @@ package is.hail.types.encoded
 import is.hail.annotations.{Region, UnsafeUtils}
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.BaseType
-import is.hail.types.physical._
-import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable}
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
+import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.virtual._
 import is.hail.utils._
 
 final case class EArray(val elementType: EType, override val required: Boolean = false) extends EContainer {
@@ -43,7 +42,7 @@ final case class EArray(val elementType: EType, override val required: Boolean =
           case t: PCanonicalDict => t.arrayRep
         }
 
-        val array = value.asInstanceOf[SIndexablePointerSettable].a
+        val array = value.asInstanceOf[SIndexablePointerValue].a
         if (!elementType.required) {
           val nMissingLocal = cb.newLocal[Int]("nMissingBytes", pArray.nMissingBytes(prefixLen))
           cb.ifx(nMissingLocal > 0, {

--- a/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBaseStruct.scala
@@ -72,9 +72,9 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
 
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
     val structValue = v.st match {
-      case SIntervalPointer(t: PCanonicalInterval) => new SBaseStructPointerSettable(
+      case SIntervalPointer(t: PCanonicalInterval) => new SBaseStructPointerValue(
         SBaseStructPointer(t.representation),
-        v.asInstanceOf[SIntervalPointerSettable].a)
+        v.asInstanceOf[SIntervalPointerValue].a)
       case _: SLocus => v.asInstanceOf[SLocusValue].structRepr(cb)
       case _ => v.asInstanceOf[SBaseStructValue]
     }
@@ -83,7 +83,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       case SBaseStructPointer(st) if st.size == size && st.fieldRequired.sameElements(fields.map(_.typ.required)) =>
         val missingBytes = UnsafeUtils.packBitsToBytes(st.nMissing)
 
-        val addr = structValue.asInstanceOf[SBaseStructPointerSettable].a
+        val addr = structValue.asInstanceOf[SBaseStructPointerValue].a
         if (nMissingBytes > 1)
           cb += out.writeBytes(addr, missingBytes - 1)
         if (nMissingBytes > 0)

--- a/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EBinary.scala
@@ -3,13 +3,12 @@ package is.hail.types.encoded
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.BaseType
-import is.hail.types.physical._
-import is.hail.types.virtual._
 import is.hail.io.{InputBuffer, OutputBuffer}
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.concrete._
+import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue, SString}
 import is.hail.types.physical.stypes.{SCode, SType, SValue}
-import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerCode, SBinaryPointerSettable, SStringPointer, SStringPointerCode, SStringPointerSettable}
-import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue, SString, SStringValue}
+import is.hail.types.virtual._
 import is.hail.utils._
 
 case object EBinaryOptional extends EBinary(false)
@@ -19,7 +18,7 @@ class EBinary(override val required: Boolean) extends EType {
 
   override def _buildEncoder(cb: EmitCodeBuilder, v: SValue, out: Value[OutputBuffer]): Unit = {
 
-    def writeCanonicalBinary(bin: SBinaryPointerSettable): Unit = {
+    def writeCanonicalBinary(bin: SBinaryPointerValue): Unit = {
       val len = cb.newLocal[Int]("len", bin.loadLength())
       cb += out.writeInt(len)
       cb += out.writeBytes(bin.bytesAddress(), len)
@@ -33,8 +32,8 @@ class EBinary(override val required: Boolean) extends EType {
     }
 
     v.st match {
-      case SBinaryPointer(_) => writeCanonicalBinary(v.asInstanceOf[SBinaryPointerSettable])
-      case SStringPointer(_) => writeCanonicalBinary(v.asInstanceOf[SStringPointerSettable].binaryRepr())
+      case SBinaryPointer(_) => writeCanonicalBinary(v.asInstanceOf[SBinaryPointerValue])
+      case SStringPointer(_) => writeCanonicalBinary(v.asInstanceOf[SStringPointerValue].binaryRepr())
       case _: SBinary => writeBytes(v.asInstanceOf[SBinaryValue].loadBytes())
       case _: SString => writeBytes(v.get.asString.toBytes().loadBytes())
     }

--- a/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/ENDArrayColumnMajor.scala
@@ -19,7 +19,7 @@ case class ENDArrayColumnMajor(elementType: EType, nDims: Int, required: Boolean
     val shapes = ndarray.shapes
     shapes.foreach(s => cb += out.writeLong(s))
 
-    SNDArray.coiterate(cb, (ndarray.get, "A")){
+    SNDArray.coiterate(cb, (ndarray, "A")){
       case Seq(elt) =>
         elementType.buildEncoder(elt.st, cb.emb.ecb)
           .apply(cb, elt.get, out)

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -55,7 +55,6 @@ abstract class EType extends BaseType with Serializable with Requiredness {
 
       mb.voidWithBuilder { cb =>
         val arg = mb.getSCodeParam(1)
-          .memoize(cb, "encoder_method_arg")
         val out = mb.getCodeParam[OutputBuffer](2)
         _buildEncoder(cb, arg, out)
       }
@@ -137,7 +136,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
   ): Unit = {
     assert(!pt.isInstanceOf[PBaseStruct]) // should be overridden for structs
     val decoded = _buildDecoder(cb, pt.virtualType, region, in).memoize(cb, "Asd")
-    pt.storeAtAddress(cb, addr, region, decoded.get, false)
+    pt.storeAtAddress(cb, addr, region, decoded, false)
   }
 
   def _buildSkip(cb: EmitCodeBuilder, r: Value[Region], in: Value[InputBuffer]): Unit

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -150,7 +150,7 @@ trait PArrayBackedContainer extends PContainer {
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] =
     arrayRep.store(cb, region, value.asIndexable.castToArray(cb), deepCopy)
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit =
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit =
     arrayRep.storeAtAddress(cb, addr, region, value.asIndexable.castToArray(cb), deepCopy)
 
   override def loadFromNested(addr: Code[Long]): Code[Long] = arrayRep.loadFromNested(addr)

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -2,9 +2,8 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.Code
-import is.hail.expr.ir.orderings.{CodeOrdering, CodeOrderingCompareConsistentWithOthers}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.SCode
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanCode, SBooleanValue}
 import is.hail.types.virtual.TBoolean
 import is.hail.utils.toRichBoolean
@@ -29,7 +28,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
 
   def sType: SBoolean.type = SBoolean
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit = {
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit = {
     cb += Region.storeBoolean(addr, value.asBoolean.boolCode(cb))
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -306,7 +306,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       cb.ifx(isElementDefined(dstAddress, currentIdx),
         {
           cb.assign(currentElementAddress, elementOffset(dstAddress, len, currentIdx))
-          this.elementType.storeAtAddress(cb, currentElementAddress, region, this.elementType.loadCheapSCode(cb, this.elementType.loadFromNested(currentElementAddress)).get, true)
+          this.elementType.storeAtAddress(cb, currentElementAddress, region, this.elementType.loadCheapSCode(cb, this.elementType.loadFromNested(currentElementAddress)), true)
         }))
   }
 
@@ -395,7 +395,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
             .consume(
               cb,
               { setElementMissing(cb, addr, idx) },
-              { pc => elementType.storeAtAddress(cb, elementOffset(addr, length, idx), region, pc.get, deepCopy) }
+              { pc => elementType.storeAtAddress(cb, elementOffset(addr, length, idx), region, pc, deepCopy) }
             )
           cb.assign(idx, idx + 1)
         })
@@ -415,8 +415,8 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeAddress(addr, store(cb, region, value.memoize(cb, "storeAtAddress"), deepCopy))
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
+    cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 
 
@@ -442,7 +442,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       f(cb, i).consume(cb,
         setElementMissing(cb, addr, i),
         { sc =>
-          elementType.storeAtAddress(cb, elementOffsetFromFirst(firstElementAddr, i), region, sc.get, deepCopy = deepCopy)
+          elementType.storeAtAddress(cb, elementOffsetFromFirst(firstElementAddr, i), region, sc, deepCopy = deepCopy)
         })
 
       cb.assign(i, i + 1)
@@ -465,7 +465,7 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
       iec.consume(cb,
         setElementMissing(cb, addr, currentElementIndex),
         { sc =>
-          elementType.storeAtAddress(cb, currentElementAddress, region, sc.get, deepCopy = deepCopy)
+          elementType.storeAtAddress(cb, currentElementAddress, region, sc, deepCopy = deepCopy)
         })
         cb.assign(currentElementIndex, currentElementIndex + 1)
         cb.assign(currentElementAddress, currentElementAddress + elementByteSize)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -164,8 +164,8 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeAddress(addr, store(cb, region, value.memoize(cb, "storeAtAddress"), deepCopy))
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
+    cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -52,13 +52,13 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
     value.st match {
       case SCanonicalCall =>
         val newAddr = cb.memoize(region.allocate(representation.alignment, representation.byteSize))
-        storeAtAddress(cb, newAddr, region, value.get, deepCopy)
+        storeAtAddress(cb, newAddr, region, value, deepCopy)
         newAddr
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeInt(addr, value.asCall.loadCanonicalRepresentation(cb))
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
+    cb += Region.storeInt(addr, value.asCall.canonicalCall(cb))
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = representation.loadFromNested(addr)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -95,19 +95,19 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
     value.st match {
       case SIntervalPointer(t: PCanonicalInterval) =>
-        representation.storeAtAddress(cb, addr, region, t.representation.loadCheapSCode(cb, value.asInstanceOf[SIntervalPointerCode].a).get, deepCopy)
+        representation.storeAtAddress(cb, addr, region, t.representation.loadCheapSCode(cb, value.asInstanceOf[SIntervalPointerValue].a), deepCopy)
       case _ =>
-        val interval = value.asInterval.memoize(cb, "pcinterval_store_at_addr")
+        val interval = value.asInterval
         val start = EmitCode.fromI(cb.emb)(cb => interval.loadStart(cb))
         val stop = EmitCode.fromI(cb.emb)(cb => interval.loadEnd(cb))
         val includesStart = EmitCode.present(cb.emb, new SBooleanValue(interval.includesStart()))
         val includesStop = EmitCode.present(cb.emb, new SBooleanValue(interval.includesEnd()))
         representation.storeAtAddress(cb, addr, region,
           SStackStruct.constructFromArgs(cb, region, representation.virtualType,
-            start, stop, includesStart, includesStop).get,
+            start, stop, includesStart, includesStop),
           deepCopy)
     }
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -107,20 +107,20 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
         representation.store(cb, region, pt.representation.loadCheapSCode(cb, value.asInstanceOf[SCanonicalLocusPointerValue].a), deepCopy)
       case _ =>
         val addr = cb.memoize(representation.allocate(region))
-        storeAtAddress(cb, addr, region, value.get, deepCopy)
+        storeAtAddress(cb, addr, region, value, deepCopy)
         addr
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
     value.st match {
       case SCanonicalLocusPointer(pt) =>
-        representation.storeAtAddress(cb, addr, region, pt.representation.loadCheapSCode(cb, value.asInstanceOf[SCanonicalLocusPointerCode].a).get, deepCopy)
+        representation.storeAtAddress(cb, addr, region, pt.representation.loadCheapSCode(cb, value.asInstanceOf[SCanonicalLocusPointerValue].a), deepCopy)
       case _ =>
-        val loc = value.asLocus.memoize(cb, "pclocus_store")
+        val loc = value.asLocus
         representation.storeAtAddress(cb, addr, region,
           SStackStruct.constructFromArgs(cb, region, representation.virtualType,
-            EmitCode.present(cb.emb, loc.contig(cb)), EmitCode.present(cb.emb, primitive(loc.position(cb)))).get,
+            EmitCode.present(cb.emb, loc.contig(cb)), EmitCode.present(cb.emb, primitive(loc.position(cb)))),
           deepCopy)
     }
   }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -3,12 +3,12 @@ package is.hail.types.physical
 import is.hail.annotations.{Annotation, NDArray, Region, UnsafeOrdering}
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{CodeParam, CodeParamType, EmitCode, EmitCodeBuilder, Param, ParamType, SCodeParam}
-import is.hail.types.physical.stypes.{SCode, SValue}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete._
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual.{TNDArray, Type}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerSettable, SNDArrayPointer, SNDArrayPointerCode, SNDArrayPointerSettable, SNDArrayPointerValue, SStackStruct}
-import org.apache.spark.sql.Row
 import is.hail.utils._
+import org.apache.spark.sql.Row
 
 final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boolean = false) extends PNDArray  {
   assert(elementType.required, "elementType must be required")
@@ -125,7 +125,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
   }
 
   def setElement(cb: EmitCodeBuilder, region: Value[Region],
-    indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], newElement: SCode, deepCopy: Boolean): Unit = {
+    indices: IndexedSeq[Value[Long]], ndAddress: Value[Long], newElement: SValue, deepCopy: Boolean): Unit = {
     elementType.storeAtAddress(cb, getElementAddress(cb, indices, ndAddress), region, newElement, deepCopy)
   }
 
@@ -191,7 +191,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       mb.emitSCode { cb =>
 
         val region = mb.getCodeParam[Region](1)
-        val dataValue = mb.getSCodeParam(2).asIndexable.memoize(cb, "pcndarray_construct_by_copying_array_datavalue")
+        val dataValue = mb.getSCodeParam(2).asIndexable
         val shape = (0 until nDims).map(i => SizeValueDyn(mb.getCodeParam[Long](3 + i)))
         val strides = (0 until nDims).map(i => mb.getCodeParam[Long](3 + nDims + i))
 
@@ -199,11 +199,11 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
         dataValue.st match {
           case SIndexablePointer(PCanonicalArray(otherElementType, _)) if otherElementType == elementType =>
-            cb += Region.copyFrom(dataValue.asInstanceOf[SIndexablePointerSettable].elementsAddress, result.firstDataAddress, dataValue.loadLength().toL * elementType.byteSize)
+            cb += Region.copyFrom(dataValue.asInstanceOf[SIndexablePointerValue].elementsAddress, result.firstDataAddress, dataValue.loadLength().toL * elementType.byteSize)
           case _ =>
             val loopCtr = cb.newLocal[Long]("pcanonical_ndarray_construct_by_copying_loop_idx")
             cb.forLoop(cb.assign(loopCtr, 0L), loopCtr < dataValue.loadLength().toL, cb.assign(loopCtr, loopCtr + 1L), {
-              elementType.storeAtAddress(cb, result.firstDataAddress + (loopCtr * elementType.byteSize), region, dataValue.loadElement(cb, loopCtr.toI).get(cb, "NDArray elements cannot be missing").get, true)
+              elementType.storeAtAddress(cb, result.firstDataAddress + (loopCtr * elementType.byteSize), region, dataValue.loadElement(cb, loopCtr.toI).get(cb, "NDArray elements cannot be missing"), true)
             })
         }
 
@@ -248,11 +248,11 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
     cb.assign(ndAddr, this.representation.allocate(region))
     shapeType.storeAtAddress(cb, cb.newLocal[Long]("construct_shape", this.representation.fieldOffset(ndAddr, "shape")),
       region,
-      SStackStruct.constructFromArgs(cb, region, shapeType.virtualType, shape.map(s => EmitCode.present(cb.emb, primitive(s))): _*).get,
+      SStackStruct.constructFromArgs(cb, region, shapeType.virtualType, shape.map(s => EmitCode.present(cb.emb, primitive(s))): _*),
       false)
     strideType.storeAtAddress(cb, cb.newLocal[Long]("construct_strides", this.representation.fieldOffset(ndAddr, "strides")),
       region,
-      SStackStruct.constructFromArgs(cb, region, strideType.virtualType, strides.map(s => EmitCode.present(cb.emb, primitive(s))): _*).get,
+      SStackStruct.constructFromArgs(cb, region, strideType.virtualType, strides.map(s => EmitCode.present(cb.emb, primitive(s))): _*),
       false)
     val newDataPointer = cb.newLocal("ndarray_construct_new_data_pointer", dataPtr)
     cb += Region.storeAddress(this.representation.fieldOffset(ndAddr, 2), newDataPointer)
@@ -350,23 +350,23 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     val addr = cb.memoize(this.representation.allocate(region))
-    storeAtAddress(cb, addr, region, value.get, deepCopy)
+    storeAtAddress(cb, addr, region, value, deepCopy)
     addr
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
     val targetAddr = cb.newLocal[Long]("pcanonical_ndarray_store_at_addr_target", addr)
-    val inputSNDValue = value.asNDArray.memoize(cb, "pcanonical_ndarray_store_at_addr_input")
+    val inputSNDValue = value.asNDArray
     val shape = inputSNDValue.shapes
     val strides = inputSNDValue.strides
     val dataAddr = inputSNDValue.firstDataAddress
     shapeType.storeAtAddress(cb, cb.newLocal[Long]("construct_shape", this.representation.fieldOffset(targetAddr, "shape")),
       region,
-      SStackStruct.constructFromArgs(cb, region, shapeType.virtualType, shape.map(s => EmitCode.present(cb.emb, primitive(s))): _*).get,
+      SStackStruct.constructFromArgs(cb, region, shapeType.virtualType, shape.map(s => EmitCode.present(cb.emb, primitive(s))): _*),
       false)
     strideType.storeAtAddress(cb, cb.newLocal[Long]("construct_strides", this.representation.fieldOffset(targetAddr, "strides")),
       region,
-      SStackStruct.constructFromArgs(cb, region, strideType.virtualType, strides.map(s => EmitCode.present(cb.emb, primitive(s))): _*).get,
+      SStackStruct.constructFromArgs(cb, region, strideType.virtualType, strides.map(s => EmitCode.present(cb.emb, primitive(s))): _*),
       false)
 
     value.st match {
@@ -379,7 +379,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
         val newDataAddr = this.allocateData(shape, region)
         cb += Region.storeAddress(this.representation.fieldOffset(targetAddr, "data"), newDataAddr)
         val outputSNDValue = new SNDArrayPointerCode(sType, targetAddr).memoize(cb, "pcanonical_ndarray_store_at_addr_output")
-        outputSNDValue.coiterateMutate(cb, region, true, (inputSNDValue.get, "input")){
+        outputSNDValue.coiterateMutate(cb, region, true, (inputSNDValue, "input")){
           case Seq(dest, elt) =>
             elt
         }

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -77,8 +77,8 @@ class PCanonicalString(val required: Boolean) extends PString {
     }
   }
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    cb += Region.storeAddress(addr, store(cb, region, value.memoize(cb, "storeAtAddress"), deepCopy))
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
+    cb += Region.storeAddress(addr, store(cb, region, value, deepCopy))
   }
 
   def loadFromNested(addr: Code[Long]): Code[Long] = binaryRepresentation.loadFromNested(addr)

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat32Code, SFloat32Value}
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TFloat32
 
 case object PFloat32Optional extends PFloat32(false)
@@ -40,7 +39,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat32
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeFloat(addr, value.asFloat.floatCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SFloat64, SFloat64Code, SFloat64Value}
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TFloat64
 
 case object PFloat64Optional extends PFloat64(false)
@@ -41,7 +40,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
 
   override def sType: SType = SFloat64
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeDouble(addr, value.asDouble.doubleCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.{Code, coerce, const, _}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code, SInt32Value}
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TInt32
 
 case object PInt32Optional extends PInt32(false)
@@ -37,7 +36,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt32
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeInt(addr, value.asInt.intCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s.{Code, coerce, const, _}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Code, SInt64Value}
-import is.hail.types.physical.stypes.{SCode, SType}
+import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TInt64
 
 case object PInt64Optional extends PInt64(false)
@@ -38,7 +37,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
 
   override def sType: SType = SInt64
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit =
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit =
     cb.append(Region.storeLong(addr, value.asLong.longCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =

--- a/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PPrimitive.scala
@@ -31,16 +31,16 @@ trait PPrimitive extends PType {
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     val newAddr = cb.memoize(region.allocate(alignment, byteSize))
-    storeAtAddress(cb, newAddr, region, value.get, deepCopy)
+    storeAtAddress(cb, newAddr, region, value, deepCopy)
     newAddr
   }
 
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
     storePrimitiveAtAddress(cb, addr, value)
   }
 
-  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SCode): Unit
+  def storePrimitiveAtAddress(cb: EmitCodeBuilder, addr: Code[Long], value: SValue): Unit
 
   def unstagedStoreJavaObject(annotation: Annotation, region: Region): Long = {
     val addr = region.allocate(this.byteSize)

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -120,7 +120,7 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] =
     throw new UnsupportedOperationException
 
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
     throw new UnsupportedOperationException
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -461,7 +461,7 @@ abstract class PType extends Serializable with Requiredness {
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long]
 
   // stores a stack value inside pre-allocated memory of this type (in a nested structure, for instance).
-  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit
+  def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -35,7 +35,7 @@ trait PUnrealizable extends PType {
 
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = unsupported
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = unsupported
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = unsupported
 
   override def containsPointers: Boolean = {
     throw new UnsupportedOperationException("containsPointers not supported on PUnrealizable")

--- a/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
@@ -96,8 +96,8 @@ case class StoredSTypePType(sType: SType, required: Boolean) extends PType {
     addr
   }
 
-  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SCode, deepCopy: Boolean): Unit = {
-    ct.store(cb, cb.newLocal[Long]("stored_stype_ptype_addr", addr), value.st.coerceOrCopy(cb, region, value.memoize(cb, "storeAtAddress"), deepCopy).valueTuple.map(_.get))
+  override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = {
+    ct.store(cb, cb.newLocal[Long]("stored_stype_ptype_addr", addr), value.st.coerceOrCopy(cb, region, value, deepCopy).valueTuple.map(_.get))
   }
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SValue = {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -7,39 +7,39 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives._
 
 object SCode {
-  def add(cb: EmitCodeBuilder, left: SCode, right: SCode, required: Boolean): SCode = {
+  def add(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Code(left.asInt.intCode(cb) + right.asInt.intCode(cb))
-      case (SFloat32, SFloat32) => new SFloat32Code(left.asFloat.floatCode(cb) + right.asFloat.floatCode(cb))
-      case (SInt64, SInt64) => new SInt64Code(left.asLong.longCode(cb) + right.asLong.longCode(cb))
-      case (SFloat64, SFloat64) => new SFloat64Code(left.asDouble.doubleCode(cb) + right.asDouble.doubleCode(cb))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) + right.asInt.intCode(cb)))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) + right.asFloat.floatCode(cb)))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) + right.asLong.longCode(cb)))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) + right.asDouble.doubleCode(cb)))
     }
   }
 
-  def multiply(cb: EmitCodeBuilder, left: SCode, right: SCode, required: Boolean): SCode = {
+  def multiply(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Code(left.asInt.intCode(cb) * right.asInt.intCode(cb))
-      case (SFloat32, SFloat32) => new SFloat32Code(left.asFloat.floatCode(cb) * right.asFloat.floatCode(cb))
-      case (SInt64, SInt64) => new SInt64Code(left.asLong.longCode(cb) * right.asLong.longCode(cb))
-      case (SFloat64, SFloat64) => new SFloat64Code(left.asDouble.doubleCode(cb) * right.asDouble.doubleCode(cb))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) * right.asInt.intCode(cb)))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) * right.asFloat.floatCode(cb)))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) * right.asLong.longCode(cb)))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) * right.asDouble.doubleCode(cb)))
     }
   }
 
-  def subtract(cb: EmitCodeBuilder, left: SCode, right: SCode, required: Boolean): SCode = {
+  def subtract(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Code(left.asInt.intCode(cb) - right.asInt.intCode(cb))
-      case (SFloat32, SFloat32) => new SFloat32Code(left.asFloat.floatCode(cb) - right.asFloat.floatCode(cb))
-      case (SInt64, SInt64) => new SInt64Code(left.asLong.longCode(cb) - right.asLong.longCode(cb))
-      case (SFloat64, SFloat64) => new SFloat64Code(left.asDouble.doubleCode(cb) - right.asDouble.doubleCode(cb))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) - right.asInt.intCode(cb)))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) - right.asFloat.floatCode(cb)))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) - right.asLong.longCode(cb)))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) - right.asDouble.doubleCode(cb)))
     }
   }
 
-  def divide(cb: EmitCodeBuilder, left: SCode, right: SCode, required: Boolean): SCode = {
+  def divide(cb: EmitCodeBuilder, left: SValue, right: SValue, required: Boolean): SValue = {
     (left.st, right.st) match {
-      case (SInt32, SInt32) => new SInt32Code(left.asInt.intCode(cb) / right.asInt.intCode(cb))
-      case (SFloat32, SFloat32) => new SFloat32Code(left.asFloat.floatCode(cb) / right.asFloat.floatCode(cb))
-      case (SInt64, SInt64) => new SInt64Code(left.asLong.longCode(cb) / right.asLong.longCode(cb))
-      case (SFloat64, SFloat64) => new SFloat64Code(left.asDouble.doubleCode(cb) / right.asDouble.doubleCode(cb))
+      case (SInt32, SInt32) => new SInt32Value(cb.memoize(left.asInt.intCode(cb) / right.asInt.intCode(cb)))
+      case (SFloat32, SFloat32) => new SFloat32Value(cb.memoize(left.asFloat.floatCode(cb) / right.asFloat.floatCode(cb)))
+      case (SInt64, SInt64) => new SInt64Value(cb.memoize(left.asLong.longCode(cb) / right.asLong.longCode(cb)))
+      case (SFloat64, SFloat64) => new SFloat64Value(cb.memoize(left.asDouble.doubleCode(cb) / right.asDouble.doubleCode(cb)))
     }
   }
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -113,7 +113,7 @@ class SIndexablePointerValue(
     }
   }
 
-  override def forEachDefined(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SCode) => Unit) {
+  override def forEachDefined(cb: EmitCodeBuilder)(f: (EmitCodeBuilder, Value[Int], SValue) => Unit) {
     st.pType match {
       case pca: PCanonicalArray =>
         val idx = cb.newLocal[Int]("foreach_pca_idx", 0)
@@ -124,7 +124,7 @@ class SIndexablePointerValue(
             {}, // do nothing,
             {
               val elt = et.loadCheapSCode(cb, et.loadFromNested(elementPtr))
-              f(cb, idx, elt.get)
+              f(cb, idx, elt)
             })
           cb.assign(idx, idx + 1)
           cb.assign(elementPtr, elementPtr + pca.elementByteSize)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -95,13 +95,13 @@ class SNDArrayPointerValue(
     deepCopy: Boolean,
     indexVars: IndexedSeq[String],
     destIndices: IndexedSeq[Int],
-    arrays: (SNDArrayCode, IndexedSeq[Int], String)*
-  )(body: IndexedSeq[SCode] => SCode
+    arrays: (SNDArrayValue, IndexedSeq[Int], String)*
+  )(body: IndexedSeq[SValue] => SValue
   ): Unit = {
-    SNDArray._coiterate(cb, indexVars, (this.get, destIndices, "dest") +: arrays: _*) { ptrs =>
-      val codes = (this.get +: arrays.map(_._1)).zip(ptrs).toFastIndexedSeq.map { case (array, ptr) =>
+    SNDArray._coiterate(cb, indexVars, (this, destIndices, "dest") +: arrays: _*) { ptrs =>
+      val codes = (this +: arrays.map(_._1)).zip(ptrs).toFastIndexedSeq.map { case (array, ptr) =>
         val pt: PType = array.st.pType.elementType
-        pt.loadCheapSCode(cb, pt.loadFromNested(ptr)).get
+        pt.loadCheapSCode(cb, pt.loadFromNested(ptr))
       }
       pt.elementType.storeAtAddress(cb, ptrs.head, region, body(codes), deepCopy)
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -90,13 +90,13 @@ class SNDArraySliceValue(
     deepCopy: Boolean,
     indexVars: IndexedSeq[String],
     destIndices: IndexedSeq[Int],
-    arrays: (SNDArrayCode, IndexedSeq[Int], String)*
-  )(body: IndexedSeq[SCode] => SCode
+    arrays: (SNDArrayValue, IndexedSeq[Int], String)*
+  )(body: IndexedSeq[SValue] => SValue
   ): Unit = {
-    SNDArray._coiterate(cb, indexVars, (this.get, destIndices, "dest") +: arrays: _*) { ptrs =>
-      val codes = (this.get +: arrays.map(_._1)).zip(ptrs).toFastIndexedSeq.map { case (array, ptr) =>
+    SNDArray._coiterate(cb, indexVars, (this, destIndices, "dest") +: arrays: _*) { ptrs =>
+      val codes = (this +: arrays.map(_._1)).zip(ptrs).toFastIndexedSeq.map { case (array, ptr) =>
         val pt: PType = array.st.pType.elementType
-        pt.loadCheapSCode(cb, pt.loadFromNested(ptr)).get
+        pt.loadCheapSCode(cb, pt.loadFromNested(ptr))
       }
       pt.elementType.storeAtAddress(cb, ptrs.head, region, body(codes), deepCopy)
     }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -339,7 +339,7 @@ class SUnreachableNDArrayValue(override val st: SUnreachableNDArray) extends SUn
   override def get: SUnreachableNDArrayCode = st.sc
 
   override def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], deepCopy: Boolean, indexVars: IndexedSeq[String],
-    destIndices: IndexedSeq[Int], arrays: (SNDArrayCode, IndexedSeq[Int], String)*)(body: IndexedSeq[SCode] => SCode): Unit = ()
+    destIndices: IndexedSeq[Int], arrays: (SNDArrayValue, IndexedSeq[Int], String)*)(body: IndexedSeq[SValue] => SValue): Unit = ()
 }
 
 case class SUnreachableContainer(virtualType: TContainer) extends SUnreachable with SContainer {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -25,7 +25,7 @@ object SNDArray {
     forEachIndexWithInitAndIncColMajor(cb, shape, shape.map(_ => (cb: EmitCodeBuilder) => ()), shape.map(_ => (cb: EmitCodeBuilder) => ()), context)(f)
   }
 
-  def coiterate(cb: EmitCodeBuilder, arrays: (SNDArrayCode, String)*)(body: IndexedSeq[SValue] => Unit): Unit = {
+  def coiterate(cb: EmitCodeBuilder, arrays: (SNDArrayValue, String)*)(body: IndexedSeq[SValue] => Unit): Unit = {
     if (arrays.isEmpty) return
     val indexVars = Array.tabulate(arrays(0)._1.st.nDims)(i => s"i$i").toFastIndexedSeq
     val indices = Array.range(0, arrays(0)._1.st.nDims).toFastIndexedSeq
@@ -40,7 +40,7 @@ object SNDArray {
   def coiterate(
     cb: EmitCodeBuilder,
     indexVars: IndexedSeq[String],
-    arrays: (SNDArrayCode, IndexedSeq[Int], String)*
+    arrays: (SNDArrayValue, IndexedSeq[Int], String)*
   )(body: IndexedSeq[SValue] => Unit
   ): Unit = {
     _coiterate(cb, indexVars, arrays: _*) { ptrs =>
@@ -55,7 +55,7 @@ object SNDArray {
   def _coiterate(
     cb: EmitCodeBuilder,
     indexVars: IndexedSeq[String],
-    arrays: (SNDArrayCode, IndexedSeq[Int], String)*
+    arrays: (SNDArrayValue, IndexedSeq[Int], String)*
   )(body: IndexedSeq[Value[Long]] => Unit
   ): Unit = {
     val indexSizes = new Array[Settable[Int]](indexVars.length)
@@ -68,13 +68,12 @@ object SNDArray {
       indexToDim: Map[Int, Int],
       name: String)
 
-    val info = arrays.toIndexedSeq.map { case (_array, indices, name) =>
+    val info = arrays.toIndexedSeq.map { case (array, indices, name) =>
       for (idx <- indices) assert(idx < indexVars.length && idx >= 0)
       // FIXME: relax this assumption to handle transposing, non-column major
       for (i <- 0 until indices.length - 1) assert(indices(i) < indices(i+1))
-      assert(indices.length == _array.st.nDims)
+      assert(indices.length == array.st.nDims)
 
-      val array = _array.memoize(cb, s"${name}_copy")
       val shape = array.shapes
       for (i <- indices.indices) {
         val idx = indices(i)
@@ -688,17 +687,17 @@ trait SNDArrayValue extends SValue {
   // Inserts any necessary dynamic assertions
   def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue
 
-  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], arrays: (SNDArrayCode, String)*)(body: IndexedSeq[SCode] => SCode): Unit =
+  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], arrays: (SNDArrayValue, String)*)(body: IndexedSeq[SValue] => SValue): Unit =
     coiterateMutate(cb, region, false, arrays: _*)(body)
 
-  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], deepCopy: Boolean, arrays: (SNDArrayCode, String)*)(body: IndexedSeq[SCode] => SCode): Unit = {
+  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], deepCopy: Boolean, arrays: (SNDArrayValue, String)*)(body: IndexedSeq[SValue] => SValue): Unit = {
     if (arrays.isEmpty) return
     val indexVars = Array.tabulate(arrays(0)._1.st.nDims)(i => s"i$i").toFastIndexedSeq
     val indices = Array.range(0, arrays(0)._1.st.nDims).toFastIndexedSeq
     coiterateMutate(cb, region, deepCopy, indexVars, indices, arrays.map { case (array, name) => (array, indices, name) }: _*)(body)
   }
 
-  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], indexVars: IndexedSeq[String], destIndices: IndexedSeq[Int], arrays: (SNDArrayCode, IndexedSeq[Int], String)*)(body: IndexedSeq[SCode] => SCode): Unit =
+  def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], indexVars: IndexedSeq[String], destIndices: IndexedSeq[Int], arrays: (SNDArrayValue, IndexedSeq[Int], String)*)(body: IndexedSeq[SValue] => SValue): Unit =
     coiterateMutate(cb, region, false, indexVars, destIndices, arrays: _*)(body)
 
   // Note: to iterate through an array in column major order, make sure the indices are in ascending order. E.g.
@@ -712,8 +711,8 @@ trait SNDArrayValue extends SValue {
     deepCopy: Boolean,
     indexVars: IndexedSeq[String],
     destIndices: IndexedSeq[Int],
-    arrays: (SNDArrayCode, IndexedSeq[Int], String)*
-  )(body: IndexedSeq[SCode] => SCode
+    arrays: (SNDArrayValue, IndexedSeq[Int], String)*
+  )(body: IndexedSeq[SValue] => SValue
   ): Unit
 
   def slice(cb: EmitCodeBuilder, indices: IndexedSeq[NDArrayIndex]): SNDArraySliceValue = {

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -6,7 +6,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.agg.TakeByRVAS
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code}
+import is.hail.types.physical.stypes.primitives.SInt32Value
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -104,7 +104,7 @@ class TakeByAggregatorSuite extends HailSuite {
           cb.whileLoop(i < n, {
             cb += (random := rng.invoke[Double, Double, Double]("runif", -10000d, 10000d).toI)
             tba.seqOp(cb, false, random, false, random)
-            ab.append(cb, new SInt32Code(random))
+            ab.append(cb, new SInt32Value(random))
             cb += (i := i + 1)
           })
           cb += ab.size.cne(n).orEmpty(Code._fatal[Unit]("bad size!"))


### PR DESCRIPTION
~Stacked on #10867~

Main changes here are converting the following methods to take/return SValue: `storeAtAddress`, `storePrimitiveAtAddress`, `coiterate`, `coiterateMutate`, `SIndexableValue.forEachDefined`, `SIndexableValue.forEachDefinedOrMissing`, `getSCodeParam`