### PR TITLE
[batch] ensure deletion of test billing projects

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -44,7 +44,6 @@ def get_billing_project_prefix():
 async def delete_all_test_billing_projects():
     billing_project_prefix = get_billing_project_prefix()
     bc = BatchClient(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
-    suppressed_exceptions = []
     try:
         for project in await bc.list_billing_projects():
             if project['billing_project'].startswith(billing_project_prefix):

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -72,11 +72,15 @@ async def random_billing_project_name(dev_client) -> AsyncGenerator[str, Any]:
         else:
             assert r['status'] != 'deleted', r
             try:
-                if r['status'] == 'open':
-                    await dev_client.close_billing_project(name)
+                async for batch in dev_client.list_batches(f'billing_project:{name}'):
+                    await batch.delete()
             finally:
-                if r['status'] != 'deleted':
-                    await dev_client.delete_billing_project(name)
+                try:
+                    if r['status'] == 'open':
+                        await dev_client.close_billing_project(name)
+                finally:
+                    if r['status'] != 'deleted':
+                        await dev_client.delete_billing_project(name)
 
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -2995,13 +2995,18 @@ steps:
     image:
       valueFrom: batch_image.image
     script: |
+      set -ex
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
-      export HAIL_TOKEN="{{ token }}"
-      cd /io/test
-      python3 -c '
+      for token in "{{ test_batch_0.token }}" "{{ test_batch_1.token }}" "{{ test_batch_2.token }}" "{{ test_batch_3.token }}" "{{ test_batch_4.token }}"
+      do
+          export HAIL_TOKEN="$token"
+          cd /io/test
+          python3 -c '
       import test_accounts
       import asyncio
-      asyncio.get_event_loop().run_until_complete(test_accounts.delete_all_test_billing_projects())'
+      asyncio.get_event_loop().run_until_complete(test_accounts.delete_all_test_billing_projects())
+      '
+      done
     inputs:
       - from: /repo/batch/test
         to: /io/test


### PR DESCRIPTION
1. Delete the right tokens in build.yaml
2. Ensure all users of `get_billing_project_name`, including `test_deleted_open_batches_do_not_prevent_billing_project_closure` delete their billing projects, if they stil exist.
3. Be a bit more careful about try-finally in deletion.