### PR TITLE
[vds] Implement resumable VariantDataset combiner state machine

### DIFF
--- a/hail/python/hail/vds/combiner/__init__.py
+++ b/hail/python/hail/vds/combiner/__init__.py
@@ -1,6 +1,9 @@
 from .combine import transform_gvcf, combine_variant_datasets
+from .variant_dataset_combiner import new_combiner, load_combiner
 
 __all__ = [
     'combine_variant_datasets',
     'transform_gvcf',
+    'new_combiner',
+    'load_combiner',
 ]

--- a/hail/python/hail/vds/combiner/__init__.py
+++ b/hail/python/hail/vds/combiner/__init__.py
@@ -1,10 +1,9 @@
 from .combine import transform_gvcf, combine_variant_datasets
-from .variant_dataset_combiner import new_combiner, load_combiner, run_combiner
+from .variant_dataset_combiner import new_combiner, load_combiner
 
 __all__ = [
     'combine_variant_datasets',
     'transform_gvcf',
     'new_combiner',
     'load_combiner',
-    'run_combiner',
 ]

--- a/hail/python/hail/vds/combiner/__init__.py
+++ b/hail/python/hail/vds/combiner/__init__.py
@@ -1,9 +1,10 @@
 from .combine import transform_gvcf, combine_variant_datasets
-from .variant_dataset_combiner import new_combiner, load_combiner
+from .variant_dataset_combiner import new_combiner, load_combiner, run_combiner
 
 __all__ = [
     'combine_variant_datasets',
     'transform_gvcf',
     'new_combiner',
     'load_combiner',
+    'run_combiner',
 ]

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -150,6 +150,12 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
             print()
             raise e
 
+    def run(self):
+        while not self.finished:
+            self.save()
+            self.step()
+        self.save()
+
     @staticmethod
     def load(path) -> 'VariantDatasetCombiner':
         fs = hl.current_backend().fs
@@ -257,14 +263,6 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
 
     def _temp_out_path(self, extra):
         return os.path.join(self.temp_path, 'combiner-intermidiates', f'{self._uuid}_{extra}')
-
-
-def run_combiner(**kwargs):
-    combiner = new_combiner(**kwargs)
-    while not combiner.finished:
-        combiner.save()
-        combiner.step()
-    combiner.save()
 
 
 def new_combiner(*,

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -178,6 +178,8 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                 }
 
     def step(self):
+        if self.finished:
+            return
         if self.gvcfs:
             self._step_gvcfs()
         else:

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -1,0 +1,297 @@
+import collections
+import hashlib
+import json
+import os
+import uuid
+
+from typing import Dict, List, Optional, Union
+
+import hail as hl
+
+from hail.utils.java import info, warning
+from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning
+from .. import VariantDataset
+
+
+VDSMetadata = collections.namedtuple('VDSMetadata', ['path', 'n_samples'])
+
+
+class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
+    default_gvcf_batch_size = 100
+    default_branch_factor = 100
+    default_target_records = 30_000
+
+    # These are used to calculate intervals for reading GVCFs in the combiner
+    # The genome interval size results in 2568 partions for GRCh38. The exome
+    # interval size assumes that they are around 2% the size of a genome and
+    # result in 65 partitions for GRCh38.
+    default_genome_interval_size = 1_200_000
+    default_exome_interval_size = 60_000_000
+
+    # TODO: need something for external header and sample names
+    __serialized_slots__ = [
+        'save_path',
+        'output_path',
+        'scratch_path',
+        'reference_genome',
+        'branch_factor',
+        'target_records',
+        'gvcf_batch_size',
+        'contig_recoding',
+        'gvcfs',
+        'vdses',
+        'gvcf_import_intervals',
+    ]
+
+    __slots__ = tuple(__serialized_slots__ + ['__vds_cache'])
+
+    def __init__(self,
+                 *,
+                 save_path: str,
+                 output_path: str,
+                 scratch_path: str,
+                 reference_genome: hl.ReferenceGenome,
+                 branch_factor: int = default_branch_factor,
+                 target_records: int = default_target_records,
+                 gvcf_batch_size: int = default_gvcf_batch_size,
+                 contig_recoding: Optional[Dict[str, str]] = None,
+                 gvcfs: List[str],
+                 vdses: List[VDSMetadata],
+                 gvcf_import_intervals: List[hl.utils.Interval],
+                 vds_cache: Optional[Dict[str, VariantDataset]] = None,
+                 ):
+        if not gvcf_import_intervals:
+            raise ValueError('gvcf import intervals must be nonempty')
+        interval = gvcf_import_intervals[0]
+        if not isinstance(interval.point_type, hl.tlocus):
+            raise ValueError(f'intervals point type must be a locus, found {interval.point_type}')
+        if interval.point_type.reference_genome != reference_genome:
+            raise ValueError(f'mismatch in intervals ({interval.point_type.reference_genome}) '
+                             f'and reference genome ({reference_genome}) types')
+        self.save_path = save_path
+        self.output_path = output_path
+        self.scratch_path = scratch_path
+        self.reference_genome = reference_genome
+        self.branch_factor = branch_factor
+        self.target_records = target_records
+        self.gvcf_batch_size = gvcf_batch_size
+        self.contig_recoding = contig_recoding
+        self.gvcfs = gvcfs
+        self.vdses = vdses
+        self.gvcf_import_intervals = gvcf_import_intervals
+        self.__vds_cache = vds_cache
+
+    def __eq__(self, other):
+        if other.__class__ != VariantDatasetCombiner:
+            return False
+        for slot in self.__serialized_slots__:
+            if getattr(self, slot) != getattr(other, slot):
+                return False
+        return True
+
+    def save(self):
+        fs = hl.current_backend().fs
+        with fs.open(self.save_path, 'w') as out:
+            json.dump(self, out, indent=2, cls=Encoder)
+
+    @staticmethod
+    def load(path) -> 'VariantDatasetCombiner':
+        fs = hl.current_backend().fs
+        with fs.open(path) as stream:
+            combiner = json.load(stream, cls=Decoder)
+            if combiner.save_path != path:
+                warning('path/save_path mismatch in loaded VariantDatasetCombiner, using '
+                        f'{path} as the new save_path for this combiner')
+                combiner.save_path = path
+            return combiner
+
+    @property
+    def finished(self) -> bool:
+        return not self.gvcfs and not self.vdses
+
+    def to_dict(self) -> dict:
+        intervals_typ = hl.tarray(hl.tinterval(hl.tlocus(self.reference_genome)))
+        return {'name': self.__class__.__name__,
+                'save_path': self.save_path,
+                'output_path': self.output_path,
+                'scratch_path': self.scratch_path,
+                'reference_genome': str(self.reference_genome),
+                'branch_factor': self.branch_factor,
+                'target_records': self.target_records,
+                'gvcf_batch_size': self.gvcf_batch_size,
+                'contig_recoding': self.contig_recoding,
+                'gvcfs': self.gvcfs,
+                'vdses': self.vdses,
+                'gvcf_import_intervals': intervals_typ._convert_to_json(self.gvcf_import_intervals),
+                }
+
+
+def new_combiner(*,
+                 output_path: str,
+                 scratch_path: str,
+                 save_path: Optional[str] = None,
+                 gvcf_paths: Optional[List[str]] = None,
+                 vds_paths: Optional[List[str]] = None,
+                 vds_sample_counts: Optional[List[int]] = None,
+                 intervals: Optional[List[hl.utils.Interval]] = None,
+                 import_interval_size: Optional[int] = None,
+                 use_genome_default_intervals: bool = False,
+                 use_exome_default_intervals: bool = False,
+                 header: Optional[str] = None,
+                 sample_names: Optional[List[str]] = None,
+                 branch_factor: int = VariantDatasetCombiner.default_branch_factor,
+                 target_records: int = VariantDatasetCombiner.default_target_records,
+                 batch_size: int = VariantDatasetCombiner.default_gvcf_batch_size,
+                 reference_genome: Union[str, hl.ReferenceGenome] = 'default',
+                 contig_recoding: Optional[Dict[str, str]] = None,
+                 force: bool = False,
+                 ) -> VariantDatasetCombiner:
+    if not (gvcf_paths or vds_paths):
+        raise ValueError("at least one  of 'gvcf_paths' or 'vds_paths' must be not empty")
+    if gvcf_paths is None:
+        gvcf_paths = []
+    if vds_paths is None:
+        vds_paths = []
+    if vds_sample_counts is not None:
+        assert len(vds_paths) == len(vds_sample_counts)
+
+    n_partition_args = (int(intervals is not None)
+                        + int(import_interval_size is not None)
+                        + int(use_genome_default_intervals)
+                        + int(use_exome_default_intervals))
+
+    if n_partition_args == 0:
+        raise ValueError("'new_combiner': require one argument from 'intervals', 'import_interval_size', "
+                         "'use_genome_default_intervals', or 'use_exome_default_intervals' to choose GVCF partitioning")
+
+    def maybe_load_from_saved_path(save_path: str) -> Optional[VariantDatasetCombiner]:
+        if force:
+            return None
+        fs = hl.current_backend().fs
+        if fs.exists(save_path):
+            try:
+                combiner = load_combiner(save_path)
+                warning(f'found existing combiner plan at {save_path}, using it')
+                # we overwrite these values as they are serialized, but not part of the
+                # hash for an autogenerated name and we want users to be able to overwrite
+                # these when resuming a combine (a common reason to need to resume a combine
+                # is a failure due to branch factor being too large)
+                combiner.branch_factor = branch_factor
+                combiner.target_records = target_records
+                combiner.gvcf_batch_size = batch_size
+                return combiner
+            except:
+                warning(f'file exists at {save_path}, but it is not a valid combiner plan, overwriting')
+        return None
+
+    # We do the first save_path check now after validating the arguments
+    if save_path is not None:
+        saved_combiner = maybe_load_from_saved_path(save_path)
+        if saved_combiner is not None:
+            return saved_combiner
+
+    if n_partition_args > 1:
+        warning("'run_combiner': multiple colliding arguments found from 'intervals', 'import_interval_size', "
+                "'use_genome_default_intervals', or 'use_exome_default_intervals'."
+                "\n  The argument found first in the list in this warning will be used, and others ignored.")
+
+    if intervals is not None:
+        pass
+    elif import_interval_size is not None:
+        intervals = calculate_even_genome_partitioning(reference_genome, import_interval_size)
+    elif use_genome_default_intervals:
+        size = VariantDatasetCombiner.default_genome_interval_size
+        intervals = calculate_even_genome_partitioning(reference_genome, size)
+    elif use_exome_default_intervals:
+        size = VariantDatasetCombiner.default_exome_interval_size
+        intervals = calculate_even_genome_partitioning(reference_genome, size)
+    assert intervals is not None
+
+    if isinstance(reference_genome, str):
+        reference_genome = hl.get_reference(reference_genome)
+
+    if save_path is None:
+        sha = hashlib.sha256()
+        sha.update(output_path.encode())
+        sha.update(scratch_path.encode())
+        sha.update(str(reference_genome).encode())
+        for path in gvcf_paths:
+            sha.update(path.encode())
+        for path in vds_paths:
+            sha.update(path.encode())
+        if header is not None:
+            sha.update(header.encode())
+        if sample_names is not None:
+            for name in sample_names:
+                sha.update(name.encode())
+        if contig_recoding is not None:
+            for key, value in sorted(contig_recoding.items()):
+                sha.update(key.encode())
+                sha.update(value.encode())
+        for interval in intervals:
+            sha.update(str(interval).encode())
+        digest = sha.hexdigest()
+        name = f'vds-combiner-plan_{digest}_{hl.__pip_version__}.json'
+        save_path = os.path.join(scratch_path, 'combiner-plans', name)
+        saved_combiner = maybe_load_from_saved_path(save_path)
+        if saved_combiner is not None:
+            return saved_combiner
+
+    if vds_sample_counts:
+        cache = None
+        vdses = [VDSMetadata(path, n_samples) for path, n_samples in zip(vds_paths, vds_sample_counts)]
+    else:
+        vdses = []
+        cache = {}
+        for path in vds_paths:
+            vds = hl.vds.read_vds(path)
+            n_samples = vds.n_samples()
+            cache[path] = vds
+            vdses.append(VDSMetadata(path, n_samples))
+
+    return VariantDatasetCombiner(save_path=save_path,
+                                  output_path=output_path,
+                                  scratch_path=scratch_path,
+                                  reference_genome=reference_genome,
+                                  branch_factor=branch_factor,
+                                  target_records=target_records,
+                                  gvcf_batch_size=batch_size,
+                                  contig_recoding=contig_recoding,
+                                  gvcfs=gvcf_paths,
+                                  vdses=vdses,
+                                  gvcf_import_intervals=intervals,
+                                  vds_cache=cache)
+
+
+def load_combiner(path: str) -> VariantDatasetCombiner:
+    return VariantDatasetCombiner.load(path)
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, VariantDatasetCombiner):
+            return o.to_dict()
+        return json.JSONEncoder.default(self, o)
+
+
+class Decoder(json.JSONDecoder):
+    def __init__(self, **kwargs):
+        super().__init__(object_hook=Decoder._object_hook, **kwargs)
+
+    @staticmethod
+    def _object_hook(obj):
+        if 'name' not in obj:
+            return obj
+        name = obj['name']
+        if name == VariantDatasetCombiner.__name__:
+            del obj['name']
+            obj['vdses'] = [VDSMetadata(*x) for x in obj['vdses']]
+
+            rg = hl.get_reference(obj['reference_genome'])
+            obj['reference_genome'] = rg
+            intervals_type = hl.tarray(hl.tinterval(hl.tlocus(rg)))
+            intervals = intervals_type._convert_from_json(obj['gvcf_import_intervals'])
+            obj['gvcf_import_intervals'] = intervals
+
+            return VariantDatasetCombiner(**obj)
+        return obj

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -2,13 +2,12 @@ import collections
 import hashlib
 import json
 import os
-import uuid
 
 from typing import Dict, List, Optional, Union
 
 import hail as hl
 
-from hail.utils.java import info, warning
+from hail.utils.java import warning
 from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning
 from .. import VariantDataset
 

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -192,7 +192,7 @@ def new_combiner(*,
                 combiner.target_records = target_records
                 combiner.gvcf_batch_size = batch_size
                 return combiner
-            except:
+            except (ValueError, TypeError):
                 warning(f'file exists at {save_path}, but it is not a valid combiner plan, overwriting')
         return None
 

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -14,7 +14,7 @@ from hail.utils import Interval
 from hail.utils.java import Env, warning
 from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning, \
     calculate_new_intervals
-from .. import VariantDataset
+from hail.vds import VariantDataset
 from .combine import combine_variant_datasets, transform_gvcf
 
 

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -254,6 +254,14 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
         return os.path.join(self.temp_path, 'combiner-intermidiates', f'{self.uuid}_{extra}')
 
 
+def run_combiner(**kwargs):
+    combiner = new_combiner(**kwargs)
+    while not combiner.finished:
+        combiner.save()
+        combiner.step()
+    combiner.save()
+
+
 def new_combiner(*,
                  output_path: str,
                  temp_path: str,

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -135,7 +135,8 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
                 fs.copy(self.save_path, backup_path)
             with fs.open(self.save_path, 'w') as out:
                 json.dump(self, out, indent=2, cls=Encoder)
-            fs.remove(backup_path)
+            if fs.exists(backup_path):
+                fs.remove(backup_path)
         except OSError as e:
             # these messages get printed, because there is absolutely no guarentee
             # that the hail context is in a sane state if any of the above operations
@@ -146,6 +147,7 @@ class VariantDatasetCombiner:  # pylint: disable=too-many-instance-attributes
             print('Dumping current state as json to standard output, you may wish '
                   'to save this output in order to resume the combiner.')
             json.dump(self, sys.stdout, indent=2, cls=Encoder)
+            print()
             raise e
 
     @staticmethod

--- a/hail/python/hail/vds/combiner/variant_dataset_combiner.py
+++ b/hail/python/hail/vds/combiner/variant_dataset_combiner.py
@@ -14,7 +14,7 @@ from hail.utils import Interval
 from hail.utils.java import Env, warning
 from hail.experimental.vcf_combiner.vcf_combiner import calculate_even_genome_partitioning, \
     calculate_new_intervals
-from hail.vds import VariantDataset
+from hail.vds.variant_dataset import VariantDataset
 from .combine import combine_variant_datasets, transform_gvcf
 
 

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -116,6 +116,9 @@ class VariantDataset:
         self.write(path, **kwargs)
         return read_vds(path)
 
+    def n_samples(self) -> int:
+        return self.reference_data.count_cols()
+
     def validate(self):
         """Eagerly checks necessary representational properties of the VDS."""
 
@@ -208,3 +211,6 @@ class VariantDataset:
         if end_before_position:
             error('found records in reference data with END before locus position\n  ' + '\n  '.join(
                 str(x) for x in end_before_position))
+
+    def _same(self, other: 'VariantDataset'):
+        return self.reference_data._same(other.reference_data) and self.variant_data._same(other.variant_data)

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -5,7 +5,7 @@ from hail.matrixtable import MatrixTable
 from hail.utils.java import info
 
 
-def read_vds(path) -> 'VariantDataset':
+def read_vds(path, *, intervals=None) -> 'VariantDataset':
     """Read in a :class:`.VariantDataset` written with :meth:`.VariantDataset.write`.
 
     Parameters
@@ -16,8 +16,8 @@ def read_vds(path) -> 'VariantDataset':
     -------
     :class:`.VariantDataset`
     """
-    reference_data = hl.read_matrix_table(VariantDataset._reference_path(path))
-    variant_data = hl.read_matrix_table(VariantDataset._variants_path(path))
+    reference_data = hl.read_matrix_table(VariantDataset._reference_path(path), _intervals=intervals)
+    variant_data = hl.read_matrix_table(VariantDataset._variants_path(path), _intervals=intervals)
 
     return VariantDataset(reference_data, variant_data)
 

--- a/hail/python/hail/vds/variant_dataset.py
+++ b/hail/python/hail/vds/variant_dataset.py
@@ -104,9 +104,9 @@ class VariantDataset:
 
         return VariantDataset(rmt, vmt)
 
-    def __init__(self, reference_data: 'MatrixTable', variant_data: 'MatrixTable'):
-        self.reference_data: 'MatrixTable' = reference_data
-        self.variant_data: 'MatrixTable' = variant_data
+    def __init__(self, reference_data: MatrixTable, variant_data: MatrixTable):
+        self.reference_data: MatrixTable = reference_data
+        self.variant_data: MatrixTable = variant_data
 
     def write(self, path, **kwargs):
         self.reference_data.write(VariantDataset._reference_path(path), **kwargs)

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -90,7 +90,7 @@ def test_combiner_plan_round_trip_serialization():
     out_file = new_temp_file(extension='vds')
     plan = new_combiner(gvcf_paths=paths,
                         output_path=out_file,
-                        scratch_path=Env.hc()._tmpdir,
+                        temp_path=Env.hc()._tmpdir,
                         save_path=plan_path,
                         reference_genome='GRCh38',
                         use_exome_default_intervals=True,

--- a/hail/python/test/hail/vds/test_combiner.py
+++ b/hail/python/test/hail/vds/test_combiner.py
@@ -1,0 +1,101 @@
+import os
+
+import hail as hl
+
+from hail.utils.java import Env
+from hail.utils.misc import new_temp_file
+from hail.vds.combiner import combine_variant_datasets, new_combiner, load_combiner, transform_gvcf
+from ..helpers import startTestHailContext, stopTestHailContext, resource, fails_local_backend, fails_service_backend
+
+setUpModule = startTestHailContext
+tearDownModule = stopTestHailContext
+
+
+all_samples = ['HG00308', 'HG00592', 'HG02230', 'NA18534', 'NA20760',
+               'NA18530', 'HG03805', 'HG02223', 'HG00637', 'NA12249',
+               'HG02224', 'NA21099', 'NA11830', 'HG01378', 'HG00187',
+               'HG01356', 'HG02188', 'NA20769', 'HG00190', 'NA18618',
+               'NA18507', 'HG03363', 'NA21123', 'HG03088', 'NA21122',
+               'HG00373', 'HG01058', 'HG00524', 'NA18969', 'HG03833',
+               'HG04158', 'HG03578', 'HG00339', 'HG00313', 'NA20317',
+               'HG00553', 'HG01357', 'NA19747', 'NA18609', 'HG01377',
+               'NA19456', 'HG00590', 'HG01383', 'HG00320', 'HG04001',
+               'NA20796', 'HG00323', 'HG01384', 'NA18613', 'NA20802']
+
+
+@fails_local_backend
+@fails_service_backend
+def test_combiner_works():
+    _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
+    paths = [resource(p) for p in _paths]
+    parts = [
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 17821257, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 18708366, reference_genome='GRCh38')),
+                    includes_end=True),
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 18708367, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 19776611, reference_genome='GRCh38')),
+                    includes_end=True),
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 19776612, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 21144633, reference_genome='GRCh38')),
+                    includes_end=True)
+    ]
+    vcfs = [transform_gvcf(mt.annotate_rows(info=mt.info.annotate(
+        MQ_DP=hl.missing(hl.tint32),
+        VarDP=hl.missing(hl.tint32),
+        QUALapprox=hl.missing(hl.tint32))))
+            for mt in hl.import_gvcfs(paths, parts, reference_genome='GRCh38',
+                                      array_elements_required=False)]
+    comb = combine_variant_datasets(vcfs)
+    assert len(parts) == comb.variant_data.n_partitions()
+    comb.variant_data._force_count_rows()
+    comb.reference_data._force_count_rows()
+
+
+@fails_local_backend
+@fails_service_backend
+def test_vcf_vds_combiner_equivalence():
+    import hail.experimental.vcf_combiner.vcf_combiner as vcf
+    import hail.vds.combiner as vds
+    _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
+    paths = [resource(p) for p in _paths]
+    parts = [
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 17821257, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 18708366, reference_genome='GRCh38')),
+                    includes_end=True),
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 18708367, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 19776611, reference_genome='GRCh38')),
+                    includes_end=True),
+        hl.Interval(start=hl.Struct(locus=hl.Locus('chr20', 19776612, reference_genome='GRCh38')),
+                    end=hl.Struct(locus=hl.Locus('chr20', 21144633, reference_genome='GRCh38')),
+                    includes_end=True)
+    ]
+    vcfs = [mt.annotate_rows(info=mt.info.annotate(
+        MQ_DP=hl.missing(hl.tint32),
+        VarDP=hl.missing(hl.tint32),
+        QUALapprox=hl.missing(hl.tint32)))
+            for mt in hl.import_gvcfs(paths, parts, reference_genome='GRCh38',
+                                      array_elements_required=False)]
+    vds = vds.combine_variant_datasets([vds.transform_gvcf(mt) for mt in vcfs])
+    smt = vcf.combine_gvcfs([vcf.transform_gvcf(mt) for mt in vcfs])
+    smt_from_vds = hl.vds.to_merged_sparse_mt(vds).drop('RGQ')
+    smt = smt.select_entries(*smt_from_vds.entry)  # harmonize fields and order
+    smt = smt.key_rows_by('locus', 'alleles')
+    assert smt._same(smt_from_vds)
+
+
+def test_combiner_plan_round_trip_serialization():
+    sample_names = all_samples[:5]
+    paths = [os.path.join(resource('gvcfs'), '1kg_chr22', f'{s}.hg38.g.vcf.gz') for s in sample_names]
+    plan_path = new_temp_file(extension='json')
+    out_file = new_temp_file(extension='vds')
+    plan = new_combiner(gvcf_paths=paths,
+                        output_path=out_file,
+                        scratch_path=Env.hc()._tmpdir,
+                        save_path=plan_path,
+                        reference_genome='GRCh38',
+                        use_exome_default_intervals=True,
+                        branch_factor=2,
+                        batch_size=2)
+    plan.save()
+    plan_loaded = load_combiner(plan_path)
+    assert plan == plan_loaded


### PR DESCRIPTION
Create a new class `VariantDatasetCombiner` that implements a simple state
machine for running a VariantDataset combiner pipeline from start to
finish.

The `VariantDatasetCombiner` structure contains pretty much everything the
old `experimental.vcf_combiner.run_combiner` method took as arguments:
`temp_path`, `output_path`, list of gvcf paths, etc.. What is new is the
addition of a `save_path` and `vds_paths`. The `save_path` is used as
a filesystem or object storage location to save the state of the
combiner so that it may be resumed. The vds paths implement the long
awaited mixed hail and gvcf inputs, that was never completed for the VCF
combiner. End users should not call `VariantDatasetCombiner.__init__`
instead preferring the free function new_combiner. The
`VariantDatasetCombiner` API is fairly simple:

    * @property finished
    * save: serialize the current state to save_path
    * step: does the next unit of work for the combiner (described in more detail below)

The public api is present in 3 free functions:

    * run_combiner: just `new_combiner` followed by `step` in a loop until done
    * new_combiner: public VariantDatasetCombiner constructor
    * load_combiner

if `new_combiner` is not given a `save_path`, it will compute one based on
the SHA-256 of it's inputs. If the file at `save_path` is present, and
a valid `VariantDatasetCombiner`, it will load it and use it, unless the
`force` argument to `new_combiner` is True. This way, every combiner has
a `save_path`.

## The `step` algorithm

If there are any gvcf paths still uncombined, they are combined
`branch_factor` at a time, using `batch_size` parallel matrix table
writes to achive good parallelism. If there is only one merged vds, and
no vds arguments remaining to be combined it is written to
`output_path`. Otherwise the new vds paths are appended to the vds list
and the vds list is sorted by number of samples.

The vds paths are always kept sorted by samples and new items are only
ever added to the end of the list and then sorted. Since python's sort
function is stable, this will produce a stable output for a given set of
inputs and batch size. In order to preserve the gvcf sample ordering
from the paths, we work from the start of the gvcf list.

Once all the gvcfs are combined, we combine the variant datasets in
reverse order (smallest number of samples to largest number of samples)
inserting the new vds into the same sorted order until there are no
remaining input vdses, writing it to `output_path`

## Not Implemented Yet

Other stepping and planning strategies may be preferable in the future,
for example we could work the vds arguments into a list of lists based
on the log base `branch_factor` of the number of samples to create
a tiered list that is processed in order rather than reinserting new
datasets into a sorted list. This may create opportunites for large
scale parallelism on a future service backend.
