### PR TITLE
Refactor ResultOp to return a single element instead of a tuple.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -304,7 +304,6 @@ object IEmitCodeGen {
 }
 
 case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, required: Boolean) {
-  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   lazy val emitType: EmitType = {
     value match {
       case pc: SValue => EmitType(pc.st, required)
@@ -1058,8 +1057,7 @@ class Emit[C](
         }
 
       case GetField(o, name) =>
-        val emitStruct = emitI(o)
-        emitStruct.flatMap(cb) { oc =>
+        emitI(o).flatMap(cb) { oc =>
           oc.asBaseStruct.loadField(cb, name)
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2001,7 +2001,7 @@ class Emit[C](
         rvAgg.storeResult(cb, sc.states(idx), pt, addr, region,
           (cb: EmitCodeBuilder) => { cb.assign(missing, true) })
 
-        IEmitCode(cb, missing, pt.loadCheapSCode(cb, addr)).copy(required = pt.required)
+        IEmitCode(cb, missing, pt.loadCheapSCode(cb, addr))
 
       case x@ApplySeeded(fn, args, seed, rt) =>
         val codeArgs = args.map(a => EmitCode.fromI(cb.emb)(emitInNewBuilder(_, a)))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -304,7 +304,7 @@ object IEmitCodeGen {
 }
 
 case class IEmitCodeGen[+A](Lmissing: CodeLabel, Lpresent: CodeLabel, value: A, required: Boolean) {
-
+  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   lazy val emitType: EmitType = {
     value match {
       case pc: SValue => EmitType(pc.st, required)
@@ -1058,7 +1058,8 @@ class Emit[C](
         }
 
       case GetField(o, name) =>
-        emitI(o).flatMap(cb) { oc =>
+        val emitStruct = emitI(o)
+        emitStruct.flatMap(cb) { oc =>
           oc.asBaseStruct.loadField(cb, name)
         }
 
@@ -1991,8 +1992,6 @@ class Emit[C](
 
       case ResultOp(idx, sig) =>
         val AggContainer(aggs, sc, _) = container.get
-
-        val pt = sig.pResultType
 
         val rvAgg = agg.Extract.getAgg(sig)
         rvAgg.result(cb, sc.states(idx), region)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1994,14 +1994,8 @@ class Emit[C](
 
         val pt = sig.pResultType
 
-        val addr = cb.newLocal("resultop_value_addr", region.allocate(pt.alignment, pt.byteSize))
-        val missing = cb.newLocal[Boolean]("result_op_was_missing", false)
-
         val rvAgg = agg.Extract.getAgg(sig)
-        rvAgg.storeResult(cb, sc.states(idx), pt, addr, region,
-          (cb: EmitCodeBuilder) => { cb.assign(missing, true) })
-
-        IEmitCode(cb, missing, pt.loadCheapSCode(cb, addr))
+        rvAgg.result(cb, sc.states(idx), region)
 
       case x@ApplySeeded(fn, args, seed, rt) =>
         val codeArgs = args.map(a => EmitCode.fromI(cb.emb)(emitInNewBuilder(_, a)))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -403,8 +403,8 @@ object EmitCode {
     new EmitCode(Lstart, ec.iec)
   }
 
-  def present(mb: EmitMethodBuilder[_], pc: SValue): EmitCode =
-    EmitCode.fromI(mb)(cb => IEmitCode.present(cb, pc))
+  def present(mb: EmitMethodBuilder[_], sv: SValue): EmitCode =
+    EmitCode.fromI(mb)(cb => IEmitCode.present(cb, sv))
 
   def missing(mb: EmitMethodBuilder[_], pt: SType): EmitCode =
     EmitCode.fromI(mb)(cb => IEmitCode.missing(cb, pt.defaultValue))

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -501,7 +501,7 @@ final case class ApplyScanOp(initOpArgs: IndexedSeq[IR], seqOpArgs: IndexedSeq[I
 final case class InitOp(i: Int, args: IndexedSeq[IR], aggSig: PhysicalAggSig) extends IR
 final case class SeqOp(i: Int, args: IndexedSeq[IR], aggSig: PhysicalAggSig) extends IR
 final case class CombOp(i1: Int, i2: Int, aggSig: PhysicalAggSig) extends IR
-final case class ResultOp(startIdx: Int, aggSigs: IndexedSeq[PhysicalAggSig]) extends IR
+final case class ResultOp(idx: Int, aggSig: PhysicalAggSig) extends IR
 
 private final case class CombOpValue(i: Int, value: IR, aggSig: PhysicalAggSig) extends IR
 final case class AggStateValue(i: Int, aggSig: AggStateSig) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -501,6 +501,13 @@ final case class ApplyScanOp(initOpArgs: IndexedSeq[IR], seqOpArgs: IndexedSeq[I
 final case class InitOp(i: Int, args: IndexedSeq[IR], aggSig: PhysicalAggSig) extends IR
 final case class SeqOp(i: Int, args: IndexedSeq[IR], aggSig: PhysicalAggSig) extends IR
 final case class CombOp(i1: Int, i2: Int, aggSig: PhysicalAggSig) extends IR
+object ResultOp {
+  def makeTuple(aggs: IndexedSeq[PhysicalAggSig]) = {
+    MakeTuple.ordered(aggs.zipWithIndex.map { case (aggSig, index) =>
+      ResultOp(index, aggSig)
+    })
+  }
+}
 final case class ResultOp(idx: Int, aggSig: PhysicalAggSig) extends IR
 
 private final case class CombOpValue(i: Int, value: IR, aggSig: PhysicalAggSig) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -42,8 +42,8 @@ object InferType {
       case _: InitOp => TVoid
       case _: SeqOp => TVoid
       case _: CombOp => TVoid
-      case ResultOp(_, aggSigs) =>
-        TTuple(aggSigs.map(_.resultType): _*)
+      case ResultOp(_, aggSig) =>
+        aggSig.resultType
       case AggStateValue(i, sig) => TBinary
       case _: CombOpValue => TVoid
       case _: InitFromSerializedValue => TVoid

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1214,8 +1214,8 @@ object IRParser {
         done(CombOp(i1, i2, aggSig))
       case "ResultOp" =>
         val i = int32_literal(it)
-        val aggSigs = p_agg_sigs(env.typEnv)(it)
-        done(ResultOp(i, aggSigs))
+        val aggSig = p_agg_sig(env.typEnv)(it)
+        done(ResultOp(i, aggSig))
       case "AggStateValue" =>
         val i = int32_literal(it)
         val sig = agg_state_signature(env.typEnv)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -111,7 +111,7 @@ object Pretty {
     case InitOp(i, args, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
     case SeqOp(i, args, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
     case CombOp(i1, i2, aggSig) => FastSeq(i1.toString, i2.toString, prettyPhysicalAggSig(aggSig))
-    case ResultOp(i, aggSigs) => FastSeq(i.toString, prettyPhysicalAggSigs(aggSigs))
+    case ResultOp(i, aggSig) => FastSeq(i.toString, prettyPhysicalAggSig(aggSig))
     case AggStateValue(i, sig) => FastSeq(i.toString, prettyAggStateSignature(sig))
     case InitFromSerializedValue(i, value, aggSig) =>
       FastSeq(i.toString, prettyAggStateSignature(aggSig))

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -719,9 +719,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
           requiredness.union(required)
       }
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
-      case ResultOp(_, sigs) =>
-        val r = coerce[RBaseStruct](requiredness)
-        r.fields.foreach { f => f.typ.fromPType(sigs(f.index).pResultType) }
+      case ResultOp(_, sig) =>
+        val r = requiredness
+        r.fromPType(sig.pResultType)
       case RunAgg(_, result, _) =>
         requiredness.unionFrom(lookup(result))
       case RunAggScan(array, name, init, seqs, result, signature) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -720,8 +720,9 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       }
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
       case ResultOp(_, sig) =>
-        val r = requiredness
-        r.fromPType(sig.pResultType)
+        requiredness.union(false)
+//        val r = requiredness
+//        r.fromPType(sig.pResultType)
       case RunAgg(_, result, _) =>
         requiredness.unionFrom(lookup(result))
       case RunAggScan(array, name, init, seqs, result, signature) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -605,15 +605,15 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
         rit.union(lookup(a).required)
         rit.elementType.unionFrom(lookup(body))
       case ApplyAggOp(initOpArgs, seqOpArgs, aggSig) => //FIXME round-tripping through ptype
-        val pResult = agg.PhysicalAggSig(aggSig.op, agg.AggStateSig(aggSig.op,
+        val emitResult = agg.PhysicalAggSig(aggSig.op, agg.AggStateSig(aggSig.op,
           initOpArgs.map(i => i -> lookup(i)),
-          seqOpArgs.map(s => s -> lookup(s)))).pResultType
-        requiredness.fromPType(pResult)
+          seqOpArgs.map(s => s -> lookup(s)))).emitResultType
+        requiredness.fromEmitType(emitResult)
       case ApplyScanOp(initOpArgs, seqOpArgs, aggSig) =>
-        val pResult = agg.PhysicalAggSig(aggSig.op, agg.AggStateSig(aggSig.op,
+        val emitResult = agg.PhysicalAggSig(aggSig.op, agg.AggStateSig(aggSig.op,
           initOpArgs.map(i => i -> lookup(i)),
-          seqOpArgs.map(s => s -> lookup(s)))).pResultType
-        requiredness.fromPType(pResult)
+          seqOpArgs.map(s => s -> lookup(s)))).emitResultType
+        requiredness.fromEmitType(emitResult)
       case MakeNDArray(data, shape, rowMajor, _) =>
         requiredness.unionFrom(lookup(data))
         requiredness.union(lookup(shape).required)
@@ -721,7 +721,7 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
       case ResultOp(_, sig) =>
         val r = requiredness
-        r.fromPType(sig.pResultType)
+        r.fromEmitType(sig.emitResultType)
       case RunAgg(_, result, _) =>
         requiredness.unionFrom(lookup(result))
       case RunAggScan(array, name, init, seqs, result, signature) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -720,9 +720,8 @@ class Requiredness(val usesAndDefs: UsesAndDefs, ctx: ExecuteContext) {
       }
       case LiftMeOut(f) => requiredness.unionFrom(lookup(f))
       case ResultOp(_, sig) =>
-        requiredness.union(false)
-//        val r = requiredness
-//        r.fromPType(sig.pResultType)
+        val r = requiredness
+        r.fromPType(sig.pResultType)
       case RunAgg(_, result, _) =>
         requiredness.unionFrom(lookup(result))
       case RunAggScan(array, name, init, seqs, result, signature) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -4,8 +4,9 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
-import is.hail.types.physical.stypes.concrete.SBaseStructPointerValue
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerValue}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual.{TFloat64, TInt32, Type}
 import is.hail.utils._
 
@@ -43,7 +44,7 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
   }
 
   def result(cb: EmitCodeBuilder, region: Value[Region]): SBaseStructPointerValue = {
-    QuantilesAggregator.resultType.loadCheapSCode(cb, aggr.invoke[Region, Long]("rvResult", region))
+    QuantilesAggregator.resultPType.loadCheapSCode(cb, aggr.invoke[Region, Long]("rvResult", region))
   }
 
   def newState(cb: EmitCodeBuilder, off: Code[Long]): Unit = cb += region.getNewRegion(regionSize)
@@ -112,7 +113,7 @@ class ApproxCDFState(val kb: EmitClassBuilder[_]) extends AggregatorState {
 class ApproxCDFAggregator extends StagedAggregator {
   type State = ApproxCDFState
 
-  def resultType: PStruct = QuantilesAggregator.resultType
+  def resultEmitType: EmitType = EmitType(SBaseStructPointer(QuantilesAggregator.resultPType), true)
   val initOpTypes: Seq[Type] = FastSeq(TInt32)
   val seqOpTypes: Seq[Type] = FastSeq(TFloat64)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.physical.stypes.concrete.SBaseStructPointerValue
 import is.hail.types.physical._
@@ -137,8 +137,7 @@ class ApproxCDFAggregator extends StagedAggregator {
     state.comb(cb, other)
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    assert(pt == resultType)
-    pt.storeAtAddress(cb, addr, region, state.result(cb, region), deepCopy = true)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    IEmitCode.present(cb, state.result(cb, region))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
@@ -737,7 +737,7 @@ class ApproxCDFStateManager(val k: Int) {
 
 object QuantilesAggregator {
   val resultPType: PCanonicalStruct =
-    PCanonicalStruct(required = true,
+    PCanonicalStruct(required = false,
       "values" -> PCanonicalArray(PFloat64(true), required = true),
       "ranks" -> PCanonicalArray(PInt64(true), required = true),
       "_compaction_counts" -> PCanonicalArray(PInt32(true), required = true))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFStateManager.scala
@@ -646,7 +646,7 @@ class ApproxCDFStateManager(val k: Int) {
 
   def rvResult(r: Region): Long = {
     val rvb = new RegionValueBuilder(r)
-    rvb.start(QuantilesAggregator.resultType)
+    rvb.start(QuantilesAggregator.resultPType)
     result(rvb)
     rvb.end()
   }
@@ -736,7 +736,7 @@ class ApproxCDFStateManager(val k: Int) {
 }
 
 object QuantilesAggregator {
-  val resultType: PCanonicalStruct =
+  val resultPType: PCanonicalStruct =
     PCanonicalStruct(required = true,
       "values" -> PCanonicalArray(PFloat64(true), required = true),
       "ranks" -> PCanonicalArray(PInt64(true), required = true),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -5,6 +5,8 @@ import is.hail.asm4s.{coerce => _, _}
 import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.{EmitType, SValue}
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SIndexablePointer}
 import is.hail.types.virtual.{TInt32, TVoid, Type}
 import is.hail.utils._
 
@@ -170,8 +172,9 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
 class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], knownLength: Boolean) extends StagedAggregator {
   type State = ArrayElementState
 
-  val resultEltType: PCanonicalTuple = PCanonicalTuple(true, nestedAggs.map(_.resultType): _*)
-  val resultType: PCanonicalArray = PCanonicalArray(resultEltType, required = knownLength)
+  val resultEltType: PCanonicalTuple = PCanonicalTuple(true, nestedAggs.map(_.resultEmitType.storageType): _*)
+  val resultPType: PCanonicalArray = PCanonicalArray(resultEltType)
+  override def resultEmitType = EmitType(SIndexablePointer(resultPType), knownLength)
 
   val initOpTypes: Seq[Type] = if (knownLength) FastSeq(TInt32, TVoid) else FastSeq(TVoid)
   val seqOpTypes: Seq[Type] = FastSeq(TInt32)
@@ -234,33 +237,37 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
 
   protected override def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     val len = state.lenRef
-    IEmitCode(cb, len < 0,
-      {
-        val resultAddr = cb.newLocal[Long]("arrayagg_result_addr", resultType.allocate(region, len))
-        resultType.stagedInitialize(cb, resultAddr, len, setMissing = false)
-        val i = cb.newLocal[Int]("arrayagg_result_i", 0)
 
-        cb.whileLoop(i < len, {
-          val addrAtI = cb.newLocal[Long]("arrayagg_result_addr_at_i", resultType.elementOffset(resultAddr, len, i))
-          resultEltType.stagedInitialize(cb, addrAtI, setMissing = false)
-          cb.assign(state.idx, i)
-          state.load(cb)
-          state.nested.toCode { case (nestedIdx, nestedState) =>
-            val nestedAddr = cb.newLocal[Long](s"arrayagg_result_nested_addr_$nestedIdx", resultEltType.fieldOffset(addrAtI, nestedIdx))
-            val nestedRes = nestedAggs(nestedIdx).result(cb, nestedState, region)
-            nestedRes.consume(cb,
-              { resultEltType.setFieldMissing(cb, addrAtI, nestedIdx)},
-              { sv => resultEltType.types(nestedIdx).storeAtAddress(cb, nestedAddr, region, sv, true)})
-//            nestedAggs(nestedIdx).result(cb, nestedState, resultEltType.types(nestedIdx), nestedAddr, region,
-//              (cb: EmitCodeBuilder) => resultEltType.setFieldMissing(cb, addrAtI, nestedIdx))
-          }
-          state.store(cb)
-          cb.assign(i, i + 1)
-        })
-        // don't need to deep copy because that's done in nested aggregators
-        resultType.loadCheapSCode(cb, resultAddr)
-      }
-    )
+    def resultBody(cb: EmitCodeBuilder): SValue = {
+      val resultAddr = cb.newLocal[Long]("arrayagg_result_addr", resultPType.allocate(region, len))
+      resultPType.stagedInitialize(cb, resultAddr, len, setMissing = false)
+      val i = cb.newLocal[Int]("arrayagg_result_i", 0)
+
+      cb.whileLoop(i < len, {
+        val addrAtI = cb.newLocal[Long]("arrayagg_result_addr_at_i", resultPType.elementOffset(resultAddr, len, i))
+        resultEltType.stagedInitialize(cb, addrAtI, setMissing = false)
+        cb.assign(state.idx, i)
+        state.load(cb)
+        state.nested.toCode { case (nestedIdx, nestedState) =>
+          val nestedAddr = cb.newLocal[Long](s"arrayagg_result_nested_addr_$nestedIdx", resultEltType.fieldOffset(addrAtI, nestedIdx))
+          val nestedRes = nestedAggs(nestedIdx).result(cb, nestedState, region)
+          nestedRes.consume(cb,
+            { resultEltType.setFieldMissing(cb, addrAtI, nestedIdx)},
+            { sv => resultEltType.types(nestedIdx).storeAtAddress(cb, nestedAddr, region, sv, true)})
+        }
+        state.store(cb)
+        cb.assign(i, i + 1)
+      })
+      // don't need to deep copy because that's done in nested aggregators
+      resultPType.loadCheapSCode(cb, resultAddr)
+    }
+
+    if (knownLength) {
+      IEmitCode.present(cb, resultBody(cb))
+    }
+    else {
+      IEmitCode(cb, len < 0, resultBody(cb))
+    }
   }
 }
 
@@ -270,7 +277,8 @@ class ArrayElementwiseOpAggregator(nestedAggs: Array[StagedAggregator]) extends 
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](TInt32, TVoid)
 
-  def resultType: PType = PCanonicalArray(PCanonicalTuple(false, nestedAggs.map(_.resultType): _*))
+  val resultPType = PCanonicalArray(PCanonicalTuple(false, nestedAggs.map(_.resultEmitType.storageType): _*))
+  override def resultEmitType = EmitType(SIndexablePointer(resultPType), false)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit =
     throw new UnsupportedOperationException("State must be initialized by ArrayElementLengthCheckAggregator.")

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -176,9 +176,9 @@ class CallStatsAggregator extends StagedAggregator {
   }
 
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     val rt = CallStatsState.resultType
-    assert(pt == rt)
+    val addr = cb.memoize(rt.allocate(region), "call_stats_aggregator_result_addr")
     rt.stagedInitialize(cb, addr, setMissing = false)
     val alleleNumber = cb.newLocal[Int]("callstats_result_alleleNumber", 0)
 
@@ -216,5 +216,6 @@ class CallStatsAggregator extends StagedAggregator {
     }
 
     homCountType.storeAtAddress(cb, rt.fieldOffset(addr, "homozygote_count"), region, homCount, deepCopy = false)
+    IEmitCode.present(cb, rt.loadCheapSCode(cb, addr))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -6,6 +6,8 @@ import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
+import is.hail.types.physical.stypes.concrete.SIndexablePointer
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
@@ -63,7 +65,8 @@ class CollectAggState(val elemVType: VirtualTypeWithReq, val kb: EmitClassBuilde
 class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregator {
   type State = CollectAggState
 
-  val resultType = PCanonicalArray(elemType.canonicalPType, required = true)
+  val sArrayType = SIndexablePointer(PCanonicalArray(elemType.canonicalPType))
+  val resultEmitType = EmitType(sArrayType, true)
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](elemType.t)
 
@@ -80,8 +83,7 @@ class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregat
     state.bll.append(cb, state.region, other.bll)
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
-    assert(resultType.required)
     // deepCopy is handled by the blocked linked list
-    IEmitCode.present(cb, state.bll.resultArray(cb, region, resultType))
+    IEmitCode.present(cb, state.bll.resultArray(cb, region, resultEmitType.storageType.asInstanceOf[PCanonicalArray]))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -79,9 +79,8 @@ class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregat
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit =
     state.bll.append(cb, state.region, other.bll)
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    assert(pt == resultType)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by the blocked linked list
-    pt.storeAtAddress(cb, addr, region, state.bll.resultArray(cb, region, resultType), deepCopy = false)
+    IEmitCode.present(cb, state.bll.resultArray(cb, region, resultType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -80,6 +80,7 @@ class CollectAggregator(val elemType: VirtualTypeWithReq) extends StagedAggregat
     state.bll.append(cb, state.region, other.bll)
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    assert(resultType.required)
     // deepCopy is handled by the blocked linked list
     IEmitCode.present(cb, state.bll.resultArray(cb, region, resultType))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -8,7 +8,8 @@ import is.hail.io._
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.SIndexablePointer
+import is.hail.types.physical.stypes.{EmitType, SValue}
 import is.hail.types.virtual.Type
 import is.hail.utils._
 
@@ -153,8 +154,10 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
   type State = AppendOnlySetState
 
   private val elemPType = elem.canonicalPType
-  val resultType: PCanonicalSet = PCanonicalSet(elemPType, true)
-  private[this] val arrayRep = resultType.arrayRep
+  val setPType = PCanonicalSet(elemPType)
+  val setSType = SIndexablePointer(setPType)
+  val resultEmitType: EmitType = EmitType(setSType, true)
+  private[this] val arrayRep = resultEmitType.storageType.asInstanceOf[PCanonicalSet].arrayRep
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](elem.t)
 
@@ -179,6 +182,6 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
     }
     assert(arrayRep.required)
     // deepCopy is handled by `storeElement` above
-    IEmitCode.present(cb, resultType.construct(finish(cb)))
+    IEmitCode.present(cb, setPType.construct(finish(cb)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -172,13 +172,12 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
     other.foreach(cb) { (cb, k) => state.insert(cb, k) }
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    assert(pt == resultType)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     val (pushElement, finish) = arrayRep.constructFromFunctions(cb, region, state.size, deepCopy = true)
     state.foreach(cb) { (cb, elt) =>
       pushElement(cb, elt.toI(cb))
     }
     // deepCopy is handled by `storeElement` above
-    resultType.storeAtAddress(cb, addr, region, finish(cb), deepCopy = false)
+    IEmitCode.present(cb, finish(cb))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -153,7 +153,7 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
   type State = AppendOnlySetState
 
   private val elemPType = elem.canonicalPType
-  val resultType: PCanonicalSet = PCanonicalSet(elemPType)
+  val resultType: PCanonicalSet = PCanonicalSet(elemPType, true)
   private[this] val arrayRep = resultType.arrayRep
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](elem.t)
@@ -177,7 +177,8 @@ class CollectAsSetAggregator(elem: VirtualTypeWithReq) extends StagedAggregator 
     state.foreach(cb) { (cb, elt) =>
       pushElement(cb, elt.toI(cb))
     }
+    assert(arrayRep.required)
     // deepCopy is handled by `storeElement` above
-    IEmitCode.present(cb, finish(cb))
+    IEmitCode.present(cb, resultType.construct(finish(cb)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -4,13 +4,15 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.interfaces.primitive
+import is.hail.types.physical.stypes.primitives.SInt64
 import is.hail.types.virtual.Type
 
 object CountAggregator extends StagedAggregator {
   type State = PrimitiveRVAState
 
-  val resultType: PType = PInt64(true)
+  val resultEmitType: EmitType = EmitType(SInt64, true)
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type]()
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.interfaces.primitive
 import is.hail.types.virtual.Type
@@ -35,9 +35,9 @@ object CountAggregator extends StagedAggregator {
     cb.assign(v1, EmitCode.present(cb.emb, primitive(cb.memoize(v1.pv.asInt64.longCode(cb) + v2.pv.asInt64.longCode(cb)))))
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     assert(state.vtypes.head.r.required)
     val ev = state.fields(0)
-    pt.storeAtAddress(cb, addr, region, ev.pv, deepCopy = true)
+    ev.toI(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -142,7 +142,7 @@ class DensifyAggregator(val arrayVType: VirtualTypeWithReq) extends StagedAggreg
   private val pt = {
     // FIXME: VirtualTypeWithReq needs better ergonomics
     val eltType = arrayVType.canonicalPType.asInstanceOf[PCanonicalArray].elementType.setRequired(false)
-    PCanonicalArray(eltType, required = true)
+    PCanonicalArray(eltType)
   }
   val resultEmitType: EmitType = EmitType(SIndexablePointer(pt), true)
   val initOpTypes: Seq[Type] = Array(TInt32)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -167,9 +167,8 @@ class DensifyAggregator(val arrayVType: VirtualTypeWithReq) extends StagedAggreg
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     val resultInWrongRegion = state.result(cb, region)
-    val ptrInRightRegion = region.allocate(pt.alignment, resultInWrongRegion.length.get.toL)
     // deepCopy needs to be done here
-    pt.storeAtAddress(cb, ptrInRightRegion, region, resultInWrongRegion, deepCopy = true)
+    val ptrInRightRegion = pt.store(cb, region, resultInWrongRegion, true)
     IEmitCode.present(cb, pt.loadCheapSCode(cb, ptrInRightRegion))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -6,7 +6,8 @@ import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.concrete.SIndexablePointerValue
+import is.hail.types.physical.stypes.EmitType
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
@@ -143,9 +144,9 @@ class DensifyAggregator(val arrayVType: VirtualTypeWithReq) extends StagedAggreg
     val eltType = arrayVType.canonicalPType.asInstanceOf[PCanonicalArray].elementType.setRequired(false)
     PCanonicalArray(eltType, required = true)
   }
-  val resultType: PCanonicalArray = pt
+  val resultEmitType: EmitType = EmitType(SIndexablePointer(pt), true)
   val initOpTypes: Seq[Type] = Array(TInt32)
-  val seqOpTypes: Seq[Type] = Array(pt.virtualType)
+  val seqOpTypes: Seq[Type] = Array(resultEmitType.virtualType)
 
   protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     assert(init.length == 1)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -8,8 +8,8 @@ import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.SingleCodeSCode
-import is.hail.types.physical.stypes.concrete.SIndexablePointerValue
+import is.hail.types.physical.stypes.{EmitType, SingleCodeSCode}
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces.SBaseStructValue
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -543,7 +543,8 @@ object DownsampleAggregator {
 class DownsampleAggregator(arrayType: VirtualTypeWithReq) extends StagedAggregator {
   type State = DownsampleState
 
-  val resultType: PCanonicalArray = PCanonicalArray(PCanonicalTuple(required = true, PFloat64(true), PFloat64(true), arrayType.canonicalPType))
+  val resultPType: PCanonicalArray = PCanonicalArray(PCanonicalTuple(required = true, PFloat64(true), PFloat64(true), arrayType.canonicalPType))
+  val resultEmitType = EmitType(SIndexablePointer(resultPType), true)
 
   val initOpTypes: Seq[Type] = Array(TInt32)
   val seqOpTypes: Seq[Type] = Array(TFloat64, TFloat64, arrayType.t)
@@ -567,6 +568,6 @@ class DownsampleAggregator(arrayType: VirtualTypeWithReq) extends StagedAggregat
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by state.resultArray
-    IEmitCode.present(cb, state.resultArray(cb, region, resultType))
+    IEmitCode.present(cb, state.resultArray(cb, region, resultPType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -565,9 +565,8 @@ class DownsampleAggregator(arrayType: VirtualTypeWithReq) extends StagedAggregat
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.merge(cb, other)
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    assert(pt == resultType)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by state.resultArray
-    pt.storeAtAddress(cb, addr, region, state.resultArray(cb, region, resultType), deepCopy = false)
+    IEmitCode.present(cb, state.resultArray(cb, region, resultType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -266,9 +266,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
   }
 
   def results: IR = {
-    MakeTuple.ordered(aggs.zipWithIndex.map { case (aggSig, index) =>
-      ResultOp(index, aggSig)
-    })
+    ResultOp.makeTuple(aggs)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -265,7 +265,11 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[PhysicalAggS
     }
   }
 
-  def results: IR = ResultOp(0, aggs)
+  def results: IR = {
+    MakeTuple.ordered(aggs.zipWithIndex.map { case (aggSig, index) =>
+      ResultOp(index, aggSig)
+    })
+  }
 }
 
 object Extract {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -7,6 +7,7 @@ import is.hail.expr.ir
 import is.hail.expr.ir._
 import is.hail.io.BufferSpec
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual._
 import is.hail.types.{BaseTypeWithRequiredness, TypeWithRequiredness, VirtualTypeWithReq}
 import is.hail.utils._
@@ -105,8 +106,8 @@ class PhysicalAggSig(val op: AggOp, val state: AggStateSig, val nestedOps: Array
   val allOps: Array[AggOp] = nestedOps :+ op
   def initOpTypes: IndexedSeq[Type] = Extract.getAgg(this).initOpTypes.toFastIndexedSeq
   def seqOpTypes: IndexedSeq[Type] = Extract.getAgg(this).seqOpTypes.toFastIndexedSeq
-  def pResultType: PType = Extract.getAgg(this).resultType
-  def resultType: Type = pResultType.virtualType
+  def emitResultType: EmitType = Extract.getAgg(this).resultEmitType
+  def resultType: Type = emitResultType.virtualType
 }
 
 case class BasicPhysicalAggSig(override val op: AggOp, override val state: AggStateSig) extends PhysicalAggSig(op, state, Array())
@@ -302,16 +303,16 @@ object Extract {
     case AggSignature(Max(), _, Seq(t)) => t
     case AggSignature(Count(), _, _) => TInt64
     case AggSignature(Take(), _, Seq(t)) => TArray(t)
-    case AggSignature(CallStats(), _, _) => CallStatsState.resultType.virtualType
+    case AggSignature(CallStats(), _, _) => CallStatsState.resultPType.virtualType
     case AggSignature(TakeBy(_), _, Seq(value, key)) => TArray(value)
     case AggSignature(PrevNonnull(), _, Seq(t)) => t
     case AggSignature(CollectAsSet(), _, Seq(t)) => TSet(t)
     case AggSignature(Collect(), _, Seq(t)) => TArray(t)
     case AggSignature(Densify(), _, Seq(t)) => t
-    case AggSignature(ImputeType(), _, _) => ImputeTypeState.resultType.virtualType
+    case AggSignature(ImputeType(), _, _) => ImputeTypeState.resultPType.virtualType
     case AggSignature(LinearRegression(), _, _) =>
-      LinearRegressionAggregator.resultType.virtualType
-    case AggSignature(ApproxCDF(), _, _) => QuantilesAggregator.resultType.virtualType
+      LinearRegressionAggregator.resultPType.virtualType
+    case AggSignature(ApproxCDF(), _, _) => QuantilesAggregator.resultPType.virtualType
     case AggSignature(Downsample(), _, Seq(_, _, label)) => DownsampleAggregator.resultType
     case AggSignature(NDArraySum(), _, Seq(t)) => t
     case AggSignature(NDArrayMultiplyAdd(), _, Seq(a : TNDArray, _)) => a

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -309,7 +309,7 @@ object Extract {
     case AggSignature(CollectAsSet(), _, Seq(t)) => TSet(t)
     case AggSignature(Collect(), _, Seq(t)) => TArray(t)
     case AggSignature(Densify(), _, Seq(t)) => t
-    case AggSignature(ImputeType(), _, _) => ImputeTypeState.resultPType.virtualType
+    case AggSignature(ImputeType(), _, _) => ImputeTypeState.resultEmitType.virtualType
     case AggSignature(LinearRegression(), _, _) =>
       LinearRegressionAggregator.resultPType.virtualType
     case AggSignature(ApproxCDF(), _, _) => QuantilesAggregator.resultPType.virtualType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -264,7 +264,7 @@ class GroupedAggregator(ktV: VirtualTypeWithReq, nestedAggs: Array[StagedAggrega
   private val kt = ktV.canonicalPType
   val resultEltType: PTuple = PCanonicalTuple(true, nestedAggs.map(_.resultEmitType.storageType): _*)
   val resultPType: PCanonicalDict = PCanonicalDict(kt, resultEltType)
-  override val resultEmitType = EmitType(SIndexablePointer(resultPType), ktV.r.required)
+  override val resultEmitType = EmitType(SIndexablePointer(resultPType), true)
   private[this] val arrayRep = resultPType.arrayRep
   private[this] val dictElt = arrayRep.elementType.asInstanceOf[PCanonicalStruct]
   val initOpTypes: Seq[Type] = Array(TVoid)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -21,7 +21,7 @@ object LinearRegressionAggregator {
 
   private val optVector = vector.setRequired(false)
 
-  val resultPType: PCanonicalStruct = PCanonicalStruct(required = true, "xty" -> optVector, "beta" -> optVector, "diag_inv" -> optVector, "beta0" -> optVector)
+  val resultPType: PCanonicalStruct = PCanonicalStruct(required = false, "xty" -> optVector, "beta" -> optVector, "diag_inv" -> optVector, "beta0" -> optVector)
 
   def computeResult(region: Region, xtyPtr: Long, xtxPtr: Long, k0: Int): Long = {
     val xty = DenseVector(UnsafeRow.readArray(vector, null, xtyPtr)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -54,10 +54,8 @@ class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
     combine(cb, ev1, ev2)
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    state.fields(0).toI(cb).consume(cb,
-      ifMissing(cb),
-      sc => pt.storeAtAddress(cb, addr, region, sc, deepCopy = true))
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    state.fields(0).toI(cb)
   }
 
   private def combine(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.expr.ir.{coerce => _, _}
+import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.{PType, typeToTypeInfo}
 import is.hail.types.virtual._
@@ -21,9 +22,8 @@ trait StagedMonoidSpec {
 
 class MonoidAggregator(monoid: StagedMonoidSpec) extends StagedAggregator {
   type State = PrimitiveRVAState
-  val typ: PType = PType.canonical(monoid.typ, required = monoid.neutral.isDefined)
-
-  def resultType: PType = typ
+  val sType = SType.canonical(monoid.typ)
+  def resultEmitType = EmitType(sType, monoid.neutral.isDefined)
 
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](monoid.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -5,17 +5,17 @@ import is.hail.asm4s.{UnitInfo, Value, _}
 import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.linalg.LinalgCodeUtils
 import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
 import is.hail.types.physical.{PCanonicalNDArray, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.{FastIndexedSeq, valueToRichCodeRegion}
 
-class NDArrayMultiplyAddAggregator(nDVTyp: VirtualTypeWithReq) extends StagedAggregator {
-  private val ndTyp = nDVTyp.canonicalPType.setRequired(false).asInstanceOf[PCanonicalNDArray]
-
+class NDArrayMultiplyAddAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator {
   override type State = TypedRegionBackedAggState
 
-  override def resultType: PType = ndTyp
+  override def resultEmitType: EmitType = ndVTyp.canonicalEmitType
+  private val ndTyp = resultEmitType.storageType.asInstanceOf[PCanonicalNDArray] // TODO: Set required false?
 
   override def initOpTypes: Seq[Type] = Array[Type]()
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{UnitInfo, Value, _}
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.linalg.LinalgCodeUtils
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
@@ -85,9 +85,7 @@ class NDArrayMultiplyAddAggregator(nDVTyp: VirtualTypeWithReq) extends StagedAgg
     cb.invokeVoid(combOpMethod)
   }
 
-  override protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    state.get(cb).consume(cb,
-      ifMissing(cb),
-      { sc => pt.storeAtAddress(cb, addr, region, sc.asNDArray, deepCopy = true) })
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    state.get(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, SCodeEmitParamType, uuid4}
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, IEmitCode, SCodeEmitParamType, uuid4}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.stypes.SCode
 import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable
@@ -79,12 +79,8 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
     cb.invokeVoid(combOpMethod)
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    state.get(cb).consume(cb,
-      ifMissing(cb),
-      { lastNDInAggState =>
-        pt.storeAtAddress(cb, addr, region, lastNDInAggState.asNDArray, deepCopy = true)
-      })
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    state.get(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, IEmitCode, SCodeEmitParamType, uuid4}
 import is.hail.types.VirtualTypeWithReq
-import is.hail.types.physical.stypes.SCode
+import is.hail.types.physical.stypes.{EmitType, SCode}
 import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable
 import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
 import is.hail.types.physical.{PCanonicalNDArray, PType}
@@ -12,11 +12,10 @@ import is.hail.types.virtual.Type
 import is.hail.utils._
 
 class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator {
-  private val ndTyp = ndVTyp.canonicalPType.setRequired(false).asInstanceOf[PCanonicalNDArray]
-
   override type State = TypedRegionBackedAggState
 
-  override def resultType: PType = ndTyp
+  override def resultEmitType: EmitType = ndVTyp.canonicalEmitType
+  private val ndTyp = resultEmitType.storageType.asInstanceOf[PCanonicalNDArray] // TODO: Set required false?
 
   override def initOpTypes: Seq[Type] = Array[Type]()
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -5,12 +5,12 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual.Type
 
 class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   type State = TypedRegionBackedAggState
-  private val pt = typ.canonicalPType.setRequired(false)
-  val resultType: PType = pt
+  val resultEmitType = EmitType(typ.canonicalEmitType.st, false)
   val initOpTypes: Seq[Type] = Array[Type]()
   val seqOpTypes: Seq[Type] = Array[Type](typ.t)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
 import is.hail.types.virtual.Type
@@ -36,9 +36,7 @@ class PrevNonNullAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
       )
   }
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    state.get(cb).consume(cb,
-      ifMissing(cb),
-      { sc => pt.storeAtAddress(cb, addr, region, sc, deepCopy = true) })
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    state.get(cb).map(cb)(sv => sv.copyToRegion(cb, region, sv.st))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -4,12 +4,13 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.PType
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual.Type
 
 abstract class StagedAggregator {
   type State <: AggregatorState
 
-  def resultType: PType
+  def resultEmitType: EmitType
   def initOpTypes: Seq[Type]
   def seqOpTypes: Seq[Type]
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.PType
 import is.hail.types.virtual.Type
 
@@ -19,11 +19,11 @@ abstract class StagedAggregator {
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State)
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode
 
   def initOp(cb: EmitCodeBuilder, state: AggregatorState, init: Array[EmitCode]) = _initOp(cb, state.asInstanceOf[State], init)
   def seqOp(cb: EmitCodeBuilder, state: AggregatorState, seq: Array[EmitCode]) = _seqOp(cb, state.asInstanceOf[State], seq)
   def combOp(cb: EmitCodeBuilder, state: AggregatorState, other: AggregatorState) = _combOp(cb, state.asInstanceOf[State], other.asInstanceOf[State])
-  def storeResult(cb: EmitCodeBuilder, state: AggregatorState, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit =
-    _storeResult(cb, state.asInstanceOf[State], pt, addr, region, ifMissing)
+  def result(cb: EmitCodeBuilder, state: AggregatorState, region: Value[Region]): IEmitCode =
+    _result(cb, state.asInstanceOf[State], region)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
@@ -125,9 +125,8 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
 
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.combine(cb, other)
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    assert(pt == resultType)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by state.resultArray
-    pt.storeAtAddress(cb, addr, region, state.resultArray(cb, region, resultType), deepCopy = false)
+    IEmitCode.present(state.resultArray(cb, region, resultType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -127,6 +127,6 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by state.resultArray
-    IEmitCode.present(state.resultArray(cb, region, resultType))
+    IEmitCode.present(cb, state.resultArray(cb, region, resultType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -6,7 +6,8 @@ import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.concrete.{SIndexablePointerCode, SIndexablePointerValue}
+import is.hail.types.physical.stypes.EmitType
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
 
@@ -104,7 +105,8 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
   type State = TakeRVAS
 
   private val pt = typ.canonicalPType
-  val resultType: PCanonicalArray = PCanonicalArray(pt, required = true)
+  val resultPType: PCanonicalArray = PCanonicalArray(pt)
+  val resultEmitType: EmitType = EmitType(SIndexablePointer(resultPType), true)
   val initOpTypes: Seq[Type] = Array(TInt32)
   val seqOpTypes: Seq[Type] = Array(typ.t)
 
@@ -127,6 +129,6 @@ class TakeAggregator(typ: VirtualTypeWithReq) extends StagedAggregator {
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // deepCopy is handled by state.resultArray
-    IEmitCode.present(cb, state.resultArray(cb, region, resultType))
+    IEmitCode.present(cb, state.resultArray(cb, region, resultPType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -566,8 +566,8 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
   protected def _combOp(cb: EmitCodeBuilder, state: State, other: State): Unit = state.combine(cb, other)
 
 
-  protected def _storeResult(cb: EmitCodeBuilder, state: State, pt: PType, addr: Value[Long], region: Value[Region], ifMissing: EmitCodeBuilder => Unit): Unit = {
-    // deepCopy is false because state.result does a deep copy
-    pt.storeAtAddress(cb, addr, region, state.result(cb, region, resultType), deepCopy = false)
+  protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
+    // state.result does a deep copy
+    IEmitCode.present(cb, state.result(cb, region, resultType))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -7,9 +7,9 @@ import is.hail.expr.ir.{Ascending, EmitClassBuilder, EmitCode, EmitCodeBuilder, 
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointerValue, SIndexablePointerValue}
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointerValue, SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.{SCode, SValue}
+import is.hail.types.physical.stypes.{EmitType, SCode, SValue}
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
 
@@ -545,7 +545,7 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
 
   type State = TakeByRVAS
 
-  val resultType: PCanonicalArray = PCanonicalArray(valueType.canonicalPType, true)
+  val resultEmitType: EmitType = EmitType(SIndexablePointer(PCanonicalArray(valueType.canonicalPType)), true)
   val initOpTypes: Seq[Type] = Array(TInt32)
   val seqOpTypes: Seq[Type] = Array(valueType.t, keyType.t)
 
@@ -568,6 +568,6 @@ class TakeByAggregator(valueType: VirtualTypeWithReq, keyType: VirtualTypeWithRe
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     // state.result does a deep copy
-    IEmitCode.present(cb, state.result(cb, region, resultType))
+    IEmitCode.present(cb, state.result(cb, region, resultEmitType.storageType.asInstanceOf[PCanonicalArray]))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -863,9 +863,7 @@ object LowerTableIR {
               val resultUID = genUID()
               val aggs = agg.Extract(newRow, resultUID, r, isScan = true)
 
-              val results: IR = MakeTuple.ordered(aggs.aggs.zipWithIndex.map { case (aggSig, index) =>
-                ResultOp(index, aggSig)
-              })
+              val results: IR = ResultOp.makeTuple(aggs.aggs)
               val initState = RunAgg(
                 aggs.init,
                 MakeTuple.ordered(aggs.aggs.zipWithIndex.map { case (sig, i) => AggStateValue(i, sig.state) }),
@@ -1202,9 +1200,7 @@ object LowerTableIR {
         val resultUID = genUID()
         val aggs = agg.Extract(query, resultUID, r, false)
 
-        def results: IR = MakeTuple.ordered(aggs.aggs.zipWithIndex.map { case (aggSig, index) =>
-          ResultOp(index, aggSig)
-        })
+        def results: IR = ResultOp.makeTuple(aggs.aggs)
 
         val lc = lower(child)
 

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -3,7 +3,7 @@ package is.hail.types
 import is.hail.annotations.{Annotation, NDArray}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete.SIndexablePointer
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SInterval, SStream}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SInterval, SNDArray, SStream}
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval, rowIterator, toMapFast}
@@ -333,6 +333,7 @@ case class RNDArray(override val elementType: TypeWithRequiredness) extends RIte
   }
   override def _matchesPType(pt: PType): Boolean = elementType.matchesPType(coerce[PNDArray](pt).elementType)
   override def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PNDArray].elementType)
+  override def _unionEmitType(emitType: EmitType): Unit = elementType.fromEmitType(emitType.st.asInstanceOf[SNDArray].elementEmitType)
   override def copy(newChildren: Seq[BaseTypeWithRequiredness]): RNDArray = {
     val Seq(newElt: TypeWithRequiredness) = newChildren
     RNDArray(newElt)

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -390,7 +390,7 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
   }
   def _unionEmitType(emitType: EmitType): Unit = {
-    emitType.st.asInstanceOf[SBaseStruct].fieldEmitTypes.zipWithIndex.foreach{ case(et, idx) => children(idx)._unionEmitType(et) }
+    emitType.st.asInstanceOf[SBaseStruct].fieldEmitTypes.zipWithIndex.foreach{ case(et, idx) => children(idx).fromEmitType(et) }
   }
 
   def unionFields(other: RStruct): Unit = {

--- a/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
+++ b/hail/src/main/scala/is/hail/types/TypeWithRequiredness.scala
@@ -2,7 +2,8 @@ package is.hail.types
 
 import is.hail.annotations.{Annotation, NDArray}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.interfaces.SStream
+import is.hail.types.physical.stypes.concrete.SIndexablePointer
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SInterval, SStream}
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.virtual._
 import is.hail.utils.{FastSeq, Interval, rowIterator, toMapFast}
@@ -197,6 +198,7 @@ case class VirtualTypeWithReq(t: Type, r: TypeWithRequiredness) {
 sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
   def _unionLiteral(a: Annotation): Unit
   def _unionPType(pType: PType): Unit
+  def _unionEmitType(emitType: EmitType): Unit
   def _matchesPType(pt: PType): Boolean
   def unionLiteral(a: Annotation): Unit =
     if (a == null) union(false) else _unionLiteral(a)
@@ -204,6 +206,10 @@ sealed abstract class TypeWithRequiredness extends BaseTypeWithRequiredness {
   def fromPType(pType: PType): Unit = {
     union(pType.required)
     _unionPType(pType)
+  }
+  def fromEmitType(emitType: EmitType): Unit = {
+    union(emitType.required)
+    _unionEmitType(emitType)
   }
   def canonicalPType(t: Type): PType
   def canonicalEmitType(t: Type): EmitType = {
@@ -232,6 +238,7 @@ final case class RPrimitive() extends TypeWithRequiredness {
   def _unionLiteral(a: Annotation): Unit = ()
   def _matchesPType(pt: PType): Boolean = RPrimitive.typeSupported(pt.virtualType)
   def _unionPType(pType: PType): Unit = assert(RPrimitive.typeSupported(pType.virtualType))
+  def _unionEmitType(emitType: EmitType) = assert(RPrimitive.typeSupported(emitType.virtualType))
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RPrimitive = {
     assert(newChildren.isEmpty)
     RPrimitive()
@@ -254,6 +261,7 @@ sealed class RIterable(val elementType: TypeWithRequiredness, eltRequired: Boole
     a.asInstanceOf[Iterable[_]].foreach(elt => elementType.unionLiteral(elt))
   def _matchesPType(pt: PType): Boolean = elementType.matchesPType(coerce[PIterable](pt).elementType)
   def _unionPType(pType: PType): Unit = elementType.fromPType(pType.asInstanceOf[PIterable].elementType)
+  def _unionEmitType(emitType: EmitType): Unit = elementType.fromEmitType(emitType.st.asInstanceOf[SIndexablePointer].elementEmitType)
   def _toString: String = s"RIterable[${ elementType.toString }]"
 
   override def _maximizeChildren(): Unit = {
@@ -349,6 +357,11 @@ case class RInterval(startType: TypeWithRequiredness, endType: TypeWithRequiredn
     startType.fromPType(pType.asInstanceOf[PInterval].pointType)
     endType.fromPType(pType.asInstanceOf[PInterval].pointType)
   }
+  def _unionEmitType(emitType: EmitType): Unit = {
+    val sInterval = emitType.st.asInstanceOf[SInterval]
+    startType.fromEmitType(sInterval.pointEmitType)
+    endType.fromEmitType(sInterval.pointEmitType)
+  }
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RInterval = {
     val Seq(newStart: TypeWithRequiredness, newEnd: TypeWithRequiredness) = newChildren
     RInterval(newStart, newEnd)
@@ -375,6 +388,9 @@ sealed abstract class RBaseStruct extends TypeWithRequiredness {
     coerce[PBaseStruct](pt).fields.forall(f => children(f.index).matchesPType(f.typ))
   def _unionPType(pType: PType): Unit = {
     pType.asInstanceOf[PBaseStruct].fields.foreach(f => children(f.index).fromPType(f.typ))
+  }
+  def _unionEmitType(emitType: EmitType): Unit = {
+    emitType.st.asInstanceOf[SBaseStruct].fieldEmitTypes.zipWithIndex.foreach{ case(et, idx) => children(idx)._unionEmitType(et) }
   }
 
   def unionFields(other: RStruct): Unit = {
@@ -425,6 +441,7 @@ case class RUnion(cases: Seq[(String, TypeWithRequiredness)]) extends TypeWithRe
   def _unionLiteral(a: Annotation): Unit = ???
   def _matchesPType(pt: PType): Boolean = ???
   def _unionPType(pType: PType): Unit = ???
+  def _unionEmitType(emitType: EmitType): Unit = ???
   def copy(newChildren: Seq[BaseTypeWithRequiredness]): RUnion = {
     assert(newChildren.length == cases.length)
     RUnion(Array.tabulate(cases.length)(i => cases(i)._1 -> coerce[TypeWithRequiredness](newChildren(i))))

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -18,6 +18,7 @@ object PCanonicalDict {
 }
 
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
+  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   val elementType = PCanonicalStruct(required = true, "key" -> keyType, "value" -> valueType)
 
   val arrayRep: PCanonicalArray = PCanonicalArray(elementType, required)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -18,7 +18,6 @@ object PCanonicalDict {
 }
 
 final case class PCanonicalDict(keyType: PType, valueType: PType, required: Boolean = false) extends PDict with PArrayBackedContainer {
-  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   val elementType = PCanonicalStruct(required = true, "key" -> keyType, "value" -> valueType)
 
   val arrayRep: PCanonicalArray = PCanonicalArray(elementType, required)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
@@ -38,7 +38,6 @@ object PCanonicalStruct {
 }
 
 final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean = false) extends PCanonicalBaseStruct(fields.map(_.typ).toArray) with PStruct {
-  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   assert(fields.zipWithIndex.forall  { case (f, i) => f.index == i })
 
   if (!fieldNames.areDistinct()) {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalStruct.scala
@@ -38,6 +38,7 @@ object PCanonicalStruct {
 }
 
 final case class PCanonicalStruct(fields: IndexedSeq[PField], required: Boolean = false) extends PCanonicalBaseStruct(fields.map(_.typ).toArray) with PStruct {
+  val stack = Thread.currentThread().getStackTrace.mkString("\n")
   assert(fields.zipWithIndex.forall  { case (f, i) => f.index == i })
 
   if (!fieldNames.areDistinct()) {

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -9,7 +9,7 @@ import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceCode,
 import is.hail.linalg.{BLAS, LAPACK}
 import is.hail.types.physical.stypes.primitives.SFloat64Code
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
-import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
+import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType, SValue}
 import is.hail.utils.{FastIndexedSeq, toRichIterable, valueToRichCodeRegion}
 
 import scala.collection.mutable
@@ -563,6 +563,7 @@ trait SNDArray extends SType {
 
   def elementType: SType
   def elementPType: PType
+  def elementEmitType: EmitType = EmitType(elementType, pType.elementType.required)
 
   def elementByteSize: Long
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -49,7 +49,7 @@ class Aggregators2Suite extends HailSuite {
       Array.fill(nPartitions)(aggSig.state),
       FastIndexedSeq(),
       FastIndexedSeq(classInfo[Region]), LongInfo,
-      ResultOp(0, Array(aggSig, aggSig)))
+      ResultOp.makeTuple(Array(aggSig, aggSig)))
     assert(rt.types(0) == rt.types(1))
 
     val resultType = rt.types(0)
@@ -83,7 +83,7 @@ class Aggregators2Suite extends HailSuite {
           Array(aggSig.state),
           FastIndexedSeq(),
           FastIndexedSeq(classInfo[Region]), LongInfo,
-          ResultOp(0, Array(aggSig)))
+          ResultOp.makeTuple(Array(aggSig)))
 
         val init = initF(ctx.fs, 0, region)
         val res = resOneF(ctx.fs, 0, region)
@@ -702,7 +702,7 @@ class Aggregators2Suite extends HailSuite {
       "foo",
       InitOp(0, FastSeq(), sig),
       SeqOp(0, FastIndexedSeq(Ref("foo", TInt32).toD), sig),
-      GetTupleElement(ResultOp(0, Array(sig)), 0),
+      ResultOp(0, sig),
       Array(sig.state)))
     assertEvalsTo(x, FastIndexedSeq(0.0, 0.0, 1.0, 3.0, 6.0))
   }
@@ -720,7 +720,7 @@ class Aggregators2Suite extends HailSuite {
             "foo",
             InitOp(0, FastSeq(), sig),
             SeqOp(0, FastIndexedSeq(Ref("foo", TInt32).toD), sig),
-            GetTupleElement(ResultOp(0, Array(sig)), 0),
+            ResultOp(0, sig),
             Array(sig.state))))
     assertEvalsTo(x, FastIndexedSeq(
       0.0, 0.0, 1.0,
@@ -736,7 +736,7 @@ class Aggregators2Suite extends HailSuite {
         InitOp(0, FastSeq(), sig),
         SeqOp(0, FastSeq(F64(1.0)), sig),
         SeqOp(0, FastSeq(F64(-5.0)), sig))),
-      ResultOp(0, FastIndexedSeq(sig)),
+      ResultOp.makeTuple(FastIndexedSeq(sig)),
       FastIndexedSeq(sig.state))
     assertEvalsTo(x, Row(-4.0))
   }
@@ -757,12 +757,12 @@ class Aggregators2Suite extends HailSuite {
                 InitOp(0, FastSeq(), sumSig),
                 SeqOp(0, FastSeq(F64(-1.0)), sumSig),
                 SeqOp(0, FastSeq(Ref("foo", TInt32).toD), sumSig))),
-              GetTupleElement(ResultOp(0, FastIndexedSeq(sumSig)), 0),
+              ResultOp(0, sumSig),
               FastIndexedSeq(sumSig.state))
           ), takeSig)
         ))
       ),
-      GetTupleElement(ResultOp(0, FastIndexedSeq(takeSig)), 0),
+      ResultOp(0, takeSig),
       FastIndexedSeq(takeSig.state))
     assertEvalsTo(x, FastIndexedSeq(-1d, 0d, 1d, 2d, 3d))
   }
@@ -788,7 +788,7 @@ class Aggregators2Suite extends HailSuite {
           SeqOp(0, FastSeq(I64(3l)), takeSig),
           CombOpValue(0, Ref("x", TBinary), takeSig),
           SeqOp(0, FastSeq(I64(0l)), takeSig))),
-        GetTupleElement(ResultOp(0, FastIndexedSeq(takeSig)), 0),
+        ResultOp(0, takeSig),
         FastIndexedSeq(takeSig.state)))
 
     assertEvalsTo(x, FastIndexedSeq(null, -1l, 2l, 3l, null, null, -1l, 2l, 0l))

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -534,14 +534,13 @@ class AggregatorsSuite extends HailSuite {
     expected: Any,
     initOpArgs: IndexedSeq[IR],
     seqOpArgs: IndexedSeq[IR]) {
-    val irToEval = AggGroupBy(key,
-      ApplyAggOp(
-        initOpArgs,
-        seqOpArgs,
-        AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ))),
-      false)
-    println(Pretty(irToEval))
-    assertEvalsTo(irToEval,
+    assertEvalsTo(
+      AggGroupBy(key,
+        ApplyAggOp(
+          initOpArgs,
+          seqOpArgs,
+          AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ))),
+        false),
       (agg, aggType),
       expected)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -534,13 +534,14 @@ class AggregatorsSuite extends HailSuite {
     expected: Any,
     initOpArgs: IndexedSeq[IR],
     seqOpArgs: IndexedSeq[IR]) {
-    assertEvalsTo(
-      AggGroupBy(key,
-        ApplyAggOp(
-          initOpArgs,
-          seqOpArgs,
-          AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ))),
-        false),
+    val irToEval = AggGroupBy(key,
+      ApplyAggOp(
+        initOpArgs,
+        seqOpArgs,
+        AggSignature(op, initOpArgs.map(_.typ), seqOpArgs.map(_.typ))),
+      false)
+    println(Pretty(irToEval))
+    assertEvalsTo(irToEval,
       (agg, aggType),
       expected)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2791,7 +2791,7 @@ class IRSuite extends HailSuite {
       InitOp(0, FastIndexedSeq(I32(2)), pCallStatsSig),
       SeqOp(0, FastIndexedSeq(i), pCollectSig),
       CombOp(0, 1, pCollectSig),
-      ResultOp(0, FastIndexedSeq(pCollectSig)),
+      ResultOp(0, pCollectSig),
       SerializeAggs(0, 0, BufferSpec.default, FastSeq(pCollectSig.state)),
       DeserializeAggs(0, 0, BufferSpec.default, FastSeq(pCollectSig.state)),
       CombOpValue(0, bin, pCollectSig),

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -330,7 +330,7 @@ class RequirednessSuite extends HailSuite {
       PCanonicalStruct(required,
         "a" -> rowType.fieldType("a"),
         "collect" -> PCanonicalArray(rowType.fieldType("b"), required),
-        "callstats" -> CallStatsState.resultType),
+        "callstats" -> CallStatsState.resultPType),
       globalType)
 
     nodes += Array(
@@ -338,7 +338,7 @@ class RequirednessSuite extends HailSuite {
       PCanonicalStruct(required,
         "a" -> rowType.fieldType("a"),
         "collect" -> PCanonicalArray(rowType.fieldType("b"), required),
-        "callstats" -> CallStatsState.resultType),
+        "callstats" -> CallStatsState.resultPType),
       globalType)
 
     val left = TableMapGlobals(

--- a/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RequirednessSuite.scala
@@ -330,7 +330,7 @@ class RequirednessSuite extends HailSuite {
       PCanonicalStruct(required,
         "a" -> rowType.fieldType("a"),
         "collect" -> PCanonicalArray(rowType.fieldType("b"), required),
-        "callstats" -> CallStatsState.resultPType),
+        "callstats" -> CallStatsState.resultPType.setRequired(true)),
       globalType)
 
     nodes += Array(
@@ -338,7 +338,7 @@ class RequirednessSuite extends HailSuite {
       PCanonicalStruct(required,
         "a" -> rowType.fieldType("a"),
         "collect" -> PCanonicalArray(rowType.fieldType("b"), required),
-        "callstats" -> CallStatsState.resultPType),
+        "callstats" -> CallStatsState.resultPType.setRequired(true)),
       globalType)
 
     val left = TableMapGlobals(


### PR DESCRIPTION
This PR:

1. Refactors `ResultOp` to just take an index and return whatever agg result is at that index. No more returning a suffix of the total aggregator tuple based on a starting index. This is necessary for me to effectively implement my Fold aggregator, which will be included in a subsequent PR. 
2. Pushes `EmitType` through aggregators, uses them as the basis for analyzing the requiredness of aggregator results.
3. Changes `_storeResult` on aggregators to instead just be `_result`, which directly returns an `IEmitCode`. No reason that `ResultOp` had to be so wound up in `PType`s, and for the most part this made the code simpler. 