### PR TITLE
[auth] Remove dead google config variables

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -16,7 +16,6 @@ from gear import create_session, Database
 log = logging.getLogger('auth.driver')
 
 PROJECT = os.environ['PROJECT']
-ZONE = os.environ['ZONE']
 DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
 
 is_test_deployment = DEFAULT_NAMESPACE != 'default'

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -53,16 +53,6 @@ spec:
               secretKeyRef:
                 name: global-config
                 key: gcp_project
-          - name: ZONE
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: gcp_zone
-          - name: HAIL_GSUITE_ORGANIZATION
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: gsuite_organization
          resources:
            requests:
              cpu: "20m"
@@ -167,16 +157,6 @@ spec:
               secretKeyRef:
                 name: global-config
                 key: domain
-          - name: PROJECT
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: gcp_project
-          - name: ZONE
-            valueFrom:
-              secretKeyRef:
-                name: global-config
-                key: gcp_zone
           - name: HAIL_GSUITE_ORGANIZATION
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This removes unused google-specific environment variables from the auth modules.