### PR TITLE
[compiler] (S)Code->(S)Value in invoke

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -1275,8 +1275,7 @@ class ThisLazyFieldRef[T: TypeInfo](cb: ClassBuilder[_], name: String, setup: Co
   private[this] val setm = cb.genMethod[Unit](s"setup_$name")
   setm.emit(Code(value := setup, present := true))
 
-  def get: Code[T] =
-    Code(present.mux(Code._empty, setm.invoke()), value.load())
+  def get: Code[T] = Code(present.mux(Code._empty, setm.invokeCode()), value.load())
 }
 
 class ThisFieldRef[T: TypeInfo](cb: ClassBuilder[_], f: Field[T]) extends Settable[T] {

--- a/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/CodeBuilder.scala
@@ -57,6 +57,17 @@ trait CodeBuilderLike {
 
   def +=(c: Code[Unit]): Unit = append(c)
 
+  def memoize[T: TypeInfo](v: Code[T], optionalName: String = ""): Value[T] = v match {
+    case b: ConstCodeBoolean => coerce[T](b.b)
+    case _ => newLocal[T]("memoize" + optionalName, v)
+  }
+
+  def memoizeAny(v: Code[_], ti: TypeInfo[_]): Value[_] = {
+    val l = newLocal("memoize")(ti)
+    append(l.storeAny(v))
+    l
+  }
+
   def assign[T](s: Settable[T], v: Code[T]): Unit = {
     append(s := v)
   }
@@ -87,7 +98,7 @@ trait CodeBuilderLike {
     define(Lafter)
   }
 
-  def whileLoop(c: Code[Boolean], emitBody: (CodeLabel) => Unit): Unit = {
+  def whileLoop(c: => Code[Boolean], emitBody: (CodeLabel) => Unit): Unit = {
     val Lstart = CodeLabel()
     val Lbody = CodeLabel()
     val Lafter = CodeLabel()
@@ -99,7 +110,7 @@ trait CodeBuilderLike {
     define(Lafter)
   }
 
-  def whileLoop(c: Code[Boolean], emitBody: => Unit): Unit = whileLoop(c, _ => emitBody)
+  def whileLoop(c: => Code[Boolean], emitBody: => Unit): Unit = whileLoop(c, _ => emitBody)
 
   def forLoop(setup: => Unit, cond: Code[Boolean], incr: => Unit, emitBody: (CodeLabel) => Unit): Unit = {
     val Lstart = CodeLabel()

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -369,7 +369,7 @@ class EmitClassBuilder[C](
     }
 
     getF.emitWithBuilder { cb =>
-      cb += storeF.invokeCode[Unit]()
+      storeF.invokeCode[Unit](cb)
       _aggOff
     }
 
@@ -955,10 +955,10 @@ class EmitMethodBuilder[C](
   }
 
 
-  def invokeCode[T](args: Param*): Code[T] = {
+  def invokeCode[T](cb: CodeBuilderLike, args: Param*): Value[T] = {
     assert(emitReturnType.isInstanceOf[CodeParamType])
     assert(args.forall(_.isInstanceOf[CodeParam]))
-    mb.invoke(args.flatMap {
+    mb.invoke(cb, args.flatMap {
       case CodeParam(c) => FastIndexedSeq(c)
       // If you hit this assertion, it means that an EmitParam was passed to
       // invokeCode. Code with EmitParams must be invoked using the EmitCodeBuilder

--- a/hail/src/main/scala/is/hail/expr/ir/Param.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Param.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
-import is.hail.asm4s.{BooleanInfo, Code, TypeInfo, classInfo}
-import is.hail.types.physical.stypes.{EmitType, SCode, SType, SingleCodeType}
+import is.hail.asm4s.{BooleanInfo, TypeInfo, Value}
+import is.hail.types.physical.stypes.{EmitType, SType, SValue, SingleCodeType}
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
@@ -59,6 +59,6 @@ case class SCodeEmitParamType(et: EmitType) extends EmitParamType {
 
 sealed trait Param
 
-case class CodeParam(c: Code[_]) extends Param
+case class CodeParam(c: Value[_]) extends Param
 case class EmitParam(ec: EmitCode) extends Param
-case class SCodeParam(sc: SCode) extends Param
+case class SCodeParam(sc: SValue) extends Param

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -95,9 +95,10 @@ trait PointerBasedRVAState extends RegionBackedAggState {
       })
   }
 
-  def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = copyFromAddress(cb, Region.loadAddress(src))
+  def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit =
+    copyFromAddress(cb, cb.memoize(Region.loadAddress(src)))
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit
+  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit
 }
 
 class TypedRegionBackedAggState(val typ: VirtualTypeWithReq, val kb: EmitClassBuilder[_]) extends AbstractTypedRegionBackedAggState(typ.canonicalPType)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AppendOnlyBTree.scala
@@ -30,8 +30,7 @@ trait BTreeKey {
     compKeys(cb, loadCompKey(cb, off), loadCompKey(cb, other))
   }
 
-  def compWithKey(cb: EmitCodeBuilder, offc: Code[Long], k: EmitValue): Value[Int] = {
-    val off = cb.newLocal[Long]("btk_comp_with_key_off", offc)
+  def compWithKey(cb: EmitCodeBuilder, off: Value[Long], k: EmitValue): Value[Int] = {
     compKeys(cb, loadCompKey(cb, off), k)
   }
 }
@@ -57,7 +56,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
   private def isLeaf(cb: EmitCodeBuilder, node: Code[Long]): Value[Boolean] =
     storageType.isFieldMissing(cb, node, 1)
 
-  private def getParent(node: Code[Long]): Code[Long] = Region.loadAddress(storageType.loadField(node, 0))
+  private def getParent(cb: EmitCodeBuilder, node: Code[Long]): Value[Long] =
+    cb.memoize(Region.loadAddress(storageType.loadField(node, 0)))
 
   private def elements(node: Code[Long]): Code[Long] = storageType.loadField(node, 2)
 
@@ -77,7 +77,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
   private def keyOffset(node: Code[Long], i: Int): Code[Long] = eltType.fieldOffset(elementsType.loadField(elements(node), i), 0)
 
-  private def loadKey(node: Code[Long], i: Int): Code[Long] = eltType.loadField(elementsType.loadField(elements(node), i), 0)
+  private def loadKey(cb: EmitCodeBuilder, node: Value[Long], i: Int): Value[Long] =
+    cb.memoize(eltType.loadField(elementsType.loadField(elements(node), i), 0))
 
   private def childOffset(node: Code[Long], i: Int): Code[Long] =
     if (i == -1)
@@ -85,8 +86,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     else
       eltType.fieldOffset(elementsType.loadField(elements(node), i), 1)
 
-  private def loadChild(node: Code[Long], i: Int): Code[Long] =
-    Region.loadAddress(childOffset(node, i))
+  private def loadChild(cb: EmitCodeBuilder, node: Code[Long], i: Int): Value[Long] =
+    cb.memoize(Region.loadAddress(childOffset(node, i)))
 
   private def setChild(cb: EmitCodeBuilder, parentC: Code[Long], i: Int, childC: Code[Long], context: String): Unit = {
     val parent = cb.newLocal[Long]("aobt_set_child_parent", parentC)
@@ -99,7 +100,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     cb += Region.storeAddress(storageType.fieldOffset(child, 0), parent)
   }
 
-  private def insert(cb: EmitCodeBuilder, nodec: Code[Long], insertIdxc: Code[Int], kc: EmitCode, childC: Code[Long]): Code[Long] = {
+  private def insert(cb: EmitCodeBuilder, nodec: Value[Long], insertIdxc: Value[Int], kc: EmitCode, childC: Value[Long]): Value[Long] = {
     val kt = key.compType.sType
     val castKCode = EmitCode.fromI(cb.emb)(cb => kc.toI(cb).map(cb)(k => kt.coerceOrCopy(cb, region, k, false)))
     val insertAt = kb.getOrGenEmitMethod("btree_insert", (this, "insert", kt),
@@ -109,17 +110,17 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       val k: EmitValue = insertAt.getEmitParam(cb, 3, region)
       val child: Value[Long] = insertAt.getCodeParam[Long](4)
 
-      def parent: Code[Long] = getParent(node)
+      def parent(cb: EmitCodeBuilder): Value[Long] = getParent(cb, node)
 
       val newNode = insertAt.newLocal[Long]()
 
-      def makeUninitialized(cb: EmitCodeBuilder, idx: Int): Code[Long] = {
+      def makeUninitialized(cb: EmitCodeBuilder, idx: Int): Value[Long] = {
         setKeyPresent(cb, node, idx)
         key.initializeEmpty(cb, keyOffset(node, idx))
         cb.ifx(!isLeaf(cb, node), {
           setChild(cb, node, idx, child, "makeUninitialized setChild")
         })
-        loadKey(node, idx)
+        loadKey(cb, node, idx)
       }
 
       def copyFrom(cb: EmitCodeBuilder, destNodeC: Code[Long], destIdx: Int, srcNodeC: Code[Long], srcIdx: Int): Unit = {
@@ -129,7 +130,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         key.copy(cb, keyOffset(srcNode, srcIdx), keyOffset(destNode, destIdx))
         cb.ifx(!isLeaf(cb, srcNode),
           {
-            setChild(cb, destNode, destIdx, loadChild(srcNode, srcIdx), "insert copyFrom")
+            setChild(cb, destNode, destIdx, loadChild(cb, srcNode, srcIdx), "insert copyFrom")
           })
       }
 
@@ -144,8 +145,8 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         val Lfound = CodeLabel()
 
         (0 until maxElements).foreach { i =>
-          val b = cb.newLocal[Boolean]("btree_insertkey_b", !hasKey(cb, parent, i))
-          cb.ifx(!b, cb.assign(b, key.compWithKey(cb, loadKey(parent, i), ev) >= 0))
+          val b = cb.newLocal[Boolean]("btree_insertkey_b", !hasKey(cb, parent(cb), i))
+          cb.ifx(!b, cb.assign(b, key.compWithKey(cb, loadKey(cb, parent(cb), i), ev) >= 0))
           cb.ifx(b, {
             cb.assign(upperBound, i)
             cb.goto(Lfound)
@@ -156,23 +157,23 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         cb.ifx(!isLeaf(cb, node), {
           setChild(cb, newNode, -1, c, "insertKey !isLeaf")
         })
-        cb.invokeCode(insertAt, parent, upperBound, ev, newNode)
+        cb.invokeCode(insertAt, parent(cb), upperBound, ev, newNode)
       }
 
 
       def promote(cb: EmitCodeBuilder, idx: Int): Unit = {
-        val nikey = cb.newLocal("aobt_insert_nikey", loadKey(node, idx))
+        val nikey = cb.newLocal("aobt_insert_nikey", loadKey(cb, node, idx))
 
         cb.ifx(!isLeaf(cb, node), {
-          setChild(cb, newNode, -1, loadChild(node, idx), "promote")
+          setChild(cb, newNode, -1, loadChild(cb, node, idx), "promote")
         })
 
         val upperBound = cb.newLocal("promote_upper_bound", maxElements)
         val Lfound = CodeLabel()
 
         (0 until maxElements).foreach { i =>
-          val b = cb.newLocal[Boolean]("btree_insert_promote_b", !hasKey(cb, parent, i))
-          cb.ifx(!b, cb.assign(b, key.compSame(cb, loadKey(parent, i), nikey) >= 0))
+          val b = cb.newLocal[Boolean]("btree_insert_promote_b", !hasKey(cb, parent(cb), i))
+          cb.ifx(!b, cb.assign(b, key.compSame(cb, loadKey(cb, parent(cb), i), nikey) >= 0))
           cb.ifx(b, {
             cb.assign(upperBound, i)
             cb.goto(Lfound)
@@ -180,7 +181,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         }
 
         cb.define(Lfound)
-        key.copy(cb, loadKey(node, idx), cb.invokeCode(insertAt, parent, upperBound, key.loadCompKey(cb, nikey), newNode))
+        key.copy(cb, loadKey(cb, node, idx), cb.invokeCode(insertAt, parent(cb), upperBound, key.loadCompKey(cb, nikey), newNode))
         setKeyMissing(cb, node, idx)
       }
 
@@ -194,7 +195,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
         cb.ifx(insertIdx > splitIdx, {
           copyToNew(cb, splitIdx + 1)
           promote(cb, splitIdx)
-          cb.assign(out, cb.invokeCode(insertAt, newNode, insertIdx - splitIdx - 1, k, child))
+          cb.assign(out, cb.invokeCode(insertAt, newNode, cb.memoize(insertIdx - splitIdx - 1), k, child))
         }, {
           copyToNew(cb, splitIdx)
           cb.ifx(insertIdx.ceq(splitIdx), {
@@ -236,7 +237,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     cb.invokeCode[Long](insertAt, nodec, insertIdxc, castKCode, childC)
   }
 
-  private def getF(cb: EmitCodeBuilder, root: Code[Long], kc: EmitCode): Code[Long] = {
+  private def getF(cb: EmitCodeBuilder, root: Value[Long], kc: EmitCode): Value[Long] = {
     val get = kb.genEmitMethod("btree_get", FastIndexedSeq[ParamType](typeInfo[Long], kc.emitParamType), typeInfo[Long])
     get.emitWithBuilder { cb =>
       val node = get.getCodeParam[Long](1)
@@ -250,14 +251,14 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
           cb.assign(keyV, insert(cb, node, const(i), k, const(0L)))
           cb.assign(cmp, 0)
         }, {
-          cb.assign(node, loadChild(node, i - 1))
+          cb.assign(node, loadChild(cb, node, i - 1))
         })
       }
 
       cb.whileLoop(cmp.cne(0), { Lcont =>
         (0 until maxElements).foreach { i =>
           cb.ifx(hasKey(cb, node, i), {
-            cb.assign(keyV, loadKey(node, i))
+            cb.assign(keyV, loadKey(cb, node, i))
             cb.assign(cmp, key.compWithKey(cb, keyV, k))
             cb.ifx(cmp.ceq(0), cb.goto(Lcont))
             cb.ifx(cmp > 0, {
@@ -280,7 +281,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
   def getOrElseInitialize(cb: EmitCodeBuilder, k: EmitCode): Code[Long] = getF(cb, root, k)
 
-  def foreach(cb: EmitCodeBuilder)(visitor: (EmitCodeBuilder, Code[Long]) => Unit): Unit = {
+  def foreach(cb: EmitCodeBuilder)(visitor: (EmitCodeBuilder, Value[Long]) => Unit): Unit = {
     val stackI = cb.newLocal[Int]("btree_foreach_stack_i", -1)
     val nodeStack = cb.newLocal("btree_foreach_node_stack", Code.newArray[Long](const(128)))
     val idxStack = cb.newLocal("btree_foreach_index_stack", Code.newArray[Int](const(128)))
@@ -318,16 +319,16 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       cb.define(Lminus1)
       cb.ifx(!isLeaf(cb, node), {
         stackUpdateIdx(0)
-        stackPush(loadChild(node, -1))
+        stackPush(loadChild(cb, node, -1))
         cb.goto(Lstart)
       })
       (0 until maxElements).foreach { i =>
         cb.define(labels(i))
         cb.ifx(hasKey(cb, node, i), {
-          visitor(cb, loadKey(node, i))
+          visitor(cb, loadKey(cb, node, i))
           cb.ifx(!isLeaf(cb, node), {
             stackUpdateIdx(i + 1)
-            stackPush(loadChild(node, i))
+            stackPush(loadChild(cb, node, i))
             cb.goto(Lstart)
           })
         }, {
@@ -340,7 +341,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     })
   }
 
-  val deepCopy: (EmitCodeBuilder, Code[Long]) => Unit = {
+  val deepCopy: (EmitCodeBuilder, Value[Long]) => Unit = {
     val f = kb.genEmitMethod("btree_deepCopy", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[Long]), typeInfo[Unit])
     f.voidWithBuilder { cb =>
       val destNode = f.getCodeParam[Long](1)
@@ -351,7 +352,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
 
       def copyChild(i: Int): Unit = {
         createNode(cb, newNode)
-        cb.invokeVoid(cb.emb, newNode, loadChild(srcNode, i))
+        cb.invokeVoid(cb.emb, newNode, loadChild(cb, srcNode, i))
       }
 
       cb.ifx(!isLeaf(cb, srcNode), {
@@ -370,10 +371,10 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
       }
     }
 
-    { (cb: EmitCodeBuilder, srcRoot: Code[Long]) => cb.invokeVoid(f, root, srcRoot) }
+    { (cb: EmitCodeBuilder, srcRoot: Value[Long]) => cb.invokeVoid(f, root, srcRoot) }
   }
 
-  def bulkStore(cb: EmitCodeBuilder, obCode: Code[OutputBuffer]
+  def bulkStore(cb: EmitCodeBuilder, obCode: Value[OutputBuffer]
   )(keyStore: (EmitCodeBuilder, Value[OutputBuffer], Code[Long]) => Unit): Unit = {
     val f = kb.genEmitMethod("btree_bulkStore", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[OutputBuffer]),
       typeInfo[Unit])
@@ -383,15 +384,15 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     f.voidWithBuilder { cb =>
       cb += ob.writeBoolean(!isLeaf(cb, node))
       cb.ifx(!isLeaf(cb, node), {
-        cb.invokeVoid(f, loadChild(node, -1), ob)
+        cb.invokeVoid(f, loadChild(cb, node, -1), ob)
       })
       val Lexit = CodeLabel()
       (0 until maxElements).foreach { i =>
         cb.ifx(hasKey(cb, node, i), {
           cb += ob.writeBoolean(true)
-          keyStore(cb, ob, loadKey(node, i))
+          keyStore(cb, ob, loadKey(cb, node, i))
           cb.ifx(!isLeaf(cb, node), {
-            cb.invokeVoid(f, loadChild(node, i), ob)
+            cb.invokeVoid(f, loadChild(cb, node, i), ob)
           })
         }, {
           cb += ob.writeBoolean(false)
@@ -403,7 +404,7 @@ class AppendOnlyBTree(kb: EmitClassBuilder[_], val key: BTreeKey, region: Value[
     cb.invokeVoid(f, root, obCode)
   }
 
-  def bulkLoad(cb: EmitCodeBuilder, ibCode: Code[InputBuffer]
+  def bulkLoad(cb: EmitCodeBuilder, ibCode: Value[InputBuffer]
   )(keyLoad: (EmitCodeBuilder, Value[InputBuffer], Code[Long]) => Unit): Unit = {
     val f = kb.genEmitMethod("btree_bulkLoad", FastIndexedSeq[ParamType](typeInfo[Long], typeInfo[InputBuffer]),
       typeInfo[Unit])

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -146,7 +146,8 @@ class ArrayElementState(val kb: EmitClassBuilder[_], val nested: StateTuple) ext
     }
   }
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
+  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
+    // FIXME: does this really need to be a field?
     val srcOff = cb.newField("aelca_copyfromaddr_srcoff", src)
     val initOffset = cb.memoize(typ.loadField(srcOff, 0))
     val eltOffset = cb.memoize(arrayType.loadElement(typ.loadField(srcOff, 1), idx))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -94,7 +94,7 @@ class CallStatsState(val kb: EmitClassBuilder[_]) extends PointerBasedRVAState {
     }
   }
 
-  def copyFromAddress(cb: EmitCodeBuilder, src: Code[Long]): Unit = {
+  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     cb.assign(off, CallStatsState.stateType.store(cb, region, CallStatsState.stateType.loadCheapSCode(cb, src), deepCopy = true))
     loadNAlleles(cb)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -113,12 +113,11 @@ class AppendOnlySetState(val kb: EmitClassBuilder[_], vt: VirtualTypeWithReq) ex
       f(cb, EmitCode.fromI(cb.emb)(cb => IEmitCode(cb, key.isKeyMissing(cb, eoff), key.loadKey(cb, eoff))))
     }
 
-  def copyFromAddress(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
-    val src = cb.newLocal[Long]("aoss_copy_from_addr_src", srcc)
+  def copyFromAddress(cb: EmitCodeBuilder, src: Value[Long]): Unit = {
     cb.assign(off, region.allocate(typ.alignment, typ.byteSize))
     cb.assign(size, Region.loadInt(typ.loadField(src, 0)))
     tree.init(cb)
-    tree.deepCopy(cb, Region.loadAddress(typ.loadField(src, 1)))
+    tree.deepCopy(cb, cb.memoize(Region.loadAddress(typ.loadField(src, 1))))
   }
 
   def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -105,7 +105,8 @@ class StagedArrayBuilder(eltType: PType, kb: EmitClassBuilder[_], region: Value[
     eltArray.stagedInitialize(cb, data, capacity, setMissing = true)
   }
 
-  def elementOffset(idx: Value[Int]): Code[Long] = eltArray.elementOffset(data, capacity, idx)
+  def elementOffset(cb: EmitCodeBuilder, idx: Value[Int]): Value[Long] =
+    cb.memoize(eltArray.elementOffset(data, capacity, idx))
 
 
   def loadElement(cb: EmitCodeBuilder, idx: Value[Int]): EmitCode = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -196,7 +196,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     finish(cb)
   }
 
-  def serialize(cb: EmitCodeBuilder, region: Value[Region], outputBuffer: Code[OutputBuffer]): Unit = {
+  def serialize(cb: EmitCodeBuilder, region: Value[Region], outputBuffer: Value[OutputBuffer]): Unit = {
     val serF = kb.genEmitMethod("blockLinkedListSerialize",
       FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[OutputBuffer]),
       typeInfo[Unit])
@@ -215,7 +215,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     cb.invokeVoid(serF, region, outputBuffer)
   }
 
-  def deserialize(cb: EmitCodeBuilder, region: Code[Region], inputBuffer: Code[InputBuffer]): Unit = {
+  def deserialize(cb: EmitCodeBuilder, region: Value[Region], inputBuffer: Value[InputBuffer]): Unit = {
     val desF = kb.genEmitMethod("blockLinkedListDeserialize",
       FastIndexedSeq[ParamType](typeInfo[Region], typeInfo[InputBuffer]),
       typeInfo[Unit])
@@ -230,7 +230,7 @@ class StagedBlockLinkedList(val elemType: PType, val kb: EmitClassBuilder[_]) {
     cb.invokeVoid(desF, region, inputBuffer)
   }
 
-  private def appendShallow(cb: EmitCodeBuilder, r: Code[Region], aCode: SValue): Unit = {
+  private def appendShallow(cb: EmitCodeBuilder, r: Value[Region], aCode: SValue): Unit = {
     val buff = aCode.asInstanceOf[SIndexablePointerValue]
     val newNode = cb.newLocal[Long]("sbll_append_shallow_newnode", nodeType.allocate(r))
     initNode(cb, newNode, buf = buff.a, count = buff.length)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -195,7 +195,8 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
     }
   }
 
-  private def elementOffset(i: Value[Int]): Code[Long] = ab.elementOffset(i)
+  private def elementOffset(cb: EmitCodeBuilder, i: Value[Int]): Value[Long] =
+    ab.elementOffset(cb, i)
 
   private def keyIsMissing(cb: EmitCodeBuilder, offset: Code[Long]): Value[Boolean] =
     indexedKeyType.isFieldMissing(cb, offset, 0)
@@ -206,7 +207,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   private def loadKey(cb: EmitCodeBuilder, offset: Value[Long]): EmitValue =
     cb.memoize(IEmitCode(cb, keyIsMissing(cb, offset), loadKeyValue(cb, offset)))
 
-  private val compareElt: (Code[Long], Code[Long]) => Code[Int] = {
+  private val compareElt: (EmitCodeBuilder, Value[Long], Value[Long]) => Value[Int] = {
     val mb = kb.genEmitMethod("i_gt_j", FastIndexedSeq[ParamType](LongInfo, LongInfo), IntInfo)
     val i = mb.getCodeParam[Long](1)
     val j = mb.getCodeParam[Long](2)
@@ -215,10 +216,10 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       indexedKeyType.loadCheapSCode(cb, eltTuple.fieldOffset(i, 0)),
       indexedKeyType.loadCheapSCode(cb, eltTuple.fieldOffset(j, 0))))
 
-    mb.invokeCode(_, _)
+    mb.invokeCode(_, _, _)
   }
 
-  private val swap: (EmitCodeBuilder, Code[Long], Code[Long]) => Unit = {
+  private val swap: (EmitCodeBuilder, Value[Long], Value[Long]) => Unit = {
     val mb = kb.genEmitMethod("swap", FastIndexedSeq[ParamType](LongInfo, LongInfo), UnitInfo)
     val i = mb.getCodeParam[Long](1)
     val j = mb.getCodeParam[Long](2)
@@ -229,37 +230,31 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       cb += Region.copyFrom(staging, j, eltTuple.byteSize)
     })
 
-    (cb: EmitCodeBuilder, x: Code[Long], y: Code[Long]) => cb.invokeVoid(mb, x, y)
+    (cb: EmitCodeBuilder, x: Value[Long], y: Value[Long]) => cb.invokeVoid(mb, x, y)
   }
 
 
-  private val rebalanceUp: (EmitCodeBuilder, Code[Int]) => Unit = {
+  private val rebalanceUp: (EmitCodeBuilder, Value[Int]) => Unit = {
     val mb = kb.genEmitMethod("rebalance_up", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
     val idx = mb.getCodeParam[Int](1)
-
-    val ii = mb.newLocal[Long]("rebalance_up_ii")
-    val jj = mb.newLocal[Long]("rebalance_up_jj")
-
-    val parent = mb.newLocal[Int]("parent")
 
     mb.voidWithBuilder { cb =>
       cb.ifx(idx > 0,
         {
-          cb.assign(parent, (idx + 1) / 2 - 1)
-          cb.assign(ii, elementOffset(idx))
-          cb.assign(jj, elementOffset(parent))
-          cb.ifx(compareElt(ii, jj) > 0,
-            {
-              swap(cb, ii, jj)
-              cb.invokeVoid(mb, parent)
-            })
+          val parent = cb.memoize((idx + 1) / 2 - 1)
+          val ii = elementOffset(cb, idx)
+          val jj = elementOffset(cb, parent)
+          cb.ifx(compareElt(cb, ii, jj) > 0, {
+            swap(cb, ii, jj)
+            cb.invokeVoid(mb, parent)
+          })
         })
     }
 
-    (cb: EmitCodeBuilder, x: Code[Int]) => cb.invokeVoid(mb, x)
+    (cb: EmitCodeBuilder, x: Value[Int]) => cb.invokeVoid(mb, x)
   }
 
-  private val rebalanceDown: (EmitCodeBuilder, Code[Int]) => Unit = {
+  private val rebalanceDown: (EmitCodeBuilder, Value[Int]) => Unit = {
     val mb = kb.genEmitMethod("rebalance_down", FastIndexedSeq[ParamType](IntInfo), UnitInfo)
     val idx = mb.getCodeParam[Int](1)
 
@@ -274,17 +269,25 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
       cb.assign(child2, child1 + 1)
       cb.ifx(child1 < ab.size,
         {
-          cb.assign(minChild, (child2 >= ab.size || compareElt(elementOffset(child1), elementOffset(child2)) > 0).mux(child1, child2))
-          cb.assign(ii, elementOffset(minChild))
-          cb.assign(jj, elementOffset(idx))
-          cb.ifx(compareElt(ii, jj) > 0,
+          cb.ifx(child2 >= ab.size, {
+            cb.assign(minChild, child1)
+          }, {
+            cb.ifx(compareElt(cb, elementOffset(cb, child1), elementOffset(cb, child2)) > 0, {
+              cb.assign(minChild, child1)
+            }, {
+              cb.assign(minChild, child2)
+            })
+          })
+          cb.assign(ii, elementOffset(cb, minChild))
+          cb.assign(jj, elementOffset(cb, idx))
+          cb.ifx(compareElt(cb, ii, jj) > 0,
             {
               swap(cb, ii, jj)
               cb.invokeVoid(mb, minChild)
             })
         })
     }
-    (cb: EmitCodeBuilder, x: Code[Int]) => cb.invokeVoid(mb, x)
+    (cb: EmitCodeBuilder, x: Value[Int]) => cb.invokeVoid(mb, x)
   }
 
   private lazy val gc: EmitCodeBuilder => Unit = {
@@ -345,13 +348,13 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
   }
 
   private def swapStaging(cb: EmitCodeBuilder): Unit = {
-    eltTuple.storeAtAddress(cb, ab.elementOffset(0), region, eltTuple.loadCheapSCode(cb, staging), true)
+    eltTuple.storeAtAddress(cb, ab.elementOffset(cb, 0), region, eltTuple.loadCheapSCode(cb, staging), true)
     rebalanceDown(cb, 0)
   }
 
   private def enqueueStaging(cb: EmitCodeBuilder): Unit = {
     ab.append(cb, eltTuple.loadCheapSCode(cb, staging))
-    rebalanceUp(cb, ab.size - 1)
+    rebalanceUp(cb, cb.memoize(ab.size - 1))
   }
 
   def seqOp(cb: EmitCodeBuilder, v: EmitCode, k: EmitCode): Unit = {
@@ -369,7 +372,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
           copyToStaging(cb, value, keyStage)
           enqueueStaging(cb)
         }, {
-          cb.assign(tempPtr, eltTuple.loadField(elementOffset(0), 0))
+          cb.assign(tempPtr, eltTuple.loadField(elementOffset(cb, 0), 0))
           cb.ifx(compareKey(cb, key, loadKey(cb, tempPtr)) < 0, {
             stageAndIndexKey(cb, key)
             copyToStaging(cb, value, keyStage)
@@ -396,43 +399,37 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
     mb.voidWithBuilder { cb =>
       val i = cb.newLocal[Int]("combine_i")
-      val offset = cb.newLocal[Long]("combine_offset")
-      val indexOffset = cb.newLocal[Long]("index_offset")
-      cb.forLoop(
-        cb.assign(i, 0),
-        i < other.ab.size,
-        cb.assign(i, i + 1),
-        {
-          cb.assign(offset, other.elementOffset(i))
-          cb.assign(indexOffset, indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1))
-          cb += Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex)
-          cb.ifx(maxSize > 0,
-            cb.ifx(ab.size < maxSize,
-              {
-                copyElementToStaging(cb, offset)
-                enqueueStaging(cb)
-              },
-              {
-                cb.assign(tempPtr, elementOffset(0))
-                cb.ifx(compareElt(offset, tempPtr) < 0,
-                  {
-                    copyElementToStaging(cb, offset)
-                    swapStaging(cb)
-                    gc(cb)
-                  })
-              }
-            ))
-        })
+      cb.forLoop(cb.assign(i, 0), i < other.ab.size, cb.assign(i, i + 1), {
+        val offset = other.elementOffset(cb, i)
+        val indexOffset = cb.memoize(indexedKeyType.fieldOffset(eltTuple.loadField(offset, 0), 1))
+        cb += Region.storeLong(indexOffset, Region.loadLong(indexOffset) + maxIndex)
+        cb.ifx(maxSize > 0,
+          cb.ifx(ab.size < maxSize,
+            {
+              copyElementToStaging(cb, offset)
+              enqueueStaging(cb)
+            },
+            {
+              cb.assign(tempPtr, elementOffset(cb, 0))
+              cb.ifx(compareElt(cb, offset, tempPtr) < 0,
+                {
+                  copyElementToStaging(cb, offset)
+                  swapStaging(cb)
+                  gc(cb)
+                })
+            }
+          ))
+      })
       cb.assign(maxIndex, maxIndex + other.maxIndex)
     }
 
     cb.invokeVoid(mb)
   }
 
-  def result(cb: EmitCodeBuilder, _r: Code[Region], resultType: PCanonicalArray): SIndexablePointerValue = {
+  def result(cb: EmitCodeBuilder, _r: Value[Region], resultType: PCanonicalArray): SIndexablePointerValue = {
     val mb = kb.genEmitMethod("take_by_result", FastIndexedSeq[ParamType](classInfo[Region]), LongInfo)
 
-    val quickSort: (Code[Long], Code[Int], Code[Int]) => Code[Unit] = {
+    val quickSort: (EmitCodeBuilder, Value[Long], Value[Int], Value[Int]) => Value[Unit] = {
       val mb = kb.genEmitMethod("result_quicksort", FastIndexedSeq[ParamType](LongInfo, IntInfo, IntInfo), UnitInfo)
       val indices = mb.getCodeParam[Long](1)
       val low = mb.getCodeParam[Int](2)
@@ -440,7 +437,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
 
       val pivotIndex = mb.newLocal[Int]("pivotIdx")
 
-      val swap: (Code[Long], Code[Long]) => Code[Unit] = {
+      val swap: (EmitCodeBuilder, Value[Long], Value[Long]) => Value[Unit] = {
         val mb = kb.genEmitMethod("quicksort_swap", FastIndexedSeq[ParamType](LongInfo, LongInfo), UnitInfo)
         val i = mb.getCodeParam[Long](1)
         val j = mb.getCodeParam[Long](2)
@@ -454,10 +451,10 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
             Region.storeInt(j, tmp)
           )
         )
-        mb.invokeCode(_, _)
+        mb.invokeCode(_, _, _)
       }
 
-      val partition: (Code[Long], Code[Int], Code[Int]) => Code[Int] = {
+      val partition: (EmitCodeBuilder, Value[Long], Value[Int], Value[Int]) => Value[Int] = {
         val mb = kb.genEmitMethod("quicksort_partition", FastIndexedSeq[ParamType](LongInfo, IntInfo, IntInfo), IntInfo)
 
         val indices = mb.getCodeParam[Long](1)
@@ -469,47 +466,51 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
         val tmpOffset = mb.newLocal[Long]("tmpOffset")
         val continue = mb.newLocal[Boolean]("continue")
 
-        def indexOffset(idx: Code[Int]): Code[Long] = indices + idx.toL * 4L
+        def indexOffset(cb: EmitCodeBuilder, idx: Value[Int]): Value[Long] =
+          cb.memoize(indices + idx.toL * 4L)
 
-        def indexAt(idx: Code[Int]): Code[Int] = Region.loadInt(indexOffset(idx))
+        def indexAt(cb: EmitCodeBuilder, idx: Value[Int]): Value[Int] =
+          cb.memoize(Region.loadInt(indexOffset(cb, idx)))
 
-        mb.emit(Code(
-          low.ceq(high).orEmpty(Code._return(low)),
-          pivotIndex := (low + high) / 2,
-          pivotOffset := Code.memoize(indexAt(pivotIndex), "tba_qsort_pivot") { i => elementOffset(i) },
-          continue := true,
-          Code.whileLoop(continue,
-            Code.whileLoop(
-              Code(
-                tmpOffset := Code.memoize(indexAt(low), "tba_qsort_pivot") { i => elementOffset(i) },
-                compareElt(tmpOffset, pivotOffset) < 0),
-              low := low + 1
-            ),
-            Code.whileLoop(
-              Code(
-                tmpOffset := Code.memoize(indexAt(high), "tba_qsort_pivot") { i => elementOffset(i) },
-                compareElt(tmpOffset, pivotOffset) > 0),
-              high := high - 1
-            ),
-            (low >= high).mux(
-              continue := false,
-              Code(
-                swap(indexOffset(low), indexOffset(high)),
-                low := low + 1,
-                high := high - 1))),
+        mb.emitWithBuilder { cb =>
+          cb.ifx(low.ceq(high), cb.append(Code._return(low)))
+          cb.assign(pivotIndex, (low + high) / 2)
+          cb.assign(pivotOffset, elementOffset(cb, indexAt(cb, pivotIndex)))
+          cb.assign(continue, true)
+          cb.whileLoop(continue, {
+            cb.whileLoop({
+              cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, low)))
+              compareElt(cb, tmpOffset, pivotOffset) < 0
+            }, {
+              cb.assign(low, low + 1)
+            })
+            cb.whileLoop({
+              cb.assign(tmpOffset, elementOffset(cb, indexAt(cb, high)))
+              compareElt(cb, tmpOffset, pivotOffset) > 0
+            }, {
+              cb.assign(high, high - 1)
+            })
+            cb.ifx(low >= high, {
+              cb.assign(continue, false)
+            }, {
+              swap(cb, indexOffset(cb, low), indexOffset(cb, high))
+              cb.assign(low, low + 1)
+              cb.assign(high, high - 1)
+            })
+          })
           high
-        )
-        )
-        mb.invokeCode(_, _, _)
+        }
+        mb.invokeCode(_, _, _, _)
       }
 
-      mb.emit(
-        (low < high).orEmpty(
-          Code(
-            pivotIndex := partition(indices, low, high),
-            mb.invokeCode(indices, low, pivotIndex),
-            mb.invokeCode(indices, pivotIndex + 1, high))))
-      mb.invokeCode(_, _, _)
+      mb.voidWithBuilder { cb =>
+        cb.ifx(low < high, {
+          cb.assign(pivotIndex, partition(cb, indices, low, high))
+          mb.invokeCode(cb, indices, low, pivotIndex)
+          mb.invokeCode(cb, indices, cb.memoize(pivotIndex + 1), high)
+        })
+      }
+      mb.invokeCode(_, _, _, _)
     }
 
     mb.emitWithBuilder[Long] { cb =>
@@ -527,7 +528,7 @@ class TakeByRVAS(val valueVType: VirtualTypeWithReq, val keyVType: VirtualTypeWi
         cb.assign(i, i + 1)
       })
 
-      cb += quickSort(indicesToSort, 0, ab.size - 1)
+      quickSort(cb, indicesToSort, 0, cb.memoize(ab.size - 1))
 
       resultType.constructFromElements(cb, r, ab.size, deepCopy = true) { case (cb, idx) =>
         val sortedIdx = cb.newLocal[Int]("tba_result_sortedidx", Region.loadInt(indexOffset(idx)))

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -223,13 +223,9 @@ package object ir {
 
   implicit def toCodeParamType(ti: TypeInfo[_]): CodeParamType = CodeParamType(ti)
 
-  implicit def toCodeParam(c: Code[_]): CodeParam = CodeParam(c)
+  implicit def toCodeParam(c: Value[_]): CodeParam = CodeParam(c)
 
-  implicit def valueToCodeParam(v: Value[_]): CodeParam = CodeParam(v)
-
-  implicit def sCodeToSCodeParam(sc: SCode): SCodeParam = SCodeParam(sc)
-
-  implicit def sValueToSCodeParam(sv: SValue): SCodeParam = SCodeParam(sv.get)
+  implicit def sValueToSCodeParam(sv: SValue): SCodeParam = SCodeParam(sv)
 
   implicit def toEmitParam(ec: EmitCode): EmitParam = EmitParam(ec)
 

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -304,7 +304,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
         cb.ifx(utils.size.ceq(next),
           parentBuilder.create(cb), {
             cb.ifx(utils.getLength(next).ceq(branchingFactor),
-              cb += m.invokeCode[Unit](CodeParam(next), CodeParam(false)))
+              m.invokeCode[Unit](cb, CodeParam(next), CodeParam(false)))
             parentBuilder.loadFrom(cb, utils, next)
           })
         internalBuilder.loadChild(cb, 0)
@@ -331,7 +331,7 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
       cb += ob.flush()
 
       cb.ifx(utils.getLength(0).ceq(branchingFactor),
-        cb += writeInternalNode.invokeCode[Unit](CodeParam(0), CodeParam(false)))
+        writeInternalNode.invokeCode[Unit](cb, CodeParam(0), CodeParam(false)))
       parentBuilder.loadFrom(cb, utils, 0)
 
       leafBuilder.loadChild(cb, 0)
@@ -348,15 +348,15 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
     m.emitWithBuilder { cb =>
       val idxOff = cb.newLocal[Long]("indexOff")
       val level = m.newLocal[Int]("level")
-      cb.ifx(leafBuilder.ab.length > 0, cb += writeLeafNode.invokeCode[Unit]())
+      cb.ifx(leafBuilder.ab.length > 0, writeLeafNode.invokeCode[Unit](cb))
       cb.assign(level, 0)
       cb.whileLoop(level < utils.size - 1, {
         cb.ifx(utils.getLength(level) > 0,
-          cb += writeInternalNode.invokeCode[Unit](CodeParam(level), CodeParam(false)))
+          writeInternalNode.invokeCode[Unit](cb, CodeParam(level), CodeParam(false)))
         cb.assign(level, level + 1)
       })
       cb.assign(idxOff, utils.bytesWritten)
-      cb += writeInternalNode.invokeCode[Unit](CodeParam(level), CodeParam(true))
+      writeInternalNode.invokeCode[Unit](cb, CodeParam(level), CodeParam(true))
       idxOff.load()
     }
     m
@@ -364,13 +364,12 @@ class StagedIndexWriter(branchingFactor: Int, keyType: PType, annotationType: PT
 
   def add(cb: EmitCodeBuilder, key: => IEmitCode, offset: Code[Long], annotation: => IEmitCode) {
     cb.ifx(leafBuilder.ab.length.ceq(branchingFactor),
-      cb += writeLeafNode.invokeCode[Unit]())
+      writeLeafNode.invokeCode[Unit](cb))
     leafBuilder.add(cb, key, offset, annotation)
     cb.assign(elementIdx, elementIdx + 1L)
   }
   def close(cb: EmitCodeBuilder): Unit = {
-    val off = cb.newLocal[Long]("lastOffset")
-    cb.assign(off, flush.invokeCode[Long]())
+    val off = flush.invokeCode[Long](cb)
     leafBuilder.close(cb)
     utils.close(cb)
     utils.writeMetadata(cb, utils.size + 1, off, elementIdx)

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -45,7 +45,7 @@ abstract class EType extends BaseType with Serializable with Requiredness {
 
   final def buildEncoder(st: SType, kb: EmitClassBuilder[_]): StagedEncoder = {
     val mb = buildEncoderMethod(st, kb);
-    { (cb: EmitCodeBuilder, sv: SValue, ob: Value[OutputBuffer]) => cb.invokeVoid(mb, sv.get, ob) }
+    { (cb: EmitCodeBuilder, sv: SValue, ob: Value[OutputBuffer]) => cb.invokeVoid(mb, sv, ob) }
   }
 
   final def buildEncoderMethod(st: SType, kb: EmitClassBuilder[_]): EmitMethodBuilder[_] = {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -216,7 +216,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       case s => SizeValueDyn(s)
     }
 
-    cb.invokeSCode(mb, FastIndexedSeq[Param](region, SCodeParam(dataCode.get)) ++ (newShape.map(CodeParam(_)) ++ strides.map(CodeParam(_))): _*)
+    cb.invokeSCode(mb, FastIndexedSeq[Param](region, SCodeParam(dataCode)) ++ (newShape.map(CodeParam(_)) ++ strides.map(CodeParam(_))): _*)
       .asNDArray
       .coerceToShape(cb, newShape)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -106,7 +106,12 @@ class FunctionSuite extends HailSuite {
     val mb2 = fb.getOrGenEmitMethod("foo", "foo", FastIndexedSeq[ParamType](), UnitInfo) { mb =>
       mb.emit(i := i - 100)
     }
-    fb.emit(Code(i := 0, mb1.invokeCode(), mb2.invokeCode(), i))
+    fb.emitWithBuilder(cb => {
+      cb.assign(i, 0)
+      mb1.invokeCode(cb)
+      mb2.invokeCode(cb)
+      i
+    })
     pool.scopedRegion { r =>
 
       assert(fb.resultWithIndex().apply(ctx.fs, 0, r)() == 2)


### PR DESCRIPTION
~Stacked on #10906~

This PR refactors `MethodBuilder.invoke` and `EmitCodeBuilder.invoke(S)Code` to take/return values.

* `invoke` now takes a `CodeBuilderLike`. It is used in places where there is only access to a `CodeBuilder` (not an `EmitCodeBuilder`), so I had to use the generic interface, and had to move a couple methods on `EmitCodeBuilder` to `CodeBuilderLike`. I have never understood this Emit/non-Emit split; would be a great simplification if we could collapse it.
* This change pushed some (S)Code->(S)Value refactorings inside some aggregator implementations, which generate and invoke internal methods.
* I had to keep a version of `MethodBuilder.invoke` that doesn't take a CodeBuilder, for use in `ThisLazyFieldRef.get`. Will have to think more about how this should work when Code is (mostly) gone. Maybe lazy fields should not subclass Value, and to access a lazy field requires an explicit `load(cb: CodeBuilder): Value[T]`.