### PR TITLE
[ci] Mostly pass through global-config in CI instead of constructing from env variables

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -23,8 +23,10 @@ log = logging.getLogger('ci')
 
 global_config = {}
 for field in os.listdir('/global-config/'):
-    with open(f'/global-config/{field}') as value:
-        global_config[field] = value.read()
+    # Kubernetes inserts some hidden files that we don't care about
+    if not field.startswith('.'):
+        with open(f'/global-config/{field}') as value:
+            global_config[field] = value.read()
 
 pretty_print_log = "jq -Rr '. as $raw | try \
 (fromjson | if .hail_log == 1 then \

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import logging
+import os
 from collections import defaultdict, Counter
 from shlex import quote as shq
 import yaml
@@ -9,24 +10,21 @@ from typing import Dict, List, Optional
 from hailtop.utils import flatten
 from .utils import generate_token
 from .environment import (
-    GCP_PROJECT,
-    GCP_ZONE,
     DOCKER_PREFIX,
-    DOCKER_ROOT_IMAGE,
-    HAIL_TEST_GCS_BUCKET,
-    HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET,
     DOMAIN,
-    IP,
     CI_UTILS_IMAGE,
     BUILDKIT_IMAGE,
     DEFAULT_NAMESPACE,
-    KUBERNETES_SERVER_URL,
     BUCKET,
 )
 from .globals import is_test_deployment
 
 log = logging.getLogger('ci')
 
+global_config = {}
+for field in os.listdir('/global-config/'):
+    with open(f'/global-config/{field}') as value:
+        global_config[field] = value.read()
 
 pretty_print_log = "jq -Rr '. as $raw | try \
 (fromjson | if .hail_log == 1 then \
@@ -172,17 +170,7 @@ class Step(abc.ABC):
 
     def input_config(self, code, scope):
         config = {}
-        config['global'] = {
-            'project': GCP_PROJECT,
-            'zone': GCP_ZONE,
-            'docker_prefix': DOCKER_PREFIX,
-            'docker_root_image': DOCKER_ROOT_IMAGE,
-            'hail_test_gcs_bucket': HAIL_TEST_GCS_BUCKET,
-            'hail_test_requester_pays_gcs_bucket': HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET,
-            'domain': DOMAIN,
-            'ip': IP,
-            'k8s_server_url': KUBERNETES_SERVER_URL,
-        }
+        config['global'] = global_config
         config['token'] = self.token
         config['deploy'] = scope == 'deploy'
         config['scope'] = scope

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -1,23 +1,10 @@
 import os
 
-GCP_PROJECT = os.environ['HAIL_GCP_PROJECT']
-assert GCP_PROJECT != ''
-GCP_ZONE = os.environ['HAIL_GCP_ZONE']
-assert GCP_ZONE != ''
-GCP_REGION = '-'.join(GCP_ZONE.split('-')[:-1])  # us-west1-a -> us-west1
-DOCKER_PREFIX = os.environ.get('HAIL_DOCKER_PREFIX', f'gcr.io/{GCP_REGION}')
-assert DOCKER_PREFIX != ''
+DOCKER_PREFIX = os.environ['HAIL_DOCKER_PREFIX']
 DOCKER_ROOT_IMAGE = os.environ['HAIL_DOCKER_ROOT_IMAGE']
-assert DOCKER_ROOT_IMAGE != ''
 DOMAIN = os.environ['HAIL_DOMAIN']
-assert DOMAIN != ''
-HAIL_TEST_GCS_BUCKET = os.environ['HAIL_TEST_GCS_BUCKET']
-assert HAIL_TEST_GCS_BUCKET != ''
-HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET = os.environ['HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET']
-assert HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET != ''
-IP = os.environ.get('HAIL_IP')
-CI_UTILS_IMAGE = os.environ.get('HAIL_CI_UTILS_IMAGE', f'{DOCKER_PREFIX}/ci-utils:latest')
+KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']
+CI_UTILS_IMAGE = os.environ['HAIL_CI_UTILS_IMAGE']
 BUILDKIT_IMAGE = os.environ['HAIL_BUILDKIT_IMAGE']
 DEFAULT_NAMESPACE = os.environ['HAIL_DEFAULT_NAMESPACE']
-KUBERNETES_SERVER_URL = os.environ['KUBERNETES_SERVER_URL']
 BUCKET = os.environ['HAIL_CI_BUCKET_NAME']

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -51,11 +51,6 @@ spec:
            - name: HAIL_WATCHED_BRANCHES
              value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'
 {% endif %}
-           - name: HAIL_GCP_PROJECT
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: gcp_project
            - name: HAIL_DOCKER_PREFIX
              valueFrom:
                secretKeyRef:
@@ -66,26 +61,6 @@ spec:
                secretKeyRef:
                  name: global-config
                  key: docker_root_image
-           - name: HAIL_TEST_GCS_BUCKET
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: hail_test_gcs_bucket
-           - name: HAIL_TEST_REQUESTER_PAYS_GCS_BUCKET
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: hail_test_requester_pays_gcs_bucket
-           - name: HAIL_GCP_ZONE
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: gcp_zone
-           - name: HAIL_IP
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: ip
            - name: HAIL_DOMAIN
              valueFrom:
                secretKeyRef:
@@ -116,6 +91,9 @@ spec:
           volumeMounts:
            - mountPath: /deploy-config
              name: deploy-config
+             readOnly: true
+           - mountPath: /global-config
+             name: global-config
              readOnly: true
            - name: session-secret-key
              mountPath: /session-secret-key
@@ -149,6 +127,9 @@ spec:
        - name: deploy-config
          secret:
            secretName: deploy-config
+       - name: global-config
+         secret:
+           secretName: global-config
        - name: session-secret-key
          secret:
            optional: false

--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -54,6 +54,16 @@ spec:
              mountPath: /ssl-config
              readOnly: true
           env:
+           - name: HAIL_IP
+             valueFrom:
+               secretKeyRef:
+                 name: global-config
+                 key: ip
+           - name: HAIL_DOMAIN
+             valueFrom:
+               secretKeyRef:
+                 name: global-config
+                 key: domain
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA

--- a/ci/test/resources/deployment.yaml
+++ b/ci/test/resources/deployment.yaml
@@ -54,16 +54,6 @@ spec:
              mountPath: /ssl-config
              readOnly: true
           env:
-           - name: HAIL_IP
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: ip
-           - name: HAIL_DOMAIN
-             valueFrom:
-               secretKeyRef:
-                 name: global-config
-                 key: domain
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA

--- a/ci/test/resources/statefulset.yaml
+++ b/ci/test/resources/statefulset.yaml
@@ -53,10 +53,6 @@ spec:
              mountPath: /ssl-config
              readOnly: true
           env:
-           - name: HAIL_IP
-             value: "{{ global.ip }}"
-           - name: HAIL_DOMAIN
-             value: "{{ global.domain }}"
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA

--- a/ci/test/resources/statefulset.yaml
+++ b/ci/test/resources/statefulset.yaml
@@ -53,6 +53,16 @@ spec:
              mountPath: /ssl-config
              readOnly: true
           env:
+           - name: HAIL_IP
+             valueFrom:
+               secretKeyRef:
+                 name: global-config
+                 key: ip
+           - name: HAIL_DOMAIN
+             valueFrom:
+               secretKeyRef:
+                 name: global-config
+                 key: domain
            - name: HAIL_DEPLOY_CONFIG_FILE
              value: /deploy-config/deploy-config.json
            - name: HAIL_SHA


### PR DESCRIPTION
There are many global config fields that CI needs in order to template build.yaml jobs that are threaded through to CI with environment variables. However, these variables are never actually used by CI and they introduce some needless dependencies to run CI (you need a GCP_PROJECT, for example, even though CI doesn't care at all). Instead of setting specific environment variables for each field that build.yaml steps need, I instead mount the global-config (read-only) to the CI container and read in the whole thing. This does potentially expose more variables to the build.yaml environment than there were previously, but I argue that none of those should be sensitive anyway or maybe don't belong in the global-config (which shouldn't be sensitive). This in part makes the process of adding global config fields easier, since right now you need separate PRs to 1) introduce the field to CI and then 2) use it in a new build.yaml step. It also makes the CI deployment.yaml cloud-agnostic. 

cc @jigold 