### PR TITLE
[batch] make tests resilient to concurrent batches

### DIFF
--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -430,8 +430,8 @@ async def test_billing_limit_tiny(make_client, dev_client, new_billing_project):
 
 async def search_batches(client, expected_batch_id, q):
     found = False
-    batches = [batch async for batch in client.list_batches(q=q, limit=200)]
-    for batch in batches:
+    batches = client.list_batches(q=q, last_batch_id=expected_batch_id + 1, limit=200)
+    async for batch in batches:
         if batch.id == expected_batch_id:
             found = True
             break


### PR DESCRIPTION
These tests only work if fewer than 200 batches were created between the batches
under test and the `list_batches` API call. This is obviously not necessarily
true in general and *certainly* not true when the Hail Query on Hail Batch is
spewing hundreds of batches per second into the system.