### PR TITLE
[bpe] remove unnecessary try-catch-raise

### DIFF
--- a/hail/python/hailtop/batch/batch_pool_executor.py
+++ b/hail/python/hailtop/batch/batch_pool_executor.py
@@ -513,10 +513,7 @@ class BatchPoolFuture:
         timeout:
             Wait this long before raising a timeout error.
         """
-        try:
-            return async_to_blocking(self.async_result(timeout))
-        except asyncio.TimeoutError as e:
-            raise concurrent.futures.TimeoutError() from e
+        return async_to_blocking(self.async_result(timeout))
 
     async def async_result(self, timeout: Optional[Union[float, int]] = None):
         """Asynchronously wait until the job is complete.


### PR DESCRIPTION
These are the exact same error:
```
In [4]: import asyncio
   ...: import concurrent
   ...: asyncio.TimeoutError == concurrent.futures.TimeoutError
Out[4]: True
```