### PR TITLE
[query] allow scipy 1.7.x as well

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -26,7 +26,7 @@ PyJWT
 pyspark>=3.1.1,<3.2.0
 python-json-logger==0.1.11
 requests==2.25.1
-scipy>1.2,<1.7
+scipy>1.2,<1.8
 sortedcontainers==2.1.0
 tabulate==0.8.3
 tqdm==4.42.1


### PR DESCRIPTION
I hope this will alleviate some version incompatibilties between SciPy 1.6 and
NumPy >1.15. See [here](https://discuss.hail.is/t/unable-to-import-hail-due-to-numpy-scipy-dependency-mismatch/2285/3).