### PR TITLE
[auth] Mount the global config in the auth driver pod

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -88,6 +88,9 @@ spec:
        - name: deploy-config
          secret:
            secretName: deploy-config
+       - name: global-config
+         secret:
+           secretName: global-config
        - name: database-server-config
          secret:
            secretName: database-server-config


### PR DESCRIPTION
#10957 introduced loading GCP-specific configuration from the global-config instead of environment variables. The auth-driver uses this but doesn't have a global-config mounted.