### PR TITLE
[compiler] Refactor ExecuteContext to live in `is.hail.backend`

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -3,9 +3,9 @@ package is.hail
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
-import is.hail.backend.{Backend, BroadcastValue}
+import is.hail.backend.{Backend, BroadcastValue, ExecuteContext}
 import is.hail.expr.ir.functions.IRFunctionRegistry
-import is.hail.expr.ir.{BaseIR, ExecuteContext}
+import is.hail.expr.ir.BaseIR
 import is.hail.io.fs.FS
 import is.hail.io.index._
 import is.hail.io.vcf._

--- a/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
@@ -1,8 +1,8 @@
 package is.hail.annotations
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
-import is.hail.backend.BroadcastValue
-import is.hail.expr.ir.{EncodedLiteral, ExecuteContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.expr.ir.EncodedLiteral
 import is.hail.types.physical.{PArray, PStruct, PType}
 import is.hail.types.virtual.{TBaseStruct, TStruct}
 import is.hail.io.{BufferSpec, Decoder, TypedCodecSpec}

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -2,7 +2,7 @@ package is.hail.backend
 
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
-import is.hail.expr.ir.{ExecuteContext, IR, SortField}
+import is.hail.expr.ir.{IR, SortField}
 import is.hail.io.fs.FS
 import is.hail.linalg.BlockMatrix
 import is.hail.types._

--- a/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/backend/ExecuteContext.scala
@@ -1,13 +1,12 @@
-package is.hail.expr.ir
+package is.hail.backend
+
+import is.hail.HailContext
+import is.hail.annotations.{Region, RegionPool}
+import is.hail.io.fs.FS
+import is.hail.utils.{ExecutionTimer, using}
 
 import java.io._
 import java.security.SecureRandom
-import is.hail.HailContext
-import is.hail.utils._
-import is.hail.annotations.{Region, RegionPool}
-import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
-import is.hail.io.fs.FS
-
 import scala.collection.mutable
 
 trait TempFileManager {
@@ -33,6 +32,7 @@ class NonOwningTempFileManager(owner: TempFileManager) extends TempFileManager {
 
   override def cleanup(): Unit = ()
 }
+
 
 object ExecuteContext {
   def scoped[T]()(f: ExecuteContext => T): T = {
@@ -92,6 +92,8 @@ class ExecuteContext(
   def fsBc: BroadcastValue[FS] = fs.broadcast
 
   private val cleanupFunctions = mutable.ArrayBuffer[() => Unit]()
+
+  private[this] val broadcasts = mutable.ArrayBuffer.empty[BroadcastValue[_]]
 
   val memo: mutable.Map[Any, Any] = new mutable.HashMap[Any, Any]()
 

--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -1,10 +1,8 @@
 package is.hail.backend.local
 
-import java.io.PrintWriter
-
 import is.hail.annotations.{Region, SafeRow, UnsafeRow}
 import is.hail.asm4s._
-import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
+import is.hail.backend._
 import is.hail.expr.ir.lowering._
 import is.hail.expr.ir.{IRParser, _}
 import is.hail.expr.{JSONAnnotationImpex, Validate}
@@ -15,8 +13,8 @@ import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.linalg.BlockMatrix
 import is.hail.types._
 import is.hail.types.encoded.EType
+import is.hail.types.physical.PTuple
 import is.hail.types.physical.stypes.{PTypeReferenceSingleCodeType, SingleCodeType}
-import is.hail.types.physical.{PTuple, PType, PVoid}
 import is.hail.types.virtual.TVoid
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
@@ -24,6 +22,7 @@ import org.apache.hadoop
 import org.json4s.DefaultFormats
 import org.json4s.jackson.{JsonMethods, Serialization}
 
+import java.io.PrintWriter
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -3,10 +3,10 @@ package is.hail.backend.service
 import is.hail.{HAIL_REVISION, HailContext}
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
+import is.hail.backend.{Backend, BackendContext, BroadcastValue, ExecuteContext, HailTaskContext}
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.lowering._
-import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, MakeTuple, SortField}
+import is.hail.expr.ir.{Compile, IR, IRParser, MakeTuple, SortField}
 import is.hail.io.fs.{FS, GoogleStorageFS}
 import is.hail.linalg.BlockMatrix
 import is.hail.services._

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackend.scala
@@ -11,7 +11,7 @@ import is.hail.expr.ir.lowering._
 import is.hail.expr.ir._
 import is.hail.types.physical.{PStruct, PTuple, PType}
 import is.hail.types.virtual.{TArray, TInterval, TStruct, TVoid, Type}
-import is.hail.backend.{Backend, BackendContext, BroadcastValue, HailTaskContext}
+import is.hail.backend._
 import is.hail.expr.ir.IRParser.parseType
 import is.hail.io.fs.{FS, HadoopFS}
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
@@ -1,8 +1,8 @@
 package is.hail.compatibility
 
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.ir.ExecuteContext
 import is.hail.types.encoded._
 import is.hail.types.virtual._
 import is.hail.io._

--- a/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AbstractMatrixTableSpec.scala
@@ -1,18 +1,18 @@
 package is.hail.expr.ir
 
-import java.io.OutputStreamWriter
-
+import is.hail.backend.ExecuteContext
+import is.hail.io.fs.FS
+import is.hail.rvd._
 import is.hail.types._
 import is.hail.types.physical.PStruct
 import is.hail.types.virtual._
-import is.hail.io.fs.FS
-import is.hail.rvd._
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.json4s._
+import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.JsonMethods.parse
-import org.json4s.jackson.{JsonMethods, Serialization}
 
+import java.io.OutputStreamWriter
 import scala.language.{existentials, implicitConversions}
 
 abstract class ComponentSpec

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -9,7 +9,7 @@ import breeze.linalg
 import breeze.linalg.DenseMatrix
 import breeze.numerics
 import is.hail.annotations.{NDArray, Region}
-import is.hail.backend.BackendContext
+import is.hail.backend.{BackendContext, ExecuteContext}
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.Nat
 import is.hail.expr.ir.lowering.{BlockMatrixStage, LowererUnsupportedOperation}

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -1,21 +1,22 @@
 package is.hail.expr.ir
 
-import java.io.DataOutputStream
-
 import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.expr.ir.lowering.{BlockMatrixStage, LowererUnsupportedOperation}
 import is.hail.io.TypedCodecSpec
 import is.hail.io.fs.FS
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata}
-import is.hail.types.{BlockMatrixType, TypeWithRequiredness}
 import is.hail.types.encoded.{EBlockMatrixNDArray, EType}
 import is.hail.types.virtual.{TArray, TNDArray, TString, Type}
+import is.hail.types.{BlockMatrixType, TypeWithRequiredness}
 import is.hail.utils._
 import is.hail.utils.richUtils.RichDenseMatrixDouble
-import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints, jackson}
+import org.json4s.{DefaultFormats, Formats, ShortTypeHints, jackson}
+
+import java.io.DataOutputStream
 
 object BlockMatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.agg.AggStateSig
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.ir.streams.{EmitStream, StreamArgType}

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{Region, SafeRow}
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.types.physical.PTuple
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.BackendContext
+import is.hail.backend.{BackendContext, ExecuteContext}
 import is.hail.expr.ir.agg.{AggStateSig, ArrayAggStateSig, GroupedStateSig}
 import is.hail.expr.ir.analyses.{ComputeMethodSplits, ControlFlowPreventsSplit, ParentPointers}
 import is.hail.expr.ir.lowering.TableStageDependency

--- a/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitClassBuilder.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{Region, RegionPool, RegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.backend.{BackendUtils, BroadcastValue}
+import is.hail.backend.{BackendUtils, BroadcastValue, ExecuteContext}
 import is.hail.expr.ir.functions.IRRandomness
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.io.fs.FS
@@ -14,9 +14,9 @@ import is.hail.types.virtual.Type
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.TaskContext
+
 import java.io._
 import java.lang.reflect.InvocationTargetException
-
 import scala.collection.mutable
 import scala.language.existentials
 

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.backend.ExecuteContext
 import is.hail.types.virtual.TStream
 import is.hail.utils.HailException
 

--- a/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/GenericTableValue.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{BroadcastRow, Region}
 import is.hail.asm4s.{Code, CodeLabel, Settable, Value}
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.Value
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.agg.{AggStateSig, PhysicalAggSig}
 import is.hail.expr.ir.functions._

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -10,6 +10,7 @@ import is.hail.linalg.BlockMatrix
 import is.hail.rvd.RVDContext
 import is.hail.utils._
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.physical.stypes.{PTypeReferenceSingleCodeType, SingleCodeType}
 import org.apache.spark.sql.Row
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerOrInterpretNonCompilable.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.{CanLowerEfficiently, DArrayLowering, LowerToDistributedArrayPass}
 import is.hail.types.virtual.TVoid
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.backend.Backend
+import is.hail.backend.{Backend, ExecuteContext}
 import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.functions.MatrixToMatrixFunction
 import is.hail.types._

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.types.physical.{PArray, PCanonicalStruct, PStruct, PType}

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixWriteBlockMatrix
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage}
 import is.hail.expr.ir.streams.StreamProducer

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.utils._
 
 object Optimize {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.agg._
 import is.hail.expr.ir.functions.RelationalFunctions
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Requiredness.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.GetElement
 import is.hail.methods.ForceCountTable
 import is.hail.types._

--- a/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/StringTableReader.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, CodeLabel, Settable, Value}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency, TableStageToRVD}
 import is.hail.expr.ir.streams.StreamProducer

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.HailTaskContext
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.{BlockMatrixToTableFunction, MatrixToTableFunction, StringFunctions, TableToTableFunction}
@@ -28,8 +28,8 @@ import org.apache.spark.sql.Row
 import org.json4s.JsonAST.JString
 import org.json4s.jackson.JsonMethods
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
-import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream, InputStream}
 
+import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream, InputStream}
 import is.hail.io.avro.AvroTableReader
 
 import scala.reflect.ClassTag

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.lowering.{RVDToTableStage, TableStage, TableStageToRVD}
 import is.hail.io.fs.FS

--- a/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableWriter.scala
@@ -1,10 +1,10 @@
 package is.hail.expr.ir
 
 import java.io.OutputStream
-
 import is.hail.GenericIndexedSeqSerializer
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage}
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.io.fs.FS

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ApproxCDFAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerValue}
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{coerce => _, _}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CallStatsAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -2,8 +2,9 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, EmitRegion, ExecuteContext, IEmitCode}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode}
 import is.hail.io._
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -3,7 +3,8 @@ package is.hail.expr.ir.agg
 import freemarker.template.utility.Execute
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.interfaces.primitive

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DensifyAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -2,8 +2,9 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode, ParamType, ExecuteContext}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode, ParamType}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, RegionPool, RegionValue}
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkTaskContext
 import is.hail.expr.ir
 import is.hail.expr.ir._

--- a/hail/src/main/scala/is/hail/expr/ir/agg/FoldAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/FoldAggregator.scala
@@ -1,7 +1,8 @@
 package is.hail.expr.ir.agg
 import is.hail.annotations.Region
 import is.hail.asm4s.{AsmFunction1RegionLong, AsmFunction2, LongInfo, Value}
-import is.hail.expr.ir.{Compile, Emit, EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, EmitEnv, EmitMethodBuilder, Env, ExecuteContext, IEmitCode, IR, SCodeEmitParamType}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{Compile, Emit, EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, EmitEnv, EmitMethodBuilder, Env, IEmitCode, IR, SCodeEmitParamType}
 import is.hail.types.physical.PType
 import is.hail.types.physical.stypes.{EmitType, SType}
 import is.hail.types.virtual.Type

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -2,8 +2,9 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, EmitRegion, ExecuteContext, IEmitCode, ParamType}
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitRegion, EmitValue, IEmitCode, ParamType}
 import is.hail.io._
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.encoded.EType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerValue, SStackStruct}

--- a/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/LinearRegressionAggregator.scala
@@ -3,7 +3,8 @@ package is.hail.expr.ir.agg
 import breeze.linalg.{DenseMatrix, DenseVector, diag, inv}
 import is.hail.annotations.{Region, RegionValueBuilder, UnsafeRow}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.{EmitType, SCode}
 import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SIndexablePointer, SIndexablePointerSettable}

--- a/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/MonoidAggregator.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.expr.ir.{coerce => _, _}
 import is.hail.types.physical.stypes.{EmitType, SType}

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{UnitInfo, Value, _}
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.linalg.LinalgCodeUtils
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.stypes.EmitType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, ExecuteContext, EmitParamType, SCodeEmitParamType, uuid4, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, IEmitCode, SCodeEmitParamType, uuid4}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical.stypes.{EmitType, SCode}
 import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitContext, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitContext, IEmitCode}
 import is.hail.types.physical.PType
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual.Type

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, ExecuteContext, IEmitCode}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -2,8 +2,9 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, _}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.orderings.StructOrdering
-import is.hail.expr.ir.{Ascending, EmitClassBuilder, EmitCode, EmitCodeBuilder, ExecuteContext, ParamType, SortOrder, EmitValue, IEmitCode}
+import is.hail.expr.ir.{Ascending, EmitClassBuilder, EmitCode, EmitCodeBuilder, EmitValue, IEmitCode, ParamType, SortOrder}
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.BlockMatrixType
 import is.hail.types.virtual.Type
 import is.hail.linalg.BlockMatrix

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MatrixWriteBlockMatrix.scala
@@ -1,9 +1,9 @@
 package is.hail.expr.ir.functions
 
 import java.io.DataOutputStream
-
 import is.hail.HailContext
-import is.hail.expr.ir.{ExecuteContext, MatrixValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.MatrixValue
 import is.hail.types.{MatrixType, RPrimitive, RTable, TypeWithRequiredness}
 import is.hail.types.virtual.{TVoid, Type}
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, GridPartitioner, WriteBlocksRDD}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.functions
 
-import is.hail.expr.ir.{ExecuteContext, LowerMatrixIR, MatrixValue, RelationalSpec, TableReader, TableValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{LowerMatrixIR, MatrixValue, RelationalSpec, TableReader, TableValue}
 import is.hail.types.virtual.Type
 import is.hail.types.{BlockMatrixType, MatrixType, RTable, TableType, TypeWithRequiredness}
 import is.hail.linalg.BlockMatrix

--- a/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.functions
 
-import is.hail.expr.ir.{ExecuteContext, TableValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.TableValue
 import is.hail.types
 import is.hail.types.virtual._
 import is.hail.rvd.RVD

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.GetElement

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.lowering
 
 import is.hail.annotations.{Annotation, ExtendedOrdering, Region, SafeRow, UnsafeRow}
 import is.hail.asm4s.{AsmFunction1RegionLong, LongInfo, classInfo}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.types.physical.{PArray, PStruct, PTuple}
 import is.hail.types.virtual.{TStream, TStruct, Type}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.lowering
 
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.methods.{ForceCountTable, NPartitionsTable}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LowerToCDA.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir.lowering
 
 import is.hail.annotations.{Region, SafeRow, UnsafeRow}
 import is.hail.asm4s.{AsmFunction1RegionLong, AsmFunction1RegionUnit, LongInfo, UnitInfo, classInfo}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.physical.{PTuple, PType}

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.agg.Extract
 import is.hail.expr.ir._
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/LoweringPipeline.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir.lowering
 
-import is.hail.expr.ir.{BaseIR, ExecuteContext, TypeCheck}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{BaseIR, TypeCheck}
 import is.hail.utils._
 
 case class LoweringPipeline(lowerings: LoweringPass*) {

--- a/hail/src/main/scala/is/hail/expr/ir/lowering/RVDToTableStage.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/lowering/RVDToTableStage.scala
@@ -2,9 +2,9 @@ package is.hail.expr.ir.lowering
 
 import is.hail.annotations.{BroadcastRow, Region, RegionValue}
 import is.hail.asm4s._
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.AnonymousDependency
-import is.hail.expr.ir.{Compile, CompileIterator, ExecuteContext, GetField, IR, In, Let, MakeStruct, PartitionRVDReader, ReadPartition, StreamRange, ToArray, _}
+import is.hail.expr.ir.{Compile, CompileIterator, GetField, IR, In, Let, MakeStruct, PartitionRVDReader, ReadPartition, StreamRange, ToArray, _}
 import is.hail.io.fs.FS
 import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.rvd.{RVD, RVDType}

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -1,10 +1,9 @@
 package is.hail.io
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
-
 import is.hail.annotations.{Region, RegionValue}
 import is.hail.asm4s.Code
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.encoded.EType
 import is.hail.types.physical.PType
 import is.hail.types.virtual.Type

--- a/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
+++ b/hail/src/main/scala/is/hail/io/RichContextRDDRegionValue.scala
@@ -1,9 +1,8 @@
 package is.hail.io
 
 import java.io._
-
 import is.hail.annotations._
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.physical._
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexWriter

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -2,8 +2,9 @@ package is.hail.io
 
 import is.hail.annotations._
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.TableStage
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitFunctionBuilder, ExecuteContext, GenericLine, GenericLines, GenericTableValue, IEmitCode, IRParser, IntArrayBuilder, LowerMatrixIR, MatrixHybridReader, TableRead, TableValue, TextReaderOptions}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitFunctionBuilder, GenericLine, GenericLines, GenericTableValue, IEmitCode, IRParser, IntArrayBuilder, LowerMatrixIR, MatrixHybridReader, TableRead, TableValue, TextReaderOptions}
 import is.hail.io.fs.FS
 import is.hail.rvd.RVDPartitioner
 import is.hail.types._

--- a/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/TypedCodecSpec.scala
@@ -1,10 +1,10 @@
 package is.hail.io
 
 import java.io._
-
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitClassBuilder, EmitFunctionBuilder, ExecuteContext}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitFunctionBuilder}
 import is.hail.types.encoded._
 import is.hail.types.physical._
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -1,11 +1,11 @@
 package is.hail.io.avro
 
 import java.io.InputStream
-
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, CodeLabel, Settable, Value}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.streams.StreamProducer
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, ExecuteContext, IEmitCode, PartitionReader}
+import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode, PartitionReader}
 import is.hail.types.physical.stypes.concrete._
 import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue, SStreamValue, primitive}
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/io/avro/AvroTableReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroTableReader.scala
@@ -1,5 +1,6 @@
 package is.hail.io.avro
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
 import is.hail.expr.ir._
 import is.hail.rvd.RVDPartitioner

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -2,9 +2,9 @@ package is.hail.io.bgen
 
 import is.hail.annotations._
 import is.hail.asm4s.AsmFunction4
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
-import is.hail.expr.ir.{ExecuteContext, PruneDeadFields}
+import is.hail.expr.ir.PruneDeadFields
 import is.hail.io.fs.FS
 import is.hail.io.index.{IndexReader, IndexReaderBuilder, LeafChild}
 import is.hail.io._

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -2,8 +2,8 @@ package is.hail.io.bgen
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.backend.BroadcastValue
-import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, ExecuteContext, IEmitCode, ParamType}
+import is.hail.backend.{BroadcastValue, ExecuteContext}
+import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, ParamType}
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexReaderBuilder
 import is.hail.io.{ByteArrayReader, HadoopFSDataBinaryReader}

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -1,8 +1,7 @@
 package is.hail.io.bgen
 
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.SparkTaskContext
-import is.hail.expr.ir.ExecuteContext
 import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexWriter

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -1,10 +1,10 @@
 package is.hail.io.bgen
 
 import is.hail.HailContext
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir
-import is.hail.expr.ir.{ExecuteContext, IRParser, IRParserEnvironment, Interpret, MatrixHybridReader, Pretty, TableIR, TableRead, TableValue}
+import is.hail.expr.ir.{IRParser, IRParserEnvironment, Interpret, MatrixHybridReader, Pretty, TableIR, TableRead, TableValue}
 import is.hail.types._
 import is.hail.types.physical.{PCanonicalStruct, PStruct, PType}
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportBGEN.scala
@@ -2,7 +2,8 @@ package is.hail.io.gen
 
 import is.hail.HailContext
 import is.hail.annotations.{RegionValue, UnsafeRow}
-import is.hail.expr.ir.{ByteArrayBuilder, ExecuteContext, MatrixValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{ByteArrayBuilder, MatrixValue}
 import is.hail.types.physical.PStruct
 import is.hail.io.fs.FS
 import is.hail.utils.BoxedArrayBuilder

--- a/hail/src/main/scala/is/hail/io/gen/ExportGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/ExportGen.scala
@@ -2,7 +2,8 @@ package is.hail.io.gen
 
 import is.hail.HailContext
 import is.hail.annotations.Region
-import is.hail.expr.ir.{ExecuteContext, MatrixValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.MatrixValue
 import is.hail.types.physical.{PString, PStruct}
 import is.hail.variant.{ArrayGenotypeView, RegionValueVariant, VariantMethods, View}
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -3,10 +3,10 @@ package is.hail.io.index
 import java.io.InputStream
 import java.util
 import java.util.Map.Entry
-
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.types.virtual.{TStruct, Type, TypeSerializer}
-import is.hail.expr.ir.{ExecuteContext, IRParser}
+import is.hail.expr.ir.IRParser
 import is.hail.types.physical.{PStruct, PType}
 import is.hail.io._
 import is.hail.io.bgen.BgenSettings

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -1,10 +1,10 @@
 package is.hail.io.index
 
 import java.io.OutputStream
-
 import is.hail.annotations.{Annotation, Region, RegionPool, RegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.{CodeParam, EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, ExecuteContext, IEmitCode, IntArrayBuilder, LongArrayBuilder, ParamType}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{CodeParam, EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, IEmitCode, IntArrayBuilder, LongArrayBuilder, ParamType}
 import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.rvd.AbstractRVDSpec

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -1,10 +1,9 @@
 package is.hail.io.plink
 
-import is.hail.expr.ir.ExecuteContext
 import java.io.{OutputStream, OutputStreamWriter}
-
 import is.hail.HailContext
 import is.hail.annotations.Region
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.MatrixValue
 import is.hail.types._
 import is.hail.types.physical.{PString, PStruct}

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -1,6 +1,7 @@
 package is.hail.io.plink
 
 import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir._
 import is.hail.expr.ir.lowering.TableStage

--- a/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
+++ b/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
@@ -3,10 +3,8 @@ package is.hail.io.reference
 import java.util
 import java.util.Map.Entry
 import java.util.concurrent.locks.{Lock, ReentrantLock}
-
 import htsjdk.samtools.reference.{ReferenceSequenceFile, ReferenceSequenceFileFactory}
-import is.hail.backend.BroadcastValue
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.utils._
 import is.hail.variant.{Locus, ReferenceGenome}
 import is.hail.io.fs.FS

--- a/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
+++ b/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
@@ -1,6 +1,6 @@
 package is.hail.io.reference
 
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.variant.{Locus, ReferenceGenome}
 import is.hail.utils._
 import is.hail.io.fs.FS

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -5,7 +5,8 @@ import htsjdk.tribble.SimpleFeature
 import htsjdk.tribble.index.tabix.{TabixFormat, TabixIndexCreator}
 import is.hail
 import is.hail.annotations.Region
-import is.hail.expr.ir.{ExecuteContext, MatrixValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.MatrixValue
 import is.hail.io.compress.{BGzipLineReader, BGzipOutputStream}
 import is.hail.io.fs.FS
 import is.hail.io.{VCFAttributes, VCFFieldAttributes, VCFMetadata}

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -2,11 +2,11 @@ package is.hail.io.vcf
 
 import htsjdk.variant.vcf._
 import is.hail.annotations._
-import is.hail.backend.BroadcastValue
 import is.hail.backend.spark.SparkBackend
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.lowering.TableStage
-import is.hail.expr.ir.{ExecuteContext, GenericLines, GenericTableValue, IR, IRParser, Literal, LowerMatrixIR, MatrixHybridReader, MatrixIR, MatrixLiteral, TableRead, TableValue}
+import is.hail.expr.ir.{GenericLines, GenericTableValue, IR, IRParser, Literal, LowerMatrixIR, MatrixHybridReader, MatrixIR, MatrixLiteral, TableRead, TableValue}
 import is.hail.io.fs.{FS, FileStatus}
 import is.hail.io.tabix._
 import is.hail.io.vcf.LoadVCF.{getHeaderLines, parseHeader, parseLines}

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -7,11 +7,11 @@ import breeze.numerics.{abs => breezeAbs, log => breezeLog, pow => breezePow, sq
 import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import is.hail._
 import is.hail.annotations._
-import is.hail.backend.{BroadcastValue, HailTaskContext}
+import is.hail.backend.{BroadcastValue, ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.utils._
 import is.hail.expr.Parser
-import is.hail.expr.ir.{CompileAndEvaluate, ExecuteContext, IR, IntArrayBuilder, TableValue}
+import is.hail.expr.ir.{CompileAndEvaluate, IR, IntArrayBuilder, TableValue}
 import is.hail.types._
 import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalStruct, PFloat64, PFloat64Optional, PFloat64Required, PInt64, PInt64Optional, PInt64Required, PStruct}
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -2,9 +2,8 @@ package is.hail.linalg
 
 import breeze.linalg.DenseMatrix
 import is.hail.HailContext
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.ExecuteContext
 import is.hail.types.virtual.{TInt64, TStruct}
 import is.hail.io.InputBuffer
 import is.hail.io.fs.FS

--- a/hail/src/main/scala/is/hail/methods/FilterPartitions.scala
+++ b/hail/src/main/scala/is/hail/methods/FilterPartitions.scala
@@ -1,9 +1,9 @@
 package is.hail.methods
 
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.TableValue
 import is.hail.expr.ir.functions.{MatrixToMatrixFunction, TableToTableFunction}
-import is.hail.expr.ir.{ExecuteContext, MatrixValue, TableValue}
 import is.hail.types.{MatrixType, TableType}
-import is.hail.rvd.RVDType
 
 case class TableFilterPartitions(parts: Seq[Int], keep: Boolean) extends TableToTableFunction {
   override def preservesPartitionCounts: Boolean = false

--- a/hail/src/main/scala/is/hail/methods/ForceCount.scala
+++ b/hail/src/main/scala/is/hail/methods/ForceCount.scala
@@ -1,8 +1,8 @@
 package is.hail.methods
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.{MatrixToValueFunction, TableToValueFunction}
-import is.hail.expr.ir.{ExecuteContext, MatrixValue, TableValue}
-
+import is.hail.expr.ir.{MatrixValue, TableValue}
 import is.hail.types.virtual.{TInt64, Type}
 import is.hail.types.{MatrixType, RTable, TableType, TypeWithRequiredness}
 

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir._
 import is.hail.expr.ir.functions.MatrixToTableFunction
 import is.hail.types.physical.{PCanonicalString, PCanonicalStruct, PFloat64, PInt64, PString, PStruct}

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -4,8 +4,9 @@ import breeze.linalg._
 import breeze.numerics.sqrt
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, IntArrayBuilder, MatrixValue, TableValue}
+import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
 import is.hail.types._
 import is.hail.types.physical.PStruct
 import is.hail.types.virtual.{TArray, TFloat64, TInt32, TStruct}

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -1,10 +1,10 @@
 package is.hail.methods
 
 import java.util
-
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, MatrixValue, TableValue}
+import is.hail.expr.ir.{MatrixValue, TableValue}
 import is.hail.types._
 import is.hail.types.physical._
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -3,8 +3,9 @@ package is.hail.methods
 import breeze.linalg._
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, IntArrayBuilder, MatrixValue, TableValue}
+import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
 import is.hail.types.virtual.{TArray, TFloat64, TStruct}
 import is.hail.types.{MatrixType, TableType}
 import is.hail.rvd.RVDType

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -1,12 +1,12 @@
 package is.hail.methods
 
 import java.io.{BufferedOutputStream, OutputStreamWriter}
-
 import is.hail.HailContext
 import is.hail.annotations.{UnsafeIndexedSeq, UnsafeRow}
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.TableAnnotationImpex
-import is.hail.expr.ir.{ExecuteContext, MatrixValue}
+import is.hail.expr.ir.MatrixValue
 import is.hail.expr.ir.functions.MatrixToValueFunction
 import is.hail.types.{MatrixType, RTable, TypeWithRequiredness}
 import is.hail.types.virtual.{TVoid, Type}

--- a/hail/src/main/scala/is/hail/methods/NPartitions.scala
+++ b/hail/src/main/scala/is/hail/methods/NPartitions.scala
@@ -1,7 +1,8 @@
 package is.hail.methods
 
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.{MatrixToValueFunction, TableToValueFunction}
-import is.hail.expr.ir.{ExecuteContext, MatrixValue, TableValue}
+import is.hail.expr.ir.{MatrixValue, TableValue}
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.types.{MatrixType, RTable, TableType, TypeWithRequiredness}
 

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -2,10 +2,10 @@ package is.hail.methods
 
 import java.io.{FileInputStream, IOException}
 import java.util.Properties
-
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.ir.{ExecuteContext, TableValue}
+import is.hail.expr.ir.TableValue
 import is.hail.expr.ir.functions.TableToTableFunction
 import is.hail.types._
 import is.hail.types.physical.{PCanonicalStruct, PStruct, PType}

--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -3,8 +3,9 @@ package is.hail.methods
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, MatrixValue, TableValue}
+import is.hail.expr.ir.{MatrixValue, TableValue}
 import is.hail.types._
 import is.hail.types.physical.{PCanonicalStruct, PStruct, PType}
 import is.hail.types.virtual._

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -5,8 +5,9 @@ import is.hail.linalg.BlockMatrix
 import is.hail.linalg.BlockMatrix.ops._
 import is.hail.utils._
 import is.hail.HailContext
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.BlockMatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, TableValue}
+import is.hail.expr.ir.TableValue
 import is.hail.types.{BlockMatrixType, TableType}
 import is.hail.types.virtual._
 import org.apache.spark.storage.StorageLevel

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -3,8 +3,9 @@ package is.hail.methods
 import breeze.linalg._
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{ExecuteContext, IntArrayBuilder, MatrixValue, TableValue}
+import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
 import is.hail.types.virtual.{TFloat64, TStruct}
 import is.hail.types.{MatrixType, TableType}
 import is.hail.rvd.RVDType

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -11,7 +11,8 @@ import org.apache.spark.sql.Row
 import com.sun.jna.Native
 import com.sun.jna.ptr.IntByReference
 import is.hail.HailContext
-import is.hail.expr.ir.{ExecuteContext, IntArrayBuilder, MatrixValue, TableValue}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{IntArrayBuilder, MatrixValue, TableValue}
 import is.hail.expr.ir.functions.MatrixToTableFunction
 import is.hail.types.virtual.{TFloat64, TInt32, TStruct, Type}
 import is.hail.rvd.RVDType

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -2,9 +2,10 @@ package is.hail.methods
 
 import com.fasterxml.jackson.core.JsonParseException
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.expr._
 import is.hail.expr.ir.functions.{RelationalFunctions, TableToTableFunction}
-import is.hail.expr.ir.{ExecuteContext, TableValue}
+import is.hail.expr.ir.TableValue
 import is.hail.io.fs.FS
 import is.hail.methods.VEP._
 import is.hail.rvd.RVD

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -2,9 +2,10 @@ package is.hail.rvd
 
 import is.hail.annotations._
 import is.hail.asm4s.AsmFunction3RegionLongLongLong
+import is.hail.backend.ExecuteContext
 import is.hail.expr.{JSONAnnotationImpex, ir}
 import is.hail.expr.ir.lowering.{TableStage, TableStageDependency}
-import is.hail.expr.ir.{ExecuteContext, IR, Literal, PartitionNativeReader, PartitionZippedIndexedNativeReader, PartitionZippedNativeReader, ReadPartition, Ref, ToStream}
+import is.hail.expr.ir.{IR, Literal, PartitionNativeReader, PartitionZippedIndexedNativeReader, PartitionZippedNativeReader, ReadPartition, Ref, ToStream}
 import is.hail.io._
 import is.hail.io.fs.FS
 import is.hail.io.index.{InternalNodeBuilder, LeafNodeBuilder}

--- a/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/KeyedRVD.scala
@@ -1,7 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations._
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.physical.PStruct
 import is.hail.types.virtual.TInterval
 import is.hail.sparkextras._

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1,9 +1,9 @@
 package is.hail.rvd
 
 import java.util
-
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir.PruneDeadFields.isSupertype
 import is.hail.types._
@@ -14,7 +14,7 @@ import is.hail.io.index.IndexWriter
 import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, RichContextRDDRegionValue, TypedCodecSpec}
 import is.hail.sparkextras._
 import is.hail.utils._
-import is.hail.expr.ir.{ExecuteContext, InferPType}
+import is.hail.expr.ir.InferPType
 import is.hail.utils.PartitionCounts.{PCSubsetOffset, getPCSubsetOffset, incrementalPCSubsetOffset}
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.TaskContext

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -2,8 +2,9 @@ package is.hail.stats
 
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV}
 import is.hail.annotations.{BroadcastRow, Region, RegionValue, RegionValueBuilder}
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkTaskContext
-import is.hail.expr.ir.{ExecuteContext, TableIR, TableLiteral, TableValue}
+import is.hail.expr.ir.{TableIR, TableLiteral, TableValue}
 import is.hail.linalg.RowMatrix
 import is.hail.rvd.{RVD, RVDType}
 import is.hail.sparkextras.ContextRDD

--- a/hail/src/main/scala/is/hail/types/encoded/EType.scala
+++ b/hail/src/main/scala/is/hail/types/encoded/EType.scala
@@ -4,7 +4,8 @@ import java.util.Map.Entry
 import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s.{coerce => _, _}
-import is.hail.expr.ir.{EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, ExecuteContext, IRParser, ParamType, PunctuationToken, TokenIterator}
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{EmitClassBuilder, EmitCodeBuilder, EmitFunctionBuilder, EmitMethodBuilder, IRParser, ParamType, PunctuationToken, TokenIterator}
 import is.hail.io._
 import is.hail.types._
 import is.hail.types.physical._

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -3,6 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.check.{Arbitrary, Gen}
 import is.hail.expr.ir
 import is.hail.expr.ir._

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -2,8 +2,9 @@ package is.hail.utils
 
 import is.hail.annotations.{Region, RegionValueBuilder}
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.types.physical.{PCanonicalTuple, PTuple, PType, stypes}
-import is.hail.expr.ir.{Compile, ExecuteContext, IR, IRParser, IRParserEnvironment, Interpret, Literal, MakeTuple, SingleCodeEmitParamType}
+import is.hail.expr.ir.{Compile, IR, IRParser, IRParserEnvironment, Interpret, Literal, MakeTuple, SingleCodeEmitParamType}
 import is.hail.types.physical.stypes.PTypeReferenceSingleCodeType
 import is.hail.types.virtual._
 import org.apache.spark.sql.Row

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -1,14 +1,12 @@
 package is.hail.utils
 
-import java.io.{ObjectInputStream, ObjectOutputStream}
-
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.ExecuteContext
 import is.hail.io.fs.FS
 import org.apache.spark.rdd.RDD
 
-import scala.reflect.ClassTag
-import scala.reflect.classTag
+import java.io.{ObjectInputStream, ObjectOutputStream}
+import scala.reflect.{ClassTag, classTag}
 
 object SpillingCollectIterator {
   def apply[T: ClassTag](localTmpdir: String, fs: FS, rdd: RDD[T], sizeLimit: Int): SpillingCollectIterator[T] = {

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -1,9 +1,9 @@
 package is.hail.expr.ir
 
 import java.util.regex.Pattern
-
 import is.hail.HailContext
 import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.lowering.TableStage

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -1,12 +1,10 @@
 package is.hail.utils.richUtils
 
 import java.io._
-
 import is.hail.HailContext
 import is.hail.annotations.{Region, RegionPool}
-import is.hail.backend.HailTaskContext
+import is.hail.backend.{ExecuteContext, HailTaskContext}
 import is.hail.backend.spark.SparkTaskContext
-import is.hail.expr.ir.ExecuteContext
 import is.hail.io.FileWriteMetadata
 import is.hail.io.fs.FS
 import is.hail.io.index.IndexWriter

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -1,8 +1,8 @@
 package is.hail.utils.richUtils
 
-import java.io.{OutputStream, OutputStreamWriter}
+import is.hail.backend.ExecuteContext
 
-import is.hail.expr.ir.ExecuteContext
+import java.io.{OutputStream, OutputStreamWriter}
 import is.hail.io.FileWriteMetadata
 import is.hail.rvd.RVDContext
 import is.hail.sparkextras._

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -1,13 +1,12 @@
 package is.hail.variant
 
 import java.io.InputStream
-
 import htsjdk.samtools.reference.FastaSequenceIndex
 import is.hail.HailContext
 import is.hail.asm4s.Code
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.check.Gen
-import is.hail.expr.ir.{EmitClassBuilder, ExecuteContext, RelationalSpec}
+import is.hail.expr.ir.{EmitClassBuilder, RelationalSpec}
 import is.hail.expr.{JSONExtractContig, JSONExtractIntervalLocus, JSONExtractReferenceGenome, Parser}
 import is.hail.io.fs.FS
 import is.hail.io.reference.LiftOver
@@ -22,6 +21,7 @@ import scala.language.implicitConversions
 import org.apache.spark.TaskContext
 import org.json4s._
 import org.json4s.jackson.{JsonMethods, Serialization}
+
 import java.lang.ThreadLocal
 
 

--- a/hail/src/test/scala/is/hail/HailSuite.scala
+++ b/hail/src/test/scala/is/hail/HailSuite.scala
@@ -1,9 +1,8 @@
 package is.hail
 
 import is.hail.annotations.{Region, RegionPool}
-import is.hail.backend.BroadcastValue
+import is.hail.backend.{BroadcastValue, ExecuteContext}
 import is.hail.backend.spark.SparkBackend
-import is.hail.expr.ir.ExecuteContext
 import is.hail.utils.{ExecutionTimer, using}
 import is.hail.io.fs.FS
 import org.apache.spark.SparkContext

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -5,6 +5,7 @@ import breeze.linalg.{DenseMatrix, Matrix, Vector}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir._
 import is.hail.expr.ir.{BindingEnv, MakeTuple, Subst}

--- a/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.annotations
 
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.types.virtual._
 import is.hail.testUtils._
 import is.hail.utils._

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.TestUtils._
 import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.lowering.LoweringPipeline
 import is.hail.expr.ir.streams.{EmitStream, StreamArgType, StreamUtils}
 import is.hail.types.physical._

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -4,6 +4,7 @@ import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.annotations.{BroadcastRow, ExtendedOrdering, Region, SafeNDArray}
 import is.hail.asm4s.{Code, Value}
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.ArrayZipBehavior.ArrayZipBehavior
 import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.IRSuite.TestFunctions

--- a/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MemoryLeakSuite.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.HailSuite
 import is.hail.TestUtils.eval
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir
 import is.hail.types.virtual.{TArray, TBoolean, TSet, TString}
 import is.hail.utils._

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.HailSuite
+import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.types._
 import is.hail.types.physical.PStruct

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.asm4s.Code
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.functions.{IRRandomness, RegistryFunctions}
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.{SInt32, SInt64}

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import is.hail.HailSuite
 import is.hail.annotations.Region
 import is.hail.asm4s._
+import is.hail.backend.ExecuteContext
 import is.hail.check.{Gen, Prop}
 import is.hail.expr.ir.agg._
 import is.hail.expr.ir.orderings.CodeOrdering

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.annotations.SafeNDArray
+import is.hail.backend.ExecuteContext
 import is.hail.expr.Nat
 import is.hail.expr.ir.TestUtils._
 import is.hail.methods.ForceCountTable

--- a/hail/src/test/scala/is/hail/fs/FSSuite.scala
+++ b/hail/src/test/scala/is/hail/fs/FSSuite.scala
@@ -1,9 +1,8 @@
 package is.hail.fs
 
 import java.io.FileNotFoundException
-
 import is.hail.HailSuite
-import is.hail.expr.ir.ExecuteContext
+import is.hail.backend.ExecuteContext
 import is.hail.io.fs.{FS, FileStatus}
 import is.hail.utils._
 import org.apache.commons.io.IOUtils

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -2,8 +2,9 @@ package is.hail.variant.vsm
 
 import is.hail.HailSuite
 import is.hail.annotations.BroadcastRow
+import is.hail.backend.ExecuteContext
 import is.hail.expr.ir
-import is.hail.expr.ir.{ExecuteContext, Interpret, MatrixAnnotateRowsTable, TableLiteral, TableRange, TableValue}
+import is.hail.expr.ir.{Interpret, MatrixAnnotateRowsTable, TableLiteral, TableRange, TableValue}
 import is.hail.types._
 import is.hail.types.virtual.{TInt32, TStruct}
 import is.hail.rvd.RVD


### PR DESCRIPTION
Instead of `is.hail.expr.ir`.

Helpful for the next change which puts `broadcast` on ExecuteContext and makes the methods on `Backend` `protected[backend]`.