### PR TITLE
[query] Improve `hl.Struct` performance

### DIFF
--- a/hail/python/hail/utils/struct.py
+++ b/hail/python/hail/utils/struct.py
@@ -44,7 +44,8 @@ class Struct(Mapping):
     """
 
     def __init__(self, **kwargs):
-        self._fields = kwargs
+        # Set this way to avoid an infinite recursion in `__getattr__`.
+        self.__dict__["_fields"] = kwargs
 
     def __contains__(self, item):
         return item in self._fields
@@ -61,15 +62,15 @@ class Struct(Mapping):
 
     def __setattr__(self, key, value):
         if key in self._fields:
-            self._fields[key] = value
+            raise ValueError("Structs are immutable, cannot overwrite a field.")
         else:
             super().__setattr__(key, value)
 
     def __getattr__(self, item):
-        if item in self._fields:
-            return self._fields[item]
-        elif item in self.__dict__:
+        if item in self.__dict__:
             return self.__dict__[item]
+        elif item in self._fields:
+            return self._fields[item]
         else:
             raise AttributeError(get_nice_attr_error(self, item))
 


### PR DESCRIPTION
Currently, constructing a `hl.Struct` is slower than I'd like, since it requires copying every field from the input `kwargs` into the `Struct` object's `__dict__`. This PR's main goal was to avoid the need to do that, by just using the input `kwargs` dict we were already saving as `_fields`. 

When working on this, I also noticed that we allowed users to mutate fields of a struct, and we didn't do so in a consistent way (`s.a` vs `s["a"]` could return different answers). I avoid that by throwing an error from now on if a user tries to modify one of the "main" fields of the struct (i.e. the ones that are in the `_fields` array).