### PR TITLE
Update links for gnomAD library

### DIFF
--- a/hail/python/hail/docs/libraries.rst
+++ b/hail/python/hail/docs/libraries.rst
@@ -5,17 +5,17 @@
 Libraries
 ===================
 
-This pages lists any external libraries we are aware of that are built on top of hail. These libraries are not developed by hail team so we cannot necessarily answer 
-questions about them, but they may provide useful functions not included in base hail.
+This pages lists any external libraries we are aware of that are built on top of Hail. These libraries are not developed by the Hail team so we cannot necessarily answer
+questions about them, but they may provide useful functions not included in base Hail.
 
 --------
 
 gnomad (Hail Utilities for gnomAD)
 ----------------------------------
 
-This repo contains a number of Hail utility functions and scripts for the `gnomAD <https://gnomad.broadinstitute.org>`_ project and the `MacArthur lab <https://macarthurlab.org/>`_.
+This repo contains a number of Hail utility functions and scripts for the `gnomAD <https://gnomad.broadinstitute.org>`_ project and the `Translational Genomics Group <https://the-tgg.org/>`_.
 
 Install with ``pip install gnomad``.
 
-More info can be found here: `PyPI <https://pypi.org/project/gnomad/>`_ and `API Reference <https://broadinstitute.github.io/gnomad_methods/api_reference/>`_
+More info can be found in the `documentation <https://broadinstitute.github.io/gnomad_methods/>`_ or on the `PyPI project page <https://pypi.org/project/gnomad/>`_.
 


### PR DESCRIPTION
Since the [gnomad library](https://pypi.org/project/gnomad/) was added to the Hail website, we've added a bit more documentation. This changes the link to the documentation home page instead of directly to the API reference section.

This also makes the description on the Hail website consistent with that on the gnomAD GitHub/PyPI/documentation pages by replacing the link to the MacArthur Lab website with a link to the Translational Genomics Group website.

Finally, this also capitalizes "Hail" in the introductory paragraph.