### PR TITLE
[hail-bench] Support running async-profiler with itimer option

### DIFF
--- a/benchmark/python/benchmark_hail/run/cli.py
+++ b/benchmark/python/benchmark_hail/run/cli.py
@@ -50,7 +50,7 @@ def main(args_):
                         action='store_true',
                         help='Print benchmarks to execute, but do not run.')
     parser.add_argument('--profile', '-p',
-                        choices=['cpu', 'alloc'],
+                        choices=['cpu', 'alloc', 'itimer'],
                         nargs='?', const='cpu',
                         help='Run with async-profiler.')
     parser.add_argument('--prof-fmt', '-f',


### PR DESCRIPTION
The default "cpu" strategy requires some permissions to make syscalls. In a container environment, don't always have these permissions. "itimer" is a fallback that doesn't require that. 