### PR TITLE
[makefile] remove trailing `/` on `DEV_CLARIFIER` that leads to a duplicate `/` in `cloud_base` path

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -218,7 +218,7 @@ $(EGG): copy-py-files
 
 # if the DEPLOY_REMOTE flag is not set, then deploy init scripts into a dev-username location
 ifndef DEPLOY_REMOTE
-DEV_CLARIFIER ?= $(shell whoami)-dev/
+DEV_CLARIFIER ?= $(shell whoami)-dev
 cloud_base ?= gs://hail-30-day/hailctl/dataproc/$(DEV_CLARIFIER)/$(HAIL_VERSION)
 UPLOAD_RETENTION =
 else


### PR DESCRIPTION
Removes the trailing slash on `DEV_CLARIFIER ?= $(shell whoami)-dev/` that causes a duplicate `/` in the `cloud_base` path when files are copied, e.g. `gs://hail-30-day/hailctl/dataproc/pcumming-dev//0.2.78-2b1cc52d1a45`.