### PR TITLE
[query] Don't rename key fields when calling `Table.join`

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2454,7 +2454,7 @@ class Table(ExprContainer):
                              f"  left:  [{', '.join(str(t) for t in left_key_types)}]\n  "
                              f"  right: [{', '.join(str(t) for t in right_key_types)}]")
         left_fields = set(self._fields)
-        right_fields = set(right._fields) - set(self.key)
+        right_fields = set(right._fields) - set(right.key)
 
         renames, _ = deduplicate(
             right_fields, max_attempts=100, already_used=left_fields)


### PR DESCRIPTION
It was not hurting anything, but this method prints out all of the fields that get deduplicated, and so it was confusing to suggest that we were deduplicating `locus -> locus_1` or whatever when the user never saw a `locus_1` field.