### PR TITLE
[make] Enforce black formatting for services except batch and gear

### DIFF
--- a/auth/Makefile
+++ b/auth/Makefile
@@ -6,11 +6,13 @@ AUTH_IMAGE := $(DOCKER_PREFIX)/auth:$(TOKEN)
 
 EXTRA_PYTHONPATH := ../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
+BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 .PHONY: check
 check:
 	$(PYTHON) -m flake8 auth
 	$(PYTHON) -m pylint --rcfile ../pylintrc auth --score=n
+	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh
 

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -9,7 +9,7 @@ HAIL_BUILDKIT_IMAGE := $(DOCKER_PREFIX)/hail-buildkit:$(TOKEN)
 EXTRA_PYTHONPATH := ../batch:../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 
-BLACK := $(PYTHON) -m black ci --line-length=120 --skip-string-normalization
+BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 .PHONY: check
 check:

--- a/memory/Makefile
+++ b/memory/Makefile
@@ -2,6 +2,7 @@ include ../config.mk
 
 PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}../hail/python:../gear
 PYTHON := PYTHONPATH=$(PYTHONPATH) python3
+BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
 
@@ -11,6 +12,7 @@ MEMORY_IMAGE := $(DOCKER_PREFIX)/memory:$(TOKEN)
 check:
 	$(PYTHON) -m flake8  --config ../setup.cfg memory
 	$(PYTHON) -m pylint --rcfile ../pylintrc memory --score=n
+	$(BLACK) --check --diff
 
 .PHONY: build
 build:

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -71,7 +71,10 @@ async def get_or_add_user(app, userdata):
     if username not in users:
         k8s_client = app['k8s_client']
         hail_identity_secret = await retry_transient_errors(
-            k8s_client.read_namespaced_secret, userdata['hail_credentials_secret_name'], DEFAULT_NAMESPACE, _request_timeout=5.0
+            k8s_client.read_namespaced_secret,
+            userdata['hail_credentials_secret_name'],
+            DEFAULT_NAMESPACE,
+            _request_timeout=5.0,
         )
         gsa_key = json.loads(base64.b64decode(hail_identity_secret.data['key.json']).decode())
         credentials = GoogleCredentials.from_credentials_data(gsa_key)

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -7,11 +7,13 @@ NOTEBOOK_NGINX_IMAGE := $(DOCKER_PREFIX)/notebook_nginx:$(TOKEN)
 
 EXTRA_PYTHONPATH := ../hail/python:../gear:../web_common
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
+BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 .PHONY: check
 check:
 	$(PYTHON) -m flake8 notebook
 	$(PYTHON) -m pylint --rcfile ../pylintrc notebook --score=n
+	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh
 

--- a/web_common/Makefile
+++ b/web_common/Makefile
@@ -1,8 +1,10 @@
 EXTRA_PYTHONPATH := ../hail/python:../gear
 PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
+BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 .PHONY: check
 check:
 	$(PYTHON) -m flake8 web_common
 	$(PYTHON) -m pylint --rcfile ../pylintrc web_common --score=n
+	$(BLACK) --check --diff
 	curlylint .


### PR DESCRIPTION
I've left out batch and gear so as not to interfere with #10920, but I intend to do those once there are no huge batch PRs on deck. I think I'm the only one with the pre-commit hooks installed because currently I can't make any small changes to batch files without introducing a ton of format changes (without disabling the pre-commit hooks).