### PR TITLE
[vds/combiner] Use fast codecs for combiner intermediates

### DIFF
--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -10,12 +10,13 @@ from hail.utils.java import Env
 @typecheck(mts=sequenceof(MatrixTable),
            prefix=str,
            overwrite=bool,
-           stage_locally=bool)
+           stage_locally=bool,
+           codec_spec=nullable(str))
 def write_matrix_tables(mts: List[MatrixTable], prefix: str, overwrite: bool = False,
-                        stage_locally: bool = False):
+                        stage_locally: bool = False, codec_spec=None):
     length = len(str(len(mts) - 1))
     paths = [f"{prefix}{str(i).rjust(length, '0')}.mt" for i in range(len(mts))]
-    writer = MatrixNativeMultiWriter(paths, overwrite, stage_locally)
+    writer = MatrixNativeMultiWriter(paths, overwrite, stage_locally, codec_spec)
     Env.backend().execute(MatrixMultiWrite([mt._mir for mt in mts], writer))
 
 

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -164,21 +164,25 @@ class MatrixBlockMatrixWriter(MatrixWriter):
 class MatrixNativeMultiWriter(object):
     @typecheck_method(paths=sequenceof(str),
                       overwrite=bool,
-                      stage_locally=bool)
-    def __init__(self, paths, overwrite, stage_locally):
+                      stage_locally=bool,
+                      codec_spec=nullable(str))
+    def __init__(self, paths, overwrite, stage_locally, codec_spec):
         self.paths = paths
         self.overwrite = overwrite
         self.stage_locally = stage_locally
+        self.codec_spec = codec_spec
 
     def render(self):
         writer = {'name': 'MatrixNativeMultiWriter',
                   'paths': list(self.paths),
                   'overwrite': self.overwrite,
-                  'stageLocally': self.stage_locally}
+                  'stageLocally': self.stage_locally,
+                  'codecSpecJSONStr': self.codec_spec}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
         return isinstance(other, MatrixNativeMultiWriter) and \
             other.paths == self.paths and \
             other.overwrite == self.overwrite and \
-            other.stage_locally == self.stage_locally
+            other.stage_locally == self.stage_locally and \
+            other.codec_spec == self.codec_spec

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -12,10 +12,12 @@ from hail.vds.variant_dataset import VariantDataset
 from hail import ir
 
 
-def write_variant_datasets(vdss, paths, overwrite=False, stage_locally=False):
+def write_variant_datasets(vdss, paths, *,
+                           overwrite=False, stage_locally=False,
+                           codec_spec=None):
     """Write many `vdses` to their corresponding path in `paths`."""
-    ref_writer = ir.MatrixNativeMultiWriter([f"{p}/reference_data" for p in paths], overwrite, stage_locally)
-    var_writer = ir.MatrixNativeMultiWriter([f"{p}/variant_data" for p in paths], overwrite, stage_locally)
+    ref_writer = ir.MatrixNativeMultiWriter([f"{p}/reference_data" for p in paths], overwrite, stage_locally, codec_spec)
+    var_writer = ir.MatrixNativeMultiWriter([f"{p}/variant_data" for p in paths], overwrite, stage_locally, codec_spec)
     Env.backend().execute(ir.MatrixMultiWrite([vds.reference_data._mir for vds in vdss], ref_writer))
     Env.backend().execute(ir.MatrixMultiWrite([vds.variant_data._mir for vds in vdss], var_writer))
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -112,7 +112,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read],
-                                ir.MatrixNativeMultiWriter([new_temp_file(), new_temp_file()], False, False)),
+                                ir.MatrixNativeMultiWriter([new_temp_file(), new_temp_file()], False, False, None)),
             ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake.bm', False, False, False)),
             ir.LiftMeOut(ir.I32(1)),
             ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')),

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -331,13 +331,13 @@ object MatrixValue {
     mvs: IndexedSeq[MatrixValue],
     paths: IndexedSeq[String],
     overwrite: Boolean,
-    stageLocally: Boolean
+    stageLocally: Boolean,
+    bufferSpec: BufferSpec
   ): Unit = {
     val first = mvs.head
     require(mvs.forall(_.typ == first.typ))
     require(mvs.length == paths.length, s"found ${ mvs.length } matrix tables but ${ paths.length } paths")
     val fs = ctx.fs
-    val bufferSpec = BufferSpec.default
 
     paths.foreach { path =>
       if (overwrite)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -484,7 +484,9 @@ object MatrixNativeMultiWriter {
 case class MatrixNativeMultiWriter(
   paths: IndexedSeq[String],
   overwrite: Boolean = false,
-  stageLocally: Boolean = false
+  stageLocally: Boolean = false,
+  codecSpecJSONStr: String = null
 ) {
-  def apply(ctx: ExecuteContext, mvs: IndexedSeq[MatrixValue]): Unit = MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, stageLocally)
+  val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
+  def apply(ctx: ExecuteContext, mvs: IndexedSeq[MatrixValue]): Unit = MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, stageLocally, bufferSpec)
 }


### PR DESCRIPTION
This requires adding a codec argument to MatrixNativeMultiWriter.