### PR TITLE
[ci] Use storage uri for ci module

### DIFF
--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -12,7 +12,7 @@ from hailtop.utils import check_shell_output
 
 from ci.build import BuildConfiguration, Code
 from ci.github import clone_or_fetch_script
-from ci.environment import KUBERNETES_SERVER_URL
+from ci.environment import KUBERNETES_SERVER_URL, STORAGE_URI
 from ci.utils import generate_token
 
 from batch.driver.k8s_cache import K8sCache
@@ -105,7 +105,7 @@ class LocalBatchBuilder:
 
         os.makedirs(f'{root}/shared')
 
-        prefix = f'gs://dummy/build/{batch_token}'
+        prefix = f'{STORAGE_URI}/build/{batch_token}'
 
         for j in self._jobs:
             job_name = j._attributes.get('name')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -14,7 +14,7 @@ from .environment import (
     CI_UTILS_IMAGE,
     BUILDKIT_IMAGE,
     DEFAULT_NAMESPACE,
-    BUCKET,
+    STORAGE_URI,
     CLOUD,
 )
 from .globals import is_test_deployment
@@ -273,7 +273,7 @@ class BuildImage2Step(Step):
         if self.inputs:
             input_files = []
             for i in self.inputs:
-                input_files.append((f'gs://{BUCKET}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
+                input_files.append((f'{STORAGE_URI}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
         else:
             input_files = None
 
@@ -456,14 +456,14 @@ class RunImageStep(Step):
         if self.inputs:
             input_files = []
             for i in self.inputs:
-                input_files.append((f'gs://{BUCKET}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
+                input_files.append((f'{STORAGE_URI}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
         else:
             input_files = None
 
         if self.outputs:
             output_files = []
             for o in self.outputs:
-                output_files.append((o["from"], f'gs://{BUCKET}/build/{batch.attributes["token"]}{o["to"]}'))
+                output_files.append((o["from"], f'{STORAGE_URI}/build/{batch.attributes["token"]}{o["to"]}'))
         else:
             output_files = None
 
@@ -955,15 +955,15 @@ EOF
         input_files = []
         if self.inputs:
             for i in self.inputs:
-                input_files.append((f'gs://{BUCKET}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
+                input_files.append((f'{STORAGE_URI}/build/{batch.attributes["token"]}{i["from"]}', i["to"]))
 
         if not self.cant_create_database:
             password_files_input = [
                 (
-                    f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.admin_password_file}',
+                    f'{STORAGE_URI}/build/{batch.attributes["token"]}/{self.admin_password_file}',
                     self.admin_password_file,
                 ),
-                (f'gs://{BUCKET}/build/{batch.attributes["token"]}/{self.user_password_file}', self.user_password_file),
+                (f'{STORAGE_URI}/build/{batch.attributes["token"]}/{self.user_password_file}', self.user_password_file),
             ]
             input_files.extend(password_files_input)
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -144,8 +144,9 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
 
 
 def storage_uri_to_url(uri: str) -> str:
-    assert uri.startswith('gs://')
-    path = uri.split('gs://')[1]
+    protocol = 'gs://'
+    assert uri.startswith(protocol)
+    path = uri[len(protocol) :]
     return f'https://console.cloud.google.com/storage/browser/{path}'
 
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -26,7 +26,7 @@ from gear import (
 from typing import Dict, Any, Optional, List
 from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
 
-from .environment import BUCKET
+from .environment import STORAGE_URI
 from .github import Repo, FQBranch, WatchedBranch, UnwatchedBranch, MergeFailureBatch, PR, select_random_teammate
 from .constants import AUTHORIZED_USERS, TEAMS
 
@@ -126,7 +126,9 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
                 j['duration'] = humanize_timedelta_msecs(j['duration'])
             page_context['batch'] = status
             page_context['jobs'] = jobs
-            page_context['artifacts'] = f'/{BUCKET}/build/{batch.attributes["token"]}'
+            artifacts_uri = f'{STORAGE_URI}/build/{batch.attributes["token"]}'
+            page_context['artifacts_uri'] = artifacts_uri
+            page_context['artifacts_url'] = storage_uri_to_url(artifacts_uri)
         else:
             page_context['exception'] = '\n'.join(
                 traceback.format_exception(None, batch.exception, batch.exception.__traceback__)
@@ -139,6 +141,12 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
     page_context['history'] = [await b.last_known_status() for b in batches]
 
     return await render_template('ci', request, userdata, 'pr.html', page_context)
+
+
+def storage_uri_to_url(uri: str) -> str:
+    assert uri.startswith('gs://')
+    path = uri.split('gs://')[1]
+    return f'https://console.cloud.google.com/storage/browser/{path}'
 
 
 async def retry_pr(wb, pr, request):

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -12,4 +12,4 @@ DEFAULT_NAMESPACE = global_config['default_namespace']
 
 CI_UTILS_IMAGE = os.environ['HAIL_CI_UTILS_IMAGE']
 BUILDKIT_IMAGE = os.environ['HAIL_BUILDKIT_IMAGE']
-BUCKET = os.environ['HAIL_CI_BUCKET_NAME']
+STORAGE_URI = os.environ['HAIL_CI_STORAGE_URI']

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -11,7 +11,8 @@
     <div class="attributes">
       <div>batch: <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></div>
       <div>artifacts:
-	<a  target="_blank" href="https://console.cloud.google.com/storage/browser{{ artifacts }}">gs:/{{ artifacts }}</a><i class="material-icons text-icon">open_in_new</i>
+        <a  target="_blank" href="{{ artifacts_url }}">{{ artifacts_uri }}</a>
+        <i class="material-icons text-icon">open_in_new</i>
       </div>
       <div>cost: {{ batch['cost'] }}</div>
       {% for name, value in batch['attributes'].items() %}

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -77,14 +77,14 @@ spec:
              value: "{{ hail_buildkit_image.image }}"
            - name: HAIL_DEFAULT_NAMESPACE
              value: "{{ default_ns.name }}"
-           - name: HAIL_CI_BUCKET_NAME
+           - name: HAIL_CI_STORAGE_URI
 {% if deploy %}
-             value: "hail-ci-bpk3h"
+             value: "gs://hail-ci-bpk3h"
 {% else %}
              valueFrom:
                secretKeyRef:
                  name: global-config
-                 key: hail_test_gcs_bucket
+                 key: test_storage_uri
 {% endif %}
           ports:
             - containerPort: 5000

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -93,7 +93,7 @@ bootstrap() {
     export HAIL_CI_UTILS_IMAGE=$DOCKER_PREFIX/ci-utils:cache
     export HAIL_BUILDKIT_IMAGE=$DOCKER_PREFIX/hail-buildkit:cache
     export HAIL_DEFAULT_NAMESPACE=$(get_global_config_field default_namespace)
-    export HAIL_CI_BUCKET_NAME=dummy
+    export HAIL_CI_STORAGE_URI=dummy
     export PYTHONPATH=$HAIL/ci:$HAIL/batch:$HAIL/hail/python:$HAIL/gear
 
     if [ -n "$3" ] && [ -n "$4" ]; then


### PR DESCRIPTION
Another small effort toward getting `gs://` out of our code. I'll follow up with a PR that puts the prod CI bucket into terraform. The `test_storage_uri` field of the global config was introduced in #11014