### PR TITLE
[infra] Put azure database in its own subnet

### DIFF
--- a/infra/azure/bootstrap.sh
+++ b/infra/azure/bootstrap.sh
@@ -49,7 +49,6 @@ run_terraform() {
         return
     fi
 
-    # export_terraform_vars
     setup_terraform_backend "$@"
     terraform apply -var-file=global.tfvars
 }

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -46,13 +46,18 @@ resource "azurerm_subnet" "k8s_subnet" {
   address_prefixes     = ["10.240.0.0/16"]
   resource_group_name  = data.azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.default.name
-
-  enforce_private_link_endpoint_network_policies = true
 }
 
 resource "azurerm_subnet" "batch_worker_subnet" {
   name                 = "batch-worker-subnet"
   address_prefixes     = ["10.128.0.0/16"]
+  resource_group_name  = data.azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.default.name
+}
+
+resource "azurerm_subnet" "db_subnet" {
+  name                 = "db-subnet"
+  address_prefixes     = ["10.44.0.0/24"]
   resource_group_name  = data.azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.default.name
 
@@ -182,7 +187,7 @@ resource "azurerm_private_endpoint" "db_k8s_endpoint" {
   name                = "${azurerm_mysql_server.db.name}-k8s-endpoint"
   resource_group_name = data.azurerm_resource_group.rg.name
   location            = data.azurerm_resource_group.rg.location
-  subnet_id           = azurerm_subnet.k8s_subnet.id
+  subnet_id           = azurerm_subnet.db_subnet.id
 
   private_service_connection {
     name                           = "${azurerm_mysql_server.db.name}-k8s-endpoint"


### PR DESCRIPTION
Since the batch workers will ultimately need to communicate with the database for CI jobs, it seems asymmetrical to put the private database connection in the k8s subnet. I've created a third small subnet just for the private database connection. Traffic across subnets is allowed by default so VMs in k8s and the batch workers should be able to access the database IP. This way we can put more restrictive rules in later (like batch workers should not be able to address VMs in the k8s subnet) without interfering with the database connection.

I've applied this change to the azure instance and verified that auth and the admin pod work with the new IP.