### PR TITLE
[infra] Configure GCP peering routes in tf intsead of manually

### DIFF
--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -84,11 +84,7 @@ Instructions:
 - Run `terraform apply -var-file="$HOME/.hail/global.tfvars"`.  At the
   time of writing, this takes ~15m.
 
-- Go to the Google Cloud console, VPC networks > default > Private
-  service connection > Private connections to services, and enable
-  Export custom routes to both connections.
-
- - Terraform created a GKE cluster named `vdc`.  Configure `kubectl`
+- Terraform created a GKE cluster named `vdc`.  Configure `kubectl`
    to point at the vdc cluster:
 
    ```

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -182,6 +182,13 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   reserved_peering_ranges = [google_compute_global_address.google_managed_services_default.name]
 }
 
+resource "google_compute_network_peering_routes_config" "private_vpc_peering_config" {
+  peering = google_service_networking_connection.private_vpc_connection.peering
+  network = google_compute_network.default.name
+  import_custom_routes = true
+  export_custom_routes = true
+}
+
 resource "google_sql_database_instance" "db" {
   name = "db-${random_id.db_name_suffix.hex}"
   database_version = "MYSQL_5_7"


### PR DESCRIPTION
The new terraform resource replaces the manual step in the README