### PR TITLE
[infra] Use the same name for azure and gcp registry push credentials

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -44,12 +44,7 @@ steps:
     public: true
     secrets:
       - name: auth-oauth2-client-secret
-      - name: gcr-push-service-account-key
-        clouds:
-          - gcp
-      - name: acr-push-credentials
-        clouds:
-          - azure
+      - name: registry-push-credentials
       - name: hail-ci-0-1-github-oauth-token
         clouds:
           - gcp

--- a/infra/azure/outputs.tf
+++ b/infra/azure/outputs.tf
@@ -37,7 +37,7 @@ output "sql_config" {
   sensitive = true
 }
 
-output "acr_push_credentials" {
+output "registry_push_credentials" {
   value = {
     appId = azurerm_container_registry.acr.admin_username
     password = azurerm_container_registry.acr.admin_password

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -352,13 +352,16 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_pus
   member = "serviceAccount:${google_service_account.gcr_push.email}"
 }
 
-resource "kubernetes_secret" "gcr_push_key" {
+# This is intended to match the secret name also used for azure credentials
+# This should ultimately be replaced by using CI's own batch-managed credentials
+# in BuildImage jobs
+resource "kubernetes_secret" "registry_push_credentials" {
   metadata {
-    name = "gcr-push-service-account-key"
+    name = "registry-push-credentials"
   }
 
   data = {
-    "gcr-push-service-account-key.json" = base64decode(google_service_account_key.gcr_push_key.private_key)
+    "credentials.json" = base64decode(google_service_account_key.gcr_push_key.private_key)
   }
 }
 

--- a/infra/k8s/main.tf
+++ b/infra/k8s/main.tf
@@ -17,13 +17,13 @@ provider "kubernetes" {
   config_path = "~/.kube_config"
 }
 
-resource "kubernetes_secret" "acr_push_credentials" {
+resource "kubernetes_secret" "registry_push_credentials" {
   metadata {
-    name = "acr-push-credentials"
+    name = "registry-push-credentials"
   }
 
   data = {
-    "credentials.json" = jsonencode(var.acr_push_credentials)
+    "credentials.json" = jsonencode(var.registry_push_credentials)
   }
 }
 

--- a/infra/k8s/variables.tf
+++ b/infra/k8s/variables.tf
@@ -27,7 +27,7 @@ variable "sql_config" {
   })
 }
 
-variable "acr_push_credentials" {
+variable "registry_push_credentials" {
   type = map
 }
 


### PR DESCRIPTION
#11005 Added support for the BuildImage job in build.py to work with `GOOGLE_APPLICATION_CREDENTIALS` or `AZURE_APPLICATION_CREDENTIALS`, but that doesn't mean that the backing secret behind those environment variables has to be different in each case. Ultimately, we would like the same k8s terraform to generate secrets for both clouds, so this changes both `gcr-push-service-account-key` and `acr-push-credentials` to just be `registry-push-credentials`. I have copied the `gcr-push-service-account-key` into a new secret with the appropriate name in `hail-vdc`.