### PR TITLE
[build.yaml] Rename global.project to global.gcp_project

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3895,13 +3895,13 @@ steps:
       gcloud -q compute instances list \
           --filter 'tags.items=batch2-agent AND labels.namespace={{ default_ns.name }}' \
           --format="table[no-heading](zone.basename(), name)" \
-          --project {{ global.project }} \
-        | xargs -n2 -r sh -c 'gcloud -q compute instances delete --zone "$1" --project {{ global.project }} "$2" || true' argv0
+          --project {{ global.gcp_project }} \
+        | xargs -n2 -r sh -c 'gcloud -q compute instances delete --zone "$1" --project {{ global.gcp_project }} "$2" || true' argv0
       gcloud -q compute disks list \
           --filter 'labels.batch=1 AND labels.namespace={{ default_ns.name }}' \
           --format="table[no-heading](zone.basename(), name)" \
-          --project {{ global.project }} \
-        | xargs -n2 -r sh -c 'gcloud -q compute disks delete --zone "$1" --project {{ global.project }} "$2" || true' argv0
+          --project {{ global.gcp_project }} \
+        | xargs -n2 -r sh -c 'gcloud -q compute disks delete --zone "$1" --project {{ global.gcp_project }} "$2" || true' argv0
     secrets:
       - name: test-gsa-key
         namespace:


### PR DESCRIPTION
The terraform sets `gcp_project` in the global-config not `project`. A few weeks ago I did a manual copy & rename of `project -> gcp_project`, `zone -> gcp_zone` etc. This is the follow-through for that conversion.