### PR TITLE
[infra] Make use of bootstrap scripts for GCP

### DIFF
--- a/infra/gcp/bootstrap.sh
+++ b/infra/gcp/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ../bootstrap_utils.sh
+
+function configure_gcloud() {
+    ZONE=${1:-"us-central1-a"}
+
+    gcloud -q auth configure-docker
+    # If you are using the Artifact Registry:
+    # gcloud -q auth configure-docker $REGION-docker.pkg.dev
+    gcloud container clusters get-credentials --zone $ZONE vdc
+}
+
+"$@"

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -591,3 +591,13 @@ resource "kubernetes_cluster_role_binding" "batch" {
     namespace = "default"
   }
 }
+
+resource "kubernetes_secret" "auth_oauth2_client_secret" {
+  metadata {
+    name = "auth-oauth2-client-secret"
+  }
+
+  data = {
+    "client_secret.json" = file("~/.hail/auth_oauth2_client_secret.json")
+  }
+}


### PR DESCRIPTION
This adds the oauth2 client secret as a terraform resource instead of uploading it by hand to k8s (though you still have to download it manually from the console. It also makes use of the `bootstrap_utils.sh` script that I introduced for azure for cloud-agnostic steps, trimming down the GCP instructions by a lot.