### PR TITLE
[query] expose `lower_tail` and `log_p` parameters in normal and chi-squared statistical functions

### DIFF
--- a/hail/python/hail/docs/functions/stats.rst
+++ b/hail/python/hail/docs/functions/stats.rst
@@ -8,6 +8,7 @@ Statistical functions
     fisher_exact_test
     contingency_table_test
     dbeta
+    dnorm
     dpois
     hardy_weinberg_test
     binom_test
@@ -24,6 +25,7 @@ Statistical functions
 .. autofunction:: fisher_exact_test
 .. autofunction:: contingency_table_test
 .. autofunction:: dbeta
+.. autofunction:: dnorm
 .. autofunction:: dpois
 .. autofunction:: hardy_weinberg_test
 .. autofunction:: binom_test

--- a/hail/python/hail/docs/functions/stats.rst
+++ b/hail/python/hail/docs/functions/stats.rst
@@ -8,6 +8,7 @@ Statistical functions
     fisher_exact_test
     contingency_table_test
     dbeta
+    dchisq
     dnorm
     dpois
     hardy_weinberg_test
@@ -25,6 +26,7 @@ Statistical functions
 .. autofunction:: fisher_exact_test
 .. autofunction:: contingency_table_test
 .. autofunction:: dbeta
+.. autofunction:: dchisq
 .. autofunction:: dnorm
 .. autofunction:: dpois
 .. autofunction:: hardy_weinberg_test

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -46,7 +46,7 @@ from .functions import literal, chi_squared_test, if_else, cond, switch, case, \
     uniroot, format, approx_equal, reversed, bit_and, bit_or, bit_xor, \
     bit_lshift, bit_rshift, bit_not, binary_search, logit, expit, \
     _values_similar, _showstr, _sort_by, _compare, _locus_windows_per_contig, \
-    shuffle, _console_log
+    shuffle, _console_log, dnorm, dchisq
 
 __all__ = ['HailType',
            'hail_type',
@@ -307,4 +307,6 @@ __all__ = ['HailType',
            'expr_oneof',
            'expr_numeric',
            'coercer_from_dtype',
-           '_console_log']
+           '_console_log',
+           'dnorm',
+           'dchisq']

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -1916,8 +1916,8 @@ def binom_test(x, n, p, alternative: str) -> Float64Expression:
     return _func("binomTest", tfloat64, x, n, p, to_expr(alt_enum))
 
 
-@typecheck(x=expr_float64, df=expr_float64, ncp=nullable(expr_float64))
-def pchisqtail(x, df, ncp=None) -> Float64Expression:
+@typecheck(x=expr_float64, df=expr_float64, ncp=nullable(expr_float64), lower_tail=expr_bool, log_p=expr_bool)
+def pchisqtail(x, df, ncp=None, lower_tail=False, log_p=False) -> Float64Expression:
     """Returns the probability under the right-tail starting at x for a chi-squared
     distribution with df degrees of freedom.
 
@@ -1937,19 +1937,24 @@ def pchisqtail(x, df, ncp=None) -> Float64Expression:
         Degrees of freedom.
     ncp: float or :class:`.Expression` of type :py:data:`.tfloat64`
         Noncentrality parameter. Defaults to 0 if unspecified.
+    lower_tail : bool or :class:`.BooleanExpression`
+        If ``True``, compute the probability of an outcome at or below `x`,
+        otherwise greater than `x`.
+    log_p : bool or :class:`.BooleanExpression`
+        Return the natural logarithm of the probability.
 
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
     if ncp is None:
-        return _func("pchisqtail", tfloat64, x, df)
+        return _func("pchisqtail", tfloat64, x, df, lower_tail, log_p)
     else:
-        return _func("pnchisqtail", tfloat64, x, df, ncp)
+        return _func("pnchisqtail", tfloat64, x, df, ncp, lower_tail, log_p)
 
 
-@typecheck(x=expr_float64)
-def pnorm(x) -> Float64Expression:
+@typecheck(x=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
+def pnorm(x, lower_tail=True, log_p=False) -> Float64Expression:
     """The cumulative probability function of a standard normal distribution.
 
     Examples
@@ -1971,12 +1976,17 @@ def pnorm(x) -> Float64Expression:
     Parameters
     ----------
     x : float or :class:`.Expression` of type :py:data:`.tfloat64`
+    lower_tail : bool or :class:`.BooleanExpression`
+        If ``True``, compute the probability of an outcome at or below `x`,
+        otherwise greater than `x`.
+    log_p : bool or :class:`.BooleanExpression`
+        Return the natural logarithm of the probability.
 
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return _func("pnorm", tfloat64, x)
+    return _func("pnorm", tfloat64, x, lower_tail, log_p)
 
 
 @typecheck(x=expr_float64, n=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
@@ -2106,8 +2116,8 @@ def ppois(x, lamb, lower_tail=True, log_p=False) -> Float64Expression:
     return _func("ppois", tfloat64, x, lamb, lower_tail, log_p)
 
 
-@typecheck(p=expr_float64, df=expr_float64)
-def qchisqtail(p, df) -> Float64Expression:
+@typecheck(p=expr_float64, df=expr_float64, ncp=nullable(expr_float64), lower_tail=expr_bool, log_p=expr_bool)
+def qchisqtail(p, df, ncp=None, lower_tail=False, log_p=False) -> Float64Expression:
     """Inverts :func:`~.pchisqtail`.
 
     Examples
@@ -2127,16 +2137,25 @@ def qchisqtail(p, df) -> Float64Expression:
         Probability.
     df : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Degrees of freedom.
+    ncp: float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Corresponds to `ncp` parameter in :func:`.pchisqtail`.
+    lower_tail : bool or :class:`.BooleanExpression`
+        Corresponds to `lower_tail` parameter in :func:`.pchisqtail`.
+    log_p : bool or :class:`.BooleanExpression`
+        Exponentiate `p`, corresponds to `log_p` parameter in :func:`.pchisqtail`.
 
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return _func("qchisqtail", tfloat64, p, df)
+    if ncp is None:
+        return _func("qchisqtail", tfloat64, p, df, lower_tail, log_p)
+    else:
+        return _func("qnchisqtail", tfloat64, p, df, ncp, lower_tail, log_p)
 
 
-@typecheck(p=expr_float64)
-def qnorm(p) -> Float64Expression:
+@typecheck(p=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
+def qnorm(p, lower_tail=True, log_p=False) -> Float64Expression:
     """Inverts :func:`~.pnorm`.
 
     Examples
@@ -2154,12 +2173,16 @@ def qnorm(p) -> Float64Expression:
     ----------
     p : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Probability.
+    lower_tail : bool or :class:`.BooleanExpression`
+        Corresponds to `lower_tail` parameter in :func:`.pnorm`.
+    log_p : bool or :class:`.BooleanExpression`
+        Exponentiate `p`, corresponds to `log_p` parameter in :func:`.pnorm`.
 
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return _func("qnorm", tfloat64, p)
+    return _func("qnorm", tfloat64, p, lower_tail, log_p)
 
 
 @typecheck(p=expr_float64, lamb=expr_float64, lower_tail=expr_bool, log_p=expr_bool)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -705,6 +705,37 @@ def dbeta(x, a, b) -> Float64Expression:
     return _func("dbeta", tfloat64, x, a, b)
 
 
+@typecheck(x=expr_float64, mu=expr_float64, sigma=expr_float64, log_p=expr_bool)
+def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
+    """Compute the probability density at x of a normal distribution with mean
+    `mu` and standard deviation `sigma`. Returns density of standard normal
+    distribution by default.
+
+    Examples
+    --------
+
+    >>> hl.eval(hl.dnorm(1))
+    0.10081881344492458
+
+    Parameters
+    ----------
+    x : :obj:`float` or :class:`.Expression` of type :py:data:`.tfloat64`
+        Number at which to compute the probability density.
+    mu : float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Mean (default = 0).
+    sigma: float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Standard deviation (default = 1).
+    log_p : :obj:`bool` or :class:`.BooleanExpression`
+        If true, the natural logarithm of the probability density is returned.
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tfloat64`
+        The (log) probability density.
+    """
+    return _func("dnorm", tfloat64, x, mu, sigma, log_p)
+
+
 @typecheck(x=expr_float64, lamb=expr_float64, log_p=expr_bool)
 def dpois(x, lamb, log_p=False) -> Float64Expression:
     """Compute the (log) probability density at x of a Poisson distribution with rate parameter `lamb`.
@@ -1953,9 +1984,11 @@ def pchisqtail(x, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
         return _func("pnchisqtail", tfloat64, x, df, ncp, lower_tail, log_p)
 
 
-@typecheck(x=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
-def pnorm(x, lower_tail=True, log_p=False) -> Float64Expression:
-    """The cumulative probability function of a standard normal distribution.
+@typecheck(x=expr_float64, mu=expr_float64, sigma=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
+def pnorm(x, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
+    """The cumulative probability function of a normal distribution with mean
+    `mu` and standard deviation `sigma`. Returns cumulative probability of
+    standard normal distribution by default.
 
     Examples
     --------
@@ -1971,11 +2004,16 @@ def pnorm(x, lower_tail=True, log_p=False) -> Float64Expression:
 
     Notes
     -----
-    Returns the left-tail probability `p` = Prob(:math:`Z < x`) with :math:`Z` a standard normal random variable.
+    Returns the left-tail probability `p` = Prob(:math:`Z < x`) with :math:`Z`
+    a normal random variable.Defaults to a standard normal random variable.
 
     Parameters
     ----------
     x : float or :class:`.Expression` of type :py:data:`.tfloat64`
+    mu : float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Mean (default = 0).
+    sigma: float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Standard deviation (default = 1).
     lower_tail : bool or :class:`.BooleanExpression`
         If ``True``, compute the probability of an outcome at or below `x`,
         otherwise greater than `x`.
@@ -1986,7 +2024,7 @@ def pnorm(x, lower_tail=True, log_p=False) -> Float64Expression:
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return _func("pnorm", tfloat64, x, lower_tail, log_p)
+    return _func("pnorm", tfloat64, x, mu, sigma, lower_tail, log_p)
 
 
 @typecheck(x=expr_float64, n=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
@@ -2154,9 +2192,11 @@ def qchisqtail(p, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
         return _func("qnchisqtail", tfloat64, p, df, ncp, lower_tail, log_p)
 
 
-@typecheck(p=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
-def qnorm(p, lower_tail=True, log_p=False) -> Float64Expression:
-    """Inverts :func:`~.pnorm`.
+@typecheck(p=expr_float64, mu=expr_float64, sigma=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
+def qnorm(p, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
+    """The quantile function of a normal distribution with mean `mu` and
+    standard deviation `sigma`, inverts :func:`~.pnorm`. Returns quantile of
+    standard normal distribution by default.
 
     Examples
     --------
@@ -2166,13 +2206,18 @@ def qnorm(p, lower_tail=True, log_p=False) -> Float64Expression:
 
     Notes
     -----
-    Returns left-quantile `x` for which p = Prob(:math:`Z` < x) with :math:`Z` a standard normal random variable.
-    `p` must satisfy 0 < `p` < 1.
+    Returns left-quantile `x` for which p = Prob(:math:`Z` < x) with :math:`Z`
+    a normal random variable with mean `mu` and standard deviation `sigma`.
+    Defaults to a standard normal random variable, and `p` must satisfy 0 < `p` < 1.
 
     Parameters
     ----------
     p : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Probability.
+    mu : float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Mean (default = 0).
+    sigma: float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Standard deviation (default = 1).
     lower_tail : bool or :class:`.BooleanExpression`
         Corresponds to `lower_tail` parameter in :func:`.pnorm`.
     log_p : bool or :class:`.BooleanExpression`
@@ -2182,7 +2227,7 @@ def qnorm(p, lower_tail=True, log_p=False) -> Float64Expression:
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
     """
-    return _func("qnorm", tfloat64, p, lower_tail, log_p)
+    return _func("qnorm", tfloat64, p, mu, sigma, lower_tail, log_p)
 
 
 @typecheck(p=expr_float64, lamb=expr_float64, lower_tail=expr_bool, log_p=expr_bool)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -705,9 +705,44 @@ def dbeta(x, a, b) -> Float64Expression:
     return _func("dbeta", tfloat64, x, a, b)
 
 
+@typecheck(x=expr_float64, df=expr_float64, ncp=nullable(expr_float64), log_p=expr_bool)
+def dchisq(x, df, ncp=None, log_p=False) -> Float64Expression:
+    """Compute the probability density at `x` of a chi-squared distribution with `df`
+    degrees of freedom.
+
+    Examples
+    --------
+
+    >>> hl.eval(hl.dchisq(1, 1))
+    6.634896601021213
+
+    >>> hl.eval(hl.dchisq(1, 1, 2))
+    6.634896601021213
+
+    Parameters
+    ----------
+    x : float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Non-negative number at which to compute the probability density.
+    df : float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Degrees of freedom.
+    ncp: float or :class:`.Expression` of type :py:data:`.tfloat64`
+        Noncentrality parameter, defaults to 0 if unspecified.
+    log_p : bool or :class:`.BooleanExpression`
+        If ``True``, the natural logarithm of the probability density is returned.
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tfloat64`
+    """
+    if ncp is None:
+        return _func("dchisq", tfloat64, x, df, log_p)
+    else:
+        return _func("dnchisq", tfloat64, x, df, ncp, log_p)
+
+
 @typecheck(x=expr_float64, mu=expr_float64, sigma=expr_float64, log_p=expr_bool)
 def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
-    """Compute the probability density at x of a normal distribution with mean
+    """Compute the probability density at `x` of a normal distribution with mean
     `mu` and standard deviation `sigma`. Returns density of standard normal
     distribution by default.
 
@@ -715,7 +750,9 @@ def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
     --------
 
     >>> hl.eval(hl.dnorm(1))
-    0.10081881344492458
+
+
+    >>> hl.eval(hl.dnorm(1, 1, 2))
 
     Parameters
     ----------
@@ -726,7 +763,7 @@ def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
     sigma: float or :class:`.Expression` of type :py:data:`.tfloat64`
         Standard deviation (default = 1).
     log_p : :obj:`bool` or :class:`.BooleanExpression`
-        If true, the natural logarithm of the probability density is returned.
+        If ``True``, the natural logarithm of the probability density is returned.
 
     Returns
     -------
@@ -753,7 +790,7 @@ def dpois(x, lamb, log_p=False) -> Float64Expression:
     lamb : :obj:`float` or :class:`.Expression` of type :py:data:`.tfloat64`
         Poisson rate parameter. Must be non-negative.
     log_p : :obj:`bool` or :class:`.BooleanExpression`
-        If true, the natural logarithm of the probability density is returned.
+        If ``True``, the natural logarithm of the probability density is returned.
 
     Returns
     -------
@@ -1967,7 +2004,7 @@ def pchisqtail(x, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
     df : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Degrees of freedom.
     ncp: float or :class:`.Expression` of type :py:data:`.tfloat64`
-        Noncentrality parameter. Defaults to 0 if unspecified.
+        Noncentrality parameter, defaults to 0 if unspecified.
     lower_tail : bool or :class:`.BooleanExpression`
         If ``True``, compute the probability of an outcome at or below `x`,
         otherwise greater than `x`.
@@ -2156,7 +2193,8 @@ def ppois(x, lamb, lower_tail=True, log_p=False) -> Float64Expression:
 
 @typecheck(p=expr_float64, df=expr_float64, ncp=nullable(expr_float64), lower_tail=expr_bool, log_p=expr_bool)
 def qchisqtail(p, df, ncp=None, lower_tail=False, log_p=False) -> Float64Expression:
-    """Inverts :func:`~.pchisqtail`.
+    """The quantile function of a chi-squared distribution with `df` degrees of
+    freedom, inverts :func:`~.pchisqtail`.
 
     Examples
     --------
@@ -2164,10 +2202,14 @@ def qchisqtail(p, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
     >>> hl.eval(hl.qchisqtail(0.01, 1))
     6.634896601021213
 
+    >>> hl.eval(hl.qchisqtail(0.01, 1, 2))
+    6.634896601021213
+
     Notes
     -----
-    Returns right-quantile `x` for which `p` = Prob(:math:`Z^2` > x) with :math:`Z^2` a chi-squared random
-    variable with degrees of freedom specified by `df`. `p` must satisfy 0 < `p` <= 1.
+    Returns right-quantile `x` for which `p` = Prob(:math:`Z^2` > x) with
+    :math:`Z^2` a chi-squared random variable with degrees of freedom specified
+    by `df`. The probability `p` must satisfy 0 < `p` < 1.
 
     Parameters
     ----------
@@ -2208,7 +2250,8 @@ def qnorm(p, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
     -----
     Returns left-quantile `x` for which p = Prob(:math:`Z` < x) with :math:`Z`
     a normal random variable with mean `mu` and standard deviation `sigma`.
-    Defaults to a standard normal random variable, and `p` must satisfy 0 < `p` < 1.
+    Defaults to a standard normal random variable, and the probability `p` must
+    satisfy 0 < `p` < 1.
 
     Parameters
     ----------

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -713,11 +713,14 @@ def dchisq(x, df, ncp=None, log_p=False) -> Float64Expression:
     Examples
     --------
 
-    >>> hl.eval(hl.dchisq(1, 1))
-    6.634896601021213
+    >>> hl.eval(hl.dchisq(1, 2))
+    0.3032653298563167
 
-    >>> hl.eval(hl.dchisq(1, 1, 2))
-    6.634896601021213
+    >>> hl.eval(hl.dchisq(1, 2, ncp=2))
+    0.17472016746112667
+
+    >>> hl.eval(hl.dchisq(1, 2, log_p=True))
+    -1.1931471805599454
 
     Parameters
     ----------
@@ -733,6 +736,7 @@ def dchisq(x, df, ncp=None, log_p=False) -> Float64Expression:
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
+        The probability density.
     """
     if ncp is None:
         return _func("dchisq", tfloat64, x, df, log_p)
@@ -750,14 +754,18 @@ def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
     --------
 
     >>> hl.eval(hl.dnorm(1))
+    0.24197072451914337
 
+    >>> hl.eval(hl.dnorm(1, mu=1, sigma=2))
+    0.19947114020071635
 
-    >>> hl.eval(hl.dnorm(1, 1, 2))
+    >>> hl.eval(hl.dnorm(1, log_p=True))
+    -1.4189385332046727
 
     Parameters
     ----------
     x : :obj:`float` or :class:`.Expression` of type :py:data:`.tfloat64`
-        Number at which to compute the probability density.
+        Real number at which to compute the probability density.
     mu : float or :class:`.Expression` of type :py:data:`.tfloat64`
         Mean (default = 0).
     sigma: float or :class:`.Expression` of type :py:data:`.tfloat64`
@@ -768,7 +776,7 @@ def dnorm(x, mu=0, sigma=1, log_p=False) -> Float64Expression:
     Returns
     -------
     :class:`.Expression` of type :py:data:`.tfloat64`
-        The (log) probability density.
+        The probability density.
     """
     return _func("dnorm", tfloat64, x, mu, sigma, log_p)
 
@@ -1995,8 +2003,14 @@ def pchisqtail(x, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
     >>> hl.eval(hl.pchisqtail(5, 1))
     0.025347318677468304
 
-    >>> hl.eval(hl.pchisqtail(3, 1, 2))
-    0.3761310507217904
+    >>> hl.eval(hl.pchisqtail(5, 1, ncp=2))
+    0.20571085634347097
+
+    >>> hl.eval(hl.pchisqtail(5, 1, lower_tail=True))
+    0.9746526813225317
+
+    >>> hl.eval(hl.pchisqtail(5, 1, log_p=True))
+    -3.6750823266311876
 
     Parameters
     ----------
@@ -2033,16 +2047,19 @@ def pnorm(x, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
     >>> hl.eval(hl.pnorm(0))
     0.5
 
-    >>> hl.eval(hl.pnorm(1))
-    0.8413447460685429
+    >>> hl.eval(hl.pnorm(1, mu=2, sigma=2))
+    0.30853753872598694
 
-    >>> hl.eval(hl.pnorm(2))
-    0.9772498680518208
+    >>> hl.eval(hl.pnorm(2, lower_tail=False))
+    0.022750131948179212
+
+    >>> hl.eval(hl.pnorm(2, log_p=True))
+    -0.023012909328963493
 
     Notes
     -----
     Returns the left-tail probability `p` = Prob(:math:`Z < x`) with :math:`Z`
-    a normal random variable.Defaults to a standard normal random variable.
+    a normal random variable. Defaults to a standard normal random variable.
 
     Parameters
     ----------
@@ -2199,11 +2216,17 @@ def qchisqtail(p, df, ncp=None, lower_tail=False, log_p=False) -> Float64Express
     Examples
     --------
 
-    >>> hl.eval(hl.qchisqtail(0.01, 1))
-    6.634896601021213
+    >>> hl.eval(hl.qchisqtail(0.05, 2))
+    5.991464547107979
 
-    >>> hl.eval(hl.qchisqtail(0.01, 1, 2))
-    6.634896601021213
+    >>> hl.eval(hl.qchisqtail(0.05, 2, ncp=2))
+    10.838131614372958
+
+    >>> hl.eval(hl.qchisqtail(0.05, 2, lower_tail=True))
+    0.10258658877510107
+
+    >>> hl.eval(hl.qchisqtail(hl.log(0.05), 2, log_p=True))
+    5.991464547107979
 
     Notes
     -----
@@ -2246,6 +2269,15 @@ def qnorm(p, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
     >>> hl.eval(hl.qnorm(0.90))
     1.2815515655446008
 
+    >>> hl.eval(hl.qnorm(0.90, mu=1, sigma=2))
+    3.5631031310892016
+
+    >>> hl.eval(hl.qnorm(0.90, lower_tail=False))
+    -1.2815515655446008
+
+    >>> hl.eval(hl.qnorm(hl.log(0.90), log_p=True))
+    1.2815515655446008
+
     Notes
     -----
     Returns left-quantile `x` for which p = Prob(:math:`Z` < x) with :math:`Z`
@@ -2275,7 +2307,8 @@ def qnorm(p, mu=0, sigma=1, lower_tail=True, log_p=False) -> Float64Expression:
 
 @typecheck(p=expr_float64, lamb=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
 def qpois(p, lamb, lower_tail=True, log_p=False) -> Float64Expression:
-    r"""Inverts :func:`~.ppois`.
+    r"""The quantile function of a Poisson distribution with rate parameter
+    `lamb`, inverts :func:`~.ppois`.
 
     Examples
     --------

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3266,6 +3266,42 @@ class Tests(unittest.TestCase):
         result = hl.eval(hl.uniroot(multiple_roots, 0, 5.5, tolerance=tol))
         self.assertTrue(any(abs(result - root) < tol for root in roots))
 
+    def test_dnorm(self):
+        self.assert_evals_to(hl.dnorm(0), 0.3989422804014327)
+        self.assert_evals_to(hl.dnorm(0, mu=1, sigma=2), 0.17603266338214976)
+        self.assert_evals_to(hl.dnorm(0, log_p=True), -0.9189385332046728)
+
+    def test_pnorm(self):
+        self.assert_evals_to(hl.pnorm(0), 0.5)
+        self.assert_evals_to(hl.pnorm(1, mu=1, sigma=2), 0.5)
+        self.assert_evals_to(hl.pnorm(1), 0.8413447460685429)
+        self.assert_evals_to(hl.pnorm(1, lower_tail=False), 0.15865525393145705)
+        self.assert_evals_to(hl.pnorm(1, log_p=True), -0.17275377902344988)
+
+    def test_qnorm(self):
+        self.assert_evals_to(hl.qnorm(hl.pnorm(0)), 0.0)
+        self.assert_evals_to(hl.qnorm(hl.pnorm(1, mu=1, sigma=2), mu=1, sigma=2), 1.0)
+        self.assert_evals_to(hl.qnorm(hl.pnorm(1)), 1.0)
+        self.assert_evals_to(hl.qnorm(hl.pnorm(1, lower_tail=False), lower_tail=False), 1.0)
+        self.assert_evals_to(hl.qnorm(hl.pnorm(1, log_p=True), log_p=True), 1.0)
+
+    def test_dchisq(self):
+        self.assert_evals_to(hl.dchisq(10, 5), 0.028334555341734464)
+        self.assert_evals_to(hl.dchisq(10, 5, ncp=5), 0.07053548900555977)
+        self.assert_evals_to(hl.dchisq(10, 5, log_p=True), -3.5636731823817143)
+
+    def test_pchisqtail(self):
+        self.assert_evals_to(hl.pchisqtail(10, 5), 0.07523524614651216)
+        self.assert_evals_to(hl.pchisqtail(10, 5, ncp=2), 0.20772889456608998)
+        self.assert_evals_to(hl.pchisqtail(10, 5, lower_tail=True), 0.9247647538534879)
+        self.assert_evals_to(hl.pchisqtail(10, 5, log_p=True), -2.5871354590744855)
+
+    def test_qchisqtail(self):
+        self.assertAlmostEqual(hl.eval(hl.qchisqtail(hl.pchisqtail(10, 5), 5)), 10.0)
+        self.assertAlmostEqual(hl.eval(hl.qchisqtail(hl.pchisqtail(10, 5, ncp=2), 5, ncp=2)), 10.0)
+        self.assertAlmostEqual(hl.eval(hl.qchisqtail(hl.pchisqtail(10, 5, lower_tail=True), 5, lower_tail=True)), 10.0)
+        self.assertAlmostEqual(hl.eval(hl.qchisqtail(hl.pchisqtail(10, 5, log_p=True), 5, log_p=True)), 10.0)
+
     def test_pT(self):
         self.assert_evals_to(hl.pT(0, 10), 0.5)
         self.assert_evals_to(hl.pT(1, 10), 0.82955343384897)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -148,7 +148,10 @@ object MathFunctions extends RegistryFunctions {
     registerScalaFunction("dbeta", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "dbeta")
 
     registerScalaFunction("pnorm", Array(TFloat64), TFloat64, null)(statsPackageClass, "pnorm")
+    registerScalaFunction("pnorm", Array(TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pnorm")
+
     registerScalaFunction("qnorm", Array(TFloat64), TFloat64, null)(statsPackageClass, "qnorm")
+    registerScalaFunction("qnorm", Array(TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "qnorm")
 
     registerScalaFunction("pT", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pT")
     registerScalaFunction("pF", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pF")
@@ -163,8 +166,12 @@ object MathFunctions extends RegistryFunctions {
     registerScalaFunction("qpois", Array(TFloat64, TFloat64, TBoolean, TBoolean), TInt32, null)(statsPackageClass, "qpois")
 
     registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "chiSquaredTail")
+    registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "chiSquaredTail")
     registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
-    registerScalaFunction("qchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "inverseChiSquaredTail")
+    registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
+
+    registerScalaFunction("qchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "inverseChiSquaredTail")
+    registerScalaFunction("qnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "inverseNonCentralChiSquaredTail")
 
     registerScalaFunction("floor", Array(TFloat32), TFloat32, null)(thisClass, "floor")
     registerScalaFunction("floor", Array(TFloat64), TFloat64, null)(thisClass, "floor")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -168,14 +168,23 @@ object MathFunctions extends RegistryFunctions {
     registerScalaFunction("qpois", Array(TFloat64, TFloat64), TInt32, null)(statsPackageClass, "qpois")
     registerScalaFunction("qpois", Array(TFloat64, TFloat64, TBoolean, TBoolean), TInt32, null)(statsPackageClass, "qpois")
 
-    registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "chiSquaredTail")
-    registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "chiSquaredTail")
+    registerScalaFunction("dchisq", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "dchisq")
+    registerScalaFunction("dchisq", Array(TFloat64, TFloat64, TBoolean), TFloat64, null)(statsPackageClass, "dchisq")
 
-    registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
-    registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
+    registerScalaFunction("dnchisq", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "dnchisq")
+    registerScalaFunction("dnchisq", Array(TFloat64, TFloat64, TFloat64, TBoolean), TFloat64, null)(statsPackageClass, "dnchisq")
 
-    registerScalaFunction("qchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "inverseChiSquaredTail")
-    registerScalaFunction("qnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "inverseNonCentralChiSquaredTail")
+    registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "pchisqtail")
+    registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pchisqtail")
+
+    registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "pnchisqtail")
+    registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pnchisqtail")
+
+    registerScalaFunction("qchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "qchisqtail")
+    registerScalaFunction("qchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "qchisqtail")
+
+    registerScalaFunction("qnchisqtail", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "qnchisqtail")
+    registerScalaFunction("qnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "qnchisqtail")
 
     registerScalaFunction("floor", Array(TFloat32), TFloat32, null)(thisClass, "floor")
     registerScalaFunction("floor", Array(TFloat64), TFloat64, null)(thisClass, "floor")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -147,11 +147,14 @@ object MathFunctions extends RegistryFunctions {
 
     registerScalaFunction("dbeta", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "dbeta")
 
+    registerScalaFunction("dnorm", Array(TFloat64), TFloat64, null)(statsPackageClass, "dnorm")
+    registerScalaFunction("dnorm", Array(TFloat64, TFloat64, TFloat64, TBoolean), TFloat64, null)(statsPackageClass, "dnorm")
+
     registerScalaFunction("pnorm", Array(TFloat64), TFloat64, null)(statsPackageClass, "pnorm")
-    registerScalaFunction("pnorm", Array(TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pnorm")
+    registerScalaFunction("pnorm", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pnorm")
 
     registerScalaFunction("qnorm", Array(TFloat64), TFloat64, null)(statsPackageClass, "qnorm")
-    registerScalaFunction("qnorm", Array(TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "qnorm")
+    registerScalaFunction("qnorm", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "qnorm")
 
     registerScalaFunction("pT", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pT")
     registerScalaFunction("pF", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "pF")
@@ -167,6 +170,7 @@ object MathFunctions extends RegistryFunctions {
 
     registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "chiSquaredTail")
     registerScalaFunction("pchisqtail", Array(TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "chiSquaredTail")
+
     registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
     registerScalaFunction("pnchisqtail", Array(TFloat64, TFloat64, TFloat64, TBoolean, TBoolean), TFloat64, null)(statsPackageClass, "nonCentralChiSquaredTail")
 

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -26,7 +26,7 @@ object LinearMixedModel {
     new LinearMixedModel(
       LMMData(gamma, residualSq, BDV(py), px, BDV(d), ydy, BDV(xdy), xdx, Option(yOpt).map(BDV(_)), Option(xOpt)))
   }
-  
+
   private val rowType = PCanonicalStruct(true,
       "idx" -> PInt64(),
       "beta" -> PFloat64(),
@@ -85,7 +85,7 @@ class LinearMixedModel(lmmData: LMMData) {
         xdx(0, 0) = (pa dot dpa) + gamma * (a dot a)
         xdx(r1, r0) := (dpa.t * px).t + gamma * (a.t * x).t // if px and x are not copied, the forms px.t * dpa and x.t * a result in a subtle bug
         xdx(r0, r1) := xdx(r1, r0).t
-       
+
         region.clear()
         rvb.start(rowType)
         try {
@@ -93,7 +93,7 @@ class LinearMixedModel(lmmData: LMMData) {
           val residualSq = ydy - (xdy dot beta)
           val sigmaSq = residualSq / dof
           val chiSq = n * math.log(nullResidualSq / residualSq)
-          val pValue = chiSquaredTail(chiSq, 1)
+          val pValue = pchisqtail(chiSq, 1)
 
           rvb.startStruct()
           rvb.addLong(i)
@@ -123,11 +123,11 @@ class LinearMixedModel(lmmData: LMMData) {
 
     LinearMixedModel.toTableIR(ctx, rvd)
   }
-  
+
   def fitFullRank(ctx: ExecuteContext, pa_t: RowMatrix): TableIR = {
     val lmmDataBc = ctx.backend.broadcast(lmmData)
     val rowType = LinearMixedModel.rowType
-    
+
     val rdd = pa_t.rows.mapPartitions { itPAt =>
       val LMMData(_, nullResidualSq, py, px, d, ydy, xdy0, xdx0, _, _) = lmmDataBc.value
       val xdy = xdy0.copy
@@ -150,15 +150,15 @@ class LinearMixedModel(lmmData: LMMData) {
         xdx(0, 0) = pa dot dpa
         xdx(r1, r0) := (dpa.t * px).t // if px is not copied, the form px.t * dpa results in a subtle bug
         xdx(r0, r1) := xdx(r1, r0).t
-        
+
         region.clear()
         rvb.start(rowType)
-        try {          
+        try {
           val beta = xdx \ xdy
           val residualSq = ydy - (xdy dot beta)
           val sigmaSq = residualSq / dof
           val chiSq = n * math.log(nullResidualSq / residualSq)
-          val pValue = chiSquaredTail(chiSq, 1)
+          val pValue = pchisqtail(chiSq, 1)
 
           rvb.startStruct()
           rvb.addLong(i)

--- a/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -104,7 +104,7 @@ object LikelihoodRatioTest extends GLMTest {
     val lrStats =
       if (fit.converged) {
         val chi2 = 2 * (fit.logLkhd - nullFit.logLkhd)
-        val p = chiSquaredTail(chi2, m - m0)
+        val p = pchisqtail(chi2, m - m0)
 
         Some(LikelihoodRatioStats(fit.b, chi2, p))
       } else
@@ -147,7 +147,7 @@ object LogisticFirthTest extends GLMTest {
       val firthStats =
         if (fitFirth.converged) {
           val chi2 = 2 * (fitFirth.logLkhd - nullFitFirth.logLkhd)
-          val p = chiSquaredTail(chi2, m - m0)
+          val p = pchisqtail(chi2, m - m0)
 
           Some(FirthStats(fitFirth.b, chi2, p))
         } else
@@ -205,7 +205,7 @@ object LogisticScoreTest extends GLMTest {
         fisher(r1, r1) := X1.t * (X1(::, *) *:* (mu *:* (1d - mu)))
 
         val chi2 = score dot (fisher \ score)
-        val p = chiSquaredTail(chi2, m - m0)
+        val p = pchisqtail(chi2, m - m0)
 
         Some(ScoreStats(chi2, p))
       } catch {

--- a/hail/src/main/scala/is/hail/stats/PoissonRegressionModel.scala
+++ b/hail/src/main/scala/is/hail/stats/PoissonRegressionModel.scala
@@ -45,7 +45,7 @@ object PoissonScoreTest extends GLMTest {
         fisher(r1, r1) := X1.t * (X1(::, *) *:* mu)
 
         val chi2 = score dot (fisher \ score)
-        val p = chiSquaredTail(chi2, m - m0)
+        val p = pchisqtail(chi2, m - m0)
 
         Some(ScoreStats(chi2, p))
       } catch {

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -321,10 +321,12 @@ package object stats {
   }
 
   // Returns the p for which p = Prob(Z < x) with Z a standard normal RV
-  def pnorm(x: Double): Double = Normal.cumulative(x, 0, 1)
+  def pnorm(x: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.cumulative(x, 0, 1, lowerTail, logP)
+  def pnorm(x: Double): Double = pnorm(x, lowerTail = true, logP = false)
 
   // Returns the x for which p = Prob(Z < x) with Z a standard normal RV
-  def qnorm(p: Double): Double = Normal.quantile(p, 0, 1, true, false)
+  def qnorm(p: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.quantile(p, 0, 1, lowerTail, logP)
+  def qnorm(p: Double): Double = qnorm(p, lowerTail = true, logP = false)
 
   // Returns the p for which p = Prob(Z < x) with Z a RV having the T distribution with n degrees of freedom
   def pT(x: Double, n: Double, lower_tail: Boolean, log_p: Boolean): Double =
@@ -334,12 +336,16 @@ package object stats {
     net.sourceforge.jdistlib.F.cumulative(x, df1, df2, lower_tail, log_p)
 
   // Returns the p for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def chiSquaredTail(x: Double, df: Double): Double = ChiSquare.cumulative(x, df, false, false)
+  def chiSquaredTail(x: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.cumulative(x, df, lowerTail, logP)
 
-  def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double) = NonCentralChiSquare.cumulative(x, df, ncp, false, false)
+  def chiSquaredTail(x: Double, df: Double): Double = chiSquaredTail(x, df, lowerTail = false, logP = false)
+
+  def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.cumulative(x, df, ncp, lowerTail, logP)
 
   // Returns the x for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def inverseChiSquaredTail(p: Double, df: Double): Double = ChiSquare.quantile(p, df, false, false)
+  def inverseChiSquaredTail(p: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.quantile(p, df, lowerTail, logP)
+
+  def inverseNonCentralChiSquaredTail(p: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.quantile(p, df, ncp, lowerTail, logP)
 
   def dbeta(x: Double, a: Double, b: Double): Double = Beta.density(x, a, b, false)
 

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -135,7 +135,7 @@ package object stats {
     val det = ad - bc
     val chiSquare = (a + b + c + d) * (det / ((a + b) * (c + d))) * (det / ((b + d) * (a + c)))
 
-    Array(chiSquaredTail(chiSquare, 1), ad / bc)
+    Array(pchisqtail(chiSquare, 1), ad / bc)
   }
 
   def contingencyTableTest(a: Int, b: Int, c: Int, d: Int, minCellCount: Int): Array[Double] = {
@@ -341,19 +341,31 @@ package object stats {
   def pF(x: Double, df1: Double, df2: Double, lower_tail: Boolean, log_p: Boolean): Double =
     net.sourceforge.jdistlib.F.cumulative(x, df1, df2, lower_tail, log_p)
 
+  def dchisq(x: Double, df: Double, logP: Boolean): Double = ChiSquare.density(x, df, logP)
+
+  def dchisq(x: Double, df: Double): Double = dchisq(x, df, logP = false)
+
+  def dnchisq(x: Double, df: Double, ncp: Double, logP: Boolean): Double = NonCentralChiSquare.density(x, df, ncp, logP)
+
+  def dnchisq(x: Double, df: Double, ncp: Double): Double = dnchisq(x, df, ncp, logP = false)
+
   // Returns the p for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def chiSquaredTail(x: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.cumulative(x, df, lowerTail, logP)
+  def pchisqtail(x: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.cumulative(x, df, lowerTail, logP)
 
-  def chiSquaredTail(x: Double, df: Double): Double = chiSquaredTail(x, df, lowerTail = false, logP = false)
+  def pchisqtail(x: Double, df: Double): Double = pchisqtail(x, df, lowerTail = false, logP = false)
 
-  def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.cumulative(x, df, ncp, lowerTail, logP)
+  def pnchisqtail(x: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.cumulative(x, df, ncp, lowerTail, logP)
 
-  def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double): Double = nonCentralChiSquaredTail(x, df, ncp, lowerTail = false, logP = false)
+  def pnchisqtail(x: Double, df: Double, ncp: Double): Double = pnchisqtail(x, df, ncp, lowerTail = false, logP = false)
 
   // Returns the x for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def inverseChiSquaredTail(p: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.quantile(p, df, lowerTail, logP)
+  def qchisqtail(p: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.quantile(p, df, lowerTail, logP)
 
-  def inverseNonCentralChiSquaredTail(p: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.quantile(p, df, ncp, lowerTail, logP)
+  def qchisqtail(p: Double, df: Double): Double = qchisqtail(p, df, lowerTail = false, logP = false)
+
+  def qnchisqtail(p: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.quantile(p, df, ncp, lowerTail, logP)
+
+  def qnchisqtail(p: Double, df: Double, ncp: Double): Double = qnchisqtail(p, df, ncp, lowerTail = false, logP = false)
 
   def dbeta(x: Double, a: Double, b: Double): Double = Beta.density(x, a, b, false)
 

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -320,13 +320,19 @@ package object stats {
     Array(pvalue, oddsRatioEstimate, confInterval._1, confInterval._2)
   }
 
+  def dnorm(x: Double, mu: Double, sigma: Double, logP: Boolean): Double = Normal.density(x, mu, sigma, logP)
+
+  def dnorm(x: Double): Double = dnorm(x, mu = 0, sigma = 1, logP = false)
+
   // Returns the p for which p = Prob(Z < x) with Z a standard normal RV
-  def pnorm(x: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.cumulative(x, 0, 1, lowerTail, logP)
-  def pnorm(x: Double): Double = pnorm(x, lowerTail = true, logP = false)
+  def pnorm(x: Double, mu: Double, sigma: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.cumulative(x, mu, sigma, lowerTail, logP)
+
+  def pnorm(x: Double): Double = pnorm(x, mu = 0, sigma = 1, lowerTail = true, logP = false)
 
   // Returns the x for which p = Prob(Z < x) with Z a standard normal RV
-  def qnorm(p: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.quantile(p, 0, 1, lowerTail, logP)
-  def qnorm(p: Double): Double = qnorm(p, lowerTail = true, logP = false)
+  def qnorm(p: Double, mu: Double, sigma: Double, lowerTail: Boolean, logP: Boolean): Double = Normal.quantile(p, mu, sigma, lowerTail, logP)
+
+  def qnorm(p: Double): Double = qnorm(p, mu = 0, sigma = 1, lowerTail = true, logP = false)
 
   // Returns the p for which p = Prob(Z < x) with Z a RV having the T distribution with n degrees of freedom
   def pT(x: Double, n: Double, lower_tail: Boolean, log_p: Boolean): Double =
@@ -341,6 +347,8 @@ package object stats {
   def chiSquaredTail(x: Double, df: Double): Double = chiSquaredTail(x, df, lowerTail = false, logP = false)
 
   def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double, lowerTail: Boolean, logP: Boolean): Double = NonCentralChiSquare.cumulative(x, df, ncp, lowerTail, logP)
+
+  def nonCentralChiSquaredTail(x: Double, df: Double, ncp: Double): Double = nonCentralChiSquaredTail(x, df, ncp, lowerTail = false, logP = false)
 
   // Returns the x for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
   def inverseChiSquaredTail(p: Double, df: Double, lowerTail: Boolean, logP: Boolean): Double = ChiSquare.quantile(p, df, lowerTail, logP)

--- a/hail/src/test/scala/is/hail/stats/StatsSuite.scala
+++ b/hail/src/test/scala/is/hail/stats/StatsSuite.scala
@@ -13,26 +13,26 @@ class StatsSuite extends HailSuite {
 
   @Test def chiSquaredTailTest() {
     val chiSq1 = new ChiSquaredDistribution(1)
-    assert(D_==(chiSquaredTail(1d,1), 1 - chiSq1.cumulativeProbability(1d)))
-    assert(D_==(chiSquaredTail(5.52341d,1), 1 - chiSq1.cumulativeProbability(5.52341d)))
+    assert(D_==(pchisqtail(1d,1), 1 - chiSq1.cumulativeProbability(1d)))
+    assert(D_==(pchisqtail(5.52341d,1), 1 - chiSq1.cumulativeProbability(5.52341d)))
 
     val chiSq2 = new ChiSquaredDistribution(2)
-    assert(D_==(chiSquaredTail(1, 2), 1 - chiSq2.cumulativeProbability(1)))
-    assert(D_==(chiSquaredTail(5.52341, 2), 1 - chiSq2.cumulativeProbability(5.52341)))
+    assert(D_==(pchisqtail(1, 2), 1 - chiSq2.cumulativeProbability(1)))
+    assert(D_==(pchisqtail(5.52341, 2), 1 - chiSq2.cumulativeProbability(5.52341)))
 
     val chiSq5 = new ChiSquaredDistribution(5.2)
-    assert(D_==(chiSquaredTail(1, 5.2), 1 - chiSq5.cumulativeProbability(1)))
-    assert(D_==(chiSquaredTail(5.52341, 5.2), 1 - chiSq5.cumulativeProbability(5.52341)))
+    assert(D_==(pchisqtail(1, 5.2), 1 - chiSq5.cumulativeProbability(1)))
+    assert(D_==(pchisqtail(5.52341, 5.2), 1 - chiSq5.cumulativeProbability(5.52341)))
 
-    assert(D_==(inverseChiSquaredTail(.1, 1.0), chiSq1.inverseCumulativeProbability(1 - .1)))
-    assert(D_==(inverseChiSquaredTail(.0001, 1.0), chiSq1.inverseCumulativeProbability(1 - .0001)))
+    assert(D_==(qchisqtail(.1, 1.0), chiSq1.inverseCumulativeProbability(1 - .1)))
+    assert(D_==(qchisqtail(.0001, 1.0), chiSq1.inverseCumulativeProbability(1 - .0001)))
 
     val a = List(.0000000001, .5, .9999999999, 1.0)
-    a.foreach(p => assert(D_==(chiSquaredTail(inverseChiSquaredTail(p, 1.0), 1.0), p)))
+    a.foreach(p => assert(D_==(pchisqtail(qchisqtail(p, 1.0), 1.0), p)))
 
     // compare with R
-    assert(math.abs(chiSquaredTail(400, 1) - 5.507248e-89) < 1e-93)
-    assert(D_==(inverseChiSquaredTail(5.507248e-89, 1), 400))
+    assert(math.abs(pchisqtail(400, 1) - 5.507248e-89) < 1e-93)
+    assert(D_==(qchisqtail(5.507248e-89, 1), 400))
   }
 
   @Test def normalTest() {


### PR DESCRIPTION
This PR exposes the `lower_tail` and `log_p` parameters in `hl.pnorm`, `hl.qnorm`, `hl.pchisqtail`, and `hl.qchisqtail`, per this [feature request](https://hail.zulipchat.com/#narrow/stream/127634-Feature-Requests/topic/log_p.20option.20for.20pnorm.2Fpchisqtail). 

While I was at it I made a few other changes, including:
- Added `hl.dnorm` and `hl.dchisq` to allow for computation of normal and chi-squared probability densities.
- Exposed `mu` and `sigma` in `hl.dnorm`, `hl.pnorm`, and `hl.qnorm` so users can specify different mean/sd values if they wish. By default these functions will still use `mu=0` and `sigma=1` for standard normal densities/cumulative probabilities/quantiles if not otherwise specified by the user.
- Added `ncp` parameter to `hl.qchisqtail` to allow users to specify a non-centrality parameter when computing quantiles.
- Added tests for all of these functions to `test_expr.py`.