### PR TITLE
[aiogoogle] retrieve any exceptions from the request task

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -64,9 +64,14 @@ class InsertObjectStream(WritableStream):
         return len(b)
 
     async def _wait_closed(self):
-        await self._it.stop()
-        async with await self._request_task as resp:
-            self._value = await resp.json()
+        try:
+            await self._it.stop()
+        except:
+            await self._request_task  # retrieve exceptions
+            raise
+        else:
+            async with await self._request_task as resp:
+                self._value = await resp.json()
 
 
 class _TaskManager:


### PR DESCRIPTION
If stop raises a CancelledError or something, we should still retrieve exceptions
from the request task.