### PR TITLE
[batch] introduce create-fast

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -726,6 +726,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if machine_type and ('cpu' in resources or 'memory' in resources):
                     raise web.HTTPBadRequest(reason='cannot specify cpu and memory with machine_type')
 
+                req_memory_bytes: Optional[int]
                 if machine_type is None:
                     if 'cpu' not in resources:
                         resources['cpu'] = BATCH_JOB_DEFAULT_CPU

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1007,7 +1007,7 @@ VALUES (%s, %s, %s);
                         f'jobs_args={json.dumps(jobs_args)}'
                         f'job_parents_args={json.dumps(job_parents_args)}'
                     ) from err
-            await asyncio.gather(write_spec_to_gcs(), insert_jobs_into_db())
+        await asyncio.gather(write_spec_to_gcs(), insert_jobs_into_db())
 
     return web.Response()
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -620,17 +620,21 @@ def check_service_account_permissions(user, sa):
 
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
 @rest_authenticated_users_only
-async def create_jobs(request, userdata):
+async def create_jobs(request: aiohttp.web.Request, userdata: dict):
     app = request.app
-    db: Database = app['db']
-    file_store: FileStore = app['file_store']
 
     if app['frozen']:
         log.info('ignoring batch create request; batch is frozen')
         raise web.HTTPServiceUnavailable()
 
     batch_id = int(request.match_info['batch_id'])
+    job_specs = await request.json()
+    return await _create_jobs(userdata, job_specs, batch_id, app)
 
+
+async def _create_jobs(userdata: dict, job_specs: dict, batch_id: int, app: aiohttp.web.Application):
+    db: Database = app['db']
+    file_store: FileStore = app['file_store']
     user = userdata['username']
 
     # restrict to what's necessary; in particular, drop the session
@@ -656,9 +660,6 @@ WHERE user = %s AND id = %s AND NOT deleted;
         if record['state'] != 'open':
             raise web.HTTPBadRequest(reason=f'batch {batch_id} is not open')
         batch_format_version = BatchFormatVersion(record['format_version'])
-
-        async with timer.step('get request json'):
-            job_specs = await request.json()
 
         async with timer.step('validate job_specs'):
             try:
@@ -732,7 +733,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     del resources['cpu']
                     req_cores_mcpu = parse_cpu_in_mcpu(resources['req_cpu'])
 
-                    if not is_valid_cores_mcpu(req_cores_mcpu):
+                    if req_cores_mcpu is None or not is_valid_cores_mcpu(req_cores_mcpu):
                         raise web.HTTPBadRequest(
                             reason=f'bad resource request for job {id}: '
                             f'cpu must be a power of two with a min of 0.25; '
@@ -903,120 +904,137 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     for k, v in attributes.items():
                         job_attributes_args.append((batch_id, job_id, k, v))
 
-        if batch_format_version.has_full_spec_in_cloud():
-            async with timer.step('write spec to cloud'):
-                await spec_writer.write()
-
         rand_token = random.randint(0, app['n_tokens'] - 1)
 
-        async with timer.step('insert jobs'):
+        async def write_spec_to_gcs():
+            if batch_format_version.has_full_spec_in_cloud():
+                async with timer.step('write spec to cloud'):
+                    await spec_writer.write()
 
-            @transaction(db)
-            async def insert(tx):
-                try:
-                    await tx.execute_many(
-                        '''
+        async def insert_jobs_into_db():
+            async with timer.step('insert jobs'):
+                @transaction(db)
+                async def insert(tx):
+                    try:
+                        await tx.execute_many(
+                            '''
 INSERT INTO jobs (batch_id, job_id, state, spec, always_run, cores_mcpu, n_pending_parents, inst_coll)
 VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
 ''',
-                        jobs_args,
-                    )
-                except pymysql.err.IntegrityError as err:
-                    # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
-                    if err.args[0] == 1062:
-                        log.info(f'bunch containing job {(batch_id, jobs_args[0][1])} already inserted ({err})')
-                        return
-                    raise
-                try:
-                    await tx.execute_many(
-                        '''
+                            jobs_args,
+                        )
+                    except pymysql.err.IntegrityError as err:
+                        # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
+                        if err.args[0] == 1062:
+                            log.info(f'bunch containing job {(batch_id, jobs_args[0][1])} already inserted ({err})')
+                            return
+                        raise
+                    try:
+                        await tx.execute_many(
+                            '''
 INSERT INTO `job_parents` (batch_id, job_id, parent_id)
 VALUES (%s, %s, %s);
 ''',
-                        job_parents_args,
-                    )
-                except pymysql.err.IntegrityError as err:
-                    # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
-                    if err.args[0] == 1062:
-                        raise web.HTTPBadRequest(text=f'bunch contains job with duplicated parents ({err})')
-                    raise
-                await tx.execute_many(
-                    '''
+                            job_parents_args,
+                        )
+                    except pymysql.err.IntegrityError as err:
+                        # 1062 ER_DUP_ENTRY https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html#error_er_dup_entry
+                        if err.args[0] == 1062:
+                            raise web.HTTPBadRequest(text=f'bunch contains job with duplicated parents ({err})')
+                        raise
+                    await tx.execute_many(
+                        '''
 INSERT INTO `job_attributes` (batch_id, job_id, `key`, `value`)
 VALUES (%s, %s, %s, %s);
 ''',
-                    job_attributes_args,
-                )
+                        job_attributes_args,
+                    )
 
-                for inst_coll, resources in inst_coll_resources.items():
-                    n_jobs = resources['n_jobs']
-                    n_ready_jobs = resources['n_ready_jobs']
-                    ready_cores_mcpu = resources['ready_cores_mcpu']
-                    n_ready_cancellable_jobs = resources['n_ready_cancellable_jobs']
-                    ready_cancellable_cores_mcpu = resources['ready_cancellable_cores_mcpu']
-
-                    await tx.execute_update(
+                    batches_inst_coll_staging_args = [
+                        (batch_id,
+                         inst_coll,
+                         rand_token,
+                         resources['n_jobs'],
+                         resources['n_ready_jobs'],
+                         resources['ready_cores_mcpu'])
+                        for inst_coll, resources in inst_coll_resources.items()]
+                    await tx.execute_many(
                         '''
 INSERT INTO batches_inst_coll_staging (batch_id, inst_coll, token, n_jobs, n_ready_jobs, ready_cores_mcpu)
 VALUES (%s, %s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
-  n_jobs = n_jobs + %s,
-  n_ready_jobs = n_ready_jobs + %s,
-  ready_cores_mcpu = ready_cores_mcpu + %s;
+  n_jobs = n_jobs + VALUES(n_jobs),
+  n_ready_jobs = n_ready_jobs + VALUES(n_ready_jobs),
+  ready_cores_mcpu = ready_cores_mcpu + VALUES(ready_cores_mcpu);
 ''',
-                        (
-                            batch_id,
-                            inst_coll,
-                            rand_token,
-                            n_jobs,
-                            n_ready_jobs,
-                            ready_cores_mcpu,
-                            n_jobs,
-                            n_ready_jobs,
-                            ready_cores_mcpu,
-                        ),
-                    )
-                    await tx.execute_update(
+                        batches_inst_coll_staging_args)
+
+                    batch_inst_coll_cancellable_resources_args = [
+                        (batch_id,
+                         inst_coll,
+                         rand_token,
+                         resources['n_ready_cancellable_jobs'],
+                         resources['ready_cancellable_cores_mcpu'])
+                        for inst_coll, resources in inst_coll_resources.items()]
+                    await tx.execute_many(
                         '''
 INSERT INTO batch_inst_coll_cancellable_resources (batch_id, inst_coll, token, n_ready_cancellable_jobs, ready_cancellable_cores_mcpu)
 VALUES (%s, %s, %s, %s, %s)
 ON DUPLICATE KEY UPDATE
-  n_ready_cancellable_jobs = n_ready_cancellable_jobs + %s,
-  ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + %s;
+  n_ready_cancellable_jobs = n_ready_cancellable_jobs + VALUES(n_ready_cancellable_jobs),
+  ready_cancellable_cores_mcpu = ready_cancellable_cores_mcpu + VALUES(ready_cancellable_cores_mcpu);
 ''',
-                        (
-                            batch_id,
-                            inst_coll,
-                            rand_token,
-                            n_ready_cancellable_jobs,
-                            ready_cancellable_cores_mcpu,
-                            n_ready_cancellable_jobs,
-                            ready_cancellable_cores_mcpu,
-                        ),
-                    )
+                        batch_inst_coll_cancellable_resources_args)
 
-                if batch_format_version.has_full_spec_in_cloud():
-                    await tx.execute_update(
-                        '''
+                    if batch_format_version.has_full_spec_in_cloud():
+                        await tx.execute_update(
+                            '''
 INSERT INTO batch_bunches (batch_id, token, start_job_id)
 VALUES (%s, %s, %s);
 ''',
-                        (batch_id, spec_writer.token, start_job_id),
-                    )
+                            (batch_id, spec_writer.token, start_job_id),
+                        )
 
-            try:
-                await insert()  # pylint: disable=no-value-for-parameter
-            except asyncio.CancelledError:
-                raise
-            except aiohttp.web.HTTPException:
-                raise
-            except Exception as err:
-                raise ValueError(
-                    f'encountered exception while inserting a bunch'
-                    f'jobs_args={json.dumps(jobs_args)}'
-                    f'job_parents_args={json.dumps(job_parents_args)}'
-                ) from err
+                try:
+                    await insert()  # pylint: disable=no-value-for-parameter
+                except asyncio.CancelledError:
+                    raise
+                except aiohttp.web.HTTPException:
+                    raise
+                except Exception as err:
+                    raise ValueError(
+                        f'encountered exception while inserting a bunch'
+                        f'jobs_args={json.dumps(jobs_args)}'
+                        f'job_parents_args={json.dumps(job_parents_args)}'
+                    ) from err
+            await asyncio.gather(write_spec_to_gcs(), insert_jobs_into_db())
+
     return web.Response()
+
+
+@routes.post('/api/v1alpha/batches/create-fast')
+@rest_authenticated_users_only
+async def create_batch_fast(request, userdata):
+    app = request.app
+    db: Database = app['db']
+
+    if app['frozen']:
+        log.info('ignoring batch create request; batch is frozen')
+        raise web.HTTPServiceUnavailable()
+
+    user = userdata['username']
+    batch_and_bunch = await request.json()
+    batch_spec = batch_and_bunch['batch']
+    bunch = batch_and_bunch['bunch']
+    batch_id = await _create_batch(batch_spec, userdata, db)
+    try:
+        await _create_jobs(userdata, bunch, batch_id, app)
+    except web.HTTPBadRequest as e:
+        if f'batch {batch_id} is not open' == e.reason:
+            return web.json_response({'id': batch_id})
+        raise
+    await _close_batch(app, batch_id, user, db)
+    return web.json_response({'id': batch_id})
 
 
 @routes.post('/api/v1alpha/batches/create')
@@ -1030,7 +1048,11 @@ async def create_batch(request, userdata):
         raise web.HTTPServiceUnavailable()
 
     batch_spec = await request.json()
+    id = await _create_batch(batch_spec, userdata, db)
+    return web.json_response({'id': id})
 
+
+async def _create_batch(batch_spec: dict, userdata: dict, db: Database):
     try:
         validate_batch(batch_spec)
     except ValidationError as e:
@@ -1112,8 +1134,7 @@ VALUES (%s, %s, %s)
             )
         return id
 
-    id = await insert()  # pylint: disable=no-value-for-parameter
-    return web.json_response({'id': id})
+    return await insert()  # pylint: disable=no-value-for-parameter
 
 
 async def _get_batch(app, batch_id):
@@ -1179,7 +1200,6 @@ async def cancel_batch(request, userdata, batch_id):  # pylint: disable=unused-a
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
 @rest_authenticated_users_only
 async def close_batch(request, userdata):
-    client_session: httpx.ClientSession = request.app['client_session']
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
 
@@ -1200,6 +1220,11 @@ WHERE user = %s AND id = %s AND NOT deleted;
     if not record:
         raise web.HTTPNotFound()
 
+    return await _close_batch(app, batch_id, user, db)
+
+
+async def _close_batch(app: aiohttp.web.Application, batch_id: int, user: str, db: Database):
+    client_session: httpx.ClientSession = app['client_session']
     try:
         now = time_msecs()
         await check_call_procedure(db, 'CALL close_batch(%s, %s);', (batch_id, now))

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -907,7 +907,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
         rand_token = random.randint(0, app['n_tokens'] - 1)
 
-        async def write_spec_to_gcs():
+        async def write_spec_to_cloud():
             if batch_format_version.has_full_spec_in_cloud():
                 async with timer.step('write spec to cloud'):
                     await spec_writer.write()
@@ -1008,7 +1008,7 @@ VALUES (%s, %s, %s);
                         f'jobs_args={json.dumps(jobs_args)}'
                         f'job_parents_args={json.dumps(job_parents_args)}'
                     ) from err
-        await asyncio.gather(write_spec_to_gcs(), insert_jobs_into_db())
+        await asyncio.gather(write_spec_to_cloud(), insert_jobs_into_db())
 
     return web.Response()
 

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 from numbers import Number
 import os
 import logging
@@ -674,7 +674,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
             job_parents_args = []
             job_attributes_args = []
 
-            inst_coll_resources = collections.defaultdict(
+            inst_coll_resources: Dict[str, Dict[str, int]] = collections.defaultdict(
                 lambda: {
                     'n_jobs': 0,
                     'n_ready_jobs': 0,

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -191,7 +191,7 @@ async def test_close_billing_project_with_open_batch_errors(
     project = new_billing_project
     await dev_client.add_user("test", project)
     client = await make_client(project)
-    b = await client.create_batch()._create()
+    b = await client.create_batch()._open_batch()
 
     try:
         await dev_client.close_billing_project(project)
@@ -642,7 +642,7 @@ async def test_deleted_open_batches_do_not_prevent_billing_project_closure(
         project = await dev_client.create_billing_project(random_billing_project_name)
         await dev_client.add_user('test', project)
         client = await make_client(project)
-        open_batch = await client.create_batch()._create()
+        open_batch = await client.create_batch()._open_batch()
         await open_batch.delete()
     finally:
         await dev_client.close_billing_project(project)

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -629,8 +629,8 @@ def test_create_idempotence(client: BatchClient):
     token = secrets.token_urlsafe(32)
     builder1 = client.create_batch(token=token)
     builder2 = client.create_batch(token=token)
-    b1 = builder1._create()
-    b2 = builder2._create()
+    b1 = builder1._open_batch()
+    b2 = builder2._open_batch()
     assert b1.id == b2.id
 
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List, Tuple
 import math
 import random
 import logging
@@ -419,13 +419,27 @@ class BatchBuilder:
 
         self._cancel_after_n_failures = cancel_after_n_failures
 
-    def create_job(self, image, command, env=None, mount_docker_socket=False,
-                   port=None, resources=None, secrets=None,
-                   service_account=None, attributes=None, parents=None,
-                   input_files=None, output_files=None, always_run=False,
-                   timeout=None, gcsfuse=None, requester_pays_project=None,
-                   mount_tokens=False, network: Optional[str] = None,
-                   unconfined: bool = False, user_code: Optional[str] = None):
+    def create_job(self,
+                   image: str,
+                   command: str,
+                   env: Optional[Dict[str, str]] = None,
+                   mount_docker_socket: bool = False,
+                   port: Optional[int] = None,
+                   resources=None,
+                   secrets=None,
+                   service_account: Optional[str] = None,
+                   attributes: Optional[Dict[str, str]] = None,
+                   parents: Optional[List[Job]] = None,
+                   input_files: Optional[List[Tuple[str, str]]] = None,
+                   output_files: Optional[List[Tuple[str, str]]] = None,
+                   always_run: bool = False,
+                   timeout=None,
+                   gcsfuse=None,
+                   requester_pays_project: Optional[str] = None,
+                   mount_tokens: bool = False,
+                   network: Optional[str] = None,
+                   unconfined: bool = False,
+                   user_code: Optional[str] = None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
 
@@ -510,7 +524,28 @@ class BatchBuilder:
         self._jobs.append(j)
         return j
 
-    async def _submit_jobs(self, batch_id, byte_job_specs, n_jobs, pbar):
+    async def _fast_create_submit_close(self, byte_job_specs: List[bytes], n_jobs: int, pbar) -> Batch:
+        assert n_jobs == len(self._job_specs)
+        b = bytearray()
+        b.extend(b'{"bunch":')
+        b.append(ord('['))
+        for i, spec in enumerate(byte_job_specs):
+            if i > 0:
+                b.append(ord(','))
+            b.extend(spec)
+        b.append(ord(']'))
+        b.extend(b',"batch":')
+        b.extend(json.dumps(self._batch_spec()).encode('utf-8'))
+        b.append(ord('}'))
+        resp = await self._client._post(
+            '/api/v1alpha/batches/create-fast',
+            data=aiohttp.BytesPayload(b, content_type='application/json', encoding='utf-8'),
+        )
+        batch_json = await resp.json()
+        pbar.update(n_jobs)
+        return Batch(self._client, batch_json['id'], self.attributes, n_jobs, self.token)
+
+    async def _submit_jobs(self, batch_id: Optional[int], byte_job_specs: List[bytes], n_jobs: int, pbar):
         assert len(byte_job_specs) > 0, byte_job_specs
 
         b = bytearray()
@@ -532,7 +567,7 @@ class BatchBuilder:
                 b, content_type='application/json', encoding='utf-8'))
         pbar.update(n_jobs)
 
-    async def _create(self):
+    def _batch_spec(self):
         n_jobs = len(self._job_specs)
         batch_spec = {'billing_project': self._client.billing_project,
                       'n_jobs': n_jobs,
@@ -543,36 +578,37 @@ class BatchBuilder:
             batch_spec['callback'] = self.callback
         if self._cancel_after_n_failures is not None:
             batch_spec['cancel_after_n_failures'] = self._cancel_after_n_failures
-        batch_json = await (await self._client._post('/api/v1alpha/batches/create',
-                                                     json=batch_spec)).json()
-        return Batch(self._client, batch_json['id'], self.attributes, n_jobs, self.token)
+        return batch_spec
+
+    async def _slow_create(self):
+        batch_spec = self._batch_spec()
+        batch_json = await (await self._client._post('/api/v1alpha/batches/create', json=batch_spec)).json()
+        return Batch(self._client, batch_json['id'], self.attributes, batch_spec['n_jobs'], self.token)
 
     MAX_BUNCH_BYTESIZE = 1024 * 1024
     MAX_BUNCH_SIZE = 1024
 
     async def submit(self,
-                     max_bunch_bytesize=MAX_BUNCH_BYTESIZE,
-                     max_bunch_size=MAX_BUNCH_SIZE,
-                     disable_progress_bar=TQDM_DEFAULT_DISABLE):
+                     max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
+                     max_bunch_size: int = MAX_BUNCH_SIZE,
+                     disable_progress_bar: Optional[bool] = TQDM_DEFAULT_DISABLE,
+                     ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0
         if self._submitted:
             raise ValueError("cannot submit an already submitted batch")
-        batch = await self._create()
-        id = batch.id
-        log.info(f'created batch {id}')
         byte_job_specs = [json.dumps(job_spec).encode('utf-8')
                           for job_spec in self._job_specs]
-        byte_job_specs_bunches = []
+        byte_job_specs_bunches: List[List[bytes]] = []
         bunch_sizes = []
-        bunch = []
+        bunch: List[bytes] = []
         bunch_n_bytes = 0
         bunch_n_jobs = 0
         for spec in byte_job_specs:
             n_bytes = len(spec)
             assert n_bytes < max_bunch_bytesize, (
-                f'every job spec must be less than max_bunch_bytesize,'
-                f' { max_bunch_bytesize }B, but {spec} is larger')
+                'every job spec must be less than max_bunch_bytesize,'
+                f' { max_bunch_bytesize }B, but {spec.decode()} is larger')
             if bunch_n_bytes + n_bytes < max_bunch_bytesize and len(bunch) < max_bunch_size:
                 bunch.append(spec)
                 bunch_n_bytes += n_bytes
@@ -590,13 +626,21 @@ class BatchBuilder:
         with tqdm(total=len(self._job_specs),
                   disable=disable_progress_bar,
                   desc='jobs submitted to queue') as pbar:
-            await bounded_gather(
-                *[functools.partial(self._submit_jobs, id, bunch, size, pbar)
-                  for bunch, size in zip(byte_job_specs_bunches, bunch_sizes)],
-                parallelism=6)
+            if len(byte_job_specs_bunches) == 1:
+                batch = await self._fast_create_submit_close(byte_job_specs_bunches[0], bunch_sizes[0], pbar)
+                id = batch.id
+            else:
+                batch = await self._slow_create()
+                id = batch.id
+                await bounded_gather(
+                    *[functools.partial(self._submit_jobs, id, bunch, size, pbar)
+                      for bunch, size in zip(byte_job_specs_bunches, bunch_sizes)
+                      ],
+                    parallelism=6,
+                )
+                await self._client._patch(f'/api/v1alpha/batches/{id}/close')
 
-        await self._client._patch(f'/api/v1alpha/batches/{id}/close')
-        log.info(f'closed batch {id}')
+        log.info(f'created batch {id}')
 
         for j in self._jobs:
             j._job = j._job._submit(batch)
@@ -715,7 +759,7 @@ class BatchClient:
                      token=b['token'],
                      last_known_status=b)
 
-    def create_batch(self, attributes=None, callback=None, token=None, cancel_after_n_failures=None):
+    def create_batch(self, attributes=None, callback=None, token=None, cancel_after_n_failures=None) -> BatchBuilder:
         return BatchBuilder(self, attributes, callback, token, cancel_after_n_failures)
 
     async def get_billing_project(self, billing_project):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -222,9 +222,12 @@ class BatchBuilder:
 
         return Job.from_async_job(async_job)
 
-    def _create(self):
-        async_batch = async_to_blocking(self._async_builder._create())
+    def _open_batch(self) -> Batch:
+        async_batch = async_to_blocking(self._async_builder._open_batch())
         return Batch.from_async_batch(async_batch)
+
+    def _close_batch(self, id: int):
+        async_to_blocking(self._async_builder._close_batch(id))
 
     def submit(self, *args, **kwargs) -> Batch:
         async_batch = async_to_blocking(self._async_builder.submit(*args, **kwargs))

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -126,6 +126,10 @@ class Batch:
     def token(self):
         return self._async_batch.token
 
+    @property
+    def submission_info(self):
+        return self._async_batch.submission_info
+
     def cancel(self):
         async_to_blocking(self._async_batch.cancel())
 

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -891,7 +891,7 @@ class ServiceTests(unittest.TestCase):
         b.run()
 
     def test_big_batch_which_uses_slow_path(self):
-        backend = ServiceBackend(remote_tmpdir=f'gs://{HAIL_TEST_GCS_BUCKET}/temporary-files')
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
         b = Batch(backend=backend)
         # 8 * 256 * 1024 = 2 MiB > 1 MiB max bunch size
         for i in range(8):

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -889,3 +889,16 @@ class ServiceTests(unittest.TestCase):
         long_str = secrets.token_urlsafe(15 * 1024)
         j1.command(f'echo "{long_str}"')
         b.run()
+
+    def test_big_batch_which_uses_slow_path(self):
+        backend = ServiceBackend(remote_tmpdir=f'gs://{HAIL_TEST_GCS_BUCKET}/temporary-files')
+        b = Batch(backend=backend)
+        # 8 * 256 * 1024 = 2 MiB > 1 MiB max bunch size
+        for i in range(8):
+            j1 = b.new_job()
+            long_str = secrets.token_urlsafe(256 * 1024)
+            j1.command(f'echo "{long_str}"')
+        batch = b.run()
+        assert not batch.submission_info.used_fast_create
+        batch_status = batch.status()
+        assert batch_status['state'] == 'success', str((batch.debug_info()))

--- a/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
+++ b/hail/src/main/scala/is/hail/services/batch_client/BatchClient.scala
@@ -74,9 +74,10 @@ class BatchClient(
   def delete(path: String, token: String): JValue =
     request(new HttpDelete(s"$baseUrl$path"))
 
-  def createJobs(batchID: Long, jobs: IndexedSeq[JObject]): Unit = {
-    val bunches = new BoxedArrayBuilder[Array[Array[Byte]]]()
+  def create(batchJson: JObject, jobs: IndexedSeq[JObject]): Long = {
+    implicit val formats: Formats = DefaultFormats
 
+    val bunches = new BoxedArrayBuilder[Array[Array[Byte]]]()
     val bunchb = new BoxedArrayBuilder[Array[Byte]]()
 
     var i = 0
@@ -98,29 +99,60 @@ class BatchClient(
     bunchb.clear()
     size = 0
 
-    val b = new ByteArrayBuilder()
-
-    i = 0 // reuse
-    while (i < bunches.length) {
-      val bunch = bunches(i)
+    val batchID = if (bunches.length == 1) {
+      val bunch = bunches(0)
+      val b = new ByteArrayBuilder()
+      b ++= "{\"bunch\":".getBytes(StandardCharsets.UTF_8)
       b += '['
       var j = 0
       while (j < bunch.length) {
         if (j > 0)
-           b += ','
+          b += ','
         b ++= bunch(j)
         j += 1
       }
       b += ']'
+      b ++= ",\"batch\":".getBytes(StandardCharsets.UTF_8)
+      b ++= JsonMethods.compact(batchJson).getBytes(StandardCharsets.UTF_8)
+      b += '}'
       val data = b.result()
-      post(
-        s"/api/v1alpha/batches/$batchID/jobs/create",
-        new ByteArrayEntity(
-          data,
-          ContentType.create("application/json")))
+      val resp = post("/api/v1alpha/batches/create-fast",
+        new ByteArrayEntity(data, ContentType.create("application/json")))
       b.clear()
-      i += 1
+      (resp \ "id").extract[Long]
+    } else {
+      val resp = post("/api/v1alpha/batches/create", json = batchJson)
+      val batchID = (resp \ "id").extract[Long]
+
+      val b = new ByteArrayBuilder()
+
+      i = 0 // reuse
+      while (i < bunches.length) {
+        val bunch = bunches(i)
+        b += '['
+        var j = 0
+        while (j < bunch.length) {
+          if (j > 0)
+            b += ','
+          b ++= bunch(j)
+          j += 1
+        }
+        b += ']'
+        val data = b.result()
+        post(
+          s"/api/v1alpha/batches/$batchID/jobs/create",
+          new ByteArrayEntity(
+            data,
+            ContentType.create("application/json")))
+        b.clear()
+        i += 1
+      }
+
+      patch(s"/api/v1alpha/batches/$batchID/close")
+      batchID
     }
+    log.info(s"run: created batch $batchID")
+    batchID
   }
 
   def waitForBatch(batchID: Long): JValue = {
@@ -150,17 +182,7 @@ class BatchClient(
   }
 
   def run(batchJson: JObject, jobs: IndexedSeq[JObject]): JValue = {
-    val resp = post("/api/v1alpha/batches/create", json = batchJson)
-
-    implicit val formats: Formats = DefaultFormats
-    val batchID = (resp \ "id").extract[Long]
-
-    log.info(s"run: created batch $batchID")
-
-    createJobs(batchID, jobs)
-
-    patch(s"/api/v1alpha/batches/$batchID/close")
-
+    val batchID = create(batchJson, jobs)
     waitForBatch(batchID)
   }
 }


### PR DESCRIPTION
This change allows batchces which fit in one bunch to be created in one
request instead of three. I found this saved a few hundred milliseconds
for batches with 1 job. This path is already well tested because most
of our test batches fit in one job.

To be clear: all the savings here is from avoiding two round-trips to front-end.