### PR TITLE
[hailtop.batch] Deprecate bucket in favor of remote_tmpdir

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -705,9 +705,9 @@ def test_verify_no_access_to_metadata_server(client: BatchClient):
 
 def test_submit_batch_in_job(client: BatchClient):
     builder = client.create_batch()
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     script = f'''import hailtop.batch as hb
-backend = hb.ServiceBackend("test", "{bucket_name}")
+backend = hb.ServiceBackend("test", remote_tmpdir="{remote_tmpdir}")
 b = hb.Batch(backend=backend)
 j = b.new_bash_job()
 j.command("echo hi")
@@ -725,9 +725,9 @@ backend.close()
 
 
 def test_cant_submit_to_default_with_other_ns_creds(client: BatchClient):
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     script = f'''import hailtop.batch as hb
-backend = hb.ServiceBackend("test", "{bucket_name}")
+backend = hb.ServiceBackend("test", remote_tmpdir="{remote_tmpdir}")
 b = hb.Batch(backend=backend)
 j = b.new_bash_job()
 j.command("echo hi")
@@ -802,12 +802,12 @@ curl -fsSL -m 5 $OTHER_IP
 
 def test_can_use_google_credentials(client: BatchClient):
     token = os.environ["HAIL_TOKEN"]
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     builder = client.create_batch()
     script = f'''import hail as hl
 import secrets
 attempt_token = secrets.token_urlsafe(5)
-location = f"gs://{ bucket_name }/{ token }/{{ attempt_token }}/test_can_use_hailctl_auth.t"
+location = f"{remote_tmpdir}/{ token }/{{ attempt_token }}/test_can_use_hailctl_auth.t"
 hl.utils.range_table(10).write(location)
 hl.read_table(location).show()
 '''

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -185,17 +185,17 @@ def test_no_parents_allowed_in_other_batches(client):
 
 
 def test_input_dependency(client):
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     batch = client.create_batch()
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'echo head1 > /io/data1; echo head2 > /io/data2'],
-        output_files=[('/io/data1', f'gs://{bucket_name}/data1'), ('/io/data2', f'gs://{bucket_name}/data2')],
+        output_files=[('/io/data1', f'{remote_tmpdir}data1'), ('/io/data2', f'{remote_tmpdir}data2')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/data1; cat /io/data2'],
-        input_files=[(f'gs://{bucket_name}/data1', '/io/data1'), (f'gs://{bucket_name}/data2', '/io/data2')],
+        input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
         parents=[head],
     )
     batch = batch.submit()
@@ -207,17 +207,17 @@ def test_input_dependency(client):
 
 
 def test_input_dependency_wildcard(client):
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     batch = client.create_batch()
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'echo head1 > /io/data1 ; echo head2 > /io/data2'],
-        output_files=[('/io/data1', f'gs://{bucket_name}/data1'), ('/io/data2', f'gs://{bucket_name}/data2')],
+        output_files=[('/io/data1', f'{remote_tmpdir}data1'), ('/io/data2', f'{remote_tmpdir}data2')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/data1 ; cat /io/data2'],
-        input_files=[(f'gs://{bucket_name}/data1', '/io/data1'), (f'gs://{bucket_name}/data2', '/io/data2')],
+        input_files=[(f'{remote_tmpdir}data1', '/io/data1'), (f'{remote_tmpdir}data2', '/io/data2')],
         parents=[head],
     )
     batch = batch.submit()
@@ -229,17 +229,17 @@ def test_input_dependency_wildcard(client):
 
 
 def test_input_dependency_directory(client):
-    bucket_name = get_user_config().get('batch', 'bucket')
+    remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
     batch = client.create_batch()
     head = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'mkdir -p /io/test/; echo head1 > /io/test/data1 ; echo head2 > /io/test/data2'],
-        output_files=[('/io/test', f'gs://{bucket_name}/test')],
+        output_files=[('/io/test', f'{remote_tmpdir}test')],
     )
     tail = batch.create_job(
         DOCKER_ROOT_IMAGE,
         command=['/bin/sh', '-c', 'cat /io/test/data1; cat /io/test/data2'],
-        input_files=[(f'gs://{bucket_name}/test', '/io/test')],
+        input_files=[(f'{remote_tmpdir}test', '/io/test')],
         parents=[head],
     )
     batch = batch.submit()

--- a/build.yaml
+++ b/build.yaml
@@ -2622,7 +2622,7 @@ steps:
       cpu: '1'
     script: |
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 /io/test/
     timeout: 600
     secrets:
@@ -2679,7 +2679,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2753,7 +2753,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2827,7 +2827,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2901,7 +2901,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2975,7 +2975,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -3205,7 +3205,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3258,7 +3258,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3311,7 +3311,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3364,7 +3364,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3417,7 +3417,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3464,7 +3464,7 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       cd /io/hailtop/batch
       hailctl config set batch/billing_project test
-      hailctl config set batch/bucket {{ global.hail_test_gcs_bucket }}
+      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
       python3 -m pytest --instafail \
         --doctest-modules \
         --doctest-glob='*.rst' \

--- a/build.yaml
+++ b/build.yaml
@@ -3203,7 +3203,6 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
-      export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
@@ -3256,7 +3255,6 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
-      export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
@@ -3309,7 +3307,6 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
-      export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
@@ -3362,7 +3359,6 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
-      export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
@@ -3415,7 +3411,6 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
-      export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \

--- a/build.yaml
+++ b/build.yaml
@@ -2622,7 +2622,7 @@ steps:
       cpu: '1'
     script: |
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest --log-cli-level=INFO -s -vv --instafail --durations=50 /io/test/
     timeout: 600
     secrets:
@@ -2679,7 +2679,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2753,7 +2753,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2827,7 +2827,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2901,7 +2901,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -2975,7 +2975,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
               --log-format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d:%(funcName)s %(message)s" \
@@ -3205,7 +3205,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3258,7 +3258,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3311,7 +3311,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3364,7 +3364,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3417,7 +3417,7 @@ steps:
       export PYTHON_DILL_IMAGE="{{ global.docker_prefix }}/python-dill:3.7-slim"
       export HAIL_TEST_GCS_BUCKET="{{ global.hail_test_gcs_bucket }}"
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --durations=0 \
               --log-cli-level=INFO \
@@ -3464,7 +3464,7 @@ steps:
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       cd /io/hailtop/batch
       hailctl config set batch/billing_project test
-      hailctl config set batch/remote_tmpdir gs://{{ global.hail_test_gcs_bucket }}/batch/
+      hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest --instafail \
         --doctest-modules \
         --doctest-glob='*.rst' \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -27,10 +27,8 @@ gcsfs==0.8.0
 # https://github.com/dask/gcsfs/issues/372
 fsspec==0.9.0
 gidgethub==4.1.0
-google-auth==1.27.0
 google-api-python-client==1.7.10
 google-cloud-logging==1.12.1
-google-cloud-storage==1.25.0
 humanize==1.0.0
 hurry.filesize==0.9
 orjson==3.6.4

--- a/hail/python/hailtop/aiocloud/aiogoogle/session.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/session.py
@@ -8,6 +8,8 @@ from .credentials import GoogleCredentials
 class GoogleSession(BaseSession):
     def __init__(self, *, credentials: Optional[GoogleCredentials] = None, credentials_file: Optional[str] = None,
                  params: Optional[Mapping[str, str]] = None, **kwargs):
+        assert credentials is None or credentials_file is None, \
+            f'specify only one of credentials or credentials_file: {(credentials, credentials_file)}'
         if credentials is None:
             if credentials_file:
                 credentials = GoogleCredentials.from_file(credentials_file)

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -338,27 +338,20 @@ class ServiceBackend(Backend[bc.Batch]):
     Examples
     --------
 
-    >>> service_backend = ServiceBackend('my-billing-account', bucket='my-bucket') # doctest: +SKIP
+    >>> service_backend = ServiceBackend(billing_project='my-billing-account', remote_tmpdir='gs://my-bucket/temporary-files/') # doctest: +SKIP
     >>> b = Batch(backend=service_backend) # doctest: +SKIP
     >>> b.run() # doctest: +SKIP
     >>> service_backend.close() # doctest: +SKIP
 
     If the Hail configuration parameters batch/billing_project and
-    batch/bucket were previously set with ``hailctl config set``, then
-    one may elide the `billing_project` and `bucket` parameters.
+    batch/remote_tmpdir were previously set with ``hailctl config set``, then
+    one may elide the `billing_project` and `remote_tmpdir` parameters.
 
     >>> service_backend = ServiceBackend()
     >>> b = Batch(backend=service_backend)
     >>> b.run() # doctest: +SKIP
     >>> service_backend.close()
 
-    Instead of a bucket, a full path may be specified for the remote temporary directory:
-
-    >>> service_backend = ServiceBackend('my-billing-account',
-    ...                                  remote_tmpdir='gs://my-bucket/temporary-files/')
-    >>> b = Batch(backend=service_backend)
-    >>> b.run() # doctest: +SKIP
-    >>> service_backend.close()
 
     Parameters
     ----------
@@ -366,11 +359,11 @@ class ServiceBackend(Backend[bc.Batch]):
         Name of billing project to use.
     bucket:
         Name of bucket to use. Should not include the ``gs://`` prefix. Cannot be used with
-        remote_tmpdir. Temporary data will be stored in the "/batch" folder of this
-        bucket. Using this parameter as a positional argument is deprecated.
+        `remote_tmpdir`. Temporary data will be stored in the "/batch" folder of this
+        bucket. This argument is deprecated. Use `remote_tmpdir` instead.
     remote_tmpdir:
-        Temporary data will be stored in this google cloud storage folder. Cannot be used with
-        bucket.
+        Temporary data will be stored in this cloud storage folder. Cannot be used with deprecated
+        argument `bucket`. Paths should start with one of gs://, hail-az://, or s3://.
     google_project:
         If specified, the project to use when authenticating with Google
         Storage. Google Storage is used to transfer serialized values between
@@ -398,9 +391,6 @@ class ServiceBackend(Backend[bc.Batch]):
             warnings.warn('Use of deprecated positional argument \'bucket\' in ServiceBackend(). Specify \'bucket\' as a keyword argument instead.')
             bucket = args[1]
 
-        if remote_tmpdir is not None and bucket is not None:
-            raise ValueError('Cannot specify both remote_tmpdir and bucket in ServiceBackend()')
-
         if billing_project is None:
             billing_project = get_user_config().get('batch', 'billing_project', fallback=None)
         if billing_project is None:
@@ -409,28 +399,44 @@ class ServiceBackend(Backend[bc.Batch]):
                 'or run `hailctl config set batch/billing_project '
                 'MY_BILLING_PROJECT`')
         self._batch_client = BatchClient(billing_project)
-        self.__fs: AsyncFS = RouterAsyncFS('file', [LocalAsyncFS(ThreadPoolExecutor()),
-                                                    GoogleStorageAsyncFS(project=google_project)])
+
+        user_config = get_user_config()
+
+        if bucket is not None:
+            warnings.warn('Use of deprecated argument \'bucket\' in ServiceBackend(). Specify \'remote_tmpdir\' as a keyword argument instead.')
+
+        if remote_tmpdir is not None and bucket is not None:
+            raise ValueError('Cannot specify both \'remote_tmpdir\' and \'bucket\' in ServiceBackend(). Specify \'remote_tmpdir\' as a keyword argument instead.')
+
+        if bucket is None and remote_tmpdir is None:
+            remote_tmpdir = user_config.get('batch', 'remote_tmpdir', fallback=None)
 
         if remote_tmpdir is None:
             if bucket is None:
-                bucket = get_user_config().get('batch', 'bucket', fallback=None)
+                bucket = user_config.get('batch', 'bucket', fallback=None)
+                warnings.warn('Using deprecated configuration setting \'batch\\bucket\'. Run `hailctl config set batch/remote_tmpdir` '
+                              'to set the default for \'remote_tmpdir\' instead.')
             if bucket is None:
                 raise ValueError(
-                    'either the bucket or remote_tmpdir parameter of ServiceBackend '
-                    'must be set or run `hailctl config set batch/bucket MY_BUCKET`')
+                    'The \'remote_tmpdir\' parameter of ServiceBackend must be set. '
+                    'Run `hailctl config set batch/remote_tmpdir REMOTE_TMPDIR`')
             if 'gs://' in bucket:
                 raise ValueError(
                     'The bucket parameter to ServiceBackend() should be a bucket name, not a path. '
                     'Use the remote_tmpdir parameter to specify a path.')
             remote_tmpdir = f'gs://{bucket}/batch'
         else:
-            if not remote_tmpdir.startswith('gs://'):
+            schemes = {'gs', 'hail-az', 's3'}
+            found_scheme = any([remote_tmpdir.startswith(f'{scheme}://') for scheme in schemes])
+            if not found_scheme:
                 raise ValueError(
-                    'remote_tmpdir must be a google storage path like gs://bucket/folder')
+                    f'remote_tmpdir must be a storage uri path like gs://bucket/folder. Possible schemes include {schemes}')
         if remote_tmpdir[-1] != '/':
             remote_tmpdir += '/'
         self.remote_tmpdir = remote_tmpdir
+
+        self.__fs: AsyncFS = RouterAsyncFS('file', [LocalAsyncFS(ThreadPoolExecutor()),
+                                                    GoogleStorageAsyncFS(project=google_project)])
 
     @property
     def _fs(self):

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -426,7 +426,7 @@ class ServiceBackend(Backend[bc.Batch]):
                     'Use the remote_tmpdir parameter to specify a path.')
             remote_tmpdir = f'gs://{bucket}/batch'
         else:
-            schemes = {'gs', 'hail-az', 's3'}
+            schemes = {'gs'}
             found_scheme = any([remote_tmpdir.startswith(f'{scheme}://') for scheme in schemes])
             if not found_scheme:
                 raise ValueError(

--- a/hail/python/hailtop/batch/docs/service.rst
+++ b/hail/python/hailtop/batch/docs/service.rst
@@ -222,19 +222,19 @@ and execute the following batch:
 .. code-block:: python
 
     >>> import hailtop.batch as hb # doctest: +SKIP
-    >>> backend = hb.ServiceBackend('my-billing-project', 'my-bucket') # doctest: +SKIP
+    >>> backend = hb.ServiceBackend('my-billing-project', remote_tmpdir='gs://my-bucket/batch/tmp/') # doctest: +SKIP
     >>> b = hb.Batch(backend=backend, name='test') # doctest: +SKIP
     >>> j = b.new_job(name='hello') # doctest: +SKIP
     >>> j.command('echo "hello world"') # doctest: +SKIP
     >>> b.run(open=True) # doctest: +SKIP
 
-You may elide the ``billing_project`` and ``bucket`` parameters if you
+You may elide the ``billing_project`` and ``remote_tmpdir`` parameters if you
 have previously set them with ``hailctl``:
 
 .. code-block:: sh
 
     hailctl config set batch/billing_project my-billing-project
-    hailctl config set batch/bucket my-bucket
+    hailctl config set batch/remote_tmpdir my-remote-tmpdir
 
 .. note::
 

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -9,7 +9,7 @@ validations = {
     ('batch', 'bucket'): (lambda x: re.fullmatch(r'[^:/\s]+', x) is not None,
                           'should be valid Google Bucket identifier, with no gs:// prefix'),
     ('batch', 'remote_tmpdir'): (lambda x: any([re.fullmatch(fr'^{scheme}://.*', x) is not None for scheme in {'gs', 's3', 'hail-az'}]),
-                                               'should be valid cloud storage URI such as gs://my-bucket/batch-tmp/'),
+                                 'should be valid cloud storage URI such as gs://my-bucket/batch-tmp/'),
     ('email',): (lambda x: re.fullmatch(r'.+@.+', x) is not None, 'should be valid email address')
 }
 

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -1,13 +1,20 @@
 import sys
 import argparse
 import re
+import warnings
 
 from hailtop.config import get_user_config, get_user_config_path
 
 validations = {
     ('batch', 'bucket'): (lambda x: re.fullmatch(r'[^:/\s]+', x) is not None,
                           'should be valid Google Bucket identifier, with no gs:// prefix'),
+    ('batch', 'remote_tmpdir'): (lambda x: any([re.fullmatch(fr'^{scheme}://.*', x) is not None for scheme in {'gs', 's3', 'hail-az'}]),
+                                               'should be valid cloud storage URI such as gs://my-bucket/batch-tmp/'),
     ('email',): (lambda x: re.fullmatch(r'.+@.+', x) is not None, 'should be valid email address')
+}
+
+deprecated_paths = {
+    ('batch', 'bucket'): '\'batch/bucket\' has been deprecated. Use \'batch/remote_tmpdir\' instead.'
 }
 
 
@@ -108,10 +115,13 @@ A parameter with more than one slash is invalid, for example:
         sys.exit(1)
 
     if args.module == 'set':
-        validation_func, msg = validations.get(tuple(path), (lambda x: True, ''))
+        path = tuple(path)
+        validation_func, msg = validations.get(path, (lambda x: True, ''))
         if not validation_func(args.value):
             print(f"Error: bad value {args.value!r} for parameter {args.parameter!r} {msg}", file=sys.stderr)
             sys.exit(1)
+        if path in deprecated_paths:
+            warnings.warn(deprecated_paths[path])
         if section not in config:
             config[section] = dict()
         config[section][key] = args.value

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -5,8 +5,7 @@ import subprocess as sp
 import tempfile
 from shlex import quote as shq
 import uuid
-import google.oauth2.service_account
-import google.cloud.storage
+import re
 
 from hailtop.batch import Batch, ServiceBackend, LocalBackend
 from hailtop.batch.exceptions import BatchException
@@ -14,6 +13,8 @@ from hailtop.batch.globals import arg_max
 from hailtop.utils import grouped
 from hailtop.config import get_user_config
 from hailtop.batch.utils import concatenate
+from hailtop.aiocloud import aiogoogle, aioazure
+from hailtop.aiotools import RouterAsyncFS
 
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
@@ -399,31 +400,37 @@ class ServiceTests(unittest.TestCase):
     def setUp(self):
         self.backend = ServiceBackend()
 
-        self.bucket_name = get_user_config().get('batch', 'bucket')
+        remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
+        if not remote_tmpdir.endswith('/'):
+            remote_tmpdir += '/'
+        self.remote_tmpdir = remote_tmpdir
 
-        self.gcs_input_dir = f'gs://{self.bucket_name}/batch-tests/resources'
+        if remote_tmpdir.startswith('gs://'):
+            self.bucket_name = re.fullmatch('gs://(?P<bucket_name>[^/]+).*', remote_tmpdir).groupdict()['bucket_name']
+        else:
+            self.bucket_name = None
+
+        self.cloud_input_dir = f'{self.remote_tmpdir}batch-tests/resources'
 
         token = uuid.uuid4()
-        self.gcs_output_path = f'/batch-tests/{token}'
-        self.gcs_output_dir = f'gs://{self.bucket_name}{self.gcs_output_path}'
+        self.cloud_output_path = f'/batch-tests/{token}'
+        self.cloud_output_dir = f'{self.remote_tmpdir}{self.cloud_output_path}'
 
         in_cluster_key_file = '/test-gsa-key/key.json'
-        if os.path.exists(in_cluster_key_file):
-            credentials = google.oauth2.service_account.Credentials.from_service_account_file(
-                in_cluster_key_file)
-        else:
-            credentials = None
-        gcs_client = google.cloud.storage.Client(project='hail-vdc', credentials=credentials)
-        bucket = gcs_client.bucket(self.bucket_name)
-        if not bucket.blob('batch-tests/resources/hello.txt').exists():
-            bucket.blob('batch-tests/resources/hello.txt').upload_from_string(
-                'hello world')
-        if not bucket.blob('batch-tests/resources/hello spaces.txt').exists():
-            bucket.blob('batch-tests/resources/hello spaces.txt').upload_from_string(
-                'hello')
-        if not bucket.blob('batch-tests/resources/hello (foo) spaces.txt').exists():
-            bucket.blob('batch-tests/resources/hello (foo) spaces.txt').upload_from_string(
-                'hello')
+        if not os.path.exists(in_cluster_key_file):
+            in_cluster_key_file = None
+
+        # FIXME: Make this lazy
+        router_fs = RouterAsyncFS('gs', [
+            aiogoogle.GoogleStorageAsyncFS(project='hail-vdc', credentials_file=in_cluster_key_file),
+        ])
+
+        if not await router_fs.exists(f'{self.remote_tmpdir}batch-tests/resources/hello.txt'):
+            await router_fs.write(f'{self.remote_tmpdir}batch-tests/resources/hello.txt', b'hello world')
+        if not await router_fs.exists(f'{self.remote_tmpdir}batch-tests/resources/hello spaces.txt'):
+            await router_fs.write(f'{self.remote_tmpdir}batch-tests/resources/hello spaces.txt', b'hello')
+        if not await router_fs.exists(f'{self.remote_tmpdir}batch-tests/resources/hello (foo) spaces.txt'):
+            await router_fs.write(f'{self.remote_tmpdir}batch-tests/resources/hello (foo) spaces.txt', b'hello')
 
     def tearDown(self):
         self.backend.close()
@@ -447,7 +454,7 @@ class ServiceTests(unittest.TestCase):
 
     def test_single_task_input(self):
         b = self.batch()
-        input = b.read_input(f'{self.gcs_input_dir}/hello.txt')
+        input = b.read_input(f'{self.cloud_input_dir}/hello.txt')
         j = b.new_job()
         j.command(f'cat {input}')
         res = b.run()
@@ -456,7 +463,7 @@ class ServiceTests(unittest.TestCase):
 
     def test_single_task_input_resource_group(self):
         b = self.batch()
-        input = b.read_input_group(foo=f'{self.gcs_input_dir}/hello.txt')
+        input = b.read_input_group(foo=f'{self.cloud_input_dir}/hello.txt')
         j = b.new_job()
         j.storage('10Gi')
         j.command(f'cat {input.foo}')
@@ -477,7 +484,7 @@ class ServiceTests(unittest.TestCase):
         b = self.batch()
         j = b.new_job()
         j.command(f'echo hello > {j.ofile}')
-        b.write_output(j.ofile, f'{self.gcs_output_dir}/test_single_task_output.txt')
+        b.write_output(j.ofile, f'{self.cloud_output_dir}/test_single_task_output.txt')
         res = b.run()
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
@@ -496,14 +503,14 @@ class ServiceTests(unittest.TestCase):
         j = b.new_job()
         j.declare_resource_group(output={'foo': '{root}.foo'})
         j.command(f'echo "hello" > {j.output.foo}')
-        b.write_output(j.output, f'{self.gcs_output_dir}/test_single_task_write_resource_group')
-        b.write_output(j.output.foo, f'{self.gcs_output_dir}/test_single_task_write_resource_group_file.txt')
+        b.write_output(j.output, f'{self.cloud_output_dir}/test_single_task_write_resource_group')
+        b.write_output(j.output.foo, f'{self.cloud_output_dir}/test_single_task_write_resource_group_file.txt')
         res = b.run()
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
 
     def test_multiple_dependent_tasks(self):
-        output_file = f'{self.gcs_output_dir}/test_multiple_dependent_tasks.txt'
+        output_file = f'{self.cloud_output_dir}/test_multiple_dependent_tasks.txt'
         b = self.batch()
         j = b.new_job()
         j.command(f'echo "0" >> {j.ofile}')
@@ -556,10 +563,10 @@ class ServiceTests(unittest.TestCase):
 
     def test_file_name_space(self):
         b = self.batch()
-        input = b.read_input(f'{self.gcs_input_dir}/hello (foo) spaces.txt')
+        input = b.read_input(f'{self.cloud_input_dir}/hello (foo) spaces.txt')
         j = b.new_job()
         j.command(f'cat {input} > {j.ofile}')
-        b.write_output(j.ofile, f'{self.gcs_output_dir}/hello (foo) spaces.txt')
+        b.write_output(j.ofile, f'{self.cloud_output_dir}/hello (foo) spaces.txt')
         res = b.run()
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
@@ -568,21 +575,22 @@ class ServiceTests(unittest.TestCase):
         b = self.batch()
         j = b.new_job()
         j.command(f'echo hello > {j.ofile}')
-        b.write_output(j.ofile, f'{self.gcs_output_dir}/test_single_job_output.txt')
+        b.write_output(j.ofile, f'{self.cloud_output_dir}/test_single_job_output.txt')
         b.run(dry_run=True)
 
     def test_verbose(self):
         b = self.batch()
-        input = b.read_input(f'{self.gcs_input_dir}/hello.txt')
+        input = b.read_input(f'{self.cloud_input_dir}/hello.txt')
         j = b.new_job()
         j.command(f'cat {input}')
-        b.write_output(input, f'{self.gcs_output_dir}/hello.txt')
+        b.write_output(input, f'{self.cloud_output_dir}/hello.txt')
         res = b.run(verbose=True)
         res_status = res.status()
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
 
     def test_gcsfuse(self):
-        path = f'/{self.bucket_name}{self.gcs_output_path}'
+        assert self.bucket_name
+        path = f'/{self.bucket_name}{self.cloud_output_path}'
 
         b = self.batch()
         head = b.new_job()
@@ -599,7 +607,8 @@ class ServiceTests(unittest.TestCase):
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
 
     def test_gcsfuse_read_only(self):
-        path = f'/{self.bucket_name}{self.gcs_output_path}'
+        assert self.bucket_name
+        path = f'/{self.bucket_name}{self.cloud_output_path}'
 
         b = self.batch()
         j = b.new_job()
@@ -611,7 +620,8 @@ class ServiceTests(unittest.TestCase):
         assert res_status['state'] == 'failure', str((res_status, res.debug_info()))
 
     def test_gcsfuse_implicit_dirs(self):
-        path = f'/{self.bucket_name}{self.gcs_output_path}'
+        assert self.bucket_name
+        path = f'/{self.bucket_name}{self.cloud_output_path}'
 
         b = self.batch()
         head = b.new_job()
@@ -628,6 +638,7 @@ class ServiceTests(unittest.TestCase):
         assert res_status['state'] == 'success', str((res_status, res.debug_info()))
 
     def test_gcsfuse_empty_string_bucket_fails(self):
+        assert self.bucket_name
         b = self.batch()
         j = b.new_job()
         with self.assertRaises(BatchException):
@@ -663,7 +674,7 @@ class ServiceTests(unittest.TestCase):
         combine = b.new_job(f'combine_output').cpu(0.25)
         for tasks in grouped(arg_max(), jobs):
             combine.command(f'cat {" ".join(shq(j.ofile) for j in jobs)} >> {combine.ofile}')
-        b.write_output(combine.ofile, f'{self.gcs_output_dir}/pipeline_benchmark_test.txt')
+        b.write_output(combine.ofile, f'{self.cloud_output_dir}/pipeline_benchmark_test.txt')
         # too slow
         # assert b.run().status()['state'] == 'success'
 
@@ -706,8 +717,8 @@ class ServiceTests(unittest.TestCase):
 
     def test_input_directory(self):
         b = self.batch()
-        input1 = b.read_input(self.gcs_input_dir)
-        input2 = b.read_input(self.gcs_input_dir.rstrip('/') + '/')
+        input1 = b.read_input(self.cloud_input_dir)
+        input2 = b.read_input(self.cloud_input_dir.rstrip('/') + '/')
         j = b.new_job()
         j.command(f'ls {input1}/hello.txt')
         j.command(f'ls {input2}/hello.txt')

--- a/hail/python/test/hailtop/batch/test_batch.py
+++ b/hail/python/test/hailtop/batch/test_batch.py
@@ -13,13 +13,12 @@ from hailtop.batch.globals import arg_max
 from hailtop.utils import grouped
 from hailtop.config import get_user_config
 from hailtop.batch.utils import concatenate
-from hailtop.aiocloud import aiogoogle, aioazure
+from hailtop.aiocloud import aiogoogle
 from hailtop.aiotools import RouterAsyncFS
 
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 PYTHON_DILL_IMAGE = os.environ['PYTHON_DILL_IMAGE']
-HAIL_TEST_GCS_BUCKET = os.environ['HAIL_TEST_GCS_BUCKET']
 
 
 class LocalTests(unittest.TestCase):
@@ -855,17 +854,8 @@ class ServiceTests(unittest.TestCase):
         job_status = res.get_job(2).status()
         assert job_status['state'] == 'Cancelled', str((job_status, res.debug_info()))
 
-    def test_service_backend_bucket_parameter(self):
-        backend = ServiceBackend(bucket=HAIL_TEST_GCS_BUCKET)
-        b = Batch(backend=backend)
-        j1 = b.new_job()
-        j1.command(f'echo hello > {j1.ofile}')
-        j2 = b.new_job()
-        j2.command(f'cat {j1.ofile}')
-        b.run()
-
     def test_service_backend_remote_tempdir_with_trailing_slash(self):
-        backend = ServiceBackend(remote_tmpdir=f'gs://{HAIL_TEST_GCS_BUCKET}/temporary-files/')
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files/')
         b = Batch(backend=backend)
         j1 = b.new_job()
         j1.command(f'echo hello > {j1.ofile}')
@@ -874,7 +864,7 @@ class ServiceTests(unittest.TestCase):
         b.run()
 
     def test_service_backend_remote_tempdir_with_no_trailing_slash(self):
-        backend = ServiceBackend(remote_tmpdir=f'gs://{HAIL_TEST_GCS_BUCKET}/temporary-files/')
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
         b = Batch(backend=backend)
         j1 = b.new_job()
         j1.command(f'echo hello > {j1.ofile}')
@@ -883,7 +873,7 @@ class ServiceTests(unittest.TestCase):
         b.run()
 
     def test_large_command(self):
-        backend = ServiceBackend(remote_tmpdir=f'gs://{HAIL_TEST_GCS_BUCKET}/temporary-files')
+        backend = ServiceBackend(remote_tmpdir=f'{self.remote_tmpdir}/temporary-files')
         b = Batch(backend=backend)
         j1 = b.new_job()
         long_str = secrets.token_urlsafe(15 * 1024)

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -35,10 +35,7 @@ class Tests(unittest.TestCase):
         remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
         token = uuid.uuid4()
         self.test_path = f'{remote_tmpdir}memory-tests/{token}'
-
-        self.fs = RouterAsyncFS('gs', [
-            aiogoogle.GoogleStorageAsyncFS(project=PROJECT)
-        ])
+        self.fs = RouterAsyncFS('gs', [aiogoogle.GoogleStorageAsyncFS(project=PROJECT)])
         self.client = BlockingMemoryClient(fs=self.fs)
         self.temp_files = set()
 

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -2,9 +2,10 @@ import unittest
 import uuid
 from memory.client import MemoryClient
 
-from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS
+from hailtop.aiocloud import aiogoogle
 from hailtop.config import get_user_config
 from hailtop.utils import async_to_blocking
+from hailtop.aiotools import RouterAsyncFS
 
 from gear.cloud_config import get_gcp_config
 
@@ -31,11 +32,13 @@ class BlockingMemoryClient:
 
 class Tests(unittest.TestCase):
     def setUp(self):
-        bucket_name = get_user_config().get('batch', 'bucket')
+        remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
         token = uuid.uuid4()
-        self.test_path = f'gs://{bucket_name}/memory-tests/{token}'
+        self.test_path = f'{remote_tmpdir}memory-tests/{token}'
 
-        self.fs = GoogleStorageAsyncFS(project=PROJECT)
+        self.fs = RouterAsyncFS('gs', [
+            aiogoogle.GoogleStorageAsyncFS(project=PROJECT)
+        ])
         self.client = BlockingMemoryClient(fs=self.fs)
         self.temp_files = set()
 


### PR DESCRIPTION
I did not fix the Hail version of the Service backend. I didn't quite understand where bucket was being used and it's not on the critical path for Azure.