### PR TITLE
[batch] Use higher subnet range for job subnets

### DIFF
--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -181,14 +181,14 @@ DOCKER_PREFIX=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.int
 
 INTERNAL_GATEWAY_IP=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/internal_ip")
 
-# private job network = 172.34.0.0/16
-# public job network = 172.35.0.0/16
+# private job network = 172.20.0.0/16
+# public job network = 172.21.0.0/16
 # [all networks] Rewrite traffic coming from containers to masquerade as the host
-iptables --table nat --append POSTROUTING --source 172.34.0.0/15 --jump MASQUERADE
+iptables --table nat --append POSTROUTING --source 172.20.0.0/15 --jump MASQUERADE
 
 # [public]
 # Block public traffic to the metadata server
-iptables --append FORWARD --source 172.35.0.0/16 --destination 169.254.169.254 --jump DROP
+iptables --append FORWARD --source 172.21.0.0/16 --destination 169.254.169.254 --jump DROP
 # But allow the internal gateway
 iptables --append FORWARD --destination $INTERNAL_GATEWAY_IP --jump ACCEPT
 # And this worker

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -182,14 +182,14 @@ DOCKER_PREFIX=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.int
 
 INTERNAL_GATEWAY_IP=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/internal_ip")
 
-# private job network = 10.0.0.0/16
-# public job network = 10.1.0.0/16
+# private job network = 10.150.0.0/16
+# public job network = 10.151.0.0/16
 # [all networks] Rewrite traffic coming from containers to masquerade as the host
-iptables --table nat --append POSTROUTING --source 10.0.0.0/15 --jump MASQUERADE
+iptables --table nat --append POSTROUTING --source 10.150.0.0/15 --jump MASQUERADE
 
 # [public]
 # Block public traffic to the metadata server
-iptables --append FORWARD --source 10.1.0.0/16 --destination 169.254.169.254 --jump DROP
+iptables --append FORWARD --source 10.151.0.0/16 --destination 169.254.169.254 --jump DROP
 # But allow the internal gateway
 iptables --append FORWARD --destination $INTERNAL_GATEWAY_IP --jump ACCEPT
 # And this worker

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -7,8 +7,7 @@ from shlex import quote as shq
 
 from gear.cloud_config import get_global_config
 
-from ....batch_configuration import (DOCKER_ROOT_IMAGE, DOCKER_PREFIX, DEFAULT_NAMESPACE,
-                                     INTERNAL_GATEWAY_IP)
+from ....batch_configuration import DOCKER_ROOT_IMAGE, DOCKER_PREFIX, DEFAULT_NAMESPACE, INTERNAL_GATEWAY_IP
 from ....file_store import FileStore
 from ....instance_config import InstanceConfig
 from ...resource_utils import unreserved_worker_data_disk_size_gib
@@ -182,14 +181,14 @@ DOCKER_PREFIX=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.int
 
 INTERNAL_GATEWAY_IP=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/internal_ip")
 
-# private job network = 10.150.0.0/16
-# public job network = 10.151.0.0/16
+# private job network = 172.34.0.0/16
+# public job network = 172.35.0.0/16
 # [all networks] Rewrite traffic coming from containers to masquerade as the host
-iptables --table nat --append POSTROUTING --source 10.150.0.0/15 --jump MASQUERADE
+iptables --table nat --append POSTROUTING --source 172.34.0.0/15 --jump MASQUERADE
 
 # [public]
 # Block public traffic to the metadata server
-iptables --append FORWARD --source 10.151.0.0/16 --destination 169.254.169.254 --jump DROP
+iptables --append FORWARD --source 172.35.0.0/16 --destination 169.254.169.254 --jump DROP
 # But allow the internal gateway
 iptables --append FORWARD --destination $INTERNAL_GATEWAY_IP --jump ACCEPT
 # And this worker

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -170,11 +170,11 @@ class NetworkNamespace:
         self.veth_job = self.network_ns_name + '-job'
 
         if private:
-            self.host_ip = f'10.0.{subnet_index}.10'
-            self.job_ip = f'10.0.{subnet_index}.11'
+            self.host_ip = f'10.150.{subnet_index}.10'
+            self.job_ip = f'10.150.{subnet_index}.11'
         else:
-            self.host_ip = f'10.1.{subnet_index}.10'
-            self.job_ip = f'10.1.{subnet_index}.11'
+            self.host_ip = f'10.151.{subnet_index}.10'
+            self.job_ip = f'10.151.{subnet_index}.11'
 
         self.port = None
         self.host_port = None

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -170,11 +170,11 @@ class NetworkNamespace:
         self.veth_job = self.network_ns_name + '-job'
 
         if private:
-            self.host_ip = f'10.150.{subnet_index}.10'
-            self.job_ip = f'10.150.{subnet_index}.11'
+            self.host_ip = f'172.34.{subnet_index}.10'
+            self.job_ip = f'172.34.{subnet_index}.11'
         else:
-            self.host_ip = f'10.151.{subnet_index}.10'
-            self.job_ip = f'10.151.{subnet_index}.11'
+            self.host_ip = f'172.35.{subnet_index}.10'
+            self.job_ip = f'172.35.{subnet_index}.11'
 
         self.port = None
         self.host_port = None

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -170,11 +170,11 @@ class NetworkNamespace:
         self.veth_job = self.network_ns_name + '-job'
 
         if private:
-            self.host_ip = f'172.34.{subnet_index}.10'
-            self.job_ip = f'172.34.{subnet_index}.11'
+            self.host_ip = f'172.20.{subnet_index}.10'
+            self.job_ip = f'172.20.{subnet_index}.11'
         else:
-            self.host_ip = f'172.35.{subnet_index}.10'
-            self.job_ip = f'172.35.{subnet_index}.11'
+            self.host_ip = f'172.21.{subnet_index}.10'
+            self.job_ip = f'172.21.{subnet_index}.11'
 
         self.port = None
         self.host_port = None


### PR DESCRIPTION
Currently we use the `10.0.0.0/15` range to assign local IPs to jobs on a worker. This is problematic if other resources in our infrastructure collide with this range. Since these are low address ranges it is quite likely that this could happen, and indeed has happened to me in a dev project where the database was assigned a `10.1.x.x` ip and CI jobs that require database access could not run. I don't have a particularly good reason to pick `10.150.0.0/15` as the new range other than I have not seen anything else use it.