### PR TITLE
[ci] Add CI infrastructure for testing outside hail-vdc

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3137,7 +3137,7 @@ steps:
         "watched_branches": [["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true, true]]
       }
       EOF
-      kubectl -n {{ default_ns.name }} create secret generic deploy-config \
+      kubectl -n {{ default_ns.name }} create secret generic ci-config \
               --from-file=./ci-config.json \
               --save-config --dry-run=client -o yaml \
           | kubectl -n {{ default_ns.name }} apply -f -

--- a/build.yaml
+++ b/build.yaml
@@ -3147,6 +3147,7 @@ steps:
         valueFrom: default_ns.name
     scopes:
       - test
+      - dev
     dependsOn:
       - default_ns
       - base_image

--- a/build.yaml
+++ b/build.yaml
@@ -3124,6 +3124,33 @@ steps:
       - default_ns
       - base_image
       - merge_code
+  - kind: runImage
+    name: create_ci_config
+    image:
+      valueFrom: base_image.image
+    script: |
+      cat >/ci-config.json <<EOF
+      {
+        "github_context": "ci-test",
+        "storage_uri": "{{ global.test_storage_uri }}",
+        "deploy_steps": [],
+        "watched_branches": [["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true, true]]
+      }
+      EOF
+      kubectl -n {{ default_ns.name }} create secret generic deploy-config \
+              --from-file=./ci-config.json \
+              --save-config --dry-run=client -o yaml \
+          | kubectl -n {{ default_ns.name }} apply -f -
+    serviceAccount:
+      name: admin
+      namespace:
+        valueFrom: default_ns.name
+    scopes:
+      - test
+    dependsOn:
+      - default_ns
+      - base_image
+      - create_ci_test_repo
   - kind: deploy
     name: deploy_ci
     namespace:
@@ -3143,6 +3170,7 @@ steps:
       - deploy_auth
       - deploy_batch
       - create_ci_test_repo
+      - create_ci_config
       - deploy_ci_agent
       - create_certs
       - hail_buildkit_image

--- a/build.yaml
+++ b/build.yaml
@@ -3129,18 +3129,13 @@ steps:
     image:
       valueFrom: base_image.image
     script: |
-      cat >/ci-config.json <<EOF
-      {
-        "github_context": "ci-test",
-        "storage_uri": "{{ global.test_storage_uri }}",
-        "deploy_steps": [],
-        "watched_branches": [["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true, true]]
-      }
-      EOF
       kubectl -n {{ default_ns.name }} create secret generic ci-config \
-              --from-file=./ci-config.json \
-              --save-config --dry-run=client -o yaml \
-          | kubectl -n {{ default_ns.name }} apply -f -
+          --from-literal=github_context="ci-test" \
+          --from-literal=storage_uri="{{ global.test_storage_uri }}" \
+          --from-literal=deploy_steps="[]" \
+          --from-literal=watched_branches="[[\"hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master\", true, true]]" \
+          --save-config --dry-run=client -o yaml \
+        | kubectl -n {{ default_ns.name }} apply -f -
     serviceAccount:
       name: admin
       namespace:

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -40,8 +40,8 @@ uvloop.install()
 deploy_config = get_deploy_config()
 
 watched_branches: List[WatchedBranch] = [
-    WatchedBranch(index, FQBranch.from_short_str(bss), deployable)
-    for (index, [bss, deployable]) in enumerate(json.loads(os.environ.get('HAIL_WATCHED_BRANCHES', '[]')))
+    WatchedBranch(index, FQBranch.from_short_str(bss), deployable, mergeable)
+    for (index, [bss, deployable, mergeable]) in enumerate(json.loads(os.environ.get('HAIL_WATCHED_BRANCHES', '[]')))
 ]
 
 routes = web.RouteTableDef()

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -1,7 +1,8 @@
 from typing import Optional, List
+import os
 
 GITHUB_CLONE_URL = 'https://github.com/'
-GITHUB_STATUS_CONTEXT = 'ci-test'
+GITHUB_STATUS_CONTEXT = os.environ["HAIL_CI_GITHUB_CONTEXT"]
 SERVICES_TEAM = 'Services'
 COMPILER_TEAM = 'Compiler'
 TEAMS = [SERVICES_TEAM, COMPILER_TEAM]

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -1,3 +1,4 @@
+import json
 import os
 from gear.cloud_config import get_global_config
 
@@ -15,3 +16,4 @@ DEFAULT_NAMESPACE = global_config['default_namespace']
 CI_UTILS_IMAGE = os.environ['HAIL_CI_UTILS_IMAGE']
 BUILDKIT_IMAGE = os.environ['HAIL_BUILDKIT_IMAGE']
 STORAGE_URI = os.environ['HAIL_CI_STORAGE_URI']
+DEPLOY_STEPS = tuple(json.loads(os.environ.get('DEPLOY_STEPS', '[]')))

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -17,6 +17,7 @@ from hailtop.utils import check_shell, check_shell_output, RETRY_FUNCTION_SCRIPT
 from .constants import GITHUB_CLONE_URL, AUTHORIZED_USERS, GITHUB_STATUS_CONTEXT, SERVICES_TEAM, COMPILER_TEAM
 from .build import BuildConfiguration, Code
 from .globals import is_test_deployment
+from .environment import DEPLOY_STEPS
 
 
 repos_lock = asyncio.Lock()
@@ -596,10 +597,11 @@ git merge {shq(self.source_sha)} -m 'merge PR'
 
 
 class WatchedBranch(Code):
-    def __init__(self, index, branch, deployable):
+    def __init__(self, index, branch, deployable, mergeable):
         self.index = index
         self.branch = branch
         self.deployable = deployable
+        self.mergeable = mergeable
 
         self.prs: Optional[Dict[str, PR]] = None
         self.sha = None
@@ -678,12 +680,14 @@ class WatchedBranch(Code):
                 if self.state_changed:
                     self.state_changed = False
                     await self._heal(batch_client, dbpool, gh)
-                    await self.try_to_merge(gh)
+                    if self.mergeable:
+                        await self.try_to_merge(gh)
         finally:
             log.info(f'update done {self.short_str()}')
             self.updating = False
 
     async def try_to_merge(self, gh):
+        assert self.mergeable
         for pr in self.prs.values():
             if pr.is_mergeable():
                 if await pr.merge(gh):
@@ -847,7 +851,7 @@ mkdir -p {shq(repo_dir)}
 '''
             )
             with open(f'{repo_dir}/build.yaml', 'r') as f:
-                config = BuildConfiguration(self, f.read(), scope='deploy')
+                config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')
             deploy_batch = batch_client.create_batch(

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -45,14 +45,10 @@ spec:
            - name: HAIL_CI_OAUTH_TOKEN
              value: /secrets/oauth-token/oauth-token
            - name: HAIL_CI_GITHUB_CONTEXT
-{% if deploy %}
              valueFrom:
                secretKeyRef:
                  name: ci-config
                  key: github_context
-{% else %}
-             value: "ci-test"
-{% endif %}
            - name: HAIL_WATCHED_BRANCHES
              valueFrom:
                secretKeyRef:

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -45,10 +45,14 @@ spec:
            - name: HAIL_CI_OAUTH_TOKEN
              value: /secrets/oauth-token/oauth-token
            - name: HAIL_CI_GITHUB_CONTEXT
+{% if deploy %}
              valueFrom:
                secretKeyRef:
                  name: ci-config
                  key: github_context
+{% else %}
+             value: "ci-test"
+{% endif %}
            - name: HAIL_WATCHED_BRANCHES
 {% if deploy %}
              valueFrom:

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -54,23 +54,20 @@ spec:
              value: "ci-test"
 {% endif %}
            - name: HAIL_WATCHED_BRANCHES
-{% if deploy %}
              valueFrom:
                secretKeyRef:
                  name: ci-config
                  key: watched_branches
-{% else %}
-             value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true, true]]'
-{% endif %}
            - name: HAIL_CI_DEPLOY_STEPS
-{% if deploy %}
              valueFrom:
                secretKeyRef:
                  name: ci-config
                  key: deploy_steps
-{% else %}
-             value: '[]'
-{% endif %}
+           - name: HAIL_CI_STORAGE_URI
+             valueFrom:
+               secretKeyRef:
+                 name: ci-config
+                 key: storage_uri
            - name: HAIL_DOCKER_PREFIX
              valueFrom:
                secretKeyRef:
@@ -97,16 +94,6 @@ spec:
              value: "{{ hail_buildkit_image.image }}"
            - name: HAIL_DEFAULT_NAMESPACE
              value: "{{ default_ns.name }}"
-           - name: HAIL_CI_STORAGE_URI
-             valueFrom:
-               secretKeyRef:
-{% if deploy %}
-                 name: ci-config
-                 key: storage_uri
-{% else %}
-                 name: global-config
-                 key: test_storage_uri
-{% endif %}
           ports:
             - containerPort: 5000
           volumeMounts:

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -44,12 +44,28 @@ spec:
              value: /deploy-config/deploy-config.json
            - name: HAIL_CI_OAUTH_TOKEN
              value: /secrets/oauth-token/oauth-token
+           - name: HAIL_CI_GITHUB_CONTEXT
+             valueFrom:
+               secretKeyRef:
+                 name: ci-config
+                 key: github_context
+           - name: HAIL_WATCHED_BRANCHES
 {% if deploy %}
-           - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-is/hail:main",true]]'
+             valueFrom:
+               secretKeyRef:
+                 name: ci-config
+                 key: watched_branches
 {% else %}
-           - name: HAIL_WATCHED_BRANCHES
-             value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true]]'
+             value: '[["hail-ci-test/ci-test-{{create_ci_test_repo.token}}:master", true, true]]'
+{% endif %}
+           - name: HAIL_CI_DEPLOY_STEPS
+{% if deploy %}
+             valueFrom:
+               secretKeyRef:
+                 name: ci-config
+                 key: deploy_steps
+{% else %}
+             value: '[]'
 {% endif %}
            - name: HAIL_DOCKER_PREFIX
              valueFrom:
@@ -78,11 +94,12 @@ spec:
            - name: HAIL_DEFAULT_NAMESPACE
              value: "{{ default_ns.name }}"
            - name: HAIL_CI_STORAGE_URI
-{% if deploy %}
-             value: "gs://hail-ci-bpk3h"
-{% else %}
              valueFrom:
                secretKeyRef:
+{% if deploy %}
+                 name: ci-config
+                 key: storage_uri
+{% else %}
                  name: global-config
                  key: test_storage_uri
 {% endif %}

--- a/infra/gcp/ci/main.tf
+++ b/infra/gcp/ci/main.tf
@@ -1,0 +1,61 @@
+module "bucket" {
+  source        = "../gcs_bucket"
+  short_name    = "hail-ci"
+  location      = var.bucket_location
+  storage_class = var.bucket_storage_class
+}
+
+resource "google_storage_bucket_iam_member" "ci_bucket_admin" {
+  bucket = module.bucket.name
+  role = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.ci_email}"
+}
+
+resource "google_storage_bucket_iam_member" "ci_gcr_admin" {
+  bucket = var.container_registry_id
+  role = "roles/storage.admin"
+  member = "serviceAccount:${var.ci_email}"
+}
+
+resource "kubernetes_secret" "ci_config" {
+  metadata {
+    name = "ci-config"
+  }
+
+  data = {
+    storage_uri      = "gs://${module.bucket.name}"
+    deploy_steps     = jsonencode(var.deploy_steps)
+    watched_branches = jsonencode(var.watched_branches)
+    github_context   = var.github_context
+  }
+}
+
+resource "kubernetes_secret" "zulip_config" {
+  metadata {
+    name = "zulip-config"
+  }
+
+  data = {
+    ".zuliprc" = file("~/.hail/.zuliprc")
+  }
+}
+
+resource "kubernetes_secret" "hail_ci_0_1_github_oauth_token" {
+  metadata {
+    name = "hail-ci-0-1-github-oauth-token"
+  }
+
+  data = {
+    "oauth-token" = var.github_oauth_token
+  }
+}
+
+resource "kubernetes_secret" "hail_ci_0_1_service_account_key" {
+  metadata {
+    name = "hail-ci-0-1-service-account-key"
+  }
+
+  data = {
+    "user1" = var.github_user1_oauth_token
+  }
+}

--- a/infra/gcp/ci/variables.tf
+++ b/infra/gcp/ci/variables.tf
@@ -1,0 +1,35 @@
+variable "github_oauth_token" {
+  type = string
+}
+
+variable "github_user1_oauth_token" {
+  type = string
+}
+
+variable "bucket_location" {
+  type = string
+}
+
+variable "bucket_storage_class" {
+  type = string
+}
+
+variable "watched_branches" {
+  type = list(tuple([string, bool, bool]))
+}
+
+variable "deploy_steps" {
+  type = list(string)
+}
+
+variable "ci_email" {
+  type = string
+}
+
+variable "container_registry_id" {
+  type = string
+}
+
+variable "github_context" {
+  type = string
+}

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -180,7 +180,7 @@ CASE
   ELSE NULL
 END AS source
 FROM `broad-ctsa.hail_billing.gcp_billing_export_v1_0055E5_9CA197_B9B894`
-WHERE DATE(_PARTITIONTIME) >= "{start_str}" AND DATE(_PARTITIONTIME) <= "{end_str}" AND project.name = "hail-vdc" AND invoice.month = "{invoice_month}"
+WHERE DATE(_PARTITIONTIME) >= "{start_str}" AND DATE(_PARTITIONTIME) <= "{end_str}" AND project.name = "{PROJECT}" AND invoice.month = "{invoice_month}"
 GROUP BY service_id, service_description, sku_id, sku_description, source;
 '''
 


### PR DESCRIPTION
This introduces the necessary pieces of infrastructure to run CI in GCP and a couple of small changes such that it can run as a secondary CI. This is currently failing because one of the secrets I introduce here in the terraform does not exist in hail-vdc. If you approve of the approach I can add it in manually. 

##  Terraform changes
This adds a new CI terraform module that adds a CI bucket, sets some permissions for the CI service account and adds some K8s secrets like github tokens and the zulip config. This allows the terraform deployment to optionally include resources needed for CI. This was the best way I could think to introduce this infra with the least changes, but it's not what I want in the long term. Right now we have one monolithic root module that includes all the resources necessary to run batch, with the option for tacking on CI. I would rather extract most of our root module into a `batch` module (and while we're break down the innards into modules like vdc, db, etc.) and have the root module be something that can be easily pieced together from the library of modules. This would be a decently big refactor and more importantly would require existing deployments to manually overhaul their terraform state, so it's something I want to do carefully but also sooner is better than later. Given how terraform state is indexed, I believe more modularity will be easier to manage in the long term.

## CI changes
This adds the following features to CI
- Watched branches can be marked as `mergeable`. `mergeable=true` should be the default behavior and `false` prevents CI from merging a PR on GitHub. This allows multiple CI's to run tests in different environments without stepping on each others' toes. This *does not*, however, consider statuses from multiple CIs when making the decision to merge a PR. That is currently based on the build status, and later should be changed to consider the collection of statuses on GitHub.
- Custom Deploy Steps: This is a collection of build.yaml steps that CI should run on `deploy`. This allows a deployment to only deploy a subset of the infrastructure to default, though it will run the entire test suite. Based on the semantics, `requested_step_names`, the empty list will deploy everything.
- Custom github context: This is just so CIs running in different clouds/environments don't step on each other in the GitHub statuses.