### PR TITLE
[auth] fix tokens

### DIFF
--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -46,7 +46,7 @@ def get_userinfo(deploy_config=None, session_id=None, client_session=None):
 
 def namespace_auth_headers(deploy_config: DeployConfig,
                            ns: str,
-                           authorize_target = True,
+                           authorize_target: bool = True,
                            *,
                            token_file: Optional[str] = None
                            ) -> Dict[str, str]:

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 import os
 import aiohttp
 from hailtop.config import get_deploy_config, DeployConfig
@@ -44,17 +44,26 @@ def get_userinfo(deploy_config=None, session_id=None, client_session=None):
         client_session=client_session))
 
 
-def namespace_auth_headers(deploy_config, ns, authorize_target=True, *, token_file=None):
-    tokens = get_tokens(token_file)
+def namespace_auth_headers(deploy_config: DeployConfig,
+                           ns: str,
+                           authorize_target = True,
+                           *,
+                           token_file: Optional[str] = None
+                           ) -> Dict[str, str]:
     headers = {}
     if authorize_target:
-        headers['Authorization'] = f'Bearer {tokens.namespace_token_or_error(ns)}'
+        headers['Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error(ns)}'
     if deploy_config.location() == 'external' and ns != 'default':
-        headers['X-Hail-Internal-Authorization'] = f'Bearer {tokens.namespace_token_or_error("default")}'
+        headers['X-Hail-Internal-Authorization'] = f'Bearer {get_tokens(token_file).namespace_token_or_error("default")}'
     return headers
 
 
-def service_auth_headers(deploy_config, service, authorize_target=True, *, token_file=None):
+def service_auth_headers(deploy_config: DeployConfig,
+                         service: str,
+                         authorize_target: bool = True,
+                         *,
+                         token_file: Optional[str] = None
+                         ) -> Dict[str, str]:
     ns = deploy_config.service_ns(service)
     return namespace_auth_headers(deploy_config, ns, authorize_target, token_file=token_file)
 

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -1,3 +1,4 @@
+from typing import Optional, Dict
 import base64
 import collections.abc
 import os
@@ -20,40 +21,40 @@ def session_id_decode_from_str(session_id_str: str) -> bytes:
 
 class Tokens(collections.abc.MutableMapping):
     @staticmethod
-    def get_tokens_file():
+    def get_tokens_file() -> str:
+        default_enduser_token_file = os.path.expanduser('~/.hail/tokens.json')
         return first_extant_file(
             os.environ.get('HAIL_TOKENS_FILE'),
-            os.path.expanduser('~/.hail/tokens.json'),
-            '/user-tokens/tokens.json'
-        )
+            default_enduser_token_file,
+            '/user-tokens/tokens.json',
+        ) or default_enduser_token_file
 
     @staticmethod
-    def default_tokens():
+    def default_tokens() -> 'Tokens':
         tokens_file = Tokens.get_tokens_file()
         if os.path.isfile(tokens_file):
             with open(tokens_file, 'r') as f:
                 log.info(f'tokens loaded from {tokens_file}')
                 return Tokens(json.load(f))
-        else:
-            log.info(f'tokens file not found: {tokens_file}')
-            return Tokens({})
+        log.info(f'tokens file not found: {tokens_file}')
+        return Tokens({})
 
     @staticmethod
-    def from_file(tokens_file):
+    def from_file(tokens_file: str) -> 'Tokens':
         with open(tokens_file, 'r') as f:
             log.info(f'tokens loaded from {tokens_file}')
             return Tokens(json.load(f))
 
-    def __init__(self, tokens):
+    def __init__(self, tokens: Dict[str, str]):
         self._tokens = tokens
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: str):
         self._tokens[key] = value
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> str:
         return self._tokens[key]
 
-    def namespace_token_or_error(self, ns):
+    def namespace_token_or_error(self, ns: str) -> str:
         if ns in self._tokens:
             return self._tokens[ns]
 
@@ -69,7 +70,7 @@ to obtain new credentials.
 ''')
         sys.exit(1)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str):
         del self._tokens[key]
 
     def __iter__(self):
@@ -78,17 +79,17 @@ to obtain new credentials.
     def __len__(self):
         return len(self._tokens)
 
-    def write(self):
+    def write(self) -> None:
         # restrict permissions to user
         with os.fdopen(os.open(self.get_tokens_file(), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), 'w') as f:
             json.dump(self._tokens, f)
 
 
-tokens = {}
-default_tokens = None
+tokens: Dict[str, Tokens] = {}
+default_tokens: Optional[Tokens] = None
 
 
-def get_tokens(file=None):
+def get_tokens(file: Optional[str] = None) -> Tokens:
     global tokens
     global default_tokens
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -52,7 +52,7 @@ def flatten(xxs):
     return [x for xs in xxs for x in xs]
 
 
-def first_extant_file(*files):
+def first_extant_file(*files: Optional[T]) -> Optional[T]:
     for f in files:
         if f is not None and os.path.isfile(f):
             return f

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -52,7 +52,7 @@ def flatten(xxs):
     return [x for xs in xxs for x in xs]
 
 
-def first_extant_file(*files: Optional[T]) -> Optional[T]:
+def first_extant_file(*files: Optional[str]) -> Optional[str]:
     for f in files:
         if f is not None and os.path.isfile(f):
             return f


### PR DESCRIPTION
1. Lazily load the tokens on the end user machine because the first time someone logs in to the default namespace, they will have no tokens.

2. Teach `get_tokens_file` to default to the default end-user location.

3. Add a bunch of types which would have caught this error.