### PR TITLE
[build.yaml] Add delete azure instances build step

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3879,7 +3879,7 @@ steps:
       - test_hailtop_batch_3
       - test_hailtop_batch_4
   - kind: runImage
-    name: delete_batch_instances
+    name: delete_gcp_batch_instances
     image:
       valueFrom: base_image.image
     alwaysRun: true
@@ -3905,6 +3905,54 @@ steps:
     scopes:
       - dev
       - test
+    clouds:
+      - gcp
+    dependsOn:
+      - default_ns
+      - base_image
+      - test_batch_invariants
+      - test_batch_0
+      - test_batch_1
+      - test_batch_2
+      - test_batch_3
+      - test_batch_4
+      - test_ci
+      - test_hailtop_batch_0
+      - test_hailtop_batch_1
+      - test_hailtop_batch_2
+      - test_hailtop_batch_3
+      - test_hailtop_batch_4
+  - kind: runImage
+    name: delete_azure_batch_instances
+    image: mcr.microsoft.com/azure-cli
+    alwaysRun: true
+    script: |
+      set -e
+      AZURE_USERNAME=$(jq -r '.appId' /test-gsa-key/key.json)
+      AZURE_PASSWORD=$(jq -r '.password' /test-gsa-key/key.json)
+      AZURE_TENANT_ID=$(jq -r '.tenant' /test-gsa-key/key.json)
+      AZURE_RESOURCE_GROUP="{{ global.azure_resource_group }}"
+      az login --username $AZURE_USERNAME --password $AZURE_PASSWORD --tenant $AZURE_TENANT_ID
+      set +e
+      az vm list --resource-group $AZURE_RESOURCE_GROUP -o tsv \
+          --query "[?tags.namespace == '{{ default_ns.name }}'].name"
+        | xargs -n1 -r sh -c 'az vm delete --resource-group $AZURE_RESOURCE_GROUP --name "$1" || true' argv0
+      az network nic list --resource-group $AZURE_RESOURCE_GROUP -o tsv \
+          --query "[?tags.namespace == '{{ default_ns.name }}'].name"
+        | xargs -n1 -r sh -c 'az network nic delete --resource-group $AZURE_RESOURCE_GROUP --name "$1" || true' argv0
+      az network public-ip list --resource-group $AZURE_RESOURCE_GROUP -o tsv \
+          --query "[?tags.namespace == '{{ default_ns.name }}'].name"
+        | xargs -n1 -r sh -c 'az network public-ip delete --resource-group $AZURE_RESOURCE_GROUP --name "$1" || true' argv0
+    secrets:
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    scopes:
+      - dev
+      - test
+    clouds:
+      - azure
     dependsOn:
       - default_ns
       - base_image


### PR DESCRIPTION
Stacked on #11057. I tested the query string and made sure the list commands worked. However, I did not test the actual delete with xargs. This was copied almost verbatim from the gcp delete instances step. I'm pretty sure by not adding the `-x` flag at the top of the script, the password won't be printed to the command line output in the logs, but I'm not 100% sure.

Also, for this to work, the test-gsa-key needs to be able to delete VM and network resources. Do we have this in GCP as well? I guess we must in order for Batch to be able to remove its instances.