### PR TITLE
[query] Use index counts rather than index iterator for reads

### DIFF
--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -201,13 +201,22 @@ class IndexReader(fs: FS,
     node.children(localIdx.toInt)
   }
 
+  def boundsByInterval(interval: Interval): (Long, Long) = {
+    boundsByInterval(interval.start, interval.end, interval.includesStart, interval.includesEnd)
+  }
+
+  def boundsByInterval(start: Annotation, end: Annotation, includesStart: Boolean, includesEnd: Boolean): (Long, Long) = {
+    require(Interval.isValid(ordering, start, end, includesStart, includesEnd))
+    val startIdx = if (includesStart) lowerBound(start) else upperBound(start)
+    val endIdx = if (includesEnd) upperBound(end) else lowerBound(end)
+    startIdx -> endIdx
+  }
+
   def queryByInterval(interval: Interval): Iterator[LeafChild] =
     queryByInterval(interval.start, interval.end, interval.includesStart, interval.includesEnd)
 
   def queryByInterval(start: Annotation, end: Annotation, includesStart: Boolean, includesEnd: Boolean): Iterator[LeafChild] = {
-    require(Interval.isValid(ordering, start, end, includesStart, includesEnd))
-    val startIdx = if (includesStart) lowerBound(start) else upperBound(start)
-    val endIdx = if (includesEnd) upperBound(end) else lowerBound(end)
+    val (startIdx, endIdx) = boundsByInterval(start, end, includesStart, includesEnd)
     iterator(startIdx, endIdx)
   }
 

--- a/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
+++ b/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
@@ -28,7 +28,9 @@ class MaybeIndexedReadZippedIterator(
 
   private[this] val startAndEnd = Option(idxr).map(_.boundsByInterval(bounds))
   private[this] val firstAnnotation = try {
-    startAndEnd.map { case (startIdx, _) => idxr.queryByIndex(startIdx) }
+    startAndEnd.flatMap { case (start, _) =>
+      if (idxr.nKeys == 0) None else Some(idxr.queryByIndex(start))
+    }
   } catch {
     case e: Exception =>
       if (idxr != null)

--- a/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
+++ b/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
@@ -26,7 +26,8 @@ class MaybeIndexedReadZippedIterator(
 
   private[this] var closed: Boolean = false
 
-  private[this] val idx = Option(idxr).map(_.queryByInterval(bounds).buffered)
+  private[this] val startAndEnd = Option(idxr).map(_.boundsByInterval(bounds))
+  private[this] var n = startAndEnd.map(x => x._2 - x._1)
 
   private[this] val trackedRowsIn = new ByteTrackingInputStream(isRows)
   private[this] val trackedEntriesIn = new ByteTrackingInputStream(isEntries)
@@ -35,10 +36,10 @@ class MaybeIndexedReadZippedIterator(
   private[this] val entriesIdxField = Option(entriesOffsetField).map { f => idxr.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
 
   private[this] val rows = try {
-    if (idx.forall(_.hasNext)) {
+    if (n.forall(_ > 0)) {
       val dec = mkRowsDec(trackedRowsIn)
-      idx.foreach { idx =>
-        val i = idx.head
+      startAndEnd.foreach { case (startIdx, _) =>
+        val i = idxr.queryByIndex(startIdx)
         val off = rowsIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
         dec.seek(off)
       }
@@ -61,8 +62,8 @@ class MaybeIndexedReadZippedIterator(
       null
     } else {
       val dec = mkEntriesDec(trackedEntriesIn)
-      idx.foreach { idx =>
-        val i = idx.head
+      startAndEnd.foreach { case (startIdx, _) =>
+        val i = idxr.queryByIndex(startIdx)
         val off = entriesIdxField.map { j => i.annotation.asInstanceOf[Row].getAs[Long](j) }.getOrElse(i.recordOffset)
         dec.seek(off)
       }
@@ -88,7 +89,7 @@ class MaybeIndexedReadZippedIterator(
 
   private var cont: Byte = if (rows != null) nextCont() else 0
 
-  def hasNext: Boolean = cont != 0 && idx.forall(_.hasNext)
+  def hasNext: Boolean = cont != 0 && n.forall(_ > 0)
 
   def next(): Long = _next()
 
@@ -96,8 +97,8 @@ class MaybeIndexedReadZippedIterator(
     if (!hasNext)
       throw new NoSuchElementException("next on empty iterator")
 
+    n = n.map(_ - 1)
     try {
-      idx.map(_.next())
       val rowOff = rows.readRegionValue(region)
       val entOff = entries.readRegionValue(region)
       val off = inserter(region, rowOff, entOff)

--- a/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
+++ b/hail/src/main/scala/is/hail/io/index/MaybeIndexedReadZippedIterator.scala
@@ -28,8 +28,8 @@ class MaybeIndexedReadZippedIterator(
 
   private[this] val startAndEnd = Option(idxr).map(_.boundsByInterval(bounds))
   private[this] val firstAnnotation = try {
-    startAndEnd.flatMap { case (start, _) =>
-      if (idxr.nKeys == 0) None else Some(idxr.queryByIndex(start))
+    startAndEnd.flatMap { case (start, end) =>
+      if (end == start || idxr.nKeys == 0) None else Some(idxr.queryByIndex(start))
     }
   } catch {
     case e: Exception =>


### PR DESCRIPTION
To do this, expose the necessary methods to get the start and end bounds
of an interval queries position within the index. Then just add
a counter to the iterators.