### PR TITLE
[compiler] Refactor EncodedLiteral / TableLiteral to use multiple byte arrays

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -76,7 +76,7 @@ object Interpret {
       case Literal(_, value) => value
       case x@EncodedLiteral(codec, value) =>
         ctx.r.getPool().scopedRegion { r =>
-          val (pt, addr) = codec.decode(ctx, x.typ, value.ba, ctx.r)
+          val (pt, addr) = codec.decodeArrays(ctx, x.typ, value.ba, ctx.r)
           SafeRow.read(pt, addr)
         }
       case Void() => ()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -31,6 +31,7 @@ import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
 
 import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream, InputStream}
 import is.hail.io.avro.AvroTableReader
+import is.hail.utils.prettyPrint.ArrayOfByteArrayInputStream
 
 import scala.reflect.ClassTag
 
@@ -76,16 +77,11 @@ class TableRunContext(val req: RequirednessAnalysis)
 
 object TableLiteral {
   def apply(value: TableValue): TableLiteral = {
-    val globalPType = PType.canonical(value.globals.t)
-    val enc = TypedCodecSpec(globalPType, BufferSpec.wireSpec) // use wireSpec to save memory
-    using(new ByteArrayEncoder(enc.buildEncoder(value.ctx, value.globals.t))) { encoder =>
-      TableLiteral(value.typ, value.rvd, enc,
-        encoder.regionValueToBytes(value.globals.value.offset))
-    }
+    TableLiteral(value.typ, value.rvd, value.globals.encoding, value.globals.encodeToByteArrays())
   }
 }
 
-case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, encodedGlobals: Array[Byte]) extends TableIR {
+case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, encodedGlobals: Array[Array[Byte]]) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
   lazy val rowCountUpperBound: Option[Long] = None
@@ -98,7 +94,7 @@ case class TableLiteral(typ: TableType, rvd: RVD, enc: AbstractTypedCodecSpec, e
   protected[ir] override def execute(ctx: ExecuteContext, r: TableRunContext): TableExecuteIntermediate = {
     val (globalPType: PStruct, dec) = enc.buildDecoder(ctx, typ.globalType)
 
-    val bais = new ByteArrayInputStream(encodedGlobals)
+    val bais = new ArrayOfByteArrayInputStream(encodedGlobals)
     val globalOffset = dec.apply(bais).readRegionValue(ctx.r)
     new TableValueIntermediate(TableValue(ctx, typ, BroadcastRow(ctx, RegionValue(ctx.r, globalOffset), globalPType), rvd))
   }

--- a/hail/src/test/scala/is/hail/expr/ir/EncodedLiteralSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EncodedLiteralSuite.scala
@@ -10,9 +10,9 @@ class EncodedLiteralSuite extends HailSuite {
     val byteArray1 = Array[Byte](1, 2, 1, 1)
     val byteArray2 = Array[Byte](1, 2, 1, 1)
     val byteArray3 = Array[Byte](0, 0, 1, 0)
-    val wba1 = new WrappedByteArray(byteArray1)
-    val wba2 = new WrappedByteArray(byteArray2)
-    val wba3 = new WrappedByteArray(byteArray3)
+    val wba1 = new WrappedByteArrays(Array(byteArray1))
+    val wba2 = new WrappedByteArrays(Array(byteArray2))
+    val wba3 = new WrappedByteArrays(Array(byteArray3))
 
     assert(wba1 == wba1)
     assert(wba1 == wba2)


### PR DESCRIPTION
Support encoded values greater than 2GB.