### PR TITLE
Updated build.gradle to use Spark 3.1.2 as default version

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -47,10 +47,10 @@ tasks.withType(JavaCompile) {
 project.ext {
     cachedBreezeVersion = null
 
-    sparkVersion = System.getProperty("spark.version", "3.1.1")
+    sparkVersion = System.getProperty("spark.version", "3.1.2")
 
     if (sparkVersion != "3.1.1") {
-        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.1.1, use other versions at your own risk.")
+        project.logger.lifecycle("WARNING: Hail primarily tested with Spark 3.1.2, use other versions at your own risk.")
     }
     scalaVersion = System.getProperty("scala.version", "2.12.13")
     scalaMajorVersion = (scalaVersion =~ /^\d+.\d+/)[0]


### PR DESCRIPTION
#11016 Updated default hail version in Makefile, but build.gradle warns if you're not using 3.1.1. That's silly, everything should be 3.1.2 now. 