### PR TITLE
[batch] Fixes to get tests to start running on Azure

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -271,7 +271,7 @@ GRANT ALL ON `{name}`.* TO '{name}'@'%';
         config = SQLConfig(
             host=server_config.host,
             port=server_config.port,
-            user=self.name,
+            user=self.name if CLOUD != 'azure' else f'{self.name}@{server_config.instance}',
             password=self.password,
             instance=server_config.instance,
             connection_name=server_config.connection_name,

--- a/batch/batch/cloud/azure/worker/instance_env.py
+++ b/batch/batch/cloud/azure/worker/instance_env.py
@@ -26,6 +26,7 @@ class AzureWorkerAPI(CloudWorkerAPI):
         self.resource_group = resource_group
         self.acr_refresh_token = AcrRefreshToken(acr_url, AadAccessToken())
 
+    @property
     def nameserver_ip(self):
         return '168.63.129.16'
 

--- a/batch/batch/cloud/azure/worker/instance_env.py
+++ b/batch/batch/cloud/azure/worker/instance_env.py
@@ -1,7 +1,6 @@
 import aiohttp
 import abc
 from typing import Dict, Optional, Tuple
-from dateutil.parser import isoparse
 import os
 
 from hailtop import httpx
@@ -26,6 +25,9 @@ class AzureWorkerAPI(CloudWorkerAPI):
         self.subscription_id = subscription_id
         self.resource_group = resource_group
         self.acr_refresh_token = AcrRefreshToken(acr_url, AadAccessToken())
+
+    def nameserver_ip(self):
+        return '168.63.129.16'
 
     def create_disk(self, instance_name: str, disk_name: str, size_in_gb: int, mount_path: str) -> AzureDisk:
         return AzureDisk(disk_name, instance_name, size_in_gb, mount_path)
@@ -67,21 +69,18 @@ class LazyShortLivedToken(abc.ABC):
 class AadAccessToken(LazyShortLivedToken):
     async def _fetch(self, session: httpx.ClientSession) -> Tuple[str, int]:
         # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
-        params = {
-            'api-version': '2018-02-01',
-            'resource': 'https://management.azure.com/'
-        }
+        params = {'api-version': '2018-02-01', 'resource': 'https://management.azure.com/'}
         async with await request_retry_transient_errors(
             session,
             'GET',
             'http://169.254.169.254/metadata/identity/oauth2/token',
             headers={'Metadata': 'true'},
             params=params,
-            timeout=aiohttp.ClientTimeout(total=60)  # type: ignore
+            timeout=aiohttp.ClientTimeout(total=60),  # type: ignore
         ) as resp:
             resp_json = await resp.json()
             access_token: str = resp_json['access_token']
-            expiration_time_ms = int(isoparse(resp_json['expires_on']).timestamp()) * 1000
+            expiration_time_ms = int(resp_json['expires_on']) * 1000
             return access_token, expiration_time_ms
 
 
@@ -104,7 +103,7 @@ class AcrRefreshToken(LazyShortLivedToken):
             f'https://{self.acr_url}/oauth2/exchange',
             headers={'Content-Type': 'application/x-www-form-urlencoded'},
             data=data,
-            timeout=aiohttp.ClientTimeout(total=60)  # type: ignore
+            timeout=aiohttp.ClientTimeout(total=60),  # type: ignore
         ) as resp:
             refresh_token: str = (await resp.json())['refresh_token']
             expiration_time_ms = time_msecs() + 60 * 60 * 1000  # token expires in 3 hours so we refresh after 1 hour

--- a/batch/batch/cloud/gcp/worker/instance_env.py
+++ b/batch/batch/cloud/gcp/worker/instance_env.py
@@ -22,6 +22,7 @@ class GCPWorkerAPI(CloudWorkerAPI):
         self.project = project
         self.zone = zone
 
+    @property
     def nameserver_ip(self):
         return '169.254.169.254'
 

--- a/batch/batch/cloud/gcp/worker/instance_env.py
+++ b/batch/batch/cloud/gcp/worker/instance_env.py
@@ -22,6 +22,9 @@ class GCPWorkerAPI(CloudWorkerAPI):
         self.project = project
         self.zone = zone
 
+    def nameserver_ip(self):
+        return '169.254.169.254'
+
     def create_disk(self, instance_name: str, disk_name: str, size_in_gb: int, mount_path: str) -> GCPDisk:
         return GCPDisk(
             zone=self.zone,

--- a/batch/batch/worker/instance_env.py
+++ b/batch/batch/worker/instance_env.py
@@ -9,6 +9,11 @@ from ..instance_config import InstanceConfig
 
 
 class CloudWorkerAPI(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def nameserver_ip(self):
+        raise NotImplementedError
+
     @abc.abstractmethod
     def create_disk(self, instance_name: str, disk_name: str, size_in_gb: int, mount_path: str) -> CloudDisk:
         raise NotImplementedError

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -200,7 +200,7 @@ class NetworkNamespace:
         # resolver.
         with open(f'/etc/netns/{self.network_ns_name}/resolv.conf', 'w') as resolv:
             if self.private:
-                resolv.write(f'nameserver {CLOUD_WORKER_API.nameserver_ip()}\n')
+                resolv.write(f'nameserver {CLOUD_WORKER_API.nameserver_ip}\n')
                 if CLOUD == 'gcp':
                     resolv.write('search c.hail-vdc.internal google.internal\n')
             else:

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -97,7 +97,6 @@ CLOUD = os.environ['CLOUD']
 CORES = int(os.environ['CORES'])
 NAME = os.environ['NAME']
 NAMESPACE = os.environ['NAMESPACE']
-INTERNAL_BATCH_DOMAIN = 'batch.hail' if NAMESPACE == 'default' else 'internal.hail'
 # ACTIVATION_TOKEN
 IP_ADDRESS = os.environ['IP_ADDRESS']
 INTERNAL_GATEWAY_IP = os.environ['INTERNAL_GATEWAY_IP']
@@ -192,14 +191,16 @@ class NetworkNamespace:
         with open(f'/etc/netns/{self.network_ns_name}/hosts', 'w') as hosts:
             hosts.write('127.0.0.1 localhost\n')
             hosts.write(f'{self.job_ip} {self.hostname}\n')
-            hosts.write(f'{INTERNAL_GATEWAY_IP} {INTERNAL_BATCH_DOMAIN}\n')
+            if NAMESPACE == 'default':
+                hosts.write(f'{INTERNAL_GATEWAY_IP} batch.hail\n')
+            hosts.write(f'{INTERNAL_GATEWAY_IP} internal.hail\n')
 
         # Jobs on the private network should have access to the metadata server
         # and our vdc. The public network should not so we use google's public
         # resolver.
         with open(f'/etc/netns/{self.network_ns_name}/resolv.conf', 'w') as resolv:
             if self.private:
-                resolv.write('nameserver 169.254.169.254\n')
+                resolv.write(f'nameserver {CLOUD_WORKER_API.nameserver_ip()}\n')
                 if CLOUD == 'gcp':
                     resolv.write('search c.hail-vdc.internal google.internal\n')
             else:

--- a/build.yaml
+++ b/build.yaml
@@ -49,8 +49,6 @@ steps:
         clouds:
           - gcp
       - name: test-gsa-key
-        clouds:
-          - gcp
       - name: test-aws-key
         clouds:
           - gcp
@@ -58,8 +56,6 @@ steps:
         clouds:
           - gcp
       - name: zulip-config
-        clouds:
-          - gcp
       - name: benchmark-gsa-key
         clouds:
           - gcp
@@ -67,11 +63,12 @@ steps:
         clouds:
           - gcp
       - name: hail-ci-0-1-service-account-key
-        clouds:
-          - gcp
       - name: test-dataproc-service-account-key
         clouds:
           - gcp
+      - name: batch-worker-ssh-public-key
+        clouds:
+          - azure
   - kind: buildImage2
     name: echo_image
     dockerFile: /io/echo/Dockerfile
@@ -331,17 +328,8 @@ steps:
           | kubectl -n {{ default_ns.name }} apply -f -
 
       # worker deploy config
-      {% if global.cloud == "gcp" %}
-        LOCATION="gce"
-      {% elif global.cloud == "azure" %}
-        LOCATION="azure"
-      {% else %}
-        echo "unknown cloud: {{ global.cloud }}"
-        exit 1
-      {% endif %}
-
       cat > deploy-config.json <<EOF
-      {"location":"$LOCATION","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
+      {"location":"gce","default_namespace":"{{ default_ns.name }}","domain":"{{ global.domain }}"}
       EOF
       kubectl -n {{ default_ns.name }} create secret generic worker-deploy-config \
               --from-file=./deploy-config.json \


### PR DESCRIPTION
Mostly random bugs that didn't get flexed until trying to run CI jobs and batch tests within jobs.
- The IP addresses used for jobs immediately got out of sync with GCP and I needed to add an `internal.hail` entry to the worker and job's `/etc/hosts` so that default batch could submit to dev batch.
- GCP's metadata server and DNS nameserver are both 169.254.169.254. Azure has a separate IP address for the latter, so I added this configuration to the CloudWorkerAPI.

Something that's not addressed here is that I needed to comment out the resource requirements for build image jobs to make them run on standards. The common 2 vCPU / 10 Gi storage / 7.5 Gi Mem lands on standards in GCP but highcpu on azure, which doesn't have disks implemented yet. I'm not sure what the correct step forward on that front is. Otherwise, dev deploying batch should be possible! I ran into multiple issues where my user's sql config was messed up because it was created from a buggy branch. I tried to fix these for the other dev namespaces (dan's which was made later was fine) but there may be some bits I missed.

I got as far as running `test_batch_0` and the tests start (!) but fail quickly because of a blob permission issue on the dev driver.