### PR TITLE
[auth] Remove guard against creating trial projects in azure

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -477,9 +477,7 @@ async def _create_user(app, user, skip_trial_bp, cleanup):
         cleanup.append(db_secret.delete)
         await db_secret.create('database-server-config', namespace_name, db_resource.secret_data())
 
-    # TODO This doesn't work on azure yet because of the circular batch dependency
-    # Once this is working, bootstrap must deploy batch not just auth
-    if CLOUD == 'gcp' and not skip_trial_bp and user['is_service_account'] != 1:
+    if not skip_trial_bp and user['is_service_account'] != 1:
         trial_bp = user['trial_bp_name']
         if trial_bp is None:
             batch_client = app['batch_client']


### PR DESCRIPTION
We put this in to remove auth's dependency on batch when batch couldn't run in azure and now this is no longer necessary.