### PR TITLE
Return paths from write_matrix_tables

### DIFF
--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -19,6 +19,8 @@ def write_matrix_tables(mts: List[MatrixTable], prefix: str, overwrite: bool = F
     writer = MatrixNativeMultiWriter(paths, overwrite, stage_locally, codec_spec)
     Env.backend().execute(MatrixMultiWrite([mt._mir for mt in mts], writer))
 
+    return paths
+
 
 @typecheck(bms=sequenceof(BlockMatrix),
            prefix=str,


### PR DESCRIPTION
I think this little change adds a lot of usability to the method.

You do not need to know how the names of the tables are constructed in the function.