### PR TITLE
[hailtop] substantially improve the performance of copy

### DIFF
--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -186,7 +186,6 @@ class S3CreatePartManager(AsyncContextManager[WritableStream]):
             self, exc_type: Optional[Type[BaseException]] = None,
             exc_value: Optional[BaseException] = None,
             exc_traceback: Optional[TracebackType] = None) -> None:
-        assert self._async_writable is not None
         await self._async_writable.wait_closed()
 
 

--- a/hail/python/hailtop/aiocloud/aioaws/fs.py
+++ b/hail/python/hailtop/aiocloud/aioaws/fs.py
@@ -151,51 +151,43 @@ class S3FileListEntry(FileListEntry):
         return self._status
 
 
-class S3CreatePartManager(AsyncContextManager[WritableStream]):
-    def __init__(self, mpc, number: int, size_hint: int):
+class S3PartWritableStream(WritableStream):
+    def __init__(self, mpc, number):
+        super().__init__()
+        self._bytes = bytearray()
         self._mpc = mpc
         self._number = number
-        self._size_hint = size_hint
-        self._async_writable: Optional[AsyncQueueWritableStream] = None
-        self._put_thread: Optional[threading.Thread] = None
-        self._exc: Optional[BaseException] = None
+
+    async def write(self, b: bytes) -> int:
+        self._bytes.extend(b)
+        return len(b)
+
+    async def _wait_closed(self) -> None:
+        resp = await blocking_to_async(
+            self._mpc._fs._thread_pool,
+            self._mpc._fs._s3.upload_part,
+            Bucket=self._mpc._bucket,
+            Key=self._mpc._name,
+            PartNumber=self._number + 1,
+            UploadId=self._mpc._upload_id,
+            Body=self._bytes)
+        self._mpc._etags[self._number] = resp['ETag']
+
+
+class S3CreatePartManager(AsyncContextManager[WritableStream]):
+    def __init__(self, mpc, number: int, size_hint: int):
+        del size_hint
+        self._async_writable: WritableStream = S3PartWritableStream(mpc, number)
 
     async def __aenter__(self) -> WritableStream:
-        async_writable, blocking_collect = async_writable_blocking_collect_pair(self._size_hint)
-        self._async_writable = async_writable
-
-        def put():
-            try:
-                b = blocking_collect.get()
-                resp = self._mpc._fs._s3.upload_part(
-                    Bucket=self._mpc._bucket,
-                    Key=self._mpc._name,
-                    PartNumber=self._number + 1,
-                    UploadId=self._mpc._upload_id,
-                    Body=b)
-                self._mpc._etags[self._number] = resp['ETag']
-            except BaseException as e:
-                self._exc = e
-
-        self._put_thread = threading.Thread(target=put)
-        self._put_thread.start()
-        return async_writable
+        return self._async_writable
 
     async def __aexit__(
             self, exc_type: Optional[Type[BaseException]] = None,
             exc_value: Optional[BaseException] = None,
             exc_traceback: Optional[TracebackType] = None) -> None:
         assert self._async_writable is not None
-        assert self._put_thread is not None
         await self._async_writable.wait_closed()
-        try:
-            await blocking_to_async(self._mpc._fs._thread_pool, self._put_thread.join)
-        finally:
-            if self._exc:
-                _, exc, _ = sys.exc_info()
-                if exc:
-                    log.info('discarding exception', exc_info=True)
-                raise self._exc
 
 
 class S3MultiPartCreate(MultiPartCreate):

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -4,6 +4,7 @@ import urllib
 import asyncio
 import logging
 import argparse
+import uvloop
 from concurrent.futures import ThreadPoolExecutor
 from hailtop.aiotools import RouterAsyncFS, Transfer, Copier
 from hailtop.utils import tqdm
@@ -101,4 +102,5 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
+    uvloop.install()
     asyncio.run(main())

--- a/hail/python/hailtop/aiotools/copy.py
+++ b/hail/python/hailtop/aiotools/copy.py
@@ -64,7 +64,7 @@ async def copy(*,
                                  gcs_kwargs=gcs_kwargs,
                                  azure_kwargs=azure_kwargs,
                                  s3_kwargs=s3_kwargs) as fs:
-            sema = asyncio.Semaphore(50)
+            sema = asyncio.Semaphore(200)
             async with sema:
                 with tqdm(desc='files', leave=False, position=0, unit='file') as file_pbar, \
                      tqdm(desc='bytes', leave=False, position=1, unit='byte', unit_scale=True, smoothing=0.1) as byte_pbar:

--- a/hail/python/hailtop/aiotools/fs/copier.py
+++ b/hail/python/hailtop/aiotools/fs/copier.py
@@ -445,7 +445,7 @@ class Copier:
         # This is essentially a limit on amount of memory in temporary
         # buffers during copying.  We allow ~10 full-sized copies to
         # run concurrently.
-        self.xfer_sema = WeightedSemaphore(10 * Copier.BUFFER_SIZE)
+        self.xfer_sema = WeightedSemaphore(100 * Copier.BUFFER_SIZE)
 
     async def _dest_type(self, transfer: Transfer):
         '''Return the (real or assumed) type of `dest`.

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -11,16 +11,17 @@ decorator<5
 Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4
 # https://github.com/dask/gcsfs/issues/372
-gcsfs==0.8.0
-# https://github.com/dask/gcsfs/issues/372
 fsspec==0.9.0
+# https://github.com/dask/gcsfs/issues/372
+gcsfs==0.8.0
 google-auth==1.27.0
-orjson==3.6.4
+google-cloud-storage==1.25.*
 humanize==1.0.0
 hurry.filesize==0.9
 janus>=0.6,<0.7
 nest_asyncio
 numpy<2
+orjson==3.6.4
 pandas>=1.1.0,<1.1.5
 parsimonious<0.9
 PyJWT
@@ -31,4 +32,4 @@ scipy>1.2,<1.8
 sortedcontainers==2.1.0
 tabulate==0.8.3
 tqdm==4.42.1
-google-cloud-storage==1.25.*
+uvloop==0.16.0


### PR DESCRIPTION
This brings the aggregate bandwidth from ~150MB/s to ~650MB/s. I'm still facing some issues with writing *to* AWS, but this eliminates a *ton* of TLS overhead. `uvloop` comes with a faster implementation of TLS.