### PR TITLE
[batch] Make test_batch_* pass in Azure

### DIFF
--- a/batch/batch/batch_format_version.py
+++ b/batch/batch/batch_format_version.py
@@ -7,7 +7,7 @@ class BatchFormatVersion:
     def __init__(self, format_version):
         self.format_version = format_version
 
-    def has_full_spec_in_gcs(self):
+    def has_full_spec_in_cloud(self):
         return self.format_version > 1
 
     def has_full_status_in_gcs(self):

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -273,7 +273,7 @@ async def _query_batch_jobs(request, batch_id):
 
     sql = f'''
 SELECT jobs.*, batches.user, batches.billing_project,  batches.format_version,
-  job_attributes.value AS name, SUM(`usage` * rate) AS cost
+  job_attributes.value AS name, COALESCE(SUM(`usage` * rate), 0) AS cost
 FROM jobs
 INNER JOIN batches ON jobs.batch_id = batches.id
 LEFT JOIN job_attributes
@@ -400,7 +400,7 @@ async def _get_attributes(app, record):
     job_id = record['job_id']
     format_version = BatchFormatVersion(record['format_version'])
 
-    if not format_version.has_full_spec_in_gcs():
+    if not format_version.has_full_spec_in_cloud():
         spec = json.loads(record['spec'])
         return spec.get('attributes')
 
@@ -423,7 +423,7 @@ async def _get_full_job_spec(app, record):
     job_id = record['job_id']
     format_version = BatchFormatVersion(record['format_version'])
 
-    if not format_version.has_full_spec_in_gcs():
+    if not format_version.has_full_spec_in_cloud():
         return json.loads(record['spec'])
 
     token, start_job_id = await SpecWriter.get_token_start_id(db, batch_id, job_id)
@@ -570,7 +570,7 @@ async def _query_batches(request, user, q):
         where_args.extend(args)
 
     sql = f'''
-SELECT batches.*, SUM(`usage` * rate) AS cost
+SELECT batches.*, COALESCE(SUM(`usage` * rate), 0) AS cost
 FROM batches
 LEFT JOIN aggregated_batch_resources
   ON batches.id = aggregated_batch_resources.batch_id
@@ -693,7 +693,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
 
                 cloud = spec.get('cloud', CLOUD)
 
-                if batch_format_version.has_full_spec_in_gcs():
+                if batch_format_version.has_full_spec_in_cloud():
                     attributes = spec.pop('attributes', None)
                 else:
                     attributes = spec.get('attributes')
@@ -703,7 +703,7 @@ WHERE user = %s AND id = %s AND NOT deleted;
                 if start_job_id is None:
                     start_job_id = job_id
 
-                if batch_format_version.has_full_spec_in_gcs() and prev_job_idx:
+                if batch_format_version.has_full_spec_in_cloud() and prev_job_idx:
                     if job_id != prev_job_idx + 1:
                         raise web.HTTPBadRequest(
                             reason=f'noncontiguous job ids found in the spec: {prev_job_idx} -> {job_id}'
@@ -903,8 +903,8 @@ WHERE user = %s AND id = %s AND NOT deleted;
                     for k, v in attributes.items():
                         job_attributes_args.append((batch_id, job_id, k, v))
 
-        if batch_format_version.has_full_spec_in_gcs():
-            async with timer.step('write spec to gcs'):
+        if batch_format_version.has_full_spec_in_cloud():
+            async with timer.step('write spec to cloud'):
                 await spec_writer.write()
 
         rand_token = random.randint(0, app['n_tokens'] - 1)
@@ -995,7 +995,7 @@ ON DUPLICATE KEY UPDATE
                         ),
                     )
 
-                if batch_format_version.has_full_spec_in_gcs():
+                if batch_format_version.has_full_spec_in_cloud():
                     await tx.execute_update(
                         '''
 INSERT INTO batch_bunches (batch_id, token, start_job_id)
@@ -1121,7 +1121,7 @@ async def _get_batch(app, batch_id):
 
     record = await db.select_and_fetchone(
         '''
-SELECT batches.*, SUM(`usage` * rate) AS cost FROM batches
+SELECT batches.*, COALESCE(SUM(`usage` * rate), 0) AS cost FROM batches
 LEFT JOIN aggregated_batch_resources
        ON batches.id = aggregated_batch_resources.batch_id
 LEFT JOIN resources
@@ -1300,7 +1300,7 @@ async def _get_job(app, batch_id, job_id):
 
     record = await db.select_and_fetchone(
         '''
-SELECT jobs.*, user, billing_project, ip_address, format_version, SUM(`usage` * rate) AS cost
+SELECT jobs.*, user, billing_project, ip_address, format_version, COALESCE(SUM(`usage` * rate), 0) AS cost
 FROM jobs
 INNER JOIN batches
   ON jobs.batch_id = batches.id

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -1474,6 +1474,8 @@ class DockerJob(Job):
                         try:
                             await self.disk.delete()
                             log.info(f'deleted disk {self.disk.name} for {self.id}')
+                        except asyncio.CancelledError:
+                            raise
                         except Exception:
                             log.exception(f'while detaching and deleting disk {self.disk.name} for {self.id}')
                         finally:

--- a/batch/sql/change_azure_test_highcpu_pool.py
+++ b/batch/sql/change_azure_test_highcpu_pool.py
@@ -1,0 +1,25 @@
+import asyncio
+import os
+
+from gear import Database
+
+
+async def main():
+    db = Database()
+    try:
+        await db.async_init()
+
+        cloud = os.environ['HAIL_CLOUD']
+        if cloud != 'azure':
+            return
+
+        await db.just_execute('''
+UPDATE `pools` SET worker_external_ssd_data_disk_size_gb = %s WHERE name = %s
+''',
+                              (375, 'highcpu'))
+    finally:
+        await db.async_close()
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/batch/test/billing_projects.py
+++ b/batch/test/billing_projects.py
@@ -1,0 +1,24 @@
+import os
+import traceback
+
+from hailtop.batch_client.aioclient import BatchClient
+
+
+def get_billing_project_prefix():
+    return f'__testproject_{os.environ["HAIL_TOKEN"]}'
+
+
+async def delete_all_test_billing_projects():
+    billing_project_prefix = get_billing_project_prefix()
+    bc = await BatchClient.create(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
+    try:
+        for project in await bc.list_billing_projects():
+            if project['billing_project'].startswith(billing_project_prefix):
+                try:
+                    print(f'deleting {project}')
+                    await bc.delete_billing_project(project['billing_project'])
+                except Exception as exc:
+                    print(f'exception deleting {project}; will continue')
+                    traceback.print_exc()
+    finally:
+        await bc.close()

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -3,12 +3,12 @@ import aiohttp
 import os
 import pytest
 import secrets
-import traceback
 from hailtop.auth import session_id_encode_to_str
 from hailtop.batch_client.aioclient import BatchClient, Batch
 from hailtop.utils import secret_alnum_string
 
 from .utils import fails_in_azure
+from .billing_projects import get_billing_project_prefix
 
 pytestmark = pytest.mark.asyncio
 
@@ -37,26 +37,6 @@ async def dev_client() -> AsyncGenerator[BatchClient, Any]:
     )
     yield bc
     await bc.close()
-
-
-def get_billing_project_prefix():
-    return f'__testproject_{os.environ["HAIL_TOKEN"]}'
-
-
-async def delete_all_test_billing_projects():
-    billing_project_prefix = get_billing_project_prefix()
-    bc = await BatchClient.create(None, token_file=os.environ['HAIL_TEST_DEV_TOKEN_FILE'])
-    try:
-        for project in await bc.list_billing_projects():
-            if project['billing_project'].startswith(billing_project_prefix):
-                try:
-                    print(f'deleting {project}')
-                    await bc.delete_billing_project(project['billing_project'])
-                except Exception as exc:
-                    print(f'exception deleting {project}; will continue')
-                    traceback.print_exc()
-    finally:
-        await bc.close()
 
 
 @pytest.fixture

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -21,7 +21,7 @@ DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 UBUNTU_IMAGE = 'ubuntu:20.04'
 NAMESPACE = os.environ.get('HAIL_DEFAULT_NAMESPACE')
 SCOPE = os.environ.get('HAIL_SCOPE', 'test')
-CLOUD = os.environ['HAIL_CLOUD']
+CLOUD = os.environ.get('HAIL_CLOUD')
 
 
 @pytest.fixture

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -11,7 +11,7 @@ from hailtop.auth import service_auth_headers
 from hailtop.utils import retry_response_returning_functions, external_requests_client_session, sync_sleep_and_backoff
 from hailtop.batch_client.client import BatchClient
 
-from .utils import legacy_batch_status
+from .utils import legacy_batch_status, smallest_machine_type, skip_in_azure, fails_in_azure
 from .failure_injecting_client_session import FailureInjectingClientSession
 
 deploy_config = get_deploy_config()
@@ -21,6 +21,7 @@ DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 UBUNTU_IMAGE = 'ubuntu:20.04'
 NAMESPACE = os.environ.get('HAIL_DEFAULT_NAMESPACE')
 SCOPE = os.environ.get('HAIL_SCOPE', 'test')
+CLOUD = os.environ['HAIL_CLOUD']
 
 
 @pytest.fixture
@@ -120,7 +121,7 @@ def test_invalid_resource_requests(client: BatchClient):
         builder.submit()
 
     builder = client.create_batch()
-    resources = {'storage': '10000000Gi', 'machine_type': 'n1-standard-1'}
+    resources = {'storage': '10000000Gi', 'machine_type': smallest_machine_type(CLOUD)}
     builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     with pytest.raises(aiohttp.client.ClientResponseError, match='resource requests.*unsatisfiable'):
         builder.submit()
@@ -197,6 +198,7 @@ def test_nonzero_storage(client: BatchClient):
     assert status['state'] == 'Success', str((status, b.debug_info()))
 
 
+@fails_in_azure()
 def test_attached_disk(client: BatchClient):
     builder = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '10M', 'storage': '400Gi'}
@@ -427,7 +429,7 @@ def test_get_job(client: BatchClient):
 
     j2 = client.get_job(*j.id)
     status2 = j2.status()
-    assert (status2['batch_id'], status2['job_id']) == j.id, str((status, b.debug_info()))
+    assert (status2['batch_id'], status2['job_id']) == j.id, str((status2, b.debug_info()))
 
 
 def test_batch(client: BatchClient):
@@ -541,7 +543,7 @@ def test_authorized_users_only():
         assert r.status_code == expected, (full_url, r, expected)
 
 
-def test_gcr_image(client: BatchClient):
+def test_cloud_image(client: BatchClient):
     builder = client.create_batch()
     j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['echo', 'test'])
     b = builder.submit()
@@ -617,8 +619,8 @@ def test_restartable_insert(client: BatchClient):
 
         b = builder.submit(max_bunch_size=1)
         b = client.get_batch(b.id)  # get a batch untainted by the FailureInjectingClientSession
-        batch = b.wait()
-        assert batch['state'] == 'success', str((status, b.debug_info()))
+        status = b.wait()
+        assert status['state'] == 'success', str((status, b.debug_info()))
         jobs = list(b.jobs())
         assert len(jobs) == 9, str((jobs, b.debug_info()))
 
@@ -684,7 +686,8 @@ def test_duplicate_parents(client: BatchClient):
         assert False, f'should receive a 400 Bad Request {batch.id}'
 
 
-def test_verify_no_access_to_metadata_server(client: BatchClient):
+@skip_in_azure()
+def test_verify_no_access_to_google_metadata_server(client: BatchClient):
     builder = client.create_batch()
     j = builder.create_job(
         os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', 'metadata.google.internal', '--max-time', '10']
@@ -695,6 +698,8 @@ def test_verify_no_access_to_metadata_server(client: BatchClient):
     job_log = j.log()
     assert "Could not resolve host" in job_log['main'], str((job_log, b.debug_info()))
 
+
+def test_verify_no_access_to_metadata_server(client: BatchClient):
     builder = client.create_batch()
     j = builder.create_job(os.environ['HAIL_CURL_IMAGE'], ['curl', '-fsSL', '169.254.169.254', '--max-time', '10'])
     builder.submit()
@@ -801,6 +806,7 @@ curl -fsSL -m 5 $OTHER_IP
     assert "Connection timed out" in job_log['main'], str((job_log, b.debug_info()))
 
 
+@skip_in_azure()
 def test_can_use_google_credentials(client: BatchClient):
     token = os.environ["HAIL_TOKEN"]
     remote_tmpdir = get_user_config().get('batch', 'remote_tmpdir')
@@ -846,7 +852,7 @@ def test_user_authentication_within_job(client: BatchClient):
     b = batch.submit()
 
     no_token_status = no_token.wait()
-    assert no_token_status['state'] == 'Failed', str((not_token_status, b.debug_info()))
+    assert no_token_status['state'] == 'Failed', str((no_token_status, b.debug_info()))
 
 
 def test_verify_access_to_public_internet(client: BatchClient):
@@ -934,6 +940,9 @@ def test_pool_highmem_instance(client: BatchClient):
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
 
+
+@fails_in_azure()
+def test_pool_highmem_instance_cheapest(client: BatchClient):
     builder = client.create_batch()
     resources = {'cpu': '1', 'memory': '5Gi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
@@ -941,14 +950,6 @@ def test_pool_highmem_instance(client: BatchClient):
     status = j.wait()
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highmem' in status['status']['worker'], str((status, b.debug_info()))
-
-    builder = client.create_batch()
-    resources = {'cpu': '0.25', 'memory': '500Mi'}
-    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
-    b = builder.submit()
-    status = j.wait()
-    assert status['state'] == 'Success', str((status, b.debug_info()))
-    assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
 
 
 def test_pool_highcpu_instance(client: BatchClient):
@@ -960,6 +961,8 @@ def test_pool_highcpu_instance(client: BatchClient):
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
+
+def test_pool_highcpu_instance_cheapest(client: BatchClient):
     builder = client.create_batch()
     resources = {'cpu': '0.25', 'memory': '50Mi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
@@ -968,6 +971,20 @@ def test_pool_highcpu_instance(client: BatchClient):
     assert status['state'] == 'Success', str((status, b.debug_info()))
     assert 'highcpu' in status['status']['worker'], str((status, b.debug_info()))
 
+
+@fails_in_azure
+def test_pool_standard_instance(client: BatchClient):
+    builder = client.create_batch()
+    resources = {'cpu': '0.25', 'memory': '500Mi'}
+    j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
+    b = builder.submit()
+    status = j.wait()
+    assert status['state'] == 'Success', str((status, b.debug_info()))
+    assert 'standard' in status['status']['worker'], str((status, b.debug_info()))
+
+
+@fails_in_azure()
+def test_pool_standard_instance_cheapest(client: BatchClient):
     builder = client.create_batch()
     resources = {'cpu': '0.5', 'memory': '1Gi'}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
@@ -979,7 +996,7 @@ def test_pool_highcpu_instance(client: BatchClient):
 
 def test_job_private_instance_preemptible(client: BatchClient):
     builder = client.create_batch()
-    resources = {'machine_type': 'n1-standard-1'}
+    resources = {'machine_type': smallest_machine_type(CLOUD)}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     b = builder.submit()
     status = j.wait()
@@ -989,7 +1006,7 @@ def test_job_private_instance_preemptible(client: BatchClient):
 
 def test_job_private_instance_nonpreemptible(client: BatchClient):
     builder = client.create_batch()
-    resources = {'machine_type': 'n1-standard-1', 'preemptible': False}
+    resources = {'machine_type': smallest_machine_type(CLOUD), 'preemptible': False}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     b = builder.submit()
     status = j.wait()
@@ -999,7 +1016,7 @@ def test_job_private_instance_nonpreemptible(client: BatchClient):
 
 def test_job_private_instance_cancel(client: BatchClient):
     builder = client.create_batch()
-    resources = {'machine_type': 'n1-standard-1'}
+    resources = {'machine_type': smallest_machine_type(CLOUD)}
     j = builder.create_job(DOCKER_ROOT_IMAGE, ['true'], resources=resources)
     b = builder.submit()
 

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -1,3 +1,7 @@
+import pytest
+import os
+
+
 def batch_status_job_counter(batch_status, job_state):
     return len([j for j in batch_status['jobs'] if j['state'] == job_state])
 
@@ -6,3 +10,21 @@ def legacy_batch_status(batch):
     status = batch.status()
     status['jobs'] = list(batch.jobs())
     return status
+
+
+def smallest_machine_type(cloud):
+    if cloud == 'gcp':
+        return 'n1-standard-1'
+    assert cloud == 'azure'
+    return 'Standard_D2d_v4'
+
+
+fails_in_azure = pytest.mark.xfail(
+    os.environ.get('HAIL_CLOUD') == 'azure',
+    reason="doesn't yet work on azure",
+    strict=True)
+
+skip_in_azure = pytest.mark.skipif(
+    os.environ.get('HAIL_CLOUD') == 'azure',
+    reason="not applicable to azure",
+    strict=True)

--- a/build.yaml
+++ b/build.yaml
@@ -3038,9 +3038,9 @@ steps:
           export HAIL_TOKEN="$token"
           cd /io/test
           python3 -c '
-      import test_accounts
+      import billing_projects
       import asyncio
-      asyncio.get_event_loop().run_until_complete(test_accounts.delete_all_test_billing_projects())
+      asyncio.get_event_loop().run_until_complete(billing_projects.delete_all_test_billing_projects())
       '
       done
     inputs:

--- a/build.yaml
+++ b/build.yaml
@@ -2350,6 +2350,8 @@ steps:
         script: /io/sql/support-azure.sql
       - name: add-azure-tables
         script: /io/sql/add_azure_tables.py
+      - name: change-azure-test-highcpu-pool
+        script: /io/sql/change_azure_test_highcpu_pool.py
     inputs:
       - from: /repo/batch/sql
         to: /io/sql
@@ -2671,6 +2673,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
+      export HAIL_CLOUD="{{ global.cloud }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2745,6 +2748,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
+      export HAIL_CLOUD="{{ global.cloud }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2819,6 +2823,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
+      export HAIL_CLOUD="{{ global.cloud }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2893,6 +2898,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
+      export HAIL_CLOUD="{{ global.cloud }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2967,6 +2973,7 @@ steps:
       export HAIL_TEST_DEV_TOKEN_FILE=/dev-tokens/tokens.json
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
+      export HAIL_CLOUD="{{ global.cloud }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \

--- a/hail/python/hailtop/batch/backend.py
+++ b/hail/python/hailtop/batch/backend.py
@@ -424,7 +424,7 @@ class ServiceBackend(Backend[bc.Batch]):
                     'Use the remote_tmpdir parameter to specify a path.')
             remote_tmpdir = f'gs://{bucket}/batch'
         else:
-            schemes = {'gs'}
+            schemes = {'gs', 'hail-az'}
             found_scheme = any([remote_tmpdir.startswith(f'{scheme}://') for scheme in schemes])
             if not found_scheme:
                 raise ValueError(


### PR DESCRIPTION
The coalesce is necessary right now because Azure has no resources so the result is None rather than 0. Since the cost is always 0, then the tests that test billing limits fail.

In addition, the tests that choose whether we select the cheapest machine won't work because all machines cost $0/hr right now due to no billing setup. Instead, we get the first pool alphabetically (highcpu). 

The reason for the database upgrade is because we're selecting the first pool alphabetically which is highcpu. The default settings don't leave enough disk space and thus require an external disk. To circumvent this, I just made the worker data disk size the same as in GCP -- 375Gi -- for the highcpu pool.