### PR TITLE
[batch] Add auth.hail to job /etc/hosts

### DIFF
--- a/batch/Dockerfile.worker
+++ b/batch/Dockerfile.worker
@@ -66,3 +66,4 @@ COPY batch/batch /batch/batch/
 RUN hail-pip-install --no-deps /batch && rm -rf /batch
 
 COPY query/log4j.properties /
+COPY letsencrypt/subdomains.txt /

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -210,7 +210,8 @@ class NetworkNamespace:
             hosts.write('127.0.0.1 localhost\n')
             hosts.write(f'{self.job_ip} {self.hostname}\n')
             if NAMESPACE == 'default':
-                hosts.write(f'{INTERNAL_GATEWAY_IP} batch.hail\n')
+                for service in ('auth', 'batch'):
+                    hosts.write(f'{INTERNAL_GATEWAY_IP} {service}.hail\n')
             hosts.write(f'{INTERNAL_GATEWAY_IP} internal.hail\n')
 
         # Jobs on the private network should have access to the metadata server

--- a/batch/batch/worker/worker.py
+++ b/batch/batch/worker/worker.py
@@ -74,6 +74,9 @@ from .credentials import CloudUserCredentials
 
 # uvloop.install()
 
+with open('/subdomains.txt', 'r') as subdomains_file:
+    HAIL_SERVICES = [line.rstrip() for line in subdomains_file.readlines()]
+
 oldwarn = warnings.warn
 
 
@@ -210,7 +213,7 @@ class NetworkNamespace:
             hosts.write('127.0.0.1 localhost\n')
             hosts.write(f'{self.job_ip} {self.hostname}\n')
             if NAMESPACE == 'default':
-                for service in ('auth', 'batch'):
+                for service in HAIL_SERVICES:
                     hosts.write(f'{INTERNAL_GATEWAY_IP} {service}.hail\n')
             hosts.write(f'{INTERNAL_GATEWAY_IP} internal.hail\n')
 


### PR DESCRIPTION
Discovered in azure when it couldn't run the auth copy-paste token tests. We don't see this in google because we use Cloud DNS for resolving *.hail to internal gateway for private jobs (we use /etc/hosts and a public resolver for public jobs). In Azure I decided to forego azure dns and just use the /etc/hosts route for all of our jobs.