### PR TITLE
[ci] Add image cleanup for PR runs in Azure

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -413,6 +413,7 @@ true
             parents=parents,
             always_run=True,
             network='private',
+            timeout=5 * 60,
         )
 
 

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -884,7 +884,7 @@ class ParsedDockerImageReference:
         self.tag = tag
         self.digest = digest
 
-    def name(self):
+    def name(self) -> str:
         if self.domain:
             return self.domain + '/' + self.path
         return self.path

--- a/infra/azure/ci/main.tf
+++ b/infra/azure/ci/main.tf
@@ -35,11 +35,3 @@ resource "azurerm_role_assignment" "ci_ci_account_contributor" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = var.ci_principal_id
 }
-
-resource "azurerm_role_assignment" "ci_acr_role" {
-  for_each = toset(["AcrPush", "AcrDelete"])
-
-  scope                = var.container_registry_id
-  role_definition_name = each.key
-  principal_id         = var.ci_principal_id
-}

--- a/infra/azure/ci/variables.tf
+++ b/infra/azure/ci/variables.tf
@@ -8,7 +8,3 @@ variable "resource_group" {
 variable "ci_principal_id" {
   type = string
 }
-
-variable "container_registry_id" {
-  type = string
-}

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -169,7 +169,6 @@ resource "azurerm_container_registry" "acr" {
   resource_group_name = data.azurerm_resource_group.rg.name
   location            = data.azurerm_resource_group.rg.location
   sku                 = var.acr_sku
-  admin_enabled       = true
 }
 
 resource "azurerm_role_assignment" "vdc_to_acr" {

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -483,6 +483,14 @@ module "ci_sp" {
   object_id      = azuread_application.ci.object_id
 }
 
+resource "azurerm_role_assignment" "ci_acr_role" {
+  for_each = toset(["AcrPush", "AcrDelete"])
+
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = each.key
+  principal_id         = module.ci_sp.principal_id
+}
+
 resource "azuread_application" "test" {
   display_name = "${data.azurerm_resource_group.rg.name}-test"
 
@@ -565,7 +573,6 @@ module "ci" {
 
   resource_group        = data.azurerm_resource_group.rg
   ci_principal_id       = module.ci_sp.principal_id
-  container_registry_id = azurerm_container_registry.acr.id
 }
 
 module "ci_k8s_resources" {

--- a/infra/azure/outputs.tf
+++ b/infra/azure/outputs.tf
@@ -41,10 +41,7 @@ output "sql_config" {
 }
 
 output "registry_push_credentials" {
-  value = {
-    appId = azurerm_container_registry.acr.admin_username
-    password = azurerm_container_registry.acr.admin_password
-  }
+  value = module.ci_sp.credentials
   sensitive = true
 }
 


### PR DESCRIPTION
Implemented image untagging for image cleanup steps (like is done in GCR) for Azure. Since old layers still should be used for caching, this just removes the tag used for an image in a test build. We can then do something like [here](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auto-purge#run-in-an-on-demand-task) where you can purge untagged layers that are older than some number of weeks where we believe they're no longer relevant to the layer cache.

I also switched out the `registry-push-credentials` that CI uses to build images from the ACR admin login to CI's service principal and eliminated the admin login from the ACR terraform resource.

I dev deployed CI and manually verified after a deploy that a tag that was cleaned up no longer showed up in acr