### PR TITLE
[build.yaml] eliminate hail_query_gcs_path

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2514,7 +2514,7 @@ steps:
       export AZURE_APPLICATION_CREDENTIALS=/test-azure-key/credentials.json
 
       {% if deploy %}
-      destination=$(cat /global-config/hail_query_gcs_path)/jars/
+      destination={{ global.query_storage_uri }}/jars/
       {% else %}
       destination={{ global.test_storage_uri }}/{{ token }}/jars/
       {% endif %}
@@ -2528,10 +2528,6 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /query-gsa-key
-      - name: global-config
-        namespace:
-          valueFrom: default_ns.name
-        mountPath: /global-config
     inputs:
       - from: /just-jar/hail.jar
         to: /io/hail.jar

--- a/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/service/ServiceBackend.scala
@@ -51,7 +51,7 @@ class User(
   val fs: GoogleStorageFS)
 
 class ServiceBackend(
-  private[this] val queryGCSJarPath: String
+  private[this] val queryStorageJarURI: String
 ) extends Backend {
   import ServiceBackend.log
 
@@ -130,7 +130,7 @@ class ServiceBackend(
             "command" -> JArray(List(
               JString("is.hail.backend.service.Worker"),
               JString(HAIL_REVISION),
-              JString(queryGCSJarPath + HAIL_REVISION + ".jar"),
+              JString(queryStorageJarURI + HAIL_REVISION + ".jar"),
               JString(root),
               JString(s"$i"))),
             "type" -> JString("jvm")),
@@ -594,11 +594,11 @@ object ServiceBackendMain {
   def main(argv: Array[String]): Unit = {
     assert(argv.length == 1, argv.toFastIndexedSeq)
     val udsAddress = argv(0)
-    val queryGCSPathEnvVar = System.getenv("HAIL_QUERY_GCS_PATH")
-    assert(queryGCSPathEnvVar != null)
-    val queryGCSJarPath = queryGCSPathEnvVar + "/jars/"
+    val queryStorageURI = System.getenv("HAIL_QUERY_STORAGE_UI")
+    assert(queryStorageURI != null)
+    val queryStorageJarURI = queryStorageURI + "/jars/"
     val executor = Executors.newCachedThreadPool()
-    val backend = new ServiceBackend(queryGCSJarPath)
+    val backend = new ServiceBackend(queryStorageJarURI)
     HailContext(backend, "hail.log", false, false, 50, skipLoggingConfiguration = true, 3)
 
     val ss = AFUNIXServerSocket.newInstance()

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -306,6 +306,12 @@ resource "azurerm_storage_container" "batch_logs" {
   container_access_type = "private"
 }
 
+resource "azurerm_storage_container" "query" {
+  name                  = "query"
+  storage_account_name  = azurerm_storage_account.batch.name
+  container_access_type = "private"
+}
+
 resource "azurerm_role_assignment" "batch_batch_account_contributor" {
   scope                = azurerm_storage_account.batch.id
   role_definition_name = "Storage Blob Data Contributor"

--- a/infra/azure/outputs.tf
+++ b/infra/azure/outputs.tf
@@ -14,6 +14,7 @@ output "global_config" {
       kubernetes_server = azurerm_kubernetes_cluster.vdc.fqdn
       batch_logs_storage_uri = "hail-az://${azurerm_storage_account.batch.name}/${azurerm_storage_container.batch_logs.name}"
       test_storage_uri = "hail-az://${azurerm_storage_account.test.name}/${azurerm_storage_container.test.name}"
+      query_storage_uri = "hail-az://${azurerm_storage_account.batch.name}/${azurerm_storage_container.query.name}"
     }
     azure = {
       # FIXME Just for testing

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -254,9 +254,10 @@ resource "kubernetes_secret" "global_config" {
     batch_gcp_regions = var.batch_gcp_regions
     batch_logs_bucket = module.batch_logs.name  # Deprecated
     batch_logs_storage_uri = "gs://${module.batch_logs.name}"
-    hail_query_gcs_path = "gs://${module.hail_query.name}"
+    hail_query_gcs_path = "gs://${module.hail_query.name}" # Deprecated
     hail_test_gcs_bucket = module.hail_test_gcs_bucket.name # Deprecated
     test_storage_uri = "gs://${module.hail_test_gcs_bucket.name}"
+    query_storage_uri  = "gs://${module.hail_query.name}"
     default_namespace = "default"
     docker_root_image = local.docker_root_image
     domain = var.domain

--- a/infra/k8s/global_config.tf
+++ b/infra/k8s/global_config.tf
@@ -14,5 +14,6 @@ resource "kubernetes_secret" "global_config" {
     kubernetes_server_url  = "https://${var.global_config.global.kubernetes_server}"
     batch_logs_storage_uri = var.global_config.global.batch_logs_storage_uri
     test_storage_uri       = var.global_config.global.test_storage_uri
+    query_storage_uri      = var.global_config.global.query_storage_uri
   }, var.global_config.azure)
 }

--- a/infra/k8s/variables.tf
+++ b/infra/k8s/variables.tf
@@ -9,6 +9,7 @@ variable "global_config" {
       docker_prefix = string,
       batch_logs_storage_uri = string,
       test_storage_uri = string,
+      query_storage_uri = string,
     }),
     azure = map(any)
   })

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -96,13 +96,13 @@ spec:
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
 {% if deploy %}
-           - name: HAIL_QUERY_GCS_PATH
+           - name: HAIL_QUERY_STORAGE_UI
              valueFrom:
                secretKeyRef:
                  name: global-config
-                 key: hail_query_gcs_path
+                 key: query_storage_uri
 {% else %}
-           - name: HAIL_QUERY_GCS_PATH
+           - name: HAIL_QUERY_STORAGE_UI
              value: {{ global.test_storage_uri }}/{{ upload_query_jar.token }}
 {% endif %}
           ports:

--- a/query/deployment.yaml
+++ b/query/deployment.yaml
@@ -95,14 +95,13 @@ spec:
              value: "{{ code.sha }}"
            - name: HAIL_QUERY_WORKER_IMAGE
              value: {{ query_image.image }}
-{% if deploy %}
            - name: HAIL_QUERY_STORAGE_UI
+{% if deploy %}
              valueFrom:
                secretKeyRef:
                  name: global-config
                  key: query_storage_uri
 {% else %}
-           - name: HAIL_QUERY_STORAGE_UI
              value: {{ global.test_storage_uri }}/{{ upload_query_jar.token }}
 {% endif %}
           ports:


### PR DESCRIPTION
After this deploys and we re-run terraform, I can remove the deprecated entry.