### PR TITLE
[query] Make flattened version of to_pandas work without Spark

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -3255,6 +3255,10 @@ class Table(ExprContainer):
         :class:`.pandas.DataFrame`
 
         """
+
+        if flatten:
+            return pandas.DataFrame.from_records(self.flatten().collect())
+
         return Env.spark_backend('to_pandas').to_pandas(self, flatten)
 
     @staticmethod


### PR DESCRIPTION
I might want collecting to pandas for plotting, so let's figure out how to completely avoid spark when going to Pandas.