### PR TITLE
[notebook] Tolerate spot instances on Azure

### DIFF
--- a/notebook/deployment.yaml
+++ b/notebook/deployment.yaml
@@ -57,6 +57,8 @@ spec:
       tolerations:
        - key: preemptible
          value: "true"
+       - key: "kubernetes.azure.com/scalesetpriority"
+         value: "spot"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This allows the notebook front end pod to be scheduled on an azure spot node.