### PR TITLE
[build.yaml] Don't write to the same output location in test_java_*

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -940,7 +940,7 @@ steps:
         to: /io/splits.tar.gz
     outputs:
       - from: /io/test-output
-        to: /test-output
+        to: /test-output-0
     secrets:
       - name: test-gsa-key
         namespace:
@@ -974,7 +974,7 @@ steps:
         to: /io/splits.tar.gz
     outputs:
       - from: /io/test-output
-        to: /test-output
+        to: /test-output-1
     secrets:
       - name: test-gsa-key
         namespace:
@@ -1008,7 +1008,7 @@ steps:
         to: /io/splits.tar.gz
     outputs:
       - from: /io/test-output
-        to: /test-output
+        to: /test-output-2
     secrets:
       - name: test-gsa-key
         namespace:
@@ -1042,7 +1042,7 @@ steps:
         to: /io/splits.tar.gz
     outputs:
       - from: /io/test-output
-        to: /test-output
+        to: /test-output-3
     secrets:
       - name: test-gsa-key
         namespace:
@@ -1076,7 +1076,7 @@ steps:
         to: /io/splits.tar.gz
     outputs:
       - from: /io/test-output
-        to: /test-output
+        to: /test-output-4
     secrets:
       - name: test-gsa-key
         namespace:


### PR DESCRIPTION
Should fix this error:

```
azure.core.exceptions.HttpResponseError: The specified block list is invalid.
```