### PR TITLE
[deploy_config] Add domain support to hailctl config

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -19,6 +19,7 @@ deploy_config = get_deploy_config()
 DOCKER_PREFIX = os.environ['DOCKER_PREFIX']
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 UBUNTU_IMAGE = 'ubuntu:20.04'
+DOMAIN = os.environ.get('HAIL_DOMAIN')
 NAMESPACE = os.environ.get('HAIL_DEFAULT_NAMESPACE')
 SCOPE = os.environ.get('HAIL_SCOPE', 'test')
 CLOUD = os.environ.get('HAIL_CLOUD')
@@ -748,6 +749,7 @@ backend.close()
             '/bin/bash',
             '-c',
             f'''
+hailctl config set domain {DOMAIN}
 rm /deploy-config/deploy-config.json
 python3 -c \'{script}\'''',
         ],

--- a/build.yaml
+++ b/build.yaml
@@ -2690,6 +2690,7 @@ steps:
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
       export HAIL_CLOUD="{{ global.cloud }}"
+      export HAIL_DOMAIN="{{ global.domain }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2765,6 +2766,7 @@ steps:
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
       export HAIL_CLOUD="{{ global.cloud }}"
+      export HAIL_DOMAIN="{{ global.domain }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2840,6 +2842,7 @@ steps:
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
       export HAIL_CLOUD="{{ global.cloud }}"
+      export HAIL_DOMAIN="{{ global.domain }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2915,6 +2918,7 @@ steps:
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
       export HAIL_CLOUD="{{ global.cloud }}"
+      export HAIL_DOMAIN="{{ global.domain }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \
@@ -2990,6 +2994,7 @@ steps:
       export HAIL_TOKEN="{{ token }}"
       export HAIL_SCOPE="{{ scope }}"
       export HAIL_CLOUD="{{ global.cloud }}"
+      export HAIL_DOMAIN="{{ global.domain }}"
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/batch/
       python3 -m pytest \
               --log-date-format="%Y-%m-%dT%H:%M:%S" \

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -5,8 +5,10 @@ import os
 import json
 import logging
 from aiohttp import web
-from ..utils import retry_transient_errors, first_extant_file
+from ..utils import retry_transient_errors, first_extant_file, first_defined_value
 from ..tls import internal_client_ssl_context
+
+from .user_config import get_user_config
 
 log = logging.getLogger('deploy_config')
 
@@ -14,7 +16,11 @@ log = logging.getLogger('deploy_config')
 class DeployConfig:
     @staticmethod
     def from_config(config) -> 'DeployConfig':
-        domain = config.get('domain', 'hail.is')
+        domain = first_defined_value(
+            config.get('domain'),
+            get_user_config().get('global', 'domain'),
+            'hail.is'
+        )
         return DeployConfig(config['location'], config['default_namespace'], domain)
 
     def get_config(self) -> Dict[str, str]:

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -18,7 +18,7 @@ class DeployConfig:
     def from_config(config) -> 'DeployConfig':
         domain = first_defined_value(
             config.get('domain'),
-            get_user_config().get('global', 'domain'),
+            get_user_config().get('global', 'domain', fallback=None),
             'hail.is'
         )
         return DeployConfig(config['location'], config['default_namespace'], domain)

--- a/hail/python/hailtop/hailctl/config/cli.py
+++ b/hail/python/hailtop/hailctl/config/cli.py
@@ -10,7 +10,7 @@ validations = {
                           'should be valid Google Bucket identifier, with no gs:// prefix'),
     ('batch', 'remote_tmpdir'): (lambda x: any([re.fullmatch(fr'^{scheme}://.*', x) is not None for scheme in {'gs', 's3', 'hail-az'}]),
                                  'should be valid cloud storage URI such as gs://my-bucket/batch-tmp/'),
-    ('email',): (lambda x: re.fullmatch(r'.+@.+', x) is not None, 'should be valid email address')
+    ('email',): (lambda x: re.fullmatch(r'.+@.+', x) is not None, 'should be valid email address'),
 }
 
 deprecated_paths = {

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -10,7 +10,8 @@ from .utils import (
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_domain, is_azure_registry_domain, parse_docker_image_reference,
     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
-    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times)
+    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times,
+    first_defined_value)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
@@ -86,4 +87,5 @@ __all__ = [
     'parse_docker_image_reference',
     'retry_all_errors_n_times',
     'parse_timestamp_msecs',
+    'first_defined_value',
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, Awaitable, Optional, Type, List, Dict, Any
+from typing import Callable, TypeVar, Awaitable, Optional, Type, List, Dict
 from types import TracebackType
 import concurrent
 import subprocess

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -59,7 +59,7 @@ def first_extant_file(*files: Optional[str]) -> Optional[str]:
     return None
 
 
-def first_defined_value(*values: Optional[Any]) -> Optional[Any]:
+def first_defined_value(*values: Optional[T]) -> Optional[T]:
     for v in values:
         if v is not None:
             return v

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, Awaitable, Optional, Type, List, Dict
+from typing import Callable, TypeVar, Awaitable, Optional, Type, List, Dict, Any
 from types import TracebackType
 import concurrent
 import subprocess
@@ -56,6 +56,13 @@ def first_extant_file(*files: Optional[str]) -> Optional[str]:
     for f in files:
         if f is not None and os.path.isfile(f):
             return f
+    return None
+
+
+def first_defined_value(*values: Optional[Any]) -> Optional[Any]:
+    for v in values:
+        if v is not None:
+            return v
     return None
 
 


### PR DESCRIPTION
I added the capability for the deploy config to find the domain from setting it in the config.ini file. This way users only use `hailctl config set domain` rather than `hailctl dev config set domain`. In addition, we use this new capability to make a test in Batch work on Azure.

CC: @danking 