### PR TITLE
[auth] Support create_initial_user in dev deploy for dev namespaces

### DIFF
--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -307,6 +307,7 @@ class K8sNamespaceResource:
         self.name = name
 
     async def create(self, name):
+        assert name != 'default'
         assert self.name is None
 
         await self._delete(name)
@@ -315,7 +316,7 @@ class K8sNamespaceResource:
         self.name = name
 
     async def _delete(self, name):
-        assert namespace != 'default'
+        assert name != 'default'
         try:
             await self.k8s_client.delete_namespace(name)
         except kube.client.rest.ApiException as e:

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -315,6 +315,7 @@ class K8sNamespaceResource:
         self.name = name
 
     async def _delete(self, name):
+        assert namespace != 'default'
         try:
             await self.k8s_client.delete_namespace(name)
         except kube.client.rest.ApiException as e:

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -547,7 +547,7 @@ async def delete_user(app, user):
         await hail_identity_secret.delete()
 
     namespace_name = user['namespace_name']
-    if namespace_name is not None:
+    if namespace_name is not None and namespace_name != DEFAULT_NAMESPACE:
         assert user['is_developer'] == 1
 
         # don't bother deleting database-server-config since we're

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -307,7 +307,7 @@ class K8sNamespaceResource:
         self.name = name
 
     async def create(self, name):
-        assert name != 'default'
+        assert name not in ('default', DEFAULT_NAMESPACE)
         assert self.name is None
 
         await self._delete(name)
@@ -316,7 +316,7 @@ class K8sNamespaceResource:
         self.name = name
 
     async def _delete(self, name):
-        assert name != 'default'
+        assert name not in ('default', DEFAULT_NAMESPACE)
         try:
             await self.k8s_client.delete_namespace(name)
         except kube.client.rest.ApiException as e:

--- a/build.yaml
+++ b/build.yaml
@@ -475,7 +475,13 @@ steps:
       valueFrom: service_base_image.image
     script: |
       set -ex
+      export NAMESPACE={{ default_ns.name }}
+      export CLOUD={{ global.cloud }}
       python3 /io/create_initial_account.py {{ code.username }} {{ code.email }}
+    serviceAccount:
+      name: admin
+      namespace:
+        valueFrom: default_ns.name
     secrets:
       - name:
           valueFrom: auth_database.user_secret_name

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -437,6 +437,7 @@ async def dev_deploy_branch(request, userdata):
         branch = FQBranch.from_short_str(params['branch'])
         steps = params['steps']
         excluded_steps = params['excluded_steps']
+        extra_config = params.get('extra_config', {})
     except asyncio.CancelledError:
         raise
     except Exception as e:
@@ -457,7 +458,7 @@ async def dev_deploy_branch(request, userdata):
         log.info('dev deploy failed: ' + message, exc_info=True)
         raise web.HTTPBadRequest(text=message) from e
 
-    unwatched_branch = UnwatchedBranch(branch, sha, userdata)
+    unwatched_branch = UnwatchedBranch(branch, sha, userdata, extra_config)
 
     batch_client = app['batch_client']
 

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -901,11 +901,12 @@ git checkout {shq(self.sha)}
 
 
 class UnwatchedBranch(Code):
-    def __init__(self, branch, sha, userdata):
+    def __init__(self, branch, sha, userdata, extra_config=None):
         self.branch = branch
         self.user = userdata['username']
         self.namespace = userdata['namespace_name']
         self.sha = sha
+        self.extra_config = extra_config
 
         self.deploy_batch = None
 
@@ -916,7 +917,7 @@ class UnwatchedBranch(Code):
         return f'repos/{self.branch.repo.short_str()}'
 
     def config(self):
-        return {
+        config = {
             'checkout_script': self.checkout_script(),
             'branch': self.branch.name,
             'repo': self.branch.repo.short_str(),
@@ -924,6 +925,9 @@ class UnwatchedBranch(Code):
             'sha': self.sha,
             'user': self.user,
         }
+        if self.extra_config is not None:
+            config.update(self.extra_config)
+        return config
 
     async def deploy(self, batch_client, steps, excluded_steps=()):
         assert not self.deploy_batch

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -1,9 +1,41 @@
 import argparse
+import base64
+import json
+import kubernetes_asyncio as kube
+import os
+
 from hailtop.utils import async_to_blocking
 from gear import Database, transaction
 
 
-async def insert_user_if_not_exists(db, username, email):
+NAMESPACE = os.environ['NAMESPACE']
+
+
+async def copy_identity_from_default(hail_credentials_secret_name: str) -> str:
+    cloud = os.environ['CLOUD']
+    await kube.config.load_kube_config()
+    k8s_client = kube.client.CoreV1Api()
+
+    secret = await k8s_client.read_namespaced_secret(hail_credentials_secret_name, 'default')
+
+    await k8s_client.create_namespaced_secret(
+        NAMESPACE,
+        kube.client.V1Secret(
+            metadata=kube.client.V1ObjectMeta(name=hail_credentials_secret_name),
+            data=secret.data,
+        ),
+    )
+
+    credentials_json = base64.b64decode(secret.data['key.json']).decode()
+    credentials = json.loads(credentials_json)
+
+    if cloud == 'gcp':
+        return credentials['client_email']
+    assert cloud == 'azure'
+    return credentials['appId']
+
+
+async def insert_user_if_not_exists(db, username, email, is_developer, is_service_account):
     @transaction(db)
     async def insert(tx):
         row = await db.execute_and_fetchone('SELECT id, state FROM users where username = %s;', (username,))
@@ -12,19 +44,37 @@ async def insert_user_if_not_exists(db, username, email):
                 return None
             return row['id']
 
+        hail_credentials_secret_name = f'{username}-gsa-key'
+
+        if NAMESPACE == 'default':
+            hail_identity = None
+            namespace_name = None
+        else:
+            hail_identity = await copy_identity_from_default(hail_credentials_secret_name)
+            namespace_name = NAMESPACE
+
         return await db.execute_insertone(
             '''
-    INSERT INTO users (state, username, email, is_developer, is_service_account)
-    VALUES (%s, %s, %s, %s, %s);
+    INSERT INTO users (state, username, email, is_developer, is_service_account, hail_identity, hail_credentials_secret_name, namespace_name)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
     ''',
-            ('creating', username, email, 1, 0),
+            (
+                'creating',
+                username,
+                email,
+                is_developer,
+                is_service_account,
+                hail_identity,
+                hail_credentials_secret_name,
+                namespace_name,
+            ),
         )
 
     return await insert()
 
 
 async def main():
-    parser = argparse.ArgumentParser(description='Create initial Hail as a service account.')
+    parser = argparse.ArgumentParser(description='Create an initial dev user.')
 
     parser.add_argument('username', help='The username of the initial user.')
     parser.add_argument('email', help='The email of the initial user.')
@@ -34,7 +84,7 @@ async def main():
     db = Database()
     await db.async_init(maxsize=50)
 
-    await insert_user_if_not_exists(db, args.username, args.email)
+    await insert_user_if_not_exists(db, args.username, args.email, True, False)
 
 
 async_to_blocking(main())

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -44,12 +44,12 @@ async def insert_user_if_not_exists(db, username, email, is_developer, is_servic
                 return None
             return row['id']
 
-        hail_credentials_secret_name = f'{username}-gsa-key'
-
         if NAMESPACE == 'default':
+            hail_credentials_secret_name = None
             hail_identity = None
             namespace_name = None
         else:
+            hail_credentials_secret_name = f'{username}-gsa-key'
             hail_identity = await copy_identity_from_default(hail_credentials_secret_name)
             namespace_name = NAMESPACE
 

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -6,7 +6,7 @@ import sys
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers
 from hailtop.httpx import client_session
-from hailtop.utils import unpack_comma_delimited_inputs
+from hailtop.utils import unpack_comma_delimited_inputs, unpack_key_value_inputs
 
 
 def init_parser(parser):
@@ -16,6 +16,8 @@ def init_parser(parser):
                         help="Comma or space-separated list of steps to run.", required=True)
     parser.add_argument("--excluded_steps", "-e", nargs='+', action='append', default=[],
                         help="Comma or space-separated list of steps to forcibly exclude. Use with caution!")
+    parser.add_argument("--extra-config", "-c", nargs="+", action='append', default=[],
+                        help="Comma or space-separate list of key=value pairs to add as extra config parameters.")
     parser.add_argument("--open", "-o",
                         action="store_true",
                         help="Open the deploy batch page in a web browser.")
@@ -32,7 +34,7 @@ class CIClient:
         headers = service_auth_headers(self._deploy_config, 'ci')
         self._session = client_session(
             raise_for_status=False,
-            timeout=aiohttp.ClientTimeout(total=60), headers=headers)
+            timeout=aiohttp.ClientTimeout(total=60), headers=headers)  # type: ignore
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -43,11 +45,12 @@ class CIClient:
             await self._session.close()
             self._session = None
 
-    async def dev_deploy_branch(self, branch, steps, excluded_steps):
+    async def dev_deploy_branch(self, branch, steps, excluded_steps, extra_config):
         data = {
             'branch': branch,
             'steps': steps,
-            'excluded_steps': excluded_steps
+            'excluded_steps': excluded_steps,
+            'extra_config': extra_config,
         }
         async with self._session.post(
                 self._deploy_config.url('ci', '/api/v1alpha/dev_deploy_branch'), json=data) as resp:
@@ -63,8 +66,9 @@ async def submit(args):
     deploy_config = get_deploy_config()
     steps = unpack_comma_delimited_inputs(args.steps)
     excluded_steps = unpack_comma_delimited_inputs(args.excluded_steps)
+    extra_config = unpack_key_value_inputs(args.extra_config)
     async with CIClient(deploy_config) as ci_client:
-        batch_id = await ci_client.dev_deploy_branch(args.branch, steps, excluded_steps)
+        batch_id = await ci_client.dev_deploy_branch(args.branch, steps, excluded_steps, extra_config)
         url = deploy_config.url('ci', f'/batches/{batch_id}')
         print(f'Created deploy batch, see {url}')
         if args.open:

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -10,7 +10,8 @@ from .utils import (
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_domain, is_azure_registry_domain, parse_docker_image_reference,
     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
-    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times)
+    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, unpack_key_value_inputs,
+    retry_all_errors_n_times)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
@@ -81,6 +82,7 @@ __all__ = [
     'bounded_gather2',
     'OnlineBoundedGather2',
     'unpack_comma_delimited_inputs',
+    'unpack_key_value_inputs',
     'is_google_registry_domain',
     'is_azure_registry_domain',
     'parse_docker_image_reference',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -48,6 +48,11 @@ def unpack_comma_delimited_inputs(inputs):
             for s in step.split(',') if s.strip()]
 
 
+def unpack_key_value_inputs(inputs):
+    key_values = [i.split('=') for i in unpack_comma_delimited_inputs(inputs)]
+    return {kv[0]: kv[1] for kv in key_values}
+
+
 def flatten(xxs):
     return [x for xs in xxs for x in xs]
 


### PR DESCRIPTION
These are the alterations that Jackie and I made to be able to add a developer account to a dev namespace. If the namespace isn't default then it grabs the credentials for the user from default instead of creating a new credential. I don't like that the extra config lives on the branch but this is how it is otherwise supported in bootstrap.py, and ultimately we should just use the auth account to hit the auth endpoint and delete the `create_initial_account` script entirely.