### PR TITLE
[ci] Small fixes for non-default CI in azure

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -46,8 +46,6 @@ steps:
       - name: auth-oauth2-client-secret
       - name: registry-push-credentials
       - name: hail-ci-0-1-github-oauth-token
-        clouds:
-          - gcp
       - name: test-gsa-key
       - name: test-aws-key
         clouds:
@@ -57,8 +55,6 @@ steps:
           - gcp
       - name: zulip-config
       - name: benchmark-gsa-key
-        clouds:
-          - gcp
       - name: billing-monitor-gsa-key
         clouds:
           - gcp

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -45,6 +45,5 @@ build: service-base
 .PHONY: deploy
 deploy: build build-ci-utils build-hail-buildkit
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	! [ -z "$(CI_DEVELOPER_TEST_REPO_TOKEN)" -a $(NAMESPACE) != "default" ]  # for dev namespaces, you must specify a github repo by its token, check your currently running CI's value for HAIL_WATCHED_BRANCHES
-	python3 jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"ci_image":{"image":"$(CI_IMAGE)"},"ci_utils_image":{"image":"$(CI_UTILS_IMAGE)"},"ci_database":{"user_secret_name":"sql-ci-user-config"},"hail_buildkit_image":{"image":"$(HAIL_BUILDKIT_IMAGE)"},"create_ci_test_repo":{"token":"$(CI_DEVELOPER_TEST_REPO_TOKEN)"}}' deployment.yaml deployment.yaml.out
+	python3 jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":$(DEPLOY),"default_ns":{"name":"$(NAMESPACE)"},"ci_image":{"image":"$(CI_IMAGE)"},"ci_utils_image":{"image":"$(CI_UTILS_IMAGE)"},"ci_database":{"user_secret_name":"sql-ci-user-config"},"hail_buildkit_image":{"image":"$(HAIL_BUILDKIT_IMAGE)"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/ci/test/resources/build.yaml
+++ b/ci/test/resources/build.yaml
@@ -50,7 +50,7 @@ steps:
     resources:
       storage: 10Gi
       cpu: "2"
-      memory: 7.5Gi
+      memory: standard
     inputs:
       - from: /repo
         to: /io/repo
@@ -97,7 +97,7 @@ steps:
     resources:
       storage: 10Gi
       cpu: "2"
-      memory: 7.5Gi
+      memory: standard
     dependsOn:
       - base_image
       - merge_code
@@ -159,7 +159,7 @@ steps:
     resources:
       storage: 10Gi
       cpu: "2"
-      memory: 7.5Gi
+      memory: standard
     inputs:
       - from: /repo
         to: /io/repo


### PR DESCRIPTION
- Allow ci-related secrets in azure
- remove `create_ci_test_repo.token` in `ci/Makefile` since that is not retrieved from the `ci-config` secret
- Use `standard` memory in the test build.yaml