### PR TITLE
[ci] Fix assertion that artifacts URI must be gs:// and fix deploy steps

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -145,10 +145,11 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
 
 
 def storage_uri_to_url(uri: str) -> str:
-    protocol = 'gs://'
-    assert uri.startswith(protocol)
-    path = uri[len(protocol) :]
-    return f'https://console.cloud.google.com/storage/browser/{path}'
+    if uri.startswith('gs://'):
+        protocol = 'gs://'
+        path = uri[len(protocol) :]
+        return f'https://console.cloud.google.com/storage/browser/{path}'
+    return uri
 
 
 async def retry_pr(wb, pr, request):

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -16,4 +16,4 @@ DEFAULT_NAMESPACE = global_config['default_namespace']
 CI_UTILS_IMAGE = os.environ['HAIL_CI_UTILS_IMAGE']
 BUILDKIT_IMAGE = os.environ['HAIL_BUILDKIT_IMAGE']
 STORAGE_URI = os.environ['HAIL_CI_STORAGE_URI']
-DEPLOY_STEPS = tuple(json.loads(os.environ.get('DEPLOY_STEPS', '[]')))
+DEPLOY_STEPS = tuple(json.loads(os.environ.get('HAIL_CI_DEPLOY_STEPS', '[]')))


### PR DESCRIPTION
This was the patch I had to apply to fix the 500s that we had yesterday in PR pages. The URI to URL rewrite enforced GCP which caused the 500. I removed the assertion but don't know yet the proper way to link to a **private** blob storage containers so I just return the URI. I looked at the [canonical URL for blob storage containers](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-uri-syntax) but appears to only work for public containers. When I looked up how to get a URL for private containers, I get a lot of articles on SAS URLs that bake a token into the URL -- not what we want. We really just use this to link to the portal/console, but when I went to the portal the URL contains subscription-specific parameters that we don't have based on just the URI. This was the point where I figured our time was best spent elsewhere… Unless I'm missing something obvious, I can add this to the bottom of the TODO list.

I also fixed the deploy_steps environment variable to match what was actually declared in the ci/deployment.yaml