### PR TITLE
[benchmark-service] Mark as GCP only

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2473,6 +2473,8 @@ steps:
       - create_accounts
       - create_billing_projects
       - deploy_batch
+    clouds:
+      - gcp
   - kind: runImage
     name: test_benchmark
     image:
@@ -2501,6 +2503,8 @@ steps:
       - default_ns
       - create_certs
       - deploy_benchmark
+    clouds:
+      - gcp
   - kind: runImage
     name: upload_query_jar
     image:


### PR DESCRIPTION
It depends on a number of GCS buckets that that we could transition to terraform/ABS in the future but thought it's not worth the time right now.