### PR TITLE
[bootstrap] Publish python-dill images to container registry

### DIFF
--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-export HAIL="$HOME/hail"
-
 get_global_config_field() {
     kubectl get secret global-config --template={{.data.$1}} | base64 --decode
 }
@@ -32,6 +30,8 @@ copy_images() {
     DOCKER_PREFIX=$(get_global_config_field docker_prefix)
     DOCKER_PREFIX=$DOCKER_PREFIX ./copy_images.sh
     cd -
+
+    make -C $HAIL/docker/python-dill push DOCKER_PREFIX=$DOCKER_PREFIX
 }
 
 generate_ssl_certs() {

--- a/infra/bootstrap_utils.sh
+++ b/infra/bootstrap_utils.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -z "$HAIL" ]]; then
+    echo 1>&2 "Path to local clone of hail repository must be set."
+    exit 1
+fi
+
 get_global_config_field() {
     kubectl get secret global-config --template={{.data.$1}} | base64 --decode
 }


### PR DESCRIPTION
Currently `docker/python-dill` images are untested and deployed manually, but used in tests and by our users. #11122 aims to both test and automatically publish those images on every release, but to move forward testing in Azure for now this pushes those images as part of the bootstrapping process.

Also removed the `export HAIL` line because operators should be able to define where their hail home is.