### PR TITLE
[batch] Fix defaulting to config.ini for domain

### DIFF
--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -5,7 +5,7 @@ import os
 import json
 import logging
 from aiohttp import web
-from ..utils import retry_transient_errors, first_extant_file, first_defined_value
+from ..utils import retry_transient_errors, first_extant_file
 from ..tls import internal_client_ssl_context
 
 from .user_config import get_user_config
@@ -16,12 +16,7 @@ log = logging.getLogger('deploy_config')
 class DeployConfig:
     @staticmethod
     def from_config(config) -> 'DeployConfig':
-        domain = first_defined_value(
-            config.get('domain'),
-            get_user_config().get('global', 'domain', fallback=None),
-            'hail.is'
-        )
-        return DeployConfig(config['location'], config['default_namespace'], domain)
+        return DeployConfig(config['location'], config['default_namespace'], config['domain'])
 
     def get_config(self) -> Dict[str, str]:
         return {
@@ -47,7 +42,7 @@ class DeployConfig:
             config = {
                 'location': 'external',
                 'default_namespace': 'default',
-                'domain': 'hail.is'
+                'domain': get_user_config().get('global', 'domain', fallback='hail.is'),
             }
         return DeployConfig.from_config(config)
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -10,8 +10,7 @@ from .utils import (
     flatten, partition, cost_str, external_requests_client_session, url_basename,
     url_join, is_google_registry_domain, is_azure_registry_domain, parse_docker_image_reference,
     url_scheme, Notice, periodically_call, dump_all_stacktraces, find_spark_home, TransientError,
-    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times,
-    first_defined_value)
+    bounded_gather2, OnlineBoundedGather2, unpack_comma_delimited_inputs, retry_all_errors_n_times)
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
@@ -87,5 +86,4 @@ __all__ = [
     'parse_docker_image_reference',
     'retry_all_errors_n_times',
     'parse_timestamp_msecs',
-    'first_defined_value',
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -59,13 +59,6 @@ def first_extant_file(*files: Optional[str]) -> Optional[str]:
     return None
 
 
-def first_defined_value(*values: Optional[T]) -> Optional[T]:
-    for v in values:
-        if v is not None:
-            return v
-    return None
-
-
 def cost_str(cost):
     if cost is None:
         return None


### PR DESCRIPTION
`config['domain']` is actually never None in `from_config` so I moved the fallback to the config.ini value of domain to the `from_config_file` function that currently hard-codes `hail.is` when there's no deploy config.