### PR TITLE
[batch] Use cloud env var for hailtop tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3268,6 +3268,7 @@ steps:
     script: |
       cd /io/hailtop
       set -ex
+      export HAIL_CLOUD={{ global.cloud }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=0
@@ -3322,6 +3323,7 @@ steps:
     script: |
       cd /io/hailtop
       set -ex
+      export HAIL_CLOUD={{ global.cloud }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=1
@@ -3376,6 +3378,7 @@ steps:
     script: |
       cd /io/hailtop
       set -ex
+      export HAIL_CLOUD={{ global.cloud }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=2
@@ -3430,6 +3433,7 @@ steps:
     script: |
       cd /io/hailtop
       set -ex
+      export HAIL_CLOUD={{ global.cloud }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=3
@@ -3484,6 +3488,7 @@ steps:
     script: |
       cd /io/hailtop
       set -ex
+      export HAIL_CLOUD={{ global.cloud }}
       export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
       export PYTEST_SPLITS=5
       export PYTEST_SPLIT_INDEX=4


### PR DESCRIPTION
The `fails_in_azure` decorator uses the `HAIL_CLOUD` environment variable and it wasn't supplied to tests. The decorator itself looks fine.