### PR TITLE
[website] fix mobile buttons

### DIFF
--- a/website/website/pages/index.html
+++ b/website/website/pages/index.html
@@ -10,7 +10,7 @@
       <div id="hero-content">
         <h1 id="logo-title">Powering genomic analysis, at every scale</h1>
         <div class="logo-subtitle">Cloud-native genomic dataframes and batch computing</div>
-        <div style="display: flex;" id="hero-button-container">
+        <div id="hero-button-container">
           <a class="button" href="#install">Install</a>
           <a class="button" href="#hail-query">Hail Query</a>
           <a class="button" href="#hail-batch">Hail Batch</a>

--- a/website/website/styles/style.scss
+++ b/website/website/styles/style.scss
@@ -167,12 +167,12 @@ img {
 }
 
 #hero-button-container {
-  display: flex;
+  display: grid;
   margin-top: 1.5625rem;
-}
-
-#hero-button-container a + a {
-  margin-left: 15px;
+  grid-gap: 1em;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  width: 100%;
+  text-align: center;
 }
 
 .button {


### PR DESCRIPTION
I tried to achieve this within the CSS flex system, but I had trouble making the buttons equal-sized. The CSS grid system seemed more suited to our needs. The `grid-gap` property tells the browser to leave at least that much space between elements (the current code achieved that with this funky `a + a` rule). The key new rules are:
```css
grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
width: 100%;
```
The first rule tells the browser to put as many columns in the grid as possible, except that:
1. no column may be less than 130px (approximately the length of the phrase "Hail Query")
2. no column may occupy more than one "fraction" of the horizontal space (which is to say: each column gets an equal portion of the horizontal space)

The second rule tells the browser how much space is available for the grid. Without that rule, the browser tries to make the grid as small as possible, i.e. one column wide.

<img width="1020" alt="Screen Shot 2021-12-13 at 4 09 29 PM" src="https://user-images.githubusercontent.com/106194/145889522-af0c2367-0f37-43e2-8451-720a25981460.png">
<img width="331" alt="Screen Shot 2021-12-13 at 4 09 17 PM" src="https://user-images.githubusercontent.com/106194/145889525-b6a12ecc-0e7c-4af1-9b0f-5a6fdda322ab.png">
<img width="379" alt="Screen Shot 2021-12-13 at 4 09 11 PM" src="https://user-images.githubusercontent.com/106194/145889526-05773377-1ada-4a5d-81de-749ddac412e1.png">
