### PR TITLE
[dataproc] fix notebooks

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -43,7 +43,7 @@ if role == 'Master':
         'ipykernel==4.10.*',
         'ipywidgets==7.4.*',
         'jupyter-console==6.0.*',
-        'nbconvert==5.5.*',
+        'nbconvert==5.6.*',
         'notebook==5.7.*',
         'qtconsole==4.5.*'
     ]


### PR DESCRIPTION
mistune 2.0.0 was released which breaks nbconvert. nbconvert 5.6.0 introduced
appropriate pinning. https://github.com/jupyter/nbconvert/commit/365683f40f85dc9304b6f1c23ca35eeb4d63b597.