### PR TITLE
[ci] Track all hail CI statuses and merge only when they all pass

### DIFF
--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -397,7 +397,9 @@ class PR(Code):
                     raise ValueError(
                         f'github sent multiple status summaries for context {context}: {s}\n\n{statuses_json}'
                     )
-                hail_statuses[context] = s['state']
+                status = s['state']
+                assert status in ('success', 'pending', 'failure')
+                hail_statuses[context] = status
         return hail_statuses
 
     async def _update_last_known_github_status(self, gh):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -571,15 +571,15 @@ mkdir -p {shq(repo_dir)}
     def is_up_to_date(self):
         return self.batch is not None and self.target_branch.sha == self.batch.attributes['target_sha']
 
-    def is_mergeable(self):
-        if self.last_known_github_status[GITHUB_STATUS_CONTEXT] == 'success':
+    def is_mergeable(self) -> bool:
+        if self.last_known_github_status[GITHUB_STATUS_CONTEXT] == GithubStatus.SUCCESS:
             assert self.build_state == 'success', (
                 self.last_known_github_status[GITHUB_STATUS_CONTEXT],
                 self.build_state,
             )
         return (
             self.review_state == 'approved'
-            and all(status == 'success' for status in self.last_known_github_status)
+            and all(status == GithubStatus.SUCCESS for status in self.last_known_github_status)
             and self.is_up_to_date()
             and all(label not in DO_NOT_MERGE for label in self.labels)
         )

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional
+from typing_extensions import Literal
 import secrets
 from shlex import quote as shq
 import json
@@ -31,6 +32,9 @@ CALLBACK_URL = deploy_config.url('ci', '/api/v1alpha/batch_callback')
 zulip_client = zulip.Client(config_file="/zulip-config/.zuliprc")
 
 TRACKED_PRS = pc.Gauge('ci_tracked_prs', 'PRs currently being monitored by CI', ['build_state', 'review_state'])
+
+
+GithubStatus = Literal['success', 'pending', 'failure']
 
 
 def select_random_teammate(team):
@@ -205,10 +209,8 @@ class PR(Code):
         # 'error', 'success', 'failure', None
         self.build_state = None
 
-        # the build_state as communicated to GitHub:
-        # 'failure', 'success', 'pending'
-        self.intended_github_status = self.github_status_from_build_state()
-        self.last_known_github_status = None
+        self.intended_github_status: GithubStatus = self.github_status_from_build_state()
+        self.last_known_github_status: Dict[str, GithubStatus] = {}
 
         # don't need to set github_changed because we are refreshing github
         self.target_branch.batch_changed = True
@@ -329,7 +331,7 @@ class PR(Code):
             'sha': self.sha,
         }
 
-    def github_status_from_build_state(self):
+    def github_status_from_build_state(self) -> GithubStatus:
         if self.build_state == 'failure' or self.build_state == 'error':
             return 'failure'
         if self.build_state == 'success' and self.batch.attributes['target_sha'] == self.target_branch.sha:
@@ -385,18 +387,19 @@ class PR(Code):
         await self._update_github_review_state(gh)
 
     @staticmethod
-    def _hail_github_status_from_statuses(statuses_json):
+    def _hail_github_status_from_statuses(statuses_json) -> Dict[str, GithubStatus]:
         statuses = statuses_json["statuses"]
-        hail_status = [s for s in statuses if s["context"] == GITHUB_STATUS_CONTEXT]
-        n_hail_status = len(hail_status)
-        if n_hail_status == 0:
-            return None
-        if n_hail_status == 1:
-            return hail_status[0]['state']
-        raise ValueError(
-            f'github sent multiple status summaries for our one '
-            f'context {GITHUB_STATUS_CONTEXT}: {hail_status}\n\n{statuses_json}'
-        )
+        hail_statuses = {}
+        for s in statuses:
+            context = s['context']
+            if context == GITHUB_STATUS_CONTEXT or context.startswith('hail-ci'):
+                if context in hail_statuses:
+                    raise ValueError(
+                        f'github sent multiple status summaries for our one '
+                        f'context {context}: {s}\n\n{statuses_json}'
+                    )
+                hail_statuses[context] = s['state']
+        return hail_statuses
 
     async def _update_last_known_github_status(self, gh):
         if self.source_sha:
@@ -547,11 +550,12 @@ mkdir -p {shq(repo_dir)}
             return
 
         if self.source_sha:
-            if self.intended_github_status != self.last_known_github_status:
-                log.info(f'Intended github status for {self.short_str()} is: {self.intended_github_status}')
-                log.info(f'Last known github status for {self.short_str()} is: {self.last_known_github_status}')
+            last_posted_status = self.last_known_github_status[GITHUB_STATUS_CONTEXT]
+            if self.intended_github_status != last_posted_status:
+                log.info(f'Intended github status for {self.short_str()} is: {last_posted_status}')
+                log.info(f'Last known github status for {self.short_str()} is: {last_posted_status}')
                 await self.post_github_status(gh, self.intended_github_status)
-                self.last_known_github_status = self.intended_github_status
+                self.last_known_github_status[GITHUB_STATUS_CONTEXT] = self.intended_github_status
 
         if not await self.authorized(dbpool):
             return
@@ -566,9 +570,14 @@ mkdir -p {shq(repo_dir)}
         return self.batch is not None and self.target_branch.sha == self.batch.attributes['target_sha']
 
     def is_mergeable(self):
+        if self.last_known_github_status[GITHUB_STATUS_CONTEXT] == 'success':
+            assert self.build_state == 'success', (
+                self.last_known_github_status[GITHUB_STATUS_CONTEXT],
+                self.build_state,
+            )
         return (
             self.review_state == 'approved'
-            and self.build_state == 'success'
+            and all(status == 'success' for status in self.last_known_github_status)
             and self.is_up_to_date()
             and all(label not in DO_NOT_MERGE for label in self.labels)
         )

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -395,8 +395,7 @@ class PR(Code):
             if context == GITHUB_STATUS_CONTEXT or context.startswith('hail-ci'):
                 if context in hail_statuses:
                     raise ValueError(
-                        f'github sent multiple status summaries for our one '
-                        f'context {context}: {s}\n\n{statuses_json}'
+                        f'github sent multiple status summaries for context {context}: {s}\n\n{statuses_json}'
                     )
                 hail_statuses[context] = s['state']
         return hail_statuses

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -1,5 +1,5 @@
 from typing import Dict, Optional
-from typing_extensions import Literal
+from typing_extensions import Literal, get_args
 import secrets
 from shlex import quote as shq
 import json
@@ -398,7 +398,7 @@ class PR(Code):
                         f'github sent multiple status summaries for context {context}: {s}\n\n{statuses_json}'
                     )
                 status = s['state']
-                assert status in ('success', 'pending', 'failure')
+                assert status in get_args(GithubStatus)
                 hail_statuses[context] = status
         return hail_statuses
 


### PR DESCRIPTION
What level of confidence do we need in this? Definitely not something our CI test suite supports.