### PR TITLE
[batch] Add updating provisioning state in Azure

### DIFF
--- a/batch/batch/cloud/azure/driver/resource_manager.py
+++ b/batch/batch/cloud/azure/driver/resource_manager.py
@@ -57,7 +57,7 @@ class AzureResourceManager(CloudResourceManager):
             # https://docs.microsoft.com/en-us/azure/virtual-machines/states-billing
             for status in spec['statuses']:
                 code = status['code']
-                if code == 'ProvisioningState/creating':
+                if code in ('ProvisioningState/creating', 'ProvisioningState/updating', 'ProvisioningState/creating/osProvisioningComplete'):
                     return VMStateCreating(spec, instance.time_created)
                 if code == 'ProvisioningState/succeeded':
                     last_start_timestamp_msecs = parse_azure_timestamp(status.get('time'))


### PR DESCRIPTION
Looking at the logs, I think these two new states are because we added the log analytics agent based on when the PR merged and the absence of these errors before December 10th.

```
Unknown azure statuses [{'code': 'ProvisioningState/updating', 'level': 'Info', 'displayStatus': 'Updating'}, {'code': 'PowerState/running', 'level': 'Info', 'displayStatus': 'VM running'}] for instance batch-worker-default-standard-166xu
```