### PR TITLE
[batch] Remove K8sCache dependence on the batch environment

### DIFF
--- a/batch/batch/driver/k8s_cache.py
+++ b/batch/batch/driver/k8s_cache.py
@@ -1,35 +1,34 @@
 from typing import Tuple
 from hailtop.utils import retry_transient_errors
+import os
 
 from hailtop.aiotools.time_limited_max_size_cache import TimeLimitedMaxSizeCache
-from ..batch_configuration import KUBERNETES_TIMEOUT_IN_SECONDS
+
+KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
 
 
 FIVE_SECONDS_NS = 5 * 1000 * 1000 * 1000
 
 
 class K8sCache:
-    def __init__(self,
-                 client,
-                 refresh_time_ns: int = FIVE_SECONDS_NS,
-                 max_size: int = 100):
+    def __init__(self, client, refresh_time_ns: int = FIVE_SECONDS_NS, max_size: int = 100):
         self.client = client
-        self.secret_cache = TimeLimitedMaxSizeCache(
-            self._get_secret_from_k8s, refresh_time_ns, max_size)
+        self.secret_cache = TimeLimitedMaxSizeCache(self._get_secret_from_k8s, refresh_time_ns, max_size)
         self.service_account_cache = TimeLimitedMaxSizeCache(
-            self._get_service_account_from_k8s, refresh_time_ns, max_size)
+            self._get_service_account_from_k8s, refresh_time_ns, max_size
+        )
 
     async def _get_secret_from_k8s(self, name_and_namespace: Tuple[str, str]):
         return await retry_transient_errors(
-            self.client.read_namespaced_secret,
-            *name_and_namespace,
-            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+            self.client.read_namespaced_secret, *name_and_namespace, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+        )
 
     async def _get_service_account_from_k8s(self, name_and_namespace: Tuple[str, str]):
         return await retry_transient_errors(
             self.client.read_namespaced_service_account,
             *name_and_namespace,
-            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+        )
 
     async def read_secret(self, name, namespace):
         return await self.secret_cache.lookup((name, namespace))

--- a/batch/batch/driver/k8s_cache.py
+++ b/batch/batch/driver/k8s_cache.py
@@ -4,8 +4,6 @@ import os
 
 from hailtop.aiotools.time_limited_max_size_cache import TimeLimitedMaxSizeCache
 
-KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
-
 
 FIVE_SECONDS_NS = 5 * 1000 * 1000 * 1000
 
@@ -17,17 +15,16 @@ class K8sCache:
         self.service_account_cache = TimeLimitedMaxSizeCache(
             self._get_service_account_from_k8s, refresh_time_ns, max_size
         )
+        self.k8s_timeout = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
 
     async def _get_secret_from_k8s(self, name_and_namespace: Tuple[str, str]):
         return await retry_transient_errors(
-            self.client.read_namespaced_secret, *name_and_namespace, _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+            self.client.read_namespaced_secret, *name_and_namespace, _request_timeout=self.k8s_timeout
         )
 
     async def _get_service_account_from_k8s(self, name_and_namespace: Tuple[str, str]):
         return await retry_transient_errors(
-            self.client.read_namespaced_service_account,
-            *name_and_namespace,
-            _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
+            self.client.read_namespaced_service_account, *name_and_namespace, _request_timeout=self.k8s_timeout
         )
 
     async def read_secret(self, name, namespace):

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -226,7 +226,7 @@ users:
                     secrets = j._secrets
                     if secrets:
                         k8s_secrets = await asyncio.gather(
-                            *[k8s_cache.read_secret(secret['name'], secret['namespace'], 5) for secret in secrets]
+                            *[k8s_cache.read_secret(secret['name'], secret['namespace']) for secret in secrets]
                         )
 
                         for secret, k8s_secret in zip(secrets, k8s_secrets):


### PR DESCRIPTION
Importing from `batch_configuration` means that for this cache to be used you must define all environment variables that batch depends on. I severed this connection and fixed a use of the k8s cache in bootstrap.py