### PR TITLE
[bootstrap] Fix positional login-id argument

### DIFF
--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -77,7 +77,7 @@ async def main():
     parser = argparse.ArgumentParser(description='Create an initial dev user.')
 
     parser.add_argument('username', help='The username of the initial user.')
-    parser.add_argument('login-id', help='The login id of the initial user.')
+    parser.add_argument('login_id', metavar='login-id', help='The login id of the initial user.')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Argparse automatically transforms internal dashes of argument names into underscores for optional arguments, but [not for positional arguments](https://bugs.python.org/issue15125), so this currently breaks on line 87 with `args.login_id` not being a valid attribute. I tested that this change works with the minimal example:

```python
import argparse


def main():
    parser = argparse.ArgumentParser(description='foo')

    parser.add_argument('username', help='The username of the initial user.')
    parser.add_argument('login_id', metavar='login-id', help='The login id of the initial user.')

    args = parser.parse_args()

    print(args.username, '\t', args.login_id)

main()
```