### PR TITLE
[grafana] Make deployable in Azure with Makefile

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1923,6 +1923,7 @@ steps:
     config: grafana/deployment.yaml
     scopes:
       - deploy
+      - test
       - dev
     dependsOn:
       - default_ns

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -3,6 +3,7 @@ include ../config.mk
 .PHONY: build push deploy
 
 TOKEN = $(shell cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 12)
+CLOUD := $(shell kubectl get secret global-config --template={{.data.cloud}} | base64 --decode)
 
 GRAFANA_NGINX_IMAGE := $(DOCKER_PREFIX)/grafana_nginx:$(TOKEN)
 
@@ -15,5 +16,5 @@ build:
 
 deploy: build
 	! [ -z $(NAMESPACE) ]  # call this like: make deploy NAMESPACE=default
-	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "gcp", "project": "$(PROJECT)"},"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}, "base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
+	python3 ../ci/jinja2_render.py '{"deploy":$(DEPLOY),"global": {"cloud": "$(CLOUD)"},"default_ns":{"name":"$(NAMESPACE)"}, "grafana_nginx_image": {"image": "$(GRAFANA_NGINX_IMAGE)"}, "base_image":{"image":"'$$(cat ../docker/base-image-ref)'"}}' deployment.yaml deployment.yaml.out
 	kubectl -n $(NAMESPACE) apply -f deployment.yaml.out

--- a/grafana/deployment.yaml
+++ b/grafana/deployment.yaml
@@ -60,6 +60,13 @@ spec:
           - name: GF_SERVER_ROOT_URL
             value: "%(protocol)s://%(domain)s/{{ default_ns.name }}/grafana/"
 {% endif %}
+{% if global.cloud == 'gcp' %}
+          - name: GCP_PROJECT
+            valueFrom:
+              secretKeyRef:
+                name: global-config
+                key: gcp_project
+{% endif %}
          volumeMounts:
           - mountPath: /var/lib/grafana
             name: grafana-storage
@@ -138,7 +145,7 @@ data:
         isDefault: true
         jsonData:
           authenticationType: gce
-          defaultProject: {{ global.gcp_project }}
+          defaultProject: $GCP_PROJECT
         editable: true
 {% endif %}
       - name: Prometheus


### PR DESCRIPTION
The Makefile was hardcoded for GCP. Grafana is still currently able to be deployed through CI, this just changes the Makefile so it's not hardcoded to `gcp` and moves the gcp project from a Makefile-set value to one set through kubernetes so the Makefile is more cloud agnostic (doesn't reference a gcp project).