### PR TITLE
[prometheus] Lower memory request to 4G

### DIFF
--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -196,7 +196,7 @@ spec:
          resources:
            requests:
              cpu: "1"
-             memory: 5G
+             memory: 4G
            limits:
              cpu: "1"
              memory: 10G


### PR DESCRIPTION
5G won't fit on our current AKS machine type. This doesn't lower the memory limit and basically ensures that prometheus will get its own node, and should be ok with that amount of memory.