### PR TITLE
[query] Fix invalid string cast

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -455,7 +455,7 @@ abstract class RegistryFunctions {
       case t if t.isPrimitive => SType.extractPrimValue(cb, code)
       case TCall => code.asCall.canonicalCall(cb)
       case TArray(TString) => code.st match {
-        case _: SJavaArrayString => cb.memoize(code.asInstanceOf[SJavaArrayStringCode].array)
+        case _: SJavaArrayString => cb.memoize(code.asInstanceOf[SJavaArrayStringValue].array)
         case _ =>
           val sv = code.asIndexable
           val arr = cb.newLocal[Array[String]]("scode_array_string", Code.newArray[String](sv.loadLength()))


### PR DESCRIPTION
Not including a test since Patrick has an open PR that obviates this kind of error completely.