### PR TITLE
[hail] loosen requirements

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,10 +10,7 @@ botocore>=1.20,<2.0
 decorator<5
 Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4
-# https://github.com/dask/gcsfs/issues/372
-fsspec==0.9.0
-# https://github.com/dask/gcsfs/issues/372
-gcsfs==0.8.0
+fsspec==2021.*
 google-auth==1.27.0
 google-cloud-storage==1.25.*
 humanize==1.0.0
@@ -31,5 +28,5 @@ requests==2.25.1
 scipy>1.2,<1.8
 sortedcontainers==2.1.0
 tabulate==0.8.3
-tqdm==4.42.1
+tqdm==4.*
 uvloop==0.16.0

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,7 +10,7 @@ botocore>=1.20,<2.0
 decorator<5
 Deprecated>=1.2.10,<1.3
 dill>=0.3.1.1,<0.4
-fsspec==2021.*
+gcsfs==2021.*
 google-auth==1.27.0
 google-cloud-storage==1.25.*
 humanize==1.0.0


### PR DESCRIPTION
A user requested we loosen requirements on fsspec and tqdm. TQDM appears to
follow semver (https://github.com/tqdm/tqdm/issues/33). GCSFS is one of the
packages that specifically caused us versioning problems before. It does not
claim a versioning policy anywhere, but they do now pin fsspec versions, so
I think we can trust them to not break in that way, at least.