### PR TITLE
[infra] use skopeo for copying when its available

### DIFF
--- a/docker/third-party/copy_images.sh
+++ b/docker/third-party/copy_images.sh
@@ -10,10 +10,23 @@ then
     exit 1
 fi
 
+if command -v skopeo
+then
+    copy_image() {
+        skopeo copy --override-os linux --override-arch amd64 docker://docker.io/$1 docker://$2
+    }
+else
+    echo Could not find skopeo, falling back to docker which will be slower.
+    copy_image() {
+        docker pull $1
+        docker tag $1 $2
+        docker push $2
+    }
+fi
+
+
 for image in ${images}
 do
     dest="${DOCKER_PREFIX}/${image}"
-    docker pull $image
-    docker tag $image $dest
-    docker push $dest
+    copy_image $image $dest
 done


### PR DESCRIPTION
skopeo avoids downloading images that are already up-to-date, so it
is often a lot faster.