### PR TITLE
[auth] Use client_secret instead of client_secret_v2

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -585,7 +585,7 @@ async def on_startup(app):
     await db.async_init(maxsize=50)
     app['db'] = db
     app['client_session'] = httpx.client_session()
-    app['flow_client'] = get_flow_client('/auth-oauth2-client-secret/client_secret_v2.json')
+    app['flow_client'] = get_flow_client('/auth-oauth2-client-secret/client_secret.json')
 
 
 async def on_cleanup(app):

--- a/infra/azure/modules/auth/main.tf
+++ b/infra/azure/modules/auth/main.tf
@@ -51,8 +51,6 @@ resource "kubernetes_secret" "auth_oauth2_client_secret" {
   }
 
   data = {
-    # For backwards compatibility, will ultimately swap and v2 removed
     "client_secret.json" = jsonencode(local.oauth2_credentials)
-    "client_secret_v2.json" = jsonencode(local.oauth2_credentials)
   }
 }


### PR DESCRIPTION
I can apply the terraform to azure after this merges and new auth pods are running.