### PR TITLE
[query] Fix insert fields simplify bug

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -230,7 +230,7 @@ object InferType {
         val tbs = coerce[TStruct](old.typ)
         val s = tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
         fieldOrder.map { fds =>
-          assert(fds.length == s.size)
+          assert(fds.length == s.size, s"${fds} != ${s.types.toIndexedSeq}")
           TStruct(fds.map(f => f -> s.fieldType(f)): _*)
         }.getOrElse(s)
       case GetField(o, name) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -276,25 +276,21 @@ object Simplify {
 
     case GetField(SelectFields(old, fields), name) => GetField(old, name)
 
-    case insert@InsertFields(InsertFields(base, fields1, fieldOrder1), fields2, fieldOrder2) =>
-      val insertType = insert.typ
+    case outer@InsertFields(InsertFields(base, fields1, fieldOrder1), fields2, fieldOrder2) =>
       val fields2Set = fields2.map(_._1).toSet
       val newFields = fields1.filter { case (name, _) => !fields2Set.contains(name) } ++ fields2
-      val ans = (fieldOrder1, fieldOrder2) match {
+      (fieldOrder1, fieldOrder2) match {
         case (Some(fo1), None) =>
           val fields1Set = fo1.toSet
           val fieldOrder = fo1 ++ fields2.map(_._1).filter(!fields1Set.contains(_))
           InsertFields(base, newFields, Some(fieldOrder))
-        case (_, _) =>
+        case (_, Some(_)) =>
           InsertFields(base, newFields, fieldOrder2)
-//        case (None, None) =>
-//          // Fields should be in insertion order
-//          //val newOrder = Some((fields1.map(_._1) ++ newFields.map(_._1)).toIndexedSeq)
-//          InsertFields(base, newFields, Some(newFields.map(_._1).toIndexedSeq))
+        case _ =>
+          // In this case, it's important to make a field order that reflects the original insertion order
+          val resultFieldOrder = outer.typ.fieldNames
+          InsertFields(base, newFields, Some(resultFieldOrder))
       }
-      //assert(ans.typ == insertType, s"fo1 = ${fieldOrder1}, fo2 = ${fieldOrder2}")
-      ans
-
     case InsertFields(MakeStruct(fields1), fields2, fieldOrder) =>
       val fields1Map = fields1.toMap
       val fields2Map = fields2.toMap

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -49,6 +49,9 @@ class SimplifySuite extends HailSuite {
 
     val ir3 = InsertFields(InsertFields(base, Seq("3" -> I32(2)), Some(FastIndexedSeq("3", "1", "2"))), Seq("4" -> I32(3)), Some(FastIndexedSeq("3", "1", "2", "4")))
     assert(Simplify(ir3) == InsertFields(base, Seq("3" -> I32(2), "4" -> I32(3)), Some(FastIndexedSeq("3", "1", "2", "4"))))
+
+    val ir4 = InsertFields(InsertFields(base, Seq("3" -> I32(0), "4" -> I32(1))), Seq("3" -> I32(5)))
+    assert(ir4.typ == Simplify(ir4).typ)
   }
 
   @Test def testInsertSelectRewriteRules() {

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -42,7 +42,7 @@ class SimplifySuite extends HailSuite {
 
   @Test def testInsertFieldsRewriteRules() {
     val ir1 = InsertFields(InsertFields(base, Seq("1" -> I32(2)), None), Seq("1" -> I32(3)), None)
-    assert(Simplify(ir1) == InsertFields(base, Seq("1" -> I32(3)), None))
+    assert(Simplify(ir1) == InsertFields(base, Seq("1" -> I32(3)), Some(FastIndexedSeq("1", "2"))))
 
     val ir2 = InsertFields(InsertFields(base, Seq("3" -> I32(2)), Some(FastIndexedSeq("3", "1", "2"))), Seq("3" -> I32(3)), None)
     assert(Simplify(ir2) == InsertFields(base, Seq("3" -> I32(3)), Some(FastIndexedSeq("3", "1", "2"))))
@@ -51,7 +51,7 @@ class SimplifySuite extends HailSuite {
     assert(Simplify(ir3) == InsertFields(base, Seq("3" -> I32(2), "4" -> I32(3)), Some(FastIndexedSeq("3", "1", "2", "4"))))
 
     val ir4 = InsertFields(InsertFields(base, Seq("3" -> I32(0), "4" -> I32(1))), Seq("3" -> I32(5)))
-    assert(ir4.typ == Simplify(ir4).typ)
+    assert(Simplify(ir4) == InsertFields(base, Seq("4" -> I32(1), "3" -> I32(5)), Some(FastIndexedSeq("1", "2", "3", "4"))))
   }
 
   @Test def testInsertSelectRewriteRules() {


### PR DESCRIPTION
Had to fix this:

```
val base = Literal(TStruct("1" -> TInt32, "2" -> TInt32), Row(1,2))
val ir4 = InsertFields(InsertFields(base, Seq("3" -> I32(0), "4" -> I32(1)), None), Seq("3" -> I32(5)), None)
```

which was getting simplified to:

```
InsertFields(base, Seq("4" -> I32(1), "3" -> I32(5), None)
```

which changes the order of the fields. Now I explicitly construct a `fieldOrder` to remedy this.
