### PR TITLE
[memory] implement azure support

### DIFF
--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,9 +1,10 @@
+import abc
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config
 
 from hailtop.aiocloud import aiogoogle, aioazure
-from hailtop.aiotools.fs import AsyncFS
+from hailtop.aiotools.fs import AsyncFS, AsyncFSFactory
 
 
 def get_identity_client(credentials_file: Optional[str] = None):
@@ -50,3 +51,11 @@ def get_cloud_async_fs(credentials_file: Optional[str] = None) -> AsyncFS:
 
     assert cloud == 'gcp', cloud
     return aiogoogle.GoogleStorageAsyncFS(credentials_file=credentials_file)
+
+
+def get_cloud_async_fs_factory() -> AsyncFSFactory:
+    cloud = get_global_config()['cloud']
+    if cloud == 'azure':
+        return aioazure.AzureAsyncFSFactory()
+    assert cloud == 'gcp', cloud
+    return aiogoogle.GoogleStorageAsyncFSFactory()

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,4 +1,3 @@
-import abc
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config

--- a/hail/python/hailtop/aiocloud/aioazure/__init__.py
+++ b/hail/python/hailtop/aiocloud/aioazure/__init__.py
@@ -1,11 +1,12 @@
 from .client import (AzureComputeClient, AzureGraphClient, AzureNetworkClient, AzureResourcesClient,
                      AzureResourceManagerClient, AzurePricingClient)
 from .credentials import AzureCredentials
-from .fs import AzureAsyncFS
+from .fs import AzureAsyncFS, AzureAsyncFSFactory
 from .session import AzureSession
 
 __all__ = [
     'AzureAsyncFS',
+    'AzureAsyncFSFactory',
     'AzureCredentials',
     'AzureSession',
     'AzureComputeClient',

--- a/hail/python/hailtop/aiocloud/aioazure/credentials.py
+++ b/hail/python/hailtop/aiocloud/aioazure/credentials.py
@@ -24,7 +24,7 @@ class AzureCredentials(CloudCredentials):
     def from_file(credentials_file: str, scopes: Optional[List[str]] = None):
         with open(credentials_file, 'r') as f:
             credentials = json.loads(f.read())
-            return AzureCredentials.from_credentials_data(credentials)
+            return AzureCredentials.from_credentials_data(credentials, scopes)
 
     @staticmethod
     def default_credentials(scopes: Optional[List[str]] = None):

--- a/hail/python/hailtop/aiocloud/aioazure/credentials.py
+++ b/hail/python/hailtop/aiocloud/aioazure/credentials.py
@@ -14,13 +14,17 @@ log = logging.getLogger(__name__)
 
 class AzureCredentials(CloudCredentials):
     @staticmethod
+    def from_credentials_data(credentials: dict, scopes: Optional[List[str]] = None):
+        credential = ClientSecretCredential(tenant_id=credentials['tenant'],
+                                            client_id=credentials['appId'],
+                                            client_secret=credentials['password'])
+        return AzureCredentials(credential, scopes)
+
+    @staticmethod
     def from_file(credentials_file: str, scopes: Optional[List[str]] = None):
         with open(credentials_file, 'r') as f:
-            data = json.loads(f.read())
-            credential = ClientSecretCredential(tenant_id=data['tenant'],
-                                                client_id=data['appId'],
-                                                client_secret=data['password'])
-            return AzureCredentials(credential, scopes)
+            credentials = json.loads(f.read())
+            return AzureCredentials.from_credentials_data(credentials)
 
     @staticmethod
     def default_credentials(scopes: Optional[List[str]] = None):

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -15,8 +15,9 @@ import azure.core.exceptions
 
 from hailtop.utils import retry_transient_errors, flatten
 from hailtop.aiotools import WriteBuffer
-from hailtop.aiotools.fs import (AsyncFS, ReadableStream, WritableStream, MultiPartCreate, FileListEntry, FileStatus,
-                                 FileAndDirectoryError, UnexpectedEOFError)
+from hailtop.aiotools.fs import (AsyncFS, AsyncFSFactory, ReadableStream, WritableStream,
+                                 MultiPartCreate, FileListEntry, FileStatus, FileAndDirectoryError,
+                                 UnexpectedEOFError)
 
 from .credentials import AzureCredentials
 
@@ -436,3 +437,20 @@ class AzureAsyncFS(AsyncFS):
 
         if self._blob_service_clients:
             await asyncio.wait([client.close() for client in self._blob_service_clients.values()])
+
+
+class GoogleStorageAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
+    def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:
+        del self
+        return AzureAsyncFS(
+            credentials=AzureCredentials.from_credentials_data(credentials_data))
+
+    def from_credentials_file(self, credentials_file: str) -> AzureAsyncFS:
+        del self
+        return AzureAsyncFS(
+            credentials=AzureCredentials.from_file(credentials_file))
+
+    def from_default_credentials(self) -> AzureAsyncFS:
+        del self
+        return AzureAsyncFS(
+            credentials=AzureCredentials.default_credentials())

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -440,17 +440,14 @@ class AzureAsyncFS(AsyncFS):
 
 
 class AzureAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
-    def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:
-        del self
+    def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:  # pylint: disable=no-self-use
         return AzureAsyncFS(
             credentials=AzureCredentials.from_credentials_data(credentials_data))
 
-    def from_credentials_file(self, credentials_file: str) -> AzureAsyncFS:
-        del self
+    def from_credentials_file(self, credentials_file: str) -> AzureAsyncFS:  # pylint: disable=no-self-use
         return AzureAsyncFS(
             credentials=AzureCredentials.from_file(credentials_file))
 
-    def from_default_credentials(self) -> AzureAsyncFS:
-        del self
+    def from_default_credentials(self) -> AzureAsyncFS:  # pylint: disable=no-self-use
         return AzureAsyncFS(
             credentials=AzureCredentials.default_credentials())

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -439,7 +439,7 @@ class AzureAsyncFS(AsyncFS):
             await asyncio.wait([client.close() for client in self._blob_service_clients.values()])
 
 
-class GoogleStorageAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
+class AzureAsyncFSFactory(AsyncFSFactory[AzureAsyncFS]):
     def from_credentials_data(self, credentials_data: dict) -> AzureAsyncFS:
         del self
         return AzureAsyncFS(

--- a/hail/python/hailtop/aiocloud/aiogoogle/__init__.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/__init__.py
@@ -1,5 +1,5 @@
 from .client import GoogleBigQueryClient, GoogleContainerClient, GoogleComputeClient, GoogleIAmClient, GoogleLoggingClient, \
-    GoogleStorageClient, GoogleStorageAsyncFS
+    GoogleStorageClient, GoogleStorageAsyncFS, GoogleStorageAsyncFSFactory
 from .credentials import GoogleCredentials, GoogleApplicationDefaultCredentials, GoogleServiceAccountCredentials
 from .session import GoogleSession
 
@@ -14,5 +14,6 @@ __all__ = [
     'GoogleIAmClient',
     'GoogleLoggingClient',
     'GoogleStorageClient',
-    'GoogleStorageAsyncFS'
+    'GoogleStorageAsyncFS',
+    'GoogleStorageAsyncFSFactory'
 ]

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/__init__.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/__init__.py
@@ -3,7 +3,7 @@ from .container_client import GoogleContainerClient
 from .compute_client import GoogleComputeClient
 from .iam_client import GoogleIAmClient
 from .logging_client import GoogleLoggingClient
-from .storage_client import GoogleStorageClient, GoogleStorageAsyncFS
+from .storage_client import GoogleStorageClient, GoogleStorageAsyncFS, GoogleStorageAsyncFSFactory
 
 __all__ = [
     'GoogleBigQueryClient',
@@ -12,5 +12,6 @@ __all__ = [
     'GoogleIAmClient',
     'GoogleLoggingClient',
     'GoogleStorageClient',
-    'GoogleStorageAsyncFS'
+    'GoogleStorageAsyncFS',
+    'GoogleStorageAsyncFSFactory'
 ]

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -11,13 +11,14 @@ import aiohttp
 from hailtop.utils import (
     secret_alnum_string, OnlineBoundedGather2,
     TransientError, retry_transient_errors)
-from hailtop.aiotools.fs import (
-    FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
-    FileAndDirectoryError, MultiPartCreate, UnexpectedEOFError)
+from hailtop.aiotools.fs import (FileStatus, FileListEntry, ReadableStream, WritableStream, AsyncFS,
+                                 AsyncFSFactory, FileAndDirectoryError, MultiPartCreate,
+                                 UnexpectedEOFError)
 from hailtop.aiotools import FeedableAsyncIterable, WriteBuffer
 
 from .base_client import GoogleBaseClient
 from ..session import GoogleSession
+from ..credentials import GoogleCredentials
 
 log = logging.getLogger(__name__)
 
@@ -686,3 +687,20 @@ class GoogleStorageAsyncFS(AsyncFS):
         if hasattr(self, '_storage_client'):
             await self._storage_client.close()
             del self._storage_client
+
+
+class GoogleStorageAsyncFSFactory(AsyncFSFactory[GoogleStorageAsyncFS]):
+    def from_credentials_data(self, credentials_data: dict) -> GoogleStorageAsyncFS:
+        del self
+        return GoogleStorageAsyncFS(
+            credentials=GoogleCredentials.from_credentials_data(credentials_data))
+
+    def from_credentials_file(self, credentials_file: str) -> GoogleStorageAsyncFS:
+        del self
+        return GoogleStorageAsyncFS(
+            credentials=GoogleCredentials.from_file(credentials_file))
+
+    def from_default_credentials(self) -> GoogleStorageAsyncFS:
+        del self
+        return GoogleStorageAsyncFS(
+            credentials=GoogleCredentials.default_credentials())

--- a/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/storage_client.py
@@ -690,17 +690,14 @@ class GoogleStorageAsyncFS(AsyncFS):
 
 
 class GoogleStorageAsyncFSFactory(AsyncFSFactory[GoogleStorageAsyncFS]):
-    def from_credentials_data(self, credentials_data: dict) -> GoogleStorageAsyncFS:
-        del self
+    def from_credentials_data(self, credentials_data: dict) -> GoogleStorageAsyncFS:  # pylint: disable=no-self-use
         return GoogleStorageAsyncFS(
             credentials=GoogleCredentials.from_credentials_data(credentials_data))
 
-    def from_credentials_file(self, credentials_file: str) -> GoogleStorageAsyncFS:
-        del self
+    def from_credentials_file(self, credentials_file: str) -> GoogleStorageAsyncFS:  # pylint: disable=no-self-use
         return GoogleStorageAsyncFS(
             credentials=GoogleCredentials.from_file(credentials_file))
 
-    def from_default_credentials(self) -> GoogleStorageAsyncFS:
-        del self
+    def from_default_credentials(self) -> GoogleStorageAsyncFS:  # pylint: disable=no-self-use
         return GoogleStorageAsyncFS(
             credentials=GoogleCredentials.default_credentials())

--- a/hail/python/hailtop/aiotools/fs/__init__.py
+++ b/hail/python/hailtop/aiotools/fs/__init__.py
@@ -1,10 +1,11 @@
-from .fs import AsyncFS, MultiPartCreate, FileListEntry, FileStatus
+from .fs import AsyncFS, AsyncFSFactory, MultiPartCreate, FileListEntry, FileStatus
 from .copier import Copier, CopyReport, SourceCopier, SourceReport, Transfer, TransferReport
 from .exceptions import UnexpectedEOFError, FileAndDirectoryError
 from .stream import ReadableStream, WritableStream, blocking_readable_stream_to_async, blocking_writable_stream_to_async
 
 __all__ = [
     'AsyncFS',
+    'AsyncFSFactory',
     'Copier',
     'CopyReport',
     'SourceCopier',

--- a/hail/python/hailtop/aiotools/fs/fs.py
+++ b/hail/python/hailtop/aiotools/fs/fs.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncContextManager, Optional, Type, Set, AsyncIterator, Callable
+from typing import (Any, AsyncContextManager, Optional, Type, Set, AsyncIterator, Callable, TypeVar,
+                    Generic)
 from types import TracebackType
 import abc
 import asyncio
@@ -230,3 +231,20 @@ class AsyncFS(abc.ABC):
         '''Part size when copying using multi-part uploads.  The part size of
         the destination filesystem is used.'''
         return 128 * 1024 * 1024
+
+
+T = TypeVar('T', bound=AsyncFS)
+
+
+class AsyncFSFactory(abc.ABC, Generic[T]):
+    @abc.abstractmethod
+    def from_credentials_data(self, credentials_data: dict) -> T:
+        pass
+
+    @abc.abstractmethod
+    def from_credentials_file(self, credentials_file: str) -> T:
+        pass
+
+    @abc.abstractmethod
+    def from_default_credentials(self) -> T:
+        pass

--- a/memory/deployment.yaml
+++ b/memory/deployment.yaml
@@ -92,6 +92,9 @@ spec:
            - name: ssl-config
              mountPath: /ssl-config
              readOnly: true
+           - mountPath: /global-config
+             name: global-config
+             readOnly: true
           resources:
             requests:
               memory: "1.25G"
@@ -117,6 +120,9 @@ spec:
          secret:
            optional: false
            secretName: ssl-config-memory
+       - name: global-config
+         secret:
+           secretName: global-config
 ---
 apiVersion: v1
 kind: Service

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -72,13 +72,13 @@ async def get_or_add_user(app, userdata):
     username = userdata['username']
     if username not in users:
         k8s_client = app['k8s_client']
-        hail_credentials_secret_name = await retry_transient_errors(
+        hail_credentials_secret = await retry_transient_errors(
             k8s_client.read_namespaced_secret,
             userdata['hail_credentials_secret_name'],
             DEFAULT_NAMESPACE,
             _request_timeout=5.0,
         )
-        cloud_credentials_data = json.loads(base64.b64decode(hail_credentials_secret_name.data['key.json']).decode())
+        cloud_credentials_data = json.loads(base64.b64decode(hail_credentials_secret.data['key.json']).decode())
         users[username] = {'fs': ASYNC_FS_FACTORY.from_credentials_data(cloud_credentials_data)}
     return users[username]
 

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -12,13 +12,13 @@ from prometheus_async.aio.web import server_stats  # type: ignore
 from typing import Set
 
 from hailtop.aiotools import AsyncFS
-from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS, GoogleCredentials
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import AsyncWorkerPool, retry_transient_errors, dump_all_stacktraces
 from hailtop import httpx
 from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_endpoints_middleware
+from gear.clients import get_cloud_async_fs_factory
 
 uvloop.install()
 
@@ -27,6 +27,8 @@ log = logging.getLogger('memory')
 routes = web.RouteTableDef()
 
 socket = '/redis/redis.sock'
+
+ASYNC_FS_FACTORY = get_cloud_async_fs_factory()
 
 
 @routes.get('/healthcheck')
@@ -70,15 +72,14 @@ async def get_or_add_user(app, userdata):
     username = userdata['username']
     if username not in users:
         k8s_client = app['k8s_client']
-        hail_identity_secret = await retry_transient_errors(
+        hail_credentials_secret_name = await retry_transient_errors(
             k8s_client.read_namespaced_secret,
             userdata['hail_credentials_secret_name'],
             DEFAULT_NAMESPACE,
             _request_timeout=5.0,
         )
-        gsa_key = json.loads(base64.b64decode(hail_identity_secret.data['key.json']).decode())
-        credentials = GoogleCredentials.from_credentials_data(gsa_key)
-        users[username] = {'fs': GoogleStorageAsyncFS(credentials=credentials)}
+        cloud_credentials_data = json.loads(base64.b64decode(hail_credentials_secret_name.data['key.json']).decode())
+        users[username] = {'fs': ASYNC_FS_FACTORY.from_credentials_data(cloud_credentials_data)}
     return users[username]
 
 


### PR DESCRIPTION
I also added factories for Google and Azure so that we only
check the global-config cloud setting once, not repeatedly
every time we create an AsyncFS.