### PR TITLE
[memory] several fixes

### DIFF
--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,4 +1,3 @@
-import abc
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,3 +1,4 @@
+import abc
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -68,7 +68,7 @@ async def write_object(request, userdata):
         finally:
             del request.app['files_in_progress'][file_key]
 
-    fut = asyncio.ensure_future(persist_and_cache)
+    fut = asyncio.ensure_future(persist_and_cache())
     request.app['files_in_progress'][file_key] = fut
     await fut
     return web.Response(status=200)

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -15,7 +15,7 @@ from hailtop.aiotools import AsyncFS
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from hailtop.utils import AsyncWorkerPool, retry_transient_errors, dump_all_stacktraces
+from hailtop.utils import retry_transient_errors, dump_all_stacktraces
 from hailtop import httpx
 from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_endpoints_middleware
 from gear.clients import get_cloud_async_fs_factory

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -68,7 +68,7 @@ async def write_object(request, userdata):
         finally:
             del request.app['files_in_progress'][file_key]
 
-    fut = asyncio.create_future(persist_and_cache)
+    fut = asyncio.ensure_future(persist_and_cache)
     request.app['files_in_progress'][file_key] = fut
     await fut
     return web.Response(status=200)


### PR DESCRIPTION
1. I taught `get_or_add_user` to serialize loading of a single user's secrets
   from kubernetes. The old code would issue multiple requests in parallel for
   a user not yet in `users`.

2. The whole situation with the worker pool and the files in progress set did
   not seem right to me. If a write comes in, we create a future corresponding
   to the write and store the future in a dictionary. If a read comes in, we
   first check redis, then we check if there is already a write or read of cloud
   storage in progress. If there is no write nor read in progress, we initiate
   a read. Before a read or write completes, it removes itself from the in-progress
   files (future reads will now see the file in redis). Writes are permitted to
   overwrite other writes that are already in progress.
