### PR TITLE
[batch] address some pylint issues

### DIFF
--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -435,7 +435,7 @@ class BatchBuilder:
 
     def create_job(self,
                    image: str,
-                   command: str,
+                   command: List[str],
                    env: Optional[Dict[str, str]] = None,
                    mount_docker_socket: bool = False,
                    port: Optional[int] = None,


### PR DESCRIPTION
Lines 381-390 had a real bug: we re-used the "b1" and "b2" variables for the rest of wait which is a dictionary, not a true handle to the batch. I went ahead and fixed all the mypy / pylons issues I found in this file.