### PR TITLE
Stop checking against Python 3.6

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1156,10 +1156,10 @@ steps:
       - hail_ubuntu_image
       - merge_code
   - kind: buildImage2
-    name: hail_pip_installed_python36_image
-    dockerFile: /io/repo/hail/Dockerfile.hail-pip-installed-python36
+    name: hail_pip_installed_python38_image
+    dockerFile: /io/repo/hail/Dockerfile.hail-pip-installed-python38
     contextPath: /io/repo
-    publishAs: hail-pip-installed-python36
+    publishAs: hail-pip-installed-python38
     inputs:
       - from: /repo
         to: /io/repo
@@ -1189,9 +1189,9 @@ steps:
     dependsOn:
       - hail_pip_installed_python37_image
   - kind: runImage
-    name: check_hail_python36
+    name: check_hail_python38
     image:
-      valueFrom: hail_pip_installed_python36_image.image
+      valueFrom: hail_pip_installed_python38_image.image
     script: |
       set -x
       SITE_PACKAGES=$(pip3 show hail | grep Location | sed 's/Location: //')
@@ -1206,7 +1206,7 @@ steps:
 
       exit $exit_status
     dependsOn:
-      - hail_pip_installed_python36_image
+      - hail_pip_installed_python38_image
   - kind: buildImage2
     name: notebook_image
     dockerFile: /io/repo/notebook/Dockerfile

--- a/hail/Dockerfile.hail-pip-installed-python38
+++ b/hail/Dockerfile.hail-pip-installed-python38
@@ -3,8 +3,8 @@ FROM {{ hail_ubuntu_image.image }}
 ENV LANG C.UTF-8
 RUN hail-apt-get-install \
     openjdk-8-jdk-headless \
-    python3.6 python3-pip \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+    python3.8 python3-pip \
+  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 
 COPY hail/python/requirements.txt requirements.txt
 COPY hail/python/dev-requirements.txt dev-requirements.txt


### PR DESCRIPTION
Python 3.6 is EOL: https://endoflife.date/python

Let's switch to checking against 3.7 and 3.8.