### PR TITLE
[hailctl] Move slow imports out of the top level

### DIFF
--- a/hail/python/hailtop/__init__.py
+++ b/hail/python/hailtop/__init__.py
@@ -1,6 +1,12 @@
+_VERSION = None
+
+
 def version() -> str:
-    import pkg_resources  # pylint: disable=import-outside-toplevel
-    return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
+    global _VERSION
+    if _VERSION is None:
+        import pkg_resources  # pylint: disable=import-outside-toplevel
+        _VERSION = pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
+    return _VERSION
 
 
 def pip_version() -> str:

--- a/hail/python/hailtop/__init__.py
+++ b/hail/python/hailtop/__init__.py
@@ -1,12 +1,7 @@
-import pkg_resources
-
-
-_VERSION = pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
+def version() -> str:
+    import pkg_resources  # pylint: disable=import-outside-toplevel
+    return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
 
 
 def pip_version() -> str:
-    return _VERSION.split('-')[0]
-
-
-def version() -> str:
-    return _VERSION
+    return version().split('-')[0]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -10,7 +10,7 @@ import secrets
 
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.auth import service_auth_headers
-from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
+from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm
 from hailtop import httpx
 
 from .globals import tasks, complete_states
@@ -390,7 +390,7 @@ class Batch:
             return await self.status()  # updates _last_known_status
         return self._last_known_status
 
-    async def wait(self, *, disable_progress_bar=TQDM_DEFAULT_DISABLE):
+    async def wait(self, *, disable_progress_bar=False):
         i = 0
         with tqdm(total=self.n_jobs,
                   disable=disable_progress_bar,
@@ -618,7 +618,7 @@ class BatchBuilder:
     async def submit(self,
                      max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
                      max_bunch_size: int = MAX_BUNCH_SIZE,
-                     disable_progress_bar: Optional[bool] = TQDM_DEFAULT_DISABLE,
+                     disable_progress_bar: bool = False,
                      ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Optional, Dict, Any, List, Tuple, Union
 import math
 import random
 import logging
@@ -10,7 +10,7 @@ import secrets
 
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.auth import service_auth_headers
-from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm
+from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
 from hailtop import httpx
 
 from .globals import tasks, complete_states
@@ -390,7 +390,7 @@ class Batch:
             return await self.status()  # updates _last_known_status
         return self._last_known_status
 
-    async def wait(self, *, disable_progress_bar=False):
+    async def wait(self, *, disable_progress_bar=TQDM_DEFAULT_DISABLE):
         i = 0
         with tqdm(total=self.n_jobs,
                   disable=disable_progress_bar,
@@ -618,7 +618,7 @@ class BatchBuilder:
     async def submit(self,
                      max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
                      max_bunch_size: int = MAX_BUNCH_SIZE,
-                     disable_progress_bar: Optional[bool] = False,
+                     disable_progress_bar: Optional[Union[bool, object]] = TQDM_DEFAULT_DISABLE,
                      ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -618,7 +618,7 @@ class BatchBuilder:
     async def submit(self,
                      max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
                      max_bunch_size: int = MAX_BUNCH_SIZE,
-                     disable_progress_bar: bool = False,
+                     disable_progress_bar: Optional[bool] = False,
                      ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,5 +1,4 @@
 from typing import Optional, Dict, Any, List, Tuple, Union
-from typing_extensions import Literal
 import math
 import random
 import logging
@@ -11,7 +10,7 @@ import secrets
 
 from hailtop.config import get_deploy_config, DeployConfig
 from hailtop.auth import service_auth_headers
-from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TQDM_DEFAULT_DISABLE
+from hailtop.utils import bounded_gather, request_retry_transient_errors, tqdm, TqdmDisableOption
 from hailtop import httpx
 
 from .globals import tasks, complete_states
@@ -391,7 +390,7 @@ class Batch:
             return await self.status()  # updates _last_known_status
         return self._last_known_status
 
-    async def wait(self, *, disable_progress_bar=TQDM_DEFAULT_DISABLE):
+    async def wait(self, *, disable_progress_bar=TqdmDisableOption.default):
         i = 0
         with tqdm(total=self.n_jobs,
                   disable=disable_progress_bar,
@@ -619,7 +618,7 @@ class BatchBuilder:
     async def submit(self,
                      max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
                      max_bunch_size: int = MAX_BUNCH_SIZE,
-                     disable_progress_bar: Optional[Union[bool, Literal[TQDM_DEFAULT_DISABLE]]] = TQDM_DEFAULT_DISABLE,
+                     disable_progress_bar: Union[bool, None, TqdmDisableOption] = TqdmDisableOption.default,
                      ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any, List, Tuple, Union
+from typing import Optional, Dict, Any, List, Tuple, Union, Literal
 import math
 import random
 import logging
@@ -618,7 +618,7 @@ class BatchBuilder:
     async def submit(self,
                      max_bunch_bytesize: int = MAX_BUNCH_BYTESIZE,
                      max_bunch_size: int = MAX_BUNCH_SIZE,
-                     disable_progress_bar: Optional[Union[bool, object]] = TQDM_DEFAULT_DISABLE,
+                     disable_progress_bar: Optional[Union[bool, Literal[TQDM_DEFAULT_DISABLE]]] = TQDM_DEFAULT_DISABLE,
                      ):
         assert max_bunch_bytesize > 0
         assert max_bunch_size > 0

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict, Any, List, Tuple, Union, Literal
+from typing import Optional, Dict, Any, List, Tuple, Union
+from typing_extensions import Literal
 import math
 import random
 import logging

--- a/hail/python/hailtop/hailctl/dataproc/deploy_metadata.py
+++ b/hail/python/hailtop/hailctl/dataproc/deploy_metadata.py
@@ -1,8 +1,8 @@
-import pkg_resources
 import yaml
 
 
 def get_deploy_metadata():
+    import pkg_resources  # pylint: disable=import-outside-toplevel
     if not pkg_resources.resource_exists("hailtop.hailctl", "deploy.yaml"):
         raise RuntimeError("package has no 'deploy.yaml' file")
 

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -1,6 +1,5 @@
 import re
 
-import pkg_resources
 import yaml
 
 from . import gcloud
@@ -226,6 +225,8 @@ def init_parser(parser):
 
 
 async def main(args, pass_through_args):
+    import pkg_resources  # pylint: disable=import-outside-toplevel
+
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -15,7 +15,7 @@ from .utils import (
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
-from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
+from .tqdm import tqdm, TqdmDisableOption
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
     rate_instance_hour_to_fraction_msec
@@ -55,7 +55,7 @@ __all__ = [
     'request_raise_transient_errors',
     'collect_agen',
     'tqdm',
-    'TQDM_DEFAULT_DISABLE',
+    'TqdmDisableOption',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
     'retry_response_returning_functions',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -15,7 +15,7 @@ from .utils import (
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
-from .tqdm import tqdm
+from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
     rate_instance_hour_to_fraction_msec
@@ -55,6 +55,7 @@ __all__ = [
     'request_raise_transient_errors',
     'collect_agen',
     'tqdm',
+    'TQDM_DEFAULT_DISABLE',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
     'retry_response_returning_functions',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -15,7 +15,7 @@ from .utils import (
 from .process import (
     CalledProcessError, check_shell, check_shell_output, check_exec_output,
     sync_check_shell, sync_check_shell_output)
-from .tqdm import tqdm, TQDM_DEFAULT_DISABLE
+from .tqdm import tqdm
 from .rates import (
     rate_cpu_hour_to_mcpu_msec, rate_gib_hour_to_mib_msec, rate_gib_month_to_mib_msec,
     rate_instance_hour_to_fraction_msec
@@ -55,7 +55,6 @@ __all__ = [
     'request_raise_transient_errors',
     'collect_agen',
     'tqdm',
-    'TQDM_DEFAULT_DISABLE',
     'RETRY_FUNCTION_SCRIPT',
     'sync_retry_transient_errors',
     'retry_response_returning_functions',

--- a/hail/python/hailtop/utils/time.py
+++ b/hail/python/hailtop/utils/time.py
@@ -1,6 +1,5 @@
 import time
 import datetime
-import humanize
 import dateutil.parser
 
 
@@ -14,6 +13,7 @@ def time_msecs_str(t) -> str:
 
 
 def humanize_timedelta_msecs(delta_msecs):
+    import humanize  # pylint: disable=import-outside-toplevel
     if delta_msecs is None:
         return None
 

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,10 +1,8 @@
-from tqdm.notebook import tqdm as tqdm_notebook
-from tqdm.auto import tqdm as tqdm_auto
-
-# To tqdm_notebook, None means do not display. To standard tqdm, None means
-# display only when connected to a TTY.
-TQDM_DEFAULT_DISABLE = False if tqdm_auto == tqdm_notebook else None
-
-
-def tqdm(*args, disable=TQDM_DEFAULT_DISABLE, **kwargs):
+def tqdm(*args, disable=False, **kwargs):
+    from tqdm.notebook import tqdm as tqdm_notebook  # pylint: disable=import-outside-toplevel
+    from tqdm.auto import tqdm as tqdm_auto  # pylint: disable=import-outside-toplevel
+    # To tqdm_notebook, None means do not display. To standard tqdm, None means
+    # display only when connected to a TTY.
+    if disable is False and tqdm_auto != tqdm_notebook:
+        disable = None
     return tqdm_auto(*args, disable=disable, **kwargs)

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,8 +1,11 @@
-def tqdm(*args, disable=False, **kwargs):
+TQDM_DEFAULT_DISABLE = object()
+
+
+def tqdm(*args, disable=TQDM_DEFAULT_DISABLE, **kwargs):
     from tqdm.notebook import tqdm as tqdm_notebook  # pylint: disable=import-outside-toplevel
     from tqdm.auto import tqdm as tqdm_auto  # pylint: disable=import-outside-toplevel
     # To tqdm_notebook, None means do not display. To standard tqdm, None means
     # display only when connected to a TTY.
-    if disable is False and tqdm_auto != tqdm_notebook:
-        disable = None
+    if disable is TQDM_DEFAULT_DISABLE:
+        disable = False if tqdm_auto == tqdm_notebook else None
     return tqdm_auto(*args, disable=disable, **kwargs)

--- a/hail/python/hailtop/utils/tqdm.py
+++ b/hail/python/hailtop/utils/tqdm.py
@@ -1,11 +1,15 @@
-TQDM_DEFAULT_DISABLE = object()
+from enum import Enum
 
 
-def tqdm(*args, disable=TQDM_DEFAULT_DISABLE, **kwargs):
+class TqdmDisableOption(Enum):
+    default = 0
+
+
+def tqdm(*args, disable=TqdmDisableOption.default, **kwargs):
     from tqdm.notebook import tqdm as tqdm_notebook  # pylint: disable=import-outside-toplevel
     from tqdm.auto import tqdm as tqdm_auto  # pylint: disable=import-outside-toplevel
     # To tqdm_notebook, None means do not display. To standard tqdm, None means
     # display only when connected to a TTY.
-    if disable is TQDM_DEFAULT_DISABLE:
+    if disable == TqdmDisableOption.default:
         disable = False if tqdm_auto == tqdm_notebook else None
     return tqdm_auto(*args, disable=disable, **kwargs)


### PR DESCRIPTION
tqdm.notebook and pkg_resources take .55s and .37s to import, respectively. humanize imports pkg_resources which is why that is moved to. Moving these out of the top level improve cold-start time from 1.5s to .5s, and never even need to be imported for invocations such as `hailctl config list`, whose runtime is entirely import time.