### PR TITLE
[fs] Add azure blob path to FileNotFound error in read

### DIFF
--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -166,7 +166,12 @@ class AzureReadableStream(ReadableStream):
             try:
                 self._downloader = await self._client.download_blob(offset=self._offset)
             except azure.core.exceptions.ResourceNotFoundError as e:
-                raise FileNotFoundError from e
+                full_name = (
+                    f'{self._client.account_name}/'
+                    f'{self._client.container_name}/'
+                    f'{self._client.blob_name}'
+                )
+                raise FileNotFoundError(full_name) from e
 
         if self._chunk_it is None:
             self._chunk_it = self._downloader.chunks()

--- a/hail/python/hailtop/aiocloud/aioazure/fs.py
+++ b/hail/python/hailtop/aiocloud/aioazure/fs.py
@@ -206,6 +206,7 @@ class AzureReadableStream(ReadableStream):
 
     def _blob_full_name(self):
         return (
+            'hail-az://'
             f'{self._client.account_name}/'
             f'{self._client.container_name}/'
             f'{self._client.blob_name}'

--- a/hail/python/test/hailtop/test_fs.py
+++ b/hail/python/test/hailtop/test_fs.py
@@ -124,8 +124,8 @@ async def test_open_nonexistent_file(filesystem: Tuple[asyncio.Semaphore, AsyncF
     try:
         async with await fs.open(file) as f:
             await f.read()
-    except FileNotFoundError:
-        pass
+    except FileNotFoundError as e:
+        assert file in str(e), e
     else:
         assert False
 


### PR DESCRIPTION
The Azure blob storage client does not include the blob name in file not found errors. This adds that information to the `FileNotFoundError` that we raise on top of the azure error in the azure fs's `read`.