### PR TITLE
[hailctl] add support for table format for hailctl batch billing list

### DIFF
--- a/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
+++ b/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
@@ -2,11 +2,12 @@ import json
 import yaml
 import aiohttp
 import csv
-import sys
 from typing import List, Dict, Callable
 import tabulate
+import io
 
-LoD = List[Dict[str, str]]
+TableData = List[Dict[str, str]]
+choices = ['json', 'yaml', 'csv', *tabulate.tabulate_formats]
 
 
 def get_batch_if_exists(client, id):
@@ -35,32 +36,32 @@ def bool_string_to_bool(bool_string):
     raise ValueError("Input could not be resolved to a bool")
 
 
-def separated_format(lod: LoD, delim: str) -> None:
-    writer = csv.writer(sys.stdout, delimiter=delim)
-    # construct header dictionary from keys of lod
-    header = {k: k for (k, v) in lod[0].items()}
+def separated_format(table_data: TableData, delim: str) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output, delimiter=delim)
+    header = {k: k for k in table_data[0].keys()}
     writer.writerow(header)
-    # for each of the elements in the list of dicts, write its values as a list to the writer
-    for d in lod:
-        writer.writerow([v for (k, v) in d.items()])
+    for d in table_data:
+        writer.writerow([v for v in d.values()])
+
+    contents = output.getvalue()
+    output.close()
+    return contents
 
 
-def table_format(lod: LoD, tablefmt: str) -> None:
-    print(tabulate.tabulate(lod, headers='keys', tablefmt=tablefmt))
+def table_format(table_data: TableData, tablefmt: str) -> str:
+    return tabulate.tabulate(table_data, headers='keys', tablefmt=tablefmt)
 
 
+# PRE-CONDITION: name is a valid option for the -o argument of the CLI
 # POST-CONDITION: the returned formatters are only guaranteed to work on non-empty lists of dictionaries
-def make_formatter(name: str) -> Callable[[List[Dict[str, str]]], None]:
+def make_formatter(name: str) -> Callable[[List[Dict[str, str]]], str]:
     if name == "json":
-        return lambda lod: print(json.dumps(lod, indent=2))
+        return lambda table_data: json.dumps(table_data, indent=2)
     if name == "yaml":
-        return lambda lod: print(yaml.dump(lod))
+        return lambda table_data: yaml.dump(table_data)
     if name == "csv":
-        return lambda lod: separated_format(lod, ',')
-    if name == "tsv":
-        return lambda lod: separated_format(lod, '\t')
-    if name == "orgtbl":
-        return lambda lod: table_format(lod, 'orgtbl')
-    if name == "grid":
-        return lambda lod: table_format(lod, 'grid')
-    raise ValueError(f'unknown format {name}')
+        return lambda table_data: separated_format(table_data, ',')
+
+    assert name in tabulate.tabulate_formats, f'unknown format {name}'
+    return lambda table_data: table_format(table_data, name)

--- a/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
+++ b/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
@@ -42,7 +42,7 @@ def separated_format(table_data: TableData, delim: str) -> str:
     header = {k: k for k in table_data[0].keys()}
     writer.writerow(header)
     for d in table_data:
-        writer.writerow([v for v in d.values()])
+        writer.writerow(d.values())
 
     contents = output.getvalue()
     output.close()

--- a/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
+++ b/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
@@ -1,6 +1,12 @@
 import json
 import yaml
 import aiohttp
+import csv
+import sys
+from typing import List, Dict, Callable
+import tabulate
+
+LoD = List[Dict[str, str]]
 
 
 def get_batch_if_exists(client, id):
@@ -29,9 +35,32 @@ def bool_string_to_bool(bool_string):
     raise ValueError("Input could not be resolved to a bool")
 
 
-def make_formatter(name):
+def separated_format(lod: LoD, delim: str) -> None:
+    writer = csv.writer(sys.stdout, delimiter=delim)
+    # construct header dictionary from keys of lod
+    header = {k: k for (k, v) in lod[0].items()}
+    writer.writerow(header)
+    # for each of the elements in the list of dicts, write its values as a list to the writer
+    for d in lod:
+        writer.writerow([v for (k, v) in d.items()])
+
+
+def table_format(lod: LoD, tablefmt: str) -> None:
+    print(tabulate.tabulate(lod, headers='keys', tablefmt=tablefmt))
+
+
+# POST-CONDITION: the returned formatters are only guaranteed to work on non-empty lists of dictionaries
+def make_formatter(name: str) -> Callable[[List[Dict[str, str]]], None]:
     if name == "json":
-        return lambda s: json.dumps(s, indent=2)
+        return lambda lod: print(json.dumps(lod, indent=2))
     if name == "yaml":
-        return yaml.dump
+        return lambda lod: print(yaml.dump(lod))
+    if name == "csv":
+        return lambda lod: separated_format(lod, ',')
+    if name == "tsv":
+        return lambda lod: separated_format(lod, '\t')
+    if name == "orgtbl":
+        return lambda lod: table_format(lod, 'orgtbl')
+    if name == "grid":
+        return lambda lod: table_format(lod, 'grid')
     raise ValueError(f'unknown format {name}')

--- a/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
+++ b/hail/python/hailtop/hailctl/batch/batch_cli_utils.py
@@ -7,7 +7,7 @@ import tabulate
 import io
 
 TableData = List[Dict[str, str]]
-choices = ['json', 'yaml', 'csv', *tabulate.tabulate_formats]
+TABLE_FORMAT_OPTIONS = ['json', 'yaml', 'csv', *tabulate.tabulate_formats]
 
 
 def get_batch_if_exists(client, id):
@@ -39,7 +39,8 @@ def bool_string_to_bool(bool_string):
 def separated_format(table_data: TableData, delim: str) -> str:
     output = io.StringIO()
     writer = csv.writer(output, delimiter=delim)
-    header = {k: k for k in table_data[0].keys()}
+    assert len(table_data) > 0
+    header = table_data[0].keys()
     writer.writerow(header)
     for d in table_data:
         writer.writerow(d.values())
@@ -53,15 +54,16 @@ def table_format(table_data: TableData, tablefmt: str) -> str:
     return tabulate.tabulate(table_data, headers='keys', tablefmt=tablefmt)
 
 
-# PRE-CONDITION: name is a valid option for the -o argument of the CLI
 # POST-CONDITION: the returned formatters are only guaranteed to work on non-empty lists of dictionaries
-def make_formatter(name: str) -> Callable[[List[Dict[str, str]]], str]:
+def make_formatter(name: str) -> Callable[[TableData], str]:
+    assert name in TABLE_FORMAT_OPTIONS, f'unknown format: {name}'
+
     if name == "json":
         return lambda table_data: json.dumps(table_data, indent=2)
     if name == "yaml":
-        return lambda table_data: yaml.dump(table_data)
+        return yaml.dump
     if name == "csv":
         return lambda table_data: separated_format(table_data, ',')
 
-    assert name in tabulate.tabulate_formats, f'unknown format {name}'
+    assert name in tabulate.tabulate_formats, f'unknown tabulate format {name}'
     return lambda table_data: table_format(table_data, name)

--- a/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
+++ b/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
@@ -1,15 +1,13 @@
 import sys
-import tabulate
-from ..batch_cli_utils import make_formatter
+from ..batch_cli_utils import make_formatter, choices
 
 
 def init_parser(parser):
     parser.add_argument('-o', type=str, default='grid',
-                        help='specify output format (json, yaml, csv, tsv, or any tabulate format)')
+                        choices=choices)
 
 
 def main(args, pass_through_args, client):  # pylint: disable=unused-argument
-    choices = ['json', 'yaml', *tabulate.tabulate_formats]
     if args.o not in choices:
         print('invalid output format:', args.o, file=sys.stderr)
         print('must be one of:', *choices, file=sys.stderr)
@@ -22,4 +20,4 @@ def main(args, pass_through_args, client):  # pylint: disable=unused-argument
             bp['users'] = "\n".join(bp['users'])
 
     format = make_formatter(args.o)
-    format(billing_projects)
+    print(format(billing_projects))

--- a/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
+++ b/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
@@ -1,16 +1,15 @@
 import sys
-from ..batch_cli_utils import make_formatter, choices
+from ..batch_cli_utils import make_formatter, TABLE_FORMAT_OPTIONS
 
 
 def init_parser(parser):
-    parser.add_argument('-o', type=str, default='grid',
-                        choices=choices)
+    parser.add_argument('-o', type=str, default='grid', choices=TABLE_FORMAT_OPTIONS)
 
 
 def main(args, pass_through_args, client):  # pylint: disable=unused-argument
-    if args.o not in choices:
+    if args.o not in TABLE_FORMAT_OPTIONS:
         print('invalid output format:', args.o, file=sys.stderr)
-        print('must be one of:', *choices, file=sys.stderr)
+        print('must be one of:', *TABLE_FORMAT_OPTIONS, file=sys.stderr)
         sys.exit(1)
 
     billing_projects = client.list_billing_projects()

--- a/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
+++ b/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
@@ -1,4 +1,3 @@
-import sys
 from ..batch_cli_utils import make_formatter, TABLE_FORMAT_OPTIONS
 
 
@@ -7,11 +6,6 @@ def init_parser(parser):
 
 
 def main(args, pass_through_args, client):  # pylint: disable=unused-argument
-    if args.o not in TABLE_FORMAT_OPTIONS:
-        print('invalid output format:', args.o, file=sys.stderr)
-        print('must be one of:', *TABLE_FORMAT_OPTIONS, file=sys.stderr)
-        sys.exit(1)
-
     billing_projects = client.list_billing_projects()
 
     if args.o not in ('json', 'yaml'):

--- a/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
+++ b/hail/python/hailtop/hailctl/batch/billing/list_billing_projects.py
@@ -1,11 +1,25 @@
+import sys
+import tabulate
 from ..batch_cli_utils import make_formatter
 
 
 def init_parser(parser):
-    parser.add_argument('-o', type=str, default='yaml', help="Specify output format",
-                        choices=["yaml", "json"])
+    parser.add_argument('-o', type=str, default='grid',
+                        help='specify output format (json, yaml, csv, tsv, or any tabulate format)')
 
 
 def main(args, pass_through_args, client):  # pylint: disable=unused-argument
+    choices = ['json', 'yaml', *tabulate.tabulate_formats]
+    if args.o not in choices:
+        print('invalid output format:', args.o, file=sys.stderr)
+        print('must be one of:', *choices, file=sys.stderr)
+        sys.exit(1)
+
     billing_projects = client.list_billing_projects()
-    print(make_formatter(args.o)(billing_projects))
+
+    if args.o not in ('json', 'yaml'):
+        for bp in billing_projects:
+            bp['users'] = "\n".join(bp['users'])
+
+    format = make_formatter(args.o)
+    format(billing_projects)

--- a/hail/python/hailtop/hailctl/batch/list_batches.py
+++ b/hail/python/hailtop/hailctl/batch/list_batches.py
@@ -1,5 +1,3 @@
-import sys
-
 from .batch_cli_utils import make_formatter, TABLE_FORMAT_OPTIONS
 
 
@@ -18,11 +16,6 @@ def init_parser(parser):
 
 
 def main(args, passthrough_args, client):  # pylint: disable=unused-argument
-    if args.o not in TABLE_FORMAT_OPTIONS:
-        print('invalid output format:', args.o, file=sys.stderr)
-        print('must be one of:', *TABLE_FORMAT_OPTIONS, file=sys.stderr)
-        sys.exit(1)
-
     batch_list = client.list_batches(q=args.query, last_batch_id=args.before, limit=args.limit)
     statuses = [batch.last_known_status() for batch in batch_list]
 

--- a/hail/python/hailtop/hailctl/batch/list_batches.py
+++ b/hail/python/hailtop/hailctl/batch/list_batches.py
@@ -1,6 +1,6 @@
 import sys
 
-from .batch_cli_utils import make_formatter, choices
+from .batch_cli_utils import make_formatter, TABLE_FORMAT_OPTIONS
 
 
 def init_parser(parser):
@@ -14,13 +14,13 @@ def init_parser(parser):
                         help='when output is tabular, print more information')
     parser.add_argument('--no-header', action='store_true', help='do not print a table header')
     parser.add_argument('-o', type=str, default='grid',
-                        choices=choices)
+                        choices=TABLE_FORMAT_OPTIONS)
 
 
 def main(args, passthrough_args, client):  # pylint: disable=unused-argument
-    if args.o not in choices:
+    if args.o not in TABLE_FORMAT_OPTIONS:
         print('invalid output format:', args.o, file=sys.stderr)
-        print('must be one of:', *choices, file=sys.stderr)
+        print('must be one of:', *TABLE_FORMAT_OPTIONS, file=sys.stderr)
         sys.exit(1)
 
     batch_list = client.list_batches(q=args.query, last_batch_id=args.before, limit=args.limit)


### PR DESCRIPTION
- Add make_formatter (in batch_cli_utils.py) options for csv, tsv, grid, and orgtbl
- Refactor list_batches.py to always use result of make_formatter
- Changed default format for `hailctl batch list` to grid