### PR TITLE
[query] Fix performance of parse_locus_interval

### DIFF
--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -3,6 +3,7 @@ package is.hail.expr
 import is.hail.utils._
 import is.hail.variant._
 
+import scala.collection.mutable.ArrayBuffer
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Position
 
@@ -83,41 +84,39 @@ object Parser extends JavaTokenParsers {
     }
   }
 
-  def oneOfLiteral(s: String*): Parser[String] = oneOfLiteral(s.toArray)
-
   def oneOfLiteral(a: Array[String]): Parser[String] = new Parser[String] {
-    var hasEnd: Boolean = false
+    val root = ParseTrieNode.generate(a)
 
-    val m = a.flatMap { s =>
-      val l = s.length
-      if (l == 0) {
-        hasEnd = true
-        None
-      }
-      else if (l == 1) {
-        Some((s.charAt(0), ""))
-      }
-      else
-        Some((s.charAt(0), s.substring(1)))
-    }.groupBy(_._1).mapValues { v => oneOfLiteral(v.map(_._2)) }
+    val sb: StringBuilder = new StringBuilder()
 
     def apply(in: Input): ParseResult[String] = {
-      m.get(in.first) match {
-        case Some(p) =>
-          p(in.rest) match {
-            case s: Success[_] =>
-              Success(in.first.toString + s.result, in.drop(s.result.length + 1))
-            case _ => Failure("", in)
-          }
-        case None =>
-          if (hasEnd)
-            Success("", in)
+
+      sb.clear()
+      var _in = in
+      var node = root
+      while (true) {
+        if (_in.atEnd)
+          if (node.hasEnd)
+            return Success(sb.result(), _in)
           else
-            Failure("", in)
+            return Failure("", in)
+
+        val nextChar = _in.first
+        val nextNode = node.search(nextChar)
+        if (nextNode == null) {
+          if (node.hasEnd)
+            return Success(sb.result(), _in)
+          else
+            return Failure("", in)
+        }
+        _in = _in.rest
+        node = nextNode
+        sb += nextChar
       }
+      return null // unreachable
     }
   }
-  
+
   def call: Parser[Call] = {
     wholeNumber ~ "/" ~ rep1sep(wholeNumber, "/") ^^ { case a0 ~ _ ~ arest =>
       CallN(coerceInt(a0) +: arest.map(coerceInt).toArray, phased = false)

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -85,33 +85,29 @@ object Parser extends JavaTokenParsers {
   }
 
   def oneOfLiteral(a: Array[String]): Parser[String] = new Parser[String] {
-    val root = ParseTrieNode.generate(a)
-
-    val sb: StringBuilder = new StringBuilder()
+    private[this] val root = ParseTrieNode.generate(a)
 
     def apply(in: Input): ParseResult[String] = {
 
-      sb.clear()
       var _in = in
       var node = root
       while (true) {
         if (_in.atEnd)
-          if (node.hasEnd)
-            return Success(sb.result(), _in)
+          if (node.value != null)
+            return Success(node.value, _in)
           else
             return Failure("", in)
 
         val nextChar = _in.first
         val nextNode = node.search(nextChar)
         if (nextNode == null) {
-          if (node.hasEnd)
-            return Success(sb.result(), _in)
+          if (node.value != null)
+            return Success(node.value, _in)
           else
             return Failure("", in)
         }
         _in = _in.rest
         node = nextNode
-        sb += nextChar
       }
       return null // unreachable
     }

--- a/hail/src/main/scala/is/hail/utils/ParseTrieNode.scala
+++ b/hail/src/main/scala/is/hail/utils/ParseTrieNode.scala
@@ -1,0 +1,64 @@
+package is.hail.utils
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * A character trie used for parsing membership in a set literal from a character sequence.
+  *
+  * The children of a node are represented in an unordered array; linear search is used to
+  * traverse the tree with the assumption that the average number of children per node is
+  * small (small enough that a O(n log n) binary search or O(1) hash lookup would be more
+  * expensive)
+  */
+class ParseTrieNode(val prev: Char, var hasEnd: Boolean, var children: ArrayBuffer[ParseTrieNode]) {
+  def search(next: Char): ParseTrieNode = {
+    var i = 0
+    while (i < children.size) {
+      val child = children(i)
+      if (child.prev == next)
+        return child
+      i += 1
+    }
+    null
+  }
+
+}
+
+object ParseTrieNode {
+  def generate(data: Array[String]): ParseTrieNode = {
+    val root = new ParseTrieNode(null.asInstanceOf[Char], false, new ArrayBuffer[ParseTrieNode])
+
+    def insert(s: String): Unit = {
+      var idx = 0
+      var node = root
+      while (idx < s.length) {
+        val next = s(idx)
+        val buff = node.children
+        var continue = true
+        var i = 0
+        while (continue) {
+          if (i >= buff.size) {
+            node = new ParseTrieNode(next, false, new ArrayBuffer[ParseTrieNode])
+            buff += node
+            continue = false
+          } else {
+            val child = buff(i)
+            if (child.prev == next) {
+              node = child
+              continue = false
+            }
+          }
+          i += 1
+        }
+
+        idx += 1
+      }
+
+      node.hasEnd = true
+    }
+
+    data.foreach(insert)
+
+    root
+  }
+}

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -141,7 +141,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   private var fastaIndexPath: String = _
   @transient private var fastaReaderCfg: FASTAReaderConfig = _
 
-  def contigParser = Parser.oneOfLiteral(contigs)
+  @transient lazy val contigParser = Parser.oneOfLiteral(contigs)
 
   val globalPosContigStarts = {
     var pos = 0L


### PR DESCRIPTION
Improve the parse trie to use iteration instead of parser recursion.