### PR TITLE
Remove jcenter dependency

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 }
 
@@ -21,7 +20,6 @@ repositories {
         dirs 'libs'
     }
     mavenCentral()
-    jcenter()
     maven { url "https://repository.cloudera.com/artifactory/cloudera-repos/" }
 }
 


### PR DESCRIPTION
Pulling shadowjar from jcenter right now isn't working. It's on maven though, so why do we need jcenter? 