### PR TITLE
Update docs to remove 3.6 from supported versions

### DIFF
--- a/hail/python/hail/docs/install/linux.rst
+++ b/hail/python/hail/docs/install/linux.rst
@@ -3,7 +3,7 @@ Install Hail on GNU/Linux
 =========================
 
 - Install Java 8.
-- Install Python 3.6+.
+- Install Python 3.7 or later.
 - Install a recent version of the C and C++ standard libraries. GCC 5.0, LLVM
   version 3.4, or any later versions suffice.
 - Install BLAS and LAPACK.
@@ -16,8 +16,8 @@ On a recent Debian-like system, the following should suffice:
    apt-get install -y \
        openjdk-8-jre-headless \
        g++ \
-       python3.6 python3-pip \
+       python3.7 python3-pip \
        libopenblas-base liblapack3
-   python3.6 -m pip install hail
+   python3.7 -m pip install hail
 
 `Now let's take Hail for a spin! <try.rst>`__

--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -11,6 +11,6 @@ Install Hail on Mac OS X
     brew cask install adoptopenjdk8
     brew install --cask adoptopenjdk8
 
-- Install Python 3.6+. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
+- Install Python 3.7 or later. We recommend `Miniconda <https://docs.conda.io/en/latest/miniconda.html#macosx-installers>`__.
 - Open Terminal.app and execute ``pip install hail``.
 - `Run your first Hail query! <try.rst>`__

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -11,7 +11,7 @@ Hail needs to be built from source on the leader node. Building Hail from source
 requires:
 
 - Java 8 JDK.
-- Python 3.6+.
+- Python 3.7 or later.
 - A recent C and a C++ compiler, GCC 5.0, LLVM 3.4, or later versions of either
   suffice.
 - The LZ4 library.

--- a/hail/python/hailtop/batch/docs/getting_started.rst
+++ b/hail/python/hailtop/batch/docs/getting_started.rst
@@ -20,7 +20,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create -n hail python'>=3.6,<3.8'
+    conda create -n hail python'>=3.7'
     conda activate hail
     pip install hail
 


### PR DESCRIPTION
Follow up to #11206. Python 3.6 is EOL, so let's not claim to support it or encourage its use anymore.