### PR TITLE
[query] include JRE 11 as an acceptable Java version in the docs

### DIFF
--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -6,9 +6,9 @@ Hail is an open-source project. We welcome contributions to the repository.
 Requirements
 ~~~~~~~~~~~~
 
-- `Java 8 JDK <https://adoptopenjdk.net/index.html>`_
-  Note: it *must* be Java **8**. Hail does not support versions 9+ due to our
-  dependency on Spark.
+- `Java 8 or 11 JDK <https://adoptopenjdk.net/index.html>`_
+  Note: it *must* be Java **8** or Java **11**. Hail does not support versions 9-10 or 12+ due to
+  our dependency on Spark.
 
 - The Python and non-pip installation requirements in `Getting Started <getting_started.html>`_
 

--- a/hail/python/hail/docs/install/linux.rst
+++ b/hail/python/hail/docs/install/linux.rst
@@ -2,7 +2,7 @@
 Install Hail on GNU/Linux
 =========================
 
-- Install Java 8.
+- Install Java 8 or Java 11.
 - Install Python 3.7 or later.
 - Install a recent version of the C and C++ standard libraries. GCC 5.0, LLVM
   version 3.4, or any later versions suffice.

--- a/hail/python/hail/docs/install/macosx.rst
+++ b/hail/python/hail/docs/install/macosx.rst
@@ -2,7 +2,7 @@
 Install Hail on Mac OS X
 ========================
 
-- Install Java 8. We recommend using a
+- Install Java 8 or Java 11. We recommend using a
   `packaged installation from Azul <https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk&show-old-builds=true>`__
   (make sure the OS version and architecture match your system) or using `Homebrew <https://brew.sh/>`__:
 

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -10,7 +10,7 @@ Hail should work with any Spark 3.1.1 cluster built with Scala 2.12.
 Hail needs to be built from source on the leader node. Building Hail from source
 requires:
 
-- Java 8 JDK.
+- Java 8 or 11 JRE.
 - Python 3.7 or later.
 - A recent C and a C++ compiler, GCC 5.0, LLVM 3.4, or later versions of either
   suffice.

--- a/hail/python/hail/docs/install/other-cluster.rst
+++ b/hail/python/hail/docs/install/other-cluster.rst
@@ -10,7 +10,7 @@ Hail should work with any Spark 3.1.1 cluster built with Scala 2.12.
 Hail needs to be built from source on the leader node. Building Hail from source
 requires:
 
-- Java 8 or 11 JRE.
+- Java 8 or 11 JDK.
 - Python 3.7 or later.
 - A recent C and a C++ compiler, GCC 5.0, LLVM 3.4, or later versions of either
   suffice.

--- a/website/website/pages/index.html
+++ b/website/website/pages/index.html
@@ -54,7 +54,7 @@ show(p)
           pip install hail</div>
         <p>
           Hail requires Python 3 and the
-          <a href="https://adoptopenjdk.net/index.html" target="_blank">Java 8 JRE</a>.
+          <a href="https://adoptopenjdk.net/index.html" target="_blank">Java 8 or 11 JRE</a>.
         </p>
         <p>GNU/Linux will also need the C and C++ standard libraries if not already installed.</p>
         <p>


### PR DESCRIPTION
I also fixed a reference to the JDK. Users do not need `javac` and friends, just a JRE (i.e. `java`).