### PR TITLE
[ci] Show github statuses in addition to build status

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -77,6 +77,7 @@ async def pr_config(app, pr: PR) -> PRConfig:
         # FIXME generate links to the merge log
         'batch_id': batch_id,
         'build_state': build_state,
+        'gh_statuses': {k: v.value for k, v in pr.last_known_github_status.items()},
         'source_branch_name': pr.source_branch.name,
         'review_state': pr.review_state,
         'author': pr.author,

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -57,6 +57,7 @@ class PRConfig(TypedDict):
     title: str
     batch_id: Optional[int]
     build_state: Optional[str]
+    gh_statuses: Dict[str, str]
     source_branch_name: str
     review_state: Optional[str]
     author: str

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import traceback
-from typing import Callable, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 import aiohttp_session  # type: ignore
 import uvloop  # type: ignore

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -6,6 +6,7 @@
     <tr>
       <th>PR</th>
       <th>Build State</th>
+      <th>Github Statuses</th>
       <th>Labels</th>
       <th>Branch</th>
       <th>Review State</th>
@@ -29,6 +30,11 @@
         {% if pr.build_state is not none and pr.out_of_date %}
           *
         {% endif %}
+      </td>
+      <td>
+        {% for context, status in pr['gh_statuses'].items() %}
+          {{ context }}: {{ status }}
+        {% endfor %}
       </td>
       <td>
         {{ pr.labels|join(", ") }}

--- a/ci/ci/templates/pr-table.html
+++ b/ci/ci/templates/pr-table.html
@@ -32,9 +32,11 @@
         {% endif %}
       </td>
       <td>
-        {% for context, status in pr['gh_statuses'].items() %}
-          {{ context }}: {{ status }}
-        {% endfor %}
+        <ol>
+          {% for context, status in pr['gh_statuses'].items() %}
+          <li>{{ context }}: {{ status }}</li>
+          {% endfor %}
+        </ol>
       </td>
       <td>
         {{ pr.labels|join(", ") }}


### PR DESCRIPTION
Currently if I visit `ci.hail.is` it shows the status of the build that CI ran in GCP. Now that we enforce all CI's pass, we can end up with situations on `ci.hail.is` where the PR is approved and the build was successful but it's not merging because the tests failed over on azure. This shows all the github statuses in addition to the cloud-local build information.