### PR TITLE
[query] provide hail.utils.guess_cloud_spark_provider

### DIFF
--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -4,7 +4,7 @@ import os
 from typing import Tuple, List, Union
 from hail.typecheck import typecheck, oneof, anytype, nullable
 from hail.utils.java import Env, info, warning
-from hail.utils.misc import divide_null
+from hail.utils.misc import divide_null, guess_cloud_spark_provider
 from hail.matrixtable import MatrixTable
 from hail.table import Table
 from hail.ir import TableToTableApply
@@ -601,10 +601,11 @@ def vep(dataset: Union[Table, MatrixTable], config=None, block_size=1000, name='
 
     """
     if config is None:
+        maybe_cloud_spark_provider = guess_cloud_spark_provider()
         maybe_config = os.getenv("VEP_CONFIG_URI")
         if maybe_config is not None:
             config = maybe_config
-        elif os.getenv('AZURE_SPARK') is not None or 'hdinsight' in os.getenv('CLASSPATH', ''):
+        elif maybe_cloud_spark_provider == 'hdinsight':
             warning('Assuming you are in a hailctl hdinsight cluster. If not, specify the config parameter to `hl.vep`.')
             config = 'file:/vep_data/vep-azure.json'
         else:

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -1,5 +1,9 @@
-from .misc import wrap_to_list, get_env_or_default, uri_path, local_path_uri, new_temp_file, new_local_temp_dir, new_local_temp_file, with_local_temp_file, storage_level, range_matrix_table, range_table, run_command, HailSeedGenerator, timestamp_path, _dumps_partitions, default_handler
-from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file, hadoop_ls, hadoop_scheme_supported, hadoop_stat, copy_log
+from .misc import (wrap_to_list, get_env_or_default, uri_path, local_path_uri, new_temp_file,
+                   new_local_temp_dir, new_local_temp_file, with_local_temp_file, storage_level,
+                   range_matrix_table, range_table, run_command, HailSeedGenerator, timestamp_path,
+                   _dumps_partitions, default_handler, guess_cloud_spark_provider)
+from .hadoop_utils import (hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file,
+                           hadoop_ls, hadoop_scheme_supported, hadoop_stat, copy_log)
 from .struct import Struct
 from .linkedlist import LinkedList
 from .interval import Interval
@@ -46,4 +50,5 @@ __all__ = ['hadoop_open',
            'default_handler',
            'deduplicate',
            'with_local_temp_file',
+           'guess_cloud_spark_provider',
            ]

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -1,3 +1,4 @@
+from typing import Literal, Optional
 import os
 import atexit
 import datetime
@@ -618,3 +619,14 @@ def default_handler():
         return display
     except ImportError:
         return print
+
+
+def guess_cloud_spark_provider() -> Optional[Literal['dataproc', 'hdinsight']]]:
+    hail_dataproc = os.environ.get('HAIL_DATAPROC')
+    azure_spark_env = os.environ.get('AZURE_SPARK')
+    hdinsight_classpath = 'hdinsight' in os.getenv('CLASSPATH', '')
+    if 'HAIL_DATAPROC' in os.environ:
+        return 'dataproc'
+    if 'AZURE_SPARK' in os.environ or 'hdinsight' in os.getenv('CLASSPATH', ''):
+        return 'hdinsight'
+    return None

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -622,9 +622,6 @@ def default_handler():
 
 
 def guess_cloud_spark_provider() -> Optional[Literal['dataproc', 'hdinsight']]:
-    hail_dataproc = os.environ.get('HAIL_DATAPROC')
-    azure_spark_env = os.environ.get('AZURE_SPARK')
-    hdinsight_classpath = 'hdinsight' in os.getenv('CLASSPATH', '')
     if 'HAIL_DATAPROC' in os.environ:
         return 'dataproc'
     if 'AZURE_SPARK' in os.environ or 'hdinsight' in os.getenv('CLASSPATH', ''):

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -1,4 +1,5 @@
-from typing import Literal, Optional
+from typing import Optional
+from typing_extensions import Literal
 import os
 import atexit
 import datetime

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -621,7 +621,7 @@ def default_handler():
         return print
 
 
-def guess_cloud_spark_provider() -> Optional[Literal['dataproc', 'hdinsight']]]:
+def guess_cloud_spark_provider() -> Optional[Literal['dataproc', 'hdinsight']]:
     hail_dataproc = os.environ.get('HAIL_DATAPROC')
     azure_spark_env = os.environ.get('AZURE_SPARK')
     hdinsight_classpath = 'hdinsight' in os.getenv('CLASSPATH', '')

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -83,6 +83,7 @@ if role == 'Master':
         'PYSPARK_PYTHON': '/opt/conda/default/bin/python',
         'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',
         'HAIL_LOG_DIR': '/home/hail',
+        'HAIL_DATAPROC': '1',
     }
 
     # VEP ENV


### PR DESCRIPTION
Grace requested this for gnomAD purposes. In Azure, we can determine this
using the classpath or envionrment variables (the env var is only available
inside Jupyter). In GCP, I added an environment variable to our Spark env
/ Jupyter env.