### PR TITLE
[style] Add isort for import sorting

### DIFF
--- a/auth/Makefile
+++ b/auth/Makefile
@@ -12,6 +12,7 @@ BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 check:
 	$(PYTHON) -m flake8 auth
 	$(PYTHON) -m pylint --rcfile ../pylintrc auth --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1,32 +1,34 @@
-import os
-import logging
 import asyncio
+import json
+import logging
+import os
+
 import aiohttp
-from aiohttp import web
 import aiohttp_session
 import uvloop
-import json
+from aiohttp import web
 from prometheus_async.aio.web import server_stats  # type: ignore
-from hailtop.config import get_deploy_config
-from hailtop.tls import internal_server_ssl_context
-from hailtop.hail_logging import AccessLogger
-from hailtop.utils import secret_alnum_string
-from hailtop import httpx
+
 from gear import (
-    setup_aiohttp_session,
-    rest_authenticated_users_only,
-    web_authenticated_developers_only,
-    web_maybe_authenticated_user,
-    web_authenticated_users_only,
-    create_session,
-    check_csrf_token,
-    transaction,
     Database,
+    check_csrf_token,
+    create_session,
     maybe_parse_bearer_header,
     monitor_endpoints_middleware,
+    rest_authenticated_users_only,
+    setup_aiohttp_session,
+    transaction,
+    web_authenticated_developers_only,
+    web_authenticated_users_only,
+    web_maybe_authenticated_user,
 )
 from gear.cloud_config import get_global_config
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, set_message, render_template
+from hailtop import httpx
+from hailtop.config import get_deploy_config
+from hailtop.hail_logging import AccessLogger
+from hailtop.tls import internal_server_ssl_context
+from hailtop.utils import secret_alnum_string
+from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .flow import get_flow_client
 

--- a/auth/auth/driver/__main__.py
+++ b/auth/auth/driver/__main__.py
@@ -4,6 +4,7 @@ from hailtop.hail_logging import configure_logging
 configure_logging()
 
 import asyncio  # noqa: E402 pylint: disable=wrong-import-position
+
 from .driver import async_main  # noqa: E402 pylint: disable=wrong-import-position
 
 loop = asyncio.get_event_loop()

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -1,21 +1,24 @@
+import asyncio
+import base64
+import json
+import logging
 import os
 import random
-import json
-import base64
-import logging
 import secrets
-import asyncio
+
 import aiohttp
-import kubernetes_asyncio.config
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
-from hailtop.utils import time_msecs, secret_alnum_string
-from hailtop.auth.sql_config import create_secret_data_from_config, SQLConfig
-from hailtop import aiotools
-from hailtop import batch_client as bc, httpx
-from gear import create_session, Database
-from gear.cloud_config import get_gcp_config, get_global_config
+import kubernetes_asyncio.config
+
+from gear import Database, create_session
 from gear.clients import get_identity_client
+from gear.cloud_config import get_gcp_config, get_global_config
+from hailtop import aiotools
+from hailtop import batch_client as bc
+from hailtop import httpx
+from hailtop.auth.sql_config import SQLConfig, create_secret_data_from_config
+from hailtop.utils import secret_alnum_string, time_msecs
 
 log = logging.getLogger('auth.driver')
 

--- a/auth/auth/flow.py
+++ b/auth/auth/flow.py
@@ -1,11 +1,12 @@
 import abc
-import msal
+import json
+import urllib.parse
+
+import aiohttp.web
 import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
-import aiohttp.web
-import json
-import urllib.parse
+import msal
 
 from gear.cloud_config import get_global_config
 

--- a/auth/setup.py
+++ b/auth/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='auth',

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -15,6 +15,7 @@ check:
 	$(PYTHON) -m flake8  --config ../setup.cfg batch
 	$(PYTHON) -m pylint --rcfile ../pylintrc batch --score=n
 	$(PYTHON) -m mypy --config-file ../setup.cfg batch
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1,8 +1,8 @@
 import json
 import logging
 
-from hailtop.utils import time_msecs_str, humanize_timedelta_msecs
 from gear import transaction
+from hailtop.utils import humanize_timedelta_msecs, time_msecs_str
 
 from .batch_format_version import BatchFormatVersion
 from .exceptions import NonExistentBatchError, OpenBatchError

--- a/batch/batch/cloud/azure/driver/billing_manager.py
+++ b/batch/batch/cloud/azure/driver/billing_manager.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
-from collections import namedtuple
 import logging
+from collections import namedtuple
+from typing import Dict, List
 
-from hailtop.aiocloud import aioazure
 from gear import Database, transaction
+from hailtop.aiocloud import aioazure
 
 from ....driver.billing_manager import (
     CloudBillingManager,
@@ -11,7 +11,6 @@ from ....driver.billing_manager import (
     product_version_to_resource,
     refresh_product_versions_from_db,
 )
-
 from .pricing import AzureVMPrice, fetch_prices
 
 log = logging.getLogger('billing_manager')

--- a/batch/batch/cloud/azure/driver/create_instance.py
+++ b/batch/batch/cloud/azure/driver/create_instance.py
@@ -1,19 +1,18 @@
-from typing import Any, Dict, Optional
 import base64
 import json
 import logging
 import os
 from shlex import quote as shq
+from typing import Any, Dict, Optional
 
 from gear.cloud_config import get_global_config
 
-from ....batch_configuration import DOCKER_ROOT_IMAGE, DOCKER_PREFIX, DEFAULT_NAMESPACE, INTERNAL_GATEWAY_IP
+from ....batch_configuration import DEFAULT_NAMESPACE, DOCKER_PREFIX, DOCKER_ROOT_IMAGE, INTERNAL_GATEWAY_IP
 from ....file_store import FileStore
 from ....instance_config import InstanceConfig
-from ...utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ...resource_utils import unreserved_worker_data_disk_size_gib
+from ...utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ..resource_utils import azure_machine_type_to_worker_type_and_cores
-
 
 log = logging.getLogger('create_instance')
 

--- a/batch/batch/cloud/azure/driver/driver.py
+++ b/batch/batch/cloud/azure/driver/driver.py
@@ -2,20 +2,18 @@ import asyncio
 import logging
 import os
 
-from hailtop import aiotools
-from hailtop.utils import periodically_call
-from hailtop.aiocloud import aioazure
 from gear import Database
 from gear.cloud_config import get_azure_config
+from hailtop import aiotools
+from hailtop.aiocloud import aioazure
+from hailtop.utils import periodically_call
 
 from ....driver.driver import CloudDriver
-from ....driver.instance_collection import Pool, JobPrivateInstanceManager, InstanceCollectionManager
+from ....driver.instance_collection import InstanceCollectionManager, JobPrivateInstanceManager, Pool
 from ....inst_coll_config import InstanceCollectionConfigs
-
 from .billing_manager import AzureBillingManager
-from .resource_manager import AzureResourceManager
 from .regions import RegionMonitor
-
+from .resource_manager import AzureResourceManager
 
 log = logging.getLogger('driver')
 

--- a/batch/batch/cloud/azure/driver/pricing.py
+++ b/batch/batch/cloud/azure/driver/pricing.py
@@ -1,17 +1,16 @@
 import abc
-from typing import List, Optional, Dict
-
 import asyncio
 import logging
+from typing import Dict, List, Optional
+
 import dateutil.parser
 
 from hailtop.aiocloud import aioazure
 from hailtop.utils import flatten, grouped, time_msecs
-from hailtop.utils.rates import rate_instance_hour_to_fraction_msec, rate_gib_month_to_mib_msec
+from hailtop.utils.rates import rate_gib_month_to_mib_msec, rate_instance_hour_to_fraction_msec
 
-from ..resource_utils import azure_valid_machine_types, azure_disk_name_to_storage_gib
-from ..resources import AzureVMResource, AzureStaticSizedDiskResource
-
+from ..resource_utils import azure_disk_name_to_storage_gib, azure_valid_machine_types
+from ..resources import AzureStaticSizedDiskResource, AzureVMResource
 
 log = logging.getLogger('pricing')
 

--- a/batch/batch/cloud/azure/driver/resource_manager.py
+++ b/batch/batch/cloud/azure/driver/resource_manager.py
@@ -1,34 +1,32 @@
-from typing import Optional, List, Tuple
+import logging
+from typing import List, Optional, Tuple
 
 import aiohttp
-import logging
 import dateutil.parser
 
 from hailtop.aiocloud import aioazure
 
-from ....file_store import FileStore
+from ....driver.instance import Instance
 from ....driver.resource_manager import (
     CloudResourceManager,
+    UnknownVMState,
     VMDoesNotExist,
     VMState,
-    UnknownVMState,
     VMStateCreating,
     VMStateRunning,
     VMStateTerminated,
 )
-from ....driver.instance import Instance
+from ....file_store import FileStore
 from ....instance_config import InstanceConfig, QuantifiedResource
-
 from ..instance_config import AzureSlimInstanceConfig
-from .create_instance import create_vm_config
 from ..resource_utils import (
+    azure_local_ssd_size,
     azure_machine_type_to_worker_type_and_cores,
     azure_worker_memory_per_core_mib,
     azure_worker_properties_to_machine_type,
-    azure_local_ssd_size,
 )
 from .billing_manager import AzureBillingManager
-
+from .create_instance import create_vm_config
 
 log = logging.getLogger('resource_manager')
 

--- a/batch/batch/cloud/azure/instance_config.py
+++ b/batch/batch/cloud/azure/instance_config.py
@@ -6,15 +6,14 @@ from ...driver.billing_manager import ProductVersions
 from ...instance_config import InstanceConfig
 from .resource_utils import azure_machine_type_to_worker_type_and_cores
 from .resources import (
-    AzureResource,
-    AzureVMResource,
-    AzureStaticSizedDiskResource,
     AzureDynamicSizedDiskResource,
-    AzureServiceFeeResource,
     AzureIPFeeResource,
+    AzureResource,
+    AzureServiceFeeResource,
+    AzureStaticSizedDiskResource,
+    AzureVMResource,
     azure_resource_from_dict,
 )
-
 
 AZURE_INSTANCE_CONFIG_VERSION = 2
 

--- a/batch/batch/cloud/azure/resource_utils.py
+++ b/batch/batch/cloud/azure/resource_utils.py
@@ -1,6 +1,7 @@
-import re
 import logging
-from typing import Optional, Tuple, Dict
+import re
+from typing import Dict, Optional, Tuple
+
 import sortedcontainers
 
 from ...globals import RESERVED_STORAGE_GB_PER_CORE

--- a/batch/batch/cloud/azure/resources.py
+++ b/batch/batch/cloud/azure/resources.py
@@ -1,15 +1,15 @@
 import abc
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from ...driver.billing_manager import ProductVersions
 from ...resources import (
+    DynamicSizedDiskResourceMixin,
+    IPFeeResourceMixin,
     QuantifiedResource,
     Resource,
+    ServiceFeeResourceMixin,
     StaticSizedDiskResourceMixin,
     VMResourceMixin,
-    IPFeeResourceMixin,
-    ServiceFeeResourceMixin,
-    DynamicSizedDiskResourceMixin,
 )
 from .resource_utils import azure_disk_from_storage_in_gib, azure_disks_by_disk_type
 

--- a/batch/batch/cloud/azure/worker/credentials.py
+++ b/batch/batch/cloud/azure/worker/credentials.py
@@ -1,6 +1,6 @@
-from typing import Dict
 import base64
 import json
+from typing import Dict
 
 from ....worker.credentials import CloudUserCredentials
 

--- a/batch/batch/cloud/azure/worker/worker_api.py
+++ b/batch/batch/cloud/azure/worker/worker_api.py
@@ -1,15 +1,16 @@
-import aiohttp
 import abc
-from typing import Dict, Optional, Tuple
 import os
+from typing import Dict, Optional, Tuple
+
+import aiohttp
 
 from hailtop import httpx
 from hailtop.utils import request_retry_transient_errors, time_msecs
 
 from ....worker.worker_api import CloudWorkerAPI
-from .disk import AzureDisk
-from .credentials import AzureUserCredentials
 from ..instance_config import AzureSlimInstanceConfig
+from .credentials import AzureUserCredentials
+from .disk import AzureDisk
 
 
 class AzureWorkerAPI(CloudWorkerAPI):

--- a/batch/batch/cloud/driver.py
+++ b/batch/batch/cloud/driver.py
@@ -1,11 +1,9 @@
-from hailtop import aiotools
-
 from gear import Database
 from gear.cloud_config import get_global_config
+from hailtop import aiotools
 
-from ..inst_coll_config import InstanceCollectionConfigs
 from ..driver.driver import CloudDriver
-
+from ..inst_coll_config import InstanceCollectionConfigs
 from .azure.driver.driver import AzureDriver
 from .gcp.driver.driver import GCPDriver
 

--- a/batch/batch/cloud/gcp/driver/activity_logs.py
+++ b/batch/batch/cloud/gcp/driver/activity_logs.py
@@ -1,12 +1,11 @@
-import re
 import json
 import logging
-from typing import Dict, Any
+import re
+from typing import Any, Dict
 
-from hailtop.utils import parse_timestamp_msecs
-from hailtop.aiocloud import aiogoogle
 from gear import Database
-
+from hailtop.aiocloud import aiogoogle
+from hailtop.utils import parse_timestamp_msecs
 
 from ....driver.instance_collection import InstanceCollectionManager
 from .zones import ZoneSuccessRate

--- a/batch/batch/cloud/gcp/driver/billing_manager.py
+++ b/batch/batch/cloud/gcp/driver/billing_manager.py
@@ -1,5 +1,5 @@
-from typing import Dict
 import logging
+from typing import Dict
 
 from gear import Database
 

--- a/batch/batch/cloud/gcp/driver/create_instance.py
+++ b/batch/batch/cloud/gcp/driver/create_instance.py
@@ -1,17 +1,17 @@
-from typing import Dict
 import base64
 import json
 import logging
 import os
 from shlex import quote as shq
+from typing import Dict
 
 from gear.cloud_config import get_global_config
 
-from ....batch_configuration import DOCKER_ROOT_IMAGE, DOCKER_PREFIX, DEFAULT_NAMESPACE, INTERNAL_GATEWAY_IP
+from ....batch_configuration import DEFAULT_NAMESPACE, DOCKER_PREFIX, DOCKER_ROOT_IMAGE, INTERNAL_GATEWAY_IP
 from ....file_store import FileStore
 from ....instance_config import InstanceConfig
-from ...utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ...resource_utils import unreserved_worker_data_disk_size_gib
+from ...utils import ACCEPTABLE_QUERY_JAR_URL_PREFIX
 from ..resource_utils import gcp_machine_type_to_worker_type_and_cores
 
 log = logging.getLogger('create_instance')

--- a/batch/batch/cloud/gcp/driver/disks.py
+++ b/batch/batch/cloud/gcp/driver/disks.py
@@ -1,10 +1,11 @@
-import logging
-import aiohttp
 import asyncio
+import logging
 from typing import List
 
+import aiohttp
+
 from hailtop.aiocloud import aiogoogle
-from hailtop.utils import time_msecs, parse_timestamp_msecs
+from hailtop.utils import parse_timestamp_msecs, time_msecs
 
 from ....driver.instance_collection import InstanceCollectionManager
 

--- a/batch/batch/cloud/gcp/driver/driver.py
+++ b/batch/batch/cloud/gcp/driver/driver.py
@@ -1,20 +1,19 @@
 import asyncio
-from hailtop import aiotools
-from hailtop.aiocloud import aiogoogle
-from hailtop.utils import periodically_call, RateLimit
+
 from gear import Database
 from gear.cloud_config import get_gcp_config
+from hailtop import aiotools
+from hailtop.aiocloud import aiogoogle
+from hailtop.utils import RateLimit, periodically_call
 
 from ....driver.driver import CloudDriver, process_outstanding_events
-from ....driver.instance_collection import Pool, JobPrivateInstanceManager, InstanceCollectionManager
+from ....driver.instance_collection import InstanceCollectionManager, JobPrivateInstanceManager, Pool
 from ....inst_coll_config import InstanceCollectionConfigs
-
-
-from .disks import delete_orphaned_disks
 from .activity_logs import process_activity_log_events_since
 from .billing_manager import GCPBillingManager
-from .zones import ZoneMonitor
+from .disks import delete_orphaned_disks
 from .resource_manager import GCPResourceManager
+from .zones import ZoneMonitor
 
 
 class GCPDriver(CloudDriver):

--- a/batch/batch/cloud/gcp/driver/resource_manager.py
+++ b/batch/batch/cloud/gcp/driver/resource_manager.py
@@ -1,35 +1,33 @@
-from typing import Optional, List, Tuple
-
-import aiohttp
 import logging
 import uuid
+from typing import List, Optional, Tuple
+
+import aiohttp
 import dateutil.parser
 
 from hailtop.aiocloud import aiogoogle
 
-from ....file_store import FileStore
+from ....driver.instance import Instance
 from ....driver.resource_manager import (
     CloudResourceManager,
+    UnknownVMState,
     VMDoesNotExist,
     VMState,
-    UnknownVMState,
     VMStateCreating,
     VMStateRunning,
     VMStateTerminated,
 )
-from ....driver.instance import Instance
+from ....file_store import FileStore
 from ....instance_config import InstanceConfig, QuantifiedResource
-
 from ..instance_config import GCPSlimInstanceConfig
-from .create_instance import create_vm_config
 from ..resource_utils import (
+    GCP_MACHINE_FAMILY,
+    family_worker_type_cores_to_gcp_machine_type,
     gcp_machine_type_to_worker_type_and_cores,
     gcp_worker_memory_per_core_mib,
-    family_worker_type_cores_to_gcp_machine_type,
-    GCP_MACHINE_FAMILY,
 )
 from .billing_manager import GCPBillingManager
-
+from .create_instance import create_vm_config
 
 log = logging.getLogger('resource_manager')
 

--- a/batch/batch/cloud/gcp/driver/zones.py
+++ b/batch/batch/cloud/gcp/driver/zones.py
@@ -1,12 +1,12 @@
 import logging
 import random
-from typing import Dict, Any, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from hailtop.aiocloud import aiogoogle
 from hailtop.utils import url_basename
 
-from ....utils import WindowFractionCounter
 from ....driver.location import CloudLocationMonitor
+from ....utils import WindowFractionCounter
 
 log = logging.getLogger('zones')
 

--- a/batch/batch/cloud/gcp/instance_config.py
+++ b/batch/batch/cloud/gcp/instance_config.py
@@ -2,18 +2,17 @@ from typing import List
 
 from ...driver.billing_manager import ProductVersions
 from ...instance_config import InstanceConfig
+from .resource_utils import family_worker_type_cores_to_gcp_machine_type, gcp_machine_type_to_parts
 from .resources import (
-    GCPResource,
     GCPComputeResource,
-    GCPMemoryResource,
-    GCPStaticSizedDiskResource,
     GCPDynamicSizedDiskResource,
     GCPIPFeeResource,
+    GCPMemoryResource,
+    GCPResource,
     GCPServiceFeeResource,
+    GCPStaticSizedDiskResource,
     gcp_resource_from_dict,
 )
-from .resource_utils import gcp_machine_type_to_parts, family_worker_type_cores_to_gcp_machine_type
-
 
 GCP_INSTANCE_CONFIG_VERSION = 5
 

--- a/batch/batch/cloud/gcp/resource_utils.py
+++ b/batch/batch/cloud/gcp/resource_utils.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 from typing import Optional, Tuple
 
 log = logging.getLogger('utils')

--- a/batch/batch/cloud/gcp/resources.py
+++ b/batch/batch/cloud/gcp/resources.py
@@ -1,16 +1,16 @@
 import abc
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from ...driver.billing_manager import ProductVersions
 from ...resources import (
-    Resource,
-    StaticSizedDiskResourceMixin,
     ComputeResourceMixin,
-    MemoryResourceMixin,
-    IPFeeResourceMixin,
-    ServiceFeeResourceMixin,
     DynamicSizedDiskResourceMixin,
+    IPFeeResourceMixin,
+    MemoryResourceMixin,
     QuantifiedResource,
+    Resource,
+    ServiceFeeResourceMixin,
+    StaticSizedDiskResourceMixin,
 )
 
 

--- a/batch/batch/cloud/gcp/worker/credentials.py
+++ b/batch/batch/cloud/gcp/worker/credentials.py
@@ -1,5 +1,5 @@
-from typing import Dict
 import base64
+from typing import Dict
 
 from ....worker.credentials import CloudUserCredentials
 

--- a/batch/batch/cloud/gcp/worker/disk.py
+++ b/batch/batch/cloud/gcp/worker/disk.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Dict, Optional
 
-from hailtop.utils import check_shell_output, LoggingTimer, retry_all_errors_n_times
 from hailtop.aiocloud import aiogoogle
+from hailtop.utils import LoggingTimer, check_shell_output, retry_all_errors_n_times
 
 from ....worker.disk import CloudDisk
 

--- a/batch/batch/cloud/gcp/worker/worker_api.py
+++ b/batch/batch/cloud/gcp/worker/worker_api.py
@@ -1,14 +1,15 @@
-import aiohttp
-from typing import Dict
 import os
+from typing import Dict
 
-from hailtop.utils import request_retry_transient_errors
+import aiohttp
+
 from hailtop import httpx
+from hailtop.utils import request_retry_transient_errors
 
 from ....worker.worker_api import CloudWorkerAPI
-from .disk import GCPDisk
-from .credentials import GCPUserCredentials
 from ..instance_config import GCPSlimInstanceConfig
+from .credentials import GCPUserCredentials
+from .disk import GCPDisk
 
 
 class GCPWorkerAPI(CloudWorkerAPI):

--- a/batch/batch/cloud/resource_utils.py
+++ b/batch/batch/cloud/resource_utils.py
@@ -1,28 +1,28 @@
 import logging
 import math
-from typing import Tuple, Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from ..globals import RESERVED_STORAGE_GB_PER_CORE
 from .azure.resource_utils import (
-    azure_worker_memory_per_core_mib,
-    azure_requested_to_actual_storage_bytes,
-    azure_machine_type_to_worker_type_and_cores,
-    azure_valid_machine_types,
-    azure_memory_to_worker_type,
     azure_is_valid_storage_request,
     azure_local_ssd_size,
+    azure_machine_type_to_worker_type_and_cores,
+    azure_memory_to_worker_type,
+    azure_requested_to_actual_storage_bytes,
     azure_valid_cores_from_worker_type,
+    azure_valid_machine_types,
+    azure_worker_memory_per_core_mib,
 )
 from .gcp.resource_utils import (
     gcp_cost_from_msec_mcpu,
-    gcp_worker_memory_per_core_mib,
-    gcp_requested_to_actual_storage_bytes,
-    gcp_machine_type_to_worker_type_and_cores,
-    gcp_valid_machine_types,
-    gcp_memory_to_worker_type,
     gcp_is_valid_storage_request,
     gcp_local_ssd_size,
+    gcp_machine_type_to_worker_type_and_cores,
+    gcp_memory_to_worker_type,
+    gcp_requested_to_actual_storage_bytes,
     gcp_valid_cores_from_worker_type,
+    gcp_valid_machine_types,
+    gcp_worker_memory_per_core_mib,
 )
 
 log = logging.getLogger('resource_utils')

--- a/batch/batch/cloud/utils.py
+++ b/batch/batch/cloud/utils.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, Set
 import os
+from typing import Any, Dict, Set
 from urllib.parse import urlparse
 
 from gear.cloud_config import get_azure_config, get_gcp_config

--- a/batch/batch/driver/billing_manager.py
+++ b/batch/batch/driver/billing_manager.py
@@ -1,9 +1,8 @@
 import abc
-from typing import Dict, Optional
 import logging
+from typing import Dict, Optional
 
 from gear import Database, transaction
-
 
 log = logging.getLogger('billing_manager')
 

--- a/batch/batch/driver/canceller.py
+++ b/batch/batch/driver/canceller.py
@@ -1,20 +1,20 @@
-import logging
 import asyncio
+import logging
 
+from gear import Database
+from hailtop import aiotools
 from hailtop.utils import (
+    AsyncWorkerPool,
     WaitableSharedPool,
+    periodically_call,
     retry_long_running,
     run_if_changed,
-    AsyncWorkerPool,
     time_msecs,
-    periodically_call,
 )
-from hailtop import aiotools
-from gear import Database
 
-from .job import unschedule_job, mark_job_complete
-from .instance_collection import InstanceCollectionManager
 from ..utils import Box
+from .instance_collection import InstanceCollectionManager
+from .job import mark_job_complete, unschedule_job
 
 log = logging.getLogger('canceller')
 

--- a/batch/batch/driver/driver.py
+++ b/batch/batch/driver/driver.py
@@ -1,13 +1,13 @@
-from typing import Callable, Awaitable
 import abc
 import datetime
+from typing import Awaitable, Callable
 
 from gear import Database
 from hailtop import aiotools
 
+from ..inst_coll_config import InstanceCollectionConfigs
 from .billing_manager import CloudBillingManager
 from .instance_collection import InstanceCollectionManager
-from ..inst_coll_config import InstanceCollectionConfigs
 
 
 async def process_outstanding_events(db: Database, process_events_since: Callable[[str], Awaitable[str]]):

--- a/batch/batch/driver/instance.py
+++ b/batch/batch/driver/instance.py
@@ -1,19 +1,20 @@
-from typing import Optional
-import json
 import base64
-import aiohttp
 import datetime
+import json
 import logging
 import secrets
+from typing import Optional
+
+import aiohttp
 import humanize
 
-from hailtop.utils import time_msecs, time_msecs_str, retry_transient_errors
-from hailtop import httpx
 from gear import Database, transaction
+from hailtop import httpx
+from hailtop.utils import retry_transient_errors, time_msecs, time_msecs_str
 
+from ..cloud.utils import instance_config_from_config_dict
 from ..globals import INSTANCE_VERSION
 from ..instance_config import InstanceConfig
-from ..cloud.utils import instance_config_from_config_dict
 
 log = logging.getLogger('instance')
 

--- a/batch/batch/driver/instance_collection/__init__.py
+++ b/batch/batch/driver/instance_collection/__init__.py
@@ -1,6 +1,6 @@
+from .base import InstanceCollection, InstanceCollectionManager
 from .job_private import JobPrivateInstanceManager
 from .pool import Pool
-from .base import InstanceCollection, InstanceCollectionManager
 
 __all__ = [
     'JobPrivateInstanceManager',

--- a/batch/batch/driver/instance_collection/base.py
+++ b/batch/batch/driver/instance_collection/base.py
@@ -1,27 +1,28 @@
-from typing import Any, Dict, Optional, Tuple, List
 import asyncio
-import sortedcontainers
-import re
-import secrets
 import collections
 import logging
+import re
+import secrets
+from typing import Any, Dict, List, Optional, Tuple
+
+import sortedcontainers
 
 from gear import Database
 from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
 from hailtop import aiotools
-from hailtop.utils import time_msecs, secret_alnum_string, periodically_call
+from hailtop.utils import periodically_call, secret_alnum_string, time_msecs
 
-from ...instance_config import QuantifiedResource
 from ...batch_configuration import WORKER_MAX_IDLE_TIME_MSECS
+from ...instance_config import QuantifiedResource
 from ..instance import Instance
 from ..location import CloudLocationMonitor
 from ..resource_manager import (
     CloudResourceManager,
+    UnknownVMState,
+    VMDoesNotExist,
     VMStateCreating,
     VMStateRunning,
     VMStateTerminated,
-    VMDoesNotExist,
-    UnknownVMState,
 )
 
 SIXTY_SECONDS_NS = 60 * 1000 * 1000 * 1000

--- a/batch/batch/driver/instance_collection/job_private.py
+++ b/batch/batch/driver/instance_collection/job_private.py
@@ -1,33 +1,32 @@
-from typing import List, Tuple
-import random
+import asyncio
 import json
 import logging
-import asyncio
+import random
+from typing import List, Tuple
+
 import sortedcontainers
 
 from gear import Database
 from hailtop import aiotools
 from hailtop.utils import (
-    Notice,
-    run_if_changed,
-    WaitableSharedPool,
-    time_msecs,
-    retry_long_running,
-    secret_alnum_string,
     AsyncWorkerPool,
+    Notice,
+    WaitableSharedPool,
     periodically_call,
+    retry_long_running,
+    run_if_changed,
+    secret_alnum_string,
+    time_msecs,
 )
 
 from ...batch_format_version import BatchFormatVersion
 from ...inst_coll_config import JobPrivateInstanceManagerConfig
-from ...utils import Box, ExceededSharesCounter
 from ...instance_config import QuantifiedResource
-
+from ...utils import Box, ExceededSharesCounter
 from ..instance import Instance
 from ..job import mark_job_creating, schedule_job
 from ..resource_manager import CloudResourceManager
-
-from .base import InstanceCollectionManager, InstanceCollection
+from .base import InstanceCollection, InstanceCollectionManager
 
 log = logging.getLogger('job_private_inst_coll')
 

--- a/batch/batch/driver/instance_collection/pool.py
+++ b/batch/batch/driver/instance_collection/pool.py
@@ -1,30 +1,30 @@
-from typing import Optional
-import sortedcontainers
-import logging
 import asyncio
+import logging
 import random
+from typing import Optional
+
+import sortedcontainers
 
 from gear import Database
 from hailtop import aiotools
 from hailtop.utils import (
-    secret_alnum_string,
-    retry_long_running,
-    run_if_changed,
-    time_msecs,
-    WaitableSharedPool,
     AsyncWorkerPool,
     Notice,
+    WaitableSharedPool,
     periodically_call,
+    retry_long_running,
+    run_if_changed,
+    secret_alnum_string,
+    time_msecs,
 )
 
 from ...batch_configuration import STANDING_WORKER_MAX_IDLE_TIME_MSECS
 from ...inst_coll_config import PoolConfig
 from ...utils import Box, ExceededSharesCounter
 from ..instance import Instance
-from ..resource_manager import CloudResourceManager
 from ..job import schedule_job
-
-from .base import InstanceCollectionManager, InstanceCollection
+from ..resource_manager import CloudResourceManager
+from .base import InstanceCollection, InstanceCollectionManager
 
 log = logging.getLogger('pool')
 

--- a/batch/batch/driver/job.py
+++ b/batch/batch/driver/job.py
@@ -1,25 +1,25 @@
-from typing import List, TYPE_CHECKING
+import asyncio
+import base64
 import json
 import logging
-import asyncio
-import aiohttp
-import base64
 import traceback
+from typing import TYPE_CHECKING, List
 
-from hailtop.aiotools import BackgroundTaskManager
-from hailtop.utils import time_msecs, Notice, retry_transient_errors
-from hailtop import httpx
+import aiohttp
+
 from gear import Database
+from hailtop import httpx
+from hailtop.aiotools import BackgroundTaskManager
+from hailtop.utils import Notice, retry_transient_errors, time_msecs
 
 from ..batch import batch_record_to_dict
-from ..globals import complete_states, tasks, STATUS_FORMAT_VERSION
 from ..batch_configuration import KUBERNETES_SERVER_URL
 from ..batch_format_version import BatchFormatVersion
-from ..spec_writer import SpecWriter
 from ..file_store import FileStore
+from ..globals import STATUS_FORMAT_VERSION, complete_states, tasks
 from ..instance_config import QuantifiedResource
+from ..spec_writer import SpecWriter
 from .instance import Instance
-
 from .k8s_cache import K8sCache
 
 if TYPE_CHECKING:

--- a/batch/batch/driver/k8s_cache.py
+++ b/batch/batch/driver/k8s_cache.py
@@ -1,9 +1,8 @@
-from typing import Tuple
-from hailtop.utils import retry_transient_errors
 import os
+from typing import Tuple
 
 from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
-
+from hailtop.utils import retry_transient_errors
 
 FIVE_SECONDS_NS = 5 * 1000 * 1000 * 1000
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -1,69 +1,62 @@
-from typing import Dict, List
-import logging
-import json
-from functools import wraps
-from collections import namedtuple, defaultdict
-import copy
 import asyncio
+import copy
+import json
+import logging
 import signal
-import dictdiffer
-from aiohttp import web
+from collections import defaultdict, namedtuple
+from functools import wraps
+from typing import Dict, List
+
 import aiohttp_session
-import kubernetes_asyncio.config
+import dictdiffer
+import googlecloudprofiler
 import kubernetes_asyncio.client
-from prometheus_async.aio.web import server_stats
+import kubernetes_asyncio.config
 import prometheus_client as pc  # type: ignore
+import uvloop
+from aiohttp import web
+from prometheus_async.aio.web import server_stats
+
 from gear import (
     Database,
-    setup_aiohttp_session,
-    rest_authenticated_developers_only,
-    web_authenticated_developers_only,
     check_csrf_token,
-    transaction,
     monitor_endpoints_middleware,
+    rest_authenticated_developers_only,
+    setup_aiohttp_session,
+    transaction,
+    web_authenticated_developers_only,
 )
 from gear.clients import get_cloud_async_fs
-from hailtop.hail_logging import AccessLogger
-from hailtop.config import get_deploy_config
-from hailtop.utils import (
-    time_msecs,
-    serialization,
-    Notice,
-    periodically_call,
-    AsyncWorkerPool,
-    dump_all_stacktraces,
-)
-from hailtop.tls import internal_server_ssl_context
 from hailtop import aiotools, httpx
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
-import googlecloudprofiler
-import uvloop
+from hailtop.config import get_deploy_config
+from hailtop.hail_logging import AccessLogger
+from hailtop.tls import internal_server_ssl_context
+from hailtop.utils import AsyncWorkerPool, Notice, dump_all_stacktraces, periodically_call, serialization, time_msecs
+from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
-from ..file_store import FileStore
 from ..batch import cancel_batch_in_db
 from ..batch_configuration import (
-    CLOUD,
-    REFRESH_INTERVAL_IN_SECONDS,
-    DEFAULT_NAMESPACE,
     BATCH_STORAGE_URI,
+    CLOUD,
+    DEFAULT_NAMESPACE,
     HAIL_SHA,
-    HAIL_SHOULD_PROFILE,
     HAIL_SHOULD_CHECK_INVARIANTS,
+    HAIL_SHOULD_PROFILE,
     MACHINE_NAME_PREFIX,
+    REFRESH_INTERVAL_IN_SECONDS,
 )
+from ..cloud.driver import get_cloud_driver
+from ..cloud.resource_utils import local_ssd_size, possible_cores_from_worker_type, unreserved_worker_data_disk_size_gib
+from ..exceptions import BatchUserError
+from ..file_store import FileStore
 from ..globals import HTTP_CLIENT_MAX_SIZE
 from ..inst_coll_config import InstanceCollectionConfigs, PoolConfig
-
+from ..utils import authorization_token, batch_only, query_billing_projects
 from .canceller import Canceller
-from .instance_collection import InstanceCollectionManager, JobPrivateInstanceManager
+from .driver import CloudDriver
+from .instance_collection import InstanceCollectionManager, JobPrivateInstanceManager, Pool
 from .job import mark_job_complete, mark_job_started
 from .k8s_cache import K8sCache
-from .instance_collection import Pool
-from .driver import CloudDriver
-from ..utils import query_billing_projects, batch_only, authorization_token
-from ..cloud.driver import get_cloud_driver
-from ..cloud.resource_utils import unreserved_worker_data_disk_size_gib, possible_cores_from_worker_type, local_ssd_size
-from ..exceptions import BatchUserError
 
 uvloop.install()
 

--- a/batch/batch/driver/resource_manager.py
+++ b/batch/batch/driver/resource_manager.py
@@ -1,13 +1,12 @@
-from typing import List, Any, Tuple
 import abc
 import logging
+from typing import Any, List, Tuple
 
 from hailtop.utils import time_msecs
 
-from .instance import Instance
 from ..file_store import FileStore
 from ..instance_config import InstanceConfig, QuantifiedResource
-
+from .instance import Instance
 
 log = logging.getLogger('compute_manager')
 

--- a/batch/batch/file_store.py
+++ b/batch/batch/file_store.py
@@ -1,11 +1,11 @@
-import logging
 import asyncio
+import logging
 
 from hailtop.aiotools.fs import AsyncFS
 
-from .spec_writer import SpecWriter
-from .globals import BATCH_FORMAT_VERSION
 from .batch_format_version import BatchFormatVersion
+from .globals import BATCH_FORMAT_VERSION
+from .spec_writer import SpecWriter
 
 log = logging.getLogger('logstore')
 

--- a/batch/batch/front_end/validate.py
+++ b/batch/batch/front_end/validate.py
@@ -1,28 +1,27 @@
 from hailtop.batch_client.parse import (
-    MEMORY_REGEX,
-    MEMORY_REGEXPAT,
     CPU_REGEX,
     CPU_REGEXPAT,
+    MEMORY_REGEX,
+    MEMORY_REGEXPAT,
     STORAGE_REGEX,
     STORAGE_REGEXPAT,
 )
-
 from hailtop.utils.validate import (
+    ValidationError,
     anyof,
     bool_type,
     dictof,
+    int_type,
     keyed,
     listof,
-    int_type,
+    non_empty_str_type,
     nullable,
     numeric,
     oneof,
     regex,
     required,
     str_type,
-    non_empty_str_type,
     switch,
-    ValidationError,
 )
 
 from ..globals import memory_types

--- a/batch/batch/inst_coll_config.py
+++ b/batch/batch/inst_coll_config.py
@@ -1,26 +1,25 @@
-from typing import Dict, Optional, Tuple
 import asyncio
 import logging
+from typing import Dict, Optional, Tuple
 
 from gear import Database
 
-from .driver.billing_manager import ProductVersions
-from .cloud.gcp.instance_config import GCPSlimInstanceConfig
-from .cloud.gcp.resource_utils import family_worker_type_cores_to_gcp_machine_type, GCP_MACHINE_FAMILY
-from .cloud.azure.resource_utils import azure_worker_properties_to_machine_type
 from .cloud.azure.instance_config import AzureSlimInstanceConfig
-from .instance_config import InstanceConfig
+from .cloud.azure.resource_utils import azure_worker_properties_to_machine_type
+from .cloud.gcp.instance_config import GCPSlimInstanceConfig
+from .cloud.gcp.resource_utils import GCP_MACHINE_FAMILY, family_worker_type_cores_to_gcp_machine_type
 from .cloud.resource_utils import (
     adjust_cores_for_memory_request,
     adjust_cores_for_packability,
+    cores_mcpu_to_memory_bytes,
+    local_ssd_size,
     machine_type_to_worker_type_cores,
     requested_storage_bytes_to_actual_storage_gib,
-    cores_mcpu_to_memory_bytes,
     valid_machine_types,
-    local_ssd_size,
 )
 from .cloud.utils import possible_cloud_locations
-
+from .driver.billing_manager import ProductVersions
+from .instance_config import InstanceConfig
 
 log = logging.getLogger('inst_coll_config')
 

--- a/batch/batch/instance_config.py
+++ b/batch/batch/instance_config.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Sequence
 import abc
+from typing import Dict, List, Sequence
 
+from .cloud.resource_utils import cores_mcpu_to_memory_bytes
 from .driver.billing_manager import ProductVersions
 from .resources import QuantifiedResource, Resource
-from .cloud.resource_utils import cores_mcpu_to_memory_bytes
 
 
 def is_power_two(n):

--- a/batch/batch/resources.py
+++ b/batch/batch/resources.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Any, Dict, Optional
+
 from typing_extensions import TypedDict
 
 

--- a/batch/batch/utils.py
+++ b/batch/batch/utils.py
@@ -1,16 +1,16 @@
-from typing import Deque, Set, Tuple, Dict, Any
-import logging
 import json
+import logging
 import secrets
-from aiohttp import web
-from functools import wraps
 from collections import deque
+from functools import wraps
+from typing import Any, Deque, Dict, Set, Tuple
+
+from aiohttp import web
 
 from gear import maybe_parse_bearer_header
 from hailtop.utils import secret_alnum_string
 
 from .cloud.resource_utils import cost_from_msec_mcpu
-
 
 log = logging.getLogger('utils')
 

--- a/batch/batch/worker/jvm_entryway_protocol.py
+++ b/batch/batch/worker/jvm_entryway_protocol.py
@@ -1,7 +1,6 @@
 import asyncio
-import struct
 import logging
-
+import struct
 
 log = logging.getLogger('jvm_entryway_protocol')
 

--- a/batch/batch/worker/worker_api.py
+++ b/batch/batch/worker/worker_api.py
@@ -2,11 +2,11 @@ import abc
 from typing import Dict
 
 from hailtop import httpx
-from hailtop.utils import check_shell, CalledProcessError, sleep_and_backoff
+from hailtop.utils import CalledProcessError, check_shell, sleep_and_backoff
 
-from .disk import CloudDisk
-from .credentials import CloudUserCredentials
 from ..instance_config import InstanceConfig
+from .credentials import CloudUserCredentials
+from .disk import CloudDisk
 
 
 class CloudWorkerAPI(abc.ABC):

--- a/batch/create_key.py
+++ b/batch/create_key.py
@@ -1,5 +1,6 @@
 import json
 import sys
+
 import hailtop.gear.auth as hj
 
 with open(sys.argv[1], 'rb') as f:

--- a/batch/download-gcs-connector.py
+++ b/batch/download-gcs-connector.py
@@ -1,6 +1,6 @@
 import os
-import urllib.request
 import shutil
+import urllib.request
 
 # Regarding explicitly selecting 2.0.1: https://github.com/hail-is/hail/issues/8343
 with urllib.request.urlopen("https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar") as input:

--- a/batch/load-test/test-max-scheduling-rate.py
+++ b/batch/load-test/test-max-scheduling-rate.py
@@ -1,7 +1,7 @@
-import hailtop.batch as hb
-import math
 import argparse
+import math
 
+import hailtop.batch as hb
 
 parser = argparse.ArgumentParser(description='Load test the Batch service using for a given max scheduling rate')
 parser.add_argument('msr', type=int, help='the maximum scheduling rate for the Batch Driver (in jobs/sec)')

--- a/batch/setup.py
+++ b/batch/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='batch',

--- a/batch/test/conftest.py
+++ b/batch/test/conftest.py
@@ -1,6 +1,7 @@
 import hashlib
-import os
 import logging
+import os
+
 import pytest
 
 log = logging.getLogger(__name__)

--- a/batch/test/failure_injecting_client_session.py
+++ b/batch/test/failure_injecting_client_session.py
@@ -1,7 +1,7 @@
 import aiohttp
 
-from hailtop.utils import async_to_blocking
 from hailtop.httpx import client_session
+from hailtop.utils import async_to_blocking
 
 
 class FailureInjectingClientSession:

--- a/batch/test/serverthread.py
+++ b/batch/test/serverthread.py
@@ -1,11 +1,12 @@
 import os
 import threading
 import time
-import requests
-from werkzeug.serving import make_server
-from flask import Response
 
-from hailtop.utils import retry_response_returning_functions, external_requests_client_session
+import requests
+from flask import Response
+from werkzeug.serving import make_server
+
+from hailtop.utils import external_requests_client_session, retry_response_returning_functions
 
 
 class ServerThread(threading.Thread):

--- a/batch/test/test_accounts.py
+++ b/batch/test/test_accounts.py
@@ -1,10 +1,12 @@
-from typing import AsyncGenerator, Any, Callable, Awaitable, Optional
-import aiohttp
 import os
-import pytest
 import secrets
+from typing import Any, AsyncGenerator, Awaitable, Callable, Optional
+
+import aiohttp
+import pytest
+
 from hailtop.auth import session_id_encode_to_str
-from hailtop.batch_client.aioclient import BatchClient, Batch
+from hailtop.batch_client.aioclient import Batch, BatchClient
 from hailtop.utils import secret_alnum_string
 
 from .billing_projects import get_billing_project_prefix

--- a/batch/test/test_aioclient.py
+++ b/batch/test/test_aioclient.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 from hailtop.batch_client.aioclient import BatchClient
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,18 +1,19 @@
-from typing import Set
 import collections
 import os
 import secrets
 import time
+from typing import Set
+
 import aiohttp
 import pytest
 
-from hailtop.config import get_deploy_config, get_user_config
 from hailtop.auth import service_auth_headers
-from hailtop.utils import retry_response_returning_functions, external_requests_client_session, sync_sleep_and_backoff
 from hailtop.batch_client.client import BatchClient
+from hailtop.config import get_deploy_config, get_user_config
+from hailtop.utils import external_requests_client_session, retry_response_returning_functions, sync_sleep_and_backoff
 
-from .utils import legacy_batch_status, smallest_machine_type, skip_in_azure, fails_in_azure
 from .failure_injecting_client_session import FailureInjectingClientSession
+from .utils import fails_in_azure, legacy_batch_status, skip_in_azure, smallest_machine_type
 
 deploy_config = get_deploy_config()
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -1,15 +1,17 @@
-import time
-import re
 import os
+import re
 import secrets
+import time
+
 import pytest
 from flask import Response
-from hailtop.config import get_user_config
-from hailtop.batch_client.client import BatchClient, Job
-import hailtop.batch_client.aioclient as aioclient
 
-from .utils import batch_status_job_counter, legacy_batch_status
+import hailtop.batch_client.aioclient as aioclient
+from hailtop.batch_client.client import BatchClient, Job
+from hailtop.config import get_user_config
+
 from .serverthread import ServerThread
+from .utils import batch_status_job_counter, legacy_batch_status
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 

--- a/batch/test/test_invariants.py
+++ b/batch/test/test_invariants.py
@@ -1,12 +1,13 @@
-import logging
 import asyncio
-import pytest
-import aiohttp
+import logging
 
-from hailtop.config import get_deploy_config
-from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
+import aiohttp
+import pytest
+
 import hailtop.utils as utils
+from hailtop.auth import service_auth_headers
+from hailtop.config import get_deploy_config
+from hailtop.httpx import client_session
 
 pytestmark = pytest.mark.asyncio
 

--- a/batch/test/test_scale.py
+++ b/batch/test/test_scale.py
@@ -1,5 +1,7 @@
 import random
+
 import pytest
+
 from hailtop.batch_client.client import BatchClient
 
 from .utils import batch_status_job_counter, legacy_batch_status

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -1,5 +1,5 @@
-from hailtop.batch_client.parse import parse_memory_in_bytes
 from batch.cloud.resource_utils import adjust_cores_for_packability
+from hailtop.batch_client.parse import parse_memory_in_bytes
 
 
 def test_packability():

--- a/batch/test/utils.py
+++ b/batch/test/utils.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 
 def batch_status_job_counter(batch_status, job_state):

--- a/batch/utils/stress.py
+++ b/batch/utils/stress.py
@@ -1,6 +1,7 @@
-import hailtop.batch as hb
-import random
 import os
+import random
+
+import hailtop.batch as hb
 
 DOCKER_ROOT_IMAGE = os.environ['DOCKER_ROOT_IMAGE']
 

--- a/batch2/proxy.py
+++ b/batch2/proxy.py
@@ -1,7 +1,8 @@
 import asyncio
-from aiohttp import web
-from hailtop.batch_client.aioclient import BatchClient
 
+from aiohttp import web
+
+from hailtop.batch_client.aioclient import BatchClient
 
 routes = web.RouteTableDef()
 

--- a/benchmark-service/benchmark/benchmark.py
+++ b/benchmark-service/benchmark/benchmark.py
@@ -1,34 +1,37 @@
 import asyncio
-import os
-from aiohttp import web
+import json
 import logging
-from gear import setup_aiohttp_session, web_authenticated_developers_only
-from hailtop.config import get_deploy_config
-from hailtop.tls import internal_server_ssl_context
-from hailtop.hail_logging import AccessLogger, configure_logging
-from hailtop.utils import retry_long_running, collect_agen, humanize_timedelta_msecs
-from hailtop.aiocloud import aiogoogle
-from hailtop import aiotools, httpx
-import hailtop.batch_client.aioclient as bc
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template
+import os
+import re
+
+import gidgethub
+import gidgethub.aiohttp
+import numpy as np
+import pandas as pd
+import plotly
+import plotly.express as px
+from aiohttp import web
 from benchmark.utils import (
-    get_geometric_mean,
-    parse_file_path,
     enumerate_list_of_trials,
+    get_geometric_mean,
     list_benchmark_files,
+    parse_file_path,
     round_if_defined,
     submit_test_batch,
 )
-import json
-import re
-import plotly
-import plotly.express as px
 from scipy.stats.mstats import gmean, hmean
-import numpy as np
-import pandas as pd
-import gidgethub
-import gidgethub.aiohttp
-from .config import START_POINT, BENCHMARK_RESULTS_PATH
+
+import hailtop.batch_client.aioclient as bc
+from gear import setup_aiohttp_session, web_authenticated_developers_only
+from hailtop import aiotools, httpx
+from hailtop.aiocloud import aiogoogle
+from hailtop.config import get_deploy_config
+from hailtop.hail_logging import AccessLogger, configure_logging
+from hailtop.tls import internal_server_ssl_context
+from hailtop.utils import collect_agen, humanize_timedelta_msecs, retry_long_running
+from web_common import render_template, setup_aiohttp_jinja2, setup_common_static_routes
+
+from .config import BENCHMARK_RESULTS_PATH, START_POINT
 
 configure_logging()
 router = web.RouteTableDef()

--- a/benchmark-service/benchmark/config.py
+++ b/benchmark-service/benchmark/config.py
@@ -1,5 +1,6 @@
-import os
 import datetime
+import os
+
 from hailtop.utils import secret_alnum_string
 
 HAIL_BENCHMARK_BUCKET_NAME = os.environ['HAIL_BENCHMARK_BUCKET_NAME']

--- a/benchmark-service/benchmark/submit.py
+++ b/benchmark-service/benchmark/submit.py
@@ -1,16 +1,15 @@
-import importlib
-import os
-import sys
-import re
-import random
 import argparse
+import importlib
 import logging
-
-from typing import Set
+import os
+import random
+import re
+import sys
 from shlex import quote as shq
+from typing import Set
 
-from hailtop.utils import sync_check_shell
 from hailtop import batch as hb
+from hailtop.utils import sync_check_shell
 
 BENCHMARK_IMAGE = 'gcr.io/hail-vdc/base:latest'
 

--- a/benchmark-service/benchmark/utils.py
+++ b/benchmark-service/benchmark/utils.py
@@ -1,10 +1,9 @@
-import re
 import logging
+import re
 
 from hailtop.aiocloud import aiogoogle
 
 from .config import BENCHMARK_RESULTS_PATH
-
 
 log = logging.getLogger('benchmark')
 

--- a/benchmark-service/setup.py
+++ b/benchmark-service/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='benchmark',

--- a/benchmark-service/test/test_update_commits.py
+++ b/benchmark-service/test/test_update_commits.py
@@ -1,11 +1,12 @@
-import logging
 import asyncio
+import logging
+
 import pytest
 
-from hailtop.config import get_deploy_config
-from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
 import hailtop.utils as utils
+from hailtop.auth import service_auth_headers
+from hailtop.config import get_deploy_config
+from hailtop.httpx import client_session
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -16,6 +16,7 @@ check:
 	$(PYTHON) -m flake8 .
 	$(PYTHON) -m pylint --rcfile ../pylintrc ci --score=n
 	$(PYTHON) -m mypy --config-file ../setup.cfg .
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh

--- a/ci/bootstrap.py
+++ b/ci/bootstrap.py
@@ -1,22 +1,20 @@
-from typing import Dict, List, Optional, Tuple
-import os
-import json
-from shlex import quote as shq
-import base64
-import asyncio
 import argparse
+import asyncio
+import base64
+import json
+import os
+from shlex import quote as shq
+from typing import Dict, List, Optional, Tuple
 
 import kubernetes_asyncio.client
 import kubernetes_asyncio.config
 
-from hailtop.utils import check_shell_output
-
-from ci.build import BuildConfiguration, Code
-from ci.github import clone_or_fetch_script
-from ci.environment import KUBERNETES_SERVER_URL, STORAGE_URI
-from ci.utils import generate_token
-
 from batch.driver.k8s_cache import K8sCache
+from ci.build import BuildConfiguration, Code
+from ci.environment import KUBERNETES_SERVER_URL, STORAGE_URI
+from ci.github import clone_or_fetch_script
+from ci.utils import generate_token
+from hailtop.utils import check_shell_output
 
 BATCH_WORKER_IMAGE = os.environ['BATCH_WORKER_IMAGE']
 

--- a/ci/bootstrap_create_accounts.py
+++ b/ci/bootstrap_create_accounts.py
@@ -1,14 +1,15 @@
-import os
 import base64
 import json
-import kubernetes_asyncio.config
+import os
+
 import kubernetes_asyncio.client
-from hailtop.utils import async_to_blocking
-from gear import Database, transaction
-from gear.cloud_config import get_global_config
-from gear.clients import get_identity_client
+import kubernetes_asyncio.config
 
 from auth.driver.driver import create_user
+from gear import Database, transaction
+from gear.clients import get_identity_client
+from gear.cloud_config import get_global_config
+from hailtop.utils import async_to_blocking
 
 CLOUD = get_global_config()['cloud']
 SCOPE = os.environ['HAIL_SCOPE']

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -1,24 +1,19 @@
 import abc
 import json
 import logging
-from collections import defaultdict, Counter
+from collections import Counter, defaultdict
 from shlex import quote as shq
-import yaml
-import jinja2
 from typing import Dict, List
-from hailtop.utils import flatten
-from .utils import generate_token
-from .environment import (
-    DOCKER_PREFIX,
-    DOMAIN,
-    CI_UTILS_IMAGE,
-    BUILDKIT_IMAGE,
-    DEFAULT_NAMESPACE,
-    STORAGE_URI,
-    CLOUD,
-)
-from .globals import is_test_deployment
+
+import jinja2
+import yaml
+
 from gear.cloud_config import get_global_config
+from hailtop.utils import flatten
+
+from .environment import BUILDKIT_IMAGE, CI_UTILS_IMAGE, CLOUD, DEFAULT_NAMESPACE, DOCKER_PREFIX, DOMAIN, STORAGE_URI
+from .globals import is_test_deployment
+from .utils import generate_token
 
 log = logging.getLogger('ci')
 

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -1,5 +1,5 @@
-from typing import Optional, List
 import os
+from typing import List, Optional
 
 GITHUB_CLONE_URL = 'https://github.com/'
 GITHUB_STATUS_CONTEXT = os.environ["HAIL_CI_GITHUB_CONTEXT"]

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 from gear.cloud_config import get_global_config
 
 global_config = get_global_config()

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -1,26 +1,27 @@
-from enum import Enum
-from typing import Dict, Optional, Set, Union
-import secrets
-from shlex import quote as shq
-import json
-import logging
 import asyncio
 import concurrent.futures
+import json
+import logging
+import os
+import random
+import secrets
+from enum import Enum
+from shlex import quote as shq
+from typing import Dict, Optional, Set, Union
+
 import aiohttp
 import gidgethub
-import zulip
-import random
-import os
 import prometheus_client as pc  # type: ignore
+import zulip
 
-from hailtop.config import get_deploy_config
 from hailtop.batch_client.aioclient import Batch
-from hailtop.utils import check_shell, check_shell_output, RETRY_FUNCTION_SCRIPT
-from .constants import GITHUB_CLONE_URL, AUTHORIZED_USERS, GITHUB_STATUS_CONTEXT, SERVICES_TEAM, COMPILER_TEAM
-from .build import BuildConfiguration, Code
-from .globals import is_test_deployment
-from .environment import DEPLOY_STEPS
+from hailtop.config import get_deploy_config
+from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 
+from .build import BuildConfiguration, Code
+from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
+from .environment import DEPLOY_STEPS
+from .globals import is_test_deployment
 
 repos_lock = asyncio.Lock()
 

--- a/ci/ci/globals.py
+++ b/ci/ci/globals.py
@@ -1,4 +1,3 @@
 from .environment import DEFAULT_NAMESPACE
 
-
 is_test_deployment = DEFAULT_NAMESPACE != 'default'

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -1,5 +1,5 @@
-import string
 import secrets
+import string
 
 
 def generate_token(size=12):

--- a/ci/create_database.py
+++ b/ci/create_database.py
@@ -1,14 +1,15 @@
-import os
-import sys
-import base64
-import string
-import json
-import secrets
 import asyncio
+import base64
+import json
+import os
+import secrets
+import string
+import sys
 from shlex import quote as shq
-from hailtop.utils import check_shell, check_shell_output
-from hailtop.auth.sql_config import create_secret_data_from_config, SQLConfig
+
 from gear import Database
+from hailtop.auth.sql_config import SQLConfig, create_secret_data_from_config
+from hailtop.utils import check_shell, check_shell_output
 
 assert len(sys.argv) == 1
 create_database_config = json.load(sys.stdin)

--- a/ci/create_initial_account.py
+++ b/ci/create_initial_account.py
@@ -1,13 +1,13 @@
 import argparse
 import base64
 import json
-import kubernetes_asyncio.config
-import kubernetes_asyncio.client
 import os
 
-from hailtop.utils import async_to_blocking
-from gear import Database, transaction
+import kubernetes_asyncio.client
+import kubernetes_asyncio.config
 
+from gear import Database, transaction
+from hailtop.utils import async_to_blocking
 
 NAMESPACE = os.environ['NAMESPACE']
 

--- a/ci/jinja2_render.py
+++ b/ci/jinja2_render.py
@@ -1,6 +1,7 @@
-import sys
-import jinja2
 import json
+import sys
+
+import jinja2
 
 
 def jinja2_render(config, input, output):

--- a/ci/setup.py
+++ b/ci/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='ci',

--- a/ci/test/resources/hello.py
+++ b/ci/test/resources/hello.py
@@ -1,10 +1,10 @@
 import os
+
 from aiohttp import web
 
+from gear import setup_aiohttp_session
 from hailtop.config import get_deploy_config
 from hailtop.tls import internal_server_ssl_context
-from gear import setup_aiohttp_session
-
 
 deploy_config = get_deploy_config()
 

--- a/ci/test/test_ci.py
+++ b/ci/test/test_ci.py
@@ -1,12 +1,13 @@
+import asyncio
 import json
 import logging
-import asyncio
+
 import pytest
 
-from hailtop.config import get_deploy_config
-from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
 import hailtop.utils as utils
+from hailtop.auth import service_auth_headers
+from hailtop.config import get_deploy_config
+from hailtop.httpx import client_session
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)

--- a/ci/wait-for.py
+++ b/ci/wait-for.py
@@ -1,8 +1,9 @@
+import argparse
+import asyncio
+import concurrent.futures
 import sys
 import traceback
-import argparse
-import concurrent.futures
-import asyncio
+
 import uvloop
 from kubernetes_asyncio import client, config
 

--- a/devbin/rotate_keys.py
+++ b/devbin/rotate_keys.py
@@ -1,16 +1,18 @@
 import asyncio
 import base64
 import itertools
-from dateutil.parser import isoparse
-from datetime import datetime, timedelta
-import pytz
 import json
-from typing import List, Tuple, Generator, Optional, TextIO
-from enum import Enum
-import warnings
 import sys
-import kubernetes_asyncio.config
+import warnings
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Generator, List, Optional, TextIO, Tuple
+
 import kubernetes_asyncio.client
+import kubernetes_asyncio.config
+import pytz
+from dateutil.parser import isoparse
+
 from hailtop.aiocloud.aiogoogle import GoogleIAmClient
 from hailtop.utils import retry_transient_errors
 

--- a/devbin/sync.py
+++ b/devbin/sync.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python3
-from typing import List, Tuple, Set
-from hailtop.aiotools import BackgroundTaskManager
-from contextlib import closing
-from hailtop.utils import check_shell, CalledProcessError
-from hailtop.utils import retry_transient_errors
-from hailtop.hail_logging import configure_logging
-from fswatch import Monitor, libfswatch
-from threading import Thread
-import os
 import argparse
 import asyncio
-import kubernetes_asyncio.config
-import kubernetes_asyncio.client
 import logging
+import os
 import re
-import sys
 import signal
+import sys
+from contextlib import closing
+from threading import Thread
+from typing import List, Set, Tuple
 
+import kubernetes_asyncio.client
+import kubernetes_asyncio.config
+from fswatch import Monitor, libfswatch
+
+from hailtop.aiotools import BackgroundTaskManager
+from hailtop.hail_logging import configure_logging
+from hailtop.utils import CalledProcessError, check_shell, retry_transient_errors
 
 configure_logging()
 log = logging.getLogger('sync.py')

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -32,6 +32,7 @@ google-api-python-client==1.7.10
 google-cloud-logging==1.12.1
 humanize==1.0.0
 hurry.filesize==0.9
+isort==5.10.1
 orjson==3.6.4
 # importlib-metadata<4: in dev-requirements, jupyter depends on (an unpinned) ipykernel which needs importlib-metadata<4
 importlib-metadata<4

--- a/etc/pdf-split-shuffle-partition/doit.py
+++ b/etc/pdf-split-shuffle-partition/doit.py
@@ -1,7 +1,8 @@
-import sys
 import subprocess as sp
-import numpy
+import sys
 from random import shuffle
+
+import numpy
 
 # python split.py N_APPLICATIONS REVIEWERS
 

--- a/etc/pdf-split-shuffle-partition/shuffle_split.py
+++ b/etc/pdf-split-shuffle-partition/shuffle_split.py
@@ -1,6 +1,7 @@
 import sys
-import numpy
 from random import shuffle
+
+import numpy
 
 # python split.py N_APPLICATIONS N_REVIEWERS
 

--- a/etc/pdf-split-shuffle-partition/split.py
+++ b/etc/pdf-split-shuffle-partition/split.py
@@ -1,6 +1,7 @@
 import sys
-import numpy
 from random import shuffle
+
+import numpy
 
 # python split.py N_APPLICATIONS N_REVIEWERS
 

--- a/gear/Makefile
+++ b/gear/Makefile
@@ -6,4 +6,5 @@ BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 check:
 	$(PYTHON) -m flake8 gear
 	$(PYTHON) -m pylint --rcfile ../pylintrc gear --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff

--- a/gear/gear/__init__.py
+++ b/gear/gear/__init__.py
@@ -1,18 +1,18 @@
-from .database import create_database_pool, Database, transaction
-from .session import setup_aiohttp_session
 from .auth import (
-    userdata_from_web_request,
+    maybe_parse_bearer_header,
+    rest_authenticated_developers_only,
+    rest_authenticated_users_only,
     userdata_from_rest_request,
+    userdata_from_web_request,
+    web_authenticated_developers_only,
     web_authenticated_users_only,
     web_maybe_authenticated_user,
-    rest_authenticated_users_only,
-    web_authenticated_developers_only,
-    rest_authenticated_developers_only,
-    maybe_parse_bearer_header,
 )
-from .csrf import new_csrf_token, check_csrf_token
-from .auth_utils import insert_user, create_session
+from .auth_utils import create_session, insert_user
+from .csrf import check_csrf_token, new_csrf_token
+from .database import Database, create_database_pool, transaction
 from .metrics import monitor_endpoints_middleware
+from .session import setup_aiohttp_session
 
 __all__ = [
     'create_database_pool',

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -1,14 +1,16 @@
-from typing import Optional
 import asyncio
 import logging
-from functools import wraps
 import urllib.parse
+from functools import wraps
+from typing import Optional
+
 import aiohttp
-from aiohttp import web
 import aiohttp_session
-from hailtop.config import get_deploy_config
-from hailtop.auth import async_get_userinfo
+from aiohttp import web
+
 from hailtop import httpx
+from hailtop.auth import async_get_userinfo
+from hailtop.config import get_deploy_config
 
 log = logging.getLogger('gear.auth')
 

--- a/gear/gear/auth_utils.py
+++ b/gear/gear/auth_utils.py
@@ -1,4 +1,5 @@
 import secrets
+
 from hailtop.auth import session_id_encode_to_str
 
 

--- a/gear/gear/clients.py
+++ b/gear/gear/clients.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
 from gear.cloud_config import get_azure_config, get_gcp_config, get_global_config
-
-from hailtop.aiocloud import aiogoogle, aioazure
+from hailtop.aiocloud import aioazure, aiogoogle
 from hailtop.aiotools.fs import AsyncFS, AsyncFSFactory
 
 

--- a/gear/gear/cloud_config.py
+++ b/gear/gear/cloud_config.py
@@ -1,6 +1,6 @@
-from typing import Dict, Set
-import os
 import json
+import os
+from typing import Dict, Set
 
 
 class AzureConfig:

--- a/gear/gear/csrf.py
+++ b/gear/gear/csrf.py
@@ -1,6 +1,7 @@
-import secrets
 import logging
+import secrets
 from functools import wraps
+
 from aiohttp import web
 
 log = logging.getLogger('gear.auth')

--- a/gear/gear/database.py
+++ b/gear/gear/database.py
@@ -1,17 +1,17 @@
-from typing import Optional
-import os
 import asyncio
-import pymysql
-import aiomysql
-import logging
 import functools
+import logging
+import os
 import ssl
 import traceback
+from typing import Optional
+
+import aiomysql
+import pymysql
 
 from gear.metrics import PrometheusSQLTimer
-from hailtop.utils import sleep_and_backoff
 from hailtop.auth.sql_config import SQLConfig
-
+from hailtop.utils import sleep_and_backoff
 
 log = logging.getLogger('gear.database')
 

--- a/gear/gear/metrics.py
+++ b/gear/gear/metrics.py
@@ -1,5 +1,5 @@
-from aiohttp import web
 import prometheus_client as pc  # type: ignore
+from aiohttp import web
 from prometheus_async.aio import time as prom_async_time  # type: ignore
 
 REQUEST_TIME = pc.Summary('http_request_latency_seconds', 'Endpoint latency in seconds', ['endpoint', 'verb'])

--- a/gear/gear/session.py
+++ b/gear/gear/session.py
@@ -1,6 +1,8 @@
 import os
+
 import aiohttp_session
 import aiohttp_session.cookie_storage
+
 from hailtop.config import get_deploy_config
 
 

--- a/gear/gear/time_limited_max_size_cache.py
+++ b/gear/gear/time_limited_max_size_cache.py
@@ -1,10 +1,10 @@
-from typing import TypeVar, Callable, Awaitable, Dict, Generic
-
-import time
 import asyncio
+import time
+from typing import Awaitable, Callable, Dict, Generic, TypeVar
+
 import prometheus_client as pc  # type: ignore
-from prometheus_async.aio import time as prom_async_time  # type: ignore
 import sortedcontainers
+from prometheus_async.aio import time as prom_async_time  # type: ignore
 
 CACHE_HITS = pc.Counter('cache_hits_count', 'Number of Cache Hits', ['cache_name'])
 CACHE_MISSES = pc.Counter('cache_misses_count', 'Number of Cache Hits', ['cache_name'])

--- a/gear/setup.py
+++ b/gear/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='gear',

--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -5,6 +5,7 @@ astroid<2.5  # https://github.com/PyCQA/pylint/issues/4131
 pre-commit==2.9.2
 black==20.8b1
 curlylint==0.12.0
+isort==5.10.1
 pytest==6.2.5
 pytest-html==1.20.0
 pytest-xdist==2.2.1

--- a/memory/Makefile
+++ b/memory/Makefile
@@ -12,6 +12,7 @@ MEMORY_IMAGE := $(DOCKER_PREFIX)/memory:$(TOKEN)
 check:
 	$(PYTHON) -m flake8  --config ../setup.cfg memory
 	$(PYTHON) -m pylint --rcfile ../pylintrc memory --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 
 .PHONY: build

--- a/memory/memory/client.py
+++ b/memory/memory/client.py
@@ -1,7 +1,6 @@
 import aiohttp
 
 from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS
-
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
 from hailtop.httpx import client_session

--- a/memory/memory/memory.py
+++ b/memory/memory/memory.py
@@ -1,25 +1,26 @@
-import aioredis
 import asyncio
 import base64
-import logging
 import json
+import logging
 import os
-import uvloop
 import signal
-from aiohttp import web
-import kubernetes_asyncio.config
-import kubernetes_asyncio.client
-from prometheus_async.aio.web import server_stats  # type: ignore
 from collections import defaultdict
 
+import aioredis
+import kubernetes_asyncio.client
+import kubernetes_asyncio.config
+import uvloop
+from aiohttp import web
+from prometheus_async.aio.web import server_stats  # type: ignore
+
+from gear import monitor_endpoints_middleware, rest_authenticated_users_only, setup_aiohttp_session
+from gear.clients import get_cloud_async_fs_factory
+from hailtop import httpx
 from hailtop.aiotools import AsyncFS
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from hailtop.utils import retry_transient_errors, dump_all_stacktraces
-from hailtop import httpx
-from gear import setup_aiohttp_session, rest_authenticated_users_only, monitor_endpoints_middleware
-from gear.clients import get_cloud_async_fs_factory
+from hailtop.utils import dump_all_stacktraces, retry_transient_errors
 
 uvloop.install()
 

--- a/memory/setup.py
+++ b/memory/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='memory',

--- a/memory/test/test_memory.py
+++ b/memory/test/test_memory.py
@@ -1,13 +1,12 @@
 import unittest
 import uuid
-from memory.client import MemoryClient
-
-from hailtop.aiocloud import aiogoogle
-from hailtop.config import get_user_config
-from hailtop.utils import async_to_blocking
-from hailtop.aiotools.router_fs import RouterAsyncFS
 
 from gear.cloud_config import get_gcp_config
+from hailtop.aiocloud import aiogoogle
+from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.config import get_user_config
+from hailtop.utils import async_to_blocking
+from memory.client import MemoryClient
 
 PROJECT = get_gcp_config().project
 

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -12,6 +12,7 @@ BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 check:
 	$(PYTHON) -m flake8 monitoring
 	$(PYTHON) -m pylint --rcfile ../pylintrc monitoring --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh

--- a/monitoring/monitoring/monitoring.py
+++ b/monitoring/monitoring/monitoring.py
@@ -1,37 +1,38 @@
-import datetime
-import calendar
 import asyncio
-import os
+import calendar
+import datetime
 import json
-from aiohttp import web
-import aiohttp_session
 import logging
+import os
 from collections import defaultdict, namedtuple
-from prometheus_async.aio.web import server_stats  # type: ignore
-import prometheus_client as pc  # type: ignore
 
+import aiohttp_session
+import prometheus_client as pc  # type: ignore
+from aiohttp import web
+from prometheus_async.aio.web import server_stats  # type: ignore
+
+from gear import (
+    Database,
+    rest_authenticated_developers_only,
+    setup_aiohttp_session,
+    transaction,
+    web_authenticated_developers_only,
+)
+from hailtop import aiotools, httpx
 from hailtop.aiocloud import aiogoogle
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
 from hailtop.utils import (
-    run_if_changed_idempotent,
-    retry_long_running,
-    time_msecs,
     cost_str,
     parse_timestamp_msecs,
-    url_basename,
     periodically_call,
+    retry_long_running,
+    run_if_changed_idempotent,
+    time_msecs,
+    url_basename,
 )
-from hailtop import aiotools, httpx
-from gear import (
-    Database,
-    setup_aiohttp_session,
-    web_authenticated_developers_only,
-    rest_authenticated_developers_only,
-    transaction,
-)
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, set_message
+from web_common import render_template, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 from .configuration import HAIL_USE_FULL_QUERY
 

--- a/monitoring/setup.py
+++ b/monitoring/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='monitoring',

--- a/monitoring/test/test_monitoring.py
+++ b/monitoring/test/test_monitoring.py
@@ -1,12 +1,13 @@
-import logging
 import asyncio
-import pytest
-import aiohttp
+import logging
 
-from hailtop.config import get_deploy_config
-from hailtop.auth import service_auth_headers
-from hailtop.httpx import client_session
+import aiohttp
+import pytest
+
 import hailtop.utils as utils
+from hailtop.auth import service_auth_headers
+from hailtop.config import get_deploy_config
+from hailtop.httpx import client_session
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -13,6 +13,7 @@ BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 check:
 	$(PYTHON) -m flake8 notebook
 	$(PYTHON) -m pylint --rcfile ../pylintrc notebook --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 	bash ../check-sql.sh

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -1,32 +1,33 @@
+import asyncio
 import logging
 import os
 import secrets
 from functools import wraps
-import asyncio
-import pymysql
+
 import aiohttp
-from aiohttp import web
 import aiohttp_session
 import aiohttp_session.cookie_storage
-import kubernetes_asyncio.config
 import kubernetes_asyncio.client
 import kubernetes_asyncio.client.rest
+import kubernetes_asyncio.config
+import pymysql
+from aiohttp import web
 from prometheus_async.aio.web import server_stats  # type: ignore
 
+from gear import (
+    check_csrf_token,
+    create_database_pool,
+    monitor_endpoints_middleware,
+    setup_aiohttp_session,
+    web_authenticated_developers_only,
+    web_authenticated_users_only,
+    web_maybe_authenticated_user,
+)
+from hailtop import httpx
 from hailtop.config import get_deploy_config
 from hailtop.hail_logging import AccessLogger
 from hailtop.tls import internal_server_ssl_context
-from hailtop import httpx
-from gear import (
-    setup_aiohttp_session,
-    create_database_pool,
-    web_authenticated_users_only,
-    web_maybe_authenticated_user,
-    web_authenticated_developers_only,
-    check_csrf_token,
-    monitor_endpoints_middleware,
-)
-from web_common import sass_compile, setup_aiohttp_jinja2, setup_common_static_routes, set_message, render_template
+from web_common import render_template, sass_compile, set_message, setup_aiohttp_jinja2, setup_common_static_routes
 
 log = logging.getLogger('notebook')
 

--- a/notebook/scale-test.py
+++ b/notebook/scale-test.py
@@ -1,13 +1,15 @@
-import math
-import time
 import argparse
 import asyncio
 import logging
+import math
+import time
+
 import aiohttp
 import numpy as np
-from hailtop.hail_logging import configure_logging
+
 from hailtop.auth import service_auth_headers
 from hailtop.config import get_deploy_config
+from hailtop.hail_logging import configure_logging
 from hailtop.httpx import client_session
 
 configure_logging()

--- a/notebook/setup.py
+++ b/notebook/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='notebook',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 line-length = 120
 skip-string-normalization = true
 force-exclude = 'hail|datasets|sql|\.mypy'
+
+[tool.isort]
+profile = "black"
+line_length = 120
+known_first_party = ["auth", "batch", "ci", "gear", "hailtop", "monitoring", "website", "web_common"]
+skip_glob = ["hail", "benchmark", "datasets", "**/sql", ".mypy"]

--- a/tls/create_certs.py
+++ b/tls/create_certs.py
@@ -1,9 +1,10 @@
 import argparse
 import json
-import yaml
 import shutil
 import subprocess as sp
 import tempfile
+
+import yaml
 
 # gear, hailtop, and web_common are not available in the create_certs image
 

--- a/web_common/Makefile
+++ b/web_common/Makefile
@@ -6,5 +6,6 @@ BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 check:
 	$(PYTHON) -m flake8 web_common
 	$(PYTHON) -m pylint --rcfile ../pylintrc web_common --score=n
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .

--- a/web_common/setup.py
+++ b/web_common/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='web_common',

--- a/web_common/web_common/__init__.py
+++ b/web_common/web_common/__init__.py
@@ -1,10 +1,10 @@
 from .web_common import (
-    sass_compile,
-    setup_aiohttp_jinja2,
-    setup_common_static_routes,
-    set_message,
     base_context,
     render_template,
+    sass_compile,
+    set_message,
+    setup_aiohttp_jinja2,
+    setup_common_static_routes,
 )
 
 __all__ = [

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -1,12 +1,14 @@
-import os
 import importlib
-import sass
-import jinja2
+import os
+
+import aiohttp
 import aiohttp_jinja2
 import aiohttp_session
-import aiohttp
-from hailtop.config import get_deploy_config
+import jinja2
+import sass
+
 from gear import new_csrf_token
+from hailtop.config import get_deploy_config
 
 deploy_config = get_deploy_config()
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -12,6 +12,7 @@ PYTHON := PYTHONPATH=$${PYTHONPATH:+$${PYTHONPATH}:}$(EXTRA_PYTHONPATH) python3
 BLACK := $(PYTHON) -m black . --line-length=120 --skip-string-normalization
 
 check:
+	$(PYTHON) -m isort . --check-only --diff
 	$(BLACK) --check --diff
 	curlylint .
 

--- a/website/setup.py
+++ b/website/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='website',

--- a/website/website/__main__.py
+++ b/website/website/__main__.py
@@ -1,4 +1,5 @@
 import sys
+
 from hailtop.hail_logging import configure_logging
 
 # configure logging before importing anything else

--- a/website/website/website.py
+++ b/website/website/website.py
@@ -1,18 +1,18 @@
-from typing import Set
-import os
-from aiohttp import web
-import jinja2
 import logging
+import os
+from typing import Set
+
 import aiohttp_session
+import jinja2
+from aiohttp import web
 from prometheus_async.aio.web import server_stats  # type: ignore
 
-from hailtop.config import get_deploy_config
-from hailtop.tls import internal_server_ssl_context
-from hailtop.hail_logging import AccessLogger
+from gear import monitor_endpoints_middleware, setup_aiohttp_session, web_maybe_authenticated_user
 from hailtop import httpx
-from gear import setup_aiohttp_session, web_maybe_authenticated_user, monitor_endpoints_middleware
-from web_common import setup_aiohttp_jinja2, setup_common_static_routes, render_template, sass_compile
-
+from hailtop.config import get_deploy_config
+from hailtop.hail_logging import AccessLogger
+from hailtop.tls import internal_server_ssl_context
+from web_common import render_template, sass_compile, setup_aiohttp_jinja2, setup_common_static_routes
 
 MODULE_PATH = os.path.dirname(__file__)
 log = logging.getLogger('website')


### PR DESCRIPTION
See `pyproject.toml` for the isort configuration. This adds isort as a part of the `check` target for the services. To manually run isort, just run `isort .` anywhere in the hail repo. It will properly find the config file and ignore non-services code. isort has a `black` setting so it should be compatible with subsequent format checks. It doesn't immediately play well with pre-commit (ignores file excludes and runs where it shouldn't e.g. migrations) so I will separately have to look into running it there. When run, it does the following:

- Inserts line breaks to keep long imports in the desired line length
- Sorts items imported from a given module, it appears first by data type (classes before functions) and then alphabetically
- Groups and orders imports by: stdlib, third party, first party (set in pyproject.toml), and local (inferred from imports that start with `.`). I like this a lot
- Sorts imports within each group by `import`vs`from … import`, then alphabetically by module