### PR TITLE
[query] fix storeEmitParam

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -47,7 +47,7 @@ class EmitContext(
   val tryingToSplit: Memo[Unit]
 )
 
-case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[Value[Region] => EmitValue]) {
+case class EmitEnv(bindings: Env[EmitValue], inputValues: IndexedSeq[(EmitCodeBuilder, Value[Region]) => IEmitCode]) {
   def bind(name: String, v: EmitValue): EmitEnv = copy(bindings = bindings.bind(name, v))
 
   def bind(newBindings: (String, EmitValue)*): EmitEnv = copy(bindings = bindings.bindIterable(newBindings))
@@ -805,6 +805,9 @@ class Emit[C](
     def presentPC(pc: SValue): IEmitCode = IEmitCode.present(cb, pc)
 
     val result: IEmitCode = (ir: @unchecked) match {
+      case In(i, expectedPType) =>
+        val ev = env.inputValues(i).apply(cb, region)
+        ev
       case I32(x) =>
         presentPC(primitive(const(x)))
       case I64(x) =>
@@ -2489,11 +2492,6 @@ class Emit[C](
         if (ev.st.virtualType != t)
           throw new RuntimeException(s"emit value type did not match specified type:\n name: $name\n  ev: ${ ev.st.virtualType }\n  ir: ${ ir.typ }")
         ev.load
-
-      case In(i, expectedPType) =>
-        // this, Code[Region], ...
-        val ev = env.inputValues(i).apply(region)
-        ev
 
       case ir@Apply(fn, typeArgs, args, rt, errorID) =>
         val impl = ir.implementation

--- a/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitCodeBuilder.scala
@@ -76,8 +76,18 @@ class EmitCodeBuilder(val emb: EmitMethodBuilder[_], var code: Code[Unit]) exten
     f
   }
 
+  def memoizeField[T: TypeInfo](v: Code[T], name: String): Value[T] = {
+    newField[T](name, v)
+  }
+
   def memoizeField[T: TypeInfo](v: Code[T]): Value[T] = {
-    newField[T]("memoize", v)
+    memoizeField[T](v, "memoize")
+  }
+
+  def memoizeFieldAny(v: Code[_], name: String, ti: TypeInfo[_]): Value[_] = {
+    val l = newField(name)(ti)
+    append(l.storeAny(v))
+    l
   }
 
   def memoize(v: EmitCode): EmitValue =

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -218,10 +218,10 @@ object EmitStream {
 
       case In(n, _) =>
         // this, Code[Region], ...
-        val param = env.inputValues(n).apply(outerRegion)
+        val param = env.inputValues(n).apply(cb, outerRegion)
         if (!param.st.isInstanceOf[SStream])
           throw new RuntimeException(s"parameter ${ 2 + n } is not a stream! t=${ param.st } }, params=${ mb.emitParamTypes }")
-        param.load.toI(cb)
+        param
 
       case ToStream(a, _requiresMemoryManagementPerElement) =>
 


### PR DESCRIPTION
Make sure result of `storeEmitParam` doesn't contain any references to the parameter, since it may be used in a different function due to method splitting.