### PR TITLE
[query] Remove SCode.memoize

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SIndexableValue}
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.physical.{PCanonicalArray, PCanonicalDict, PCanonicalSet}
 import is.hail.types.virtual.{TArray, TDict, TSet, Type}
 import is.hail.utils.FastIndexedSeq

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -2,9 +2,8 @@ package is.hail.expr.ir
 
 import is.hail.asm4s._
 import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.types.physical._
 import is.hail.types.physical.stypes._
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructValue, SContainer, SInterval, SIntervalCode, SIntervalValue}
+import is.hail.types.physical.stypes.interfaces._
 import is.hail.utils.FastIndexedSeq
 
 import scala.language.existentials

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -7,7 +7,7 @@ import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.SValue
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointerCode, SStackStruct}
+import is.hail.types.physical.stypes.concrete.SStackStruct
 import is.hail.types.physical.stypes.interfaces.SBinaryValue
 import is.hail.utils._
 
@@ -185,7 +185,7 @@ class PrimitiveRVAState(val vtypes: Array[VirtualTypeWithReq], val kb: EmitClass
   def createState(cb: EmitCodeBuilder): Unit = {}
 
   private[this] def loadVarsFromRegion(cb: EmitCodeBuilder, srcc: Code[Long]): Unit = {
-    val pv = new SBaseStructPointerCode(sStorageType, srcc).memoize(cb, "prim_rvastate_load_vars")
+    val pv = storageType.loadCheapSCode(cb, srcc)
     foreachField { (i, es) =>
       cb.assign(es, pv.loadField(cb, i))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -46,9 +46,8 @@ class GroupedBTreeKey(kt: PType, kb: EmitClassBuilder[_], region: Value[Region],
   def isKeyMissing(cb: EmitCodeBuilder, off: Code[Long]): Value[Boolean] =
     storageType.isFieldMissing(cb, off, 0)
 
-  def loadKey(cb: EmitCodeBuilder, off: Code[Long]): SValue = {
-    kt.loadCheapSCodeField(cb, storageType.loadField(off, 0))
-  }
+  def loadKey(cb: EmitCodeBuilder, off: Code[Long]): SValue =
+    cb.memoizeField(kt.loadCheapSCode(cb, storageType.loadField(off, 0)), "loadKey")
 
   def initValue(cb: EmitCodeBuilder, destc: Code[Long], k: EmitCode, rIdx: Code[Int]): Unit = {
     val dest = cb.newLocal("ga_init_value_dest", destc)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ImputeTypeAggregator.scala
@@ -4,12 +4,11 @@ import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{EmitClassBuilder, EmitCode, EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerValue, SStackStruct}
+import is.hail.types.physical.stypes.concrete.SStackStruct
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanCode}
-import is.hail.types.virtual.{TBaseStruct, TBoolean, TInt32, TString, TStruct, Type}
+import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanValue}
+import is.hail.types.virtual._
 import is.hail.types.{RPrimitive, VirtualTypeWithReq}
 import is.hail.utils._
 
@@ -161,7 +160,7 @@ class ImputeTypeAggregator() extends StagedAggregator {
 
   protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region]): IEmitCode = {
     val emitCodes = Array(state.getAnyNonMissing, state.getAllDefined, state.getSupportsBool, state.getSupportsI32, state.getSupportsI64, state.getSupportsF64).
-      map(bool => new SBooleanCode(bool).memoize(cb, "impute_type_bools")).map(sbv => EmitCode.present(cb.emb, sbv))
+      map(bool => new SBooleanValue(cb.memoize(bool))).map(sbv => EmitCode.present(cb.emb, sbv))
     val sv = SStackStruct.constructFromArgs(cb, region, resultEmitType.virtualType.asInstanceOf[TBaseStruct], emitCodes:_*)
     IEmitCode.present(cb, sv)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -6,9 +6,9 @@ import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.linalg.LinalgCodeUtils
 import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical.PCanonicalNDArray
 import is.hail.types.physical.stypes.EmitType
-import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
-import is.hail.types.physical.{PCanonicalNDArray, PType}
+import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayValue}
 import is.hail.types.virtual.Type
 import is.hail.utils.{FastIndexedSeq, valueToRichCodeRegion}
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -3,12 +3,11 @@ package is.hail.expr.ir.agg
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
-import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, EmitParamType, IEmitCode, SCodeEmitParamType, uuid4}
+import is.hail.expr.ir.{CodeParamType, EmitCode, EmitCodeBuilder, IEmitCode}
 import is.hail.types.VirtualTypeWithReq
+import is.hail.types.physical.PCanonicalNDArray
+import is.hail.types.physical.stypes.interfaces.SNDArrayValue
 import is.hail.types.physical.stypes.{EmitType, SCode}
-import is.hail.types.physical.stypes.concrete.SNDArrayPointerSettable
-import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArrayValue}
-import is.hail.types.physical.{PCanonicalNDArray, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ndarrays/EmitNDArray.scala
@@ -1,15 +1,13 @@
 package is.hail.expr.ir.ndarrays
 
 import is.hail.annotations.Region
-import is.hail.expr.ir._
-import is.hail.types.physical.{PCanonicalArray, PCanonicalNDArray, PFloat32, PFloat32Required, PFloat64, PFloat64Required, PInt32, PInt32Required, PInt64, PInt64Required, PNumeric, PType}
-import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode}
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
-import is.hail.utils._
 import is.hail.asm4s._
+import is.hail.expr.ir._
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat64, SInt32, SInt64}
-import is.hail.types.virtual.{TFloat32, TFloat64, TInt32, TInt64, TNDArray}
+import is.hail.types.physical.stypes.{SType, SValue}
+import is.hail.types.physical._
+import is.hail.types.virtual._
+import is.hail.utils._
 
 abstract class NDArrayProducer {
   outer =>

--- a/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/StreamUtils.scala
@@ -3,9 +3,9 @@ package is.hail.expr.ir.streams
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode, IR, NDArrayMap, NDArrayMap2, Ref, RunAggScan, StagedArrayBuilder, StreamFilter, StreamFlatMap, StreamFold, StreamFold2, StreamFor, StreamJoinRightDistinct, StreamMap, StreamScan, StreamZip, StreamZipJoin}
-import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SIndexableValue}
-import is.hail.types.physical.stypes.SingleCodeType
 import is.hail.types.physical.PCanonicalArray
+import is.hail.types.physical.stypes.SingleCodeType
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.utils.HailException
 
 trait StreamArgType {

--- a/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
+++ b/hail/src/main/scala/is/hail/io/avro/AvroPartitionReader.scala
@@ -1,13 +1,12 @@
 package is.hail.io.avro
 
-import java.io.InputStream
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, CodeLabel, Settable, Value}
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.streams.StreamProducer
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, IEmitCode, PartitionReader}
 import is.hail.types.physical.stypes.concrete._
-import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue, SStreamValue, primitive}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SStreamValue, primitive}
 import is.hail.types.virtual._
 import is.hail.types.{RField, RStruct, TypeWithRequiredness}
 import org.apache.avro.Schema
@@ -16,6 +15,7 @@ import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericRecord}
 import org.apache.avro.io.DatumReader
 import org.json4s.{Extraction, JValue}
 
+import java.io.InputStream
 import scala.collection.JavaConverters._
 
 case class AvroPartitionReader(schema: Schema) extends PartitionReader {

--- a/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
+++ b/hail/src/main/scala/is/hail/linalg/LinalgCodeUtils.scala
@@ -5,8 +5,7 @@ import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
 import is.hail.types.physical.PCanonicalNDArray
 import is.hail.types.physical.stypes.concrete.SUnreachableNDArray
-import is.hail.types.physical.stypes.interfaces.{SNDArray, SNDArrayCode, SNDArraySettable, SNDArrayValue}
-import is.hail.utils.FastIndexedSeq
+import is.hail.types.physical.stypes.interfaces.{SNDArraySettable, SNDArrayValue}
 
 object LinalgCodeUtils {
   def checkColumnMajor(pndv: SNDArrayValue, cb: EmitCodeBuilder): Value[Boolean] = {

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -141,11 +141,12 @@ trait PArrayBackedContainer extends PContainer {
 
   override def sType: SIndexablePointer = SIndexablePointer(setRequired(false).asInstanceOf[PArrayBackedContainer])
 
-  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue =
-    new SIndexablePointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue =
-    new SIndexablePointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue = {
+    val a = cb.memoize(addr)
+    val length = cb.memoize(loadLength(a))
+    val elementsAddr = cb.memoize(firstElementOffset(a, length))
+    new SIndexablePointerValue(sType, a, length, elementsAddr)
+  }
 
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] =
     arrayRep.store(cb, region, value.asIndexable.castToArray(cb), deepCopy)

--- a/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBaseStruct.scala
@@ -3,9 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.check.Gen
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode, SortOrder}
-import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.utils._
 
 object PBaseStruct {

--- a/hail/src/main/scala/is/hail/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBinary.scala
@@ -1,12 +1,8 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations.{Region, UnsafeOrdering}
 import is.hail.asm4s._
-import is.hail.check.Arbitrary._
-import is.hail.check.Gen
-import is.hail.expr.ir.orderings.{CodeOrdering, CodeOrderingCompareConsistentWithOthers}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.interfaces.{SBinaryCode, SBinaryValue}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TBinary
 
 abstract class PBinary extends PType {

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -33,10 +33,7 @@ class PBoolean(override val required: Boolean) extends PType with PPrimitive {
   }
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanValue =
-  new SBooleanCode(Region.loadBoolean(addr)).memoize(cb, "loadCheapSCodeField")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SBooleanValue =
-    new SBooleanCode(Region.loadBoolean(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SBooleanValue(cb.memoize(Region.loadBoolean(addr)))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeByte(addr, annotation.asInstanceOf[Boolean].toByte)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -362,11 +362,12 @@ final case class PCanonicalArray(elementType: PType, required: Boolean = false) 
 
   def sType: SIndexablePointer = SIndexablePointer(setRequired(false))
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue =
-    new SIndexablePointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue =
-    new SIndexablePointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIndexablePointerValue = {
+    val a = cb.memoize(addr)
+    val length = cb.memoize(loadLength(a))
+    val offset = cb.memoize(firstElementOffset(a, length))
+    new SIndexablePointerValue(sType, a, length, offset)
+  }
 
   def storeContentsAtAddress(cb: EmitCodeBuilder, addr: Value[Long], region: Value[Region], indexable: SIndexableValue, deepCopy: Boolean): Unit = {
     val length = indexable.loadLength()

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -152,10 +152,7 @@ abstract class PCanonicalBaseStruct(val types: Array[PType]) extends PBaseStruct
   override def sType: SBaseStructPointer = SBaseStructPointer(setRequired(false).asInstanceOf[PCanonicalBaseStruct])
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructPointerValue =
-    new SBaseStructPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructPointerValue =
-    new SBaseStructPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+    new SBaseStructPointerValue(sType, cb.memoize(addr))
 
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -137,10 +137,7 @@ class PCanonicalBinary(val required: Boolean) extends PBinary {
   def sType: SBinaryPointer = SBinaryPointer(setRequired(false))
 
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerValue =
-    new SBinaryPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SBinaryPointerValue =
-    new SBinaryPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+    new SBinaryPointerValue(sType, cb.memoize(addr))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -43,10 +43,7 @@ final case class PCanonicalCall(required: Boolean = false) extends PCall {
   def sType: SCall = SCanonicalCall
 
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalCallValue =
-    new SCanonicalCallCode(Region.loadInt(addr)).memoize(cb, "loadCheapSCode")
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalCallValue =
-    new SCanonicalCallCode(Region.loadInt(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SCanonicalCallValue(cb.memoize(Region.loadInt(addr)))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalDict.scala
@@ -1,10 +1,9 @@
 package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
-import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TDict, Type}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SIndexableCode, SIndexableValue}
 import org.apache.spark.sql.Row
 
 object PCanonicalDict {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -75,11 +75,12 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
 
   override def sType: SIntervalPointer = SIntervalPointer(setRequired(false))
 
-  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIntervalPointerValue =
-    new SIntervalPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SIntervalPointerValue =
-    new SIntervalPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+  override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SIntervalPointerValue = {
+    val a = cb.memoize(addr)
+    val incStart = cb.memoize(includesStart(a))
+    val incEnd = cb.memoize(includesEnd(a))
+    new SIntervalPointerValue(sType, a, incStart, incEnd)
+  }
 
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -95,11 +95,11 @@ final case class PCanonicalLocus(rgBc: BroadcastRG, required: Boolean = false) e
 
   def sType: SCanonicalLocusPointer = SCanonicalLocusPointer(setRequired(false))
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalLocusPointerValue =
-    new SCanonicalLocusPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalLocusPointerValue = {
+    val a = cb.memoize(addr)
+    new SCanonicalLocusPointerValue(sType, a, cb.memoize(contigAddr(a)), cb.memoize(position(a)))
+  }
 
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SCanonicalLocusPointerValue =
-    new SCanonicalLocusPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalNDArray.scala
@@ -341,11 +341,15 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
 
   def sType: SNDArrayPointer = SNDArrayPointer(setRequired(false))
 
-  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SNDArrayPointerValue =
-    new SNDArrayPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SNDArrayPointerValue =
-    new SNDArrayPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+  def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SNDArrayPointerValue = {
+    val a = cb.memoize(addr)
+    val shapeTuple = shapeType.loadCheapSCode(cb, representation.loadField(a, "shape"))
+    val shape = Array.tabulate(nDims)(i => SizeValueDyn(shapeTuple.loadField(cb, i).get(cb).asLong.longCode(cb)))
+    val strideTuple = strideType.loadCheapSCode(cb, representation.loadField(a, "strides"))
+    val strides = Array.tabulate(nDims)(strideTuple.loadField(cb, _).get(cb).asLong.longCode(cb))
+    val firstDataAddress = cb.memoize(dataFirstElementPointer(a))
+    new SNDArrayPointerValue(sType, a, shape, strides, firstDataAddress)
+  }
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     val addr = cb.memoize(this.representation.allocate(region))
@@ -377,7 +381,7 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       case _ =>
         val newDataAddr = this.allocateData(shape, region)
         cb += Region.storeAddress(this.representation.fieldOffset(targetAddr, "data"), newDataAddr)
-        val outputSNDValue = new SNDArrayPointerCode(sType, targetAddr).memoize(cb, "pcanonical_ndarray_store_at_addr_output")
+        val outputSNDValue = loadCheapSCode(cb, targetAddr)
         outputSNDValue.coiterateMutate(cb, region, true, (inputSNDValue, "input")){
           case Seq(dest, elt) =>
             elt

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalSet.scala
@@ -1,8 +1,8 @@
 package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
-import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SIndexableValue}
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TSet, Type}
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -63,10 +63,7 @@ class PCanonicalString(val required: Boolean) extends PString {
   def sType: SStringPointer = SStringPointer(setRequired(false))
 
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SStringPointerValue =
-    new SStringPointerCode(sType, addr).memoize(cb, "loadCheapSCode")
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SStringPointerValue =
-    new SStringPointerCode(sType, addr).memoizeField(cb, "loadCheapSCodeField")
+    new SStringPointerValue(sType, cb.memoize(addr))
 
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = {
     value.st match {

--- a/hail/src/main/scala/is/hail/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PContainer.scala
@@ -2,8 +2,7 @@ package is.hail.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SIndexableCode, SIndexableValue}
+import is.hail.expr.ir.EmitCodeBuilder
 
 abstract class PContainer extends PIterable {
   override def containsPointers: Boolean = true

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -43,10 +43,7 @@ class PFloat32(override val required: Boolean) extends PNumeric with PPrimitive 
     cb.append(Region.storeFloat(addr, value.asFloat.floatCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =
-    new SFloat32Code(Region.loadFloat(addr)).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SFloat32Value =
-    new SFloat32Code(Region.loadFloat(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SFloat32Value(cb.memoize(Region.loadFloat(addr)))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeFloat(addr, annotation.asInstanceOf[Float])

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -44,10 +44,7 @@ class PFloat64(override val required: Boolean) extends PNumeric with PPrimitive 
     cb.append(Region.storeDouble(addr, value.asDouble.doubleCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =
-    new SFloat64Code(Region.loadDouble(addr)).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SFloat64Value =
-    new SFloat64Code(Region.loadDouble(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SFloat64Value(cb.memoize(Region.loadDouble(addr)))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeDouble(addr, annotation.asInstanceOf[Double])

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -40,10 +40,7 @@ class PInt32(override val required: Boolean) extends PNumeric with PPrimitive {
     cb.append(Region.storeInt(addr, value.asInt.intCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =
-    new SInt32Code(Region.loadInt(addr)).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SInt32Value =
-    new SInt32Code(Region.loadInt(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SInt32Value(cb.memoize(Region.loadInt(addr)))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeInt(addr, annotation.asInstanceOf[Int])

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -41,10 +41,7 @@ class PInt64(override val required: Boolean) extends PNumeric with PPrimitive {
     cb.append(Region.storeLong(addr, value.asLong.longCode(cb)))
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =
-    new SInt64Code(Region.loadLong(addr)).memoize(cb, "loadCheapSCode")
-
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SInt64Value =
-    new SInt64Code(Region.loadLong(addr)).memoizeField(cb, "loadCheapSCodeField")
+    new SInt64Value(cb.memoize(Region.loadLong(addr)))
 
   override def unstagedStoreJavaObjectAtAddress(addr: Long, annotation: Annotation, region: Region): Unit = {
     Region.storeLong(addr, annotation.asInstanceOf[Long])

--- a/hail/src/main/scala/is/hail/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInterval.scala
@@ -3,9 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.check.Gen
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SIntervalCode, SIntervalValue}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TInterval
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PLocus.scala
@@ -2,8 +2,6 @@ package is.hail.types.physical
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.interfaces.{SLocusCode, SLocusValue}
 import is.hail.types.virtual.TLocus
 import is.hail.variant._
 

--- a/hail/src/main/scala/is/hail/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PString.scala
@@ -1,10 +1,8 @@
 package is.hail.types.physical
 
+import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.annotations.{UnsafeOrdering, _}
-import is.hail.expr.ir.orderings.{CodeOrdering, CodeOrderingCompareConsistentWithOthers}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.interfaces.{SStringCode, SStringValue}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.virtual.TString
 
 abstract class PString extends PType {

--- a/hail/src/main/scala/is/hail/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PStruct.scala
@@ -1,10 +1,8 @@
 package is.hail.types.physical
 
-import is.hail.annotations._
 import is.hail.asm4s.{Code, Value}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.stypes.interfaces.{SBaseStructCode, SBaseStructValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.SBaseStructValue
 import is.hail.types.virtual.{Field, TStruct}
 
 trait PStruct extends PBaseStruct {

--- a/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PSubsetStruct.scala
@@ -1,12 +1,11 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Annotation, Region, UnsafeUtils}
-import is.hail.asm4s.{Code, Settable, SettableBuilder, Value, coerce, const}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.BaseStruct
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructValue}
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.annotations.{Annotation, Region}
+import is.hail.asm4s.{Code, Value}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.SSubsetStruct
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructValue}
 import is.hail.types.virtual.TStruct
 import is.hail.utils._
 
@@ -125,9 +124,6 @@ final case class PSubsetStruct(ps: PStruct, _fieldNames: IndexedSeq[String]) ext
   }
 
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue =
-    throw new UnsupportedOperationException
-
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SBaseStructValue =
     throw new UnsupportedOperationException
 
   def unstagedStoreAtAddress(addr: Long, region: Region, srcPType: PType, srcAddress: Long, deepCopy: Boolean): Unit = {

--- a/hail/src/main/scala/is/hail/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PType.scala
@@ -456,8 +456,6 @@ abstract class PType extends Serializable with Requiredness {
   // return a SCode that can cheaply operate on the region representation. Generally a pointer type, but not necessarily (e.g. primitives).
   def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SValue
 
-  def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SValue
-
   // stores a stack value as a region value of this type
   def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long]
 

--- a/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PUnrealizable.scala
@@ -31,8 +31,6 @@ trait PUnrealizable extends PType {
 
   override def loadCheapSCode(cb: EmitCodeBuilder, addr: Code[Long]): SValue = unsupported
 
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SValue = unsupported
-
   override def store(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): Value[Long] = unsupported
 
   override def storeAtAddress(cb: EmitCodeBuilder, addr: Code[Long], region: Value[Region], value: SValue, deepCopy: Boolean): Unit = unsupported

--- a/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
+++ b/hail/src/main/scala/is/hail/types/physical/StoredSTypePType.scala
@@ -104,10 +104,6 @@ case class StoredSTypePType(sType: SType, required: Boolean) extends PType {
     sType.fromValues(ct.loadValues(cb, cb.newLocal[Long]("stored_stype_ptype_loaded_addr")))
   }
 
-  override def loadCheapSCodeField(cb: EmitCodeBuilder, addr: Code[Long]): SValue = {
-    sType.fromValues(ct.loadValues(cb, cb.newField[Long]("stored_stype_ptype_loaded_addr")))
-  }
-
   override def loadFromNested(addr: Code[Long]): Code[Long] = addr
 
   override def deepRename(t: Type): PType = StoredSTypePType(sType.castRename(t), required)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -46,62 +46,7 @@ object SCode {
   def _empty: SValue = SVoidValue
 }
 
-abstract class SCode {
-
-  def st: SType
-
-  def asBoolean: SBooleanCode = asInstanceOf[SBooleanCode]
-
-  def asInt: SInt32Code = asInstanceOf[SInt32Code]
-
-  def asInt32: SInt32Code = asInstanceOf[SInt32Code]
-
-  def asLong: SInt64Code = asInstanceOf[SInt64Code]
-
-  def asInt64: SInt64Code = asInstanceOf[SInt64Code]
-
-  def asFloat: SFloat32Code = asInstanceOf[SFloat32Code]
-
-  def asFloat32: SFloat32Code = asInstanceOf[SFloat32Code]
-
-  def asFloat64: SFloat64Code = asInstanceOf[SFloat64Code]
-
-  def asDouble: SFloat64Code = asInstanceOf[SFloat64Code]
-
-  def asPrimitive: SPrimitiveCode = asInstanceOf[SPrimitiveCode]
-
-  def asBinary: SBinaryCode = asInstanceOf[SBinaryCode]
-
-  def asIndexable: SIndexableCode = asInstanceOf[SIndexableCode]
-
-  def asBaseStruct: SBaseStructCode = asInstanceOf[SBaseStructCode]
-
-  def asString: SStringCode = asInstanceOf[SStringCode]
-
-  def asInterval: SIntervalCode = asInstanceOf[SIntervalCode]
-
-  def asNDArray: SNDArrayCode = asInstanceOf[SNDArrayCode]
-
-  def asLocus: SLocusCode = asInstanceOf[SLocusCode]
-
-  def asCall: SCallCode = asInstanceOf[SCallCode]
-
-  def asStream: SStreamCode = asInstanceOf[SStreamCode]
-
-  def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: SType): SValue =
-    castTo(cb, region, destType, false)
-
-  def castTo(cb: EmitCodeBuilder, region: Value[Region], destType: SType, deepCopy: Boolean): SValue = {
-    destType.coerceOrCopy(cb, region, this.memoize(cb, "castTo"), deepCopy)
-  }
-
-  def copyToRegion(cb: EmitCodeBuilder, region: Value[Region], destType: SType): SValue =
-    destType.coerceOrCopy(cb, region, this.memoize(cb, "copyToRegion"), deepCopy = true)
-
-  def memoize(cb: EmitCodeBuilder, name: String): SValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SValue
-}
+abstract class SCode
 
 trait SValue {
   def st: SType
@@ -177,13 +122,6 @@ object SSettable {
       sb.newSettable(s"${ name }_${ st.getClass.getSimpleName }_$i")(ti)
     })
   }
-}
-
-trait SUnrealizableCode extends SCode {
-  private def unsupported: Nothing =
-    throw new UnsupportedOperationException(s"$this is not realizable")
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SValue = unsupported
 }
 
 trait SUnrealizableValue extends SValue

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -146,7 +146,7 @@ case class StreamSingleCodeType(requiresMemoryManagementPerElement: Boolean, elt
       }
 
       override val element: EmitCode =
-        EmitCode.fromI(mb)(cb => IEmitCode.present(cb, eltType.loadCheapSCodeField(cb, rvAddr)))
+        EmitCode.fromI(mb)(cb => IEmitCode.present(cb, cb.memoizeField(eltType.loadCheapSCode(cb, rvAddr), "stream_input_element")))
 
       override def close(cb: EmitCodeBuilder): Unit = {}
     }
@@ -163,7 +163,7 @@ case class PTypeReferenceSingleCodeType(pt: PType) extends SingleCodeType {
   override def loadedSType: SType = pt.sType
 
   def loadToSValue(cb: EmitCodeBuilder, r: Value[Region], c: Value[_]): SValue =
-    pt.loadCheapSCodeField(cb, coerce[Long](c))
+    cb.memoizeField(pt.loadCheapSCode(cb, coerce[Long](c)), "PTypeReferenceSingleCodeType")
 
   def virtualType: Type = pt.virtualType
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructSettable, SBaseStructValue}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue}
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
 import is.hail.types.physical.{PBaseStruct, PType}
 import is.hail.types.virtual.{TBaseStruct, Type}
@@ -87,18 +87,4 @@ final class SBaseStructPointerSettable(
   }
 }
 
-class SBaseStructPointerCode(val st: SBaseStructPointer, val a: Code[Long]) extends SBaseStructCode {
-  val pt: PBaseStruct = st.pType
-
-  def code: Code[_] = a
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SBaseStructPointerValue = {
-    val s = SBaseStructPointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBaseStructPointerValue = memoize(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructPointerValue = memoize(cb, name, cb.fieldBuilder)
-}
+class SBaseStructPointerCode(val st: SBaseStructPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -2,8 +2,8 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryCode, SBinaryValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PBinary, PType}
 import is.hail.types.virtual.Type
@@ -84,24 +84,4 @@ final class SBinaryPointerSettable(
   override def store(cb: EmitCodeBuilder, pc: SCode): Unit = cb.assign(a, pc.asInstanceOf[SBinaryPointerCode].a)
 }
 
-class SBinaryPointerCode(val st: SBinaryPointer, val a: Code[Long]) extends SBinaryCode {
-  private val pt: PBinary = st.pType
-
-  def code: Code[_] = a
-
-  def loadLength(): Code[Int] = pt.loadLength(a)
-
-  def loadBytes(): Code[Array[Byte]] = pt.loadBytes(a)
-
-  def memoize(cb: EmitCodeBuilder, sb: SettableBuilder, name: String): SBinaryPointerValue = {
-    val s = SBinaryPointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBinaryPointerValue =
-    memoize(cb, cb.localBuilder, name)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBinaryPointerValue =
-    memoize(cb, cb.fieldBuilder, name)
-}
+class SBinaryPointerCode(val st: SBinaryPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -2,8 +2,8 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.interfaces.{SCall, SCallCode, SCallValue, SIndexableValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.{SCall, SCallValue, SIndexableValue}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCall, PCanonicalCall, PType}
 import is.hail.types.virtual.{TCall, Type}
@@ -66,7 +66,7 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
 
   override val st: SCanonicalCall.type = SCanonicalCall
 
-  override def get: SCallCode = new SCanonicalCallCode(call)
+  override def get: SCode = new SCanonicalCallCode(call)
 
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(call)
 
@@ -154,23 +154,4 @@ final class SCanonicalCallSettable(override val call: Settable[Int]) extends SCa
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(call)
 }
 
-class SCanonicalCallCode(val call: Code[Int]) extends SCallCode {
-
-  val pt: PCall = PCanonicalCall(false)
-
-  val st: SCanonicalCall.type = SCanonicalCall
-
-  def code: Code[_] = call
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SCanonicalCallValue = {
-    val s = SCanonicalCallSettable(sb, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SCanonicalCallValue = memoize(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SCanonicalCallValue = memoize(cb, name, cb.fieldBuilder)
-
-  def loadCanonicalRepresentation(cb: EmitCodeBuilder): Code[Int] = call
-}
+class SCanonicalCallCode(val call: Code[Int]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -2,13 +2,13 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
+import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalLocus, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
-import is.hail.variant.{Locus, ReferenceGenome}
+import is.hail.variant.ReferenceGenome
 
 
 final case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
@@ -104,27 +104,4 @@ final class SCanonicalLocusPointerSettable(
     SBaseStructPointer(st.pType.representation), a)
 }
 
-class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Long]) extends SLocusCode {
-  val pt: PCanonicalLocus = st.pType
-
-  def code: Code[_] = a
-
-  def position(cb: EmitCodeBuilder): Code[Int] = pt.position(a)
-
-  def getLocusObj(cb: EmitCodeBuilder): Code[Locus] = {
-    val loc = memoize(cb, "get_locus_code_memo")
-    Code.newInstance[Locus, String, Int](loc.contig(cb).asString.loadString(cb), loc.position(cb))
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SCanonicalLocusPointerSettable = {
-    val s = SCanonicalLocusPointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SCanonicalLocusPointerSettable = memoize(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SCanonicalLocusPointerSettable = memoize(cb, name, cb.fieldBuilder)
-
-  def structRepr(cb: EmitCodeBuilder): SBaseStructCode = new SBaseStructPointerCode(SBaseStructPointer(st.pType.representation), a)
-}
+class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -3,9 +3,9 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableCode, SIndexableValue}
 import is.hail.types.physical.stypes._
-import is.hail.types.physical.{PArray, PCanonicalArray, PCanonicalDict, PCanonicalSet, PContainer, PType}
+import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableValue}
+import is.hail.types.physical._
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
@@ -54,23 +54,7 @@ final case class SIndexablePointer(pType: PContainer) extends SContainer {
 }
 
 
-class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extends SIndexableCode {
-  val pt: PContainer = st.pType
-
-  def code: Code[_] = a
-
-  override def codeLoadLength(): Code[Int] = pt.loadLength(a)
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIndexablePointerValue = {
-    val s = SIndexablePointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  override def memoize(cb: EmitCodeBuilder, name: String): SIndexablePointerValue = memoize(cb, name, cb.localBuilder)
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SIndexablePointerValue = memoize(cb, name, cb.fieldBuilder)
-}
+class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extends SCode
 
 class SIndexablePointerValue(
   override val st: SIndexablePointer,

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -4,8 +4,8 @@ import is.hail.annotations.Region
 import is.hail.asm4s.{BooleanInfo, Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
 import is.hail.expr.ir.orderings.CodeOrdering
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SInterval, SIntervalCode, SIntervalValue}
 import is.hail.types.physical.stypes._
+import is.hail.types.physical.stypes.interfaces.{SInterval, SIntervalValue}
 import is.hail.types.physical.{PInterval, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
@@ -120,22 +120,4 @@ final class SIntervalPointerSettable(
   }
 }
 
-class SIntervalPointerCode(val st: SIntervalPointer, val a: Code[Long]) extends SIntervalCode {
-  val pt = st.pType
-
-  def code: Code[_] = a
-
-  def codeIncludesStart(): Code[Boolean] = pt.includesStart(a)
-
-  def codeIncludesEnd(): Code[Boolean] = pt.includesEnd(a)
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIntervalPointerValue = {
-    val s = SIntervalPointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SIntervalPointerValue = memoize(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SIntervalPointerValue = memoize(cb, name, cb.fieldBuilder)
-}
+class SIntervalPointerCode(val st: SIntervalPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaArray.scala
@@ -3,8 +3,8 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableCode, SIndexableValue}
 import is.hail.types.physical.stypes._
+import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableValue}
 import is.hail.types.physical.{PCanonicalArray, PCanonicalString, PType}
 import is.hail.types.virtual.{TArray, TString, Type}
 import is.hail.utils.FastIndexedSeq
@@ -58,19 +58,7 @@ final case class SJavaArrayString(elementRequired: Boolean) extends SContainer {
     new SJavaArrayStringValue(this, cb.memoize(arr))
 }
 
-class SJavaArrayStringCode(val st: SJavaArrayString, val array: Code[Array[String]]) extends SIndexableCode {
-  def codeLoadLength(): Code[Int] = array.length()
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SIndexableValue = {
-    val s = SJavaArrayStringSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue = memoize(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SIndexableValue = memoize(cb, name, cb.fieldBuilder)
-}
+class SJavaArrayStringCode(val st: SJavaArrayString, val array: Code[Array[String]]) extends SCode
 
 class SJavaArrayStringValue(
   val st: SJavaArrayString,
@@ -78,7 +66,7 @@ class SJavaArrayStringValue(
 ) extends SIndexableValue {
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(array)
 
-  override def get: SIndexableCode = new SJavaArrayStringCode(st, array)
+  override def get: SCode = new SJavaArrayStringCode(st, array)
 
   override def loadLength(): Value[Int] = new Value[Int] {
     override def get: Code[Int] = array.length()

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaBytes.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaBytes.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical.stypes.concrete
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryCode, SBinaryValue}
+import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalBinary, PType}
 import is.hail.types.virtual._
@@ -39,23 +39,7 @@ case object SJavaBytes extends SBinary {
   }
 }
 
-class SJavaBytesCode(val bytes: Code[Array[Byte]]) extends SBinaryCode {
-  def st: SBinary = SJavaBytes
-
-  def loadLength(): Code[Int] = bytes.invoke[Int]("length")
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SBinaryValue = {
-    val s = new SJavaBytesSettable(sb.newSettable[Array[Byte]](s"${name}_javabytearray"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBinaryValue = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBinaryValue = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  override def loadBytes(): Code[Array[Byte]] = bytes
-}
+class SJavaBytesCode(val bytes: Code[Array[Byte]]) extends SCode
 
 class SJavaBytesValue(val bytes: Value[Array[Byte]]) extends SBinaryValue {
   override def st: SBinary = SJavaBytes

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -47,27 +47,7 @@ case object SJavaString extends SString {
     new SJavaStringValue(cb.memoize(s))
 }
 
-class SJavaStringCode(val s: Code[String]) extends SStringCode {
-  def st: SString = SJavaString
-
-  def loadLength(): Code[Int] = s.invoke[Int]("length")
-
-  def loadString(): Code[String] = s
-
-  def toBytes(): SBinaryCode = {
-    new SJavaBytesCode(s.invoke[Array[Byte]]("getBytes"))
-  }
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SValue = {
-    val s = new SJavaStringSettable(sb.newSettable[String](s"${name}_javastring"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SValue = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SValue = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-}
+class SJavaStringCode(val s: Code[String]) extends SCode
 
 class SJavaStringValue(val s: Value[String]) extends SStringValue {
   override def st: SString = SJavaString

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -135,18 +135,4 @@ final class SNDArrayPointerSettable(
   }
 }
 
-class SNDArrayPointerCode(val st: SNDArrayPointer, val a: Code[Long]) extends SNDArrayCode {
-  val pt: PCanonicalNDArray = st.pType
-
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SNDArrayPointerValue = {
-    val s = SNDArrayPointerSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  override def memoize(cb: EmitCodeBuilder, name: String): SNDArrayPointerValue =
-    memoize(cb, name, cb.localBuilder)
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SNDArrayPointerValue =
-    memoize(cb, name, cb.fieldBuilder)
-}
+class SNDArrayPointerCode(val st: SNDArrayPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArraySlice.scala
@@ -2,10 +2,10 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitValue}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitValue}
+import is.hail.types.physical.stypes._
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives.SInt64
-import is.hail.types.physical.stypes._
 import is.hail.types.physical.{PCanonicalNDArray, PType}
 import is.hail.types.virtual.{TNDArray, Type}
 import is.hail.utils.toRichIterable
@@ -129,16 +129,4 @@ final class SNDArraySliceSettable(
   }
 }
 
-class SNDArraySliceCode(val st: SNDArraySlice, val shape: IndexedSeq[Code[Long]], val strides: IndexedSeq[Code[Long]], val dataFirstElement: Code[Long]) extends SNDArrayCode {
-  def memoize(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SNDArrayValue = {
-    val s = SNDArraySliceSettable(sb, st, name)
-    s.store(cb, this)
-    s
-  }
-
-  override def memoize(cb: EmitCodeBuilder, name: String): SNDArrayValue =
-    memoize(cb, name, cb.localBuilder)
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SValue =
-    memoize(cb, name, cb.fieldBuilder)
-}
+class SNDArraySliceCode(val st: SNDArraySlice, val shape: IndexedSeq[Code[Long]], val strides: IndexedSeq[Code[Long]], val dataFirstElement: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -1,11 +1,11 @@
 package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, Settable, TypeInfo, Value}
+import is.hail.asm4s.{Settable, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitSettable, EmitValue, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructSettable, SBaseStructValue}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue}
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
-import is.hail.types.physical.{PCanonicalBaseStruct, PCanonicalStruct, PCanonicalTuple, PTupleField, PType}
+import is.hail.types.physical._
 import is.hail.types.virtual.{TBaseStruct, TStruct, TTuple, Type}
 
 object SStackStruct {
@@ -24,7 +24,7 @@ object SStackStruct {
       structType.constructFromFields(cb, region, as, false)
     } else {
       val st = SStackStruct(t, as.map(_.emitType))
-      new SStackStructCode(st, as).memoize(cb, "SStackStruct_constructFromArgs")
+      st.fromEmitCodes(cb, as)
     }
   }
 }
@@ -67,6 +67,11 @@ final case class SStackStruct(virtualType: TBaseStruct, fieldEmitTypes: IndexedS
       val start = settableStarts(i)
       et.fromValues(values.slice(start, start + et.nSettables))
     })
+  }
+
+  def fromEmitCodes(cb: EmitCodeBuilder, values: IndexedSeq[EmitCode]): SStackStructValue = {
+    val s = new SStackStructValue(this, values.map(cb.memoize))
+    s
   }
 
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue = {
@@ -141,26 +146,4 @@ final class SStackStructSettable(
   }
 }
 
-class SStackStructCode(val st: SStackStruct, val codes: IndexedSeq[EmitCode]) extends SBaseStructCode {
-  override def memoize(cb: EmitCodeBuilder, name: String): SStackStructSettable = {
-    new SStackStructSettable(st, codes.indices.map { i =>
-      val code = codes(i)
-      val es = cb.emb.newEmitLocal(s"${ name }_$i", code.emitType)
-      es.store(cb, code)
-      es
-    })
-  }
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SStackStructSettable = {
-    new SStackStructSettable(st, codes.indices.map { i =>
-      val code = codes(i)
-      val es = cb.emb.newEmitField(s"${ name }_$i", code.emitType)
-      es.store(cb, code)
-      es
-    })
-  }
-
-  override def loadSingleField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
-    codes(fieldIdx).toI(cb)
-  }
-}
+class SStackStructCode(val st: SStackStruct, val codes: IndexedSeq[EmitCode]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -2,11 +2,10 @@ package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
 import is.hail.asm4s.{Code, LongInfo, Settable, SettableBuilder, TypeInfo, Value}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.physical.stypes.interfaces.{SBinaryCode, SString, SStringCode, SStringValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.interfaces.{SString, SStringValue}
 import is.hail.types.physical.stypes.{SCode, SSettable, SType, SValue}
-import is.hail.types.physical.{PCanonicalString, PString, PType}
+import is.hail.types.physical.{PString, PType}
 import is.hail.types.virtual.Type
 import is.hail.utils.FastIndexedSeq
 
@@ -47,29 +46,7 @@ final case class SStringPointer(pType: PString) extends SString {
 }
 
 
-class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends SStringCode {
-  val pt: PString = st.pType
-
-  def loadLength(): Code[Int] = pt.loadLength(a)
-
-  def loadString(): Code[String] = pt.loadString(a)
-
-  def toBytes(): SBinaryPointerCode = new SBinaryPointerCode(SBinaryPointer(pt.binaryRepresentation), a)
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SStringPointerValue = {
-    val s = new SStringPointerSettable(st, sb.newSettable[Long]("sstringpointer_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SStringPointerValue =
-    memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SStringPointerValue =
-    memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def binaryRepr: SBinaryPointerCode = new SBinaryPointerCode(SBinaryPointer(st.pType.binaryRepresentation), a)
-}
+class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends SCode
 
 class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SStringValue {
   val pt: PString = st.pType

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -1,9 +1,9 @@
 package is.hail.types.physical.stypes.concrete
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, Settable, TypeInfo, Value}
+import is.hail.asm4s.{Settable, TypeInfo, Value}
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
-import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructCode, SBaseStructSettable, SBaseStructValue}
+import is.hail.types.physical.stypes.interfaces.{SBaseStruct, SBaseStructSettable, SBaseStructValue}
 import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
 import is.hail.types.physical.{PCanonicalStruct, PType}
 import is.hail.types.virtual.{TStruct, Type}
@@ -86,7 +86,7 @@ final case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[Strin
 class SSubsetStructValue(val st: SSubsetStruct, prev: SBaseStructValue) extends SBaseStructValue {
   override lazy val valueTuple: IndexedSeq[Value[_]] = prev.valueTuple
 
-  override def get: SSubsetStructCode = new SSubsetStructCode(st, prev.get.asBaseStruct)
+  override def get: SSubsetStructCode = new SSubsetStructCode(st, prev.get)
 
   override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     prev.loadField(cb, st.newToOldFieldMapping(fieldIdx))
@@ -102,12 +102,4 @@ final class SSubsetStructSettable(st: SSubsetStruct, prev: SBaseStructSettable) 
   override def store(cb: EmitCodeBuilder, pv: SCode): Unit = prev.store(cb, pv.asInstanceOf[SSubsetStructCode].prev)
 }
 
-class SSubsetStructCode(val st: SSubsetStruct, val prev: SBaseStructCode) extends SBaseStructCode {
-  def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue = {
-    new SSubsetStructSettable(st, prev.memoize(cb, name).asInstanceOf[SBaseStructSettable])
-  }
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue = {
-    new SSubsetStructSettable(st, prev.memoizeField(cb, name).asInstanceOf[SBaseStructSettable])
-  }
-}
+class SSubsetStructCode(val st: SSubsetStruct, val prev: SCode) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBaseStruct.scala
@@ -34,8 +34,6 @@ trait SBaseStructSettable extends SBaseStructValue with SSettable
 trait SBaseStructValue extends SValue {
   def st: SBaseStruct
 
-  override def get: SBaseStructCode
-
   def isFieldMissing(cb: EmitCodeBuilder, fieldIdx: Int): Value[Boolean]
 
   def isFieldMissing(cb: EmitCodeBuilder, fieldName: String): Value[Boolean] =
@@ -77,29 +75,5 @@ trait SBaseStructValue extends SValue {
 
     val pcs = PCanonicalStruct(false, allFields.map { case (f, ec) => (f, ec.emitType.storageType) }: _*)
     pcs.constructFromFields(cb, region, allFields.map(_._2.load), false)
-  }
-}
-
-trait SBaseStructCode extends SCode {
-  self =>
-  def st: SBaseStruct
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBaseStructValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBaseStructValue
-
-  final def loadSingleField(cb: EmitCodeBuilder, fieldName: String): IEmitCode = loadSingleField(cb, st.fieldIdx(fieldName))
-
-  def loadSingleField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
-    memoize(cb, "structcode_loadsinglefield")
-      .loadField(cb, fieldIdx)
-  }
-
-  protected[stypes] def _insert(newType: TStruct, fields: (String, EmitCode)*): SBaseStructCode = {
-    new SInsertFieldsStructCode(
-      SInsertFieldsStruct(newType, st, fields.map { case (name, ec) => (name, ec.emitType) }.toFastIndexedSeq),
-      this,
-      fields.map(_._2).toFastIndexedSeq
-    )
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SBinary.scala
@@ -4,7 +4,7 @@ import is.hail.asm4s.Code.invokeStatic1
 import is.hail.asm4s.{Code, Value}
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.primitives.SInt32Value
-import is.hail.types.physical.stypes.{SCode, SType, SValue}
+import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.{RPrimitive, TypeWithRequiredness}
 
 trait SBinary extends SType {
@@ -12,8 +12,6 @@ trait SBinary extends SType {
 }
 
 trait SBinaryValue extends SValue {
-  override def get: SBinaryCode
-
   def loadLength(cb: EmitCodeBuilder): Value[Int]
 
   def loadBytes(cb: EmitCodeBuilder): Value[Array[Byte]]
@@ -23,14 +21,3 @@ trait SBinaryValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.util.Arrays, Array[Byte], Int]("hashCode", loadBytes(cb))))
 }
-
-trait SBinaryCode extends SCode {
-  def loadLength(): Code[Int]
-
-  def loadBytes(): Code[Array[Byte]]
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBinaryValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBinaryValue
-}
-

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SCall.scala
@@ -28,11 +28,3 @@ trait SCallValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(canonicalCall(cb))
 }
-
-trait SCallCode extends SCode {
-  def memoize(cb: EmitCodeBuilder, name: String): SCallValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SCallValue
-
-  def loadCanonicalRepresentation(cb: EmitCodeBuilder): Code[Int]
-}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SContainer.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
 import is.hail.types.physical.PCanonicalArray
 import is.hail.types.physical.stypes.primitives.SInt32Value
-import is.hail.types.physical.stypes.{EmitType, SCode, SType, SValue}
+import is.hail.types.physical.stypes.{EmitType, SType, SValue}
 import is.hail.types.{RIterable, TypeWithRequiredness}
 
 trait SContainer extends SType {
@@ -16,8 +16,6 @@ trait SContainer extends SType {
 
 trait SIndexableValue extends SValue {
   def st: SContainer
-
-  override def get: SIndexableCode
 
   def loadLength(): Value[Int]
 
@@ -80,14 +78,3 @@ trait SIndexableValue extends SValue {
     }
   }
 }
-
-trait SIndexableCode extends SCode {
-  def st: SContainer
-
-  def codeLoadLength(): Code[Int]
-
-  def memoize(cb: EmitCodeBuilder, name: String): SIndexableValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SIndexableValue
-}
-

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SInterval.scala
@@ -32,15 +32,3 @@ trait SIntervalValue extends SValue {
 
   def isEmpty(cb: EmitCodeBuilder): Value[Boolean]
 }
-
-trait SIntervalCode extends SCode {
-  def st: SInterval
-
-  def codeIncludesStart(): Code[Boolean]
-
-  def codeIncludesEnd(): Code[Boolean]
-
-  def memoize(cb: EmitCodeBuilder, name: String): SIntervalValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SIntervalValue
-}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SLocus.scala
@@ -31,15 +31,3 @@ trait SLocusValue extends SValue {
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     structRepr(cb).hash(cb)
 }
-
-trait SLocusCode extends SCode {
-  def st: SLocus
-
-  def position(cb: EmitCodeBuilder): Code[Int]
-
-  def getLocusObj(cb: EmitCodeBuilder): Code[Locus]
-
-  def memoize(cb: EmitCodeBuilder, name: String): SLocusValue
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SLocusValue
-}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -583,7 +583,7 @@ final class SizeValueStatic(val v: Long) extends SizeValue {
 trait SNDArrayValue extends SValue {
   def st: SNDArray
 
-  override def get: SNDArrayCode
+  override def get: SCode
 
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SValue
 
@@ -737,9 +737,3 @@ trait SNDArrayValue extends SValue {
 }
 
 trait SNDArraySettable extends SNDArrayValue with SSettable
-
-trait SNDArrayCode extends SCode {
-  def st: SNDArray
-
-  def memoize(cb: EmitCodeBuilder, name: String): SNDArrayValue
-}

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -1,13 +1,13 @@
 package is.hail.types.physical.stypes.interfaces
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, Settable, TypeInfo, Value}
+import is.hail.asm4s.{Settable, TypeInfo, Value}
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.expr.ir.streams.StreamProducer
-import is.hail.types.{RIterable, TypeWithRequiredness}
-import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType, SUnrealizableCode, SUnrealizableValue, SValue}
 import is.hail.types.physical.PType
+import is.hail.types.physical.stypes._
 import is.hail.types.virtual.{TStream, Type}
+import is.hail.types.{RIterable, TypeWithRequiredness}
 
 final case class SStream(elementEmitType: EmitType) extends SType {
   def elementType: SType = elementEmitType.st
@@ -38,15 +38,7 @@ final case class SStream(elementEmitType: EmitType) extends SType {
   override def _typeWithRequiredness: TypeWithRequiredness = RIterable(elementEmitType.typeWithRequiredness.r)
 }
 
-object SStreamCode{
-  def apply(producer: StreamProducer): SStreamCode = SStreamCode(SStream(producer.element.emitType), producer)
-}
-
-final case class SStreamCode(st: SStream, producer: StreamProducer) extends SCode with SUnrealizableCode {
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SValue = SStreamValue(st, producer)
-
-  override def memoize(cb: EmitCodeBuilder, name: String): SValue = SStreamValue(st, producer)
-}
+final case class SStreamCode(st: SStream, producer: StreamProducer) extends SCode
 
 object SStreamValue{
   def apply(producer: StreamProducer): SStreamValue = SStreamValue(SStream(producer.element.emitType), producer)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
@@ -13,7 +13,7 @@ trait SString extends SType {
 }
 
 trait SStringValue extends SValue {
-  override def get: SStringCode
+  override def get: SCode
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(loadString(cb).invoke[Int]("hashCode")))
@@ -23,12 +23,4 @@ trait SStringValue extends SValue {
   def loadString(cb: EmitCodeBuilder): Value[String]
 
   def toBytes(cb: EmitCodeBuilder): SBinaryValue
-}
-
-trait SStringCode extends SCode {
-  def loadLength(): Code[Int]
-
-  def loadString(): Code[String]
-
-  def toBytes(): SBinaryCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -1,12 +1,11 @@
 package is.hail.types.physical.stypes.interfaces
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{Code, Settable, TypeInfo, UnitInfo, Value}
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder, SortOrder}
-import is.hail.types.{RPrimitive, TypeWithRequiredness}
-import is.hail.types.physical.stypes.{SCode, SSettable, SType, SUnrealizableCode, SUnrealizableValue, SValue}
-import is.hail.types.physical.{PType, PVoid}
+import is.hail.asm4s.{Settable, TypeInfo, Value}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.TypeWithRequiredness
+import is.hail.types.physical.PType
+import is.hail.types.physical.stypes._
 import is.hail.types.virtual.{TVoid, Type}
 import is.hail.utils.FastIndexedSeq
 
@@ -33,13 +32,7 @@ case object SVoid extends SType {
   override def containsPointers: Boolean = false
 }
 
-case object SVoidCode extends SCode with SUnrealizableCode {
-  self =>
-
-  override def st: SType = SVoid
-
-  def memoize(cb: EmitCodeBuilder, name: String): SValue = SVoidValue
-}
+case object SVoidCode extends SCode
 
 case object SVoidValue extends SValue with SUnrealizableValue {
   self =>

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -40,23 +40,7 @@ case object SBoolean extends SPrimitive {
   override def storageType(): PType = PBoolean()
 }
 
-class SBooleanCode(val code: Code[Boolean]) extends SPrimitiveCode {
-  override def _primitiveCode: Code[_] = code
-
-  def st: SBoolean.type = SBoolean
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SBooleanSettable = {
-    val s = new SBooleanSettable(sb.newSettable[Boolean]("sboolean_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SBooleanSettable = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SBooleanSettable = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def boolCode(cb: EmitCodeBuilder): Code[Boolean] = code
-}
+class SBooleanCode(val code: Code[Boolean]) extends SCode
 
 class SBooleanValue(x: Value[Boolean]) extends SPrimitiveValue {
   val pt: PBoolean = PBoolean()
@@ -84,5 +68,5 @@ object SBooleanSettable {
 class SBooleanSettable(x: Settable[Boolean]) extends SBooleanValue(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asBoolean.boolCode(cb))
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SBooleanCode].code)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -38,25 +38,7 @@ case object SFloat32 extends SPrimitive {
   override def storageType(): PType = PFloat32()
 }
 
-class SFloat32Code(val code: Code[Float]) extends SPrimitiveCode {
-  override def _primitiveCode: Code[_] = code
-
-  val pt: PFloat32 = PFloat32(false)
-
-  override def st: SFloat32.type = SFloat32
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SFloat32Value = {
-    val s = new SFloat32Settable(sb.newSettable[Float]("sint64_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  override def memoize(cb: EmitCodeBuilder, name: String): SFloat32Value = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  override def memoizeField(cb: EmitCodeBuilder, name: String): SFloat32Value = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def floatCode(cb: EmitCodeBuilder): Code[Float] = code
-}
+class SFloat32Code(val code: Code[Float]) extends SCode
 
 class SFloat32Value(x: Value[Float]) extends SPrimitiveValue {
   val pt: PFloat32 = PFloat32()
@@ -84,5 +66,5 @@ object SFloat32Settable {
 final class SFloat32Settable(x: Settable[Float]) extends SFloat32Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asFloat.floatCode(cb))
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SFloat32Code].code)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -50,23 +50,7 @@ object SFloat64Code {
   def apply(code: Code[Double]): SFloat64Code = new SFloat64Code(code)
 }
 
-class SFloat64Code(val code: Code[Double]) extends SPrimitiveCode {
-  override def _primitiveCode: Code[_] = code
-
-  def st: SFloat64.type = SFloat64
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SFloat64Value = {
-    val s = new SFloat64Settable(sb.newSettable[Double]("sint64_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SFloat64Value = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SFloat64Value = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def doubleCode(cb: EmitCodeBuilder): Code[Double] = code
-}
+class SFloat64Code(val code: Code[Double]) extends SCode
 
 object SFloat64Value {
   def apply(code: Value[Double]): SFloat64Value = new SFloat64Value(code)
@@ -98,5 +82,5 @@ object SFloat64Settable {
 final class SFloat64Settable(x: Settable[Double]) extends SFloat64Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asDouble.doubleCode(cb))
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SFloat64Code].code)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -38,23 +38,7 @@ case object SInt32 extends SPrimitive {
   override def storageType(): PType = PInt32()
 }
 
-class SInt32Code(val code: Code[Int]) extends SPrimitiveCode {
-  override def _primitiveCode: Code[_] = code
-
-  def st: SInt32.type = SInt32
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SInt32Value = {
-    val s = new SInt32Settable(sb.newSettable[Int]("sInt32_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SInt32Value = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SInt32Value = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def intCode(cb: EmitCodeBuilder): Code[Int] = code
-}
+class SInt32Code(val code: Code[Int]) extends SCode
 
 class SInt32Value(x: Value[Int]) extends SPrimitiveValue {
   val pt: PInt32 = PInt32(false)
@@ -82,5 +66,5 @@ object SInt32Settable {
 final class SInt32Settable(x: Settable[Int]) extends SInt32Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInt.intCode(cb))
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SInt32Code].code)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -39,23 +39,7 @@ case object SInt64 extends SPrimitive {
   override def storageType(): PType = PInt64()
 }
 
-class SInt64Code(val code: Code[Long]) extends SPrimitiveCode {
-  override def _primitiveCode: Code[_] = code
-
-  def st: SInt64.type = SInt64
-
-  private[this] def memoizeWithBuilder(cb: EmitCodeBuilder, name: String, sb: SettableBuilder): SInt64Value = {
-    val s = new SInt64Settable(sb.newSettable[Long]("sint64_memoize"))
-    s.store(cb, this)
-    s
-  }
-
-  def memoize(cb: EmitCodeBuilder, name: String): SInt64Value = memoizeWithBuilder(cb, name, cb.localBuilder)
-
-  def memoizeField(cb: EmitCodeBuilder, name: String): SInt64Value = memoizeWithBuilder(cb, name, cb.fieldBuilder)
-
-  def longCode(cb: EmitCodeBuilder): Code[Long] = code
-}
+class SInt64Code(val code: Code[Long]) extends SCode
 
 class SInt64Value(x: Value[Long]) extends SPrimitiveValue {
   val pt: PInt64 = PInt64(false)
@@ -83,5 +67,5 @@ object SInt64Settable {
 final class SInt64Settable(x: Settable[Long]) extends SInt64Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asLong.longCode(cb))
+  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SInt64Code].code)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SPrimitive.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SPrimitive.scala
@@ -14,13 +14,6 @@ trait SPrimitive extends SType {
   def containsPointers: Boolean = false
 }
 
-abstract class SPrimitiveCode extends SCode {
-  override def st: SPrimitive
-
-  protected[primitives] def _primitiveCode: Code[_]
-  final def primitiveCode[T]: Code[T] = coerce[T](_primitiveCode)
-}
-
 abstract class SPrimitiveValue extends SValue {
   override def st: SPrimitive
 

--- a/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/CodeSuite.scala
@@ -2,12 +2,11 @@ package is.hail.asm4s
 
 import is.hail.HailSuite
 import is.hail.annotations.Region
-import is.hail.expr.ir.{EmitCodeBuilder, EmitFunctionBuilder, IEmitCode}
-import is.hail.types.physical.{PCanonicalArray, PCanonicalBaseStruct, PCanonicalString, PCanonicalStruct, PField, PFloat32, PInt32, PType}
-import is.hail.types.physical.stypes.SCode
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerCode, SIndexablePointer, SIndexablePointerCode, SStringPointer}
-import is.hail.types.physical.stypes.interfaces.{SString, SStringCode}
-import is.hail.types.physical.stypes.primitives.{SFloat32Code, SFloat64Code, SInt32Code, SInt64Code}
+import is.hail.expr.ir.{EmitCodeBuilder, EmitFunctionBuilder}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete._
+import is.hail.types.physical.stypes.primitives.{SFloat32Value, SFloat64Value, SInt32Value, SInt64Value}
+import is.hail.types.physical._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
@@ -29,10 +28,10 @@ class CodeSuite extends HailSuite {
   }
   @Test def testHash() {
     val fields = IndexedSeq(PField("a", PCanonicalString(), 0), PField("b", PInt32(), 1), PField("c", PFloat32(), 2))
-    assert(hashTestNumHelper(new SInt32Code(6)) == hashTestNumHelper(new SInt32Code(6)))
-    assert(hashTestNumHelper(new SInt64Code(5000000000l)) == hashTestNumHelper(new SInt64Code(5000000000l)))
-    assert(hashTestNumHelper(new SFloat32Code(3.14f)) == hashTestNumHelper(new SFloat32Code(3.14f)))
-    assert(hashTestNumHelper(new SFloat64Code(5000000000.89d)) == hashTestNumHelper(new SFloat64Code(5000000000.89d)))
+    assert(hashTestNumHelper(new SInt32Value(6)) == hashTestNumHelper(new SInt32Value(6)))
+    assert(hashTestNumHelper(new SInt64Value(5000000000l)) == hashTestNumHelper(new SInt64Value(5000000000l)))
+    assert(hashTestNumHelper(new SFloat32Value(3.14f)) == hashTestNumHelper(new SFloat32Value(3.14f)))
+    assert(hashTestNumHelper(new SFloat64Value(5000000000.89d)) == hashTestNumHelper(new SFloat64Value(5000000000.89d)))
     assert(hashTestStringHelper("dog")== hashTestStringHelper("dog"))
     assert(hashTestArrayHelper(IndexedSeq(1,2,3,4,5,6)) == hashTestArrayHelper(IndexedSeq(1,2,3,4,5,6)))
     assert(hashTestArrayHelper(IndexedSeq(1,2)) != hashTestArrayHelper(IndexedSeq(3,4,5,6,7)))
@@ -40,12 +39,11 @@ class CodeSuite extends HailSuite {
     assert(hashTestStructHelper(Row("w", 8, .009f), fields) != hashTestStructHelper(Row("opaque", 8, .009f), fields))
   }
 
-  def hashTestNumHelper(toHash: SCode): Int = {
+  def hashTestNumHelper(v: SValue): Int = {
     val fb = EmitFunctionBuilder[Int](ctx, "test_hash")
     val mb = fb.apply_method
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
-      val i = toHash.memoize(cb, "value_to_hash")
-      val hash = i.hash(cb)
+      val hash = v.hash(cb)
       hash.intCode(cb)
     })
     fb.result()()()
@@ -73,10 +71,8 @@ class CodeSuite extends HailSuite {
     val mb = fb.apply_method
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
       val arrayPointer = fb.emb.getCodeParam[Long](1)
-      val sIndexPointer = SIndexablePointer(pArray)
-      val arrayToHash = new SIndexablePointerCode(sIndexPointer, arrayPointer)
-      val i = arrayToHash.memoize(cb, "value_to_hash")
-      val hash = i.hash(cb)
+      val arrayToHash = pArray.loadCheapSCode(cb, arrayPointer)
+      val hash = arrayToHash.hash(cb)
       hash.intCode(cb)
     })
     val region = Region(pool=pool)
@@ -90,10 +86,8 @@ class CodeSuite extends HailSuite {
     val mb = fb.apply_method
     mb.emit(EmitCodeBuilder.scopedCode(mb) { cb =>
       val structPointer = fb.emb.getCodeParam[Long](1)
-      val sIndexPointer = SBaseStructPointer(pStruct)
-      val structToHash = new SBaseStructPointerCode(sIndexPointer, structPointer)
-      val i = structToHash.memoize(cb, "value_to_hash")
-      val hash = i.hash(cb)
+      val structToHash = pStruct.loadCheapSCode(cb, structPointer)
+      val hash = structToHash.hash(cb)
       hash.intCode(cb)
     })
     val region = Region(pool=pool)


### PR DESCRIPTION
Replace uses of `new SFooCode(...).memoize(cb)` with one of
* `new SFooValue(...)`
* for pointer types, `pType.loadCheapSCode(cb, addr)`

With `memoize` no longer used, all `SCode` methods are unused. I delete all the class bodies, but leave the concrete `SCode` classes, because `SSettable.store(cb, SValue)` is still implemented as `SSettable.store(cb, sv.get)`. Fixing that will be the next PR.

Delete `loadCheapSCodeField`, replace uses with `cb.memoizeField(loadCheapSCode(...))`.