### PR TITLE
[query] Finish removing SCode

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -3,25 +3,27 @@ package is.hail.expr.ir
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.backend.{ExecuteContext, HailTaskContext}
+import is.hail.backend.ExecuteContext
 import is.hail.backend.spark.{SparkBackend, SparkTaskContext}
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.{BlockMatrixToTableFunction, MatrixToTableFunction, StringFunctions, TableToTableFunction}
 import is.hail.expr.ir.lowering.{LowererUnsupportedOperation, TableStage, TableStageDependency}
 import is.hail.expr.ir.streams.{StreamArgType, StreamProducer}
 import is.hail.io._
+import is.hail.io.avro.AvroTableReader
 import is.hail.io.fs.FS
-import is.hail.io.index.{IndexReadIterator, IndexReader, IndexReaderBuilder, LeafChild, MaybeIndexedReadZippedIterator}
+import is.hail.io.index.{IndexReadIterator, IndexReader, IndexReaderBuilder, LeafChild}
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, BlockMatrixReadRowBlockedRDD}
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
 import is.hail.types._
+import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete.SInsertFieldsStruct
-import is.hail.types.physical.{stypes, _}
+import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SStreamValue}
 import is.hail.types.physical.stypes.{BooleanSingleCodeType, Int32SingleCodeType, PTypeReferenceSingleCodeType, StreamSingleCodeType}
-import is.hail.types.physical.stypes.interfaces.{SBaseStructValue, SStream, SStreamCode, SStreamValue}
 import is.hail.types.virtual._
 import is.hail.utils._
+import is.hail.utils.prettyPrint.ArrayOfByteArrayInputStream
 import org.apache.spark.TaskContext
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.sql.Row
@@ -29,10 +31,7 @@ import org.json4s.JsonAST.JString
 import org.json4s.jackson.JsonMethods
 import org.json4s.{DefaultFormats, Extraction, Formats, JValue, ShortTypeHints}
 
-import java.io.{ByteArrayInputStream, DataInputStream, DataOutputStream, InputStream}
-import is.hail.io.avro.AvroTableReader
-import is.hail.utils.prettyPrint.ArrayOfByteArrayInputStream
-
+import java.io.{DataInputStream, DataOutputStream, InputStream}
 import scala.reflect.ClassTag
 
 object TableIR {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedBlockLinkedList.scala
@@ -6,8 +6,8 @@ import is.hail.expr.ir._
 import is.hail.io.{InputBuffer, OutputBuffer}
 import is.hail.types.encoded._
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointerCode, SIndexablePointerSettable, SIndexablePointerValue}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.SIndexablePointerValue
 import is.hail.utils._
 
 object StagedBlockLinkedList {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -8,7 +8,7 @@ import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer}
 import is.hail.types.VirtualTypeWithReq
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.EmitType
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.virtual.{TInt32, Type}
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/NDArrayFunctions.scala
@@ -9,8 +9,8 @@ import is.hail.types.coerce
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SNDArrayPointer}
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SBooleanCode, SBooleanValue}
-import is.hail.types.physical.{PBooleanRequired, PCanonicalNDArray, PCanonicalStruct, PFloat64Required, PType}
+import is.hail.types.physical.stypes.primitives.SBooleanValue
+import is.hail.types.physical._
 import is.hail.types.virtual._
 
 object  NDArrayFunctions extends RegistryFunctions {

--- a/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/streams/EmitStream.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.orderings.StructOrdering
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.SUnreachable
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SInt32Code, SInt32Value}
+import is.hail.types.physical.stypes.primitives.SInt32Value
 import is.hail.types.physical.{PCanonicalArray, PCanonicalStruct}
 import is.hail.types.virtual.TStream
 import is.hail.types.{TypeWithRequiredness, VirtualTypeWithReq}

--- a/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PArrayBackedContainer.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeOrdering}
 import is.hail.asm4s.{Code, Value}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerValue}
-import is.hail.types.physical.stypes.interfaces.SContainer
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 
 trait PArrayBackedContainer extends PContainer {
   val arrayRep: PArray

--- a/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PBoolean.scala
@@ -1,10 +1,10 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations._
 import is.hail.asm4s.Code
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.SValue
-import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanCode, SBooleanValue}
+import is.hail.types.physical.stypes.primitives.{SBoolean, SBooleanValue}
 import is.hail.types.virtual.TBoolean
 import is.hail.utils.toRichBoolean
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalArray.scala
@@ -1,11 +1,11 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, _}
+import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.ir.{EmitCode, EmitCodeBuilder, EmitMethodBuilder, IEmitCode}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerCode, SIndexablePointerSettable, SIndexablePointerValue}
-import is.hail.types.physical.stypes.interfaces.{SContainer, SIndexableValue}
+import is.hail.expr.ir.{EmitCodeBuilder, IEmitCode}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
+import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TArray, Type}
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBaseStruct.scala
@@ -4,9 +4,8 @@ import is.hail.annotations.{Annotation, Region, UnsafeRow, UnsafeUtils}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
 import is.hail.types.BaseStruct
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerCode, SBaseStructPointerSettable, SBaseStructPointerValue}
-import is.hail.types.physical.stypes.interfaces.SBaseStruct
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SBaseStructPointer, SBaseStructPointerValue}
 import is.hail.utils._
 import org.apache.spark.sql.Row
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalBinary.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerCode, SBinaryPointerSettable, SBinaryPointerValue}
-import is.hail.types.physical.stypes.interfaces.{SBinary, SBinaryValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SBinaryPointer, SBinaryPointerValue}
 import is.hail.utils._
 
 case object PCanonicalBinaryOptional extends PCanonicalBinary(false)

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalCall.scala
@@ -2,10 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region, UnsafeOrdering}
 import is.hail.asm4s._
-import is.hail.expr.ir.orderings.CodeOrdering
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SCanonicalCall, SCanonicalCallCode, SCanonicalCallValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SCanonicalCall, SCanonicalCallValue}
 import is.hail.types.physical.stypes.interfaces.SCall
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalInterval.scala
@@ -3,10 +3,10 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SIntervalPointer, SIntervalPointerCode, SIntervalPointerValue, SStackStruct, SUnreachableInterval}
-import is.hail.types.physical.stypes.interfaces.{SIntervalValue, primitive}
-import is.hail.types.physical.stypes.primitives.{SBooleanCode, SBooleanValue}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SIntervalPointer, SIntervalPointerValue, SStackStruct}
+import is.hail.types.physical.stypes.interfaces.primitive
+import is.hail.types.physical.stypes.primitives.SBooleanValue
 import is.hail.types.virtual.{TInterval, Type}
 import is.hail.utils.{FastIndexedSeq, Interval}
 import org.apache.spark.sql.Row

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalLocus.scala
@@ -3,9 +3,9 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitCodeBuilder}
-import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerCode, SCanonicalLocusPointerValue, SStackStruct}
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SCanonicalLocusPointer, SCanonicalLocusPointerValue, SStackStruct}
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.{SCode, SValue}
 import is.hail.utils.FastIndexedSeq
 import is.hail.variant._
 

--- a/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PCanonicalString.scala
@@ -2,9 +2,9 @@ package is.hail.types.physical
 
 import is.hail.annotations.{Annotation, Region}
 import is.hail.asm4s.{Code, Value}
-import is.hail.expr.ir.{EmitCodeBuilder, EmitMethodBuilder}
-import is.hail.types.physical.stypes.{SCode, SValue}
-import is.hail.types.physical.stypes.concrete.{SStringPointer, SStringPointerCode, SStringPointerValue}
+import is.hail.expr.ir.EmitCodeBuilder
+import is.hail.types.physical.stypes.SValue
+import is.hail.types.physical.stypes.concrete.{SStringPointer, SStringPointerValue}
 
 case object PCanonicalStringOptional extends PCanonicalString(false)
 

--- a/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat32.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat32Code, SFloat32Value}
+import is.hail.types.physical.stypes.primitives.{SFloat32, SFloat32Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TFloat32
 

--- a/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PFloat64.scala
@@ -3,7 +3,7 @@ package is.hail.types.physical
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.{SFloat64, SFloat64Code, SFloat64Value}
+import is.hail.types.physical.stypes.primitives.{SFloat64, SFloat64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TFloat64
 

--- a/hail/src/main/scala/is/hail/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt32.scala
@@ -1,9 +1,9 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations._
 import is.hail.asm4s.{Code, coerce, const, _}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Code, SInt32Value}
+import is.hail.types.physical.stypes.primitives.{SInt32, SInt32Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TInt32
 

--- a/hail/src/main/scala/is/hail/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/PInt64.scala
@@ -1,9 +1,9 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations._
 import is.hail.asm4s.{Code, coerce, const, _}
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Code, SInt64Value}
+import is.hail.types.physical.stypes.primitives.{SInt64, SInt64Value}
 import is.hail.types.physical.stypes.{SType, SValue}
 import is.hail.types.virtual.TInt64
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SCode.scala
@@ -46,14 +46,10 @@ object SCode {
   def _empty: SValue = SVoidValue
 }
 
-abstract class SCode
-
 trait SValue {
   def st: SType
 
   def valueTuple: IndexedSeq[Value[_]]
-
-  def get: SCode
 
   def asBoolean: SBooleanValue = asInstanceOf[SBooleanValue]
 
@@ -108,10 +104,7 @@ trait SValue {
 
 
 trait SSettable extends SValue {
-  def store(cb: EmitCodeBuilder, v: SCode): Unit
-
-  def store(cb: EmitCodeBuilder, v: SValue): Unit =
-    store(cb, v.get)
+  def store(cb: EmitCodeBuilder, v: SValue): Unit
 
   def settableTuple(): IndexedSeq[Settable[_]]
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/SingleCodeSCode.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.ir.streams.{StreamArgType, StreamProducer}
 import is.hail.types.physical.PType
-import is.hail.types.physical.stypes.interfaces.{SStream, SStreamCode, SStreamValue}
+import is.hail.types.physical.stypes.interfaces.{SStream, SStreamValue}
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 import is.hail.utils._

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBaseStructPointer.scala
@@ -55,8 +55,6 @@ class SBaseStructPointerValue(
 ) extends SBaseStructValue {
   val pt: PBaseStruct = st.pType
 
-  override def get: SBaseStructPointerCode = new SBaseStructPointerCode(st, a)
-
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a)
 
   override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
@@ -82,9 +80,7 @@ final class SBaseStructPointerSettable(
 ) extends SBaseStructPointerValue(st, a) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  override def store(cb: EmitCodeBuilder, pv: SCode): Unit = {
-    cb.assign(a, pv.asInstanceOf[SBaseStructPointerCode].a)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    cb.assign(a, v.asInstanceOf[SBaseStructPointerValue].a)
   }
 }
-
-class SBaseStructPointerCode(val st: SBaseStructPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SBinaryPointer.scala
@@ -56,8 +56,6 @@ class SBinaryPointerValue(
 
   def bytesAddress(): Code[Long] = st.pType.bytesAddress(a)
 
-  override def get: SBinaryPointerCode = new SBinaryPointerCode(st, a)
-
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a)
 
   override def loadLength(cb: EmitCodeBuilder): Value[Int] =
@@ -81,7 +79,6 @@ final class SBinaryPointerSettable(
 ) extends SBinaryPointerValue(st, a) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  override def store(cb: EmitCodeBuilder, pc: SCode): Unit = cb.assign(a, pc.asInstanceOf[SBinaryPointerCode].a)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(a, v.asInstanceOf[SBinaryPointerValue].a)
 }
-
-class SBinaryPointerCode(val st: SBinaryPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalCall.scala
@@ -66,8 +66,6 @@ class SCanonicalCallValue(val call: Value[Int]) extends SCallValue {
 
   override val st: SCanonicalCall.type = SCanonicalCall
 
-  override def get: SCode = new SCanonicalCallCode(call)
-
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(call)
 
   override def ploidy(cb: EmitCodeBuilder): Value[Int] =
@@ -148,10 +146,8 @@ object SCanonicalCallSettable {
 }
 
 final class SCanonicalCallSettable(override val call: Settable[Int]) extends SCanonicalCallValue(call) with SSettable {
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit =
-    cb.assign(call, v.asInstanceOf[SCanonicalCallCode].call)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(call, v.asInstanceOf[SCanonicalCallValue].call)
 
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(call)
 }
-
-class SCanonicalCallCode(val call: Code[Int]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -25,7 +25,12 @@ final case class SCanonicalLocusPointer(pType: PCanonicalLocus) extends SLocus {
   override def _coerceOrCopy(cb: EmitCodeBuilder, region: Value[Region], value: SValue, deepCopy: Boolean): SValue =
     value match {
       case value: SLocusValue =>
-        new SCanonicalLocusPointerValue(this, pType.store(cb, region, value, deepCopy), value.contigLong(cb), value.position(cb))
+        val locusCopy = pType.store(cb, region, value, deepCopy)
+        val contigCopy = if (deepCopy)
+          cb.memoize(pType.contigAddr(locusCopy))
+        else
+          value.contigLong(cb)
+        new SCanonicalLocusPointerValue(this, locusCopy, contigCopy, value.position(cb))
     }
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(LongInfo, LongInfo, IntInfo)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SCanonicalLocusPointer.scala
@@ -61,8 +61,6 @@ class SCanonicalLocusPointerValue(
 ) extends SLocusValue {
   val pt: PCanonicalLocus = st.pType
 
-  override def get = new SCanonicalLocusPointerCode(st, a)
-
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a, _contig, _position)
 
   override def contig(cb: EmitCodeBuilder): SStringValue = {
@@ -94,14 +92,13 @@ final class SCanonicalLocusPointerSettable(
 ) extends SCanonicalLocusPointerValue(st, a, _contig, _position) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, _contig, _position)
 
-  override def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(a, pc.asInstanceOf[SCanonicalLocusPointerCode].a)
-    cb.assign(_contig, pt.contigAddr(a))
-    cb.assign(_position, pt.position(a))
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+    case v: SCanonicalLocusPointerValue =>
+      cb.assign(a, v.a)
+      cb.assign(_contig, v._contig)
+      cb.assign(_position, v._position)
   }
 
   override def structRepr(cb: EmitCodeBuilder): SBaseStructPointerSettable = new SBaseStructPointerSettable(
     SBaseStructPointer(st.pType.representation), a)
 }
-
-class SCanonicalLocusPointerCode(val st: SCanonicalLocusPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIndexablePointer.scala
@@ -53,9 +53,6 @@ final case class SIndexablePointer(pType: PContainer) extends SContainer {
   override def containsPointers: Boolean = pType.containsPointers
 }
 
-
-class SIndexablePointerCode(val st: SIndexablePointer, val a: Code[Long]) extends SCode
-
 class SIndexablePointerValue(
   override val st: SIndexablePointer,
   val a: Value[Long],
@@ -63,8 +60,6 @@ class SIndexablePointerValue(
   val elementsAddress: Value[Long]
 ) extends SIndexableValue {
   val pt: PContainer = st.pType
-
-  override def get: SIndexablePointerCode = new SIndexablePointerCode(st, a)
 
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a, length, elementsAddress)
 
@@ -129,9 +124,10 @@ final class SIndexablePointerSettable(
 ) extends SIndexablePointerValue(st, a, length, elementsAddress) with SSettable {
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, length, elementsAddress)
 
-  def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(a, pc.asInstanceOf[SIndexablePointerCode].a)
-    cb.assign(length, pt.loadLength(a))
-    cb.assign(elementsAddress, pt.firstElementOffset(a, length))
+  def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+    case v: SIndexablePointerValue =>
+      cb.assign(a, v.a)
+      cb.assign(length, v.length)
+      cb.assign(elementsAddress, v.elementsAddress)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SIntervalPointer.scala
@@ -59,8 +59,6 @@ class SIntervalPointerValue(
   val includesStart: Value[Boolean],
   val includesEnd: Value[Boolean]
 ) extends SIntervalValue {
-  override def get: SIntervalPointerCode = new SIntervalPointerCode(st, a)
-
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a, includesStart, includesEnd)
 
   val pt: PInterval = st.pType
@@ -113,11 +111,10 @@ final class SIntervalPointerSettable(
 ) extends SIntervalPointerValue(st, a, includesStart, includesEnd) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a, includesStart, includesEnd)
 
-  override def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(a, pc.asInstanceOf[SIntervalPointerCode].a)
-    cb.assign(includesStart, pt.includesStart(a.load()))
-    cb.assign(includesEnd, pt.includesEnd(a.load()))
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+    case v: SIntervalPointerValue =>
+      cb.assign(a, v.a)
+      cb.assign(includesStart, v.includesStart)
+      cb.assign(includesEnd, v.includesEnd)
   }
 }
-
-class SIntervalPointerCode(val st: SIntervalPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaArray.scala
@@ -58,15 +58,11 @@ final case class SJavaArrayString(elementRequired: Boolean) extends SContainer {
     new SJavaArrayStringValue(this, cb.memoize(arr))
 }
 
-class SJavaArrayStringCode(val st: SJavaArrayString, val array: Code[Array[String]]) extends SCode
-
 class SJavaArrayStringValue(
   val st: SJavaArrayString,
   val array: Value[Array[String]]
 ) extends SIndexableValue {
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(array)
-
-  override def get: SCode = new SJavaArrayStringCode(st, array)
 
   override def loadLength(): Value[Int] = new Value[Int] {
     override def get: Code[Int] = array.length()
@@ -109,7 +105,7 @@ final class SJavaArrayStringSettable(
 ) extends SJavaArrayStringValue(st, array) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(array)
 
-  override def store(cb: EmitCodeBuilder, pc: SCode): Unit = {
-    cb.assign(array, pc.asInstanceOf[SJavaArrayStringCode].array)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    cb.assign(array, v.asInstanceOf[SJavaArrayStringValue].array)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaBytes.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaBytes.scala
@@ -39,14 +39,10 @@ case object SJavaBytes extends SBinary {
   }
 }
 
-class SJavaBytesCode(val bytes: Code[Array[Byte]]) extends SCode
-
 class SJavaBytesValue(val bytes: Value[Array[Byte]]) extends SBinaryValue {
   override def st: SBinary = SJavaBytes
 
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(bytes)
-
-  override def get: SJavaBytesCode = new SJavaBytesCode(bytes)
 
   override def loadLength(cb: EmitCodeBuilder): Value[Int] =
     cb.memoize(bytes.length())
@@ -66,7 +62,7 @@ object SJavaBytesSettable {
 final class SJavaBytesSettable(override val bytes: Settable[Array[Byte]]) extends SJavaBytesValue(bytes) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(bytes)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = {
-    cb.assign(bytes, v.asInstanceOf[SJavaBytesCode].bytes)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    cb.assign(bytes, v.asInstanceOf[SJavaBytesValue].bytes)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SJavaString.scala
@@ -47,14 +47,10 @@ case object SJavaString extends SString {
     new SJavaStringValue(cb.memoize(s))
 }
 
-class SJavaStringCode(val s: Code[String]) extends SCode
-
 class SJavaStringValue(val s: Value[String]) extends SStringValue {
   override def st: SString = SJavaString
 
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(s)
-
-  override def get: SJavaStringCode = new SJavaStringCode(s)
 
   override def loadLength(cb: EmitCodeBuilder): Value[Int] =
     cb.memoize(s.invoke[Int]("length"))
@@ -74,7 +70,7 @@ object SJavaStringSettable {
 final class SJavaStringSettable(override val s: Settable[String]) extends SJavaStringValue(s) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(s)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = {
-    cb.assign(s, v.asInstanceOf[SJavaStringCode].s)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    cb.assign(s, v.asInstanceOf[SJavaStringValue].s)
   }
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SNDArrayPointer.scala
@@ -82,8 +82,6 @@ class SNDArrayPointerValue(
     pt.elementType.loadCheapSCode(cb, loadElementAddress(indices, cb))
   }
 
-  override def get: SNDArrayPointerCode = new SNDArrayPointerCode(st, a)
-
   override def coerceToShape(cb: EmitCodeBuilder, otherShape: IndexedSeq[SizeValue]): SNDArrayValue = {
     cb.ifx(!hasShape(cb, otherShape), cb._fatal("incompatible shapes"))
     new SNDArrayPointerValue(st, a, otherShape, strides, firstDataAddress)
@@ -127,12 +125,11 @@ final class SNDArrayPointerSettable(
 ) extends SNDArrayPointerValue(st, a, shape.map(SizeValueDyn.apply), strides, firstDataAddress) with SNDArraySettable {
   def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a) ++ shape ++ strides ++ FastIndexedSeq(firstDataAddress)
 
-  def store(cb: EmitCodeBuilder, v: SCode): Unit = {
-    cb.assign(a, v.asInstanceOf[SNDArrayPointerCode].a)
-    pt.loadShapes(cb, a, shape)
-    pt.loadStrides(cb, a, strides)
-    cb.assign(firstDataAddress, pt.dataFirstElementPointer(a))
+  def store(cb: EmitCodeBuilder, v: SValue): Unit = v match {
+    case v: SNDArrayPointerValue =>
+      cb.assign(a, v.a)
+      (shape, v.shapes).zipped.foreach(cb.assign(_, _))
+      (strides, v.strides).zipped.foreach(cb.assign(_, _))
+      cb.assign(firstDataAddress, v.firstDataAddress)
   }
 }
-
-class SNDArrayPointerCode(val st: SNDArrayPointer, val a: Code[Long]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStackStruct.scala
@@ -117,8 +117,6 @@ final case class SStackStruct(virtualType: TBaseStruct, fieldEmitTypes: IndexedS
 class SStackStructValue(val st: SStackStruct, val values: IndexedSeq[EmitValue]) extends SBaseStructValue {
   override lazy val valueTuple: IndexedSeq[Value[_]] = values.flatMap(_.valueTuple)
 
-  override def get: SStackStructCode = new SStackStructCode(st, values.map(_.load))
-
   override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     values(fieldIdx).toI(cb)
   }
@@ -140,10 +138,9 @@ final class SStackStructSettable(
 ) extends SStackStructValue(st, settables) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = settables.flatMap(_.settableTuple())
 
-  override def store(cb: EmitCodeBuilder, pv: SCode): Unit = {
-    val ssc = pv.asInstanceOf[SStackStructCode]
-    settables.zip(ssc.codes).foreach { case (s, c) => s.store(cb, c) }
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    (settables, v.asInstanceOf[SStackStructValue].values).zipped.foreach { (s, c) =>
+      s.store(cb, c)
+    }
   }
 }
-
-class SStackStructCode(val st: SStackStruct, val codes: IndexedSeq[EmitCode]) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SStringPointer.scala
@@ -45,15 +45,10 @@ final case class SStringPointer(pType: PString) extends SString {
   override def containsPointers: Boolean = pType.containsPointers
 }
 
-
-class SStringPointerCode(val st: SStringPointer, val a: Code[Long]) extends SCode
-
 class SStringPointerValue(val st: SStringPointer, val a: Value[Long]) extends SStringValue {
   val pt: PString = st.pType
 
   override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(a)
-
-  override def get: SStringPointerCode = new SStringPointerCode(st, a)
 
   def binaryRepr(): SBinaryPointerValue = new SBinaryPointerValue(SBinaryPointer(st.pType.binaryRepresentation), a)
 
@@ -77,8 +72,8 @@ object SStringPointerSettable {
 final class SStringPointerSettable(st: SStringPointer, override val a: Settable[Long]) extends SStringPointerValue(st, a) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(a)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = {
-    cb.assign(a, v.asInstanceOf[SStringPointerCode].a)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {
+    cb.assign(a, v.asInstanceOf[SStringPointerValue].a)
   }
 
   override def binaryRepr(): SBinaryPointerSettable = new SBinaryPointerSettable(SBinaryPointer(st.pType.binaryRepresentation), a)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SSubsetStruct.scala
@@ -83,10 +83,8 @@ final case class SSubsetStruct(parent: SBaseStruct, fieldNames: IndexedSeq[Strin
   override def containsPointers: Boolean = parent.containsPointers
 }
 
-class SSubsetStructValue(val st: SSubsetStruct, prev: SBaseStructValue) extends SBaseStructValue {
+class SSubsetStructValue(val st: SSubsetStruct, val prev: SBaseStructValue) extends SBaseStructValue {
   override lazy val valueTuple: IndexedSeq[Value[_]] = prev.valueTuple
-
-  override def get: SSubsetStructCode = new SSubsetStructCode(st, prev.get)
 
   override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode = {
     prev.loadField(cb, st.newToOldFieldMapping(fieldIdx))
@@ -99,7 +97,6 @@ class SSubsetStructValue(val st: SSubsetStruct, prev: SBaseStructValue) extends 
 final class SSubsetStructSettable(st: SSubsetStruct, prev: SBaseStructSettable) extends SSubsetStructValue(st, prev) with SBaseStructSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = prev.settableTuple()
 
-  override def store(cb: EmitCodeBuilder, pv: SCode): Unit = prev.store(cb, pv.asInstanceOf[SSubsetStructCode].prev)
+  override def store(cb: EmitCodeBuilder, pv: SValue): Unit =
+    prev.store(cb, pv.asInstanceOf[SSubsetStructValue].prev)
 }
-
-class SSubsetStructCode(val st: SSubsetStruct, val prev: SCode) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/concrete/SUnreachable.scala
@@ -39,8 +39,6 @@ abstract class SUnreachable extends SType {
 
   val sv: SUnreachableValue
 
-  val sc: SCode
-
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SSettable = sv
 
   override def fromValues(values: IndexedSeq[Value[_]]): SUnreachableValue = sv
@@ -57,7 +55,7 @@ abstract class SUnreachableValue extends SSettable {
 
   override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq()
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = {}
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit = {}
 }
 
 case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable with SBaseStruct {
@@ -69,11 +67,7 @@ case class SUnreachableStruct(virtualType: TBaseStruct) extends SUnreachable wit
   override def fieldIdx(fieldName: String): Int = virtualType.fieldIdx(fieldName)
 
   override val sv = new SUnreachableStructValue(this)
-
-  override val sc = new SUnreachableStructCode(this)
 }
-
-class SUnreachableStructCode(val st: SUnreachableStruct) extends SCode
 
 class SUnreachableStructValue(override val st: SUnreachableStruct) extends SUnreachableValue with SBaseStructValue {
   override def loadField(cb: EmitCodeBuilder, fieldIdx: Int): IEmitCode =
@@ -92,19 +86,13 @@ class SUnreachableStructValue(override val st: SUnreachableStruct) extends SUnre
 
   override def _insert(newType: TStruct, fields: (String, EmitValue)*): SBaseStructValue =
     new SUnreachableStructValue(SUnreachableStruct(newType))
-
-  override def get: SCode = st.sc
 }
 
 case object SUnreachableBinary extends SUnreachable with SBinary {
   override def virtualType: Type = TBinary
 
   override val sv = new SUnreachableBinaryValue
-
-  override val sc = new SUnreachableBinaryCode
 }
-
-class SUnreachableBinaryCode extends SCode
 
 class SUnreachableBinaryValue extends SUnreachableValue with SBinaryValue {
   override def loadByte(cb: EmitCodeBuilder, i: Code[Int]): Value[Byte] = const(0.toByte)
@@ -114,8 +102,6 @@ class SUnreachableBinaryValue extends SUnreachableValue with SBinaryValue {
   override def loadLength(cb: EmitCodeBuilder): Value[Int] = const(0)
 
   override def st: SUnreachableBinary.type = SUnreachableBinary
-
-  override def get: SUnreachableBinaryCode = st.sc
 }
 
 case object SUnreachableString extends SUnreachable with SString {
@@ -123,12 +109,8 @@ case object SUnreachableString extends SUnreachable with SString {
 
   override val sv = new SUnreachableStringValue
 
-  override val sc = new SUnreachableStringCode
-
   override def constructFromString(cb: EmitCodeBuilder, r: Value[Region], s: Code[String]): SStringValue = sv
 }
-
-class SUnreachableStringCode extends SCode
 
 class SUnreachableStringValue extends SUnreachableValue with SStringValue {
   override def st: SUnreachableString.type = SUnreachableString
@@ -138,14 +120,10 @@ class SUnreachableStringValue extends SUnreachableValue with SStringValue {
   override def loadString(cb: EmitCodeBuilder): Value[String] = Code._null[String]
 
   override def toBytes(cb: EmitCodeBuilder): SBinaryValue = SUnreachableBinary.sv
-
-  override def get: SUnreachableStringCode = st.sc
 }
 
 case class SUnreachableLocus(virtualType: TLocus) extends SUnreachable with SLocus {
   override val sv = new SUnreachableLocusValue(this)
-
-  override val sc = new SUnreachableLocusCode(this)
 
   override def contigType: SString = SUnreachableString
 
@@ -160,21 +138,13 @@ class SUnreachableLocusValue(override val st: SUnreachableLocus) extends SUnreac
   override def contigLong(cb: EmitCodeBuilder): Value[Long] = const(0)
 
   override def structRepr(cb: EmitCodeBuilder): SBaseStructValue = SUnreachableStruct(TStruct("contig" -> TString, "position" -> TInt32)).defaultValue.asInstanceOf[SUnreachableStructValue]
-
-  override def get: SUnreachableLocusCode = st.sc
 }
-
-class SUnreachableLocusCode(val st: SUnreachableLocus) extends SCode
 
 case object SUnreachableCall extends SUnreachable with SCall {
   override def virtualType: Type = TCall
 
   override val sv = new SUnreachableCallValue
-
-  override val sc = new SUnreachableCallCode
 }
-
-class SUnreachableCallCode extends SCode
 
 class SUnreachableCallValue extends SUnreachableValue with SCallValue {
   override def unphase(cb: EmitCodeBuilder): SCallValue = this
@@ -191,8 +161,6 @@ class SUnreachableCallValue extends SUnreachableValue with SCallValue {
 
   override def st: SUnreachableCall.type = SUnreachableCall
 
-  override def get: SUnreachableCallCode = st.sc
-
   override def lgtToGT(cb: EmitCodeBuilder, localAlleles: SIndexableValue, errorID: Value[Int]): SCallValue = st.sv
 }
 
@@ -200,14 +168,10 @@ class SUnreachableCallValue extends SUnreachableValue with SCallValue {
 case class SUnreachableInterval(virtualType: TInterval) extends SUnreachable with SInterval {
   override val sv = new SUnreachableIntervalValue(this)
 
-  override val sc = new SUnreachableIntervalCode(this)
-
   override def pointType: SType = SUnreachable.fromVirtualType(virtualType.pointType)
 
   override def pointEmitType: EmitType = EmitType(pointType, true)
 }
-
-class SUnreachableIntervalCode(val st: SUnreachableInterval) extends SCode
 
 class SUnreachableIntervalValue(override val st: SUnreachableInterval) extends SUnreachableValue with SIntervalValue {
   override def includesStart(): Value[Boolean] = const(false)
@@ -223,15 +187,11 @@ class SUnreachableIntervalValue(override val st: SUnreachableInterval) extends S
   override def endDefined(cb: EmitCodeBuilder): Value[Boolean] = const(false)
 
   override def isEmpty(cb: EmitCodeBuilder): Value[Boolean] = const(false)
-
-  override def get: SUnreachableIntervalCode = st.sc
 }
 
 
 case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with SNDArray {
   override val sv = new SUnreachableNDArrayValue(this)
-
-  override val sc = new SUnreachableNDArrayCode(this)
 
   override def nDims: Int = virtualType.nDims
 
@@ -243,8 +203,6 @@ case class SUnreachableNDArray(virtualType: TNDArray) extends SUnreachable with 
 
   override def elementByteSize: Long = 0L
 }
-
-class SUnreachableNDArrayCode(val st: SUnreachableNDArray) extends SCode
 
 class SUnreachableNDArrayValue(override val st: SUnreachableNDArray) extends SUnreachableValue with SNDArraySettable {
   override def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SValue = SUnreachable.fromVirtualType(st.virtualType.elementType).defaultValue
@@ -267,16 +225,12 @@ class SUnreachableNDArrayValue(override val st: SUnreachableNDArray) extends SUn
 
   override def firstDataAddress: Value[Long] = const(0L)
 
-  override def get: SUnreachableNDArrayCode = st.sc
-
   override def coiterateMutate(cb: EmitCodeBuilder, region: Value[Region], deepCopy: Boolean, indexVars: IndexedSeq[String],
     destIndices: IndexedSeq[Int], arrays: (SNDArrayValue, IndexedSeq[Int], String)*)(body: IndexedSeq[SValue] => SValue): Unit = ()
 }
 
 case class SUnreachableContainer(virtualType: TContainer) extends SUnreachable with SContainer {
   override val sv = new SUnreachableContainerValue(this)
-
-  override val sc = new SUnreachableContainerCode(this)
 
   lazy val elementType: SType = SUnreachable.fromVirtualType(virtualType.elementType)
 
@@ -294,8 +248,4 @@ class SUnreachableContainerValue(override val st: SUnreachableContainer) extends
 
   override def castToArray(cb: EmitCodeBuilder): SIndexableValue =
     SUnreachable.fromVirtualType(st.virtualType.arrayElementsRepr).defaultValue.asIndexable
-
-  override def get: SUnreachableContainerCode = st.sc
 }
-
-class SUnreachableContainerCode(val st: SUnreachableContainer) extends SCode

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SNDArray.scala
@@ -3,13 +3,11 @@ package is.hail.types.physical.stypes.interfaces
 import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir.EmitCodeBuilder
-import is.hail.types.{RNDArray, TypeWithRequiredness}
-import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
-import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceCode, SNDArraySliceValue}
 import is.hail.linalg.{BLAS, LAPACK}
-import is.hail.types.physical.stypes.primitives.SFloat64Code
+import is.hail.types.physical.stypes.concrete.{SNDArraySlice, SNDArraySliceValue}
+import is.hail.types.physical.stypes.{EmitType, SSettable, SType, SValue}
 import is.hail.types.physical.{PCanonicalNDArray, PNDArray, PType}
-import is.hail.types.physical.stypes.{EmitType, SCode, SSettable, SType, SValue}
+import is.hail.types.{RNDArray, TypeWithRequiredness}
 import is.hail.utils.{FastIndexedSeq, toRichIterable, valueToRichCodeRegion}
 
 import scala.collection.mutable
@@ -582,8 +580,6 @@ final class SizeValueStatic(val v: Long) extends SizeValue {
 
 trait SNDArrayValue extends SValue {
   def st: SNDArray
-
-  override def get: SCode
 
   def loadElement(indices: IndexedSeq[Value[Long]], cb: EmitCodeBuilder): SValue
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SStream.scala
@@ -38,14 +38,10 @@ final case class SStream(elementEmitType: EmitType) extends SType {
   override def _typeWithRequiredness: TypeWithRequiredness = RIterable(elementEmitType.typeWithRequiredness.r)
 }
 
-final case class SStreamCode(st: SStream, producer: StreamProducer) extends SCode
-
 object SStreamValue{
   def apply(producer: StreamProducer): SStreamValue = SStreamValue(SStream(producer.element.emitType), producer)
 }
 
 final case class SStreamValue(st: SStream, producer: StreamProducer) extends SUnrealizableValue {
   def valueTuple: IndexedSeq[Value[_]] = throw new NotImplementedError()
-
-  def get: SStreamCode = SStreamCode(st, producer)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SString.scala
@@ -13,8 +13,6 @@ trait SString extends SType {
 }
 
 trait SStringValue extends SValue {
-  override def get: SCode
-
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(loadString(cb).invoke[Int]("hashCode")))
 

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/SVoid.scala
@@ -32,14 +32,10 @@ case object SVoid extends SType {
   override def containsPointers: Boolean = false
 }
 
-case object SVoidCode extends SCode
-
 case object SVoidValue extends SValue with SUnrealizableValue {
   self =>
 
   override def st: SType = SVoid
 
   override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq()
-
-  override def get: SCode = SVoidCode
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/package.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/interfaces/package.scala
@@ -5,21 +5,6 @@ import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 
 package object interfaces {
-
-  def primitive(x: Code[Long]): SInt64Code = new SInt64Code(x)
-  def primitive(x: Code[Int]): SInt32Code = new SInt32Code(x)
-  def primitive(x: Code[Double]): SFloat64Code = new SFloat64Code(x)
-  def primitive(x: Code[Float]): SFloat32Code = new SFloat32Code(x)
-  def primitive(x: Code[Boolean]): SBooleanCode = new SBooleanCode(x)
-
-  def primitive(t: Type, x: Code[_]): SCode = t match {
-    case TInt32 => primitive(coerce[Int](x))
-    case TInt64 => primitive(coerce[Long](x))
-    case TFloat32 => primitive(coerce[Float](x))
-    case TFloat64 => primitive(coerce[Double](x))
-    case TBoolean => primitive(coerce[Boolean](x))
-  }
-
   def primitive(x: Value[Long]): SInt64Value = new SInt64Value(x)
   def primitive(x: Value[Int]): SInt32Value = new SInt32Value(x)
   def primitive(x: Value[Double]): SFloat64Value = new SFloat64Value(x)

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SBoolean.scala
@@ -40,20 +40,16 @@ case object SBoolean extends SPrimitive {
   override def storageType(): PType = PBoolean()
 }
 
-class SBooleanCode(val code: Code[Boolean]) extends SCode
-
-class SBooleanValue(x: Value[Boolean]) extends SPrimitiveValue {
+class SBooleanValue(val value: Value[Boolean]) extends SPrimitiveValue {
   val pt: PBoolean = PBoolean()
 
   override def st: SBoolean.type = SBoolean
 
-  override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(x)
+  override lazy val valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(value)
 
-  override def _primitiveValue: Value[_] = x
+  override def _primitiveValue: Value[_] = value
 
-  override def get: SBooleanCode = new SBooleanCode(x)
-
-  def boolCode(cb: EmitCodeBuilder): Value[Boolean] = x
+  def boolCode(cb: EmitCodeBuilder): Value[Boolean] = value
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(boolCode(cb).toI))
@@ -68,5 +64,6 @@ object SBooleanSettable {
 class SBooleanSettable(x: Settable[Boolean]) extends SBooleanValue(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SBooleanCode].code)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(x, v.asInstanceOf[SBooleanValue].value)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat32.scala
@@ -38,20 +38,16 @@ case object SFloat32 extends SPrimitive {
   override def storageType(): PType = PFloat32()
 }
 
-class SFloat32Code(val code: Code[Float]) extends SCode
-
-class SFloat32Value(x: Value[Float]) extends SPrimitiveValue {
+class SFloat32Value(val value: Value[Float]) extends SPrimitiveValue {
   val pt: PFloat32 = PFloat32()
 
-  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(x)
+  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(value)
 
   override def st: SFloat32.type = SFloat32
 
-  override def _primitiveValue: Value[_] = x
+  override def _primitiveValue: Value[_] = value
 
-  override def get: SCode = new SFloat32Code(x)
-
-  def floatCode(cb: EmitCodeBuilder): Value[Float] = x
+  def floatCode(cb: EmitCodeBuilder): Value[Float] = value
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(Code.invokeStatic1[java.lang.Float, Float, Int]("floatToIntBits", floatCode(cb))))
@@ -66,5 +62,6 @@ object SFloat32Settable {
 final class SFloat32Settable(x: Settable[Float]) extends SFloat32Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SFloat32Code].code)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(x, v.asInstanceOf[SFloat32Value].value)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SFloat64.scala
@@ -24,13 +24,6 @@ case object SFloat64 extends SPrimitive {
 
   override def settableTupleTypes(): IndexedSeq[TypeInfo[_]] = FastIndexedSeq(DoubleInfo)
 
-  def loadFrom(cb: EmitCodeBuilder, region: Value[Region], pt: PType, addr: Code[Long]): SCode = {
-    pt match {
-      case _: PFloat64 =>
-        new SFloat64Code(Region.loadDouble(addr))
-    }
-  }
-
   override def fromSettables(settables: IndexedSeq[Settable[_]]): SFloat64Settable = {
     val IndexedSeq(x: Settable[Double@unchecked]) = settables
     assert(x.ti == DoubleInfo)
@@ -46,28 +39,20 @@ case object SFloat64 extends SPrimitive {
   override def storageType(): PType = PFloat64()
 }
 
-object SFloat64Code {
-  def apply(code: Code[Double]): SFloat64Code = new SFloat64Code(code)
-}
-
-class SFloat64Code(val code: Code[Double]) extends SCode
-
 object SFloat64Value {
   def apply(code: Value[Double]): SFloat64Value = new SFloat64Value(code)
 }
 
-class SFloat64Value(x: Value[Double]) extends SPrimitiveValue {
+class SFloat64Value(val value: Value[Double]) extends SPrimitiveValue {
   val pt: PFloat64 = PFloat64(false)
 
-  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(x)
+  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(value)
 
   override def st: SFloat64.type = SFloat64
 
-  override def _primitiveValue: Value[_] = x
+  override def _primitiveValue: Value[_] = value
 
-  override def get: SCode = new SFloat64Code(x)
-
-  def doubleCode(cb: EmitCodeBuilder): Value[Double] = x
+  def doubleCode(cb: EmitCodeBuilder): Value[Double] = value
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Double, Double, Int]("hashCode", doubleCode(cb))))
@@ -82,5 +67,6 @@ object SFloat64Settable {
 final class SFloat64Settable(x: Settable[Double]) extends SFloat64Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SFloat64Code].code)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(x, v.asInstanceOf[SFloat64Value].value)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt32.scala
@@ -38,20 +38,16 @@ case object SInt32 extends SPrimitive {
   override def storageType(): PType = PInt32()
 }
 
-class SInt32Code(val code: Code[Int]) extends SCode
-
-class SInt32Value(x: Value[Int]) extends SPrimitiveValue {
+class SInt32Value(val value: Value[Int]) extends SPrimitiveValue {
   val pt: PInt32 = PInt32(false)
 
-  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(x)
+  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(value)
 
   override def st: SInt32.type = SInt32
 
-  override def _primitiveValue: Value[_] = x
+  override def _primitiveValue: Value[_] = value
 
-  override def get: SCode = new SInt32Code(x)
-
-  def intCode(cb: EmitCodeBuilder): Value[Int] = x
+  def intCode(cb: EmitCodeBuilder): Value[Int] = value
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(intCode(cb))
@@ -66,5 +62,6 @@ object SInt32Settable {
 final class SInt32Settable(x: Settable[Int]) extends SInt32Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SInt32Code].code)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(x, v.asInstanceOf[SInt32Value].value)
 }

--- a/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
+++ b/hail/src/main/scala/is/hail/types/physical/stypes/primitives/SInt64.scala
@@ -39,20 +39,16 @@ case object SInt64 extends SPrimitive {
   override def storageType(): PType = PInt64()
 }
 
-class SInt64Code(val code: Code[Long]) extends SCode
-
-class SInt64Value(x: Value[Long]) extends SPrimitiveValue {
+class SInt64Value(val value: Value[Long]) extends SPrimitiveValue {
   val pt: PInt64 = PInt64(false)
 
-  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(x)
+  override def valueTuple: IndexedSeq[Value[_]] = FastIndexedSeq(value)
 
   override def st: SInt64.type = SInt64
 
-  override def _primitiveValue: Value[_] = x
+  override def _primitiveValue: Value[_] = value
 
-  override def get: SCode = new SInt64Code(x)
-
-  def longCode(cb: EmitCodeBuilder): Value[Long] = x
+  def longCode(cb: EmitCodeBuilder): Value[Long] = value
 
   override def hash(cb: EmitCodeBuilder): SInt32Value =
     new SInt32Value(cb.memoize(invokeStatic1[java.lang.Long, Long, Int]("hashCode", longCode(cb))))
@@ -67,5 +63,6 @@ object SInt64Settable {
 final class SInt64Settable(x: Settable[Long]) extends SInt64Value(x) with SSettable {
   override def settableTuple(): IndexedSeq[Settable[_]] = FastIndexedSeq(x)
 
-  override def store(cb: EmitCodeBuilder, v: SCode): Unit = cb.assign(x, v.asInstanceOf[SInt64Code].code)
+  override def store(cb: EmitCodeBuilder, v: SValue): Unit =
+    cb.assign(x, v.asInstanceOf[SInt64Value].value)
 }

--- a/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedConstructorSuite.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder, IEmitCode, RequirednessSu
 import is.hail.types.physical._
 import is.hail.types.physical.stypes.concrete.SStringPointer
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SInt32Code, SInt32Value}
+import is.hail.types.physical.stypes.primitives.SInt32Value
 import is.hail.types.virtual._
 import is.hail.utils._
 import org.apache.spark.sql.Row

--- a/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/agg/DownsampleSuite.scala
@@ -5,9 +5,8 @@ import is.hail.annotations.{Region, RegionPool}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitCode, EmitFunctionBuilder}
 import is.hail.types.VirtualTypeWithReq
-import is.hail.types.physical.stypes.primitives.{SFloat64Code, SFloat64Value, SInt32Code}
+import is.hail.types.physical.stypes.primitives.SFloat64Value
 import is.hail.types.physical.{PCanonicalArray, PCanonicalString}
-import is.hail.utils.FastIndexedSeq
 import org.testng.annotations.Test
 
 class DownsampleSuite extends HailSuite {


### PR DESCRIPTION
Stacked on #11240

Rewrite all `SSettable.store` implementations to take an `SValue`. With that, `SCode` and subclasses are safe to delete.